### PR TITLE
Fix scp test

### DIFF
--- a/bootstrap/tether/scp/scp_test.go
+++ b/bootstrap/tether/scp/scp_test.go
@@ -47,8 +47,12 @@ func scpTest(t *testing.T, mode Mode) {
 		return
 	}
 
-	sourceFile := "/etc/fstab"
-	destFile := "./fstab"
+	sourceFile := "scp_test.go"
+	tmpFile, err := ioutil.TempFile("", sourceFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	destFile := tmpFile.Name()
 
 	var sourceFileMd5 []byte
 	var md5wg sync.WaitGroup


### PR DESCRIPTION
- Failed on darwin since /etc/fstab doesn't exist
- Use a tmp file for unique name and location outside of the source tree
