### PR TITLE
Change scratch Image ID to be scratch

### DIFF
--- a/portlayer/linux/storage/store.go
+++ b/portlayer/linux/storage/store.go
@@ -55,6 +55,10 @@ func (s *LocalStore) GetImageStore(storeName string) (*url.URL, error) {
 	return u, nil
 }
 
+func (s *LocalStore) ListImageStores() ([]*url.URL, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
 // WriteImage creates a new image layer from the given parent.
 // Eg parentImage + newLayer = new Image built from parent
 //

--- a/portlayer/storage/storage.go
+++ b/portlayer/storage/storage.go
@@ -20,6 +20,9 @@ type ImageStorer interface {
 	// Gets the url to an image store via name
 	GetImageStore(storeName string) (*url.URL, error)
 
+	// ListImageStores lists the available image stores
+	ListImageStores() ([]*url.URL, error)
+
 	// WriteImage creates a new image layer from the given parent.  Eg
 	// parentImage + newLayer = new Image built from parent
 	//

--- a/portlayer/storage/store_cache_test.go
+++ b/portlayer/storage/store_cache_test.go
@@ -28,6 +28,10 @@ func (c *MockDataStore) CreateImageStore(storeName string) (*url.URL, error) {
 	return u, nil
 }
 
+func (c *MockDataStore) ListImageStores() ([]*url.URL, error) {
+	return nil, nil
+}
+
 func (c *MockDataStore) WriteImage(parent *Image, ID string, r io.Reader) (*Image, error) {
 	i := Image{
 		ID:     ID,


### PR DESCRIPTION
Scratch on the dockerhub doesn't have an ID.  `FROM scratch` is now a
NOOP.  Modified the store_cache to account for this.  We now check for
the "scratch" ID.

Modified cache `WriteImage` to call cache `GetImage` on the passed in parent, but
pass the retrieved image to the datastore `WriteImage`.  This
optimization allows the portlayer REST API to avoid doing any lookups.
