### PR TITLE
implement misc.GetSystemInformation partially

### DIFF
--- a/apiservers/docker/restapi/handlers/misc_handlers.go
+++ b/apiservers/docker/restapi/handlers/misc_handlers.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/go-swagger/go-swagger/httpkit/middleware"
 
+	"github.com/vmware/vic/apiservers/docker/models"
 	"github.com/vmware/vic/apiservers/docker/restapi/operations"
 	"github.com/vmware/vic/apiservers/docker/restapi/operations/misc"
 )
@@ -28,7 +29,18 @@ func (handlers *MiscHandlersImpl) GetEvents(params misc.GetEventsParams) middlew
 }
 
 func (handlers *MiscHandlersImpl) GetSystemInfo() middleware.Responder {
-	return middleware.NotImplemented("operation misc.GetSystemInformation has not yet been implemented")
+	Driver := "Portlayer Storage"
+	IndexServerAddress := "https://index.docker.io/v1/"
+	ServerVersion := "0.0.1"
+	Name := "VIC"
+
+	info := &models.SystemInformation{
+		Driver:             &Driver,
+		IndexServerAddress: &IndexServerAddress,
+		ServerVersion:      &ServerVersion,
+		Name:               &Name,
+	}
+	return misc.NewGetSystemInformationOK().WithPayload(info)
 }
 
 func (handlers *MiscHandlersImpl) GetVersion() middleware.Responder {


### PR DESCRIPTION
so that we don't get

Warning: failed to get default registry endpoint from daemon
    (Error response from daemon: "operation misc.GetSystemInformation has not yet been implemented").
    Using system default: https://index.docker.io/v1/

when we try to pull an image. "docker info" also shows some info now.

Full implementation should follow https://github.com/docker/docker/blob/master/daemon/info.go
