### PR TITLE
Internationalization

### DIFF
--- a/pkg/i18n/i18n.go
+++ b/pkg/i18n/i18n.go
@@ -1,0 +1,106 @@
+// Copyright 2016 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package i18n provides functionality to retrieve strings from a
+// messages catalog based on a key (string ID).
+//
+// The messages catalog is loaded from a file containing all of the
+// strings for a given language. Here is an example:
+//
+// `messages/en`
+// greeting=hello
+// thanks=thank you
+//
+// `messages/es`
+// greeting=hola
+// thanks=gracias
+//
+// To use the translation functionality, call LoadLanguage with the desired
+// messages file for the local language. Replace uses of string literals
+// with a call to T and a given string ID. If the string ID is not present
+// in the loaded messages file, the string ID will be returned as the default.
+//
+// Once initialized, Printer can also be used directly with fmt-like print functions.
+// This can be used to include format strings for localization as below:
+//
+// `val := Printer.Sprintf("You know nothing %s", "Jon Snow")`
+//
+//  The corresponding messages catalogs would be:
+//
+// `messages/en`
+// You know nothing %s=You know nothing %s
+//
+// `messages/es`
+// You know nothing %s=No sabes nada %s
+//
+package i18n
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+
+	"golang.org/x/text/language"
+	"golang.org/x/text/message"
+)
+
+// Printer is the message printer used by T
+// to obtain a translated value.
+var Printer *message.Printer
+
+func getPrinter(scanner *bufio.Scanner, lang language.Tag) (*message.Printer, error) {
+	catalog := message.DefaultCatalog
+	scanner.Split(bufio.ScanLines)
+	for scanner.Scan() {
+		s := scanner.Text()
+		line := strings.SplitN(s, "=", 2)
+		if len(line) != 2 {
+			return nil, fmt.Errorf("Invalid line in messages file: %v", line)
+		}
+		catalog.SetString(lang, line[0], line[1])
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+	return catalog.Printer(lang), nil
+}
+
+// LoadLanguage sets the package level Printer after loading
+// the desired language file from the path messagesFile.
+func LoadLanguage(lang language.Tag, messagesFile string) error {
+	f, err := os.Open(messagesFile)
+	if err != nil {
+		return fmt.Errorf("Failed to open messages file: %v", err)
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	printer, err := getPrinter(scanner, lang)
+	if err == nil {
+		Printer = printer
+	}
+	return err
+}
+
+// T (Translate) takes the message key stringID and returns the string
+// value that the key maps to in the loaded messages file. If the key
+// is not found, stringID is returned as the default value.
+func T(stringID string) string {
+	k := message.Key(stringID, stringID)
+	if Printer == nil {
+		panic("Message file has not been loaded. Call LoadLanguage.")
+	}
+	return Printer.Sprintf(k)
+}

--- a/pkg/i18n/i18n_test.go
+++ b/pkg/i18n/i18n_test.go
@@ -1,0 +1,98 @@
+// Copyright 2016 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package i18n
+
+import (
+	"bufio"
+	"strings"
+	"testing"
+
+	"golang.org/x/text/language"
+)
+
+const testData = `key1=message1 english
+key2=message2 english
+format key %s=format message english %s`
+
+const badTestData = `key1message1`
+
+func TestGetPrinter(t *testing.T) {
+	scanner := bufio.NewScanner(strings.NewReader(testData))
+	p, err := getPrinter(scanner, language.English)
+	if p == nil {
+		t.Errorf("Failed to getPrinter: %s", err)
+	}
+}
+
+func TestGetPrinterInvalid(t *testing.T) {
+	scanner := bufio.NewScanner(strings.NewReader(badTestData))
+	p, err := getPrinter(scanner, language.English)
+	if err == nil {
+		t.Errorf("Failed to get an expected error.")
+	}
+	if p != nil {
+		t.Errorf("Got an unexpected printer from getPrinter")
+	}
+}
+
+func TestPrinterFormat(t *testing.T) {
+	scanner := bufio.NewScanner(strings.NewReader(testData))
+	p, _ := getPrinter(scanner, language.English)
+	Printer = p
+	testKey := "format key %s"
+	expectedValue := "format message english HAI"
+
+	val := Printer.Sprintf(testKey, "HAI")
+	if val != expectedValue {
+		t.Errorf("Got: %s Expected: %s", val, expectedValue)
+	}
+}
+
+func TestTranslate(t *testing.T) {
+	scanner := bufio.NewScanner(strings.NewReader(testData))
+	p, _ := getPrinter(scanner, language.English)
+	Printer = p
+	testKey := "key1"
+	expectedValue := "message1 english"
+
+	val := T(testKey)
+	if val != expectedValue {
+		t.Errorf("Got: %s Expected: %s", val, expectedValue)
+	}
+}
+
+func TestTranslateDefault(t *testing.T) {
+	scanner := bufio.NewScanner(strings.NewReader(testData))
+	p, _ := getPrinter(scanner, language.English)
+	Printer = p
+	testKey := "undefined"
+
+	val := T(testKey)
+	if val != testKey {
+		t.Errorf("Got: %s Expected: %s", val, testKey)
+	}
+}
+
+func TestUnloadedTranslate(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("Did not receive expected panic.")
+		}
+	}()
+
+	Printer = nil
+	testKey := "key1"
+	T(testKey)
+}


### PR DESCRIPTION
Addresses #134

This is a thin wrapper around https://godoc.org/golang.org/x/text/message, which provides message cataloging functionality. We store each language's messages in a file of key/value pairs. 

To use the translation functionality, call LoadLanguage with the desired messages file for the local language. Replace uses of string literals with a call to Translate and a given string ID. If the string ID is not present in the loaded messages file, the provided default value will be returned. 
Alternatively, use the package level Printer directly with fmt-like print functions.

Compared to https://github.com/maximilien/i18n4go:
i18n4go provides tooling for extracting strings and managing the strings and translations. Uses json language files. This one seemed like a bit much for us since it extracts all strings and uses an exclusion file.

Compared to https://github.com/nicksnyder/go-i18n:
go-i18n is pretty similar to what I've done with text/message. Uses json language files. 

I ended up picking https://godoc.org/golang.org/x/text/message because the fmt-like print functions are easy to use and the message catalog is straightforward to create for only the strings that we want to localize. 

```
⇒  go test . -v                   
=== RUN   TestGetPrinter
--- PASS: TestGetPrinter (0.00s)
=== RUN   TestGetPrinterInvalid
--- PASS: TestGetPrinterInvalid (0.00s)
=== RUN   TestPrinterFormat
--- PASS: TestPrinterFormat (0.00s)
=== RUN   TestTranslate
--- PASS: TestTranslate (0.00s)
=== RUN   TestUnloadedTranslate
--- PASS: TestUnloadedTranslate (0.00s)
PASS
ok      github.com/vmware/vic/pkg/i18n  0.002s
```
