### PR TITLE
Vagrant windows hack and gitignore of tmp files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.vagrant/
 binary/
 
 bootstrap/targets/linux/tether/

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -9,7 +9,8 @@ Vagrant.configure(2) do |config|
   config.vm.synced_folder ".", "/vagrant", disabled: true
 
   dirs.split(File::PATH_SEPARATOR).each do |dir|
-    config.vm.synced_folder dir, dir
+    gdir = dir.sub("C\:", "/C")
+    config.vm.synced_folder dir, gdir
   end
 
   [:vmware_fusion, :vmware_workstation].each do |visor|


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[  ] There is an associated issue that is labelled
[  ] Code is up-to-date with the `master` branch
[  ] You've successfully run `make test` locally
[  ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/vmware/vic/blob/master/.github/CONTRIBUTING.md
-->

Fixes # 230

Adds .vagrant to .gitignore so running vagrant from in the repo doesn't
cause new files to present.
This also adds a very basic hack to correct the guest path in vagrant for
synced folders - having a : in the path prevents make from working in the
vagrant box, so this replaces C: with /C
