### PR TITLE
Improvements to vicadmin tests

### DIFF
--- a/vicadmin/vicadm.go
+++ b/vicadmin/vicadm.go
@@ -532,7 +532,7 @@ func (s *server) stop() error {
 }
 
 func (s *server) tarContainerLogs(res http.ResponseWriter, req *http.Request) {
-	readers := append(defaultReaders, commandReader("du -sh /var/lib/docker"))
+	readers := append(defaultReaders, commandReader("sudo du -sh /var/lib/docker"))
 
 	if config.Service != "" {
 		c, err := client()


### PR DESCRIPTION
Fixes # warnings that were being seen during:
- pprof collection
- /var/lib/docker permission denied

Also squashes the tests on no linux systems, but does not address the sudo prompt that can occur.
