### PR TITLE
Integration tests for imagec.

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -8,6 +8,13 @@ build:
   environment:
     GOPATH: /drone
     SHELL: /bin/bash
+    DOCKER_API_VERSION: "1.21"
+  volumes:
+      - "/var/run/docker.sock:/var/run/docker.sock"
   commands:
+    - wget -q https://get.docker.com/builds/Linux/x86_64/docker-latest
+    - chmod +x docker-latest
+    - mv docker-latest /usr/local/bin/docker
     - make all
     - make test
+    - make integration-tests

--- a/Dockerfile.integration-tests
+++ b/Dockerfile.integration-tests
@@ -1,0 +1,29 @@
+# Copyright 2016 VMware, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM golang:1.6.0
+RUN apt-get update -yq
+RUN apt-get install -yq jq
+RUN git clone https://github.com/sstephenson/bats /tmp/bats
+RUN mkdir -p /go/src/github.com/vmware/vic/tests/helpers
+WORKDIR /go/src/github.com/vmware/vic/tests/helpers
+RUN git clone https://github.com/ztombol/bats-assert
+RUN git clone https://github.com/ztombol/bats-support
+WORKDIR /tmp/bats
+RUN ./install.sh /usr/local
+WORKDIR /go/src
+RUN mkdir -p github.com/vmware/vic
+ADD ./ github.com/vmware/vic
+WORKDIR github.com/vmware/vic/tests
+CMD /usr/local/bin/bats -t .

--- a/Makefile
+++ b/Makefile
@@ -115,6 +115,10 @@ vendor: $(GVT)
 	@echo restoring vendor
 	$(GOPATH)/bin/gvt restore
 
+integration-tests:
+	docker build -t imagec_tests -f Dockerfile.integration-tests .
+	docker run --rm imagec_tests
+
 test:
 	# test everything but vendor
 	$(GO) test -v $(TEST_OPTS) github.com/vmware/vic/bootstrap/...

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,4 @@
+# Integration & Functional Tests for VIC
+
+Integration tests can be run by calling `make integration-tests` from the project's root directory.
+Note that you must have Docker installed and your user must be in the `docker` group in order to run these tests.

--- a/tests/helpers/helpers.bash
+++ b/tests/helpers/helpers.bash
@@ -1,0 +1,67 @@
+# Copyright 2016 VMware, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# starts the port layer server in the background, waits for it to start, saves the pid to $port_layer_pid
+start_port_layer () {
+    [ "$1" = "" ] && port="8080" || port="$1"
+    "$GOPATH"/src/github.com/vmware/vic/binary/port-layer-server --port="$port" --path=/tmp/portlayer > /dev/null 2>&1 &
+    while ! curl localhost:"$port"/_ping > /dev/null 2>&1; do
+        sleep 1
+    done
+    port_layer_pid="$!"
+}
+
+# kills the port layer
+kill_port_layer () {
+    kill $port_layer_pid > /dev/null 2>&1
+}
+
+# returns the IDs of each FS layer represented in the manifest
+# in the order of appearance
+get_ids() { # assumes cwd is basedir of image
+    # find the id with jq
+    cat manifest.json | jq -r ".history[].v1Compatibility|fromjson.id"
+}
+
+# usage:
+# get_checksum INDEX
+# returns the checksum for the INDEXth layer in the manifest in the cwd
+get_checksum () { # assume cwd is basedir of image
+    jq -r ".fsLayers[$1].blobSum" < manifest.json | cut -d: -f2
+}
+
+# usage:
+# verify_checksums /path/to/basedir/containing/manifest
+# returns an error code if calculated sha256sums of the FS tarballs
+# do not match the hash recorded in the manifest
+# otherwise terminates and returns nothing
+verify_checksums () {
+    # cd to the directory with a manifest file
+    pushd "$1"
+
+    index=0
+    # get list of ids and iterate
+    for id in $(get_ids); do
+        manifest_checksum=$(get_checksum $index) # find manifest hash
+        pushd $id # cd into fs basedir
+
+        # check the manifest checksum against calculated hash from tarball
+        [[ $manifest_checksum = $(sha256sum $id.tar | awk '{print $1}') ]] || exit 1
+
+        popd
+        index=$((index + 1))
+    done
+
+    popd
+}

--- a/tests/imagec.bats
+++ b/tests/imagec.bats
@@ -1,0 +1,107 @@
+# Copyright 2016 VMware, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#!/usr/bin/env bats
+
+load helpers/helpers
+load 'helpers/bats-support/load'
+load 'helpers/bats-assert/load'
+
+imagec="$GOPATH/src/github.com/vmware/vic/binary/imagec"
+IMAGES_DIR="images"
+DEFAULT_IMAGE="https/registry-1.docker.io/v2/library/photon/latest"
+ALT_IMAGE="https/registry-1.docker.io/v2/tatsushid/tinycore"
+
+setup () {
+    # create temp directories & start the port layer server
+    mkdir -p /tmp/imagec_test_dir
+    mkdir -p /tmp/portlayer
+    cd /tmp/imagec_test_dir
+    start_port_layer
+}
+
+teardown() {
+    # stop the port layer between tests
+    kill_port_layer
+    cd >/dev/null
+    # nuke everything between tests
+    rm -rf /tmp/imagec_test_dir
+    rm -rf /tmp/portlayer
+}
+
+@test "imagec run without arguments downloads photon into default destination from Docker Hub" {
+    run "$imagec"
+    assert_success
+    assert [ -d "$IMAGES_DIR/$DEFAULT_IMAGE" ] # check that the correct dir is created
+    assert [ -e imagec.log ] # check the existence of the default logfile
+    assert [ -n imagec.log ] # logfile shouldn't be empty either
+    assert verify_checksums "$IMAGES_DIR/$DEFAULT_IMAGE" # make sure we got the right image
+}
+
+@test "imagec -help should show usage information" {
+    run $imagec --help
+    assert_failure # default 'you called -help' error code
+    [[ ${lines[0]} =~ Usage.*imagec.* ]]
+}
+
+@test "imagec -debug should enable debugging and -stdout outputs logs to stdout" {
+    # should get at least one line with 'level=output' present
+    run [ $("$imagec" -stdout -debug | grep "level=debug" | wc -l) -ge 1 ]
+    assert_success
+    assert verify_checksums "$IMAGES_DIR/$DEFAULT_IMAGE"
+}
+
+@test "imagec -destination allows us to change where the image is saved" {
+    run "$imagec" -destination foo
+    assert_success
+    assert verify_checksums "foo/$DEFAULT_IMAGE"
+}
+
+@test "imagec -digest should specify tag name or image digest to download" {
+    run "$imagec" -digest 7.0-x86_64 -image tatsushid/tinycore
+    assert_success
+    assert verify_checksums "$IMAGES_DIR/$ALT_IMAGE"/7.0-x86_64
+}
+
+@test "imagec -host should allow us to specify which host runs the portlayer API" {
+    assert kill_port_layer # it was started on 8080 by setup()
+    assert start_port_layer 1337 # restart it on 1337 cause we're elite
+    run "$imagec" -host localhost:1337
+    assert_success
+    assert verify_checksums "$IMAGES_DIR/$DEFAULT_IMAGE"
+}
+
+@test "imagec -image should allow specifying a specific image to download" {
+    run "$imagec" -image tatsushid/tinycore
+    assert_success
+    assert verify_checksums "$IMAGES_DIR/$ALT_IMAGE/latest"
+}
+
+@test "imagec -logfile should change the path of the installer log file (default \"imagec.log\")" {
+    run "$imagec" -logfile foo.log
+    assert_success
+    assert [ $(wc -l foo.log | awk '{print $1}') -ge 1 ] # logfile shouldn't be empty
+}
+
+@test "imagec -registry should allow us to change the registry" {
+    skip "test not implemented"
+}
+
+@test "imagec -timeout duration should change the HTTP timeout (default 1m0s)" {
+    skip "test not implemented"
+}
+
+@test "imagec -username and -password should allow us to specify a username and password for a private registry" {
+    skip "test not implemented"
+}


### PR DESCRIPTION
These are a first pass at integration tests for imagec. This is still something of a WIP to address https://github.com/vmware/vic/issues/90 but I'll merge it when I get a few LGTM's

Things I'm still considering: names of files, where these tests should live in the repository, and how to test against a private registry (working on spinning up another docker container through the makefile)

The gist of these changes & some things to review in this PR:
1) An update to the Makefile to allow us to run integration tests via `make`. I'm open to suggestions about where this has been added in. I did not add these steps under `make test` because these tests run slowly and further integration tests will probably increase that execution time in the future.
2) Three tests are still unimplemented in the `imagec.bats` file. This file also contains the meat of the tests themselves. The most interesting piece of the actual functionality verification is `verify_checksums` in `helpers.bash`. Ping me on Slack if you have ideas about testing the HTTP timeout. These three tests are at the bottom of `imagec.bats`
3) I created a new /tests directory in the main repository. I can move these tests into imagec/ if that would be better, but I thought more functional/integration tests will be coming sooner or later so it might be useful to have a repo-wide non-Go-tests directory
