### PR TITLE
Delete swagger on make clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -186,3 +186,6 @@ clean:
 	rm -rf ./apiservers/portlayer/cmd/
 	rm -rf ./apiservers/portlayer/models/
 	rm -rf ./apiservers/portlayer/restapi/operations/
+
+	@echo removing swagger generator...
+	rm -f $(GOPATH)/bin/swagger$(BIN_ARCH)


### PR DESCRIPTION
Make sure we delete the current swagger generator on
make clean.  It's the only way to pick up new changes
to the vendored swagger code.  We can either do this
or rebuild the swagger generator before every api server
build.
