### PR TITLE
Adding pkg/vsphere/disk

### DIFF
--- a/pkg/vsphere/disk/disk.go
+++ b/pkg/vsphere/disk/disk.go
@@ -1,0 +1,149 @@
+// Copyright 2016 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package disk
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+)
+
+// VirtualDisk represents a VMDK in the datastore, the device node it may be
+// attached at (if it's attached), the mountpoint it is mounted at (if
+// mounted), and other configuration.
+type VirtualDisk struct {
+	// The URI in the datastore this disk can be found with
+	DatastoreURI string
+
+	// The device node the disk is attached to
+	DevicePath string
+
+	// The path on the filesystem this device is attached to.
+	MountPath string
+
+	// To avoid attach/detach races, this lock serializes operations to the disk.
+	l sync.Mutex
+}
+
+func NewVirtualDisk(DatastoreURI string) (*VirtualDisk, error) {
+	if err := VerifyDatastoreDiskURI(DatastoreURI); err != nil {
+		return nil, err
+	}
+
+	d := &VirtualDisk{
+		DatastoreURI: DatastoreURI,
+	}
+
+	return d, nil
+}
+
+func (d *VirtualDisk) lock() {
+	d.l.Lock()
+}
+
+func (d *VirtualDisk) unlock() {
+	d.l.Unlock()
+}
+
+func (d *VirtualDisk) setAttached(devicePath string) error {
+	if d.isAttached() {
+		return fmt.Errorf("%s is already attached (%s)", d.DatastoreURI, devicePath)
+	}
+
+	if devicePath == "" {
+		return fmt.Errorf("no device path specified")
+	}
+
+	d.DevicePath = devicePath
+	return nil
+}
+
+func (d *VirtualDisk) canBeDetached() error {
+	if !d.isAttached() {
+		return fmt.Errorf("%s is already detached", d.DatastoreURI)
+	}
+
+	if d.isMounted() {
+		return fmt.Errorf("%s is mounted (%s)", d.DatastoreURI, d.MountPath)
+	}
+
+	return nil
+}
+
+func (d *VirtualDisk) setDetached() error {
+	if !d.isAttached() {
+		return fmt.Errorf("%s is already dettached", d.DatastoreURI)
+	}
+
+	if d.isMounted() {
+		return fmt.Errorf("%s is still mounted (%s)", d.DatastoreURI, d.MountPath)
+	}
+
+	d.DevicePath = ""
+	return nil
+}
+
+func (d *VirtualDisk) isAttached() bool {
+	return d.DevicePath != ""
+}
+
+func (d *VirtualDisk) setMounted(mountPath string) error {
+	if !d.isAttached() {
+		return fmt.Errorf("%s isn't attached", d.DatastoreURI)
+	}
+
+	if d.isMounted() {
+		return fmt.Errorf("%s already mounted", d.DatastoreURI)
+	}
+
+	if mountPath == "" {
+		return fmt.Errorf("mountPath missing")
+	}
+
+	d.MountPath = mountPath
+	return nil
+}
+
+func (d *VirtualDisk) isMounted() bool {
+	return d.MountPath != ""
+}
+
+func (d *VirtualDisk) canBeUnmounted() error {
+	if !d.isAttached() {
+		return fmt.Errorf("%s is detached", d.DatastoreURI)
+	}
+
+	if !d.isMounted() {
+		return fmt.Errorf("%s is unmounted", d.DatastoreURI)
+	}
+
+	return nil
+}
+
+func (d *VirtualDisk) setUmounted() error {
+	if !d.isMounted() {
+		return fmt.Errorf("%s already unmounted", d.DatastoreURI)
+	}
+
+	d.MountPath = ""
+	return nil
+}
+
+func VerifyDatastoreDiskURI(name string) error {
+	if !strings.HasSuffix(name, ".vmdk") {
+		return fmt.Errorf("%s isn't a vmdk", name)
+	}
+	return nil
+}

--- a/pkg/vsphere/disk/disk_manager.go
+++ b/pkg/vsphere/disk/disk_manager.go
@@ -1,0 +1,272 @@
+// Copyright 2016 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package disk
+
+import (
+	"fmt"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/juju/errors"
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25/types"
+	"github.com/vmware/vic/pkg/trace"
+	"github.com/vmware/vic/pkg/vsphere/session"
+	"golang.org/x/net/context"
+)
+
+const (
+	MaxAttachedDisks = 8
+)
+
+// Manager manages disks for the vm it runs on.  The expectation is this is run
+// from a VM on a vsphere instance.  This VM creates disks on ESX, attaches
+// them to itself, writes to them, then detaches them.
+type Manager struct {
+	// We can't have more than this number of disks attached.
+	maxAttached chan bool
+
+	// reference to the vm this is running on.
+	vm *object.VirtualMachine
+
+	// The controller on this vm.
+	controller *types.ParaVirtualSCSIController
+
+	// The PCI + SCSI device /dev node string format the disks can be attached with
+	byPathFormat string
+}
+
+func NewDiskManager(ctx context.Context, session *session.Session) (*Manager, error) {
+	vm, err := getSelf(ctx, session)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	// create handle to the docker daemon VM as we need to mount disks on it
+	controller, byPathFormat, err := verifyParavirtualScsiController(ctx, vm)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	d := &Manager{
+		maxAttached:  make(chan bool, MaxAttachedDisks),
+		vm:           vm,
+		controller:   controller,
+		byPathFormat: byPathFormat,
+	}
+	return d, nil
+}
+
+// CreateAndAttach creates a new vmdk child from parent of the given size.
+// Returns a VirtualDisk corresponding to the created and attached disk.  The
+// newDiskURI and parentURI are both Datastore URI paths in the form of
+// [datastoreN] /path/to/disk.vmdk.
+func (m *Manager) CreateAndAttach(ctx context.Context, newDiskURI,
+	parentURI string,
+	capacity int64) (*VirtualDisk, error) {
+	defer trace.End(trace.Begin(newDiskURI))
+
+	// ensure we abide by max attached disks limits
+	m.maxAttached <- true
+
+	d, err := NewVirtualDisk(newDiskURI)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	spec := m.createDiskSpec(newDiskURI, parentURI, capacity)
+
+	log.Infof("Attempting to create/attach vmdk for layer or volume %s at %s, with parent %s", newDiskURI, newDiskURI, parentURI)
+
+	if err := m.vm.AddDevice(ctx, spec); err != nil {
+		log.Errorf("vmdk storage driver failed to attach disk: %s", errors.ErrorStack(err))
+		return nil, errors.Trace(err)
+	}
+
+	log.Debugf("Mapping vmdk to pci device %s", newDiskURI)
+	devicePath, err := m.devicePathByURI(ctx, newDiskURI)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	d.setAttached(devicePath)
+
+	if err := waitForPath(ctx, devicePath); err != nil {
+		log.Infof("waitForPath failed for %s with %s", newDiskURI, errors.ErrorStack(err))
+		// ensure that the disk is detached if it's the publish that's failed
+
+		if detachErr := m.Detach(ctx, d); detachErr != nil {
+			log.Debugf("detach(%s) failed with %s", newDiskURI, errors.ErrorStack(detachErr))
+		}
+
+		return nil, errors.Trace(err)
+	}
+
+	return d, nil
+}
+
+func (m *Manager) createDiskSpec(childURI, parentURI string, capacity int64) *types.VirtualDisk {
+	// TODO: migrate this method to govmomi CreateDisk method
+	backing := &types.VirtualDiskFlatVer2BackingInfo{
+		DiskMode:        string(types.VirtualDiskModeIndependent_persistent),
+		ThinProvisioned: types.NewBool(true),
+		VirtualDeviceFileBackingInfo: types.VirtualDeviceFileBackingInfo{
+			FileName: childURI,
+		},
+	}
+
+	if parentURI != "" {
+		backing.Parent = &types.VirtualDiskFlatVer2BackingInfo{
+			VirtualDeviceFileBackingInfo: types.VirtualDeviceFileBackingInfo{
+				FileName: parentURI,
+			},
+		}
+	}
+
+	disk := &types.VirtualDisk{
+		VirtualDevice: types.VirtualDevice{
+			Key:           -1,
+			ControllerKey: m.controller.Key,
+			UnitNumber:    -1,
+			Backing:       backing,
+		},
+		CapacityInKB: capacity,
+	}
+
+	return disk
+}
+
+// Create creates a disk without a parent (and doesn't attach it).
+func (m *Manager) Create(ctx context.Context, newDiskURI string, capacityKB int64) (*VirtualDisk, error) {
+	defer trace.End(trace.Begin(newDiskURI))
+
+	vdm := object.NewVirtualDiskManager(m.vm.Client())
+
+	d, err := NewVirtualDisk(newDiskURI)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	spec := &types.FileBackedVirtualDiskSpec{
+		VirtualDiskSpec: types.VirtualDiskSpec{
+			DiskType:    string(types.VirtualDiskTypeThin),
+			AdapterType: string(types.VirtualDiskAdapterTypeLsiLogic),
+		},
+
+		CapacityKb: capacityKB,
+	}
+
+	log.Infof("Attempting to create vmdk for layer or volume %s", d.DatastoreURI)
+
+	task, err := vdm.CreateVirtualDisk(ctx, d.DatastoreURI, nil, spec)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	err = task.Wait(ctx)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	return d, nil
+}
+
+// TODO(FA) this doesn't work since delta disks get set with `deletable =
+// false` when they become parents.  This needs some thought and will require
+// some answers from a larger context.
+//func (m *DiskManager) Delete(ctx context.Context, d *VirtualDisk) error {
+//	defer trace.End(trace.Begin(d.DatastoreURI))
+//
+//	log.Infof("Deleting %s", d.DatastoreURI)
+//
+//	d.lock()
+//	defer d.unlock()
+//
+//	if d.isAttached() {
+//		return fmt.Errorf("cannot delete %s, still attached (%s)", d.DatastoreURI, d.devicePath)
+//	}
+//
+//	// TODO(FA) Check if disk is a parent.
+//
+//	vdm := object.NewVirtualDiskManager(m.vm.Client())
+//	task, err := vdm.DeleteVirtualDisk(ctx, d.DatastoreURI, nil)
+//	if err != nil {
+//		return err
+//	}
+//
+//	err = task.Wait(ctx)
+//	if err != nil {
+//		return errors.Trace(err)
+//	}
+//
+//	return nil
+// }
+
+func (m *Manager) Detach(ctx context.Context, d *VirtualDisk) error {
+	defer trace.End(trace.Begin(d.DevicePath))
+	log.Infof("starting detaching disk %s", d.DevicePath)
+
+	d.lock()
+	defer d.unlock()
+
+	if err := d.canBeDetached(); err != nil {
+		return errors.Trace(err)
+	}
+
+	spec := types.VirtualMachineConfigSpec{}
+
+	disk, err := findDisk(ctx, m.vm, d.DatastoreURI)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	config := []types.BaseVirtualDeviceConfigSpec{
+		&types.VirtualDeviceConfigSpec{
+			Device:    disk,
+			Operation: types.VirtualDeviceConfigSpecOperationRemove,
+		},
+	}
+
+	spec.DeviceChange = config
+
+	task, err := m.vm.Reconfigure(ctx, spec)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	err = task.Wait(ctx)
+	if err != nil {
+		log.Warnf("detach for %s failed with %s", d.DevicePath, errors.ErrorStack(err))
+		return errors.Trace(err)
+	}
+
+	func() {
+		select {
+		case <-m.maxAttached:
+		default:
+		}
+	}()
+
+	return d.setDetached()
+}
+
+func (m *Manager) devicePathByURI(ctx context.Context, datastoreURI string) (string, error) {
+	disk, err := findDisk(ctx, m.vm, datastoreURI)
+	if err != nil {
+		log.Debugf("findDisk failed for %s with %s", datastoreURI, errors.ErrorStack(err))
+		return "", errors.Trace(err)
+	}
+
+	return fmt.Sprintf(m.byPathFormat, disk.UnitNumber), nil
+}

--- a/pkg/vsphere/disk/disk_manager_test.go
+++ b/pkg/vsphere/disk/disk_manager_test.go
@@ -1,0 +1,151 @@
+// Copyright 2016 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package disk
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/vic/pkg/vsphere/session"
+	"golang.org/x/net/context"
+)
+
+func URL(t *testing.T) string {
+	s := os.Getenv("TEST_URL")
+	if s == "" {
+		t.SkipNow()
+	}
+	return s
+}
+
+// Create a lineage of disks inheriting from eachother, write portion of a
+// string to each, the confirm the result is the whole string
+func TestCreateAndDetach(t *testing.T) {
+	log.SetLevel(log.DebugLevel)
+	config := &session.Config{
+		Service:       URL(t),
+		Insecure:      true,
+		Keepalive:     time.Duration(5) * time.Minute,
+		DatastorePath: "/ha-datacenter/datastore/*",
+	}
+	client, err := session.NewSession(config).Create(context.Background())
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	imagestore := client.Datastore.Path("imagestore")
+
+	fm := object.NewFileManager(client.Vim25())
+
+	// create a directory in the datastore
+	// eat the error because we dont care if it exists
+	fm.MakeDirectory(context.TODO(), imagestore, nil, true)
+
+	vdm, err := NewDiskManager(context.TODO(), client)
+	if !assert.NoError(t, err) || !assert.NotNil(t, vdm) {
+		return
+	}
+
+	diskSize := int64(1 << 10)
+	parent, err := vdm.Create(context.TODO(), client.Datastore.Path("imagestore/scratch.vmdk"), diskSize)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	numChildren := 3
+	children := make([]*VirtualDisk, numChildren)
+
+	testString := "Ground control to Major Tom"
+	writeSize := len(testString) / numChildren
+	// Create children which inherit from eachother
+	for i := 0; i < numChildren; i++ {
+
+		child, err := vdm.CreateAndAttach(context.TODO(), client.Datastore.Path(fmt.Sprintf("imagestore/child%d.vmdk", i)), parent.DatastoreURI, 0)
+		if !assert.NoError(t, err) {
+			return
+		}
+
+		children[i] = child
+
+		// Write directly to the disk
+		f, err := os.OpenFile(child.DevicePath, os.O_RDWR, os.FileMode(0777))
+		if !assert.NoError(t, err) {
+			return
+		}
+
+		start := i * writeSize
+		end := start + writeSize
+
+		if i == numChildren-1 {
+			// last chunk, write to the end.
+			_, err = f.WriteAt([]byte(testString[start:]), int64(start))
+			if !assert.NoError(t, err) {
+				return
+			}
+			// Try to read the whole string
+			b := make([]byte, len(testString))
+			f.Seek(0, 0)
+			_, err = f.Read(b)
+			if !assert.NoError(t, err) {
+				return
+			}
+
+			//check against the test string
+			if !assert.True(t, strings.Compare(testString, string(b)) == 0) {
+				return
+			}
+
+		} else {
+			_, err = f.WriteAt([]byte(testString[start:end]), int64(start))
+			if !assert.NoError(t, err) {
+				return
+			}
+		}
+
+		f.Close()
+
+		err = vdm.Detach(context.TODO(), child)
+		if !assert.NoError(t, err) {
+			return
+		}
+
+		// use this image as the next parent
+		parent = child
+	}
+
+	//	// Nuke the images
+	//	for i := len(children) - 1; i >= 0; i-- {
+	//		err = vdm.Delete(context.TODO(), children[i])
+	//		if !assert.NoError(t, err) {
+	//			return
+	//		}
+	//	}
+
+	// Nuke the image store
+	task, err := fm.DeleteDatastoreFile(context.TODO(), imagestore, nil)
+	if !assert.NoError(t, err) {
+		return
+	}
+	_, err = task.WaitForResult(context.TODO(), nil)
+	if !assert.NoError(t, err) {
+		return
+	}
+}

--- a/pkg/vsphere/disk/util.go
+++ b/pkg/vsphere/disk/util.go
@@ -1,0 +1,212 @@
+// Copyright 2016 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package disk
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/juju/errors"
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25/types"
+	"github.com/vmware/vic/pkg/trace"
+	"github.com/vmware/vic/pkg/vsphere/guest"
+	"github.com/vmware/vic/pkg/vsphere/session"
+	"golang.org/x/net/context"
+)
+
+const (
+	// The duration waitForPath will tolerate before timing out.
+	pathTimeout = 5 * time.Second
+)
+
+func waitForPath(ctx context.Context, path string) error {
+	defer trace.End(trace.Begin(path))
+	timeout := time.Duration(pathTimeout)
+
+	ctx, _ = context.WithTimeout(ctx, timeout)
+	done := make(chan struct{})
+
+	go func() {
+		for {
+			if _, err := os.Stat(path); err == nil {
+				close(done)
+				break
+			}
+
+			// We've timed out.
+			if ctx.Err() != nil {
+				break
+			}
+			time.Sleep(200 * time.Microsecond)
+		}
+	}()
+
+	log.Debugf("Waiting for attached disk to appear in /dev/disk/by-path, or timeout")
+	select {
+	case <-done:
+		log.Infof("Attached disk present at %s", path)
+	case <-ctx.Done():
+		if ctx.Err() != nil {
+			return errors.Errorf("timeout waiting for layer to present as %s", path)
+		}
+	}
+
+	return nil
+}
+
+// ensures that a paravirtual scsi controller is present and determines the
+// base path of disks attached to it returns a handle to the controller and a
+// format string, with a single decimal for the disk unit number which will
+// result in the /dev/disk/by-path path
+func verifyParavirtualScsiController(ctx context.Context, vm *object.VirtualMachine) (*types.ParaVirtualSCSIController, string, error) {
+	devices, err := vm.Device(ctx)
+	if err != nil {
+		log.Errorf("vmware driver failed to retrieve device list for VM %s: %s", vm, errors.ErrorStack(err))
+		return nil, "", errors.Trace(err)
+	}
+
+	controller := devices.PickController((*types.ParaVirtualSCSIController)(nil)).(*types.ParaVirtualSCSIController)
+	if controller == nil {
+		err = errors.Errorf("vmware driver failed to find a paravirtual SCSI controller - ensure setup ran correctly")
+		log.Error(err.Error())
+		return nil, "", errors.Trace(err)
+	}
+
+	// build the base path
+	// first we determine which label we're looking for (requires VMW hardware version >=10)
+	targetLabel := fmt.Sprintf("SCSI%d", controller.BusNumber)
+	log.Debugf("Looking for scsi controller with label %s", targetLabel)
+
+	pciBase := "/sys/bus/pci/devices"
+	pciBus, err := os.Open(pciBase)
+	if err != nil {
+		log.Errorf("Failed to open %s for reading: %s", pciBase, errors.ErrorStack(err))
+		return controller, "", errors.Trace(err)
+	}
+	defer pciBus.Close()
+
+	pciDevices, err := pciBus.Readdirnames(0)
+	if err != nil {
+		log.Errorf("Failed to read contents of %s: %s", pciBase, errors.ErrorStack(err))
+		return controller, "", errors.Trace(err)
+	}
+
+	var buf = make([]byte, len(targetLabel))
+	var controllerName string
+
+	for _, n := range pciDevices {
+		nlabel := fmt.Sprintf("%s/%s/label", pciBase, n)
+		flabel, err := os.Open(nlabel)
+		if err != nil {
+			if !os.IsNotExist(err) {
+				log.Errorf("Unable to read label from %s: %s", nlabel, errors.ErrorStack(err))
+			}
+			continue
+		}
+		defer flabel.Close()
+
+		_, err = flabel.Read(buf)
+		if err != nil {
+			log.Errorf("Unable to read label from %s: %s", nlabel, errors.ErrorStack(err))
+			continue
+		}
+
+		if targetLabel == string(buf) {
+			// we've found our controller
+			controllerName = n
+			log.Debugf("Found pvscsi controller directory: %s", controllerName)
+
+			break
+		}
+	}
+
+	if controllerName == "" {
+		err := errors.Errorf("Failed to locate pvscsi controller directory")
+		log.Errorf(err.Error())
+		return controller, "", errors.Trace(err)
+	}
+
+	formatString := fmt.Sprintf("/dev/disk/by-path/pci-%s-scsi-0:0:%%d:0", controllerName)
+	log.Debugf("Returning the following format string for disk location: %s", formatString)
+	return controller, formatString, nil
+}
+
+// Find the disk by name attached to the given vm.
+func findDisk(ctx context.Context, vm *object.VirtualMachine, name string) (*types.VirtualDisk, error) {
+	defer trace.End(trace.Begin(vm.String()))
+
+	log.Debugf("Looking for attached disk matching filename %s", name)
+
+	devices, err := vm.Device(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to refresh devices for vm: %s", errors.ErrorStack(err))
+	}
+
+	candidates := devices.Select(func(device types.BaseVirtualDevice) bool {
+		db := device.GetVirtualDevice().Backing
+		if db == nil {
+			return false
+		}
+
+		backing, ok := device.GetVirtualDevice().Backing.(*types.VirtualDiskFlatVer2BackingInfo)
+		if !ok {
+			return false
+		}
+
+		log.Debugf("backing file name %s", backing.VirtualDeviceFileBackingInfo.FileName)
+		match := strings.HasSuffix(backing.VirtualDeviceFileBackingInfo.FileName, name)
+		if match {
+			log.Debugf("Found candidate disk for %s at %s", name, backing.VirtualDeviceFileBackingInfo.FileName)
+		}
+
+		return match
+	})
+
+	if len(candidates) == 0 {
+		log.Warnf("No disks match name: %s", name)
+		return nil, os.ErrNotExist
+	}
+
+	if len(candidates) > 1 {
+		return nil, errors.Errorf("Too many disks match name: %s", name)
+	}
+
+	return candidates[0].(*types.VirtualDisk), nil
+}
+
+// getSelf gets VirtualMachine reference for the VM this process is running on
+func getSelf(ctx context.Context, s *session.Session) (*object.VirtualMachine, error) {
+	u, err := guest.UUID()
+	if err != nil {
+		return nil, err
+	}
+
+	search := object.NewSearchIndex(s.Vim25())
+	ref, err := search.FindByUuid(ctx, s.Datacenter, u, true, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	if ref == nil {
+		return nil, fmt.Errorf("can't find the hosting vm")
+	}
+
+	vm := object.NewVirtualMachine(s.Client.Client, ref.Reference())
+	return vm, nil
+}


### PR DESCRIPTION
The disk package implements a Disk Manager which is used to create VMDK
images.  Disks can be created by themselves or from a parent (e.g. a
delta disk).  The API uses VirtualDisk structs as both handles and
state.  It is up to the caller to maintain these structs (cache them,
discover them, etc).  Correctness is implemented by the VirtualDisk
itself by checking if a disk is mounted and/or attached.

The test is very minimal at this point.  It creates a set of virtual
disks which inherit from eachother and attempts to write a portion of a
string to each.  If the leaf of the disks can be used to read the full
string, the test passes.

Still TBD in this package
-Deleting of delta disks by identifying which disk is a leaf
-Creating a whitelist of which disks cannot be mutated (e.g. any cache
or the root disks)

Fixes vmware/vic#11
