### PR TITLE
Building vic not supported on OSX

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -154,8 +154,12 @@ $(imagec): imagec/*.go $(portlayerapi-client)
 	@CGO_ENABLED=0 $(GO) build -o ./$@ --ldflags '-extldflags "-static"'  ./$(dir $<)
 
 $(docker-engine-api): $(portlayerapi-client) apiservers/engine/server/*.go apiservers/engine/backends/*.go
+ifeq ($(OS),linux)
 	@echo Building docker-engine-api server...
 	@$(GO) build -o $@ ./apiservers/engine/server
+else
+	@echo skipping docker-engine-api server, cannot build on non-linux
+endif
 
 # Common portlayer dependencies between client and server
 PORTLAYER_DEPS ?= apiservers/portlayer/swagger.yml \

--- a/README.md
+++ b/README.md
@@ -11,13 +11,15 @@ See [CONTRIBUTING](CONTRIBUTING.md) for details on submitting changes and the co
 
 ## Building binaries for development
 
-To build the bootstrap binaries, ensure `GOPATH` is set, then issue the following.
+Some of the project binaries can only be built on Linux.  If you are developing on a Mac or Windows OS, then the easiest way to facilitate a build is by utilizing the project's Vagrantfile.  The Vagrantfile will share the directory where the file is executed and set the GOPATH based on that share.
+
+To build the bootstrap binaries, ensure `GOPATH` is set, then issue the following command in the root directory:
 ```
 $ make all
 ```
 This will install required tools, build the bootstrap binaries `tether-windows`, `tether-linux`, `rpctool` and server binaries `docker-server`, `port-layer-server`.  The binaries will be created in the `./binaries` directory.
 
-To run tests after a successfull build, issue the following.
+To run tests after a successfull build, issue the following:
 ```
 $ make test
 ```

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,11 +2,14 @@
 
 Vagrant.configure(2) do |config|
   dirs = ENV["GOPATH"] || Dir.home
+  gdir = nil
 
   config.vm.box = "boxcutter/ubuntu1504-docker"
   config.vm.network "forwarded_port", guest: 2375, host: 12375
   config.vm.host_name = "devbox"
   config.vm.synced_folder ".", "/vagrant", disabled: true
+  config.ssh.username = "vagrant"
+
 
   dirs.split(File::PATH_SEPARATOR).each do |dir|
     gdir = dir.sub("C\:", "/C")
@@ -20,6 +23,6 @@ Vagrant.configure(2) do |config|
   end
 
   Dir["machines/devbox/provision*.sh"].each do |path|
-    config.vm.provision "shell", path: path
+    config.vm.provision "shell", path: path, args: ["#{gdir}",config.ssh.username]
   end
 end

--- a/machines/devbox/provision.sh
+++ b/machines/devbox/provision.sh
@@ -2,6 +2,13 @@
 
 apt-get update
 
+# set GOPATH based on shared folder of vagrant
+pro="/home/"${BASH_ARGV[0]}"/.profile"
+echo "export GOPATH="${BASH_ARGV[1]} >> $pro
+
+# add GOPATH/bin to the PATH
+echo "export PATH=$PATH:"${BASH_ARGV[1]}"/bin" >> $pro
+
 packages=(curl lsof strace git shellcheck)
 
 for package in "${packages[@]}" ; do


### PR DESCRIPTION
- vagrant file now sets GOPATH and PATH:GOPATH/bin
- Makefile has linux check
- README updated with linux building requirement

fixes #279
