### PR TITLE
Use pvscsi controller for devbox vm

### DIFF
--- a/machines/devbox/deploy-esx.sh
+++ b/machines/devbox/deploy-esx.sh
@@ -46,7 +46,7 @@ vm_memory=${VM_MEMORY-$(grep memsize "$config" | awk -F'"' '{print $4}')}
 if [ -z "$(govc ls "vm/$vm_name")" ] ; then
     echo "creating VM ${vm_name}..."
 
-    govc vm.create -m "$vm_memory" -c 2 -g ubuntu64Guest -on=false "$vm_name"
+    govc vm.create -m "$vm_memory" -c 2 -g ubuntu64Guest -disk.controller=pvscsi -on=false "$vm_name"
 
     govc vm.disk.attach -vm "$vm_name" -link=true -disk "$name/$disk"
 


### PR DESCRIPTION
Portlayer storage testing requires the pvsci controller to work.  The
default is to use the lsi scsi controller if unspecified otherwise.
