### PR TITLE
Do not require default network in VC session

### DIFF
--- a/pkg/vsphere/session/session.go
+++ b/pkg/vsphere/session/session.go
@@ -213,9 +213,11 @@ func (s *Session) Populate(ctx context.Context) (*Session, error) {
 		}
 	}
 
-	s.Network, err = finder.NetworkOrDefault(ctx, s.NetworkPath)
-	if err != nil {
-		errs = append(errs, err.Error())
+	if s.NetworkPath != "" {
+		s.Network, err = finder.NetworkOrDefault(ctx, s.NetworkPath)
+		if err != nil {
+			errs = append(errs, err.Error())
+		}
 	}
 
 	s.Pool, err = finder.ResourcePoolOrDefault(ctx, s.PoolPath)


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[  ] There is an associated issue that is labelled
[  ] Code is up-to-date with the `master` branch
[  ] You've successfully run `make test` locally
[  ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/vmware/vic/blob/master/.github/CONTRIBUTING.md
-->

  Network is not required for all VC resource query.

  #315 modify session so that default network is not required
