### PR TITLE
Fix vsphere ImageStore restart parent mkdir panic

### DIFF
--- a/portlayer/vsphere/storage/store.go
+++ b/portlayer/vsphere/storage/store.go
@@ -60,7 +60,6 @@ func NewImageStore(ctx context.Context, s *session.Session) (*ImageStore, error)
 		s:  s,
 	}
 
-	// Ignore the error if the parent path already exists
 	err = vis.makeImageStoreParentDir(ctx)
 	if err != nil {
 		return nil, err
@@ -254,7 +253,7 @@ func (v *ImageStore) makeImageStoreParentDir(ctx context.Context) error {
 	}
 
 	for _, f := range res.File {
-		folder, ok := f.(*types.FolderFileInfo)
+		folder, ok := f.(*types.FileInfo)
 		if !ok {
 			continue
 		}

--- a/portlayer/vsphere/storage/store_test.go
+++ b/portlayer/vsphere/storage/store_test.go
@@ -56,6 +56,21 @@ func setup(t *testing.T) (*portlayer.NameLookupCache, *session.Session, error) {
 	return s, client, nil
 }
 
+func TestRestartImageStore(t *testing.T) {
+	// Start the image store once
+	_, client, err := setup(t)
+	if !assert.NoError(t, err) {
+		return
+	}
+	defer rm(t, client, "")
+
+	// now start it again
+	vsImageStore, err := NewImageStore(context.TODO(), client)
+	if !assert.NoError(t, err) || !assert.NotNil(t, vsImageStore) {
+		return
+	}
+}
+
 // Create an image store then test it exists
 func TestCreateAndGetImageStore(t *testing.T) {
 	vsis, client, err := setup(t)


### PR DESCRIPTION
We couldn't restart the image store because the parent directory would
be recreated (and panic).  Check the directory exists and return if it
does.
