### PR TITLE
Extend copyright check

### DIFF
--- a/.githooks/pre-commit/80-header-check
+++ b/.githooks/pre-commit/80-header-check
@@ -1,4 +1,17 @@
 #!/bin/bash
+# Copyright 2016 VMware, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 set -e -o pipefail
 

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,17 @@
+# Copyright 2016 VMware, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 GO ?= go
 GOVERSION ?= go1.6
 OS := $(shell uname | tr '[:upper:]' '[:lower:]')
@@ -263,7 +277,7 @@ $(bootstrap-debug): isos/bootstrap.sh $(tether-linux) $(rpctool) $(iso-base) $(b
 
 $(bootstrap-staging): isos/bootstrap-staging.sh $(iso-base)
 	@echo staging for bootstrap
-	@$< -c $(BIN)/yum-cache.tgz -p $(iso-base) -o $@ 
+	@$< -c $(BIN)/yum-cache.tgz -p $(iso-base) -o $@
 
 $(bootstrap-staging-debug): isos/bootstrap-staging.sh $(iso-base)
 	@echo staging debug for bootstrap

--- a/coverage
+++ b/coverage
@@ -1,4 +1,18 @@
 #!/bin/sh
+# Copyright 2016 VMware, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # Generate test coverage statistics for Go packages.
 #
 # Works around the fact that `go test -coverprofile` does not work

--- a/isos/appliance-staging.sh
+++ b/isos/appliance-staging.sh
@@ -1,4 +1,18 @@
 #!/bin/bash
+# Copyright 2016 VMware, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # Build the appliance filesystem ontop of the base
 
 # exit on failure and configure debug, include util functions

--- a/isos/appliance.sh
+++ b/isos/appliance.sh
@@ -1,4 +1,18 @@
 #!/bin/bash
+# Copyright 2016 VMware, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # Build the appliance filesystem ontop of the base
 
 # exit on failure and configure debug, include util functions

--- a/isos/appliance/imagec.sh
+++ b/isos/appliance/imagec.sh
@@ -1,4 +1,18 @@
 #!/bin/bash
+# Copyright 2016 VMware, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 
 # imagec wrapper file - furnish the pretence of rpctool based default args
 

--- a/isos/appliance/launcher.sh
+++ b/isos/appliance/launcher.sh
@@ -1,4 +1,18 @@
 #!/bin/bash
+# Copyright 2016 VMware, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 
 logFileDir="/var/log/vic/"
 mkdir -p "$logFileDir"

--- a/isos/base.sh
+++ b/isos/base.sh
@@ -1,4 +1,18 @@
 #!/bin/bash
+# Copyright 2016 VMware, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # Build the base of a bootable ISO
 
 # exit on failure and configure debug, include util functions

--- a/isos/base/utils.sh
+++ b/isos/base/utils.sh
@@ -1,4 +1,18 @@
 #!/bin/bash
+# Copyright 2016 VMware, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 
 # utility functions for staged authoring of ISOs
 [ -n "$DEBUG" ] && set -x

--- a/isos/bootstrap-staging.sh
+++ b/isos/bootstrap-staging.sh
@@ -1,4 +1,18 @@
 #!/bin/bash
+# Copyright 2016 VMware, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # Build the bootstrap filesystem ontop of the base
 
 # exit on failure

--- a/isos/bootstrap.sh
+++ b/isos/bootstrap.sh
@@ -1,4 +1,18 @@
 #!/bin/bash
+# Copyright 2016 VMware, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # Build the bootstrap filesystem ontop of the base
 
 # exit on failure

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -1,3 +1,17 @@
+# Copyright 2016 VMware, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 SPECFILE = linux-esx.spec
 CONFIG = config-esx-4.2.0
 

--- a/kernel/build.sh
+++ b/kernel/build.sh
@@ -1,4 +1,18 @@
 #!/bin/bash
+# Copyright 2016 VMware, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 
 NAME=kernel
 

--- a/machines/devbox/deploy-esx.sh
+++ b/machines/devbox/deploy-esx.sh
@@ -1,4 +1,18 @@
 #!/bin/bash -e
+# Copyright 2016 VMware, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 
 # Deploy Vagrant box to esx
 set -e

--- a/machines/devbox/provision-drone.sh
+++ b/machines/devbox/provision-drone.sh
@@ -1,4 +1,18 @@
 #!/bin/bash
+# Copyright 2016 VMware, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 
 # This depends on docker being on the box and running
 

--- a/machines/devbox/provision.sh
+++ b/machines/devbox/provision.sh
@@ -1,4 +1,18 @@
 #!/bin/bash -e
+# Copyright 2016 VMware, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 
 apt-get update && apt-get -y dist-upgrade
 

--- a/scripts/header-check.sh
+++ b/scripts/header-check.sh
@@ -1,18 +1,37 @@
 #!/bin/bash
-# Easy & Dumb header check for CI jobs, currently checks ".go" files only.
+# Copyright 2016 VMware, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Simple script that will check files of type .go, .sh, .bash or Makefile
+# for the copyright header.
 #
 # This will be called by the CI system (with no args) to perform checking and
 # fail the job if headers are not correctly set. It can also be called with the
 # 'fix' argument to automatically add headers to the missing files.
 #
 # Check if headers are fine:
-#   $ ./hack/header-check.sh
+#   $ ./scripts/header-check.sh
 # Check and fix headers:
-#   $ ./hack/header-check.sh fix
+#   All changes must be committed for fix to work
+#   $ ./scripts/header-check.sh fix
 
 set -e -o pipefail
 
-# Header check, starts from 1, evaluated as regex, change at will.
+# These header variables MUST match the first two lines of the
+# VMware-copyright file in the scripts directory.
+#
+# These will be evaluated as a regex against the target file
 HEADER[1]="^\/\/ Copyright [0-9]{4} VMware, Inc\. All Rights Reserved\.$"
 HEADER[2]="^\/\/$"
 
@@ -20,17 +39,65 @@ HEADER[2]="^\/\/$"
 ERR=false
 FAIL=false
 
-for file in $(git ls-files | grep "\.go$" | grep -v vendor/); do
+for file in $(git ls-files | grep -e "\.go$" -e "Makefile$" -e "\.sh$" -e "\.bash$" | grep -v vendor/); do
   echo -n "Header check: $file... "
+  # get the file extention / type
+  ext=${file##*.}
+
+  # increment line count in certain cases
+  increment=false
+
+  # should we be incrementing the line count
+  if [[ $ext == "sh" ]]; then
+    increment=true
+  fi
+
   for count in $(seq 1 ${#HEADER[@]}); do
-    if [[ ! $(sed ${count}q\;d ${file}) =~ ${HEADER[$count]} ]]; then
+    if [[ $ext != "go" ]]; then
+        # if not go code assuming # will suffice
+        text="${HEADER[$count]/'\/\/'/#}"
+      else
+        text=${HEADER[$count]}
+    fi
+
+    if [[ "$increment" = true ]]; then
+      line=$((count + 1))
+    else
+      line=$count
+    fi
+    # do we have a header match?
+    if [[ ! $(sed ${line}q\;d ${file}) =~ ${text} ]]; then
       ERR=true
     fi
   done
+
   if [ $ERR == true ]; then
+    # is there is a fix argument and are all changes committed
     if [[ $# -gt 0 && $1 =~ [[:upper:]fix] ]]; then
-      cat ./scripts/VMware-copyright ${file} > ${file}.new
+      # based on file type fix the copyright
+      case "$ext" in
+        go)
+          cat ./scripts/VMware-copyright |  ${file} > ${file}.new
+          ;;
+        sh)
+          head -1 ${file} > ${file}.new
+          cat ./scripts/VMware-copyright | sed 's/\/\//\#/1' >> ${file}.new
+          grep -v '#!/bin/bash' ${file} >> ${file}.new
+          ;;
+        *)
+          cat ./scripts/VMware-copyright | sed 's/\/\//\#/1' > ${file}.new
+          cat ${file} >> ${file}.new
+          ;;
+      esac
+
+      if [ "$(uname -s)" = "Darwin" ]; then
+        permissions=$(stat -f "%OLp" ${file})
+      else
+        permissions=$(stat --format '%a' ${file})
+      fi
       mv ${file}.new ${file}
+      # make permissions the same
+      chmod $permissions ${file}
       echo "$(tput -T xterm setaf 3)FIXING$(tput -T xterm sgr0)"
       ERR=false
     else

--- a/tests/helpers/helpers.bash
+++ b/tests/helpers/helpers.bash
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#    http:#www.apache.org/licenses/LICENSE-2.0
+#    http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
Extended copyright check to include the following file types:
    \* .sh
    \* .bash
    \* Makefile

Files that were fixed by the header check are included in this
commit

fixes 325
