### PR TITLE
Update govmomi

### DIFF
--- a/pkg/vsphere/disk/disk_manager.go
+++ b/pkg/vsphere/disk/disk_manager.go
@@ -146,7 +146,6 @@ func (m *Manager) createDiskSpec(childURI, parentURI string, capacity int64, fla
 		VirtualDevice: types.VirtualDevice{
 			Key:           -1,
 			ControllerKey: m.controller.Key,
-			UnitNumber:    -1,
 			Backing:       backing,
 		},
 		CapacityInKB: capacity,

--- a/pkg/vsphere/spec/disk.go
+++ b/pkg/vsphere/spec/disk.go
@@ -34,8 +34,6 @@ func NewVirtualDisk(controller types.BaseVirtualController) *types.VirtualDisk {
 	return &types.VirtualDisk{
 		VirtualDevice: types.VirtualDevice{
 			ControllerKey: controller.GetVirtualController().Key,
-			// Zero value is a valid UnitNumber. Set it to -1 so that ESXi/vCenter can assign one for us.
-			UnitNumber: -1,
 		},
 	}
 }

--- a/pkg/vsphere/spec/ide.go
+++ b/pkg/vsphere/spec/ide.go
@@ -20,7 +20,7 @@ import (
 )
 
 // NewVirtualIDEController returns a VirtualIDEController spec with key.
-func NewVirtualIDEController(key int) *types.VirtualIDEController {
+func NewVirtualIDEController(key int32) *types.VirtualIDEController {
 	defer trace.End(trace.Begin(""))
 
 	return &types.VirtualIDEController{
@@ -55,7 +55,6 @@ func NewVirtualCdrom(device *types.VirtualIDEController) *types.VirtualCdrom {
 	return &types.VirtualCdrom{
 		VirtualDevice: types.VirtualDevice{
 			ControllerKey: device.Key,
-			UnitNumber:    -1,
 		},
 	}
 }
@@ -89,8 +88,6 @@ func NewVirtualFloppy(device *types.VirtualIDEController) *types.VirtualFloppy {
 	return &types.VirtualFloppy{
 		VirtualDevice: types.VirtualDevice{
 			ControllerKey: device.Key,
-			// Zero value is a valid UnitNumber. Set it to -1 so that ESXi/vCenter can assign one for us.
-			UnitNumber: -1,
 		},
 	}
 }

--- a/pkg/vsphere/spec/scsi.go
+++ b/pkg/vsphere/spec/scsi.go
@@ -22,7 +22,7 @@ import (
 )
 
 // NewVirtualSCSIController returns a VirtualSCSIController with bus number and key.
-func NewVirtualSCSIController(bus int, key int) types.VirtualSCSIController {
+func NewVirtualSCSIController(bus int32, key int32) types.VirtualSCSIController {
 	defer trace.End(trace.Begin(fmt.Sprintf("%d - %d", bus, key)))
 
 	return types.VirtualSCSIController{

--- a/pkg/vsphere/spec/spec.go
+++ b/pkg/vsphere/spec/spec.go
@@ -43,7 +43,7 @@ type VirtualMachineConfigSpecConfig struct {
 	Name string
 
 	// Number of CPUs
-	NumCPUs int
+	NumCPUs int32
 	// Memory - in MB
 	MemoryMB int64
 
@@ -78,7 +78,7 @@ type VirtualMachineConfigSpec struct {
 	config *VirtualMachineConfigSpecConfig
 
 	// internal value to keep track of next ID
-	key int
+	key int32
 }
 
 // NewVirtualMachineConfigSpec returns a VirtualMachineConfigSpec
@@ -269,7 +269,7 @@ func (s *VirtualMachineConfigSpec) ImageStoreName() string {
 	return s.config.ImageStoreName
 }
 
-func (s *VirtualMachineConfigSpec) generateNextKey() int {
+func (s *VirtualMachineConfigSpec) generateNextKey() int32 {
 
 	s.key -= 10
 	return s.key

--- a/pkg/vsphere/spec/spec_test.go
+++ b/pkg/vsphere/spec/spec_test.go
@@ -74,9 +74,9 @@ func TestVirtualMachineConfigSpec(t *testing.T) {
 		NetworkName:   strings.Split(session.Network.Reference().Value, "-")[0],
 	}
 	// FIXME: find a better way to pass those
-	scsibus := 0
-	scsikey := 100
-	idekey := 200
+	var scsibus int32
+	var scsikey int32 = 100
+	var idekey int32 = 200
 
 	root, _ := NewVirtualMachineConfigSpec(ctx, session, specconfig)
 	scsi := NewVirtualSCSIController(scsibus, scsikey)

--- a/vendor/github.com/vmware/govmomi/CHANGELOG.md
+++ b/vendor/github.com/vmware/govmomi/CHANGELOG.md
@@ -1,6 +1,12 @@
 # changelog
 
-### (unreleased)
+### 0.5.0 (2016-03-30)
+
+Generated fields using xsd type 'int' change to Go type 'int32'
+
+VirtualDevice.UnitNumber field changed to pointer type
+
+### 0.4.0 (2016-02-26)
 
 * Add method to convert virtual device list to array with virtual device
   changes that can be used in the VirtualMachineConfigSpec.

--- a/vendor/github.com/vmware/govmomi/CONTRIBUTING.md
+++ b/vendor/github.com/vmware/govmomi/CONTRIBUTING.md
@@ -1,0 +1,92 @@
+# Contributing to govmomi
+
+## Getting started
+
+First, fork the repository on GitHub to your personal account.
+
+Note that _GOPATH_ can be any directory, the example below uses _$HOME/govmomi_.
+Change _$USER_ below to your github username if they are not the same.
+
+``` shell
+export GOPATH=$HOME/govmomi
+mkdir -p $GOPATH/src/github.com/vmware
+cd $GOPATH/src/github.com/vmware
+git clone git@github.com:vmware/govmomi.git
+cd govmomi
+git config push.default nothing # anything to avoid pushing to vmware/govmomi by default
+git remote rename origin vmware
+git remote add $USER git@github.com:$USER/govmomi.git
+git fetch $USER
+```
+
+## Contribution flow
+
+This is a rough outline of what a contributor's workflow looks like:
+
+- Create a topic branch from where you want to base your work.
+- Make commits of logical units.
+- Make sure your commit messages are in the proper format (see below).
+- Push your changes to a topic branch in your fork of the repository.
+- Submit a pull request to vmware/govmomi.
+
+Example:
+
+``` shell
+git checkout -b my-new-feature vmware/master
+git commit -a
+git push $USER my-new-feature
+```
+
+### Stay in sync with upstream
+
+When your branch gets out of sync with the vmware/master branch, use the following to update:
+
+``` shell
+git checkout my-new-feature
+git fetch -a
+git rebase vmware/master
+git push --force-with-lease $USER my-new-feature
+```
+
+### Updating pull requests
+
+If your PR fails to pass CI or needs changes based on code review, you'll most likely want to squash these changes into
+existing commits.
+
+If your pull request contains a single commit or your changes are related to the most recent commit, you can simply
+amend the commit.
+
+``` shell
+git add .
+git commit --amend
+git push --force-with-lease $USER my-new-feature
+```
+
+If you need to squash changes into an earlier commit, you can use:
+
+``` shell
+git add .
+git commit --fixup <commit>
+git rebase -i --autosquash vmware/master
+git push --force-with-lease $USER my-new-feature
+```
+
+Be sure to add a comment to the PR indicating your new changes are ready to review, as github does not generate a
+notification when you git push.
+
+### Code style
+
+The coding style suggested by the Golang community is used in govmomi. See the
+[style doc](https://github.com/golang/go/wiki/CodeReviewComments) for details.
+
+Try to limit column width to 120 characters for both code and markdown documents such as this one.
+
+### Format of the Commit Message
+
+We follow the conventions on [How to Write a Git Commit Message](http://chris.beams.io/posts/git-commit/).
+
+Be sure to include any related GitHub issue references in the commit message.
+
+## Reporting Bugs and Creating Issues
+
+When opening a new issue, try to roughly follow the commit message format conventions above.

--- a/vendor/github.com/vmware/govmomi/CONTRIBUTORS
+++ b/vendor/github.com/vmware/govmomi/CONTRIBUTORS
@@ -4,23 +4,32 @@
 #
 
 Alvaro Miranda <kikitux@gmail.com>
-Amit Bathla <abathla@vmware.com>
+Amit Bathla <abathla@.vmware.com>
+Andrew Chin <andrew@andrewtchin.com>
+Arran Walker <arran.walker@zopa.com>
 Bob Killen <killen.bob@gmail.com>
 Bruce Downs <bdowns@vmware.com>
 Clint Greenwood <cgreenwood@vmware.com> <clint.greenwood@gmail.com>
+Cédric Blomart <cblomart@gmail.com>
 Danny Lockard <danny.lockard@banno.com>
 Doug MacEachern <dougm@vmware.com>
 Eloy Coto <eloy.coto@gmail.com>
 Eric Yutao <eric.yutao@gmail.com>
+Fabio Rapposelli <fabio@vmware.com>
 Faiyaz Ahmed <ahmedf@vmware.com>
 Gavin Gray <gavin@infinio.com>
 Gavrie Philipson <gavrie@philipson.co.il> <gavrie.philipson@elastifile.com>
+George Hicken <ghicken@vmware.com>
+Gerrit Renker <Gerrit.Renker@ctl.io>
+gthombare <gthombare@vmware.com>
+Isaac Rodman <isaac@eyz.us>
 Louie Jiang <jiangl@vmware.com>
 Mevan Samaratunga <mevansam@gmail.com>
 Pieter Noordhuis <pnoordhuis@vmware.com> <pcnoordhuis@gmail.com>
 runner.mei <runner.mei@gmail.com>
 S.Çağlar Onur <conur@vmware.com>
 Takaaki Furukawa <takaaki.frkw@gmail.com> <takaaki.furukawa@mail.rakuten.com>
+Steve Purcell <steve@sanityinc.com>
 Yang Yang <yangy@vmware.com>
 Yuya Kusakabe <yuya.kusakabe@gmail.com>
 Zach Tucker <ztucker@vmware.com>

--- a/vendor/github.com/vmware/govmomi/event/helper.go
+++ b/vendor/github.com/vmware/govmomi/event/helper.go
@@ -1,0 +1,116 @@
+/*
+Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package event
+
+import (
+	"fmt"
+
+	"golang.org/x/net/context"
+
+	"github.com/vmware/govmomi/property"
+	"github.com/vmware/govmomi/view"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+func multipleObjectEvents(ctx context.Context, m Manager, objects []types.ManagedObjectReference, pageSize int32, tail bool, force bool, prop []string, f func([]types.BaseEvent) error) error {
+	// create an EventHistoryCollector for each object
+	var collectors []types.ManagedObjectReference
+	for _, o := range objects {
+		filter := types.EventFilterSpec{
+			Entity: &types.EventFilterSpecByEntity{
+				Entity:    o,
+				Recursion: types.EventFilterSpecRecursionOptionAll,
+			},
+		}
+
+		collector, err := m.CreateCollectorForEvents(ctx, filter)
+		if err != nil {
+			return fmt.Errorf("[%#v] %s", o, err)
+		}
+		defer collector.Destroy(ctx)
+
+		err = collector.SetPageSize(ctx, pageSize)
+		if err != nil {
+			return err
+		}
+
+		collectors = append(collectors, collector.Reference())
+	}
+
+	// create and populate a ListView
+	viewMgr := view.NewManager(m.Client())
+	listView, err := viewMgr.CreateListView(ctx, collectors)
+	if err != nil {
+		return err
+	}
+	count := 0
+	// Retrieve the property from the objects in the ListView
+	return property.WaitForView(ctx, property.DefaultCollector(m.Client()), listView.Reference(), collectors[0], prop, func(pc []types.PropertyChange) bool {
+		for _, u := range pc {
+			if u.Name != prop[0] {
+				continue
+			}
+			if u.Val == nil {
+				continue
+			}
+			f(u.Val.(types.ArrayOfEvent).Event)
+		}
+		count++
+		if count == len(collectors) && !tail {
+			return true
+		}
+		return false
+	})
+
+}
+
+func singleObjectEvents(ctx context.Context, m Manager, object types.ManagedObjectReference, pageSize int32, tail bool, force bool, prop []string, f func([]types.BaseEvent) error) error {
+	filter := types.EventFilterSpec{
+		Entity: &types.EventFilterSpecByEntity{
+			Entity:    object,
+			Recursion: types.EventFilterSpecRecursionOptionAll,
+		},
+	}
+
+	collector, err := m.CreateCollectorForEvents(ctx, filter)
+	if err != nil {
+		return fmt.Errorf("[%#v] %s", object, err)
+	}
+	defer collector.Destroy(ctx)
+
+	err = collector.SetPageSize(ctx, pageSize)
+	if err != nil {
+		return err
+	}
+
+	return property.Wait(ctx, property.DefaultCollector(m.Client()), collector.Reference(), prop, func(pc []types.PropertyChange) bool {
+		for _, u := range pc {
+			if u.Name != prop[0] {
+				continue
+			}
+			if u.Val == nil {
+				continue
+			}
+			f(u.Val.(types.ArrayOfEvent).Event)
+
+		}
+		if !tail {
+			return true
+		}
+		return false
+	})
+}

--- a/vendor/github.com/vmware/govmomi/event/history_collector.go
+++ b/vendor/github.com/vmware/govmomi/event/history_collector.go
@@ -46,7 +46,7 @@ func (h HistoryCollector) LatestPage(ctx context.Context) ([]types.BaseEvent, er
 	return o.LatestPage, nil
 }
 
-func (h HistoryCollector) ReadNextEvents(ctx context.Context, maxCount int) ([]types.BaseEvent, error) {
+func (h HistoryCollector) ReadNextEvents(ctx context.Context, maxCount int32) ([]types.BaseEvent, error) {
 	req := types.ReadNextEvents{
 		This:     h.Reference(),
 		MaxCount: maxCount,
@@ -60,7 +60,7 @@ func (h HistoryCollector) ReadNextEvents(ctx context.Context, maxCount int) ([]t
 	return res.Returnval, nil
 }
 
-func (h HistoryCollector) ReadPreviousEvents(ctx context.Context, maxCount int) ([]types.BaseEvent, error) {
+func (h HistoryCollector) ReadPreviousEvents(ctx context.Context, maxCount int32) ([]types.BaseEvent, error) {
 	req := types.ReadPreviousEvents{
 		This:     h.Reference(),
 		MaxCount: maxCount,

--- a/vendor/github.com/vmware/govmomi/event/manager.go
+++ b/vendor/github.com/vmware/govmomi/event/manager.go
@@ -17,9 +17,11 @@ limitations under the License.
 package event
 
 import (
+	"fmt"
 	"reflect"
 	"sync"
 
+	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/property"
 	"github.com/vmware/govmomi/vim25"
 	"github.com/vmware/govmomi/vim25/methods"
@@ -29,22 +31,20 @@ import (
 )
 
 type Manager struct {
-	reference types.ManagedObjectReference
-
-	c *vim25.Client
+	object.Common
 
 	eventCategory   map[string]string
 	eventCategoryMu *sync.Mutex
+	maxObjects      int
 }
 
 func NewManager(c *vim25.Client) *Manager {
 	m := Manager{
-		reference: *c.ServiceContent.EventManager,
-
-		c: c,
+		Common: object.NewCommon(c, *c.ServiceContent.EventManager),
 
 		eventCategory:   make(map[string]string),
 		eventCategoryMu: new(sync.Mutex),
+		maxObjects:      10,
 	}
 
 	return &m
@@ -52,26 +52,26 @@ func NewManager(c *vim25.Client) *Manager {
 
 func (m Manager) CreateCollectorForEvents(ctx context.Context, filter types.EventFilterSpec) (*HistoryCollector, error) {
 	req := types.CreateCollectorForEvents{
-		This:   m.reference,
+		This:   m.Common.Reference(),
 		Filter: filter,
 	}
 
-	res, err := methods.CreateCollectorForEvents(ctx, m.c, &req)
+	res, err := methods.CreateCollectorForEvents(ctx, m.Client(), &req)
 	if err != nil {
 		return nil, err
 	}
 
-	return NewHistoryCollector(m.c, res.Returnval), nil
+	return NewHistoryCollector(m.Client(), res.Returnval), nil
 }
 
 func (m Manager) LogUserEvent(ctx context.Context, entity types.ManagedObjectReference, msg string) error {
 	req := types.LogUserEvent{
-		This:   m.reference,
+		This:   m.Common.Reference(),
 		Entity: entity,
 		Msg:    msg,
 	}
 
-	_, err := methods.LogUserEvent(ctx, m.c, &req)
+	_, err := methods.LogUserEvent(ctx, m.Client(), &req)
 	if err != nil {
 		return err
 	}
@@ -81,12 +81,12 @@ func (m Manager) LogUserEvent(ctx context.Context, entity types.ManagedObjectRef
 
 func (m Manager) PostEvent(ctx context.Context, eventToPost types.BaseEvent, taskInfo types.TaskInfo) error {
 	req := types.PostEvent{
-		This:        m.reference,
+		This:        m.Common.Reference(),
 		EventToPost: eventToPost,
 		TaskInfo:    &taskInfo,
 	}
 
-	_, err := methods.PostEvent(ctx, m.c, &req)
+	_, err := methods.PostEvent(ctx, m.Client(), &req)
 	if err != nil {
 		return err
 	}
@@ -96,11 +96,11 @@ func (m Manager) PostEvent(ctx context.Context, eventToPost types.BaseEvent, tas
 
 func (m Manager) QueryEvents(ctx context.Context, filter types.EventFilterSpec) ([]types.BaseEvent, error) {
 	req := types.QueryEvents{
-		This:   m.reference,
+		This:   m.Common.Reference(),
 		Filter: filter,
 	}
 
-	res, err := methods.QueryEvents(ctx, m.c, &req)
+	res, err := methods.QueryEvents(ctx, m.Client(), &req)
 	if err != nil {
 		return nil, err
 	}
@@ -110,11 +110,11 @@ func (m Manager) QueryEvents(ctx context.Context, filter types.EventFilterSpec) 
 
 func (m Manager) RetrieveArgumentDescription(ctx context.Context, eventTypeID string) ([]types.EventArgDesc, error) {
 	req := types.RetrieveArgumentDescription{
-		This:        m.reference,
+		This:        m.Common.Reference(),
 		EventTypeId: eventTypeID,
 	}
 
-	res, err := methods.RetrieveArgumentDescription(ctx, m.c, &req)
+	res, err := methods.RetrieveArgumentDescription(ctx, m.Client(), &req)
 	if err != nil {
 		return nil, err
 	}
@@ -133,7 +133,7 @@ func (m Manager) eventCategoryMap(ctx context.Context) (map[string]string, error
 	var o mo.EventManager
 
 	ps := []string{"description.eventInfo"}
-	err := property.DefaultCollector(m.c).RetrieveOne(ctx, m.reference, ps, &o)
+	err := property.DefaultCollector(m.Client()).RetrieveOne(ctx, m.Common.Reference(), ps, &o)
 	if err != nil {
 		return nil, err
 	}
@@ -158,4 +158,23 @@ func (m Manager) EventCategory(ctx context.Context, event types.BaseEvent) (stri
 	class := reflect.TypeOf(event).Elem().Name()
 
 	return eventCategory[class], nil
+}
+
+// Get the events from the specified object(s) and optionanlly tail the event stream
+func (m Manager) Events(ctx context.Context, objects []types.ManagedObjectReference, pageSize int32, tail bool, force bool, f func([]types.BaseEvent) error) error {
+
+	if len(objects) >= m.maxObjects && !force {
+		return fmt.Errorf("Maximum number of objects to monitor (%d) exceeded, refine search \n", m.maxObjects)
+	}
+
+	// property that will be monitored
+	prop := []string{"latestPage"}
+
+	// call to helper functions to reduce the number of temporary objects
+	if len(objects) > 1 {
+		return multipleObjectEvents(ctx, m, objects, pageSize, tail, force, prop, f)
+	}
+
+	return singleObjectEvents(ctx, m, objects[0], pageSize, tail, force, prop, f)
+
 }

--- a/vendor/github.com/vmware/govmomi/find/finder.go
+++ b/vendor/github.com/vmware/govmomi/find/finder.go
@@ -669,6 +669,27 @@ func (f *Finder) ResourcePoolOrDefault(ctx context.Context, path string) (*objec
 	return f.DefaultResourcePool(ctx)
 }
 
+func (f *Finder) DefaultFolder(ctx context.Context) (*object.Folder, error) {
+	ref, err := f.vmFolder(ctx)
+	if err != nil {
+		return nil, toDefaultError(err)
+	}
+	folder := object.NewFolder(f.client, ref.Reference())
+
+	return folder, nil
+}
+
+func (f *Finder) FolderOrDefault(ctx context.Context, path string) (*object.Folder, error) {
+	if path != "" {
+		folder, err := f.Folder(ctx, path)
+		if err != nil {
+			return nil, err
+		}
+		return folder, nil
+	}
+	return f.DefaultFolder(ctx)
+}
+
 func (f *Finder) VirtualMachineList(ctx context.Context, path string) ([]*object.VirtualMachine, error) {
 	es, err := f.find(ctx, f.vmFolder, false, path)
 	if err != nil {

--- a/vendor/github.com/vmware/govmomi/gen/gen_from_vmodl.rb
+++ b/vendor/github.com/vmware/govmomi/gen/gen_from_vmodl.rb
@@ -80,6 +80,7 @@ class Prop
       case type
       when "string"
       when "int"
+        type = "int32"
       when "boolean"
         type ="bool"
       when "long"

--- a/vendor/github.com/vmware/govmomi/govc/CHANGELOG.md
+++ b/vendor/github.com/vmware/govmomi/govc/CHANGELOG.md
@@ -1,6 +1,22 @@
 # changelog
 
-### (unreleased)
+### 0.5.0 (2016-03-30)
+
+* Add dvs.portgroup.info command
+
+* Add `-folder` flag to vm.create command
+
+* Add `-dump` flag to OutputFlag
+
+* Add `-f` flag to events command
+
+* Add `-mode` flag to vm.disk.create command
+
+* Add `-net` flag to device.info command
+
+* Add `-eager` and `-thick` options to vm.create command
+
+### 0.4.0 (2016-02-26)
 
 * Add support for placement in datastore cluster to vm.create command
 

--- a/vendor/github.com/vmware/govmomi/govc/dvs/portgroup/add.go
+++ b/vendor/github.com/vmware/govmomi/govc/dvs/portgroup/add.go
@@ -56,7 +56,8 @@ func (cmd *add) Register(ctx context.Context, f *flag.FlagSet) {
 	f.StringVar(&cmd.DVPortgroupConfigSpec.Type, "type", ptypes[0],
 		fmt.Sprintf("Portgroup type (%s)", strings.Join(ptypes, "|")))
 
-	f.IntVar(&cmd.DVPortgroupConfigSpec.NumPorts, "nports", 128, "Number of ports")
+	cmd.DVPortgroupConfigSpec.NumPorts = 128 // default
+	f.Var(flags.NewInt32(&cmd.DVPortgroupConfigSpec.NumPorts), "nports", "Number of ports")
 }
 
 func (cmd *add) Process(ctx context.Context) error {

--- a/vendor/github.com/vmware/govmomi/govc/dvs/portgroup/info.go
+++ b/vendor/github.com/vmware/govmomi/govc/dvs/portgroup/info.go
@@ -1,0 +1,165 @@
+/*
+Copyright (c) 2015-2016 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package portgroup
+
+import (
+	"flag"
+	"fmt"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25/methods"
+	"github.com/vmware/govmomi/vim25/mo"
+	"github.com/vmware/govmomi/vim25/types"
+	"golang.org/x/net/context"
+)
+
+type info struct {
+	*flags.DatacenterFlag
+
+	pg         string
+	active     bool
+	connected  bool
+	inside     bool
+	uplinkPort bool
+	vlanID     int
+	count      uint
+}
+
+func init() {
+	cli.Register("dvs.portgroup.info", &info{})
+}
+
+func (cmd *info) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.DatacenterFlag, ctx = flags.NewDatacenterFlag(ctx)
+	cmd.DatacenterFlag.Register(ctx, f)
+
+	f.StringVar(&cmd.pg, "pg", "", "Distributed Virtual Portgroup")
+	f.BoolVar(&cmd.active, "active", false, "Filter by port active or inactive status")
+	f.BoolVar(&cmd.connected, "connected", false, "Filter by port connected or disconnected status")
+	f.BoolVar(&cmd.inside, "inside", true, "Filter by port inside or outside status")
+	f.BoolVar(&cmd.uplinkPort, "uplinkPort", false, "Filter for uplink ports")
+	f.IntVar(&cmd.vlanID, "vlan", 0, "Filter by VLAN ID (0 = unfiltered)")
+	f.UintVar(&cmd.count, "count", 0, "Number of matches to return (0 = unlimited)")
+}
+
+func (cmd *info) Process(ctx context.Context) error {
+	if err := cmd.ClientFlag.Process(ctx); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (cmd *info) Run(ctx context.Context, f *flag.FlagSet) error {
+	if f.NArg() != 1 {
+		return flag.ErrHelp
+	}
+
+	client, err := cmd.Client()
+	if err != nil {
+		return err
+	}
+
+	finder, err := cmd.Finder()
+	if err != nil {
+		return err
+	}
+
+	// Retrieve DVS reference
+	net, err := finder.Network(ctx, f.Arg(0))
+	if err != nil {
+		return err
+	}
+
+	// Convert to DVS object type
+	dvs, ok := net.(*object.DistributedVirtualSwitch)
+	if !ok {
+		return fmt.Errorf("%s (%s) is not a DVS", f.Arg(0), net.Reference().Type)
+	}
+
+	// Set base search criteria
+	criteria := types.DistributedVirtualSwitchPortCriteria{
+		Connected:  types.NewBool(cmd.connected),
+		Active:     types.NewBool(cmd.active),
+		UplinkPort: types.NewBool(cmd.uplinkPort),
+		Inside:     types.NewBool(cmd.inside),
+	}
+
+	// If a distributed virtual portgroup path is set, then add its portgroup key to the base criteria
+	if len(cmd.pg) > 0 {
+		// Retrieve distributed virtual portgroup reference
+		net, err = finder.Network(ctx, cmd.pg)
+		if err != nil {
+			return err
+		}
+
+		// Convert distributed virtual portgroup object type
+		dvpg, ok := net.(*object.DistributedVirtualPortgroup)
+		if !ok {
+			return fmt.Errorf("%s (%s) is not a DVPG", cmd.pg, net.Reference().Type)
+		}
+
+		// Obtain portgroup key property
+		var dvp mo.DistributedVirtualPortgroup
+		if err := dvpg.Properties(ctx, dvpg.Reference(), []string{"key"}, &dvp); err != nil {
+			return err
+		}
+
+		// Add portgroup key to port search criteria
+		criteria.PortgroupKey = []string{dvp.Key}
+	}
+
+	// Prepare request
+	req := types.FetchDVPorts{
+		This:     dvs.Reference(),
+		Criteria: &criteria,
+	}
+
+	// Fetch ports
+	res, err := methods.FetchDVPorts(ctx, client, &req)
+	if err != nil {
+		return err
+	}
+
+	var returnedPorts uint
+
+	// Iterate over returned ports
+	for _, port := range res.Returnval {
+		portConfigSetting := port.Config.Setting.(*types.VMwareDVSPortSetting)
+		portVlan := portConfigSetting.Vlan.(*types.VmwareDistributedVirtualSwitchVlanIdSpec)
+		portVlanID := portVlan.VlanId
+
+		// Show port info if: VLAN ID is not defined, or VLAN ID matches requested VLAN
+		if cmd.vlanID == 0 || portVlanID == int32(cmd.vlanID) {
+			returnedPorts++
+
+			fmt.Printf("PortgroupKey: %s\n", port.PortgroupKey)
+			fmt.Printf("DvsUuid:      %s\n", port.DvsUuid)
+			fmt.Printf("VlanId:       %d\n", portVlanID)
+			fmt.Printf("PortKey:      %s\n\n", port.Key)
+
+			// If we are limiting the count and have reached the count, then stop returning output
+			if cmd.count > 0 && returnedPorts == cmd.count {
+				break
+			}
+		}
+	}
+
+	return nil
+}

--- a/vendor/github.com/vmware/govmomi/govc/events/command.go
+++ b/vendor/github.com/vmware/govmomi/govc/events/command.go
@@ -33,10 +33,13 @@ import (
 type events struct {
 	*flags.DatacenterFlag
 
-	Max int
+	Max   int32
+	Tail  bool
+	Force bool
 }
 
 func init() {
+	// initialize with the maximum allowed objects set
 	cli.Register("events", &events{})
 }
 
@@ -44,7 +47,10 @@ func (cmd *events) Register(ctx context.Context, f *flag.FlagSet) {
 	cmd.DatacenterFlag, ctx = flags.NewDatacenterFlag(ctx)
 	cmd.DatacenterFlag.Register(ctx, f)
 
-	f.IntVar(&cmd.Max, "n", 25, "Output the last N events")
+	cmd.Max = 25 // default
+	f.Var(flags.NewInt32(&cmd.Max), "n", "Output the last N events")
+	f.BoolVar(&cmd.Tail, "f", false, "Tail event stream")
+	f.BoolVar(&cmd.Force, "force", false, "Force event collection: use with CAUTION ")
 }
 
 func (cmd *events) Process(ctx context.Context) error {
@@ -54,55 +60,9 @@ func (cmd *events) Process(ctx context.Context) error {
 	return nil
 }
 
-func (cmd *events) Usage() string {
-	return "[PATH]..."
-}
-
-func (cmd *events) Run(ctx context.Context, f *flag.FlagSet) error {
-	c, err := cmd.Client()
-	if err != nil {
-		return err
-	}
-
-	m := event.NewManager(c)
-
-	objs, err := cmd.ManagedObjects(ctx, f.Args())
-	if err != nil {
-		return err
-	}
-
-	var events []types.BaseEvent
-
-	for _, o := range objs {
-		filter := types.EventFilterSpec{
-			Entity: &types.EventFilterSpecByEntity{
-				Entity:    o,
-				Recursion: types.EventFilterSpecRecursionOptionAll,
-			},
-		}
-
-		collector, err := m.CreateCollectorForEvents(ctx, filter)
-		if err != nil {
-			return fmt.Errorf("[%#v] %s", o, err)
-		}
-		defer collector.Destroy(ctx)
-
-		err = collector.SetPageSize(ctx, cmd.Max)
-		if err != nil {
-			return err
-		}
-
-		page, err := collector.LatestPage(ctx)
-		if err != nil {
-			return err
-		}
-
-		events = append(events, page...)
-	}
-
-	event.Sort(events)
-
-	for _, e := range events {
+func (cmd *events) printEvents(ctx context.Context, page []types.BaseEvent, m *event.Manager) error {
+	event.Sort(page)
+	for _, e := range page {
 		cat, err := m.EventCategory(ctx, e)
 		if err != nil {
 			return err
@@ -118,6 +78,42 @@ func (cmd *events) Run(ctx context.Context, f *flag.FlagSet) error {
 		fmt.Fprintf(os.Stdout, "[%s] [%s] %s\n",
 			event.CreatedTime.Local().Format(time.ANSIC),
 			cat, msg)
+	}
+	return nil
+}
+
+func (cmd *events) Usage() string {
+	return "[PATH]..."
+}
+
+func (cmd *events) Run(ctx context.Context, f *flag.FlagSet) error {
+	c, err := cmd.Client()
+	if err != nil {
+		return err
+	}
+
+	objs, err := cmd.ManagedObjects(ctx, f.Args())
+	if err != nil {
+		return err
+	}
+
+	if len(objs) > 0 {
+		// need an event manager
+		m := event.NewManager(c)
+
+		// get the event stream
+		err := m.Events(ctx, objs, cmd.Max, cmd.Tail, cmd.Force, func(ee []types.BaseEvent) error {
+			err = cmd.printEvents(ctx, ee, m)
+			if err != nil {
+				return err
+			}
+			return nil
+		})
+
+		if err != nil {
+			return err
+		}
+
 	}
 
 	return nil

--- a/vendor/github.com/vmware/govmomi/govc/flags/datacenter.go
+++ b/vendor/github.com/vmware/govmomi/govc/flags/datacenter.go
@@ -87,7 +87,7 @@ func (flag *DatacenterFlag) Finder() (*find.Finder, error) {
 		return nil, err
 	}
 
-	finder := find.NewFinder(c, flag.JSON)
+	finder := find.NewFinder(c, flag.JSON || flag.Dump)
 
 	// Datacenter is not required (ls command for example).
 	// Set for relative func if dc flag is given or

--- a/vendor/github.com/vmware/govmomi/govc/flags/folder.go
+++ b/vendor/github.com/vmware/govmomi/govc/flags/folder.go
@@ -1,0 +1,85 @@
+/*
+Copyright (c) 2014-2016 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package flags
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/vmware/govmomi/object"
+	"golang.org/x/net/context"
+)
+
+type FolderFlag struct {
+	common
+
+	*DatacenterFlag
+
+	name   string
+	folder *object.Folder
+}
+
+var folderFlagKey = flagKey("folder")
+
+func NewFolderFlag(ctx context.Context) (*FolderFlag, context.Context) {
+	if v := ctx.Value(folderFlagKey); v != nil {
+		return v.(*FolderFlag), ctx
+	}
+
+	v := &FolderFlag{}
+	v.DatacenterFlag, ctx = NewDatacenterFlag(ctx)
+	ctx = context.WithValue(ctx, folderFlagKey, v)
+	return v, ctx
+}
+
+func (flag *FolderFlag) Register(ctx context.Context, f *flag.FlagSet) {
+	flag.RegisterOnce(func() {
+		flag.DatacenterFlag.Register(ctx, f)
+
+		env := "GOVC_FOLDER"
+		value := os.Getenv(env)
+		usage := fmt.Sprintf("Folder [%s]", env)
+		f.StringVar(&flag.name, "folder", value, usage)
+	})
+}
+
+func (flag *FolderFlag) Process(ctx context.Context) error {
+	return flag.ProcessOnce(func() error {
+		if err := flag.DatacenterFlag.Process(ctx); err != nil {
+			return err
+		}
+		return nil
+	})
+}
+
+func (flag *FolderFlag) Folder() (*object.Folder, error) {
+	if flag.folder != nil {
+		return flag.folder, nil
+	}
+
+	finder, err := flag.Finder()
+	if err != nil {
+		return nil, err
+	}
+
+	if flag.folder, err = finder.FolderOrDefault(context.TODO(), flag.name); err != nil {
+		return nil, err
+	}
+
+	return flag.folder, nil
+}

--- a/vendor/github.com/vmware/govmomi/govc/flags/int32.go
+++ b/vendor/github.com/vmware/govmomi/govc/flags/int32.go
@@ -1,0 +1,46 @@
+/*
+Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package flags
+
+import (
+	"flag"
+	"fmt"
+	"strconv"
+)
+
+// This flag type is internal to stdlib:
+// https://github.com/golang/go/blob/master/src/cmd/internal/obj/flag.go
+type int32Value int32
+
+func (i *int32Value) Set(s string) error {
+	v, err := strconv.ParseInt(s, 0, 64)
+	*i = int32Value(v)
+	return err
+}
+
+func (i *int32Value) Get() interface{} {
+	return int32(*i)
+}
+
+func (i *int32Value) String() string {
+	return fmt.Sprintf("%v", *i)
+}
+
+// NewInt32 behaves as flag.IntVar, but using an int32 type.
+func NewInt32(v *int32) flag.Value {
+	return (*int32Value)(v)
+}

--- a/vendor/github.com/vmware/govmomi/govc/flags/network.go
+++ b/vendor/github.com/vmware/govmomi/govc/flags/network.go
@@ -35,6 +35,7 @@ type NetworkFlag struct {
 	net     object.NetworkReference
 	adapter string
 	address string
+	isset   bool
 }
 
 var networkFlagKey = flagKey("network")
@@ -56,7 +57,7 @@ func (flag *NetworkFlag) Register(ctx context.Context, f *flag.FlagSet) {
 
 		env := "GOVC_NETWORK"
 		value := os.Getenv(env)
-		flag.Set(value)
+		flag.name = value
 		usage := fmt.Sprintf("Network [%s]", env)
 		f.Var(flag, "net", usage)
 		f.StringVar(&flag.adapter, "net.adapter", "e1000", "Network adapter type")
@@ -79,7 +80,12 @@ func (flag *NetworkFlag) String() string {
 
 func (flag *NetworkFlag) Set(name string) error {
 	flag.name = name
+	flag.isset = true
 	return nil
+}
+
+func (flag *NetworkFlag) IsSet() bool {
+	return flag.isset
 }
 
 func (flag *NetworkFlag) Network() (object.NetworkReference, error) {

--- a/vendor/github.com/vmware/govmomi/govc/flags/output.go
+++ b/vendor/github.com/vmware/govmomi/govc/flags/output.go
@@ -28,6 +28,8 @@ import (
 	"golang.org/x/net/context"
 
 	"github.com/vmware/govmomi/vim25/progress"
+
+	"github.com/davecgh/go-spew/spew"
 )
 
 type OutputWriter interface {
@@ -39,6 +41,7 @@ type OutputFlag struct {
 
 	JSON bool
 	TTY  bool
+	Dump bool
 }
 
 var outputFlagKey = flagKey("output")
@@ -56,6 +59,7 @@ func NewOutputFlag(ctx context.Context) (*OutputFlag, context.Context) {
 func (flag *OutputFlag) Register(ctx context.Context, f *flag.FlagSet) {
 	flag.RegisterOnce(func() {
 		f.BoolVar(&flag.JSON, "json", false, "Enable JSON output")
+		f.BoolVar(&flag.Dump, "dump", false, "Enable output dump")
 	})
 }
 
@@ -102,6 +106,9 @@ func (flag *OutputFlag) WriteResult(result OutputWriter) error {
 
 	if flag.JSON {
 		err = json.NewEncoder(out).Encode(result)
+	} else if flag.Dump {
+		scs := spew.ConfigState{Indent: "    "}
+		scs.Fdump(out, result)
 	} else {
 		err = result.Write(out)
 	}

--- a/vendor/github.com/vmware/govmomi/govc/host/autostart/configure.go
+++ b/vendor/github.com/vmware/govmomi/govc/host/autostart/configure.go
@@ -41,9 +41,9 @@ func (cmd *configure) Register(ctx context.Context, f *flag.FlagSet) {
 	cmd.AutostartFlag.Register(ctx, f)
 
 	f.Var(flags.NewOptionalBool(&cmd.Enabled), "enabled", "")
-	f.IntVar(&cmd.StartDelay, "start-delay", 0, "")
+	f.Var(flags.NewInt32(&cmd.StartDelay), "start-delay", "")
 	f.StringVar(&cmd.StopAction, "stop-action", "", "")
-	f.IntVar(&cmd.StopDelay, "stop-delay", 0, "")
+	f.Var(flags.NewInt32(&cmd.StopDelay), "stop-delay", "")
 	f.Var(flags.NewOptionalBool(&cmd.WaitForHeartbeat), "wait-for-heartbeat", "")
 }
 

--- a/vendor/github.com/vmware/govmomi/govc/host/firewall/find.go
+++ b/vendor/github.com/vmware/govmomi/govc/host/firewall/find.go
@@ -58,7 +58,7 @@ func (cmd *find) Register(ctx context.Context, f *flag.FlagSet) {
 	f.StringVar((*string)(&cmd.Direction), "direction", string(types.HostFirewallRuleDirectionOutbound), "Direction")
 	f.StringVar((*string)(&cmd.PortType), "type", string(types.HostFirewallRulePortTypeDst), "Port type")
 	f.StringVar((*string)(&cmd.Protocol), "proto", string(types.HostFirewallRuleProtocolTcp), "Protocol")
-	f.IntVar(&cmd.Port, "port", 0, "Port")
+	f.Var(flags.NewInt32(&cmd.Port), "port", "Port")
 }
 
 func (cmd *find) Process(ctx context.Context) error {

--- a/vendor/github.com/vmware/govmomi/govc/host/info.go
+++ b/vendor/github.com/vmware/govmomi/govc/host/info.go
@@ -140,7 +140,7 @@ func (r *infoResult) Write(w io.Writer) error {
 		s := host.Summary
 		h := s.Hardware
 		z := s.QuickStats
-		ncpu := int(h.NumCpuPkgs * h.NumCpuCores)
+		ncpu := int32(h.NumCpuPkgs * h.NumCpuCores)
 		cpuUsage := 100 * float64(z.OverallCpuUsage) / float64(ncpu*h.CpuMhz)
 		memUsage := 100 * float64(z.OverallMemoryUsage<<20) / float64(h.MemorySize)
 

--- a/vendor/github.com/vmware/govmomi/govc/host/maintenance/enter.go
+++ b/vendor/github.com/vmware/govmomi/govc/host/maintenance/enter.go
@@ -30,7 +30,7 @@ import (
 type enter struct {
 	*flags.HostSystemFlag
 
-	timeout  int
+	timeout  int32
 	evacuate bool
 }
 
@@ -42,7 +42,7 @@ func (cmd *enter) Register(ctx context.Context, f *flag.FlagSet) {
 	cmd.HostSystemFlag, ctx = flags.NewHostSystemFlag(ctx)
 	cmd.HostSystemFlag.Register(ctx, f)
 
-	f.IntVar(&cmd.timeout, "timeout", 0, "Timeout")
+	f.Var(flags.NewInt32(&cmd.timeout), "timeout", "Timeout")
 	f.BoolVar(&cmd.evacuate, "evacuate", false, "Evacuate powered off VMs")
 }
 

--- a/vendor/github.com/vmware/govmomi/govc/host/maintenance/exit.go
+++ b/vendor/github.com/vmware/govmomi/govc/host/maintenance/exit.go
@@ -30,7 +30,7 @@ import (
 type exit struct {
 	*flags.HostSystemFlag
 
-	timeout int
+	timeout int32
 }
 
 func init() {
@@ -41,7 +41,7 @@ func (cmd *exit) Register(ctx context.Context, f *flag.FlagSet) {
 	cmd.HostSystemFlag, ctx = flags.NewHostSystemFlag(ctx)
 	cmd.HostSystemFlag.Register(ctx, f)
 
-	f.IntVar(&cmd.timeout, "timeout", 0, "Timeout")
+	f.Var(flags.NewInt32(&cmd.timeout), "timeout", "Timeout")
 }
 
 func (cmd *exit) Process(ctx context.Context) error {

--- a/vendor/github.com/vmware/govmomi/govc/host/portgroup/add.go
+++ b/vendor/github.com/vmware/govmomi/govc/host/portgroup/add.go
@@ -40,7 +40,7 @@ func (cmd *add) Register(ctx context.Context, f *flag.FlagSet) {
 	cmd.HostSystemFlag.Register(ctx, f)
 
 	f.StringVar(&cmd.spec.VswitchName, "vswitch", "", "vSwitch Name")
-	f.IntVar(&cmd.spec.VlanId, "vlan", 0, "VLAN ID")
+	f.Var(flags.NewInt32(&cmd.spec.VlanId), "vlan", "VLAN ID")
 }
 
 func (cmd *add) Process(ctx context.Context) error {

--- a/vendor/github.com/vmware/govmomi/govc/host/vswitch/add.go
+++ b/vendor/github.com/vmware/govmomi/govc/host/vswitch/add.go
@@ -40,8 +40,9 @@ func (cmd *add) Register(ctx context.Context, f *flag.FlagSet) {
 	cmd.HostSystemFlag, ctx = flags.NewHostSystemFlag(ctx)
 	cmd.HostSystemFlag.Register(ctx, f)
 
-	f.IntVar(&cmd.spec.NumPorts, "ports", 128, "Number of ports")
-	f.IntVar(&cmd.spec.Mtu, "mtu", 0, "MTU")
+	cmd.spec.NumPorts = 128 // default
+	f.Var(flags.NewInt32(&cmd.spec.NumPorts), "ports", "Number of ports")
+	f.Var(flags.NewInt32(&cmd.spec.Mtu), "mtu", "MTU")
 	f.StringVar(&cmd.nic, "nic", "", "Bridge nic device")
 }
 

--- a/vendor/github.com/vmware/govmomi/govc/importx/lease_updater.go
+++ b/vendor/github.com/vmware/govmomi/govc/importx/lease_updater.go
@@ -116,7 +116,7 @@ func (l *leaseUpdater) run() {
 			// "Completion status represented as an integer in the 0-100 range."
 			// Always report the current value of percent, as it will renew the
 			// lease even if the value hasn't changed or is 0.
-			percent := int(float32(100*atomic.LoadInt64(&l.pos)) / float32(l.total))
+			percent := int32(float32(100*atomic.LoadInt64(&l.pos)) / float32(l.total))
 			err := l.lease.HttpNfcLeaseProgress(context.TODO(), percent)
 			if err != nil {
 				fmt.Printf("from lease updater: %s\n", err)

--- a/vendor/github.com/vmware/govmomi/govc/importx/ovf.go
+++ b/vendor/github.com/vmware/govmomi/govc/importx/ovf.go
@@ -231,16 +231,6 @@ func (cmd *ovfx) Import(fpath string) (*types.ManagedObjectReference, error) {
 		}
 	}
 
-	// TODO: ImportSpec may have unitNumber==0, but this field is optional in the wsdl
-	// and hence omitempty in the struct tag; but unitNumber is required for certain devices.
-	s := &spec.ImportSpec.(*types.VirtualMachineImportSpec).ConfigSpec
-	for _, d := range s.DeviceChange {
-		n := &d.GetVirtualDeviceConfigSpec().Device.GetVirtualDevice().UnitNumber
-		if *n == 0 {
-			*n = -1
-		}
-	}
-
 	var host *object.HostSystem
 	if cmd.SearchFlag.IsSet() {
 		if host, err = cmd.HostSystem(); err != nil {

--- a/vendor/github.com/vmware/govmomi/govc/importx/vmdk.go
+++ b/vendor/github.com/vmware/govmomi/govc/importx/vmdk.go
@@ -428,46 +428,23 @@ func (c *configSpec) AddChange(d types.BaseVirtualDeviceConfigSpec) {
 }
 
 func (c *configSpec) AddDisk(ds *object.Datastore, path string) {
-	controller := &types.VirtualLsiLogicController{
-		VirtualSCSIController: types.VirtualSCSIController{
-			SharedBus: types.VirtualSCSISharingNoSharing,
-			VirtualController: types.VirtualController{
-				BusNumber: 0,
-				VirtualDevice: types.VirtualDevice{
-					Key: -1,
-				},
-			},
-		},
+	var devices object.VirtualDeviceList
+
+	controller, err := devices.CreateSCSIController("")
+	if err != nil {
+		panic(err)
+	}
+	devices = append(devices, controller)
+
+	disk := devices.CreateDisk(controller.(types.BaseVirtualController), ds.Reference(), ds.Path(path))
+	devices = append(devices, disk)
+
+	spec, err := devices.ConfigSpec(types.VirtualDeviceConfigSpecOperationAdd)
+	if err != nil {
+		panic(err)
 	}
 
-	controllerSpec := &types.VirtualDeviceConfigSpec{
-		Device:    controller,
-		Operation: types.VirtualDeviceConfigSpecOperationAdd,
-	}
-
-	c.AddChange(controllerSpec)
-
-	disk := &types.VirtualDisk{
-		VirtualDevice: types.VirtualDevice{
-			Key:           -1,
-			ControllerKey: -1,
-			UnitNumber:    -1,
-			Backing: &types.VirtualDiskFlatVer2BackingInfo{
-				VirtualDeviceFileBackingInfo: types.VirtualDeviceFileBackingInfo{
-					FileName: ds.Path(path),
-				},
-				DiskMode:        string(types.VirtualDiskModePersistent),
-				ThinProvisioned: types.NewBool(true),
-			},
-		},
-	}
-
-	diskSpec := &types.VirtualDeviceConfigSpec{
-		Device:    disk,
-		Operation: types.VirtualDeviceConfigSpecOperationAdd,
-	}
-
-	c.AddChange(diskSpec)
+	c.DeviceChange = append(c.DeviceChange, spec...)
 }
 
 var dsPathRegexp = regexp.MustCompile(`^\[.*\] (.*)$`)

--- a/vendor/github.com/vmware/govmomi/govc/logs/command.go
+++ b/vendor/github.com/vmware/govmomi/govc/logs/command.go
@@ -31,7 +31,7 @@ import (
 type logs struct {
 	*flags.HostSystemFlag
 
-	Max int
+	Max int32
 	Key string
 }
 
@@ -43,7 +43,8 @@ func (cmd *logs) Register(ctx context.Context, f *flag.FlagSet) {
 	cmd.HostSystemFlag, ctx = flags.NewHostSystemFlag(ctx)
 	cmd.HostSystemFlag.Register(ctx, f)
 
-	f.IntVar(&cmd.Max, "n", 25, "Output the last N logs")
+	cmd.Max = 25 // default
+	f.Var(flags.NewInt32(&cmd.Max), "n", "Output the last N logs")
 	f.StringVar(&cmd.Key, "log", "", "Log file key")
 }
 

--- a/vendor/github.com/vmware/govmomi/govc/pool/destroy.go
+++ b/vendor/github.com/vmware/govmomi/govc/pool/destroy.go
@@ -28,7 +28,7 @@ import (
 type destroy struct {
 	*flags.DatacenterFlag
 
-	recursive bool
+	children bool
 }
 
 func init() {
@@ -39,7 +39,7 @@ func (cmd *destroy) Register(ctx context.Context, f *flag.FlagSet) {
 	cmd.DatacenterFlag, ctx = flags.NewDatacenterFlag(ctx)
 	cmd.DatacenterFlag.Register(ctx, f)
 
-	f.BoolVar(&cmd.recursive, "r", false, "Remove all child resource pools recursively")
+	f.BoolVar(&cmd.children, "children", false, "Remove all children pools")
 }
 
 func (cmd *destroy) Process(ctx context.Context) error {
@@ -79,20 +79,20 @@ func (cmd *destroy) Run(ctx context.Context, f *flag.FlagSet) error {
 		}
 
 		for _, pool := range pools {
-			if cmd.recursive {
+			if cmd.children {
 				err = pool.DestroyChildren(context.TODO())
 				if err != nil {
 					return err
 				}
-			}
-
-			task, err := pool.Destroy(context.TODO())
-			if err != nil {
-				return err
-			}
-			err = task.Wait(context.TODO())
-			if err != nil {
-				return err
+			} else {
+				task, err := pool.Destroy(context.TODO())
+				if err != nil {
+					return err
+				}
+				err = task.Wait(context.TODO())
+				if err != nil {
+					return err
+				}
 			}
 		}
 	}

--- a/vendor/github.com/vmware/govmomi/govc/pool/resource_config_spec.go
+++ b/vendor/github.com/vmware/govmomi/govc/pool/resource_config_spec.go
@@ -44,7 +44,7 @@ func (s *sharesInfo) Set(val string) error {
 		}
 
 		s.Level = types.SharesLevelCustom
-		s.Shares = n
+		s.Shares = int32(n)
 	}
 
 	return nil

--- a/vendor/github.com/vmware/govmomi/govc/test/device.bats
+++ b/vendor/github.com/vmware/govmomi/govc/test/device.bats
@@ -17,6 +17,15 @@ load test_helper
 
   run govc device.info -vm $vm ide-20000
   assert_failure
+
+  run govc device.info -vm $vm -net enoent
+  assert_failure
+
+  run govc device.info -vm $vm -net "VM Network" ide-200
+  assert_failure
+
+  result=$(govc device.info -vm $vm -net "VM Network" | grep "MAC Address" | wc -l)
+  [ $result -eq 1 ]
 }
 
 @test "device.boot" {

--- a/vendor/github.com/vmware/govmomi/govc/test/images/update.sh
+++ b/vendor/github.com/vmware/govmomi/govc/test/images/update.sh
@@ -9,10 +9,10 @@ ttylinux="ttylinux-pc_i486-16.1"
 files="${ttylinux}.iso ${ttylinux}-live.ova ${ttylinux}.ova"
 
 for name in $files ; do
-  wget -O $name $base_url/$name
+  wget -qO $name $base_url/$name
 done
 
-wget -N https://github.com/icebreaker/floppybird/raw/master/build/floppybird.img
+wget -qN https://github.com/icebreaker/floppybird/raw/master/build/floppybird.img
 
 # extract ova so we can also use the .vmdk and .ovf files directly
 tar -xvf ${ttylinux}.ova

--- a/vendor/github.com/vmware/govmomi/govc/test/import.bats
+++ b/vendor/github.com/vmware/govmomi/govc/test/import.bats
@@ -50,6 +50,7 @@ load test_helper
 }
 
 @test "import.ovf with name as argument" {
+  skip_if_vca
   name=$(new_id)
 
   run govc import.ova -name="${name}" $GOVC_IMAGES/${TTYLINUX_NAME}.ova

--- a/vendor/github.com/vmware/govmomi/govc/test/license.bats
+++ b/vendor/github.com/vmware/govmomi/govc/test/license.bats
@@ -18,6 +18,7 @@ get_property() {
 }
 
 @test "license.add" {
+  skip_if_vca
   verify_evaluation
 
   run govc license.add -json 00000-00000-00000-00000-00001 00000-00000-00000-00000-00002
@@ -36,6 +37,7 @@ get_property() {
 }
 
 @test "license.list" {
+  skip_if_vca
   verify_evaluation
 
   run govc license.list -json

--- a/vendor/github.com/vmware/govmomi/govc/test/ls.bats
+++ b/vendor/github.com/vmware/govmomi/govc/test/ls.bats
@@ -39,15 +39,15 @@ load test_helper
   [ ${#lines[@]} -ge 1 ]
 
   local path=${lines[0]}
-  run govc ls $path
+  run govc ls "$path"
   assert_success
   [ ${#lines[@]} -eq 1 ]
 
-  run govc ls network/$(basename $path)
+  run govc ls "network/$(basename "$path")"
   assert_success
   [ ${#lines[@]} -eq 1 ]
 
-  run govc ls /*/network/$(basename $path)
+  run govc ls "/*/network/$(basename "$path")"
   assert_success
   [ ${#lines[@]} -eq 1 ]
 }

--- a/vendor/github.com/vmware/govmomi/govc/test/test_helper.bash
+++ b/vendor/github.com/vmware/govmomi/govc/test/test_helper.bash
@@ -1,7 +1,9 @@
+# set the following variables only if they've not been set
 GOVC_TEST_URL=${GOVC_TEST_URL-"https://root:vagrant@localhost:18443/sdk"}
 export GOVC_URL=$GOVC_TEST_URL
-export GOVC_DATASTORE=datastore1
-export GOVC_NETWORK="VM Network"
+export GOVC_DATASTORE=${GOVC_DATASTORE-datastore1}
+export GOVC_NETWORK=${GOVC_NETWORK-"VM Network"}
+
 export GOVC_INSECURE=true
 unset GOVC_DATACENTER
 unset GOVC_USERNAME
@@ -35,6 +37,7 @@ PATH="$(dirname $BATS_TEST_DIRNAME):$PATH"
 teardown() {
   govc ls vm | grep govc-test- | $xargs -r govc vm.destroy
   govc datastore.ls | grep govc-test- | awk '{print ($NF)}' | $xargs -n1 -r govc datastore.rm
+  govc ls "host/*/Resources/govc-test-*" | $xargs -r govc pool.destroy
 }
 
 new_id() {
@@ -100,6 +103,12 @@ vcsim_env() {
   else
     skip "requires vcsim"
   fi
+}
+
+skip_if_vca() {
+    if [ -n "$VCA" ]; then
+        skip "disabled in vCA"
+    fi
 }
 
 # remove username/password from $GOVC_URL and set $GOVC_{USERNAME,PASSWORD}

--- a/vendor/github.com/vmware/govmomi/govc/test/vm.bats
+++ b/vendor/github.com/vmware/govmomi/govc/test/vm.bats
@@ -3,6 +3,7 @@
 load test_helper
 
 @test "vm.ip" {
+  skip
   id=$(new_ttylinux_vm)
 
   run govc vm.power -on $id
@@ -13,6 +14,7 @@ load test_helper
 }
 
 @test "vm.ip -esxcli" {
+  skip
   id=$(new_ttylinux_vm)
 
   run govc vm.power -on $id

--- a/vendor/github.com/vmware/govmomi/govc/vm/change.go
+++ b/vendor/github.com/vmware/govmomi/govc/vm/change.go
@@ -60,7 +60,7 @@ func (cmd *change) Register(ctx context.Context, f *flag.FlagSet) {
 	cmd.VirtualMachineFlag.Register(ctx, f)
 
 	f.Int64Var(&cmd.MemoryMB, "m", 0, "Size in MB of memory")
-	f.IntVar(&cmd.NumCPUs, "c", 0, "Number of CPUs")
+	f.Var(flags.NewInt32(&cmd.NumCPUs), "c", "Number of CPUs")
 	f.StringVar(&cmd.GuestId, "g", "", "Guest OS")
 	f.StringVar(&cmd.Name, "name", "", "Display name")
 	f.Var(&cmd.extraConfig, "e", "ExtraConfig. <key>=<value>")

--- a/vendor/github.com/vmware/govmomi/govc/vm/create.go
+++ b/vendor/github.com/vmware/govmomi/govc/vm/create.go
@@ -39,6 +39,7 @@ type create struct {
 	*flags.ResourcePoolFlag
 	*flags.HostSystemFlag
 	*flags.NetworkFlag
+	*flags.FolderFlag
 
 	name       string
 	memory     int
@@ -67,6 +68,7 @@ type create struct {
 	StoragePod   *object.StoragePod
 	ResourcePool *object.ResourcePool
 	HostSystem   *object.HostSystem
+	Folder       *object.Folder
 }
 
 func init() {
@@ -94,6 +96,9 @@ func (cmd *create) Register(ctx context.Context, f *flag.FlagSet) {
 
 	cmd.NetworkFlag, ctx = flags.NewNetworkFlag(ctx)
 	cmd.NetworkFlag.Register(ctx, f)
+
+	cmd.FolderFlag, ctx = flags.NewFolderFlag(ctx)
+	cmd.FolderFlag.Register(ctx, f)
 
 	f.IntVar(&cmd.memory, "m", 1024, "Size in MB of memory")
 	f.IntVar(&cmd.cpus, "c", 1, "Number of CPUs")
@@ -132,6 +137,9 @@ func (cmd *create) Process(ctx context.Context) error {
 		return err
 	}
 	if err := cmd.NetworkFlag.Process(ctx); err != nil {
+		return err
+	}
+	if err := cmd.FolderFlag.Process(ctx); err != nil {
 		return err
 	}
 
@@ -194,6 +202,10 @@ func (cmd *create) Run(ctx context.Context, f *flag.FlagSet) error {
 		if cmd.ResourcePool, err = cmd.ResourcePoolFlag.ResourcePool(); err != nil {
 			return err
 		}
+	}
+
+	if cmd.Folder, err = cmd.FolderFlag.Folder(); err != nil {
+		return err
 	}
 
 	// Verify ISO exists
@@ -264,7 +276,7 @@ func (cmd *create) createVM(ctx context.Context) (*object.Task, error) {
 	spec := &types.VirtualMachineConfigSpec{
 		Name:     cmd.name,
 		GuestId:  cmd.guestID,
-		NumCPUs:  cmd.cpus,
+		NumCPUs:  int32(cmd.cpus),
 		MemoryMB: int64(cmd.memory),
 	}
 
@@ -307,16 +319,13 @@ func (cmd *create) createVM(ctx context.Context) (*object.Task, error) {
 		}
 	}
 
-	folders, err := cmd.Datacenter.Folders(ctx)
-	if err != nil {
-		return nil, err
-	}
+	folder := cmd.Folder
 
 	spec.Files = &types.VirtualMachineFileInfo{
 		VmPathName: fmt.Sprintf("[%s]", datastore.Name()),
 	}
 
-	return folders.VmFolder.CreateVM(ctx, *spec, cmd.ResourcePool, cmd.HostSystem)
+	return folder.CreateVM(ctx, *spec, cmd.ResourcePool, cmd.HostSystem)
 }
 
 func (cmd *create) addStorage(devices object.VirtualDeviceList) (object.VirtualDeviceList, error) {

--- a/vendor/github.com/vmware/govmomi/govc/vm/guest/file_attr.go
+++ b/vendor/github.com/vmware/govmomi/govc/vm/guest/file_attr.go
@@ -21,6 +21,7 @@ import (
 
 	"golang.org/x/net/context"
 
+	"github.com/vmware/govmomi/govc/flags"
 	"github.com/vmware/govmomi/vim25/types"
 )
 
@@ -33,8 +34,8 @@ func newFileAttrFlag(ctx context.Context) (*FileAttrFlag, context.Context) {
 }
 
 func (flag *FileAttrFlag) Register(ctx context.Context, f *flag.FlagSet) {
-	f.IntVar(&flag.OwnerId, "uid", 0, "User ID")
-	f.IntVar(&flag.GroupId, "gid", 0, "Group ID")
+	f.Var(flags.NewInt32(&flag.OwnerId), "uid", "User ID")
+	f.Var(flags.NewInt32(&flag.GroupId), "gid", "Group ID")
 	f.Int64Var(&flag.Permissions, "perm", 0, "File permissions")
 }
 

--- a/vendor/github.com/vmware/govmomi/govc/vm/guest/ls.go
+++ b/vendor/github.com/vmware/govmomi/govc/vm/guest/ls.go
@@ -52,7 +52,7 @@ func (cmd *ls) Run(ctx context.Context, f *flag.FlagSet) error {
 		return err
 	}
 
-	offset := 0
+	var offset int32
 	tw := tabwriter.NewWriter(os.Stdout, 3, 0, 2, ' ', 0)
 
 	for {
@@ -71,7 +71,7 @@ func (cmd *ls) Run(ctx context.Context, f *flag.FlagSet) error {
 		if info.Remaining == 0 {
 			break
 		}
-		offset += len(info.Files)
+		offset += int32(len(info.Files))
 	}
 
 	return nil

--- a/vendor/github.com/vmware/govmomi/guest/file_manager.go
+++ b/vendor/github.com/vmware/govmomi/guest/file_manager.go
@@ -142,7 +142,7 @@ func (m FileManager) InitiateFileTransferToGuest(ctx context.Context, auth types
 	return res.Returnval, nil
 }
 
-func (m FileManager) ListFiles(ctx context.Context, auth types.BaseGuestAuthentication, filePath string, index int, maxResults int, matchPattern string) (*types.GuestListFileInfo, error) {
+func (m FileManager) ListFiles(ctx context.Context, auth types.BaseGuestAuthentication, filePath string, index int32, maxResults int32, matchPattern string) (*types.GuestListFileInfo, error) {
 	req := types.ListFilesInGuest{
 		This:         m.Reference(),
 		Vm:           m.vm,

--- a/vendor/github.com/vmware/govmomi/object/authorization_manager.go
+++ b/vendor/github.com/vmware/govmomi/object/authorization_manager.go
@@ -38,7 +38,7 @@ func NewAuthorizationManager(c *vim25.Client) *AuthorizationManager {
 
 type AuthorizationRoleList []types.AuthorizationRole
 
-func (l AuthorizationRoleList) ById(id int) *types.AuthorizationRole {
+func (l AuthorizationRoleList) ById(id int32) *types.AuthorizationRole {
 	for _, role := range l {
 		if role.RoleId == id {
 			return &role

--- a/vendor/github.com/vmware/govmomi/object/custom_fields_manager.go
+++ b/vendor/github.com/vmware/govmomi/object/custom_fields_manager.go
@@ -69,7 +69,7 @@ func (m CustomFieldsManager) Add(ctx context.Context, name string, moType string
 	return &res.Returnval, nil
 }
 
-func (m CustomFieldsManager) Remove(ctx context.Context, key int) error {
+func (m CustomFieldsManager) Remove(ctx context.Context, key int32) error {
 	req := types.RemoveCustomFieldDef{
 		This: m.Reference(),
 		Key:  key,
@@ -79,7 +79,7 @@ func (m CustomFieldsManager) Remove(ctx context.Context, key int) error {
 	return err
 }
 
-func (m CustomFieldsManager) Rename(ctx context.Context, key int, name string) error {
+func (m CustomFieldsManager) Rename(ctx context.Context, key int32, name string) error {
 	req := types.RenameCustomFieldDef{
 		This: m.Reference(),
 		Key:  key,
@@ -90,7 +90,7 @@ func (m CustomFieldsManager) Rename(ctx context.Context, key int, name string) e
 	return err
 }
 
-func (m CustomFieldsManager) Set(ctx context.Context, entity types.ManagedObjectReference, key int, value string) error {
+func (m CustomFieldsManager) Set(ctx context.Context, entity types.ManagedObjectReference, key int32, value string) error {
 	req := types.SetField{
 		This:   m.Reference(),
 		Entity: entity,
@@ -113,7 +113,7 @@ func (m CustomFieldsManager) Field(ctx context.Context) ([]types.CustomFieldDef,
 	return fm.Field, nil
 }
 
-func (m CustomFieldsManager) FindKey(ctx context.Context, key string) (int, error) {
+func (m CustomFieldsManager) FindKey(ctx context.Context, key string) (int32, error) {
 	field, err := m.Field(ctx)
 	if err != nil {
 		return -1, err
@@ -128,7 +128,7 @@ func (m CustomFieldsManager) FindKey(ctx context.Context, key string) (int, erro
 	k, err := strconv.Atoi(key)
 	if err == nil {
 		// assume literal int key
-		return k, nil
+		return int32(k), nil
 	}
 
 	return -1, ErrKeyNameNotFound

--- a/vendor/github.com/vmware/govmomi/object/diagnostic_manager.go
+++ b/vendor/github.com/vmware/govmomi/object/diagnostic_manager.go
@@ -35,7 +35,7 @@ func NewDiagnosticManager(c *vim25.Client) *DiagnosticManager {
 	return &m
 }
 
-func (m DiagnosticManager) BrowseLog(ctx context.Context, host *HostSystem, key string, start, lines int) (*types.DiagnosticManagerLogHeader, error) {
+func (m DiagnosticManager) BrowseLog(ctx context.Context, host *HostSystem, key string, start, lines int32) (*types.DiagnosticManagerLogHeader, error) {
 	req := types.BrowseDiagnosticLog{
 		This:  m.Reference(),
 		Key:   key,

--- a/vendor/github.com/vmware/govmomi/object/history_collector.go
+++ b/vendor/github.com/vmware/govmomi/object/history_collector.go
@@ -60,7 +60,7 @@ func (h HistoryCollector) Rewind(ctx context.Context) error {
 	return err
 }
 
-func (h HistoryCollector) SetPageSize(ctx context.Context, maxCount int) error {
+func (h HistoryCollector) SetPageSize(ctx context.Context, maxCount int32) error {
 	req := types.SetCollectorPageSize{
 		This:     h.Reference(),
 		MaxCount: maxCount,

--- a/vendor/github.com/vmware/govmomi/object/host_system.go
+++ b/vendor/github.com/vmware/govmomi/object/host_system.go
@@ -142,7 +142,7 @@ func (h HostSystem) Reconnect(ctx context.Context, cnxSpec *types.HostConnectSpe
 	return NewTask(h.c, res.Returnval), nil
 }
 
-func (h HostSystem) EnterMaintenanceMode(ctx context.Context, timeout int, evacuate bool, spec *types.HostMaintenanceSpec) (*Task, error) {
+func (h HostSystem) EnterMaintenanceMode(ctx context.Context, timeout int32, evacuate bool, spec *types.HostMaintenanceSpec) (*Task, error) {
 	req := types.EnterMaintenanceMode_Task{
 		This:                  h.Reference(),
 		Timeout:               timeout,
@@ -158,7 +158,7 @@ func (h HostSystem) EnterMaintenanceMode(ctx context.Context, timeout int, evacu
 	return NewTask(h.c, res.Returnval), nil
 }
 
-func (h HostSystem) ExitMaintenanceMode(ctx context.Context, timeout int) (*Task, error) {
+func (h HostSystem) ExitMaintenanceMode(ctx context.Context, timeout int32) (*Task, error) {
 	req := types.ExitMaintenanceMode_Task{
 		This:    h.Reference(),
 		Timeout: timeout,

--- a/vendor/github.com/vmware/govmomi/object/http_nfc_lease.go
+++ b/vendor/github.com/vmware/govmomi/object/http_nfc_lease.go
@@ -82,7 +82,7 @@ func (o HttpNfcLease) HttpNfcLeaseGetManifest(ctx context.Context) error {
 }
 
 // HttpNfcLeaseProgress wraps methods.HttpNfcLeaseProgress
-func (o HttpNfcLease) HttpNfcLeaseProgress(ctx context.Context, percent int) error {
+func (o HttpNfcLease) HttpNfcLeaseProgress(ctx context.Context, percent int32) error {
 	req := types.HttpNfcLeaseProgress{
 		This:    o.Reference(),
 		Percent: percent,

--- a/vendor/github.com/vmware/govmomi/object/list_view.go
+++ b/vendor/github.com/vmware/govmomi/object/list_view.go
@@ -1,0 +1,43 @@
+/*
+Copyright (c) 2015 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package object
+
+import (
+	"github.com/vmware/govmomi/vim25"
+	"github.com/vmware/govmomi/vim25/methods"
+	"github.com/vmware/govmomi/vim25/types"
+	"golang.org/x/net/context"
+)
+
+type ListView struct {
+	Common
+}
+
+func NewListView(c *vim25.Client, ref types.ManagedObjectReference) *ListView {
+	return &ListView{
+		Common: NewCommon(c, ref),
+	}
+}
+
+func (v ListView) Destroy(ctx context.Context) error {
+	req := types.DestroyView{
+		This: v.Reference(),
+	}
+
+	_, err := methods.DestroyView(ctx, v.c, &req)
+	return err
+}

--- a/vendor/github.com/vmware/govmomi/object/virtual_device_list.go
+++ b/vendor/github.com/vmware/govmomi/object/virtual_device_list.go
@@ -126,7 +126,8 @@ func (l VirtualDeviceList) SelectByBackingInfo(backing types.BaseVirtualDeviceBa
 			return a.DeviceName == b.DeviceName
 		case *types.VirtualEthernetCardDistributedVirtualPortBackingInfo:
 			b := backing.(*types.VirtualEthernetCardDistributedVirtualPortBackingInfo)
-			return a.Port.SwitchUuid == b.Port.SwitchUuid
+			return a.Port.SwitchUuid == b.Port.SwitchUuid &&
+				a.Port.PortgroupKey == b.Port.PortgroupKey
 		case *types.VirtualDiskFlatVer2BackingInfo:
 			b := backing.(*types.VirtualDiskFlatVer2BackingInfo)
 			if a.Parent != nil && b.Parent != nil {
@@ -156,7 +157,7 @@ func (l VirtualDeviceList) Find(name string) types.BaseVirtualDevice {
 }
 
 // FindByKey returns the device matching the given key.
-func (l VirtualDeviceList) FindByKey(key int) types.BaseVirtualDevice {
+func (l VirtualDeviceList) FindByKey(key int32) types.BaseVirtualDevice {
 	for _, device := range l {
 		if device.GetVirtualDevice().Key == key {
 			return device
@@ -249,13 +250,13 @@ var scsiBusNumbers = []int{0, 1, 2, 3}
 
 // newSCSIBusNumber returns the bus number to use for adding a new SCSI bus device.
 // -1 is returned if there are no bus numbers available.
-func (l VirtualDeviceList) newSCSIBusNumber() int {
+func (l VirtualDeviceList) newSCSIBusNumber() int32 {
 	var used []int
 
 	for _, d := range l.SelectByType((*types.VirtualSCSIController)(nil)) {
 		num := d.(types.BaseVirtualSCSIController).GetVirtualSCSIController().BusNumber
 		if num >= 0 {
-			used = append(used, num)
+			used = append(used, int(num))
 		} // else caller is creating a new vm using SCSIControllerTypes
 	}
 
@@ -263,7 +264,7 @@ func (l VirtualDeviceList) newSCSIBusNumber() int {
 
 	for i, n := range scsiBusNumbers {
 		if i == len(used) || n != used[i] {
-			return n
+			return int32(n)
 		}
 	}
 
@@ -309,16 +310,16 @@ func (l VirtualDeviceList) PickController(kind types.BaseVirtualController) type
 }
 
 // newUnitNumber returns the unit number to use for attaching a new device to the given controller.
-func (l VirtualDeviceList) newUnitNumber(c types.BaseVirtualController) int {
+func (l VirtualDeviceList) newUnitNumber(c types.BaseVirtualController) int32 {
 	key := c.GetVirtualController().Key
-	max := -1
+	var max int32 = -1
 
 	for _, device := range l {
 		d := device.GetVirtualDevice()
 
 		if d.ControllerKey == key {
-			if d.UnitNumber > max {
-				max = d.UnitNumber
+			if d.UnitNumber != nil && *d.UnitNumber > max {
+				max = *d.UnitNumber
 			}
 		}
 	}
@@ -331,8 +332,8 @@ func (l VirtualDeviceList) newUnitNumber(c types.BaseVirtualController) int {
 // we're only adding new devices), so any positive keys could conflict with device keys
 // that are already in use. To avoid this type of conflict, we can use negative keys
 // here, which will be resolved to positive keys by vSphere as the reconfiguration is done.
-func (l VirtualDeviceList) NewKey() int {
-	key := -200
+func (l VirtualDeviceList) NewKey() int32 {
+	var key int32 = -200
 
 	for _, device := range l {
 		d := device.GetVirtualDevice()
@@ -348,10 +349,8 @@ func (l VirtualDeviceList) NewKey() int {
 func (l VirtualDeviceList) AssignController(device types.BaseVirtualDevice, c types.BaseVirtualController) {
 	d := device.GetVirtualDevice()
 	d.ControllerKey = c.GetVirtualController().Key
-	d.UnitNumber = l.newUnitNumber(c)
-	if d.UnitNumber == 0 {
-		d.UnitNumber = -1 // TODO: this field is annotated as omitempty
-	}
+	d.UnitNumber = new(int32)
+	*d.UnitNumber = l.newUnitNumber(c)
 	if d.Key == 0 {
 		d.Key = -1
 	}
@@ -764,14 +763,18 @@ func (l VirtualDeviceList) Type(device types.BaseVirtualDevice) string {
 // Name returns a stable, human-readable name for the given device
 func (l VirtualDeviceList) Name(device types.BaseVirtualDevice) string {
 	var key string
+	var UnitNumber int32
 	d := device.GetVirtualDevice()
-	dtype := l.Type(device)
+	if d.UnitNumber != nil {
+		UnitNumber = *d.UnitNumber
+	}
 
+	dtype := l.Type(device)
 	switch dtype {
 	case DeviceTypeEthernet:
-		key = fmt.Sprintf("%d", d.UnitNumber-7)
+		key = fmt.Sprintf("%d", UnitNumber-7)
 	case DeviceTypeDisk:
-		key = fmt.Sprintf("%d-%d", d.ControllerKey, d.UnitNumber)
+		key = fmt.Sprintf("%d-%d", d.ControllerKey, UnitNumber)
 	default:
 		key = fmt.Sprintf("%d", d.Key)
 	}

--- a/vendor/github.com/vmware/govmomi/object/virtual_device_list_test.go
+++ b/vendor/github.com/vmware/govmomi/object/virtual_device_list_test.go
@@ -24,6 +24,10 @@ import (
 	"github.com/vmware/govmomi/vim25/types"
 )
 
+func intPtrValue(val int32) *int32 {
+	return &val
+}
+
 var devices = VirtualDeviceList([]types.BaseVirtualDevice{
 	&types.VirtualIDEController{
 		VirtualController: types.VirtualController{
@@ -39,10 +43,10 @@ var devices = VirtualDeviceList([]types.BaseVirtualDevice{
 				Connectable:   (*types.VirtualDeviceConnectInfo)(nil),
 				SlotInfo:      nil,
 				ControllerKey: 0,
-				UnitNumber:    0,
+				UnitNumber:    intPtrValue(0),
 			},
 			BusNumber: 0,
-			Device:    []int{3001, 3000},
+			Device:    []int32{3001, 3000},
 		},
 	},
 	&types.VirtualIDEController{
@@ -59,10 +63,10 @@ var devices = VirtualDeviceList([]types.BaseVirtualDevice{
 				Connectable:   (*types.VirtualDeviceConnectInfo)(nil),
 				SlotInfo:      nil,
 				ControllerKey: 0,
-				UnitNumber:    0,
+				UnitNumber:    intPtrValue(0),
 			},
 			BusNumber: 1,
-			Device:    []int{3002},
+			Device:    []int32{3002},
 		},
 	},
 	&types.VirtualPS2Controller{
@@ -79,10 +83,10 @@ var devices = VirtualDeviceList([]types.BaseVirtualDevice{
 				Connectable:   (*types.VirtualDeviceConnectInfo)(nil),
 				SlotInfo:      nil,
 				ControllerKey: 0,
-				UnitNumber:    0,
+				UnitNumber:    intPtrValue(0),
 			},
 			BusNumber: 0,
-			Device:    []int{600, 700},
+			Device:    []int32{600, 700},
 		},
 	},
 	&types.VirtualPCIController{
@@ -99,10 +103,10 @@ var devices = VirtualDeviceList([]types.BaseVirtualDevice{
 				Connectable:   (*types.VirtualDeviceConnectInfo)(nil),
 				SlotInfo:      nil,
 				ControllerKey: 0,
-				UnitNumber:    0,
+				UnitNumber:    intPtrValue(0),
 			},
 			BusNumber: 0,
-			Device:    []int{500, 12000, 1000, 4000},
+			Device:    []int32{500, 12000, 1000, 4000},
 		},
 	},
 	&types.VirtualSIOController{
@@ -119,10 +123,10 @@ var devices = VirtualDeviceList([]types.BaseVirtualDevice{
 				Connectable:   (*types.VirtualDeviceConnectInfo)(nil),
 				SlotInfo:      nil,
 				ControllerKey: 0,
-				UnitNumber:    0,
+				UnitNumber:    intPtrValue(0),
 			},
 			BusNumber: 0,
-			Device:    []int{9000},
+			Device:    []int32{9000},
 		},
 	},
 	&types.VirtualKeyboard{
@@ -138,7 +142,7 @@ var devices = VirtualDeviceList([]types.BaseVirtualDevice{
 			Connectable:   (*types.VirtualDeviceConnectInfo)(nil),
 			SlotInfo:      nil,
 			ControllerKey: 300,
-			UnitNumber:    0,
+			UnitNumber:    intPtrValue(0),
 		},
 	},
 	&types.VirtualPointingDevice{
@@ -157,7 +161,7 @@ var devices = VirtualDeviceList([]types.BaseVirtualDevice{
 			Connectable:   (*types.VirtualDeviceConnectInfo)(nil),
 			SlotInfo:      nil,
 			ControllerKey: 300,
-			UnitNumber:    1,
+			UnitNumber:    intPtrValue(1),
 		},
 	},
 	&types.VirtualMachineVideoCard{
@@ -173,7 +177,7 @@ var devices = VirtualDeviceList([]types.BaseVirtualDevice{
 			Connectable:   (*types.VirtualDeviceConnectInfo)(nil),
 			SlotInfo:      nil,
 			ControllerKey: 100,
-			UnitNumber:    0,
+			UnitNumber:    intPtrValue(0),
 		},
 		VideoRamSizeInKB: 4096,
 		NumDisplays:      1,
@@ -197,7 +201,7 @@ var devices = VirtualDeviceList([]types.BaseVirtualDevice{
 				PciSlotNumber:            33,
 			},
 			ControllerKey: 100,
-			UnitNumber:    17,
+			UnitNumber:    intPtrValue(17),
 		},
 		Id: 1754519335,
 		AllowUnrestrictedCommunication: types.NewBool(false),
@@ -217,7 +221,7 @@ var devices = VirtualDeviceList([]types.BaseVirtualDevice{
 					Connectable:   (*types.VirtualDeviceConnectInfo)(nil),
 					SlotInfo:      nil,
 					ControllerKey: 100,
-					UnitNumber:    3,
+					UnitNumber:    intPtrValue(3),
 				},
 				BusNumber: 0,
 				Device:    nil,
@@ -253,7 +257,7 @@ var devices = VirtualDeviceList([]types.BaseVirtualDevice{
 			},
 			SlotInfo:      nil,
 			ControllerKey: 200,
-			UnitNumber:    1,
+			UnitNumber:    intPtrValue(1),
 		},
 	},
 	&types.VirtualDisk{
@@ -307,7 +311,7 @@ var devices = VirtualDeviceList([]types.BaseVirtualDevice{
 			Connectable:   (*types.VirtualDeviceConnectInfo)(nil),
 			SlotInfo:      nil,
 			ControllerKey: 200,
-			UnitNumber:    0,
+			UnitNumber:    intPtrValue(0),
 		},
 		CapacityInKB:    30720,
 		CapacityInBytes: 31457280,
@@ -361,7 +365,7 @@ var devices = VirtualDeviceList([]types.BaseVirtualDevice{
 			Connectable:   (*types.VirtualDeviceConnectInfo)(nil),
 			SlotInfo:      nil,
 			ControllerKey: 201,
-			UnitNumber:    0,
+			UnitNumber:    intPtrValue(0),
 		},
 		CapacityInKB:    10000000,
 		CapacityInBytes: 10240000000,
@@ -414,7 +418,7 @@ var devices = VirtualDeviceList([]types.BaseVirtualDevice{
 					PciSlotNumber:            32,
 				},
 				ControllerKey: 100,
-				UnitNumber:    7,
+				UnitNumber:    intPtrValue(7),
 			},
 			AddressType:      "generated",
 			MacAddress:       "00:0c:29:93:d7:27",
@@ -447,7 +451,7 @@ var devices = VirtualDeviceList([]types.BaseVirtualDevice{
 			},
 			SlotInfo:      nil,
 			ControllerKey: 400,
-			UnitNumber:    0,
+			UnitNumber:    intPtrValue(0),
 		},
 		YieldOnPoll: true,
 	},
@@ -614,8 +618,8 @@ func TestPickController(t *testing.T) {
 
 	tests := []struct {
 		ctype types.BaseVirtualController
-		key   int
-		unit  int
+		key   int32
+		unit  int32
 	}{
 		{
 			(*types.VirtualIDEController)(nil), 201, 1,
@@ -642,10 +646,11 @@ func TestPickController(t *testing.T) {
 		}
 
 		dev := &types.VirtualDevice{
-			Key:           rand.Int(),
-			UnitNumber:    unit,
+			Key:           int32(rand.Int()),
+			UnitNumber:    new(int32),
 			ControllerKey: key,
 		}
+		*dev.UnitNumber = unit
 
 		list = append(list, dev)
 		c.Device = append(c.Device, dev.Key)
@@ -831,7 +836,7 @@ func TestName(t *testing.T) {
 			&types.VirtualE1000{
 				VirtualEthernetCard: types.VirtualEthernetCard{
 					VirtualDevice: types.VirtualDevice{
-						UnitNumber: 7,
+						UnitNumber: intPtrValue(7),
 					},
 				},
 			},

--- a/vendor/github.com/vmware/govmomi/property/wait.go
+++ b/vendor/github.com/vmware/govmomi/property/wait.go
@@ -64,9 +64,66 @@ func Wait(ctx context.Context, c *Collector, obj types.ManagedObjectReference, p
 	if err != nil {
 		return err
 	}
+	return waitLoop(ctx, p, f)
+}
 
+// WaitForView waits for any of the specified properties of the managed
+// objects in the View to change. It calls the specified function for every update it
+// receives. If this function returns false, it continues waiting for
+// subsequent updates. If this function returns true, it stops waiting and
+// returns.
+//
+// To only receive updates for the View's specified managed objects, the function
+// creates a new property collector and calls CreateFilter. A new property
+// collector is required because filters can only be added, not removed.
+//
+// The newly created collector is destroyed before this function returns (both
+// in case of success or error).
+//
+// The code assumes that all objects in the View are the same type
+func WaitForView(ctx context.Context, c *Collector, view types.ManagedObjectReference, obj types.ManagedObjectReference, ps []string, f func([]types.PropertyChange) bool) error {
+	p, err := c.Create(ctx)
+	if err != nil {
+		return err
+	}
+
+	// Attempt to destroy the collector using the background context, as the
+	// specified context may have timed out or have been cancelled.
+	defer p.Destroy(context.Background())
+
+	req := types.CreateFilter{
+
+		Spec: types.PropertyFilterSpec{
+			ObjectSet: []types.ObjectSpec{
+				{
+					Obj: view,
+					SelectSet: []types.BaseSelectionSpec{
+						&types.TraversalSpec{
+							SelectionSpec: types.SelectionSpec{
+								Name: "traverseEntities",
+							},
+							Path: "view",
+							Type: view.Type}},
+				},
+			},
+			PropSet: []types.PropertySpec{
+				types.PropertySpec{
+					Type:    obj.Type,
+					PathSet: ps,
+				},
+			},
+		}}
+
+	err = p.CreateFilter(ctx, req)
+	if err != nil {
+		return err
+	}
+	return waitLoop(ctx, p, f)
+}
+
+func waitLoop(ctx context.Context, c *Collector, f func([]types.PropertyChange) bool) error {
 	for version := ""; ; {
-		res, err := p.WaitForUpdates(ctx, version)
+		res, err := c.WaitForUpdates(ctx, version)
 		if err != nil {
 			return err
 		}
@@ -80,12 +137,11 @@ func Wait(ctx context.Context, c *Collector, obj types.ManagedObjectReference, p
 
 		for _, fs := range res.FilterSet {
 			for _, os := range fs.ObjectSet {
-				if os.Obj == obj {
-					if f(os.ChangeSet) {
-						return nil
-					}
+				if f(os.ChangeSet) {
+					return nil
 				}
 			}
 		}
 	}
+
 }

--- a/vendor/github.com/vmware/govmomi/view/list_view.go
+++ b/vendor/github.com/vmware/govmomi/view/list_view.go
@@ -1,0 +1,33 @@
+/*
+Copyright (c) 2015 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package view
+
+import (
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type ListView struct {
+	*object.ListView
+}
+
+func NewListView(c *vim25.Client, ref types.ManagedObjectReference) *ListView {
+	return &ListView{
+		ListView: object.NewListView(c, ref),
+	}
+}

--- a/vendor/github.com/vmware/govmomi/view/manager.go
+++ b/vendor/github.com/vmware/govmomi/view/manager.go
@@ -1,0 +1,51 @@
+/*
+Copyright (c) 2015 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package view
+
+import (
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25"
+	"github.com/vmware/govmomi/vim25/methods"
+	"github.com/vmware/govmomi/vim25/types"
+	"golang.org/x/net/context"
+)
+
+type Manager struct {
+	object.Common
+}
+
+func NewManager(c *vim25.Client) *Manager {
+	m := Manager{
+		object.NewCommon(c, *c.ServiceContent.ViewManager),
+	}
+
+	return &m
+}
+
+func (m Manager) CreateListView(ctx context.Context, objects []types.ManagedObjectReference) (*ListView, error) {
+	req := types.CreateListView{
+		This: m.Common.Reference(),
+		Obj:  objects,
+	}
+
+	res, err := methods.CreateListView(ctx, m.Client(), &req)
+	if err != nil {
+		return nil, err
+	}
+
+	return NewListView(m.Client(), res.Returnval), nil
+}

--- a/vendor/github.com/vmware/govmomi/vim25/methods/methods.go
+++ b/vendor/github.com/vmware/govmomi/vim25/methods/methods.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package methods
 
 import (

--- a/vendor/github.com/vmware/govmomi/vim25/mo/mo.go
+++ b/vendor/github.com/vmware/govmomi/vim25/mo/mo.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package mo
 
 import (
@@ -299,7 +300,7 @@ type EventManager struct {
 
 	Description  types.EventDescription `mo:"description"`
 	LatestEvent  types.BaseEvent        `mo:"latestEvent"`
-	MaxCollector int                    `mo:"maxCollector"`
+	MaxCollector int32                  `mo:"maxCollector"`
 }
 
 func (m EventManager) Reference() types.ManagedObjectReference {
@@ -945,7 +946,7 @@ func init() {
 type HttpNfcLease struct {
 	Self types.ManagedObjectReference
 
-	InitializeProgress int                         `mo:"initializeProgress"`
+	InitializeProgress int32                       `mo:"initializeProgress"`
 	Info               *types.HttpNfcLeaseInfo     `mo:"info"`
 	State              types.HttpNfcLeaseState     `mo:"state"`
 	Error              *types.LocalizedMethodFault `mo:"error"`
@@ -1066,7 +1067,7 @@ type ManagedEntity struct {
 	OverallStatus       types.ManagedEntityStatus      `mo:"overallStatus"`
 	ConfigStatus        types.ManagedEntityStatus      `mo:"configStatus"`
 	ConfigIssue         []types.BaseEvent              `mo:"configIssue"`
-	EffectiveRole       []int                          `mo:"effectiveRole"`
+	EffectiveRole       []int32                        `mo:"effectiveRole"`
 	Permission          []types.Permission             `mo:"permission"`
 	Name                string                         `mo:"name"`
 	DisabledMethod      []string                       `mo:"disabledMethod"`
@@ -1438,7 +1439,7 @@ type TaskManager struct {
 
 	RecentTask   []types.ManagedObjectReference `mo:"recentTask"`
 	Description  types.TaskDescription          `mo:"description"`
-	MaxCollector int                            `mo:"maxCollector"`
+	MaxCollector int32                          `mo:"maxCollector"`
 }
 
 func (m TaskManager) Reference() types.ManagedObjectReference {
@@ -1461,6 +1462,18 @@ func (m UserDirectory) Reference() types.ManagedObjectReference {
 
 func init() {
 	t["UserDirectory"] = reflect.TypeOf((*UserDirectory)(nil)).Elem()
+}
+
+type VRPResourceManager struct {
+	Self types.ManagedObjectReference
+}
+
+func (m VRPResourceManager) Reference() types.ManagedObjectReference {
+	return m.Self
+}
+
+func init() {
+	t["VRPResourceManager"] = reflect.TypeOf((*VRPResourceManager)(nil)).Elem()
 }
 
 type View struct {

--- a/vendor/github.com/vmware/govmomi/vim25/types/enum.go
+++ b/vendor/github.com/vmware/govmomi/vim25/types/enum.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package types
 
 import "reflect"

--- a/vendor/github.com/vmware/govmomi/vim25/types/if.go
+++ b/vendor/github.com/vmware/govmomi/vim25/types/if.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package types
 
 import "reflect"

--- a/vendor/github.com/vmware/govmomi/vim25/types/types.go
+++ b/vendor/github.com/vmware/govmomi/vim25/types/types.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package types
 
 import (
@@ -258,7 +259,7 @@ func init() {
 type ActiveDirectoryFault struct {
 	VimFault
 
-	ErrorCode int `xml:"errorCode,omitempty"`
+	ErrorCode int32 `xml:"errorCode,omitempty"`
 }
 
 func init() {
@@ -314,7 +315,7 @@ func init() {
 }
 
 type AddAuthorizationRoleResponse struct {
-	Returnval int `xml:"returnval"`
+	Returnval int32 `xml:"returnval"`
 }
 
 type AddCustomFieldDef AddCustomFieldDefRequestType
@@ -652,7 +653,7 @@ func init() {
 type AfterStartupTaskScheduler struct {
 	TaskScheduler
 
-	Minute int `xml:"minute"`
+	Minute int32 `xml:"minute"`
 }
 
 func init() {
@@ -663,7 +664,7 @@ type AgentInstallFailed struct {
 	HostConnectFault
 
 	Reason          string `xml:"reason,omitempty"`
-	StatusCode      int    `xml:"statusCode,omitempty"`
+	StatusCode      int32  `xml:"statusCode,omitempty"`
 	InstallerOutput string `xml:"installerOutput,omitempty"`
 }
 
@@ -807,7 +808,7 @@ type AlarmInfo struct {
 	Entity           ManagedObjectReference `xml:"entity"`
 	LastModifiedTime time.Time              `xml:"lastModifiedTime"`
 	LastModifiedUser string                 `xml:"lastModifiedUser"`
-	CreationEventId  int                    `xml:"creationEventId"`
+	CreationEventId  int32                  `xml:"creationEventId"`
 }
 
 func init() {
@@ -860,8 +861,8 @@ func init() {
 type AlarmSetting struct {
 	DynamicData
 
-	ToleranceRange     int `xml:"toleranceRange"`
-	ReportingFrequency int `xml:"reportingFrequency"`
+	ToleranceRange     int32 `xml:"toleranceRange"`
+	ReportingFrequency int32 `xml:"reportingFrequency"`
 }
 
 func init() {
@@ -898,7 +899,7 @@ type AlarmSpec struct {
 	Enabled         bool                `xml:"enabled"`
 	Expression      BaseAlarmExpression `xml:"expression,typeattr"`
 	Action          BaseAlarmAction     `xml:"action,omitempty,typeattr"`
-	ActionFrequency int                 `xml:"actionFrequency,omitempty"`
+	ActionFrequency int32               `xml:"actionFrequency,omitempty"`
 	Setting         *AlarmSetting       `xml:"setting,omitempty"`
 }
 
@@ -917,7 +918,7 @@ type AlarmState struct {
 	Acknowledged       *bool                  `xml:"acknowledged"`
 	AcknowledgedByUser string                 `xml:"acknowledgedByUser,omitempty"`
 	AcknowledgedTime   *time.Time             `xml:"acknowledgedTime"`
-	EventKey           int                    `xml:"eventKey,omitempty"`
+	EventKey           int32                  `xml:"eventKey,omitempty"`
 }
 
 func init() {
@@ -981,7 +982,7 @@ func init() {
 type AllocateIpv4AddressRequestType struct {
 	This         ManagedObjectReference `xml:"_this"`
 	Dc           ManagedObjectReference `xml:"dc"`
-	PoolId       int                    `xml:"poolId"`
+	PoolId       int32                  `xml:"poolId"`
 	AllocationId string                 `xml:"allocationId"`
 }
 
@@ -1002,7 +1003,7 @@ func init() {
 type AllocateIpv6AddressRequestType struct {
 	This         ManagedObjectReference `xml:"_this"`
 	Dc           ManagedObjectReference `xml:"dc"`
-	PoolId       int                    `xml:"poolId"`
+	PoolId       int32                  `xml:"poolId"`
 	AllocationId string                 `xml:"allocationId"`
 }
 
@@ -3430,7 +3431,7 @@ func init() {
 }
 
 type ArrayOfInt struct {
-	Int []int `xml:"int,omitempty"`
+	Int []int32 `xml:"int,omitempty"`
 }
 
 func init() {
@@ -5288,7 +5289,7 @@ func init() {
 type AuthorizationRole struct {
 	DynamicData
 
-	RoleId    int             `xml:"roleId"`
+	RoleId    int32           `xml:"roleId"`
 	System    bool            `xml:"system"`
 	Name      string          `xml:"name"`
 	Info      BaseDescription `xml:"info,typeattr"`
@@ -5303,8 +5304,8 @@ type AutoStartDefaults struct {
 	DynamicData
 
 	Enabled          *bool  `xml:"enabled"`
-	StartDelay       int    `xml:"startDelay,omitempty"`
-	StopDelay        int    `xml:"stopDelay,omitempty"`
+	StartDelay       int32  `xml:"startDelay,omitempty"`
+	StopDelay        int32  `xml:"stopDelay,omitempty"`
 	WaitForHeartbeat *bool  `xml:"waitForHeartbeat"`
 	StopAction       string `xml:"stopAction,omitempty"`
 }
@@ -5317,11 +5318,11 @@ type AutoStartPowerInfo struct {
 	DynamicData
 
 	Key              ManagedObjectReference        `xml:"key"`
-	StartOrder       int                           `xml:"startOrder"`
-	StartDelay       int                           `xml:"startDelay"`
+	StartOrder       int32                         `xml:"startOrder"`
+	StartDelay       int32                         `xml:"startDelay"`
 	WaitForHeartbeat AutoStartWaitHeartbeatSetting `xml:"waitForHeartbeat"`
 	StartAction      string                        `xml:"startAction"`
-	StopDelay        int                           `xml:"stopDelay"`
+	StopDelay        int32                         `xml:"stopDelay"`
 	StopAction       string                        `xml:"stopAction"`
 }
 
@@ -5504,8 +5505,8 @@ type BrowseDiagnosticLogRequestType struct {
 	This  ManagedObjectReference  `xml:"_this"`
 	Host  *ManagedObjectReference `xml:"host,omitempty"`
 	Key   string                  `xml:"key"`
-	Start int                     `xml:"start,omitempty"`
-	Lines int                     `xml:"lines,omitempty"`
+	Start int32                   `xml:"start,omitempty"`
+	Lines int32                   `xml:"lines,omitempty"`
 }
 
 func init() {
@@ -6591,7 +6592,7 @@ type ChoiceOption struct {
 	OptionType
 
 	ChoiceInfo   []BaseElementDescription `xml:"choiceInfo,typeattr"`
-	DefaultIndex int                      `xml:"defaultIndex,omitempty"`
+	DefaultIndex int32                    `xml:"defaultIndex,omitempty"`
 }
 
 func init() {
@@ -6808,11 +6809,11 @@ func init() {
 type ClusterComputeResourceSummary struct {
 	ComputeResourceSummary
 
-	CurrentFailoverLevel int                                `xml:"currentFailoverLevel"`
+	CurrentFailoverLevel int32                              `xml:"currentFailoverLevel"`
 	AdmissionControlInfo BaseClusterDasAdmissionControlInfo `xml:"admissionControlInfo,omitempty,typeattr"`
-	NumVmotions          int                                `xml:"numVmotions"`
-	TargetBalance        int                                `xml:"targetBalance,omitempty"`
-	CurrentBalance       int                                `xml:"currentBalance,omitempty"`
+	NumVmotions          int32                              `xml:"numVmotions"`
+	TargetBalance        int32                              `xml:"targetBalance,omitempty"`
+	CurrentBalance       int32                              `xml:"currentBalance,omitempty"`
 	UsageSummary         *ClusterUsageSummary               `xml:"usageSummary,omitempty"`
 	CurrentEVCModeKey    string                             `xml:"currentEVCModeKey,omitempty"`
 	DasData              BaseClusterDasData                 `xml:"dasData,omitempty,typeattr"`
@@ -6968,7 +6969,7 @@ type ClusterDasConfigInfo struct {
 	VmMonitoring               string                               `xml:"vmMonitoring,omitempty"`
 	HostMonitoring             string                               `xml:"hostMonitoring,omitempty"`
 	VmComponentProtecting      string                               `xml:"vmComponentProtecting,omitempty"`
-	FailoverLevel              int                                  `xml:"failoverLevel,omitempty"`
+	FailoverLevel              int32                                `xml:"failoverLevel,omitempty"`
 	AdmissionControlPolicy     BaseClusterDasAdmissionControlPolicy `xml:"admissionControlPolicy,omitempty,typeattr"`
 	AdmissionControlEnabled    *bool                                `xml:"admissionControlEnabled"`
 	DefaultVmSettings          *ClusterDasVmSettings                `xml:"defaultVmSettings,omitempty"`
@@ -7005,12 +7006,12 @@ type ClusterDasFailoverLevelAdvancedRuntimeInfo struct {
 	ClusterDasAdvancedRuntimeInfo
 
 	SlotInfo                  ClusterDasFailoverLevelAdvancedRuntimeInfoSlotInfo    `xml:"slotInfo"`
-	TotalSlots                int                                                   `xml:"totalSlots"`
-	UsedSlots                 int                                                   `xml:"usedSlots"`
-	UnreservedSlots           int                                                   `xml:"unreservedSlots"`
-	TotalVms                  int                                                   `xml:"totalVms"`
-	TotalHosts                int                                                   `xml:"totalHosts"`
-	TotalGoodHosts            int                                                   `xml:"totalGoodHosts"`
+	TotalSlots                int32                                                 `xml:"totalSlots"`
+	UsedSlots                 int32                                                 `xml:"usedSlots"`
+	UnreservedSlots           int32                                                 `xml:"unreservedSlots"`
+	TotalVms                  int32                                                 `xml:"totalVms"`
+	TotalHosts                int32                                                 `xml:"totalHosts"`
+	TotalGoodHosts            int32                                                 `xml:"totalGoodHosts"`
 	HostSlots                 []ClusterDasFailoverLevelAdvancedRuntimeInfoHostSlots `xml:"hostSlots,omitempty"`
 	VmsRequiringMultipleSlots []ClusterDasFailoverLevelAdvancedRuntimeInfoVmSlots   `xml:"vmsRequiringMultipleSlots,omitempty"`
 }
@@ -7023,7 +7024,7 @@ type ClusterDasFailoverLevelAdvancedRuntimeInfoHostSlots struct {
 	DynamicData
 
 	Host  ManagedObjectReference `xml:"host"`
-	Slots int                    `xml:"slots"`
+	Slots int32                  `xml:"slots"`
 }
 
 func init() {
@@ -7033,9 +7034,9 @@ func init() {
 type ClusterDasFailoverLevelAdvancedRuntimeInfoSlotInfo struct {
 	DynamicData
 
-	NumVcpus int `xml:"numVcpus"`
-	CpuMHz   int `xml:"cpuMHz"`
-	MemoryMB int `xml:"memoryMB"`
+	NumVcpus int32 `xml:"numVcpus"`
+	CpuMHz   int32 `xml:"cpuMHz"`
+	MemoryMB int32 `xml:"memoryMB"`
 }
 
 func init() {
@@ -7046,7 +7047,7 @@ type ClusterDasFailoverLevelAdvancedRuntimeInfoVmSlots struct {
 	DynamicData
 
 	Vm    ManagedObjectReference `xml:"vm"`
-	Slots int                    `xml:"slots"`
+	Slots int32                  `xml:"slots"`
 }
 
 func init() {
@@ -7076,7 +7077,7 @@ type ClusterDasHostRecommendation struct {
 	DynamicData
 
 	Host      ManagedObjectReference `xml:"host"`
-	DrsRating int                    `xml:"drsRating,omitempty"`
+	DrsRating int32                  `xml:"drsRating,omitempty"`
 }
 
 func init() {
@@ -7132,7 +7133,7 @@ type ClusterDpmConfigInfo struct {
 
 	Enabled             *bool             `xml:"enabled"`
 	DefaultDpmBehavior  DpmBehavior       `xml:"defaultDpmBehavior,omitempty"`
-	HostPowerActionRate int               `xml:"hostPowerActionRate,omitempty"`
+	HostPowerActionRate int32             `xml:"hostPowerActionRate,omitempty"`
 	Option              []BaseOptionValue `xml:"option,omitempty,typeattr"`
 }
 
@@ -7168,7 +7169,7 @@ type ClusterDrsConfigInfo struct {
 	Enabled                   *bool             `xml:"enabled"`
 	EnableVmBehaviorOverrides *bool             `xml:"enableVmBehaviorOverrides"`
 	DefaultVmBehavior         DrsBehavior       `xml:"defaultVmBehavior,omitempty"`
-	VmotionRate               int               `xml:"vmotionRate,omitempty"`
+	VmotionRate               int32             `xml:"vmotionRate,omitempty"`
 	Option                    []BaseOptionValue `xml:"option,omitempty,typeattr"`
 }
 
@@ -7214,13 +7215,13 @@ type ClusterDrsMigration struct {
 	Key                   string                 `xml:"key"`
 	Time                  time.Time              `xml:"time"`
 	Vm                    ManagedObjectReference `xml:"vm"`
-	CpuLoad               int                    `xml:"cpuLoad,omitempty"`
+	CpuLoad               int32                  `xml:"cpuLoad,omitempty"`
 	MemoryLoad            int64                  `xml:"memoryLoad,omitempty"`
 	Source                ManagedObjectReference `xml:"source"`
-	SourceCpuLoad         int                    `xml:"sourceCpuLoad,omitempty"`
+	SourceCpuLoad         int32                  `xml:"sourceCpuLoad,omitempty"`
 	SourceMemoryLoad      int64                  `xml:"sourceMemoryLoad,omitempty"`
 	Destination           ManagedObjectReference `xml:"destination"`
-	DestinationCpuLoad    int                    `xml:"destinationCpuLoad,omitempty"`
+	DestinationCpuLoad    int32                  `xml:"destinationCpuLoad,omitempty"`
 	DestinationMemoryLoad int64                  `xml:"destinationMemoryLoad,omitempty"`
 }
 
@@ -7232,7 +7233,7 @@ type ClusterDrsRecommendation struct {
 	DynamicData
 
 	Key           string                `xml:"key"`
-	Rating        int                   `xml:"rating"`
+	Rating        int32                 `xml:"rating"`
 	Reason        string                `xml:"reason"`
 	ReasonText    string                `xml:"reasonText"`
 	MigrationList []ClusterDrsMigration `xml:"migrationList"`
@@ -7364,7 +7365,7 @@ func init() {
 type ClusterFailoverLevelAdmissionControlInfo struct {
 	ClusterDasAdmissionControlInfo
 
-	CurrentFailoverLevel int `xml:"currentFailoverLevel"`
+	CurrentFailoverLevel int32 `xml:"currentFailoverLevel"`
 }
 
 func init() {
@@ -7374,7 +7375,7 @@ func init() {
 type ClusterFailoverLevelAdmissionControlPolicy struct {
 	ClusterDasAdmissionControlPolicy
 
-	FailoverLevel int                   `xml:"failoverLevel"`
+	FailoverLevel int32                 `xml:"failoverLevel"`
 	SlotPolicy    BaseClusterSlotPolicy `xml:"slotPolicy,omitempty,typeattr"`
 }
 
@@ -7385,8 +7386,8 @@ func init() {
 type ClusterFailoverResourcesAdmissionControlInfo struct {
 	ClusterDasAdmissionControlInfo
 
-	CurrentCpuFailoverResourcesPercent    int `xml:"currentCpuFailoverResourcesPercent"`
-	CurrentMemoryFailoverResourcesPercent int `xml:"currentMemoryFailoverResourcesPercent"`
+	CurrentCpuFailoverResourcesPercent    int32 `xml:"currentCpuFailoverResourcesPercent"`
+	CurrentMemoryFailoverResourcesPercent int32 `xml:"currentMemoryFailoverResourcesPercent"`
 }
 
 func init() {
@@ -7396,8 +7397,8 @@ func init() {
 type ClusterFailoverResourcesAdmissionControlPolicy struct {
 	ClusterDasAdmissionControlPolicy
 
-	CpuFailoverResourcesPercent    int `xml:"cpuFailoverResourcesPercent"`
-	MemoryFailoverResourcesPercent int `xml:"memoryFailoverResourcesPercent"`
+	CpuFailoverResourcesPercent    int32 `xml:"cpuFailoverResourcesPercent"`
+	MemoryFailoverResourcesPercent int32 `xml:"memoryFailoverResourcesPercent"`
 }
 
 func init() {
@@ -7407,8 +7408,8 @@ func init() {
 type ClusterFixedSizeSlotPolicy struct {
 	ClusterSlotPolicy
 
-	Cpu    int `xml:"cpu"`
-	Memory int `xml:"memory"`
+	Cpu    int32 `xml:"cpu"`
+	Memory int32 `xml:"memory"`
 }
 
 func init() {
@@ -7451,9 +7452,9 @@ type ClusterHostPowerAction struct {
 	ClusterAction
 
 	OperationType        HostPowerOperationType `xml:"operationType"`
-	PowerConsumptionWatt int                    `xml:"powerConsumptionWatt,omitempty"`
-	CpuCapacityMHz       int                    `xml:"cpuCapacityMHz,omitempty"`
-	MemCapacityMB        int                    `xml:"memCapacityMB,omitempty"`
+	PowerConsumptionWatt int32                  `xml:"powerConsumptionWatt,omitempty"`
+	CpuCapacityMHz       int32                  `xml:"cpuCapacityMHz,omitempty"`
+	MemCapacityMB        int32                  `xml:"memCapacityMB,omitempty"`
 }
 
 func init() {
@@ -7464,7 +7465,7 @@ type ClusterHostRecommendation struct {
 	DynamicData
 
 	Host   ManagedObjectReference `xml:"host"`
-	Rating int                    `xml:"rating"`
+	Rating int32                  `xml:"rating"`
 }
 
 func init() {
@@ -7585,7 +7586,7 @@ type ClusterRecommendation struct {
 	Key            string                  `xml:"key"`
 	Type           string                  `xml:"type"`
 	Time           time.Time               `xml:"time"`
-	Rating         int                     `xml:"rating"`
+	Rating         int32                   `xml:"rating"`
 	Reason         string                  `xml:"reason"`
 	ReasonText     string                  `xml:"reasonText"`
 	WarningText    string                  `xml:"warningText,omitempty"`
@@ -7610,10 +7611,10 @@ func init() {
 type ClusterResourceUsageSummary struct {
 	DynamicData
 
-	CpuUsedMHz        int   `xml:"cpuUsedMHz"`
-	CpuCapacityMHz    int   `xml:"cpuCapacityMHz"`
-	MemUsedMB         int   `xml:"memUsedMB"`
-	MemCapacityMB     int   `xml:"memCapacityMB"`
+	CpuUsedMHz        int32 `xml:"cpuUsedMHz"`
+	CpuCapacityMHz    int32 `xml:"cpuCapacityMHz"`
+	MemUsedMB         int32 `xml:"memUsedMB"`
+	MemCapacityMB     int32 `xml:"memCapacityMB"`
 	StorageUsedMB     int64 `xml:"storageUsedMB"`
 	StorageCapacityMB int64 `xml:"storageCapacityMB"`
 }
@@ -7625,7 +7626,7 @@ func init() {
 type ClusterRuleInfo struct {
 	DynamicData
 
-	Key          int                 `xml:"key,omitempty"`
+	Key          int32               `xml:"key,omitempty"`
 	Status       ManagedEntityStatus `xml:"status,omitempty"`
 	Enabled      *bool               `xml:"enabled"`
 	Name         string              `xml:"name,omitempty"`
@@ -7671,19 +7672,19 @@ func init() {
 type ClusterUsageSummary struct {
 	DynamicData
 
-	TotalCpuCapacityMhz         int   `xml:"totalCpuCapacityMhz"`
-	TotalMemCapacityMB          int   `xml:"totalMemCapacityMB"`
-	CpuReservationMhz           int   `xml:"cpuReservationMhz"`
-	MemReservationMB            int   `xml:"memReservationMB"`
-	PoweredOffCpuReservationMhz int   `xml:"poweredOffCpuReservationMhz,omitempty"`
-	PoweredOffMemReservationMB  int   `xml:"poweredOffMemReservationMB,omitempty"`
-	CpuDemandMhz                int   `xml:"cpuDemandMhz"`
-	MemDemandMB                 int   `xml:"memDemandMB"`
+	TotalCpuCapacityMhz         int32 `xml:"totalCpuCapacityMhz"`
+	TotalMemCapacityMB          int32 `xml:"totalMemCapacityMB"`
+	CpuReservationMhz           int32 `xml:"cpuReservationMhz"`
+	MemReservationMB            int32 `xml:"memReservationMB"`
+	PoweredOffCpuReservationMhz int32 `xml:"poweredOffCpuReservationMhz,omitempty"`
+	PoweredOffMemReservationMB  int32 `xml:"poweredOffMemReservationMB,omitempty"`
+	CpuDemandMhz                int32 `xml:"cpuDemandMhz"`
+	MemDemandMB                 int32 `xml:"memDemandMB"`
 	StatsGenNumber              int64 `xml:"statsGenNumber"`
-	CpuEntitledMhz              int   `xml:"cpuEntitledMhz"`
-	MemEntitledMB               int   `xml:"memEntitledMB"`
-	PoweredOffVmCount           int   `xml:"poweredOffVmCount"`
-	TotalVmCount                int   `xml:"totalVmCount"`
+	CpuEntitledMhz              int32 `xml:"cpuEntitledMhz"`
+	MemEntitledMB               int32 `xml:"memEntitledMB"`
+	PoweredOffVmCount           int32 `xml:"poweredOffVmCount"`
+	TotalVmCount                int32 `xml:"totalVmCount"`
 }
 
 func init() {
@@ -7695,7 +7696,7 @@ type ClusterVmComponentProtectionSettings struct {
 
 	VmStorageProtectionForAPD string `xml:"vmStorageProtectionForAPD,omitempty"`
 	EnableAPDTimeoutForHosts  *bool  `xml:"enableAPDTimeoutForHosts"`
-	VmTerminateDelayForAPDSec int    `xml:"vmTerminateDelayForAPDSec,omitempty"`
+	VmTerminateDelayForAPDSec int32  `xml:"vmTerminateDelayForAPDSec,omitempty"`
 	VmReactionOnAPDCleared    string `xml:"vmReactionOnAPDCleared,omitempty"`
 	VmStorageProtectionForPDL string `xml:"vmStorageProtectionForPDL,omitempty"`
 }
@@ -7732,10 +7733,10 @@ type ClusterVmToolsMonitoringSettings struct {
 	Enabled          *bool  `xml:"enabled"`
 	VmMonitoring     string `xml:"vmMonitoring,omitempty"`
 	ClusterSettings  *bool  `xml:"clusterSettings"`
-	FailureInterval  int    `xml:"failureInterval,omitempty"`
-	MinUpTime        int    `xml:"minUpTime,omitempty"`
-	MaxFailures      int    `xml:"maxFailures,omitempty"`
-	MaxFailureWindow int    `xml:"maxFailureWindow,omitempty"`
+	FailureInterval  int32  `xml:"failureInterval,omitempty"`
+	MinUpTime        int32  `xml:"minUpTime,omitempty"`
+	MaxFailures      int32  `xml:"maxFailures,omitempty"`
+	MaxFailureWindow int32  `xml:"maxFailureWindow,omitempty"`
 }
 
 func init() {
@@ -7904,14 +7905,14 @@ func init() {
 type ComputeResourceSummary struct {
 	DynamicData
 
-	TotalCpu          int                 `xml:"totalCpu"`
+	TotalCpu          int32               `xml:"totalCpu"`
 	TotalMemory       int64               `xml:"totalMemory"`
 	NumCpuCores       int16               `xml:"numCpuCores"`
 	NumCpuThreads     int16               `xml:"numCpuThreads"`
-	EffectiveCpu      int                 `xml:"effectiveCpu"`
+	EffectiveCpu      int32               `xml:"effectiveCpu"`
 	EffectiveMemory   int64               `xml:"effectiveMemory"`
-	NumHosts          int                 `xml:"numHosts"`
-	NumEffectiveHosts int                 `xml:"numEffectiveHosts"`
+	NumHosts          int32               `xml:"numHosts"`
+	NumEffectiveHosts int32               `xml:"numEffectiveHosts"`
 	OverallStatus     ManagedEntityStatus `xml:"overallStatus"`
 }
 
@@ -7936,9 +7937,9 @@ func init() {
 type ConfigTarget struct {
 	DynamicData
 
-	NumCpus                     int                                         `xml:"numCpus"`
-	NumCpuCores                 int                                         `xml:"numCpuCores"`
-	NumNumaNodes                int                                         `xml:"numNumaNodes"`
+	NumCpus                     int32                                       `xml:"numCpus"`
+	NumCpuCores                 int32                                       `xml:"numCpuCores"`
+	NumNumaNodes                int32                                       `xml:"numNumaNodes"`
 	SmcPresent                  *bool                                       `xml:"smcPresent"`
 	Datastore                   []VirtualMachineDatastoreInfo               `xml:"datastore,omitempty"`
 	Network                     []VirtualMachineNetworkInfo                 `xml:"network,omitempty"`
@@ -7955,7 +7956,7 @@ type ConfigTarget struct {
 	ScsiPassthrough             []VirtualMachineScsiPassthroughInfo         `xml:"scsiPassthrough,omitempty"`
 	ScsiDisk                    []VirtualMachineScsiDiskDeviceInfo          `xml:"scsiDisk,omitempty"`
 	IdeDisk                     []VirtualMachineIdeDiskDeviceInfo           `xml:"ideDisk,omitempty"`
-	MaxMemMBOptimalPerf         int                                         `xml:"maxMemMBOptimalPerf"`
+	MaxMemMBOptimalPerf         int32                                       `xml:"maxMemMBOptimalPerf"`
 	ResourcePool                *ResourcePoolRuntimeInfo                    `xml:"resourcePool,omitempty"`
 	AutoVmotion                 *bool                                       `xml:"autoVmotion"`
 	PciPassthrough              []BaseVirtualMachinePciPassthroughInfo      `xml:"pciPassthrough,omitempty,typeattr"`
@@ -8072,7 +8073,7 @@ func init() {
 
 type ConfigurePowerPolicyRequestType struct {
 	This ManagedObjectReference `xml:"_this"`
-	Key  int                    `xml:"key"`
+	Key  int32                  `xml:"key"`
 }
 
 func init() {
@@ -8298,7 +8299,7 @@ func init() {
 type CpuIncompatible struct {
 	VirtualHardwareCompatibilityIssue
 
-	Level        int                     `xml:"level"`
+	Level        int32                   `xml:"level"`
 	RegisterName string                  `xml:"registerName"`
 	RegisterBits string                  `xml:"registerBits,omitempty"`
 	DesiredBits  string                  `xml:"desiredBits,omitempty"`
@@ -8767,7 +8768,7 @@ func init() {
 }
 
 type CreateIpPoolResponse struct {
-	Returnval int `xml:"returnval"`
+	Returnval int32 `xml:"returnval"`
 }
 
 type CreateListView CreateListViewRequestType
@@ -9304,7 +9305,7 @@ type CurrentTimeResponse struct {
 type CustomFieldDef struct {
 	DynamicData
 
-	Key                     int                 `xml:"key"`
+	Key                     int32               `xml:"key"`
 	Name                    string              `xml:"name"`
 	Type                    string              `xml:"type"`
 	ManagedObjectType       string              `xml:"managedObjectType,omitempty"`
@@ -9327,7 +9328,7 @@ func init() {
 type CustomFieldDefEvent struct {
 	CustomFieldEvent
 
-	FieldKey int    `xml:"fieldKey"`
+	FieldKey int32  `xml:"fieldKey"`
 	Name     string `xml:"name"`
 }
 
@@ -9374,7 +9375,7 @@ func init() {
 type CustomFieldValue struct {
 	DynamicData
 
-	Key int `xml:"key"`
+	Key int32 `xml:"key"`
 }
 
 func init() {
@@ -9385,7 +9386,7 @@ type CustomFieldValueChangedEvent struct {
 	CustomFieldEvent
 
 	Entity   ManagedEntityEventArgument `xml:"entity"`
-	FieldKey int                        `xml:"fieldKey"`
+	FieldKey int32                      `xml:"fieldKey"`
 	Name     string                     `xml:"name"`
 	Value    string                     `xml:"value"`
 }
@@ -9505,7 +9506,7 @@ type CustomizationFixedIpV6 struct {
 	CustomizationIpV6Generator
 
 	IpAddress  string `xml:"ipAddress"`
-	SubnetMask int    `xml:"subnetMask"`
+	SubnetMask int32  `xml:"subnetMask"`
 }
 
 func init() {
@@ -9547,9 +9548,9 @@ type CustomizationGuiUnattended struct {
 	DynamicData
 
 	Password       *CustomizationPassword `xml:"password,omitempty"`
-	TimeZone       int                    `xml:"timeZone"`
+	TimeZone       int32                  `xml:"timeZone"`
 	AutoLogon      bool                   `xml:"autoLogon"`
-	AutoLogonCount int                    `xml:"autoLogonCount"`
+	AutoLogonCount int32                  `xml:"autoLogonCount"`
 }
 
 func init() {
@@ -9626,7 +9627,7 @@ type CustomizationLicenseFilePrintData struct {
 	DynamicData
 
 	AutoMode  CustomizationLicenseDataMode `xml:"autoMode"`
-	AutoUsers int                          `xml:"autoUsers,omitempty"`
+	AutoUsers int32                        `xml:"autoUsers,omitempty"`
 }
 
 func init() {
@@ -10001,7 +10002,7 @@ type DVPortStatus struct {
 	Blocked                                bool           `xml:"blocked"`
 	VlanIds                                []NumericRange `xml:"vlanIds,omitempty"`
 	TrunkingMode                           *bool          `xml:"trunkingMode"`
-	Mtu                                    int            `xml:"mtu,omitempty"`
+	Mtu                                    int32          `xml:"mtu,omitempty"`
 	LinkPeer                               string         `xml:"linkPeer,omitempty"`
 	MacAddress                             string         `xml:"macAddress,omitempty"`
 	StatusDetail                           string         `xml:"statusDetail,omitempty"`
@@ -10020,7 +10021,7 @@ type DVPortgroupConfigInfo struct {
 
 	Key                          string                                    `xml:"key"`
 	Name                         string                                    `xml:"name"`
-	NumPorts                     int                                       `xml:"numPorts"`
+	NumPorts                     int32                                     `xml:"numPorts"`
 	DistributedVirtualSwitch     *ManagedObjectReference                   `xml:"distributedVirtualSwitch,omitempty"`
 	DefaultPortConfig            BaseDVPortSetting                         `xml:"defaultPortConfig,omitempty,typeattr"`
 	Description                  string                                    `xml:"description,omitempty"`
@@ -10043,7 +10044,7 @@ type DVPortgroupConfigSpec struct {
 
 	ConfigVersion                string                                    `xml:"configVersion,omitempty"`
 	Name                         string                                    `xml:"name,omitempty"`
-	NumPorts                     int                                       `xml:"numPorts,omitempty"`
+	NumPorts                     int32                                     `xml:"numPorts,omitempty"`
 	PortNameFormat               string                                    `xml:"portNameFormat,omitempty"`
 	DefaultPortConfig            BaseDVPortSetting                         `xml:"defaultPortConfig,omitempty,typeattr"`
 	Description                  string                                    `xml:"description,omitempty"`
@@ -10179,9 +10180,9 @@ type DVSConfigInfo struct {
 
 	Uuid                                string                                    `xml:"uuid"`
 	Name                                string                                    `xml:"name"`
-	NumStandalonePorts                  int                                       `xml:"numStandalonePorts"`
-	NumPorts                            int                                       `xml:"numPorts"`
-	MaxPorts                            int                                       `xml:"maxPorts"`
+	NumStandalonePorts                  int32                                     `xml:"numStandalonePorts"`
+	NumPorts                            int32                                     `xml:"numPorts"`
+	MaxPorts                            int32                                     `xml:"maxPorts"`
 	UplinkPortPolicy                    BaseDVSUplinkPortPolicy                   `xml:"uplinkPortPolicy,typeattr"`
 	UplinkPortgroup                     []ManagedObjectReference                  `xml:"uplinkPortgroup,omitempty"`
 	DefaultPortConfig                   BaseDVPortSetting                         `xml:"defaultPortConfig,typeattr"`
@@ -10197,12 +10198,12 @@ type DVSConfigInfo struct {
 	SwitchIpAddress                     string                                    `xml:"switchIpAddress,omitempty"`
 	CreateTime                          time.Time                                 `xml:"createTime"`
 	NetworkResourceManagementEnabled    *bool                                     `xml:"networkResourceManagementEnabled"`
-	DefaultProxySwitchMaxNumPorts       int                                       `xml:"defaultProxySwitchMaxNumPorts,omitempty"`
+	DefaultProxySwitchMaxNumPorts       int32                                     `xml:"defaultProxySwitchMaxNumPorts,omitempty"`
 	HealthCheckConfig                   []BaseDVSHealthCheckConfig                `xml:"healthCheckConfig,omitempty,typeattr"`
 	InfrastructureTrafficResourceConfig []DvsHostInfrastructureTrafficResource    `xml:"infrastructureTrafficResourceConfig,omitempty"`
 	NetworkResourceControlVersion       string                                    `xml:"networkResourceControlVersion,omitempty"`
 	VmVnicNetworkResourcePool           []DVSVmVnicNetworkResourcePool            `xml:"vmVnicNetworkResourcePool,omitempty"`
-	PnicCapacityRatioForReservation     int                                       `xml:"pnicCapacityRatioForReservation,omitempty"`
+	PnicCapacityRatioForReservation     int32                                     `xml:"pnicCapacityRatioForReservation,omitempty"`
 }
 
 func init() {
@@ -10214,8 +10215,8 @@ type DVSConfigSpec struct {
 
 	ConfigVersion                       string                                         `xml:"configVersion,omitempty"`
 	Name                                string                                         `xml:"name,omitempty"`
-	NumStandalonePorts                  int                                            `xml:"numStandalonePorts,omitempty"`
-	MaxPorts                            int                                            `xml:"maxPorts,omitempty"`
+	NumStandalonePorts                  int32                                          `xml:"numStandalonePorts,omitempty"`
+	MaxPorts                            int32                                          `xml:"maxPorts,omitempty"`
 	UplinkPortPolicy                    BaseDVSUplinkPortPolicy                        `xml:"uplinkPortPolicy,omitempty,typeattr"`
 	UplinkPortgroup                     []ManagedObjectReference                       `xml:"uplinkPortgroup,omitempty"`
 	DefaultPortConfig                   BaseDVPortSetting                              `xml:"defaultPortConfig,omitempty,typeattr"`
@@ -10226,7 +10227,7 @@ type DVSConfigSpec struct {
 	VendorSpecificConfig                []DistributedVirtualSwitchKeyedOpaqueBlob      `xml:"vendorSpecificConfig,omitempty"`
 	Contact                             *DVSContactInfo                                `xml:"contact,omitempty"`
 	SwitchIpAddress                     string                                         `xml:"switchIpAddress,omitempty"`
-	DefaultProxySwitchMaxNumPorts       int                                            `xml:"defaultProxySwitchMaxNumPorts,omitempty"`
+	DefaultProxySwitchMaxNumPorts       int32                                          `xml:"defaultProxySwitchMaxNumPorts,omitempty"`
 	InfrastructureTrafficResourceConfig []DvsHostInfrastructureTrafficResource         `xml:"infrastructureTrafficResourceConfig,omitempty"`
 	NetworkResourceControlVersion       string                                         `xml:"networkResourceControlVersion,omitempty"`
 }
@@ -10280,7 +10281,7 @@ type DVSFeatureCapability struct {
 	NetworkResourceManagementSupported  bool                                    `xml:"networkResourceManagementSupported"`
 	VmDirectPathGen2Supported           bool                                    `xml:"vmDirectPathGen2Supported"`
 	NicTeamingPolicy                    []string                                `xml:"nicTeamingPolicy,omitempty"`
-	NetworkResourcePoolHighShareValue   int                                     `xml:"networkResourcePoolHighShareValue,omitempty"`
+	NetworkResourcePoolHighShareValue   int32                                   `xml:"networkResourcePoolHighShareValue,omitempty"`
 	NetworkResourceManagementCapability *DVSNetworkResourceManagementCapability `xml:"networkResourceManagementCapability,omitempty"`
 	HealthCheckCapability               BaseDVSHealthCheckCapability            `xml:"healthCheckCapability,omitempty,typeattr"`
 	RollbackCapability                  *DVSRollbackCapability                  `xml:"rollbackCapability,omitempty"`
@@ -10304,7 +10305,7 @@ type DVSHealthCheckConfig struct {
 	DynamicData
 
 	Enable   *bool `xml:"enable"`
-	Interval int   `xml:"interval,omitempty"`
+	Interval int32 `xml:"interval,omitempty"`
 }
 
 func init() {
@@ -10408,7 +10409,7 @@ type DVSNetworkResourceManagementCapability struct {
 	DynamicData
 
 	NetworkResourceManagementSupported       bool  `xml:"networkResourceManagementSupported"`
-	NetworkResourcePoolHighShareValue        int   `xml:"networkResourcePoolHighShareValue"`
+	NetworkResourcePoolHighShareValue        int32 `xml:"networkResourcePoolHighShareValue"`
 	QosSupported                             bool  `xml:"qosSupported"`
 	UserDefinedNetworkResourcePoolsSupported bool  `xml:"userDefinedNetworkResourcePoolsSupported"`
 	NetworkResourceControlVersion3Supported  *bool `xml:"networkResourceControlVersion3Supported"`
@@ -10437,7 +10438,7 @@ type DVSNetworkResourcePoolAllocationInfo struct {
 
 	Limit       int64       `xml:"limit,omitempty"`
 	Shares      *SharesInfo `xml:"shares,omitempty"`
-	PriorityTag int         `xml:"priorityTag,omitempty"`
+	PriorityTag int32       `xml:"priorityTag,omitempty"`
 }
 
 func init() {
@@ -10537,7 +10538,7 @@ type DVSSummary struct {
 
 	Name          string                               `xml:"name"`
 	Uuid          string                               `xml:"uuid"`
-	NumPorts      int                                  `xml:"numPorts"`
+	NumPorts      int32                                `xml:"numPorts"`
 	ProductInfo   *DistributedVirtualSwitchProductSpec `xml:"productInfo,omitempty"`
 	HostMember    []ManagedObjectReference             `xml:"hostMember,omitempty"`
 	Vm            []ManagedObjectReference             `xml:"vm,omitempty"`
@@ -10545,7 +10546,7 @@ type DVSSummary struct {
 	PortgroupName []string                             `xml:"portgroupName,omitempty"`
 	Description   string                               `xml:"description,omitempty"`
 	Contact       *DVSContactInfo                      `xml:"contact,omitempty"`
-	NumHosts      int                                  `xml:"numHosts,omitempty"`
+	NumHosts      int32                                `xml:"numHosts,omitempty"`
 }
 
 func init() {
@@ -10600,7 +10601,7 @@ func init() {
 type DailyTaskScheduler struct {
 	HourlyTaskScheduler
 
-	Hour int `xml:"hour"`
+	Hour int32 `xml:"hour"`
 }
 
 func init() {
@@ -11586,7 +11587,7 @@ func init() {
 type DestroyIpPoolRequestType struct {
 	This  ManagedObjectReference `xml:"_this"`
 	Dc    ManagedObjectReference `xml:"dc"`
-	Id    int                    `xml:"id"`
+	Id    int32                  `xml:"id"`
 	Force bool                   `xml:"force"`
 }
 
@@ -11902,8 +11903,8 @@ func init() {
 type DiagnosticManagerLogHeader struct {
 	DynamicData
 
-	LineStart int      `xml:"lineStart"`
-	LineEnd   int      `xml:"lineEnd"`
+	LineStart int32    `xml:"lineStart"`
+	LineEnd   int32    `xml:"lineEnd"`
 	LineText  []string `xml:"lineText,omitempty"`
 }
 
@@ -12290,7 +12291,7 @@ func init() {
 type DiskNotSupported struct {
 	VirtualHardwareCompatibilityIssue
 
-	Disk int `xml:"disk"`
+	Disk int32 `xml:"disk"`
 }
 
 func init() {
@@ -12347,7 +12348,7 @@ type DistributedVirtualPort struct {
 	Conflict         bool                                   `xml:"conflict"`
 	ConflictPortKey  string                                 `xml:"conflictPortKey,omitempty"`
 	State            *DVPortState                           `xml:"state,omitempty"`
-	ConnectionCookie int                                    `xml:"connectionCookie,omitempty"`
+	ConnectionCookie int32                                  `xml:"connectionCookie,omitempty"`
 	LastStatusChange time.Time                              `xml:"lastStatusChange"`
 	HostLocalPort    *bool                                  `xml:"hostLocalPort"`
 }
@@ -12400,7 +12401,7 @@ type DistributedVirtualSwitchHostMemberConfigInfo struct {
 	DynamicData
 
 	Host                 *ManagedObjectReference                       `xml:"host,omitempty"`
-	MaxProxySwitchPorts  int                                           `xml:"maxProxySwitchPorts"`
+	MaxProxySwitchPorts  int32                                         `xml:"maxProxySwitchPorts"`
 	VendorSpecificConfig []DistributedVirtualSwitchKeyedOpaqueBlob     `xml:"vendorSpecificConfig,omitempty"`
 	Backing              BaseDistributedVirtualSwitchHostMemberBacking `xml:"backing,typeattr"`
 }
@@ -12415,7 +12416,7 @@ type DistributedVirtualSwitchHostMemberConfigSpec struct {
 	Operation            string                                        `xml:"operation"`
 	Host                 ManagedObjectReference                        `xml:"host"`
 	Backing              BaseDistributedVirtualSwitchHostMemberBacking `xml:"backing,omitempty,typeattr"`
-	MaxProxySwitchPorts  int                                           `xml:"maxProxySwitchPorts,omitempty"`
+	MaxProxySwitchPorts  int32                                         `xml:"maxProxySwitchPorts,omitempty"`
 	VendorSpecificConfig []DistributedVirtualSwitchKeyedOpaqueBlob     `xml:"vendorSpecificConfig,omitempty"`
 }
 
@@ -12439,7 +12440,7 @@ type DistributedVirtualSwitchHostMemberPnicSpec struct {
 	PnicDevice         string `xml:"pnicDevice"`
 	UplinkPortKey      string `xml:"uplinkPortKey,omitempty"`
 	UplinkPortgroupKey string `xml:"uplinkPortgroupKey,omitempty"`
-	ConnectionCookie   int    `xml:"connectionCookie,omitempty"`
+	ConnectionCookie   int32  `xml:"connectionCookie,omitempty"`
 }
 
 func init() {
@@ -12449,7 +12450,7 @@ func init() {
 type DistributedVirtualSwitchHostMemberRuntimeState struct {
 	DynamicData
 
-	CurrentMaxProxySwitchPorts int `xml:"currentMaxProxySwitchPorts"`
+	CurrentMaxProxySwitchPorts int32 `xml:"currentMaxProxySwitchPorts"`
 }
 
 func init() {
@@ -12595,7 +12596,7 @@ type DistributedVirtualSwitchPortConnection struct {
 	SwitchUuid       string `xml:"switchUuid"`
 	PortgroupKey     string `xml:"portgroupKey,omitempty"`
 	PortKey          string `xml:"portKey,omitempty"`
-	ConnectionCookie int    `xml:"connectionCookie,omitempty"`
+	ConnectionCookie int32  `xml:"connectionCookie,omitempty"`
 }
 
 func init() {
@@ -13240,8 +13241,8 @@ func init() {
 type DvsIpPortRange struct {
 	DvsIpPort
 
-	StartPortNumber int `xml:"startPortNumber"`
-	EndPortNumber   int `xml:"endPortNumber"`
+	StartPortNumber int32 `xml:"startPortNumber"`
+	EndPortNumber   int32 `xml:"endPortNumber"`
 }
 
 func init() {
@@ -13550,7 +13551,7 @@ func init() {
 type DvsRateLimitNetworkRuleAction struct {
 	DvsNetworkRuleAction
 
-	PacketsPerSecond int `xml:"packetsPerSecond"`
+	PacketsPerSecond int32 `xml:"packetsPerSecond"`
 }
 
 func init() {
@@ -13600,9 +13601,9 @@ func init() {
 type DvsResourceRuntimeInfo struct {
 	DynamicData
 
-	Capacity                         int                                       `xml:"capacity,omitempty"`
-	Usage                            int                                       `xml:"usage,omitempty"`
-	Available                        int                                       `xml:"available,omitempty"`
+	Capacity                         int32                                     `xml:"capacity,omitempty"`
+	Usage                            int32                                     `xml:"usage,omitempty"`
+	Available                        int32                                     `xml:"available,omitempty"`
 	AllocatedResource                []DvsVnicAllocatedResource                `xml:"allocatedResource,omitempty"`
 	VmVnicNetworkResourcePoolRuntime []DvsVmVnicNetworkResourcePoolRuntimeInfo `xml:"vmVnicNetworkResourcePoolRuntime,omitempty"`
 }
@@ -13647,7 +13648,7 @@ func init() {
 type DvsSingleIpPort struct {
 	DvsIpPort
 
-	PortNumber int `xml:"portNumber"`
+	PortNumber int32 `xml:"portNumber"`
 }
 
 func init() {
@@ -13689,7 +13690,7 @@ type DvsTrafficRule struct {
 
 	Key         string                        `xml:"key,omitempty"`
 	Description string                        `xml:"description,omitempty"`
-	Sequence    int                           `xml:"sequence,omitempty"`
+	Sequence    int32                         `xml:"sequence,omitempty"`
 	Qualifier   []BaseDvsNetworkRuleQualifier `xml:"qualifier,omitempty,typeattr"`
 	Action      BaseDvsNetworkRuleAction      `xml:"action,omitempty,typeattr"`
 	Direction   string                        `xml:"direction,omitempty"`
@@ -13704,7 +13705,7 @@ type DvsTrafficRuleset struct {
 
 	Key        string           `xml:"key,omitempty"`
 	Enabled    *bool            `xml:"enabled"`
-	Precedence int              `xml:"precedence,omitempty"`
+	Precedence int32            `xml:"precedence,omitempty"`
 	Rules      []DvsTrafficRule `xml:"rules,omitempty"`
 }
 
@@ -13715,8 +13716,8 @@ func init() {
 type DvsUpdateTagNetworkRuleAction struct {
 	DvsNetworkRuleAction
 
-	QosTag  int `xml:"qosTag,omitempty"`
-	DscpTag int `xml:"dscpTag,omitempty"`
+	QosTag  int32 `xml:"qosTag,omitempty"`
+	DscpTag int32 `xml:"dscpTag,omitempty"`
 }
 
 func init() {
@@ -13779,9 +13780,9 @@ type DvsVmVnicNetworkResourcePoolRuntimeInfo struct {
 
 	Key               string                     `xml:"key"`
 	Name              string                     `xml:"name,omitempty"`
-	Capacity          int                        `xml:"capacity,omitempty"`
-	Usage             int                        `xml:"usage,omitempty"`
-	Available         int                        `xml:"available,omitempty"`
+	Capacity          int32                      `xml:"capacity,omitempty"`
+	Usage             int32                      `xml:"usage,omitempty"`
+	Available         int32                      `xml:"available,omitempty"`
 	Status            string                     `xml:"status"`
 	AllocatedResource []DvsVnicAllocatedResource `xml:"allocatedResource,omitempty"`
 }
@@ -14025,7 +14026,7 @@ type EVCMode struct {
 	FeatureRequirement    []VirtualMachineFeatureRequirement `xml:"featureRequirement,omitempty"`
 	Vendor                string                             `xml:"vendor"`
 	Track                 []string                           `xml:"track,omitempty"`
-	VendorTier            int                                `xml:"vendorTier"`
+	VendorTier            int32                              `xml:"vendorTier"`
 }
 
 func init() {
@@ -14311,7 +14312,7 @@ type EnterLockdownModeResponse struct {
 
 type EnterMaintenanceModeRequestType struct {
 	This                  ManagedObjectReference `xml:"_this"`
-	Timeout               int                    `xml:"timeout"`
+	Timeout               int32                  `xml:"timeout"`
 	EvacuatePoweredOffVms *bool                  `xml:"evacuatePoweredOffVms"`
 	MaintenanceSpec       *HostMaintenanceSpec   `xml:"maintenanceSpec,omitempty"`
 }
@@ -14495,7 +14496,7 @@ type EsxAgentHostManagerUpdateConfigResponse struct {
 type EvacuateVsanNodeRequestType struct {
 	This            ManagedObjectReference `xml:"_this"`
 	MaintenanceSpec HostMaintenanceSpec    `xml:"maintenanceSpec"`
-	Timeout         int                    `xml:"timeout"`
+	Timeout         int32                  `xml:"timeout"`
 }
 
 func init() {
@@ -14543,8 +14544,8 @@ type EvcManagerResponse struct {
 type Event struct {
 	DynamicData
 
-	Key                  int                           `xml:"key"`
-	ChainId              int                           `xml:"chainId"`
+	Key                  int32                         `xml:"key"`
+	ChainId              int32                         `xml:"chainId"`
 	CreatedTime          time.Time                     `xml:"createdTime"`
 	UserName             string                        `xml:"userName"`
 	Datacenter           *DatacenterEventArgument      `xml:"datacenter,omitempty"`
@@ -14661,7 +14662,7 @@ type EventFilterSpec struct {
 	Entity             *EventFilterSpecByEntity   `xml:"entity,omitempty"`
 	Time               *EventFilterSpecByTime     `xml:"time,omitempty"`
 	UserName           *EventFilterSpecByUsername `xml:"userName,omitempty"`
-	EventChainId       int                        `xml:"eventChainId,omitempty"`
+	EventChainId       int32                      `xml:"eventChainId,omitempty"`
 	Alarm              *ManagedObjectReference    `xml:"alarm,omitempty"`
 	ScheduledTask      *ManagedObjectReference    `xml:"scheduledTask,omitempty"`
 	DisableFullMessage *bool                      `xml:"disableFullMessage"`
@@ -14774,7 +14775,7 @@ func init() {
 
 type ExitMaintenanceModeRequestType struct {
 	This    ManagedObjectReference `xml:"_this"`
-	Timeout int                    `xml:"timeout"`
+	Timeout int32                  `xml:"timeout"`
 }
 
 func init() {
@@ -14886,7 +14887,7 @@ type ExpiredFeatureLicense struct {
 	NotEnoughLicenses
 
 	Feature        string    `xml:"feature"`
-	Count          int       `xml:"count"`
+	Count          int32     `xml:"count"`
 	ExpirationDate time.Time `xml:"expirationDate"`
 }
 
@@ -15241,7 +15242,7 @@ type ExtensionManagerIpAllocationUsage struct {
 	DynamicData
 
 	ExtensionKey string `xml:"extensionKey"`
-	NumAddresses int    `xml:"numAddresses"`
+	NumAddresses int32  `xml:"numAddresses"`
 }
 
 func init() {
@@ -15406,7 +15407,7 @@ func init() {
 type FaultToleranceConfigInfo struct {
 	DynamicData
 
-	Role          int      `xml:"role"`
+	Role          int32    `xml:"role"`
 	InstanceUuids []string `xml:"instanceUuids"`
 	ConfigPaths   []string `xml:"configPaths"`
 	Orphaned      *bool    `xml:"orphaned"`
@@ -15594,7 +15595,7 @@ func init() {
 type FcoeConfig struct {
 	DynamicData
 
-	PriorityClass int                        `xml:"priorityClass"`
+	PriorityClass int32                      `xml:"priorityClass"`
 	SourceMac     string                     `xml:"sourceMac"`
 	VlanRange     []FcoeConfigVlanRange      `xml:"vlanRange"`
 	Capabilities  FcoeConfigFcoeCapabilities `xml:"capabilities"`
@@ -15621,7 +15622,7 @@ type FcoeConfigFcoeSpecification struct {
 	DynamicData
 
 	UnderlyingPnic string                `xml:"underlyingPnic"`
-	PriorityClass  int                   `xml:"priorityClass,omitempty"`
+	PriorityClass  int32                 `xml:"priorityClass,omitempty"`
 	SourceMac      string                `xml:"sourceMac,omitempty"`
 	VlanRange      []FcoeConfigVlanRange `xml:"vlanRange,omitempty"`
 }
@@ -15633,8 +15634,8 @@ func init() {
 type FcoeConfigVlanRange struct {
 	DynamicData
 
-	VlanLow  int `xml:"vlanLow"`
-	VlanHigh int `xml:"vlanHigh"`
+	VlanLow  int32 `xml:"vlanLow"`
+	VlanHigh int32 `xml:"vlanHigh"`
 }
 
 func init() {
@@ -16416,7 +16417,7 @@ type GatewayToHostConnectFault struct {
 	GatewayConnectFault
 
 	Hostname string `xml:"hostname"`
-	Port     int    `xml:"port,omitempty"`
+	Port     int32  `xml:"port,omitempty"`
 }
 
 func init() {
@@ -16957,7 +16958,7 @@ type GuestInfoNamespaceGenerationInfo struct {
 	DynamicData
 
 	Key          string `xml:"key"`
-	GenerationNo int    `xml:"generationNo"`
+	GenerationNo int32  `xml:"generationNo"`
 }
 
 func init() {
@@ -16968,7 +16969,7 @@ type GuestListFileInfo struct {
 	DynamicData
 
 	Files     []GuestFileInfo `xml:"files,omitempty"`
-	Remaining int             `xml:"remaining"`
+	Remaining int32           `xml:"remaining"`
 }
 
 func init() {
@@ -17008,7 +17009,7 @@ type GuestNicInfo struct {
 	IpAddress      []string              `xml:"ipAddress,omitempty"`
 	MacAddress     string                `xml:"macAddress,omitempty"`
 	Connected      bool                  `xml:"connected"`
-	DeviceConfigId int                   `xml:"deviceConfigId"`
+	DeviceConfigId int32                 `xml:"deviceConfigId"`
 	DnsConfig      *NetDnsConfigInfo     `xml:"dnsConfig,omitempty"`
 	IpConfig       *NetIpConfigInfo      `xml:"ipConfig,omitempty"`
 	NetBIOSConfig  BaseNetBIOSConfigInfo `xml:"netBIOSConfig,omitempty,typeattr"`
@@ -17052,18 +17053,18 @@ type GuestOsDescriptor struct {
 	Id                              string          `xml:"id"`
 	Family                          string          `xml:"family"`
 	FullName                        string          `xml:"fullName"`
-	SupportedMaxCPUs                int             `xml:"supportedMaxCPUs"`
-	NumSupportedPhysicalSockets     int             `xml:"numSupportedPhysicalSockets,omitempty"`
-	NumSupportedCoresPerSocket      int             `xml:"numSupportedCoresPerSocket,omitempty"`
-	SupportedMinMemMB               int             `xml:"supportedMinMemMB"`
-	SupportedMaxMemMB               int             `xml:"supportedMaxMemMB"`
-	RecommendedMemMB                int             `xml:"recommendedMemMB"`
-	RecommendedColorDepth           int             `xml:"recommendedColorDepth"`
+	SupportedMaxCPUs                int32           `xml:"supportedMaxCPUs"`
+	NumSupportedPhysicalSockets     int32           `xml:"numSupportedPhysicalSockets,omitempty"`
+	NumSupportedCoresPerSocket      int32           `xml:"numSupportedCoresPerSocket,omitempty"`
+	SupportedMinMemMB               int32           `xml:"supportedMinMemMB"`
+	SupportedMaxMemMB               int32           `xml:"supportedMaxMemMB"`
+	RecommendedMemMB                int32           `xml:"recommendedMemMB"`
+	RecommendedColorDepth           int32           `xml:"recommendedColorDepth"`
 	SupportedDiskControllerList     []string        `xml:"supportedDiskControllerList"`
 	RecommendedSCSIController       string          `xml:"recommendedSCSIController,omitempty"`
 	RecommendedDiskController       string          `xml:"recommendedDiskController"`
-	SupportedNumDisks               int             `xml:"supportedNumDisks"`
-	RecommendedDiskSizeMB           int             `xml:"recommendedDiskSizeMB"`
+	SupportedNumDisks               int32           `xml:"supportedNumDisks"`
+	RecommendedDiskSizeMB           int32           `xml:"recommendedDiskSizeMB"`
 	RecommendedCdromController      string          `xml:"recommendedCdromController,omitempty"`
 	SupportedEthernetCard           []string        `xml:"supportedEthernetCard"`
 	RecommendedEthernetCard         string          `xml:"recommendedEthernetCard,omitempty"`
@@ -17087,7 +17088,7 @@ type GuestOsDescriptor struct {
 	SupportLevel                    string          `xml:"supportLevel,omitempty"`
 	SupportedForCreate              *bool           `xml:"supportedForCreate"`
 	VRAMSizeInKB                    *IntOption      `xml:"vRAMSizeInKB,omitempty"`
-	NumSupportedFloppyDevices       int             `xml:"numSupportedFloppyDevices,omitempty"`
+	NumSupportedFloppyDevices       int32           `xml:"numSupportedFloppyDevices,omitempty"`
 	WakeOnLanEthernetCard           []string        `xml:"wakeOnLanEthernetCard,omitempty"`
 	SupportsPvscsiControllerForBoot *bool           `xml:"supportsPvscsiControllerForBoot"`
 	DiskUuidEnabled                 *bool           `xml:"diskUuidEnabled"`
@@ -17115,8 +17116,8 @@ func init() {
 type GuestPosixFileAttributes struct {
 	GuestFileAttributes
 
-	OwnerId     int   `xml:"ownerId,omitempty"`
-	GroupId     int   `xml:"groupId,omitempty"`
+	OwnerId     int32 `xml:"ownerId,omitempty"`
+	GroupId     int32 `xml:"groupId,omitempty"`
 	Permissions int64 `xml:"permissions,omitempty"`
 }
 
@@ -17133,7 +17134,7 @@ type GuestProcessInfo struct {
 	CmdLine   string     `xml:"cmdLine"`
 	StartTime time.Time  `xml:"startTime"`
 	EndTime   *time.Time `xml:"endTime"`
-	ExitCode  int        `xml:"exitCode,omitempty"`
+	ExitCode  int32      `xml:"exitCode,omitempty"`
 }
 
 func init() {
@@ -17224,7 +17225,7 @@ func init() {
 type GuestRegValueDwordSpec struct {
 	GuestRegValueDataSpec
 
-	Value int `xml:"value"`
+	Value int32 `xml:"value"`
 }
 
 func init() {
@@ -17415,8 +17416,8 @@ func init() {
 type GuestScreenInfo struct {
 	DynamicData
 
-	Width  int `xml:"width"`
-	Height int `xml:"height"`
+	Width  int32 `xml:"width"`
+	Height int32 `xml:"height"`
 }
 
 func init() {
@@ -17848,10 +17849,10 @@ type HostCapability struct {
 	VmotionSupported                          bool            `xml:"vmotionSupported"`
 	StandbySupported                          bool            `xml:"standbySupported"`
 	IpmiSupported                             *bool           `xml:"ipmiSupported"`
-	MaxSupportedVMs                           int             `xml:"maxSupportedVMs,omitempty"`
-	MaxRunningVMs                             int             `xml:"maxRunningVMs,omitempty"`
-	MaxSupportedVcpus                         int             `xml:"maxSupportedVcpus,omitempty"`
-	MaxRegisteredVMs                          int             `xml:"maxRegisteredVMs,omitempty"`
+	MaxSupportedVMs                           int32           `xml:"maxSupportedVMs,omitempty"`
+	MaxRunningVMs                             int32           `xml:"maxRunningVMs,omitempty"`
+	MaxSupportedVcpus                         int32           `xml:"maxSupportedVcpus,omitempty"`
+	MaxRegisteredVMs                          int32           `xml:"maxRegisteredVMs,omitempty"`
 	DatastorePrincipalSupported               bool            `xml:"datastorePrincipalSupported"`
 	SanSupported                              bool            `xml:"sanSupported"`
 	NfsSupported                              bool            `xml:"nfsSupported"`
@@ -17872,7 +17873,7 @@ type HostCapability struct {
 	StorageVMotionSupported                   *bool           `xml:"storageVMotionSupported"`
 	VmotionWithStorageVMotionSupported        *bool           `xml:"vmotionWithStorageVMotionSupported"`
 	VmotionAcrossNetworkSupported             *bool           `xml:"vmotionAcrossNetworkSupported"`
-	MaxNumDisksSVMotion                       int             `xml:"maxNumDisksSVMotion,omitempty"`
+	MaxNumDisksSVMotion                       int32           `xml:"maxNumDisksSVMotion,omitempty"`
 	HbrNicSelectionSupported                  *bool           `xml:"hbrNicSelectionSupported"`
 	VrNfcNicSelectionSupported                *bool           `xml:"vrNfcNicSelectionSupported"`
 	RecordReplaySupported                     *bool           `xml:"recordReplaySupported"`
@@ -17882,7 +17883,7 @@ type HostCapability struct {
 	SmpFtSupported                            *bool           `xml:"smpFtSupported"`
 	FtCompatibilityIssues                     []string        `xml:"ftCompatibilityIssues,omitempty"`
 	SmpFtCompatibilityIssues                  []string        `xml:"smpFtCompatibilityIssues,omitempty"`
-	MaxVcpusPerFtVm                           int             `xml:"maxVcpusPerFtVm,omitempty"`
+	MaxVcpusPerFtVm                           int32           `xml:"maxVcpusPerFtVm,omitempty"`
 	LoginBySSLThumbprintSupported             *bool           `xml:"loginBySSLThumbprintSupported"`
 	CloneFromSnapshotSupported                *bool           `xml:"cloneFromSnapshotSupported"`
 	DeltaDiskBackingsSupported                *bool           `xml:"deltaDiskBackingsSupported"`
@@ -17894,13 +17895,13 @@ type HostCapability struct {
 	VmDirectPathGen2Supported                 *bool           `xml:"vmDirectPathGen2Supported"`
 	VmDirectPathGen2UnsupportedReason         []string        `xml:"vmDirectPathGen2UnsupportedReason,omitempty"`
 	VmDirectPathGen2UnsupportedReasonExtended string          `xml:"vmDirectPathGen2UnsupportedReasonExtended,omitempty"`
-	SupportedVmfsMajorVersion                 []int           `xml:"supportedVmfsMajorVersion,omitempty"`
+	SupportedVmfsMajorVersion                 []int32         `xml:"supportedVmfsMajorVersion,omitempty"`
 	VStorageCapable                           *bool           `xml:"vStorageCapable"`
 	SnapshotRelayoutSupported                 *bool           `xml:"snapshotRelayoutSupported"`
 	FirewallIpRulesSupported                  *bool           `xml:"firewallIpRulesSupported"`
 	ServicePackageInfoSupported               *bool           `xml:"servicePackageInfoSupported"`
-	MaxHostRunningVms                         int             `xml:"maxHostRunningVms,omitempty"`
-	MaxHostSupportedVcpus                     int             `xml:"maxHostSupportedVcpus,omitempty"`
+	MaxHostRunningVms                         int32           `xml:"maxHostRunningVms,omitempty"`
+	MaxHostSupportedVcpus                     int32           `xml:"maxHostSupportedVcpus,omitempty"`
 	VmfsDatastoreMountCapable                 *bool           `xml:"vmfsDatastoreMountCapable"`
 	EightPlusHostVmfsSharedAccessSupported    *bool           `xml:"eightPlusHostVmfsSharedAccessSupported"`
 	NestedHVSupported                         *bool           `xml:"nestedHVSupported"`
@@ -18262,7 +18263,7 @@ type HostConfigSummary struct {
 	DynamicData
 
 	Name                  string                   `xml:"name"`
-	Port                  int                      `xml:"port"`
+	Port                  int32                    `xml:"port"`
 	SslThumbprint         string                   `xml:"sslThumbprint,omitempty"`
 	Product               *AboutInfo               `xml:"product,omitempty"`
 	VmotionEnabled        bool                     `xml:"vmotionEnabled"`
@@ -18359,7 +18360,7 @@ type HostConnectSpec struct {
 	DynamicData
 
 	HostName           string                  `xml:"hostName,omitempty"`
-	Port               int                     `xml:"port,omitempty"`
+	Port               int32                   `xml:"port,omitempty"`
 	SslThumbprint      string                  `xml:"sslThumbprint,omitempty"`
 	UserName           string                  `xml:"userName,omitempty"`
 	Password           string                  `xml:"password,omitempty"`
@@ -18395,7 +18396,7 @@ func init() {
 type HostCpuIdInfo struct {
 	DynamicData
 
-	Level  int    `xml:"level"`
+	Level  int32  `xml:"level"`
 	Vendor string `xml:"vendor,omitempty"`
 	Eax    string `xml:"eax,omitempty"`
 	Ebx    string `xml:"ebx,omitempty"`
@@ -18625,7 +18626,7 @@ type HostDateTimeSystemTimeZone struct {
 	Key         string `xml:"key"`
 	Name        string `xml:"name"`
 	Description string `xml:"description"`
-	GmtOffset   int    `xml:"gmtOffset"`
+	GmtOffset   int32  `xml:"gmtOffset"`
 }
 
 func init() {
@@ -18670,10 +18671,10 @@ type HostDhcpServiceSpec struct {
 	DynamicData
 
 	VirtualSwitch        string `xml:"virtualSwitch"`
-	DefaultLeaseDuration int    `xml:"defaultLeaseDuration"`
+	DefaultLeaseDuration int32  `xml:"defaultLeaseDuration"`
 	LeaseBeginIp         string `xml:"leaseBeginIp"`
 	LeaseEndIp           string `xml:"leaseEndIp"`
-	MaxLeaseDuration     int    `xml:"maxLeaseDuration"`
+	MaxLeaseDuration     int32  `xml:"maxLeaseDuration"`
 	UnlimitedLease       bool   `xml:"unlimitedLease"`
 	IpSubnetAddr         string `xml:"ipSubnetAddr"`
 	IpSubnetMask         string `xml:"ipSubnetMask"`
@@ -18688,7 +18689,7 @@ type HostDiagnosticPartition struct {
 
 	StorageType    string                `xml:"storageType"`
 	DiagnosticType string                `xml:"diagnosticType"`
-	Slots          int                   `xml:"slots"`
+	Slots          int32                 `xml:"slots"`
 	Id             HostScsiDiskPartition `xml:"id"`
 }
 
@@ -18788,8 +18789,8 @@ type HostDiskDimensionsChs struct {
 	DynamicData
 
 	Cylinder int64 `xml:"cylinder"`
-	Head     int   `xml:"head"`
-	Sector   int   `xml:"sector"`
+	Head     int32 `xml:"head"`
+	Sector   int32 `xml:"sector"`
 }
 
 func init() {
@@ -18799,7 +18800,7 @@ func init() {
 type HostDiskDimensionsLba struct {
 	DynamicData
 
-	BlockSize int   `xml:"blockSize"`
+	BlockSize int32 `xml:"blockSize"`
 	Block     int64 `xml:"block"`
 }
 
@@ -18857,7 +18858,7 @@ func init() {
 type HostDiskPartitionAttributes struct {
 	DynamicData
 
-	Partition          int    `xml:"partition"`
+	Partition          int32  `xml:"partition"`
 	StartSector        int64  `xml:"startSector"`
 	EndSector          int64  `xml:"endSector"`
 	Type               string `xml:"type"`
@@ -18874,7 +18875,7 @@ func init() {
 type HostDiskPartitionBlockRange struct {
 	DynamicData
 
-	Partition int                   `xml:"partition,omitempty"`
+	Partition int32                 `xml:"partition,omitempty"`
 	Type      string                `xml:"type"`
 	Start     HostDiskDimensionsLba `xml:"start"`
 	End       HostDiskDimensionsLba `xml:"end"`
@@ -19071,7 +19072,7 @@ type HostFibreChannelOverEthernetHbaLinkInfo struct {
 
 	VnportMac string `xml:"vnportMac"`
 	FcfMac    string `xml:"fcfMac"`
-	VlanId    int    `xml:"vlanId"`
+	VlanId    int32  `xml:"vlanId"`
 }
 
 func init() {
@@ -19083,7 +19084,7 @@ type HostFibreChannelOverEthernetTargetTransport struct {
 
 	VnportMac string `xml:"vnportMac"`
 	FcfMac    string `xml:"fcfMac"`
-	VlanId    int    `xml:"vlanId"`
+	VlanId    int32  `xml:"vlanId"`
 }
 
 func init() {
@@ -19195,8 +19196,8 @@ func init() {
 type HostFirewallRule struct {
 	DynamicData
 
-	Port      int                       `xml:"port"`
-	EndPort   int                       `xml:"endPort,omitempty"`
+	Port      int32                     `xml:"port"`
+	EndPort   int32                     `xml:"endPort,omitempty"`
 	Direction HostFirewallRuleDirection `xml:"direction"`
 	PortType  HostFirewallRulePortType  `xml:"portType,omitempty"`
 	Protocol  string                    `xml:"protocol"`
@@ -19238,7 +19239,7 @@ type HostFirewallRulesetIpNetwork struct {
 	DynamicData
 
 	Network      string `xml:"network"`
-	PrefixLength int    `xml:"prefixLength"`
+	PrefixLength int32  `xml:"prefixLength"`
 }
 
 func init() {
@@ -19383,12 +19384,12 @@ type HostHardwareSummary struct {
 	OtherIdentifyingInfo []HostSystemIdentificationInfo `xml:"otherIdentifyingInfo,omitempty"`
 	MemorySize           int64                          `xml:"memorySize"`
 	CpuModel             string                         `xml:"cpuModel"`
-	CpuMhz               int                            `xml:"cpuMhz"`
+	CpuMhz               int32                          `xml:"cpuMhz"`
 	NumCpuPkgs           int16                          `xml:"numCpuPkgs"`
 	NumCpuCores          int16                          `xml:"numCpuCores"`
 	NumCpuThreads        int16                          `xml:"numCpuThreads"`
-	NumNics              int                            `xml:"numNics"`
-	NumHBAs              int                            `xml:"numHBAs"`
+	NumNics              int32                          `xml:"numNics"`
+	NumHBAs              int32                          `xml:"numHBAs"`
 }
 
 func init() {
@@ -19418,7 +19419,7 @@ type HostHostBusAdapter struct {
 
 	Key    string `xml:"key,omitempty"`
 	Device string `xml:"device"`
-	Bus    int    `xml:"bus"`
+	Bus    int32  `xml:"bus"`
 	Status string `xml:"status"`
 	Model  string `xml:"model"`
 	Driver string `xml:"driver,omitempty"`
@@ -19564,8 +19565,8 @@ type HostInternetScsiHba struct {
 	IScsiAlias                 string                                        `xml:"iScsiAlias,omitempty"`
 	ConfiguredSendTarget       []HostInternetScsiHbaSendTarget               `xml:"configuredSendTarget,omitempty"`
 	ConfiguredStaticTarget     []HostInternetScsiHbaStaticTarget             `xml:"configuredStaticTarget,omitempty"`
-	MaxSpeedMb                 int                                           `xml:"maxSpeedMb,omitempty"`
-	CurrentSpeedMb             int                                           `xml:"currentSpeedMb,omitempty"`
+	MaxSpeedMb                 int32                                         `xml:"maxSpeedMb,omitempty"`
+	CurrentSpeedMb             int32                                         `xml:"currentSpeedMb,omitempty"`
 }
 
 func init() {
@@ -19679,12 +19680,12 @@ type HostInternetScsiHbaIPCapabilities struct {
 	Ipv4EnableSettable                           *bool `xml:"ipv4EnableSettable"`
 	Ipv6EnableSettable                           *bool `xml:"ipv6EnableSettable"`
 	Ipv6PrefixLengthSettable                     *bool `xml:"ipv6PrefixLengthSettable"`
-	Ipv6PrefixLength                             int   `xml:"ipv6PrefixLength,omitempty"`
+	Ipv6PrefixLength                             int32 `xml:"ipv6PrefixLength,omitempty"`
 	Ipv6DhcpConfigurationSettable                *bool `xml:"ipv6DhcpConfigurationSettable"`
 	Ipv6LinkLocalAutoConfigurationSettable       *bool `xml:"ipv6LinkLocalAutoConfigurationSettable"`
 	Ipv6RouterAdvertisementConfigurationSettable *bool `xml:"ipv6RouterAdvertisementConfigurationSettable"`
 	Ipv6DefaultGatewaySettable                   *bool `xml:"ipv6DefaultGatewaySettable"`
-	Ipv6MaxStaticAddressesSupported              int   `xml:"ipv6MaxStaticAddressesSupported,omitempty"`
+	Ipv6MaxStaticAddressesSupported              int32 `xml:"ipv6MaxStaticAddressesSupported,omitempty"`
 }
 
 func init() {
@@ -19705,7 +19706,7 @@ type HostInternetScsiHbaIPProperties struct {
 	Ipv6SubnetMask            string                             `xml:"ipv6SubnetMask,omitempty"`
 	Ipv6DefaultGateway        string                             `xml:"ipv6DefaultGateway,omitempty"`
 	ArpRedirectEnabled        *bool                              `xml:"arpRedirectEnabled"`
-	Mtu                       int                                `xml:"mtu,omitempty"`
+	Mtu                       int32                              `xml:"mtu,omitempty"`
 	JumboFramesEnabled        *bool                              `xml:"jumboFramesEnabled"`
 	Ipv4Enabled               *bool                              `xml:"ipv4Enabled"`
 	Ipv6Enabled               *bool                              `xml:"ipv6Enabled"`
@@ -19734,7 +19735,7 @@ type HostInternetScsiHbaIscsiIpv6Address struct {
 	DynamicData
 
 	Address      string `xml:"address"`
-	PrefixLength int    `xml:"prefixLength"`
+	PrefixLength int32  `xml:"prefixLength"`
 	Origin       string `xml:"origin"`
 	Operation    string `xml:"operation,omitempty"`
 }
@@ -19757,7 +19758,7 @@ type HostInternetScsiHbaSendTarget struct {
 	DynamicData
 
 	Address                  string                                       `xml:"address"`
-	Port                     int                                          `xml:"port,omitempty"`
+	Port                     int32                                        `xml:"port,omitempty"`
 	AuthenticationProperties *HostInternetScsiHbaAuthenticationProperties `xml:"authenticationProperties,omitempty"`
 	DigestProperties         *HostInternetScsiHbaDigestProperties         `xml:"digestProperties,omitempty"`
 	SupportedAdvancedOptions []OptionDef                                  `xml:"supportedAdvancedOptions,omitempty"`
@@ -19773,7 +19774,7 @@ type HostInternetScsiHbaStaticTarget struct {
 	DynamicData
 
 	Address                  string                                       `xml:"address"`
-	Port                     int                                          `xml:"port,omitempty"`
+	Port                     int32                                        `xml:"port,omitempty"`
 	IScsiName                string                                       `xml:"iScsiName"`
 	DiscoveryMethod          string                                       `xml:"discoveryMethod,omitempty"`
 	AuthenticationProperties *HostInternetScsiHbaAuthenticationProperties `xml:"authenticationProperties,omitempty"`
@@ -19813,7 +19814,7 @@ func init() {
 type HostInventoryFull struct {
 	NotEnoughLicenses
 
-	Capacity int `xml:"capacity"`
+	Capacity int32 `xml:"capacity"`
 }
 
 func init() {
@@ -19823,7 +19824,7 @@ func init() {
 type HostInventoryFullEvent struct {
 	LicenseEvent
 
-	Capacity int `xml:"capacity"`
+	Capacity int32 `xml:"capacity"`
 }
 
 func init() {
@@ -19882,7 +19883,7 @@ type HostIpConfigIpV6Address struct {
 	DynamicData
 
 	IpAddress    string     `xml:"ipAddress"`
-	PrefixLength int        `xml:"prefixLength"`
+	PrefixLength int32      `xml:"prefixLength"`
 	Origin       string     `xml:"origin,omitempty"`
 	DadState     string     `xml:"dadState,omitempty"`
 	Lifetime     *time.Time `xml:"lifetime"`
@@ -19944,7 +19945,7 @@ type HostIpRouteEntry struct {
 	DynamicData
 
 	Network      string `xml:"network"`
-	PrefixLength int    `xml:"prefixLength"`
+	PrefixLength int32  `xml:"prefixLength"`
 	Gateway      string `xml:"gateway"`
 	DeviceName   string `xml:"deviceName,omitempty"`
 }
@@ -20095,11 +20096,11 @@ func init() {
 type HostListSummaryQuickStats struct {
 	DynamicData
 
-	OverallCpuUsage           int `xml:"overallCpuUsage,omitempty"`
-	OverallMemoryUsage        int `xml:"overallMemoryUsage,omitempty"`
-	DistributedCpuFairness    int `xml:"distributedCpuFairness,omitempty"`
-	DistributedMemoryFairness int `xml:"distributedMemoryFairness,omitempty"`
-	Uptime                    int `xml:"uptime,omitempty"`
+	OverallCpuUsage           int32 `xml:"overallCpuUsage,omitempty"`
+	OverallMemoryUsage        int32 `xml:"overallMemoryUsage,omitempty"`
+	DistributedCpuFairness    int32 `xml:"distributedCpuFairness,omitempty"`
+	DistributedMemoryFairness int32 `xml:"distributedMemoryFairness,omitempty"`
+	Uptime                    int32 `xml:"uptime,omitempty"`
 }
 
 func init() {
@@ -20149,8 +20150,8 @@ type HostLowLevelProvisioningManagerDiskLayoutSpec struct {
 	DynamicData
 
 	ControllerType string `xml:"controllerType"`
-	BusNumber      int    `xml:"busNumber"`
-	UnitNumber     int    `xml:"unitNumber"`
+	BusNumber      int32  `xml:"busNumber"`
+	UnitNumber     *int32 `xml:"unitNumber"`
 	SrcFilename    string `xml:"srcFilename"`
 	DstFilename    string `xml:"dstFilename"`
 }
@@ -20209,7 +20210,7 @@ func init() {
 type HostLowLevelProvisioningManagerSnapshotLayoutSpec struct {
 	DynamicData
 
-	Id          int                                             `xml:"id"`
+	Id          int32                                           `xml:"id"`
 	SrcFilename string                                          `xml:"srcFilename"`
 	DstFilename string                                          `xml:"dstFilename"`
 	Disk        []HostLowLevelProvisioningManagerDiskLayoutSpec `xml:"disk,omitempty"`
@@ -20515,12 +20516,12 @@ type HostNatServiceNameServiceSpec struct {
 
 	DnsAutoDetect bool     `xml:"dnsAutoDetect"`
 	DnsPolicy     string   `xml:"dnsPolicy"`
-	DnsRetries    int      `xml:"dnsRetries"`
-	DnsTimeout    int      `xml:"dnsTimeout"`
+	DnsRetries    int32    `xml:"dnsRetries"`
+	DnsTimeout    int32    `xml:"dnsTimeout"`
 	DnsNameServer []string `xml:"dnsNameServer,omitempty"`
-	NbdsTimeout   int      `xml:"nbdsTimeout"`
-	NbnsRetries   int      `xml:"nbnsRetries"`
-	NbnsTimeout   int      `xml:"nbnsTimeout"`
+	NbdsTimeout   int32    `xml:"nbdsTimeout"`
+	NbnsRetries   int32    `xml:"nbnsRetries"`
+	NbnsTimeout   int32    `xml:"nbnsTimeout"`
 }
 
 func init() {
@@ -20532,8 +20533,8 @@ type HostNatServicePortForwardSpec struct {
 
 	Type           string `xml:"type"`
 	Name           string `xml:"name"`
-	HostPort       int    `xml:"hostPort"`
-	GuestPort      int    `xml:"guestPort"`
+	HostPort       int32  `xml:"hostPort"`
+	GuestPort      int32  `xml:"guestPort"`
 	GuestIpAddress string `xml:"guestIpAddress"`
 }
 
@@ -20549,7 +20550,7 @@ type HostNatServiceSpec struct {
 	AllowAnyOui      bool                            `xml:"allowAnyOui"`
 	ConfigPort       bool                            `xml:"configPort"`
 	IpGatewayAddress string                          `xml:"ipGatewayAddress"`
-	UdpTimeout       int                             `xml:"udpTimeout"`
+	UdpTimeout       int32                           `xml:"udpTimeout"`
 	PortForward      []HostNatServicePortForwardSpec `xml:"portForward,omitempty"`
 	NameService      *HostNatServiceNameServiceSpec  `xml:"nameService,omitempty"`
 }
@@ -20567,7 +20568,7 @@ type HostNetCapabilities struct {
 	SupportsVlan               bool     `xml:"supportsVlan"`
 	UsesServiceConsoleNic      bool     `xml:"usesServiceConsoleNic"`
 	SupportsNetworkHints       bool     `xml:"supportsNetworkHints"`
-	MaxPortGroupsPerVswitch    int      `xml:"maxPortGroupsPerVswitch,omitempty"`
+	MaxPortGroupsPerVswitch    int32    `xml:"maxPortGroupsPerVswitch,omitempty"`
 	VswitchConfigSupported     bool     `xml:"vswitchConfigSupported"`
 	VnicConfigSupported        bool     `xml:"vnicConfigSupported"`
 	IpRouteConfigSupported     bool     `xml:"ipRouteConfigSupported"`
@@ -20599,7 +20600,7 @@ type HostNetStackInstance struct {
 	Name                            string                  `xml:"name,omitempty"`
 	DnsConfig                       BaseHostDnsConfig       `xml:"dnsConfig,omitempty,typeattr"`
 	IpRouteConfig                   BaseHostIpRouteConfig   `xml:"ipRouteConfig,omitempty,typeattr"`
-	RequestedMaxNumberOfConnections int                     `xml:"requestedMaxNumberOfConnections,omitempty"`
+	RequestedMaxNumberOfConnections int32                   `xml:"requestedMaxNumberOfConnections,omitempty"`
 	CongestionControlAlgorithm      string                  `xml:"congestionControlAlgorithm,omitempty"`
 	IpV6Enabled                     *bool                   `xml:"ipV6Enabled"`
 	RouteTableConfig                *HostIpRouteTableConfig `xml:"routeTableConfig,omitempty"`
@@ -20740,11 +20741,11 @@ type HostNicFailureCriteria struct {
 	DynamicData
 
 	CheckSpeed        string `xml:"checkSpeed,omitempty"`
-	Speed             int    `xml:"speed,omitempty"`
+	Speed             int32  `xml:"speed,omitempty"`
 	CheckDuplex       *bool  `xml:"checkDuplex"`
 	FullDuplex        *bool  `xml:"fullDuplex"`
 	CheckErrorPercent *bool  `xml:"checkErrorPercent"`
-	Percentage        int    `xml:"percentage,omitempty"`
+	Percentage        int32  `xml:"percentage,omitempty"`
 	CheckBeacon       *bool  `xml:"checkBeacon"`
 }
 
@@ -20863,7 +20864,7 @@ type HostNumaInfo struct {
 	DynamicData
 
 	Type     string         `xml:"type"`
-	NumNodes int            `xml:"numNodes"`
+	NumNodes int32          `xml:"numNodes"`
 	NumaNode []HostNumaNode `xml:"numaNode,omitempty"`
 }
 
@@ -20890,7 +20891,7 @@ type HostNumericSensorInfo struct {
 	Name           string                 `xml:"name"`
 	HealthState    BaseElementDescription `xml:"healthState,omitempty,typeattr"`
 	CurrentReading int64                  `xml:"currentReading"`
-	UnitModifier   int                    `xml:"unitModifier"`
+	UnitModifier   int32                  `xml:"unitModifier"`
 	BaseUnits      string                 `xml:"baseUnits"`
 	RateUnits      string                 `xml:"rateUnits,omitempty"`
 	SensorType     string                 `xml:"sensorType"`
@@ -20978,7 +20979,7 @@ type HostPatchManagerPatchManagerOperationSpec struct {
 	DynamicData
 
 	Proxy     string `xml:"proxy,omitempty"`
-	Port      int    `xml:"port,omitempty"`
+	Port      int32  `xml:"port,omitempty"`
 	UserName  string `xml:"userName,omitempty"`
 	Password  string `xml:"password,omitempty"`
 	CmdOption string `xml:"cmdOption,omitempty"`
@@ -21092,7 +21093,7 @@ type HostPlacedVirtualNicIdentifier struct {
 
 	Vm          ManagedObjectReference `xml:"vm"`
 	VnicKey     string                 `xml:"vnicKey"`
-	Reservation int                    `xml:"reservation,omitempty"`
+	Reservation int32                  `xml:"reservation,omitempty"`
 }
 
 func init() {
@@ -21142,9 +21143,9 @@ type HostPlugStoreTopologyPath struct {
 
 	Key           string `xml:"key"`
 	Name          string `xml:"name"`
-	ChannelNumber int    `xml:"channelNumber,omitempty"`
-	TargetNumber  int    `xml:"targetNumber,omitempty"`
-	LunNumber     int    `xml:"lunNumber,omitempty"`
+	ChannelNumber int32  `xml:"channelNumber,omitempty"`
+	TargetNumber  int32  `xml:"targetNumber,omitempty"`
+	LunNumber     int32  `xml:"lunNumber,omitempty"`
 	Adapter       string `xml:"adapter,omitempty"`
 	Target        string `xml:"target,omitempty"`
 	Device        string `xml:"device,omitempty"`
@@ -21242,7 +21243,7 @@ type HostPortGroupSpec struct {
 	DynamicData
 
 	Name        string            `xml:"name"`
-	VlanId      int               `xml:"vlanId"`
+	VlanId      int32             `xml:"vlanId"`
 	VswitchName string            `xml:"vswitchName"`
 	Policy      HostNetworkPolicy `xml:"policy"`
 }
@@ -21254,7 +21255,7 @@ func init() {
 type HostPosixAccountSpec struct {
 	HostAccountSpec
 
-	PosixId     int   `xml:"posixId,omitempty"`
+	PosixId     int32 `xml:"posixId,omitempty"`
 	ShellAccess *bool `xml:"shellAccess"`
 }
 
@@ -21279,7 +21280,7 @@ func init() {
 type HostPowerPolicy struct {
 	DynamicData
 
-	Key         int    `xml:"key"`
+	Key         int32  `xml:"key"`
 	Name        string `xml:"name"`
 	ShortName   string `xml:"shortName"`
 	Description string `xml:"description"`
@@ -21402,11 +21403,11 @@ type HostProxySwitch struct {
 	DvsUuid                     string                         `xml:"dvsUuid"`
 	DvsName                     string                         `xml:"dvsName"`
 	Key                         string                         `xml:"key"`
-	NumPorts                    int                            `xml:"numPorts"`
-	ConfigNumPorts              int                            `xml:"configNumPorts,omitempty"`
-	NumPortsAvailable           int                            `xml:"numPortsAvailable"`
+	NumPorts                    int32                          `xml:"numPorts"`
+	ConfigNumPorts              int32                          `xml:"configNumPorts,omitempty"`
+	NumPortsAvailable           int32                          `xml:"numPortsAvailable"`
 	UplinkPort                  []KeyValue                     `xml:"uplinkPort,omitempty"`
-	Mtu                         int                            `xml:"mtu,omitempty"`
+	Mtu                         int32                          `xml:"mtu,omitempty"`
 	Pnic                        []string                       `xml:"pnic,omitempty"`
 	Spec                        HostProxySwitchSpec            `xml:"spec"`
 	HostLag                     []HostProxySwitchHostLagConfig `xml:"hostLag,omitempty"`
@@ -21532,7 +21533,7 @@ type HostRuntimeInfoNetStackInstanceRuntimeInfo struct {
 	NetStackInstanceKey    string   `xml:"netStackInstanceKey"`
 	State                  string   `xml:"state,omitempty"`
 	VmknicKeys             []string `xml:"vmknicKeys,omitempty"`
-	MaxNumberOfConnections int      `xml:"maxNumberOfConnections,omitempty"`
+	MaxNumberOfConnections int32    `xml:"maxNumberOfConnections,omitempty"`
 	CurrentIpV6Enabled     *bool    `xml:"currentIpV6Enabled"`
 }
 
@@ -21571,7 +21572,7 @@ type HostScsiDiskPartition struct {
 	DynamicData
 
 	DiskName  string `xml:"diskName"`
-	Partition int    `xml:"partition"`
+	Partition int32  `xml:"partition"`
 }
 
 func init() {
@@ -21604,7 +21605,7 @@ type HostScsiTopologyLun struct {
 	DynamicData
 
 	Key     string `xml:"key"`
-	Lun     int    `xml:"lun"`
+	Lun     int32  `xml:"lun"`
 	ScsiLun string `xml:"scsiLun"`
 }
 
@@ -21616,7 +21617,7 @@ type HostScsiTopologyTarget struct {
 	DynamicData
 
 	Key       string                  `xml:"key"`
-	Target    int                     `xml:"target"`
+	Target    int32                   `xml:"target"`
 	Lun       []HostScsiTopologyLun   `xml:"lun,omitempty"`
 	Transport BaseHostTargetTransport `xml:"transport,omitempty,typeattr"`
 }
@@ -21690,7 +21691,7 @@ type HostServiceTicket struct {
 	DynamicData
 
 	Host           string `xml:"host,omitempty"`
-	Port           int    `xml:"port,omitempty"`
+	Port           int32  `xml:"port,omitempty"`
 	SslThumbprint  string `xml:"sslThumbprint,omitempty"`
 	Service        string `xml:"service"`
 	ServiceVersion string `xml:"serviceVersion"`
@@ -21736,7 +21737,7 @@ type HostSnmpConfigSpec struct {
 	DynamicData
 
 	Enabled             *bool                 `xml:"enabled"`
-	Port                int                   `xml:"port,omitempty"`
+	Port                int32                 `xml:"port,omitempty"`
 	ReadOnlyCommunities []string              `xml:"readOnlyCommunities,omitempty"`
 	TrapTargets         []HostSnmpDestination `xml:"trapTargets,omitempty"`
 	Option              []KeyValue            `xml:"option,omitempty"`
@@ -21750,7 +21751,7 @@ type HostSnmpDestination struct {
 	DynamicData
 
 	HostName  string `xml:"hostName"`
-	Port      int    `xml:"port"`
+	Port      int32  `xml:"port"`
 	Community string `xml:"community"`
 }
 
@@ -21761,10 +21762,10 @@ func init() {
 type HostSnmpSystemAgentLimits struct {
 	DynamicData
 
-	MaxReadOnlyCommunities int                     `xml:"maxReadOnlyCommunities"`
-	MaxTrapDestinations    int                     `xml:"maxTrapDestinations"`
-	MaxCommunityLength     int                     `xml:"maxCommunityLength"`
-	MaxBufferSize          int                     `xml:"maxBufferSize"`
+	MaxReadOnlyCommunities int32                   `xml:"maxReadOnlyCommunities"`
+	MaxTrapDestinations    int32                   `xml:"maxTrapDestinations"`
+	MaxCommunityLength     int32                   `xml:"maxCommunityLength"`
+	MaxBufferSize          int32                   `xml:"maxBufferSize"`
 	Capability             HostSnmpAgentCapability `xml:"capability,omitempty"`
 }
 
@@ -21775,8 +21776,8 @@ func init() {
 type HostSriovConfig struct {
 	HostPciPassthruConfig
 
-	SriovEnabled       bool `xml:"sriovEnabled"`
-	NumVirtualFunction int  `xml:"numVirtualFunction"`
+	SriovEnabled       bool  `xml:"sriovEnabled"`
+	NumVirtualFunction int32 `xml:"numVirtualFunction"`
 }
 
 func init() {
@@ -21786,12 +21787,12 @@ func init() {
 type HostSriovInfo struct {
 	HostPciPassthruInfo
 
-	SriovEnabled                bool `xml:"sriovEnabled"`
-	SriovCapable                bool `xml:"sriovCapable"`
-	SriovActive                 bool `xml:"sriovActive"`
-	NumVirtualFunctionRequested int  `xml:"numVirtualFunctionRequested"`
-	NumVirtualFunction          int  `xml:"numVirtualFunction"`
-	MaxVirtualFunctionSupported int  `xml:"maxVirtualFunctionSupported"`
+	SriovEnabled                bool  `xml:"sriovEnabled"`
+	SriovCapable                bool  `xml:"sriovCapable"`
+	SriovActive                 bool  `xml:"sriovActive"`
+	NumVirtualFunctionRequested int32 `xml:"numVirtualFunctionRequested"`
+	NumVirtualFunction          int32 `xml:"numVirtualFunction"`
+	MaxVirtualFunctionSupported int32 `xml:"maxVirtualFunctionSupported"`
 }
 
 func init() {
@@ -22010,7 +22011,7 @@ func init() {
 type HostSystemSwapConfigurationSystemSwapOption struct {
 	DynamicData
 
-	Key int `xml:"key"`
+	Key int32 `xml:"key"`
 }
 
 func init() {
@@ -22060,7 +22061,7 @@ func init() {
 type HostTpmDigestInfo struct {
 	HostDigestInfo
 
-	PcrNumber int `xml:"pcrNumber"`
+	PcrNumber int32 `xml:"pcrNumber"`
 }
 
 func init() {
@@ -22080,7 +22081,7 @@ func init() {
 type HostTpmEventLogEntry struct {
 	DynamicData
 
-	PcrIndex     int                     `xml:"pcrIndex"`
+	PcrIndex     int32                   `xml:"pcrIndex"`
 	EventDetails BaseHostTpmEventDetails `xml:"eventDetails,typeattr"`
 }
 
@@ -22119,9 +22120,9 @@ type HostUnresolvedVmfsExtent struct {
 	DevicePath   string                `xml:"devicePath"`
 	VmfsUuid     string                `xml:"vmfsUuid"`
 	IsHeadExtent bool                  `xml:"isHeadExtent"`
-	Ordinal      int                   `xml:"ordinal"`
-	StartBlock   int                   `xml:"startBlock"`
-	EndBlock     int                   `xml:"endBlock"`
+	Ordinal      int32                 `xml:"ordinal"`
+	StartBlock   int32                 `xml:"startBlock"`
+	EndBlock     int32                 `xml:"endBlock"`
 	Reason       string                `xml:"reason"`
 }
 
@@ -22168,7 +22169,7 @@ type HostUnresolvedVmfsVolume struct {
 	Extent        []HostUnresolvedVmfsExtent            `xml:"extent"`
 	VmfsLabel     string                                `xml:"vmfsLabel"`
 	VmfsUuid      string                                `xml:"vmfsUuid"`
-	TotalBlocks   int                                   `xml:"totalBlocks"`
+	TotalBlocks   int32                                 `xml:"totalBlocks"`
 	ResolveStatus HostUnresolvedVmfsVolumeResolveStatus `xml:"resolveStatus"`
 }
 
@@ -22359,7 +22360,7 @@ type HostVffsSpec struct {
 
 	DevicePath   string                 `xml:"devicePath"`
 	Partition    *HostDiskPartitionSpec `xml:"partition,omitempty"`
-	MajorVersion int                    `xml:"majorVersion"`
+	MajorVersion int32                  `xml:"majorVersion"`
 	VolumeName   string                 `xml:"volumeName"`
 }
 
@@ -22370,7 +22371,7 @@ func init() {
 type HostVffsVolume struct {
 	HostFileSystemVolume
 
-	MajorVersion int                     `xml:"majorVersion"`
+	MajorVersion int32                   `xml:"majorVersion"`
 	Version      string                  `xml:"version"`
 	Uuid         string                  `xml:"uuid"`
 	Extent       []HostScsiDiskPartition `xml:"extent"`
@@ -22457,7 +22458,7 @@ type HostVirtualNicSpec struct {
 	Mac                    string                                  `xml:"mac,omitempty"`
 	DistributedVirtualPort *DistributedVirtualSwitchPortConnection `xml:"distributedVirtualPort,omitempty"`
 	Portgroup              string                                  `xml:"portgroup,omitempty"`
-	Mtu                    int                                     `xml:"mtu,omitempty"`
+	Mtu                    int32                                   `xml:"mtu,omitempty"`
 	TsoEnabled             *bool                                   `xml:"tsoEnabled"`
 	NetStackInstanceKey    string                                  `xml:"netStackInstanceKey,omitempty"`
 	OpaqueNetwork          *HostVirtualNicOpaqueNetworkSpec        `xml:"opaqueNetwork,omitempty"`
@@ -22474,9 +22475,9 @@ type HostVirtualSwitch struct {
 
 	Name              string                `xml:"name"`
 	Key               string                `xml:"key"`
-	NumPorts          int                   `xml:"numPorts"`
-	NumPortsAvailable int                   `xml:"numPortsAvailable"`
-	Mtu               int                   `xml:"mtu,omitempty"`
+	NumPorts          int32                 `xml:"numPorts"`
+	NumPortsAvailable int32                 `xml:"numPortsAvailable"`
+	Mtu               int32                 `xml:"mtu,omitempty"`
 	Portgroup         []string              `xml:"portgroup,omitempty"`
 	Pnic              []string              `xml:"pnic,omitempty"`
 	Spec              HostVirtualSwitchSpec `xml:"spec"`
@@ -22499,7 +22500,7 @@ func init() {
 type HostVirtualSwitchBeaconConfig struct {
 	DynamicData
 
-	Interval int `xml:"interval"`
+	Interval int32 `xml:"interval"`
 }
 
 func init() {
@@ -22551,10 +22552,10 @@ func init() {
 type HostVirtualSwitchSpec struct {
 	DynamicData
 
-	NumPorts int                         `xml:"numPorts"`
+	NumPorts int32                       `xml:"numPorts"`
 	Bridge   BaseHostVirtualSwitchBridge `xml:"bridge,omitempty,typeattr"`
 	Policy   *HostNetworkPolicy          `xml:"policy,omitempty"`
-	Mtu      int                         `xml:"mtu,omitempty"`
+	Mtu      int32                       `xml:"mtu,omitempty"`
 }
 
 func init() {
@@ -22588,8 +22589,8 @@ type HostVmfsSpec struct {
 	DynamicData
 
 	Extent       HostScsiDiskPartition `xml:"extent"`
-	BlockSizeMb  int                   `xml:"blockSizeMb,omitempty"`
-	MajorVersion int                   `xml:"majorVersion"`
+	BlockSizeMb  int32                 `xml:"blockSizeMb,omitempty"`
+	MajorVersion int32                 `xml:"majorVersion"`
 	VolumeName   string                `xml:"volumeName"`
 }
 
@@ -22600,9 +22601,9 @@ func init() {
 type HostVmfsVolume struct {
 	HostFileSystemVolume
 
-	BlockSizeMb      int                     `xml:"blockSizeMb"`
-	MaxBlocks        int                     `xml:"maxBlocks"`
-	MajorVersion     int                     `xml:"majorVersion"`
+	BlockSizeMb      int32                   `xml:"blockSizeMb"`
+	MaxBlocks        int32                   `xml:"maxBlocks"`
+	MajorVersion     int32                   `xml:"majorVersion"`
 	Version          string                  `xml:"version"`
 	Uuid             string                  `xml:"uuid"`
 	Extent           []HostScsiDiskPartition `xml:"extent"`
@@ -22742,7 +22743,7 @@ func init() {
 type HourlyTaskScheduler struct {
 	RecurrentTaskScheduler
 
-	Minute int `xml:"minute"`
+	Minute int32 `xml:"minute"`
 }
 
 func init() {
@@ -22848,7 +22849,7 @@ type HttpNfcLeaseInfo struct {
 	Entity                ManagedObjectReference           `xml:"entity"`
 	DeviceUrl             []HttpNfcLeaseDeviceUrl          `xml:"deviceUrl,omitempty"`
 	TotalDiskCapacityInKB int64                            `xml:"totalDiskCapacityInKB"`
-	LeaseTimeout          int                              `xml:"leaseTimeout"`
+	LeaseTimeout          int32                            `xml:"leaseTimeout"`
 	HostMap               []HttpNfcLeaseDatastoreLeaseInfo `xml:"hostMap,omitempty"`
 }
 
@@ -22879,7 +22880,7 @@ func init() {
 
 type HttpNfcLeaseProgressRequestType struct {
 	This    ManagedObjectReference `xml:"_this"`
-	Percent int                    `xml:"percent"`
+	Percent int32                  `xml:"percent"`
 }
 
 func init() {
@@ -23447,8 +23448,8 @@ type InsufficientAgentVmsDeployed struct {
 	InsufficientResourcesFault
 
 	HostName            string `xml:"hostName"`
-	RequiredNumAgentVms int    `xml:"requiredNumAgentVms"`
-	CurrentNumAgentVms  int    `xml:"currentNumAgentVms"`
+	RequiredNumAgentVms int32  `xml:"requiredNumAgentVms"`
+	CurrentNumAgentVms  int32  `xml:"currentNumAgentVms"`
 }
 
 func init() {
@@ -23760,7 +23761,7 @@ func init() {
 type IntExpression struct {
 	NegatableExpression
 
-	Value int `xml:"value,omitempty"`
+	Value int32 `xml:"value,omitempty"`
 }
 
 func init() {
@@ -23770,9 +23771,9 @@ func init() {
 type IntOption struct {
 	OptionType
 
-	Min          int `xml:"min"`
-	Max          int `xml:"max"`
-	DefaultValue int `xml:"defaultValue"`
+	Min          int32 `xml:"min"`
+	Max          int32 `xml:"max"`
+	DefaultValue int32 `xml:"defaultValue"`
 }
 
 func init() {
@@ -23782,7 +23783,7 @@ func init() {
 type IntPolicy struct {
 	InheritablePolicy
 
-	Value int `xml:"value,omitempty"`
+	Value int32 `xml:"value,omitempty"`
 }
 
 func init() {
@@ -23908,7 +23909,7 @@ func init() {
 type InvalidController struct {
 	InvalidDeviceSpec
 
-	ControllerKey int `xml:"controllerKey"`
+	ControllerKey int32 `xml:"controllerKey"`
 }
 
 func init() {
@@ -24038,7 +24039,7 @@ func init() {
 type InvalidDeviceSpec struct {
 	InvalidVmConfig
 
-	DeviceIndex int `xml:"deviceIndex"`
+	DeviceIndex int32 `xml:"deviceIndex"`
 }
 
 func init() {
@@ -24583,16 +24584,16 @@ func init() {
 type InventoryDescription struct {
 	DynamicData
 
-	NumHosts           int `xml:"numHosts"`
-	NumVirtualMachines int `xml:"numVirtualMachines"`
-	NumResourcePools   int `xml:"numResourcePools,omitempty"`
-	NumClusters        int `xml:"numClusters,omitempty"`
-	NumCpuDev          int `xml:"numCpuDev,omitempty"`
-	NumNetDev          int `xml:"numNetDev,omitempty"`
-	NumDiskDev         int `xml:"numDiskDev,omitempty"`
-	NumvCpuDev         int `xml:"numvCpuDev,omitempty"`
-	NumvNetDev         int `xml:"numvNetDev,omitempty"`
-	NumvDiskDev        int `xml:"numvDiskDev,omitempty"`
+	NumHosts           int32 `xml:"numHosts"`
+	NumVirtualMachines int32 `xml:"numVirtualMachines"`
+	NumResourcePools   int32 `xml:"numResourcePools,omitempty"`
+	NumClusters        int32 `xml:"numClusters,omitempty"`
+	NumCpuDev          int32 `xml:"numCpuDev,omitempty"`
+	NumNetDev          int32 `xml:"numNetDev,omitempty"`
+	NumDiskDev         int32 `xml:"numDiskDev,omitempty"`
+	NumvCpuDev         int32 `xml:"numvCpuDev,omitempty"`
+	NumvNetDev         int32 `xml:"numvNetDev,omitempty"`
+	NumvDiskDev        int32 `xml:"numvDiskDev,omitempty"`
 }
 
 func init() {
@@ -24685,7 +24686,7 @@ func init() {
 type IpPool struct {
 	DynamicData
 
-	Id                     int                     `xml:"id,omitempty"`
+	Id                     int32                   `xml:"id,omitempty"`
 	Name                   string                  `xml:"name,omitempty"`
 	Ipv4Config             *IpPoolIpPoolConfigInfo `xml:"ipv4Config,omitempty"`
 	Ipv6Config             *IpPoolIpPoolConfigInfo `xml:"ipv6Config,omitempty"`
@@ -24694,10 +24695,10 @@ type IpPool struct {
 	HostPrefix             string                  `xml:"hostPrefix,omitempty"`
 	HttpProxy              string                  `xml:"httpProxy,omitempty"`
 	NetworkAssociation     []IpPoolAssociation     `xml:"networkAssociation,omitempty"`
-	AvailableIpv4Addresses int                     `xml:"availableIpv4Addresses,omitempty"`
-	AvailableIpv6Addresses int                     `xml:"availableIpv6Addresses,omitempty"`
-	AllocatedIpv4Addresses int                     `xml:"allocatedIpv4Addresses,omitempty"`
-	AllocatedIpv6Addresses int                     `xml:"allocatedIpv6Addresses,omitempty"`
+	AvailableIpv4Addresses int32                   `xml:"availableIpv4Addresses,omitempty"`
+	AvailableIpv6Addresses int32                   `xml:"availableIpv6Addresses,omitempty"`
+	AllocatedIpv4Addresses int32                   `xml:"allocatedIpv4Addresses,omitempty"`
+	AllocatedIpv6Addresses int32                   `xml:"allocatedIpv6Addresses,omitempty"`
 }
 
 func init() {
@@ -24746,7 +24747,7 @@ type IpRange struct {
 	IpAddress
 
 	AddressPrefix string `xml:"addressPrefix"`
-	PrefixLength  int    `xml:"prefixLength,omitempty"`
+	PrefixLength  int32  `xml:"prefixLength,omitempty"`
 }
 
 func init() {
@@ -25085,14 +25086,14 @@ type JoinDomain_TaskResponse struct {
 type KernelModuleInfo struct {
 	DynamicData
 
-	Id              int                     `xml:"id"`
+	Id              int32                   `xml:"id"`
 	Name            string                  `xml:"name"`
 	Version         string                  `xml:"version"`
 	Filename        string                  `xml:"filename"`
 	OptionString    string                  `xml:"optionString"`
 	Loaded          bool                    `xml:"loaded"`
 	Enabled         bool                    `xml:"enabled"`
-	UseCount        int                     `xml:"useCount"`
+	UseCount        int32                   `xml:"useCount"`
 	ReadOnlySection KernelModuleSectionInfo `xml:"readOnlySection"`
 	WritableSection KernelModuleSectionInfo `xml:"writableSection"`
 	TextSection     KernelModuleSectionInfo `xml:"textSection"`
@@ -25108,7 +25109,7 @@ type KernelModuleSectionInfo struct {
 	DynamicData
 
 	Address int64 `xml:"address"`
-	Length  int   `xml:"length,omitempty"`
+	Length  int32 `xml:"length,omitempty"`
 }
 
 func init() {
@@ -25175,7 +25176,7 @@ type LatencySensitivity struct {
 	DynamicData
 
 	Level       LatencySensitivitySensitivityLevel `xml:"level"`
-	Sensitivity int                                `xml:"sensitivity,omitempty"`
+	Sensitivity int32                              `xml:"sensitivity,omitempty"`
 }
 
 func init() {
@@ -25249,8 +25250,8 @@ type LicenseAvailabilityInfo struct {
 	DynamicData
 
 	Feature   LicenseFeatureInfo `xml:"feature"`
-	Total     int                `xml:"total"`
-	Available int                `xml:"available"`
+	Total     int32              `xml:"total"`
+	Available int32              `xml:"available"`
 }
 
 func init() {
@@ -25391,8 +25392,8 @@ type LicenseManagerLicenseInfo struct {
 	LicenseKey string        `xml:"licenseKey"`
 	EditionKey string        `xml:"editionKey"`
 	Name       string        `xml:"name"`
-	Total      int           `xml:"total"`
-	Used       int           `xml:"used,omitempty"`
+	Total      int32         `xml:"total"`
+	Used       int32         `xml:"used,omitempty"`
 	CostUnit   string        `xml:"costUnit"`
 	Properties []KeyAnyValue `xml:"properties,omitempty"`
 	Labels     []KeyValue    `xml:"labels,omitempty"`
@@ -25417,7 +25418,7 @@ type LicenseReservationInfo struct {
 
 	Key      string                      `xml:"key"`
 	State    LicenseReservationInfoState `xml:"state"`
-	Required int                         `xml:"required"`
+	Required int32                       `xml:"required"`
 }
 
 func init() {
@@ -25533,7 +25534,7 @@ type LimitExceeded struct {
 	VimFault
 
 	Property string `xml:"property,omitempty"`
-	Limit    int    `xml:"limit,omitempty"`
+	Limit    int32  `xml:"limit,omitempty"`
 }
 
 func init() {
@@ -25562,7 +25563,7 @@ type LinkLayerDiscoveryProtocolInfo struct {
 
 	ChassisId  string        `xml:"chassisId"`
 	PortId     string        `xml:"portId"`
-	TimeToLive int           `xml:"timeToLive"`
+	TimeToLive int32         `xml:"timeToLive"`
 	Parameter  []KeyAnyValue `xml:"parameter,omitempty"`
 }
 
@@ -25639,8 +25640,8 @@ type ListFilesInGuestRequestType struct {
 	Vm           ManagedObjectReference  `xml:"vm"`
 	Auth         BaseGuestAuthentication `xml:"auth,typeattr"`
 	FilePath     string                  `xml:"filePath"`
-	Index        int                     `xml:"index,omitempty"`
-	MaxResults   int                     `xml:"maxResults,omitempty"`
+	Index        int32                   `xml:"index,omitempty"`
+	MaxResults   int32                   `xml:"maxResults,omitempty"`
 	MatchPattern string                  `xml:"matchPattern,omitempty"`
 }
 
@@ -26391,9 +26392,9 @@ func init() {
 type MemorySizeNotRecommended struct {
 	VirtualHardwareCompatibilityIssue
 
-	MemorySizeMB    int `xml:"memorySizeMB"`
-	MinMemorySizeMB int `xml:"minMemorySizeMB"`
-	MaxMemorySizeMB int `xml:"maxMemorySizeMB"`
+	MemorySizeMB    int32 `xml:"memorySizeMB"`
+	MinMemorySizeMB int32 `xml:"minMemorySizeMB"`
+	MaxMemorySizeMB int32 `xml:"maxMemorySizeMB"`
 }
 
 func init() {
@@ -26409,9 +26410,9 @@ func init() {
 type MemorySizeNotSupported struct {
 	VirtualHardwareCompatibilityIssue
 
-	MemorySizeMB    int `xml:"memorySizeMB"`
-	MinMemorySizeMB int `xml:"minMemorySizeMB"`
-	MaxMemorySizeMB int `xml:"maxMemorySizeMB"`
+	MemorySizeMB    int32 `xml:"memorySizeMB"`
+	MinMemorySizeMB int32 `xml:"minMemorySizeMB"`
+	MaxMemorySizeMB int32 `xml:"maxMemorySizeMB"`
 }
 
 func init() {
@@ -26422,8 +26423,8 @@ type MemorySizeNotSupportedByDatastore struct {
 	VirtualHardwareCompatibilityIssue
 
 	Datastore       ManagedObjectReference `xml:"datastore"`
-	MemorySizeMB    int                    `xml:"memorySizeMB"`
-	MaxMemorySizeMB int                    `xml:"maxMemorySizeMB"`
+	MemorySizeMB    int32                  `xml:"memorySizeMB"`
+	MaxMemorySizeMB int32                  `xml:"maxMemorySizeMB"`
 }
 
 func init() {
@@ -26483,8 +26484,8 @@ func init() {
 
 type MergePermissionsRequestType struct {
 	This      ManagedObjectReference `xml:"_this"`
-	SrcRoleId int                    `xml:"srcRoleId"`
-	DstRoleId int                    `xml:"dstRoleId"`
+	SrcRoleId int32                  `xml:"srcRoleId"`
+	DstRoleId int32                  `xml:"dstRoleId"`
 }
 
 func init() {
@@ -26595,10 +26596,10 @@ type MetricAlarmExpression struct {
 	Operator       MetricAlarmOperator `xml:"operator"`
 	Type           string              `xml:"type"`
 	Metric         PerfMetricId        `xml:"metric"`
-	Yellow         int                 `xml:"yellow,omitempty"`
-	YellowInterval int                 `xml:"yellowInterval,omitempty"`
-	Red            int                 `xml:"red,omitempty"`
-	RedInterval    int                 `xml:"redInterval,omitempty"`
+	Yellow         int32               `xml:"yellow,omitempty"`
+	YellowInterval int32               `xml:"yellowInterval,omitempty"`
+	Red            int32               `xml:"red,omitempty"`
+	RedInterval    int32               `xml:"redInterval,omitempty"`
 }
 
 func init() {
@@ -26762,8 +26763,8 @@ type MismatchedBundle struct {
 
 	BundleUuid        string `xml:"bundleUuid"`
 	HostUuid          string `xml:"hostUuid"`
-	BundleBuildNumber int    `xml:"bundleBuildNumber"`
-	HostBuildNumber   int    `xml:"hostBuildNumber"`
+	BundleBuildNumber int32  `xml:"bundleBuildNumber"`
+	HostBuildNumber   int32  `xml:"hostBuildNumber"`
 }
 
 func init() {
@@ -26948,7 +26949,7 @@ func init() {
 type MksConnectionLimitReached struct {
 	InvalidState
 
-	ConnectionLimit int `xml:"connectionLimit"`
+	ConnectionLimit int32 `xml:"connectionLimit"`
 }
 
 func init() {
@@ -26999,7 +27000,7 @@ type ModifyListViewResponse struct {
 type MonthlyByDayTaskScheduler struct {
 	MonthlyTaskScheduler
 
-	Day int `xml:"day"`
+	Day int32 `xml:"day"`
 }
 
 func init() {
@@ -27029,7 +27030,7 @@ type MountError struct {
 	CustomizationFault
 
 	Vm        ManagedObjectReference `xml:"vm"`
-	DiskIndex int                    `xml:"diskIndex"`
+	DiskIndex int32                  `xml:"diskIndex"`
 }
 
 func init() {
@@ -27349,7 +27350,7 @@ func init() {
 type MultipleCertificatesVerifyFaultThumbprintData struct {
 	DynamicData
 
-	Port       int    `xml:"port"`
+	Port       int32  `xml:"port"`
 	Thumbprint string `xml:"thumbprint"`
 }
 
@@ -27413,7 +27414,7 @@ func init() {
 type NamespaceLimitReached struct {
 	VimFault
 
-	Limit int `xml:"limit,omitempty"`
+	Limit int32 `xml:"limit,omitempty"`
 }
 
 func init() {
@@ -27639,7 +27640,7 @@ type NetIpConfigInfoIpAddress struct {
 	DynamicData
 
 	IpAddress    string     `xml:"ipAddress"`
-	PrefixLength int        `xml:"prefixLength"`
+	PrefixLength int32      `xml:"prefixLength"`
 	Origin       string     `xml:"origin,omitempty"`
 	State        string     `xml:"state,omitempty"`
 	Lifetime     *time.Time `xml:"lifetime"`
@@ -27665,7 +27666,7 @@ type NetIpConfigSpecIpAddressSpec struct {
 	DynamicData
 
 	IpAddress    string `xml:"ipAddress"`
-	PrefixLength int    `xml:"prefixLength"`
+	PrefixLength int32  `xml:"prefixLength"`
 	Operation    string `xml:"operation"`
 }
 
@@ -27698,7 +27699,7 @@ type NetIpRouteConfigInfoIpRoute struct {
 	DynamicData
 
 	Network      string                      `xml:"network"`
-	PrefixLength int                         `xml:"prefixLength"`
+	PrefixLength int32                       `xml:"prefixLength"`
 	Gateway      NetIpRouteConfigInfoGateway `xml:"gateway"`
 }
 
@@ -27731,7 +27732,7 @@ type NetIpRouteConfigSpecIpRouteSpec struct {
 	DynamicData
 
 	Network      string                          `xml:"network"`
-	PrefixLength int                             `xml:"prefixLength"`
+	PrefixLength int32                           `xml:"prefixLength"`
 	Gateway      NetIpRouteConfigSpecGatewaySpec `xml:"gateway"`
 	Operation    string                          `xml:"operation"`
 }
@@ -27898,7 +27899,7 @@ type NetworkSummary struct {
 	Name       string                  `xml:"name"`
 	Accessible bool                    `xml:"accessible"`
 	IpPoolName string                  `xml:"ipPoolName,omitempty"`
-	IpPoolId   int                     `xml:"ipPoolId,omitempty"`
+	IpPoolId   int32                   `xml:"ipPoolId,omitempty"`
 }
 
 func init() {
@@ -27924,8 +27925,8 @@ func init() {
 type NicSettingMismatch struct {
 	CustomizationFault
 
-	NumberOfNicsInSpec int `xml:"numberOfNicsInSpec"`
-	NumberOfNicsInVM   int `xml:"numberOfNicsInVM"`
+	NumberOfNicsInSpec int32 `xml:"numberOfNicsInSpec"`
+	NumberOfNicsInVM   int32 `xml:"numberOfNicsInVM"`
 }
 
 func init() {
@@ -28474,8 +28475,8 @@ func init() {
 type NotEnoughCpus struct {
 	VirtualHardwareCompatibilityIssue
 
-	NumCpuDest int `xml:"numCpuDest"`
-	NumCpuVm   int `xml:"numCpuVm"`
+	NumCpuDest int32 `xml:"numCpuDest"`
+	NumCpuVm   int32 `xml:"numCpuVm"`
 }
 
 func init() {
@@ -28758,8 +28759,8 @@ func init() {
 type NumVirtualCoresPerSocketNotSupported struct {
 	VirtualHardwareCompatibilityIssue
 
-	MaxSupportedCoresPerSocketDest int `xml:"maxSupportedCoresPerSocketDest"`
-	NumCoresPerSocketVm            int `xml:"numCoresPerSocketVm"`
+	MaxSupportedCoresPerSocketDest int32 `xml:"maxSupportedCoresPerSocketDest"`
+	NumCoresPerSocketVm            int32 `xml:"numCoresPerSocketVm"`
 }
 
 func init() {
@@ -28775,7 +28776,7 @@ func init() {
 type NumVirtualCpusExceedsLimit struct {
 	InsufficientResourcesFault
 
-	MaxSupportedVcpus int `xml:"maxSupportedVcpus"`
+	MaxSupportedVcpus int32 `xml:"maxSupportedVcpus"`
 }
 
 func init() {
@@ -28792,7 +28793,7 @@ type NumVirtualCpusIncompatible struct {
 	VmConfigFault
 
 	Reason string `xml:"reason"`
-	NumCpu int    `xml:"numCpu"`
+	NumCpu int32  `xml:"numCpu"`
 }
 
 func init() {
@@ -28808,8 +28809,8 @@ func init() {
 type NumVirtualCpusNotSupported struct {
 	VirtualHardwareCompatibilityIssue
 
-	MaxSupportedVcpusDest int `xml:"maxSupportedVcpusDest"`
-	NumCpuVm              int `xml:"numCpuVm"`
+	MaxSupportedVcpusDest int32 `xml:"maxSupportedVcpusDest"`
+	NumCpuVm              int32 `xml:"numCpuVm"`
 }
 
 func init() {
@@ -28825,8 +28826,8 @@ func init() {
 type NumericRange struct {
 	DynamicData
 
-	Start int `xml:"start"`
-	End   int `xml:"end"`
+	Start int32 `xml:"start"`
+	End   int32 `xml:"end"`
 }
 
 func init() {
@@ -29191,7 +29192,7 @@ func init() {
 type OvfConsumerInvalidSection struct {
 	OvfConsumerCallbackFault
 
-	LineNumber  int    `xml:"lineNumber"`
+	LineNumber  int32  `xml:"lineNumber"`
 	Description string `xml:"description"`
 }
 
@@ -29222,7 +29223,7 @@ func init() {
 type OvfConsumerOvfSection struct {
 	DynamicData
 
-	LineNumber int    `xml:"lineNumber"`
+	LineNumber int32  `xml:"lineNumber"`
 	Xml        string `xml:"xml"`
 }
 
@@ -29302,7 +29303,7 @@ type OvfCpuCompatibility struct {
 	OvfImport
 
 	RegisterName         string `xml:"registerName"`
-	Level                int    `xml:"level"`
+	Level                int32  `xml:"level"`
 	RegisterValue        string `xml:"registerValue"`
 	DesiredRegisterValue string `xml:"desiredRegisterValue"`
 }
@@ -29591,7 +29592,7 @@ type OvfFileItem struct {
 	CompressionMethod string `xml:"compressionMethod,omitempty"`
 	ChunkSize         int64  `xml:"chunkSize,omitempty"`
 	Size              int64  `xml:"size,omitempty"`
-	CimType           int    `xml:"cimType"`
+	CimType           int32  `xml:"cimType"`
 	Create            bool   `xml:"create"`
 }
 
@@ -29708,7 +29709,7 @@ func init() {
 type OvfInvalidPackage struct {
 	OvfFault
 
-	LineNumber int `xml:"lineNumber"`
+	LineNumber int32 `xml:"lineNumber"`
 }
 
 func init() {
@@ -29825,7 +29826,7 @@ func init() {
 type OvfMappedOsId struct {
 	OvfImport
 
-	OvfId             int    `xml:"ovfId"`
+	OvfId             int32  `xml:"ovfId"`
 	OvfDescription    string `xml:"ovfDescription"`
 	TargetDescription string `xml:"targetDescription"`
 }
@@ -29888,7 +29889,7 @@ type OvfMissingHardware struct {
 	OvfImport
 
 	Name         string `xml:"name"`
-	ResourceType int    `xml:"resourceType"`
+	ResourceType int32  `xml:"resourceType"`
 }
 
 func init() {
@@ -30278,7 +30279,7 @@ func init() {
 type OvfUnknownEntity struct {
 	OvfSystemFault
 
-	LineNumber int `xml:"lineNumber"`
+	LineNumber int32 `xml:"lineNumber"`
 }
 
 func init() {
@@ -30428,7 +30429,7 @@ func init() {
 type OvfUnsupportedPackage struct {
 	OvfFault
 
-	LineNumber int `xml:"lineNumber,omitempty"`
+	LineNumber int32 `xml:"lineNumber,omitempty"`
 }
 
 func init() {
@@ -30462,7 +30463,7 @@ type OvfUnsupportedSubType struct {
 
 	ElementName   string `xml:"elementName"`
 	InstanceId    string `xml:"instanceId"`
-	DeviceType    int    `xml:"deviceType"`
+	DeviceType    int32  `xml:"deviceType"`
 	DeviceSubType string `xml:"deviceSubType"`
 }
 
@@ -30481,7 +30482,7 @@ type OvfUnsupportedType struct {
 
 	Name       string `xml:"name"`
 	InstanceId string `xml:"instanceId"`
-	DeviceType int    `xml:"deviceType"`
+	DeviceType int32  `xml:"deviceType"`
 }
 
 func init() {
@@ -30778,15 +30779,15 @@ func init() {
 type PerfCounterInfo struct {
 	DynamicData
 
-	Key                 int                    `xml:"key"`
+	Key                 int32                  `xml:"key"`
 	NameInfo            BaseElementDescription `xml:"nameInfo,typeattr"`
 	GroupInfo           BaseElementDescription `xml:"groupInfo,typeattr"`
 	UnitInfo            BaseElementDescription `xml:"unitInfo,typeattr"`
 	RollupType          PerfSummaryType        `xml:"rollupType"`
 	StatsType           PerfStatsType          `xml:"statsType"`
-	Level               int                    `xml:"level,omitempty"`
-	PerDeviceLevel      int                    `xml:"perDeviceLevel,omitempty"`
-	AssociatedCounterId []int                  `xml:"associatedCounterId,omitempty"`
+	Level               int32                  `xml:"level,omitempty"`
+	PerDeviceLevel      int32                  `xml:"perDeviceLevel,omitempty"`
+	AssociatedCounterId []int32                `xml:"associatedCounterId,omitempty"`
 }
 
 func init() {
@@ -30828,11 +30829,11 @@ func init() {
 type PerfInterval struct {
 	DynamicData
 
-	Key            int    `xml:"key"`
-	SamplingPeriod int    `xml:"samplingPeriod"`
+	Key            int32  `xml:"key"`
+	SamplingPeriod int32  `xml:"samplingPeriod"`
 	Name           string `xml:"name"`
-	Length         int    `xml:"length"`
-	Level          int    `xml:"level,omitempty"`
+	Length         int32  `xml:"length"`
+	Level          int32  `xml:"level,omitempty"`
 	Enabled        bool   `xml:"enabled"`
 }
 
@@ -30843,7 +30844,7 @@ func init() {
 type PerfMetricId struct {
 	DynamicData
 
-	CounterId int    `xml:"counterId"`
+	CounterId int32  `xml:"counterId"`
 	Instance  string `xml:"instance"`
 }
 
@@ -30887,7 +30888,7 @@ type PerfProviderSummary struct {
 	Entity           ManagedObjectReference `xml:"entity"`
 	CurrentSupported bool                   `xml:"currentSupported"`
 	SummarySupported bool                   `xml:"summarySupported"`
-	RefreshRate      int                    `xml:"refreshRate,omitempty"`
+	RefreshRate      int32                  `xml:"refreshRate,omitempty"`
 }
 
 func init() {
@@ -30900,9 +30901,9 @@ type PerfQuerySpec struct {
 	Entity     ManagedObjectReference `xml:"entity"`
 	StartTime  *time.Time             `xml:"startTime"`
 	EndTime    *time.Time             `xml:"endTime"`
-	MaxSample  int                    `xml:"maxSample,omitempty"`
+	MaxSample  int32                  `xml:"maxSample,omitempty"`
 	MetricId   []PerfMetricId         `xml:"metricId,omitempty"`
-	IntervalId int                    `xml:"intervalId,omitempty"`
+	IntervalId int32                  `xml:"intervalId,omitempty"`
 	Format     string                 `xml:"format,omitempty"`
 }
 
@@ -30914,7 +30915,7 @@ type PerfSampleInfo struct {
 	DynamicData
 
 	Timestamp time.Time `xml:"timestamp"`
-	Interval  int       `xml:"interval"`
+	Interval  int32     `xml:"interval"`
 }
 
 func init() {
@@ -30998,9 +30999,9 @@ func init() {
 type PerformanceManagerCounterLevelMapping struct {
 	DynamicData
 
-	CounterId      int `xml:"counterId"`
-	AggregateLevel int `xml:"aggregateLevel,omitempty"`
-	PerDeviceLevel int `xml:"perDeviceLevel,omitempty"`
+	CounterId      int32 `xml:"counterId"`
+	AggregateLevel int32 `xml:"aggregateLevel,omitempty"`
+	PerDeviceLevel int32 `xml:"perDeviceLevel,omitempty"`
 }
 
 func init() {
@@ -31023,7 +31024,7 @@ type Permission struct {
 	Entity    *ManagedObjectReference `xml:"entity,omitempty"`
 	Principal string                  `xml:"principal"`
 	Group     bool                    `xml:"group"`
-	RoleId    int                     `xml:"roleId"`
+	RoleId    int32                   `xml:"roleId"`
 	Propagate bool                    `xml:"propagate"`
 }
 
@@ -31140,10 +31141,10 @@ func init() {
 type PhysicalNicCdpInfo struct {
 	DynamicData
 
-	CdpVersion       int                             `xml:"cdpVersion,omitempty"`
-	Timeout          int                             `xml:"timeout,omitempty"`
-	Ttl              int                             `xml:"ttl,omitempty"`
-	Samples          int                             `xml:"samples,omitempty"`
+	CdpVersion       int32                           `xml:"cdpVersion,omitempty"`
+	Timeout          int32                           `xml:"timeout,omitempty"`
+	Ttl              int32                           `xml:"ttl,omitempty"`
+	Samples          int32                           `xml:"samples,omitempty"`
 	DevId            string                          `xml:"devId,omitempty"`
 	Address          string                          `xml:"address,omitempty"`
 	PortId           string                          `xml:"portId,omitempty"`
@@ -31151,10 +31152,10 @@ type PhysicalNicCdpInfo struct {
 	SoftwareVersion  string                          `xml:"softwareVersion,omitempty"`
 	HardwarePlatform string                          `xml:"hardwarePlatform,omitempty"`
 	IpPrefix         string                          `xml:"ipPrefix,omitempty"`
-	IpPrefixLen      int                             `xml:"ipPrefixLen,omitempty"`
-	Vlan             int                             `xml:"vlan,omitempty"`
+	IpPrefixLen      int32                           `xml:"ipPrefixLen,omitempty"`
+	Vlan             int32                           `xml:"vlan,omitempty"`
 	FullDuplex       *bool                           `xml:"fullDuplex"`
-	Mtu              int                             `xml:"mtu,omitempty"`
+	Mtu              int32                           `xml:"mtu,omitempty"`
 	SystemName       string                          `xml:"systemName,omitempty"`
 	SystemOID        string                          `xml:"systemOID,omitempty"`
 	MgmtAddr         string                          `xml:"mgmtAddr,omitempty"`
@@ -31179,7 +31180,7 @@ func init() {
 type PhysicalNicHint struct {
 	DynamicData
 
-	VlanId int `xml:"vlanId,omitempty"`
+	VlanId int32 `xml:"vlanId,omitempty"`
 }
 
 func init() {
@@ -31213,8 +31214,8 @@ func init() {
 type PhysicalNicLinkInfo struct {
 	DynamicData
 
-	SpeedMb int  `xml:"speedMb"`
-	Duplex  bool `xml:"duplex"`
+	SpeedMb int32 `xml:"speedMb"`
+	Duplex  bool  `xml:"duplex"`
 }
 
 func init() {
@@ -31387,7 +31388,7 @@ func init() {
 type PodDiskLocator struct {
 	DynamicData
 
-	DiskId          int                             `xml:"diskId"`
+	DiskId          int32                           `xml:"diskId"`
 	DiskMoveType    string                          `xml:"diskMoveType,omitempty"`
 	DiskBackingInfo BaseVirtualDeviceBackingInfo    `xml:"diskBackingInfo,omitempty,typeattr"`
 	Profile         []BaseVirtualMachineProfileSpec `xml:"profile,omitempty,typeattr"`
@@ -31438,7 +31439,7 @@ func init() {
 type PosixUserSearchResult struct {
 	UserSearchResult
 
-	Id          int   `xml:"id"`
+	Id          int32 `xml:"id"`
 	ShellAccess *bool `xml:"shellAccess"`
 }
 
@@ -31467,7 +31468,7 @@ type PostEventResponse struct {
 
 type PowerDownHostToStandByRequestType struct {
 	This                  ManagedObjectReference `xml:"_this"`
-	TimeoutSec            int                    `xml:"timeoutSec"`
+	TimeoutSec            int32                  `xml:"timeoutSec"`
 	EvacuatePoweredOffVms *bool                  `xml:"evacuatePoweredOffVms"`
 }
 
@@ -31547,7 +31548,7 @@ type PowerOnFtSecondaryTimedout struct {
 
 	Vm      ManagedObjectReference `xml:"vm"`
 	VmName  string                 `xml:"vmName"`
-	Timeout int                    `xml:"timeout"`
+	Timeout int32                  `xml:"timeout"`
 }
 
 func init() {
@@ -31639,7 +31640,7 @@ func init() {
 
 type PowerUpHostFromStandByRequestType struct {
 	This       ManagedObjectReference `xml:"_this"`
-	TimeoutSec int                    `xml:"timeoutSec"`
+	TimeoutSec int32                  `xml:"timeoutSec"`
 }
 
 func init() {
@@ -31686,7 +31687,7 @@ type ProductComponentInfo struct {
 	Id      string `xml:"id"`
 	Name    string `xml:"name"`
 	Version string `xml:"version"`
-	Release int    `xml:"release"`
+	Release int32  `xml:"release"`
 }
 
 func init() {
@@ -32239,7 +32240,7 @@ type QueryAvailablePerfMetricRequestType struct {
 	Entity     ManagedObjectReference `xml:"entity"`
 	BeginTime  *time.Time             `xml:"beginTime"`
 	EndTime    *time.Time             `xml:"endTime"`
-	IntervalId int                    `xml:"intervalId,omitempty"`
+	IntervalId int32                  `xml:"intervalId,omitempty"`
 }
 
 func init() {
@@ -32352,7 +32353,7 @@ func init() {
 type QueryChangedDiskAreasRequestType struct {
 	This        ManagedObjectReference  `xml:"_this"`
 	Snapshot    *ManagedObjectReference `xml:"snapshot,omitempty"`
-	DeviceKey   int                     `xml:"deviceKey"`
+	DeviceKey   int32                   `xml:"deviceKey"`
 	StartOffset int64                   `xml:"startOffset"`
 	ChangeId    string                  `xml:"changeId"`
 }
@@ -32550,7 +32551,7 @@ func init() {
 type QueryConnectionInfoRequestType struct {
 	This          ManagedObjectReference `xml:"_this"`
 	Hostname      string                 `xml:"hostname"`
-	Port          int                    `xml:"port"`
+	Port          int32                  `xml:"port"`
 	Username      string                 `xml:"username"`
 	Password      string                 `xml:"password"`
 	SslThumbprint string                 `xml:"sslThumbprint,omitempty"`
@@ -32992,7 +32993,7 @@ func init() {
 type QueryIPAllocationsRequestType struct {
 	This         ManagedObjectReference `xml:"_this"`
 	Dc           ManagedObjectReference `xml:"dc"`
-	PoolId       int                    `xml:"poolId"`
+	PoolId       int32                  `xml:"poolId"`
 	ExtensionKey string                 `xml:"extensionKey"`
 }
 
@@ -33165,8 +33166,8 @@ type QueryMemoryOverheadExResponse struct {
 type QueryMemoryOverheadRequestType struct {
 	This         ManagedObjectReference `xml:"_this"`
 	MemorySize   int64                  `xml:"memorySize"`
-	VideoRamSize int                    `xml:"videoRamSize,omitempty"`
-	NumVcpus     int                    `xml:"numVcpus"`
+	VideoRamSize int32                  `xml:"videoRamSize,omitempty"`
+	NumVcpus     int32                  `xml:"numVcpus"`
 }
 
 func init() {
@@ -33405,7 +33406,7 @@ func init() {
 
 type QueryPerfCounterByLevelRequestType struct {
 	This  ManagedObjectReference `xml:"_this"`
-	Level int                    `xml:"level"`
+	Level int32                  `xml:"level"`
 }
 
 func init() {
@@ -33418,7 +33419,7 @@ type QueryPerfCounterByLevelResponse struct {
 
 type QueryPerfCounterRequestType struct {
 	This      ManagedObjectReference `xml:"_this"`
-	CounterId []int                  `xml:"counterId"`
+	CounterId []int32                `xml:"counterId"`
 }
 
 func init() {
@@ -33756,7 +33757,7 @@ func init() {
 }
 
 type QueryUsedVlanIdInDvsResponse struct {
-	Returnval []int `xml:"returnval,omitempty"`
+	Returnval []int32 `xml:"returnval,omitempty"`
 }
 
 type QueryVMotionCompatibility QueryVMotionCompatibilityRequestType
@@ -33817,7 +33818,7 @@ func init() {
 }
 
 type QueryVirtualDiskFragmentationResponse struct {
-	Returnval int `xml:"returnval"`
+	Returnval int32 `xml:"returnval"`
 }
 
 type QueryVirtualDiskGeometry QueryVirtualDiskGeometryRequestType
@@ -33869,7 +33870,7 @@ func init() {
 type QueryVmfsDatastoreCreateOptionsRequestType struct {
 	This             ManagedObjectReference `xml:"_this"`
 	DevicePath       string                 `xml:"devicePath"`
-	VmfsMajorVersion int                    `xml:"vmfsMajorVersion,omitempty"`
+	VmfsMajorVersion int32                  `xml:"vmfsMajorVersion,omitempty"`
 }
 
 func init() {
@@ -33948,8 +33949,8 @@ func init() {
 type QueryVsanObjectUuidsByFilterRequestType struct {
 	This    ManagedObjectReference `xml:"_this"`
 	Uuids   []string               `xml:"uuids,omitempty"`
-	Limit   int                    `xml:"limit,omitempty"`
-	Version int                    `xml:"version,omitempty"`
+	Limit   int32                  `xml:"limit,omitempty"`
+	Version int32                  `xml:"version,omitempty"`
 }
 
 func init() {
@@ -34187,7 +34188,7 @@ func init() {
 
 type ReadNextEventsRequestType struct {
 	This     ManagedObjectReference `xml:"_this"`
-	MaxCount int                    `xml:"maxCount"`
+	MaxCount int32                  `xml:"maxCount"`
 }
 
 func init() {
@@ -34206,7 +34207,7 @@ func init() {
 
 type ReadNextTasksRequestType struct {
 	This     ManagedObjectReference `xml:"_this"`
-	MaxCount int                    `xml:"maxCount"`
+	MaxCount int32                  `xml:"maxCount"`
 }
 
 func init() {
@@ -34220,8 +34221,8 @@ type ReadNextTasksResponse struct {
 type ReadOnlyDisksWithLegacyDestination struct {
 	MigrationFault
 
-	RoDiskCount   int  `xml:"roDiskCount"`
-	TimeoutDanger bool `xml:"timeoutDanger"`
+	RoDiskCount   int32 `xml:"roDiskCount"`
+	TimeoutDanger bool  `xml:"timeoutDanger"`
 }
 
 func init() {
@@ -34242,7 +34243,7 @@ func init() {
 
 type ReadPreviousEventsRequestType struct {
 	This     ManagedObjectReference `xml:"_this"`
-	MaxCount int                    `xml:"maxCount"`
+	MaxCount int32                  `xml:"maxCount"`
 }
 
 func init() {
@@ -34261,7 +34262,7 @@ func init() {
 
 type ReadPreviousTasksRequestType struct {
 	This     ManagedObjectReference `xml:"_this"`
-	MaxCount int                    `xml:"maxCount"`
+	MaxCount int32                  `xml:"maxCount"`
 }
 
 func init() {
@@ -34770,7 +34771,7 @@ type RectifyDvsOnHost_TaskResponse struct {
 type RecurrentTaskScheduler struct {
 	TaskScheduler
 
-	Interval int `xml:"interval"`
+	Interval int32 `xml:"interval"`
 }
 
 func init() {
@@ -35124,7 +35125,7 @@ func init() {
 type ReleaseIpAllocationRequestType struct {
 	This         ManagedObjectReference `xml:"_this"`
 	Dc           ManagedObjectReference `xml:"dc"`
-	PoolId       int                    `xml:"poolId"`
+	PoolId       int32                  `xml:"poolId"`
 	AllocationId string                 `xml:"allocationId"`
 }
 
@@ -35256,7 +35257,7 @@ func init() {
 
 type RemoveAuthorizationRoleRequestType struct {
 	This       ManagedObjectReference `xml:"_this"`
-	RoleId     int                    `xml:"roleId"`
+	RoleId     int32                  `xml:"roleId"`
 	FailIfUsed bool                   `xml:"failIfUsed"`
 }
 
@@ -35275,7 +35276,7 @@ func init() {
 
 type RemoveCustomFieldDefRequestType struct {
 	This ManagedObjectReference `xml:"_this"`
-	Key  int                    `xml:"key"`
+	Key  int32                  `xml:"key"`
 }
 
 func init() {
@@ -35326,7 +35327,7 @@ type RemoveDiskMappingRequestType struct {
 	This            ManagedObjectReference `xml:"_this"`
 	Mapping         []VsanHostDiskMapping  `xml:"mapping"`
 	MaintenanceSpec *HostMaintenanceSpec   `xml:"maintenanceSpec,omitempty"`
-	Timeout         int                    `xml:"timeout,omitempty"`
+	Timeout         int32                  `xml:"timeout,omitempty"`
 }
 
 func init() {
@@ -35347,7 +35348,7 @@ type RemoveDiskRequestType struct {
 	This            ManagedObjectReference `xml:"_this"`
 	Disk            []HostScsiDisk         `xml:"disk"`
 	MaintenanceSpec *HostMaintenanceSpec   `xml:"maintenanceSpec,omitempty"`
-	Timeout         int                    `xml:"timeout,omitempty"`
+	Timeout         int32                  `xml:"timeout,omitempty"`
 }
 
 func init() {
@@ -35560,7 +35561,7 @@ func init() {
 
 type RemovePerfIntervalRequestType struct {
 	This         ManagedObjectReference `xml:"_this"`
-	SamplePeriod int                    `xml:"samplePeriod"`
+	SamplePeriod int32                  `xml:"samplePeriod"`
 }
 
 func init() {
@@ -35743,7 +35744,7 @@ func init() {
 
 type RenameCustomFieldDefRequestType struct {
 	This ManagedObjectReference `xml:"_this"`
-	Key  int                    `xml:"key"`
+	Key  int32                  `xml:"key"`
 	Name string                 `xml:"name"`
 }
 
@@ -35886,7 +35887,7 @@ type ReplicationConfigSpec struct {
 	Generation            int64                         `xml:"generation"`
 	VmReplicationId       string                        `xml:"vmReplicationId"`
 	Destination           string                        `xml:"destination"`
-	Port                  int                           `xml:"port"`
+	Port                  int32                         `xml:"port"`
 	Rpo                   int64                         `xml:"rpo"`
 	QuiesceGuestEnabled   bool                          `xml:"quiesceGuestEnabled"`
 	Paused                bool                          `xml:"paused"`
@@ -35904,7 +35905,7 @@ type ReplicationDiskConfigFault struct {
 
 	Reason string                  `xml:"reason,omitempty"`
 	VmRef  *ManagedObjectReference `xml:"vmRef,omitempty"`
-	Key    int                     `xml:"key,omitempty"`
+	Key    int32                   `xml:"key,omitempty"`
 }
 
 func init() {
@@ -35948,7 +35949,7 @@ func init() {
 type ReplicationInfoDiskSettings struct {
 	DynamicData
 
-	Key               int    `xml:"key"`
+	Key               int32  `xml:"key"`
 	DiskReplicationId string `xml:"diskReplicationId"`
 }
 
@@ -36043,7 +36044,7 @@ func init() {
 type ReplicationVmProgressInfo struct {
 	DynamicData
 
-	Progress              int   `xml:"progress"`
+	Progress              int32 `xml:"progress"`
 	BytesTransferred      int64 `xml:"bytesTransferred"`
 	BytesToTransfer       int64 `xml:"bytesToTransfer"`
 	ChecksumTotalBytes    int64 `xml:"checksumTotalBytes,omitempty"`
@@ -36162,7 +36163,7 @@ func init() {
 
 type ResetCounterLevelMappingRequestType struct {
 	This     ManagedObjectReference `xml:"_this"`
-	Counters []int                  `xml:"counters"`
+	Counters []int32                `xml:"counters"`
 }
 
 func init() {
@@ -36536,8 +36537,8 @@ type ResourcePoolQuickStats struct {
 	HostMemoryUsage              int64 `xml:"hostMemoryUsage,omitempty"`
 	DistributedCpuEntitlement    int64 `xml:"distributedCpuEntitlement,omitempty"`
 	DistributedMemoryEntitlement int64 `xml:"distributedMemoryEntitlement,omitempty"`
-	StaticCpuEntitlement         int   `xml:"staticCpuEntitlement,omitempty"`
-	StaticMemoryEntitlement      int   `xml:"staticMemoryEntitlement,omitempty"`
+	StaticCpuEntitlement         int32 `xml:"staticCpuEntitlement,omitempty"`
+	StaticMemoryEntitlement      int32 `xml:"staticMemoryEntitlement,omitempty"`
 	PrivateMemory                int64 `xml:"privateMemory,omitempty"`
 	SharedMemory                 int64 `xml:"sharedMemory,omitempty"`
 	SwappedMemory                int64 `xml:"swappedMemory,omitempty"`
@@ -36593,7 +36594,7 @@ type ResourcePoolSummary struct {
 	Config             ResourceConfigSpec      `xml:"config"`
 	Runtime            ResourcePoolRuntimeInfo `xml:"runtime"`
 	QuickStats         *ResourcePoolQuickStats `xml:"quickStats,omitempty"`
-	ConfiguredMemoryMB int                     `xml:"configuredMemoryMB,omitempty"`
+	ConfiguredMemoryMB int32                   `xml:"configuredMemoryMB,omitempty"`
 }
 
 func init() {
@@ -36920,7 +36921,7 @@ type RetrieveObjectScheduledTaskResponse struct {
 type RetrieveOptions struct {
 	DynamicData
 
-	MaxObjects int `xml:"maxObjects,omitempty"`
+	MaxObjects int32 `xml:"maxObjects,omitempty"`
 }
 
 func init() {
@@ -37003,7 +37004,7 @@ func init() {
 
 type RetrieveRolePermissionsRequestType struct {
 	This   ManagedObjectReference `xml:"_this"`
-	RoleId int                    `xml:"roleId"`
+	RoleId int32                  `xml:"roleId"`
 }
 
 func init() {
@@ -37137,7 +37138,7 @@ func init() {
 type RoleEventArgument struct {
 	EventArgument
 
-	RoleId int    `xml:"roleId"`
+	RoleId int32  `xml:"roleId"`
 	Name   string `xml:"name"`
 }
 
@@ -37494,7 +37495,7 @@ type ScheduledTaskInfo struct {
 	State            TaskInfoState           `xml:"state"`
 	Error            *LocalizedMethodFault   `xml:"error,omitempty"`
 	Result           AnyType                 `xml:"result,omitempty,typeattr"`
-	Progress         int                     `xml:"progress,omitempty"`
+	Progress         int32                   `xml:"progress,omitempty"`
 	ActiveTask       *ManagedObjectReference `xml:"activeTask,omitempty"`
 	TaskObject       *ManagedObjectReference `xml:"taskObject,omitempty"`
 }
@@ -37554,12 +37555,12 @@ type ScsiLun struct {
 	Vendor           string               `xml:"vendor,omitempty"`
 	Model            string               `xml:"model,omitempty"`
 	Revision         string               `xml:"revision,omitempty"`
-	ScsiLevel        int                  `xml:"scsiLevel,omitempty"`
+	ScsiLevel        int32                `xml:"scsiLevel,omitempty"`
 	SerialNumber     string               `xml:"serialNumber,omitempty"`
 	DurableName      *ScsiLunDurableName  `xml:"durableName,omitempty"`
 	AlternateName    []ScsiLunDurableName `xml:"alternateName,omitempty"`
 	StandardInquiry  []byte               `xml:"standardInquiry,omitempty"`
-	QueueDepth       int                  `xml:"queueDepth,omitempty"`
+	QueueDepth       int32                `xml:"queueDepth,omitempty"`
 	OperationalState []string             `xml:"operationalState"`
 	Capabilities     *ScsiLunCapabilities `xml:"capabilities,omitempty"`
 	VStorageSupport  string               `xml:"vStorageSupport,omitempty"`
@@ -37606,7 +37607,7 @@ func init() {
 type SeSparseVirtualDiskSpec struct {
 	FileBackedVirtualDiskSpec
 
-	GrainSizeKb int `xml:"grainSizeKb,omitempty"`
+	GrainSizeKb int32 `xml:"grainSizeKb,omitempty"`
 }
 
 func init() {
@@ -38122,7 +38123,7 @@ func init() {
 
 type SetCollectorPageSizeRequestType struct {
 	This     ManagedObjectReference `xml:"_this"`
-	MaxCount int                    `xml:"maxCount"`
+	MaxCount int32                  `xml:"maxCount"`
 }
 
 func init() {
@@ -38197,7 +38198,7 @@ func init() {
 type SetFieldRequestType struct {
 	This   ManagedObjectReference `xml:"_this"`
 	Entity ManagedObjectReference `xml:"entity"`
-	Key    int                    `xml:"key"`
+	Key    int32                  `xml:"key"`
 	Value  string                 `xml:"value"`
 }
 
@@ -38330,8 +38331,8 @@ func init() {
 
 type SetScreenResolutionRequestType struct {
 	This   ManagedObjectReference `xml:"_this"`
-	Width  int                    `xml:"width"`
-	Height int                    `xml:"height"`
+	Width  int32                  `xml:"width"`
+	Height int32                  `xml:"height"`
 }
 
 func init() {
@@ -38416,7 +38417,7 @@ func init() {
 type SharesInfo struct {
 	DynamicData
 
-	Shares int         `xml:"shares"`
+	Shares int32       `xml:"shares"`
 	Level  SharesLevel `xml:"level"`
 }
 
@@ -38438,7 +38439,7 @@ func init() {
 type ShrinkDiskFault struct {
 	VimFault
 
-	DiskId int `xml:"diskId,omitempty"`
+	DiskId int32 `xml:"diskId,omitempty"`
 }
 
 func init() {
@@ -39200,11 +39201,11 @@ func init() {
 type StorageDrsIoLoadBalanceConfig struct {
 	DynamicData
 
-	ReservablePercentThreshold int    `xml:"reservablePercentThreshold,omitempty"`
-	ReservableIopsThreshold    int    `xml:"reservableIopsThreshold,omitempty"`
+	ReservablePercentThreshold int32  `xml:"reservablePercentThreshold,omitempty"`
+	ReservableIopsThreshold    int32  `xml:"reservableIopsThreshold,omitempty"`
 	ReservableThresholdMode    string `xml:"reservableThresholdMode,omitempty"`
-	IoLatencyThreshold         int    `xml:"ioLatencyThreshold,omitempty"`
-	IoLoadImbalanceThreshold   int    `xml:"ioLoadImbalanceThreshold,omitempty"`
+	IoLatencyThreshold         int32  `xml:"ioLatencyThreshold,omitempty"`
+	IoLoadImbalanceThreshold   int32  `xml:"ioLoadImbalanceThreshold,omitempty"`
 }
 
 func init() {
@@ -39252,7 +39253,7 @@ type StorageDrsPodConfigInfo struct {
 	Enabled                bool                              `xml:"enabled"`
 	IoLoadBalanceEnabled   bool                              `xml:"ioLoadBalanceEnabled"`
 	DefaultVmBehavior      string                            `xml:"defaultVmBehavior"`
-	LoadBalanceInterval    int                               `xml:"loadBalanceInterval,omitempty"`
+	LoadBalanceInterval    int32                             `xml:"loadBalanceInterval,omitempty"`
 	DefaultIntraVmAffinity *bool                             `xml:"defaultIntraVmAffinity"`
 	SpaceLoadBalanceConfig *StorageDrsSpaceLoadBalanceConfig `xml:"spaceLoadBalanceConfig,omitempty"`
 	IoLoadBalanceConfig    *StorageDrsIoLoadBalanceConfig    `xml:"ioLoadBalanceConfig,omitempty"`
@@ -39271,7 +39272,7 @@ type StorageDrsPodConfigSpec struct {
 	Enabled                *bool                             `xml:"enabled"`
 	IoLoadBalanceEnabled   *bool                             `xml:"ioLoadBalanceEnabled"`
 	DefaultVmBehavior      string                            `xml:"defaultVmBehavior,omitempty"`
-	LoadBalanceInterval    int                               `xml:"loadBalanceInterval,omitempty"`
+	LoadBalanceInterval    int32                             `xml:"loadBalanceInterval,omitempty"`
 	DefaultIntraVmAffinity *bool                             `xml:"defaultIntraVmAffinity"`
 	SpaceLoadBalanceConfig *StorageDrsSpaceLoadBalanceConfig `xml:"spaceLoadBalanceConfig,omitempty"`
 	IoLoadBalanceConfig    *StorageDrsIoLoadBalanceConfig    `xml:"ioLoadBalanceConfig,omitempty"`
@@ -39313,9 +39314,9 @@ type StorageDrsSpaceLoadBalanceConfig struct {
 	DynamicData
 
 	SpaceThresholdMode            string `xml:"spaceThresholdMode,omitempty"`
-	SpaceUtilizationThreshold     int    `xml:"spaceUtilizationThreshold,omitempty"`
-	FreeSpaceThresholdGB          int    `xml:"freeSpaceThresholdGB,omitempty"`
-	MinSpaceUtilizationDifference int    `xml:"minSpaceUtilizationDifference,omitempty"`
+	SpaceUtilizationThreshold     int32  `xml:"spaceUtilizationThreshold,omitempty"`
+	FreeSpaceThresholdGB          int32  `xml:"freeSpaceThresholdGB,omitempty"`
+	MinSpaceUtilizationDifference int32  `xml:"minSpaceUtilizationDifference,omitempty"`
 }
 
 func init() {
@@ -39379,7 +39380,7 @@ type StorageIOAllocationInfo struct {
 
 	Limit       int64       `xml:"limit,omitempty"`
 	Shares      *SharesInfo `xml:"shares,omitempty"`
-	Reservation int         `xml:"reservation,omitempty"`
+	Reservation int32       `xml:"reservation,omitempty"`
 }
 
 func init() {
@@ -39415,12 +39416,12 @@ type StorageIORMConfigSpec struct {
 
 	Enabled                  *bool  `xml:"enabled"`
 	CongestionThresholdMode  string `xml:"congestionThresholdMode,omitempty"`
-	CongestionThreshold      int    `xml:"congestionThreshold,omitempty"`
-	PercentOfPeakThroughput  int    `xml:"percentOfPeakThroughput,omitempty"`
+	CongestionThreshold      int32  `xml:"congestionThreshold,omitempty"`
+	PercentOfPeakThroughput  int32  `xml:"percentOfPeakThroughput,omitempty"`
 	StatsCollectionEnabled   *bool  `xml:"statsCollectionEnabled"`
 	ReservationEnabled       *bool  `xml:"reservationEnabled"`
 	StatsAggregationDisabled *bool  `xml:"statsAggregationDisabled"`
-	ReservableIopsThreshold  int    `xml:"reservableIopsThreshold,omitempty"`
+	ReservableIopsThreshold  int32  `xml:"reservableIopsThreshold,omitempty"`
 }
 
 func init() {
@@ -39432,12 +39433,12 @@ type StorageIORMInfo struct {
 
 	Enabled                  bool   `xml:"enabled"`
 	CongestionThresholdMode  string `xml:"congestionThresholdMode,omitempty"`
-	CongestionThreshold      int    `xml:"congestionThreshold"`
-	PercentOfPeakThroughput  int    `xml:"percentOfPeakThroughput,omitempty"`
+	CongestionThreshold      int32  `xml:"congestionThreshold"`
+	PercentOfPeakThroughput  int32  `xml:"percentOfPeakThroughput,omitempty"`
 	StatsCollectionEnabled   *bool  `xml:"statsCollectionEnabled"`
 	ReservationEnabled       *bool  `xml:"reservationEnabled"`
 	StatsAggregationDisabled *bool  `xml:"statsAggregationDisabled"`
-	ReservableIopsThreshold  int    `xml:"reservableIopsThreshold,omitempty"`
+	ReservableIopsThreshold  int32  `xml:"reservableIopsThreshold,omitempty"`
 }
 
 func init() {
@@ -39467,14 +39468,14 @@ func init() {
 type StoragePerformanceSummary struct {
 	DynamicData
 
-	Interval              int       `xml:"interval"`
-	Percentile            []int     `xml:"percentile"`
+	Interval              int32     `xml:"interval"`
+	Percentile            []int32   `xml:"percentile"`
 	DatastoreReadLatency  []float64 `xml:"datastoreReadLatency"`
 	DatastoreWriteLatency []float64 `xml:"datastoreWriteLatency"`
 	DatastoreVmLatency    []float64 `xml:"datastoreVmLatency"`
 	DatastoreReadIops     []float64 `xml:"datastoreReadIops"`
 	DatastoreWriteIops    []float64 `xml:"datastoreWriteIops"`
-	SiocActivityDuration  int       `xml:"siocActivityDuration"`
+	SiocActivityDuration  int32     `xml:"siocActivityDuration"`
 }
 
 func init() {
@@ -39525,7 +39526,7 @@ type StoragePlacementSpec struct {
 	Host                      *ManagedObjectReference     `xml:"host,omitempty"`
 	Folder                    *ManagedObjectReference     `xml:"folder,omitempty"`
 	DisallowPrerequisiteMoves *bool                       `xml:"disallowPrerequisiteMoves"`
-	ResourceLeaseDurationSec  int                         `xml:"resourceLeaseDurationSec,omitempty"`
+	ResourceLeaseDurationSec  int32                       `xml:"resourceLeaseDurationSec,omitempty"`
 }
 
 func init() {
@@ -39816,7 +39817,7 @@ type TaskFilterSpec struct {
 	State         []TaskInfoState           `xml:"state,omitempty"`
 	Alarm         *ManagedObjectReference   `xml:"alarm,omitempty"`
 	ScheduledTask *ManagedObjectReference   `xml:"scheduledTask,omitempty"`
-	EventChainId  []int                     `xml:"eventChainId,omitempty"`
+	EventChainId  []int32                   `xml:"eventChainId,omitempty"`
 	Tag           []string                  `xml:"tag,omitempty"`
 	ParentTaskKey []string                  `xml:"parentTaskKey,omitempty"`
 	RootTaskKey   []string                  `xml:"rootTaskKey,omitempty"`
@@ -39892,12 +39893,12 @@ type TaskInfo struct {
 	Cancelable    bool                     `xml:"cancelable"`
 	Error         *LocalizedMethodFault    `xml:"error,omitempty"`
 	Result        AnyType                  `xml:"result,omitempty,typeattr"`
-	Progress      int                      `xml:"progress,omitempty"`
+	Progress      int32                    `xml:"progress,omitempty"`
 	Reason        BaseTaskReason           `xml:"reason,typeattr"`
 	QueueTime     time.Time                `xml:"queueTime"`
 	StartTime     *time.Time               `xml:"startTime"`
 	CompleteTime  *time.Time               `xml:"completeTime"`
-	EventChainId  int                      `xml:"eventChainId"`
+	EventChainId  int32                    `xml:"eventChainId"`
 	ChangeTag     string                   `xml:"changeTag,omitempty"`
 	ParentTaskKey string                   `xml:"parentTaskKey,omitempty"`
 	RootTaskKey   string                   `xml:"rootTaskKey,omitempty"`
@@ -40214,8 +40215,8 @@ func init() {
 type TooManyDisksOnLegacyHost struct {
 	MigrationFault
 
-	DiskCount     int  `xml:"diskCount"`
-	TimeoutDanger bool `xml:"timeoutDanger"`
+	DiskCount     int32 `xml:"diskCount"`
+	TimeoutDanger bool  `xml:"timeoutDanger"`
 }
 
 func init() {
@@ -40329,7 +40330,7 @@ func init() {
 type ToolsConfigInfo struct {
 	DynamicData
 
-	ToolsVersion         int                                  `xml:"toolsVersion,omitempty"`
+	ToolsVersion         int32                                `xml:"toolsVersion,omitempty"`
 	AfterPowerOn         *bool                                `xml:"afterPowerOn"`
 	AfterResume          *bool                                `xml:"afterResume"`
 	BeforeGuestStandby   *bool                                `xml:"beforeGuestStandby"`
@@ -40348,7 +40349,7 @@ func init() {
 type ToolsConfigInfoToolsLastInstallInfo struct {
 	DynamicData
 
-	Counter int                   `xml:"counter"`
+	Counter int32                 `xml:"counter"`
 	Fault   *LocalizedMethodFault `xml:"fault,omitempty"`
 }
 
@@ -40711,8 +40712,8 @@ type UninstallServiceResponse struct {
 type UnlicensedVirtualMachinesEvent struct {
 	LicenseEvent
 
-	Unlicensed int `xml:"unlicensed"`
-	Available  int `xml:"available"`
+	Unlicensed int32 `xml:"unlicensed"`
+	Available  int32 `xml:"available"`
 }
 
 func init() {
@@ -40722,7 +40723,7 @@ func init() {
 type UnlicensedVirtualMachinesFoundEvent struct {
 	LicenseEvent
 
-	Available int `xml:"available"`
+	Available int32 `xml:"available"`
 }
 
 func init() {
@@ -41065,7 +41066,7 @@ func init() {
 
 type UpdateAuthorizationRoleRequestType struct {
 	This    ManagedObjectReference `xml:"_this"`
-	RoleId  int                    `xml:"roleId"`
+	RoleId  int32                  `xml:"roleId"`
 	NewName string                 `xml:"newName"`
 	PrivIds []string               `xml:"privIds,omitempty"`
 }
@@ -41884,7 +41885,7 @@ func init() {
 
 type UpdateProgressRequestType struct {
 	This        ManagedObjectReference `xml:"_this"`
-	PercentDone int                    `xml:"percentDone"`
+	PercentDone int32                  `xml:"percentDone"`
 }
 
 func init() {
@@ -42344,7 +42345,7 @@ func init() {
 type UpgradeVsanObjectsRequestType struct {
 	This       ManagedObjectReference `xml:"_this"`
 	Uuids      []string               `xml:"uuids"`
-	NewVersion int                    `xml:"newVersion"`
+	NewVersion int32                  `xml:"newVersion"`
 }
 
 func init() {
@@ -42632,11 +42633,11 @@ type VAppEntityConfigInfo struct {
 
 	Key               *ManagedObjectReference `xml:"key,omitempty"`
 	Tag               string                  `xml:"tag,omitempty"`
-	StartOrder        int                     `xml:"startOrder,omitempty"`
-	StartDelay        int                     `xml:"startDelay,omitempty"`
+	StartOrder        int32                   `xml:"startOrder,omitempty"`
+	StartDelay        int32                   `xml:"startDelay,omitempty"`
 	WaitingForGuest   *bool                   `xml:"waitingForGuest"`
 	StartAction       string                  `xml:"startAction,omitempty"`
-	StopDelay         int                     `xml:"stopDelay,omitempty"`
+	StopDelay         int32                   `xml:"stopDelay,omitempty"`
 	StopAction        string                  `xml:"stopAction,omitempty"`
 	DestroyWithParent *bool                   `xml:"destroyWithParent"`
 }
@@ -42689,7 +42690,7 @@ func init() {
 type VAppOvfSectionInfo struct {
 	DynamicData
 
-	Key             int    `xml:"key,omitempty"`
+	Key             int32  `xml:"key,omitempty"`
 	Namespace       string `xml:"namespace,omitempty"`
 	Type            string `xml:"type,omitempty"`
 	AtEnvelopeLevel *bool  `xml:"atEnvelopeLevel"`
@@ -42713,7 +42714,7 @@ func init() {
 type VAppProductInfo struct {
 	DynamicData
 
-	Key         int    `xml:"key"`
+	Key         int32  `xml:"key"`
 	ClassId     string `xml:"classId,omitempty"`
 	InstanceId  string `xml:"instanceId,omitempty"`
 	Name        string `xml:"name,omitempty"`
@@ -42762,7 +42763,7 @@ func init() {
 type VAppPropertyInfo struct {
 	DynamicData
 
-	Key              int    `xml:"key"`
+	Key              int32  `xml:"key"`
 	ClassId          string `xml:"classId,omitempty"`
 	InstanceId       string `xml:"instanceId,omitempty"`
 	Id               string `xml:"id,omitempty"`
@@ -43061,7 +43062,7 @@ type VMwareDVSConfigInfo struct {
 
 	VspanSession                []VMwareVspanSession         `xml:"vspanSession,omitempty"`
 	PvlanConfig                 []VMwareDVSPvlanMapEntry     `xml:"pvlanConfig,omitempty"`
-	MaxMtu                      int                          `xml:"maxMtu"`
+	MaxMtu                      int32                        `xml:"maxMtu"`
 	LinkDiscoveryProtocolConfig *LinkDiscoveryProtocolConfig `xml:"linkDiscoveryProtocolConfig,omitempty"`
 	IpfixConfig                 *VMwareIpfixConfig           `xml:"ipfixConfig,omitempty"`
 	LacpGroupConfig             []VMwareDvsLacpGroupConfig   `xml:"lacpGroupConfig,omitempty"`
@@ -43078,7 +43079,7 @@ type VMwareDVSConfigSpec struct {
 
 	PvlanConfigSpec             []VMwareDVSPvlanConfigSpec   `xml:"pvlanConfigSpec,omitempty"`
 	VspanConfigSpec             []VMwareDVSVspanConfigSpec   `xml:"vspanConfigSpec,omitempty"`
-	MaxMtu                      int                          `xml:"maxMtu,omitempty"`
+	MaxMtu                      int32                        `xml:"maxMtu,omitempty"`
 	LinkDiscoveryProtocolConfig *LinkDiscoveryProtocolConfig `xml:"linkDiscoveryProtocolConfig,omitempty"`
 	IpfixConfig                 *VMwareIpfixConfig           `xml:"ipfixConfig,omitempty"`
 	LacpApiVersion              string                       `xml:"lacpApiVersion,omitempty"`
@@ -43179,8 +43180,8 @@ func init() {
 type VMwareDVSPvlanMapEntry struct {
 	DynamicData
 
-	PrimaryVlanId   int    `xml:"primaryVlanId"`
-	SecondaryVlanId int    `xml:"secondaryVlanId"`
+	PrimaryVlanId   int32  `xml:"primaryVlanId"`
+	SecondaryVlanId int32  `xml:"secondaryVlanId"`
 	PvlanType       string `xml:"pvlanType"`
 }
 
@@ -43279,7 +43280,7 @@ type VMwareDvsLacpGroupConfig struct {
 	Key                  string                   `xml:"key,omitempty"`
 	Name                 string                   `xml:"name,omitempty"`
 	Mode                 string                   `xml:"mode,omitempty"`
-	UplinkNum            int                      `xml:"uplinkNum,omitempty"`
+	UplinkNum            int32                    `xml:"uplinkNum,omitempty"`
 	LoadbalanceAlgorithm string                   `xml:"loadbalanceAlgorithm,omitempty"`
 	Vlan                 *VMwareDvsLagVlanConfig  `xml:"vlan,omitempty"`
 	Ipfix                *VMwareDvsLagIpfixConfig `xml:"ipfix,omitempty"`
@@ -43326,11 +43327,11 @@ type VMwareIpfixConfig struct {
 	DynamicData
 
 	CollectorIpAddress  string `xml:"collectorIpAddress,omitempty"`
-	CollectorPort       int    `xml:"collectorPort,omitempty"`
+	CollectorPort       int32  `xml:"collectorPort,omitempty"`
 	ObservationDomainId int64  `xml:"observationDomainId,omitempty"`
-	ActiveFlowTimeout   int    `xml:"activeFlowTimeout"`
-	IdleFlowTimeout     int    `xml:"idleFlowTimeout"`
-	SamplingRate        int    `xml:"samplingRate"`
+	ActiveFlowTimeout   int32  `xml:"activeFlowTimeout"`
+	IdleFlowTimeout     int32  `xml:"idleFlowTimeout"`
+	SamplingRate        int32  `xml:"samplingRate"`
 	InternalFlowsOnly   bool   `xml:"internalFlowsOnly"`
 }
 
@@ -43366,7 +43367,7 @@ type VMwareVspanPort struct {
 	PortKey                   []string `xml:"portKey,omitempty"`
 	UplinkPortName            []string `xml:"uplinkPortName,omitempty"`
 	WildcardPortConnecteeType []string `xml:"wildcardPortConnecteeType,omitempty"`
-	Vlans                     []int    `xml:"vlans,omitempty"`
+	Vlans                     []int32  `xml:"vlans,omitempty"`
 	IpAddress                 []string `xml:"ipAddress,omitempty"`
 }
 
@@ -43384,12 +43385,12 @@ type VMwareVspanSession struct {
 	SourcePortTransmitted *VMwareVspanPort `xml:"sourcePortTransmitted,omitempty"`
 	SourcePortReceived    *VMwareVspanPort `xml:"sourcePortReceived,omitempty"`
 	DestinationPort       *VMwareVspanPort `xml:"destinationPort,omitempty"`
-	EncapsulationVlanId   int              `xml:"encapsulationVlanId,omitempty"`
+	EncapsulationVlanId   int32            `xml:"encapsulationVlanId,omitempty"`
 	StripOriginalVlan     bool             `xml:"stripOriginalVlan"`
-	MirroredPacketLength  int              `xml:"mirroredPacketLength,omitempty"`
+	MirroredPacketLength  int32            `xml:"mirroredPacketLength,omitempty"`
 	NormalTrafficAllowed  bool             `xml:"normalTrafficAllowed"`
 	SessionType           string           `xml:"sessionType,omitempty"`
-	SamplingRate          int              `xml:"samplingRate,omitempty"`
+	SamplingRate          int32            `xml:"samplingRate,omitempty"`
 }
 
 func init() {
@@ -43582,7 +43583,7 @@ func init() {
 type VimVasaProviderStatePerArray struct {
 	DynamicData
 
-	Priority int    `xml:"priority"`
+	Priority int32  `xml:"priority"`
 	ArrayId  string `xml:"arrayId"`
 	Active   bool   `xml:"active"`
 }
@@ -43768,8 +43769,8 @@ func init() {
 type VirtualController struct {
 	VirtualDevice
 
-	BusNumber int   `xml:"busNumber"`
-	Device    []int `xml:"device,omitempty"`
+	BusNumber int32   `xml:"busNumber"`
+	Device    []int32 `xml:"device,omitempty"`
 }
 
 func init() {
@@ -43790,13 +43791,13 @@ func init() {
 type VirtualDevice struct {
 	DynamicData
 
-	Key           int                          `xml:"key"`
+	Key           int32                        `xml:"key"`
 	DeviceInfo    BaseDescription              `xml:"deviceInfo,omitempty,typeattr"`
 	Backing       BaseVirtualDeviceBackingInfo `xml:"backing,omitempty,typeattr"`
 	Connectable   *VirtualDeviceConnectInfo    `xml:"connectable,omitempty"`
 	SlotInfo      BaseVirtualDeviceBusSlotInfo `xml:"slotInfo,omitempty,typeattr"`
-	ControllerKey int                          `xml:"controllerKey,omitempty"`
-	UnitNumber    int                          `xml:"unitNumber,omitempty"`
+	ControllerKey int32                        `xml:"controllerKey,omitempty"`
+	UnitNumber    *int32                       `xml:"unitNumber"`
 }
 
 func init() {
@@ -43928,7 +43929,7 @@ type VirtualDeviceOption struct {
 	ControllerType            string                           `xml:"controllerType,omitempty"`
 	AutoAssignController      *BoolOption                      `xml:"autoAssignController,omitempty"`
 	BackingOption             []BaseVirtualDeviceBackingOption `xml:"backingOption,omitempty,typeattr"`
-	DefaultBackingOptionIndex int                              `xml:"defaultBackingOptionIndex,omitempty"`
+	DefaultBackingOptionIndex int32                            `xml:"defaultBackingOptionIndex,omitempty"`
 	LicensingLimit            []string                         `xml:"licensingLimit,omitempty"`
 	Deprecated                bool                             `xml:"deprecated"`
 	PlugAndPlay               bool                             `xml:"plugAndPlay"`
@@ -43942,7 +43943,7 @@ func init() {
 type VirtualDevicePciBusSlotInfo struct {
 	VirtualDeviceBusSlotInfo
 
-	PciSlotNumber int `xml:"pciSlotNumber"`
+	PciSlotNumber int32 `xml:"pciSlotNumber"`
 }
 
 func init() {
@@ -44029,7 +44030,7 @@ func init() {
 type VirtualDiskAntiAffinityRuleSpec struct {
 	ClusterRuleInfo
 
-	DiskId []int `xml:"diskId"`
+	DiskId []int32 `xml:"diskId"`
 }
 
 func init() {
@@ -44113,7 +44114,7 @@ type VirtualDiskFlatVer2BackingInfo struct {
 	Parent                 *VirtualDiskFlatVer2BackingInfo `xml:"parent,omitempty"`
 	DeltaDiskFormat        string                          `xml:"deltaDiskFormat,omitempty"`
 	DigestEnabled          *bool                           `xml:"digestEnabled"`
-	DeltaGrainSize         int                             `xml:"deltaGrainSize,omitempty"`
+	DeltaGrainSize         int32                           `xml:"deltaGrainSize,omitempty"`
 	DeltaDiskFormatVariant string                          `xml:"deltaDiskFormatVariant,omitempty"`
 	Sharing                string                          `xml:"sharing,omitempty"`
 }
@@ -44145,7 +44146,7 @@ type VirtualDiskId struct {
 	DynamicData
 
 	Vm     ManagedObjectReference `xml:"vm"`
-	DiskId int                    `xml:"diskId"`
+	DiskId int32                  `xml:"diskId"`
 }
 
 func init() {
@@ -44196,7 +44197,7 @@ func init() {
 type VirtualDiskPartitionedRawDiskVer2BackingInfo struct {
 	VirtualDiskRawDiskVer2BackingInfo
 
-	Partition []int `xml:"partition"`
+	Partition []int32 `xml:"partition"`
 }
 
 func init() {
@@ -44277,7 +44278,7 @@ type VirtualDiskSeSparseBackingInfo struct {
 	Parent          *VirtualDiskSeSparseBackingInfo `xml:"parent,omitempty"`
 	DeltaDiskFormat string                          `xml:"deltaDiskFormat,omitempty"`
 	DigestEnabled   *bool                           `xml:"digestEnabled"`
-	GrainSize       int                             `xml:"grainSize,omitempty"`
+	GrainSize       int32                           `xml:"grainSize,omitempty"`
 }
 
 func init() {
@@ -44626,9 +44627,9 @@ func init() {
 type VirtualHardware struct {
 	DynamicData
 
-	NumCPU              int                 `xml:"numCPU"`
-	NumCoresPerSocket   int                 `xml:"numCoresPerSocket,omitempty"`
-	MemoryMB            int                 `xml:"memoryMB"`
+	NumCPU              int32               `xml:"numCPU"`
+	NumCoresPerSocket   int32               `xml:"numCoresPerSocket,omitempty"`
+	MemoryMB            int32               `xml:"memoryMB"`
 	VirtualICH7MPresent *bool               `xml:"virtualICH7MPresent"`
 	VirtualSMCPresent   *bool               `xml:"virtualSMCPresent"`
 	Device              []BaseVirtualDevice `xml:"device,omitempty,typeattr"`
@@ -44655,10 +44656,10 @@ func init() {
 type VirtualHardwareOption struct {
 	DynamicData
 
-	HwVersion             int                       `xml:"hwVersion"`
+	HwVersion             int32                     `xml:"hwVersion"`
 	VirtualDeviceOption   []BaseVirtualDeviceOption `xml:"virtualDeviceOption,typeattr"`
 	DeviceListReadonly    bool                      `xml:"deviceListReadonly"`
-	NumCPU                []int                     `xml:"numCPU"`
+	NumCPU                []int32                   `xml:"numCPU"`
 	NumCoresPerSocket     *IntOption                `xml:"numCoresPerSocket,omitempty"`
 	NumCpuReadonly        bool                      `xml:"numCpuReadonly"`
 	MemoryMB              LongOption                `xml:"memoryMB"`
@@ -44781,7 +44782,7 @@ func init() {
 type VirtualMachineAffinityInfo struct {
 	DynamicData
 
-	AffinitySet []int `xml:"affinitySet,omitempty"`
+	AffinitySet []int32 `xml:"affinitySet,omitempty"`
 }
 
 func init() {
@@ -44822,7 +44823,7 @@ func init() {
 type VirtualMachineBootOptionsBootableDiskDevice struct {
 	VirtualMachineBootOptionsBootableDevice
 
-	DeviceKey int `xml:"deviceKey"`
+	DeviceKey int32 `xml:"deviceKey"`
 }
 
 func init() {
@@ -44832,7 +44833,7 @@ func init() {
 type VirtualMachineBootOptionsBootableEthernetDevice struct {
 	VirtualMachineBootOptionsBootableDevice
 
-	DeviceKey int `xml:"deviceKey"`
+	DeviceKey int32 `xml:"deviceKey"`
 }
 
 func init() {
@@ -44967,7 +44968,7 @@ type VirtualMachineConfigInfo struct {
 	VAssertsEnabled              *bool                                      `xml:"vAssertsEnabled"`
 	ChangeTrackingEnabled        *bool                                      `xml:"changeTrackingEnabled"`
 	Firmware                     string                                     `xml:"firmware,omitempty"`
-	MaxMksConnections            int                                        `xml:"maxMksConnections,omitempty"`
+	MaxMksConnections            int32                                      `xml:"maxMksConnections,omitempty"`
 	GuestAutoLockEnabled         *bool                                      `xml:"guestAutoLockEnabled"`
 	ManagedBy                    *ManagedByInfo                             `xml:"managedBy,omitempty"`
 	MemoryReservationLockedToMax *bool                                      `xml:"memoryReservationLockedToMax"`
@@ -45015,7 +45016,7 @@ type VirtualMachineConfigOption struct {
 	Version                          string                   `xml:"version"`
 	Description                      string                   `xml:"description"`
 	GuestOSDescriptor                []GuestOsDescriptor      `xml:"guestOSDescriptor"`
-	GuestOSDefaultIndex              int                      `xml:"guestOSDefaultIndex"`
+	GuestOSDefaultIndex              int32                    `xml:"guestOSDefaultIndex"`
 	HardwareOptions                  VirtualHardwareOption    `xml:"hardwareOptions"`
 	Capabilities                     VirtualMachineCapability `xml:"capabilities"`
 	Datastore                        DatastoreOption          `xml:"datastore"`
@@ -45070,8 +45071,8 @@ type VirtualMachineConfigSpec struct {
 	Flags                        *VirtualMachineFlagInfo           `xml:"flags,omitempty"`
 	ConsolePreferences           *VirtualMachineConsolePreferences `xml:"consolePreferences,omitempty"`
 	PowerOpInfo                  *VirtualMachineDefaultPowerOpInfo `xml:"powerOpInfo,omitempty"`
-	NumCPUs                      int                               `xml:"numCPUs,omitempty"`
-	NumCoresPerSocket            int                               `xml:"numCoresPerSocket,omitempty"`
+	NumCPUs                      int32                             `xml:"numCPUs,omitempty"`
+	NumCoresPerSocket            int32                             `xml:"numCoresPerSocket,omitempty"`
 	MemoryMB                     int64                             `xml:"memoryMB,omitempty"`
 	MemoryHotAddEnabled          *bool                             `xml:"memoryHotAddEnabled"`
 	CpuHotAddEnabled             *bool                             `xml:"cpuHotAddEnabled"`
@@ -45096,7 +45097,7 @@ type VirtualMachineConfigSpec struct {
 	VAssertsEnabled              *bool                             `xml:"vAssertsEnabled"`
 	ChangeTrackingEnabled        *bool                             `xml:"changeTrackingEnabled"`
 	Firmware                     string                            `xml:"firmware,omitempty"`
-	MaxMksConnections            int                               `xml:"maxMksConnections,omitempty"`
+	MaxMksConnections            int32                             `xml:"maxMksConnections,omitempty"`
 	GuestAutoLockEnabled         *bool                             `xml:"guestAutoLockEnabled"`
 	ManagedBy                    *ManagedByInfo                    `xml:"managedBy,omitempty"`
 	MemoryReservationLockedToMax *bool                             `xml:"memoryReservationLockedToMax"`
@@ -45117,12 +45118,12 @@ type VirtualMachineConfigSummary struct {
 	Name                string                       `xml:"name"`
 	Template            bool                         `xml:"template"`
 	VmPathName          string                       `xml:"vmPathName"`
-	MemorySizeMB        int                          `xml:"memorySizeMB,omitempty"`
-	CpuReservation      int                          `xml:"cpuReservation,omitempty"`
-	MemoryReservation   int                          `xml:"memoryReservation,omitempty"`
-	NumCpu              int                          `xml:"numCpu,omitempty"`
-	NumEthernetCards    int                          `xml:"numEthernetCards,omitempty"`
-	NumVirtualDisks     int                          `xml:"numVirtualDisks,omitempty"`
+	MemorySizeMB        int32                        `xml:"memorySizeMB,omitempty"`
+	CpuReservation      int32                        `xml:"cpuReservation,omitempty"`
+	MemoryReservation   int32                        `xml:"memoryReservation,omitempty"`
+	NumCpu              int32                        `xml:"numCpu,omitempty"`
+	NumEthernetCards    int32                        `xml:"numEthernetCards,omitempty"`
+	NumVirtualDisks     int32                        `xml:"numVirtualDisks,omitempty"`
 	Uuid                string                       `xml:"uuid,omitempty"`
 	InstanceUuid        string                       `xml:"instanceUuid,omitempty"`
 	GuestId             string                       `xml:"guestId,omitempty"`
@@ -45193,7 +45194,7 @@ type VirtualMachineDatastoreVolumeOption struct {
 	DynamicData
 
 	FileSystemType string `xml:"fileSystemType"`
-	MajorVersion   int    `xml:"majorVersion,omitempty"`
+	MajorVersion   int32  `xml:"majorVersion,omitempty"`
 }
 
 func init() {
@@ -45239,7 +45240,7 @@ type VirtualMachineDeviceRuntimeInfo struct {
 	DynamicData
 
 	RuntimeState BaseVirtualMachineDeviceRuntimeInfoDeviceRuntimeState `xml:"runtimeState,typeattr"`
-	Key          int                                                   `xml:"key"`
+	Key          int32                                                 `xml:"key"`
 }
 
 func init() {
@@ -45282,10 +45283,10 @@ func init() {
 type VirtualMachineDisplayTopology struct {
 	DynamicData
 
-	X      int `xml:"x"`
-	Y      int `xml:"y"`
-	Width  int `xml:"width"`
-	Height int `xml:"height"`
+	X      int32 `xml:"x"`
+	Y      int32 `xml:"y"`
+	Width  int32 `xml:"width"`
+	Height int32 `xml:"height"`
 }
 
 func init() {
@@ -45343,7 +45344,7 @@ func init() {
 type VirtualMachineFileLayoutDiskLayout struct {
 	DynamicData
 
-	Key      int      `xml:"key"`
+	Key      int32    `xml:"key"`
 	DiskFile []string `xml:"diskFile"`
 }
 
@@ -45367,7 +45368,7 @@ func init() {
 type VirtualMachineFileLayoutExDiskLayout struct {
 	DynamicData
 
-	Key   int                                  `xml:"key"`
+	Key   int32                                `xml:"key"`
 	Chain []VirtualMachineFileLayoutExDiskUnit `xml:"chain,omitempty"`
 }
 
@@ -45378,7 +45379,7 @@ func init() {
 type VirtualMachineFileLayoutExDiskUnit struct {
 	DynamicData
 
-	FileKey []int `xml:"fileKey"`
+	FileKey []int32 `xml:"fileKey"`
 }
 
 func init() {
@@ -45388,7 +45389,7 @@ func init() {
 type VirtualMachineFileLayoutExFileInfo struct {
 	DynamicData
 
-	Key             int    `xml:"key"`
+	Key             int32  `xml:"key"`
 	Name            string `xml:"name"`
 	Type            string `xml:"type"`
 	Size            int64  `xml:"size"`
@@ -45405,8 +45406,8 @@ type VirtualMachineFileLayoutExSnapshotLayout struct {
 	DynamicData
 
 	Key       ManagedObjectReference                 `xml:"key"`
-	DataKey   int                                    `xml:"dataKey"`
-	MemoryKey int                                    `xml:"memoryKey,omitempty"`
+	DataKey   int32                                  `xml:"dataKey"`
+	MemoryKey int32                                  `xml:"memoryKey,omitempty"`
 	Disk      []VirtualMachineFileLayoutExDiskLayout `xml:"disk,omitempty"`
 }
 
@@ -45498,8 +45499,8 @@ func init() {
 type VirtualMachineIdeDiskDevicePartitionInfo struct {
 	DynamicData
 
-	Id       int `xml:"id"`
-	Capacity int `xml:"capacity"`
+	Id       int32 `xml:"id"`
+	Capacity int32 `xml:"capacity"`
 }
 
 func init() {
@@ -45612,7 +45613,7 @@ type VirtualMachineMksTicket struct {
 	Ticket        string `xml:"ticket"`
 	CfgFile       string `xml:"cfgFile"`
 	Host          string `xml:"host,omitempty"`
-	Port          int    `xml:"port,omitempty"`
+	Port          int32  `xml:"port,omitempty"`
 	SslThumbprint string `xml:"sslThumbprint,omitempty"`
 }
 
@@ -45707,25 +45708,25 @@ func init() {
 type VirtualMachineQuickStats struct {
 	DynamicData
 
-	OverallCpuUsage              int                 `xml:"overallCpuUsage,omitempty"`
-	OverallCpuDemand             int                 `xml:"overallCpuDemand,omitempty"`
-	GuestMemoryUsage             int                 `xml:"guestMemoryUsage,omitempty"`
-	HostMemoryUsage              int                 `xml:"hostMemoryUsage,omitempty"`
+	OverallCpuUsage              int32               `xml:"overallCpuUsage,omitempty"`
+	OverallCpuDemand             int32               `xml:"overallCpuDemand,omitempty"`
+	GuestMemoryUsage             int32               `xml:"guestMemoryUsage,omitempty"`
+	HostMemoryUsage              int32               `xml:"hostMemoryUsage,omitempty"`
 	GuestHeartbeatStatus         ManagedEntityStatus `xml:"guestHeartbeatStatus"`
-	DistributedCpuEntitlement    int                 `xml:"distributedCpuEntitlement,omitempty"`
-	DistributedMemoryEntitlement int                 `xml:"distributedMemoryEntitlement,omitempty"`
-	StaticCpuEntitlement         int                 `xml:"staticCpuEntitlement,omitempty"`
-	StaticMemoryEntitlement      int                 `xml:"staticMemoryEntitlement,omitempty"`
-	PrivateMemory                int                 `xml:"privateMemory,omitempty"`
-	SharedMemory                 int                 `xml:"sharedMemory,omitempty"`
-	SwappedMemory                int                 `xml:"swappedMemory,omitempty"`
-	BalloonedMemory              int                 `xml:"balloonedMemory,omitempty"`
-	ConsumedOverheadMemory       int                 `xml:"consumedOverheadMemory,omitempty"`
-	FtLogBandwidth               int                 `xml:"ftLogBandwidth,omitempty"`
-	FtSecondaryLatency           int                 `xml:"ftSecondaryLatency,omitempty"`
+	DistributedCpuEntitlement    int32               `xml:"distributedCpuEntitlement,omitempty"`
+	DistributedMemoryEntitlement int32               `xml:"distributedMemoryEntitlement,omitempty"`
+	StaticCpuEntitlement         int32               `xml:"staticCpuEntitlement,omitempty"`
+	StaticMemoryEntitlement      int32               `xml:"staticMemoryEntitlement,omitempty"`
+	PrivateMemory                int32               `xml:"privateMemory,omitempty"`
+	SharedMemory                 int32               `xml:"sharedMemory,omitempty"`
+	SwappedMemory                int32               `xml:"swappedMemory,omitempty"`
+	BalloonedMemory              int32               `xml:"balloonedMemory,omitempty"`
+	ConsumedOverheadMemory       int32               `xml:"consumedOverheadMemory,omitempty"`
+	FtLogBandwidth               int32               `xml:"ftLogBandwidth,omitempty"`
+	FtSecondaryLatency           int32               `xml:"ftSecondaryLatency,omitempty"`
 	FtLatencyStatus              ManagedEntityStatus `xml:"ftLatencyStatus,omitempty"`
 	CompressedMemory             int64               `xml:"compressedMemory,omitempty"`
-	UptimeSeconds                int                 `xml:"uptimeSeconds,omitempty"`
+	UptimeSeconds                int32               `xml:"uptimeSeconds,omitempty"`
 	SsdSwappedMemory             int64               `xml:"ssdSwappedMemory,omitempty"`
 }
 
@@ -45755,7 +45756,7 @@ func init() {
 type VirtualMachineRelocateSpecDiskLocator struct {
 	DynamicData
 
-	DiskId          int                             `xml:"diskId"`
+	DiskId          int32                           `xml:"diskId"`
 	Datastore       ManagedObjectReference          `xml:"datastore"`
 	DiskMoveType    string                          `xml:"diskMoveType,omitempty"`
 	DiskBackingInfo BaseVirtualDeviceBackingInfo    `xml:"diskBackingInfo,omitempty,typeattr"`
@@ -45781,9 +45782,9 @@ type VirtualMachineRuntimeInfo struct {
 	SuspendInterval           int64                                        `xml:"suspendInterval,omitempty"`
 	Question                  *VirtualMachineQuestionInfo                  `xml:"question,omitempty"`
 	MemoryOverhead            int64                                        `xml:"memoryOverhead,omitempty"`
-	MaxCpuUsage               int                                          `xml:"maxCpuUsage,omitempty"`
-	MaxMemoryUsage            int                                          `xml:"maxMemoryUsage,omitempty"`
-	NumMksConnections         int                                          `xml:"numMksConnections"`
+	MaxCpuUsage               int32                                        `xml:"maxCpuUsage,omitempty"`
+	MaxMemoryUsage            int32                                        `xml:"maxMemoryUsage,omitempty"`
+	NumMksConnections         int32                                        `xml:"numMksConnections"`
 	RecordReplayState         VirtualMachineRecordReplayState              `xml:"recordReplayState,omitempty"`
 	CleanPowerOff             *bool                                        `xml:"cleanPowerOff"`
 	NeedSecondaryReason       string                                       `xml:"needSecondaryReason,omitempty"`
@@ -45818,7 +45819,7 @@ type VirtualMachineScsiDiskDeviceInfo struct {
 
 	Disk          *HostScsiDisk `xml:"disk,omitempty"`
 	TransportHint string        `xml:"transportHint,omitempty"`
-	LunNumber     int           `xml:"lunNumber,omitempty"`
+	LunNumber     int32         `xml:"lunNumber,omitempty"`
 }
 
 func init() {
@@ -45830,7 +45831,7 @@ type VirtualMachineScsiPassthroughInfo struct {
 
 	ScsiClass          string `xml:"scsiClass"`
 	Vendor             string `xml:"vendor"`
-	PhysicalUnitNumber int    `xml:"physicalUnitNumber"`
+	PhysicalUnitNumber int32  `xml:"physicalUnitNumber"`
 }
 
 func init() {
@@ -45863,7 +45864,7 @@ type VirtualMachineSnapshotTree struct {
 	Vm                ManagedObjectReference       `xml:"vm"`
 	Name              string                       `xml:"name"`
 	Description       string                       `xml:"description"`
-	Id                int                          `xml:"id,omitempty"`
+	Id                int32                        `xml:"id,omitempty"`
 	CreateTime        time.Time                    `xml:"createTime"`
 	State             VirtualMachinePowerState     `xml:"state"`
 	Quiesced          bool                         `xml:"quiesced"`
@@ -45953,7 +45954,7 @@ type VirtualMachineTicket struct {
 	Ticket        string `xml:"ticket"`
 	CfgFile       string `xml:"cfgFile"`
 	Host          string `xml:"host,omitempty"`
-	Port          int    `xml:"port,omitempty"`
+	Port          int32  `xml:"port,omitempty"`
 	SslThumbprint string `xml:"sslThumbprint,omitempty"`
 }
 
@@ -45978,8 +45979,8 @@ type VirtualMachineUsbInfo struct {
 	VirtualMachineTargetInfo
 
 	Description  string                 `xml:"description"`
-	Vendor       int                    `xml:"vendor"`
-	Product      int                    `xml:"product"`
+	Vendor       int32                  `xml:"vendor"`
+	Product      int32                  `xml:"product"`
 	PhysicalPath string                 `xml:"physicalPath"`
 	Family       []string               `xml:"family,omitempty"`
 	Speed        []string               `xml:"speed,omitempty"`
@@ -46076,7 +46077,7 @@ type VirtualMachineVideoCard struct {
 	VirtualDevice
 
 	VideoRamSizeInKB       int64  `xml:"videoRamSizeInKB,omitempty"`
-	NumDisplays            int    `xml:"numDisplays,omitempty"`
+	NumDisplays            int32  `xml:"numDisplays,omitempty"`
 	UseAutoDetect          *bool  `xml:"useAutoDetect"`
 	Enable3DSupport        *bool  `xml:"enable3DSupport"`
 	Use3dRenderer          string `xml:"use3dRenderer,omitempty"`
@@ -46090,7 +46091,7 @@ func init() {
 type VirtualMachineWipeResult struct {
 	DynamicData
 
-	DiskId              int   `xml:"diskId"`
+	DiskId              int32 `xml:"diskId"`
 	ShrinkableDiskSpace int64 `xml:"shrinkableDiskSpace"`
 }
 
@@ -46206,7 +46207,7 @@ type VirtualPCIPassthroughVmiopBackingOption struct {
 	VirtualPCIPassthroughPluginBackingOption
 
 	Vgpu         StringOption `xml:"vgpu"`
-	MaxInstances int          `xml:"maxInstances"`
+	MaxInstances int32        `xml:"maxInstances"`
 }
 
 func init() {
@@ -46391,7 +46392,7 @@ type VirtualSCSIController struct {
 
 	HotAddRemove       *bool              `xml:"hotAddRemove"`
 	SharedBus          VirtualSCSISharing `xml:"sharedBus"`
-	ScsiCtlrUnitNumber int                `xml:"scsiCtlrUnitNumber,omitempty"`
+	ScsiCtlrUnitNumber int32              `xml:"scsiCtlrUnitNumber,omitempty"`
 }
 
 func init() {
@@ -46405,9 +46406,9 @@ type VirtualSCSIControllerOption struct {
 	NumSCSICdroms      IntOption            `xml:"numSCSICdroms"`
 	NumSCSIPassthrough IntOption            `xml:"numSCSIPassthrough"`
 	Sharing            []VirtualSCSISharing `xml:"sharing"`
-	DefaultSharedIndex int                  `xml:"defaultSharedIndex"`
+	DefaultSharedIndex int32                `xml:"defaultSharedIndex"`
 	HotAddRemove       BoolOption           `xml:"hotAddRemove"`
-	ScsiCtlrUnitNumber int                  `xml:"scsiCtlrUnitNumber"`
+	ScsiCtlrUnitNumber int32                `xml:"scsiCtlrUnitNumber"`
 }
 
 func init() {
@@ -46644,7 +46645,7 @@ type VirtualSriovEthernetCardSriovBackingInfo struct {
 
 	PhysicalFunctionBacking *VirtualPCIPassthroughDeviceBackingInfo `xml:"physicalFunctionBacking,omitempty"`
 	VirtualFunctionBacking  *VirtualPCIPassthroughDeviceBackingInfo `xml:"virtualFunctionBacking,omitempty"`
-	VirtualFunctionIndex    int                                     `xml:"virtualFunctionIndex,omitempty"`
+	VirtualFunctionIndex    int32                                   `xml:"virtualFunctionIndex,omitempty"`
 }
 
 func init() {
@@ -46685,8 +46686,8 @@ type VirtualUSB struct {
 	VirtualDevice
 
 	Connected bool     `xml:"connected"`
-	Vendor    int      `xml:"vendor,omitempty"`
-	Product   int      `xml:"product,omitempty"`
+	Vendor    int32    `xml:"vendor,omitempty"`
+	Product   int32    `xml:"product,omitempty"`
 	Family    []string `xml:"family,omitempty"`
 	Speed     []string `xml:"speed,omitempty"`
 }
@@ -46721,7 +46722,7 @@ func init() {
 type VirtualUSBControllerPciBusSlotInfo struct {
 	VirtualDevicePciBusSlotInfo
 
-	EhciPciSlotNumber int `xml:"ehciPciSlotNumber,omitempty"`
+	EhciPciSlotNumber int32 `xml:"ehciPciSlotNumber,omitempty"`
 }
 
 func init() {
@@ -47063,7 +47064,7 @@ func init() {
 type VmConfigFileInfo struct {
 	FileInfo
 
-	ConfigVersion int `xml:"configVersion,omitempty"`
+	ConfigVersion int32 `xml:"configVersion,omitempty"`
 }
 
 func init() {
@@ -47084,7 +47085,7 @@ func init() {
 type VmConfigFileQueryFilter struct {
 	DynamicData
 
-	MatchConfigVersion []int `xml:"matchConfigVersion,omitempty"`
+	MatchConfigVersion []int32 `xml:"matchConfigVersion,omitempty"`
 }
 
 func init() {
@@ -47143,7 +47144,7 @@ type VmConfigInfo struct {
 	OvfSection              []VAppOvfSectionInfo `xml:"ovfSection,omitempty"`
 	OvfEnvironmentTransport []string             `xml:"ovfEnvironmentTransport,omitempty"`
 	InstallBootRequired     bool                 `xml:"installBootRequired"`
-	InstallBootStopDelay    int                  `xml:"installBootStopDelay"`
+	InstallBootStopDelay    int32                `xml:"installBootStopDelay"`
 }
 
 func init() {
@@ -47168,7 +47169,7 @@ type VmConfigSpec struct {
 	OvfSection              []VAppOvfSectionSpec  `xml:"ovfSection,omitempty"`
 	OvfEnvironmentTransport []string              `xml:"ovfEnvironmentTransport,omitempty"`
 	InstallBootRequired     *bool                 `xml:"installBootRequired"`
-	InstallBootStopDelay    int                   `xml:"installBootStopDelay,omitempty"`
+	InstallBootStopDelay    int32                 `xml:"installBootStopDelay,omitempty"`
 }
 
 func init() {
@@ -47296,7 +47297,7 @@ type VmDiskFileInfo struct {
 
 	DiskType        string   `xml:"diskType,omitempty"`
 	CapacityKb      int64    `xml:"capacityKb,omitempty"`
-	HardwareVersion int      `xml:"hardwareVersion,omitempty"`
+	HardwareVersion int32    `xml:"hardwareVersion,omitempty"`
 	ControllerType  string   `xml:"controllerType,omitempty"`
 	DiskExtents     []string `xml:"diskExtents,omitempty"`
 	Thin            *bool    `xml:"thin"`
@@ -47321,7 +47322,7 @@ type VmDiskFileQueryFilter struct {
 	DynamicData
 
 	DiskType             []string `xml:"diskType,omitempty"`
-	MatchHardwareVersion []int    `xml:"matchHardwareVersion,omitempty"`
+	MatchHardwareVersion []int32  `xml:"matchHardwareVersion,omitempty"`
 	ControllerType       []string `xml:"controllerType,omitempty"`
 	Thin                 *bool    `xml:"thin"`
 }
@@ -47617,7 +47618,7 @@ type VmFaultToleranceTooManyFtVcpusOnHost struct {
 	InsufficientResourcesFault
 
 	HostName      string `xml:"hostName,omitempty"`
-	MaxNumFtVcpus int    `xml:"maxNumFtVcpus"`
+	MaxNumFtVcpus int32  `xml:"maxNumFtVcpus"`
 }
 
 func init() {
@@ -47634,7 +47635,7 @@ type VmFaultToleranceTooManyVMsOnHost struct {
 	InsufficientResourcesFault
 
 	HostName    string `xml:"hostName,omitempty"`
-	MaxNumFtVms int    `xml:"maxNumFtVms"`
+	MaxNumFtVms int32  `xml:"maxNumFtVms"`
 }
 
 func init() {
@@ -47759,7 +47760,7 @@ func init() {
 type VmLimitLicense struct {
 	NotEnoughLicenses
 
-	Limit int `xml:"limit"`
+	Limit int32 `xml:"limit"`
 }
 
 func init() {
@@ -48266,7 +48267,7 @@ type VmSmpFaultToleranceTooManyVMsOnHost struct {
 	InsufficientResourcesFault
 
 	HostName       string `xml:"hostName,omitempty"`
-	MaxNumSmpFtVms int    `xml:"maxNumSmpFtVms"`
+	MaxNumSmpFtVms int32  `xml:"maxNumSmpFtVms"`
 }
 
 func init() {
@@ -48460,8 +48461,8 @@ type VmValidateMaxDevice struct {
 	VimFault
 
 	Device string `xml:"device"`
-	Max    int    `xml:"max"`
-	Count  int    `xml:"count"`
+	Max    int32  `xml:"max"`
+	Count  int32  `xml:"count"`
 }
 
 func init() {
@@ -48718,7 +48719,7 @@ func init() {
 type VmwareDistributedVirtualSwitchPvlanSpec struct {
 	VmwareDistributedVirtualSwitchVlanSpec
 
-	PvlanId int `xml:"pvlanId"`
+	PvlanId int32 `xml:"pvlanId"`
 }
 
 func init() {
@@ -48738,7 +48739,7 @@ func init() {
 type VmwareDistributedVirtualSwitchVlanIdSpec struct {
 	VmwareDistributedVirtualSwitchVlanSpec
 
-	VlanId int `xml:"vlanId"`
+	VlanId int32 `xml:"vlanId"`
 }
 
 func init() {
@@ -48796,7 +48797,7 @@ func init() {
 type VramLimitLicense struct {
 	NotEnoughLicenses
 
-	Limit int `xml:"limit"`
+	Limit int32 `xml:"limit"`
 }
 
 func init() {
@@ -48918,7 +48919,7 @@ type VsanHostClusterStatusStateCompletionEstimate struct {
 	DynamicData
 
 	CompleteTime    *time.Time `xml:"completeTime"`
-	PercentComplete int        `xml:"percentComplete,omitempty"`
+	PercentComplete int32      `xml:"percentComplete,omitempty"`
 }
 
 func init() {
@@ -49080,7 +49081,7 @@ type VsanHostRuntimeInfo struct {
 
 	MembershipList []VsanHostMembershipInfo       `xml:"membershipList,omitempty"`
 	DiskIssues     []VsanHostRuntimeInfoDiskIssue `xml:"diskIssues,omitempty"`
-	AccessGenNo    int                            `xml:"accessGenNo,omitempty"`
+	AccessGenNo    int32                          `xml:"accessGenNo,omitempty"`
 }
 
 func init() {
@@ -49102,7 +49103,7 @@ type VsanHostVsanDiskInfo struct {
 	DynamicData
 
 	VsanUuid      string `xml:"vsanUuid"`
-	FormatVersion int    `xml:"formatVersion"`
+	FormatVersion int32  `xml:"formatVersion"`
 }
 
 func init() {
@@ -49317,7 +49318,7 @@ type VsanUpgradeSystemUpgradeStatus struct {
 	History    []BaseVsanUpgradeSystemUpgradeHistoryItem `xml:"history,omitempty,typeattr"`
 	Aborted    *bool                                     `xml:"aborted"`
 	Completed  *bool                                     `xml:"completed"`
-	Progress   int                                       `xml:"progress,omitempty"`
+	Progress   int32                                     `xml:"progress,omitempty"`
 }
 
 func init() {
@@ -49532,8 +49533,8 @@ type WaitForUpdatesResponse struct {
 type WaitOptions struct {
 	DynamicData
 
-	MaxWaitSeconds   int `xml:"maxWaitSeconds,omitempty"`
-	MaxObjectUpdates int `xml:"maxObjectUpdates,omitempty"`
+	MaxWaitSeconds   int32 `xml:"maxWaitSeconds,omitempty"`
+	MaxObjectUpdates int32 `xml:"maxObjectUpdates,omitempty"`
 }
 
 func init() {

--- a/vendor/github.com/vmware/govmomi/vim25/types/types_test.go
+++ b/vendor/github.com/vmware/govmomi/vim25/types/types_test.go
@@ -49,7 +49,7 @@ func TestVirtualMachineConfigSpec(t *testing.T) {
 					VirtualDevice: VirtualDevice{
 						Key:           0,
 						ControllerKey: 1000,
-						UnitNumber:    0,
+						UnitNumber:    new(int32), // zero default value
 						Backing: &VirtualDiskFlatVer2BackingInfo{
 							DiskMode:        string(VirtualDiskModePersistent),
 							ThinProvisioned: NewBool(true),

--- a/vendor/manifest
+++ b/vendor/manifest
@@ -846,7 +846,7 @@
 		{
 			"importpath": "github.com/vmware/govmomi",
 			"repository": "https://github.com/vmware/govmomi",
-			"revision": "de8bc1350da57b2ab4a83fa608e6025bc06e606f",
+			"revision": "c1b29993f383c32fc3fadb90892909668699810a",
 			"branch": "master"
 		},
 		{


### PR DESCRIPTION
Update to govmomi release 0.5.0 (vmware/govmomi@c1b2999)

Update pkg/vsphere:
- VirtualDevice.UnitNumber is now pointer type and optional (vmware/govmomi@e077bcf)
- Switch to int32 type for xsd int fields (vmware/govmomi@f74a896)

Closes #292
