### PR TITLE
Fix devicePathByURI function

### DIFF
--- a/pkg/vsphere/disk/disk_manager.go
+++ b/pkg/vsphere/disk/disk_manager.go
@@ -146,6 +146,7 @@ func (m *Manager) createDiskSpec(childURI, parentURI string, capacity int64, fla
 		VirtualDevice: types.VirtualDevice{
 			Key:           -1,
 			ControllerKey: m.controller.Key,
+			UnitNumber:    new(int32),
 			Backing:       backing,
 		},
 		CapacityInKB: capacity,
@@ -271,5 +272,5 @@ func (m *Manager) devicePathByURI(ctx context.Context, datastoreURI string) (str
 		return "", errors.Trace(err)
 	}
 
-	return fmt.Sprintf(m.byPathFormat, disk.UnitNumber), nil
+	return fmt.Sprintf(m.byPathFormat, *disk.UnitNumber), nil
 }


### PR DESCRIPTION
Otherwise we get 

> time="2016-04-01T04:39:28Z" level=error msg="vmdk storage driver failed to attach disk: Invalid configuration for device '0'." 

error from portlayer
