### PR TITLE
Start to use "github.com/docker/docker/reference"

### DIFF
--- a/apiservers/engine/backends/image.go
+++ b/apiservers/engine/backends/image.go
@@ -21,7 +21,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strings"
 
 	"github.com/docker/docker/reference"
 	"github.com/docker/engine-api/types"
@@ -78,21 +77,9 @@ func (i *Image) PullImage(ref reference.Named, metaHeaders map[string][]string, 
 
 	binImageC := "imagec"
 
-	var cmdArgs, nameParts []string
+	var cmdArgs []string
 
-	libraryParts := strings.Split(ref.String(), "/")
-
-	if len(libraryParts) > 1 {
-		nameParts = strings.Split(libraryParts[1], ":")
-	} else {
-		nameParts = strings.Split(libraryParts[0], ":")
-	}
-
-	cmdArgs = append(cmdArgs, "-image", "library/"+nameParts[0])
-
-	if len(nameParts) > 1 {
-		cmdArgs = append(cmdArgs, "-digest", nameParts[1])
-	}
+	cmdArgs = append(cmdArgs, "-reference", ref.String())
 
 	if authConfig != nil {
 		if len(authConfig.Username) > 0 {

--- a/cmd/imagec/doc.go
+++ b/cmd/imagec/doc.go
@@ -12,5 +12,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:generate swagger generate client -A PortLayer -t ../apiservers/portlayer -f ../apiservers/portlayer/swagger.yml
+//go:generate swagger generate client -A PortLayer -t ../../apiservers/portlayer -f ../../apiservers/portlayer/swagger.yml
 package main

--- a/tests/imagec.bats
+++ b/tests/imagec.bats
@@ -51,8 +51,13 @@ teardown() {
     assert [ kill_port_layer ]
 }
 
-@test "imagec run without arguments downloads photon into default destination from Docker Hub" {
+@test "imagec run without arguments fails" {
     run "$imagec" -standalone
+    assert_failure
+}
+
+@test "imagec run with -reference photon should download library/photon image" {
+    run "$imagec" -standalone -reference photon
     assert_success
     assert [ -d "$IMAGES_DIR/$DEFAULT_IMAGE" ] # check that the correct dir is created
     assert [ -e imagec.log ] # check the existence of the default logfile
@@ -68,19 +73,19 @@ teardown() {
 
 @test "imagec -debug should enable debugging and -stdout outputs logs to stdout" {
     # should get at least one line with 'level=output' present
-    run [ $("$imagec" -standalone -stdout -debug | grep "level=debug" | wc -l) -ge 1 ]
+    run [ $("$imagec" -standalone -reference photon -stdout -debug | grep "level=debug" | wc -l) -ge 1 ]
     assert_success
     assert verify_checksums "$IMAGES_DIR/$DEFAULT_IMAGE"
 }
 
 @test "imagec -destination allows us to change where the image is saved" {
-    run "$imagec" -standalone -destination foo
+    run "$imagec" -standalone -reference photon -destination foo
     assert_success
     assert verify_checksums "foo/$DEFAULT_IMAGE"
 }
 
-@test "imagec -digest should specify tag name or image digest to download" {
-    run "$imagec" -standalone -digest 7.0-x86_64 -image tatsushid/tinycore
+@test "imagec -reference NAME:DIGEST should specify tag name or image digest to download" {
+    run "$imagec" -standalone -reference tatsushid/tinycore:7.0-x86_64
     assert_success
     assert verify_checksums "$IMAGES_DIR/$ALT_IMAGE"/7.0-x86_64
 }
@@ -96,19 +101,19 @@ teardown() {
 
 @test "imagec -standalone should allow us to run imagec without portlayer API" {
 #    assert kill_port_layer # it was started on 8080 by setup()
-    run "$imagec" -standalone
+    run "$imagec" -standalone -reference photon
     assert_success
     assert verify_checksums "$IMAGES_DIR/$DEFAULT_IMAGE"
 }
 
 @test "imagec -image should allow specifying a specific image to download" {
-    run "$imagec" -standalone -image tatsushid/tinycore
+    run "$imagec" -standalone -reference tatsushid/tinycore
     assert_success
     assert verify_checksums "$IMAGES_DIR/$ALT_IMAGE/latest"
 }
 
 @test "imagec -logfile should change the path of the installer log file (default \"imagec.log\")" {
-    run "$imagec" -standalone -logfile foo.log
+    run "$imagec" -standalone -reference photon -logfile foo.log
     assert_success
     assert [ $(wc -l foo.log | awk '{print $1}') -ge 1 ] # logfile shouldn't be empty
 }


### PR DESCRIPTION
for docker personality. This way our apiserver stop parsing the
reference string.

We also start to support syntax supported by docker client.

Fixes #398
