### PR TITLE
Fix container creation

### DIFF
--- a/pkg/vsphere/spec/disk.go
+++ b/pkg/vsphere/spec/disk.go
@@ -34,6 +34,7 @@ func NewVirtualDisk(controller types.BaseVirtualController) *types.VirtualDisk {
 	return &types.VirtualDisk{
 		VirtualDevice: types.VirtualDevice{
 			ControllerKey: controller.GetVirtualController().Key,
+			UnitNumber:    new(int32),
 		},
 	}
 }

--- a/pkg/vsphere/spec/ide.go
+++ b/pkg/vsphere/spec/ide.go
@@ -55,6 +55,7 @@ func NewVirtualCdrom(device *types.VirtualIDEController) *types.VirtualCdrom {
 	return &types.VirtualCdrom{
 		VirtualDevice: types.VirtualDevice{
 			ControllerKey: device.Key,
+			UnitNumber:    new(int32),
 		},
 	}
 }
@@ -88,6 +89,7 @@ func NewVirtualFloppy(device *types.VirtualIDEController) *types.VirtualFloppy {
 	return &types.VirtualFloppy{
 		VirtualDevice: types.VirtualDevice{
 			ControllerKey: device.Key,
+			UnitNumber:    new(int32),
 		},
 	}
 }


### PR DESCRIPTION
Looks like it got broken after merging govmomi release 0.5.0. Set the
UnitNumber to its zero value otherwise ESXi fails with following;

2016-04-01T19:22:38.686Z info hostd[3C8C2B70] [Originator@6876 sub=Default opID=00d72bfe user=root] No unit number specified for device 1
