### PR TITLE
Handle cmdless container create

### DIFF
--- a/apiservers/portlayer/restapi/handlers/exec_handlers.go
+++ b/apiservers/portlayer/restapi/handlers/exec_handlers.go
@@ -97,6 +97,17 @@ func (handler *ExecHandlersImpl) ContainerCreateHandler(params exec.ContainerCre
 		name = *params.Name
 	}
 
+	// create and fill the metadata.Cmd struct
+	cmd := metadata.Cmd{
+		Env: params.CreateConfig.Env,
+		Dir: *params.CreateConfig.WorkingDir,
+	}
+	// FIXME: https://github.com/vmware/vic/issues/411
+	if len(params.CreateConfig.Cmd) > 0 {
+		cmd.Path = params.CreateConfig.Cmd[0]
+		cmd.Args = params.CreateConfig.Cmd
+	}
+
 	m := metadata.ExecutorConfig{
 		Common: metadata.Common{
 			ID:   id,
@@ -108,12 +119,7 @@ func (handler *ExecHandlersImpl) ContainerCreateHandler(params exec.ContainerCre
 					ID: id,
 				},
 				Tty: false,
-				Cmd: metadata.Cmd{
-					Path: params.CreateConfig.Cmd[0],
-					Args: params.CreateConfig.Cmd,
-					Env:  params.CreateConfig.Env,
-					Dir:  *params.CreateConfig.WorkingDir,
-				},
+				Cmd: cmd,
 			},
 		},
 	}


### PR DESCRIPTION
We don't have a mechanism to pass metadata to the exec layer right now.

Wordaround that inside the exec layer instead of panic'ing. Later tether
will fail like following as expected.

```
INFO[0000] Started reaping child processes
ERRO[0000] failed to start container process: fork/exec : no such file or directory
ERRO[0000] failed to launch  for 2071b9e338884a38a1878949b70cfc7c84a89e15e4150162c286ff0a87a9a503: failed to start container process: fork/exec : no such file or directory
ERRO[0000] failed to launch  for 2071b9e338884a38a1878949b70cfc7c84a89e15e4150162c286ff0a87a9a503: failed to start container process: fork/exec : no such file or directory
INFO[0000] Powering off the system
```

We can remove that hack after https://github.com/vmware/vic/issues/411
