### PR TITLE
Add haveged to the appliance and bootstrap ISOs

### DIFF
--- a/isos/appliance-staging.sh
+++ b/isos/appliance-staging.sh
@@ -81,6 +81,7 @@ unpack $PACKAGE $PKGDIR
 #   tndf      # so we can deploy other packages into the appliance live - MUST BE REMOVED FOR SHIPPING
 #   vim       # basic editing function
 yum_cached -c $cache -u -p $PKGDIR install \
+    haveged \
     systemd \
     openssh \
     e2fsprogs \

--- a/isos/bootstrap-staging.sh
+++ b/isos/bootstrap-staging.sh
@@ -105,6 +105,7 @@ yum_cached -c $cache -u -p $PKGDIR install \
     iproute2 \
     libtirpc \
     grep \
+    haveged \
     systemd \
     -y --nogpgcheck
 

--- a/isos/bootstrap/bootstrap
+++ b/isos/bootstrap/bootstrap
@@ -79,10 +79,10 @@ if mount -t ext4 /dev/disk/by-label/containerfs ${MOUNTPOINT}; then
 if [ -x /sbin/ip -o -x /bin/ip ]; then
     addr=$(ip addr show eno1  | grep " inet " | cut -d " " -f6)
     gateway=$(ip route show | grep "^default" | cut -d " " -f3)
-    
-    echo "Setting IP addr to " \$addr > /dev/ttyS2
-    echo "Setting route to" \$gateway > /dev/ttyS2
-    
+
+    echo "Setting IP addr to " \$addr > /dev/ttyS1
+    echo "Setting route to" \$gateway > /dev/ttyS1
+
     ip addr add \$addr dev eno1
     ip link set dev eno1 up
     ip route add default via \$gateway dev eno1

--- a/isos/bootstrap/bootstrap.debug
+++ b/isos/bootstrap/bootstrap.debug
@@ -69,10 +69,10 @@ if mount -t ext4 /dev/disk/by-label/containerfs ${MOUNTPOINT}; then
     cp /bin/tether ${MOUNTPOINT}/.tether/tether-debug
 
     /sbin/rpctool -get "vic.configblob" > ${MOUNTPOINT}/.tether/tether.config
-    
+
     # temporary hack for waiting the network
     while ! ip addr show eno1 | grep " inet "; do sleep 1;done
-    
+
     cat << EOF > ${MOUNTPOINT}/.tether/tether
 #!/bin/sh
 
@@ -80,10 +80,10 @@ if mount -t ext4 /dev/disk/by-label/containerfs ${MOUNTPOINT}; then
 if [ -x /sbin/ip -o -x /bin/ip ]; then
     addr=$(ip addr show eno1  | grep " inet " | cut -d " " -f6)
     gateway=$(ip route show | grep "^default" | cut -d " " -f3)
-    
-    echo "Setting IP addr to " \$addr > /dev/ttyS2
-    echo "Setting route to" \$gateway > /dev/ttyS2
-    
+
+    echo "Setting IP addr to " \$addr > /dev/ttyS1
+    echo "Setting route to" \$gateway > /dev/ttyS1
+
     ip addr add \$addr dev eno1
     ip link set dev eno1 up
     ip route add default via \$gateway dev eno1


### PR DESCRIPTION
to introduce entropy to the vms. Otherwise we observe unexpected side effects
like long startup times.

04-Apr-2016 22:07:13.431 INFO [main]
org.apache.catalina.startup.Catalina.start Server startup in 1436 ms

vs

04-Apr-2016 21:33:18.264 INFO [main]
org.apache.catalina.startup.Catalina.start Server startup in 128991 ms

Also fix logging for the container vms