### PR TITLE
Make WriteImage endpoint RESTful again - fixes #239

### DIFF
--- a/apiservers/portlayer/swagger.yml
+++ b/apiservers/portlayer/swagger.yml
@@ -94,7 +94,6 @@ paths:
           description: "error"
           schema:
            $ref: "#/definitions/Error"
-  /storage/{store_name}/writeImage:
     post:
       description: "Creates a new image layer in an image store"
       summary: "Creates a new image layer"


### PR DESCRIPTION
This replaces the extraneous `POST storage/{store_name}/writeImage` endpoint with the more RESTful `POST storage/{store_name}` endpoint.

Fixes #239. 
