### PR TITLE
Introduce -resolv to imagec

### DIFF
--- a/apiservers/engine/server/main.go
+++ b/apiservers/engine/server/main.go
@@ -168,7 +168,7 @@ func startServerWithOptions(cli *CliOptions) *apiserver.Server {
 
 func setAPIRoutes(api *apiserver.Server) {
 	imageHandler := &vicbackends.Image{ProductName: productName}
-	containerHandler := &vicbackends.Container{ProductName: productName}
+	containerHandler := &vicbackends.Container{ProductName: productName, HackMap: make(map[string]vicbackends.V1Compatibility)}
 	volumeHandler := &vicbackends.Volume{ProductName: productName}
 	networkHandler := &vicbackends.Network{ProductName: productName}
 	systemHandler := &vicbackends.System{ProductName: productName}

--- a/apiservers/portlayer/restapi/handlers/exec_handlers.go
+++ b/apiservers/portlayer/restapi/handlers/exec_handlers.go
@@ -149,8 +149,8 @@ func (handler *ExecHandlersImpl) ContainerCreateHandler(params exec.ContainerCre
 
 	ctx := context.Background()
 
-	log.Debugf("Cmd: %#v", params.CreateConfig.Cmd)
-	log.Debugf("EntryPoint: %#v", params.CreateConfig.EntryPoint)
+	log.Debugf("Path: %#v", params.CreateConfig.Path)
+	log.Debugf("Args: %#v", params.CreateConfig.Args)
 	log.Debugf("Env: %#v", params.CreateConfig.Env)
 	log.Debugf("WorkingDir: %#v", params.CreateConfig.WorkingDir)
 
@@ -164,13 +164,10 @@ func (handler *ExecHandlersImpl) ContainerCreateHandler(params exec.ContainerCre
 
 	// create and fill the metadata.Cmd struct
 	cmd := metadata.Cmd{
-		Env: params.CreateConfig.Env,
-		Dir: *params.CreateConfig.WorkingDir,
-	}
-	// FIXME: https://github.com/vmware/vic/issues/411
-	if len(params.CreateConfig.Cmd) > 0 {
-		cmd.Path = params.CreateConfig.Cmd[0]
-		cmd.Args = params.CreateConfig.Cmd
+		Env:  params.CreateConfig.Env,
+		Dir:  *params.CreateConfig.WorkingDir,
+		Path: *params.CreateConfig.Path,
+		Args: append([]string{*params.CreateConfig.Path}, params.CreateConfig.Args...),
 	}
 
 	m := metadata.ExecutorConfig{

--- a/apiservers/portlayer/swagger.yml
+++ b/apiservers/portlayer/swagger.yml
@@ -393,12 +393,12 @@ definitions:
         $ref: "#/definitions/ImageStore"
       image:
         type: string
-      cmd:
+      path:
+        type: string
+      args:
         type: array
         items:
           type: string
-      entryPoint:
-        type: string
       workingDir:
         type: string
       env:


### PR DESCRIPTION
which returns the metadata of that image that corresponds given reference.
Remove hardcoded values from hackMap and start to fill it via calling
the imagec with new -resolv flag.

Fill required metadata in docker persona and pass it to port-layer.

Change port-layer's exec handler parameters so that they match with tether.

We have now the ability to pull and run images from public or private repos.