### PR TITLE
Support restart of the storage port layer

### DIFF
--- a/apiservers/portlayer/restapi/handlers/storage_handlers.go
+++ b/apiservers/portlayer/restapi/handlers/storage_handlers.go
@@ -72,7 +72,7 @@ func (handler *StorageHandlersImpl) Configure(api *operations.PortLayerAPI, netC
 	// The imagestore is implemented via a cache which is backed via an
 	// implementation that writes to disks.  The cache is used to avoid
 	// expensive metadata lookups.
-	storageLayer.DataStore = ds
+	storageLayer = spl.NewLookupCache(ds)
 
 	api.StorageCreateImageStoreHandler = storage.CreateImageStoreHandlerFunc(handler.CreateImageStore)
 	api.StorageGetImageHandler = storage.GetImageHandlerFunc(handler.GetImage)

--- a/apiservers/portlayer/restapi/handlers/storage_handlers.go
+++ b/apiservers/portlayer/restapi/handlers/storage_handlers.go
@@ -175,7 +175,7 @@ func (handler *StorageHandlersImpl) WriteImage(params storage.WriteImageParams) 
 		ID:    params.ParentID,
 	}
 
-	image, err := storageLayer.WriteImage(context.TODO(), parent, params.ImageID, params.Sum, params.ImageFile)
+	image, err := storageLayer.WriteImage(context.TODO(), parent, params.ImageID, nil, params.Sum, params.ImageFile)
 	if err != nil {
 		return storage.NewWriteImageDefault(http.StatusInternalServerError).WithPayload(
 			&models.Error{

--- a/apiservers/portlayer/restapi/handlers/storage_handlers_test.go
+++ b/apiservers/portlayer/restapi/handlers/storage_handlers_test.go
@@ -93,7 +93,7 @@ func (c *MockDataStore) GetImage(ctx context.Context, store *url.URL, ID string)
 
 // ListImages resturns a list of Images for a list of IDs, or all if no IDs are passed
 func (c *MockDataStore) ListImages(ctx context.Context, store *url.URL, IDs []string) ([]*spl.Image, error) {
-	return nil, nil
+	return nil, fmt.Errorf("store (%s) doesn't exist", store.String())
 }
 
 func TestCreateImageStore(t *testing.T) {

--- a/apiservers/portlayer/restapi/handlers/storage_handlers_test.go
+++ b/apiservers/portlayer/restapi/handlers/storage_handlers_test.go
@@ -67,11 +67,12 @@ func (c *MockDataStore) ListImageStores(ctx context.Context) ([]*url.URL, error)
 	return nil, nil
 }
 
-func (c *MockDataStore) WriteImage(ctx context.Context, parent *spl.Image, ID string, r io.Reader) (*spl.Image, error) {
+func (c *MockDataStore) WriteImage(ctx context.Context, parent *spl.Image, ID string, meta map[string][]byte, r io.Reader) (*spl.Image, error) {
 	i := spl.Image{
-		ID:     ID,
-		Store:  parent.Store,
-		Parent: parent.SelfLink,
+		ID:       ID,
+		Store:    parent.Store,
+		Parent:   parent.SelfLink,
+		Metadata: meta,
 	}
 
 	return &i, nil
@@ -187,7 +188,7 @@ func TestGetImage(t *testing.T) {
 	}
 
 	// add the image to the store
-	image, err := storageLayer.WriteImage(context.TODO(), &parent, testImageID, testImageSum, nil)
+	image, err := storageLayer.WriteImage(context.TODO(), &parent, testImageID, nil, testImageSum, nil)
 	if !assert.NotNil(t, image) {
 		return
 	}
@@ -254,7 +255,7 @@ func TestListImages(t *testing.T) {
 	parent.Store = &testStoreURL
 	for i := 1; i < 50; i++ {
 		id := fmt.Sprintf("id-%d", i)
-		img, err := storageLayer.WriteImage(context.TODO(), &parent, id, testImageSum, nil)
+		img, err := storageLayer.WriteImage(context.TODO(), &parent, id, nil, testImageSum, nil)
 		if !assert.NoError(t, err) {
 			return
 		}

--- a/pkg/vsphere/disk/disk_manager.go
+++ b/pkg/vsphere/disk/disk_manager.go
@@ -152,6 +152,9 @@ func (m *Manager) createDiskSpec(childURI, parentURI string, capacity int64, fla
 		CapacityInKB: capacity,
 	}
 
+	// It's possible the VCH has a disk already attached.
+	*disk.VirtualDevice.UnitNumber = -1
+
 	return disk
 }
 

--- a/pkg/vsphere/disk/disk_manager_test.go
+++ b/pkg/vsphere/disk/disk_manager_test.go
@@ -47,9 +47,10 @@ func TestCreateAndDetach(t *testing.T) {
 	fm.MakeDirectory(context.TODO(), imagestore, nil, true)
 
 	vdm, err := NewDiskManager(context.TODO(), client)
-	if err.Error() == "can't find the hosting vm" {
+	if err != nil && err.Error() == "can't find the hosting vm" {
 		t.Skip("Skipping: test must be run in a VM")
 	}
+
 	if !assert.NoError(t, err) || !assert.NotNil(t, vdm) {
 		return
 	}

--- a/portlayer/storage/image.go
+++ b/portlayer/storage/image.go
@@ -34,6 +34,9 @@ type Image struct {
 	Parent *url.URL
 
 	Store *url.URL
+
+	// Metadata associated with the image.
+	Metadata map[string][]byte
 }
 
 func Parse(u *url.URL) (*Image, error) {

--- a/portlayer/storage/storage.go
+++ b/portlayer/storage/storage.go
@@ -44,8 +44,9 @@ type ImageStorer interface {
 	//
 	// parent - The parent image to create the new image from.
 	// ID - textual ID for the image to be written
+	// meta - metadata associated with the image
 	// r - the image tar to be written
-	WriteImage(ctx context.Context, parent *Image, ID string, r io.Reader) (*Image,
+	WriteImage(ctx context.Context, parent *Image, ID string, meta map[string][]byte, r io.Reader) (*Image,
 		error)
 
 	// GetImage queries the image store for the specified image.

--- a/portlayer/storage/store_cache.go
+++ b/portlayer/storage/store_cache.go
@@ -89,7 +89,7 @@ func (c *NameLookupCache) CreateImageStore(ctx context.Context, storeName string
 	c.storeCache[*u] = make(map[string]Image)
 
 	// Create the root image
-	scratch, err := c.DataStore.WriteImage(ctx, &Image{Store: u}, Scratch.ID, nil)
+	scratch, err := c.DataStore.WriteImage(ctx, &Image{Store: u}, Scratch.ID, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -110,7 +110,7 @@ func (c *NameLookupCache) ListImageStores(ctx context.Context) ([]*url.URL, erro
 	return stores, nil
 }
 
-func (c *NameLookupCache) WriteImage(ctx context.Context, parent *Image, ID, sum string, r io.Reader) (*Image, error) {
+func (c *NameLookupCache) WriteImage(ctx context.Context, parent *Image, ID string, meta map[string][]byte, sum string, r io.Reader) (*Image, error) {
 	// Check the parent exists (at least in the cache).
 	p, err := c.GetImage(ctx, parent.Store, parent.ID)
 	if err != nil {
@@ -120,7 +120,7 @@ func (c *NameLookupCache) WriteImage(ctx context.Context, parent *Image, ID, sum
 	h := sha256.New()
 	t := io.TeeReader(r, h)
 
-	i, err := c.DataStore.WriteImage(ctx, p, ID, t)
+	i, err := c.DataStore.WriteImage(ctx, p, ID, meta, t)
 	if err != nil {
 		return nil, err
 	}

--- a/portlayer/vsphere/storage/parent.go
+++ b/portlayer/vsphere/storage/parent.go
@@ -32,6 +32,19 @@ import (
 
 const parentMFile = "parentMap"
 
+// Parent relationships This file will go away when First Class Disk
+// support is added to vsphere.  Currently, we can't get a disk spec for a
+// disk after creating the disk (and the spec) from vsphere.  Basically, if
+// we have a vmdk in the datastore, we have no way of getting the delta
+// disk's (if it even is a delta disk) spec to find it's immediate parent.
+// This map is used to persist the parent relationship for the disk which
+// we maintain outside of the vsphere API.  So, for now, persist this data
+// in the datastore and look it up when we need it.  We write a map file
+// every time a new disk is created, and swap it with the original map
+// file.  Then, at startup, we read the file, and rebuild this map in
+// memory.  At runtime, we consult the map to find which disk is the parent
+// of a given disk.
+
 // Implements the cache used to lookup an image's parent
 type parentM struct {
 	// location in the datastore in datastore URI format

--- a/portlayer/vsphere/storage/parent.go
+++ b/portlayer/vsphere/storage/parent.go
@@ -1,0 +1,138 @@
+// Copyright 2016 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storage
+
+import (
+	"bytes"
+	"encoding/json"
+	"io/ioutil"
+	"path"
+	"sync"
+
+	"golang.org/x/net/context"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25/soap"
+	"github.com/vmware/vic/pkg/vsphere/session"
+	"github.com/vmware/vic/pkg/vsphere/tasks"
+)
+
+const parentMFile = "parentMap"
+
+// Implements the cache used to lookup an image's parent
+type parentM struct {
+	// location in the datastore in datastore URI format
+	mFilePath string
+
+	// map of image ID to parent ID
+	db map[string]string
+
+	sess *session.Session
+
+	l sync.Mutex
+}
+
+// Starts here.  Tries to create a new parentM or load an existing one.
+func restoreParentMap(ctx context.Context, s *session.Session) (*parentM, error) {
+	p := &parentM{
+		mFilePath: path.Join(datastoreParentPath, parentMFile),
+		sess:      s,
+	}
+
+	// Download the map file
+	if err := p.download(ctx); err != nil {
+		log.Infof("err = %#v", err)
+		return nil, err
+	}
+
+	return p, nil
+}
+
+// Add sets the parent for image i to parent
+func (p *parentM) Add(i string, parent string) {
+	p.l.Lock()
+	defer p.l.Unlock()
+
+	p.db[i] = parent
+}
+
+// Get gets a given image's parent
+func (p *parentM) Get(i string) string {
+	p.l.Lock()
+	defer p.l.Unlock()
+
+	return p.db[i]
+}
+
+// Save persists the parent map to the datastore
+func (p *parentM) Save(ctx context.Context) error {
+	p.l.Lock()
+	defer p.l.Unlock()
+
+	buf, err := json.Marshal(p.db)
+	if err != nil {
+		return err
+	}
+
+	// upload to an ephemeral file
+	tmp := p.mFilePath + ".tmp"
+	tmpURI := p.sess.Datastore.Path(tmp)
+
+	parentMURI := p.sess.Datastore.Path(p.mFilePath)
+
+	r := bytes.NewReader(buf)
+	if err = p.sess.Datastore.Upload(ctx, r, tmp, &soap.DefaultUpload); err != nil {
+		log.Errorf("Error uploading %s: %s", tmp, err)
+		return err
+	}
+
+	fm := object.NewFileManager(p.sess.Vim25())
+	err = tasks.Wait(ctx, func(context.Context) (tasks.Waiter, error) {
+		log.Infof("Saving parent map (%s)", p.mFilePath)
+		return fm.MoveDatastoreFile(ctx, tmpURI, nil, parentMURI, nil, true)
+	})
+
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (p *parentM) download(ctx context.Context) error {
+	p.l.Lock()
+	defer p.l.Unlock()
+
+	p.db = make(map[string]string)
+
+	rc, _, err := p.sess.Datastore.Download(ctx, p.mFilePath, &soap.DefaultDownload)
+	if err != nil {
+		// We need to check for 404 vs something else here.
+		return nil
+	}
+	defer rc.Close()
+
+	buf, err := ioutil.ReadAll(rc)
+	if err != nil {
+		return err
+	}
+
+	if err = json.Unmarshal(buf, &p.db); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/portlayer/vsphere/storage/parent_test.go
+++ b/portlayer/vsphere/storage/parent_test.go
@@ -1,0 +1,111 @@
+// Copyright 2016 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storage
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/vmware/vic/pkg/vsphere/session"
+	"github.com/vmware/vic/pkg/vsphere/test"
+	"golang.org/x/net/context"
+)
+
+func parentSetup(t *testing.T) *session.Session {
+	datastoreParentPath = "testingParentDirectory"
+
+	return test.Session(context.TODO(), t)
+}
+
+func TestParentEmptyRestore(t *testing.T) {
+	client := parentSetup(t)
+	if client == nil {
+		return
+	}
+
+	par, err := restoreParentMap(context.TODO(), client)
+	if !assert.NoError(t, err) && !assert.NotNil(t, par) {
+		return
+	}
+}
+
+func TestParentEmptySaveRestore(t *testing.T) {
+	client := parentSetup(t)
+	if client == nil {
+		return
+	}
+	// Nuke the parent image store directory
+	defer rm(t, client, "")
+
+	par, err := restoreParentMap(context.TODO(), client)
+	if !assert.NoError(t, err) && !assert.NotNil(t, par) {
+		return
+	}
+
+	err = par.Save(context.TODO())
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	p, err := restoreParentMap(context.TODO(), client)
+	if !assert.NoError(t, err) && !assert.NotNil(t, p) {
+		return
+	}
+}
+
+// Write some child -> parent mappings and see if we can read them.
+func TestParentSaveRestore(t *testing.T) {
+	client := parentSetup(t)
+	if client == nil {
+		return
+	}
+	// Nuke the parent image store directory
+	defer rm(t, client, "")
+
+	par, err := restoreParentMap(context.TODO(), client)
+	if !assert.NoError(t, err) && !assert.NotNil(t, par) {
+		return
+	}
+
+	expected := make(map[string]string)
+	for i := 0; i < 10; i++ {
+		child := fmt.Sprintf("c%d", i)
+		parent := fmt.Sprintf("p%d", i)
+		expected[child] = parent
+		par.Add(child, parent)
+	}
+	err = par.Save(context.TODO())
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	// load into a different map
+	p, err := restoreParentMap(context.TODO(), client)
+	if !assert.NoError(t, err) && !assert.NotNil(t, p) {
+		return
+	}
+
+	// check if the 2nd map loaded everything correctly
+	if !assert.Equal(t, expected, p.db) {
+		return
+	}
+
+	// Now save it to be extra paranoid
+	err = p.Save(context.TODO())
+	if !assert.NoError(t, err) {
+		return
+	}
+}

--- a/portlayer/vsphere/storage/store.go
+++ b/portlayer/vsphere/storage/store.go
@@ -128,6 +128,11 @@ func (v *ImageStore) CreateImageStore(ctx context.Context, storeName string) (*u
 
 	log.Infof("Creating imagestore directory %s", imagestore)
 	if err = v.fm.MakeDirectory(ctx, imagestore, nil, false); err != nil {
+		soapFault := soap.ToSoapFault(err)
+		if _, ok := soapFault.VimFault().(types.FileAlreadyExists); ok {
+			// Rest API expects this error
+			err = os.ErrExist
+		}
 		return nil, err
 	}
 

--- a/portlayer/vsphere/storage/store_test.go
+++ b/portlayer/vsphere/storage/store_test.go
@@ -97,6 +97,12 @@ func TestCreateAndGetImageStore(t *testing.T) {
 	if !assert.Error(t, err) || !assert.Nil(t, u) {
 		return
 	}
+
+	// Test for a store that already exists
+	u, err = vsis.CreateImageStore(context.TODO(), storeName)
+	if !assert.Error(t, err) || !assert.Nil(t, u) || !assert.Equal(t, err, os.ErrExist) {
+		return
+	}
 }
 
 func TestListImageStore(t *testing.T) {

--- a/portlayer/vsphere/storage/store_test.go
+++ b/portlayer/vsphere/storage/store_test.go
@@ -51,9 +51,7 @@ func setup(t *testing.T) (*portlayer.NameLookupCache, *session.Session, error) {
 		return nil, nil, err
 	}
 
-	s := &portlayer.NameLookupCache{
-		DataStore: vsImageStore,
-	}
+	s := portlayer.NewLookupCache(vsImageStore)
 
 	return s, client, nil
 }
@@ -143,6 +141,13 @@ func TestCreateImageLayers(t *testing.T) {
 	if !assert.NoError(t, err) {
 		return
 	}
+
+	// Get an image that doesn't exist and check for error
+	grbg, err := cacheStore.GetImage(context.TODO(), storeURL, "garbage")
+	if !assert.Error(t, err) || !assert.Nil(t, grbg) {
+		return
+	}
+
 	// base this image off scratch
 	parent, err := cacheStore.GetImage(context.TODO(), storeURL, portlayer.Scratch.ID)
 	if !assert.NoError(t, err) {

--- a/portlayer/vsphere/storage/store_test.go
+++ b/portlayer/vsphere/storage/store_test.go
@@ -197,10 +197,7 @@ func TestCreateImageLayers(t *testing.T) {
 			return
 		}
 
-		assert.Equal(t, writtenImage.ID, vsImage.ID)
-		assert.Equal(t, writtenImage.SelfLink, vsImage.SelfLink)
-		assert.Equal(t, writtenImage.Store, vsImage.Store)
-		assert.Equal(t, writtenImage.Metadata, vsImage.Metadata)
+		assert.Equal(t, writtenImage, vsImage)
 
 		// make the next image a child of the one we just created
 		parent = writtenImage

--- a/portlayer/vsphere/storage/store_test.go
+++ b/portlayer/vsphere/storage/store_test.go
@@ -26,7 +26,6 @@ import (
 	"sort"
 	"testing"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/vic/pkg/vsphere/disk"
@@ -130,7 +129,7 @@ func TestListImageStore(t *testing.T) {
 func TestCreateImageLayers(t *testing.T) {
 	numLayers := 3
 
-	vsis, client, err := setup(t)
+	cacheStore, client, err := setup(t)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -138,86 +137,77 @@ func TestCreateImageLayers(t *testing.T) {
 	// Nuke the parent image store directory
 	defer rm(t, client, "")
 
-	storeURL, err := vsis.CreateImageStore(context.TODO(), "testStore")
+	vsStore := cacheStore.DataStore.(*ImageStore)
+
+	storeURL, err := cacheStore.CreateImageStore(context.TODO(), "testStore")
 	if !assert.NoError(t, err) {
 		return
 	}
 	// base this image off scratch
-	parent, err := vsis.GetImage(context.TODO(), storeURL, portlayer.Scratch.ID)
+	parent, err := cacheStore.GetImage(context.TODO(), storeURL, portlayer.Scratch.ID)
 	if !assert.NoError(t, err) {
 		return
 	}
 
 	// Keep a list of all files we're extracting via layers so we can verify
 	// they exist in the leaf layer.  Ext adds lost+found, so add it here.
-	expected := []string{"lost+found"}
+	expectedFilesOnDisk := []string{"lost+found"}
 
 	for layer := 0; layer < numLayers; layer++ {
-		// Create a buffer to write our archive to.
-		buf := new(bytes.Buffer)
-
-		// Create a new tar archive.
-		tw := tar.NewWriter(buf)
 
 		dirName := fmt.Sprintf("dir%d", layer)
-
 		// Add some files to the archive.
-		var files = []struct {
-			Name string
-			Type byte
-			Body string
-		}{
+		var files = []tarFile{
 			{dirName, tar.TypeDir, ""},
 			{dirName + "/readme.txt", tar.TypeReg, "This archive contains some text files."},
 			{dirName + "/gopher.txt", tar.TypeReg, "Gopher names:\nGeorge\nGeoffrey\nGonzo"},
 			{dirName + "/todo.txt", tar.TypeReg, "Get animal handling license."},
 		}
 
-		for _, file := range files {
-			hdr := &tar.Header{
-				Name:     file.Name,
-				Mode:     0777,
-				Typeflag: file.Type,
-				Size:     int64(len(file.Body)),
-			}
-
-			if err := tw.WriteHeader(hdr); err != nil {
-				log.Fatalln(err)
-			}
-
-			expected = append(expected, file.Name)
-
-			if file.Type == tar.TypeDir {
-				continue
-			}
-
-			if _, err := tw.Write([]byte(file.Body)); err != nil {
-				log.Fatalln(err)
-			}
+		for _, i := range files {
+			expectedFilesOnDisk = append(expectedFilesOnDisk, i.Name)
 		}
 
-		// Make sure to check the error on Close.
-		if err := tw.Close(); err != nil {
-			log.Fatalln(err)
+		// meta for the image
+		meta := make(map[string][]byte)
+		meta[dirName+"_meta"] = []byte("Some Meta")
+		meta[dirName+"_moreMeta"] = []byte("Some More Meta")
+		meta[dirName+"_scorpions"] = []byte("Here I am, rock you like a hurricane")
+
+		// Tar the files
+		buf, err := tarFiles(files, meta)
+		if !assert.NoError(t, err) {
+			return
 		}
 
+		// Calculate the checksum
 		h := sha256.New()
 		h.Write(buf.Bytes())
 		sum := fmt.Sprintf("sha256:%x", h.Sum(nil))
 
-		newImage, err := vsis.WriteImage(context.TODO(), parent, dirName, sum, buf)
-		if !assert.NoError(t, err) || !assert.NotNil(t, newImage) {
+		// Write the image via the cache (which writes to the vsphere impl)
+		writtenImage, err := cacheStore.WriteImage(context.TODO(), parent, dirName, meta, sum, buf)
+		if !assert.NoError(t, err) || !assert.NotNil(t, writtenImage) {
 			return
 		}
 
+		// Get the image directly via the vsphere image store impl.
+		vsImage, err := vsStore.GetImage(context.TODO(), parent.Store, dirName)
+		if !assert.NoError(t, err) || !assert.NotNil(t, vsImage) {
+			return
+		}
+
+		assert.Equal(t, writtenImage.ID, vsImage.ID)
+		assert.Equal(t, writtenImage.SelfLink, vsImage.SelfLink)
+		assert.Equal(t, writtenImage.Store, vsImage.Store)
+		assert.Equal(t, writtenImage.Metadata, vsImage.Metadata)
+
 		// make the next image a child of the one we just created
-		parent = newImage
+		parent = writtenImage
 	}
 
-	// verify we did anything by attaching the last layer rdonly
-	v := vsis.DataStore.(*ImageStore)
-
-	roDisk, err := mountLayerRO(v, parent)
+	// verify the disk's data by attaching the last layer rdonly
+	roDisk, err := mountLayerRO(vsStore, parent)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -227,12 +217,12 @@ func TestCreateImageLayers(t *testing.T) {
 		return
 	}
 
-	defer v.dm.Detach(context.TODO(), roDisk)
+	defer vsStore.dm.Detach(context.TODO(), roDisk)
 	defer os.RemoveAll(p)
 	defer roDisk.Unmount()
 
-	actual := []string{}
-	// Diff the contents
+	filesFoundOnDisk := []string{}
+	// Diff the contents of the RO file of the last child (with all of the contents)
 	err = filepath.Walk(p, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
@@ -241,7 +231,7 @@ func TestCreateImageLayers(t *testing.T) {
 		f := path[len(p):]
 		if f != "" {
 			// strip the slash
-			actual = append(actual, f[1:])
+			filesFoundOnDisk = append(filesFoundOnDisk, f[1:])
 		}
 		return nil
 	})
@@ -249,19 +239,60 @@ func TestCreateImageLayers(t *testing.T) {
 		return
 	}
 
-	sort.Strings(actual)
-	sort.Strings(expected)
+	sort.Strings(filesFoundOnDisk)
+	sort.Strings(expectedFilesOnDisk)
 
-	log.Infof("actual = %s", actual)
-	log.Infof("expected = %s", expected)
-	if !assert.Equal(t, expected, actual) {
+	if !assert.Equal(t, expectedFilesOnDisk, filesFoundOnDisk) {
 		return
 	}
 }
 
+type tarFile struct {
+	Name string
+	Type byte
+	Body string
+}
+
+func tarFiles(files []tarFile, meta map[string][]byte) (*bytes.Buffer, error) {
+	// Create a buffer to write our archive to.
+	buf := new(bytes.Buffer)
+
+	// Create a new tar archive.
+	tw := tar.NewWriter(buf)
+
+	// Write data to the tar as if it came from the hub
+	for _, file := range files {
+		hdr := &tar.Header{
+			Name:     file.Name,
+			Mode:     0777,
+			Typeflag: file.Type,
+			Size:     int64(len(file.Body)),
+		}
+
+		if err := tw.WriteHeader(hdr); err != nil {
+			return nil, err
+		}
+
+		if file.Type == tar.TypeDir {
+			continue
+		}
+
+		if _, err := tw.Write([]byte(file.Body)); err != nil {
+			return nil, err
+		}
+	}
+
+	// Make sure to check the error on Close.
+	if err := tw.Close(); err != nil {
+		return nil, err
+	}
+
+	return buf, nil
+}
+
 func mountLayerRO(v *ImageStore, parent *portlayer.Image) (*disk.VirtualDisk, error) {
-	roName := v.imageStoreDatastoreURI("testStore") + "/" + parent.ID + "-ro.vmdk"
-	parentDsURI := v.imageDiskDatastoreURI("testStore", parent.ID)
+	roName := v.datastorePath(v.imageStorePath("testStore")) + "/" + parent.ID + "-ro.vmdk"
+	parentDsURI := v.datastorePath(v.imageDiskPath("testStore", parent.ID))
 	roDisk, err := v.dm.CreateAndAttach(context.TODO(), roName, parentDsURI, 0, os.O_RDONLY)
 	if err != nil {
 		return nil, err

--- a/vendor/github.com/vmware/govmomi/govc/test/vm.bats
+++ b/vendor/github.com/vmware/govmomi/govc/test/vm.bats
@@ -400,3 +400,32 @@ load test_helper
   run govc device.info -vm $vm disk-1000-0
   assert_success
 }
+
+@test "vm.clone" {
+  vcsim_env
+  vm=$(new_ttylinux_vm)
+  clone=$(new_id)
+  
+  run govc vm.clone -vm $vm $clone
+  assert_success
+
+  result=$(govc device.ls -vm $clone | grep disk- | wc -l)
+  [ $result -eq 0 ]
+
+  result=$(govc device.ls -vm $clone | grep cdrom- | wc -l)
+  [ $result -eq 0 ]
+}
+
+@test "vm.clone change resources" {
+  vcsim_env
+  vm=$(new_ttylinux_vm)
+  clone=$(new_id)
+  
+  run govc vm.clone -m 1024 -c 2 -vm $vm $clone
+  assert_success
+
+  run govc vm.info $clone
+  assert_success
+  assert_line "Memory: 1024MB"
+  assert_line "CPU: 2 vCPU(s)"
+}

--- a/vendor/github.com/vmware/govmomi/govc/vm/clone.go
+++ b/vendor/github.com/vmware/govmomi/govc/vm/clone.go
@@ -1,0 +1,383 @@
+/*
+Copyright (c) 2014-2016 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vm
+
+import (
+	"flag"
+	"fmt"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25"
+	"github.com/vmware/govmomi/vim25/types"
+	"golang.org/x/net/context"
+)
+
+type clone struct {
+	*flags.ClientFlag
+	*flags.DatacenterFlag
+	*flags.DatastoreFlag
+	*flags.StoragePodFlag
+	*flags.ResourcePoolFlag
+	*flags.HostSystemFlag
+	*flags.NetworkFlag
+	*flags.FolderFlag
+	*flags.VirtualMachineFlag
+
+	name          string
+	memory        int
+	cpus          int
+	on            bool
+	force         bool
+	template      bool
+	customization string
+	waitForIP     bool
+
+	Client         *vim25.Client
+	Datacenter     *object.Datacenter
+	Datastore      *object.Datastore
+	StoragePod     *object.StoragePod
+	ResourcePool   *object.ResourcePool
+	HostSystem     *object.HostSystem
+	Folder         *object.Folder
+	VirtualMachine *object.VirtualMachine
+}
+
+func init() {
+	cli.Register("vm.clone", &clone{})
+}
+
+func (cmd *clone) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.ClientFlag, ctx = flags.NewClientFlag(ctx)
+	cmd.ClientFlag.Register(ctx, f)
+
+	cmd.DatacenterFlag, ctx = flags.NewDatacenterFlag(ctx)
+	cmd.DatacenterFlag.Register(ctx, f)
+
+	cmd.DatastoreFlag, ctx = flags.NewDatastoreFlag(ctx)
+	cmd.DatastoreFlag.Register(ctx, f)
+
+	cmd.StoragePodFlag, ctx = flags.NewStoragePodFlag(ctx)
+	cmd.StoragePodFlag.Register(ctx, f)
+
+	cmd.ResourcePoolFlag, ctx = flags.NewResourcePoolFlag(ctx)
+	cmd.ResourcePoolFlag.Register(ctx, f)
+
+	cmd.HostSystemFlag, ctx = flags.NewHostSystemFlag(ctx)
+	cmd.HostSystemFlag.Register(ctx, f)
+
+	cmd.NetworkFlag, ctx = flags.NewNetworkFlag(ctx)
+	cmd.NetworkFlag.Register(ctx, f)
+
+	cmd.FolderFlag, ctx = flags.NewFolderFlag(ctx)
+	cmd.FolderFlag.Register(ctx, f)
+
+	cmd.VirtualMachineFlag, ctx = flags.NewVirtualMachineFlag(ctx)
+	cmd.VirtualMachineFlag.Register(ctx, f)
+
+	f.IntVar(&cmd.memory, "m", 0, "Size in MB of memory")
+	f.IntVar(&cmd.cpus, "c", 0, "Number of CPUs")
+	f.BoolVar(&cmd.on, "on", true, "Power on VM. Default is true if -disk argument is given.")
+	f.BoolVar(&cmd.force, "force", false, "Create VM if vmx already exists")
+	f.BoolVar(&cmd.template, "template", false, "Create a Template")
+	f.StringVar(&cmd.customization, "customization", "", "Customization Specification Name")
+	f.BoolVar(&cmd.waitForIP, "waitip", false, "Wait for VM to acquire IP address")
+}
+
+func (cmd *clone) Process(ctx context.Context) error {
+	if err := cmd.ClientFlag.Process(ctx); err != nil {
+		return err
+	}
+	if err := cmd.DatacenterFlag.Process(ctx); err != nil {
+		return err
+	}
+	if err := cmd.DatastoreFlag.Process(ctx); err != nil {
+		return err
+	}
+	if err := cmd.StoragePodFlag.Process(ctx); err != nil {
+		return err
+	}
+	if err := cmd.ResourcePoolFlag.Process(ctx); err != nil {
+		return err
+	}
+	if err := cmd.HostSystemFlag.Process(ctx); err != nil {
+		return err
+	}
+	if err := cmd.NetworkFlag.Process(ctx); err != nil {
+		return err
+	}
+	if err := cmd.FolderFlag.Process(ctx); err != nil {
+		return err
+	}
+	if err := cmd.VirtualMachineFlag.Process(ctx); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (cmd *clone) Run(ctx context.Context, f *flag.FlagSet) error {
+	var err error
+
+	if len(f.Args()) != 1 {
+		return flag.ErrHelp
+	}
+
+	cmd.name = f.Arg(0)
+	if cmd.name == "" {
+		return flag.ErrHelp
+	}
+
+	cmd.Client, err = cmd.ClientFlag.Client()
+	if err != nil {
+		return err
+	}
+
+	cmd.Datacenter, err = cmd.DatacenterFlag.Datacenter()
+	if err != nil {
+		return err
+	}
+
+	if cmd.StoragePodFlag.Isset() {
+		cmd.StoragePod, err = cmd.StoragePodFlag.StoragePod()
+		if err != nil {
+			return err
+		}
+	} else {
+		cmd.Datastore, err = cmd.DatastoreFlag.Datastore()
+		if err != nil {
+			return err
+		}
+	}
+
+	cmd.HostSystem, err = cmd.HostSystemFlag.HostSystemIfSpecified()
+	if err != nil {
+		return err
+	}
+
+	if cmd.HostSystem != nil {
+		if cmd.ResourcePool, err = cmd.HostSystem.ResourcePool(context.TODO()); err != nil {
+			return err
+		}
+	} else {
+		// -host is optional
+		if cmd.ResourcePool, err = cmd.ResourcePoolFlag.ResourcePool(); err != nil {
+			return err
+		}
+	}
+
+	if cmd.Folder, err = cmd.FolderFlag.Folder(); err != nil {
+		return err
+	}
+
+	if cmd.VirtualMachine, err = cmd.VirtualMachineFlag.VirtualMachine(); err != nil {
+		return err
+	}
+
+	task, err := cmd.cloneVM(context.TODO())
+	if err != nil {
+		return err
+	}
+
+	info, err := task.WaitForResult(context.TODO(), nil)
+	if err != nil {
+		return err
+	}
+
+	vm := object.NewVirtualMachine(cmd.Client, info.Result.(types.ManagedObjectReference))
+
+	if cmd.cpus > 0 || cmd.memory > 0 {
+		vmConfigSpec := types.VirtualMachineConfigSpec{}
+		if cmd.cpus > 0 {
+			vmConfigSpec.NumCPUs = int32(cmd.cpus)
+		}
+		if cmd.memory > 0 {
+			vmConfigSpec.MemoryMB = int64(cmd.memory)
+		}
+		task, err := vm.Reconfigure(context.TODO(), vmConfigSpec)
+		if err != nil {
+			return err
+		}
+		_, err = task.WaitForResult(context.TODO(), nil)
+		if err != nil {
+			return err
+		}
+	}
+
+	if cmd.on {
+		task, err := vm.PowerOn(context.TODO())
+		if err != nil {
+			return err
+		}
+
+		_, err = task.WaitForResult(context.TODO(), nil)
+		if err != nil {
+			return err
+		}
+
+		if cmd.waitForIP {
+			_, err = vm.WaitForIP(ctx)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func (cmd *clone) cloneVM(ctx context.Context) (*object.Task, error) {
+
+	// search for the first network card of the source
+	devices, err := cmd.VirtualMachine.Device(ctx)
+	if err != nil {
+		return nil, err
+	}
+	var card *types.VirtualEthernetCard
+	for _, device := range devices {
+		if c, ok := device.(types.BaseVirtualEthernetCard); ok {
+			card = c.GetVirtualEthernetCard()
+			break
+		}
+	}
+	if card == nil {
+		return nil, fmt.Errorf("No network device found.")
+	}
+
+	// get the new backing information
+	dev, err := cmd.NetworkFlag.Device()
+	if err != nil {
+		return nil, err
+	}
+
+	//set backing info
+	card.Backing = dev.(types.BaseVirtualEthernetCard).GetVirtualEthernetCard().Backing
+
+	// prepare virtual device config spec for network card
+	configSpecs := []types.BaseVirtualDeviceConfigSpec{
+		&types.VirtualDeviceConfigSpec{
+			Operation: types.VirtualDeviceConfigSpecOperationEdit,
+			Device:    card,
+		},
+	}
+
+	folderref := cmd.Folder.Reference()
+	poolref := cmd.ResourcePool.Reference()
+
+	relocateSpec := types.VirtualMachineRelocateSpec{
+		DeviceChange: configSpecs,
+		Folder:       &folderref,
+		Pool:         &poolref,
+	}
+
+	if cmd.HostSystem != nil {
+		hostref := cmd.HostSystem.Reference()
+		relocateSpec.Host = &hostref
+	}
+
+	cloneSpec := &types.VirtualMachineCloneSpec{
+		Location: relocateSpec,
+		PowerOn:  false,
+		Template: cmd.template,
+	}
+
+	// clone to storage pod
+	datastoreref := types.ManagedObjectReference{}
+	if cmd.StoragePod != nil && cmd.Datastore == nil {
+		storagePod := cmd.StoragePod.Reference()
+
+		// Build pod selection spec from config spec
+		podSelectionSpec := types.StorageDrsPodSelectionSpec{
+			StoragePod: &storagePod,
+		}
+
+		// Get the virtual machine reference
+		vmref := cmd.VirtualMachine.Reference()
+
+		// Build the placement spec
+		storagePlacementSpec := types.StoragePlacementSpec{
+			Folder:           &folderref,
+			Vm:               &vmref,
+			CloneName:        cmd.name,
+			CloneSpec:        cloneSpec,
+			PodSelectionSpec: podSelectionSpec,
+			Type:             string(types.StoragePlacementSpecPlacementTypeClone),
+		}
+
+		// Get the storage placement result
+		storageResourceManager := object.NewStorageResourceManager(cmd.Client)
+		result, err := storageResourceManager.RecommendDatastores(ctx, storagePlacementSpec)
+		if err != nil {
+			return nil, err
+		}
+
+		// Get the recommendations
+		recommendations := result.Recommendations
+		if len(recommendations) == 0 {
+			return nil, fmt.Errorf("no recommendations")
+		}
+
+		// Get the first recommendation
+		datastoreref = recommendations[0].Action[0].(*types.StoragePlacementAction).Destination
+	} else if cmd.StoragePod == nil && cmd.Datastore != nil {
+		datastoreref = cmd.Datastore.Reference()
+	} else {
+		return nil, fmt.Errorf("Please provide either a datastore or a storagepod")
+	}
+
+	// Set the destination datastore
+	cloneSpec.Location.Datastore = &datastoreref
+
+	// Check if vmx already exists
+	if !cmd.force {
+		vmxPath := fmt.Sprintf("%s/%s.vmx", cmd.name, cmd.name)
+
+		datastore := object.NewDatastore(cmd.Client, datastoreref)
+
+		_, err := datastore.Stat(ctx, vmxPath)
+		if err == nil {
+			dsPath := cmd.Datastore.Path(vmxPath)
+			return nil, fmt.Errorf("File %s already exists", dsPath)
+		}
+	}
+
+	// check if customization specification requested
+	if len(cmd.customization) > 0 {
+		// get the customization spec manager
+		customizationSpecManager := object.NewCustomizationSpecManager(cmd.Client)
+		// check if customization specification exists
+		exists, err := customizationSpecManager.DoesCustomizationSpecExist(ctx, cmd.customization)
+		if err != nil {
+			return nil, err
+		}
+		if exists == false {
+			return nil, fmt.Errorf("Customization specification %s does not exists.", cmd.customization)
+		}
+		// get the customization specification
+		customSpecItem, err := customizationSpecManager.GetCustomizationSpec(ctx, cmd.customization)
+		if err != nil {
+			return nil, err
+		}
+		customSpec := customSpecItem.Spec
+		// set the customization
+		cloneSpec.Customization = &customSpec
+	}
+
+	// clone virtualmachine
+	return cmd.VirtualMachine.Clone(ctx, cmd.Folder, cmd.name, *cloneSpec)
+}

--- a/vendor/github.com/vmware/govmomi/object/datastore.go
+++ b/vendor/github.com/vmware/govmomi/object/datastore.go
@@ -220,7 +220,16 @@ func (d Datastore) UploadFile(ctx context.Context, file string, path string, par
 	return d.Client().UploadFile(file, u, p)
 }
 
-// DownloadFile via soap.Upload with an http service ticket
+// Download via soap.Download with an http service ticket
+func (d Datastore) Download(ctx context.Context, path string, param *soap.Download) (io.ReadCloser, int64, error) {
+	u, p, err := d.downloadTicket(ctx, path, param)
+	if err != nil {
+		return nil, 0, err
+	}
+	return d.Client().Download(u, p)
+}
+
+// DownloadFile via soap.Download with an http service ticket
 func (d Datastore) DownloadFile(ctx context.Context, path string, file string, param *soap.Download) error {
 	u, p, err := d.downloadTicket(ctx, path, param)
 	if err != nil {

--- a/vendor/manifest
+++ b/vendor/manifest
@@ -846,7 +846,7 @@
 		{
 			"importpath": "github.com/vmware/govmomi",
 			"repository": "https://github.com/vmware/govmomi",
-			"revision": "c1b29993f383c32fc3fadb90892909668699810a",
+			"revision": "95f3801b43e3392c084188944bb09407b5934ead",
 			"branch": "master"
 		},
 		{


### PR DESCRIPTION
The cache is now repopulated (lazily) when WriteImage, GetImage, or ListImages is called. In each instance, the datastore is queried via the vsphere storage implementation, then the cache is populated with returned image data.

Also added metadata handling in WriteImage and GetImage.

Tested the daemon using the appliance/installer to pull some well known images. All worked without issue.

The metadata needs to be plumbed up to the REST api but this PR was getting a bit weighty and decided to hold off on that.