### PR TITLE
Avoid race condition in the installer

### DIFF
--- a/isos/appliance/launcher.sh
+++ b/isos/appliance/launcher.sh
@@ -18,7 +18,16 @@ logFileDir="/var/log/vic/"
 mkdir -p "$logFileDir"
 
 nameInterfaces() {
-    for net in $(rpctool -get vch/networks); do
+    echo "Waiting for network interface configuration"
+    while true ; do
+        networks=($(rpctool -get vch/networks))
+        if [ ${#networks[@]} -ne 0 ] ; then
+            break
+        fi
+        sleep 1
+    done
+
+    for net in "${networks[@]}" ; do
         mac=$(rpctool -get vch/networks/$net)
 
         # interface name for mac, with trailing :


### PR DESCRIPTION
The VCH needs to be powered on to generate its MAC addresses.  After
power on, the installer configures vch/networks via guestinfo.  It is
possible for the VCH launcher to run before this configuration is set,
causing install to fail.

Change the launcher to poll for vch/networks to avoid the race.