### PR TITLE
Enable tools auto kernel modules

### DIFF
--- a/machines/devbox/provision.sh
+++ b/machines/devbox/provision.sh
@@ -23,6 +23,9 @@ echo "export GOPATH="${BASH_ARGV[1]} >> $pro
 # add GOPATH/bin to the PATH
 echo "export PATH=$PATH:"${BASH_ARGV[1]}"/bin" >> $pro
 
+# vmwaretools automatic kernel update
+echo "answer AUTO_KMODS_ENABLED yes" | tee -a /etc/vmware-tools/locations
+
 packages=(curl lsof strace git shellcheck tree mc silversearcher-ag jq)
 for package in "${packages[@]}" ; do
     apt-get -y install "$package"


### PR DESCRIPTION

This will enable the auto kernel modules feature of vmware tools.
This will allow tools to reconfigure when the kernel is updated and
ensure the shared folders are still operational

Fixes #499