### PR TITLE
Network names in scopes

### DIFF
--- a/apiservers/portlayer/restapi/handlers/exec_handlers.go
+++ b/apiservers/portlayer/restapi/handlers/exec_handlers.go
@@ -88,6 +88,7 @@ func (handler *ExecHandlersImpl) addContainerToScope(name string, ns *models.Net
 
 	var err error
 	var s *network.Scope
+
 	switch ns.NetworkName {
 	// docker's default network, usually maps to the default bridge network
 	case "default":
@@ -126,8 +127,6 @@ func (handler *ExecHandlersImpl) addContainerToScope(name string, ns *models.Net
 			Mask: e.Subnet().Mask,
 		},
 		Network: metadata.ContainerNetwork{
-			// FIXME: https://github.com/vmware/vic/issues/444
-			// FIXME: this needs to point to switch or port group name
 			Name: e.Scope().Name(),
 			Gateway: net.IPNet{
 				IP:   e.Gateway(),

--- a/portlayer/network/scope.go
+++ b/portlayer/network/scope.go
@@ -37,6 +37,8 @@ type Scope struct {
 	containers map[string]*Container
 	endpoints  []*Endpoint
 	space      *AddressSpace
+
+	NetworkName string // portgroup name specified in VCH guestinfo (e.g. under "networks/bridge")
 }
 
 type IPAM struct {

--- a/portlayer/network/scope_test.go
+++ b/portlayer/network/scope_test.go
@@ -19,6 +19,8 @@ import (
 	"net"
 	"reflect"
 	"testing"
+
+	"github.com/vmware/vic/pkg/vsphere/session"
 )
 
 func makeIP(a, b, c, d byte) *net.IP {
@@ -27,8 +29,14 @@ func makeIP(a, b, c, d byte) *net.IP {
 }
 
 func TestScopeAddRemoveContainer(t *testing.T) {
+	origBridgeNetworkName := getBridgeNetworkName
+	getBridgeNetworkName = mockBridgeNetworkName
+	defer func() { getBridgeNetworkName = origBridgeNetworkName }()
+
 	var err error
-	ctx, err := NewContext(net.IPNet{IP: net.IPv4(172, 16, 0, 0), Mask: net.CIDRMask(12, 32)}, net.CIDRMask(16, 32))
+	sess := &session.Session{}
+
+	ctx, err := NewContext(net.IPNet{IP: net.IPv4(172, 16, 0, 0), Mask: net.CIDRMask(12, 32)}, net.CIDRMask(16, 32), sess)
 	if err != nil {
 		t.Errorf("NewContext() => (nil, %s), want (ctx, nil)", err)
 		return


### PR DESCRIPTION
Get portgroup name from VCH guestinfo (only for bridge network at this time) and put it in the Scope so container VMs can know which to connect to.

Fixes #444
