### PR TITLE
Serialize entire struct to/from guestinfo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -166,7 +166,6 @@ govet: $(find . -type f -name '*.go' -not -path "./vendor/*" -not -path "apiserv
 	@echo checking go vet...
 	@$(GO) tool vet -all $$(find . -type f -name '*.go' -not -path "./vendor/*")
 	@$(GO) tool vet -shadow $$(find . -type f -name '*.go' -not -path "./vendor/*")
-	@touch $@
 
 vendor: $(GVT)
 	@echo restoring vendor

--- a/pkg/vsphere/extraconfig/decode.go
+++ b/pkg/vsphere/extraconfig/decode.go
@@ -1,0 +1,284 @@
+// Copyright 2016 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package extraconfig
+
+import (
+	"fmt"
+	"reflect"
+	"strconv"
+	"strings"
+	"time"
+
+	log "github.com/Sirupsen/logrus"
+
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+var (
+	DecodeLogLevel = log.InfoLevel
+)
+
+// fromString converts string representation of a basic type to basic type
+func fromString(field reflect.Value, value string) reflect.Value {
+	switch field.Kind() {
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		s, err := strconv.ParseInt(value, 10, 64)
+		if err != nil {
+			log.Errorf("Failed to convert value %#v (%s) to int: %s", value, field.Kind(), err.Error())
+			return field
+		}
+		return reflect.ValueOf(int(s))
+
+	case reflect.Bool:
+		s, err := strconv.ParseBool(value)
+		if err != nil {
+			log.Errorf("Failed to convert value %#v (%s) to bool: %s", value, field.Kind(), err.Error())
+			return field
+		}
+		return reflect.ValueOf(s)
+
+	case reflect.String:
+		return reflect.ValueOf(value)
+
+	case reflect.Float32, reflect.Float64:
+		s, err := strconv.ParseFloat(value, 64)
+		if err != nil {
+			log.Errorf("Failed to convert value %#v (%s) to float: %s", value, field.Kind(), err.Error())
+			return field
+		}
+		return reflect.ValueOf(s)
+
+	}
+	log.Debugf("Invalid Kind: %s (%#v)", field.Kind(), value)
+
+	return field
+}
+
+// decodeWithPrefix convert []types.BaseOptionValue to type dest
+func decodeWithPrefix(kv map[string]string, dest interface{}, prefix string) interface{} {
+	// value representing the run-time data
+	value := reflect.ValueOf(dest).Elem()
+	log.Debugf("Value: %#v", value)
+
+	// determine the kind as it changes how we get underlying data
+	switch value.Kind() {
+	case reflect.Invalid:
+		log.Errorf("Invalid Kind: %#v", value)
+		return nil
+
+	case reflect.Struct:
+		// iterate through every struct type field
+		for i := 0; i < value.NumField(); i++ {
+			// get the underlying struct field
+			structField := value.Type().Field(i)
+			//skip unexported fields
+			if structField.PkgPath != "" {
+				log.Debugf("Skipping %s (not exported)", structField.Name)
+				continue
+			}
+
+			// get the annotations
+			tags := structField.Tag
+			log.Debugf("Tags: %#v", tags)
+
+			// do we have DefaultTagName?
+			if tags.Get(DefaultTagName) == "" {
+				log.Debugf("Skipping %s (not vic)", structField.Name)
+				continue
+			}
+
+			// get the scopes
+			scopes := strings.Split(tags.Get("scope"), ",")
+			log.Debugf("Scopes: %#v", scopes)
+
+			// get the keys and split properties from it
+			keys := strings.Split(tags.Get("key"), ",")
+			key, properties := keys[0], keys[1:]
+			log.Debugf("Keys: %#v Properties: %#v", key, properties)
+
+			// returns the i'th field of the struct i
+			field := value.Field(i)
+
+			// process properties
+			if len(properties) > 0 {
+				// do not recurse into nested type
+				if properties[0] == "omitnested" {
+					log.Debugf("Skipping %s (omitnested)", key)
+					continue
+				}
+
+				log.Debugf("Unknown property %s (%s)", key, properties[0])
+				continue
+			}
+
+			// re-calculate the key based on the scope and prefix
+			if key = calculateKey(scopes, prefix, key); key == "" {
+				log.Debugf("Skipping %s (unknown scope %s)", key, scopes)
+				continue
+			}
+
+			// Dump what we have so far
+			log.Debugf("Key: %s, Properties: %q Kind: %s Value: %s", key, properties, field.Kind(), field.String())
+
+			// ensure we have the tag
+			v, ok := kv[key]
+			if ok {
+				log.Debugf("Setting the %s with %s", key, v)
+				// set the field with the value
+				field.Set(fromString(field, v))
+			}
+
+			// all check passed, start to work on i'th field of the struct dest
+			switch field.Kind() {
+			case reflect.Struct:
+				log.Debugf("Struct begin")
+
+				// type cast struct to supported types (eg; time.Time, url.Url etc.)
+				switch field.Interface().(type) {
+				case time.Time:
+					// from https://golang.org/src/time/format.go?s=12854:12883#L407
+					t, err := time.Parse("2006-01-02 15:04:05.999999999 -0700 MST", v)
+					if err != nil {
+						log.Errorf("Failed to convert value %#v to time: %s", v, err.Error())
+					}
+					field.Set(reflect.ValueOf(t))
+				default:
+					member := reflect.New(field.Type())
+					decodeWithPrefix(kv, member.Interface(), key)
+					field.Set(member.Elem())
+				}
+				log.Debugf("Struct end")
+
+			case reflect.Slice, reflect.Array:
+				// recurse for struct, slice and array types
+				log.Debugf("Slice|Array begin")
+
+				lengthValue := fromString(reflect.ValueOf(0), v)
+				length := int(lengthValue.Int()) + 1
+
+				// create the slice
+				slice := reflect.MakeSlice(field.Type(), length, length)
+				if field.Type().Elem().Kind() == reflect.Struct {
+					for i := 0; i < length; i++ {
+						member := reflect.New(field.Type().Elem())
+						// convert key to name|index format
+						key := fmt.Sprintf("%s|%d", key, i)
+						decodeWithPrefix(kv, member.Interface(), key)
+
+						// set the i'th slice item
+						slice.Index(i).Set(member.Elem())
+					}
+				} else {
+					// convert key to name~ format
+					key := fmt.Sprintf("%s~", key)
+					// lookup the key and split it
+					values := strings.Split(kv[key], "|")
+					for i := 0; i < length; i++ {
+						v := values[i]
+						t := field.Type().Elem()
+						k := fromString(reflect.Zero(t), v)
+						// set the i'th slice item
+						slice.Index(i).Set(k)
+					}
+				}
+				// set the slice
+				field.Set(slice)
+
+				log.Debugf("Slice|Array end")
+
+			case reflect.Map:
+				log.Debugf("Map begin")
+
+				// create and set the map if neccessary
+				if field.IsNil() {
+					field.Set(reflect.MakeMap(field.Type()))
+				}
+
+				// split v and iterate over it
+				for _, value := range strings.Split(v, "|") {
+					if field.Type().Elem().Kind() == reflect.Struct {
+						member := reflect.New(field.Type().Elem())
+
+						key := fmt.Sprintf("%s|%s", key, value)
+						decodeWithPrefix(kv, member.Interface(), key)
+
+						t := field.Type().Key()
+						k := fromString(reflect.Zero(t), value)
+						field.SetMapIndex(k, member.Elem())
+					} else {
+						values := strings.Split(v, "|")
+						for i := 0; i < len(values); i++ {
+							v := values[i]
+							// convert key to name|mapkey format
+							key := fmt.Sprintf("%s|%s", key, v)
+							t := field.Type().Elem()
+							k := fromString(reflect.Zero(t), kv[key])
+
+							// set the map item
+							field.SetMapIndex(reflect.ValueOf(v), k)
+						}
+					}
+				}
+
+				log.Debugf("Map end")
+
+			case reflect.Ptr:
+				log.Debugf("Prt begin")
+				// FIXME: non struct pointers
+				if field.Type().Elem().Kind() == reflect.Struct {
+					v, ok := kv[key]
+					if ok {
+						if field.Type().Elem() == reflect.TypeOf(time.Time{}) {
+							// from https://golang.org/src/time/format.go?s=12854:12883#L407
+							t, err := time.Parse("2006-01-02 15:04:05.999999999 -0700 MST", v)
+							if err != nil {
+								log.Errorf("Failed to convert value %#v to time: %s", v, err.Error())
+							}
+							// set the pointer
+							field.Set(reflect.ValueOf(&t))
+						} else {
+							member := reflect.New(field.Type().Elem())
+
+							decodeWithPrefix(kv, member.Interface(), key)
+
+							// set the pointer
+							field.Set(member)
+						}
+					}
+				}
+				log.Debugf("Ptr end")
+			}
+		}
+		return dest
+	default:
+		log.Debugf("Skipping not supported kind %s", value.Kind())
+		return nil
+	}
+}
+
+// Decode convert given type to []types.BaseOptionValue
+func Decode(src []types.BaseOptionValue, dest interface{}) interface{} {
+	log.SetLevel(DecodeLogLevel)
+
+	// create the key/value store from the extraconfig slice for lookups
+	kv := make(map[string]string)
+	for i := range src {
+		k := src[i].GetOptionValue().Key
+		v := src[i].GetOptionValue().Value.(string)
+		kv[k] = v
+	}
+
+	return decodeWithPrefix(kv, dest, DefaultPrefix)
+}

--- a/pkg/vsphere/extraconfig/doc.go
+++ b/pkg/vsphere/extraconfig/doc.go
@@ -1,0 +1,47 @@
+// Copyright 2016 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package extraconfig
+
+/*
+Package extraconfig provides Encode/Decode methods to convert data between Go structs and VMware Extraconfig values.
+
+The implementation understands the following set of annotations and map the fields to appropriate extraConfig keys - in the case where the key describes a boolean state, ommitting the annotation implies the opposite:
+
+hidden - hidden from GuestOS
+read-only - value can only be modified via vSphere APIs
+read-write - value can be modified
+non-persistent - value will be lost on VM reboot
+volatile - field is not exported directly, but via a function that freshens the value each time)
+
+The struct fields are required to be annotated with the "vic" tag, otherwise extraconfig package simply skips them. Scope and key tags are also required.
+
+Scope tag can contain multiple values (comma seperated)
+Key tag can contain extra properties (comma seperated) but the first element has to the name of the key.
+
+type Example struct {
+    // skipped - does not contain any tag
+	Note string
+
+    // skipped - does not contain scope and key
+	ID string `vic:"0.1"`
+
+    // valid - extraconfig will encode this using a read-only key (as instructed by scope)
+	Name string `vic:"0.1" scope:"read-only" key:"name"`
+
+    // valid - but extraconfig won't nest into the struct (so it's value will be type's zero value)
+	Time time.Time `vic:"0.1" scope:"volatile" key:"time,omitnested"`
+}
+
+*/

--- a/pkg/vsphere/extraconfig/encode.go
+++ b/pkg/vsphere/extraconfig/encode.go
@@ -1,0 +1,319 @@
+// Copyright 2016 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package extraconfig
+
+import (
+	"fmt"
+	"reflect"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	log "github.com/Sirupsen/logrus"
+
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+const (
+	// DefaultTagName value
+	DefaultTagName = "vic"
+	// DefaultPrefix value
+	DefaultPrefix = ""
+	// DefaultGuestInfoPrefix value
+	DefaultGuestInfoPrefix = "guestinfo"
+)
+
+const (
+	// Invalid value
+	Invalid = 1 << iota
+	// Hidden value
+	Hidden
+	// ReadOnly value
+	ReadOnly
+	// ReadWrite value
+	ReadWrite
+	// NonPersistent value
+	NonPersistent
+	// Volatile value
+	Volatile
+)
+
+var (
+	// EncodeLogLevel value
+	EncodeLogLevel = log.InfoLevel
+)
+
+// toString converts a basic type to its string representation
+func toString(field reflect.Value) string {
+	switch field.Kind() {
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return strconv.FormatInt(field.Int(), 10)
+	case reflect.Bool:
+		return strconv.FormatBool(field.Bool())
+	case reflect.String:
+		return field.String()
+	case reflect.Float32, reflect.Float64:
+		return strconv.FormatFloat(field.Float(), 'E', -1, 64)
+	default:
+		return ""
+	}
+}
+
+// calculateScope returns the uint representation of scope tag
+func calculateScope(scopes []string) uint {
+	var scope uint
+	for _, v := range scopes {
+		switch v {
+		case "hidden":
+			scope |= Hidden
+		case "read-only":
+			scope |= ReadOnly
+		case "read-write":
+			scope |= ReadWrite
+		case "non-persistent":
+			scope |= NonPersistent
+		case "volatile":
+			scope |= Volatile
+		default:
+			return Invalid
+		}
+	}
+	return scope
+}
+
+// calculateKey calculates the key based on the scope and prefix
+func calculateKey(scopes []string, prefix string, key string) string {
+	scope := calculateScope(scopes)
+	if scope&Invalid != 0 || scope&NonPersistent != 0 {
+		return ""
+	}
+
+	var guestinfo string
+	var seperator string
+
+	// Trim the whitespaces
+	key = strings.TrimSpace(key)
+
+	if scope&Hidden != 0 {
+		guestinfo = ""
+		seperator = "~"
+	}
+	if scope&ReadOnly != 0 {
+		guestinfo = DefaultGuestInfoPrefix
+		seperator = "/"
+	}
+	if scope&ReadWrite != 0 {
+		guestinfo = DefaultGuestInfoPrefix
+		seperator = "."
+	}
+
+	// no need to add another DefaultGuestInfoPrefix as a prefix if we already have one
+	if strings.Contains(prefix, DefaultGuestInfoPrefix) {
+		guestinfo = ""
+	}
+
+	if guestinfo == "" && prefix == "" {
+		return key
+	}
+
+	if guestinfo == "" {
+		return strings.Join([]string{prefix, key}, seperator)
+	}
+
+	if prefix == "" {
+		return strings.Join([]string{guestinfo, key}, seperator)
+	}
+
+	return strings.Join([]string{guestinfo, prefix, key}, seperator)
+}
+
+func encodeWithPrefix(src interface{}, prefix string) []types.BaseOptionValue {
+	var config []types.BaseOptionValue
+
+	// value representing the run-time data
+	value := reflect.ValueOf(src)
+	log.Debugf("Value: %#v", value)
+
+	// determine the kind as it changes how we get underlying data
+	switch value.Kind() {
+	case reflect.Invalid:
+		log.Errorf("Invalid Kind: %#v", value)
+		return nil
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
+		reflect.Bool, reflect.String, reflect.Float32, reflect.Float64:
+		// handle basic types directly
+		log.Debugf("Basic type: %s", prefix)
+
+		return append(config, &types.OptionValue{Key: prefix, Value: toString(value)})
+	case reflect.Slice, reflect.Array:
+		log.Debugf("Slice BEGIN: %s", prefix)
+
+		var values []string
+		// iterate over slice to find what's underneath
+		for i := 0; i < value.Len(); i++ {
+			// recurse if we have a struct type
+			// otherwise add its value to values
+			if value.Index(i).Kind() == reflect.Struct {
+				key := fmt.Sprintf("%s|%d", prefix, i)
+				config = append(config, encodeWithPrefix(value.Index(i).Interface(), key)...)
+			} else {
+				values = append(values, toString(value.Index(i)))
+			}
+		}
+		// set the slice key with the values seperated by |
+		if len(values) > 0 {
+			// sort the values before joining
+			sort.Strings(values)
+			// prefix~ contains the items
+			config = append(config, &types.OptionValue{Key: fmt.Sprintf("%s~", prefix), Value: strings.Join(values, "|")})
+		}
+		// prefix contains the count
+		config = append(config, &types.OptionValue{Key: prefix, Value: fmt.Sprintf("%d", value.Len()-1)})
+
+		log.Debugf("Slice END %s %s", prefix, values)
+
+		return config
+
+	case reflect.Struct:
+		// iterate through every struct type field
+		for i := 0; i < value.NumField(); i++ {
+			// get the underlying struct field
+			structField := value.Type().Field(i)
+			//skip unexported fields
+			if structField.PkgPath != "" {
+				log.Debugf("Skipping %s (not exported)", structField.Name)
+				continue
+			}
+
+			// get the annotations
+			tags := structField.Tag
+			log.Debugf("Tags: %#v", tags)
+
+			// do we have DefaultTagName?
+			if tags.Get(DefaultTagName) == "" {
+				log.Debugf("Skipping %s (not vic)", structField.Name)
+				continue
+			}
+
+			// get the scopes
+			scopes := strings.Split(tags.Get("scope"), ",")
+			log.Debugf("Scopes: %#v", scopes)
+
+			// get the keys and split properties from it
+			keys := strings.Split(tags.Get("key"), ",")
+			key, properties := keys[0], keys[1:]
+			log.Debugf("Keys: %#v Properties: %#v", key, properties)
+
+			// returns the i'th field of the struct src
+			field := value.Field(i)
+
+			// process properties
+			if len(properties) > 0 {
+				// do not recurse into nested type
+				if properties[0] == "omitnested" {
+					config = append(config, &types.OptionValue{Key: key, Value: toString(field)})
+					log.Debugf("Skipping %s (omitnested)", key)
+					continue
+				}
+
+				log.Debugf("Unknown property %s (%s)", key, properties[0])
+				continue
+			}
+
+			// re-calculate the key based on the scope and prefix
+			if key = calculateKey(scopes, prefix, key); key == "" {
+				log.Debugf("Skipping %s (unknown scope %s)", key, scopes)
+				continue
+			}
+
+			// Dump what we have so far
+			log.Debugf("Key: %s, Properties: %q Kind: %s Value: %s", key, properties, field.Kind(), field.String())
+
+			// all check passed, start to work on i'th field of the struct src
+			switch field.Kind() {
+			case reflect.Struct, reflect.Slice, reflect.Array:
+				// recurse for struct, slice and array types
+				log.Debugf("Struct|Slice|Array begin")
+
+				// type cast struct to supported types (eg; time.Time, url.Url etc.)
+				switch field.Interface().(type) {
+				case time.Time:
+					config = append(config, &types.OptionValue{Key: key, Value: field.Interface().(time.Time).String()})
+				default:
+					config = append(config, encodeWithPrefix(field.Interface(), key)...)
+				}
+				log.Debugf("Struct|Slice|Array end")
+				continue
+
+			case reflect.Map:
+				log.Debugf("Map begin")
+
+				var keys []string
+				// iterate over keys and recurse
+				for _, v := range field.MapKeys() {
+					keys = append(keys, toString(v))
+					key := fmt.Sprintf("%s|%s", key, toString(v))
+					config = append(config, encodeWithPrefix(field.MapIndex(v).Interface(), key)...)
+				}
+				// sort the keys before joining
+				sort.Strings(keys)
+				config = append(config, &types.OptionValue{Key: key, Value: strings.Join(keys, "|")})
+
+				log.Debugf("Map end")
+				continue
+
+			case reflect.Ptr:
+				log.Debugf("Prt begin")
+
+				if field.IsNil() {
+					log.Debugf("Skipping nil pointer")
+					continue
+				}
+
+				// type cast struct to supported types (eg; time.Time, url.Url etc.) or recurse
+				switch field.Elem().Interface().(type) {
+				case time.Time:
+					config = append(config, &types.OptionValue{Key: key, Value: field.Interface().(*time.Time).String()})
+				default:
+					// follow the pointer and recurse
+					config = append(config, encodeWithPrefix(field.Elem().Interface(), key)...)
+
+					if len(config) > 0 {
+						// add the ptr itself
+						config = append(config, &types.OptionValue{Key: key, Value: config[len(config)-1].GetOptionValue().Key})
+					}
+				}
+
+				log.Debugf("Ptr end")
+				continue
+			}
+			// otherwise add it directly
+			config = append(config, &types.OptionValue{Key: key, Value: toString(field)})
+		}
+		return config
+
+	default:
+		log.Debugf("Skipping not supported kind %s", value.Kind())
+		return nil
+	}
+}
+
+// Encode converts given type to []types.BaseOptionValue slice
+func Encode(src interface{}) []types.BaseOptionValue {
+	log.SetLevel(EncodeLogLevel)
+
+	return encodeWithPrefix(src, DefaultPrefix)
+}

--- a/pkg/vsphere/extraconfig/extraconfig_test.go
+++ b/pkg/vsphere/extraconfig/extraconfig_test.go
@@ -1,0 +1,622 @@
+// Copyright 2016 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package extraconfig
+
+import (
+	"net/url"
+	"os/exec"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+// [BEGIN] SLIMMED DOWNED and MODIFIED VERSION of github.com/vmware/vic/metadata
+type Common struct {
+	ExecutionEnvironment string
+
+	ID string `vic:"0.1" scope:"hidden" key:"id"`
+
+	Name string `vic:"0.1" scope:"hidden" key:"name"`
+
+	Notes string `vic:"0.1" scope:"hidden" key:"notes"`
+}
+
+type ContainerVM struct {
+	Common `vic:"0.1" scope:"read-only" key:"common"`
+
+	Version string `vic:"0.1" scope:"hidden" key:"version"`
+
+	Aliases map[string]string
+
+	Interaction url.URL
+
+	AgentKey []byte
+}
+
+type ExecutorConfig struct {
+	Common `vic:"0.1" scope:"read-only" key:"common"`
+
+	Sessions map[string]SessionConfig `vic:"0.1" scope:"hidden" key:"sessions"`
+
+	Key []byte `json:"byte"`
+}
+
+type Cmd struct {
+	Path string `vic:"0.1" scope:"hidden" key:"path"`
+
+	Args []string `vic:"0.1" scope:"hidden" key:"args"`
+
+	Env []string `vic:"0.1" scope:"hidden" key:"env"`
+
+	Dir string `vic:"0.1" scope:"hidden" key:"dir"`
+
+	Cmd *exec.Cmd `vic:"0.1" scope:"hidden" key:"cmd"`
+}
+
+type SessionConfig struct {
+	Common `vic:"0.1" scope:"hidden" key:"common" json:"page"`
+
+	Cmd Cmd `vic:"0.1" scope:"hidden" key:"cmd"`
+
+	Tty bool `vic:"0.1" scope:"hidden" key:"tty"`
+}
+
+// [END] SLIMMED VERSION of github.com/vmware/vic/metadata
+
+func TestBasic(t *testing.T) {
+	type Type struct {
+		Int    int     `vic:"0.1" scope:"read-write" key:"int"`
+		Bool   bool    `vic:"0.1" scope:"read-write" key:"bool"`
+		Float  float64 `vic:"0.1" scope:"read-write" key:"float"`
+		String string  `vic:"0.1" scope:"read-write" key:"string"`
+	}
+
+	Struct := Type{
+		42,
+		true,
+		3.14,
+		"Grrr",
+	}
+
+	encoded := Encode(Struct)
+	expected := []types.BaseOptionValue{
+		&types.OptionValue{DynamicData: types.DynamicData{}, Key: "guestinfo.int", Value: "42"},
+		&types.OptionValue{DynamicData: types.DynamicData{}, Key: "guestinfo.bool", Value: "true"},
+		&types.OptionValue{DynamicData: types.DynamicData{}, Key: "guestinfo.float", Value: "3.14E+00"},
+		&types.OptionValue{DynamicData: types.DynamicData{}, Key: "guestinfo.string", Value: "Grrr"},
+	}
+	assert.Equal(t, encoded, expected, "Encoded and expected does not match")
+
+	var decoded Type
+	Decode(encoded, &decoded)
+
+	assert.Equal(t, Struct, decoded, "Encoded and decoded does not match")
+}
+
+func TestBasicMap(t *testing.T) {
+	t.Skip("https://github.com/stretchr/testify/issues/288")
+
+	type Type struct {
+		IntMap map[string]int `vic:"0.1" scope:"read-only" key:"intmap"`
+	}
+
+	IntMap := Type{
+		map[string]int{
+			"1st": 12345,
+			"2nd": 67890,
+		},
+	}
+
+	// Encode
+	encoded := Encode(IntMap)
+	expected := []types.BaseOptionValue{
+		&types.OptionValue{DynamicData: types.DynamicData{}, Key: "guestinfo/intmap|1st", Value: "12345"},
+		&types.OptionValue{DynamicData: types.DynamicData{}, Key: "guestinfo/intmap|2nd", Value: "67890"},
+		&types.OptionValue{DynamicData: types.DynamicData{}, Key: "guestinfo/intmap", Value: "1st|2nd"},
+	}
+	assert.Equal(t, encoded, expected, "Encoded and expected does not match")
+
+	// Decode to new variable
+	var decoded Type
+	Decode(encoded, &decoded)
+
+	assert.Equal(t, IntMap, decoded, "Encoded and decoded does not match")
+
+	// Decode to already existing variable
+	IntMapOptimusPrime := Type{
+		map[string]int{
+			"first":  1,
+			"second": 2,
+			"1st":    0,
+		},
+	}
+	Decode(encoded, &IntMapOptimusPrime)
+
+	// We expect a merge and over-write
+	expectedOptimusPrime := Type{
+		map[string]int{
+			"1st":    12345,
+			"2nd":    67890,
+			"first":  1,
+			"second": 2,
+		},
+	}
+	assert.Equal(t, IntMapOptimusPrime, expectedOptimusPrime, "Decoded and expected does not match")
+
+}
+
+func TestBasicSlice(t *testing.T) {
+	type Type struct {
+		IntSlice []int `vic:"0.1" scope:"read-only" key:"intslice"`
+	}
+
+	IntSlice := Type{
+		[]int{1, 2, 3, 4, 5},
+	}
+
+	encoded := Encode(IntSlice)
+	expected := []types.BaseOptionValue{
+		&types.OptionValue{DynamicData: types.DynamicData{}, Key: "guestinfo/intslice~", Value: "1|2|3|4|5"},
+		&types.OptionValue{DynamicData: types.DynamicData{}, Key: "guestinfo/intslice", Value: "4"},
+	}
+	assert.Equal(t, encoded, expected, "Encoded and expected does not match")
+
+	var decoded Type
+	Decode(encoded, &decoded)
+
+	assert.Equal(t, IntSlice, decoded, "Encoded and decoded does not match")
+}
+
+func TestEmbedded(t *testing.T) {
+
+	type Type struct {
+		Common `vic:"0.1" scope:"read-only" key:"common"`
+	}
+
+	Embedded := Type{
+		Common: Common{
+			ID:   "0xDEADBEEF",
+			Name: "Embedded",
+		},
+	}
+
+	encoded := Encode(Embedded)
+	expected := []types.BaseOptionValue{
+		&types.OptionValue{DynamicData: types.DynamicData{}, Key: "guestinfo/common~id", Value: "0xDEADBEEF"},
+		&types.OptionValue{DynamicData: types.DynamicData{}, Key: "guestinfo/common~name", Value: "Embedded"},
+		&types.OptionValue{DynamicData: types.DynamicData{}, Key: "guestinfo/common~notes", Value: ""},
+	}
+	assert.Equal(t, encoded, expected, "Encoded and expected does not match")
+
+	var decoded Type
+	Decode(encoded, &decoded)
+
+	assert.Equal(t, Embedded, decoded, "Encoded and decoded does not match")
+}
+
+func TestStruct(t *testing.T) {
+	type Type struct {
+		Common Common `vic:"0.1" scope:"read-only" key:"common"`
+	}
+
+	Struct := Type{
+		Common: Common{
+			ID:   "0xDEADBEEF",
+			Name: "Struct",
+		},
+	}
+
+	encoded := Encode(Struct)
+	expected := []types.BaseOptionValue{
+		&types.OptionValue{DynamicData: types.DynamicData{}, Key: "guestinfo/common~id", Value: "0xDEADBEEF"},
+		&types.OptionValue{DynamicData: types.DynamicData{}, Key: "guestinfo/common~name", Value: "Struct"},
+		&types.OptionValue{DynamicData: types.DynamicData{}, Key: "guestinfo/common~notes", Value: ""},
+	}
+	assert.Equal(t, encoded, expected, "Encoded and expected does not match")
+
+	var decoded Type
+	Decode(encoded, &decoded)
+
+	assert.Equal(t, Struct, decoded, "Encoded and decoded does not match")
+}
+
+func TestTime(t *testing.T) {
+	type Type struct {
+		Time time.Time `vic:"0.1" scope:"read-only" key:"time"`
+	}
+
+	Time := Type{
+		Time: time.Date(2009, 11, 10, 23, 00, 00, 0, time.UTC),
+	}
+
+	encoded := Encode(Time)
+	expected := []types.BaseOptionValue{
+		&types.OptionValue{DynamicData: types.DynamicData{}, Key: "guestinfo/time", Value: "2009-11-10 23:00:00 +0000 UTC"},
+	}
+	assert.Equal(t, encoded, expected, "Encoded and expected does not match")
+
+	var decoded Type
+	Decode(encoded, &decoded)
+
+	assert.Equal(t, Time, decoded, "Encoded and decoded does not match")
+}
+
+func TestTimePointer(t *testing.T) {
+	d := time.Date(2009, 11, 10, 23, 00, 00, 0, time.UTC)
+
+	type Type struct {
+		Time *time.Time `vic:"0.1" scope:"read-only" key:"time"`
+	}
+
+	Time := Type{
+		Time: &d,
+	}
+
+	encoded := Encode(Time)
+	expected := []types.BaseOptionValue{
+		&types.OptionValue{DynamicData: types.DynamicData{}, Key: "guestinfo/time", Value: "2009-11-10 23:00:00 +0000 UTC"},
+	}
+	assert.Equal(t, encoded, expected, "Encoded and expected does not match")
+
+	var decoded Type
+	Decode(encoded, &decoded)
+
+	assert.Equal(t, Time, decoded, "Encoded and decoded does not match")
+}
+
+func TestStructMap(t *testing.T) {
+	t.Skip("https://github.com/stretchr/testify/issues/288")
+
+	type Type struct {
+		StructMap map[string]Common `vic:"0.1" scope:"read-only" key:"map"`
+	}
+
+	StructMap := Type{
+		map[string]Common{
+			"Key1": Common{
+				ID:   "0xDEADBEEF",
+				Name: "beef",
+			},
+			"Key2": Common{
+				ID:   "0x8BADF00D",
+				Name: "food",
+			},
+			"Key3": Common{
+				ID:   "0xDEADF00D",
+				Name: "dead",
+			},
+		},
+	}
+
+	encoded := Encode(StructMap)
+	expected := []types.BaseOptionValue{
+		&types.OptionValue{DynamicData: types.DynamicData{}, Key: "guestinfo/map|Key1~id", Value: "0xDEADBEEF"},
+		&types.OptionValue{DynamicData: types.DynamicData{}, Key: "guestinfo/map|Key1~name", Value: "beef"},
+		&types.OptionValue{DynamicData: types.DynamicData{}, Key: "guestinfo/map|Key1~notes", Value: ""},
+		&types.OptionValue{DynamicData: types.DynamicData{}, Key: "guestinfo/map|Key2~id", Value: "0x8BADF00D"},
+		&types.OptionValue{DynamicData: types.DynamicData{}, Key: "guestinfo/map|Key2~name", Value: "food"},
+		&types.OptionValue{DynamicData: types.DynamicData{}, Key: "guestinfo/map|Key2~notes", Value: ""},
+		&types.OptionValue{DynamicData: types.DynamicData{}, Key: "guestinfo/map|Key3~id", Value: "0xDEADF00D"},
+		&types.OptionValue{DynamicData: types.DynamicData{}, Key: "guestinfo/map|Key3~name", Value: "dead"},
+		&types.OptionValue{DynamicData: types.DynamicData{}, Key: "guestinfo/map|Key3~notes", Value: ""},
+		&types.OptionValue{DynamicData: types.DynamicData{}, Key: "guestinfo/map", Value: "Key1|Key2|Key3"},
+	}
+	assert.Equal(t, encoded, expected, "Encoded and expected does not match")
+
+	var decoded Type
+	Decode(encoded, &decoded)
+
+	assert.Equal(t, StructMap, decoded, "Encoded and decoded does not match")
+}
+
+func TestIntStructMap(t *testing.T) {
+	t.Skip("https://github.com/stretchr/testify/issues/288")
+
+	type Type struct {
+		StructMap map[int]Common `vic:"0.1" scope:"read-only" key:"map"`
+	}
+
+	StructMap := Type{
+		map[int]Common{
+			1: Common{
+				ID:   "0xDEADBEEF",
+				Name: "beef",
+			},
+			2: Common{
+				ID:   "0x8BADF00D",
+				Name: "food",
+			},
+			3: Common{
+				ID:   "0xDEADF00D",
+				Name: "dead",
+			},
+		},
+	}
+
+	encoded := Encode(StructMap)
+	expected := []types.BaseOptionValue{
+		&types.OptionValue{DynamicData: types.DynamicData{}, Key: "guestinfo/map|1~id", Value: "0xDEADBEEF"},
+		&types.OptionValue{DynamicData: types.DynamicData{}, Key: "guestinfo/map|1~name", Value: "beef"},
+		&types.OptionValue{DynamicData: types.DynamicData{}, Key: "guestinfo/map|1~notes", Value: ""},
+		&types.OptionValue{DynamicData: types.DynamicData{}, Key: "guestinfo/map|2~id", Value: "0x8BADF00D"},
+		&types.OptionValue{DynamicData: types.DynamicData{}, Key: "guestinfo/map|2~name", Value: "food"},
+		&types.OptionValue{DynamicData: types.DynamicData{}, Key: "guestinfo/map|2~notes", Value: ""},
+		&types.OptionValue{DynamicData: types.DynamicData{}, Key: "guestinfo/map|3~id", Value: "0xDEADF00D"},
+		&types.OptionValue{DynamicData: types.DynamicData{}, Key: "guestinfo/map|3~name", Value: "dead"},
+		&types.OptionValue{DynamicData: types.DynamicData{}, Key: "guestinfo/map|3~notes", Value: ""},
+		&types.OptionValue{DynamicData: types.DynamicData{}, Key: "guestinfo/map", Value: "1|2|3"},
+	}
+	assert.Equal(t, encoded, expected, "Encoded and expected does not match")
+
+	var decoded Type
+	Decode(encoded, &decoded)
+
+	assert.Equal(t, StructMap, decoded, "Encoded and decoded does not match")
+}
+
+func TestStructSlice(t *testing.T) {
+	type Type struct {
+		StructSlice []Common `vic:"0.1" scope:"read-only" key:"slice"`
+	}
+
+	StructSlice := Type{
+		[]Common{
+			Common{
+				ID:   "0xDEADFEED",
+				Name: "feed",
+			},
+			Common{
+				ID:   "0xFACEFEED",
+				Name: "face",
+			},
+		},
+	}
+
+	encoded := Encode(StructSlice)
+	expected := []types.BaseOptionValue{
+		&types.OptionValue{DynamicData: types.DynamicData{}, Key: "guestinfo/slice|0~id", Value: "0xDEADFEED"},
+		&types.OptionValue{DynamicData: types.DynamicData{}, Key: "guestinfo/slice|0~name", Value: "feed"},
+		&types.OptionValue{DynamicData: types.DynamicData{}, Key: "guestinfo/slice|0~notes", Value: ""},
+		&types.OptionValue{DynamicData: types.DynamicData{}, Key: "guestinfo/slice|1~id", Value: "0xFACEFEED"},
+		&types.OptionValue{DynamicData: types.DynamicData{}, Key: "guestinfo/slice|1~name", Value: "face"},
+		&types.OptionValue{DynamicData: types.DynamicData{}, Key: "guestinfo/slice|1~notes", Value: ""},
+		&types.OptionValue{DynamicData: types.DynamicData{}, Key: "guestinfo/slice", Value: "1"},
+	}
+	assert.Equal(t, encoded, expected, "Encoded and expected does not match")
+
+	var decoded Type
+	Decode(encoded, &decoded)
+
+	assert.Equal(t, StructSlice, decoded, "Encoded and decoded does not match")
+}
+
+func TestMultipleScope(t *testing.T) {
+	MultipleScope := struct {
+		MultipleScope string `vic:"0.1" scope:"read-only,hidden,non-persistent" key:"multiscope"`
+	}{
+		"MultipleScope",
+	}
+
+	encoded := Encode(MultipleScope)
+	var expected []types.BaseOptionValue
+	assert.Equal(t, encoded, expected, "Not equal")
+}
+
+func TestUnknownScope(t *testing.T) {
+	UnknownScope := struct {
+		UnknownScope int `vic:"0.1" scope:"unknownscope" key:"unknownscope"`
+	}{
+		42,
+	}
+
+	encoded := Encode(UnknownScope)
+	var expected []types.BaseOptionValue
+	assert.Equal(t, encoded, expected, "Not equal")
+}
+
+func TestUnknownProperty(t *testing.T) {
+	UnknownProperty := struct {
+		UnknownProperty int `vic:"0.1" scope:"hidden" key:"unknownproperty,unknownproperty"`
+	}{
+		42,
+	}
+
+	encoded := Encode(UnknownProperty)
+	var expected []types.BaseOptionValue
+	assert.Equal(t, encoded, expected, "Not equal")
+}
+
+func TestOmitNested(t *testing.T) {
+	OmitNested := struct {
+		Time        time.Time `vic:"0.1" scope:"volatile" key:"time,omitnested"`
+		CurrentTime time.Time `vic:"0.1" scope:"volatile" key:"time"`
+	}{
+		Time:        time.Date(2009, 11, 10, 23, 00, 00, 0, time.UTC),
+		CurrentTime: time.Date(2009, 11, 10, 23, 00, 00, 0, time.UTC),
+	}
+
+	encoded := Encode(OmitNested)
+	expected := []types.BaseOptionValue{
+		&types.OptionValue{DynamicData: types.DynamicData{}, Key: "time", Value: ""},
+		&types.OptionValue{DynamicData: types.DynamicData{}, Key: "time", Value: "2009-11-10 23:00:00 +0000 UTC"},
+	}
+	assert.Equal(t, encoded, expected, "Encoded and decoded does not match")
+
+}
+
+func TestPointer(t *testing.T) {
+	type Type struct {
+		Pointer           *ContainerVM `vic:"0.1" scope:"hidden" key:"pointer"`
+		PointerOmitnested *ContainerVM `vic:"0.1" scope:"non-persistent" key:"pointeromitnested,omitnested"`
+	}
+
+	Pointer := Type{
+		Pointer: &ContainerVM{Version: "0.1"},
+	}
+
+	encoded := Encode(Pointer)
+	expected := []types.BaseOptionValue{
+		&types.OptionValue{DynamicData: types.DynamicData{}, Key: "guestinfo/pointer/common~id", Value: ""},
+		&types.OptionValue{DynamicData: types.DynamicData{}, Key: "guestinfo/pointer/common~name", Value: ""},
+		&types.OptionValue{DynamicData: types.DynamicData{}, Key: "guestinfo/pointer/common~notes", Value: ""},
+		&types.OptionValue{DynamicData: types.DynamicData{}, Key: "pointer~version", Value: "0.1"},
+		&types.OptionValue{DynamicData: types.DynamicData{}, Key: "pointer", Value: "pointer~version"},
+		&types.OptionValue{DynamicData: types.DynamicData{}, Key: "pointeromitnested", Value: ""},
+	}
+	assert.Equal(t, encoded, expected, "Encoded and expected does not match")
+
+	var decoded Type
+	Decode(encoded, &decoded)
+
+	assert.Equal(t, Pointer, decoded, "Encoded and decoded does not match")
+}
+
+func TestComplex(t *testing.T) {
+	type Type struct {
+		ExecutorConfig ExecutorConfig `vic:"0.1" scope:"hidden" key:"executorconfig"`
+	}
+
+	ExecutorConfig := Type{
+		ExecutorConfig{
+			Sessions: map[string]SessionConfig{
+				"Session1": SessionConfig{
+					Common: Common{
+						ID:   "SessionID",
+						Name: "SessionName",
+					},
+					Tty: true,
+					Cmd: Cmd{
+						Path: "/vmware",
+						Args: []string{"-standalone", "/bin/imagec"},
+						Env:  []string{"PATH=/bin", "USER=imagec"},
+						Dir:  "/",
+					},
+				},
+			},
+		},
+	}
+	encoded := Encode(ExecutorConfig)
+	expected := []types.BaseOptionValue{
+		&types.OptionValue{DynamicData: types.DynamicData{}, Key: "guestinfo/executorconfig/common~id", Value: ""},
+		&types.OptionValue{DynamicData: types.DynamicData{}, Key: "guestinfo/executorconfig/common~name", Value: ""},
+		&types.OptionValue{DynamicData: types.DynamicData{}, Key: "guestinfo/executorconfig/common~notes", Value: ""},
+		&types.OptionValue{DynamicData: types.DynamicData{}, Key: "executorconfig~sessions|Session1~common~id", Value: "SessionID"},
+		&types.OptionValue{DynamicData: types.DynamicData{}, Key: "executorconfig~sessions|Session1~common~name", Value: "SessionName"},
+		&types.OptionValue{DynamicData: types.DynamicData{}, Key: "executorconfig~sessions|Session1~common~notes", Value: ""},
+		&types.OptionValue{DynamicData: types.DynamicData{}, Key: "executorconfig~sessions|Session1~cmd~path", Value: "/vmware"},
+		&types.OptionValue{DynamicData: types.DynamicData{}, Key: "executorconfig~sessions|Session1~cmd~args~", Value: "-standalone|/bin/imagec"},
+		&types.OptionValue{DynamicData: types.DynamicData{}, Key: "executorconfig~sessions|Session1~cmd~args", Value: "1"},
+		&types.OptionValue{DynamicData: types.DynamicData{}, Key: "executorconfig~sessions|Session1~cmd~env~", Value: "PATH=/bin|USER=imagec"},
+		&types.OptionValue{DynamicData: types.DynamicData{}, Key: "executorconfig~sessions|Session1~cmd~env", Value: "1"},
+		&types.OptionValue{DynamicData: types.DynamicData{}, Key: "executorconfig~sessions|Session1~cmd~dir", Value: "/"},
+		&types.OptionValue{DynamicData: types.DynamicData{}, Key: "executorconfig~sessions|Session1~tty", Value: "true"},
+		&types.OptionValue{DynamicData: types.DynamicData{}, Key: "executorconfig~sessions", Value: "Session1"},
+	}
+	assert.Equal(t, encoded, expected, "Encoded and expected does not match")
+
+	var decoded Type
+	Decode(encoded, &decoded)
+
+	assert.Equal(t, ExecutorConfig, decoded, "Encoded and decoded does not match")
+}
+
+func TestComplexPointer(t *testing.T) {
+	type Type struct {
+		ExecutorConfig *ExecutorConfig `vic:"0.1" scope:"hidden" key:"executorconfig"`
+	}
+
+	ExecutorConfig := Type{
+		&ExecutorConfig{
+			Sessions: map[string]SessionConfig{
+				"Session1": SessionConfig{
+					Common: Common{
+						ID:   "SessionID",
+						Name: "SessionName",
+					},
+					Tty: true,
+					Cmd: Cmd{
+						Path: "/vmware",
+						Args: []string{"-standalone", "/bin/imagec"},
+						Env:  []string{"PATH=/bin", "USER=imagec"},
+						Dir:  "/",
+					},
+				},
+			},
+		},
+	}
+
+	encoded := Encode(ExecutorConfig)
+	expected := []types.BaseOptionValue{
+		&types.OptionValue{DynamicData: types.DynamicData{}, Key: "guestinfo/executorconfig/common~id", Value: ""},
+		&types.OptionValue{DynamicData: types.DynamicData{}, Key: "guestinfo/executorconfig/common~name", Value: ""},
+		&types.OptionValue{DynamicData: types.DynamicData{}, Key: "guestinfo/executorconfig/common~notes", Value: ""},
+		&types.OptionValue{DynamicData: types.DynamicData{}, Key: "executorconfig~sessions|Session1~common~id", Value: "SessionID"},
+		&types.OptionValue{DynamicData: types.DynamicData{}, Key: "executorconfig~sessions|Session1~common~name", Value: "SessionName"},
+		&types.OptionValue{DynamicData: types.DynamicData{}, Key: "executorconfig~sessions|Session1~common~notes", Value: ""},
+		&types.OptionValue{DynamicData: types.DynamicData{}, Key: "executorconfig~sessions|Session1~cmd~path", Value: "/vmware"},
+		&types.OptionValue{DynamicData: types.DynamicData{}, Key: "executorconfig~sessions|Session1~cmd~args~", Value: "-standalone|/bin/imagec"},
+		&types.OptionValue{DynamicData: types.DynamicData{}, Key: "executorconfig~sessions|Session1~cmd~args", Value: "1"},
+		&types.OptionValue{DynamicData: types.DynamicData{}, Key: "executorconfig~sessions|Session1~cmd~env~", Value: "PATH=/bin|USER=imagec"},
+		&types.OptionValue{DynamicData: types.DynamicData{}, Key: "executorconfig~sessions|Session1~cmd~env", Value: "1"},
+		&types.OptionValue{DynamicData: types.DynamicData{}, Key: "executorconfig~sessions|Session1~cmd~dir", Value: "/"},
+		&types.OptionValue{DynamicData: types.DynamicData{}, Key: "executorconfig~sessions|Session1~tty", Value: "true"},
+		&types.OptionValue{DynamicData: types.DynamicData{}, Key: "executorconfig~sessions", Value: "Session1"},
+		&types.OptionValue{DynamicData: types.DynamicData{}, Key: "executorconfig", Value: "executorconfig~sessions"},
+	}
+	assert.Equal(t, encoded, expected, "Encoded and expected does not match")
+
+	var decoded Type
+	Decode(encoded, &decoded)
+
+	assert.Equal(t, ExecutorConfig, decoded, "Encoded and decoded does not match")
+}
+
+func TestInsideOutside(t *testing.T) {
+	type Inside struct {
+		ID   string `vic:"0.1" scope:"read-write" key:"id"`
+		Name string `vic:"0.1" scope:"read-write" key:"name"`
+	}
+
+	type Outside struct {
+		Inside Inside `vic:"0.1" scope:"read-only" key:"inside"`
+		ID     string `vic:"0.1" scope:"read-write" key:"id"`
+		Name   string `vic:"0.1" scope:"read-write" key:"name"`
+	}
+	outside := Outside{
+		Inside: Inside{
+			ID:   "inside",
+			Name: "Inside",
+		},
+		ID:   "outside",
+		Name: "Outside",
+	}
+
+	encoded := Encode(outside)
+	expected := []types.BaseOptionValue{
+		&types.OptionValue{DynamicData: types.DynamicData{}, Key: "guestinfo/inside.id", Value: "inside"},
+		&types.OptionValue{DynamicData: types.DynamicData{}, Key: "guestinfo/inside.name", Value: "Inside"},
+		&types.OptionValue{DynamicData: types.DynamicData{}, Key: "guestinfo.id", Value: "outside"},
+		&types.OptionValue{DynamicData: types.DynamicData{}, Key: "guestinfo.name", Value: "Outside"},
+	}
+	assert.Equal(t, encoded, expected, "Encoded and expected does not match")
+
+	var decoded Outside
+	Decode(encoded, &decoded)
+
+	assert.Equal(t, outside, decoded, "Encoded and decoded does not match")
+
+}


### PR DESCRIPTION
Introduce the encoder. It encodes "vic" tagged structs and their members
into []types.BaseOptionValue so that VM spec can directly consume them.

Following is the result of calling encoder on T
```
    T := struct {
        ExecutorConfig ExecutorConfig `vic:"0.1" scope:"hidden" key:"executorconfig"`
    }{
        ExecutorConfig{
            Sessions: map[string]SessionConfig{
                "Session1": SessionConfig{
                    Common: Common{
                        ID:   "SessionID",
                        Name: "SessionName",
                    },
                    Tty: true,
                    Cmd: Cmd{
                        Path: "/vmware",
                        Args: []string{"/bin/imagec", "-standalone"},
                        Env:  []string{"PATH=/bin", "USER=imagec"},
                        Dir:  "/",
                    },
                },
            },
        },
    }

    encode_test.go:327: &types.OptionValue{DynamicData:types.DynamicData{}, Key:"guestinfo/executorconfig/common~id", Value:""}
    encode_test.go:327: &types.OptionValue{DynamicData:types.DynamicData{}, Key:"guestinfo/executorconfig/common~name", Value:""}
    encode_test.go:327: &types.OptionValue{DynamicData:types.DynamicData{}, Key:"guestinfo/executorconfig/common~notes", Value:""}
    encode_test.go:327: &types.OptionValue{DynamicData:types.DynamicData{}, Key:"executorconfig~sessions|Session1~common~id", Value:"SessionID"}
    encode_test.go:327: &types.OptionValue{DynamicData:types.DynamicData{}, Key:"executorconfig~sessions|Session1~common~name", Value:"SessionName"}
    encode_test.go:327: &types.OptionValue{DynamicData:types.DynamicData{}, Key:"executorconfig~sessions|Session1~common~notes", Value:""}
    encode_test.go:327: &types.OptionValue{DynamicData:types.DynamicData{}, Key:"executorconfig~sessions|Session1~cmd~path", Value:"/vmware"}
    encode_test.go:327: &types.OptionValue{DynamicData:types.DynamicData{}, Key:"executorconfig~sessions|Session1~cmd~args", Value:"/bin/imagec|-standalone"}
    encode_test.go:327: &types.OptionValue{DynamicData:types.DynamicData{}, Key:"executorconfig~sessions|Session1~cmd~env", Value:"PATH=/bin|USER=imagec"}
    encode_test.go:327: &types.OptionValue{DynamicData:types.DynamicData{}, Key:"executorconfig~sessions|Session1~cmd~dir", Value:"/"}
    encode_test.go:327: &types.OptionValue{DynamicData:types.DynamicData{}, Key:"executorconfig~sessions|Session1~tty", Value:"true"}
    encode_test.go:327: &types.OptionValue{DynamicData:types.DynamicData{}, Key:"executorconfig~sessions", Value:"Session1"}
```
Map tests are disabled because of github.com/stretchr/testify/issues/288