### PR TITLE
Log warning instead of returning 404 when storename doesn't exist

### DIFF
--- a/apiservers/engine/backends/image.go
+++ b/apiservers/engine/backends/image.go
@@ -18,7 +18,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
 	"net/http"
 	"os"
 	"os/exec"
@@ -26,6 +25,7 @@ import (
 	"sort"
 	"strings"
 
+	log "github.com/Sirupsen/logrus"
 	derr "github.com/docker/docker/errors"
 	v1 "github.com/docker/docker/image"
 	"github.com/docker/docker/reference"
@@ -87,8 +87,8 @@ func (i *Image) Images(filterArgs string, filter string, all bool) ([]*types.Ima
 
 	images, err := client.Storage.ListImages(params)
 	if err != nil {
-		return result,
-			derr.NewErrorWithStatusCode(err, http.StatusInternalServerError)
+		log.Warning(err)
+		return result, nil
 	}
 
 	// build a map from image id to image v1Compatibility metadata

--- a/apiservers/engine/server/main.go
+++ b/apiservers/engine/server/main.go
@@ -160,7 +160,7 @@ func startServerWithOptions(cli *CliOptions) *apiserver.Server {
 		log.Fatal(err)
 	}
 
-	log.Println("Listener created for HTTP on TCP ", cli.fullserver)
+	log.Println("Listener created for HTTP on TCP", cli.fullserver)
 	api.Accept(cli.fullserver, l...)
 
 	return api


### PR DESCRIPTION
This is consistent with docker behavior in that docker images should not return an error.

