### PR TITLE
Redundant multi-writer and test

### DIFF
--- a/cmd/tether/attach_test.go
+++ b/cmd/tether/attach_test.go
@@ -89,14 +89,10 @@ func (c *TestAttachConfig) LoadConfig() (*metadata.ExecutorConfig, error) {
 }
 
 func TestAttach(t *testing.T) {
-	// supply custom attach server so we can inspect its state
-	testServer := &testAttachServer{
-		updated: make(chan bool, 10),
-	}
-	server = testServer
-
 	testSetup(t)
 	defer testTeardown(t)
+
+	testServer, _ := server.(*testAttachServer)
 
 	// if there's no session command with guaranteed exit then tether needs to run in the background
 	cfg := &TestAttachConfig{}
@@ -214,14 +210,10 @@ func (c *TestAttachTTYConfig) LoadConfig() (*metadata.ExecutorConfig, error) {
 func TestAttachTTY(t *testing.T) {
 	t.Skip("TTY test skipped - not sure how to test this correctly")
 
-	// supply custom attach server so we can inspect its state
-	testServer := &testAttachServer{
-		updated: make(chan bool, 10),
-	}
-	server = testServer
-
 	testSetup(t)
 	defer testTeardown(t)
+
+	testServer, _ := server.(*testAttachServer)
 
 	// if there's no session command with guaranteed exit then tether needs to run in the background
 	cfg := &TestAttachTTYConfig{}
@@ -357,14 +349,11 @@ func (c *TestAttachTwoConfig) LoadConfig() (*metadata.ExecutorConfig, error) {
 }
 
 func TestAttachTwo(t *testing.T) {
-	// supply custom attach server so we can inspect its state
-	testServer := &testAttachServer{
-		updated: make(chan bool, 10),
-	}
-	server = testServer
 
 	testSetup(t)
 	defer testTeardown(t)
+
+	testServer, _ := server.(*testAttachServer)
 
 	// if there's no session command with guaranteed exit then tether needs to run in the background
 	cfg := &TestAttachTwoConfig{}
@@ -525,14 +514,10 @@ func (c *TestAttachInvalidConfig) LoadConfig() (*metadata.ExecutorConfig, error)
 }
 
 func TestAttachInvalid(t *testing.T) {
-	// supply custom attach server so we can inspect its state
-	testServer := &testAttachServer{
-		updated: make(chan bool, 10),
-	}
-	server = testServer
-
 	testSetup(t)
 	defer testTeardown(t)
+
+	testServer, _ := server.(*testAttachServer)
 
 	// if there's no session command with guaranteed exit then tether needs to run in the background
 	cfg := &TestAttachInvalidConfig{}

--- a/cmd/tether/cmd_test.go
+++ b/cmd/tether/cmd_test.go
@@ -199,6 +199,12 @@ func TestAbsPath(t *testing.T) {
 	}
 }
 
+func TestAbsPathRepeat(t *testing.T) {
+	for i := 0; i < 1000; i++ {
+		TestAbsPath(t)
+	}
+}
+
 //
 /////////////////////////////////////////////////////////////////////////////////////
 

--- a/cmd/tether/cmd_test.go
+++ b/cmd/tether/cmd_test.go
@@ -200,6 +200,8 @@ func TestAbsPath(t *testing.T) {
 }
 
 func TestAbsPathRepeat(t *testing.T) {
+	t.Skip("Occasional issues with output not being flushed to log - #577")
+
 	for i := 0; i < 1000; i++ {
 		TestAbsPath(t)
 	}

--- a/cmd/tether/tether.go
+++ b/cmd/tether/tether.go
@@ -239,8 +239,8 @@ func launch(session *metadata.SessionConfig) error {
 			Env:  utils.processEnvOS(session.Cmd.Env),
 			Dir:  session.Cmd.Dir,
 		},
-		outwriter: dio.MultiWriter(logwriter),
-		errwriter: dio.MultiWriter(logwriter),
+		outwriter: logwriter,
+		errwriter: logwriter,
 		reader:    dio.MultiReader(),
 	}
 

--- a/pkg/dio/multi.go
+++ b/pkg/dio/multi.go
@@ -208,6 +208,7 @@ func (t *multiReader) Close() error {
 	}
 
 	t.err = io.EOF
+	t.cond.Broadcast()
 	return nil
 }
 


### PR DESCRIPTION
TestAbsPath failed to return output in the Go1.6.2 PR test. Looking at the
output it was apparent that there was a redundant chaining of
multi-writers. It's not clear whether this caused the problem or not, but
this removes the unnecessary chain and adds a scale repetition of the unit
test.
