### PR TITLE
Fix docker build instructions in README.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ apiservers/portlayer/models
 apiservers/portlayer/restapi/*.go
 apiservers/portlayer/restapi/operations
 !apiservers/portlayer/restapi/configure_port_layer.go
+govet

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ drone exec -trusted -cache
 
 To build without modifying the local system:
 ```
-docker run -v $(pwd):/go/src/github.com/vmware/vic -w /go/src/github.com/vmware/vic golang:1.6 make all
+docker run -v $(pwd):/go/src/github.com/vmware/vic -w /go/src/github.com/vmware/vic golang:1.6.2 make all
 ```
 
 To build directly:


### PR DESCRIPTION
Two small changes, one to prevent `govet` from making your branch dirty after a build, and one to update the docker-based build instructions to reference the correct Docker image to build from, now that we're on 1.6.2 (golang:1.6 does fail)