### PR TITLE
Added govet file to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ apiservers/portlayer/models
 apiservers/portlayer/restapi/*.go
 apiservers/portlayer/restapi/operations
 !apiservers/portlayer/restapi/configure_port_layer.go
+govet


### PR DESCRIPTION
Does what it says on the tin. After a build, govet file doesn't make your branch dirty. Real simple.
