### PR TITLE
Fix 556: network creation failed

### DIFF
--- a/install/management/dispatcher.go
+++ b/install/management/dispatcher.go
@@ -103,7 +103,9 @@ func (d *Dispatcher) initDiagnosticLogs(conf *configuration.Configuration) {
 	} else {
 		// vCenter w/ manual DRS or standalone ESXi
 		var host *object.HostSystem
-		host = d.session.Host
+		if d.isVC {
+			host = d.session.Host
+		}
 
 		diagnosticLogs[d.session.Host.Reference().Value] =
 			&diagnosticLog{"hostd", "hostd.log", 0, host, true}

--- a/install/management/network.go
+++ b/install/management/network.go
@@ -48,7 +48,7 @@ func (d *Dispatcher) createBridgeNetwork(conf *configuration.Configuration) erro
 		return err
 	}
 
-	if err = hostNetSystem.AddVirtualSwitch(d.ctx, conf.BridgeNetworkPath, &types.HostVirtualSwitchSpec{
+	if err = hostNetSystem.AddVirtualSwitch(d.ctx, conf.BridgeNetworkName, &types.HostVirtualSwitchSpec{
 		NumPorts: 1024,
 	}); err != nil {
 		err = errors.Errorf("Failed to add virtual switch (%s): %s", conf.BridgeNetworkName, err)


### PR DESCRIPTION
Fixes #556 
Network creation failed in ESXi for the network path is specified, but only the name is required.
This should be caused by incorrect variable rename.
