### PR TITLE
Reduce imagec memory usage

### DIFF
--- a/apiservers/engine/backends/container.go
+++ b/apiservers/engine/backends/container.go
@@ -121,7 +121,7 @@ func (c *Container) ContainerCreate(config types.ContainerCreateConfig) (types.C
 	if !found {
 		// FIXME: This is a temporary workaround until we have a name resolution story.
 		// Call imagec with -resolv parameter to learn the name of the vmdk and put it into in-memory map
-		cmdArgs := []string{"-reference", config.Config.Image, "-resolv", "-standalone"}
+		cmdArgs := []string{"-reference", config.Config.Image, "-resolv", "-standalone", "-destination", os.TempDir()}
 
 		out, err := goexec.Command("/sbin/imagec", cmdArgs...).Output()
 		if err != nil {

--- a/apiservers/engine/backends/image.go
+++ b/apiservers/engine/backends/image.go
@@ -198,6 +198,9 @@ func (i *Image) PullImage(ref reference.Named, metaHeaders map[string][]string, 
 		cmdArgs = append(cmdArgs, "-host", portLayerServer)
 	}
 
+	// intruct imagec to use os.TempDir
+	cmdArgs = append(cmdArgs, "-destination", os.TempDir())
+
 	fetcherPath := getImageFetcherPath(binImageC)
 
 	log.Printf("PullImage: cmd = %s %+v\n", fetcherPath, cmdArgs)


### PR DESCRIPTION
Start to stream filesystem directly instead of passing byte slices
around. The VCH filesystem is ramdisk anyway so we won't lose anything.

Reduces the overall memory consumption 100x for some edge cases
(eg; 600 MB vs 6 MB while downloading golang:1.6.2)