### PR TITLE
Tether assigns IP to container interface

### DIFF
--- a/cmd/tether/tether.go
+++ b/cmd/tether/tether.go
@@ -134,6 +134,14 @@ func run(loader metadata.ConfigLoader) error {
 			return errors.New(detail)
 		}
 
+		for _, v := range config.Networks {
+			if err := ops.Apply(&v); err != nil {
+				detail := fmt.Sprintf("failed to apply network endpoint config: %s", err)
+				log.Error(detail)
+				return errors.New(detail)
+			}
+		}
+
 		// process the sessions and launch if needed
 		attach := false
 		for id, session := range config.Sessions {

--- a/cmd/tether/utils_linux.go
+++ b/cmd/tether/utils_linux.go
@@ -21,6 +21,8 @@ import (
 	"io/ioutil"
 	"net"
 	"os"
+	"path"
+	"strconv"
 	"syscall"
 	"time"
 
@@ -90,6 +92,47 @@ func (t *osopsLinux) SetHostname(hostname string) error {
 	return nil
 }
 
+func slotToPCIAddr(pciSlot int32) (string, error) {
+	slotPath := path.Join("/sys/bus/pci/slots/", strconv.Itoa(int(pciSlot)), "/address")
+	f, err := os.Open(slotPath)
+	if err != nil {
+		return "", fmt.Errorf("unable to open slotPath %s: %s", slotPath, err)
+	}
+	defer f.Close()
+
+	buf, err := ioutil.ReadAll(f)
+	if err != nil {
+		return "", err
+	}
+
+	return string(buf), nil
+}
+
+func pciToMAC(pciAddr string) (string, error) {
+	intPath := path.Join("/sys/bus/pci/devices/", pciAddr, "/net")
+	ifaces, err := ioutil.ReadDir(intPath)
+	if err != nil {
+		return "", fmt.Errorf("unable to read intPath %s", intPath)
+	}
+	if len(ifaces) != 1 {
+		return "", fmt.Errorf("unexpected number of interfaces found at %s", intPath)
+	}
+
+	addrPath := path.Join(intPath, ifaces[0].Name(), "address")
+	f, err := os.Open(addrPath)
+	if err != nil {
+		return "", fmt.Errorf("unable to open addrPath %s: %s", addrPath, err)
+	}
+	defer f.Close()
+
+	buf, err := ioutil.ReadAll(f)
+	if err != nil {
+		return "", err
+	}
+
+	return string(buf), nil
+}
+
 func linkByAddress(address string) (netlink.Link, error) {
 	nis, err := net.Interfaces()
 	if err != nil {
@@ -106,12 +149,27 @@ func linkByAddress(address string) (netlink.Link, error) {
 	return nil, fmt.Errorf("unable to locate interface for address %s", address)
 }
 
+func linkByPCIAddr(pciAddr string) (netlink.Link, error) {
+	mac, err := pciToMAC(pciAddr)
+	if err != nil {
+		return nil, err
+	}
+	_, err = net.ParseMAC(mac)
+	if err != nil {
+		return nil, err
+	}
+	log.Debugf("MAC addr for PCI slot %s: %s", pciAddr, mac)
+
+	return linkByAddress(mac)
+}
+
 // Apply takes the network endpoint configuration and applies it to the system
 func (t *osopsLinux) Apply(endpoint *metadata.NetworkEndpoint) error {
 	defer trace.End(trace.Begin("applying endpoint configuration for " + endpoint.Network.Name))
 
 	// Locate interface
-	link, err := linkByAddress(endpoint.MAC)
+	pciAddr := slotToPCIAddr(endpoint.PCISlot)
+	link, err := linkByPCIAddr(pciAddr)
 	if err != nil {
 		return err
 	}
@@ -128,21 +186,6 @@ func (t *osopsLinux) Apply(endpoint *metadata.NetworkEndpoint) error {
 	if err != nil {
 		detail := fmt.Sprintf("unable to set interface name: %s", err)
 		return errors.New(detail)
-	}
-
-	// Remove any existing addresses
-	existingAddr, err := netlink.AddrList(link, syscall.AF_UNSPEC)
-	if err != nil {
-		detail := fmt.Sprintf("failed to list existing address for %s: %s", endpoint.Network.Name, err)
-		return errors.New(detail)
-	}
-
-	for _, oldAddr := range existingAddr {
-		err = netlink.AddrDel(link, &oldAddr)
-		if err != nil {
-			detail := fmt.Sprintf("failed to del existing address for %s: %s", endpoint.Network.Name, err)
-			return errors.New(detail)
-		}
 	}
 
 	// Set IP address

--- a/metadata/network_interface.go
+++ b/metadata/network_interface.go
@@ -26,6 +26,10 @@ type NetworkEndpoint struct {
 
 	// The MAC address for the vNIC - this allows for interface idenitifcaton in the guest
 	MAC string
+
+	// The PCI slot for the vNIC - this allows for interface idenitifcaton in the guest
+	PCISlot int32
+
 	// The network in which this information should be interpreted. This is embedded directly rather than
 	// as a pointer so that we can ensure the data is consistent
 	Network ContainerNetwork


### PR DESCRIPTION
For each network endpoint, find the desired interface by using supplied PCI slot number. Set the configured IP address on the interface.

Fixes #455 

