### PR TITLE
Tether assigns IP to container interface

### DIFF
--- a/cmd/tether/tether.go
+++ b/cmd/tether/tether.go
@@ -134,6 +134,14 @@ func run(loader metadata.ConfigLoader) error {
 			return errors.New(detail)
 		}
 
+		for _, v := range config.Networks {
+			if err := ops.Apply(&v); err != nil {
+				detail := fmt.Sprintf("failed to apply network endpoint config: %s", err)
+				log.Error(detail)
+				return errors.New(detail)
+			}
+		}
+
 		// process the sessions and launch if needed
 		attach := false
 		for id, session := range config.Sessions {

--- a/metadata/network_interface.go
+++ b/metadata/network_interface.go
@@ -26,6 +26,10 @@ type NetworkEndpoint struct {
 
 	// The MAC address for the vNIC - this allows for interface idenitifcaton in the guest
 	MAC string
+
+	// The PCI slot for the vNIC - this allows for interface idenitifcaton in the guest
+	PCISlot int32
+
 	// The network in which this information should be interpreted. This is embedded directly rather than
 	// as a pointer so that we can ensure the data is consistent
 	Network ContainerNetwork


### PR DESCRIPTION
For each network endpoint, find the desired interface by using supplied PCI slot number. Set the configured IP address on the interface.

Fixes #455

LGTMed in https://github.com/vmware/vic/pull/580