### PR TITLE
Fix go vet errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ GOLINT ?= $(GOPATH)/bin/golint$(BIN_ARCH)
 GVT ?= $(GOPATH)/bin/gvt$(BIN_ARCH)
 
 .PHONY: all tools clean test check \
-	goversion goimports gvt gopath \
+	goversion goimports gvt gopath govet \
 	isos tethers apiservers copyright
 
 .DEFAULT_GOAL := all
@@ -159,10 +159,10 @@ $(go-imports): $(GOIMPORTS) $(find . -type f -name '*.go' -not -path "./vendor/*
 	@! $(GOIMPORTS) -d $$(find . -type f -name '*.go' -not -path "./vendor/*") 2>&1 | egrep -v '^$$'
 	@touch $@
 
-govet: $(find . -type f -name '*.go' -not -path "./vendor/*" -not -path "apiservers/portlayer") $(PORTLAYER_DEPS)
+govet:
 	@echo checking go vet...
-	@$(GO) tool vet -all $$(find . -type f -name '*.go' -not -path "./vendor/*")
-	@$(GO) tool vet -shadow $$(find . -type f -name '*.go' -not -path "./vendor/*")
+	@$(GO) tool vet -all $$(find . -mindepth 1 -maxdepth 1 -type d -not -name vendor)
+	@$(GO) tool vet -shadow $$(find . -mindepth 1 -maxdepth 1 -type d -not -name vendor)
 
 vendor: $(GVT)
 	@echo restoring vendor
@@ -301,4 +301,3 @@ clean:
 	rm -fr ./tests/helpers/bats-support/
 
 	@tests/docker-tests/run-tests.sh clean
-	

--- a/cmd/imagec/docker.go
+++ b/cmd/imagec/docker.go
@@ -190,8 +190,8 @@ func FetchImageBlob(options ImageCOptions, image *ImageWithMeta) error {
 	h := sha256.New()
 
 	progress.Update(po, image.String(), "Verifying Checksum")
-	if _, err := io.Copy(h, in); err != nil {
-		return err
+	if _, cerr := io.Copy(h, in); cerr != nil {
+		return cerr
 	}
 
 	// Calculate the sum

--- a/cmd/imagec/fetcher.go
+++ b/cmd/imagec/fetcher.go
@@ -151,9 +151,9 @@ func (u *URLFetcher) fetch(ctx context.Context, url *url.URL, ID string) (string
 	in := res.Body
 	// stream progress as json and body into a file - only if we have an ID and a Content-Length header
 	if hdr := res.Header.Get("Content-Length"); ID != "" && hdr != "" {
-		cl, err := strconv.ParseInt(hdr, 10, 64)
-		if err != nil {
-			return "", err
+		cl, cerr := strconv.ParseInt(hdr, 10, 64)
+		if cerr != nil {
+			return "", cerr
 		}
 
 		in = progress.NewProgressReader(

--- a/cmd/tether/scp/scp_test.go
+++ b/cmd/tether/scp/scp_test.go
@@ -113,54 +113,54 @@ func scp(port int, serverMode Mode, sourceFile, destFile string) error {
 	// copy from the server
 	if serverMode == SOURCE {
 
-		sshPipe, err := session.StdoutPipe()
-		if err != nil {
-			return fmt.Errorf("error openning pipe %s", err)
+		sshPipe, serr := session.StdoutPipe()
+		if serr != nil {
+			return fmt.Errorf("error openning pipe %s", serr)
 		}
 
-		ok, err := session.SendRequest(string(serverMode), true, []byte(sourceFile))
+		ok, serr := session.SendRequest(string(serverMode), true, []byte(sourceFile))
 		if !ok {
 			return fmt.Errorf("not ok")
 		}
-		if err != nil {
-			return fmt.Errorf("error sending request %s", err)
+		if serr != nil {
+			return fmt.Errorf("error sending request %s", serr)
 		}
 
 		// write the result locally using the scp protocol operation
-		op, err = Write(ioutil.NopCloser(sshPipe), destFile)
-		if err != nil {
-			return fmt.Errorf("error writing %s", err)
+		op, serr = Write(ioutil.NopCloser(sshPipe), destFile)
+		if serr != nil {
+			return fmt.Errorf("error writing %s", serr)
 		}
 
 	} else {
 
-		sshPipe, err := session.StdinPipe()
-		if err != nil {
-			return fmt.Errorf("error openning pipe %s", err)
+		sshPipe, serr := session.StdinPipe()
+		if serr != nil {
+			return fmt.Errorf("error openning pipe %s", serr)
 		}
 
 		// copy to the server
-		ok, err := session.SendRequest(string(serverMode), true, []byte(destFile))
+		ok, serr := session.SendRequest(string(serverMode), true, []byte(destFile))
 		if !ok {
 			return fmt.Errorf("not ok")
 		}
-		if err != nil {
-			return fmt.Errorf("error sending request %s", err)
+		if serr != nil {
+			return fmt.Errorf("error sending request %s", serr)
 		}
 
 		// open the file for reading locally
-		op, err = OpenFile(sourceFile, os.O_RDONLY, 0)
-		if err != nil {
-			return err
+		op, serr = OpenFile(sourceFile, os.O_RDONLY, 0)
+		if serr != nil {
+			return serr
 		}
 		// read the file into the pipe
-		n, err := op.Read(sshPipe)
-		if err != nil {
-			return fmt.Errorf("error reading %s", err)
+		n, serr := op.Read(sshPipe)
+		if serr != nil {
+			return fmt.Errorf("error reading %s", serr)
 		}
 
-		if err = session.Close(); err != nil {
-			return fmt.Errorf("error closing sesson %s", err)
+		if serr = session.Close(); serr != nil {
+			return fmt.Errorf("error closing sesson %s", serr)
 		}
 
 		log.Printf("scp copied %d bytes to server", n)

--- a/install/management/appliance.go
+++ b/install/management/appliance.go
@@ -60,9 +60,9 @@ func (d *Dispatcher) removeApplianceIfForced(conf *configuration.Configuration) 
 	}
 	log.Debugf("Appliance is found")
 	if vm != nil && d.force {
-		if ok, err := d.isVCH(vm); !ok {
-			err = errors.Errorf("VM %s is found, but is not VCH appliance, please choose different name", conf.DisplayName)
-			return err
+		if ok, verr := d.isVCH(vm); !ok {
+			verr = errors.Errorf("VM %s is found, but is not VCH appliance, please choose different name", conf.DisplayName)
+			return verr
 		}
 		log.Infof("Appliance exists, remove it...")
 		_, err = tasks.WaitForResult(d.ctx, func(ctx context.Context) (tasks.ResultWaiter, error) {

--- a/pkg/serial/handshake.go
+++ b/pkg/serial/handshake.go
@@ -119,8 +119,8 @@ func readMultiple(conn net.Conn, b []byte) (int, error) {
 	// toggle between this behaviour and blocking read at a windows level
 	n, err := conn.Read(b)
 	if err == nil && n == 1 {
-		n, err := conn.Read(b[1:])
-		return n + 1, err
+		cn, cerr := conn.Read(b[1:])
+		return cn + 1, cerr
 	}
 	return n, err
 }

--- a/pkg/vsphere/disk/disk_manager_test.go
+++ b/pkg/vsphere/disk/disk_manager_test.go
@@ -70,16 +70,16 @@ func TestCreateAndDetach(t *testing.T) {
 	for i := 0; i < numChildren; i++ {
 
 		p := client.Datastore.Path(fmt.Sprintf("imagestore/child%d.vmdk", i))
-		child, err := vdm.CreateAndAttach(context.TODO(), p, parent.DatastoreURI, 0, os.O_RDWR)
-		if !assert.NoError(t, err) {
+		child, cerr := vdm.CreateAndAttach(context.TODO(), p, parent.DatastoreURI, 0, os.O_RDWR)
+		if !assert.NoError(t, cerr) {
 			return
 		}
 
 		children[i] = child
 
 		// Write directly to the disk
-		f, err := os.OpenFile(child.DevicePath, os.O_RDWR, os.FileMode(0777))
-		if !assert.NoError(t, err) {
+		f, cerr := os.OpenFile(child.DevicePath, os.O_RDWR, os.FileMode(0777))
+		if !assert.NoError(t, cerr) {
 			return
 		}
 
@@ -88,15 +88,15 @@ func TestCreateAndDetach(t *testing.T) {
 
 		if i == numChildren-1 {
 			// last chunk, write to the end.
-			_, err = f.WriteAt([]byte(testString[start:]), int64(start))
-			if !assert.NoError(t, err) {
+			_, cerr = f.WriteAt([]byte(testString[start:]), int64(start))
+			if !assert.NoError(t, cerr) {
 				return
 			}
 			// Try to read the whole string
 			b := make([]byte, len(testString))
 			f.Seek(0, 0)
-			_, err = f.Read(b)
-			if !assert.NoError(t, err) {
+			_, cerr = f.Read(b)
+			if !assert.NoError(t, cerr) {
 				return
 			}
 
@@ -106,16 +106,16 @@ func TestCreateAndDetach(t *testing.T) {
 			}
 
 		} else {
-			_, err = f.WriteAt([]byte(testString[start:end]), int64(start))
-			if !assert.NoError(t, err) {
+			_, cerr = f.WriteAt([]byte(testString[start:end]), int64(start))
+			if !assert.NoError(t, cerr) {
 				return
 			}
 		}
 
 		f.Close()
 
-		err = vdm.Detach(context.TODO(), child)
-		if !assert.NoError(t, err) {
+		cerr = vdm.Detach(context.TODO(), child)
+		if !assert.NoError(t, cerr) {
 			return
 		}
 

--- a/pkg/vsphere/extraconfig/decode.go
+++ b/pkg/vsphere/extraconfig/decode.go
@@ -181,21 +181,21 @@ func decodeWithPrefix(kv map[string]string, dest interface{}, prefix string) int
 					for i := 0; i < length; i++ {
 						member := reflect.New(field.Type().Elem())
 						// convert key to name|index format
-						key := fmt.Sprintf("%s|%d", key, i)
-						decodeWithPrefix(kv, member.Interface(), key)
+						mkey := fmt.Sprintf("%s|%d", key, i)
+						decodeWithPrefix(kv, member.Interface(), mkey)
 
 						// set the i'th slice item
 						slice.Index(i).Set(member.Elem())
 					}
 				} else {
 					// convert key to name~ format
-					key := fmt.Sprintf("%s~", key)
+					mkey := fmt.Sprintf("%s~", key)
 					// lookup the key and split it
-					values := strings.Split(kv[key], "|")
+					values := strings.Split(kv[mkey], "|")
 					for i := 0; i < length; i++ {
-						v := values[i]
+						x := values[i]
 						t := field.Type().Elem()
-						k := fromString(reflect.Zero(t), v)
+						k := fromString(reflect.Zero(t), x)
 						// set the i'th slice item
 						slice.Index(i).Set(k)
 					}
@@ -218,8 +218,8 @@ func decodeWithPrefix(kv map[string]string, dest interface{}, prefix string) int
 					if field.Type().Elem().Kind() == reflect.Struct {
 						member := reflect.New(field.Type().Elem())
 
-						key := fmt.Sprintf("%s|%s", key, value)
-						decodeWithPrefix(kv, member.Interface(), key)
+						mkey := fmt.Sprintf("%s|%s", key, value)
+						decodeWithPrefix(kv, member.Interface(), mkey)
 
 						t := field.Type().Key()
 						k := fromString(reflect.Zero(t), value)
@@ -229,9 +229,9 @@ func decodeWithPrefix(kv map[string]string, dest interface{}, prefix string) int
 						for i := 0; i < len(values); i++ {
 							v := values[i]
 							// convert key to name|mapkey format
-							key := fmt.Sprintf("%s|%s", key, v)
+							mkey := fmt.Sprintf("%s|%s", key, v)
 							t := field.Type().Elem()
-							k := fromString(reflect.Zero(t), kv[key])
+							k := fromString(reflect.Zero(t), kv[mkey])
 
 							// set the map item
 							field.SetMapIndex(reflect.ValueOf(v), k)

--- a/pkg/vsphere/extraconfig/encode.go
+++ b/pkg/vsphere/extraconfig/encode.go
@@ -269,8 +269,8 @@ func encodeWithPrefix(src interface{}, prefix string) []types.BaseOptionValue {
 				// iterate over keys and recurse
 				for _, v := range field.MapKeys() {
 					keys = append(keys, toString(v))
-					key := fmt.Sprintf("%s|%s", key, toString(v))
-					config = append(config, encodeWithPrefix(field.MapIndex(v).Interface(), key)...)
+					mkey := fmt.Sprintf("%s|%s", key, toString(v))
+					config = append(config, encodeWithPrefix(field.MapIndex(v).Interface(), mkey)...)
 				}
 				// sort the keys before joining
 				sort.Strings(keys)

--- a/pkg/vsphere/simulator/datacenter_test.go
+++ b/pkg/vsphere/simulator/datacenter_test.go
@@ -51,11 +51,11 @@ func TestDatacenterCreateFolders(t *testing.T) {
 			e := Map.Get(ref).(mo.Entity)
 
 			if e.Entity().Name == "" {
-				t.Errorf("empty name")
+				t.Error("empty name")
 			}
 
 			if *e.Entity().Parent != test.dc.Self {
-				t.Error()
+				t.Fail()
 			}
 
 			if test.isVC {
@@ -65,7 +65,7 @@ func TestDatacenterCreateFolders(t *testing.T) {
 				}
 
 				if len(f.ChildType) < 2 {
-					t.Error()
+					t.Fail()
 				}
 			} else {
 				f, ok := e.(*mo.Folder)
@@ -74,7 +74,7 @@ func TestDatacenterCreateFolders(t *testing.T) {
 				}
 
 				if len(f.ChildType) != 1 {
-					t.Error()
+					t.Fail()
 				}
 			}
 		}

--- a/pkg/vsphere/simulator/folder_test.go
+++ b/pkg/vsphere/simulator/folder_test.go
@@ -84,7 +84,7 @@ func TestFolderVC(t *testing.T) {
 
 		e := o.(mo.Entity).Entity()
 		if *e.Parent != f.Reference() {
-			t.Error()
+			t.Fail()
 		}
 	}
 

--- a/pkg/vsphere/simulator/registry_test.go
+++ b/pkg/vsphere/simulator/registry_test.go
@@ -32,19 +32,19 @@ func TestRegistry(t *testing.T) {
 	e := r.Get(ref)
 
 	if e.Reference() != ref {
-		t.Error()
+		t.Fail()
 	}
 
 	r.Remove(ref)
 
 	if r.Get(ref) != nil {
-		t.Error()
+		t.Fail()
 	}
 
 	r.Put(e)
 	e = r.Get(ref)
 
 	if e.Reference() != ref {
-		t.Error()
+		t.Fail()
 	}
 }

--- a/pkg/vsphere/simulator/simulator_test.go
+++ b/pkg/vsphere/simulator/simulator_test.go
@@ -150,7 +150,7 @@ func TestUnmarshal(t *testing.T) {
 	for i, req := range requests {
 		method, err := UnmarshalBody([]byte(req.data))
 		if err != nil {
-			t.Errorf("failed to decode %d (%s):", i, req, err)
+			t.Errorf("failed to decode %d (%s): %s", i, req, err)
 		}
 		if !reflect.DeepEqual(method.Body, req.body) {
 			t.Errorf("malformed body %d (%#v):", i, method.Body)
@@ -244,7 +244,7 @@ func TestServeHTTP(t *testing.T) {
 		}
 
 		if now.After(time.Now()) {
-			t.Error()
+			t.Fail()
 		}
 	}
 }

--- a/pkg/vsphere/spec/spec.go
+++ b/pkg/vsphere/spec/spec.go
@@ -89,10 +89,10 @@ func NewVirtualMachineConfigSpec(ctx context.Context, session *session.Session, 
 	log.Debugf("Adding metadata to the configspec: %+v", config.Metadata)
 	// TEMPORARY
 
-	metadata, err := metadata.New().StoreConfig(&config.Metadata)
-	if err != nil {
-		log.Errorf("failed to marshal container metadata: %s", err)
-		return nil, err
+	md, cerr := metadata.New().StoreConfig(&config.Metadata)
+	if cerr != nil {
+		log.Errorf("failed to marshal container metadata: %s", cerr)
+		return nil, cerr
 	}
 
 	spec := &types.VirtualMachineConfigSpec{
@@ -129,7 +129,7 @@ func NewVirtualMachineConfigSpec(ctx context.Context, session *session.Session, 
 			&types.OptionValue{Key: "tools.upgrade.policy", Value: "manual"},
 
 			// TEMPORARY
-			&types.OptionValue{Key: "guestInfo.vic.configblob", Value: metadata},
+			&types.OptionValue{Key: "guestInfo.vic.configblob", Value: md},
 		},
 	}
 

--- a/pkg/vsphere/spec/spec_test.go
+++ b/pkg/vsphere/spec/spec_test.go
@@ -41,7 +41,7 @@ func TestVirtualMachineConfigSpec(t *testing.T) {
 		PoolPath:       "/ha-datacenter/host/*/Resources",
 	}
 
-	session, err := session.NewSession(sessionconfig).Create(ctx)
+	s, err := session.NewSession(sessionconfig).Create(ctx)
 	if err != nil {
 		t.Logf("%+v", err.Error())
 		if _, ok := err.(*find.MultipleFoundError); !ok {
@@ -50,7 +50,7 @@ func TestVirtualMachineConfigSpec(t *testing.T) {
 			t.SkipNow()
 		}
 	}
-	defer session.Logout(ctx)
+	defer s.Logout(ctx)
 
 	specconfig := &VirtualMachineConfigSpecConfig{
 		NumCPUs:       2,
@@ -61,16 +61,16 @@ func TestVirtualMachineConfigSpec(t *testing.T) {
 
 		ID: "zombie_attack",
 
-		BootMediaPath: session.Datastore.Path("brainz.iso"),
-		VMPathName:    fmt.Sprintf("[%s]", session.Datastore.Name()),
-		NetworkName:   strings.Split(session.Network.Reference().Value, "-")[0],
+		BootMediaPath: s.Datastore.Path("brainz.iso"),
+		VMPathName:    fmt.Sprintf("[%s]", s.Datastore.Name()),
+		NetworkName:   strings.Split(s.Network.Reference().Value, "-")[0],
 	}
 	// FIXME: find a better way to pass those
 	var scsibus int32
 	var scsikey int32 = 100
 	var idekey int32 = 200
 
-	root, _ := NewVirtualMachineConfigSpec(ctx, session, specconfig)
+	root, _ := NewVirtualMachineConfigSpec(ctx, s, specconfig)
 	scsi := NewVirtualSCSIController(scsibus, scsikey)
 
 	pv := NewParaVirtualSCSIController(scsi)

--- a/pkg/vsphere/test/test.go
+++ b/pkg/vsphere/test/test.go
@@ -42,12 +42,12 @@ func Session(ctx context.Context, t *testing.T) *session.Session {
 		PoolPath:       "/ha-datacenter/host/*/Resources",
 	}
 
-	session, err := session.NewSession(config).Create(ctx)
+	s, err := session.NewSession(config).Create(ctx)
 	if err != nil {
 		t.Errorf("ERROR: %s", err)
 		t.SkipNow()
 	}
-	return session
+	return s
 }
 
 // SpecConfig returns a spec.VirtualMachineConfigSpecConfig struct

--- a/portlayer/network/scope_test.go
+++ b/portlayer/network/scope_test.go
@@ -66,24 +66,24 @@ func TestScopeAddRemoveContainer(t *testing.T) {
 
 	for _, te := range tests1 {
 		t.Logf("testing name = %s, ip = %v", te.name, te.ip)
-		e, err := s.AddContainer(te.name, te.ip)
+		e, aerr := s.AddContainer(te.name, te.ip)
 		if te.err != nil {
-			if err == nil {
+			if aerr == nil {
 				t.Errorf("s.AddContainer() => (_, nil), want (_, err)")
 				continue
 			}
 
-			if reflect.TypeOf(err) != reflect.TypeOf(te.err) {
-				t.Errorf("s.AddContainer() => (_, %v), want (_, %v)", reflect.TypeOf(err), reflect.TypeOf(te.err))
+			if reflect.TypeOf(aerr) != reflect.TypeOf(te.err) {
+				t.Errorf("s.AddContainer() => (_, %v), want (_, %v)", reflect.TypeOf(aerr), reflect.TypeOf(te.err))
 				continue
 			}
 
 			// for any other error other than DuplicateResourcError
 			// verify that the container was not added
-			if _, ok := err.(DuplicateResourceError); !ok {
-				c, err := s.Container(te.name)
-				if _, ok := err.(ResourceNotFoundError); !ok || c != nil {
-					t.Errorf("s.Container(%s) => (%v, %v), want (nil, err)", te.name, c, err)
+			if _, ok := aerr.(DuplicateResourceError); !ok {
+				c, cerr := s.Container(te.name)
+				if _, ok := cerr.(ResourceNotFoundError); !ok || c != nil {
+					t.Errorf("s.Container(%s) => (%v, %v), want (nil, err)", te.name, c, cerr)
 				}
 			}
 
@@ -122,9 +122,9 @@ func TestScopeAddRemoveContainer(t *testing.T) {
 			t.Errorf("s.endpoints does not contain %v", e)
 		}
 
-		c, err := s.Container(te.name)
-		if err != nil {
-			t.Errorf("s.Container(%s) => (nil, %s), want (c, nil)", te.name, err)
+		c, aerr := s.Container(te.name)
+		if aerr != nil {
+			t.Errorf("s.Container(%s) => (nil, %s), want (c, nil)", te.name, aerr)
 			continue
 		}
 

--- a/portlayer/storage/store_cache_test.go
+++ b/portlayer/storage/store_cache_test.go
@@ -109,8 +109,8 @@ func TestListImages(t *testing.T) {
 	for i := 1; i < 50; i++ {
 		id := fmt.Sprintf("ID-%d", i)
 
-		img, err := s.WriteImage(context.TODO(), &parent, id, nil, testSum, nil)
-		if !assert.NoError(t, err) {
+		img, werr := s.WriteImage(context.TODO(), &parent, id, nil, testSum, nil)
+		if !assert.NoError(t, werr) {
 			return
 		}
 		if !assert.NotNil(t, img) {
@@ -182,8 +182,8 @@ func TestImageStoreRestart(t *testing.T) {
 	for i := 1; i < 50; i++ {
 		id := fmt.Sprintf("ID-%d", i)
 
-		img, err := firstCache.WriteImage(context.TODO(), &parent, id, nil, testSum, nil)
-		if !assert.NoError(t, err) {
+		img, werr := firstCache.WriteImage(context.TODO(), &parent, id, nil, testSum, nil)
+		if !assert.NoError(t, werr) {
 			return
 		}
 		if !assert.NotNil(t, img) {
@@ -195,8 +195,8 @@ func TestImageStoreRestart(t *testing.T) {
 
 	// get the images from the second cache to ensure it goes to the ds
 	for id, expectedImg := range expectedImages {
-		img, err := secondCache.GetImage(context.TODO(), storeURL, id)
-		if !assert.NoError(t, err) || !assert.Equal(t, expectedImg, img) {
+		img, werr := secondCache.GetImage(context.TODO(), storeURL, id)
+		if !assert.NoError(t, werr) || !assert.Equal(t, expectedImg, img) {
 			return
 		}
 	}
@@ -204,8 +204,8 @@ func TestImageStoreRestart(t *testing.T) {
 	// Nuke the second cache's datastore.  All data should come from the cache.
 	secondCache.DataStore = nil
 	for id, expectedImg := range expectedImages {
-		img, err := secondCache.GetImage(context.TODO(), storeURL, id)
-		if !assert.NoError(t, err) || !assert.Equal(t, expectedImg, img) {
+		img, gerr := secondCache.GetImage(context.TODO(), storeURL, id)
+		if !assert.NoError(t, gerr) || !assert.Equal(t, expectedImg, img) {
 			return
 		}
 	}

--- a/portlayer/vsphere/storage/store.go
+++ b/portlayer/vsphere/storage/store.go
@@ -219,15 +219,15 @@ func (v *ImageStore) WriteImage(ctx context.Context, parent *portlayer.Image, ID
 	// will be descended from this created and prepared fs.
 	if ID == portlayer.Scratch.ID {
 		// Create the disk
-		vmdisk, err := v.dm.CreateAndAttach(ctx, ImageDiskDsURI, "", defaultDiskSize, os.O_RDWR)
-		if err != nil {
-			return nil, err
+		vmdisk, cerr := v.dm.CreateAndAttach(ctx, ImageDiskDsURI, "", defaultDiskSize, os.O_RDWR)
+		if cerr != nil {
+			return nil, cerr
 		}
 		defer v.dm.Detach(ctx, vmdisk)
 
 		// Make the filesystem and set its label to defaultDiskLabel
-		if err = vmdisk.Mkfs(defaultDiskLabel); err != nil {
-			return nil, err
+		if cerr = vmdisk.Mkfs(defaultDiskLabel); cerr != nil {
+			return nil, cerr
 		}
 	} else {
 
@@ -237,34 +237,34 @@ func (v *ImageStore) WriteImage(ctx context.Context, parent *portlayer.Image, ID
 
 		// Create the disk
 		parentDiskDsURI := v.datastorePath(v.imageDiskPath(storeName, parent.ID))
-		vmdisk, err := v.dm.CreateAndAttach(ctx, ImageDiskDsURI, parentDiskDsURI, 0, os.O_RDWR)
-		if err != nil {
-			return nil, err
+		vmdisk, cerr := v.dm.CreateAndAttach(ctx, ImageDiskDsURI, parentDiskDsURI, 0, os.O_RDWR)
+		if cerr != nil {
+			return nil, cerr
 		}
 		defer v.dm.Detach(ctx, vmdisk)
 
-		dir, err := ioutil.TempDir("", "mnt-"+ID)
-		if err != nil {
-			return nil, err
+		dir, cerr := ioutil.TempDir("", "mnt-"+ID)
+		if cerr != nil {
+			return nil, cerr
 		}
 		defer os.RemoveAll(dir)
 
-		if err := vmdisk.Mount(dir, nil); err != nil {
-			return nil, err
+		if merr := vmdisk.Mount(dir, nil); merr != nil {
+			return nil, merr
 		}
 		defer vmdisk.Unmount()
 
 		// Untar the archive
-		err = archive.Untar(r, dir, &archive.TarOptions{})
-		if err != nil {
-			return nil, err
+		cerr = archive.Untar(r, dir, &archive.TarOptions{})
+		if cerr != nil {
+			return nil, cerr
 		}
 
 		// persist the relationship
 		v.parents.Add(ID, parent.ID)
 
-		if err = v.parents.Save(ctx); err != nil {
-			return nil, err
+		if cerr = v.parents.Save(ctx); cerr != nil {
+			return nil, cerr
 		}
 	}
 

--- a/portlayer/vsphere/storage/store_test.go
+++ b/portlayer/vsphere/storage/store_test.go
@@ -191,8 +191,8 @@ func TestCreateImageLayers(t *testing.T) {
 		meta[dirName+"_scorpions"] = []byte("Here I am, rock you like a hurricane")
 
 		// Tar the files
-		buf, err := tarFiles(files, meta)
-		if !assert.NoError(t, err) {
+		buf, terr := tarFiles(files, meta)
+		if !assert.NoError(t, terr) {
 			return
 		}
 
@@ -202,16 +202,16 @@ func TestCreateImageLayers(t *testing.T) {
 		sum := fmt.Sprintf("sha256:%x", h.Sum(nil))
 
 		// Write the image via the cache (which writes to the vsphere impl)
-		writtenImage, err := cacheStore.WriteImage(context.TODO(), parent, dirName, meta, sum, buf)
-		if !assert.NoError(t, err) || !assert.NotNil(t, writtenImage) {
+		writtenImage, terr := cacheStore.WriteImage(context.TODO(), parent, dirName, meta, sum, buf)
+		if !assert.NoError(t, terr) || !assert.NotNil(t, writtenImage) {
 			return
 		}
 
 		expectedImages[dirName] = writtenImage
 
 		// Get the image directly via the vsphere image store impl.
-		vsImage, err := vsStore.GetImage(context.TODO(), parent.Store, dirName)
-		if !assert.NoError(t, err) || !assert.NotNil(t, vsImage) {
+		vsImage, terr := vsStore.GetImage(context.TODO(), parent.Store, dirName)
+		if !assert.NoError(t, terr) || !assert.NotNil(t, vsImage) {
 			return
 		}
 


### PR DESCRIPTION
Don't know why this isn't happening in CI, via 'make check':

```
./cmd/imagec/docker.go:193: declaration of err shadows declaration at ./cmd/imagec/docker.go:154: 
./cmd/imagec/fetcher.go:154: declaration of err shadows declaration at ./cmd/imagec/fetcher.go:117: 
```