### PR TITLE
Update list image params to use the new format

### DIFF
--- a/apiservers/engine/backends/image.go
+++ b/apiservers/engine/backends/image.go
@@ -74,9 +74,7 @@ func (i *Image) Images(filterArgs string, filter string, all bool) ([]*types.Ima
 				http.StatusInternalServerError)
 	}
 
-	params := &storage.ListImagesParams{
-		StoreName: host,
-	}
+	params := storage.NewListImagesParams().WithStoreName(host)
 
 	client := PortLayerClient()
 	if client == nil {


### PR DESCRIPTION
This brings the docker personality image backend up to date with recent go-swagger changes regarding how params are created.
