### PR TITLE
Add scratch to ListImages in the datastore

### DIFF
--- a/apiservers/portlayer/restapi/handlers/storage_handlers.go
+++ b/apiservers/portlayer/restapi/handlers/storage_handlers.go
@@ -142,7 +142,6 @@ func (handler *StorageHandlersImpl) ListImages(params storage.ListImagesParams) 
 			})
 	}
 
-	// FIXME(jzt): not populating the cache at startup will result in 404's
 	images, err := storageLayer.ListImages(context.TODO(), u, params.Ids)
 	if err != nil {
 		return storage.NewListImagesNotFound().WithPayload(

--- a/apiservers/portlayer/restapi/handlers/storage_handlers_test.go
+++ b/apiservers/portlayer/restapi/handlers/storage_handlers_test.go
@@ -257,7 +257,6 @@ func TestListImages(t *testing.T) {
 
 	// create a set of images
 	images := make(map[string]*spl.Image)
-	images[spl.Scratch.ID] = &spl.Scratch
 	parent := spl.Scratch
 	parent.Store = &testStoreURL
 	for i := 1; i < 50; i++ {

--- a/portlayer/storage/store_cache_test.go
+++ b/portlayer/storage/store_cache_test.go
@@ -103,7 +103,6 @@ func TestListImages(t *testing.T) {
 
 	// Create a set of images
 	images := make(map[string]*Image)
-	images[Scratch.ID] = &Scratch
 	parent := Scratch
 	parent.Store = storeURL
 	testSum := "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
@@ -218,8 +217,7 @@ func TestImageStoreRestart(t *testing.T) {
 		return
 	}
 
-	// add 1 for scratch
-	if !assert.Equal(t, len(expectedImages)+1, len(imageList)) {
+	if !assert.Equal(t, len(expectedImages), len(imageList)) {
 		return
 	}
 

--- a/portlayer/vsphere/storage/store.go
+++ b/portlayer/vsphere/storage/store.go
@@ -355,9 +355,6 @@ func (v *ImageStore) ListImages(ctx context.Context, store *url.URL, IDs []strin
 		}
 
 		ID := file.Path
-		if ID == portlayer.Scratch.ID {
-			continue
-		}
 
 		img, err := v.GetImage(ctx, store, ID)
 		if err != nil {

--- a/portlayer/vsphere/storage/store_test.go
+++ b/portlayer/vsphere/storage/store_test.go
@@ -159,6 +159,7 @@ func TestCreateImageLayers(t *testing.T) {
 	if !assert.NoError(t, err) {
 		return
 	}
+	parent.Metadata = make(map[string][]byte)
 
 	// Keep a list of all files we're extracting via layers so we can verify
 	// they exist in the leaf layer.  Ext adds lost+found, so add it here.
@@ -166,6 +167,7 @@ func TestCreateImageLayers(t *testing.T) {
 
 	// Keep a list of images we created
 	expectedImages := make(map[string]*portlayer.Image)
+	expectedImages[parent.ID] = parent
 
 	for layer := 0; layer < numLayers; layer++ {
 


### PR DESCRIPTION
Filter it out in the cache.  The cache expects scratch to exist in its
list of images to validate the image store directory isn't corrupt.

Fixes #621