### PR TITLE
Add apiservers/engine/backends to list of test directories

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -181,6 +181,7 @@ TEST_DIRS+=github.com/vmware/vic/cmd/vic-machine
 TEST_DIRS+=github.com/vmware/vic/portlayer
 TEST_DIRS+=github.com/vmware/vic/pkg
 TEST_DIRS+=github.com/vmware/vic/apiservers/portlayer
+TEST_DIRS+=github.com/vmware/vic/apiservers/engine/backends
 TEST_DIRS+=github.com/vmware/vic/install
 
 


### PR DESCRIPTION
I forgot to do this in my last PR, so the tests aren't currently running.