### PR TITLE
Squashing errors when run in clean tree

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ endif
 
 # utility function to dynamically generate go dependencies
 define godeps
-	$(wildcard $1) $(shell $(BASE_DIR)/scripts/go-deps.sh $(BASE_PKG)/$(dir $1))
+	$(wildcard $1) $(shell $(BASE_DIR)/scripts/go-deps.sh $(dir $1))
 endef
 
 # target aliases - environment variable definition

--- a/scripts/go-deps.sh
+++ b/scripts/go-deps.sh
@@ -23,5 +23,9 @@
 
 PKG=$1
 
-echo "Generating deps for $PKG" >&2
-go list -f '{{join .Deps "\n"}}' $PKG |  xargs go list -f '{{if not .Standard}}{{.ImportPath}}{{end}}' | sed -e 's:github.com/vmware/vic/\(.*\)$:\1/*:'
+if [ -d $PKG ]; then
+    echo "Generating deps for $PKG" >&2
+    go list -f '{{join .Deps "\n"}}' github.com/vmware/vic/$PKG 2>/dev/null |  xargs go list -f '{{if not .Standard}}{{.ImportPath}}{{end}}' 2>/dev/null | sed -e 's:github.com/vmware/vic/\(.*\)$:\1/*:'
+else
+    echo "Skipping generation of deps for non-existant package $PKG" >&2
+fi


### PR DESCRIPTION
When run in a clean build we were seeing errors due to missing swagger
generated packages.

Fixes #352 

