### PR TITLE
Tether connection handling fixes and add attach server to PL

### DIFF
--- a/apiservers/portlayer/restapi/configure_port_layer.go
+++ b/apiservers/portlayer/restapi/configure_port_layer.go
@@ -44,6 +44,7 @@ var portlayerhandlers = []handler{
 	&handlers.MiscHandlersImpl{},
 	&handlers.ScopesHandlersImpl{},
 	&handlers.ExecHandlersImpl{},
+	&handlers.AttachHandlersImpl{},
 }
 
 func configureFlags(api *operations.PortLayerAPI) {

--- a/apiservers/portlayer/restapi/handlers/attach_handlers.go
+++ b/apiservers/portlayer/restapi/handlers/attach_handlers.go
@@ -1,0 +1,37 @@
+// Copyright 2016 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package handlers
+
+import (
+	log "github.com/Sirupsen/logrus"
+	"github.com/vmware/vic/apiservers/portlayer/restapi/operations"
+	"github.com/vmware/vic/portlayer/attach"
+	"github.com/vmware/vic/portlayer/network"
+)
+
+// AttachHandlersImpl is the receiver for all container attach methods.
+type AttachHandlersImpl struct {
+	s *attach.Server
+}
+
+func (a *AttachHandlersImpl) Configure(api *operations.PortLayerAPI, dc *network.Context) {
+	// XXX this needs to live on the mgmt netwerk
+	a.s = attach.NewAttachServer("", 0)
+
+	if err := a.s.Start(); err != nil {
+		log.Fatalf("Attach server unable to start: %s", err)
+		return
+	}
+}

--- a/cmd/tether/attach_test.go
+++ b/cmd/tether/attach_test.go
@@ -24,6 +24,7 @@ import (
 	"net"
 	"sync"
 	"testing"
+	"time"
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
@@ -504,3 +505,54 @@ func TestAttachInvalid(t *testing.T) {
 
 //
 /////////////////////////////////////////////////////////////////////////////////////
+
+// Start the tether, start a mock esx serial to tcp connection, start the
+// attach server, try to Get() the tether's attached session.
+func TestMockAttachTetherToPL(t *testing.T) {
+	testSetup(t)
+	defer testTeardown(t)
+
+	// Start the PL attach server
+	testServer := attach.NewAttachServer("", 2377)
+	assert.NoError(t, testServer.Start())
+	defer testServer.Stop()
+
+	cfg := metadata.ExecutorConfig{
+		Common: metadata.Common{
+			ID:   "attach",
+			Name: "tether_test_executor",
+		},
+
+		Sessions: map[string]metadata.SessionConfig{
+			"attach": metadata.SessionConfig{
+				Common: metadata.Common{
+					ID:   "attach",
+					Name: "tether_test_session",
+				},
+				Tty:    false,
+				Attach: true,
+				Cmd: metadata.Cmd{
+					Path: "/usr/bin/tee",
+					// grep, matching everything, reading from stdin
+					Args: []string{"/usr/bin/tee", pathPrefix + "/tee.out"},
+					Env:  []string{},
+					Dir:  "/",
+				},
+			},
+		},
+		Key: genKey(),
+	}
+
+	startTether(t, &cfg)
+
+	// create a conn on the mock pipe.  Reads from pipe, echos to network.
+	_, err := mockNetworkToSerialConnection(testServer.Addr())
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	_, err = testServer.Get(context.Background(), "attach", 600*time.Second)
+	if !assert.NoError(t, err) {
+		return
+	}
+}

--- a/cmd/tether/attach_test.go
+++ b/cmd/tether/attach_test.go
@@ -99,7 +99,7 @@ func TestAttach(t *testing.T) {
 	}
 
 	// create client on the mock pipe
-	conn, err := mockSerialConnection(context.Background())
+	conn, err := mockBackChannel(context.Background())
 	if err != nil {
 		t.Error(err)
 		return
@@ -203,7 +203,7 @@ func TestAttachTTY(t *testing.T) {
 	}
 
 	// create client on the mock pipe
-	conn, err := mockSerialConnection(context.Background())
+	conn, err := mockBackChannel(context.Background())
 	if err != nil {
 		t.Error(err)
 		return
@@ -327,7 +327,7 @@ func TestAttachTwo(t *testing.T) {
 	}
 
 	// create client on the mock pipe
-	conn, err := mockSerialConnection(context.Background())
+	conn, err := mockBackChannel(context.Background())
 	if err != nil {
 		t.Error(err)
 		return
@@ -471,7 +471,7 @@ func TestAttachInvalid(t *testing.T) {
 	}
 
 	// create client on the mock pipe
-	conn, err := mockSerialConnection(context.Background())
+	conn, err := mockBackChannel(context.Background())
 	if err != nil {
 		t.Error(err)
 		return

--- a/cmd/tether/main_linux.go
+++ b/cmd/tether/main_linux.go
@@ -34,8 +34,6 @@ func main() {
 		halt()
 	}()
 
-	log.SetLevel(log.DebugLevel)
-
 	// where to look for the various devices and files related to tether
 	pathPrefix = "/.tether"
 

--- a/cmd/tether/main_linux.go
+++ b/cmd/tether/main_linux.go
@@ -34,6 +34,8 @@ func main() {
 		halt()
 	}()
 
+	log.SetLevel(log.DebugLevel)
+
 	// where to look for the various devices and files related to tether
 	pathPrefix = "/.tether"
 

--- a/cmd/tether/tether_linux.go
+++ b/cmd/tether/tether_linux.go
@@ -176,7 +176,7 @@ func (t *osopsLinux) backchannel(ctx context.Context) (net.Conn, error) {
 	}
 
 	// HACK: currently RawConn dosn't implement timeout so throttle the spinning
-	ticker := time.NewTicker(1000 * time.Millisecond)
+	ticker := time.NewTicker(10 * time.Millisecond)
 	for {
 		select {
 		case <-ticker.C:

--- a/cmd/tether/tether_linux.go
+++ b/cmd/tether/tether_linux.go
@@ -189,6 +189,10 @@ func (t *osopsLinux) backchannel(ctx context.Context) (net.Conn, error) {
 	}
 
 	// HACK: currently RawConn dosn't implement timeout so throttle the spinning
+
+	// This needs to tick *faster* than the ticker in connection.go on the
+	// portlayer side.  The PL sends the first syn and if this isn't waiting,
+	// alignment will take a few rounds (or it may never happen).
 	ticker := time.NewTicker(10 * time.Millisecond)
 	for {
 		select {

--- a/cmd/tether/tether_linux.go
+++ b/cmd/tether/tether_linux.go
@@ -30,6 +30,7 @@ import (
 	"unsafe"
 
 	"golang.org/x/crypto/ssh"
+	"golang.org/x/crypto/ssh/terminal"
 	"golang.org/x/net/context"
 
 	log "github.com/Sirupsen/logrus"
@@ -164,6 +165,18 @@ func (t *osopsLinux) backchannel(ctx context.Context) (net.Conn, error) {
 		detail := fmt.Sprintf("failed to open serial port for backchannel: %s", err)
 		log.Error(detail)
 		return nil, errors.New(detail)
+	}
+
+	// set the provided FDs to raw if it's a termial
+	// 0 is the uninitialized value for Fd
+	if f.Fd() != 0 && terminal.IsTerminal(int(f.Fd())) {
+		log.Debug("setting terminal to raw mode")
+		s, err := terminal.MakeRaw(int(f.Fd()))
+		if err != nil {
+			return nil, err
+		}
+
+		log.Infof("s = %#v", s)
 	}
 
 	log.Infof("creating raw connection from ttyS0 (fd=%d)\n", f.Fd())

--- a/cmd/tether/tether_test.go
+++ b/cmd/tether/tether_test.go
@@ -350,7 +350,7 @@ func runTether(t *testing.T, cfg *metadata.ExecutorConfig) (extraconfig.DataSour
 }
 
 // create client on the mock pipe
-func mockSerialConnection(ctx context.Context) (net.Conn, error) {
+func mockBackChannel(ctx context.Context) (net.Conn, error) {
 	log.Info("opening ttyS0 pipe pair for backchannel")
 	c, err := os.OpenFile(pathPrefix+"/ttyS0c", os.O_RDONLY|syscall.O_NOCTTY, 0777)
 	if err != nil {

--- a/cmd/tether/tether_test.go
+++ b/cmd/tether/tether_test.go
@@ -17,11 +17,13 @@ package main
 import (
 	"errors"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net"
 	"os"
 	"path"
 	"runtime"
+	"sync"
 	"syscall"
 	"testing"
 	"time"
@@ -156,7 +158,7 @@ func (t *mocker) backchannel(ctx context.Context) (net.Conn, error) {
 	}
 
 	// still run handshake over it to test that
-	ticker := time.NewTicker(1000 * time.Millisecond)
+	ticker := time.NewTicker(10 * time.Millisecond)
 	for {
 		select {
 		case <-ticker.C:
@@ -405,4 +407,47 @@ func OptionValueArrayToString(options []types.BaseOptionValue) string {
 	}
 
 	return fmt.Sprintf("%#v", kv)
+}
+
+// create client on the mock pipe and dial the given host:port
+func mockNetworkToSerialConnection(host string) (*sync.WaitGroup, error) {
+	log.Info("opening ttyS0 pipe pair for backchannel")
+	c, err := os.OpenFile(pathPrefix+"/ttyS0c", os.O_RDONLY|syscall.O_NOCTTY, 0777)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open cpipe for backchannel: %s", err)
+	}
+
+	fmt.Println("Here")
+	s, err := os.OpenFile(pathPrefix+"/ttyS0s", os.O_WRONLY|syscall.O_NOCTTY, 0777)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open spipe for backchannel: %s", err)
+	}
+
+	log.Infof("creating raw connection from ttyS0 pipe pair (c=%d, s=%d)\n", c.Fd(), s.Fd())
+	fconn, err := serial.NewHalfDuplixFileConn(c, s, pathPrefix+"/ttyS0", "file")
+	if err != nil {
+		return nil, fmt.Errorf("failed to create raw connection from ttyS0 pipe pair: %s", err)
+	}
+
+	// Dial the attach server.  This is a TCP client
+	networkClientCon, err := net.Dial("tcp", host)
+	if err != nil {
+		return nil, err
+	}
+	log.Debugf("dialed %s", host)
+
+	wg := sync.WaitGroup{}
+	wg.Add(2)
+
+	go func() {
+		io.Copy(networkClientCon, fconn)
+		wg.Done()
+	}()
+
+	go func() {
+		io.Copy(fconn, networkClientCon)
+		wg.Done()
+	}()
+
+	return &wg, nil
 }

--- a/pkg/serial/handshake.go
+++ b/pkg/serial/handshake.go
@@ -40,7 +40,6 @@ func PurgeIncoming(conn net.Conn) {
 	buf := make([]byte, 255)
 
 	// read until the incoming channel is empty
-	log.Debug("purging incoming channel")
 	conn.SetReadDeadline(time.Now().Add(time.Duration(10 * time.Millisecond)))
 	for n, err := conn.Read(buf); n != 0 || err == nil; n, err = conn.Read(buf) {
 		log.Debugf("discarding following %d bytes from input channel\n", n)
@@ -72,9 +71,8 @@ func HandshakeClient(ctx context.Context, conn net.Conn) error {
 
 	rand.Read(syn[1:])
 
-	log.Debug("client: writing syn")
 	conn.Write(syn)
-	log.Debug("client: reading synack")
+
 	if n, err := io.ReadFull(conn, buf[:3]); n != 3 || err != nil {
 
 		if n == 0 && err != nil {

--- a/pkg/serial/rawconn.go
+++ b/pkg/serial/rawconn.go
@@ -23,7 +23,6 @@ import (
 	"time"
 
 	log "github.com/Sirupsen/logrus"
-	"github.com/docker/docker/pkg/term"
 )
 
 const verbose = false
@@ -59,19 +58,6 @@ func NewTypedConn(r NamedReadChannel, w NamedWriteChannel, net string) (*RawConn
 		remoteAddr: *NewRawAddr(net, w.Name()),
 		err:        make(chan error, 1),
 		closed:     false,
-	}
-
-	// set the provided FDs to raw if it's a termial
-	// 0 is the uninitialized value for Fd
-	fds := []uintptr{r.Fd(), w.Fd()}
-	for _, fd := range fds {
-		if fd != 0 && term.IsTerminal(fd) {
-			log.Debug("setting terminal into raw mode")
-			_, err := term.SetRawTerminal(fd)
-			if err != nil {
-				return nil, err
-			}
-		}
 	}
 
 	return conn, nil

--- a/portlayer/attach/connector.go
+++ b/portlayer/attach/connector.go
@@ -246,6 +246,7 @@ func (c *Connector) serve() {
 			continue
 		}
 
+		log.Info("Received incoming connection")
 		go c.processIncoming(conn)
 	}
 }

--- a/portlayer/attach/connector.go
+++ b/portlayer/attach/connector.go
@@ -137,22 +137,30 @@ func (c *Connector) Remove(id string) {
 
 // takes the base connection, determines the ID of the source and stashes it in the map
 func (c *Connector) processIncoming(conn net.Conn) {
+	var err error
+	defer func() {
+		if err != nil && conn != nil {
+			conn.Close()
+		}
+	}()
 
 	for {
 		if conn == nil {
 			log.Infof("connection closed")
 			return
 		}
-		defer conn.Close()
+
+		serial.PurgeIncoming(conn)
 
 		// TODO needs timeout handling.  This could take 30s.
 		ctx, cancel := context.WithTimeout(context.TODO(), 50*time.Millisecond)
-		if err := serial.HandshakeClient(ctx, conn); err == nil {
+		if err = serial.HandshakeClient(ctx, conn); err == nil {
 			log.Debugf("New connection")
 			cancel()
 			break
 		} else if err == io.EOF {
 			log.Debugf("caught EOF")
+			conn.Close()
 			return
 		}
 	}
@@ -167,21 +175,30 @@ func (c *Connector) processIncoming(conn net.Conn) {
 	}
 
 	log.Debugf("Initiating ssh handshake with new connection attempt")
-	ccon, newchan, request, err := ssh.NewClientConn(conn, "", config)
+	var (
+		ccon    ssh.Conn
+		newchan <-chan ssh.NewChannel
+		request <-chan *ssh.Request
+	)
+
+	ccon, newchan, request, err = ssh.NewClientConn(conn, "", config)
 	if err != nil {
 		log.Errorf("SSH connection could not be established: %s", errors.ErrorStack(err))
 		return
 	}
 
 	client := ssh.NewClient(ccon, newchan, request)
-	ids, err := SSHls(client)
+
+	var ids []string
+	ids, err = SSHls(client)
 	if err != nil {
 		log.Errorf("SSH connection could not be established: %s", errors.ErrorStack(err))
 		return
 	}
 
+	var si SessionInteraction
 	for _, id := range ids {
-		si, err := SSHAttach(client, id)
+		si, err = SSHAttach(client, id)
 		if err != nil {
 			log.Errorf("SSH connection could not be established (id=%s): %s", id, errors.ErrorStack(err))
 			return
@@ -199,7 +216,6 @@ func (c *Connector) processIncoming(conn net.Conn) {
 
 		c.cond.Broadcast()
 		c.mutex.Unlock()
-
 	}
 
 	return

--- a/portlayer/attach/connector.go
+++ b/portlayer/attach/connector.go
@@ -153,6 +153,11 @@ func (c *Connector) processIncoming(conn net.Conn) {
 		serial.PurgeIncoming(conn)
 
 		// TODO needs timeout handling.  This could take 30s.
+
+		// This needs to timeout with a *longer* wait than the ticker set on
+		// the tether side (in tether_linux.go) or alignment may not happen.
+		// The PL sends the first SYN in the handshake and if the tether is not
+		// waiting, the handshake may never succeed.
 		ctx, cancel := context.WithTimeout(context.TODO(), 50*time.Millisecond)
 		if err = serial.HandshakeClient(ctx, conn); err == nil {
 			log.Debugf("New connection")

--- a/portlayer/attach/server.go
+++ b/portlayer/attach/server.go
@@ -17,6 +17,9 @@ package attach
 import (
 	"fmt"
 	"net"
+	"time"
+
+	"golang.org/x/net/context"
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/vmware/vic/pkg/errors"
@@ -69,4 +72,12 @@ func (n *Server) Stop() error {
 	err := n.l.Close()
 	n.connServer.Stop()
 	return err
+}
+
+func (n *Server) Addr() string {
+	return n.l.Addr().String()
+}
+
+func (n *Server) Get(ctx context.Context, id string, timeout time.Duration) (*Connection, error) {
+	return n.connServer.Get(ctx, id, timeout)
 }

--- a/portlayer/attach/server_test.go
+++ b/portlayer/attach/server_test.go
@@ -42,6 +42,12 @@ func TestAttachStartStop(t *testing.T) {
 		assert.NoError(t, err)
 		assert.NotNil(t, c)
 
+		buf := make([]byte, 1)
+		c.Read(buf)
+		if !assert.Error(t, serial.HandshakeServer(context.Background(), c)) {
+			return
+		}
+
 		if !assert.NoError(t, serial.HandshakeServer(context.Background(), c)) {
 			return
 		}

--- a/portlayer/attach/server_test.go
+++ b/portlayer/attach/server_test.go
@@ -80,8 +80,8 @@ func TestAttachStartStop(t *testing.T) {
 
 func TestAttachSshSession(t *testing.T) {
 	log.SetLevel(log.InfoLevel)
-	s := NewAttachServer("", -1)
 
+	s := NewAttachServer("", -1)
 	assert.NoError(t, s.Start())
 	defer s.Stop()
 

--- a/vendor/golang.org/x/crypto/ssh/terminal/util.go
+++ b/vendor/golang.org/x/crypto/ssh/terminal/util.go
@@ -44,6 +44,7 @@ func MakeRaw(fd int) (*State, error) {
 	}
 
 	newState := oldState.termios
+	newState.Oflag &^= syscall.OPOST
 	newState.Iflag &^= syscall.ISTRIP | syscall.INLCR | syscall.ICRNL | syscall.IGNCR | syscall.IXON | syscall.IXOFF
 	newState.Lflag &^= syscall.ECHO | syscall.ICANON | syscall.ISIG
 	if _, _, err := syscall.Syscall6(syscall.SYS_IOCTL, uintptr(fd), ioctlWriteTermios, uintptr(unsafe.Pointer(&newState)), 0, 0, 0); err != 0 {


### PR DESCRIPTION
Retry failed connections faster than 1s per attempt.
Add test to mess with network alignment of bytes between serial attach
server and test client.
Add Purge function before handshake on the PL side to purge the line of
any (buffered) data.
Fix stacked connection close defers in session attach connector when
connection fails.