### PR TITLE
Actually fix port-layer-server ar issue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -253,7 +253,7 @@ $(portlayerapi-server): $(PORTLAYER_DEPS) $(SWAGGER)
 
 $(portlayerapi): $(call godeps,apiservers/portlayer/cmd/port-layer-server/*.go) $(portlayerapi-server) $(portlayerapi-client)
 	@echo building Portlayer API server...
-	@$(GO) build $(RACE) -o $@ ./$(dir $<)
+	@$(GO) build $(RACE) -o $@ ./apiservers/portlayer/cmd/port-layer-server
 
 $(iso-base): isos/base.sh isos/base/*.repo isos/base/isolinux/** isos/base/xorriso-options.cfg
 	@echo building iso-base docker image


### PR DESCRIPTION
Why this worked locally I cannot say, but when the package directory is completely deleted the $(dir $<) construction fails as a target of go build. This hard codes the target go package for the bin/port-layer-server target in the same fashion as for docker-engine-api

Fixes: #352

