### PR TITLE
Fix for #649

### DIFF
--- a/cmd/vic-machine/install.go
+++ b/cmd/vic-machine/install.go
@@ -178,8 +178,8 @@ func processParams() {
 	data.conf.ResourcePoolPath = data.computeResourcePath
 	data.conf.ImageDatastoreName = data.imageDatastoreName
 	data.conf.ImageStorePath = fmt.Sprintf("/%s/datastore/%s", data.conf.DatacenterName, data.imageDatastoreName)
-	data.conf.ExtenalNetworkPath = fmt.Sprintf("/%s/network/%s", data.conf.DatacenterName, data.externalNetworkName)
-	data.conf.ExtenalNetworkName = data.externalNetworkName
+	data.conf.ExternalNetworkPath = fmt.Sprintf("/%s/network/%s", data.conf.DatacenterName, data.externalNetworkName)
+	data.conf.ExternalNetworkName = data.externalNetworkName
 	data.conf.BridgeNetworkPath = fmt.Sprintf("/%s/network/%s", data.conf.DatacenterName, data.bridgeNetworkName)
 	data.conf.BridgeNetworkName = data.bridgeNetworkName
 	if data.managementNetworkName != "" {

--- a/install/configuration/config.go
+++ b/install/configuration/config.go
@@ -40,8 +40,8 @@ type Configuration struct {
 	ImageStorePath        string
 	ImageDatastoreName    string
 	ResourcePoolPath      string
-	ExtenalNetworkPath    string
-	ExtenalNetworkName    string
+	ExternalNetworkPath   string
+	ExternalNetworkName   string
 	ManagementNetworkPath string
 	ManagementNetworkName string
 	BridgeNetworkName     string
@@ -103,7 +103,7 @@ func (conf *Configuration) ValidateConfiguration() error {
 		return err
 	}
 
-	if _, err = conf.Session.Finder.NetworkOrDefault(conf.Context, conf.ExtenalNetworkPath); err != nil {
+	if _, err = conf.Session.Finder.NetworkOrDefault(conf.Context, conf.ExternalNetworkPath); err != nil {
 		log.Errorf("Unable to get network: %s", err)
 		return err
 	}

--- a/install/management/appliance.go
+++ b/install/management/appliance.go
@@ -107,13 +107,13 @@ func (d *Dispatcher) getNetworkDevices(conf *configuration.Configuration) ([]typ
 	d.nics[conf.BridgeNetworkName] = "bridge"
 
 	// client network
-	network, err = d.session.Finder.NetworkOrDefault(d.ctx, conf.ExtenalNetworkPath)
+	network, err = d.session.Finder.NetworkOrDefault(d.ctx, conf.ExternalNetworkPath)
 	if err != nil {
 		err = errors.Errorf("Failed to get external network: %s", err)
 		return nil, err
 	}
 	d.networks["client"] = network
-	d.nics[conf.ExtenalNetworkName] = "client"
+	d.nics[conf.ExternalNetworkName] = "client"
 
 	// management network
 	if conf.ManagementNetworkName != "" {

--- a/install/management/appliance.go
+++ b/install/management/appliance.go
@@ -170,9 +170,9 @@ func (d *Dispatcher) createApplianceSpec(conf *configuration.Configuration) (*ty
 			&types.OptionValue{Key: "guestinfo.vch/components", Value: "/sbin/docker-engine-server /sbin/port-layer-server /sbin/vicadmin"},
 			&types.OptionValue{Key: "guestinfo.vch/sbin/imagec", Value: "-debug -logfile=/var/log/vic/imagec.log -insecure"},
 			&types.OptionValue{Key: "guestinfo.vch/sbin/port-layer-server",
-				Value: fmt.Sprintf("--host=localhost --port=8080 --insecure --sdk=%s --datacenter=%s --cluster=%s --pool=%s/%s --datastore=%s --network=%s --vch=%s",
-					conf.TargetPath, conf.DatacenterName, conf.ClusterPath, conf.ResourcePoolPath, conf.DisplayName,
-					conf.ImageStorePath, conf.ExtenalNetworkPath, conf.DisplayName)},
+				Value: fmt.Sprintf("--host=localhost --port=8080 --insecure --sdk=%s --datacenter=%s --cluster=%s --pool=%s --datastore=%s --network=%s --vch=%s",
+					conf.TargetPath, conf.DatacenterName, conf.ClusterPath, d.vchPoolPath,
+					conf.ImageStorePath, conf.ExternalNetworkPath, conf.DisplayName)},
 		},
 		DeviceChange: []types.BaseVirtualDeviceConfigSpec{
 			&types.VirtualDeviceConfigSpec{


### PR DESCRIPTION
Fixes #649 
Also renames two typo'd variables, ExternalNetworkName and ExternalNetworkPath from ExtenalNetwork(Path/Name) respectively. Did this in a separate commit for clarity in code review.

Integration test run results: http://smithers.eng.vmware.com:8080/job/ian_tests_his_fork/3/console
(also tested manually)