### PR TITLE
Rename storage package for vsphere impl to vsphere

### DIFF
--- a/apiservers/portlayer/restapi/handlers/storage_handlers.go
+++ b/apiservers/portlayer/restapi/handlers/storage_handlers.go
@@ -31,7 +31,7 @@ import (
 
 	"github.com/vmware/vic/portlayer/network"
 	spl "github.com/vmware/vic/portlayer/storage"
-	vsphere "github.com/vmware/vic/portlayer/storage/vsphere"
+	"github.com/vmware/vic/portlayer/storage/vsphere"
 	"github.com/vmware/vic/portlayer/util"
 )
 

--- a/portlayer/storage/vsphere/parent.go
+++ b/portlayer/storage/vsphere/parent.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package storage
+package vsphere
 
 import (
 	"bytes"

--- a/portlayer/storage/vsphere/parent_test.go
+++ b/portlayer/storage/vsphere/parent_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package storage
+package vsphere
 
 import (
 	"fmt"

--- a/portlayer/storage/vsphere/store.go
+++ b/portlayer/storage/vsphere/store.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package storage
+package vsphere
 
 import (
 	"bytes"

--- a/portlayer/storage/vsphere/store_test.go
+++ b/portlayer/storage/vsphere/store_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package storage
+package vsphere
 
 import (
 	"archive/tar"


### PR DESCRIPTION
Renamed the directory in an earlier change without renaming the package.
Fixed for parity;  directory and package now have the same name
(vsphere).