### PR TITLE
Support resizing of pty windows

### DIFF
--- a/cmd/tether/attach_test.go
+++ b/cmd/tether/attach_test.go
@@ -529,7 +529,7 @@ func TestMockAttachTetherToPL(t *testing.T) {
 					ID:   "attach",
 					Name: "tether_test_session",
 				},
-				Tty:    false,
+				Tty:    true,
 				Attach: true,
 				Cmd: metadata.Cmd{
 					Path: "/usr/bin/tee",
@@ -551,8 +551,22 @@ func TestMockAttachTetherToPL(t *testing.T) {
 		return
 	}
 
-	_, err = testServer.Get(context.Background(), "attach", 600*time.Second)
+	var pty attach.SessionInteraction
+	pty, err = testServer.Get(context.Background(), "attach", 600*time.Second)
 	if !assert.NoError(t, err) {
+		return
+	}
+
+	err = pty.Resize(1, 2, 3, 4)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	if !assert.Equal(t, mocked.windowCol, uint32(1)) {
+		return
+	}
+
+	if !assert.Equal(t, mocked.windowRow, uint32(2)) {
 		return
 	}
 }

--- a/cmd/tether/tether_darwin.go
+++ b/cmd/tether/tether_darwin.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 
 	"github.com/vmware/vic/pkg/dio"
+	"github.com/vmware/vic/portlayer/attach"
 
 	"golang.org/x/crypto/ssh"
 	"golang.org/x/net/context"
@@ -74,7 +75,7 @@ func (t *osopsOSX) establishPty(session *SessionConfig) error {
 	return errors.New("unimplemented on OSX")
 }
 
-func (t *osopsOSX) resizePty(pty uintptr, winSize *WindowChangeMsg) error {
+func (t *osopsOSX) resizePty(pty uintptr, winSize *attach.WindowChangeMsg) error {
 	return errors.New("unimplemented on OSX")
 }
 

--- a/cmd/tether/tether_linux.go
+++ b/cmd/tether/tether_linux.go
@@ -38,6 +38,7 @@ import (
 	"github.com/vmware/vic/pkg/dio"
 	"github.com/vmware/vic/pkg/serial"
 	"github.com/vmware/vic/pkg/trace"
+	"github.com/vmware/vic/portlayer/attach"
 )
 
 // allow us to pick up some of the osops implementations when mocking
@@ -276,7 +277,7 @@ type winsize struct {
 	wsYpixel uint16
 }
 
-func (t *osopsLinux) resizePty(pty uintptr, winSize *WindowChangeMsg) error {
+func (t *osopsLinux) resizePty(pty uintptr, winSize *attach.WindowChangeMsg) error {
 	defer trace.End(trace.Begin("resize pty"))
 
 	ws := &winsize{uint16(winSize.Rows), uint16(winSize.Columns), uint16(winSize.WidthPx), uint16(winSize.HeightPx)}

--- a/cmd/tether/tether_windows.go
+++ b/cmd/tether/tether_windows.go
@@ -32,6 +32,7 @@ import (
 	winserial "github.com/tarm/serial"
 	"github.com/vmware/vic/pkg/dio"
 	"github.com/vmware/vic/pkg/serial"
+	"github.com/vmware/vic/portlayer/attach"
 )
 
 // allow us to pick up some of the osops implementations when mocking
@@ -219,6 +220,6 @@ func (t *osopsWin) establishPty(session *SessionConfig) error {
 	return errors.New("unimplemented on windows")
 }
 
-func (t *osopsWin) resizePty(pty uintptr, winSize *WindowChangeMsg) error {
+func (t *osopsWin) resizePty(pty uintptr, winSize *attach.WindowChangeMsg) error {
 	return errors.New("unimplemented on windows")
 }

--- a/cmd/tether/utils.go
+++ b/cmd/tether/utils.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/vmware/vic/metadata"
 	"github.com/vmware/vic/pkg/dio"
+	"github.com/vmware/vic/portlayer/attach"
 	"golang.org/x/crypto/ssh"
 	"golang.org/x/net/context"
 )
@@ -41,7 +42,7 @@ type utilities interface {
 	sessionLogWriter() (dio.DynamicMultiWriter, error)
 	processEnvOS(env []string) []string
 	establishPty(session *SessionConfig) error
-	resizePty(pty uintptr, winSize *WindowChangeMsg) error
+	resizePty(pty uintptr, winSize *attach.WindowChangeMsg) error
 	signalProcess(process *os.Process, sig ssh.Signal) error
 	backchannel(ctx context.Context) (net.Conn, error)
 }

--- a/portlayer/attach/client.go
+++ b/portlayer/attach/client.go
@@ -37,6 +37,9 @@ type SessionInteraction interface {
 	// Stdin stream
 	Stdin() io.WriteCloser
 	Close() error
+
+	// Resize the terminal
+	Resize(cols, rows, widthpx, heightpx uint32) error
 }
 
 type attachSSH struct {
@@ -111,4 +114,20 @@ func (t *attachSSH) Stdin() io.WriteCloser {
 
 func (t *attachSSH) Close() error {
 	return t.channel.Close()
+}
+
+// Resize resizes the terminal.
+func (t *attachSSH) Resize(cols, rows, widthpx, heightpx uint32) error {
+
+	msg := ssh.Marshal(WindowChangeMsg{cols, rows, widthpx, heightpx})
+	ok, err := t.channel.SendRequest(WindowChangeReq, true, msg)
+	if err == nil && !ok {
+		return fmt.Errorf("unknown error")
+	}
+
+	if err != nil {
+		return fmt.Errorf("resize error: %s", err)
+	}
+
+	return nil
 }

--- a/portlayer/attach/messages.go
+++ b/portlayer/attach/messages.go
@@ -1,0 +1,30 @@
+// Copyright 2016 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package attach
+
+// All of the messages passed over the ssh channel/global mux are (or will be)
+// defined here.
+
+const (
+	WindowChangeReq = "window-change"
+)
+
+// WindowChangeMsg the RFC4254 struct
+type WindowChangeMsg struct {
+	Columns  uint32
+	Rows     uint32
+	WidthPx  uint32
+	HeightPx uint32
+}

--- a/portlayer/attach/server.go
+++ b/portlayer/attach/server.go
@@ -78,6 +78,6 @@ func (n *Server) Addr() string {
 	return n.l.Addr().String()
 }
 
-func (n *Server) Get(ctx context.Context, id string, timeout time.Duration) (*Connection, error) {
+func (n *Server) Get(ctx context.Context, id string, timeout time.Duration) (SessionInteraction, error) {
 	return n.connServer.Get(ctx, id, timeout)
 }


### PR DESCRIPTION
Exports the SystemInteraction interface.  Was previously exporting Connection which had all of its members private.  

Also removed some `payload` reply cruft which isn't/can't be used on an ssh channel.  

Moved the resize message to the `attach` package.
