### PR TITLE
Add signal to attach server and cleanup ssh messages to come out of attach package

### DIFF
--- a/cmd/tether/attach.go
+++ b/cmd/tether/attach.go
@@ -314,7 +314,7 @@ func (t *attachServerSSH) channelMux(in <-chan *ssh.Request, process *os.Process
 			if pty == nil {
 				ok = false
 				log.Errorf("illegal window-change request for non-tty")
-			} else if err = ssh.Unmarshal(req.Payload, &msg); err != nil {
+			} else if err = msg.Unmarshal(req.Payload); err != nil {
 				ok = false
 				log.Errorf(err.Error())
 			} else if err = utils.resizePty(pty.Fd(), &msg); err != nil {

--- a/cmd/tether/attach.go
+++ b/cmd/tether/attach.go
@@ -32,24 +32,6 @@ const (
 	attachChannelType = "attach"
 )
 
-var (
-	Signals = map[ssh.Signal]int{
-		ssh.SIGABRT: 6,
-		ssh.SIGALRM: 14,
-		ssh.SIGFPE:  8,
-		ssh.SIGHUP:  1,
-		ssh.SIGILL:  4,
-		ssh.SIGINT:  2,
-		ssh.SIGKILL: 9,
-		ssh.SIGPIPE: 13,
-		ssh.SIGQUIT: 3,
-		ssh.SIGSEGV: 11,
-		ssh.SIGTERM: 15,
-		ssh.SIGUSR1: 10,
-		ssh.SIGUSR2: 12,
-	}
-)
-
 type stringMsg struct {
 	Signal string
 }
@@ -321,14 +303,14 @@ func (t *attachServerSSH) channelMux(in <-chan *ssh.Request, process *os.Process
 				ok = false
 				log.Errorf(err.Error())
 			}
-		case "signal":
-			msg := stringMsg{}
-			if err = ssh.Unmarshal(req.Payload, &msg); err != nil {
+		case attach.SignalReq:
+			msg := attach.SignalMsg{}
+			if err = msg.Unmarshal(req.Payload); err != nil {
 				ok = false
 				log.Errorf(err.Error())
 			} else {
 				log.Infof("Sending signal %s to container process, pid=%d\n", string(msg.Signal), process.Pid)
-				err = utils.signalProcess(process, ssh.Signal(msg.Signal))
+				err = utils.signalProcess(process, msg.Signal)
 				if err != nil {
 					log.Errorf("Failed to dispatch signal to process: %s\n", err)
 				}

--- a/cmd/tether/attach.go
+++ b/cmd/tether/attach.go
@@ -32,14 +32,6 @@ const (
 	attachChannelType = "attach"
 )
 
-type stringMsg struct {
-	Signal string
-}
-
-type stringArrayMsg struct {
-	Strings []string
-}
-
 // server is the singleton attachServer for the tether - there can be only one
 // as the backchannel line protocol may not provide multiplexing of connections
 var server attachServer
@@ -251,16 +243,16 @@ func (t *attachServerSSH) globalMux(reqchan <-chan *ssh.Request) {
 		log.Infof("received global request type %v", req.Type)
 
 		switch req.Type {
-		case "container-ids":
+		case attach.ContainersReq:
 			keys := make([]string, len(config.Sessions))
 			i := 0
 			for k := range config.Sessions {
 				keys[i] = k
 				i++
 			}
-			msg := stringArrayMsg{Strings: keys}
+			msg := attach.ContainersMsg{IDs: keys}
+			payload = msg.Marshal()
 
-			payload = []byte(ssh.Marshal(msg))
 		default:
 			ok = false
 			payload = []byte("unknown global request type: " + req.Type)

--- a/cmd/tether/attach_test.go
+++ b/cmd/tether/attach_test.go
@@ -561,12 +561,14 @@ func TestMockAttachTetherToPL(t *testing.T) {
 	if !assert.NoError(t, err) {
 		return
 	}
-
-	if !assert.Equal(t, mocked.windowCol, uint32(1)) {
+	if !assert.Equal(t, mocked.windowCol, uint32(1)) || !assert.Equal(t, mocked.windowRow, uint32(2)) {
 		return
 	}
 
-	if !assert.Equal(t, mocked.windowRow, uint32(2)) {
+	if err = pty.Signal("HUP"); !assert.NoError(t, err) {
+		return
+	}
+	if !assert.Equal(t, mocked.signal, ssh.Signal("HUP")) {
 		return
 	}
 }

--- a/cmd/tether/tether_linux.go
+++ b/cmd/tether/tether_linux.go
@@ -294,7 +294,7 @@ func (t *osopsLinux) resizePty(pty uintptr, winSize *attach.WindowChangeMsg) err
 }
 
 func (t *osopsLinux) signalProcess(process *os.Process, sig ssh.Signal) error {
-	signal := Signals[sig]
+	signal := attach.Signals[sig]
 	defer trace.End(trace.Begin(fmt.Sprintf("signal process %d: %d", process.Pid, signal)))
 
 	s := syscall.Signal(signal)

--- a/cmd/tether/tether_test.go
+++ b/cmd/tether/tether_test.go
@@ -68,6 +68,7 @@ type mocker struct {
 
 	windowCol uint32
 	windowRow uint32
+	signal    ssh.Signal
 }
 
 func (t *mocker) setup() error {
@@ -100,6 +101,7 @@ func (t *mocker) resizePty(pty uintptr, winSize *attach.WindowChangeMsg) error {
 }
 
 func (t *mocker) signalProcess(process *os.Process, sig ssh.Signal) error {
+	t.signal = sig
 	return t.utils.signalProcess(process, sig)
 }
 

--- a/portlayer/attach/client.go
+++ b/portlayer/attach/client.go
@@ -119,8 +119,8 @@ func (t *attachSSH) Close() error {
 // Resize resizes the terminal.
 func (t *attachSSH) Resize(cols, rows, widthpx, heightpx uint32) error {
 
-	msg := ssh.Marshal(WindowChangeMsg{cols, rows, widthpx, heightpx})
-	ok, err := t.channel.SendRequest(WindowChangeReq, true, msg)
+	msg := WindowChangeMsg{cols, rows, widthpx, heightpx}
+	ok, err := t.channel.SendRequest(WindowChangeReq, true, msg.Marshal())
 	if err == nil && !ok {
 		return fmt.Errorf("unknown error")
 	}

--- a/portlayer/attach/client.go
+++ b/portlayer/attach/client.go
@@ -15,7 +15,6 @@
 package attach
 
 import (
-	"errors"
 	"fmt"
 	"io"
 
@@ -52,19 +51,14 @@ type attachSSH struct {
 func SSHls(client *ssh.Client) ([]string, error) {
 	ok, reply, err := client.SendRequest(ContainersReq, true, nil)
 	if !ok || err != nil {
-		detail := fmt.Sprintf("failed to get container IDs from remote: %s", err)
-		log.Error(detail)
-		return nil, errors.New(detail)
+		return nil, fmt.Errorf("failed to get container IDs from remote: %s", err)
 	}
 
 	ids := ContainersMsg{}
 
-	err = ids.Unmarshal(reply)
-	if err != nil {
-		detail := fmt.Sprintf("failed to unmarshall ids from remote: %s", err)
-		log.Error(detail)
+	if err = ids.Unmarshal(reply); err != nil {
 		log.Debugf("raw IDs response: %+v", reply)
-		return nil, err
+		return nil, fmt.Errorf("failed to unmarshal ids from remote: %s", err)
 	}
 
 	return ids.IDs, nil

--- a/portlayer/attach/client.go
+++ b/portlayer/attach/client.go
@@ -118,7 +118,6 @@ func (t *attachSSH) Close() error {
 
 // Resize resizes the terminal.
 func (t *attachSSH) Resize(cols, rows, widthpx, heightpx uint32) error {
-
 	msg := WindowChangeMsg{cols, rows, widthpx, heightpx}
 	ok, err := t.channel.SendRequest(WindowChangeReq, true, msg.Marshal())
 	if err == nil && !ok {

--- a/portlayer/attach/client.go
+++ b/portlayer/attach/client.go
@@ -50,18 +50,16 @@ type attachSSH struct {
 }
 
 func SSHls(client *ssh.Client) ([]string, error) {
-	ok, reply, err := client.SendRequest(requestContainerIDs, true, nil)
+	ok, reply, err := client.SendRequest(ContainersReq, true, nil)
 	if !ok || err != nil {
 		detail := fmt.Sprintf("failed to get container IDs from remote: %s", err)
 		log.Error(detail)
 		return nil, errors.New(detail)
 	}
 
-	ids := struct {
-		Strings []string
-	}{}
+	ids := ContainersMsg{}
 
-	err = ssh.Unmarshal(reply, &ids)
+	err = ids.Unmarshal(reply)
 	if err != nil {
 		detail := fmt.Sprintf("failed to unmarshall ids from remote: %s", err)
 		log.Error(detail)
@@ -69,7 +67,7 @@ func SSHls(client *ssh.Client) ([]string, error) {
 		return nil, err
 	}
 
-	return ids.Strings, nil
+	return ids.IDs, nil
 }
 
 // SSHAttach returns a stream connection to the requested session

--- a/portlayer/attach/client.go
+++ b/portlayer/attach/client.go
@@ -95,7 +95,17 @@ func SSHAttach(client *ssh.Client, id string) (SessionInteraction, error) {
 }
 
 func (t *attachSSH) Signal(signal ssh.Signal) error {
-	return errors.New("signal is unimplemented")
+	msg := SignalMsg{signal}
+	ok, err := t.channel.SendRequest(SignalReq, true, msg.Marshal())
+	if err == nil && !ok {
+		return fmt.Errorf("unknown error")
+	}
+
+	if err != nil {
+		return fmt.Errorf("signal error: %s", err)
+	}
+
+	return nil
 }
 
 func (t *attachSSH) Stdout() io.Reader {

--- a/portlayer/attach/connector.go
+++ b/portlayer/attach/connector.go
@@ -29,12 +29,6 @@ import (
 	"golang.org/x/net/context"
 )
 
-// XXX This should be a shared data struct
-// The supported requests on the tether ssh server
-const (
-	requestContainerIDs = "container-ids"
-)
-
 // Connection represents a communication channel initiated by the client TO the
 // client.  The client connects (via TCP) to the server, then the server
 // initiates an SSH connection over the same sock to the client.

--- a/portlayer/attach/messages.go
+++ b/portlayer/attach/messages.go
@@ -51,3 +51,44 @@ func (wc *WindowChangeMsg) Marshal() []byte {
 func (wc *WindowChangeMsg) Unmarshal(payload []byte) error {
 	return ssh.Unmarshal(payload, wc)
 }
+
+var (
+	Signals = map[ssh.Signal]int{
+		ssh.SIGABRT: 6,
+		ssh.SIGALRM: 14,
+		ssh.SIGFPE:  8,
+		ssh.SIGHUP:  1,
+		ssh.SIGILL:  4,
+		ssh.SIGINT:  2,
+		ssh.SIGKILL: 9,
+		ssh.SIGPIPE: 13,
+		ssh.SIGQUIT: 3,
+		ssh.SIGSEGV: 11,
+		ssh.SIGTERM: 15,
+		ssh.SIGUSR1: 10,
+		ssh.SIGUSR2: 12,
+	}
+)
+
+// SignalMsg
+const SignalReq = "signal"
+
+type SignalMsg struct {
+	Signal ssh.Signal
+}
+
+func (s *SignalMsg) RequestType() string {
+	return SignalReq
+}
+
+func (s *SignalMsg) Marshal() []byte {
+	return ssh.Marshal(*s)
+}
+
+func (s *SignalMsg) Unmarshal(payload []byte) error {
+	return ssh.Unmarshal(payload, s)
+}
+
+func (s *SignalMsg) Signum() int {
+	return Signals[s.Signal]
+}

--- a/portlayer/attach/messages.go
+++ b/portlayer/attach/messages.go
@@ -14,17 +14,40 @@
 
 package attach
 
+import "golang.org/x/crypto/ssh"
+
 // All of the messages passed over the ssh channel/global mux are (or will be)
 // defined here.
 
-const (
-	WindowChangeReq = "window-change"
-)
+type Message interface {
+	// Returns the message name
+	RequestType() string
+
+	// Marshalled version of the message
+	Marshal() []byte
+
+	// Unmarshal unpacks the message
+	Unmarshal([]byte) error
+}
 
 // WindowChangeMsg the RFC4254 struct
+const WindowChangeReq = "window-change"
+
 type WindowChangeMsg struct {
 	Columns  uint32
 	Rows     uint32
 	WidthPx  uint32
 	HeightPx uint32
+}
+
+func (wc *WindowChangeMsg) RequestType() string {
+	return WindowChangeReq
+}
+
+func (wc *WindowChangeMsg) Marshal() []byte {
+	return ssh.Marshal(*wc)
+}
+
+func (wc *WindowChangeMsg) Unmarshal(payload []byte) error {
+	return ssh.Unmarshal(payload, wc)
 }

--- a/portlayer/attach/messages.go
+++ b/portlayer/attach/messages.go
@@ -92,3 +92,22 @@ func (s *SignalMsg) Unmarshal(payload []byte) error {
 func (s *SignalMsg) Signum() int {
 	return Signals[s.Signal]
 }
+
+// ContainersMsg
+const ContainersReq = "container-ids"
+
+type ContainersMsg struct {
+	IDs []string
+}
+
+func (s *ContainersMsg) RequestType() string {
+	return ContainersReq
+}
+
+func (s *ContainersMsg) Marshal() []byte {
+	return ssh.Marshal(*s)
+}
+
+func (s *ContainersMsg) Unmarshal(payload []byte) error {
+	return ssh.Unmarshal(payload, s)
+}

--- a/portlayer/attach/messages_test.go
+++ b/portlayer/attach/messages_test.go
@@ -1,0 +1,45 @@
+// Copyright 2016 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package attach
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWindowChange(t *testing.T) {
+	s := &WindowChangeMsg{1, 2, 3, 4}
+
+	assert.Equal(t, s.RequestType(), WindowChangeReq)
+
+	tmp := s.Marshal()
+	out := &WindowChangeMsg{}
+	out.Unmarshal(tmp)
+
+	assert.Equal(t, s, out)
+}
+
+func TestSignal(t *testing.T) {
+	s := &SignalMsg{"HUP"}
+
+	assert.Equal(t, s.RequestType(), SignalReq)
+
+	tmp := s.Marshal()
+	out := &SignalMsg{}
+	out.Unmarshal(tmp)
+
+	assert.Equal(t, s, out)
+}

--- a/portlayer/attach/messages_test.go
+++ b/portlayer/attach/messages_test.go
@@ -43,3 +43,15 @@ func TestSignal(t *testing.T) {
 
 	assert.Equal(t, s, out)
 }
+
+func TestContainers(t *testing.T) {
+	s := &ContainersMsg{IDs: []string{"foo", "bar", "baz"}}
+
+	assert.Equal(t, s.RequestType(), ContainersReq)
+
+	tmp := s.Marshal()
+	out := &ContainersMsg{}
+	out.Unmarshal(tmp)
+
+	assert.Equal(t, s, out)
+}

--- a/portlayer/attach/server_test.go
+++ b/portlayer/attach/server_test.go
@@ -130,10 +130,9 @@ func TestAttachSshSession(t *testing.T) {
 		wg.Add(1)
 		defer wg.Done()
 		for req := range reqs {
-			if req.Type == requestContainerIDs {
-				req.Reply(true, ssh.Marshal(struct {
-					Strings []string
-				}{[]string{expectedID}}))
+			if req.Type == ContainersReq {
+				msg := ContainersMsg{IDs: []string{expectedID}}
+				req.Reply(true, msg.Marshal())
 				break
 			}
 		}


### PR DESCRIPTION
The majority of this code is cleanup.  We had messages defined in (the main package) of tether but were being used in both tether and PL.  
