### PR TITLE
Make go-deps silent by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ endif
 
 # utility function to dynamically generate go dependencies
 define godeps
-	$(wildcard $1) $(shell $(BASE_DIR)/scripts/go-deps.sh $(dir $1))
+	$(wildcard $1) $(shell $(BASE_DIR)/scripts/go-deps.sh $(dir $1) $(MAKEFLAGS))
 endef
 
 # target aliases - environment variable definition

--- a/scripts/go-deps.sh
+++ b/scripts/go-deps.sh
@@ -21,11 +21,20 @@
 #     pkg       This is github.com/vmware/vic/cmd/imagec for example
 #
 
-PKG=$1
+pkg=$1
+flags=$2
 
-if [ -d $PKG ]; then
-    echo "Generating deps for $PKG" >&2
-    go list -f '{{join .Deps "\n"}}' github.com/vmware/vic/$PKG 2>/dev/null |  xargs go list -f '{{if not .Standard}}{{.ImportPath}}{{end}}' 2>/dev/null | sed -e 's:github.com/vmware/vic/\(.*\)$:\1/*:'
+if [ -d "$pkg" ]; then
+    if [[ "$flags" == *d* ]]
+    then
+        # Only output if make is given the '-d' flag
+        echo "Generating deps for $pkg" >&2
+    fi
+
+    go list -f '{{join .Deps "\n"}}' github.com/vmware/vic/"$pkg" 2>/dev/null | \
+        xargs go list -f '{{if not .Standard}}{{.ImportPath}}{{end}}' 2>/dev/null | \
+        sed -e 's:github.com/vmware/vic/\(.*\)$:\1/*:'
 else
-    echo "Skipping generation of deps for non-existant package $PKG" >&2
+    echo "$0: package '$pkg' does not exist" >&2
+    exit 1
 fi


### PR DESCRIPTION
These messages were included in 'gopath' target output, breaking GOPATH
when set via go-projectile.

- go-deps.sh is now silent unless make is given the '-d' flag (or error)

- script is now shellcheck clean