### PR TITLE
Startblock

### DIFF
--- a/cmd/tether/cmd_test.go
+++ b/cmd/tether/cmd_test.go
@@ -224,19 +224,9 @@ func TestMissingBinary(t *testing.T) {
 	extraconfig.Decode(src, &cfg)
 
 	// check the launch status was failed
-	// status := cfg.Sessions["abspath"].ExitStatus
-	// if err == nil {
-	// 	t.Error("Expected error from missing binary")
-	// }
+	status := cfg.Sessions["missing"].Started
 
-	// read the output from the session
-	log, err := ioutil.ReadFile(pathPrefix + "/ttyS2")
-	if err != nil {
-		fmt.Printf("Failed to open log file for command: %s", err)
-	}
-	if len(log) > 0 {
-		fmt.Printf("Command output: %s", string(log))
-	}
+	assert.Equal(t, "fork/exec /not/there: no such file or directory", status, "Expected status to have a command not found error message")
 }
 
 //

--- a/cmd/tether/tether.go
+++ b/cmd/tether/tether.go
@@ -195,7 +195,7 @@ func handleSessionExit(session *SessionConfig) error {
 	// record exit status
 	// FIXME: we cannot have this embedded knowledge of the extraconfig encoding pattern, but not
 	// currently sure how to expose it neatly via a utility function
-	extraconfig.EncodeWithPrefix(dataSink, session.ExitStatus, fmt.Sprintf("sessions|%s/status", session.ID))
+	extraconfig.EncodeWithPrefix(dataSink, session.ExitStatus, fmt.Sprintf(".sessions|%s.status", session.ID))
 	log.Infof("%s exit code: %d", session.ID, session.ExitStatus)
 
 	// check for executor behaviour
@@ -250,11 +250,21 @@ func launch(session *SessionConfig) error {
 		if err != nil {
 			detail := fmt.Sprintf("failed to start container process: %s", err)
 			log.Error(detail)
+
+			// Set the Started key to the detailed error message
+			session.Started = detail
+			// save the modified value back to the vmx file
+			extraconfig.EncodeWithPrefix(dataSink, session.Started, fmt.Sprintf(".sessions|%s.started", session.ID))
+
 			return errors.New(detail)
 		}
 
 		// ChildReaper will use this channel to inform us the wait status of the child.
 		config.pids[session.Cmd.Process.Pid] = session
+		// Set the Started key to "true"
+		session.Started = "true"
+		// save the modified value back to the vmx file
+		extraconfig.EncodeWithPrefix(dataSink, session.Started, fmt.Sprintf(".sessions|%s.started", session.ID))
 
 		log.Debugf("Launched command with pid %d", session.Cmd.Process.Pid)
 

--- a/cmd/tether/tether.go
+++ b/cmd/tether/tether.go
@@ -195,7 +195,7 @@ func handleSessionExit(session *SessionConfig) error {
 	// record exit status
 	// FIXME: we cannot have this embedded knowledge of the extraconfig encoding pattern, but not
 	// currently sure how to expose it neatly via a utility function
-	extraconfig.EncodeWithPrefix(dataSink, session.ExitStatus, fmt.Sprintf(".sessions|%s.status", session.ID))
+	extraconfig.EncodeWithPrefix(dataSink, session.ExitStatus, fmt.Sprintf("guestinfo..sessions|%s.status", session.ID))
 	log.Infof("%s exit code: %d", session.ID, session.ExitStatus)
 
 	// check for executor behaviour
@@ -252,9 +252,9 @@ func launch(session *SessionConfig) error {
 			log.Error(detail)
 
 			// Set the Started key to the detailed error message
-			session.Started = detail
+			session.Started = err.Error()
 			// save the modified value back to the vmx file
-			extraconfig.EncodeWithPrefix(dataSink, session.Started, fmt.Sprintf(".sessions|%s.started", session.ID))
+			extraconfig.EncodeWithPrefix(dataSink, session.Started, fmt.Sprintf("guestinfo..sessions|%s.started", session.ID))
 
 			return errors.New(detail)
 		}
@@ -264,7 +264,7 @@ func launch(session *SessionConfig) error {
 		// Set the Started key to "true"
 		session.Started = "true"
 		// save the modified value back to the vmx file
-		extraconfig.EncodeWithPrefix(dataSink, session.Started, fmt.Sprintf(".sessions|%s.started", session.ID))
+		extraconfig.EncodeWithPrefix(dataSink, session.Started, fmt.Sprintf("guestinfo..sessions|%s.started", session.ID))
 
 		log.Debugf("Launched command with pid %d", session.Cmd.Process.Pid)
 

--- a/pkg/vsphere/extraconfig/encode_linux.go
+++ b/pkg/vsphere/extraconfig/encode_linux.go
@@ -39,6 +39,7 @@ func GuestInfoSink() (DataSink, error) {
 
 		log.Debugf("GuestInfoSink: setting key: %s, value: %#v", key, value)
 		err := guestinfo.SetString(key, value)
+		log.Debugf("GuestInfoSink: error: %#v", err)
 		return err
 	}, nil
 }

--- a/pkg/vsphere/vm/vm.go
+++ b/pkg/vsphere/vm/vm.go
@@ -116,3 +116,18 @@ func (vm *VirtualMachine) FetchExtraConfig(ctx context.Context) (map[string]stri
 	}
 	return info, nil
 }
+
+// WaitForExtraConfig waits until key shows up with the expected value inside the ExtraConfig
+func (vm *VirtualMachine) WaitForExtraConfig(ctx context.Context, waitFunc func(pc []types.PropertyChange) bool) error {
+	// Get the default collector
+	p := property.DefaultCollector(vm.Vim25())
+
+	// Wait on config.extraConfig
+	// https://www.vmware.com/support/developer/vc-sdk/visdk2xpubs/ReferenceGuide/vim.vm.ConfigInfo.html
+	err := property.Wait(ctx, p, vm.Reference(), []string{"config.extraConfig"}, waitFunc)
+	if err != nil {
+		log.Errorf("Property collector error: %s", err)
+		return err
+	}
+	return nil
+}

--- a/portlayer/exec/container.go
+++ b/portlayer/exec/container.go
@@ -165,7 +165,11 @@ func (c *Container) Start(ctx context.Context) error {
 	ctx, cancel := context.WithTimeout(ctx, propertyCollectorTimeout)
 	defer cancel()
 
-	c.vm.WaitForExtraConfig(ctx, waitFunc)
+	err = c.vm.WaitForExtraConfig(ctx, waitFunc)
+	if err != nil {
+		return fmt.Errorf("unable to wait for process launch status: %s", err.Error())
+	}
+
 	if detail != "true" {
 		return errors.New(detail)
 	}


### PR DESCRIPTION
Blocks until the container process has been launched. This will either return:
* nil: no error - process launched successfully
* err: process failed to launch - err contains the error message from the tether.

Fixes #426