### PR TITLE
Path resolution for tether binaries

### DIFF
--- a/cmd/tether/cmd_test.go
+++ b/cmd/tether/cmd_test.go
@@ -71,8 +71,6 @@ func TestPathLookup(t *testing.T) {
 /////////////////////////////////////////////////////////////////////////////////////
 
 func TestRelativePath(t *testing.T) {
-	t.Skip("Relative path resolution not yet implemented")
-
 	testSetup(t)
 	defer testTeardown(t)
 
@@ -226,7 +224,7 @@ func TestMissingBinary(t *testing.T) {
 	// check the launch status was failed
 	status := cfg.Sessions["missing"].Started
 
-	assert.Equal(t, "fork/exec /not/there: no such file or directory", status, "Expected status to have a command not found error message")
+	assert.Equal(t, "/not/there: no such file or directory", status, "Expected status to have a command not found error message")
 }
 
 //

--- a/cmd/tether/tether.go
+++ b/cmd/tether/tether.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	"os/signal"
 	"syscall"
 
@@ -215,10 +216,17 @@ func handleSessionExit(session *SessionConfig) error {
 func launch(session *SessionConfig) error {
 	defer trace.End(trace.Begin("launching session " + session.ID))
 
+	// encode the result whether success or error
+	defer func() {
+		extraconfig.EncodeWithPrefix(dataSink, session.Started, fmt.Sprintf("guestinfo..sessions|%s.started", session.ID))
+	}()
+
 	logwriter, err := utils.sessionLogWriter()
 	if err != nil {
 		detail := fmt.Sprintf("failed to get log writer for session: %s", err)
 		log.Error(detail)
+		session.Started = detail
+
 		return errors.New(detail)
 	}
 
@@ -233,9 +241,20 @@ func launch(session *SessionConfig) error {
 	session.Cmd.Stderr = session.errwriter
 	session.Cmd.Stdin = session.reader
 
+	resolved, err := exec.LookPath(session.Cmd.Path)
+	if err != nil {
+		pretty := fmt.Errorf("%s: no such file or directory", session.Cmd.Path)
+		log.Errorf("Path lookup failed for %s: %s", session.Cmd.Path, err)
+		session.Started = pretty.Error()
+		return pretty
+	}
+	log.Debugf("Resolved %s to %s", session.Cmd.Path, resolved)
+	session.Cmd.Path = resolved
+
 	// Use the mutex to make creating a child and adding the child pid into the
 	// childPidTable appear atomic to the reaper function. Use a anonymous function
 	// so we can defer unlocking locally
+	// logging is done after the function to keep the locked time as low as possible
 	err = func() error {
 		config.pidMutex.Lock()
 		defer config.pidMutex.Unlock()
@@ -248,30 +267,30 @@ func launch(session *SessionConfig) error {
 		}
 
 		if err != nil {
-			detail := fmt.Sprintf("failed to start container process: %s", err)
-			log.Error(detail)
-
-			// Set the Started key to the detailed error message
-			session.Started = err.Error()
-			// save the modified value back to the vmx file
-			extraconfig.EncodeWithPrefix(dataSink, session.Started, fmt.Sprintf("guestinfo..sessions|%s.started", session.ID))
-
-			return errors.New(detail)
+			return err
 		}
 
 		// ChildReaper will use this channel to inform us the wait status of the child.
 		config.pids[session.Cmd.Process.Pid] = session
-		// Set the Started key to "true"
-		session.Started = "true"
-		// save the modified value back to the vmx file
-		extraconfig.EncodeWithPrefix(dataSink, session.Started, fmt.Sprintf("guestinfo..sessions|%s.started", session.ID))
-
-		log.Debugf("Launched command with pid %d", session.Cmd.Process.Pid)
 
 		return nil
 	}()
 
-	return err
+	if err != nil {
+		detail := fmt.Sprintf("failed to start container process: %s", err)
+		log.Error(detail)
+
+		// Set the Started key to the undecorated error message
+		session.Started = err.Error()
+
+		return errors.New(detail)
+	}
+
+	// Set the Started key to "true" - this indicates a successful launch
+	session.Started = "true"
+	log.Debugf("Launched command with pid %d", session.Cmd.Process.Pid)
+
+	return nil
 }
 
 func logConfig(config *ExecutorConfig) {


### PR DESCRIPTION
This adds path resolution for tether binaries. Also reshuffles where
logging and launch status reporting happens to reduce the time the pid
mutex is held for.

Fixes #708 

