### PR TITLE
relative path support

### DIFF
--- a/cmd/tether/tether.go
+++ b/cmd/tether/tether.go
@@ -18,7 +18,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"os/exec"
 	"os/signal"
 	"syscall"
 
@@ -241,12 +240,11 @@ func launch(session *SessionConfig) error {
 	session.Cmd.Stderr = session.errwriter
 	session.Cmd.Stdin = session.reader
 
-	resolved, err := exec.LookPath(session.Cmd.Path)
+	resolved, err := lookPath(session.Cmd.Path, session.Cmd.Env)
 	if err != nil {
-		pretty := fmt.Errorf("%s: no such file or directory", session.Cmd.Path)
 		log.Errorf("Path lookup failed for %s: %s", session.Cmd.Path, err)
-		session.Started = pretty.Error()
-		return pretty
+		session.Started = err.Error()
+		return err
 	}
 	log.Debugf("Resolved %s to %s", session.Cmd.Path, resolved)
 	session.Cmd.Path = resolved

--- a/cmd/tether/tether_darwin.go
+++ b/cmd/tether/tether_darwin.go
@@ -71,6 +71,10 @@ func (t *osopsOSX) processEnvOS(env []string) []string {
 	return env
 }
 
+func lookPath(file string, env []string) (string, error) {
+	return "", errors.New("unimplemented on OSX")
+}
+
 func (t *osopsOSX) establishPty(session *SessionConfig) error {
 	return errors.New("unimplemented on OSX")
 }

--- a/cmd/tether/tether_windows.go
+++ b/cmd/tether/tether_windows.go
@@ -212,6 +212,10 @@ func (t *osopsWin) processEnvOS(env []string) []string {
 	return env
 }
 
+func lookPath(file string, env []string) (string, error) {
+	return "", errors.New("unimplemented on windows")
+}
+
 func (t *osopsWin) signalProcess(process *os.Process, sig ssh.Signal) error {
 	return errors.New("unimplemented on windows")
 }


### PR DESCRIPTION
Use cmd.Env path for lookup as this needs to use the PATH provided for the container, not the system environment inherited by tether.

Fixes #708 
