### PR TITLE
Forward ssh key to vagrant devbox

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -3,6 +3,7 @@
 Vagrant.configure(2) do |config|
   dirs = ENV['GOPATH'] || Dir.home
   gdir = nil
+  config.ssh.forward_agent = true
   config.vm.define "vic_dev" do | vic_dev |
     vic_dev.vm.box = 'cbednarski/ubuntu-1604'
     vic_dev.vm.network 'forwarded_port', guest: 2375, host: 12375


### PR DESCRIPTION
This will forward your ssh key to the vagrant devbox when you connect via `vagrant ssh`, preventing you from having to create your own devbox ssh key and add it to your github account.