### PR TITLE
Implements docker stop - ticket 363

### DIFF
--- a/portlayer/exec/container.go
+++ b/portlayer/exec/container.go
@@ -126,6 +126,7 @@ func (c *Container) Commit(ctx context.Context, sess *session.Session, s *types.
 // Start starts a container vm with the given params
 func (c *Container) Start(ctx context.Context) error {
 	defer trace.End(trace.Begin("Container.Start"))
+	//no need to grab the lock, there is no state change to the container
 
 	if c.vm == nil {
 		return fmt.Errorf("vm not set")
@@ -172,6 +173,27 @@ func (c *Container) Start(ctx context.Context) error {
 
 	if detail != "true" {
 		return errors.New(detail)
+	}
+
+	return nil
+}
+
+func (c *Container) Stop(ctx context.Context) error {
+	defer trace.End(trace.Begin("Container.Stop"))
+	//no need to grab the lock, there is no state change to the container
+
+	if c.vm == nil {
+		return fmt.Errorf("vm not set")
+	}
+
+	//TODO: make the shutdown much cleaner, right now we just pull the plug on the vm.(may need corresponding work in tether.)
+
+	// Power off
+	_, err := tasks.WaitForResult(ctx, func(ctx context.Context) (tasks.ResultWaiter, error) {
+		return c.vm.PowerOff(ctx)
+	})
+	if err != nil {
+		return err
 	}
 
 	return nil

--- a/portlayer/exec/handle.go
+++ b/portlayer/exec/handle.go
@@ -143,6 +143,7 @@ func (h *Handle) Commit(ctx context.Context, sess *session.Session) error {
 		return nil // already committed
 	}
 
+	h.SetSpec(nil)
 	cfg := make(map[string]string)
 	extraconfig.Encode(extraconfig.MapSink(cfg), h.ExecConfig)
 	s := h.Spec.Spec()
@@ -160,7 +161,10 @@ func (h *Handle) Commit(ctx context.Context, sess *session.Session) error {
 			}
 
 		case StateStopped:
-			// TODO
+			// stop the container
+			if err := h.Container.Stop(ctx); err != nil {
+				return err
+			}
 		}
 	}
 


### PR DESCRIPTION
Fixes #363 

This is our minimal lifecycle implementation of docker stop. it
does not cleanly shut down VMs at the moment. It simply calls
poweroff through govmomi as a first pass. Goals in the future
should involve an interaction with the tether which will allow
us to signal the vm to shutdown all of the services it is
running before a poweroff call. @sflxn @jzt @hmahmood @cgtexmex 