### PR TITLE
Fix vSAN with stateless ESXi

### DIFF
--- a/machines/vcsa/README.md
+++ b/machines/vcsa/README.md
@@ -20,7 +20,7 @@ But, you should already be using and loving jq for other tasks: http://stedolan.
 ### create-esxi-vm.sh
 
 This script creates a VM running stateless ESXi, booted via cdrom/iso.
-It will create 2 disks:
+It will create 2 disks by default:
 
 * vSAN cache disk (Virtual SSD)
 
@@ -31,6 +31,13 @@ by a vSAN enabled cluster.
 
 Note that for a cluster to use vSAN, it will need at least 3 of these
 ESXi VMs.
+
+To create an ESXi VM for standalone use, use the `-s` flag and optionally increase the default disk size with the `-d`
+flag:
+
+```
+./create-esxi-vm.sh -s -d 56 $GOVC_URL my-esxi-vm
+```
 
 ### create-vcsa-vm.sh
 
@@ -95,5 +102,5 @@ Where "ESX_LICENSE" should be that of "vSphere 6 per CPU, Enterprise Plus".
 And "VCSA_LICENSE" should be that of "vCenter Server 6, Standard".
 
 ```
-ESX_LICENSE=... VCSA_LICENSE=... /assign-licenses.sh
+ESX_LICENSE=... VCSA_LICENSE=... ./assign-licenses.sh
 ```

--- a/machines/vcsa/create-cluster.sh
+++ b/machines/vcsa/create-cluster.sh
@@ -19,8 +19,8 @@ export GOVC_INSECURE=1
 export GOVC_USERNAME=${GOVC_USERNAME:-"Administrator@vsphere.local"}
 if [ -z "$GOVC_PASSWORD" ] ; then
     # extract password from $GOVC_URL
-    eval "$(govc env | grep GOVC_PASSWORD=)"
-    export GOVC_PASSWORD
+    password=$(govc env | grep GOVC_PASSWORD= | cut -d= -f 2-)
+    export GOVC_PASSWORD="$password"
 fi
 
 usage() {

--- a/machines/vcsa/create-esxi-vm.sh
+++ b/machines/vcsa/create-esxi-vm.sh
@@ -24,7 +24,7 @@ disk=48
 mem=16
 iso=VMware-VMvisor-6.0.0-3634798.x86_64.iso
 
-while getopts d:i:m:s: flag
+while getopts d:i:m:s flag
 do
     case $flag in
         d)
@@ -78,17 +78,6 @@ id=$(govc device.cdrom.add -vm "$name")
 echo "Inserting $boot in $name cdrom device..."
 govc device.cdrom.insert -vm "$name" -device "$id" "$boot"
 
-if [ -n "$standalone" ] ; then
-    echo "Creating $name disk for use by ESXi..."
-    govc vm.disk.create -vm "$name" -name "$name"/disk1 -size "${disk}G"
-else
-    echo "Creating $name disks for use by vSAN..."
-    govc vm.disk.create -vm "$name" -name "$name"/vsan-cache -size "$((disk/2))G"
-    govc vm.disk.create -vm "$name" -name "$name"/vsan-store -size "${disk}G"
-
-    govc vm.change -e scsi0:0.virtualSSD=1 -e scsi0:1.virtualSSD=0 -vm "$name"
-fi
-
 echo "Powering on $name VM..."
 govc vm.power -on "$name"
 
@@ -100,10 +89,10 @@ vm_ip=$(govc vm.ip "$name")
 # extract password from $GOVC_URL
 password=$(govc env | grep GOVC_PASSWORD= | cut -d= -f 2-)
 
-GOVC_URL="root:@${vm_ip}"
-echo "Waiting for $name hostd (via GOVC_URL=$GOVC_URL)..."
+esx_url="root:@${vm_ip}"
+echo "Waiting for $name hostd (via GOVC_URL=$esx_url)..."
 while true; do
-    if govc about 2>/dev/null; then
+    if govc about -u "$esx_url" 2>/dev/null; then
         break
     fi
 
@@ -111,12 +100,27 @@ while true; do
     sleep 1
 done
 
-if [ -z "$standalone" ] ; then
-    # Stateless esx will claim disks for its own use,
-    # vSAN cannot autoclaim mounted disks, so unmount.
-    echo "Unmounting datastores for use with vSAN..."
+if [ -n "$standalone" ] ; then
+    echo "Creating $name disk for use by ESXi..."
+    govc vm.disk.create -vm "$name" -name "$name"/disk1 -size "${disk}G"
+else
+    echo "Creating $name disks for use by vSAN..."
+    govc vm.disk.create -vm "$name" -name "$name"/vsan-cache -size "$((disk/2))G"
+    govc vm.disk.create -vm "$name" -name "$name"/vsan-store -size "${disk}G"
+fi
 
-    govc ls datastore | xargs -n1 -I% govc datastore.remove -ds % '*'
+# Set target to the ESXi VM
+GOVC_URL="$esx_url"
+
+if [ -n "$standalone" ] ; then
+    disk=$(govc host.storage.info -rescan | grep /vmfs/devices/disks | awk '{print $1}' | xargs basename)
+    echo "Creating datastore on disk ${disk}..."
+    govc datastore.create -type vmfs -name datastore1 -disk="$disk" '*'
+else
+    echo "Rescanning HBA for new devices..."
+    disk=$(govc host.storage.info -rescan | grep /vmfs/devices/disks | awk '{print $1}' | sort | head -n1)
+    echo "Marking ${disk} as SSD..."
+    govc host.storage.mark -ssd "$disk"
 fi
 
 echo "Installing host client..."


### PR DESCRIPTION
Commit 1cc8ebb was not good enough when used in a fresh environment.
So, rather than unmount the ESX datastores, add virtual disks after ESXi
has booted.  This requires 2 additional changes:

- rescan HBA to pickup the new devices

- mark disk as SSD (extraConfig trick does not work after VM has booted)