### PR TITLE
Calculate diffID for each layer in imagec

### DIFF
--- a/cmd/imagec/imagec.go
+++ b/cmd/imagec/imagec.go
@@ -84,6 +84,7 @@ type ImageCOptions struct {
 type ImageWithMeta struct {
 	*models.Image
 
+	diffID  string
 	layer   FSLayer
 	history History
 }
@@ -298,10 +299,11 @@ func DownloadImageBlobs(images []ImageWithMeta) error {
 		go func(image ImageWithMeta) {
 			defer wg.Done()
 
-			err := FetchImageBlob(options, &image)
+			diffID, err := FetchImageBlob(options, &image)
 			if err != nil {
 				results <- fmt.Errorf("%s/%s returned %s", options.image, image.layer.BlobSum, err)
 			} else {
+				image.diffID = diffID
 				results <- nil
 			}
 		}(images[i])

--- a/cmd/imagec/imagec_test.go
+++ b/cmd/imagec/imagec_test.go
@@ -178,9 +178,12 @@ func TestFetchImageBlob(t *testing.T) {
 		history: History{V1Compatibility: LayerHistory},
 		layer:   FSLayer{BlobSum: DigestSHA256LayerContent},
 	}
-	err = FetchImageBlob(options, &image)
+	diffID, err := FetchImageBlob(options, &image)
 	if err != nil {
 		t.Errorf(err.Error())
+	}
+	if diffID == "" {
+		t.Errorf("Expected a diffID, got nil.")
 	}
 
 	tar, err := ioutil.ReadFile(path.Join(DestinationDirectory(), LayerID, LayerID+".tar"))


### PR DESCRIPTION
Currently this just logs the diffID and stores it in the `ImageWithMeta` struct for each layer after it is calculated.

Fixes #775

