### PR TITLE
Construct image metadata in imagec and use it to calculate image iD

### DIFF
--- a/cmd/imagec/storage.go
+++ b/cmd/imagec/storage.go
@@ -74,7 +74,7 @@ func CreateImageStore(storename string) error {
 }
 
 // ListImages lists the images from given image store
-func ListImages(storename string, images []ImageWithMeta) (map[string]*models.Image, error) {
+func ListImages(storename string, images []*ImageWithMeta) (map[string]*models.Image, error) {
 	defer trace.End(trace.Begin(storename))
 
 	transport := httptransport.New(options.host, "/", []string{"http"})


### PR DESCRIPTION
Currently, these changes can create everything we need in the image metadata JSON. It currently uses this metadata to calculate the sha256 sum that will serve as the Image ID. Currently, this ID is logged to imagec's output, but will be persisted to the storage portlayer in the next task (#777).

Fixes #776 
