### PR TITLE
Add vsphere simulator WaitForUpdates support

### DIFF
--- a/pkg/vsphere/simulator/property_filter.go
+++ b/pkg/vsphere/simulator/property_filter.go
@@ -1,0 +1,36 @@
+// Copyright 2016 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package simulator
+
+import (
+	"github.com/vmware/govmomi/vim25/methods"
+	"github.com/vmware/govmomi/vim25/mo"
+	"github.com/vmware/govmomi/vim25/soap"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type PropertyFilter struct {
+	mo.PropertyFilter
+}
+
+func (*PropertyFilter) DestroyPropertyFilter(c *types.DestroyPropertyFilter) soap.HasFault {
+	body := &methods.DestroyPropertyFilterBody{}
+
+	Map.Remove(c.This)
+
+	body.Res = &types.DestroyPropertyFilterResponse{}
+
+	return body
+}

--- a/pkg/vsphere/simulator/task.go
+++ b/pkg/vsphere/simulator/task.go
@@ -1,0 +1,94 @@
+// Copyright 2016 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package simulator
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+	"time"
+
+	"github.com/vmware/govmomi/vim25/mo"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+const vTaskSuffix = "_Task" // vmomi suffix
+const sTaskSuffix = "Task"  // simulator suffix (avoiding golint warning)
+
+type Task struct {
+	mo.Task
+
+	runner TaskRunner
+}
+
+func NewTask(runner TaskRunner) *Task {
+	ref := runner.Reference()
+	name := reflect.TypeOf(runner).Elem().Name()
+	id := name
+
+	if strings.HasSuffix(id, sTaskSuffix) {
+		id = id[:len(id)-len(sTaskSuffix)]
+		name = id + vTaskSuffix
+	}
+
+	task := &Task{
+		runner: runner,
+	}
+
+	task.Self = Map.CreateReference(task)
+
+	task.Info.Key = task.Self.Value
+	task.Info.Task = task.Self
+	task.Info.Name = ucFirst(name)
+	task.Info.DescriptionId = fmt.Sprintf("%s.%s", ref.Type, id)
+	task.Info.Entity = &ref
+	task.Info.EntityName = ref.Value
+
+	task.Info.QueueTime = time.Now()
+	task.Info.State = types.TaskInfoStateQueued
+
+	Map.Put(task)
+
+	return task
+}
+
+type TaskRunner interface {
+	mo.Reference
+
+	Run(*Task) (types.AnyType, types.BaseMethodFault)
+}
+
+func (t *Task) Run() {
+	now := time.Now()
+	t.Info.StartTime = &now
+
+	t.Info.State = types.TaskInfoStateRunning
+
+	res, err := t.runner.Run(t)
+
+	now = time.Now()
+	t.Info.CompleteTime = &now
+
+	if err != nil {
+		t.Info.State = types.TaskInfoStateError
+		t.Info.Error = &types.LocalizedMethodFault{
+			Fault:            err,
+			LocalizedMessage: fmt.Sprintf("%T", err),
+		}
+	} else {
+		t.Info.Result = res
+		t.Info.State = types.TaskInfoStateSuccess
+	}
+}

--- a/pkg/vsphere/simulator/task_test.go
+++ b/pkg/vsphere/simulator/task_test.go
@@ -1,0 +1,63 @@
+// Copyright 2016 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package simulator
+
+import (
+	"testing"
+
+	"github.com/vmware/govmomi/vim25/mo"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type addWaterTask struct {
+	*mo.Folder
+
+	fault types.BaseMethodFault
+}
+
+func (a *addWaterTask) Run(task *Task) (types.AnyType, types.BaseMethodFault) {
+	return nil, a.fault
+}
+
+func TestNewTask(t *testing.T) {
+	f := &mo.Folder{}
+	f.Self = Map.CreateReference(f)
+
+	add := &addWaterTask{f, nil}
+	task := NewTask(add)
+	info := &task.Info
+
+	if info.Name != "AddWater_Task" {
+		t.Errorf("name=%s", info.Name)
+	}
+
+	if info.DescriptionId != "Folder.addWater" {
+		t.Errorf("descriptionId=%s", info.DescriptionId)
+	}
+
+	task.Run()
+
+	if info.State != types.TaskInfoStateSuccess {
+		t.Fail()
+	}
+
+	add.fault = &types.ManagedObjectNotFound{}
+
+	task.Run()
+
+	if info.State != types.TaskInfoStateError {
+		t.Fail()
+	}
+}


### PR DESCRIPTION
Needed to implement #738 to support #734, as the client side needs to poll for Task state.  Implemented Folder.AddStandaloneHost_Task to exercise Task polling, and we'll need most of that logic to complete #734