### PR TITLE
Refactor vcsim moref generation

### DIFF
--- a/pkg/vsphere/simulator/folder_test.go
+++ b/pkg/vsphere/simulator/folder_test.go
@@ -175,6 +175,15 @@ func TestFolderVC(t *testing.T) {
 			if host.Name != test.name {
 				t.Fail()
 			}
+
+			if ref == esx.HostSystem.Self {
+				t.Error("expected new host Self reference")
+			}
+
+			pool := Map.Get(*host.Parent).(*mo.ComputeResource).ResourcePool
+			if *pool == esx.ResourcePool.Self {
+				t.Error("expected new pool Self reference")
+			}
 		}
 
 		if res.State != test.state {

--- a/pkg/vsphere/simulator/host_system.go
+++ b/pkg/vsphere/simulator/host_system.go
@@ -75,26 +75,24 @@ func CreateStandaloneHost(f *Folder, spec types.HostConnectSpec) (*HostSystem, t
 		return nil, &types.NoHost{}
 	}
 
+	pool := esx.ResourcePool
 	host := NewHostSystem(esx.HostSystem)
 
 	host.Summary.Config.Name = spec.HostName
 	host.Name = host.Summary.Config.Name
-	host.Self = Map.CreateReference(host)
+	host.Runtime.ConnectionState = types.HostSystemConnectionStateDisconnected
 
 	cr := &mo.ComputeResource{}
-	cr.Self = Map.CreateReference(cr)
+
+	Map.PutEntity(cr, Map.NewEntity(host))
+
+	Map.PutEntity(cr, Map.NewEntity(&pool))
+
 	cr.Name = host.Name
 	cr.Host = append(cr.Host, host.Reference())
-	Map.PutEntity(cr, host)
-
-	pool := esx.ResourcePool
-	pool.Self = Map.CreateReference(&pool)
 	cr.ResourcePool = &pool.Self
-	Map.PutEntity(cr, &pool)
 
 	f.putChild(cr)
-
-	host.Runtime.ConnectionState = types.HostSystemConnectionStateDisconnected
 
 	return host, nil
 }

--- a/pkg/vsphere/simulator/property_collector.go
+++ b/pkg/vsphere/simulator/property_collector.go
@@ -312,9 +312,8 @@ func (pc *PropertyCollector) CreateFilter(c *types.CreateFilter) soap.HasFault {
 	filter := &PropertyFilter{}
 	filter.PartialUpdates = c.PartialUpdates
 	filter.Spec = c.Spec
-	filter.Self = Map.CreateReference(filter)
-	pc.Filter = append(pc.Filter, filter.Self)
-	Map.Put(filter)
+
+	pc.Filter = append(pc.Filter, Map.Put(filter).Reference())
 
 	body.Res = &types.CreateFilterResponse{
 		Returnval: filter.Self,
@@ -327,11 +326,9 @@ func (pc *PropertyCollector) CreatePropertyCollector(c *types.CreatePropertyColl
 	body := &methods.CreatePropertyCollectorBody{}
 
 	cpc := &PropertyCollector{}
-	cpc.Self = Map.CreateReference(cpc)
-	Map.Put(cpc)
 
 	body.Res = &types.CreatePropertyCollectorResponse{
-		Returnval: cpc.Self,
+		Returnval: Map.Put(cpc).Reference(),
 	}
 
 	return body

--- a/pkg/vsphere/simulator/task.go
+++ b/pkg/vsphere/simulator/task.go
@@ -47,7 +47,7 @@ func NewTask(runner TaskRunner) *Task {
 		runner: runner,
 	}
 
-	task.Self = Map.CreateReference(task)
+	Map.Put(task)
 
 	task.Info.Key = task.Self.Value
 	task.Info.Task = task.Self
@@ -58,8 +58,6 @@ func NewTask(runner TaskRunner) *Task {
 
 	task.Info.QueueTime = time.Now()
 	task.Info.State = types.TaskInfoStateQueued
-
-	Map.Put(task)
 
 	return task
 }

--- a/pkg/vsphere/simulator/task_test.go
+++ b/pkg/vsphere/simulator/task_test.go
@@ -33,7 +33,7 @@ func (a *addWaterTask) Run(task *Task) (types.AnyType, types.BaseMethodFault) {
 
 func TestNewTask(t *testing.T) {
 	f := &mo.Folder{}
-	f.Self = Map.CreateReference(f)
+	Map.NewEntity(f)
 
 	add := &addWaterTask{f, nil}
 	task := NewTask(add)


### PR DESCRIPTION
Generating a ManagedObjectReference.Value was a bit cumbersome.
Refactor so the Registry takes care of this in most cases.  The
exception is the case where we want to use an object template,
such as esx.HostSystem, where the caller still needs to set the new
Value.