### PR TITLE
Minimal docker rm

### DIFF
--- a/lib/apiservers/portlayer/restapi/configure_port_layer.go
+++ b/lib/apiservers/portlayer/restapi/configure_port_layer.go
@@ -17,18 +17,17 @@ package restapi
 import (
 	"net/http"
 
-	"golang.org/x/net/context"
-
 	log "github.com/Sirupsen/logrus"
 
 	errors "github.com/go-swagger/go-swagger/errors"
 	httpkit "github.com/go-swagger/go-swagger/httpkit"
 	"github.com/go-swagger/go-swagger/swag"
-
 	"github.com/vmware/vic/lib/apiservers/portlayer/restapi/handlers"
 	"github.com/vmware/vic/lib/apiservers/portlayer/restapi/operations"
 	"github.com/vmware/vic/lib/apiservers/portlayer/restapi/options"
 	"github.com/vmware/vic/pkg/vsphere/session"
+
+	"golang.org/x/net/context"
 )
 
 // This file is safe to edit. Once it exists it will not be overwritten

--- a/lib/apiservers/portlayer/restapi/handlers/containers_handlers.go
+++ b/lib/apiservers/portlayer/restapi/handlers/containers_handlers.go
@@ -54,7 +54,7 @@ func (handler *ContainersHandlersImpl) Configure(api *operations.PortLayerAPI, h
 	api.ContainersGetHandler = containers.GetHandlerFunc(handler.GetHandler)
 	api.ContainersCommitHandler = containers.CommitHandlerFunc(handler.CommitHandler)
 	api.ContainersGetStateHandler = containers.GetStateHandlerFunc(handler.GetStateHandler)
-
+	api.ContainersContainerRemoveHandler = containers.ContainerRemoveHandlerFunc(handler.RemoveContainerHandler)
 	handler.handlerCtx = handlerCtx
 }
 
@@ -209,4 +209,22 @@ func (handler *ContainersHandlersImpl) CommitHandler(params containers.CommitPar
 	}
 
 	return containers.NewCommitOK()
+}
+
+func (handler *ContainersHandlersImpl) RemoveContainerHandler(params containers.ContainerRemoveParams) middleware.Responder {
+	defer trace.End(trace.Begin("Containers.RemoveContainerHandler"))
+
+	//get the indicated container for removal
+	cID := exec.ParseID(params.ID)
+	h := exec.GetContainer(cID)
+	if h == nil {
+		return containers.NewContainerRemoveNotFound()
+	}
+
+	err := h.Container.Remove(context.Background())
+	if err != nil {
+		return containers.NewContainerRemoveInternalServerError()
+	}
+
+	return containers.NewContainerRemoveOK()
 }

--- a/lib/apiservers/portlayer/swagger.yml
+++ b/lib/apiservers/portlayer/swagger.yml
@@ -440,6 +440,30 @@ paths:
           description: "Error"
           schema:
             $ref: "#/definitions/Error"
+    delete:
+      description: "Remove a container from existence"
+      operationId: ContainerRemove
+      tags: ["containers"]
+      consumes:
+        - application/octet-stream
+      parameters:
+        - name: id
+          required: true
+          in: path
+          type: string
+      responses:
+        '200': 
+          description: "OK"
+        '400':
+          description: "bad parameter"
+        '404':
+          description: "no such container"
+        '500':
+          description: "server error"
+        default:
+          description: "Error"
+          schema:
+            $ref: "#/definitions/Error"
   /containers/{handle}:
     put:
       description: "Commit and close a container handle"


### PR DESCRIPTION

Fixes #782 and is the beginning of #364 

This also addresses the final remaining command missing for #688.

Right now this will not work from a direct pull and build due to a bug with our current vendored version of go-swagger and the delete function. one proposition that I would like to discuss in this PR is moving the call to `/containers/delete/{id}` and posing the call as a `POST` instead. This can be used to circumvent the `DELETE` content type bug in go-swagger. 

The exec layer portion removes containers from the container map which is in the exec layer. the handler for now only calls the vmremove function. future functionality will have us commiting a spec change for detaching the volume's before removal. 

We only currently support the most minimal `rm` call the only parameter which is supported is the `name` parameter. the parameters left for future implementation are `force` and `v` which is a bool for whether or not to remove associated volumes before deletion. 
