### PR TITLE
Persist image metadata to portlayer storage

### DIFF
--- a/cmd/imagec/imagec_test.go
+++ b/cmd/imagec/imagec_test.go
@@ -45,8 +45,8 @@ const (
 	// sha256 sum of LayerContent
 	DigestSHA256LayerContent = "sha256:18adac3bcad6124ed2e0d8dcc3beef8d540786ef8ef52c1f9fd71fdbfe36aa8e"
 
-	//DigestSHA256EmptyTar is the canonical sha256 digest of empty data
-	DigestSHA256EmptyTar = "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+	//DigestSHA256EmptyData is the canonical sha256 digest of empty data
+	DigestSHA256EmptyData = "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
 )
 
 func TestLearnAuthURL(t *testing.T) {
@@ -110,7 +110,7 @@ func TestFetchImageManifest(t *testing.T) {
 			manifest := &Manifest{
 				Name:     Image,
 				Tag:      Tag,
-				FSLayers: []FSLayer{FSLayer{BlobSum: DigestSHA256EmptyTar}},
+				FSLayers: []FSLayer{FSLayer{BlobSum: DigestSHA256EmptyData}},
 			}
 
 			body, err := json.Marshal(manifest)
@@ -140,7 +140,7 @@ func TestFetchImageManifest(t *testing.T) {
 	if err != nil {
 		t.Errorf(err.Error())
 	}
-	if manifest.FSLayers[0].BlobSum != DigestSHA256EmptyTar {
+	if manifest.FSLayers[0].BlobSum != DigestSHA256EmptyData {
 		t.Errorf("Returned manifest %#v is different than expected", manifest)
 	}
 }
@@ -175,8 +175,8 @@ func TestFetchImageBlob(t *testing.T) {
 			Parent: &parent,
 			Store:  Storename,
 		},
-		history: History{V1Compatibility: LayerHistory},
-		layer:   FSLayer{BlobSum: DigestSHA256LayerContent},
+		meta:  LayerHistory,
+		layer: FSLayer{BlobSum: DigestSHA256LayerContent},
 	}
 	diffID, err := FetchImageBlob(options, &image)
 	if err != nil {

--- a/cmd/imagec/storage.go
+++ b/cmd/imagec/storage.go
@@ -29,7 +29,7 @@ import (
 	"github.com/vmware/vic/pkg/trace"
 )
 
-const HistoryKey = "v1Compatibility"
+const MetaDataKey = "metaData"
 
 // PingPortLayer calls the _ping endpoint of the portlayer
 func PingPortLayer() (bool, error) {
@@ -113,18 +113,19 @@ func WriteImage(image *ImageWithMeta, data io.ReadCloser) error {
 	transport.Consumers["application/octet-stream"] = httpkit.ByteStreamConsumer()
 	transport.Producers["application/octet-stream"] = httpkit.ByteStreamProducer()
 
-	history := new(string)
-	historyBlob := new(string)
-	*history = HistoryKey
-	*historyBlob = image.history.V1Compatibility
+	key := new(string)
+	blob := new(string)
+
+	*key = MetaDataKey
+	*blob = image.meta
 
 	r, err := client.Storage.WriteImage(
 		storage.NewWriteImageParams().
 			WithImageID(image.ID).
 			WithParentID(*image.Parent).
 			WithStoreName(image.Store).
-			WithMetadatakey(history).
-			WithMetadataval(historyBlob).
+			WithMetadatakey(key).
+			WithMetadataval(blob).
 			WithImageFile(data).
 			WithSum(image.layer.BlobSum),
 	)


### PR DESCRIPTION
This refactors imagec to allow for image metadata to be persisted to portlayer storage.

Fixes #777 
