### PR TITLE
Check for null struct fields when converting images

### DIFF
--- a/lib/apiservers/engine/backends/image.go
+++ b/lib/apiservers/engine/backends/image.go
@@ -236,13 +236,17 @@ func resolveImageSize(v1Map map[string]*v1.V1Image, resolved map[string]int64, i
 }
 
 func convertV1ImageToDockerImage(v1Image *v1.V1Image) *types.Image {
+	var labels map[string]string
+	if v1Image.Config != nil {
+		labels = v1Image.Config.Labels
+	}
+
 	return &types.Image{
-		ID:       v1Image.ID,
-		ParentID: v1Image.Parent,
-		RepoTags: []string{"<fixme>:<fixme>"}, // TODO(jzt): replace with actual tags
-		//RepoDigests: []string{"<fixme>:<fixme>"},
+		ID:          v1Image.ID,
+		ParentID:    v1Image.Parent,
+		RepoTags:    []string{"fixme:fixme"}, // TODO(jzt): replace with actual tags
 		Created:     v1Image.Created.Unix(),
 		VirtualSize: v1Image.Size,
-		Labels:      v1Image.Config.Labels,
+		Labels:      labels,
 	}
 }


### PR DESCRIPTION
Note: The output of `docker images` will remain incorrect until #387 is refactored to use the image metadata work that is currently in progress (see #423). @mhagen-vmware if that output is breaking a test, I'd just skip it for now.

Fixes #913

