### PR TITLE
Grab bag of fixes

### DIFF
--- a/lib/apiservers/engine/backends/container.go
+++ b/lib/apiservers/engine/backends/container.go
@@ -37,6 +37,7 @@ import (
 	"github.com/vmware/vic/lib/apiservers/portlayer/client/scopes"
 	"github.com/vmware/vic/lib/apiservers/portlayer/client/storage"
 	"github.com/vmware/vic/lib/apiservers/portlayer/models"
+	"github.com/vmware/vic/lib/guest"
 	"github.com/vmware/vic/pkg/trace"
 )
 
@@ -168,10 +169,10 @@ func (c *Container) ContainerCreate(config types.ContainerCreateConfig) (types.C
 	log.Printf("config.Config' = %+v", config.Config)
 
 	// Call the Exec port layer to create the container
-	host, err := os.Hostname()
+	host, err := guest.UUID()
 	if err != nil {
 		return types.ContainerCreateResponse{},
-			derr.NewErrorWithStatusCode(fmt.Errorf("container.ContainerCreate got unexpected error getting hostname"),
+			derr.NewErrorWithStatusCode(fmt.Errorf("container.ContainerCreate got unexpected error getting VCH UUID"),
 				http.StatusInternalServerError)
 	}
 

--- a/lib/guest/linux.go
+++ b/lib/guest/linux.go
@@ -115,7 +115,7 @@ func (l *LinuxGuestType) Controller() *types.BaseVirtualController {
 func UUID() (string, error) {
 	id, err := ioutil.ReadFile(UUIDPath)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("error retrieving vm uuid: %s", err)
 	}
 
 	uuidstr := string(id[:])

--- a/lib/portlayer/attach/server.go
+++ b/lib/portlayer/attach/server.go
@@ -78,6 +78,9 @@ func (n *Server) Addr() string {
 	return n.l.Addr().String()
 }
 
+// Get returns the session interface for the given container.  If the container
+// cannot be found, this call will wait for the given timeout.
+// id is ID of the container.
 func (n *Server) Get(ctx context.Context, id string, timeout time.Duration) (SessionInteraction, error) {
 	return n.connServer.Get(ctx, id, timeout)
 }

--- a/lib/portlayer/storage/vsphere/parent.go
+++ b/lib/portlayer/storage/vsphere/parent.go
@@ -26,6 +26,7 @@ import (
 	log "github.com/Sirupsen/logrus"
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/vim25/soap"
+	"github.com/vmware/vic/lib/guest"
 	"github.com/vmware/vic/pkg/vsphere/session"
 	"github.com/vmware/vic/pkg/vsphere/tasks"
 )
@@ -60,8 +61,15 @@ type parentM struct {
 
 // Starts here.  Tries to create a new parentM or load an existing one.
 func restoreParentMap(ctx context.Context, s *session.Session) (*parentM, error) {
+
+	// Use the UUID of VCH as the root in the datastore.
+	host, err := guest.UUID()
+	if err != nil {
+		return nil, err
+	}
+
 	p := &parentM{
-		mFilePath: path.Join(datastoreParentPath, parentMFile),
+		mFilePath: path.Join(datastoreParentPath, host, parentMFile),
 		sess:      s,
 	}
 

--- a/lib/portlayer/storage/vsphere/store.go
+++ b/lib/portlayer/storage/vsphere/store.go
@@ -93,6 +93,7 @@ func (v *ImageStore) datastorePath(p string) string {
 }
 
 // Returns the path to a given image store
+// `/VIC/imageStoreName/
 func (v *ImageStore) imageStorePath(storeName string) string {
 	return path.Join(datastoreParentPath, storeName)
 }


### PR DESCRIPTION
* Add a comment in the attach GET method.

* WriteImage in the vsphere implementation of the storage interface wasn't checking if the image already existed.  Instead it would attempt to write the image, and the caller would get some obscure vsphere error about scsi attach of some disk address.  Since the image already exists, just move on.

* Move the root of the image store from the hostname of the VCH to the UUID of the vch.  We use the UUID to get the MoRef of the vm the VCH is running on, so it is safe to use this same UUID as the root of our image store.  Also using the UUID (which can be gathered via the `/sys`) means we don't need to infect the docker api server or imagec with unnecessary govmomi calls.  We can easily replace this `UUID()` call to something gathered from `guestinfo`.  But we can punt on this for now.