### PR TITLE
recover from a panic and fw it to the caller

### DIFF
--- a/cmd/imagec/imagec.go
+++ b/cmd/imagec/imagec.go
@@ -23,6 +23,7 @@ import (
 	"net/url"
 	"os"
 	"path"
+	"runtime/debug"
 	"runtime/trace"
 	"strings"
 	"sync"
@@ -459,6 +460,12 @@ func CreateImageConfig(images []*ImageWithMeta, manifest *Manifest) error {
 }
 
 func main() {
+	defer func() {
+		if r := recover(); r != nil {
+			fmt.Fprintf(os.Stderr, string(sf.FormatError(fmt.Errorf("%s : %s", r, debug.Stack()))))
+		}
+	}()
+
 	// Enable profiling if mode is set
 	switch options.profiling {
 	case "cpu":


### PR DESCRIPTION
so that we get

```
Using default tag: latest
latest: Pulling from library/busybox

385e281300cc: Already exists
a3ed95caeb02: Already exists
runtime error: index out of range : goroutine 1 [running]:
runtime/debug.Stack(0x0, 0x0, 0x0)
    /usr/local/go/src/runtime/debug/stack.go:24 +0x80
main.main.func1()
    /opt/go/src/github.com/vmware/vic/cmd/imagec/imagec.go:465 +0x59
panic(0xf1e2e0, 0xc820010020)
    /usr/local/go/src/runtime/panic.go:443 +0x4e9
main.CreateImageConfig(0xc8202e3e80, 0x0, 0x2, 0xc82047bae0, 0x0, 0x0)
    /opt/go/src/github.com/vmware/vic/cmd/imagec/imagec.go:388 +0xeda
main.main()
    /opt/go/src/github.com/vmware/vic/cmd/imagec/imagec.go:604 +0x14a4
```
instead of
```
Using default tag: latest
latest: Pulling from library/busybox

385e281300cc: Already exists
a3ed95caeb02: Already exists
invalid character 'p' looking for beginning of value
```