### PR TITLE
Reimplementation of docker list images backend code

### DIFF
--- a/cmd/imagec/imagec.go
+++ b/cmd/imagec/imagec.go
@@ -43,6 +43,7 @@ import (
 
 	"github.com/vmware/vic/lib/apiservers/portlayer/models"
 	"github.com/vmware/vic/lib/guest"
+	"github.com/vmware/vic/lib/metadata"
 	"github.com/vmware/vic/pkg/i18n"
 
 	"github.com/pkg/profile"
@@ -369,7 +370,6 @@ func WriteImageBlobs(images []*ImageWithMeta) error {
 		defer in.Close()
 
 		// Write the image
-		// FIXME: send metadata when portlayer supports it
 		err = WriteImage(image, in)
 		if err != nil {
 			return fmt.Errorf("Failed to write to image store: %s", err)
@@ -443,10 +443,10 @@ func CreateImageConfig(images []*ImageWithMeta, manifest *Manifest) error {
 	// prepare metadata
 	result.V1Image.Parent = image.Parent
 	result.Size = size
-	metaData := ImageConfig{
+	metaData := metadata.ImageConfig{
 		V1Image: result.V1Image,
 		ImageID: sum,
-		Tag:     manifest.Tag,
+		Tag:     options.digest,
 		Name:    manifest.Name,
 		DiffIDs: diffIDs,
 		History: history,

--- a/lib/metadata/image_config.go
+++ b/lib/metadata/image_config.go
@@ -1,0 +1,31 @@
+// Copyright 2016 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metadata
+
+import (
+	docker "github.com/docker/docker/image"
+)
+
+// ImageConfig contains configuration data describing images and their layers
+type ImageConfig struct {
+	docker.V1Image
+
+	// image specific data
+	ImageID string            `json:"image_id,omitempty"`
+	Tag     string            `json:"tag,omitempty"`
+	Name    string            `json:"name,omitempty"`
+	DiffIDs map[string]string `json:"diff_ids,omitempty"`
+	History []docker.History  `json:"history,omitempty"`
+}


### PR DESCRIPTION
imagec still needs to update an image's tags when we pull using a different tag for the same image (see #976).

Fixes #387, #975 
