### PR TITLE
Docker volume rm engine stubbing

### DIFF
--- a/lib/apiservers/portlayer/restapi/handlers/storage_handlers.go
+++ b/lib/apiservers/portlayer/restapi/handlers/storage_handlers.go
@@ -32,6 +32,7 @@ import (
 	spl "github.com/vmware/vic/lib/portlayer/storage"
 	"github.com/vmware/vic/lib/portlayer/storage/vsphere"
 	"github.com/vmware/vic/lib/portlayer/util"
+	"github.com/vmware/vic/pkg/trace"
 )
 
 // StorageHandlersImpl is the receiver for all of the storage handler methods
@@ -79,6 +80,7 @@ func (handler *StorageHandlersImpl) Configure(api *operations.PortLayerAPI, hand
 	api.StorageGetImageTarHandler = storage.GetImageTarHandlerFunc(handler.GetImageTar)
 	api.StorageListImagesHandler = storage.ListImagesHandlerFunc(handler.ListImages)
 	api.StorageWriteImageHandler = storage.WriteImageHandlerFunc(handler.WriteImage)
+	api.StorageRemoveVolumeHandler = storage.RemoveVolumeHandlerFunc(handler.RemoveVolume)
 }
 
 // CreateImageStore creates a new image store
@@ -190,6 +192,12 @@ func (handler *StorageHandlersImpl) WriteImage(params storage.WriteImageParams) 
 	}
 	i := convertImage(image)
 	return storage.NewWriteImageCreated().WithPayload(i)
+}
+
+//RemoveVolume : Remove a Volume from existence
+func (handler *StorageHandlersImpl) RemoveVolume(storage.RemoveVolumeParams) middleware.Responder {
+	defer trace.End(trace.Begin("storage_handlers.RemoveVolume"))
+	return storage.NewRemoveVolumeOK() //TODO: this is just a stub for now.
 }
 
 // convert an SPL Image to a swagger-defined Image

--- a/lib/apiservers/portlayer/swagger.yml
+++ b/lib/apiservers/portlayer/swagger.yml
@@ -193,6 +193,56 @@ paths:
           description: "error"
           schema:
             $ref: "#/definitions/Error"
+  /storage/volumes/{name}:
+    get:
+      description: "Get a Volume Handle"
+      operationId: GetVolume
+      tags: ["storage"]
+      consumes:
+        - application/json
+        - application/octet-stream
+      produces:
+        - application/json
+      parameters:
+        - name: name
+          required: true
+          in: path
+          type: string
+      responses:
+        '404':
+          description: "Volume not found"
+          schema:
+            $ref: "#/definitions/Error"
+        '200':
+          description: "OK"
+          schema:
+            type: string
+    delete:
+      summary: "Remove a volume"
+      tags: ["storage"]
+      operationId: RemoveVolume
+      parameters:
+        - name: name
+          type: string
+          in: path
+          required: true
+      responses:
+        '200':
+          description: "Volume successfully removed"
+          schema:
+            $ref: "#/definitions/Error"
+        '404':
+          description: "Volume not found"
+          schema:
+            $ref: "#/definitions/Error"
+        '409':
+          description: "Volume in use"
+          schema:
+            $ref: "#/definitions/Error"
+        '500':
+          description: "Server Error"
+          schema:
+            $ref: "#/definitions/Error"
   /scopes:
     post:
       summary: "Create a new scope"


### PR DESCRIPTION
addresses part of #916 and #429 

This PR is meant to implement things on the docker-engine-server side of `docker volume rm` well leaving stubbing in the portlayer for further implementation. 
