### PR TITLE
Add a whilelist of log files

### DIFF
--- a/cmd/vicadmin/vicadm.go
+++ b/cmd/vicadmin/vicadm.go
@@ -49,8 +49,16 @@ import (
 )
 
 var (
-	logFileDir = "/var/log/vic/"
-	config     struct {
+	logFileDir  = "/var/log/vic/"
+	logFileList = []string{
+		"docker-engine-server.log",
+		"imagec.log",
+		"port-layer-server.log",
+		"vicadmin.log",
+		"watchdog.log",
+	}
+
+	config struct {
 		session.Config
 		addr         string
 		dockerHost   string
@@ -95,11 +103,8 @@ type Authenticator interface {
 
 func logFiles() []string {
 	names := []string{}
-	files, _ := ioutil.ReadDir(logFileDir)
-	for _, f := range files {
-		if !f.IsDir() {
-			names = append(names, fmt.Sprintf("%s/%s", logFileDir, f.Name()))
-		}
+	for _, f := range logFileList {
+		names = append(names, fmt.Sprintf("%s/%s", logFileDir, f))
 	}
 
 	return names


### PR DESCRIPTION
vicadmin does a ioutil.ReadDir to get the file names once it starts.
Since this function gets called once some log files end up missing
as they may not exists at that time.

Current approach works right now because we start vicadmin after
starting docker-server and port-layer but that's because we start
services in alphabetical order.

This minor change simply adds a list hard coded whitelist of log files
that we are interested in. I opted in to this approach thinking that
we should only show known log files in vicadmin interface instead of
everything in that directory.

Fixes #552