### PR TITLE
Don't block waiting for IP when starting container on vCenter

### DIFF
--- a/isos/bootstrap/bootstrap
+++ b/isos/bootstrap/bootstrap
@@ -54,35 +54,8 @@ if mount -t ext4 /dev/disk/by-label/containerfs ${MOUNTPOINT}; then
     # switch to the new root
     echo "prepping for switch to container filesystem"
 
-    if [ -x ${MOUNTPOINT}/bin/sh ]; then
-        # copy the init binary into the new root - ideally I'd run this purely from memory without a presence on the filesystem
-        cp /bin/tether ${MOUNTPOINT}/.tether/tether-bin
-
-        # temporary hack for waiting the network
-        while ! ip addr show eno1 | grep " inet "; do sleep 1;done
-
-        cat << EOF > ${MOUNTPOINT}/.tether/tether
-#!/bin/sh
-
-if [ -x /sbin/ip -o -x /bin/ip ]; then
-    addr=$(ip addr show eno1  | grep " inet " | cut -d " " -f6)
-    gateway=$(ip route show | grep "^default" | cut -d " " -f3)
-
-    echo "Setting IP addr to " \$addr > /dev/ttyS1
-    echo "Setting route to" \$gateway > /dev/ttyS1
-
-    ip addr add \$addr dev eno1
-    ip link set dev eno1 up
-    ip route add default via \$gateway dev eno1
-fi
-
-/.tether/tether-bin
-EOF
-        chmod +x ${MOUNTPOINT}/.tether/tether
-    else
-        # Just copy tether as container vm doesn't come with sh
-        cp /bin/tether ${MOUNTPOINT}/.tether/tether
-    fi
+    # Just copy tether as container vm doesn't come with sh
+    cp /bin/tether ${MOUNTPOINT}/.tether/tether
 
     # We don't want eth0 for --net=none passed
     if [ -d /sys/module/vmxnet3/ ] && [ $(cat /sys/class/net/eno1/address) == "ff:ff:ff:ff:ff:ff" ]; then


### PR DESCRIPTION
Previously starting a container in vC would fail because we wait for an IP addr that is never assigned
```
⇒  docker -H 10.17.109.145:2376 --tls --tlscert='./chin-vic-16-cert.pem' --tlskey='./chin-vic-16-key.pem' start 651c6fec49091a77109a1b95c845fa43fbcc9f41079b90569952fd48331c3650
Error response from daemon: server error from portlayer
Error: failed to start containers: 651c6fec49091a77109a1b95c845fa43fbcc9f41079b90569952fd48331c3650
```

Now:
```
chin@CORPORATE:~/go/src/github.com/vmware/vic|bug/vc-start-container 
⇒  docker -H 10.17.109.126:2376 --tls --tlscert='./chin-vic-19-bug-cert.pem' --tlskey='./chin-vic-19-bug-key.pem' create busybox /bin/ls
c87b87872dc96b0ab914f4f113916656f3be0cfdb1f2b5518e65e0ea1726b923
chin@CORPORATE:~/go/src/github.com/vmware/vic|bug/vc-start-container 
⇒  docker -H 10.17.109.126:2376 --tls --tlscert='./chin-vic-19-bug-cert.pem' --tlskey='./chin-vic-19-bug-key.pem' start c87b87872dc96b0ab914f4f113916656f3be0cfdb1f2b5518e65e0ea1726b923
c87b87872dc96b0ab914f4f113916656f3be0cfdb1f2b5518e65e0ea1726b923
chin@CORPORATE:~/go/src/github.com/vmware/vic|bug/vc-start-container 
⇒  docker -H 10.17.109.126:2376 --tls --tlscert='./chin-vic-19-bug-cert.pem' --tlskey='./chin-vic-19-bug-key.pem' stop c87b87872dc96b0ab914f4f113916656f3be0cfdb1f2b5518e65e0ea1726b923 
c87b87872dc96b0ab914f4f113916656f3be0cfdb1f2b5518e65e0ea1726b923
chin@CORPORATE:~/go/src/github.com/vmware/vic|bug/vc-start-container 
⇒  docker -H 10.17.109.126:2376 --tls --tlscert='./chin-vic-19-bug-cert.pem' --tlskey='./chin-vic-19-bug-key.pem' rm c87b87872dc96b0ab914f4f113916656f3be0cfdb1f2b5518e65e0ea1726b923  
c87b87872dc96b0ab914f4f113916656f3be0cfdb1f2b5518e65e0ea1726b923
```