### PR TITLE
First pass at calculation and persistence of image digest

### DIFF
--- a/cmd/imagec/imagec.go
+++ b/cmd/imagec/imagec.go
@@ -63,7 +63,7 @@ type ImageCOptions struct {
 
 	registry string
 	image    string
-	digest   string
+	tag      string
 
 	destination string
 
@@ -170,10 +170,10 @@ func ParseReference() error {
 		return err
 	}
 
-	options.digest = reference.DefaultTag
+	options.tag = reference.DefaultTag
 	if !reference.IsNameOnly(ref) {
 		if tagged, ok := ref.(reference.NamedTagged); ok {
-			options.digest = tagged.Tag()
+			options.tag = tagged.Tag()
 		}
 	}
 
@@ -221,7 +221,7 @@ func DestinationDirectory() string {
 		u.Host,
 		u.Path,
 		options.image,
-		options.digest,
+		options.tag,
 	)
 }
 
@@ -446,7 +446,8 @@ func CreateImageConfig(images []*ImageWithMeta, manifest *Manifest) error {
 	metaData := metadata.ImageConfig{
 		V1Image: result.V1Image,
 		ImageID: sum,
-		Tag:     options.digest,
+		Digest:  manifest.Digest,
+		Tag:     options.tag,
 		Name:    manifest.Name,
 		DiffIDs: diffIDs,
 		History: history,
@@ -581,7 +582,7 @@ func main() {
 	// HACK: Required to learn the name of the vmdk from given reference
 	// Used by docker personality until metadata support lands
 	if !options.resolv {
-		progress.Message(po, options.digest, "Pulling from "+options.image)
+		progress.Message(po, options.tag, "Pulling from "+options.image)
 	}
 
 	// Create the ImageWithMeta slice to hold Image structs
@@ -614,11 +615,10 @@ func main() {
 		log.Fatalf(err.Error())
 	}
 
-	// FIXME: Dump the digest
-	//progress.Message(po, "", "Digest: 0xDEAD:BEEF")
+	progress.Message(po, "", "Digest: "+manifest.Digest)
 	if len(images) > 0 {
-		progress.Message(po, "", "Status: Downloaded newer image for "+options.image+":"+options.digest)
+		progress.Message(po, "", "Status: Downloaded newer image for "+options.image+":"+options.tag)
 	} else {
-		progress.Message(po, "", "Status: Image is up to date for "+options.image+":"+options.digest)
+		progress.Message(po, "", "Status: Image is up to date for "+options.image+":"+options.tag)
 	}
 }

--- a/cmd/imagec/imagec_test.go
+++ b/cmd/imagec/imagec_test.go
@@ -88,7 +88,7 @@ func TestLearnRegistryURL(t *testing.T) {
 
 	options.registry = s.URL[7:]
 	options.image = Image
-	options.digest = Tag
+	options.tag = Tag
 
 	// should fail
 	_, err := LearnRegistryURL(options)
@@ -115,7 +115,7 @@ func TestLearnAuthURL(t *testing.T) {
 
 	options.registry = s.URL
 	options.image = Image
-	options.digest = Tag
+	options.tag = Tag
 
 	url, err := LearnAuthURL(options)
 	if err != nil {
@@ -162,24 +162,48 @@ func TestFetchImageManifest(t *testing.T) {
 		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
 
-			manifest := &Manifest{
-				Name:     Image,
-				Tag:      Tag,
-				FSLayers: []FSLayer{FSLayer{BlobSum: DigestSHA256EmptyData}},
+			manifest := `
+{
+	"schemaVersion": 1,
+	"name": "library/photon",
+	"tag": "latest",
+	"architecture": "amd64",
+	"fsLayers": [
+			{
+				"blobSum": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
 			}
-
-			body, err := json.Marshal(manifest)
-			if err != nil {
-				t.Errorf(err.Error())
+	],
+	"history": [
+			{
+				"v1Compatibility": "{\"architecture\":\"amd64\",\"config\":{\"Hostname\":\"156e10b83429\",\"Domainname\":\"\",\"User\":\"\",\"AttachStdin\":false,\"AttachStdout\":false,\"AttachStderr\":false,\"Tty\":false,\"OpenStdin\":false,\"StdinOnce\":false,\"Env\":null,\"Cmd\":[\"sh\"],\"Image\":\"56ed16bd6310cca65920c653a9bb22de6b235990dcaa1742ff839867aed730e5\",\"Volumes\":null,\"WorkingDir\":\"\",\"Entrypoint\":null,\"OnBuild\":null,\"Labels\":{}},\"container\":\"5f8098ec29947b5bea80483cd3275008911ce87438fed628e34ec0c522665510\",\"container_config\":{\"Hostname\":\"156e10b83429\",\"Domainname\":\"\",\"User\":\"\",\"AttachStdin\":false,\"AttachStdout\":false,\"AttachStderr\":false,\"Tty\":false,\"OpenStdin\":false,\"StdinOnce\":false,\"Env\":null,\"Cmd\":[\"/bin/sh\",\"-c\",\"#(nop) CMD [\\\"sh\\\"]\"],\"Image\":\"56ed16bd6310cca65920c653a9bb22de6b235990dcaa1742ff839867aed730e5\",\"Volumes\":null,\"WorkingDir\":\"\",\"Entrypoint\":null,\"OnBuild\":null,\"Labels\":{}},\"created\":\"2016-03-18T18:22:48.810791943Z\",\"docker_version\":\"1.9.1\",\"id\":\"437595becdebaaaf3a4fc3db02c59a980f955dee825c153308c670610bb694e1\",\"os\":\"linux\",\"parent\":\"920777304d1d5e337bc59877253e946f224df5aae64c72538672eb74637b3c9e\"}"
 			}
-			w.Write(body)
+	],
+	"signatures": [
+			{
+				"header": {
+						"jwk": {
+							"crv": "P-256",
+							"kid": "LUQI:WBTB:JRDU:TTD2:FUVY:EMCB:64HP:MZF6:SGFS:XAB6:JPUK:6PK4",
+							"kty": "EC",
+							"x": "zjkAuFGpCuWOBl-iMMzZqgl_1cid-04S04-k-A1qEeU",
+							"y": "9HWcOMfVFUMXJGeNajIAlPicL4UOsCJSpqRcIxpUl0Q"
+						},
+						"alg": "ES256"
+				},
+				"signature": "dTXnnt3IkTScpZhyyqRlmZFcQV1QzD7lWDqnjlD4Cj-KsMuGd1pl5QpFL2Cadw-8KeTBlSleSecxjHU4t3yhCQ",
+				"protected": "eyJmb3JtYXRMZW5ndGgiOjE5MjIsImZvcm1hdFRhaWwiOiJDbjAiLCJ0aW1lIjoiMjAxNi0wNi0wOVQxNzoyMzo1NFoifQ"
+			}
+	]
+}
+`
+			w.Write([]byte(manifest))
 
 		}))
 	defer s.Close()
 
 	options.registry = s.URL
 	options.image = Image
-	options.digest = Tag
+	options.tag = Tag
 	options.token = &Token{Token: OAuthToken}
 
 	// create a temporary directory
@@ -233,7 +257,7 @@ func TestFetchImageBlob(t *testing.T) {
 
 	options.registry = s.URL
 	options.image = Image
-	options.digest = Tag
+	options.tag = Tag
 	options.token = &Token{Token: OAuthToken}
 
 	// create a temporary directory

--- a/lib/apiservers/engine/backends/image.go
+++ b/lib/apiservers/engine/backends/image.go
@@ -205,11 +205,13 @@ func convertV1ImageToDockerImage(image *metadata.ImageConfig) *types.Image {
 
 	// TODO(jzt): change ImageConfig to contain a map from image name to all of its tags
 	repoTag := fmt.Sprintf("%s:%s", image.Name, image.Tag)
+	repoDigest := fmt.Sprintf("%s:%s", image.Name, image.Digest)
 
 	return &types.Image{
 		ID:          image.ImageID,
 		ParentID:    image.Parent,
 		RepoTags:    []string{repoTag},
+		RepoDigests: []string{repoDigest},
 		Created:     image.Created.Unix(),
 		Size:        image.Size,
 		VirtualSize: image.Size,

--- a/lib/metadata/image_config.go
+++ b/lib/metadata/image_config.go
@@ -24,6 +24,7 @@ type ImageConfig struct {
 
 	// image specific data
 	ImageID string            `json:"image_id,omitempty"`
+	Digest  string            `json:"digest,omitempty"`
 	Tag     string            `json:"tag,omitempty"`
 	Name    string            `json:"name,omitempty"`
 	DiffIDs map[string]string `json:"diff_ids,omitempty"`


### PR DESCRIPTION
The image digest is now properly calculated and displayed after you pull an image. It's also persisted in the image metadata. We currently lack the understanding and logic to differentiate between tags and digests in a way that the user would expect from a docker persona.

Fixes #974, with some caveats.

