### PR TITLE
Add support for VSAN in the storage layer

### DIFF
--- a/lib/portlayer/storage/vsphere/datastore.go
+++ b/lib/portlayer/storage/vsphere/datastore.go
@@ -1,0 +1,266 @@
+// Copyright 2016 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vsphere
+
+import (
+	"io"
+	"path"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25/mo"
+	"github.com/vmware/govmomi/vim25/soap"
+	"github.com/vmware/govmomi/vim25/types"
+	"github.com/vmware/vic/pkg/vsphere/session"
+	"github.com/vmware/vic/pkg/vsphere/tasks"
+	"golang.org/x/net/context"
+)
+
+// Datastore gives access to the datastore regardless of type (esx, esx + vc,
+// or esx + vc + vsan).  Also wraps paths to a given root directory
+type datastore struct {
+	// The Datastore API likes everything in "path/to/thing" format.
+	ds *object.Datastore
+
+	s *session.Session
+
+	// The FileManager API likes everything in "[dsname] path/to/thing" format.
+	fm *object.FileManager
+
+	// the name of the datastore path (in case of vsan, this is the human readable name)
+	rootname string
+
+	// The datastore url (including root)
+	rooturl string
+
+	// datastore path (not in url form)
+	rootdir string
+}
+
+// newDatastore returns a Datastore.
+// ctx is a context,
+// s is an authenticated session
+// ds is the vsphere datastore
+// root is the top level directory to root all data.  If root does not exist,
+// it will be created.  If it already exists, NOOP. This cannot be empty.
+func newDatastore(ctx context.Context, s *session.Session, ds *object.Datastore, root string) (*datastore, error) {
+	d := &datastore{
+		ds:       ds,
+		s:        s,
+		rootname: root,
+		fm:       object.NewFileManager(s.Vim25()),
+	}
+
+	if err := d.mkRootDir(ctx, root); err != nil {
+		log.Infof("error creating root directory %s: %s", root, err)
+		return nil, err
+	}
+
+	log.Infof("Datastore path is %s", d.rooturl)
+	return d, nil
+}
+
+func (d *datastore) Summary(ctx context.Context) (*types.DatastoreSummary, error) {
+
+	var mds mo.Datastore
+	if err := d.ds.Properties(ctx, d.ds.Reference(), []string{"info", "summary"}, &mds); err != nil {
+		return nil, err
+	}
+
+	return &mds.Summary, nil
+}
+
+// Mkdir creates directories.
+func (d *datastore) Mkdir(ctx context.Context, createParentDirectories bool, dirs ...string) (string, error) {
+	// XXX TODO check if exists
+
+	upth := path.Join(dirs...)
+	upth = path.Join(d.rooturl, upth)
+
+	log.Infof("Creating directory %s", upth)
+
+	if err := d.fm.MakeDirectory(ctx, upth, d.s.Datacenter, createParentDirectories); err != nil {
+		return "", err
+	}
+
+	return upth, nil
+}
+
+// Ls returns a list of dirents at the given path (relative to root)
+//
+// A note aboutpaths and the datastore browser.
+// None of these work paths work
+// r, err := ds.Ls(ctx, "ds:///vmfs/volumes/vsan:52a67632ac3497a3-411916fd50bedc27/0ea65357-0494-d42d-2ede-000c292dc5b5")
+// r, err := ds.Ls(ctx, "[vsanDatastore] ds:///vmfs/volumes/vsan:52a67632ac3497a3-411916fd50bedc27/")
+// r, err := ds.Ls(ctx, "[vsanDatastore] //vmfs/volumes/vsan:52a67632ac3497a3-411916fd50bedc27/")
+// r, err := ds.Ls(ctx, "[] ds:///vmfs/volumes/vsan:52a67632ac3497a3-411916fd50bedc27/0ea65357-0494-d42d-2ede-000c292dc5b5")
+// r, err := ds.Ls(ctx, "[] /vmfs/volumes/vsan:52a67632ac3497a3-411916fd50bedc27/0ea65357-0494-d42d-2ede-000c292dc5b5")
+// r, err := ds.Ls(ctx, "[] ../vmfs/volumes/vsan:52a67632ac3497a3-411916fd50bedc27/0ea65357-0494-d42d-2ede-000c292dc5b5")
+// r, err := ds.Ls(ctx, "[] ./vmfs/volumes/vsan:52a67632ac3497a3-411916fd50bedc27/0ea65357-0494-d42d-2ede-000c292dc5b5")
+// r, err := ds.Ls(ctx, "[52a67632ac3497a3-411916fd50bedc27] /0ea65357-0494-d42d-2ede-000c292dc5b5")
+// r, err := ds.Ls(ctx, "[vsan:52a67632ac3497a3-411916fd50bedc27] /0ea65357-0494-d42d-2ede-000c292dc5b5")
+// r, err := ds.Ls(ctx, "[vsan:52a67632ac3497a3-411916fd50bedc27] 0ea65357-0494-d42d-2ede-000c292dc5b5")
+// r, err := ds.Ls(ctx, "[vsanDatastore] /vmfs/volumes/vsan:52a67632ac3497a3-411916fd50bedc27/0ea65357-0494-d42d-2ede-000c292dc5b5")
+
+// The only URI that works on VC + VSAN.
+// r, err := ds.Ls(ctx, "[vsanDatastore] /0ea65357-0494-d42d-2ede-000c292dc5b5")
+//
+func (d *datastore) Ls(ctx context.Context, p string) (*types.HostDatastoreBrowserSearchResults, error) {
+	spec := types.HostDatastoreBrowserSearchSpec{
+		MatchPattern: []string{"*"},
+	}
+
+	b, err := d.ds.Browser(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	task, err := b.SearchDatastore(ctx, path.Join(d.rooturl, p), &spec)
+	if err != nil {
+		return nil, err
+	}
+
+	info, err := task.WaitForResult(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	res := info.Result.(types.HostDatastoreBrowserSearchResults)
+	return &res, nil
+}
+
+// LsDirs returns a list of dirents at the given path (relative to root)
+func (d *datastore) LsDirs(ctx context.Context, p string) (*types.ArrayOfHostDatastoreBrowserSearchResults, error) {
+	spec := types.HostDatastoreBrowserSearchSpec{
+		MatchPattern: []string{"*"},
+	}
+
+	b, err := d.ds.Browser(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	task, err := b.SearchDatastoreSubFolders(ctx, path.Join(d.rooturl, p), &spec)
+	if err != nil {
+		return nil, err
+	}
+
+	info, err := task.WaitForResult(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	res := info.Result.(types.ArrayOfHostDatastoreBrowserSearchResults)
+	return &res, nil
+}
+
+func (d *datastore) Upload(ctx context.Context, r io.Reader, pth string) error {
+	return d.ds.Upload(ctx, r, path.Join(d.rootdir, pth), &soap.DefaultUpload)
+}
+
+func (d *datastore) Download(ctx context.Context, pth string) (io.ReadCloser, error) {
+	rc, _, err := d.ds.Download(ctx, path.Join(d.rootdir, pth), &soap.DefaultDownload)
+	return rc, err
+}
+
+func (d *datastore) Stat(ctx context.Context, pth string) (types.BaseFileInfo, error) {
+	return d.ds.Stat(ctx, path.Join(d.rootdir, pth))
+}
+
+func (d *datastore) Mv(ctx context.Context, fromPath, toPath string) error {
+	from := path.Join(d.rooturl, fromPath)
+	to := path.Join(d.rooturl, toPath)
+	err := tasks.Wait(ctx, func(context.Context) (tasks.Waiter, error) {
+		return d.fm.MoveDatastoreFile(ctx, from, d.s.Datacenter, to, d.s.Datacenter, true)
+	})
+
+	return err
+}
+
+func (d *datastore) IsVSAN(ctx context.Context) bool {
+	dsType, _ := d.ds.Type(ctx)
+	return dsType == types.HostFileSystemVolumeFileSystemTypeVsan
+}
+
+// This creates the root directory in the datastore and sets the rooturl and
+// rootdir in the datastore struct so we can reuse it for other routines.  This
+// handles vsan + vc, vsan + esx, and esx.  The URI conventions are not the
+// same for each and this tries to create the directory and stash the relevant
+// result so the URI doesn't need to be recomputed for every datastore
+// operation.
+func (d *datastore) mkRootDir(ctx context.Context, rootdir string) error {
+
+	// Handle vsan
+	// Vsan will complain if the root dir exists.  Just call it directly and
+	// swallow the error if it's already there.
+	if d.IsVSAN(ctx) {
+		nm := object.NewDatastoreNamespaceManager(d.s.Vim25())
+
+		// This returns the vmfs path (including the datastore and directory
+		// UUIDs).  Use the directory UUID in future operations because it is
+		// the stable path which we can use regardless of vsan state.
+		uuid, err := nm.CreateDirectory(ctx, d.ds, rootdir, "")
+		if err != nil {
+			if !soap.IsSoapFault(err) {
+				return err
+			}
+
+			soapFault := soap.ToSoapFault(err)
+			_, ok := soapFault.VimFault().(types.FileAlreadyExists)
+			if ok {
+				// XXX UGLY HACK until we move this into the installer.  Use the
+				// display name if the dir exists since we can't get the UUID after the
+				// directory is created.
+
+				uuid = rootdir
+				err = nil
+			} else {
+				return err
+			}
+		}
+
+		// set the root url to the UUID of the dir we created
+		d.rootdir = path.Base(uuid)
+		d.rooturl = d.ds.Path(d.rootdir)
+		log.Infof("Created image store parent directory (%s) at %s", rootdir, d.rooturl)
+		return nil
+	}
+
+	// Handle regular local datastore
+	// check if it already exists
+	_, err := d.Ls(ctx, d.ds.Path(rootdir))
+	if err != nil && !types.IsFileNotFound(err) {
+		return err
+	}
+
+	d.rootdir = rootdir
+	d.rooturl = d.ds.Path(rootdir)
+
+	// dir already exists
+	if err == nil {
+		return err
+	}
+
+	// dir does not exist
+	if err != nil && types.IsFileNotFound(err) {
+		log.Infof("Creating image store parent directory %s", d.rooturl)
+		err = d.fm.MakeDirectory(ctx, d.rooturl, d.s.Datacenter, false)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/lib/portlayer/storage/vsphere/datastore_test.go
+++ b/lib/portlayer/storage/vsphere/datastore_test.go
@@ -1,0 +1,140 @@
+// Copyright 2016 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vsphere
+
+import (
+	"math/rand"
+	"testing"
+	"time"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/vmware/vic/pkg/vsphere/session"
+	"github.com/vmware/vic/pkg/vsphere/tasks"
+	"github.com/vmware/vic/pkg/vsphere/test/env"
+	"golang.org/x/net/context"
+)
+
+func Session(ctx context.Context, t *testing.T) *session.Session {
+	config := &session.Config{
+		Service: env.URL(t),
+
+		/// XXX Why does this insist on having this field populated?
+		DatastorePath: env.DS(t),
+
+		Insecure:  true,
+		Keepalive: time.Duration(5) * time.Minute,
+	}
+
+	s, err := session.NewSession(config).Create(ctx)
+	if err != nil {
+		t.SkipNow()
+	}
+
+	return s
+}
+
+func TestDatastoreSummary(t *testing.T) {
+	ctx, ds, cleanupfunc := dSsetup(t)
+	if t.Failed() {
+		return
+	}
+	defer cleanupfunc()
+
+	//fmt.Printf("ds.ds = %#v", ds.ds.Reference().Summary)
+	summary, err := ds.Summary(ctx)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	t.Logf("Name:\t%s\n", summary.Name)
+	t.Logf("  Path:\t%s\n", ds.ds.InventoryPath)
+	t.Logf("  Type:\t%s\n", summary.Type)
+	t.Logf("  URL:\t%s\n", summary.Url)
+	t.Logf("  Capacity:\t%.1f GB\n", float64(summary.Capacity)/(1<<30))
+	t.Logf("  Free:\t%.1f GB\n", float64(summary.FreeSpace)/(1<<30))
+}
+
+func TestDatastoreCreateDir(t *testing.T) {
+	ctx, ds, cleanupfunc := dSsetup(t)
+	if t.Failed() {
+		return
+	}
+	defer cleanupfunc()
+
+	_, err := ds.Ls(ctx, "")
+	if !assert.NoError(t, err) {
+		return
+	}
+}
+
+func TestDatastoreMkdirAndLs(t *testing.T) {
+	ctx, ds, cleanupfunc := dSsetup(t)
+	if t.Failed() {
+		return
+	}
+	defer cleanupfunc()
+
+	dirs := []string{"dir1", "dir1/child1"}
+
+	// create the dir then test it exists by calling ls
+	for _, dir := range dirs {
+		_, err := ds.Mkdir(ctx, true, dir)
+		if !assert.NoError(t, err) {
+			return
+		}
+
+		_, err = ds.Ls(ctx, dir)
+		if !assert.NoError(t, err) {
+			return
+		}
+	}
+}
+
+// From https://siongui.github.io/2015/04/13/go-generate-random-string/
+func RandomString(strlen int) string {
+	rand.Seed(time.Now().UTC().UnixNano())
+	const chars = "abcdefghijklmnopqrstuvwxyz0123456789"
+	result := make([]byte, strlen)
+	for i := 0; i < strlen; i++ {
+		result[i] = chars[rand.Intn(len(chars))]
+	}
+	return string(result)
+}
+
+func dSsetup(t *testing.T) (context.Context, *datastore, func()) {
+	ctx := context.Background()
+	sess := Session(ctx, t)
+	log.SetLevel(log.DebugLevel)
+
+	ds, err := newDatastore(ctx, sess, sess.Datastore, RandomString(10)+"dstests")
+	if !assert.NoError(t, err) {
+		return ctx, nil, nil
+	}
+
+	f := func() {
+		log.Debugf("Removing test root %s", ds.rooturl)
+		err := tasks.Wait(ctx, func(context.Context) (tasks.Waiter, error) {
+			return ds.fm.DeleteDatastoreFile(ctx, ds.rooturl, sess.Datacenter)
+		})
+
+		if err != nil {
+			log.Errorf(err.Error())
+			return
+		}
+	}
+
+	return ctx, ds, f
+}

--- a/pkg/vsphere/disk/disk_ext4_test.go
+++ b/pkg/vsphere/disk/disk_ext4_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/docker/docker/pkg/mount"
 	"github.com/stretchr/testify/assert"
 	"github.com/vmware/govmomi/object"
-	"github.com/vmware/vic/pkg/vsphere/test"
 	"golang.org/x/net/context"
 )
 
@@ -32,7 +31,7 @@ import (
 func TestCreateFS(t *testing.T) {
 	log.SetLevel(log.DebugLevel)
 
-	client := test.Session(context.Background(), t)
+	client := Session(context.Background(), t)
 	if client == nil {
 		return
 	}

--- a/pkg/vsphere/test/env/env.go
+++ b/pkg/vsphere/test/env/env.go
@@ -28,3 +28,11 @@ func URL(t *testing.T) string {
 	}
 	return s
 }
+
+func DS(t *testing.T) string {
+	s := os.Getenv("VIC_ESX_TEST_DATASTORE")
+	if s == "" && t != nil {
+		t.Skip("Skipping: No test ESX DATASTORE defined")
+	}
+	return s
+}


### PR DESCRIPTION
Fixes #710

VSAN uses namespaces for top-level directories which themselves are VMFS
filesystems.  The top-level directory is a symlink to the VMFS
(represented by a uuid).  This UUID is the stable path to the namespace
and should be used instead of the directory symlink.  This change uses
that and simplifies the datastore URI convetion so we don't have to
compute the URI format for each datastore or fm govmomi API call.  The
`datastore` struct wraps all of the datastore methods and supplies the
right arguments in the appropriate datastore URI format for the given
vsphere datastore.

Tested against VC + VSAN, ESX + VSAN, and ESX.