### PR TITLE
Add vcsim Datastore HTTP interface

### DIFF
--- a/pkg/vsphere/simulator/datastore_test.go
+++ b/pkg/vsphere/simulator/datastore_test.go
@@ -15,9 +15,21 @@
 package simulator
 
 import (
+	"fmt"
+	"net/http"
+	"os"
+	"path"
 	"testing"
 
+	"golang.org/x/net/context"
+
+	"github.com/vmware/govmomi"
+	"github.com/vmware/govmomi/find"
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25/soap"
 	"github.com/vmware/govmomi/vim25/types"
+	"github.com/vmware/vic/pkg/vsphere/simulator/esx"
+	"github.com/vmware/vic/pkg/vsphere/simulator/vc"
 )
 
 func TestParseDatastorePath(t *testing.T) {
@@ -87,4 +99,242 @@ func TestRefreshDatastore(t *testing.T) {
 			}
 		}
 	}
+}
+
+func TestDatastoreHTTP(t *testing.T) {
+	models := []func() (*browseDatastoreModel, error){
+		browseDatastoreModelWithESX,
+		browseDatastoreModelWithVC,
+	}
+
+	ctx := context.Background()
+	src := "datastore_test.go"
+	dst := "tmp.go"
+
+	for _, model := range models {
+		m, err := model()
+		defer m.Server.Close()
+
+		download := func(name string, fail bool) {
+			_, _, err = m.Datastore.Download(ctx, name, nil)
+			if fail {
+				if err == nil {
+					t.Fatal("expected error")
+				}
+			} else {
+				if err != nil {
+					t.Error(err)
+				}
+			}
+		}
+
+		upload := func(name string, fail bool, method string) {
+			f, err := os.Open(src)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer f.Close()
+
+			p := soap.DefaultUpload
+			p.Method = method
+
+			err = m.Datastore.Upload(ctx, f, name, &p)
+			if fail {
+				if err == nil {
+					t.Fatalf("%s %s: expected error", method, name)
+				}
+			} else {
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+		}
+
+		// GET file does not exist = fail
+		download(dst, true)
+
+		// PUT file = ok
+		upload(dst, false, "PUT")
+
+		// GET file exists = ok
+		download(dst, false)
+
+		// POST file exists = fail
+		upload(dst, true, "POST")
+
+		// POST file does not exist = ok
+		upload(dst+".post", false, "POST")
+
+		// PATCH method not supported = fail
+		upload(dst+".patch", true, "PATCH")
+
+		// PUT path is directory = fail
+		upload("", true, "PUT")
+
+		// GET datastore does not exist = fail
+		download(dst, false)
+
+		// cover the case where datacenter or datastore lookup fails
+		for _, q := range []string{"dcName=nope", "dsName=nope"} {
+			u := *m.Server.URL
+			u.RawQuery = q
+			u.Path = path.Join(folderPrefix, dst)
+
+			r, err := http.Get(u.String())
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if r.StatusCode == http.StatusOK {
+				t.Error("expected failure")
+			}
+		}
+	}
+}
+
+// TODO: this is a copy of vmCreateModel; we should make these helpers public elsewhere
+type browseDatastoreModel struct {
+	Service *Service
+	Server  *Server
+
+	Client     *govmomi.Client
+	Finder     *find.Finder
+	Datacenter *object.Datacenter
+	Folders    *object.DatacenterFolders
+	Cluster    *object.ClusterComputeResource
+	Pool       *object.ResourcePool
+	Host       *object.HostSystem
+	Datastore  *object.Datastore
+}
+
+func browseDatastoreModelWithESX() (*browseDatastoreModel, error) {
+	m := new(browseDatastoreModel)
+
+	m.Service = New(NewServiceInstance(esx.ServiceContent, esx.RootFolder))
+	m.Server = m.Service.NewServer()
+
+	ctx := context.Background()
+
+	c, err := govmomi.NewClient(ctx, m.Server.URL, true)
+	if err != nil {
+		return nil, err
+	}
+
+	m.Client = c
+
+	m.Finder = find.NewFinder(c.Client, false)
+
+	m.Datacenter, err = m.Finder.DefaultDatacenter(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	m.Finder.SetDatacenter(m.Datacenter)
+
+	m.Folders, err = m.Datacenter.Folders(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	m.Host, err = m.Finder.DefaultHostSystem(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	m.Pool, err = m.Finder.DefaultResourcePool(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	_, err = m.Server.TempDatastore(ctx, m.Host)
+	if err != nil {
+		return nil, err
+	}
+
+	m.Datastore, err = m.Finder.DefaultDatastore(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return m, nil
+}
+
+func browseDatastoreModelWithVC() (*browseDatastoreModel, error) {
+	m := new(browseDatastoreModel)
+
+	m.Service = New(NewServiceInstance(vc.ServiceContent, vc.RootFolder))
+
+	m.Server = m.Service.NewServer()
+
+	ctx := context.Background()
+
+	c, err := govmomi.NewClient(ctx, m.Server.URL, true)
+	if err != nil {
+		return nil, err
+	}
+
+	m.Client = c
+
+	f := object.NewRootFolder(c.Client)
+
+	m.Datacenter, err = f.CreateDatacenter(ctx, "dc1")
+	if err != nil {
+		return nil, err
+	}
+
+	m.Finder = find.NewFinder(c.Client, false)
+
+	m.Datacenter, err = m.Finder.DefaultDatacenter(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	m.Finder.SetDatacenter(m.Datacenter)
+
+	m.Folders, err = m.Datacenter.Folders(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	m.Cluster, err = m.Folders.HostFolder.CreateCluster(ctx, "cluster1", types.ClusterConfigSpecEx{})
+	if err != nil {
+		return nil, err
+	}
+
+	m.Pool, err = m.Finder.ResourcePool(ctx, "*/*")
+	if err != nil {
+		return nil, err
+	}
+
+	var hosts []*object.HostSystem
+
+	for i := 0; i < 3; i++ {
+		spec := types.HostConnectSpec{
+			HostName: fmt.Sprintf("host-%d", i),
+		}
+
+		task, cerr := m.Cluster.AddHost(ctx, spec, true, nil, nil)
+		if cerr != nil {
+			return nil, cerr
+		}
+
+		info, cerr := task.WaitForResult(ctx, nil)
+		if cerr != nil {
+			return nil, cerr
+		}
+
+		hosts = append(hosts, object.NewHostSystem(c.Client, info.Result.(types.ManagedObjectReference)))
+	}
+
+	_, err = m.Server.TempDatastore(ctx, hosts...)
+	if err != nil {
+		return nil, err
+	}
+
+	m.Datastore, err = m.Finder.DefaultDatastore(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return m, nil
 }

--- a/pkg/vsphere/simulator/host_datastore_system.go
+++ b/pkg/vsphere/simulator/host_datastore_system.go
@@ -93,6 +93,15 @@ func (dss *HostDatastoreSystem) CreateLocalDatastore(c *types.CreateLocalDatasto
 		return r
 	}
 
+	ds.Host = append(ds.Host, types.DatastoreHostMount{
+		Key: dss.Host.Reference(),
+		MountInfo: types.HostMountInfo{
+			AccessMode: string(types.HostMountModeReadWrite),
+			Mounted:    types.NewBool(true),
+			Accessible: types.NewBool(true),
+		},
+	})
+
 	_ = ds.RefreshDatastore(&types.RefreshDatastore{This: ds.Self})
 
 	r.Res = &types.CreateLocalDatastoreResponse{

--- a/pkg/vsphere/simulator/property_collector.go
+++ b/pkg/vsphere/simulator/property_collector.go
@@ -41,6 +41,10 @@ var errMissingField = errors.New("missing field")
 var errEmptyField = errors.New("empty field")
 
 func fieldValueInterface(f reflect.StructField, rval reflect.Value) interface{} {
+	if rval.Kind() == reflect.Ptr {
+		rval = rval.Elem()
+	}
+
 	pval := rval.Interface()
 
 	if rval.Kind() == reflect.Slice {
@@ -106,8 +110,6 @@ func fieldRefs(f interface{}) []types.ManagedObjectReference {
 	switch fv := f.(type) {
 	case types.ManagedObjectReference:
 		return []types.ManagedObjectReference{fv}
-	case *types.ManagedObjectReference:
-		return []types.ManagedObjectReference{*fv}
 	case *types.ArrayOfManagedObjectReference:
 		return fv.ManagedObjectReference
 	case nil:

--- a/pkg/vsphere/simulator/session_manager.go
+++ b/pkg/vsphere/simulator/session_manager.go
@@ -26,6 +26,8 @@ import (
 
 type SessionManager struct {
 	mo.SessionManager
+
+	ServiceHostName string
 }
 
 func NewSessionManager(ref types.ManagedObjectReference) object.Reference {
@@ -50,4 +52,15 @@ func (s *SessionManager) Login(login *types.Login) soap.HasFault {
 	}
 
 	return body
+}
+
+func (s *SessionManager) AcquireGenericServiceTicket(ticket *types.AcquireGenericServiceTicket) soap.HasFault {
+	return &methods.AcquireGenericServiceTicketBody{
+		Res: &types.AcquireGenericServiceTicketResponse{
+			Returnval: types.SessionManagerGenericServiceTicket{
+				Id:       "TODO",
+				HostName: s.ServiceHostName,
+			},
+		},
+	}
 }

--- a/pkg/vsphere/simulator/simulator.go
+++ b/pkg/vsphere/simulator/simulator.go
@@ -24,12 +24,14 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"os"
+	"path"
 	"path/filepath"
 	"reflect"
 	"strings"
 
 	"golang.org/x/net/context"
 
+	"github.com/vmware/govmomi/find"
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/vim25"
 	"github.com/vmware/govmomi/vim25/soap"
@@ -188,16 +190,89 @@ func (s *Service) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+func (s *Service) findDatastore(query url.Values) (*Datastore, error) {
+	ctx := context.Background()
+
+	finder := find.NewFinder(s.client, false)
+	dc, err := finder.DatacenterOrDefault(ctx, query.Get("dcName"))
+	if err != nil {
+		return nil, err
+	}
+
+	finder.SetDatacenter(dc)
+
+	ds, err := finder.DatastoreOrDefault(ctx, query.Get("dsName"))
+	if err != nil {
+		return nil, err
+	}
+
+	return Map.Get(ds.Reference()).(*Datastore), nil
+}
+
+const folderPrefix = "/folder/"
+
+func (s *Service) ServeDatastore(w http.ResponseWriter, r *http.Request) {
+	ds, ferr := s.findDatastore(r.URL.Query())
+	if ferr != nil {
+		log.Printf("failed to locate datastore with query params: %s", r.URL.RawQuery)
+		w.WriteHeader(http.StatusNotFound)
+		return
+	}
+
+	file := strings.TrimPrefix(r.URL.Path, folderPrefix)
+	p := path.Join(ds.Info.GetDatastoreInfo().Url, file)
+
+	switch r.Method {
+	case "GET":
+		f, err := os.Open(p)
+		if err != nil {
+			log.Printf("failed to %s '%s': %s", r.Method, p, err)
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		defer f.Close()
+
+		_, _ = io.Copy(w, f)
+	case "POST":
+		_, err := os.Stat(p)
+		if err == nil {
+			// File exists
+			w.WriteHeader(http.StatusConflict)
+			return
+		}
+
+		// File does not exist, fallthrough to create via PUT logic
+		fallthrough
+	case "PUT":
+		f, err := os.Create(p)
+		if err != nil {
+			log.Printf("failed to %s '%s': %s", r.Method, p, err)
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		defer f.Close()
+
+		_, _ = io.Copy(f, r.Body)
+	default:
+		w.WriteHeader(http.StatusMethodNotAllowed)
+	}
+}
+
 // NewServer returns an http Server instance for the given service
 func (s *Service) NewServer() *Server {
 	mux := http.NewServeMux()
 	path := "/sdk"
 	mux.Handle(path, s)
 
+	mux.HandleFunc(folderPrefix, s.ServeDatastore)
+
 	ts := httptest.NewServer(mux)
 
 	u, _ := url.Parse(ts.URL)
 	u.Path = path
+
+	// Redirect clients to this http server, rather than HostSystem.Name
+	Map.Get(*s.client.ServiceContent.SessionManager).(*SessionManager).ServiceHostName = u.Host
 
 	return &Server{
 		Server: ts,


### PR DESCRIPTION
Currently fails CI as it depends on https://github.com/vmware/govmomi/pull/525

Which in turn fails govmomi CI, due to invalid configuration of the ESX host used by CI.
