### PR TITLE
Fixed link to achitecture diagram.

### DIFF
--- a/index.html
+++ b/index.html
@@ -76,7 +76,7 @@
 
             <p>vSphere Integrated Containers is a container runtime for vSphere, allowing developers familiar with Docker to develop in containers and deploy them alongside traditional VM-based workloads on vSphere clusters, and allowing for these workloads to be managed through the vSphere UI in a way familiar to existing vSphere admins.</p>
 
-            <p>See <a href="https://github.com/vmware/vic/blob/master/arch.md" target="_blank">vSphere Integrated Containers Architecture</a> for a high level overview.</p>
+            <p>See <a href="https://github.com/vmware/vic/blob/master/doc/design/arch/arch.md" target="_blank">vSphere Integrated Containers Architecture</a> for a high level overview.</p>
           </div>
         </div>
       </div>


### PR DESCRIPTION
[skip ci] Per comment by @caglar10ur in https://github.com/vmware/vic/pull/1030, I have fixed the link to the architecture doc in the new VIC landing page.

See http://stuclem.github.io/vic/ for a preview.