### PR TITLE
Friendly Name refactor and persistence to VMX file

### DIFF
--- a/lib/apiservers/portlayer/swagger.yml
+++ b/lib/apiservers/portlayer/swagger.yml
@@ -747,6 +747,8 @@ definitions:
   ContainerCreateConfig:
     type: object
     properties:
+      name:
+        type: string
       imageStore:
         $ref: "#/definitions/ImageStore"
       image:

--- a/lib/portlayer/exec/handle.go
+++ b/lib/portlayer/exec/handle.go
@@ -171,6 +171,9 @@ func (h *Handle) Create(ctx context.Context, sess *session.Session, config *Cont
 		return fmt.Errorf("spec already set")
 	}
 
+	// update the handle with Metadata
+	h.ExecConfig = config.Metadata
+
 	// Convert the management hostname to IP
 	ips, err := net.LookupIP(managementHostName)
 	if err != nil {


### PR DESCRIPTION
This change accomplishes two things:

* Refactors friendly name generation to the docker persona
* Persists the name into the vmx file via the extra config mechanism

Fixes #997