### PR TITLE
Print error message from command execution

### DIFF
--- a/cmd/vic-machine/main.go
+++ b/cmd/vic-machine/main.go
@@ -45,5 +45,7 @@ func main() {
 		},
 	}
 	app.Version = fmt.Sprintf("%s.%s", MajorVersion, BuildID)
-	app.Run(os.Args)
+	if err := app.Run(os.Args); err != nil {
+		fmt.Fprintln(os.Stderr, "Error: ", err.Error())
+	}
 }


### PR DESCRIPTION
  urface/cli does not print out usage error in the general usage error message, but will return the detail message to caller. So modify main function to print out detailed message.

Fixes: #1050 