### PR TITLE
Container VM create date persisted to vmx file

### DIFF
--- a/lib/metadata/container_vm.go
+++ b/lib/metadata/container_vm.go
@@ -25,7 +25,10 @@ type Common struct {
 	ID string `vic:"0.1" scope:"read-only" key:"id"`
 
 	// Convenience field to record a human readable name
-	Name string `vic:"0.1" scope:"read-only" key:"name"`
+	Name string `vic:"0.1" scope:"read-write" key:"name"`
+
+	// creation timestamp
+	Created string `vic:"0.1" scope:"read-only" key:"created"`
 
 	// Freeform notes related to the entity
 	Notes string `vic:"0.1" scope:"hidden" key:"notes"`

--- a/lib/portlayer/exec/handle.go
+++ b/lib/portlayer/exec/handle.go
@@ -21,6 +21,7 @@ import (
 	"net"
 	"strings"
 	"sync"
+	"time"
 
 	"golang.org/x/net/context"
 
@@ -173,7 +174,8 @@ func (h *Handle) Create(ctx context.Context, sess *session.Session, config *Cont
 
 	// update the handle with Metadata
 	h.ExecConfig = config.Metadata
-
+	// add create time to config
+	h.ExecConfig.Common.Created = time.Now().UTC().String()
 	// Convert the management hostname to IP
 	ips, err := net.LookupIP(managementHostName)
 	if err != nil {


### PR DESCRIPTION
This provides an enhancement to support ps & a bug fix to support rename

- add created date to vmx file -- this is needed for docker ps
- changed name to read-write to support docker rename

Fixes #1040