### PR TITLE
Don't call Close() on nil ssh.ServerConn

### DIFF
--- a/cmd/tether/attach.go
+++ b/cmd/tether/attach.go
@@ -184,7 +184,11 @@ func (t *attachServerSSH) run() error {
 		return err
 	}
 
-	defer sConn.Close()
+	defer func() {
+		if sConn != nil {
+			sConn.Close()
+		}
+	}()
 
 	// Global requests
 	go t.globalMux(reqs)


### PR DESCRIPTION
Fixes following panic
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xb code=0x1 addr=0x0 pc=0x482d46]

goroutine 15 [running]:
panic(0xf80c40, 0xc8200100f0)
    /usr/local/go/src/runtime/panic.go:481 +0x3e6
github.com/vmware/vic/cmd/tether.(*attachServerSSH).run(0xc82018f1a0, 0x0, 0x0)
    /opt/go/src/github.com/vmware/vic/cmd/tether/attach.go:187 +0x1dc6
created by github.com/vmware/vic/cmd/tether.(*attachServerSSH).start
    /opt/go/src/github.com/vmware/vic/cmd/tether/attach.go:133 +0x68e
exit status 2
FAIL    github.com/vmware/vic/cmd/tether    0.030s
```