### PR TITLE
testing the new ci system and cleaning up some files

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -240,5 +240,3 @@ The layout in the repo is as follows - this is a recent reorganisation so there 
 * pkg - packages that are not tightly coupled to vmware/vic and could be usefully consumed in other projects. There is still some sanitization to do here.
 * tests - integration and system test code that doesn't use go test
 * vendor - standard Go vendor model
-
-


### PR DESCRIPTION
https://ci2.vmware.run is setup and will start taking the CI builds. Eventually it will switch back to ci.vmware.run.

This PR is cleaning out 2 lines at the end of the contrib file while also kicking off a testci build