### PR TITLE
vic-machine delete

### DIFF
--- a/cmd/vic-machine/common/target.go
+++ b/cmd/vic-machine/common/target.go
@@ -1,0 +1,110 @@
+// Copyright 2016 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"fmt"
+	"net/url"
+	"os"
+
+	log "github.com/Sirupsen/logrus"
+
+	"github.com/urfave/cli"
+	"github.com/vmware/vic/pkg/flags"
+
+	"golang.org/x/crypto/ssh/terminal"
+)
+
+type Target struct {
+	URL *url.URL
+
+	User     string
+	Password *string
+}
+
+func NewTarget() *Target {
+	return &Target{}
+}
+
+func (t *Target) TargetFlags() []cli.Flag {
+	return []cli.Flag{
+		cli.GenericFlag{
+			Name:  "target, t",
+			Value: flags.NewURLFlag(&t.URL),
+			Usage: "ESXi or vCenter connection URL, sample root:password@VC-FQDN",
+		},
+		cli.StringFlag{
+			Name:        "user, u",
+			Value:       "",
+			Usage:       "ESX or vCenter user",
+			Destination: &t.User,
+		},
+		cli.GenericFlag{
+			Name:  "password, p",
+			Value: flags.NewOptionalString(&t.Password),
+			Usage: "ESX or vCenter password",
+		},
+	}
+}
+
+func (t *Target) URLWithoutPassword() *url.URL {
+	if t.URL == nil {
+		return nil
+	}
+
+	withoutCredentials := *t.URL
+	withoutCredentials.User = url.User(t.URL.User.Username())
+	return &withoutCredentials
+}
+
+func (t *Target) ProcessTargets() error {
+	if t.URL == nil {
+		return cli.NewExitError("--target argument must be specified", 1)
+	}
+
+	var urlUser string
+	var urlPassword *string
+
+	if t.URL.User != nil {
+		urlUser = t.URL.User.Username()
+		if passwd, set := t.URL.User.Password(); set {
+			urlPassword = &passwd
+		}
+	}
+	if t.User == "" && urlUser == "" {
+		return cli.NewExitError("User to login must be specified in --user or --target URL", 1)
+	} else if t.User == "" && urlUser != "" {
+		t.User = urlUser
+	}
+
+	//prompt for passwd if not specified
+	if t.Password == nil && urlPassword == nil {
+		log.Print("Please enter ESX or vCenter password: ")
+		b, err := terminal.ReadPassword(int(os.Stdin.Fd()))
+		if err != nil {
+			message := fmt.Sprintf("Failed to read password from stdin: %s", err)
+			cli.NewExitError(message, 1)
+		}
+		sb := string(b)
+		t.Password = &sb
+	} else if t.Password == nil && urlPassword != nil {
+		t.Password = urlPassword
+	}
+
+	// Override username password if set
+	t.URL.User = url.UserPassword(t.User, *t.Password)
+
+	return nil
+}

--- a/cmd/vic-machine/common/target_test.go
+++ b/cmd/vic-machine/common/target_test.go
@@ -1,0 +1,95 @@
+// Copyright 2016 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/urfave/cli"
+	"github.com/vmware/govmomi/vim25/soap"
+)
+
+func TestFlags(t *testing.T) {
+	target := NewTarget()
+	flags := target.TargetFlags()
+
+	if len(flags) != 3 {
+		t.Errorf("Wrong flag numbers")
+	}
+}
+
+func TestURLWithoutPassword(t *testing.T) {
+	target := NewTarget()
+	target.URL, _ = soap.ParseURL("root:pass@127.0.0.1")
+	if target.URLWithoutPassword().String() != "https://root@127.0.0.1/sdk" {
+		t.Errorf("Unexpected return of without password URL string, %s", target.URLWithoutPassword().String())
+	}
+}
+
+func TestProcess(t *testing.T) {
+	passwd := "pass"
+	url1, _ := soap.ParseURL("127.0.0.1")
+	url2, _ := soap.ParseURL("root:@127.0.0.1")
+	url3, _ := soap.ParseURL("line:password@127.0.0.1")
+	url4, _ := soap.ParseURL("root:pass@127.0.0.1")
+	result, _ := url.Parse("https://root:pass@127.0.0.1/sdk")
+	passEmpty := ""
+	result1, _ := url.Parse("https://root:@127.0.0.1/sdk")
+	tests := []struct {
+		URL      *url.URL
+		User     string
+		Password *string
+
+		err    error
+		result *url.URL
+	}{
+		{nil, "", nil, cli.NewExitError("--target argument must be specified", 1), nil},
+		{nil, "root", nil, cli.NewExitError("--target argument must be specified", 1), nil},
+		{nil, "root", &passwd, cli.NewExitError("--target argument must be specified", 1), nil},
+		{url1, "root", &passwd, nil, result},
+		{url4, "", nil, nil, result},
+		{url3, "root", &passwd, nil, result},
+		{url2, "", &passwd, nil, result},
+		{url1, "root", &passEmpty, nil, result1},
+	}
+
+	for _, test := range tests {
+		target := NewTarget()
+		target.URL = test.URL
+		target.User = test.User
+		target.Password = test.Password
+		if target.URL != nil {
+			t.Logf("Before processing, url: %s", target.URL.String())
+		}
+		e := target.ProcessTargets()
+		if test.err != nil {
+			if e == nil {
+				t.Errorf("Empty error")
+			}
+			if e.Error() != test.err.Error() {
+				t.Errorf("Unexpected error message: %s", e.Error())
+			}
+		} else if e != nil {
+			t.Errorf("Unexpected error %s", e.Error())
+		} else {
+			if target.URL != test.URL {
+				t.Errorf("unexpected result url: %s", target.URL.String())
+			} else {
+				t.Logf("result url: %s", target.URL.String())
+			}
+		}
+	}
+}

--- a/cmd/vic-machine/create/install_test.go
+++ b/cmd/vic-machine/create/install_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 var (
-	data = &Create{}
+	create = NewCreate()
 )
 
 func TestImageNotFound(t *testing.T) {
@@ -39,9 +39,9 @@ func TestImageNotFound(t *testing.T) {
 
 	os.Args = []string{"cmd", "create", fmt.Sprintf("-appliance-iso=%s", tmpfile.Name())}
 	flag.Parse()
-	data.applianceISO = tmpfile.Name()
-	data.osType = "linux"
-	if _, err = data.checkImagesFiles(); err == nil {
+	create.applianceISO = tmpfile.Name()
+	create.osType = "linux"
+	if _, err = create.checkImagesFiles(); err == nil {
 		t.Errorf("Error is expected for boot iso file is not found.")
 	}
 }
@@ -63,11 +63,11 @@ func TestImageChecks(t *testing.T) {
 
 	os.Args = []string{"cmd", "create", fmt.Sprintf("-bootstrap-iso=%s", tmpfile.Name())}
 	flag.Parse()
-	data.applianceISO = ""
-	data.bootstrapISO = tmpfile.Name()
-	data.osType = "linux"
+	create.applianceISO = ""
+	create.bootstrapISO = tmpfile.Name()
+	create.osType = "linux"
 	var imageFiles []string
-	if imageFiles, err = data.checkImagesFiles(); err != nil {
+	if imageFiles, err = create.checkImagesFiles(); err != nil {
 		t.Errorf("Error returned: %s", err)
 	}
 	found := false
@@ -86,7 +86,7 @@ func TestLoadKey(t *testing.T) {
 	log.SetLevel(log.InfoLevel)
 	os.Args = []string{"cmd", "create"}
 	flag.Parse()
-	if _, err := data.loadCertificate(); err != nil {
+	if _, err := create.loadCertificate(); err != nil {
 		t.Errorf("Error returned: %s", err)
 	}
 }
@@ -95,8 +95,8 @@ func TestGenKey(t *testing.T) {
 	log.SetLevel(log.InfoLevel)
 	os.Args = []string{"cmd", "create"}
 	flag.Parse()
-	data.tlsGenerate = true
-	if _, err := data.loadCertificate(); err != nil {
+	create.tlsGenerate = true
+	if _, err := create.loadCertificate(); err != nil {
 		t.Errorf("Error returned: %s", err)
 	}
 }

--- a/cmd/vic-machine/data/data.go
+++ b/cmd/vic-machine/data/data.go
@@ -1,0 +1,50 @@
+// Copyright 2016 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package data
+
+import (
+	"time"
+
+	"github.com/vmware/vic/cmd/vic-machine/common"
+)
+
+// Data wrapps all parameters required by value validation
+type Data struct {
+	*common.Target
+
+	ComputeResourcePath string
+	ImageDatastoreName  string
+	DisplayName         string
+
+	ContainerDatastoreName string
+	ExternalNetworkName    string
+	ManagementNetworkName  string
+	BridgeNetworkName      string
+
+	NumCPUs  int
+	MemoryMB int
+
+	Insecure bool
+	Timeout  time.Duration
+
+	Force bool
+}
+
+func NewData() *Data {
+	d := &Data{
+		Target: common.NewTarget(),
+	}
+	return d
+}

--- a/cmd/vic-machine/delete/delete.go
+++ b/cmd/vic-machine/delete/delete.go
@@ -1,0 +1,126 @@
+// Copyright 2016 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package delete
+
+import (
+	"io"
+	"os"
+	"time"
+
+	log "github.com/Sirupsen/logrus"
+
+	"github.com/urfave/cli"
+	"github.com/vmware/vic/cmd/vic-machine/data"
+	"github.com/vmware/vic/cmd/vic-machine/validate"
+	"github.com/vmware/vic/lib/install/management"
+	"github.com/vmware/vic/pkg/errors"
+)
+
+// Delete has all input parameters for vic-machine delete command
+type Uninstall struct {
+	*data.Data
+
+	id      string
+	logfile string
+
+	executor *management.Dispatcher
+}
+
+func NewUninstall() *Uninstall {
+	d := &Uninstall{}
+	d.Data = data.NewData()
+	return d
+}
+
+// Flags return all cli flags for delete
+func (d *Uninstall) Flags() []cli.Flag {
+	flags := []cli.Flag{
+		cli.StringFlag{
+			Name:        "vch-id",
+			Value:       "",
+			Usage:       "The ID of the Virtual Container Host - not supported until vic-machine ls is ready",
+			Destination: &d.id,
+		},
+		cli.StringFlag{
+			Name:        "compute-resource",
+			Value:       "",
+			Usage:       "Compute resource path, e.g. /ha-datacenter/host/myCluster/Resources/myRP",
+			Destination: &d.ComputeResourcePath,
+		},
+		cli.BoolFlag{
+			Name:        "force",
+			Usage:       "Force the uninstall",
+			Destination: &d.Force,
+		},
+		cli.DurationFlag{
+			Name:        "timeout",
+			Value:       3 * time.Minute,
+			Usage:       "Time to wait for appliance initialization",
+			Destination: &d.Timeout,
+		},
+		cli.StringFlag{
+			Name:        "name",
+			Value:       "",
+			Usage:       "The name of the Virtual Container Host",
+			Destination: &d.DisplayName,
+		},
+	}
+	flags = append(d.TargetFlags(), flags...)
+	return flags
+}
+
+func (d *Uninstall) processParams() error {
+	if err := d.ProcessTargets(); err != nil {
+		return err
+	}
+
+	if (d.ComputeResourcePath == "" || d.DisplayName == "") && d.id == "" {
+		return cli.NewExitError("--compute-resource, --name or --vch-id should be specified", 1)
+	}
+
+	d.logfile = "delete.log"
+	d.Insecure = true
+	return nil
+}
+
+func (d *Uninstall) Run(cli *cli.Context) error {
+	var err error
+	if err = d.processParams(); err != nil {
+		return err
+	}
+
+	// Open log file
+	f, err := os.OpenFile(d.logfile, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0644)
+	if err != nil {
+		err = errors.Errorf("Error opening logfile %s: %v", d.logfile, err)
+		return err
+	}
+	defer f.Close()
+
+	// Initiliaze logger with default TextFormatter
+	log.SetFormatter(&log.TextFormatter{ForceColors: true, FullTimestamp: true})
+	// SetOutput to io.MultiWriter so that we can log to stdout and a file
+	log.SetOutput(io.MultiWriter(os.Stdout, f))
+
+	log.Infof("### Deleting VCH ####")
+
+	validator := validate.NewValidator()
+	rp, err := validator.GetResourcePool(d.Data)
+	if err != nil {
+		err = errors.Errorf("%s. Exiting...", err)
+		return err
+	}
+	return errors.Errorf("VCH delete function is not implemented, %s", rp)
+}

--- a/cmd/vic-machine/main.go
+++ b/cmd/vic-machine/main.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/urfave/cli"
 	"github.com/vmware/vic/cmd/vic-machine/create"
+	uninstall "github.com/vmware/vic/cmd/vic-machine/delete"
 )
 
 var (
@@ -36,12 +37,19 @@ func main() {
 	app.EnableBashCompletion = true
 
 	create := create.NewCreate()
+	uninstall := uninstall.NewUninstall()
 	app.Commands = []cli.Command{
 		{
 			Name:   "create",
 			Usage:  "Deploy VCH",
 			Action: create.Run,
 			Flags:  create.Flags(),
+		},
+		{
+			Name:   "delete",
+			Usage:  "Delete VCH and associated resources",
+			Action: uninstall.Run,
+			Flags:  uninstall.Flags(),
 		},
 	}
 	app.Version = fmt.Sprintf("%s.%s", MajorVersion, BuildID)

--- a/cmd/vic-machine/validate/network.go
+++ b/cmd/vic-machine/validate/network.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package create
+package validate
 
 import (
 	log "github.com/Sirupsen/logrus"

--- a/lib/install/management/dispatcher.go
+++ b/lib/install/management/dispatcher.go
@@ -173,7 +173,7 @@ func (d *Dispatcher) uploadImages(conf *metadata.VirtualContainerHostConfigSpec)
 			base := filepath.Base(image)
 			err = d.session.Datastore.UploadFile(d.ctx, image, d.vmPathName+"/"+base, nil)
 			if err != nil {
-				log.Errorf("\t\tUpload failed for %s", image)
+				log.Errorf("\t\tUpload failed for %s, %s", image, err)
 				if d.force {
 					log.Warnf("\t\tSkipping %s...", image)
 					results <- nil

--- a/pkg/flags/url_flag.go
+++ b/pkg/flags/url_flag.go
@@ -1,0 +1,51 @@
+// Copyright 2016 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package flags
+
+import (
+	"flag"
+	"net/url"
+
+	"github.com/vmware/govmomi/vim25/soap"
+)
+
+type URLFlag struct {
+	u **url.URL
+}
+
+func (f *URLFlag) Set(s string) error {
+	var err error
+	url, err := soap.ParseURL(s)
+	*f.u = url
+	return err
+}
+
+func (f *URLFlag) Get() interface{} {
+	return *f.u
+}
+
+func (f *URLFlag) String() string {
+	if *f.u == nil {
+		return "<nil>"
+	}
+	return (*f.u).String()
+}
+
+func (f *URLFlag) IsBoolFlag() bool { return false }
+
+// NewURLFlag returns a flag.Value.
+func NewURLFlag(u **url.URL) flag.Value {
+	return &URLFlag{u}
+}

--- a/pkg/flags/url_flag_test.go
+++ b/pkg/flags/url_flag_test.go
@@ -1,0 +1,51 @@
+// Copyright 2016 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package flags
+
+import (
+	"flag"
+	"net/url"
+	"testing"
+)
+
+func TestURLFlag(t *testing.T) {
+	fs := flag.NewFlagSet("", flag.ContinueOnError)
+	var val *url.URL
+
+	fs.Var(NewURLFlag(&val), "url", "url flag")
+
+	u := fs.Lookup("url")
+
+	if u.DefValue != "<nil>" {
+		t.Errorf("DefValue: %s", u.DefValue)
+	}
+
+	if u.Value.String() != "<nil>" {
+		t.Errorf("Value: %s", u.Value)
+	}
+
+	u.Value.Set("127.0.0.1")
+
+	if u.Value.String() != "https://:@127.0.0.1/sdk" {
+		t.Errorf("Value after set: %s", u.Value)
+	}
+
+	if val == nil {
+		t.Errorf("val is not set")
+	}
+	if val.String() != "https://:@127.0.0.1/sdk" {
+		t.Errorf("val is not set correctly: %s", val.String())
+	}
+}


### PR DESCRIPTION
Fixes #897 

Add vic-machine command line, without backend resource delete yet. Has error information if user execute delete command.
Refactor vic-machine create command, to reuse common flags and validator between delete and create.