### PR TITLE
In case some of the containers are still powered on at end of test, d…

### DIFF
--- a/tests/resources/Util.robot
+++ b/tests/resources/Util.robot
@@ -29,8 +29,20 @@ Install VIC Appliance To Test Server
     Log To Console  Installer completed successfully: ${vch-name}...
 
 Cleanup VIC Appliance On Test Server
-    ${uuid}=  Run  govc vm.info -json\=true ${vch-name} | jq -r '.VirtualMachines[0].Config.Uuid'
+    # Let's attempt to cleanup any container related to the VCH appliance first
+    ${list}=  Run  govc ls /ha-datacenter/vm
+    ${list}=  Split To Lines  ${list}
+    :FOR  ${vm}  IN  @{list}
+    \   Continue For Loop If  '${vm}'=='/ha-datacenter/vm/${vch-name}'
+    \   ${raw}=  Run  govc vm.info -json=true ${vm}
+    \   ${status}  ${message}=  Run Keyword And Ignore Error  Should Contain  ${raw}  ${vch-name}
+    \   ${name}=  Run Keyword If  '${status}'=='PASS'  Run  govc vm.info -json\=true ${vm} | jq -r '.VirtualMachines[0].Name'
+    \   ${uuid}=  Run Keyword If  '${status}'=='PASS'  Run  govc vm.info -json\=true ${vm} | jq -r '.VirtualMachines[0].Config.Uuid'
+    \   Run Keyword If  '${status}'=='PASS'  Run  govc vm.destroy ${name}
+    \   Run Keyword If  '${status}'=='PASS'  Run  govc datastore.rm ${uuid}
 
+    # Then we can try to cleanup the VCH itself
+    ${uuid}=  Run  govc vm.info -json\=true ${vch-name} | jq -r '.VirtualMachines[0].Config.Uuid'
     ${output}=  Run  govc vm.destroy ${vch-name}
     ${output}=  Run  govc pool.destroy %{GOVC_RESOURCE_POOL}/${vch-name}
     ${output}=  Run  govc datastore.rm ${vch-name}


### PR DESCRIPTION
As part of #1091 , this will clean up especially the docker integration tests which currently leave a few containers powered on and hanging around, which rapidly runs us out of resources.