### PR TITLE
DHCP address tolerance

### DIFF
--- a/cmd/tether/attach.go
+++ b/cmd/tether/attach.go
@@ -84,6 +84,7 @@ func (t *attachServerSSH) Reload(config *tether.ExecutorConfig) error {
 
 // Stop needed for tether.Extensions interface
 func (t *attachServerSSH) Stop() error {
+	defer trace.End(trace.Begin("stop attach server"))
 	// calling server.start not t.start so that test impl gets invoked
 	server.stop()
 	return nil

--- a/cmd/tether/attach_test.go
+++ b/cmd/tether/attach_test.go
@@ -145,6 +145,11 @@ func mockBackChannel(ctx context.Context) (net.Conn, error) {
 			if err == nil {
 				return conn, nil
 			}
+			if err == io.EOF {
+				// with unix pipes the open will block until both ends are open, therefore
+				// EOF means the other end has been intentionally closed
+				return nil, err
+			}
 		case <-ctx.Done():
 			conn.Close()
 			ticker.Stop()

--- a/cmd/tether/tether_test.go
+++ b/cmd/tether/tether_test.go
@@ -60,8 +60,8 @@ type Mocker struct {
 
 	// the hostname of the system
 	Hostname string
-	// the ip configuration for mac indexed interfaces
-	IPs map[string]net.IPNet
+	// the ip configuration for name index networks
+	IPs map[string]net.IP
 	// filesystem mounts, indexed by disk label
 	Mounts map[string]string
 
@@ -131,7 +131,7 @@ func (t *Mocker) SetHostname(hostname string) error {
 // Apply takes the network endpoint configuration and applies it to the system
 func (t *Mocker) Apply(endpoint *metadata.NetworkEndpoint) error {
 	defer trace.End(trace.Begin("mocking endpoint configuration for " + endpoint.Network.Name))
-	t.IPs[endpoint.Network.Name] = endpoint.IP
+	t.IPs[endpoint.Network.Name] = endpoint.Assigned
 
 	return nil
 }

--- a/lib/metadata/network_interface.go
+++ b/lib/metadata/network_interface.go
@@ -21,8 +21,15 @@ import "net"
 // b. identified - the guestOS can determine which interface it corresponds to
 // c. configured - the guestOS can configure the interface correctly
 type NetworkEndpoint struct {
-	// IP addresses to assign - may be empty if DHCP
-	IP net.IPNet `vic:"0.1" scope:"read-only" key:"ip"`
+	// Common.Name - the nic alias requested (only one name and one alias possible in linux)
+	// Common.ID - pci slot of the vnic allowing for interface identifcation in-guest
+	Common
+
+	// IP address to assign - nil if DHCP
+	Static *net.IPNet `vic:"0.1" scope:"read-only" key:"staticip"`
+
+	// Actual IP address assigned
+	Assigned net.IP `vic:"0.1" scope:"read-write" key:"ip"`
 
 	// The PCI slot for the vNIC - this allows for interface idenitifcaton in the guest
 	PCISlot int32 `vic:"0.1" scope:"read-only" key:"pcislot"`
@@ -41,6 +48,8 @@ type ContainerNetwork struct {
 	// The network scope the IP belongs to.
 	// The IP address is the default gateway
 	Gateway net.IPNet `vic:"0.1" scope:"read-only" key:"gateway"`
+	// Should this gateway be the default route for containers on the network
+	Default bool `vic:"0.1" scope:"read-only" key:"default"`
 
 	// The set of nameservers associated with this network - may be empty
 	Nameservers []net.IP `vic:"0.1" scope:"read-only" key:"dns"`

--- a/lib/portlayer/network/context.go
+++ b/lib/portlayer/network/context.go
@@ -419,7 +419,7 @@ func (c *Context) BindContainer(h *exec.Handle) ([]*Endpoint, error) {
 			s.removeContainer(con)
 		}()
 
-		if _, err = s.addContainer(con, &ne.IP.IP); err != nil {
+		if _, err = s.addContainer(con, &ne.Static.IP); err != nil {
 			return nil, err
 		}
 	}
@@ -427,8 +427,8 @@ func (c *Context) BindContainer(h *exec.Handle) ([]*Endpoint, error) {
 	endpoints := con.Endpoints()
 	for _, e := range endpoints {
 		ne := h.ExecConfig.Networks[e.Scope().Name()]
-		ne.IP.IP = e.IP()
-		ne.IP.Mask = e.Scope().Subnet().Mask
+		ne.Static.IP = e.IP()
+		ne.Static.Mask = e.Scope().Subnet().Mask
 		ne.Network.Gateway = net.IPNet{IP: e.gateway, Mask: e.subnet.Mask}
 	}
 
@@ -458,7 +458,7 @@ func (c *Context) UnbindContainer(h *exec.Handle) error {
 				return
 			}
 
-			s.addContainer(con, &ne.IP.IP)
+			s.addContainer(con, &ne.Static.IP)
 		}()
 
 		e := con.Endpoint(s)
@@ -467,7 +467,7 @@ func (c *Context) UnbindContainer(h *exec.Handle) error {
 		}
 
 		if !e.static {
-			ne.IP = net.IPNet{IP: net.IPv4zero}
+			ne.Static = &net.IPNet{IP: net.IPv4zero}
 		}
 	}
 
@@ -632,9 +632,9 @@ func (c *Context) AddContainer(h *exec.Handle, scope string, ip *net.IP) error {
 		},
 	}
 
-	ne.IP.IP = net.IPv4zero
+	ne.Static = &net.IPNet{IP: net.IPv4zero}
 	if ip != nil {
-		ne.IP.IP = *ip
+		ne.Static.IP = *ip
 	}
 
 	h.ExecConfig.Networks[s.Name()] = ne

--- a/lib/portlayer/network/context_test.go
+++ b/lib/portlayer/network/context_test.go
@@ -486,12 +486,12 @@ func TestContextAddContainer(t *testing.T) {
 			t.Fatalf("case %d; ctx.AddContainer(%v, %s, %s) => ne.NetworkName == %s, want %s", i, te.h, te.scope, te.ip, ne.Network.Name, s.Name())
 		}
 
-		if te.ip != nil && !te.ip.Equal(ne.IP.IP) {
-			t.Fatalf("case %d; ctx.AddContainer(%v, %s, %s) => ne.IP.IP == %s, want %s", i, te.h, te.scope, te.ip, ne.IP.IP, te.ip)
+		if te.ip != nil && !te.ip.Equal(ne.Static.IP) {
+			t.Fatalf("case %d; ctx.AddContainer(%v, %s, %s) => ne.Static.IP == %s, want %s", i, te.h, te.scope, te.ip, ne.Static.IP, te.ip)
 		}
 
-		if te.ip == nil && !ne.IP.IP.Equal(net.IPv4zero) {
-			t.Fatalf("case %d; ctx.AddContainer(%v, %s, %s) => ne.IP.IP == %s, want %s", i, te.h, te.scope, te.ip, ne.IP.IP, net.IPv4zero)
+		if te.ip == nil && !ne.Static.IP.Equal(net.IPv4zero) {
+			t.Fatalf("case %d; ctx.AddContainer(%v, %s, %s) => ne.Static.IP == %s, want %s", i, te.h, te.scope, te.ip, ne.Static.IP, net.IPv4zero)
 		}
 	}
 }
@@ -643,11 +643,11 @@ func TestContextBindUnbindContainer(t *testing.T) {
 				}
 
 				ne := te.h.ExecConfig.Networks[s]
-				if !ne.IP.IP.Equal(te.ips[i]) {
-					t.Fatalf("%d: ctx.BindContainer(%s) => metadata endpoint IP %s, want %s", te.i, te.h, ne.IP.IP, te.ips[i])
+				if !ne.Static.IP.Equal(te.ips[i]) {
+					t.Fatalf("%d: ctx.BindContainer(%s) => metadata endpoint IP %s, want %s", te.i, te.h, ne.Static.IP, te.ips[i])
 				}
-				if ne.IP.Mask.String() != e.Scope().Subnet().Mask.String() {
-					t.Fatalf("%d: ctx.BindContainer(%s) => metadata endpoint IP mask %s, want %s", te.i, te.h, ne.IP.Mask.String(), e.Scope().Subnet().Mask.String())
+				if ne.Static.Mask.String() != e.Scope().Subnet().Mask.String() {
+					t.Fatalf("%d: ctx.BindContainer(%s) => metadata endpoint IP mask %s, want %s", te.i, te.h, ne.Static.Mask.String(), e.Scope().Subnet().Mask.String())
 				}
 				if !ne.Network.Gateway.IP.Equal(e.Scope().Gateway()) {
 					t.Fatalf("%d: ctx.BindContainer(%s) => metadata endpoint gateway %s, want %s", te.i, te.h, ne.Network.Gateway.IP, e.Scope().Gateway())
@@ -715,11 +715,11 @@ func TestContextBindUnbindContainer(t *testing.T) {
 				t.Fatalf("%d: container endpoint not present in %v", te.i, te.h.ExecConfig)
 			}
 
-			if !te.static && !ne.IP.IP.Equal(net.IPv4zero) {
+			if !te.static && !ne.Static.IP.Equal(net.IPv4zero) {
 				t.Fatalf("%d: endpoint IP should be zero in %v", te.i, ne)
 			}
 
-			if te.static && ne.IP.IP.Equal(net.IPv4zero) {
+			if te.static && ne.Static.IP.Equal(net.IPv4zero) {
 				t.Fatalf("%d: endpoint IP should not be zero in %v", te.i, ne)
 			}
 		}

--- a/lib/tether/ops_linux.go
+++ b/lib/tether/ops_linux.go
@@ -81,7 +81,7 @@ func (t *BaseOperations) SetHostname(hostname string) error {
 	// add entry to hosts for resolution without nameservers
 	hosts, err := os.OpenFile(hostsFile, os.O_APPEND|os.O_WRONLY, 0644)
 	if err != nil {
-		detail := fmt.Sprintf("failed to update hosts with hostname: %s", err)
+		detail := fmt.Sprintf("failed to update %s with hostname: %s", hostsFile, err)
 		return errors.New(detail)
 	}
 	defer hosts.Close()
@@ -372,7 +372,7 @@ func (t *BaseOperations) Apply(endpoint *metadata.NetworkEndpoint) error {
 	if len(endpoint.Network.Nameservers) > 0 {
 		resolv, err := os.OpenFile(resolvFile, os.O_APPEND|os.O_WRONLY, 0644)
 		if err != nil {
-			detail := fmt.Sprintf("failed to update resolv.confg for endpoint %s: %s", endpoint.Network.Name, err)
+			detail := fmt.Sprintf("failed to update %s for endpoint %s: %s", resolvFile, endpoint.Network.Name, err)
 			return errors.New(detail)
 		}
 		defer resolv.Close()

--- a/lib/tether/ops_linux.go
+++ b/lib/tether/ops_linux.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -46,7 +47,7 @@ type BaseOperations struct {
 }
 
 // SetHostname sets both the kernel hostname and /etc/hostname to the specified string
-func (t *BaseOperations) SetHostname(hostname string) error {
+func (t *BaseOperations) SetHostname(hostname string, aliases ...string) error {
 	defer trace.End(trace.Begin("setting hostname to " + hostname))
 
 	old, err := os.Hostname()
@@ -79,14 +80,15 @@ func (t *BaseOperations) SetHostname(hostname string) error {
 	}
 
 	// add entry to hosts for resolution without nameservers
-	hosts, err := os.OpenFile("/etc/hosts", os.O_APPEND|os.O_WRONLY, 0644)
+	hosts, err := os.OpenFile(hostsFile, os.O_APPEND|os.O_WRONLY, 0644)
 	if err != nil {
 		detail := fmt.Sprintf("failed to update hosts with hostname: %s", err)
 		return errors.New(detail)
 	}
 	defer hosts.Close()
 
-	_, err = hosts.WriteString(fmt.Sprintf("127.0.0.1 %s", hostname))
+	names := strings.Join(aliases, " ")
+	_, err = hosts.WriteString(fmt.Sprintf("\n127.0.0.1 %s %s\n", hostname, names))
 	if err != nil {
 		detail := fmt.Sprintf("failed to add hosts entry for hostname %s: %s", hostname, err)
 		return errors.New(detail)
@@ -143,40 +145,254 @@ func linkBySlot(slot int32) (netlink.Link, error) {
 	return netlink.LinkByName(name)
 }
 
+func renameLink(link netlink.Link, slot int32, endpoint *metadata.NetworkEndpoint) (netlink.Link, error) {
+	if link.Attrs().Name == endpoint.Name || link.Attrs().Alias == endpoint.Name || endpoint.Name == "" {
+		// if the network is already identified, whether as primary name or alias it doesn't need repeating.
+		// if the name is empty then it should not be aliases or named directly. IPAM data should still be applied.
+		return link, nil
+	}
+
+	if strings.HasPrefix(link.Attrs().Name, "eno") {
+		log.Infof("Renaming link %s to %s", link.Attrs().Name, endpoint.Name)
+
+		err := netlink.LinkSetDown(link)
+		if err != nil {
+			detail := fmt.Sprintf("failed to set link %s down for rename: %s", endpoint.Name, err)
+			return nil, errors.New(detail)
+		}
+
+		err = netlink.LinkSetName(link, endpoint.Name)
+		if err != nil {
+			return nil, err
+		}
+
+		err = netlink.LinkSetUp(link)
+		if err != nil {
+			detail := fmt.Sprintf("failed to bring link %s up after rename: %s", endpoint.Name, err)
+			return nil, errors.New(detail)
+		}
+
+		// reacquire link with updated attributes
+		link, err := linkBySlot(slot)
+		if err != nil {
+			detail := fmt.Sprintf("unable to reacquire link %s after rename pass: %s", endpoint.ID, err)
+			return nil, errors.New(detail)
+		}
+
+		return link, nil
+	}
+
+	if link.Attrs().Alias == "" {
+		log.Infof("Aliasing link %s to %s", link.Attrs().Name, endpoint.Name)
+		err := netlink.LinkSetAlias(link, endpoint.Name)
+		if err != nil {
+			return nil, err
+		}
+
+		// reacquire link with updated attributes
+		link, err := linkBySlot(slot)
+		if err != nil {
+			detail := fmt.Sprintf("unable to reacquire link %s after rename pass: %s", endpoint.ID, err)
+			return nil, errors.New(detail)
+		}
+
+		return link, nil
+	}
+
+	log.Warnf("Unable to add additional alias on link %s for %s", link.Attrs().Name, endpoint.Name)
+	return link, nil
+}
+
+// assignIP assigns an IP to a NIC, using a label to provide an associated between address and network role.
+// returns true if an address has been updated so that /etc/hosts can be updated.
+func assignIP(link netlink.Link, endpoint *metadata.NetworkEndpoint) (bool, error) {
+
+	// get the current ip addresses on the link
+	active, err := netlink.AddrList(link, netlink.FAMILY_V4)
+	if err != nil {
+		detail := fmt.Sprintf("unable to confirm assigned IP address for net %s: %s", endpoint.Network.Name, err)
+		return false, errors.New(detail)
+	}
+
+	// Set IP address if it's specified - this is now named for for the network role rather than the nic
+	if len(endpoint.Static.IP) > 0 {
+		addr, err := netlink.ParseAddr(endpoint.Static.String())
+		if err != nil {
+			detail := fmt.Sprintf("failed to parse address for %s ednpoint: %s", endpoint.Network.Name, err)
+			return false, errors.New(detail)
+		}
+
+		// see if there's a need to set an address
+		for _, ipaddr := range active {
+			log.Debugf("checking existing IPs on link: %s vs %s", ipaddr.IP.String(), addr.IP.String())
+			// couldn't get bytes.Equal to match this - trailing data in the array maybe?
+			if ipaddr.IP.String() == addr.IP.String() {
+				log.Infof("address is already assigned to link, skipping assignment")
+				// ensure the assigned field is set no matter what
+				endpoint.Assigned = addr.IP
+
+				return false, nil
+			}
+		}
+
+		// add a label to identify the network
+		addr.Label = fmt.Sprintf("%s:%s", link.Attrs().Name, endpoint.Network.Name)
+		if err = netlink.AddrAdd(link, addr); err != nil {
+			detail := fmt.Sprintf("failed to add address to %s: %s", endpoint.Network.Name, err)
+			return false, errors.New(detail)
+		}
+
+		// report it
+		endpoint.Assigned = endpoint.Static.IP
+		log.Infof("Added IP address for %s: %s", endpoint.Network.Name, endpoint.Assigned.String())
+
+		return true, nil
+	}
+
+	// TODO: split the entire network management out into an extension.
+	// move extensions to Pre/Post so we can ensure setup prior to session launch
+	// this will allow us to release leases on shutdown or disconnect
+
+	// if there's already an address assigned, obtain it otherwise wait for one
+	for {
+		// update the current ip addresses on the link
+		active, err = netlink.AddrList(link, netlink.FAMILY_V4)
+		if err != nil {
+			detail := fmt.Sprintf("unable to confirm assigned IP address for net %s: %s", endpoint.Network.Name, err)
+			return false, errors.New(detail)
+		}
+
+		if len(endpoint.Network.Gateway.IP) > 0 {
+			// if gateway is supplied filter with it
+			for _, ipaddr := range active {
+				if ipaddr.IP == nil {
+					continue
+				}
+
+				if endpoint.Network.Gateway.Contains(ipaddr.IP) {
+					// couldn't get bytes.Equal to match even when the string addresses do
+					updated := endpoint.Assigned.String() != ipaddr.IP.String()
+					if updated {
+						endpoint.Assigned = ipaddr.IP
+					}
+					log.Infof("Using dynamic IP for network %s: %s", endpoint.Network.Name, endpoint.Assigned.String())
+					return updated, nil
+				}
+
+				log.Debugf("rejecting IP %s on link %s due to mismatch with endpoint gateway", ipaddr.IP.String(), endpoint.Network.Name)
+			}
+		} else if len(active) > 0 {
+			// if no gateway is specified then just take the first non-nil address
+			for _, ipaddr := range active {
+				if ipaddr.IP == nil {
+					continue
+				}
+
+				updated := endpoint.Assigned.String() != ipaddr.IP.String()
+				if updated {
+					endpoint.Assigned = ipaddr.IP
+				}
+
+				log.Infof("Using dynamic IP (unvetted) for network %s: %s", endpoint.Network.Name, endpoint.Assigned.String())
+				return updated, nil
+			}
+		}
+
+		// we don't want to busy wait but I don't currently know how to wait for interface updates
+		time.Sleep(100 * time.Millisecond)
+	}
+}
+
 // Apply takes the network endpoint configuration and applies it to the system
 func (t *BaseOperations) Apply(endpoint *metadata.NetworkEndpoint) error {
 	defer trace.End(trace.Begin("applying endpoint configuration for " + endpoint.Network.Name))
 
 	// Locate interface
-	link, err := linkBySlot(endpoint.PCISlot)
+	slot, err := strconv.Atoi(endpoint.PCISlot)
 	if err != nil {
-		return err
+		detail := fmt.Sprintf("endpoint ID must be a base10 numeric pci slot identifier: %s", err)
+		return errors.New(detail)
 	}
-
-	// Set IP address
-	addr, err := netlink.ParseAddr(endpoint.IP.String())
+	link, err := linkBySlot(int32(slot))
 	if err != nil {
-		detail := fmt.Sprintf("failed to parse address for %s: %s", endpoint.Network.Name, err)
+		detail := fmt.Sprintf("unable to acquire reference to link %s: %s", endpoint.ID, err)
 		return errors.New(detail)
 	}
 
-	if err = netlink.AddrAdd(link, addr); err != nil {
-		detail := fmt.Sprintf("failed to add address to %s: %s", endpoint.Network.Name, err)
+	// TODO: add dhcp client code
+
+	// rename the link if needed
+	link, err = renameLink(link, int32(slot), endpoint)
+	if err != nil {
+		detail := fmt.Sprintf("unable to reacquire link %s after rename pass: %s", endpoint.ID, err)
+		return errors.New(detail)
+	}
+
+	// assign IP address as needed
+	updated, err := assignIP(link, endpoint)
+	if err != nil {
+		detail := fmt.Sprintf("unable to assign IP for net %s: %s", endpoint.Network.Name, err)
 		return errors.New(detail)
 	}
 
 	// Add routes
-	_, defaultNet, _ := net.ParseCIDR("0.0.0.0/0")
-	route := netlink.Route{LinkIndex: link.Attrs().Index, Dst: defaultNet, Gw: endpoint.Network.Gateway.IP}
-	err = netlink.RouteAdd(&route)
-	if err != nil {
-		if errno, ok := err.(syscall.Errno); !ok || errno != syscall.EEXIST {
-			detail := fmt.Sprintf("failed to add gateway route for endpoint %s: %s", endpoint.Network.Name, err)
-			return errors.New(detail)
+	if endpoint.Network.Default && len(endpoint.Network.Gateway.IP) > 0 {
+		_, defaultNet, _ := net.ParseCIDR("0.0.0.0/0")
+		route := netlink.Route{LinkIndex: link.Attrs().Index, Dst: defaultNet, Gw: endpoint.Network.Gateway.IP}
+		err = netlink.RouteAdd(&route)
+		if err != nil {
+			if errno, ok := err.(syscall.Errno); !ok || errno != syscall.EEXIST {
+				detail := fmt.Sprintf("failed to add gateway route for endpoint %s: %s", endpoint.Network.Name, err)
+				return errors.New(detail)
+			}
 		}
+
+		log.Infof("Added route to %s interface: %s", endpoint.Network.Name, defaultNet.String())
 	}
 
-	// TODO update /etc/hosts and /etc/resolv.conf
+	// if there's not been any updates made then we don't want to edit hosts and nameservers
+	if !updated {
+		return nil
+	}
+
+	// Add /etc/hosts entry
+	if endpoint.Network.Name != "" {
+		hosts, err := os.OpenFile(hostsFile, os.O_APPEND|os.O_WRONLY, 0644)
+		if err != nil {
+			detail := fmt.Sprintf("failed to update hosts for endpoint %s: %s", endpoint.Network.Name, err)
+			return errors.New(detail)
+		}
+		defer hosts.Close()
+
+		entry := fmt.Sprintf("%s localhost.%s", endpoint.Assigned, endpoint.Network.Name)
+		_, err = hosts.WriteString(fmt.Sprintf("\n%s\n", entry))
+		if err != nil {
+			detail := fmt.Sprintf("failed to add nameserver for endpoint %s: %s", endpoint.Network.Name, err)
+			return errors.New(detail)
+		}
+
+		log.Infof("Added hosts entry: %s", entry)
+	}
+
+	// Add nameservers
+	// This is incredibly trivial for now - should be updated to a less messy approach
+	if len(endpoint.Network.Nameservers) > 0 {
+		resolv, err := os.OpenFile(resolvFile, os.O_APPEND|os.O_WRONLY, 0644)
+		if err != nil {
+			detail := fmt.Sprintf("failed to update resolv.confg for endpoint %s: %s", endpoint.Network.Name, err)
+			return errors.New(detail)
+		}
+		defer resolv.Close()
+
+		for _, server := range endpoint.Network.Nameservers {
+			_, err = resolv.WriteString("nameserver " + server.String())
+			if err != nil {
+				detail := fmt.Sprintf("failed to add nameserver for endpoint %s: %s", endpoint.Network.Name, err)
+				return errors.New(detail)
+			}
+			log.Infof("Added nameserver: %s", server.String())
+		}
+	}
 
 	return nil
 }


### PR DESCRIPTION
This adds support for:
* structured renaming of NICs
* publishing of DHCP addresses on interfaces
* use of DHCP address if already assigned to interface

This is broken out from the larger change for #746
