### PR TITLE
RFC: Registering a vSphere Extension for eventual use w/ RBAC

### DIFF
--- a/cmd/vicadmin/vicadm.go
+++ b/cmd/vicadmin/vicadm.go
@@ -87,9 +87,9 @@ func init() {
 
 	flag.StringVar(&config.addr, "l", ":2378", "Listen address")
 	flag.StringVar(&config.dockerHost, "docker-host", "127.0.0.1:2376", "Docker host")
-	flag.StringVar(&config.CertFile, "cert", "", "VMOMI Client certificate file")
+	flag.StringVar(&config.ExtensionCert, "cert", "", "VMOMI Client certificate file")
 	flag.StringVar(&config.hostCertFile, "hostcert", "", "Host certificate file")
-	flag.StringVar(&config.KeyFile, "key", "", "VMOMI Client private key file")
+	flag.StringVar(&config.ExtensionKey, "key", "", "VMOMI Client private key file")
 	flag.StringVar(&config.hostKeyFile, "hostkey", "", "Host private key file")
 	flag.StringVar(&config.Service, "sdk", "", "The ESXi or vCenter URL")
 	flag.StringVar(&config.DatacenterPath, "dc", "", "Name of the Datacenter")

--- a/lib/install/data/data.go
+++ b/lib/install/data/data.go
@@ -74,6 +74,8 @@ type InstallerData struct {
 	Cluster    types.ManagedObjectReference
 
 	ImageFiles []string
+
+	Extension types.Extension
 }
 
 func NewData() *Data {

--- a/lib/install/management/appliance.go
+++ b/lib/install/management/appliance.go
@@ -302,6 +302,7 @@ func (d *Dispatcher) findAppliance(conf *metadata.VirtualContainerHostConfigSpec
 	return newVM, nil
 }
 
+// retrieves the uuid of the appliance vm to create a unique vsphere extension name
 func (d *Dispatcher) generateExtensionName(conf *metadata.VirtualContainerHostConfigSpec) error {
 	// must be called after appliance VM is created
 	vm, err := d.findAppliance(conf)
@@ -313,12 +314,10 @@ func (d *Dispatcher) generateExtensionName(conf *metadata.VirtualContainerHostCo
 	var o mo.VirtualMachine
 	err = vm.Properties(d.ctx, vm.Reference(), []string{"config.uuid"}, &o)
 	if err != nil {
-		return errors.Errorf("Could get VM UUID from appliance VM")
+		return errors.Errorf("Could not get VM UUID from appliance VM due to error: %s", err)
 	}
 
-	// identifier for extension, which vSphere calls a 'key' but we want to avoid confusion w/ privkey
-	extensionIDKey := "com.vmware.vic." + o.Config.Uuid
-	conf.ExtensionName = extensionIDKey
+	conf.ExtensionName = "com.vmware.vic." + o.Config.Uuid
 	return nil
 }
 

--- a/lib/install/management/dispatcher.go
+++ b/lib/install/management/dispatcher.go
@@ -185,10 +185,11 @@ func (d *Dispatcher) Dispatch(conf *metadata.VirtualContainerHostConfigSpec, set
 		return errors.Errorf("Uploading images failed with %s. Exiting...", err)
 	}
 
-	if err = d.registerExtension(conf, settings.Extension); err != nil {
-		return errors.Errorf("Error registering VCH vSphere extension: %s", err)
+	if d.session.IsVC() {
+		if err = d.registerExtension(conf, settings.Extension); err != nil {
+			return errors.Errorf("Error registering VCH vSphere extension: %s", err)
+		}
 	}
-
 	_, err = tasks.WaitForResult(d.ctx, func(ctx context.Context) (tasks.ResultWaiter, error) {
 		return d.appliance.PowerOn(ctx)
 	})

--- a/lib/install/management/dispatcher.go
+++ b/lib/install/management/dispatcher.go
@@ -133,7 +133,7 @@ func (d *Dispatcher) initDiagnosticLogs(conf *metadata.VirtualContainerHostConfi
 	}
 }
 
-func (d *Dispatcher) registerExtension(conf *metadata.VirtualContainerHostConfigSpec, settings *data.InstallerData) error {
+func (d *Dispatcher) registerExtension(conf *metadata.VirtualContainerHostConfigSpec, extension types.Extension) error {
 	log.Infoln("Registering VCH as a vSphere extension")
 
 	// vSphere confusingly calls the 'name' of the extension a 'key'
@@ -144,14 +144,13 @@ func (d *Dispatcher) registerExtension(conf *metadata.VirtualContainerHostConfig
 
 	extensionManager := object.NewExtensionManager(d.session.Vim25())
 
-	if err := extensionManager.Register(d.ctx, settings.Extension); err != nil {
-		log.Errorf("Could not register the vSphere extension")
+	if err := extensionManager.Register(d.ctx, extension); err != nil {
+		log.Errorf("Could not register the vSphere extension due to err: %s", err)
 		return err
 	}
 
-	// TODO: set com.vmware.vic as a const
 	if err := extensionManager.SetCertificate(d.ctx, conf.ExtensionName, conf.ExtensionCert); err != nil {
-		log.Errorf("Could not set the certificate on the vSphere extension")
+		log.Errorf("Could not set the certificate on the vSphere extension due to error: %s", err)
 		return err
 	}
 
@@ -185,7 +184,7 @@ func (d *Dispatcher) Dispatch(conf *metadata.VirtualContainerHostConfigSpec, set
 		return errors.Errorf("Uploading images failed with %s. Exiting...", err)
 	}
 
-	if err = d.registerExtension(conf, settings); err != nil {
+	if err = d.registerExtension(conf, settings.Extension); err != nil {
 		return errors.Errorf("Error registering VCH vSphere extension: %s", err)
 	}
 

--- a/lib/install/management/dispatcher.go
+++ b/lib/install/management/dispatcher.go
@@ -32,6 +32,7 @@ import (
 	"github.com/vmware/vic/pkg/vsphere/tasks"
 	"github.com/vmware/vic/pkg/vsphere/vm"
 
+	"github.com/vmware/govmomi/vim25/types"
 	"golang.org/x/net/context"
 )
 

--- a/lib/install/validate/validator.go
+++ b/lib/install/validate/validator.go
@@ -360,11 +360,7 @@ func (v *Validator) generateBridgeName(ctx, input *data.Data, conf *metadata.Vir
 func (v *Validator) target(ctx context.Context, input *data.Data, conf *metadata.VirtualContainerHostConfigSpec) {
 	defer trace.End(trace.Begin(""))
 
-	targetURL, err := url.Parse(v.Session.Service)
-	if err != nil {
-		v.NoteIssue(fmt.Errorf("Error processing target after transformation to SOAP endpoint: %s, %s", v.Session.Service, err))
-		return
-	}
+	targetURL := input.Target.URLWithoutPassword()
 
 	conf.Target = *targetURL
 	conf.Insecure = input.Insecure

--- a/lib/install/validate/validator.go
+++ b/lib/install/validate/validator.go
@@ -361,6 +361,14 @@ func (v *Validator) target(ctx context.Context, input *data.Data, conf *metadata
 	defer trace.End(trace.Begin(""))
 
 	targetURL := input.Target.URLWithoutPassword()
+	if !v.IsVC() {
+		var err error
+		targetURL, err = url.Parse(v.Session.Service)
+		if err != nil {
+			v.NoteIssue(fmt.Errorf("Error processing target after transformation to SOAP endpoint: %s, %s", v.Session.Service, err))
+			return
+		}
+	}
 
 	conf.Target = *targetURL
 	conf.Insecure = input.Insecure

--- a/lib/metadata/virtual_container_host.go
+++ b/lib/metadata/virtual_container_host.go
@@ -66,6 +66,11 @@ type VirtualContainerHostConfigSpec struct {
 	// Certificates for specific system access, keyed by FQDN
 	HostCertificates map[string]*RawCertificate
 
+	// Certificate for authentication as vSphere Extension
+	ExtensionCert string `vic:"0.1" scope:"read-only" key:"extension_cert"`
+	ExtensionKey  string `vic:"0.1" scope:"read-only" key:"extension_key"`
+	ExtensionName string `vic:"0.1" scope:"read-only" key:"extension_name"`
+
 	// Port Layer - storage
 	// Datastore URLs for image stores - the top layer is [0], the bottom layer is [len-1]
 	ImageStores []url.URL `vic:"0.1" scope:"read-only" key:"image_stores"`
@@ -98,6 +103,10 @@ type VirtualContainerHostConfigSpec struct {
 
 	// Allow custom naming convention for containerVMs
 	ContainerNameConvention string
+
+	// Used for authentication against e.g. the Docker HTTP endpoint
+	UserKeyPEM  string `vic:"0.1" scope:"read-only" key:"key_pem"`
+	UserCertPEM string `vic:"0.1" scope:"read-only" key:"cert_pem"`
 }
 
 // RawCertificate is present until we add extraconfig support for [][]byte slices that are present

--- a/pkg/certificate/certificate.go
+++ b/pkg/certificate/certificate.go
@@ -46,8 +46,9 @@ func NewKeyPair(tlsGenerate bool, keyFile, certFile string) *Keypair {
 	}
 }
 
-func CreateRawKeyPair() (bytes.Buffer, bytes.Buffer, error) {
-	var cert, key bytes.Buffer
+// CreateRawKeyPair generates a default certificate / key and returns them as bytes buffers
+// If you wish to save them to files as a side effect, use GetCertificate() instead
+func CreateRawKeyPair() (cert bytes.Buffer, key bytes.Buffer, err error) {
 	org := "VMware"
 	priv, err := rsa.GenerateKey(rand.Reader, 2048)
 	if err != nil {

--- a/pkg/certificate/certificate.go
+++ b/pkg/certificate/certificate.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package create
+package certificate
 
 import (
 	"bytes"
@@ -46,11 +46,12 @@ func NewKeyPair(tlsGenerate bool, keyFile, certFile string) *Keypair {
 	}
 }
 
-func (k *Keypair) generate() error {
-	org := ""
+func CreateRawKeyPair() (bytes.Buffer, bytes.Buffer, error) {
+	var cert, key bytes.Buffer
+	org := "VMware"
 	priv, err := rsa.GenerateKey(rand.Reader, 2048)
 	if err != nil {
-		return err
+		return cert, key, err
 	}
 
 	notBefore := time.Now()
@@ -60,7 +61,7 @@ func (k *Keypair) generate() error {
 	serialNumber, err := rand.Int(rand.Reader, serialNumberLimit)
 	if err != nil {
 		err = errors.Errorf("Failed to generate random number: %s", err)
-		return err
+		return cert, key, err
 	}
 
 	template := x509.Certificate{
@@ -77,21 +78,30 @@ func (k *Keypair) generate() error {
 	derBytes, err := x509.CreateCertificate(rand.Reader, &template, &template, &priv.PublicKey, priv)
 	if err != nil {
 		err = errors.Errorf("Failed to generate x509 certificate: %s", err)
-		return err
+		return cert, key, err
 	}
 
-	var cert bytes.Buffer
 	err = pem.Encode(&cert, &pem.Block{Type: "CERTIFICATE", Bytes: derBytes})
 	if err != nil {
-		return err
+		err = errors.Errorf("Failed to encode x509 certificate: %s", err)
+		return cert, key, err
 	}
 
-	var key bytes.Buffer
 	err = pem.Encode(&key, &pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(priv)})
 	if err != nil {
 		err = errors.Errorf("Failed to encode tls key pairs: %s", err)
+		return cert, key, err
+	}
+
+	return cert, key, nil
+}
+
+func (k *Keypair) generate() error {
+	cert, key, err := CreateRawKeyPair()
+	if err != nil {
 		return err
 	}
+
 	certFile, err := os.Create(k.certFile)
 	if err != nil {
 		err = errors.Errorf("Failed to create key/cert file %s: %s", k.certFile, err)

--- a/pkg/certificate/certificate_test.go
+++ b/pkg/certificate/certificate_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package create
+package certificate
 
 import (
 	"bytes"

--- a/pkg/certificate/certificate_test.go
+++ b/pkg/certificate/certificate_test.go
@@ -20,6 +20,8 @@ import (
 	"strings"
 	"testing"
 
+	"crypto/tls"
+
 	log "github.com/Sirupsen/logrus"
 )
 
@@ -27,6 +29,41 @@ const (
 	keyFile  = "./key.pem"
 	certFile = "./cert.pem"
 )
+
+func TestCreateRawKeyPair(t *testing.T) {
+	cert, key, err := CreateRawKeyPair()
+	if err != nil {
+		t.Errorf("CreateRawKeyPair failed with error %s", err)
+	}
+
+	certString := cert.String()
+	keyString := key.String()
+
+	log.Infof("cert: %s", certString)
+	log.Infof("key: %s", keyString)
+
+	if !strings.HasPrefix(certString, "-----BEGIN CERTIFICATE-----") {
+		t.Errorf("Certificate lacks proper prefix; must not have been generated properly.")
+	}
+
+	if !strings.HasSuffix(certString, "-----END CERTIFICATE-----\n") {
+		t.Errorf("Certificate lacks proper suffix; must not have been generated properly.")
+	}
+
+	if !strings.HasPrefix(keyString, "-----BEGIN RSA PRIVATE KEY-----") {
+		t.Errorf("Private key lacks proper prefix; must not have been generated properly.")
+	}
+
+	if !strings.HasSuffix(keyString, "-----END RSA PRIVATE KEY-----\n") {
+		t.Errorf("Private key lacks proper suffix; must not have been generated properly.")
+	}
+
+	_, err = tls.X509KeyPair([]byte(certString), []byte(keyString))
+	if err != nil {
+		t.Errorf("Unable to load X509 key pair(%s,%s): %s", certString, keyString, err)
+	}
+
+}
 
 func TestGenerate(t *testing.T) {
 	log.SetLevel(log.InfoLevel)

--- a/pkg/vsphere/session/session.go
+++ b/pkg/vsphere/session/session.go
@@ -41,12 +41,15 @@ import (
 	"github.com/vmware/govmomi/vim25"
 	"github.com/vmware/govmomi/vim25/soap"
 	"github.com/vmware/govmomi/vim25/types"
+	"github.com/vmware/vic/lib/metadata"
 	"github.com/vmware/vic/pkg/errors"
+	"github.com/vmware/vic/pkg/vsphere/extraconfig"
 )
 
 // Config contains the configuration used to create a Session.
 type Config struct {
 	// SDK URL or proxy
+	// TODO make sure this doesn't contain credentials
 	Service string
 	// Allow insecure connection to Service
 	Insecure bool
@@ -60,13 +63,17 @@ type Config struct {
 	NetworkPath    string
 	PoolPath       string
 
-	CertFile string
-	KeyFile  string
+	// keypair for the vSphere extension
+	ExtensionCert string
+	ExtensionKey  string
+
+	// confusingly vSphere calls this the extension key
+	ExtensionName string
 }
 
 // HasCertificate checks for presence of a certificate and keyfile
 func (c *Config) HasCertificate() bool {
-	return c.CertFile != "" && c.KeyFile != ""
+	return c.ExtensionCert != "" && c.ExtensionKey != ""
 }
 
 // Session caches vSphere objects obtained by querying the SDK.
@@ -113,7 +120,18 @@ func (s *Session) IsVSAN(ctx context.Context) bool {
 
 // Create accepts a Config and returns a Session with the cached vSphere resources.
 func (s *Session) Create(ctx context.Context) (*Session, error) {
-	_, err := s.Connect(ctx)
+	var vchExtraConfig metadata.VirtualContainerHostConfigSpec
+	source, err := extraconfig.GuestInfoSource()
+	if err != nil {
+		return nil, err
+	}
+
+	extraconfig.Decode(source, &vchExtraConfig)
+	s.ExtensionKey = vchExtraConfig.ExtensionKey
+	s.ExtensionCert = vchExtraConfig.ExtensionCert
+	s.ExtensionName = vchExtraConfig.ExtensionName
+
+	_, err = s.Connect(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -159,9 +177,10 @@ func (s *Session) Connect(ctx context.Context) (*Session, error) {
 		}
 
 		// load the certificates
-		cert, err2 := tls.LoadX509KeyPair(s.CertFile, s.KeyFile)
+		cert, err2 := tls.X509KeyPair([]byte(s.ExtensionCert), []byte(s.ExtensionKey))
 		if err2 != nil {
-			return nil, errors.Errorf("Unable to load X509 key pair(%s,%s): %s", s.CertFile, s.KeyFile, err2)
+			return nil, errors.Errorf("Unable to load X509 key pair(%s,%s): %s",
+				s.ExtensionCert, s.ExtensionKey, err2)
 		}
 
 		// create the new client
@@ -178,9 +197,11 @@ func (s *Session) Connect(ctx context.Context) (*Session, error) {
 
 	// and now that the keepalive is registered we can log in to trigger it
 	if !s.HasCertificate() {
+		log.Debugf("Trying to log in with username/password in lieu of cert")
 		err = s.Client.Login(ctx, user)
 	} else {
-		err = s.LoginExtensionByCertificate(ctx, user.Username(), "")
+		log.Debugf("Logging into extension %s", s.ExtensionName)
+		err = s.LoginExtensionByCertificate(ctx, s.ExtensionName, "")
 	}
 	if err != nil {
 		return nil, errors.Errorf("Failed to log in to %s: %s", soapURL.String(), err)


### PR DESCRIPTION
_This is currently WIP but it's time to start taking feedback_

This PR adds a routine to vic-machine to register a vSphere extension for us to do certificate-based authentication against. This is in lieu of creating a 'service account' or having a VI admin do this. Presumably more advanced RBAC may involve SSO-based authentication & authorization but this change allows the VCH to have the permissions allowed to it by the vSphere extension API without storing the VI admin's credentials in plain text.

It modifies the shared vSphere Session object to prefer certificates to username/password, and uses the extraconfig library to store the generated cert/key added to the extension.

TODO:
* More extensive testing (so far I've only tested against vSphere and behavior against ESX is undefined -- this will _obviously_ be addressed before merge) & test cases need to be written

* Strip the VI admin credentials from anywhere they might appear _outside of this change_ and outside of vic-machine (which needs them to bootstrap the install process).

* Anything y'all suggest

* If @emlin merges `delete` before this gets in I'll have to add a routine to that to unregister the extension also.