### PR TITLE
Update image cache in background

### DIFF
--- a/lib/apiservers/engine/backends/image.go
+++ b/lib/apiservers/engine/backends/image.go
@@ -63,7 +63,12 @@ func (i *Image) ImageHistory(imageName string) ([]*types.ImageHistory, error) {
 func (i *Image) Images(filterArgs string, filter string, all bool) ([]*types.Image, error) {
 
 	imageCache := ImageCache()
-	images := imageCache.GetImages()
+
+	images, err := imageCache.GetImages()
+	if err != nil {
+		return nil, fmt.Errorf("Error retrieving image list: %s", err)
+	}
+
 	result := make([]*types.Image, 0, len(images))
 
 	for _, image := range images {
@@ -73,7 +78,6 @@ func (i *Image) Images(filterArgs string, filter string, all bool) ([]*types.Ima
 	// sort on creation time
 	sort.Sort(sort.Reverse(byCreated(result)))
 
-	log.Infof("Returning %d elements to docker client", len(result))
 	return result, nil
 }
 

--- a/lib/apiservers/engine/backends/vicbackends.go
+++ b/lib/apiservers/engine/backends/vicbackends.go
@@ -15,8 +15,10 @@
 package vicbackends
 
 import (
-	"fmt"
 	"net"
+	"time"
+
+	log "github.com/Sirupsen/logrus"
 
 	httptransport "github.com/go-swagger/go-swagger/httpkit/client"
 	"github.com/vmware/vic/lib/apiservers/engine/backends/cache"
@@ -24,7 +26,9 @@ import (
 )
 
 const (
-	Imagec = "imagec"
+	Imagec           = "imagec"
+	Retries          = 5
+	RetryTimeSeconds = 2
 )
 
 var (
@@ -45,10 +49,23 @@ func Init(portLayerAddr string) error {
 	portLayerServerAddr = portLayerAddr
 
 	imageCache = cache.NewImageCache()
-	// update the image cache at startup
-	if err := imageCache.Update(portLayerClient); err != nil {
-		return fmt.Errorf("Error refreshing image cache: %s", err)
-	}
+
+	// attempt to update the image cache at startup
+	log.Info("Refreshing image cache...")
+	go func() {
+		for i := 0; i < Retries; i++ {
+
+			// initial pause to wait for the portlayer to come up
+			time.Sleep(RetryTimeSeconds * time.Second)
+
+			if err := imageCache.Update(portLayerClient); err == nil {
+				log.Info("Image cache updated successfully")
+				return
+			}
+			log.Info("Failed to refresh image cache, retrying...")
+		}
+		log.Warn("Failed to refresh image cache. Is the portlayer server down?")
+	}()
 
 	return nil
 }


### PR DESCRIPTION
This updates the image cache in the docker persona in a goroutine. Previously it would exit every time the cache failed to update, causing restarts by the watchdog. It now retries 5 times, ultimately logging a warning upon failure to update.

This change also includes some minor log cleanup.

Fixes #1138.