### PR TITLE
Move images url namespace to /images

### DIFF
--- a/lib/apiservers/portlayer/restapi/handlers/storage_handlers.go
+++ b/lib/apiservers/portlayer/restapi/handlers/storage_handlers.go
@@ -109,7 +109,7 @@ func (handler *StorageHandlersImpl) CreateImageStore(params storage.CreateImageS
 func (handler *StorageHandlersImpl) GetImage(params storage.GetImageParams) middleware.Responder {
 	id := params.ID
 
-	url, err := util.StoreNameToURL(params.StoreName)
+	url, err := util.ImageStoreNameToURL(params.StoreName)
 	if err != nil {
 		return storage.NewGetImageDefault(http.StatusInternalServerError).WithPayload(
 			&models.Error{
@@ -134,7 +134,7 @@ func (handler *StorageHandlersImpl) GetImageTar(params storage.GetImageTarParams
 
 // ListImages returns a list of images in a store
 func (handler *StorageHandlersImpl) ListImages(params storage.ListImagesParams) middleware.Responder {
-	u, err := util.StoreNameToURL(params.StoreName)
+	u, err := util.ImageStoreNameToURL(params.StoreName)
 	if err != nil {
 		return storage.NewListImagesDefault(http.StatusInternalServerError).WithPayload(
 			&models.Error{
@@ -162,7 +162,7 @@ func (handler *StorageHandlersImpl) ListImages(params storage.ListImagesParams) 
 
 // WriteImage writes an image to an image store
 func (handler *StorageHandlersImpl) WriteImage(params storage.WriteImageParams) middleware.Responder {
-	u, err := util.StoreNameToURL(params.StoreName)
+	u, err := util.ImageStoreNameToURL(params.StoreName)
 	if err != nil {
 		return storage.NewWriteImageDefault(http.StatusInternalServerError).WithPayload(
 			&models.Error{

--- a/lib/apiservers/portlayer/restapi/handlers/storage_handlers_test.go
+++ b/lib/apiservers/portlayer/restapi/handlers/storage_handlers_test.go
@@ -41,7 +41,7 @@ var (
 	testStoreURL    = url.URL{
 		Scheme: "http",
 		Host:   testHostName,
-		Path:   "/storage/" + testStoreName,
+		Path:   "/" + util.ImageURLPath + "/" + testStoreName,
 	}
 )
 
@@ -51,7 +51,7 @@ type MockDataStore struct {
 // GetImageStore checks to see if a named image store exists and returls the
 // URL to it if so or error.
 func (c *MockDataStore) GetImageStore(ctx context.Context, storeName string) (*url.URL, error) {
-	u, err := util.StoreNameToURL(storeName)
+	u, err := util.ImageStoreNameToURL(storeName)
 	if err != nil {
 		return nil, err
 	}
@@ -59,7 +59,7 @@ func (c *MockDataStore) GetImageStore(ctx context.Context, storeName string) (*u
 }
 
 func (c *MockDataStore) CreateImageStore(ctx context.Context, storeName string) (*url.URL, error) {
-	u, err := util.StoreNameToURL(storeName)
+	u, err := util.ImageStoreNameToURL(storeName)
 	if err != nil {
 		return nil, err
 	}
@@ -163,7 +163,7 @@ func TestGetImage(t *testing.T) {
 	if !assert.Nil(t, err, "Error while creating image store") {
 		return
 	}
-	if !assert.Equal(t, &testStoreURL, url) {
+	if !assert.Equal(t, testStoreURL.String(), url.String()) {
 		return
 	}
 
@@ -195,7 +195,7 @@ func TestGetImage(t *testing.T) {
 	expectedMeta["foo"] = []byte("bar")
 	// add the image to the store
 	image, err := storageLayer.WriteImage(context.TODO(), &parent, testImageID, expectedMeta, testImageSum, nil)
-	if !assert.NotNil(t, image) {
+	if !assert.NoError(t, err) || !assert.NotNil(t, image) {
 		return
 	}
 

--- a/lib/portlayer/storage/image.go
+++ b/lib/portlayer/storage/image.go
@@ -95,7 +95,7 @@ func Parse(u *url.URL) (*Image, error) {
 
 	segments := strings.Split(filepath.Clean(u.Path), "/")
 
-	if segments[0] != util.StoragePath {
+	if segments[0] != util.StorageURLPath {
 		return nil, errors.New("not a storage path")
 	}
 
@@ -103,7 +103,7 @@ func Parse(u *url.URL) (*Image, error) {
 		return nil, errors.New("uri path mismatch")
 	}
 
-	store, err := util.StoreNameToURL(segments[2])
+	store, err := util.ImageStoreNameToURL(segments[2])
 	if err != nil {
 		return nil, err
 	}

--- a/lib/portlayer/storage/store_cache.go
+++ b/lib/portlayer/storage/store_cache.go
@@ -60,7 +60,7 @@ func NewLookupCache(ds ImageStorer) *NameLookupCache {
 // GetImageStore checks to see if a named image store exists and returls the
 // URL to it if so or error.
 func (c *NameLookupCache) GetImageStore(ctx context.Context, storeName string) (*url.URL, error) {
-	store, err := util.StoreNameToURL(storeName)
+	store, err := util.ImageStoreNameToURL(storeName)
 	if err != nil {
 		return nil, err
 	}
@@ -73,7 +73,7 @@ func (c *NameLookupCache) GetImageStore(ctx context.Context, storeName string) (
 	if !ok {
 		log.Info("Refreshing image cache from datastore.")
 		// Store isn't in the cache.  Look it up in the datastore.
-		storeName, err := util.StoreName(store)
+		storeName, err := util.ImageStoreName(store)
 		if err != nil {
 			return nil, err
 		}
@@ -149,7 +149,7 @@ func (c *NameLookupCache) WriteImage(ctx context.Context, parent *Image, ID stri
 	// Check the parent exists (at least in the cache).
 	p, err := c.GetImage(ctx, parent.Store, parent.ID)
 	if err != nil {
-		return nil, fmt.Errorf("parent (%s) doesn't exist in %s", parent.ID, parent.Store.String())
+		return nil, fmt.Errorf("parent (%s) doesn't exist in %s: %s", parent.ID, parent.Store.String(), err)
 	}
 
 	// Check the image doesn't already exist in the cache.  A miss in this will trigger a datastore lookup.
@@ -184,7 +184,7 @@ func (c *NameLookupCache) WriteImage(ctx context.Context, parent *Image, ID stri
 
 // GetImage gets the specified image from the given store by retreiving it from the cache.
 func (c *NameLookupCache) GetImage(ctx context.Context, store *url.URL, ID string) (*Image, error) {
-	storeName, err := util.StoreName(store)
+	storeName, err := util.ImageStoreName(store)
 	if err != nil {
 		return nil, err
 	}
@@ -216,7 +216,7 @@ func (c *NameLookupCache) GetImage(ctx context.Context, store *url.URL, ID strin
 
 // ListImages resturns a list of Images for a list of IDs, or all if no IDs are passed
 func (c *NameLookupCache) ListImages(ctx context.Context, store *url.URL, IDs []string) ([]*Image, error) {
-	storeName, err := util.StoreName(store)
+	storeName, err := util.ImageStoreName(store)
 	if err != nil {
 		return nil, err
 	}

--- a/lib/portlayer/storage/store_cache_test.go
+++ b/lib/portlayer/storage/store_cache_test.go
@@ -46,7 +46,7 @@ func (c *MockDataStore) GetImageStore(ctx context.Context, storeName string) (*u
 }
 
 func (c *MockDataStore) CreateImageStore(ctx context.Context, storeName string) (*url.URL, error) {
-	u, err := util.StoreNameToURL(storeName)
+	u, err := util.ImageStoreNameToURL(storeName)
 	if err != nil {
 		return nil, err
 	}

--- a/lib/portlayer/storage/vsphere/store.go
+++ b/lib/portlayer/storage/vsphere/store.go
@@ -115,7 +115,7 @@ func (v *ImageStore) imageMetadataDirPath(storeName, imageName string) string {
 
 func (v *ImageStore) CreateImageStore(ctx context.Context, storeName string) (*url.URL, error) {
 	// convert the store name to a port layer url.
-	u, err := util.StoreNameToURL(storeName)
+	u, err := util.ImageStoreNameToURL(storeName)
 	if err != nil {
 		return nil, err
 	}
@@ -130,7 +130,7 @@ func (v *ImageStore) CreateImageStore(ctx context.Context, storeName string) (*u
 // GetImageStore checks to see if the image store exists on disk and returns an
 // error or the store's URL.
 func (v *ImageStore) GetImageStore(ctx context.Context, storeName string) (*url.URL, error) {
-	u, err := util.StoreNameToURL(storeName)
+	u, err := util.ImageStoreNameToURL(storeName)
 	if err != nil {
 		return nil, err
 	}
@@ -161,7 +161,7 @@ func (v *ImageStore) ListImageStores(ctx context.Context) ([]*url.URL, error) {
 		if !ok {
 			continue
 		}
-		u, err := util.StoreNameToURL(folder.Path)
+		u, err := util.ImageStoreNameToURL(folder.Path)
 		if err != nil {
 			return nil, err
 		}
@@ -182,7 +182,7 @@ func (v *ImageStore) ListImageStores(ctx context.Context) ([]*url.URL, error) {
 func (v *ImageStore) WriteImage(ctx context.Context, parent *portlayer.Image, ID string, meta map[string][]byte,
 	r io.Reader) (*portlayer.Image, error) {
 
-	storeName, err := util.StoreName(parent.Store)
+	storeName, err := util.ImageStoreName(parent.Store)
 	if err != nil {
 		return nil, err
 	}
@@ -276,7 +276,7 @@ func (v *ImageStore) WriteImage(ctx context.Context, parent *portlayer.Image, ID
 
 func (v *ImageStore) GetImage(ctx context.Context, store *url.URL, ID string) (*portlayer.Image, error) {
 
-	storeName, err := util.StoreName(store)
+	storeName, err := util.ImageStoreName(store)
 	if err != nil {
 		return nil, err
 	}
@@ -326,7 +326,7 @@ func (v *ImageStore) GetImage(ctx context.Context, store *url.URL, ID string) (*
 
 func (v *ImageStore) ListImages(ctx context.Context, store *url.URL, IDs []string) ([]*portlayer.Image, error) {
 
-	storeName, err := util.StoreName(store)
+	storeName, err := util.ImageStoreName(store)
 	if err != nil {
 		return nil, err
 	}

--- a/lib/portlayer/util/paths_test.go
+++ b/lib/portlayer/util/paths_test.go
@@ -17,37 +17,40 @@ package util
 import (
 	"net/url"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
-func TestStoreName(t *testing.T) {
-	u, _ := url.Parse("/storage/imgstore/image")
-	store, err := StoreName(u)
-	if err != nil {
-		t.Errorf("StoreName failed %v", err)
+func TestImageStoreName(t *testing.T) {
+	u, _ := url.Parse("/storage/images/imgstore/image")
+	store, err := ImageStoreName(u)
+	if !assert.NoError(t, err) {
+		return
 	}
+
 	expectedStore := "imgstore"
-	if store != expectedStore {
-		t.Errorf("Got: %s Expected: %s", store, expectedStore)
+	if !assert.Equal(t, expectedStore, store) {
+		return
 	}
 }
 
-func TestStoreNameErrors(t *testing.T) {
+func TestImageStoreNameErrors(t *testing.T) {
 	u, _ := url.Parse("fail")
-	_, err := StoreName(u)
+	_, err := ImageStoreName(u)
 	expectedError := "invalid uri path"
 	if err.Error() != expectedError {
 		t.Errorf("Got: %s Expected: %s", err, expectedError)
 	}
 
 	u, _ = url.Parse("/storage:123")
-	_, err = StoreName(u)
+	_, err = ImageStoreName(u)
 	expectedError = "not a storage path"
 	if err.Error() != expectedError {
 		t.Errorf("Got: %s Expected: %s", err, expectedError)
 	}
 
 	u, _ = url.Parse("/storage")
-	_, err = StoreName(u)
+	_, err = ImageStoreName(u)
 	expectedError = "uri path mismatch"
 	if err.Error() != expectedError {
 		t.Errorf("Got: %s Expected: %s", err, expectedError)
@@ -56,15 +59,15 @@ func TestStoreNameErrors(t *testing.T) {
 
 func TestImageURL(t *testing.T) {
 	DefaultHost, _ = url.Parse("http://foo.com/")
-	storeName := "storage"
-	imageName := "image"
+	storeName := "storeName"
+	imageName := "imageName"
 
 	u, err := ImageURL(storeName, imageName)
 	if err != nil {
 		t.Errorf("ImageURL failed %v", err)
 	}
-	expectedURL := "http://foo.com/storage/image"
-	if u.String() != expectedURL {
-		t.Errorf("Got: %s Expected: %s", u, expectedURL)
+	expectedURL := "http://foo.com/storage/images/storeName/imageName"
+	if !assert.Equal(t, expectedURL, u.String()) {
+		return
 	}
 }

--- a/lib/portlayer/util/util_test.go
+++ b/lib/portlayer/util/util_test.go
@@ -16,16 +16,16 @@ package util
 
 import (
 	"net/url"
-	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestServiceUrl(t *testing.T) {
 	DefaultHost, _ = url.Parse("http://foo.com/")
-	u := ServiceURL(StoragePath)
+	u := ServiceURL(StorageURLPath)
 
-	if strings.Compare(u.String(), "http://foo.com/storage/") != 0 {
-		t.Fail()
+	if !assert.Equal(t, "http://foo.com/storage", u.String()) {
 		return
 	}
 }


### PR DESCRIPTION
The storage layer API for images used urls to specifiy datastore
locations.  These URLs are different than vsphere datastore URLs.  We
use URLs to avoid embedding any vsphere semantics in the APIs including
using datastore URLs.

Images used the form `http://<host>/storage/<image store name>/<image
name>`.  To differentiate between images and volumes, Images are being
moved to `http://<host>/storage/images/<image store name>/<image name>`.