### PR TITLE
Add name resolution support to port-layer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -259,11 +259,11 @@ $(portlayerapi-client): $(PORTLAYER_DEPS)  $(SWAGGER)
 
 $(portlayerapi-server): $(PORTLAYER_DEPS) $(SWAGGER)
 	@echo regenerating swagger models and operations for Portlayer API server...
-	@$(SWAGGER) generate server -A PortLayer --template-dir lib/apiservers/templates -t $(realpath $(dir $<)) -f $<
+	@$(SWAGGER) generate server --exclude-main -A PortLayer --template-dir lib/apiservers/templates -t $(realpath $(dir $<)) -f $<
 
-$(portlayerapi): $(call godeps,lib/apiservers/portlayer/cmd/port-layer-server/*.go) $(portlayerapi-server) $(portlayerapi-client)
+$(portlayerapi): $(call godeps,cmd/port-layer-server/*.go) $(portlayerapi-server) $(portlayerapi-client)
 	@echo building Portlayer API server...
-	@$(TIME) $(GO) build $(RACE) -o $@ ./lib/apiservers/portlayer/cmd/port-layer-server
+	@$(TIME) $(GO) build $(RACE) -o $@ ./cmd/port-layer-server
 
 $(iso-base): isos/base.sh isos/base/*.repo isos/base/isolinux/** isos/base/xorriso-options.cfg
 	@echo building iso-base docker image

--- a/cmd/port-layer-server/main.go
+++ b/cmd/port-layer-server/main.go
@@ -1,0 +1,85 @@
+// Copyright 2016 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"log"
+	"os"
+	"os/signal"
+	"syscall"
+
+	spec "github.com/go-swagger/go-swagger/spec"
+	flags "github.com/jessevdk/go-flags"
+
+	"github.com/vmware/vic/lib/apiservers/portlayer/restapi"
+	"github.com/vmware/vic/lib/apiservers/portlayer/restapi/operations"
+
+	"github.com/vmware/vic/lib/dns"
+)
+
+var (
+	options = dns.ServerOptions{}
+)
+
+func main() {
+	swaggerSpec, err := spec.New(restapi.SwaggerJSON, "")
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	api := operations.NewPortLayerAPI(swaggerSpec)
+	server := restapi.NewServer(api)
+	defer server.Shutdown()
+
+	parser := flags.NewParser(server, flags.Default)
+	parser.ShortDescription = `Port Layer API`
+	parser.LongDescription = `Port Layer API`
+
+	server.ConfigureFlags()
+	for _, optsGroup := range api.CommandLineOptionsGroups {
+		parser.AddGroup(optsGroup.ShortDescription, optsGroup.LongDescription, optsGroup.Options)
+	}
+
+	if _, err := parser.Parse(); err != nil {
+		os.Exit(1)
+	}
+
+	server.ConfigureAPI()
+
+	// BEGIN
+	// Start the DNS Server
+	dnsserver := dns.NewServer(options)
+	if dnsserver != nil {
+		dnsserver.Start()
+	}
+
+	// handle the signals and gracefully shutdown the server
+	sig := make(chan os.Signal, 1)
+	signal.Notify(sig, syscall.SIGINT, syscall.SIGTERM)
+
+	go func() {
+		<-sig
+		dnsserver.Stop()
+	}()
+
+	go func() {
+		dnsserver.Wait()
+	}()
+	// END
+
+	if err := server.Serve(); err != nil {
+		log.Fatalln(err)
+	}
+}

--- a/lib/dns/cache.go
+++ b/lib/dns/cache.go
@@ -1,0 +1,155 @@
+// Copyright 2016 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dns
+
+import (
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	mdns "github.com/miekg/dns"
+)
+
+// Item represents an item in the cache
+type Item struct {
+	Expiration time.Time
+	Msg        *mdns.Msg
+}
+
+// CacheOptions represents the cache options
+type CacheOptions struct {
+	// Max capacity of cache, after this limit cache starts to evict random elements
+	capacity int
+	// Default ttl used by items
+	ttl time.Duration
+}
+
+// Cache stores dns.Msgs and their expiration time
+type Cache struct {
+	CacheOptions
+
+	// Protects following map
+	sync.RWMutex
+	m map[string]*Item
+
+	// atomic cache hits & misses counters
+	// ^ cause we update them while holding the read lock
+	hits   uint64
+	misses uint64
+}
+
+// NewCache returns a new cache
+func NewCache(options CacheOptions) *Cache {
+	return &Cache{
+		CacheOptions: options,
+		m:            make(map[string]*Item, options.capacity),
+	}
+}
+
+// Capacity returns the capacity of the cache
+func (c *Cache) Capacity() int {
+	return c.capacity
+}
+
+// Count returns the element count of the cache
+func (c *Cache) Count() int {
+	c.RLock()
+	defer c.RUnlock()
+	return len(c.m)
+}
+
+func generateKey(q mdns.Question) string {
+	return fmt.Sprintf("%s:%s", q.Name, mdns.TypeToString[q.Qtype])
+}
+
+// Add adds dns.Msg to the cache
+func (c *Cache) Add(msg *mdns.Msg) {
+	c.Lock()
+	defer c.Unlock()
+
+	if len(c.m) >= c.capacity {
+		// pick a random key and remove it
+		for k := range c.m {
+			delete(c.m, k)
+			break
+		}
+	}
+
+	key := generateKey(msg.Question[0])
+	if _, ok := c.m[key]; !ok {
+		c.m[key] = &Item{
+			Expiration: time.Now().UTC().Add(c.ttl),
+			Msg:        msg.Copy(),
+		}
+	}
+}
+
+// Remove removes the dns.Msg from the cache
+func (c *Cache) Remove(msg *mdns.Msg) {
+	c.Lock()
+	defer c.Unlock()
+
+	if len(c.m) <= 0 {
+		return
+	}
+
+	key := generateKey(msg.Question[0])
+	delete(c.m, key)
+}
+
+// Get returns the dns.Msg from the cache
+func (c *Cache) Get(msg *mdns.Msg) *mdns.Msg {
+	key := generateKey(msg.Question[0])
+
+	c.RLock()
+	e, ok := c.m[key]
+	c.RUnlock()
+
+	if ok {
+		atomic.AddUint64(&c.hits, 1)
+
+		if time.Since(e.Expiration) < 0 {
+			return e.Msg.Copy()
+		}
+		// Expired msg, remove it from the cache
+		c.Remove(msg)
+	} else {
+		atomic.AddUint64(&c.misses, 1)
+	}
+	return nil
+}
+
+// Hits returns the number of cache hits
+func (c *Cache) Hits() uint64 {
+	return atomic.LoadUint64(&c.hits)
+}
+
+// Misses returns the number of cache misses
+func (c *Cache) Misses() uint64 {
+	return atomic.LoadUint64(&c.misses)
+}
+
+// Reset resets the cache
+func (c *Cache) Reset() {
+	c.Lock()
+	defer c.Unlock()
+
+	// drop the old map for GC and reset counters
+	c.m = make(map[string]*Item, c.capacity)
+	atomic.StoreUint64(&c.hits, 0)
+	atomic.StoreUint64(&c.misses, 0)
+
+}

--- a/lib/dns/cache_test.go
+++ b/lib/dns/cache_test.go
@@ -1,0 +1,222 @@
+// Copyright 2016 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dns
+
+import (
+	"math/rand"
+	"sync"
+	"testing"
+	"time"
+
+	mdns "github.com/miekg/dns"
+)
+
+func init() {
+	rand.Seed(time.Now().UnixNano())
+}
+
+func RandStringRunes(n int) string {
+	runes := []rune("abcdefghijklmnopqrstuvwxyz")
+
+	b := make([]rune, n)
+	for i := range b {
+		b[i] = runes[rand.Intn(len(runes))]
+	}
+	return string(b)
+}
+
+func RandDNSType() uint16 {
+	types := []uint16{
+		mdns.TypeA,
+		mdns.TypeAAAA,
+	}
+	return types[rand.Intn(len(types))]
+}
+
+func NewMsg() *mdns.Msg {
+	m := &mdns.Msg{}
+	name := RandStringRunes(16) + ".vmware.local."
+	qtype := RandDNSType()
+	m.SetQuestion(name, qtype)
+	return m
+}
+
+func TestCache(t *testing.T) {
+	o := CacheOptions{
+		capacity: 10,
+		ttl:      10 * time.Second,
+	}
+	c := NewCache(o)
+
+	var msgs []*mdns.Msg
+	for i := 0; i < 10; i++ {
+		msgs = append(msgs, NewMsg())
+	}
+
+	for _, msg := range msgs {
+		c.Add(msg)
+	}
+	if c.Count() != len(msgs) {
+		t.Fatalf("Add failed")
+	}
+
+	for _, msg := range msgs {
+		m := c.Get(msg)
+		if m.Question[0] != msg.Question[0] {
+			t.Fatalf("Get failed")
+		}
+	}
+
+	for _, msg := range msgs {
+		c.Remove(msg)
+	}
+	if c.Count() != 0 {
+		t.Fatalf("Remove failed")
+	}
+}
+
+func TestCapacity(t *testing.T) {
+	o := CacheOptions{
+		capacity: 10,
+		ttl:      10 * time.Second,
+	}
+	c := NewCache(o)
+
+	var msgs []*mdns.Msg
+	for i := 0; i < 100; i++ {
+		msgs = append(msgs, NewMsg())
+	}
+
+	for _, msg := range msgs {
+		c.Add(msg)
+	}
+
+	if c.Count() != c.Capacity() {
+		t.Fatalf("Add failed")
+	}
+}
+
+func TestReset(t *testing.T) {
+	o := CacheOptions{
+		capacity: 10,
+		ttl:      10 * time.Second,
+	}
+	c := NewCache(o)
+
+	var msgs []*mdns.Msg
+	for i := 0; i < 10; i++ {
+		msgs = append(msgs, NewMsg())
+	}
+
+	for _, msg := range msgs {
+		c.Add(msg)
+	}
+	if c.Count() != len(msgs) {
+		t.Fatalf("Add failed")
+	}
+
+	c.Reset()
+
+	if c.Count() != 0 {
+		t.Fatalf("Reset failed")
+	}
+}
+
+func TestExpiration(t *testing.T) {
+	o := CacheOptions{
+		capacity: 100,
+		ttl:      time.Nanosecond,
+	}
+	c := NewCache(o)
+
+	var msgs []*mdns.Msg
+	for i := 0; i < 100; i++ {
+		msgs = append(msgs, NewMsg())
+	}
+
+	for _, msg := range msgs {
+		c.Add(msg)
+	}
+	for _, msg := range msgs {
+		// All of them should be expired
+		if c.Get(msg) != nil {
+			t.Fatalf("Get failed")
+		}
+	}
+}
+
+// For best result run with -race
+func TestConcurrency(t *testing.T) {
+	var wg sync.WaitGroup
+
+	samplesize := 2 ^ 14
+	o := CacheOptions{
+		capacity: samplesize,
+		ttl:      10 * time.Minute,
+	}
+	c := NewCache(o)
+
+	var msgs []*mdns.Msg
+	for i := 0; i < samplesize; i++ {
+		msgs = append(msgs, NewMsg())
+	}
+
+	writer := func() {
+		wg.Add(1)
+		defer wg.Done()
+
+		for _, msg := range msgs {
+			c.Add(msg)
+		}
+	}
+
+	reader := func() {
+		wg.Add(1)
+		defer wg.Done()
+
+		for _, msg := range msgs {
+			c.Get(msg)
+		}
+	}
+
+	remover := func() {
+		wg.Add(1)
+		defer wg.Done()
+
+		for _, msg := range msgs {
+			c.Remove(msg)
+		}
+	}
+
+	// 3 writer + 2 removed and > 5 readers until c.Count reaches 0
+	go writer()
+	go writer()
+	go writer()
+
+	for {
+		for i := 0; i < 5; i++ {
+			go reader()
+		}
+		//
+		if c.Count() == 0 {
+			break
+		}
+	}
+
+	go remover()
+	go remover()
+
+	wg.Wait()
+}

--- a/lib/dns/dns.go
+++ b/lib/dns/dns.go
@@ -1,0 +1,460 @@
+// Copyright 2016 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dns
+
+import (
+	"bufio"
+	"fmt"
+	"net"
+	"os"
+	"strings"
+
+	"sync"
+	"time"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/vmware/vic/pkg/trace"
+
+	mdns "github.com/miekg/dns"
+)
+
+const (
+	DefaultPort      = 53
+	DefaultTTL       = 600 * time.Second
+	DefaultCacheSize = 1024
+)
+
+var (
+	options = ServerOptions{}
+)
+
+// ServerOptions represents the server options
+type ServerOptions struct {
+	IP   string
+	Port int
+
+	Nameservers flagMultipleVar
+
+	Timeout time.Duration
+
+	TTL       time.Duration
+	CacheSize int
+
+	Debug bool
+
+	Profiling string
+}
+
+// Server represents udp/tcp server and clients
+type Server struct {
+	ServerOptions
+
+	// used for serving dns
+	udpserver *mdns.Server
+	udpconn   *net.UDPConn
+
+	tcpserver *mdns.Server
+	tcplisten *net.TCPListener
+
+	// used for forwarding queries
+	udpclient *mdns.Client
+	tcpclient *mdns.Client
+
+	// used for speeding up external lookups
+	cache *Cache
+	wg    *sync.WaitGroup
+}
+
+type flagMultipleVar []string
+
+func (i *flagMultipleVar) String() string {
+	return fmt.Sprint(*i)
+}
+
+func (i *flagMultipleVar) Set(value string) error {
+	*i = append(*i, value)
+	return nil
+}
+
+// NewServer returns a new Server
+func NewServer(options ServerOptions) *Server {
+	var err error
+
+	// Default TTL
+	if options.TTL == 0 {
+		options.TTL = DefaultTTL
+	}
+
+	// Default port
+	if options.Port == 0 {
+		options.Port = DefaultPort
+	}
+
+	// Default nameservers
+	if len(options.Nameservers) == 0 {
+		options.Nameservers = resolvconf()
+	}
+
+	// Default cache size
+	if options.CacheSize == 0 {
+		options.CacheSize = DefaultCacheSize
+	}
+
+	server := &Server{
+		ServerOptions: options,
+		cache:         NewCache(CacheOptions{options.CacheSize, options.TTL}),
+		wg:            new(sync.WaitGroup),
+	}
+
+	udpaddr := &net.UDPAddr{
+		IP:   net.ParseIP(server.IP),
+		Port: server.Port,
+	}
+
+	server.udpconn, err = net.ListenUDP("udp", udpaddr)
+	if err != nil {
+		log.Errorf("ListenUDP failed %s", err)
+		return nil
+	}
+
+	tcpaddr := &net.TCPAddr{
+		IP:   net.ParseIP(server.IP),
+		Port: server.Port,
+	}
+
+	server.tcplisten, err = net.ListenTCP("tcp", tcpaddr)
+	if err != nil {
+		log.Errorf("ListenTCP failed %s", err)
+		return nil
+	}
+
+	server.udpclient = &mdns.Client{
+		Net:            "udp",
+		ReadTimeout:    server.Timeout,
+		WriteTimeout:   server.Timeout,
+		SingleInflight: true,
+	}
+
+	server.tcpclient = &mdns.Client{
+		Net:            "tcp",
+		ReadTimeout:    server.Timeout,
+		WriteTimeout:   server.Timeout,
+		SingleInflight: true,
+	}
+
+	return server
+}
+
+// Addr returns the ip:port of the server
+func (s *Server) Addr() string {
+	return fmt.Sprintf("%s:%d", s.IP, s.Port)
+}
+
+func respServerFailure(w mdns.ResponseWriter, r *mdns.Msg) error {
+	m := new(mdns.Msg)
+	m.SetRcode(r, mdns.RcodeServerFailure)
+	// Does not matter if this write fails
+	return w.WriteMsg(m)
+}
+
+func respNotImplemented(w mdns.ResponseWriter, r *mdns.Msg) error {
+	m := &mdns.Msg{}
+	m.SetReply(r)
+	m.Compress = true
+
+	m.Authoritative = false
+	m.RecursionDesired = false
+	m.RecursionAvailable = false
+	m.Rcode = mdns.RcodeNotImplemented
+
+	if err := w.WriteMsg(m); err != nil {
+		log.Errorf("Error writing RcodeNotImplemented response, %s", err)
+		return err
+	}
+	return nil
+}
+
+func resolvconf() []string {
+	var servers []string
+
+	file, err := os.Open("/etc/resolv.conf")
+	if err != nil {
+		return nil
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := scanner.Text()
+
+		// comment.
+		if len(line) > 0 && (line[0] == ';' || line[0] == '#') {
+			continue
+		}
+		f := strings.SplitN(line, " ", 2)
+
+		if len(f) < 1 {
+			continue
+		}
+
+		if f[0] == "nameserver" {
+			if len(f) > 1 && len(servers) < 3 { // small, but the standard limit
+				// One more check: make sure server name is
+				// just an IP address.  Otherwise we need DNS
+				// to look it up.
+				if net.ParseIP(f[1]) != nil {
+					servers = append(servers, f[1])
+				}
+			}
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return nil
+	}
+	return servers
+}
+
+// HandleForwarding forwards a request to the nameservers and returns the response
+func (s *Server) HandleForwarding(w mdns.ResponseWriter, request *mdns.Msg) error {
+	defer trace.End(trace.Begin(request.String()))
+
+	var r *mdns.Msg
+	var err error
+	var try int
+
+	if len(s.Nameservers) == 0 {
+		log.Errorf("No nameservers defined, can not forward")
+
+		return respServerFailure(w, request)
+	}
+
+	// Do we have it in the cache
+	if m := s.cache.Get(request); m != nil {
+		log.Debugf("Cache hit %#v", m)
+
+		// Overwrite the ID with the request's ID
+		m.Id = request.Id
+		m.Compress = true
+		m.Truncated = false
+
+		if err := w.WriteMsg(m); err != nil {
+			log.Errorf("Error writing response, %s", err)
+			return err
+		}
+		return nil
+	}
+
+	// which protocol  are they talking
+	tcp := false
+	if _, ok := w.RemoteAddr().(*net.TCPAddr); ok {
+		tcp = true
+	}
+
+	// Use request ID for "random" nameserver selection.
+	nsid := int(request.Id) % len(s.Nameservers)
+
+Redo:
+	nameserver := s.Nameservers[nsid]
+	if i := strings.Index(nameserver, ":"); i < 0 {
+		nameserver += ":53"
+	}
+
+	if tcp {
+		r, _, err = s.tcpclient.Exchange(request, nameserver)
+	} else {
+		r, _, err = s.udpclient.Exchange(request, nameserver)
+	}
+	if err != nil {
+		// Seen an error, this can only mean, "server not reached", try again but only if we have not exausted our nameservers.
+		if try < len(s.Nameservers) {
+			try++
+			nsid = (nsid + 1) % len(s.Nameservers)
+			goto Redo
+		}
+
+		log.Errorf("Failure to forward request %q", err)
+		return respServerFailure(w, request)
+	}
+
+	// We have a response so cache it
+	s.cache.Add(r)
+
+	r.Compress = true
+	if err := w.WriteMsg(r); err != nil {
+		log.Errorf("Error writing response, %s", err)
+		return err
+	}
+	return nil
+}
+
+// HandleVIC returns a response to a container name/id request
+func (s *Server) HandleVIC(question mdns.Question) []mdns.RR {
+	defer trace.End(trace.Begin(question.String()))
+
+	//TODO
+	log.Warnf("NOT IMPLEMENTED")
+
+	return nil
+}
+
+// ServeDNS implements the handler interface
+func (s *Server) ServeDNS(w mdns.ResponseWriter, r *mdns.Msg) {
+	defer trace.End(trace.Begin(r.String()))
+
+	clientIP, _, err := net.SplitHostPort(w.RemoteAddr().String())
+	if err != nil {
+		log.Infof("Request from %s", clientIP)
+	}
+
+	if r == nil || len(r.Question) == 0 {
+		return
+	}
+
+	// Reject multi-question query
+	if len(r.Question) != 1 {
+		log.Errorf("Rejected multi-question query")
+
+		respServerFailure(w, r)
+		return
+	}
+	q := r.Question[0]
+
+	if q.Qclass != mdns.ClassINET {
+		log.Errorf("Rejected non-inet query")
+
+		respNotImplemented(w, r)
+		return
+	}
+
+	// Reject any query
+	if q.Qtype == mdns.TypeANY {
+		log.Errorf("Rejected ANY query")
+
+		respNotImplemented(w, r)
+		return
+	}
+
+	// Start crafting reply msg
+	m := &mdns.Msg{}
+	m.SetReply(r)
+
+	m.Authoritative = true
+	m.RecursionAvailable = true
+	m.Compress = true
+
+	// VIC
+	answer := s.HandleVIC(q)
+	if answer != nil {
+		m.Answer = append(m.Answer, answer...)
+	}
+
+	if answer == nil {
+		s.HandleForwarding(w, r)
+		return
+	}
+
+	// which protocol we are talking
+	tcp := false
+	if _, ok := w.LocalAddr().(*net.TCPAddr); ok {
+		tcp = true
+	}
+
+	// 512 byte payload guarantees that DNS packets can be reassembled if fragmented in transit.
+	bufsize := 512
+
+	// With EDNS0 in use a larger payload size can be specified.
+	if o := r.IsEdns0(); o != nil {
+		bufsize = int(o.UDPSize())
+	}
+
+	// Make sure we are not smaller than 512
+	if bufsize < 512 {
+		bufsize = 512
+	}
+
+	// with TCP we can send up to 64K
+	if tcp {
+		bufsize = mdns.MaxMsgSize - 1
+	}
+
+	// trim the answer RRs one by one till the whole message fits within the reply size
+	if m.Len() > bufsize {
+		if tcp {
+			m.Truncated = true
+		}
+
+		for m.Len() > bufsize {
+			m.Answer = m.Answer[:len(m.Answer)-1]
+		}
+	}
+
+	if err := w.WriteMsg(m); err != nil {
+		log.Errorf("Error writing response, %s", err)
+	}
+	w.Close()
+}
+
+// Start starts the DNS server
+func (s *Server) Start() {
+	udpserver := &mdns.Server{
+		Handler:    s,
+		PacketConn: s.udpconn,
+	}
+	s.udpserver = udpserver
+
+	s.wg.Add(1)
+	go func() {
+		defer s.wg.Done()
+
+		udpserver.ActivateAndServe()
+		log.Debugf("UDP server exited")
+	}()
+	log.Infof("Ready for queries on udp://%s", s.Addr())
+
+	tcpserver := &mdns.Server{Handler: s, Listener: s.tcplisten}
+	s.tcpserver = tcpserver
+
+	s.wg.Add(1)
+	go func() {
+		defer s.wg.Done()
+
+		tcpserver.ActivateAndServe()
+		log.Debugf("TCP server exited")
+	}()
+	log.Infof("Ready for queries on tcp://%s", s.Addr())
+
+}
+
+// Stop stops the DNS server gracefully
+func (s *Server) Stop() {
+	if s.udpserver != nil {
+		log.Debugf("Shutting down udpserver")
+		s.udpserver.Shutdown()
+	}
+	s.udpconn = nil
+	s.udpserver = nil
+
+	if s.tcpserver != nil {
+		log.Debugf("Shutting down tcpserver")
+		s.tcpserver.Shutdown()
+	}
+	s.tcplisten = nil
+	s.tcpserver = nil
+}
+
+// Wait block until wg returns
+func (s *Server) Wait() {
+	s.wg.Wait()
+}

--- a/lib/dns/dns_test.go
+++ b/lib/dns/dns_test.go
@@ -1,0 +1,74 @@
+// Copyright 2016 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dns
+
+import (
+	"testing"
+
+	log "github.com/Sirupsen/logrus"
+
+	mdns "github.com/miekg/dns"
+)
+
+var (
+	types = []uint16{
+		mdns.TypeA,
+		mdns.TypeTXT,
+		mdns.TypeAAAA,
+	}
+
+	names = []string{
+		"facebook.com.",
+		"google.com.",
+	}
+)
+
+func TestForwarding(t *testing.T) {
+	log.SetLevel(log.PanicLevel)
+
+	options.IP = "127.0.0.1"
+	options.Port = 5354
+
+	server := NewServer(options)
+	if server != nil {
+		server.Start()
+	}
+
+	c := new(mdns.Client)
+
+	size := 1024
+	for i := 0; i < size; i++ {
+		for _, Δ := range types {
+			for _, Θ := range names {
+				m := new(mdns.Msg)
+
+				m.SetQuestion(Θ, Δ)
+
+				r, _, err := c.Exchange(m, server.Addr())
+				if err != nil || len(r.Answer) == 0 {
+					t.Fatalf("Exchange failed: %s", err)
+				}
+			}
+		}
+	}
+
+	n := len(types) * len(names)
+	if server.cache.Hits() != uint64(n*size-n) && server.cache.Misses() != uint64(size) {
+		t.Fatalf("Cache hits %d misses %d", server.cache.Hits(), server.cache.Misses())
+	}
+
+	server.Stop()
+	server.Wait()
+}


### PR DESCRIPTION
This adds a forwarding domain name serving capability to port-layer. The
forwarded queries are cached locally with a pre-defined TTL. The cache
lazily removes the expired items and evicts items randomly when it is
full.

This change set also moves the port-layer-server main function from
swagger generated area to under cmd/ and adds --exclude-main parameter
to swagger call to instruct it to not to re-generate main.go file.

Container name resolution is not implemented and will follow as a
separate PR.

Partially fixes #84