### PR TITLE
Add VolumeStorer API to the storage port layer

### DIFF
--- a/doc/design/volumes.md
+++ b/doc/design/volumes.md
@@ -1,0 +1,53 @@
+# Volume support
+
+Volumes are mutable disk devices, backed by `.vmdk`, whos lifetime is decoupled from that of the container VM.
+
+### Requirements
+- To create a `volume` by `ID` in PL on the specified datastore + path via `volumestore` name and return a URI pointing it.
+- To create "anonymous" `volumes and identify them with a generated `ID`.
+- To (statefully) remove a `volume` via the PL by its URI.
+- To reference an existing `volume` in the `spec` for a new container by its vmkd path
+- Store (immutable) metadata in `"key"/[]byte{"value"}` form.
+
+
+### Filesystem requirements
+Mirrors what exists in the storage layer for images.  Currently there is an implementation for `ext4`, but the underlying `disk` implementation is opaque to this.  In short, we'll use `ext4` for now, but using any other filesystem shouldn't be a huge change.
+
+
+### Datastore destination
+The VI admin will specify datastore + paths which volumes should be created on, giving each of them a `volumestore` to identify them.  For instance `[datastore1] /path/to/volumes` can be identified by volumestore name `datastoreWithVolumes`.  The the docker user can supply this volumestore name to as a driver arg when creating the volume.  The result will be a `.vmdk` created in the `[datastore1] /path/to/volumes/VIC/<vch uuid>/volumes/<volume name>/<volume name>.vmdk`
+
+### Definitions
+```
+// Unique identifier for the volume.  Enumeration of volumes is done via these tags.
+type Tag string
+
+type Volume struct {
+	// Identifies the volume
+	Tag 	Tag
+
+	// The datastore the volume lives on
+	Datastore *object.Datastore
+
+	// Metadata the volume is included with.  Is persisted along side the volume vmdk.
+	Info    map[string][]byte
+
+	// Namespace in the storage layer to look up this volume.
+	SelfLink url.URL
+}
+
+// VolumeStorer is an interface to create, remove, enumerate, and get Volumes.
+type VolumeStorer interface {
+	// Creates a volume on the given volume store, of the given size, with the given metadata.
+	VolumeCreate(ctx context.Context, ID string, store *url.URL, capacityMB uint64, info map[string][]byte) (*Volume, error)
+
+	// Get an existing volume via it's ID.
+	VolumeGet(ctx context.Context, ID string) (*Volume, error)
+
+	// Destroys a volume
+	VolumeDestroy(ctx context.Context, ID string) error
+
+	// Lists all volumes
+	VolumesList(ctx context.Context) ([]*Volume, error)
+}
+```

--- a/lib/portlayer/portlayer.go
+++ b/lib/portlayer/portlayer.go
@@ -30,8 +30,13 @@ import (
 	"golang.org/x/net/context"
 )
 
+// XXX TODO(FA) use this in the _handlers the swagger server includes.
+//
+// API defines the interface the REST server used by the portlayer expects the
+// implementation side to export
 type API interface {
 	storage.ImageStorer
+	storage.VolumeStorer
 }
 
 func Init(ctx context.Context, sess *session.Session) error {

--- a/lib/portlayer/storage/volume.go
+++ b/lib/portlayer/storage/volume.go
@@ -1,0 +1,94 @@
+// Copyright 2016 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storage
+
+import (
+	"errors"
+	"net/url"
+	"path/filepath"
+	"strings"
+
+	"github.com/vmware/vic/lib/portlayer/util"
+
+	"golang.org/x/net/context"
+)
+
+// Volume is the handle to identify a volume on the backing store.  The URI
+// namespace used to identify the Volume in the storage layer has the following
+// path scheme:
+//
+// `/storage/volumes/<volume store identifier, usually the vch uuid>/<volume id>`
+//
+type Volume struct {
+	// Identifies the volume
+	ID string
+
+	// The volumestore the volume lives on. (e.g the datastore + vch + configured vol directory)
+	Store *url.URL
+
+	// Metadata the volume is included with.  Is persisted along side the volume vmdk.
+	Info map[string][]byte
+
+	// Namespace in the storage layer to look up this volume.
+	SelfLink *url.URL
+}
+
+// VolumeStorer is an interface to create, remove, enumerate, and get Volumes.
+type VolumeStorer interface {
+	// Creates a volume on the given volume store, of the given size, with the given metadata.
+	VolumeCreate(ctx context.Context, ID string, store *url.URL, capacityMB uint64, info map[string][]byte) (*Volume, error)
+
+	// Get an existing volume via it's ID.
+	VolumeGet(ctx context.Context, ID string) (*Volume, error)
+
+	// Destroys a volume
+	VolumeDestroy(ctx context.Context, ID string) error
+
+	// Lists all volumes
+	VolumesList(ctx context.Context) ([]*Volume, error)
+}
+
+func (v *Volume) Parse(u *url.URL) error {
+	// Check the path isn't malformed.
+	if !filepath.IsAbs(u.Path) {
+		return errors.New("invalid uri path")
+	}
+
+	segments := strings.Split(filepath.Clean(u.Path), "/")[1:]
+
+	if segments[0] != util.StorageURLPath {
+		return errors.New("not a storage path")
+	}
+
+	if len(segments) < 3 {
+		return errors.New("uri path mismatch")
+	}
+
+	store, err := util.VolumeStoreNameToURL(segments[2])
+	if err != nil {
+		return err
+	}
+
+	id := segments[3]
+
+	var SelfLink url.URL
+	SelfLink = *u
+
+	v.ID = id
+	v.SelfLink = &SelfLink
+	v.Store = store
+
+	return nil
+}

--- a/lib/portlayer/storage/volume_cache.go
+++ b/lib/portlayer/storage/volume_cache.go
@@ -1,0 +1,137 @@
+// Copyright 2016 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storage
+
+import (
+	"net/url"
+	"os"
+	"sync"
+
+	log "github.com/Sirupsen/logrus"
+	"golang.org/x/net/context"
+)
+
+// VolumeLookupCache caches Volume references to volumes in the system.
+type VolumeLookupCache struct {
+
+	// Maps IDs to Volumes.
+	//
+	// id -> Volume
+	vlc     map[string]Volume
+	vlcLock sync.Mutex
+
+	// The underlying data storage implementation
+	volumeStore VolumeStorer
+}
+
+func NewVolumeLookupCache(ctx context.Context, vs VolumeStorer) (*VolumeLookupCache, error) {
+	v := &VolumeLookupCache{
+		vlc:         make(map[string]Volume),
+		volumeStore: vs,
+	}
+
+	return v, v.rebuildCache(ctx)
+}
+
+func (v *VolumeLookupCache) VolumeCreate(ctx context.Context, ID string, store *url.URL, capacityMB uint64, info map[string][]byte) (*Volume, error) {
+	v.vlcLock.Lock()
+	defer v.vlcLock.Unlock()
+
+	// check if it exists
+	_, ok := v.vlc[ID]
+	if ok {
+		return nil, os.ErrExist
+	}
+
+	vol, err := v.volumeStore.VolumeCreate(ctx, ID, store, capacityMB, info)
+	if err != nil {
+		return nil, err
+	}
+	// Add it to the cache.
+	v.vlc[vol.ID] = *vol
+
+	return vol, nil
+}
+
+func (v *VolumeLookupCache) VolumeDestroy(ctx context.Context, ID string) error {
+	v.vlcLock.Lock()
+	defer v.vlcLock.Unlock()
+
+	// Check if it exists
+	vol, ok := v.vlc[ID]
+	if !ok {
+		return os.ErrNotExist
+	}
+
+	// remove it from the volumestore
+	if err := v.volumeStore.VolumeDestroy(ctx, ID); err != nil {
+		return err
+	}
+	delete(v.vlc, vol.ID)
+
+	return nil
+}
+
+func (v *VolumeLookupCache) VolumeGet(ctx context.Context, ID string) (*Volume, error) {
+	v.vlcLock.Lock()
+	defer v.vlcLock.Unlock()
+
+	// look in the cache
+	vol, ok := v.vlc[ID]
+	if !ok {
+		return nil, os.ErrNotExist
+	}
+
+	return &vol, nil
+}
+
+func (v *VolumeLookupCache) VolumesList(ctx context.Context) ([]*Volume, error) {
+	v.vlcLock.Lock()
+	defer v.vlcLock.Unlock()
+
+	// look in the cache, return the list
+	l := make([]*Volume, 0, len(v.vlc))
+	for _, vol := range v.vlc {
+		// this is idiotic
+		var e Volume
+		e = vol
+		l = append(l, &e)
+	}
+
+	return l, nil
+}
+
+// goto the volume store and repopulate the cache.
+func (v *VolumeLookupCache) rebuildCache(ctx context.Context) error {
+
+	// Lock everything because we're rewriting the whole cache
+	v.vlcLock.Lock()
+	defer v.vlcLock.Unlock()
+
+	log.Info("Refreshing volume cache.")
+	// if it's not in the cache, check the volumeStore, cache the result, and return the list.
+	vols, err := v.volumeStore.VolumesList(ctx)
+	if err != nil {
+		return err
+	}
+
+	for _, vol := range vols {
+		log.Infof("Volumestore: Found vol %s on store %s.", vol.ID, vol.Store)
+		// Add it to the cache.
+		v.vlc[vol.ID] = *vol
+	}
+
+	return nil
+}

--- a/lib/portlayer/storage/volume_cache_test.go
+++ b/lib/portlayer/storage/volume_cache_test.go
@@ -1,0 +1,219 @@
+// Copyright 2016 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storage
+
+import (
+	"fmt"
+	"net/url"
+	"os"
+	"sync"
+	"testing"
+
+	"golang.org/x/net/context"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/vmware/vic/lib/portlayer/util"
+)
+
+type MockVolumeStore struct {
+	// id -> volume
+	db map[string]*Volume
+}
+
+func NewMockVolumeStore() *MockVolumeStore {
+	m := &MockVolumeStore{
+		db: make(map[string]*Volume),
+	}
+
+	return m
+}
+
+// Creates a volume on the given volume store, of the given size, with the given metadata.
+func (m *MockVolumeStore) VolumeCreate(ctx context.Context, ID string, store *url.URL, capacityMB uint64, info map[string][]byte) (*Volume, error) {
+	storeName, err := util.VolumeStoreName(store)
+	if err != nil {
+		return nil, err
+	}
+
+	selfLink, err := util.VolumeURL(storeName, ID)
+	if err != nil {
+		return nil, err
+	}
+
+	vol := &Volume{
+		ID:       ID,
+		Store:    store,
+		SelfLink: selfLink,
+	}
+
+	m.db[ID] = vol
+
+	return vol, nil
+}
+
+// Get an existing volume via it's ID and volume store.
+func (m *MockVolumeStore) VolumeGet(ctx context.Context, ID string) (*Volume, error) {
+	vol, ok := m.db[ID]
+	if !ok {
+		return nil, os.ErrNotExist
+	}
+
+	return vol, nil
+}
+
+// Destroys a volume
+func (m *MockVolumeStore) VolumeDestroy(ctx context.Context, ID string) error {
+	if _, ok := m.db[ID]; !ok {
+		return os.ErrNotExist
+	}
+
+	delete(m.db, ID)
+
+	return nil
+}
+
+// Lists all volumes on the given volume store`
+func (m *MockVolumeStore) VolumesList(ctx context.Context) ([]*Volume, error) {
+	var i int
+	list := make([]*Volume, len(m.db))
+	for _, v := range m.db {
+		t := *v
+		list[i] = &t
+		i++
+	}
+
+	return list, nil
+}
+
+func TestVolumeCreateGetListAndDelete(t *testing.T) {
+	mvs := NewMockVolumeStore()
+	v, err := NewVolumeLookupCache(context.TODO(), mvs)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	storeURL, err := util.VolumeStoreNameToURL("testStore")
+	if !assert.NoError(t, err) || !assert.NotNil(t, storeURL) {
+		return
+	}
+
+	inVols := make(map[string]*Volume)
+	wg := &sync.WaitGroup{}
+	createFn := func(i int) {
+		defer wg.Done()
+
+		id := fmt.Sprintf("ID-%d", i)
+
+		// Write to the datastore
+		vol, err := v.VolumeCreate(context.TODO(), id, storeURL, 0, nil)
+		if !assert.NoError(t, err) || !assert.NotNil(t, vol) {
+			return
+		}
+
+		inVols[id] = vol
+	}
+
+	// Create a set of volumes
+	numVolumes := 5
+	wg.Add(numVolumes)
+	for i := 0; i < numVolumes; i++ {
+		go createFn(i)
+	}
+	wg.Wait()
+
+	getFn := func(inVol *Volume) {
+		vol, err := v.VolumeGet(context.TODO(), inVol.ID)
+		if !assert.NoError(t, err) || !assert.NotNil(t, vol) {
+			return
+		}
+
+		if !assert.Equal(t, inVol, vol) {
+			return
+		}
+		wg.Done()
+	}
+
+	wg.Add(numVolumes)
+	for _, inVol := range inVols {
+		getFn(inVol)
+	}
+	wg.Wait()
+
+	volumeList, err := v.VolumesList(context.TODO())
+	if !assert.NoError(t, err) || !assert.Equal(t, numVolumes, len(volumeList)) {
+		return
+	}
+
+	// Test that the list returned by VolumeList matches our inVols list.  Then
+	// delete each vol via the cache, then check the datastore to ensure it's
+	// empty
+	for _, outVol := range volumeList {
+		if !assert.Equal(t, inVols[outVol.ID], outVol) {
+			return
+		}
+
+		if err = v.VolumeDestroy(context.TODO(), outVol.ID); !assert.NoError(t, err) {
+			return
+		}
+	}
+
+	// check the datastore is empty.
+	if !assert.Empty(t, mvs.db) {
+		return
+	}
+}
+
+// Create 2 store caches but use the same backing datastore.  Create images
+// with the first cache, then get the image with the second.  This simulates
+// restart since the second cache is empty and has to go to the backing store.
+func TestVolumeCacheRestart(t *testing.T) {
+	mvs := NewMockVolumeStore()
+	firstCache, err := NewVolumeLookupCache(context.TODO(), mvs)
+	if !assert.NoError(t, err) || !assert.NotNil(t, firstCache) {
+		return
+	}
+
+	storeURL, err := util.VolumeStoreNameToURL("testStore")
+	if !assert.NoError(t, err) || !assert.NotNil(t, storeURL) {
+		return
+	}
+
+	// Create a set of volumes
+	inVols := make(map[string]*Volume)
+	for i := 1; i < 50; i++ {
+		id := fmt.Sprintf("ID-%d", i)
+
+		// Write to the datastore
+		vol, err := firstCache.VolumeCreate(context.TODO(), id, storeURL, 0, nil)
+		if !assert.NoError(t, err) || !assert.NotNil(t, vol) {
+			return
+		}
+
+		inVols[id] = vol
+	}
+
+	secondCache, err := NewVolumeLookupCache(context.TODO(), mvs)
+	if !assert.NoError(t, err) || !assert.NotNil(t, secondCache) {
+		return
+	}
+
+	// get the vols from the second cache to ensure it goes to the ds
+	for _, expectedVol := range inVols {
+		vol, err := secondCache.VolumeGet(context.TODO(), expectedVol.ID)
+		if !assert.NoError(t, err) || !assert.Equal(t, expectedVol, vol) {
+			return
+		}
+	}
+}

--- a/lib/portlayer/storage/volume_test.go
+++ b/lib/portlayer/storage/volume_test.go
@@ -1,0 +1,53 @@
+// Copyright 2016 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storage
+
+import (
+	"net/url"
+	"path"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/vmware/vic/lib/portlayer/util"
+)
+
+func TestVolumeParseURL(t *testing.T) {
+	util.DefaultHost, _ = url.Parse("http://foo.com/")
+
+	in, _ := url.Parse(util.DefaultHost.String())
+	in.Path = "/" + path.Join("storage", "volumes", "volStore", "volName")
+
+	v := &Volume{}
+	err := v.Parse(in)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	if !assert.Equal(t, "volName", v.ID) {
+		return
+	}
+
+	volStore, _ := url.Parse(util.DefaultHost.String())
+	util.AppendDir(volStore, "/storage/volumes/volStore")
+	if !assert.Equal(t, volStore.String(), v.Store.String()) {
+		return
+	}
+
+	util.AppendDir(volStore, "volName")
+	if !assert.Equal(t, volStore.String(), v.SelfLink.String()) {
+		return
+	}
+
+}

--- a/lib/portlayer/util/paths.go
+++ b/lib/portlayer/util/paths.go
@@ -28,7 +28,7 @@ const (
 	VolumeURLPath  = StorageURLPath + "/volumes"
 )
 
-// StoreNameToURL parses the image URL in the form /storage/images/<image store>/<image name>
+// ImageStoreNameToURL parses the image URL in the form /storage/images/<image store>/<image name>
 func ImageStoreNameToURL(storeName string) (*url.URL, error) {
 	a := ServiceURL(ImageURLPath)
 	AppendDir(a, storeName)
@@ -43,8 +43,13 @@ func ImageStoreName(u *url.URL) (string, error) {
 
 	segments := strings.Split(filepath.Clean(u.Path), "/")[1:]
 
-	if segments[0] != filepath.Clean(StorageURLPath) {
+	if len(segments) < 3 ||
+		segments[0] != filepath.Clean(StorageURLPath) {
 		return "", errors.New("not a storage path")
+	}
+
+	if segments[1] != "images" {
+		return "", errors.New("not an imagestore path")
 	}
 
 	if len(segments) < 2 {
@@ -60,6 +65,46 @@ func ImageURL(storeName, imageName string) (*url.URL, error) {
 		return nil, err
 	}
 	AppendDir(u, imageName)
+	return u, nil
+}
+
+// VolumeStoreNameToURL parses the volume URL in the form /storage/volumes/<volume store>/<volume name>
+func VolumeStoreNameToURL(storeName string) (*url.URL, error) {
+	a := ServiceURL(VolumeURLPath)
+	AppendDir(a, storeName)
+	return a, nil
+}
+
+func VolumeStoreName(u *url.URL) (string, error) {
+	// Check the path isn't malformed.
+	if !filepath.IsAbs(u.Path) {
+		return "", errors.New("invalid uri path")
+	}
+
+	segments := strings.Split(filepath.Clean(u.Path), "/")[1:]
+
+	if len(segments) < 3 ||
+		segments[0] != filepath.Clean(StorageURLPath) {
+		return "", errors.New("not a storage path")
+	}
+
+	if segments[1] != "volumes" {
+		return "", errors.New("not an volumestore path")
+	}
+
+	if len(segments) < 2 {
+		return "", errors.New("uri path mismatch")
+	}
+
+	return segments[2], nil
+}
+
+func VolumeURL(storeName, volumeName string) (*url.URL, error) {
+	u, err := VolumeStoreNameToURL(storeName)
+	if err != nil {
+		return nil, err
+	}
+	AppendDir(u, volumeName)
 	return u, nil
 }
 

--- a/lib/portlayer/util/paths_test.go
+++ b/lib/portlayer/util/paths_test.go
@@ -51,7 +51,7 @@ func TestImageStoreNameErrors(t *testing.T) {
 
 	u, _ = url.Parse("/storage")
 	_, err = ImageStoreName(u)
-	expectedError = "uri path mismatch"
+	expectedError = "not a storage path"
 	if err.Error() != expectedError {
 		t.Errorf("Got: %s Expected: %s", err, expectedError)
 	}
@@ -67,6 +67,57 @@ func TestImageURL(t *testing.T) {
 		t.Errorf("ImageURL failed %v", err)
 	}
 	expectedURL := "http://foo.com/storage/images/storeName/imageName"
+	if !assert.Equal(t, expectedURL, u.String()) {
+		return
+	}
+}
+
+func TestVolumeStoreName(t *testing.T) {
+	u, _ := url.Parse("/storage/volumes/volstore/volume")
+	store, err := VolumeStoreName(u)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	expectedStore := "volstore"
+	if !assert.Equal(t, expectedStore, store) {
+		return
+	}
+}
+
+func TestVolumeStoreNameErrors(t *testing.T) {
+	u, _ := url.Parse("fail")
+	_, err := VolumeStoreName(u)
+	expectedError := "invalid uri path"
+	if err.Error() != expectedError {
+		t.Errorf("Got: %s Expected: %s", err, expectedError)
+	}
+
+	u, _ = url.Parse("/storage:123")
+	_, err = VolumeStoreName(u)
+	expectedError = "not a storage path"
+	if err.Error() != expectedError {
+		t.Errorf("Got: %s Expected: %s", err, expectedError)
+	}
+
+	u, _ = url.Parse("/storage")
+	_, err = VolumeStoreName(u)
+	expectedError = "not a storage path"
+	if err.Error() != expectedError {
+		t.Errorf("Got: %s Expected: %s", err, expectedError)
+	}
+}
+
+func TestVolumeURL(t *testing.T) {
+	DefaultHost, _ = url.Parse("http://foo.com/")
+	storeName := "storeName"
+	volumeName := "volumeName"
+
+	u, err := VolumeURL(storeName, volumeName)
+	if err != nil {
+		t.Errorf("VolumeURL failed %v", err)
+	}
+	expectedURL := "http://foo.com/storage/volumes/storeName/volumeName"
 	if !assert.Equal(t, expectedURL, u.String()) {
 		return
 	}


### PR DESCRIPTION
Includes a VolumeStorer interface definition to store/retrieve/remove
volumes.

Implements a cache implementation of the interface so as to avoid
unnecessary datastore operations.

This code isn't being called yet but is in support of #915 #916 and #917.