### PR TITLE
Correct the vicadmin and personality nonTLS path

### DIFF
--- a/cmd/vic-machine/create/create.go
+++ b/cmd/vic-machine/create/create.go
@@ -193,10 +193,6 @@ func (c *Create) processParams() error {
 		return err
 	}
 
-	if c.ComputeResourcePath == "" {
-		return cli.NewExitError("--compute-resource Compute resource path must be specified", 1)
-	}
-
 	if c.ImageDatastoreName == "" {
 		return cli.NewExitError("--image-datastore Image datastore name must be specified", 1)
 	}
@@ -369,15 +365,16 @@ func (c *Create) Run(cli *cli.Context) error {
 	if c.key != "" {
 		// if we're generating then there's no CA currently
 		if len(vchConfig.CertificateAuthorities) > 0 {
-			tls = fmt.Sprintf("--tls --tlscert='%s' --tlskey='%s'", c.cert, c.key)
+			tls = fmt.Sprintf(" --tls --tlscert='%s' --tlskey='%s'", c.cert, c.key)
 		} else {
-			tls = "--tls"
+			tls = " --tls"
 		}
 	}
 	log.Infof("DOCKER_HOST=%s:%s", executor.HostIP, executor.DockerPort)
+	log.Infof("DOCKER_OPTS=\"-H %s:%s%s\"", executor.HostIP, executor.DockerPort, tls)
 	log.Infof("")
 	log.Infof("Connect to docker:")
-	log.Infof("docker -H %s:%s %s info", executor.HostIP, executor.DockerPort, tls)
+	log.Infof("docker -H %s:%s %sinfo", executor.HostIP, executor.DockerPort, tls)
 
 	log.Infof("Installer completed successfully")
 	return nil

--- a/cmd/vic-machine/validate/validator.go
+++ b/cmd/vic-machine/validate/validator.go
@@ -375,6 +375,12 @@ func (v *Validator) target(ctx context.Context, input *data.Data, conf *metadata
 func (v *Validator) certificate(ctx context.Context, input *data.Data, conf *metadata.VirtualContainerHostConfigSpec) {
 	defer trace.End(trace.Begin(""))
 
+	if len(input.CertPEM) == 0 && len(input.KeyPEM) == 0 {
+		// if there's no data supplied then we're configuring without TLS
+		log.Debug("Configuring without TLS due to empty key and cert buffers")
+		return
+	}
+
 	// check the cert can be loaded
 	_, err := tls.X509KeyPair(input.CertPEM, input.KeyPEM)
 	v.NoteIssue(err)

--- a/lib/metadata/virtual_container_host.go
+++ b/lib/metadata/virtual_container_host.go
@@ -16,6 +16,7 @@ package metadata
 
 import (
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"net/mail"
 	"net/url"
@@ -221,6 +222,18 @@ func CreateSession(cmd string, args ...string) *SessionConfig {
 	return cfg
 }
 
-func (t *RawCertificate) Certificate() (tls.Certificate, error) {
-	return tls.X509KeyPair(t.Cert, t.Key)
+func (t *RawCertificate) Certificate() (*tls.Certificate, error) {
+	if t.IsNil() {
+		return nil, errors.New("nil certificate")
+	}
+	cert, err := tls.X509KeyPair(t.Cert, t.Key)
+	return &cert, err
+}
+
+func (t *RawCertificate) IsNil() bool {
+	if t == nil {
+		return true
+	}
+
+	return len(t.Cert) == 0 && len(t.Key) == 0
 }


### PR DESCRIPTION
This fixes the non-TLS path for docker personality and vicadmin. It makes it explicit that if a certificate was specified but cannot be loaded that the fall back to non-TLS isn't acceptable.

This also neatens some of the vic-machine output around TLS arguments and displays DOCKER_OPTS as an alternative to the full command line

Fixes #1161 
