### PR TITLE
Use network backing info for debug network

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .vagrant/
+.vscode/
 .cover/
 bin/
 binary/

--- a/lib/apiservers/portlayer/restapi/configure_port_layer.go
+++ b/lib/apiservers/portlayer/restapi/configure_port_layer.go
@@ -75,7 +75,6 @@ func configureAPI(api *operations.PortLayerAPI) http.Handler {
 		ClusterPath:    options.PortLayerOptions.ClusterPath,
 		PoolPath:       options.PortLayerOptions.PoolPath,
 		DatastorePath:  options.PortLayerOptions.DatastorePath,
-		NetworkPath:    options.PortLayerOptions.NetworkPath,
 	}
 
 	sess, err := session.NewSession(sessionconfig).Create(ctx)

--- a/lib/apiservers/portlayer/restapi/handlers/interaction_handlers.go
+++ b/lib/apiservers/portlayer/restapi/handlers/interaction_handlers.go
@@ -62,7 +62,6 @@ func (i *InteractionHandlersImpl) Configure(api *operations.PortLayerAPI, _ *Han
 		ClusterPath:    options.PortLayerOptions.ClusterPath,
 		PoolPath:       options.PortLayerOptions.PoolPath,
 		DatastorePath:  options.PortLayerOptions.DatastorePath,
-		NetworkPath:    options.PortLayerOptions.NetworkPath,
 	}
 
 	interactionSession, err = session.NewSession(sessionconfig).Create(ctx)

--- a/lib/apiservers/portlayer/restapi/handlers/storage_handlers.go
+++ b/lib/apiservers/portlayer/restapi/handlers/storage_handlers.go
@@ -57,7 +57,6 @@ func (handler *StorageHandlersImpl) Configure(api *operations.PortLayerAPI, hand
 		ClusterPath:    options.PortLayerOptions.ClusterPath,
 		PoolPath:       options.PortLayerOptions.PoolPath,
 		DatastorePath:  options.PortLayerOptions.DatastorePath,
-		NetworkPath:    options.PortLayerOptions.NetworkPath,
 	}
 
 	storageSession, err = session.NewSession(sessionconfig).Create(ctx)

--- a/lib/apiservers/portlayer/restapi/options/options.go
+++ b/lib/apiservers/portlayer/restapi/options/options.go
@@ -27,7 +27,6 @@ type PortLayerOptionsType struct {
 	ClusterPath    string `long:"cluster" default:"" description:"Cluster path" env:"CS_PATH" required:"true"`
 	PoolPath       string `long:"pool" default:"" description:"Resource pool path" env:"POOL_PATH" required:"true"`
 	DatastorePath  string `long:"datastore" default:"/ha-datacenter/datastore/*" description:"Datastore path" env:"DS_PATH" required:"true"`
-	NetworkPath    string `long:"network" default:"/ha-datacenter/network/*" description:"Network path" env:"NET_PATH" required:"true"`
 
 	VCHName string `long:"vch" default:"" description:"VCH name" env:"VCH_NAME" required:"true"`
 

--- a/lib/install/management/appliance.go
+++ b/lib/install/management/appliance.go
@@ -17,7 +17,6 @@ package management
 import (
 	"fmt"
 	"strconv"
-	"strings"
 	"time"
 
 	log "github.com/Sirupsen/logrus"
@@ -416,7 +415,6 @@ func (d *Dispatcher) createAppliance(conf *metadata.VirtualContainerHostConfigSp
 	},
 	)
 
-	netname := strings.Split(conf.Networks["client"].Network.ID, "-")[1]
 	conf.AddComponent("port-layer", &metadata.SessionConfig{
 		Cmd: metadata.Cmd{
 			Path: "/sbin/port-layer-server",
@@ -431,7 +429,6 @@ func (d *Dispatcher) createAppliance(conf *metadata.VirtualContainerHostConfigSp
 				"--cluster=" + settings.ClusterPath,
 				"--pool=" + settings.ResourcePoolPath,
 				"--datastore=" + conf.ImageStores[0].Host,
-				"--network=" + fmt.Sprintf("/%s/network/%s", settings.DatacenterName, netname),
 				"--vch=" + conf.ExecutorConfig.Name,
 			},
 		},

--- a/lib/portlayer/exec/config.go
+++ b/lib/portlayer/exec/config.go
@@ -46,4 +46,8 @@ type Configuration struct {
 
 	// Allow custom naming convention for containerVMs
 	ContainerNameConvention string
+
+	// FIXME: temporary work around for injecting network path of debug nic
+	Networks     map[string]*metadata.NetworkEndpoint `vic:"0.1" scope:"read-only" key:"init/networks"`
+	DebugNetwork object.NetworkReference
 }

--- a/lib/portlayer/portlayer.go
+++ b/lib/portlayer/portlayer.go
@@ -59,6 +59,22 @@ func Init(ctx context.Context, sess *session.Session) error {
 		return err
 	}
 	exec.Config.ResourcePool = r.(*object.ResourcePool)
+	//FIXME: temporary injection of debug network for debug nic
+	ne := exec.Config.Networks["client"]
+	if ne == nil {
+		detail := fmt.Sprintf("could not get client network reference for debug nic - this code can be removed once network mapping/dhcp client is present")
+		log.Errorf(detail)
+		return err
+	}
+	nr := new(types.ManagedObjectReference)
+	nr.FromString(ne.Network.ID)
+	r, err = f.ObjectReference(ctx, *nr)
+	if err != nil {
+		detail := fmt.Sprintf("could not get client network reference from %s: %s", nr.String(), err)
+		log.Errorf(detail)
+		return err
+	}
+	exec.Config.DebugNetwork = r.(object.NetworkReference)
 
 	extraconfig.Decode(source, &network.Config)
 	log.Debugf("Decoded VCH config for network: %#v", network.Config)

--- a/lib/spec/network.go
+++ b/lib/spec/network.go
@@ -62,11 +62,7 @@ func NewVirtualE1000() *types.VirtualE1000 {
 func (s *VirtualMachineConfigSpec) addVirtualNIC(device types.BaseVirtualDevice) *VirtualMachineConfigSpec {
 	device.GetVirtualDevice().Key = s.generateNextKey()
 
-	device.GetVirtualDevice().Backing = &types.VirtualEthernetCardNetworkBackingInfo{
-		VirtualDeviceDeviceBackingInfo: types.VirtualDeviceDeviceBackingInfo{
-			DeviceName: s.NetworkName(),
-		},
-	}
+	device.GetVirtualDevice().Backing = s.DebugNetwork()
 	return s.AddVirtualDevice(device)
 }
 

--- a/lib/spec/spec.go
+++ b/lib/spec/spec.go
@@ -63,8 +63,8 @@ type VirtualMachineConfigSpecConfig struct {
 	// URI of the network serial port
 	ConnectorURI string
 
-	// Name of the network
-	NetworkName string
+	// Network backing info
+	DebugNetwork types.BaseVirtualDeviceBackingInfo
 
 	// Name of the image store
 	ImageStoreName string
@@ -231,10 +231,10 @@ func (s *VirtualMachineConfigSpec) VMPathName() string {
 }
 
 // NetworkName returns the network name
-func (s *VirtualMachineConfigSpec) NetworkName() string {
+func (s *VirtualMachineConfigSpec) DebugNetwork() types.BaseVirtualDeviceBackingInfo {
 	defer trace.End(trace.Begin(s.config.ID))
 
-	return s.config.NetworkName
+	return s.config.DebugNetwork
 }
 
 // ConnectorURI returns the connector URI

--- a/pkg/vsphere/test/test.go
+++ b/pkg/vsphere/test/test.go
@@ -17,7 +17,6 @@ package test
 import (
 	"fmt"
 	"math/rand"
-	"strings"
 	"testing"
 	"time"
 
@@ -52,6 +51,11 @@ func Session(ctx context.Context, t *testing.T) *session.Session {
 
 // SpecConfig returns a spec.VirtualMachineConfigSpecConfig struct
 func SpecConfig(session *session.Session) *spec.VirtualMachineConfigSpecConfig {
+	backing, err := session.Network.EthernetCardBackingInfo(context.TODO())
+	if err != nil {
+		return nil
+	}
+
 	return &spec.VirtualMachineConfigSpecConfig{
 		NumCPUs:       2,
 		MemoryMB:      2048,
@@ -63,7 +67,7 @@ func SpecConfig(session *session.Session) *spec.VirtualMachineConfigSpecConfig {
 		Name:          "zombie_attack",
 		BootMediaPath: session.Datastore.Path("brainz.iso"),
 		VMPathName:    fmt.Sprintf("[%s]", session.Datastore.Name()),
-		NetworkName:   strings.Split(session.Network.Reference().Value, "-")[1],
+		DebugNetwork:  backing,
 	}
 }
 

--- a/pkg/vsphere/vm/vm_test.go
+++ b/pkg/vsphere/vm/vm_test.go
@@ -140,10 +140,15 @@ func TestVMAttributes(t *testing.T) {
 	// Wrap the result with our version of VirtualMachine
 	vm := NewVirtualMachine(ctx, session, *moref)
 
+	uuid, err := guest.UUID()
+	if err != nil {
+		t.Fatalf("unable to get UUID for guest - used for VM name: %s", err)
+	}
+
 	if folder, err := vm.FolderName(ctx); err != nil {
 		t.Fatalf("ERROR: %s", err)
 	} else {
-		assert.Equal(t, "deadbeef", folder)
+		assert.Equal(t, uuid, folder)
 	}
 
 	_, err = tasks.WaitForResult(ctx, func(ctx context.Context) (tasks.ResultWaiter, error) {


### PR DESCRIPTION
The debug network was using name mangling based on the moref which is utterly horrific and doesn't work reliably in vCenter. We cannot yet get rid of the debug network (see #1180) so this gets the backing info via the extraconfig mechanisms.

Fixes #1180 
