### PR TITLE
Multiple image tag support

### DIFF
--- a/cmd/imagec/imagec_test.go
+++ b/cmd/imagec/imagec_test.go
@@ -415,3 +415,32 @@ func TestNewHook(t *testing.T) {
 		t.Errorf("Fatal test failed %s", string(b.Bytes()))
 	}
 }
+
+func TestArrayUpdate(t *testing.T) {
+	attributes := []string{"green", "blue", "red"}
+
+	// remove an existing value
+	attributes, chg := arrayUpdate("green", attributes, Remove)
+	if !chg && len(attributes) == 2 {
+		t.Error("arrayUpdate failed to remove existing value")
+	}
+
+	// add a new value
+	attributes, chg = arrayUpdate("green", attributes, Add)
+	if !chg && len(attributes) == 3 {
+		t.Error("arrayUpdate failed to add new value")
+	}
+
+	// add existing value
+	attributes, chg = arrayUpdate("green", attributes, Add)
+	if chg && len(attributes) == 3 {
+		t.Error("arrayUpdate failed while adding existing value")
+	}
+
+	// attempt to remove non-existent value
+	attributes, chg = arrayUpdate("foobar", attributes, Remove)
+	if chg && len(attributes) == 3 {
+		t.Error("arrayUpdate failed while removing non-existent value")
+	}
+
+}

--- a/lib/apiservers/engine/backends/cache/image_cache.go
+++ b/lib/apiservers/engine/backends/cache/image_cache.go
@@ -130,17 +130,20 @@ func (c *ImageCache) Update(client *client.PortLayer) error {
 				continue
 			}
 
-			ref, err = reference.WithTag(ref, imageConfig.Tag)
-			if err != nil {
-				log.Errorf("Tried to create tagged reference from %s and tag %s: %s", imageConfig.Name, imageConfig.Tag, err.Error())
-				continue
-			}
+			for id := range imageConfig.Tags {
+				tag := imageConfig.Tags[id]
+				ref, err = reference.WithTag(ref, tag)
+				if err != nil {
+					log.Errorf("Tried to create tagged reference from %s and tag %s: %s", imageConfig.Name, tag, err.Error())
+					continue
+				}
 
-			if tagged, ok := ref.(reference.NamedTagged); ok {
-				taggedName := tagged.Name() + ":" + tagged.Tag()
-				c.cacheByName[taggedName] = imageConfig
-			} else {
-				c.cacheByName[ref.Name()] = imageConfig
+				if tagged, ok := ref.(reference.NamedTagged); ok {
+					taggedName := fmt.Sprintf("%s:%s", tagged.Name(), tagged.Tag())
+					c.cacheByName[taggedName] = imageConfig
+				} else {
+					c.cacheByName[ref.Name()] = imageConfig
+				}
 			}
 		}
 	}

--- a/lib/apiservers/portlayer/restapi/handlers/storage_handlers_test.go
+++ b/lib/apiservers/portlayer/restapi/handlers/storage_handlers_test.go
@@ -81,6 +81,9 @@ func (c *MockDataStore) WriteImage(ctx context.Context, parent *spl.Image, ID st
 
 	return &i, nil
 }
+func (c *MockDataStore) WriteMetadata(ctx context.Context, storeName string, ID string, meta map[string][]byte) error {
+	return nil
+}
 
 // GetImage gets the specified image from the given store by retreiving it from the cache.
 func (c *MockDataStore) GetImage(ctx context.Context, store *url.URL, ID string) (*spl.Image, error) {

--- a/lib/metadata/image_config.go
+++ b/lib/metadata/image_config.go
@@ -23,9 +23,9 @@ type ImageConfig struct {
 	docker.V1Image
 
 	// image specific data
-	ImageID string            `json:"image_id,omitempty"`
-	Digest  string            `json:"digest,omitempty"`
-	Tag     string            `json:"tag,omitempty"`
+	ImageID string            `json:"image_id"`
+	Digests []string          `json:"digests,omitempty"`
+	Tags    []string          `json:"tags,omitempty"`
 	Name    string            `json:"name,omitempty"`
 	DiffIDs map[string]string `json:"diff_ids,omitempty"`
 	History []docker.History  `json:"history,omitempty"`

--- a/lib/portlayer/storage/image.go
+++ b/lib/portlayer/storage/image.go
@@ -76,6 +76,13 @@ type ImageStorer interface {
 	WriteImage(ctx context.Context, parent *Image, ID string, meta map[string][]byte, r io.Reader) (*Image,
 		error)
 
+	// WriteMetadata will write the provided metadata to the image store
+	//
+	// storeName - The image store to query name - The name of the image (optional)
+	// ID - textual ID for the image
+	// meta - metadata associated with the image
+	WriteMetadata(ctx context.Context, storeName string, ID string, meta map[string][]byte) error
+
 	// GetImage queries the image store for the specified image.
 	//
 	// store - The image store to query name - The name of the image (optional)

--- a/lib/portlayer/storage/store_cache_test.go
+++ b/lib/portlayer/storage/store_cache_test.go
@@ -72,6 +72,10 @@ func (c *MockDataStore) WriteImage(ctx context.Context, parent *Image, ID string
 	return i, nil
 }
 
+func (c *MockDataStore) WriteMetadata(ctx context.Context, storeName string, ID string, meta map[string][]byte) error {
+	return nil
+}
+
 // GetImage gets the specified image from the given store by retreiving it from the cache.
 func (c *MockDataStore) GetImage(ctx context.Context, store *url.URL, ID string) (*Image, error) {
 	i, ok := c.db[*store][ID]

--- a/lib/portlayer/storage/vsphere/store.go
+++ b/lib/portlayer/storage/vsphere/store.go
@@ -267,7 +267,7 @@ func (v *ImageStore) WriteImage(ctx context.Context, parent *portlayer.Image, ID
 	}
 
 	// Write the metadata to the datastore
-	err = v.writeMeta(ctx, storeName, ID, meta)
+	err = v.WriteMetadata(ctx, storeName, ID, meta)
 	if err != nil {
 		return nil, err
 	}
@@ -369,7 +369,7 @@ func (v *ImageStore) ListImages(ctx context.Context, store *url.URL, IDs []strin
 // directory under the image's parent directory.  Each blob in the metadata map
 // is written to a file with the corresponding name.  Likewise, when we read it
 // back (on restart) we populate the map accordingly.
-func (v *ImageStore) writeMeta(ctx context.Context, storeName string, ID string,
+func (v *ImageStore) WriteMetadata(ctx context.Context, storeName string, ID string,
 	meta map[string][]byte) error {
 	// XXX this should be done via disklib so this meta follows the disk in
 	// case of motion.


### PR DESCRIPTION
This change will provide support for multiple tags per docker image.  For example two pull requests were initiated which resulted in one image being downloaded -- a single Image ID with multiple tags.  

```
REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
busybox             1.24.2              47bcc53f74dc        3 months ago        1.113 MB
busybox             latest              47bcc53f74dc        3 months ago        1.113 MB
```

This is considered a temporary fix until a more robust key / value store is implemented in the future.  This is only addressing multiple tags and not multiple digests, so it partially fixes #976 
