### PR TITLE
Move parentMap file to VCH namespace

### DIFF
--- a/lib/portlayer/storage/vsphere/parent_test.go
+++ b/lib/portlayer/storage/vsphere/parent_test.go
@@ -21,6 +21,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+const testStore = "testStore"
+
 func TestParentEmptyRestore(t *testing.T) {
 	ctx, ds, cleanupfunc := dSsetup(t)
 	if t.Failed() {
@@ -28,7 +30,7 @@ func TestParentEmptyRestore(t *testing.T) {
 	}
 	defer cleanupfunc()
 
-	par, err := restoreParentMap(ctx, ds)
+	par, err := restoreParentMap(ctx, ds, testStore)
 	if !assert.NoError(t, err) && !assert.NotNil(t, par) {
 		return
 	}
@@ -41,7 +43,7 @@ func TestParentEmptySaveRestore(t *testing.T) {
 	}
 	defer cleanupfunc()
 
-	par, err := restoreParentMap(ctx, ds)
+	par, err := restoreParentMap(ctx, ds, testStore)
 	if !assert.NoError(t, err) && !assert.NotNil(t, par) {
 		return
 	}
@@ -51,7 +53,7 @@ func TestParentEmptySaveRestore(t *testing.T) {
 		return
 	}
 
-	p, err := restoreParentMap(ctx, ds)
+	p, err := restoreParentMap(ctx, ds, testStore)
 	if !assert.NoError(t, err) && !assert.NotNil(t, p) {
 		return
 	}
@@ -65,7 +67,7 @@ func TestParentSaveRestore(t *testing.T) {
 	}
 	defer cleanupfunc()
 
-	par, err := restoreParentMap(ctx, ds)
+	par, err := restoreParentMap(ctx, ds, testStore)
 	if !assert.NoError(t, err) && !assert.NotNil(t, par) {
 		return
 	}
@@ -83,7 +85,7 @@ func TestParentSaveRestore(t *testing.T) {
 	}
 
 	// load into a different map
-	p, err := restoreParentMap(ctx, ds)
+	p, err := restoreParentMap(ctx, ds, testStore)
 	if !assert.NoError(t, err) && !assert.NotNil(t, p) {
 		return
 	}

--- a/lib/portlayer/storage/vsphere/store.go
+++ b/lib/portlayer/storage/vsphere/store.go
@@ -74,16 +74,10 @@ func NewImageStore(ctx context.Context, s *session.Session) (*ImageStore, error)
 		return nil, err
 	}
 
-	pm, err := restoreParentMap(ctx, ds)
-	if err != nil {
-		return nil, err
-	}
-
 	vis := &ImageStore{
-		dm:      dm,
-		ds:      ds,
-		s:       s,
-		parents: pm,
+		dm: dm,
+		ds: ds,
+		s:  s,
 	}
 
 	return vis, nil
@@ -124,6 +118,13 @@ func (v *ImageStore) CreateImageStore(ctx context.Context, storeName string) (*u
 		return nil, err
 	}
 
+	if v.parents == nil {
+		pm, err := restoreParentMap(ctx, v.ds, storeName)
+		if err != nil {
+			return nil, err
+		}
+		v.parents = pm
+	}
 	return u, nil
 }
 
@@ -144,6 +145,14 @@ func (v *ImageStore) GetImageStore(ctx context.Context, storeName string) (*url.
 	_, ok := info.(*types.FolderFileInfo)
 	if !ok {
 		return nil, fmt.Errorf("Stat error:  path doesn't exist (%s)", p)
+	}
+
+	if v.parents == nil {
+		pm, err := restoreParentMap(ctx, v.ds, storeName)
+		if err != nil {
+			return nil, err
+		}
+		v.parents = pm
 	}
 
 	return u, nil


### PR DESCRIPTION
To avoid concurrent write between multiple VCH, move the parentMap file to VCH directory.