### PR TITLE
Check firewall rules for tether traffic, update port

### DIFF
--- a/cmd/tether/attach_test.go
+++ b/cmd/tether/attach_test.go
@@ -651,7 +651,7 @@ func TestMockAttachTetherToPL(t *testing.T) {
 	defer testTeardown(t)
 
 	// Start the PL attach server
-	testServer := attach.NewAttachServer("", 2377)
+	testServer := attach.NewAttachServer("", 8080)
 	assert.NoError(t, testServer.Start())
 	defer testServer.Stop()
 

--- a/lib/apiservers/portlayer/restapi/handlers/containers_handlers.go
+++ b/lib/apiservers/portlayer/restapi/handlers/containers_handlers.go
@@ -42,10 +42,6 @@ type ContainersHandlersImpl struct {
 	handlerCtx *HandlerContext
 }
 
-const (
-	serialOverLANPort = 2377
-)
-
 // Configure assigns functions to all the exec api handlers
 func (handler *ContainersHandlersImpl) Configure(api *operations.PortLayerAPI, handlerCtx *HandlerContext) {
 	api.ContainersCreateHandler = containers.CreateHandlerFunc(handler.CreateHandler)

--- a/lib/apiservers/portlayer/restapi/handlers/interaction_handlers.go
+++ b/lib/apiservers/portlayer/restapi/handlers/interaction_handlers.go
@@ -31,6 +31,7 @@ import (
 	"github.com/vmware/vic/lib/apiservers/portlayer/restapi/operations/interaction"
 	"github.com/vmware/vic/lib/apiservers/portlayer/restapi/options"
 	"github.com/vmware/vic/lib/portlayer/attach"
+	"github.com/vmware/vic/lib/portlayer/exec"
 	"github.com/vmware/vic/pkg/vsphere/session"
 )
 
@@ -69,7 +70,7 @@ func (i *InteractionHandlersImpl) Configure(api *operations.PortLayerAPI, _ *Han
 		log.Fatalf("InteractionHandler ERROR: %s", err)
 	}
 
-	i.attachServer = attach.NewAttachServer("", 0)
+	i.attachServer = attach.NewAttachServer(exec.ManagementHostName, 0)
 
 	if err := i.attachServer.Start(); err != nil {
 		log.Fatalf("Attach server unable to start: %s", err)

--- a/lib/portlayer/attach/server.go
+++ b/lib/portlayer/attach/server.go
@@ -22,12 +22,8 @@ import (
 	"golang.org/x/net/context"
 
 	log "github.com/Sirupsen/logrus"
+	"github.com/vmware/vic/lib/portlayer"
 	"github.com/vmware/vic/pkg/errors"
-)
-
-const (
-	// docker official ports are 2375 and 2376
-	serialOverLANPort = 2377
 )
 
 // AttachServer waits for TCP client connections on serialOverLANPort, then
@@ -43,7 +39,7 @@ type Server struct {
 
 func NewAttachServer(ip string, port int) *Server {
 	if port == 0 {
-		port = serialOverLANPort
+		port = portlayer.SerialOverLANPort
 	}
 
 	return &Server{ip: ip, port: port}

--- a/lib/portlayer/exec/handle.go
+++ b/lib/portlayer/exec/handle.go
@@ -37,8 +37,8 @@ import (
 )
 
 const (
-	serialOverLANPort  = 2377
-	managementHostName = "management.localhost"
+	serialOverLANPort  = 8080
+	ManagementHostName = "management.localhost"
 )
 
 // ContainerCreateConfig defines the parameters for Create call
@@ -178,20 +178,20 @@ func (h *Handle) Create(ctx context.Context, sess *session.Session, config *Cont
 	// add create time to config
 	h.ExecConfig.Common.Created = time.Now().UTC().String()
 	// Convert the management hostname to IP
-	ips, err := net.LookupIP(managementHostName)
+	ips, err := net.LookupIP(ManagementHostName)
 	if err != nil {
-		log.Errorf("Unable to look up %s during create of %s: %s", managementHostName, config.Metadata.ID, err)
+		log.Errorf("Unable to look up %s during create of %s: %s", ManagementHostName, config.Metadata.ID, err)
 		return err
 	}
 
 	if len(ips) == 0 {
-		log.Errorf("No IP found for %s during create of %s", managementHostName, config.Metadata.ID)
-		return fmt.Errorf("No IP found on %s", managementHostName)
+		log.Errorf("No IP found for %s during create of %s", ManagementHostName, config.Metadata.ID)
+		return fmt.Errorf("No IP found on %s", ManagementHostName)
 	}
 
 	if len(ips) > 1 {
-		log.Errorf("Multiple IPs found for %s during create of %s: %v", managementHostName, config.Metadata.ID, ips)
-		return fmt.Errorf("Multiple IPs found on %s: %#v", managementHostName, ips)
+		log.Errorf("Multiple IPs found for %s during create of %s: %v", ManagementHostName, config.Metadata.ID, ips)
+		return fmt.Errorf("Multiple IPs found on %s: %#v", ManagementHostName, ips)
 	}
 
 	URI := fmt.Sprintf("tcp://%s:%d", ips[0], serialOverLANPort)

--- a/lib/portlayer/portlayer.go
+++ b/lib/portlayer/portlayer.go
@@ -30,6 +30,11 @@ import (
 	"golang.org/x/net/context"
 )
 
+const (
+	// docker official ports are 2375 and 2376
+	SerialOverLANPort = 8080
+)
+
 // XXX TODO(FA) use this in the _handlers the swagger server includes.
 //
 // API defines the interface the REST server used by the portlayer expects the


### PR DESCRIPTION
Switch serialOverLANPort to 8080 which is open outbound by default. 
Provide firewall check in vic-machine and warn if the firewall is misconfigured. 
If the firewall would prevent VIC from running properly as configured, validation would fail and install would halt.

```
INFO[2016-06-23T12:41:59-07:00] ### Installing VCH ####                      
INFO[2016-06-23T12:41:59-07:00] Generating certificate/key pair - private key in ./chin-vic-38-key.pem 
INFO[2016-06-23T12:42:00-07:00] Validating supplied configuration            
INFO[2016-06-23T12:42:01-07:00] Firewall status: DISABLED on /Datacenter/host/Austin/patty.eng.vmware.com 
INFO[2016-06-23T12:42:01-07:00] Firewall configuration OK on hosts:          
INFO[2016-06-23T12:42:01-07:00]   /Datacenter/host/Austin/patty.eng.vmware.com 
```

Fixes #801 

