### PR TITLE
Remove vSphere VCH extension in vic-machine delete

### DIFF
--- a/cmd/vic-machine/delete/delete.go
+++ b/cmd/vic-machine/delete/delete.go
@@ -146,10 +146,10 @@ func (d *Uninstall) Run(cli *cli.Context) error {
 	if validator.IsVC() {
 		log.Infoln("Removing VCH vSphere extension")
 		if err = executor.GenerateExtensionName(vchConfig); err != nil {
-			return err
+			log.Errorf("Wasn't able to get extension name during VCH deletion. Failed with error: %s", err)
 		}
 		if err = executor.UnregisterExtension(vchConfig.ExtensionName); err != nil {
-			return err
+			log.Errorf("Wasn't able to remove extension %s due to error: %s", vchConfig.ExtensionName, err)
 		}
 	}
 

--- a/cmd/vic-machine/delete/delete.go
+++ b/cmd/vic-machine/delete/delete.go
@@ -146,10 +146,10 @@ func (d *Uninstall) Run(cli *cli.Context) error {
 	if validator.IsVC() {
 		log.Infoln("Removing VCH vSphere extension")
 		if err = executor.GenerateExtensionName(vchConfig); err != nil {
-			log.Errorf("Wasn't able to get extension name during VCH deletion. Failed with error: %s", err)
+			log.Warnf("Wasn't able to get extension name during VCH deletion. Failed with error: %s", err)
 		}
 		if err = executor.UnregisterExtension(vchConfig.ExtensionName); err != nil {
-			log.Errorf("Wasn't able to remove extension %s due to error: %s", vchConfig.ExtensionName, err)
+			log.Warnf("Wasn't able to remove extension %s due to error: %s", vchConfig.ExtensionName, err)
 		}
 	}
 

--- a/cmd/vic-machine/delete/delete.go
+++ b/cmd/vic-machine/delete/delete.go
@@ -143,6 +143,16 @@ func (d *Uninstall) Run(cli *cli.Context) error {
 		return err
 	}
 
+	if validator.IsVC() {
+		log.Infoln("Removing VCH vSphere extension")
+		if err = executor.GenerateExtensionName(vchConfig); err != nil {
+			return err
+		}
+		if err = executor.UnregisterExtension(vchConfig.ExtensionName); err != nil {
+			return err
+		}
+	}
+
 	if err = executor.DeleteVCH(vchConfig); err != nil {
 		executor.CollectDiagnosticLogs()
 		return err

--- a/lib/install/management/appliance.go
+++ b/lib/install/management/appliance.go
@@ -303,7 +303,7 @@ func (d *Dispatcher) findAppliance(conf *metadata.VirtualContainerHostConfigSpec
 }
 
 // retrieves the uuid of the appliance vm to create a unique vsphere extension name
-func (d *Dispatcher) generateExtensionName(conf *metadata.VirtualContainerHostConfigSpec) error {
+func (d *Dispatcher) GenerateExtensionName(conf *metadata.VirtualContainerHostConfigSpec) error {
 	// must be called after appliance VM is created
 	vm, err := d.findAppliance(conf)
 
@@ -390,7 +390,10 @@ func (d *Dispatcher) createAppliance(conf *metadata.VirtualContainerHostConfigSp
 	log.Debugf("vm inventory path: %s", vm2.InventoryPath)
 
 	// create an extension to register the appliance as
-	d.generateExtensionName(conf)
+	if err = d.GenerateExtensionName(conf); err != nil {
+		return errors.Errorf("Could not generate extension name during appliance creation due to error: %s", err)
+	}
+
 	settings.Extension = types.Extension{
 		Description: &types.Description{
 			Label:   "VIC",


### PR DESCRIPTION
Adds functionality to clean out the VCH extension when `vic-machine delete` is run.
Pretty minor/straightforward addition.