### PR TITLE
[dns] Introduce network scopes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,6 +63,11 @@ vic-machine-linux := $(BIN)/vic-machine-linux
 vic-machine-windows := $(BIN)/vic-machine-windows.exe
 vic-machine-darwin := $(BIN)/vic-machine-darwin
 vch-init := $(BIN)/vch-init
+# NOT BUILT WITH make all TARGET
+# vic-dns variants to create standalone DNS service.
+vic-dns-linux := $(BIN)/vic-dns-linux
+vic-dns-windows := $(BIN)/vic-dns-windows.exe
+vic-dns-darwin := $(BIN)/vic-dns-darwin
 
 tether-linux := $(BIN)/tether-linux
 tether-windows := $(BIN)/tether-windows.exe
@@ -102,6 +107,9 @@ bootstrap-debug: $(bootstrap-debug)
 bootstrap-staging-debug: $(bootstrap-staging-debug)
 iso-base: $(iso-base)
 vic-machine: $(vic-machine-linux) $(vic-machine-windows) $(vic-machine-darwin)
+# NOT BUILT WITH make all TARGET
+# vic-dns variants to create standalone DNS service.
+vic-dns: $(vic-dns-linux) $(vic-dns-windows) $(vic-dns-darwin)
 
 swagger: $(SWAGGER)
 
@@ -169,7 +177,7 @@ $(go-lint): $(GOLINT)
 gopath:
 	@echo -n $(GOPATH)
 
-$(go-imports): $(GOIMPORTS) $(find . -type f -name '*.go' -not -path "./vendor/*" -not -path "lib/apiservers/portlayer") $(PORTLAYER_DEPS)
+$(go-imports): $(GOIMPORTS) $(find . -type f -name '*.go' -not -path "./vendor/*") $(PORTLAYER_DEPS)
 	@echo checking go imports...
 	@! $(GOIMPORTS) -d $$(find . -type f -name '*.go' -not -path "./vendor/*") 2>&1 | egrep -v '^$$'
 	@touch $@
@@ -308,6 +316,18 @@ $(vic-machine-windows): $(call godeps,cmd/vic-machine/*.go)
 $(vic-machine-darwin): $(call godeps,cmd/vic-machine/*.go)
 	@echo building vic-machine darwin...
 	@GOARCH=amd64 GOOS=darwin $(TIME) $(GO) build $(RACE) -ldflags "-X github.com/vmware/vic/cmd/vic-machine.BuildID=$(BUILD_NUMBER)" -o ./$@ ./$(dir $<)
+
+$(vic-dns-linux): $(call godeps,cmd/vic-dns/*.go)
+	@echo building vic-dns linux...
+	@GOARCH=amd64 GOOS=linux $(TIME) $(GO) build $(RACE) -o ./$@ ./$(dir $<)
+
+$(vic-dns-windows): $(call godeps,cmd/vic-dns/*.go)
+	@echo building vic-dns windows...
+	@GOARCH=amd64 GOOS=windows $(TIME) $(GO) build $(RACE) -o ./$@ ./$(dir $<)
+
+$(vic-dns-darwin): $(call godeps,cmd/vic-dns/*.go)
+	@echo building vic-dns darwin...
+	@GOARCH=amd64 GOOS=darwin $(TIME) $(GO) build $(RACE) -o ./$@ ./$(dir $<)
 
 clean:
 	rm -rf $(BIN)

--- a/cmd/vic-dns/main.go
+++ b/cmd/vic-dns/main.go
@@ -1,0 +1,79 @@
+// Copyright 2016 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"os/signal"
+	"runtime/debug"
+	"syscall"
+
+	log "github.com/Sirupsen/logrus"
+
+	"github.com/vmware/vic/lib/dns"
+)
+
+var (
+	options = dns.ServerOptions{}
+)
+
+func init() {
+	flag.StringVar(&options.IP, "ip", dns.DefaultIP, "IP to use")
+	flag.IntVar(&options.Port, "port", dns.DefaultPort, "Port to bind")
+
+	flag.Var(&options.Nameservers, "nameservers", "Nameservers to use")
+
+	flag.DurationVar(&options.Timeout, "timeout", dns.DefaultTimeout, "Timeout for external DNS queries")
+
+	flag.DurationVar(&options.TTL, "ttl", dns.DefaultTTL, "TTL")
+	flag.IntVar(&options.CacheSize, "cachesize", dns.DefaultCacheSize, "Cache size to use")
+
+	flag.BoolVar(&options.Debug, "debug", false, "Enable debugging")
+
+	flag.Parse()
+}
+
+func main() {
+	defer func() {
+		if r := recover(); r != nil {
+			fmt.Fprintf(os.Stderr, fmt.Sprintf("%s : %s", r, debug.Stack()))
+		}
+	}()
+	// Initiliaze logger with default TextFormatter
+	log.SetFormatter(&log.TextFormatter{DisableColors: false, FullTimestamp: true})
+
+	// Set the log level
+	if options.Debug {
+		log.SetLevel(log.DebugLevel)
+	}
+
+	server := dns.NewServer(options)
+	if server != nil {
+		server.Start()
+	}
+
+	// handle the signals and gracefully shutdown the server
+	sig := make(chan os.Signal, 1)
+	signal.Notify(sig, syscall.SIGINT, syscall.SIGTERM)
+
+	go func() {
+		log.Warnf("signal %s received", <-sig)
+		server.Stop()
+	}()
+
+	server.Wait()
+}

--- a/lib/portlayer/exec/id.go
+++ b/lib/portlayer/exec/id.go
@@ -27,11 +27,16 @@ func ParseID(id string) ID {
 	return ID(id)
 }
 
+// Truncate returns the truncated ID
+func (id ID) TruncateID() ID {
+	return ID(stringid.TruncateID(string(id)))
+}
+
 func (id ID) String() string {
 	return string(id)
 }
 
-// GeneratID generates a new container ID
+// GenerateID generates a new container ID
 func GenerateID() ID {
 	return ParseID(stringid.GenerateNonCryptoID())
 }

--- a/lib/portlayer/network/container.go
+++ b/lib/portlayer/network/container.go
@@ -23,7 +23,8 @@ import (
 type Container struct {
 	sync.Mutex
 
-	id        exec.ID
+	id exec.ID
+
 	endpoints []*Endpoint
 }
 


### PR DESCRIPTION
- we now have a seperate vic-dns binary to create standalone DNS service
- context now inserts/removed truncated id and common/name into
the map of containers (using SCOPE:NAME as a key)
- dns part of the PL now iterates over scopes to map requester IP adress
and returns the SCOPE:NAME key as a response
- tether now generates /etc/resolv.conf for containers