### PR TITLE
WIP: diagnostic and logging improvements

### DIFF
--- a/lib/install/management/appliance.go
+++ b/lib/install/management/appliance.go
@@ -417,6 +417,7 @@ func (d *Dispatcher) createAppliance(conf *metadata.VirtualContainerHostConfigSp
 			},
 			Env: []string{
 				"PATH=/sbin:/bin",
+				"GOTRACEBACK=all",
 			},
 		},
 	},
@@ -442,6 +443,7 @@ func (d *Dispatcher) createAppliance(conf *metadata.VirtualContainerHostConfigSp
 			},
 			Env: []string{
 				"PATH=/sbin",
+				"GOTRACEBACK=all",
 			},
 		},
 	},
@@ -462,6 +464,9 @@ func (d *Dispatcher) createAppliance(conf *metadata.VirtualContainerHostConfigSp
 				"--pool=" + settings.ResourcePoolPath,
 				"--datastore=" + conf.ImageStores[0].Host,
 				"--vch=" + conf.ExecutorConfig.Name,
+			},
+			Env: []string{
+				"GOTRACEBACK=all",
 			},
 		},
 	},

--- a/lib/install/validate/validator.go
+++ b/lib/install/validate/validator.go
@@ -172,6 +172,9 @@ func (v *Validator) basics(ctx context.Context, input *data.Data, conf *metadata
 
 	// TODO: ensure that displayname doesn't violate constraints (length, characters, etc)
 	conf.SetName(input.DisplayName)
+	if input.Debug.Debug {
+		conf.SetDebug(1)
+	}
 
 	conf.Name = input.DisplayName
 }

--- a/lib/metadata/container_vm.go
+++ b/lib/metadata/container_vm.go
@@ -35,6 +35,9 @@ type Common struct {
 	// Convenience field to record a human readable name
 	Name string `vic:"0.1" scope:"read-only" key:"name"`
 
+	// Should debugging be enabled on whatever component this is and at what level
+	DebugLevel int `vic:"0.1" scope:"read-only" key:"debug"`
+
 	// creation timestamp
 	Created string `vic:"0.1" scope:"read-only" key:"created"`
 

--- a/lib/metadata/virtual_container_host.go
+++ b/lib/metadata/virtual_container_host.go
@@ -45,8 +45,6 @@ type VirtualContainerHostConfigSpec struct {
 	Insecure bool `vic:"0.1" scope:"read-only" key:"insecure"`
 	// The session timeout
 	Keepalive time.Duration `vic:"0.1" scope:"read-only" key:"keepalive"`
-	// Turn on debug logging
-	Debug bool `vic:"0.1" scope:"read-only" key:"debug"`
 	// Virtual Container Host version
 	Version string `vic:"0.1" scope:"read-only" key:"version"`
 
@@ -143,6 +141,11 @@ func (t *VirtualContainerHostConfigSpec) SetHostCertificate(key *[]byte) {
 // SetName sets the name of the VCH - this will be used as the hostname for the appliance
 func (t *VirtualContainerHostConfigSpec) SetName(name string) {
 	t.ExecutorConfig.Name = name
+}
+
+// SetName sets the name of the VCH - this will be used as the hostname for the appliance
+func (t *VirtualContainerHostConfigSpec) SetDebug(level int) {
+	t.ExecutorConfig.DebugLevel = level
 }
 
 // SetMoref sets the moref of the VCH - this allows components to acquire a handle to

--- a/lib/portlayer/exec/config.go
+++ b/lib/portlayer/exec/config.go
@@ -27,7 +27,7 @@ var Config Configuration
 // Configuration is a slice of the VCH config that is relevent to the exec part of the port layer
 type Configuration struct {
 	// Turn on debug logging
-	Debug bool `vic:"0.1" scope:"read-only" key:"debug"`
+	DebugLevel int `vic:"0.1" scope:"read-only" key:"init/common/debug"`
 
 	// Port Layer - exec
 	// Default containerVM capacity

--- a/lib/portlayer/exec/handle.go
+++ b/lib/portlayer/exec/handle.go
@@ -177,6 +177,9 @@ func (h *Handle) Create(ctx context.Context, sess *session.Session, config *Cont
 	h.ExecConfig = config.Metadata
 	// add create time to config
 	h.ExecConfig.Common.Created = time.Now().UTC().String()
+	// configure with debug
+	h.ExecConfig.DebugLevel = Config.DebugLevel
+
 	// Convert the management hostname to IP
 	ips, err := net.LookupIP(managementHostName)
 	if err != nil {

--- a/lib/portlayer/storage/vsphere/parent.go
+++ b/lib/portlayer/storage/vsphere/parent.go
@@ -24,6 +24,7 @@ import (
 	"golang.org/x/net/context"
 
 	log "github.com/Sirupsen/logrus"
+	"github.com/vmware/vic/pkg/trace"
 )
 
 const mapFile = "parentMap"
@@ -56,6 +57,8 @@ type parentM struct {
 
 // Starts here.  Tries to create a new parentM or load an existing one.
 func restoreParentMap(ctx context.Context, ds *datastore, storeName string) (*parentM, error) {
+	defer trace.End(trace.Begin(storeName))
+
 	p := &parentM{
 		ds: ds,
 	}
@@ -67,11 +70,14 @@ func restoreParentMap(ctx context.Context, ds *datastore, storeName string) (*pa
 		return nil, err
 	}
 
+	log.Debugf("Loaded parent map from store %s", storeName)
 	return p, nil
 }
 
 // Add sets the parent for image i to parent
 func (p *parentM) Add(i string, parent string) {
+	defer trace.End(trace.Begin(parent))
+
 	p.l.Lock()
 	defer p.l.Unlock()
 
@@ -88,6 +94,8 @@ func (p *parentM) Get(i string) string {
 
 // Save persists the parent map to the datastore
 func (p *parentM) Save(ctx context.Context) error {
+	defer trace.End(trace.Begin(""))
+
 	p.l.Lock()
 	defer p.l.Unlock()
 
@@ -115,6 +123,8 @@ func (p *parentM) Save(ctx context.Context) error {
 }
 
 func (p *parentM) download(ctx context.Context) error {
+	defer trace.End(trace.Begin(""))
+
 	p.l.Lock()
 	defer p.l.Unlock()
 

--- a/lib/tether/config.go
+++ b/lib/tether/config.go
@@ -30,6 +30,9 @@ type ExecutorConfig struct {
 	// ID corresponds to that of the primary session
 	ID string `vic:"0.1" scope:"read-only" key:"common/id"`
 
+	// Debug level required for the executor as a whole
+	Debug int `vic:"0.1" scope:"read-only" key:"common/debug"`
+
 	// Exclusive access to childPidTable
 	pidMutex sync.Mutex
 

--- a/lib/tether/tether.go
+++ b/lib/tether/tether.go
@@ -154,6 +154,12 @@ func (t *tether) Start() error {
 		extraconfig.Decode(t.src, t.config)
 		logConfig(t.config)
 
+		// get the log level required
+		// this is really basic debug toggle for now
+		if t.config.Debug > 0 {
+			log.SetLevel(log.DebugLevel)
+		}
+
 		if err := t.ops.SetHostname(stringid.TruncateID(t.config.ID), t.config.Name); err != nil {
 			detail := fmt.Sprintf("failed to set hostname: %s", err)
 			log.Error(detail)
@@ -240,10 +246,8 @@ func (t *tether) handleSessionExit(session *SessionConfig) {
 
 	// close down the IO
 	session.Reader.Close()
-	// live.outwriter.Close()
-	// live.errwriter.Close()
-
-	// flush session log output
+	session.Outwriter.Close()
+	session.Errwriter.Close()
 
 	// record exit status
 	// FIXME: we cannot have this embedded knowledge of the extraconfig encoding pattern, but not

--- a/pkg/dio/multi_test.go
+++ b/pkg/dio/multi_test.go
@@ -26,7 +26,7 @@ import (
 func init() {
 	// enable verbose logging during tests
 	log.SetLevel(log.DebugLevel)
-	verbose = true
+	Verbose = true
 }
 
 func TestMultiWrite(t *testing.T) {


### PR DESCRIPTION
This is a collection of debug and diagnostic improvements. Specifying --debug on the vic-machine command line will cause vic-machine and tether to emit significantly more debug info. This configuration has not yet been glued into the rest of the components in the appliance.

This closes the outwriters in the tether to force flushing - the data was present in one log, but not necessarily in the individual component logs.

This also adds entry/exit trace to the storage portion of the portlayer that were necessary for debugging #1191 

Towards: #709 
Fixes: #1031 