### PR TITLE
Update govmomi

### DIFF
--- a/pkg/vsphere/simulator/simulator.go
+++ b/pkg/vsphere/simulator/simulator.go
@@ -274,6 +274,11 @@ func (s *Service) NewServer() *Server {
 		Path:   path,
 	}
 
+	// Enable use of SessionManagerGenericServiceTicket.HostName in govmomi, disabled by default.
+	opts := u.Query()
+	opts.Set("GOVMOMI_USE_SERVICE_TICKET_HOSTNAME", "true")
+	u.RawQuery = opts.Encode()
+
 	// Redirect clients to this http server, rather than HostSystem.Name
 	Map.Get(*s.client.ServiceContent.SessionManager).(*SessionManager).ServiceHostName = u.Host
 

--- a/vendor/github.com/vmware/govmomi/govc/flags/client.go
+++ b/vendor/github.com/vmware/govmomi/govc/flags/client.go
@@ -23,6 +23,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"io/ioutil"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -360,6 +361,15 @@ func (flag *ClientFlag) newClient() (*vim25.Client, error) {
 
 	m := session.NewManager(c)
 	u := flag.url.User
+
+	if u.Username() == "" {
+		// Assume we are running on an ESX or Workstation host if no username is provided
+		u, err = flag.localTicket(context.TODO(), m)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	if isTunnel {
 		err = m.LoginExtensionByCertificate(context.TODO(), u.Username(), "")
 		if err != nil {
@@ -378,6 +388,20 @@ func (flag *ClientFlag) newClient() (*vim25.Client, error) {
 	}
 
 	return c, nil
+}
+
+func (flag *ClientFlag) localTicket(ctx context.Context, m *session.Manager) (*url.Userinfo, error) {
+	ticket, err := m.AcquireLocalTicket(ctx, os.Getenv("USER"))
+	if err != nil {
+		return nil, err
+	}
+
+	password, err := ioutil.ReadFile(ticket.PasswordFilePath)
+	if err != nil {
+		return nil, err
+	}
+
+	return url.UserPassword(ticket.UserName, string(password)), nil
 }
 
 // apiVersionValid returns whether or not the API version supported by the

--- a/vendor/github.com/vmware/govmomi/object/datastore.go
+++ b/vendor/github.com/vmware/govmomi/object/datastore.go
@@ -131,14 +131,20 @@ func (d Datastore) useServiceTicketHostName(name string) bool {
 		return false
 	}
 
-	// An escape hatch, as it is still possible to have HostName that doesn't resolve via DNS,
-	// or resolves to an address that isn't reachable.
-	env := os.Getenv("GOVMOMI_USE_SERVICE_TICKET_HOSTNAME")
-	if env == "0" || env == "false" {
-		return false
+	// Still possible to have HostName that don't resolve via DNS,
+	// so we default to false.
+	key := "GOVMOMI_USE_SERVICE_TICKET_HOSTNAME"
+
+	val := d.c.URL().Query().Get(key)
+	if val == "" {
+		val = os.Getenv(key)
 	}
 
-	return true
+	if val == "1" || val == "true" {
+		return true
+	}
+
+	return false
 }
 
 // ServiceTicket obtains a ticket via AcquireGenericServiceTicket and returns it an http.Cookie with the url.URL

--- a/vendor/github.com/vmware/govmomi/session/manager.go
+++ b/vendor/github.com/vmware/govmomi/session/manager.go
@@ -161,3 +161,17 @@ func (sm *Manager) AcquireGenericServiceTicket(ctx context.Context, spec types.B
 
 	return &res.Returnval, nil
 }
+
+func (sm *Manager) AcquireLocalTicket(ctx context.Context, userName string) (*types.SessionManagerLocalTicket, error) {
+	req := types.AcquireLocalTicket{
+		This:     sm.Reference(),
+		UserName: userName,
+	}
+
+	res, err := methods.AcquireLocalTicket(ctx, sm.client, &req)
+	if err != nil {
+		return nil, err
+	}
+
+	return &res.Returnval, nil
+}

--- a/vendor/manifest
+++ b/vendor/manifest
@@ -643,7 +643,7 @@
 			"importpath": "github.com/vmware/govmomi",
 			"repository": "https://github.com/vmware/govmomi",
 			"vcs": "git",
-			"revision": "2ea2177d487a14d242936bdfe714ff92d41585df",
+			"revision": "7fa1170e982422167e3caca74744e075b6a65b2a",
 			"branch": "master"
 		},
 		{


### PR DESCRIPTION
The govmomi change reverts to the old datastore HTTP behavior of using
the IP address rather than service ticket hostname.

This requires a change to the simulator, where we need to use the
service ticket hostname.

Fixes #1164