### PR TITLE
Introduce --link/--net-alias support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,15 +13,6 @@ install-*.tar.gz
 # generally a bad idea to check certificates into repos - whitelist if needed
 **/*.pem
 
-bootstrap/targets/linux/tether/
-imagec/imagec
-
-lib/apiservers/docker/cmd
-lib/apiservers/docker/models
-lib/apiservers/docker/restapi/*.go
-lib/apiservers/docker/restapi/operations
-!lib/apiservers/docker/restapi/configure_docker.go
-
 lib/apiservers/portlayer/client/
 lib/apiservers/portlayer/cmd
 lib/apiservers/portlayer/models

--- a/Makefile
+++ b/Makefile
@@ -341,9 +341,5 @@ clean:
 	rm -rf ./lib/apiservers/portlayer/models/
 	rm -rf ./lib/apiservers/portlayer/restapi/operations/
 
-	rm -f lib/apiservers/docker/restapi/doc.go
-	rm -f lib/apiservers/docker/restapi/embedded_spec.go
-	rm -f lib/apiservers/docker/restapi/server.go
-	rm -fr lib/apiservers/docker/cmd
-	rm -fr lib/apiservers/docker/models
-	rm -fr lib/apiservers/docker/restapi/operations
+	rm -f *.log
+	rm -f *.pem

--- a/cmd/docker/main.go
+++ b/cmd/docker/main.go
@@ -106,6 +106,8 @@ func handleFlags() (*CliOptions, bool) {
 	portLayerAddr := flag.String("port-layer-addr", "127.0.0.1", "Port layer server address")
 	portLayerPort := flag.Uint("port-layer-port", 9001, "Port Layer server port")
 
+	debug := flag.Bool("debug", false, "Enable debuglevel logging")
+
 	flag.Parse()
 
 	if *enableTLS && (len(*certfile) == 0 || len(*keyfile) == 0) {
@@ -120,6 +122,10 @@ func handleFlags() (*CliOptions, bool) {
 			fmt.Fprintf(os.Stderr, "tlsverfiy requested, but tls-ca-certificate, tls-certificate, tls-key were all not specified\n")
 			return nil, false
 		}
+	}
+
+	if *debug || vchConfig.Diagnostics.DebugLevel > 0 {
+		log.SetLevel(log.DebugLevel)
 	}
 
 	cli := &CliOptions{

--- a/lib/apiservers/engine/backends/image.go
+++ b/lib/apiservers/engine/backends/image.go
@@ -115,7 +115,7 @@ func (i *Image) ExportImage(names []string, outStream io.Writer) error {
 func (i *Image) PullImage(ctx context.Context, ref reference.Named, metaHeaders map[string][]string, authConfig *types.AuthConfig, outStream io.Writer) error {
 	defer trace.End(trace.Begin("PullImage"))
 
-	log.Printf("PullImage: ref = %+v, metaheaders = %+v\n", ref, metaHeaders)
+	log.Debugf("PullImage: ref = %+v, metaheaders = %+v\n", ref, metaHeaders)
 
 	var cmdArgs []string
 
@@ -139,7 +139,7 @@ func (i *Image) PullImage(ctx context.Context, ref reference.Named, metaHeaders 
 	// intruct imagec to use os.TempDir
 	cmdArgs = append(cmdArgs, "-destination", os.TempDir())
 
-	log.Printf("PullImage: cmd = %s %+v\n", Imagec, cmdArgs)
+	log.Debugf("PullImage: cmd = %s %+v\n", Imagec, cmdArgs)
 
 	cmd := exec.Command(Imagec, cmdArgs...)
 	cmd.Stdout = outStream
@@ -149,14 +149,14 @@ func (i *Image) PullImage(ctx context.Context, ref reference.Named, metaHeaders 
 	err := cmd.Start()
 
 	if err != nil {
-		log.Printf("Error starting %s - %s\n", Imagec, err)
+		log.Errorf("Error starting %s - %s\n", Imagec, err)
 		return fmt.Errorf("Error starting %s - %s\n", Imagec, err)
 	}
 
 	err = cmd.Wait()
 
 	if err != nil {
-		log.Println("imagec exit code:", err)
+		log.Errorf("imagec exit code: %s", err)
 		return err
 	}
 

--- a/lib/apiservers/portlayer/restapi/handlers/scopes_handlers.go
+++ b/lib/apiservers/portlayer/restapi/handlers/scopes_handlers.go
@@ -16,9 +16,10 @@ package handlers
 
 import (
 	"fmt"
-	"log"
 	"net"
 	"net/http"
+
+	log "github.com/Sirupsen/logrus"
 
 	middleware "github.com/go-swagger/go-swagger/httpkit/middleware"
 
@@ -184,7 +185,16 @@ func (handler *ScopesHandlersImpl) ScopesAddContainer(params scopes.AddContainer
 			ip = &i
 		}
 
-		return handler.netCtx.AddContainer(h, params.Config.NetworkConfig.NetworkName, ip)
+		if params.Config.NetworkConfig.Aliases != nil {
+			log.Debugf("Links/Aliases: %#v", params.Config.NetworkConfig.Aliases)
+		}
+
+		options := &network.AddContainerOptions{
+			Scope:   params.Config.NetworkConfig.NetworkName,
+			IP:      ip,
+			Aliases: params.Config.NetworkConfig.Aliases,
+		}
+		return handler.netCtx.AddContainer(h, options)
 	}()
 
 	if err != nil {

--- a/lib/apiservers/portlayer/swagger.yml
+++ b/lib/apiservers/portlayer/swagger.yml
@@ -965,6 +965,10 @@ definitions:
         type: string
       address:
         type: string
+      aliases:
+        type: array
+        items:
+          type: string
   ContainerGetStateResponse:
     type: object
     required:

--- a/lib/dns/dns_test.go
+++ b/lib/dns/dns_test.go
@@ -114,8 +114,12 @@ func TestVIC(t *testing.T) {
 	con := exec.NewContainer("foo")
 	ip := net.IPv4(172, 16, 0, 2)
 
+	ctxOptions := &network.AddContainerOptions{
+		Scope: "bridge",
+		IP:    &ip,
+	}
 	// add it
-	err = network.DefaultContext.AddContainer(con, "bridge", &ip)
+	err = network.DefaultContext.AddContainer(con, ctxOptions)
 	if err != nil {
 		t.Fatalf("%s", err)
 	}

--- a/lib/metadata/network_interface.go
+++ b/lib/metadata/network_interface.go
@@ -58,4 +58,7 @@ type ContainerNetwork struct {
 
 	// The IP ranges for this network
 	Pools []ip.Range `vic:"0.1" scope:"read-only" key:"pools"`
+
+	// set of network wide links and aliases for this container on this network
+	Aliases []string `vic:"0.1" scope:"hidden" key:"aliases"`
 }

--- a/lib/portlayer/network/scope_test.go
+++ b/lib/portlayer/network/scope_test.go
@@ -61,7 +61,6 @@ func TestScopeAddRemoveContainer(t *testing.T) {
 	}
 
 	for _, te := range tests1 {
-		t.Logf("testing id = %v, ip = %v", te.c, te.ip)
 		var e *Endpoint
 		e, err = s.addContainer(te.c, te.ip)
 		if te.err != nil {
@@ -138,8 +137,11 @@ func TestScopeAddRemoveContainer(t *testing.T) {
 		}
 	}
 
+	options := &AddContainerOptions{
+		Scope: ctx.defaultScope.Name(),
+	}
 	bound := exec.NewContainer("bound")
-	ctx.AddContainer(bound, ctx.defaultScope.Name(), nil)
+	ctx.AddContainer(bound, options)
 	ctx.BindContainer(bound)
 
 	// test RemoveContainer


### PR DESCRIPTION
- Add -debug flag to the docker engine
- Change various log levels to Debugf
- Set -debug flag in docker-machine by default
- Start passing links to the portlayer
- Start passing aliases to the portlayer (after flattening them)
- Tidy up .gitignore/Makefile