### PR TITLE
Use image vmdk leaf layer for container config

### DIFF
--- a/cmd/imagec/imagec.go
+++ b/cmd/imagec/imagec.go
@@ -561,6 +561,7 @@ func CreateImageConfig(images []*ImageWithMeta, manifest *Manifest) error {
 	// prepare metadata
 	result.V1Image.Parent = image.Parent
 	result.Size = size
+	result.V1Image.ID = imageLayer.ID
 	metaData := metadata.ImageConfig{
 		V1Image: result.V1Image,
 		ImageID: sum,

--- a/lib/apiservers/engine/backends/container.go
+++ b/lib/apiservers/engine/backends/container.go
@@ -154,7 +154,7 @@ func (c *Container) ContainerCreate(config types.ContainerCreateConfig) (types.C
 
 	// provide basic container config via the image
 	container := &viccontainer.VicContainer{
-		ID:     image.Parent,
+		ID:     image.ID,
 		Config: image.Config,
 	}
 


### PR DESCRIPTION
Image metadata was missing the layer id for the image layer (leaf layer).  Additionally the container create was configuring the container with the leaf layer's parent.  Both of those issues have been corrected.

Fixes #1269