### PR TITLE
Add GetDatastores to the datastore helper

### DIFF
--- a/lib/portlayer/storage/volume.go
+++ b/lib/portlayer/storage/volume.go
@@ -17,6 +17,7 @@ package storage
 import (
 	"crypto/md5"
 	"errors"
+	"fmt"
 	"net/url"
 	"path/filepath"
 	"strings"
@@ -100,10 +101,10 @@ func NewVolume(store *url.URL, ID string, device Disk) (*Volume, error) {
 
 // given an ID, compute the volume's label
 func label(ID string) string {
-	h := md5.New()
 
 	// e2label's manpage says the label size is 16 chars
-	return string(h.Sum([]byte(ID)))[:16]
+	m := md5.Sum([]byte(ID))
+	return fmt.Sprintf("%x", m)[:16]
 }
 
 func (v *Volume) Parse(u *url.URL) error {

--- a/lib/portlayer/storage/vsphere/datastore.go
+++ b/lib/portlayer/storage/vsphere/datastore.go
@@ -16,6 +16,7 @@ package vsphere
 
 import (
 	"io"
+	"net/url"
 	"path"
 	"strings"
 
@@ -82,6 +83,31 @@ func NewDatastore(ctx context.Context, s *session.Session, ds *object.Datastore,
 
 	log.Infof("Datastore path is %s", d.RootURL)
 	return d, nil
+}
+
+// GetDatastores returns a map of datastores given a map of names and urls
+func GetDatastores(ctx context.Context, s *session.Session, dsURLs map[string]*url.URL) (map[string]*Datastore, error) {
+	stores := make(map[string]*Datastore)
+
+	fm := object.NewFileManager(s.Vim25())
+	for name, dsURL := range dsURLs {
+
+		vsDs, err := s.Finder.DatastoreOrDefault(ctx, s.DatastorePath)
+		if err != nil {
+			return nil, err
+		}
+
+		d := &Datastore{
+			ds:      vsDs,
+			s:       s,
+			fm:      fm,
+			RootURL: dsURL.Path,
+		}
+
+		stores[name] = d
+	}
+
+	return stores, nil
 }
 
 func (d *Datastore) Summary(ctx context.Context) (*types.DatastoreSummary, error) {


### PR DESCRIPTION
This helps us go from RootURLs (persisted by `vic-machine`) in the port layer to the `Datastore` object.

Also fixes the hashing of the IDs for volume label.  For whatever reason, previously it was just returning a slice of the input ID.