### PR TITLE
Fix vic-machine delete to parse compute resource

### DIFF
--- a/cmd/vic-machine/delete/delete.go
+++ b/cmd/vic-machine/delete/delete.go
@@ -132,7 +132,7 @@ func (d *Uninstall) Run(cli *cli.Context) error {
 	}
 	executor.InitDiagnosticLogs(vchConfig)
 
-	if validator.IsVC() {
+	if validator.IsVC {
 		log.Infoln("Removing VCH vSphere extension")
 		if err = executor.GenerateExtensionName(vchConfig); err != nil {
 			log.Warnf("Wasn't able to get extension name during VCH deletion. Failed with error: %s", err)

--- a/lib/install/management/finder.go
+++ b/lib/install/management/finder.go
@@ -82,6 +82,8 @@ func (d *Dispatcher) NewVCHFromComputePath(computePath string, name string) (*vm
 		Context: d.ctx,
 	}
 
+	v.DatacenterPath = d.session.Datacenter.InventoryPath
+	v.IsVC = v.Session.IsVC()
 	parent, err := v.ResourcePoolHelper(d.ctx, computePath)
 	if err != nil {
 		return nil, "", err


### PR DESCRIPTION
Fixes #1296

  this fix will have vic-machine delete support relative path and 'cluster'/'pool' format for compute-resource, which usually works for vic-machine create.