### PR TITLE
adds storage layer implementation of VolumeJoin, handler code for Vol… [ci skip]

### DIFF
--- a/doc/design/volumes.md
+++ b/doc/design/volumes.md
@@ -39,7 +39,7 @@ type Volume struct {
 // VolumeStorer is an interface to create, remove, enumerate, and get Volumes.
 type VolumeStorer interface {
 	// Creates a volume on the given volume store, of the given size, with the given metadata.
-	VolumeCreate(ctx context.Context, ID string, store *url.URL, capacityMB uint64, info map[string][]byte) (*Volume, error)
+	VolumeCreate(ctx context.Context, ID string, store *url.URL, capacityKB uint64, info map[string][]byte) (*Volume, error)
 
 	// Get an existing volume via it's ID.
 	VolumeGet(ctx context.Context, ID string) (*Volume, error)

--- a/doc/design/volumes/ContainerCreateWithVolumes.md
+++ b/doc/design/volumes/ContainerCreateWithVolumes.md
@@ -62,4 +62,4 @@ The function signature should look as such
 func (v *VolumeStore) Join(container_handle *Handle, volume *Volume, diskOpts map[string]string)
 ```
 
-this will be added to the VolumeStore interface that is in Faiyaz's PR # 1196 - Volumes on vSphere
+this will be added to a new file called vm.go as part of the vsphere package under the storage layer code in the Portlayer.

--- a/doc/design/volumes/ContainerCreateWithVolumes.md
+++ b/doc/design/volumes/ContainerCreateWithVolumes.md
@@ -34,3 +34,32 @@ docker create -v "name:/mnt/pnt:<some basic opts>"
 __NOTE:__ : in MountPoint for the volume metadata(docker perspective) we need to include something that says "Mountpoint is a block device" or something along those lines.
 
 
+### Join call for attaching a volume to a vm
+
+This call, which will be implemented in the volume portion of the storage layer within the portlayer srever, will involve a config spec change. The three things needed for this call are the handle to the container, a filled volume struct, and the driver options for the device addition(such as rw/ro). We will add a value to the extraconfig->executorConfig which will append a new Mountspec for the device to be mounted. The Op type will be an "Add"
+
+
+```
+[]DeviceChange{
+    op:Add,
+    state(?):exists,
+    VirtualDevice{
+    file:<vmdkPath->(should come from volume struct)>
+    }
+}
+
+[]Extraconfig.append{
+    executorConfig:
+        label:<generated on creation, should be md5 sum>
+        MountPoint:<where to mount the vmdk in the container>
+}
+
+```
+
+The function signature should look as such
+
+```
+func (v *VolumeStore) Join(container_handle *Handle, volume *Volume, diskOpts map[string]string)
+```
+
+this will be added to the VolumeStore interface that is in Faiyaz's PR # 1196 - Volumes on vSphere

--- a/lib/apiservers/engine/backends/container.go
+++ b/lib/apiservers/engine/backends/container.go
@@ -295,8 +295,9 @@ func (c *Container) ContainerCreate(config types.ContainerCreateConfig) (types.C
 		//NOTE: for now we are passing the flags directly through. This is NOT SAFE and only a stop gap.
 		flags["Mode"] = fields.VolumeFlags
 		joinParams := storage.NewVolumeJoinParams().WithJoinArgs(&models.VolumeJoinConfig{
-			Flags:  flags,
-			Handle: h,
+			Flags:     flags,
+			Handle:    h,
+			MountPath: fields.VolumeDest,
 		}).WithName(fields.VolumeID)
 
 		res, err := client.Storage.VolumeJoin(joinParams)

--- a/lib/apiservers/engine/backends/container.go
+++ b/lib/apiservers/engine/backends/container.go
@@ -40,6 +40,8 @@ import (
 	"github.com/docker/engine-api/types/container"
 	"github.com/docker/engine-api/types/strslice"
 
+	"github.com/google/uuid"
+
 	"github.com/vmware/vic/lib/apiservers/engine/backends/cache"
 	viccontainer "github.com/vmware/vic/lib/apiservers/engine/backends/container"
 	"github.com/vmware/vic/lib/apiservers/portlayer/client"
@@ -55,6 +57,12 @@ import (
 
 // Container struct represents the Container
 type Container struct {
+}
+
+type volumeFields struct {
+	VolumeID    string
+	VolumeDest  string
+	VolumeFlags string
 }
 
 const (
@@ -142,8 +150,7 @@ func (c *Container) ContainerCreate(config types.ContainerCreateConfig) (types.C
 	var err error
 
 	//TODO: validate the config parameters
-	log.Debugf("config.Config = %+v", config.Config)
-
+	log.Printf("config.Config = %+v", config.Config)
 	// Get an API client to the portlayer
 	client := PortLayerClient()
 	if client == nil {
@@ -263,6 +270,25 @@ func (c *Container) ContainerCreate(config types.ContainerCreateConfig) (types.C
 		}()
 
 		h = addContRes.Payload
+	}
+
+	//Volume Attachment Section
+	for i, v := range config.HostConfig.Binds {
+		fields, err, shouldExist := processVolumeParam(v)
+		var volumeResponse models.VolumeResponse
+		if err != nil {
+			return nil, derr.NewErrorWithStatusCode(fmt.Errorf("Server error from Portlayer: %s", err), http.StatusBadRequest)
+		}
+		if !shouldExist {
+			//FIXME: in the future a default Capacity will be expected from ExtraConfig<vic-machine>
+			volumeRquest := models.VolumeRequest{
+				Capacity: 1024,
+				Driver:   "vsphere",
+				Store:    "default",
+			}
+			client.Storage.CreateVolume(storage.NewCreateVolumeParams().WithVolumeRequest(volumeRequest * models.VolumeRequest))
+		}
+
 	}
 
 	// commit the create op
@@ -1430,4 +1456,33 @@ func copyEscapable(dst io.Writer, src io.ReadCloser, keys []byte) (written int64
 // to the docker client approved format
 func clientFriendlyContainerName(name string) string {
 	return fmt.Sprintf("/%s", name)
+}
+
+func processVolumeParam(volString string) (volumeFields, error, bool) {
+	volumeStrings := strings.Split(volString, ":")
+	fields := volumeFields{}
+	created := true
+	switch len(volumeStrings) {
+	case 1:
+		VolumeID, err := uuid.NewUUID()
+		if err != nil {
+			return volumeFields{}, nil, false
+		}
+		fields.VolumeID = VolumeID.String()
+		fields.VolumeDest = volumeStrings[0]
+		fields.VolumeFlags = "rw"
+		created = false
+	case 2:
+		fields.VolumeID = volumeStrings[0]
+		fields.VolumeDest = volumeStrings[1]
+		fields.VolumeFlags = "rw"
+	case 3:
+		fields.VolumeID = volumeStrings[0]
+		fields.VolumeDest = volumeStrings[1]
+		fields.VolumeFlags = volumeStrings[2]
+	default:
+		//NOTE: the docker cli should cover this case. This is here for posterity.
+		return volumeFields{}, fmt.Errorf("Volume bind input is invalid : -v %s", volString), false
+	}
+	return fields, nil, created
 }

--- a/lib/apiservers/engine/backends/container.go
+++ b/lib/apiservers/engine/backends/container.go
@@ -272,7 +272,7 @@ func (c *Container) ContainerCreate(config types.ContainerCreateConfig) (types.C
 
 		h = addContRes.Payload
 	}
-
+	msg, name, time := trace.Begin("Container.ContainerCreate - VolumeSection")
 	//Volume Attachment Section
 	for _, v := range config.HostConfig.Binds {
 		fields, shouldExist, err := processVolumeParam(v)
@@ -312,6 +312,7 @@ func (c *Container) ContainerCreate(config types.ContainerCreateConfig) (types.C
 			return types.ContainerCreateResponse{}, derr.NewErrorWithStatusCode(fmt.Errorf("Server error from Portlayer: %s", err), http.StatusInternalServerError)
 		}
 	}
+	trace.End(msg, name, time)
 	// commit the create op
 	_, err = client.Containers.Commit(containers.NewCommitParams().WithHandle(h))
 	if err != nil {

--- a/lib/apiservers/engine/backends/container.go
+++ b/lib/apiservers/engine/backends/container.go
@@ -219,6 +219,7 @@ func (c *Container) ContainerCreate(config types.ContainerCreateConfig) (types.C
 		return types.ContainerCreateResponse{}, derr.NewRequestNotFoundError(fmt.Errorf("No command specified"))
 	}
 
+	log.Printf("ContainerCreate config' = %+v", config)
 	// Call the Exec port layer to create the container
 	host, err := guest.UUID()
 	if err != nil {
@@ -250,9 +251,9 @@ func (c *Container) ContainerCreate(config types.ContainerCreateConfig) (types.C
 		addContRes, err := client.Scopes.AddContainer(scopes.NewAddContainerParams().
 			WithScope(netConf.NetworkName).
 			WithConfig(&models.ScopesAddContainerConfig{
-			Handle:        h,
-			NetworkConfig: netConf,
-		}))
+				Handle:        h,
+				NetworkConfig: netConf,
+			}))
 
 		if err != nil {
 			log.Errorf("ContainerCreate: Scopes error: %s", err.Error())

--- a/lib/apiservers/engine/backends/container.go
+++ b/lib/apiservers/engine/backends/container.go
@@ -282,6 +282,7 @@ func (c *Container) ContainerCreate(config types.ContainerCreateConfig) (types.C
 		//NOTE: This should be the guard for the case of an anonymous volume.
 		if !shouldExist {
 			//NOTE: we should not expect any driver args if the drive is anonymous.
+			log.Infof("anonymous volume being created - Container Create - volume mount section")
 			metadata := make(map[string]string)
 			metadata["flags"] = fields.VolumeFlags
 			volumeRequest := models.VolumeRequest{

--- a/lib/apiservers/engine/backends/container.go
+++ b/lib/apiservers/engine/backends/container.go
@@ -245,7 +245,7 @@ func (c *Container) ContainerCreate(config types.ContainerCreateConfig) (types.C
 	id := createResults.Payload.ID
 	h := createResults.Payload.Handle
 
-	log.Infof("Network Configuration Section - Container Create")
+	log.Debugf("Network Configuration Section - Container Create")
 	// configure networking
 	netConf := toModelsNetworkConfig(config)
 	if netConf != nil {
@@ -274,7 +274,7 @@ func (c *Container) ContainerCreate(config types.ContainerCreateConfig) (types.C
 		h = addContRes.Payload
 	}
 	//Volume Attachment Section
-	msg, name, time := trace.Begin("Container.ContainerCreate - VolumeSection")
+	log.Debugf("Container.ContainerCreate - VolumeSection")
 	log.Debugf("Raw Volume arguments : binds:  %#v : volumes : %#v", config.HostConfig.Binds, config.Config.Volumes)
 	var joinList []volumeFields
 
@@ -305,7 +305,6 @@ func (c *Container) ContainerCreate(config types.ContainerCreateConfig) (types.C
 		}
 		h = res.Payload
 	}
-	trace.End(msg, name, time)
 	// commit the create op
 	_, err = client.Containers.Commit(containers.NewCommitParams().WithHandle(h))
 	if err != nil {

--- a/lib/apiservers/engine/backends/container_test.go
+++ b/lib/apiservers/engine/backends/container_test.go
@@ -22,7 +22,7 @@ import (
 
 func TestProcessVolumeParams(t *testing.T) {
 	rawTestVolumes := []string{"/blah", "testVolume:/mount", "testVolume:/mount/path:r"}
-	processedTestVolumes := make([]volumeFields, 0)
+	var processedTestVolumes []volumeFields
 
 	for _, testString := range rawTestVolumes {
 		processedFields, err := processVolumeParam(testString)
@@ -46,7 +46,7 @@ func TestProcessVolumeParams(t *testing.T) {
 
 func TestProcessSpecifiedVolumes(t *testing.T) {
 	rawTestVolumes := []string{"masterVolume:/blah", "testVolume:/mount:r", "specVol:/mount/path:r"}
-	processedTestVolumes := make([]volumeFields, 0)
+	var processedTestVolumes []volumeFields
 
 	processedFields, err := processSpecifiedVolumes(rawTestVolumes)
 	assert.Nil(t, err)
@@ -65,5 +65,4 @@ func TestProcessSpecifiedVolumes(t *testing.T) {
 	assert.Equal(t, "testVolume", processedTestVolumes[2].VolumeID)
 	assert.Equal(t, "/mount/path", processedTestVolumes[2].VolumeDest)
 	assert.Equal(t, "r", processedTestVolumes[2].VolumeFlags)
-
 }

--- a/lib/apiservers/engine/backends/container_test.go
+++ b/lib/apiservers/engine/backends/container_test.go
@@ -31,17 +31,17 @@ func TestProcessVolumeParams(t *testing.T) {
 	}
 	assert.Equal(t, 3, len(processedTestVolumes))
 
-	assert.NotEmpty(t, processedTestVolumes[0].VolumeID)
-	assert.Equal(t, "/blah", processedTestVolumes[0].VolumeDest)
-	assert.Equal(t, "rw", processedTestVolumes[0].VolumeFlags)
+	assert.NotEmpty(t, processedTestVolumes[0].ID)
+	assert.Equal(t, "/blah", processedTestVolumes[0].Dest)
+	assert.Equal(t, "rw", processedTestVolumes[0].Flags)
 
-	assert.Equal(t, "testVolume", processedTestVolumes[1].VolumeID)
-	assert.Equal(t, "/mount", processedTestVolumes[1].VolumeDest)
-	assert.Equal(t, "rw", processedTestVolumes[1].VolumeFlags)
+	assert.Equal(t, "testVolume", processedTestVolumes[1].ID)
+	assert.Equal(t, "/mount", processedTestVolumes[1].Dest)
+	assert.Equal(t, "rw", processedTestVolumes[1].Flags)
 
-	assert.Equal(t, "testVolume", processedTestVolumes[2].VolumeID)
-	assert.Equal(t, "/mount/path", processedTestVolumes[2].VolumeDest)
-	assert.Equal(t, "r", processedTestVolumes[2].VolumeFlags)
+	assert.Equal(t, "testVolume", processedTestVolumes[2].ID)
+	assert.Equal(t, "/mount/path", processedTestVolumes[2].Dest)
+	assert.Equal(t, "r", processedTestVolumes[2].Flags)
 }
 
 func TestProcessSpecifiedVolumes(t *testing.T) {
@@ -54,15 +54,15 @@ func TestProcessSpecifiedVolumes(t *testing.T) {
 
 	assert.Len(t, processedFields, 3)
 
-	assert.Equal(t, "masterVolume", processedTestVolumes[0].VolumeID)
-	assert.Equal(t, "/blah", processedTestVolumes[0].VolumeDest)
-	assert.Equal(t, "rw", processedTestVolumes[0].VolumeFlags)
+	assert.Equal(t, "masterVolume", processedTestVolumes[0].ID)
+	assert.Equal(t, "/blah", processedTestVolumes[0].Dest)
+	assert.Equal(t, "rw", processedTestVolumes[0].Flags)
 
-	assert.Equal(t, "testVolume", processedTestVolumes[1].VolumeID)
-	assert.Equal(t, "/mount", processedTestVolumes[1].VolumeDest)
-	assert.Equal(t, "r", processedTestVolumes[1].VolumeFlags)
+	assert.Equal(t, "testVolume", processedTestVolumes[1].ID)
+	assert.Equal(t, "/mount", processedTestVolumes[1].Dest)
+	assert.Equal(t, "r", processedTestVolumes[1].Flags)
 
-	assert.Equal(t, "testVolume", processedTestVolumes[2].VolumeID)
-	assert.Equal(t, "/mount/path", processedTestVolumes[2].VolumeDest)
-	assert.Equal(t, "r", processedTestVolumes[2].VolumeFlags)
+	assert.Equal(t, "testVolume", processedTestVolumes[2].ID)
+	assert.Equal(t, "/mount/path", processedTestVolumes[2].Dest)
+	assert.Equal(t, "r", processedTestVolumes[2].Flags)
 }

--- a/lib/apiservers/engine/backends/container_test.go
+++ b/lib/apiservers/engine/backends/container_test.go
@@ -1,0 +1,69 @@
+// Copyright 2016 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vicbackends
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestProcessVolumeParams(t *testing.T) {
+	rawTestVolumes := []string{"/blah", "testVolume:/mount", "testVolume:/mount/path:r"}
+	processedTestVolumes := make([]volumeFields, 0)
+
+	for _, testString := range rawTestVolumes {
+		processedFields, err := processVolumeParam(testString)
+		assert.Nil(t, err)
+		processedTestVolumes = append(processedTestVolumes, processedFields)
+	}
+	assert.Equal(t, 3, len(processedTestVolumes))
+
+	assert.NotEmpty(t, processedTestVolumes[0].VolumeID)
+	assert.Equal(t, "/blah", processedTestVolumes[0].VolumeDest)
+	assert.Equal(t, "rw", processedTestVolumes[0].VolumeFlags)
+
+	assert.Equal(t, "testVolume", processedTestVolumes[1].VolumeID)
+	assert.Equal(t, "/mount", processedTestVolumes[1].VolumeDest)
+	assert.Equal(t, "rw", processedTestVolumes[1].VolumeFlags)
+
+	assert.Equal(t, "testVolume", processedTestVolumes[2].VolumeID)
+	assert.Equal(t, "/mount/path", processedTestVolumes[2].VolumeDest)
+	assert.Equal(t, "r", processedTestVolumes[2].VolumeFlags)
+}
+
+func TestProcessSpecifiedVolumes(t *testing.T) {
+	rawTestVolumes := []string{"masterVolume:/blah", "testVolume:/mount:r", "specVol:/mount/path:r"}
+	processedTestVolumes := make([]volumeFields, 0)
+
+	processedFields, err := processSpecifiedVolumes(rawTestVolumes)
+	assert.Nil(t, err)
+	processedTestVolumes = append(processedTestVolumes, processedFields...)
+
+	assert.Len(t, processedFields, 3)
+
+	assert.Equal(t, "masterVolume", processedTestVolumes[0].VolumeID)
+	assert.Equal(t, "/blah", processedTestVolumes[0].VolumeDest)
+	assert.Equal(t, "rw", processedTestVolumes[0].VolumeFlags)
+
+	assert.Equal(t, "testVolume", processedTestVolumes[1].VolumeID)
+	assert.Equal(t, "/mount", processedTestVolumes[1].VolumeDest)
+	assert.Equal(t, "r", processedTestVolumes[1].VolumeFlags)
+
+	assert.Equal(t, "testVolume", processedTestVolumes[2].VolumeID)
+	assert.Equal(t, "/mount/path", processedTestVolumes[2].VolumeDest)
+	assert.Equal(t, "r", processedTestVolumes[2].VolumeFlags)
+
+}

--- a/lib/apiservers/portlayer/restapi/handlers/storage_handlers.go
+++ b/lib/apiservers/portlayer/restapi/handlers/storage_handlers.go
@@ -316,7 +316,7 @@ func (handler *StorageHandlersImpl) VolumeJoin(params storage.VolumeJoinParams) 
 		})
 	}
 	log.Infof("found volume %s for volume join", volume.ID)
-	actualHandle, err = vsphereSpl.VolumeJoin(context.Background(), actualHandle, volume, params.JoinArgs.Flags)
+	actualHandle, err = vsphereSpl.VolumeJoin(context.Background(), actualHandle, volume, params.JoinArgs.MountPath, params.JoinArgs.Flags)
 	if err != nil {
 		log.Errorf("Volumes: StorageHandler : %#v", err)
 		return storage.NewVolumeJoinInternalServerError().WithPayload(&models.Error{

--- a/lib/apiservers/portlayer/restapi/handlers/storage_handlers.go
+++ b/lib/apiservers/portlayer/restapi/handlers/storage_handlers.go
@@ -18,8 +18,6 @@ import (
 	"net/http"
 	"os"
 
-	// "github.com/google/uuid"
-
 	log "github.com/Sirupsen/logrus"
 	"github.com/go-swagger/go-swagger/httpkit/middleware"
 	"github.com/go-swagger/go-swagger/swag"
@@ -113,6 +111,7 @@ func (handler *StorageHandlersImpl) Configure(api *operations.PortLayerAPI, hand
 	api.StorageWriteImageHandler = storage.WriteImageHandlerFunc(handler.WriteImage)
 	api.StorageRemoveVolumeHandler = storage.RemoveVolumeHandlerFunc(handler.RemoveVolume)
 	api.StorageCreateVolumeHandler = storage.CreateVolumeHandlerFunc(handler.CreateVolume)
+	api.StorageVolumeJoinHandler = storage.VolumeJoinHandlerFunc(handler.VolumeJoin)
 }
 
 // CreateImageStore creates a new image store
@@ -247,7 +246,7 @@ func (handler *StorageHandlersImpl) CreateVolume(params storage.CreateVolumePara
 
 	capacity := uint64(0)
 	if params.VolumeRequest.Capacity < 0 {
-		capacity = uint64(1) //FIXME: this should look for a default cap and set or fail here.
+		capacity = uint64(1024) //FIXME: this should look for a default cap and set or fail here.
 	} else {
 		capacity = uint64(params.VolumeRequest.Capacity)
 	}
@@ -302,7 +301,7 @@ func convertImage(image *spl.Image) *models.Image {
 	}
 }
 
-func (handler *StorageHandlersImpl) VolumeJoin(params *storage.VolumeJoinParams) middleware.Responder {
+func (handler *StorageHandlersImpl) VolumeJoin(params storage.VolumeJoinParams) middleware.Responder {
 	actualHandle := epl.GetHandle(params.JoinArgs.Handle)
 
 	//Note: Name should already be populated by now.

--- a/lib/apiservers/portlayer/restapi/handlers/storage_handlers.go
+++ b/lib/apiservers/portlayer/restapi/handlers/storage_handlers.go
@@ -315,7 +315,7 @@ func (handler *StorageHandlersImpl) VolumeJoin(params storage.VolumeJoinParams) 
 		})
 	}
 
-	actualHandle, err = vsphere.VolumeJoin(context.TODO(), actualHandle, volume, params.JoinArgs.Flags)
+	actualHandle, err = vsphereSpl.VolumeJoin(context.TODO(), actualHandle, volume, params.JoinArgs.Flags)
 	if err != nil {
 		log.Errorf("Volumes: StorageHandler : %#v", err)
 		return storage.NewVolumeJoinInternalServerError().WithPayload(&models.Error{

--- a/lib/apiservers/portlayer/restapi/handlers/storage_handlers_test.go
+++ b/lib/apiservers/portlayer/restapi/handlers/storage_handlers_test.go
@@ -62,7 +62,7 @@ func NewMockVolumeStore() *MockVolumeStore {
 }
 
 // Creates a volume on the given volume store, of the given size, with the given metadata.
-func (m *MockVolumeStore) VolumeCreate(ctx context.Context, ID string, store *url.URL, capacityMB uint64, info map[string][]byte) (*spl.Volume, error) {
+func (m *MockVolumeStore) VolumeCreate(ctx context.Context, ID string, store *url.URL, capacityKB uint64, info map[string][]byte) (*spl.Volume, error) {
 	storeName, err := util.VolumeStoreName(store)
 	if err != nil {
 		return nil, err

--- a/lib/apiservers/portlayer/swagger.yml
+++ b/lib/apiservers/portlayer/swagger.yml
@@ -1061,9 +1061,12 @@ definitions:
     type: object
     required:
       - Handle
+      - MountPath
       - Flags
     properties:
       Handle:
+        type: string
+      MountPath:
         type: string
       Flags:
         type: object

--- a/lib/apiservers/portlayer/swagger.yml
+++ b/lib/apiservers/portlayer/swagger.yml
@@ -305,6 +305,38 @@ paths:
           description: "Server Error"
           schema:
             $ref: "#/definitions/Error"
+    post:
+      description: "Attach a volume to a container"
+      operationId: VolumeJoin
+      tags: ["storage"]
+      consumes:
+        - application/json
+        - application/octet-stream
+      produces:
+        - application/json
+      parameters:
+        - name: name
+          required: true
+          type: string
+          in: path
+        - name: JoinArgs
+          in: body
+          required: true
+          schema:
+            $ref: "#/definitions/VolumeJoinConfig"
+      responses:
+        '200':
+          description: "OK"
+          schema:
+            type: string
+        '500':
+          description: "ServerError"
+          schema:
+            $ref: "#/definitions/Error"
+        default:
+          description: "error"
+          schema:
+            $ref: "#/definitions/Error"
   /scopes:
     post:
       summary: "Create a new scope"
@@ -1025,6 +1057,19 @@ definitions:
         type: object
         additionalProperties:
           type: string
+  VolumeJoinConfig:
+    type: object
+    required:
+      - Handle
+      - Flags
+    properties:
+      Handle:
+        type: string
+      Flags:
+        type: object
+        additionalProperties:
+          type: string
+
 
   # The following definitions are definitions used to get container information
   ContainerInfo:

--- a/lib/portlayer/exec/container.go
+++ b/lib/portlayer/exec/container.go
@@ -333,7 +333,8 @@ func infraContainers(ctx context.Context, sess *session.Session) ([]mo.VirtualMa
 
 	// popluate the vm property of the vch resource pool
 	if err := Config.ResourcePool.Properties(ctx, Config.ResourcePool.Reference(), []string{"vm"}, &rp); err != nil {
-		log.Errorf("List failed to get %s resource pool child vms: %s", Config.ResourcePool.Name(), err)
+		name := Config.ResourcePool.Name()
+		log.Errorf("List failed to get %s resource pool child vms: %s", name, err)
 		return nil, err
 	}
 	vms, err := populateVMAttributes(ctx, sess, rp.Vm)

--- a/lib/portlayer/storage/volume.go
+++ b/lib/portlayer/storage/volume.go
@@ -36,7 +36,7 @@ type Disk interface {
 // VolumeStorer is an interface to create, remove, enumerate, and get Volumes.
 type VolumeStorer interface {
 	// Creates a volume on the given volume store, of the given size, with the given metadata.
-	VolumeCreate(ctx context.Context, ID string, store *url.URL, capacityMB uint64, info map[string][]byte) (*Volume, error)
+	VolumeCreate(ctx context.Context, ID string, store *url.URL, capacityKB uint64, info map[string][]byte) (*Volume, error)
 
 	// Get an existing volume via it's ID.
 	VolumeGet(ctx context.Context, ID string) (*Volume, error)

--- a/lib/portlayer/storage/volume.go
+++ b/lib/portlayer/storage/volume.go
@@ -46,6 +46,8 @@ type VolumeStorer interface {
 
 	// Lists all volumes
 	VolumesList(ctx context.Context) ([]*Volume, error)
+
+	//Modifies the config spec of a container to attach a volume
 }
 
 // Volume is the handle to identify a volume on the backing store.  The URI

--- a/lib/portlayer/storage/volume_cache.go
+++ b/lib/portlayer/storage/volume_cache.go
@@ -45,7 +45,7 @@ func NewVolumeLookupCache(ctx context.Context, vs VolumeStorer) (*VolumeLookupCa
 	return v, v.rebuildCache(ctx)
 }
 
-func (v *VolumeLookupCache) VolumeCreate(ctx context.Context, ID string, store *url.URL, capacityMB uint64, info map[string][]byte) (*Volume, error) {
+func (v *VolumeLookupCache) VolumeCreate(ctx context.Context, ID string, store *url.URL, capacityKB uint64, info map[string][]byte) (*Volume, error) {
 	v.vlcLock.Lock()
 	defer v.vlcLock.Unlock()
 
@@ -55,7 +55,7 @@ func (v *VolumeLookupCache) VolumeCreate(ctx context.Context, ID string, store *
 		return nil, os.ErrExist
 	}
 
-	vol, err := v.volumeStore.VolumeCreate(ctx, ID, store, capacityMB, info)
+	vol, err := v.volumeStore.VolumeCreate(ctx, ID, store, capacityKB, info)
 	if err != nil {
 		return nil, err
 	}

--- a/lib/portlayer/storage/volume_cache_test.go
+++ b/lib/portlayer/storage/volume_cache_test.go
@@ -41,7 +41,7 @@ func NewMockVolumeStore() *MockVolumeStore {
 }
 
 // Creates a volume on the given volume store, of the given size, with the given metadata.
-func (m *MockVolumeStore) VolumeCreate(ctx context.Context, ID string, store *url.URL, capacityMB uint64, info map[string][]byte) (*Volume, error) {
+func (m *MockVolumeStore) VolumeCreate(ctx context.Context, ID string, store *url.URL, capacityKB uint64, info map[string][]byte) (*Volume, error) {
 	storeName, err := util.VolumeStoreName(store)
 	if err != nil {
 		return nil, err

--- a/lib/portlayer/storage/vsphere/vm.go
+++ b/lib/portlayer/storage/vsphere/vm.go
@@ -37,7 +37,7 @@ func VolumeJoin(ctx context.Context, handle *exec.Handle, volume *storage.Volume
 	newMountSpec := metadata.MountSpec{
 		Source: url.URL{
 			Scheme: "label",
-			Host:   volume.Label,
+			Path:   volume.Label,
 		},
 		Path: mountPath,
 		Mode: diskOpts["Mode"],

--- a/lib/portlayer/storage/vsphere/vm.go
+++ b/lib/portlayer/storage/vsphere/vm.go
@@ -39,6 +39,7 @@ func VolumeJoin(ctx context.Context, handle *exec.Handle, volume *storage.Volume
 		Source: url.URL{
 			Scheme: "label",
 			Host:   volume.Label,
+			Mode:   DiskOpts["Mode"],
 		},
 		Path: mountPath,
 	}

--- a/lib/portlayer/storage/vsphere/vm.go
+++ b/lib/portlayer/storage/vsphere/vm.go
@@ -27,21 +27,19 @@ import (
 	"golang.org/x/net/context"
 )
 
-func VolumeJoin(ctx context.Context, handle *exec.Handle, volume *storage.Volume, diskOpts map[string]string) (*exec.Handle, error) {
+func VolumeJoin(ctx context.Context, handle *exec.Handle, volume *storage.Volume, mountPath string, diskOpts map[string]string) (*exec.Handle, error) {
 	defer trace.End(trace.Begin("vsphere.VolumeJoin"))
 
 	if _, ok := handle.ExecConfig.Mounts[volume.ID]; ok {
 		return nil, fmt.Errorf("Volume with ID %s is already in container %s's mountspec'", volume.ID, handle.Container.ID)
 	}
 
-	//TODO: populate the mode field of the MountSpec from the diskOpts(rw/ro)
-	diskPath := volume.Device.DiskPath()
 	newMountSpec := metadata.MountSpec{
 		Source: url.URL{
 			Scheme: "label",
 			Host:   volume.Label,
 		},
-		Path: diskPath,
+		Path: mountPath,
 		Mode: diskOpts["Mode"],
 	}
 

--- a/lib/portlayer/storage/vsphere/vm.go
+++ b/lib/portlayer/storage/vsphere/vm.go
@@ -39,9 +39,9 @@ func VolumeJoin(ctx context.Context, handle *exec.Handle, volume *storage.Volume
 		Source: url.URL{
 			Scheme: "label",
 			Host:   volume.Label,
-			Mode:   DiskOpts["Mode"],
 		},
 		Path: mountPath,
+		Mode: diskOpts["Mode"],
 	}
 
 	unitNumber := int32(-1)

--- a/lib/portlayer/storage/vsphere/vm.go
+++ b/lib/portlayer/storage/vsphere/vm.go
@@ -31,7 +31,7 @@ func VolumeJoin(ctx context.Context, handle *exec.Handle, volume *storage.Volume
 	defer trace.End(trace.Begin("vsphere.VolumeJoin"))
 
 	if _, ok := handle.ExecConfig.Mounts[volume.ID]; ok {
-		return nil, fmt.Errorf("Volume with ID %s is already in container %s's mountspec'", volume.ID, handle.Container.ID)
+		return nil, fmt.Errorf("Volume with ID %s is already in container %s's mountspec'", volume.ID, handle.Container.ExecConfig.ID)
 	}
 
 	newMountSpec := metadata.MountSpec{

--- a/lib/portlayer/storage/vsphere/vm.go
+++ b/lib/portlayer/storage/vsphere/vm.go
@@ -1,0 +1,76 @@
+// Copyright 2016 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vsphere
+
+import (
+	"fmt"
+	"net/url"
+
+	"github.com/vmware/govmomi/vim25/types"
+	"github.com/vmware/vic/lib/metadata"
+	"github.com/vmware/vic/lib/portlayer/exec"
+	"github.com/vmware/vic/lib/portlayer/storage"
+	"github.com/vmware/vic/pkg/trace"
+
+	"golang.org/x/net/context"
+)
+
+func VolumeJoin(ctx context.Context, handle *exec.Handle, volume *storage.Volume, diskOpts map[string]string) (*exec.Handle, error) {
+	defer trace.End(trace.Begin("vsphere.VolumeJoin"))
+
+	//TODO: populate the mode field of the MountSpec from the diskOpts(rw/ro)
+	mountPath, err := volume.Device.MountPath()
+	if err != nil {
+		return nil, err
+	}
+	newMountSpec := metadata.MountSpec{
+		Source: url.URL{
+			Scheme: "label",
+			Host:   volume.Label,
+		},
+		Path: mountPath,
+	}
+
+	unitNumber := int32(-1)
+	diskDevice := &types.VirtualDisk{
+		CapacityInKB: 0,
+		VirtualDevice: types.VirtualDevice{
+			Key:           -1,
+			ControllerKey: 100, //FIXME: This is hardcoded for now and should be located from the config spec in the future.y
+			UnitNumber:    &unitNumber,
+			Backing: &types.VirtualDiskFlatVer2BackingInfo{
+				DiskMode: string(types.VirtualDiskModeIndependent_persistent),
+				VirtualDeviceFileBackingInfo: types.VirtualDeviceFileBackingInfo{
+					FileName: volume.Device.DiskPath(),
+				},
+			},
+		},
+	}
+
+	config := &types.VirtualDeviceConfigSpec{
+		Device:        diskDevice,
+		Operation:     types.VirtualDeviceConfigSpecOperationAdd,
+		FileOperation: "", //blank for existing disk
+	}
+
+	handle.Spec.DeviceChange = append(handle.Spec.DeviceChange, config)
+
+	if _, ok := handle.ExecConfig.Mounts[volume.ID]; !ok {
+		return nil, fmt.Errorf("Volume with ID %s is already in container %s's mountspec'", volume.ID, handle.Container.ID)
+	}
+	handle.ExecConfig.Mounts[volume.ID] = newMountSpec
+
+	return handle, nil
+}

--- a/lib/portlayer/storage/vsphere/volume.go
+++ b/lib/portlayer/storage/vsphere/volume.go
@@ -113,7 +113,7 @@ func (v *VolumeStore) volDiskDsURL(store *url.URL, ID string) (string, error) {
 	return path.Join(dstore.RootURL, v.volDirPath(ID), ID+".vmdk"), nil
 }
 
-func (v *VolumeStore) VolumeCreate(ctx context.Context, ID string, store *url.URL, capacityMB uint64, info map[string][]byte) (*storage.Volume, error) {
+func (v *VolumeStore) VolumeCreate(ctx context.Context, ID string, store *url.URL, capacityKB uint64, info map[string][]byte) (*storage.Volume, error) {
 
 	// find the datastore
 	dstore, err := v.getDatastore(store)
@@ -135,7 +135,7 @@ func (v *VolumeStore) VolumeCreate(ctx context.Context, ID string, store *url.UR
 	}
 
 	// Create the disk
-	vmdisk, err := v.dm.CreateAndAttach(ctx, volDiskDsURL, "", int64(capacityMB), os.O_RDWR)
+	vmdisk, err := v.dm.CreateAndAttach(ctx, volDiskDsURL, "", int64(capacityKB), os.O_RDWR)
 	if err != nil {
 		return nil, err
 	}

--- a/lib/tether/ops_linux.go
+++ b/lib/tether/ops_linux.go
@@ -581,6 +581,9 @@ func (t *BaseOperations) MountLabel(source, target string, ctx context.Context) 
 		return fmt.Errorf("unable to create mount point %s: %s", target, err)
 	}
 
+	// convert the source to a filesystem path
+	source = "/dev/disk/by-label/" + source
+
 	// do..while ! timedout
 	var timeout bool
 	for timeout = false; !timeout; {


### PR DESCRIPTION
Implements VolumeJoin and provides functionality for a `docker create -v` call to succeed. This PR will involve changes to the docker engine server and the portlayer. Mostly it involves modifying the config spec of the container so that on commit the vmdk is mounted appropriately. It also involves logic for creating a default volume if an anonymous volume is the `-v` target. 

