### PR TITLE
Get volume stores from the vch's extra config

### DIFF
--- a/lib/portlayer/portlayer.go
+++ b/lib/portlayer/portlayer.go
@@ -103,5 +103,8 @@ func Init(ctx context.Context, sess *session.Session) error {
 		n.PortGroup = r.(object.NetworkReference)
 	}
 
+	// Grab the storage layer config blobs from extra config
+	extraconfig.Decode(source, &storage.Config)
+	log.Debugf("Decoded VCH config for storage: %#v", storage.Config)
 	return nil
 }

--- a/lib/portlayer/storage/config.go
+++ b/lib/portlayer/storage/config.go
@@ -1,0 +1,34 @@
+// Copyright 2016 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storage
+
+import "net/url"
+
+var Config Configuration
+
+// Configuration is a slice of the VCH config that is relevent to the exec part of the port layer
+type Configuration struct {
+	// Turn on debug logging
+	DebugLevel int `vic:"0.1" scope:"read-only" key:"init/common/debug"`
+
+	////////////// Port Layer - storage
+	// Datastore URLs for image stores - the top layer is [0], the bottom layer is [len-1]
+	ImageStores []url.URL `vic:"0.1" scope:"read-only" key:"image_stores"`
+
+	// Permitted datastore URL roots for volumes
+	// Keyed by the volume store name (which is used by the docker user to
+	// refer to the datstore + path), valued by the datastores and the path.
+	VolumeLocations map[string]url.URL `vic:"0.1" scope:"read-only"`
+}

--- a/lib/portlayer/storage/vsphere/datastore.go
+++ b/lib/portlayer/storage/vsphere/datastore.go
@@ -86,7 +86,7 @@ func NewDatastore(ctx context.Context, s *session.Session, ds *object.Datastore,
 }
 
 // GetDatastores returns a map of datastores given a map of names and urls
-func GetDatastores(ctx context.Context, s *session.Session, dsURLs map[string]*url.URL) (map[string]*Datastore, error) {
+func GetDatastores(ctx context.Context, s *session.Session, dsURLs map[string]url.URL) (map[string]*Datastore, error) {
 	stores := make(map[string]*Datastore)
 
 	fm := object.NewFileManager(s.Vim25())

--- a/lib/portlayer/storage/vsphere/datastore_test.go
+++ b/lib/portlayer/storage/vsphere/datastore_test.go
@@ -67,14 +67,14 @@ func TestDatastoreGetDatastores(t *testing.T) {
 	t.Logf("  Capacity:\t%.1f GB\n", float64(firstSummary.Capacity)/(1<<30))
 	t.Logf("  Free:\t%.1f GB\n", float64(firstSummary.FreeSpace)/(1<<30))
 
-	inMap := make(map[string]*url.URL)
+	inMap := make(map[string]url.URL)
 
 	p, err := url.Parse(ds.RootURL)
 	if !assert.NoError(t, err) {
 		return
 	}
 
-	inMap["foo"] = p
+	inMap["foo"] = *p
 
 	dstores, err := GetDatastores(context.TODO(), ds.s, inMap)
 	if !assert.NoError(t, err) || !assert.NotNil(t, dstores) {


### PR DESCRIPTION

Fixes #429

vic-machine will add the volume store names and their datastore + path
to the extra config of the vch when it instantiates it.  The portlayer
will now retrieve this, iterate it, and call `AddStore` for each of
these so the docker user can refer to the store by the given name.  The
resulting volume will be created in the path above.

With #1293 and this change, things work.

```
$ ./vic-machine-linux create ... --image-datastore datastore1 --volume-store doobie:datastore1/voloom
...
$ docker -H 192.168.8.223:2376 --tls volume create --name MyVolume -o VolumeStore=doobie -o Capacity=1024
MyVolume
...
[root@esxbox:/vmfs/volumes/56dcdc1c-ce4398df-7d12-000c29fc9a54] ls -lah voloom/VIC/volumes/MyVolume/
...
-rw-------    1 root     root        1.0G Jun 30 21:17 MyVolume-flat.vmdk
-rw-------    1 root     root         494 Jun 30 21:17 MyVolume.vmdk

```