### PR TITLE
Fix vicadmin failure in non-virtualized case

### DIFF
--- a/cmd/vicadmin/vicadm.go
+++ b/cmd/vicadmin/vicadm.go
@@ -115,7 +115,9 @@ func init() {
 	src, err := extraconfig.GuestInfoSource()
 	if err != nil {
 		log.Errorf("Unable to load configuration from guestinfo")
+		return
 	}
+
 	extraconfig.Decode(src, &vchConfig)
 }
 

--- a/pkg/vsphere/extraconfig/decode.go
+++ b/pkg/vsphere/extraconfig/decode.go
@@ -435,6 +435,12 @@ type DataSource func(string) (string, error)
 // Decode populates a destination with data from the supplied data source
 func Decode(src DataSource, dest interface{}) interface{} {
 	defer log.SetLevel(log.GetLevel())
+
+	if src == nil {
+		log.Warnf("Decode source is nil - unable to continue")
+		return dest
+	}
+
 	log.SetLevel(DecodeLogLevel)
 
 	value := decode(src, reflect.ValueOf(dest), DefaultPrefix, Unbounded)
@@ -446,6 +452,12 @@ func Decode(src DataSource, dest interface{}) interface{} {
 // the specified prefix - this allows for decode into substructres.
 func DecodeWithPrefix(src DataSource, dest interface{}, prefix string) interface{} {
 	defer log.SetLevel(log.GetLevel())
+
+	if src == nil {
+		log.Warnf("Decode source is nil - unable to continue")
+		return dest
+	}
+
 	log.SetLevel(DecodeLogLevel)
 
 	value := decode(src, reflect.ValueOf(dest), prefix, Unbounded)


### PR DESCRIPTION
Addresses an error in vicadmin's use of extraconfig package that only occurs in non-virtualized environments.

Fixes #1306

