### PR TITLE
 Fix vic-machine delete to parse compute resource

### DIFF
--- a/cmd/vic-machine/delete/delete.go
+++ b/cmd/vic-machine/delete/delete.go
@@ -120,7 +120,7 @@ func (d *Uninstall) Run(cli *cli.Context) error {
 	}
 	executor := management.NewDispatcher(validator.Context, validator.Session, nil, d.Force)
 
-	vch, _, err := executor.NewVCHFromComputePath(d.Data.ComputeResourcePath, d.Data.DisplayName)
+	vch, _, err := executor.NewVCHFromComputePath(d.Data.ComputeResourcePath, d.Data.DisplayName, validator)
 	if err != nil {
 		log.Errorf("Failed to get Virtual Container Host %s", d.DisplayName)
 		return err

--- a/cmd/vic-machine/inspect/inspect.go
+++ b/cmd/vic-machine/inspect/inspect.go
@@ -114,7 +114,7 @@ func (i *Inspect) Run(cli *cli.Context) error {
 	}
 	executor := management.NewDispatcher(validator.Context, validator.Session, nil, i.Force)
 
-	vch, path, err := executor.NewVCHFromComputePath(i.Data.ComputeResourcePath, i.Data.DisplayName)
+	vch, path, err := executor.NewVCHFromComputePath(i.Data.ComputeResourcePath, i.Data.DisplayName, validator)
 	if err != nil {
 		log.Errorf("Failed to get Virtual Container Host %s", i.DisplayName)
 		return err

--- a/lib/install/management/finder.go
+++ b/lib/install/management/finder.go
@@ -72,15 +72,10 @@ func (d *Dispatcher) NewVCHFromID(id string) (*vm.VirtualMachine, error) {
 	return vmm, nil
 }
 
-func (d *Dispatcher) NewVCHFromComputePath(computePath string, name string) (*vm.VirtualMachine, string, error) {
+func (d *Dispatcher) NewVCHFromComputePath(computePath string, name string, v *validate.Validator) (*vm.VirtualMachine, string, error) {
 	defer trace.End(trace.Begin(fmt.Sprintf("path %s, name %s", computePath, name)))
 
 	var err error
-
-	v := &validate.Validator{
-		Session: d.session,
-		Context: d.ctx,
-	}
 
 	parent, err := v.ResourcePoolHelper(d.ctx, computePath)
 	if err != nil {


### PR DESCRIPTION
Fixes #1296 
  this fix will have vic-machine delete work with relative path and for 'cluster'/'pool' format

@andrewtchin Decided to go with this solution. Cause this will make vic-machine delete keep same behavior with vic-machine create, to parse parameters.