### PR TITLE
Fix usage string in volume-store flag in vic-machine create

### DIFF
--- a/cmd/vic-machine/create/create.go
+++ b/cmd/vic-machine/create/create.go
@@ -206,7 +206,7 @@ func (c *Create) Flags() []cli.Flag {
 		cli.StringSliceFlag{
 			Name:  "volume-store",
 			Value: &c.volumeStores,
-			Usage: "Specify location and label for volume store; path optional: \"label:datastore:path\" or \"label:datastore\"",
+			Usage: "Specify location and label for volume store; path optional: \"label:datastore/path\" or \"label:datastore\"",
 		},
 	}
 	preFlags := append(c.TargetFlags(), c.ComputeFlags()...)


### PR DESCRIPTION
In my PR yesterday I forgot to fix the help message that goes along with usage of `--volume_store` in `vic-machine create`

This fixes that message to be correct.
