### PR TITLE
Fix usage string in vic-machine create --volume-store

### DIFF
--- a/cmd/vic-machine/create/create.go
+++ b/cmd/vic-machine/create/create.go
@@ -206,7 +206,7 @@ func (c *Create) Flags() []cli.Flag {
 		cli.StringSliceFlag{
 			Name:  "volume-store",
 			Value: &c.volumeStores,
-			Usage: "Specify location and label for volume store; path optional: \"label:datastore:path\" or \"label:datastore\"",
+			Usage: "Specify location and label for volume store; path optional: \"label:datastore/path\" or \"label:datastore\"",
 		},
 	}
 	preFlags := append(c.TargetFlags(), c.ComputeFlags()...)


### PR DESCRIPTION
Yesterday I forgot to update the usage help text for `vic-machine create --volume-store` to reflect reality in my PR so this fixes that issue.
