### PR TITLE
Add container name cache

### DIFF
--- a/lib/apiservers/engine/backends/cache/container_cache.go
+++ b/lib/apiservers/engine/backends/cache/container_cache.go
@@ -1,0 +1,91 @@
+// Copyright 2016 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cache
+
+import (
+	"sync"
+
+	log "github.com/Sirupsen/logrus"
+
+	"github.com/docker/docker/pkg/truncindex"
+
+	"github.com/vmware/vic/lib/apiservers/engine/backends/container"
+)
+
+// Tracks our container info from calls
+type CCache struct {
+	m sync.RWMutex
+
+	idIndex          *truncindex.TruncIndex
+	containersByID   map[string]*container.VicContainer
+	containersByName map[string]*container.VicContainer
+}
+
+var containerCache *CCache
+
+func init() {
+	containerCache = &CCache{
+		idIndex:          truncindex.NewTruncIndex([]string{}),
+		containersByID:   make(map[string]*container.VicContainer),
+		containersByName: make(map[string]*container.VicContainer),
+	}
+}
+
+// ContainerCache returns a reference to the container cache
+func ContainerCache() *CCache {
+	return containerCache
+}
+
+func (cc *CCache) GetContainer(nameOrID string) *container.VicContainer {
+	cc.m.RLock()
+	defer cc.m.RUnlock()
+
+	// get the full ID if we only have a prefix
+	if cid, err := cc.idIndex.Get(nameOrID); err == nil {
+		nameOrID = cid
+	}
+
+	if container := cc.getContainerByID(nameOrID); container != nil {
+		return container
+	}
+
+	return cc.getContainerByName(nameOrID)
+}
+
+func (cc *CCache) getContainerByID(id string) *container.VicContainer {
+	if container, exist := cc.containersByID[id]; exist {
+		return container
+	}
+	return nil
+}
+
+func (cc *CCache) getContainerByName(name string) *container.VicContainer {
+	if container, exist := cc.containersByName[name]; exist {
+		return container
+	}
+	return nil
+}
+
+func (cc *CCache) SaveContainer(container *container.VicContainer) {
+	cc.m.Lock()
+	defer cc.m.Unlock()
+
+	// TODO(jzt): this probably shouldn't assume a valid container ID
+	if err := cc.idIndex.Add(container.ContainerID); err != nil {
+		log.Warnf("Error inserting ID into index: %s", err)
+	}
+	cc.containersByID[container.ContainerID] = container
+	cc.containersByName[container.Name] = container
+}

--- a/lib/apiservers/engine/backends/container.go
+++ b/lib/apiservers/engine/backends/container.go
@@ -38,6 +38,7 @@ import (
 	"github.com/docker/engine-api/types/container"
 	"github.com/docker/engine-api/types/strslice"
 
+	"github.com/vmware/vic/lib/apiservers/engine/backends/cache"
 	viccontainer "github.com/vmware/vic/lib/apiservers/engine/backends/container"
 	"github.com/vmware/vic/lib/apiservers/portlayer/client"
 	"github.com/vmware/vic/lib/apiservers/portlayer/client/containers"
@@ -146,8 +147,15 @@ func (c *Container) ContainerCreate(config types.ContainerCreateConfig) (types.C
 				http.StatusInternalServerError)
 	}
 
+	// bail early if container name already exists
+	if exists := cache.ContainerCache().GetContainer(config.Name); exists != nil {
+		return types.ContainerCreateResponse{},
+			derr.NewErrorWithStatusCode(fmt.Errorf("Conflict. The name \"%s\" is already in use by container %s. You have to remove (or rename) that container to be able to re use that name.", config.Name, exists.ContainerID),
+				http.StatusConflict)
+	}
+
 	// get the image from the cache
-	image, err := getImageConfigFromCache(config.Config.Image)
+	image, err := cache.ImageCache().GetImage(config.Config.Image)
 	if err != nil {
 		// if no image found then error thrown and a pull
 		// will be initiated by the docker client
@@ -229,7 +237,6 @@ func (c *Container) ContainerCreate(config types.ContainerCreateConfig) (types.C
 			// roll back the AddContainer call
 			if _, err2 := client.Scopes.RemoveContainer(scopes.NewRemoveContainerParams().WithHandle(h).WithScope(netConf.NetworkName)); err2 != nil {
 				log.Warnf("could not roll back container add: %s", err2)
-
 			}
 		}()
 
@@ -258,9 +265,10 @@ func (c *Container) ContainerCreate(config types.ContainerCreateConfig) (types.C
 	container.Config.OpenStdin = config.Config.OpenStdin
 	container.Config.StdinOnce = config.Config.StdinOnce
 	container.ContainerID = createResults.Payload.ID
+	container.Name = config.Name
 
 	log.Debugf("Container create: %#v", container)
-	viccontainer.GetCache().SaveContainer(createResults.Payload.ID, container)
+	cache.ContainerCache().SaveContainer(container)
 
 	// Success!
 	log.Debugf("container.ContainerCreate succeeded.  Returning container handle %s", *createResults.Payload)
@@ -391,11 +399,21 @@ func (c *Container) containerStart(name string, hostConfig *container.HostConfig
 		// need to look at in hostConfig
 	}
 
+	var id = name
+	cachedContainer := cache.ContainerCache().GetContainer(name)
+	if cachedContainer != nil {
+		id = cachedContainer.ContainerID
+	} else {
+		return derr.NewRequestNotFoundError(fmt.Errorf("No such container: %s", id))
+	}
+
+	log.Debugf("Found cached container: %#v", cachedContainer)
+
 	// get a handle to the container
-	getRes, err := client.Containers.Get(containers.NewGetParams().WithID(name))
+	getRes, err := client.Containers.Get(containers.NewGetParams().WithID(id))
 	if err != nil {
 		if _, ok := err.(*containers.GetNotFound); ok {
-			return derr.NewRequestNotFoundError(fmt.Errorf("No such container: %s", name))
+			return derr.NewRequestNotFoundError(fmt.Errorf("No such container: %s", id))
 		}
 		return derr.NewErrorWithStatusCode(fmt.Errorf("server error from portlayer"), http.StatusInternalServerError)
 	}
@@ -563,7 +581,7 @@ func (c *Container) ContainerInspect(name string, size bool, version version.Ver
 	defer trace.End(trace.Begin("ContainerInspect"))
 
 	// Look up the container info in the metadata cache
-	vc := viccontainer.GetCache().GetContainerByName(name)
+	vc := cache.ContainerCache().GetContainer(name)
 	if vc == nil {
 		return nil, derr.NewRequestNotFoundError(fmt.Errorf("No such container: %s", name))
 	}
@@ -645,7 +663,7 @@ func (c *Container) Containers(config *types.ContainerListOptions) ([]*types.Con
 func (c *Container) ContainerAttach(prefixOrName string, ca *backend.ContainerAttachConfig) error {
 	defer trace.End(trace.Begin("ContainerAttach"))
 
-	vc := viccontainer.GetCache().GetContainerByName(prefixOrName)
+	vc := cache.ContainerCache().GetContainer(prefixOrName)
 
 	if vc == nil {
 		//FIXME: If we didn't find in the cache, we should goto the port layer and

--- a/lib/apiservers/engine/backends/container/viccontainer.go
+++ b/lib/apiservers/engine/backends/container/viccontainer.go
@@ -15,32 +15,18 @@
 package container
 
 import (
-	"sync"
-
 	"github.com/docker/docker/runconfig"
 	containertypes "github.com/docker/engine-api/types/container"
 )
 
-// This is VIC's abridged version of Docker's container object.
+// VicContainer is VIC's abridged version of Docker's container object.
 type VicContainer struct {
 	*runconfig.StreamConfig
 
+	Name        string
 	ID          string
 	ContainerID string
 	Config      *containertypes.Config
-}
-
-// Tracks our container info from calls
-type Cache struct {
-	m sync.RWMutex
-
-	containerStore map[string]*VicContainer
-}
-
-var cache *Cache
-
-func init() {
-	cache = &Cache{containerStore: make(map[string]*VicContainer)}
 }
 
 func NewVicContainer() *VicContainer {
@@ -48,26 +34,4 @@ func NewVicContainer() *VicContainer {
 		StreamConfig: runconfig.NewStreamConfig(),
 		Config:       &containertypes.Config{},
 	}
-}
-
-func GetCache() *Cache {
-	return cache
-}
-
-func (cc *Cache) GetContainerByName(name string) *VicContainer {
-	cc.m.RLock()
-	defer cc.m.RUnlock()
-
-	if container, exist := cc.containerStore[name]; exist {
-		return container
-	}
-
-	return nil
-}
-
-func (cc *Cache) SaveContainer(name string, container *VicContainer) {
-	cc.m.Lock()
-	defer cc.m.Unlock()
-
-	cc.containerStore[name] = container
 }

--- a/lib/apiservers/engine/backends/image.go
+++ b/lib/apiservers/engine/backends/image.go
@@ -25,11 +25,11 @@ import (
 
 	"golang.org/x/net/context"
 
-	derr "github.com/docker/docker/errors"
 	"github.com/docker/docker/reference"
 	"github.com/docker/engine-api/types"
 	"github.com/docker/engine-api/types/container"
 	"github.com/docker/engine-api/types/registry"
+	"github.com/vmware/vic/lib/apiservers/engine/backends/cache"
 	"github.com/vmware/vic/lib/metadata"
 	"github.com/vmware/vic/pkg/trace"
 )
@@ -64,12 +64,7 @@ func (i *Image) ImageHistory(imageName string) ([]*types.ImageHistory, error) {
 func (i *Image) Images(filterArgs string, filter string, all bool) ([]*types.Image, error) {
 	defer trace.End(trace.Begin("Images"))
 
-	imageCache := ImageCache()
-
-	images, err := imageCache.GetImages()
-	if err != nil {
-		return nil, fmt.Errorf("Error retrieving image list: %s", err)
-	}
+	images := cache.ImageCache().GetImages()
 
 	result := make([]*types.Image, 0, len(images))
 
@@ -88,7 +83,7 @@ func (i *Image) Images(filterArgs string, filter string, all bool) ([]*types.Ima
 func (i *Image) LookupImage(name string) (*types.ImageInspect, error) {
 	defer trace.End(trace.Begin("LookupImage (docker inspect)"))
 
-	imageConfig, err := getImageConfigFromCache(name)
+	imageConfig, err := cache.ImageCache().GetImage(name)
 	if err != nil {
 		return nil, err
 	}
@@ -161,7 +156,7 @@ func (i *Image) PullImage(ctx context.Context, ref reference.Named, metaHeaders 
 	}
 
 	client := PortLayerClient()
-	ImageCache().Update(client)
+	cache.ImageCache().Update(client)
 	return nil
 }
 
@@ -191,40 +186,6 @@ func convertV1ImageToDockerImage(image *metadata.ImageConfig) *types.Image {
 		VirtualSize: image.Size,
 		Labels:      labels,
 	}
-}
-
-// Retrieve the image metadata from the image cache.
-func getImageConfigFromCache(image string) (*metadata.ImageConfig, error) {
-	// Use docker reference code to validate the id's format
-	digest, named, err := reference.ParseIDOrReference(image)
-	if err != nil {
-		return nil, err
-	}
-
-	// Try to get the image config from our image cache
-	imageCache := ImageCache()
-
-	if digest != "" {
-		config, err := imageCache.GetImageByDigest(digest)
-		if err != nil {
-			log.Errorf("Inspect lookup failed for image %s: %s.  Returning no such image.", image, err)
-			return nil, derr.NewRequestNotFoundError(fmt.Errorf("No such image: %s", image))
-		}
-		if config != nil {
-			return config, nil
-		}
-	} else {
-		config, err := imageCache.GetImageByNamed(named)
-		if err != nil {
-			log.Errorf("Inspect lookup failed for image %s: %s.  Returning no such image.", image, err)
-			return nil, derr.NewRequestNotFoundError(fmt.Errorf("No such image: %s", image))
-		}
-		if config != nil {
-			return config, nil
-		}
-	}
-
-	return nil, derr.NewRequestNotFoundError(fmt.Errorf("No such image: %s", image))
 }
 
 // Converts the data structure retrieved from the portlayer.  This src datastructure

--- a/lib/apiservers/engine/backends/system.go
+++ b/lib/apiservers/engine/backends/system.go
@@ -27,6 +27,7 @@ import (
 
 	log "github.com/Sirupsen/logrus"
 
+	"github.com/vmware/vic/lib/apiservers/engine/backends/cache"
 	"github.com/vmware/vic/lib/apiservers/portlayer/client"
 	"github.com/vmware/vic/lib/apiservers/portlayer/client/misc"
 	"github.com/vmware/vic/pkg/trace"
@@ -85,7 +86,7 @@ func (s *System) SystemInfo() (*types.Info, error) {
 	}
 
 	// Retrieve number of images from storage port layer
-	numImages, err := getImageCount(plClient)
+	numImages := getImageCount(plClient)
 	if err != nil {
 		log.Infof("System.SytemInfo unable to get image count: %s.", err.Error())
 	}
@@ -255,15 +256,10 @@ func pingPortlayer(plClient *client.PortLayer) bool {
 	return false
 }
 
-func getImageCount(plClient *client.PortLayer) (int, error) {
-	imageCache := ImageCache()
+func getImageCount(plClient *client.PortLayer) int {
 
-	images, err := imageCache.GetImages()
-	if err != nil {
-		return 0, err
-	}
-
-	return len(images), nil
+	images := cache.ImageCache().GetImages()
+	return len(images)
 }
 
 func getContainerStatus(plClient *client.PortLayer) (ContainerStatus, error) {

--- a/lib/apiservers/engine/backends/vicbackends.go
+++ b/lib/apiservers/engine/backends/vicbackends.go
@@ -27,10 +27,14 @@ import (
 
 const (
 	Imagec             = "imagec"
-	Retries            = 5
-	RetryTimeSeconds   = 2
 	PortlayerName      = "Backend Engine"
 	IndexServerAddress = "registry-1.docker.io"
+
+	// Retries defines how many times to attempt refreshing the image cache at startup
+	Retries = 5
+
+	// RetryTimeSeconds defines how many seconds to wait between retries
+	RetryTimeSeconds = 2
 )
 
 var (
@@ -40,8 +44,7 @@ var (
 	productName         string
 	productVersion      string
 
-	imageCache *cache.ImageCache
-	vchConfig  *metadata.VirtualContainerHostConfigSpec
+	vchConfig *metadata.VirtualContainerHostConfigSpec
 )
 
 func Init(portLayerAddr, product string, config *metadata.VirtualContainerHostConfigSpec) error {
@@ -68,8 +71,6 @@ func Init(portLayerAddr, product string, config *metadata.VirtualContainerHostCo
 	portLayerClient = client.New(t, nil)
 	portLayerServerAddr = portLayerAddr
 
-	imageCache = cache.NewImageCache()
-
 	// attempt to update the image cache at startup
 	log.Info("Refreshing image cache...")
 	go func() {
@@ -78,7 +79,7 @@ func Init(portLayerAddr, product string, config *metadata.VirtualContainerHostCo
 			// initial pause to wait for the portlayer to come up
 			time.Sleep(RetryTimeSeconds * time.Second)
 
-			if err := imageCache.Update(portLayerClient); err == nil {
+			if err := cache.ImageCache().Update(portLayerClient); err == nil {
 				log.Info("Image cache updated successfully")
 				return
 			}
@@ -100,10 +101,6 @@ func PortLayerServer() string {
 
 func PortLayerName() string {
 	return portLayerName
-}
-
-func ImageCache() *cache.ImageCache {
-	return imageCache
 }
 
 func ProductName() string {

--- a/vendor/github.com/tchap/go-patricia/LICENSE
+++ b/vendor/github.com/tchap/go-patricia/LICENSE
@@ -1,0 +1,20 @@
+The MIT License (MIT)
+
+Copyright (c) 2014 The AUTHORS
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/vendor/github.com/tchap/go-patricia/patricia/children.go
+++ b/vendor/github.com/tchap/go-patricia/patricia/children.go
@@ -1,0 +1,244 @@
+// Copyright (c) 2014 The go-patricia AUTHORS
+//
+// Use of this source code is governed by The MIT License
+// that can be found in the LICENSE file.
+
+package patricia
+
+import "sort"
+
+type childList interface {
+	length() int
+	head() *Trie
+	add(child *Trie) childList
+	replace(b byte, child *Trie)
+	remove(child *Trie)
+	next(b byte) *Trie
+	walk(prefix *Prefix, visitor VisitorFunc) error
+}
+
+type tries []*Trie
+
+func (t tries) Len() int {
+	return len(t)
+}
+
+func (t tries) Less(i, j int) bool {
+	strings := sort.StringSlice{string(t[i].prefix), string(t[j].prefix)}
+	return strings.Less(0, 1)
+}
+
+func (t tries) Swap(i, j int) {
+	t[i], t[j] = t[j], t[i]
+}
+
+type sparseChildList struct {
+	children tries
+}
+
+func newSparseChildList(maxChildrenPerSparseNode int) childList {
+	return &sparseChildList{
+		children: make(tries, 0, DefaultMaxChildrenPerSparseNode),
+	}
+}
+
+func (list *sparseChildList) length() int {
+	return len(list.children)
+}
+
+func (list *sparseChildList) head() *Trie {
+	return list.children[0]
+}
+
+func (list *sparseChildList) add(child *Trie) childList {
+	// Search for an empty spot and insert the child if possible.
+	if len(list.children) != cap(list.children) {
+		list.children = append(list.children, child)
+		return list
+	}
+
+	// Otherwise we have to transform to the dense list type.
+	return newDenseChildList(list, child)
+}
+
+func (list *sparseChildList) replace(b byte, child *Trie) {
+	// Seek the child and replace it.
+	for i, node := range list.children {
+		if node.prefix[0] == b {
+			list.children[i] = child
+			return
+		}
+	}
+}
+
+func (list *sparseChildList) remove(child *Trie) {
+	for i, node := range list.children {
+		if node.prefix[0] == child.prefix[0] {
+			list.children = append(list.children[:i], list.children[i+1:]...)
+			return
+		}
+	}
+
+	// This is not supposed to be reached.
+	panic("removing non-existent child")
+}
+
+func (list *sparseChildList) next(b byte) *Trie {
+	for _, child := range list.children {
+		if child.prefix[0] == b {
+			return child
+		}
+	}
+	return nil
+}
+
+func (list *sparseChildList) walk(prefix *Prefix, visitor VisitorFunc) error {
+
+	sort.Sort(list.children)
+
+	for _, child := range list.children {
+		*prefix = append(*prefix, child.prefix...)
+		if child.item != nil {
+			err := visitor(*prefix, child.item)
+			if err != nil {
+				if err == SkipSubtree {
+					*prefix = (*prefix)[:len(*prefix)-len(child.prefix)]
+					continue
+				}
+				*prefix = (*prefix)[:len(*prefix)-len(child.prefix)]
+				return err
+			}
+		}
+
+		err := child.children.walk(prefix, visitor)
+		*prefix = (*prefix)[:len(*prefix)-len(child.prefix)]
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+type denseChildList struct {
+	min      int
+	max      int
+	children []*Trie
+}
+
+func newDenseChildList(list *sparseChildList, child *Trie) childList {
+	var (
+		min int = 255
+		max int = 0
+	)
+	for _, child := range list.children {
+		b := int(child.prefix[0])
+		if b < min {
+			min = b
+		}
+		if b > max {
+			max = b
+		}
+	}
+
+	b := int(child.prefix[0])
+	if b < min {
+		min = b
+	}
+	if b > max {
+		max = b
+	}
+
+	children := make([]*Trie, max-min+1)
+	for _, child := range list.children {
+		children[int(child.prefix[0])-min] = child
+	}
+	children[int(child.prefix[0])-min] = child
+
+	return &denseChildList{min, max, children}
+}
+
+func (list *denseChildList) length() int {
+	return list.max - list.min + 1
+}
+
+func (list *denseChildList) head() *Trie {
+	return list.children[0]
+}
+
+func (list *denseChildList) add(child *Trie) childList {
+	b := int(child.prefix[0])
+
+	switch {
+	case list.min <= b && b <= list.max:
+		if list.children[b-list.min] != nil {
+			panic("dense child list collision detected")
+		}
+		list.children[b-list.min] = child
+
+	case b < list.min:
+		children := make([]*Trie, list.max-b+1)
+		children[0] = child
+		copy(children[list.min-b:], list.children)
+		list.children = children
+		list.min = b
+
+	default: // b > list.max
+		children := make([]*Trie, b-list.min+1)
+		children[b-list.min] = child
+		copy(children, list.children)
+		list.children = children
+		list.max = b
+	}
+
+	return list
+}
+
+func (list *denseChildList) replace(b byte, child *Trie) {
+	list.children[int(b)-list.min] = nil
+	list.children[int(child.prefix[0])-list.min] = child
+}
+
+func (list *denseChildList) remove(child *Trie) {
+	i := int(child.prefix[0]) - list.min
+	if list.children[i] == nil {
+		// This is not supposed to be reached.
+		panic("removing non-existent child")
+	}
+	list.children[i] = nil
+}
+
+func (list *denseChildList) next(b byte) *Trie {
+	i := int(b)
+	if i < list.min || list.max < i {
+		return nil
+	}
+	return list.children[i-list.min]
+}
+
+func (list *denseChildList) walk(prefix *Prefix, visitor VisitorFunc) error {
+	for _, child := range list.children {
+		if child == nil {
+			continue
+		}
+		*prefix = append(*prefix, child.prefix...)
+		if child.item != nil {
+			if err := visitor(*prefix, child.item); err != nil {
+				if err == SkipSubtree {
+					*prefix = (*prefix)[:len(*prefix)-len(child.prefix)]
+					continue
+				}
+				*prefix = (*prefix)[:len(*prefix)-len(child.prefix)]
+				return err
+			}
+		}
+
+		err := child.children.walk(prefix, visitor)
+		*prefix = (*prefix)[:len(*prefix)-len(child.prefix)]
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/vendor/github.com/tchap/go-patricia/patricia/patricia.go
+++ b/vendor/github.com/tchap/go-patricia/patricia/patricia.go
@@ -1,0 +1,467 @@
+// Copyright (c) 2014 The go-patricia AUTHORS
+//
+// Use of this source code is governed by The MIT License
+// that can be found in the LICENSE file.
+
+package patricia
+
+import (
+	"errors"
+)
+
+//------------------------------------------------------------------------------
+// Trie
+//------------------------------------------------------------------------------
+
+const (
+	DefaultMaxPrefixPerNode         = 10
+	DefaultMaxChildrenPerSparseNode = 8
+)
+
+type (
+	Prefix      []byte
+	Item        interface{}
+	VisitorFunc func(prefix Prefix, item Item) error
+)
+
+// Trie is a generic patricia trie that allows fast retrieval of items by prefix.
+// and other funky stuff.
+//
+// Trie is not thread-safe.
+type Trie struct {
+	prefix Prefix
+	item   Item
+
+	maxPrefixPerNode         int
+	maxChildrenPerSparseNode int
+
+	children childList
+}
+
+// Public API ------------------------------------------------------------------
+
+type Option func(*Trie)
+
+// Trie constructor.
+func NewTrie(options ...Option) *Trie {
+	trie := &Trie{}
+
+	for _, opt := range options {
+		opt(trie)
+	}
+
+	if trie.maxPrefixPerNode <= 0 {
+		trie.maxPrefixPerNode = DefaultMaxPrefixPerNode
+	}
+	if trie.maxChildrenPerSparseNode <= 0 {
+		trie.maxChildrenPerSparseNode = DefaultMaxChildrenPerSparseNode
+	}
+
+	trie.children = newSparseChildList(trie.maxChildrenPerSparseNode)
+	return trie
+}
+
+func MaxPrefixPerNode(value int) Option {
+	return func(trie *Trie) {
+		trie.maxPrefixPerNode = value
+	}
+}
+
+func MaxChildrenPerSparseNode(value int) Option {
+	return func(trie *Trie) {
+		trie.maxChildrenPerSparseNode = value
+	}
+}
+
+// Item returns the item stored in the root of this trie.
+func (trie *Trie) Item() Item {
+	return trie.item
+}
+
+// Insert inserts a new item into the trie using the given prefix. Insert does
+// not replace existing items. It returns false if an item was already in place.
+func (trie *Trie) Insert(key Prefix, item Item) (inserted bool) {
+	return trie.put(key, item, false)
+}
+
+// Set works much like Insert, but it always sets the item, possibly replacing
+// the item previously inserted.
+func (trie *Trie) Set(key Prefix, item Item) {
+	trie.put(key, item, true)
+}
+
+// Get returns the item located at key.
+//
+// This method is a bit dangerous, because Get can as well end up in an internal
+// node that is not really representing any user-defined value. So when nil is
+// a valid value being used, it is not possible to tell if the value was inserted
+// into the tree by the user or not. A possible workaround for this is not to use
+// nil interface as a valid value, even using zero value of any type is enough
+// to prevent this bad behaviour.
+func (trie *Trie) Get(key Prefix) (item Item) {
+	_, node, found, leftover := trie.findSubtree(key)
+	if !found || len(leftover) != 0 {
+		return nil
+	}
+	return node.item
+}
+
+// Match returns what Get(prefix) != nil would return. The same warning as for
+// Get applies here as well.
+func (trie *Trie) Match(prefix Prefix) (matchedExactly bool) {
+	return trie.Get(prefix) != nil
+}
+
+// MatchSubtree returns true when there is a subtree representing extensions
+// to key, that is if there are any keys in the tree which have key as prefix.
+func (trie *Trie) MatchSubtree(key Prefix) (matched bool) {
+	_, _, matched, _ = trie.findSubtree(key)
+	return
+}
+
+// Visit calls visitor on every node containing a non-nil item
+// in alphabetical order.
+//
+// If an error is returned from visitor, the function stops visiting the tree
+// and returns that error, unless it is a special error - SkipSubtree. In that
+// case Visit skips the subtree represented by the current node and continues
+// elsewhere.
+func (trie *Trie) Visit(visitor VisitorFunc) error {
+	return trie.walk(nil, visitor)
+}
+
+// VisitSubtree works much like Visit, but it only visits nodes matching prefix.
+func (trie *Trie) VisitSubtree(prefix Prefix, visitor VisitorFunc) error {
+	// Nil prefix not allowed.
+	if prefix == nil {
+		panic(ErrNilPrefix)
+	}
+
+	// Empty trie must be handled explicitly.
+	if trie.prefix == nil {
+		return nil
+	}
+
+	// Locate the relevant subtree.
+	_, root, found, leftover := trie.findSubtree(prefix)
+	if !found {
+		return nil
+	}
+	prefix = append(prefix, leftover...)
+
+	// Visit it.
+	return root.walk(prefix, visitor)
+}
+
+// VisitPrefixes visits only nodes that represent prefixes of key.
+// To say the obvious, returning SkipSubtree from visitor makes no sense here.
+func (trie *Trie) VisitPrefixes(key Prefix, visitor VisitorFunc) error {
+	// Nil key not allowed.
+	if key == nil {
+		panic(ErrNilPrefix)
+	}
+
+	// Empty trie must be handled explicitly.
+	if trie.prefix == nil {
+		return nil
+	}
+
+	// Walk the path matching key prefixes.
+	node := trie
+	prefix := key
+	offset := 0
+	for {
+		// Compute what part of prefix matches.
+		common := node.longestCommonPrefixLength(key)
+		key = key[common:]
+		offset += common
+
+		// Partial match means that there is no subtree matching prefix.
+		if common < len(node.prefix) {
+			return nil
+		}
+
+		// Call the visitor.
+		if item := node.item; item != nil {
+			if err := visitor(prefix[:offset], item); err != nil {
+				return err
+			}
+		}
+
+		if len(key) == 0 {
+			// This node represents key, we are finished.
+			return nil
+		}
+
+		// There is some key suffix left, move to the children.
+		child := node.children.next(key[0])
+		if child == nil {
+			// There is nowhere to continue, return.
+			return nil
+		}
+
+		node = child
+	}
+}
+
+// Delete deletes the item represented by the given prefix.
+//
+// True is returned if the matching node was found and deleted.
+func (trie *Trie) Delete(key Prefix) (deleted bool) {
+	// Nil prefix not allowed.
+	if key == nil {
+		panic(ErrNilPrefix)
+	}
+
+	// Empty trie must be handled explicitly.
+	if trie.prefix == nil {
+		return false
+	}
+
+	// Find the relevant node.
+	parent, node, _, leftover := trie.findSubtree(key)
+	if len(leftover) != 0 {
+		return false
+	}
+
+	// If the item is already set to nil, there is nothing to do.
+	if node.item == nil {
+		return false
+	}
+
+	// Delete the item.
+	node.item = nil
+
+	// Compact since that might be possible now.
+	if compacted := node.compact(); compacted != node {
+		if parent == nil {
+			*node = *compacted
+		} else {
+			parent.children.replace(node.prefix[0], compacted)
+			*parent = *parent.compact()
+		}
+	}
+
+	return true
+}
+
+// DeleteSubtree finds the subtree exactly matching prefix and deletes it.
+//
+// True is returned if the subtree was found and deleted.
+func (trie *Trie) DeleteSubtree(prefix Prefix) (deleted bool) {
+	// Nil prefix not allowed.
+	if prefix == nil {
+		panic(ErrNilPrefix)
+	}
+
+	// Empty trie must be handled explicitly.
+	if trie.prefix == nil {
+		return false
+	}
+
+	// Locate the relevant subtree.
+	parent, root, found, _ := trie.findSubtree(prefix)
+	if !found {
+		return false
+	}
+
+	// If we are in the root of the trie, reset the trie.
+	if parent == nil {
+		root.prefix = nil
+		root.children = newSparseChildList(trie.maxPrefixPerNode)
+		return true
+	}
+
+	// Otherwise remove the root node from its parent.
+	parent.children.remove(root)
+	return true
+}
+
+// Internal helper methods -----------------------------------------------------
+
+func (trie *Trie) put(key Prefix, item Item, replace bool) (inserted bool) {
+	// Nil prefix not allowed.
+	if key == nil {
+		panic(ErrNilPrefix)
+	}
+
+	var (
+		common int
+		node   *Trie = trie
+		child  *Trie
+	)
+
+	if node.prefix == nil {
+		if len(key) <= trie.maxPrefixPerNode {
+			node.prefix = key
+			goto InsertItem
+		}
+		node.prefix = key[:trie.maxPrefixPerNode]
+		key = key[trie.maxPrefixPerNode:]
+		goto AppendChild
+	}
+
+	for {
+		// Compute the longest common prefix length.
+		common = node.longestCommonPrefixLength(key)
+		key = key[common:]
+
+		// Only a part matches, split.
+		if common < len(node.prefix) {
+			goto SplitPrefix
+		}
+
+		// common == len(node.prefix) since never (common > len(node.prefix))
+		// common == len(former key) <-> 0 == len(key)
+		// -> former key == node.prefix
+		if len(key) == 0 {
+			goto InsertItem
+		}
+
+		// Check children for matching prefix.
+		child = node.children.next(key[0])
+		if child == nil {
+			goto AppendChild
+		}
+		node = child
+	}
+
+SplitPrefix:
+	// Split the prefix if necessary.
+	child = new(Trie)
+	*child = *node
+	*node = *NewTrie()
+	node.prefix = child.prefix[:common]
+	child.prefix = child.prefix[common:]
+	child = child.compact()
+	node.children = node.children.add(child)
+
+AppendChild:
+	// Keep appending children until whole prefix is inserted.
+	// This loop starts with empty node.prefix that needs to be filled.
+	for len(key) != 0 {
+		child := NewTrie()
+		if len(key) <= trie.maxPrefixPerNode {
+			child.prefix = key
+			node.children = node.children.add(child)
+			node = child
+			goto InsertItem
+		} else {
+			child.prefix = key[:trie.maxPrefixPerNode]
+			key = key[trie.maxPrefixPerNode:]
+			node.children = node.children.add(child)
+			node = child
+		}
+	}
+
+InsertItem:
+	// Try to insert the item if possible.
+	if replace || node.item == nil {
+		node.item = item
+		return true
+	}
+	return false
+}
+
+func (trie *Trie) compact() *Trie {
+	// Only a node with a single child can be compacted.
+	if trie.children.length() != 1 {
+		return trie
+	}
+
+	child := trie.children.head()
+
+	// If any item is set, we cannot compact since we want to retain
+	// the ability to do searching by key. This makes compaction less usable,
+	// but that simply cannot be avoided.
+	if trie.item != nil || child.item != nil {
+		return trie
+	}
+
+	// Make sure the combined prefixes fit into a single node.
+	if len(trie.prefix)+len(child.prefix) > trie.maxPrefixPerNode {
+		return trie
+	}
+
+	// Concatenate the prefixes, move the items.
+	child.prefix = append(trie.prefix, child.prefix...)
+	if trie.item != nil {
+		child.item = trie.item
+	}
+
+	return child
+}
+
+func (trie *Trie) findSubtree(prefix Prefix) (parent *Trie, root *Trie, found bool, leftover Prefix) {
+	// Find the subtree matching prefix.
+	root = trie
+	for {
+		// Compute what part of prefix matches.
+		common := root.longestCommonPrefixLength(prefix)
+		prefix = prefix[common:]
+
+		// We used up the whole prefix, subtree found.
+		if len(prefix) == 0 {
+			found = true
+			leftover = root.prefix[common:]
+			return
+		}
+
+		// Partial match means that there is no subtree matching prefix.
+		if common < len(root.prefix) {
+			leftover = root.prefix[common:]
+			return
+		}
+
+		// There is some prefix left, move to the children.
+		child := root.children.next(prefix[0])
+		if child == nil {
+			// There is nowhere to continue, there is no subtree matching prefix.
+			return
+		}
+
+		parent = root
+		root = child
+	}
+}
+
+func (trie *Trie) walk(actualRootPrefix Prefix, visitor VisitorFunc) error {
+	var prefix Prefix
+	// Allocate a bit more space for prefix at the beginning.
+	if actualRootPrefix == nil {
+		prefix = make(Prefix, 32+len(trie.prefix))
+		copy(prefix, trie.prefix)
+		prefix = prefix[:len(trie.prefix)]
+	} else {
+		prefix = make(Prefix, 32+len(actualRootPrefix))
+		copy(prefix, actualRootPrefix)
+		prefix = prefix[:len(actualRootPrefix)]
+	}
+
+	// Visit the root first. Not that this works for empty trie as well since
+	// in that case item == nil && len(children) == 0.
+	if trie.item != nil {
+		if err := visitor(prefix, trie.item); err != nil {
+			if err == SkipSubtree {
+				return nil
+			}
+			return err
+		}
+	}
+
+	// Then continue to the children.
+	return trie.children.walk(&prefix, visitor)
+}
+
+func (trie *Trie) longestCommonPrefixLength(prefix Prefix) (i int) {
+	for ; i < len(prefix) && i < len(trie.prefix) && prefix[i] == trie.prefix[i]; i++ {
+	}
+	return
+}
+
+// Errors ----------------------------------------------------------------------
+
+var (
+	SkipSubtree  = errors.New("Skip this subtree")
+	ErrNilPrefix = errors.New("Nil prefix passed into a method call")
+)

--- a/vendor/manifest
+++ b/vendor/manifest
@@ -588,6 +588,14 @@
 			"branch": "master"
 		},
 		{
+			"importpath": "github.com/tchap/go-patricia",
+			"repository": "https://github.com/tchap/go-patricia",
+			"vcs": "git",
+			"revision": "d87fea6fbcb44d59ff7dacbbcc347c66fca67724",
+			"branch": "HEAD",
+			"notests": true
+		},
+		{
 			"importpath": "github.com/tylerb/graceful",
 			"repository": "https://github.com/tylerb/graceful",
 			"vcs": "",


### PR DESCRIPTION
This pull request contains the following changes:

- container and image caches both now live in the  `github.com/vmware/vic/lib/apiservers/engine/backends/cache` package
- the image cache has been refactored to be more consistent with the container cache
- implemented the ability to specify just the prefix of a container ID or image ID. This required the vendoring of `github.com/tchap/go-patricia` (in a separate commit for readability)
- locking around the image cache has been improved, and the design has been brought up to spec as per conversations with @hickeng and @hmahmood 
- a container name cache was also added, allowing us to start containers by name. It will not yet persist after a persona restart until cache reconstruction code is in.
- general cleanup and organizational refactoring

Fixes #1234, addresses the 2nd item in #1154 

