### PR TITLE
Fixes inability to call vic-machine delete again if it fails due to powered on containerVMs

### DIFF
--- a/cmd/vic-machine/delete/delete.go
+++ b/cmd/vic-machine/delete/delete.go
@@ -134,16 +134,6 @@ func (d *Uninstall) Run(cli *cli.Context) error {
 	}
 	executor.InitDiagnosticLogs(vchConfig)
 
-	if validator.IsVC() {
-		log.Infoln("Removing VCH vSphere extension")
-		if err = executor.GenerateExtensionName(vchConfig); err != nil {
-			log.Warnf("Failed to get extension name during VCH deletion: %s", err)
-		}
-		if err = executor.UnregisterExtension(vchConfig.ExtensionName); err != nil {
-			log.Warnf("Failed to remove extension %s: %s", vchConfig.ExtensionName, err)
-		}
-	}
-
 	if err = executor.DeleteVCH(vchConfig); err != nil {
 		executor.CollectDiagnosticLogs()
 		log.Errorf("%s", err)

--- a/lib/install/management/create.go
+++ b/lib/install/management/create.go
@@ -122,3 +122,30 @@ func (d *Dispatcher) uploadImages(files []string) error {
 	}
 	return nil
 }
+
+func (d *Dispatcher) RegisterExtension(conf *metadata.VirtualContainerHostConfigSpec, extension types.Extension) error {
+	defer trace.End(trace.Begin(conf.ExtensionName))
+
+	log.Infoln("Registering VCH as a vSphere extension")
+
+	// vSphere confusingly calls the 'name' of the extension a 'key'
+	// This variable is named IdKey as to not confuse it with its private key
+	if conf.ExtensionCert == "" {
+		return errors.Errorf("Extension certificate does not exist")
+	}
+
+	extensionManager := object.NewExtensionManager(d.session.Vim25())
+
+	extension.LastHeartbeatTime = time.Now().UTC()
+	if err := extensionManager.Register(d.ctx, extension); err != nil {
+		log.Errorf("Could not register the vSphere extension due to err: %s", err)
+		return err
+	}
+
+	if err := extensionManager.SetCertificate(d.ctx, conf.ExtensionName, conf.ExtensionCert); err != nil {
+		log.Errorf("Could not set the certificate on the vSphere extension due to error: %s", err)
+		return err
+	}
+
+	return nil
+}

--- a/lib/install/management/create.go
+++ b/lib/install/management/create.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"sync"
+	"time"
 
 	log "github.com/Sirupsen/logrus"
 
@@ -26,6 +27,9 @@ import (
 	"github.com/vmware/vic/pkg/errors"
 	"github.com/vmware/vic/pkg/trace"
 	"github.com/vmware/vic/pkg/vsphere/tasks"
+
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25/types"
 
 	"golang.org/x/net/context"
 )

--- a/lib/install/management/delete.go
+++ b/lib/install/management/delete.go
@@ -194,3 +194,13 @@ func (d *Dispatcher) networkDevices(vmm *vm.VirtualMachine) ([]types.BaseVirtual
 	}
 	return devices, nil
 }
+
+func (d *Dispatcher) UnregisterExtension(name string) error {
+	defer trace.End(trace.Begin(name))
+
+	extensionManager := object.NewExtensionManager(d.session.Vim25())
+	if err := extensionManager.Unregister(d.ctx, name); err != nil {
+		return errors.Errorf("Failed to remove extension w/ name %s due to error: %s", name, err)
+	}
+	return nil
+}

--- a/lib/install/management/delete.go
+++ b/lib/install/management/delete.go
@@ -66,6 +66,17 @@ func (d *Dispatcher) DeleteVCH(conf *metadata.VirtualContainerHostConfigSpec) er
 		// stop here, leave vch appliance there for next time delete
 		return errors.New(strings.Join(errs, "\n"))
 	}
+
+	if d.isVC {
+		log.Infoln("Removing VCH vSphere extension")
+		if err = d.GenerateExtensionName(conf); err != nil {
+			log.Warnf("Failed to get extension name during VCH deletion: %s", err)
+		}
+		if err = d.UnregisterExtension(conf.ExtensionName); err != nil {
+			log.Warnf("Failed to remove extension %s: %s", conf.ExtensionName, err)
+		}
+	}
+
 	err = d.deleteVM(vmm, true)
 	if err != nil {
 		log.Debugf("Error deleting appliance VM %s", err)

--- a/lib/install/management/dispatcher.go
+++ b/lib/install/management/dispatcher.go
@@ -21,18 +21,14 @@ import (
 
 	log "github.com/Sirupsen/logrus"
 
-	"time"
-
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/vic/lib/metadata"
-	"github.com/vmware/vic/pkg/errors"
 	"github.com/vmware/vic/pkg/trace"
 	"github.com/vmware/vic/pkg/vsphere/compute"
 	"github.com/vmware/vic/pkg/vsphere/diagnostic"
 	"github.com/vmware/vic/pkg/vsphere/session"
 	"github.com/vmware/vic/pkg/vsphere/vm"
 
-	"github.com/vmware/govmomi/vim25/types"
 	"golang.org/x/net/context"
 )
 

--- a/lib/install/management/dispatcher.go
+++ b/lib/install/management/dispatcher.go
@@ -151,33 +151,6 @@ func (d *Dispatcher) InitDiagnosticLogs(conf *metadata.VirtualContainerHostConfi
 	}
 }
 
-func (d *Dispatcher) RegisterExtension(conf *metadata.VirtualContainerHostConfigSpec, extension types.Extension) error {
-	defer trace.End(trace.Begin(conf.ExtensionName))
-
-	log.Infoln("Registering VCH as a vSphere extension")
-
-	// vSphere confusingly calls the 'name' of the extension a 'key'
-	// This variable is named IdKey as to not confuse it with its private key
-	if conf.ExtensionCert == "" {
-		return errors.Errorf("Extension certificate does not exist")
-	}
-
-	extensionManager := object.NewExtensionManager(d.session.Vim25())
-
-	extension.LastHeartbeatTime = time.Now().UTC()
-	if err := extensionManager.Register(d.ctx, extension); err != nil {
-		log.Errorf("Could not register the vSphere extension due to err: %s", err)
-		return err
-	}
-
-	if err := extensionManager.SetCertificate(d.ctx, conf.ExtensionName, conf.ExtensionCert); err != nil {
-		log.Errorf("Could not set the certificate on the vSphere extension due to error: %s", err)
-		return err
-	}
-
-	return nil
-}
-
 func (d *Dispatcher) CollectDiagnosticLogs() {
 	defer trace.End(trace.Begin(""))
 

--- a/lib/install/management/dispatcher.go
+++ b/lib/install/management/dispatcher.go
@@ -178,16 +178,6 @@ func (d *Dispatcher) RegisterExtension(conf *metadata.VirtualContainerHostConfig
 	return nil
 }
 
-func (d *Dispatcher) UnregisterExtension(name string) error {
-	defer trace.End(trace.Begin(name))
-
-	extensionManager := object.NewExtensionManager(d.session.Vim25())
-	if err := extensionManager.Unregister(d.ctx, name); err != nil {
-		return errors.Errorf("Failed to remove extension w/ name %s due to error: %s", name, err)
-	}
-	return nil
-}
-
 func (d *Dispatcher) CollectDiagnosticLogs() {
 	defer trace.End(trace.Begin(""))
 


### PR DESCRIPTION
Fixes #1338 by moving the unregistration of the vSphere extension to after the attempted power off of any running containers. If the user did not choose `--force`, then the containers are left running & vic-machine bails _before_ the extension is removed. If they chose to use the `force`, the containers are powered off, deleted, and the extension is unregistered later.

Also RegisterExtension and UnregisterExtension were moved to their respective command files for better organization.