### PR TITLE
Adds volume store deletion to vic-machine delete

### DIFF
--- a/cmd/vic-machine/create/create_test.go
+++ b/cmd/vic-machine/create/create_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/vmware/vic/pkg/ip"
 )
 
-func TestParseConatainerNetworkGateways(t *testing.T) {
+func TestParseContainerNetworkGateways(t *testing.T) {
 	var tests = []struct {
 		cgs []string
 		gws map[string]net.IPNet

--- a/lib/install/management/create_test.go
+++ b/lib/install/management/create_test.go
@@ -80,6 +80,7 @@ func TestMain(t *testing.T) {
 		//		testCreateNetwork(ctx, validator.Session, conf, t)
 
 		testCreateVolumeStores(ctx, validator.Session, conf, false, t)
+		testDeleteVolumeStores(ctx, validator.Session, conf, 1, t)
 		errConf := &metadata.VirtualContainerHostConfigSpec{}
 		*errConf = *conf
 		errConf.VolumeLocations = make(map[string]*url.URL)
@@ -196,6 +197,20 @@ func testCreateVolumeStores(ctx context.Context, sess *session.Session, conf *me
 	if err != nil {
 		t.Errorf("Unexpected error: %s", err)
 	}
+}
+
+func testDeleteVolumeStores(ctx context.Context, sess *session.Session, conf *metadata.VirtualContainerHostConfigSpec, numVols int, t *testing.T) {
+	d := &Dispatcher{
+		session: sess,
+		ctx:     ctx,
+		isVC:    sess.IsVC(),
+		force:   true,
+	}
+
+	if removed := d.deleteVolumeStoreIfForced(conf); removed != numVols {
+		t.Errorf("Did not successfully remove all specified volumes")
+	}
+
 }
 
 // FIXME: Failed to find IDE controller in simulator, so create appliance failed

--- a/lib/install/management/delete.go
+++ b/lib/install/management/delete.go
@@ -55,6 +55,8 @@ func (d *Dispatcher) DeleteVCH(conf *metadata.VirtualContainerHostConfigSpec) er
 		errs = append(errs, err.Error())
 	}
 
+	d.deleteVolumeStoreIfForced(conf) // logs errors but doesn't ever bail out if it has an issue
+
 	if err = d.deleteNetworkDevices(vmm, conf); err != nil {
 		errs = append(errs, err.Error())
 	}
@@ -84,10 +86,6 @@ func (d *Dispatcher) DeleteVCH(conf *metadata.VirtualContainerHostConfigSpec) er
 	if err = d.destroyResourcePoolIfEmpty(conf); err != nil {
 		log.Warnf("VCH resource pool is not removed, %s", err)
 	}
-
-	log.Infoln("Removing volume stores...")
-	d.deleteVolumeStoreIfForced(conf) // logs errors but doesn't ever bail out if it has an issue
-
 	return nil
 }
 

--- a/lib/install/management/delete.go
+++ b/lib/install/management/delete.go
@@ -15,8 +15,6 @@
 package management
 
 import (
-	"bytes"
-	"fmt"
 	"strings"
 
 	log "github.com/Sirupsen/logrus"
@@ -88,10 +86,8 @@ func (d *Dispatcher) DeleteVCH(conf *metadata.VirtualContainerHostConfigSpec) er
 	}
 
 	log.Infoln("Removing volume stores...")
-	if err = d.deleteVolumeStoreIfForced(conf); err != nil {
-		log.Warnf("Error while deleting volume store: %s", err)
-		return err
-	}
+	d.deleteVolumeStoreIfForced(conf) // logs errors but doesn't ever bail out if it has an issue
+
 	return nil
 }
 
@@ -147,46 +143,6 @@ func (d *Dispatcher) DeleteVCHInstances(vmm *vm.VirtualMachine, conf *metadata.V
 		return errors.New(strings.Join(errs, "\n"))
 	}
 
-	return nil
-}
-
-func (d *Dispatcher) deleteVolumeStoreIfForced(conf *metadata.VirtualContainerHostConfigSpec) error {
-	if d.force {
-
-		for label, url := range conf.VolumeLocations {
-
-			// separate the host from the path in the provided path URL
-			pathAry := strings.SplitN(url.Path, " ", 2)
-			if len(pathAry) != 2 {
-				return errors.New("Didn't receive an expected volume store path format")
-			}
-
-			// convert the URL path to vSphere style pathing, and omit everything from the path except the root of the volume store
-			vSpherePath := fmt.Sprintf("%s %s", pathAry[0], strings.Split(pathAry[1], "/")[0])
-
-			// connect to vSphere and do the actual deletion
-			m := object.NewFileManager(d.session.Vim25())
-			log.Infof("Deleting volume store %s at path %s", label, vSpherePath)
-			task, err := m.DeleteDatastoreFile(d.ctx, vSpherePath, d.session.Datacenter)
-			if err != nil {
-				return errors.Errorf("Failed to start delete of %s due to error: %s", vSpherePath, err)
-			}
-
-			if err = task.Wait(d.ctx); err != nil {
-				return errors.Errorf("Failed to finish delete of %s due to error: %s", vSpherePath, err)
-			}
-
-		}
-
-	} else {
-		volumeStores := new(bytes.Buffer)
-		for label, url := range conf.VolumeLocations {
-			if _, err := volumeStores.WriteString(fmt.Sprintf("\t%s: %s\n", label, url.Path)); err != nil {
-				return err
-			}
-		}
-		log.Warnf("Since --force was not specified, the following volume stores will not be removed. Use the vSphere UI to delete content you do not wish to keep.\n%s", volumeStores.String())
-	}
 	return nil
 }
 

--- a/lib/install/management/store_files.go
+++ b/lib/install/management/store_files.go
@@ -56,13 +56,6 @@ func (d *Dispatcher) DeleteStores(vchVM *vm.VirtualMachine, conf *metadata.Virtu
 	if emptyImages, err = d.deleteImages(ds, path); err != nil {
 		errs = append(errs, err.Error())
 	}
-	log.Infof("Removing volumes")
-	if emptyVolumes, err = d.deleteVolumes(ds, path); err != nil {
-		errs = append(errs, err.Error())
-	} else if !emptyVolumes {
-		log.Infof("Volumes directory %s is not empty, to delete with --force specified", path)
-	}
-
 	if emptyImages && emptyVolumes {
 		// if not empty, don't try to delete parent directory here
 		log.Debugf("Removing stores directory")
@@ -89,14 +82,6 @@ func (d *Dispatcher) deleteImages(ds *object.Datastore, root string) (bool, erro
 	p := path.Join(root, vsphere.StorageImageDir)
 	// alway forcing delete images
 	return d.deleteDatastoreFiles(ds, p, true)
-}
-
-func (d *Dispatcher) deleteVolumes(ds *object.Datastore, root string) (bool, error) {
-	defer trace.End(trace.Begin(""))
-
-	p := path.Join(root, volumeRoot)
-	// if not forced delete, leave volumes there. Cause user data can be persisted in volumes
-	return d.deleteDatastoreFiles(ds, p, d.force)
 }
 
 func (d *Dispatcher) deleteDatastoreFiles(ds *object.Datastore, path string, force bool) (bool, error) {

--- a/lib/install/management/store_files.go
+++ b/lib/install/management/store_files.go
@@ -226,10 +226,10 @@ func (d *Dispatcher) deleteVolumeStoreIfForced(conf *metadata.VirtualContainerHo
 			log.Errorf("Error finding datastore %s: %s", dsURL.Host, err)
 			continue
 		}
-		if len(datastores) != 1 {
+		if len(datastores) > 1 {
 			foundDatastores := new(bytes.Buffer)
 			for _, d := range datastores {
-				foundDatastores.WriteString(fmt.Sprintf("\n%s\n", d))
+				foundDatastores.WriteString(fmt.Sprintf("\n%s\n", d.InventoryPath))
 			}
 			log.Errorf("Ambiguous datastore name (%s) provided. Results were: %s", dsURL.Host, foundDatastores)
 			continue

--- a/lib/install/management/store_files.go
+++ b/lib/install/management/store_files.go
@@ -44,7 +44,7 @@ func (d *Dispatcher) DeleteStores(vchVM *vm.VirtualMachine, conf *metadata.Virtu
 
 	ds := d.session.Datastore
 
-	path, err := d.getVCHRootDir(vchVM)
+	p, err := d.getVCHRootDir(vchVM) // p would be path but there's an imported package called path
 	if err != nil {
 		return err
 	}
@@ -53,13 +53,15 @@ func (d *Dispatcher) DeleteStores(vchVM *vm.VirtualMachine, conf *metadata.Virtu
 	var emptyImages bool
 	var emptyVolumes bool
 	log.Infof("Removing images")
-	if emptyImages, err = d.deleteImages(ds, path); err != nil {
+	if emptyImages, err = d.deleteImages(ds, p); err != nil {
 		errs = append(errs, err.Error())
 	}
+	emptyVolumes, err = d.deleteDatastoreFiles(ds, path.Join(p, volumeRoot), d.force)
+
 	if emptyImages && emptyVolumes {
 		// if not empty, don't try to delete parent directory here
 		log.Debugf("Removing stores directory")
-		if err = d.deleteParent(ds, path); err != nil {
+		if err = d.deleteParent(ds, p); err != nil {
 			errs = append(errs, err.Error())
 		}
 	}

--- a/lib/portlayer/storage/vsphere/datastore.go
+++ b/lib/portlayer/storage/vsphere/datastore.go
@@ -15,6 +15,7 @@
 package vsphere
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"net/url"
@@ -22,7 +23,6 @@ import (
 	"regexp"
 	"strings"
 
-	"errors"
 	log "github.com/Sirupsen/logrus"
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/vim25/mo"

--- a/lib/portlayer/storage/vsphere/datastore_test.go
+++ b/lib/portlayer/storage/vsphere/datastore_test.go
@@ -128,21 +128,32 @@ func TestDatastoreMkdirAndLs(t *testing.T) {
 }
 
 func TestDatastoreToURLParsing(t *testing.T) {
-	expected := "ds://datastore1/path/to/thing"
+	expectedURL := "ds://datastore1/path/to/thing"
 
-	input := []string{
-		"[datastore1] /path/to/thing",
-		"[datastore1] path/to/thing",
-		"[datastore1] ///path////to/thing",
+	input := [][]string{
+		{"[datastore1] /path/to/thing", expectedURL},
+		{"[datastore1] path/to/thing", expectedURL},
+		{"[datastore1] ///path////to/thing", expectedURL},
+		{"[Datastore (1)] /path/to/thing", "ds://Datastore%20(1)/path/to/thing"},
+		{"[datastore1] path", "ds://datastore1/path"},
 	}
 
-	for _, in := range input {
-		u, err := DatastoreToURL(in)
+	dsoutputs := []string{
+		"[datastore1] /path/to/thing",
+		"[datastore1] path/to/thing",
+		"[datastore1] /path/to/thing",
+		"[Datastore (1)] /path/to/thing",
+		"[datastore1] path",
+	}
+
+	for i, in := range input {
+		u, err := DatastoreToURL(in[0])
+
 		if !assert.NoError(t, err) || !assert.NotNil(t, u) {
 			return
 		}
 
-		if !assert.Equal(t, expected, u.String()) {
+		if !assert.Equal(t, in[1], u.String()) {
 			return
 		}
 
@@ -151,7 +162,7 @@ func TestDatastoreToURLParsing(t *testing.T) {
 			return
 		}
 
-		if !assert.Equal(t, input[0], out) {
+		if !assert.Equal(t, dsoutputs[i], out) {
 			return
 		}
 	}

--- a/lib/portlayer/storage/vsphere/datastore_test.go
+++ b/lib/portlayer/storage/vsphere/datastore_test.go
@@ -127,6 +127,36 @@ func TestDatastoreMkdirAndLs(t *testing.T) {
 	}
 }
 
+func TestDatastoreToURLParsing(t *testing.T) {
+	expected := "ds://datastore1/path/to/thing"
+
+	input := []string{
+		"[datastore1] /path/to/thing",
+		"[datastore1] path/to/thing",
+		"[datastore1] ///path////to/thing",
+	}
+
+	for _, in := range input {
+		u, err := DatastoreToURL(in)
+		if !assert.NoError(t, err) || !assert.NotNil(t, u) {
+			return
+		}
+
+		if !assert.Equal(t, expected, u.String()) {
+			return
+		}
+
+		out, err := URLtoDatastore(u)
+		if !assert.NoError(t, err) || !assert.True(t, len(out) > 0) {
+			return
+		}
+
+		if !assert.Equal(t, input[0], out) {
+			return
+		}
+	}
+}
+
 // From https://siongui.github.io/2015/04/13/go-generate-random-string/
 func RandomString(strlen int) string {
 	rand.Seed(time.Now().UTC().UnixNano())


### PR DESCRIPTION
Does what it says on the tin -- vic-machine will now remove volume stores upon VCH destruction.

If the user does not specify `--force`, the volume stores used by the VCH are printed for their reference and optional manual removal.

Pretty straightforward and self-contained.