### PR TITLE
Fix pprof data collection

### DIFF
--- a/lib/pprof/pprof.go
+++ b/lib/pprof/pprof.go
@@ -70,7 +70,7 @@ func GetPprofEndpoint(component PprofPort) *url.URL {
 		}
 	}
 
-	endpoint, err := url.Parse(fmt.Sprintf("%s:%d", ip, port))
+	endpoint, err := url.Parse(fmt.Sprintf("http://%s:%d", ip, port))
 	if err != nil {
 		return nil
 	}
@@ -84,10 +84,11 @@ func StartPprof(name string, component PprofPort) error {
 		log.Error(err.Error())
 		return err
 	}
+	location := url.String()[7:] // Strip off leading "http://"
 
-	log.Info(fmt.Sprintf("Launching %s server on %s", name, url.String()))
+	log.Info(fmt.Sprintf("Launching %s server on %s", name, location))
 	go func() {
-		log.Info(http.ListenAndServe(url.String(), nil))
+		log.Info(http.ListenAndServe(location, nil))
 	}()
 
 	return nil


### PR DESCRIPTION
Fixes #1417

During the course of PR review, the pprof code got refactored several times which involved dropping the leading "http://" from the pprof endpoints.  This PR addresses that problem.