### PR TITLE
Add a deadline parameter to the attach streams in port layer

### DIFF
--- a/lib/apiservers/engine/backends/container/viccontainer.go
+++ b/lib/apiservers/engine/backends/container/viccontainer.go
@@ -15,14 +15,11 @@
 package container
 
 import (
-	"github.com/docker/docker/runconfig"
 	containertypes "github.com/docker/engine-api/types/container"
 )
 
 // VicContainer is VIC's abridged version of Docker's container object.
 type VicContainer struct {
-	*runconfig.StreamConfig
-
 	Name        string
 	ID          string
 	ContainerID string
@@ -31,7 +28,6 @@ type VicContainer struct {
 
 func NewVicContainer() *VicContainer {
 	return &VicContainer{
-		StreamConfig: runconfig.NewStreamConfig(),
-		Config:       &containertypes.Config{},
+		Config: &containertypes.Config{},
 	}
 }

--- a/lib/apiservers/portlayer/swagger.yml
+++ b/lib/apiservers/portlayer/swagger.yml
@@ -798,6 +798,10 @@ paths:
           in: path
           type: string
           required: true
+        - name: deadline
+          in: query
+          type: string
+          format: datetime
         - name: raw_stream
           in: body
           schema:
@@ -829,6 +833,10 @@ paths:
           in: path
           type: string
           required: true
+        - name: deadline
+          in: query
+          type: string
+          format: datetime
       responses:
         '500':
           description: "Failed to get stdout"
@@ -857,6 +865,10 @@ paths:
           in: path
           type: string
           required: true
+        - name: deadline
+          in: query
+          type: string
+          format: datetime
       responses:
         '500':
           description: "Failed to get stderr"


### PR DESCRIPTION
A deadline can now be passed into each attach stream request.  The
deadline is a hard set time instead of a timeout.  This allows the
caller to better manage total timeout for each attach.  Also make
a call to flush in WriteResponse() to ensure the header goes out
before the body does.