### PR TITLE
Container inspect in the personality server

### DIFF
--- a/lib/apiservers/engine/backends/container.go
+++ b/lib/apiservers/engine/backends/container.go
@@ -287,7 +287,7 @@ func (c *Container) ContainerCreate(config types.ContainerCreateConfig) (types.C
 	container.Name = config.Name
 
 	log.Debugf("Container create: %#v", container)
-	cache.ContainerCache().SaveContainer(container)
+	cache.ContainerCache().AddContainer(container)
 
 	// Success!
 	log.Debugf("container.ContainerCreate succeeded.  Returning container handle %s", *createResults.Payload)
@@ -405,6 +405,9 @@ func (c *Container) ContainerRm(name string, config *types.ContainerRmConfig) er
 		}
 		return derr.NewErrorWithStatusCode(fmt.Errorf("server error from portlayer"), http.StatusInternalServerError)
 	}
+	// delete container from the cache
+	cache.ContainerCache().DeleteContainer(name)
+
 	return nil
 }
 

--- a/lib/apiservers/portlayer/restapi/handlers/containers_handlers.go
+++ b/lib/apiservers/portlayer/restapi/handlers/containers_handlers.go
@@ -286,6 +286,11 @@ func convertContainerToContainerInfo(container *exec.Container) *models.Containe
 	tty := container.ExecConfig.Sessions[ccid].Tty
 	info.ContainerConfig.Tty = &tty
 
+	attach := container.ExecConfig.Sessions[ccid].Attach
+	info.ContainerConfig.AttachStdin = &attach
+	info.ContainerConfig.AttachStdout = &attach
+	info.ContainerConfig.AttachStderr = &attach
+
 	path := container.ExecConfig.Sessions[ccid].Cmd.Path
 	dir := container.ExecConfig.Sessions[ccid].Cmd.Dir
 	info.ProcessConfig.ExecPath = &path


### PR DESCRIPTION
This is simply Loc's original work #1307 + adjustments required for the
ContainerInfo API.

Also removes the containers from the cache after a docker rm

Fixes #370

Requires #1427 and #1428