### PR TITLE
Correct handling of disks on container delete

### DIFF
--- a/lib/apiservers/portlayer/restapi/handlers/containers_handlers.go
+++ b/lib/apiservers/portlayer/restapi/handlers/containers_handlers.go
@@ -217,7 +217,7 @@ func (handler *ContainersHandlersImpl) RemoveContainerHandler(params containers.
 		return containers.NewContainerRemoveNotFound()
 	}
 
-	err := h.Container.Remove(context.Background())
+	err := h.Container.Remove(context.Background(), handler.handlerCtx.Session)
 	if err != nil {
 		return containers.NewContainerRemoveInternalServerError()
 	}

--- a/pkg/vsphere/vm/vm.go
+++ b/pkg/vsphere/vm/vm.go
@@ -252,3 +252,20 @@ func (vm *VirtualMachine) UUID(ctx context.Context) (string, error) {
 
 	return mvm.Summary.Config.Uuid, nil
 }
+
+// DeleteExceptDisks destroys the VM after detaching all virtual disks
+func (vm *VirtualMachine) DeleteExceptDisks(ctx context.Context) (*object.Task, error) {
+	devices, err := vm.Device(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	disks := devices.SelectByType(&types.VirtualDisk{})
+
+	err = vm.RemoveDevice(ctx, true, disks...)
+	if err != nil {
+		return nil, err
+	}
+
+	return vm.Destroy(ctx)
+}


### PR DESCRIPTION
This corrects the handling of disks (both vmfs and vsan) when deleting container VMs.
This is an inefficient implementation in terms of number of remote API operations but uses only public calls.

Fixes #1383 

