### PR TITLE
remove timeout and combine logs

### DIFF
--- a/cmd/vic-machine/create/create.go
+++ b/cmd/vic-machine/create/create.go
@@ -17,7 +17,6 @@ package create
 import (
 	"encoding"
 	"fmt"
-	"io"
 	"net"
 	"os"
 	"path/filepath"
@@ -381,18 +380,6 @@ func (c *Create) checkImagesFiles() ([]string, error) {
 
 func (c *Create) Run(cli *cli.Context) error {
 	var err error
-	// Open log file
-	f, err := os.OpenFile(c.logfile, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0644)
-	if err != nil {
-		err = errors.Errorf("Error opening logfile %s: %v", c.logfile, err)
-		return err
-	}
-	defer f.Close()
-
-	// Initiliaze logger with default TextFormatter
-	log.SetFormatter(&log.TextFormatter{ForceColors: true, FullTimestamp: true})
-	// SetOutput to io.MultiWriter so that we can log to stdout and a file
-	log.SetOutput(io.MultiWriter(os.Stdout, f))
 
 	if c.Debug.Debug > 0 {
 		log.SetLevel(log.DebugLevel)

--- a/cmd/vic-machine/delete/delete.go
+++ b/cmd/vic-machine/delete/delete.go
@@ -55,7 +55,7 @@ func (d *Uninstall) Flags() []cli.Flag {
 		cli.DurationFlag{
 			Name:        "timeout",
 			Value:       3 * time.Minute,
-			Usage:       "Time to wait for appliance initialization",
+			Usage:       "Time to wait to delete vsphere resources",
 			Destination: &d.Timeout,
 		},
 	}

--- a/cmd/vic-machine/delete/delete.go
+++ b/cmd/vic-machine/delete/delete.go
@@ -15,8 +15,6 @@
 package delete
 
 import (
-	"io"
-	"os"
 	"time"
 
 	log "github.com/Sirupsen/logrus"
@@ -90,19 +88,6 @@ func (d *Uninstall) Run(cli *cli.Context) error {
 	if err = d.processParams(); err != nil {
 		return err
 	}
-
-	// Open log file
-	f, err := os.OpenFile(d.logfile, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0644)
-	if err != nil {
-		err = errors.Errorf("Error opening logfile %s: %v", d.logfile, err)
-		return err
-	}
-	defer f.Close()
-
-	// Initiliaze logger with default TextFormatter
-	log.SetFormatter(&log.TextFormatter{ForceColors: true, FullTimestamp: true})
-	// SetOutput to io.MultiWriter so that we can log to stdout and a file
-	log.SetOutput(io.MultiWriter(os.Stdout, f))
 
 	if d.Debug.Debug > 0 {
 		log.SetLevel(log.DebugLevel)

--- a/cmd/vic-machine/inspect/inspect.go
+++ b/cmd/vic-machine/inspect/inspect.go
@@ -15,8 +15,6 @@
 package inspect
 
 import (
-	"io"
-	"os"
 	"time"
 
 	log "github.com/Sirupsen/logrus"
@@ -85,19 +83,6 @@ func (i *Inspect) Run(cli *cli.Context) error {
 	if err = i.processParams(); err != nil {
 		return err
 	}
-
-	// Open log file
-	f, err := os.OpenFile(i.logfile, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0644)
-	if err != nil {
-		err = errors.Errorf("Error opening logfile %s: %v", i.logfile, err)
-		return err
-	}
-	defer f.Close()
-
-	// Initiliaze logger with default TextFormatter
-	log.SetFormatter(&log.TextFormatter{ForceColors: true, FullTimestamp: true})
-	// SetOutput to io.MultiWriter so that we can log to stdout and a file
-	log.SetOutput(io.MultiWriter(os.Stdout, f))
 
 	if i.Debug.Debug > 0 {
 		log.SetLevel(log.DebugLevel)

--- a/cmd/vic-machine/inspect/inspect.go
+++ b/cmd/vic-machine/inspect/inspect.go
@@ -15,8 +15,6 @@
 package inspect
 
 import (
-	"time"
-
 	log "github.com/Sirupsen/logrus"
 
 	"github.com/urfave/cli"
@@ -46,18 +44,9 @@ func NewInspect() *Inspect {
 
 // Flags return all cli flags for delete
 func (i *Inspect) Flags() []cli.Flag {
-	flags := []cli.Flag{
-		cli.DurationFlag{
-			Name:        "timeout",
-			Value:       3 * time.Minute,
-			Usage:       "Time to wait for appliance initialization",
-			Destination: &i.Timeout,
-		},
-	}
 	preFlags := append(i.TargetFlags(), i.IDFlags()...)
 	preFlags = append(preFlags, i.ComputeFlags()...)
-	flags = append(preFlags, flags...)
-	flags = append(flags, i.DebugFlags()...)
+	flags := append(preFlags, i.DebugFlags()...)
 
 	return flags
 }

--- a/lib/install/data/data.go
+++ b/lib/install/data/data.go
@@ -89,6 +89,7 @@ func NewData() *Data {
 		MappedNetworksGateways: make(map[string]net.IPNet),
 		MappedNetworksIPRanges: make(map[string][]ip.Range),
 		MappedNetworksDNS:      make(map[string][]net.IP),
+		Timeout:                3 * time.Minute,
 	}
 	return d
 }


### PR DESCRIPTION
Fixes #1303 #1262 

This request will remove timeout from vic-machine respect, cause that command just query objects from vsphere.

Also combine all vic-machine command log to one single log file, vic-machine.log. Separated logs files does not make the story easier. And will lose some log information, if that's returned to vic-machine main file.
