### PR TITLE
Update output when suggesting resource pools

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Building the project is done with a combination of make and containers, with gol
 
 To build as closely as possible to the formal build:
 ```
-drone exec -trusted -cache
+drone exec -trusted -cache -e VIC_ESX_TEST_URL=""
 ```
 
 To build without modifying the local system:

--- a/lib/install/validate/validator.go
+++ b/lib/install/validate/validator.go
@@ -1004,6 +1004,7 @@ func (v *Validator) suggestComputeResource(path string) {
 
 	if matches != nil {
 		// we've collected recommendations - displayname
+		log.Info("Suggested values for --compute-resource:")
 		for _, p := range matches {
 			log.Infof("  %s", v.inventoryPathToComputePath(p))
 		}
@@ -1056,7 +1057,7 @@ func (v *Validator) listResourcePools(path string) []string {
 
 	pools, err := v.Session.Finder.ResourcePoolList(v.Context, path+"/*")
 	if err != nil {
-		log.Errorf("Unable to list pools for %s: %s", path, err)
+		log.Debugf("Unable to list pools for %s: %s", path, err)
 		return nil
 	}
 


### PR DESCRIPTION
Fixes #1344 

Output now looks like:
```
INFO[2016-07-12T22:31:56Z] ### Installing VCH ####                      
INFO[2016-07-12T22:31:56Z] Generating certificate/key pair - private key in ./virtual-container-host-key.pem 
INFO[2016-07-12T22:31:57Z] Validating supplied configuration            
INFO[2016-07-12T22:31:57Z] Suggesting valid values for --compute-resource based on /CNA-DC/host/Mgmt2/Resources 
INFO[2016-07-12T22:31:57Z] Suggested values for --compute-resource:     
INFO[2016-07-12T22:31:57Z]   Mgmt                                       
INFO[2016-07-12T22:31:57Z]   cloud                                      
ERRO[2016-07-12T22:31:57Z] Firewall check SKIPPED                       
ERRO[2016-07-12T22:31:57Z]   cluster not set                            
ERRO[2016-07-12T22:31:57Z] License check SKIPPED                        
ERRO[2016-07-12T22:31:57Z]   cluster not set                            
ERRO[2016-07-12T22:31:57Z] DRS check SKIPPED                            
ERRO[2016-07-12T22:31:57Z]   cluster not set                            
ERRO[2016-07-12T22:31:57Z] Compatibility check SKIPPED                  
ERRO[2016-07-12T22:31:57Z]   cluster not set                            
ERRO[2016-07-12T22:31:57Z] --------------------                         
ERRO[2016-07-12T22:31:57Z] resource pool '/CNA-DC/host/Mgmt2/Resources' not found 
ERRO[2016-07-12T22:31:57Z] Firewall check SKIPPED                       
ERRO[2016-07-12T22:31:57Z] License check SKIPPED                        
ERRO[2016-07-12T22:31:57Z] DRS check SKIPPED                            
ERRO[2016-07-12T22:31:57Z] Compatibility check SKIPPED                  
ERRO[2016-07-12T22:31:57Z] Create cannot continue: configuration validation failed 
--------------------
vic-machine-linux failed: validation of configuration failed
```