### PR TITLE
vcsim: Avoid NPE in datastore search

### DIFF
--- a/pkg/vsphere/simulator/datastore_test.go
+++ b/pkg/vsphere/simulator/datastore_test.go
@@ -292,6 +292,7 @@ func TestDatastoreHTTP(t *testing.T) {
 		// PUT file = ok
 		upload(dst, false, "PUT")
 		stat(dst, false)
+		ls("", false)
 
 		// GET file exists = ok
 		download(dst, false)

--- a/pkg/vsphere/simulator/host_datastore_browser.go
+++ b/pkg/vsphere/simulator/host_datastore_browser.go
@@ -39,6 +39,10 @@ type searchDatastoreTask struct {
 
 func (s *searchDatastoreTask) addFile(dir string, name string) {
 	details := s.req.SearchSpec.Details
+	if details == nil {
+		details = new(types.FileQueryFlags)
+	}
+
 	file := path.Join(dir, name)
 	st, err := os.Stat(file)
 	if err != nil {


### PR DESCRIPTION
The search spec details field is optional.