### PR TITLE
Temporarily remove default SSH access from appliance for TP3

### DIFF
--- a/isos/appliance-staging.sh
+++ b/isos/appliance-staging.sh
@@ -112,6 +112,9 @@ yum_cached -p $PKGDIR clean all
 pwhash=$(openssl passwd -1 -salt vic password)
 sed -i -e "s/^root:[^:]*:/root:${pwhash}:/" $(rootfs_dir $PKGDIR)/etc/shadow
 
+# 1218: Temporarily disable SSH for TP3
+rm $(rootfs_dir $PKGDIR)/usr/lib/systemd/system/sshd@.service
+
 # Allow root login via ssh
 sed -i -e "s/\#*PermitRootLogin\s.*/PermitRootLogin yes/" $(rootfs_dir $PKGDIR)/etc/ssh/sshd_config
 

--- a/lib/install/management/inspect.go
+++ b/lib/install/management/inspect.go
@@ -59,10 +59,10 @@ func (d *Dispatcher) InspectVCH(vch *vm.VirtualMachine, conf *metadata.VirtualCo
 }
 
 func (d *Dispatcher) ShowVCH(conf *metadata.VirtualContainerHostConfigSpec, key string, cert string) {
-#1218: Temporarily disable SSH access for TP3
-//	log.Infof("")
-//	log.Infof("SSH to appliance (default=root:password)")
-//	log.Infof("ssh root@%s", d.HostIP)
+	// #1218: Temporarily disable SSH access for TP3
+	//	log.Infof("")
+	//	log.Infof("SSH to appliance (default=root:password)")
+	//	log.Infof("ssh root@%s", d.HostIP)
 	log.Infof("")
 	log.Infof("Log server:")
 	log.Infof("%s://%s:2378", d.VICAdminProto, d.HostIP)

--- a/lib/install/management/inspect.go
+++ b/lib/install/management/inspect.go
@@ -59,9 +59,10 @@ func (d *Dispatcher) InspectVCH(vch *vm.VirtualMachine, conf *metadata.VirtualCo
 }
 
 func (d *Dispatcher) ShowVCH(conf *metadata.VirtualContainerHostConfigSpec, key string, cert string) {
-	log.Infof("")
-	log.Infof("SSH to appliance (default=root:password)")
-	log.Infof("ssh root@%s", d.HostIP)
+#1218: Temporarily disable SSH access for TP3
+//	log.Infof("")
+//	log.Infof("SSH to appliance (default=root:password)")
+//	log.Infof("ssh root@%s", d.HostIP)
 	log.Infof("")
 	log.Infof("Log server:")
 	log.Infof("%s://%s:2378", d.VICAdminProto, d.HostIP)


### PR DESCRIPTION
This will be re-enabled once TP3 has been tagged. This is for bug 1218, but it should not be closed by this PR as this is simply a workaround