### PR TITLE
fix panic in network connect case

### DIFF
--- a/lib/apiservers/engine/backends/network.go
+++ b/lib/apiservers/engine/backends/network.go
@@ -190,12 +190,15 @@ func (n *Network) ConnectContainerToNetwork(containerName, networkName string, e
 
 	h := getRes.Payload
 	nc := &models.NetworkConfig{NetworkName: networkName}
-	if endpointConfig != nil && endpointConfig.IPAMConfig != nil && endpointConfig.IPAMConfig.IPv4Address != "" {
-		nc.Address = &endpointConfig.IPAMConfig.IPv4Address
-	}
+	if endpointConfig != nil {
+		if endpointConfig.IPAMConfig != nil && endpointConfig.IPAMConfig.IPv4Address != "" {
+			nc.Address = &endpointConfig.IPAMConfig.IPv4Address
 
-	// Pass Links and Aliases to PL
-	nc.Aliases = EP2Alias(endpointConfig)
+		}
+
+		// Pass Links and Aliases to PL
+		nc.Aliases = EP2Alias(endpointConfig)
+	}
 
 	addConRes, err := client.Scopes.AddContainer(scopes.NewAddContainerParams().
 		WithScope(nc.NetworkName).


### PR DESCRIPTION
This addresses a panic during network connect of a second network. I think this would have only occurred if the two networks were bridge & an external but unconfirmed.

This doesn't address the underlying issue that is in https://github.com/vmware/vic/issues/1459 but does allow network connect to work in this scenario.

Towards #1459 
