### PR TITLE
Reduce the size of our binaries and ISOs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -226,7 +226,7 @@ endif
 
 $(vic-init): $(call godeps,cmd/vic-init/*.go)
 	@echo building vic-init
-	@CGO_ENABLED=1 GOOS=linux GOARCH=amd64 $(GO) build $(RACE) -tags netgo -installsuffix netgo -ldflags '-extldflags "-static"' -o ./$@ ./$(dir $<)
+	@CGO_ENABLED=1 GOOS=linux GOARCH=amd64 $(GO) build $(RACE) -tags netgo -installsuffix netgo -o ./$@ ./$(dir $<)
 
 $(tether-linux): $(call godeps,cmd/tether/*.go)
 	@echo building tether-linux

--- a/cmd/docker/main.go
+++ b/cmd/docker/main.go
@@ -32,7 +32,7 @@ import (
 	"github.com/docker/docker/pkg/signal"
 	"github.com/docker/go-connections/tlsconfig"
 	"github.com/vmware/vic/lib/apiservers/engine/backends"
-	"github.com/vmware/vic/lib/metadata"
+	"github.com/vmware/vic/lib/config"
 	"github.com/vmware/vic/lib/pprof"
 	"github.com/vmware/vic/pkg/trace"
 	"github.com/vmware/vic/pkg/vsphere/extraconfig"
@@ -55,7 +55,7 @@ const (
 	productName = "vSphere Integrated Containers"
 )
 
-var vchConfig metadata.VirtualContainerHostConfigSpec
+var vchConfig config.VirtualContainerHostConfigSpec
 
 func init() {
 	trace.Logger.Level = log.DebugLevel

--- a/cmd/tether/attach.go
+++ b/cmd/tether/attach.go
@@ -22,7 +22,7 @@ import (
 	"syscall"
 
 	log "github.com/Sirupsen/logrus"
-	"github.com/vmware/vic/lib/portlayer/attach"
+	"github.com/vmware/vic/cmd/tether/msgs"
 	"github.com/vmware/vic/lib/tether"
 	"github.com/vmware/vic/pkg/trace"
 	"golang.org/x/crypto/ssh"
@@ -286,14 +286,14 @@ func (t *attachServerSSH) globalMux(reqchan <-chan *ssh.Request) {
 		log.Infof("received global request type %v", req.Type)
 
 		switch req.Type {
-		case attach.ContainersReq:
+		case msgs.ContainersReq:
 			keys := make([]string, len(t.config.Sessions))
 			i := 0
 			for k := range t.config.Sessions {
 				keys[i] = k
 				i++
 			}
-			msg := attach.ContainersMsg{IDs: keys}
+			msg := msgs.ContainersMsg{IDs: keys}
 			payload = msg.Marshal()
 
 		default:
@@ -326,8 +326,8 @@ func (t *attachServerSSH) channelMux(in <-chan *ssh.Request, process *os.Process
 		ok := true
 
 		switch req.Type {
-		case attach.WindowChangeReq:
-			msg := attach.WindowChangeMsg{}
+		case msgs.WindowChangeReq:
+			msg := msgs.WindowChangeMsg{}
 			if pty == nil {
 				ok = false
 				log.Errorf("illegal window-change request for non-tty")
@@ -338,8 +338,8 @@ func (t *attachServerSSH) channelMux(in <-chan *ssh.Request, process *os.Process
 				ok = false
 				log.Errorf(err.Error())
 			}
-		case attach.SignalReq:
-			msg := attach.SignalMsg{}
+		case msgs.SignalReq:
+			msg := msgs.SignalMsg{}
 			if err = msg.Unmarshal(req.Payload); err != nil {
 				ok = false
 				log.Errorf(err.Error())

--- a/cmd/tether/attach_darwin.go
+++ b/cmd/tether/attach_darwin.go
@@ -24,7 +24,7 @@ import (
 	"golang.org/x/crypto/ssh"
 	"golang.org/x/net/context"
 
-	"github.com/vmware/vic/lib/portlayer/attach"
+	"github.com/vmware/vic/cmd/tether/msgs"
 	"github.com/vmware/vic/pkg/serial"
 )
 
@@ -51,7 +51,7 @@ func (t *attachServerSSH) Start() error {
 	return errors.New("not supported on OSX")
 }
 
-func resizePty(pty uintptr, winSize *attach.WindowChangeMsg) error {
+func resizePty(pty uintptr, winSize *msgs.WindowChangeMsg) error {
 	return errors.New("not supported on OSX")
 }
 

--- a/cmd/tether/attach_linux.go
+++ b/cmd/tether/attach_linux.go
@@ -19,7 +19,6 @@ import (
 	"errors"
 	"fmt"
 	"net"
-	_ "net/http/pprof"
 	"os"
 	"syscall"
 	"time"
@@ -30,7 +29,7 @@ import (
 	"golang.org/x/net/context"
 
 	log "github.com/Sirupsen/logrus"
-	"github.com/vmware/vic/lib/portlayer/attach"
+	"github.com/vmware/vic/cmd/tether/msgs"
 	"github.com/vmware/vic/pkg/serial"
 	"github.com/vmware/vic/pkg/trace"
 )
@@ -108,7 +107,7 @@ func (t *attachServerSSH) Start() error {
 	return nil
 }
 
-func resizePty(pty uintptr, winSize *attach.WindowChangeMsg) error {
+func resizePty(pty uintptr, winSize *msgs.WindowChangeMsg) error {
 	defer trace.End(trace.Begin(""))
 
 	ws := &winsize{uint16(winSize.Rows), uint16(winSize.Columns), uint16(winSize.WidthPx), uint16(winSize.HeightPx)}
@@ -125,7 +124,7 @@ func resizePty(pty uintptr, winSize *attach.WindowChangeMsg) error {
 }
 
 func signalProcess(process *os.Process, sig ssh.Signal) error {
-	signal := attach.Signals[sig]
+	signal := msgs.Signals[sig]
 	defer trace.End(trace.Begin(fmt.Sprintf("signal process %d: %s", process.Pid, sig)))
 
 	s := syscall.Signal(signal)

--- a/cmd/tether/attach_test.go
+++ b/cmd/tether/attach_test.go
@@ -35,7 +35,7 @@ import (
 	"golang.org/x/crypto/ssh"
 	"golang.org/x/net/context"
 
-	"github.com/vmware/vic/lib/metadata"
+	"github.com/vmware/vic/lib/config/executor"
 	"github.com/vmware/vic/lib/portlayer/attach"
 	"github.com/vmware/vic/lib/tether"
 	"github.com/vmware/vic/pkg/serial"
@@ -228,21 +228,21 @@ func TestAttach(t *testing.T) {
 
 	testServer, _ := server.(*testAttachServer)
 
-	cfg := metadata.ExecutorConfig{
-		Common: metadata.Common{
+	cfg := executor.ExecutorConfig{
+		Common: executor.Common{
 			ID:   "attach",
 			Name: "tether_test_executor",
 		},
 
-		Sessions: map[string]metadata.SessionConfig{
-			"attach": metadata.SessionConfig{
-				Common: metadata.Common{
+		Sessions: map[string]executor.SessionConfig{
+			"attach": executor.SessionConfig{
+				Common: executor.Common{
 					ID:   "attach",
 					Name: "tether_test_session",
 				},
 				Tty:    false,
 				Attach: true,
-				Cmd: metadata.Cmd{
+				Cmd: executor.Cmd{
 					Path: "/usr/bin/tee",
 					// grep, matching everything, reading from stdin
 					Args: []string{"/usr/bin/tee", pathPrefix + "/tee.out"},
@@ -325,21 +325,21 @@ func TestAttachTTY(t *testing.T) {
 
 	testServer, _ := server.(*testAttachServer)
 
-	cfg := metadata.ExecutorConfig{
-		Common: metadata.Common{
+	cfg := executor.ExecutorConfig{
+		Common: executor.Common{
 			ID:   "attach",
 			Name: "tether_test_executor",
 		},
 
-		Sessions: map[string]metadata.SessionConfig{
-			"attach": metadata.SessionConfig{
-				Common: metadata.Common{
+		Sessions: map[string]executor.SessionConfig{
+			"attach": executor.SessionConfig{
+				Common: executor.Common{
 					ID:   "attach",
 					Name: "tether_test_session",
 				},
 				Tty:    true,
 				Attach: true,
-				Cmd: metadata.Cmd{
+				Cmd: executor.Cmd{
 					Path: "/usr/bin/tee",
 					// grep, matching everything, reading from stdin
 					Args: []string{"/usr/bin/tee", pathPrefix + "/tee.out"},
@@ -425,21 +425,21 @@ func TestAttachTwo(t *testing.T) {
 
 	testServer, _ := server.(*testAttachServer)
 
-	cfg := metadata.ExecutorConfig{
-		Common: metadata.Common{
+	cfg := executor.ExecutorConfig{
+		Common: executor.Common{
 			ID:   "tee1",
 			Name: "tether_test_executor",
 		},
 
-		Sessions: map[string]metadata.SessionConfig{
-			"tee1": metadata.SessionConfig{
-				Common: metadata.Common{
+		Sessions: map[string]executor.SessionConfig{
+			"tee1": executor.SessionConfig{
+				Common: executor.Common{
 					ID:   "tee1",
 					Name: "tether_test_session",
 				},
 				Tty:    false,
 				Attach: true,
-				Cmd: metadata.Cmd{
+				Cmd: executor.Cmd{
 					Path: "/usr/bin/tee",
 					// grep, matching everything, reading from stdin
 					Args: []string{"/usr/bin/tee", pathPrefix + "/tee.out"},
@@ -447,14 +447,14 @@ func TestAttachTwo(t *testing.T) {
 					Dir:  "/",
 				},
 			},
-			"tee2": metadata.SessionConfig{
-				Common: metadata.Common{
+			"tee2": executor.SessionConfig{
+				Common: executor.Common{
 					ID:   "tee2",
 					Name: "tether_test_session2",
 				},
 				Tty:    false,
 				Attach: true,
-				Cmd: metadata.Cmd{
+				Cmd: executor.Cmd{
 					Path: "/usr/bin/tee",
 					// grep, matching everything, reading from stdin
 					Args: []string{"/usr/bin/tee", pathPrefix + "/tee2.out"},
@@ -578,21 +578,21 @@ func TestAttachInvalid(t *testing.T) {
 
 	testServer, _ := server.(*testAttachServer)
 
-	cfg := metadata.ExecutorConfig{
-		Common: metadata.Common{
+	cfg := executor.ExecutorConfig{
+		Common: executor.Common{
 			ID:   "attachinvalid",
 			Name: "tether_test_executor",
 		},
 
-		Sessions: map[string]metadata.SessionConfig{
-			"valid": metadata.SessionConfig{
-				Common: metadata.Common{
+		Sessions: map[string]executor.SessionConfig{
+			"valid": executor.SessionConfig{
+				Common: executor.Common{
 					ID:   "valid",
 					Name: "tether_test_session",
 				},
 				Tty:    true,
 				Attach: true,
-				Cmd: metadata.Cmd{
+				Cmd: executor.Cmd{
 					Path: "/usr/bin/tee",
 					// grep, matching everything, reading from stdin
 					Args: []string{"/usr/bin/tee", pathPrefix + "/tee.out"},
@@ -655,21 +655,21 @@ func TestMockAttachTetherToPL(t *testing.T) {
 	assert.NoError(t, testServer.Start())
 	defer testServer.Stop()
 
-	cfg := metadata.ExecutorConfig{
-		Common: metadata.Common{
+	cfg := executor.ExecutorConfig{
+		Common: executor.Common{
 			ID:   "attach",
 			Name: "tether_test_executor",
 		},
 
-		Sessions: map[string]metadata.SessionConfig{
-			"attach": metadata.SessionConfig{
-				Common: metadata.Common{
+		Sessions: map[string]executor.SessionConfig{
+			"attach": executor.SessionConfig{
+				Common: executor.Common{
 					ID:   "attach",
 					Name: "tether_test_session",
 				},
 				Tty:    true,
 				Attach: true,
-				Cmd: metadata.Cmd{
+				Cmd: executor.Cmd{
 					Path: "/usr/bin/tee",
 					// grep, matching everything, reading from stdin
 					Args: []string{"/usr/bin/tee", pathPrefix + "/tee.out"},

--- a/cmd/tether/attach_windows.go
+++ b/cmd/tether/attach_windows.go
@@ -26,7 +26,7 @@ import (
 	"golang.org/x/net/context"
 
 	log "github.com/Sirupsen/logrus"
-	"github.com/vmware/vic/lib/portlayer/attach"
+	"github.com/vmware/vic/cmd/tether/msgs"
 	"github.com/vmware/vic/pkg/serial"
 )
 
@@ -79,7 +79,7 @@ func (t *attachServerSSH) Start() error {
 	return nil
 }
 
-func resizePty(pty uintptr, winSize *attach.WindowChangeMsg) error {
+func resizePty(pty uintptr, winSize *msgs.WindowChangeMsg) error {
 	return errors.New("not supported on windows")
 }
 

--- a/cmd/tether/msgs/messages.go
+++ b/cmd/tether/msgs/messages.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package attach
+package msgs
 
 import "golang.org/x/crypto/ssh"
 

--- a/cmd/tether/msgs/messages_test.go
+++ b/cmd/tether/msgs/messages_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package attach
+package msgs
 
 import (
 	"testing"

--- a/cmd/tether/ops_linux.go
+++ b/cmd/tether/ops_linux.go
@@ -18,7 +18,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	_ "net/http/pprof"
 	"os"
 	"syscall"
 

--- a/cmd/tether/tether_test.go
+++ b/cmd/tether/tether_test.go
@@ -29,8 +29,7 @@ import (
 	"golang.org/x/crypto/ssh"
 	"golang.org/x/net/context"
 
-	"github.com/vmware/govmomi/vim25/types"
-	"github.com/vmware/vic/lib/metadata"
+	"github.com/vmware/vic/lib/config/executor"
 	"github.com/vmware/vic/lib/tether"
 	"github.com/vmware/vic/pkg/dio"
 	"github.com/vmware/vic/pkg/trace"
@@ -169,7 +168,7 @@ func TestMain(m *testing.M) {
 	os.Exit(retCode)
 }
 
-func StartAttachTether(t *testing.T, cfg *metadata.ExecutorConfig) (tether.Tether, extraconfig.DataSource, net.Conn) {
+func StartAttachTether(t *testing.T, cfg *executor.ExecutorConfig) (tether.Tether, extraconfig.DataSource, net.Conn) {
 	store := map[string]string{}
 	sink := extraconfig.MapSink(store)
 	src := extraconfig.MapSource(store)
@@ -197,18 +196,6 @@ func StartAttachTether(t *testing.T, cfg *metadata.ExecutorConfig) (tether.Tethe
 	}
 
 	return tthr, src, conn
-}
-
-func OptionValueArrayToString(options []types.BaseOptionValue) string {
-	// create the key/value store from the extraconfig slice for lookups
-	kv := make(map[string]string)
-	for i := range options {
-		k := options[i].GetOptionValue().Key
-		v := options[i].GetOptionValue().Value.(string)
-		kv[k] = v
-	}
-
-	return fmt.Sprintf("%#v", kv)
 }
 
 func tetherTestSetup(t *testing.T) string {

--- a/cmd/vic-init/restart_test.go
+++ b/cmd/vic-init/restart_test.go
@@ -21,7 +21,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/vmware/vic/lib/metadata"
+	"github.com/vmware/vic/lib/config/executor"
 	"github.com/vmware/vic/lib/tether"
 	"github.com/vmware/vic/pkg/vsphere/extraconfig"
 )
@@ -36,22 +36,22 @@ func TestRestart(t *testing.T) {
 	testSetup(t)
 	defer testTeardown(t)
 
-	cfg := metadata.ExecutorConfig{
-		Common: metadata.Common{
+	cfg := executor.ExecutorConfig{
+		Common: executor.Common{
 			ID:   "pathlookup",
 			Name: "tether_test_executor",
 		},
-		Diagnostics: metadata.Diagnostics{
+		Diagnostics: executor.Diagnostics{
 			DebugLevel: 2,
 		},
-		Sessions: map[string]metadata.SessionConfig{
-			"pathlookup": metadata.SessionConfig{
-				Common: metadata.Common{
+		Sessions: map[string]executor.SessionConfig{
+			"pathlookup": executor.SessionConfig{
+				Common: executor.Common{
 					ID:   "pathlookup",
 					Name: "tether_test_session",
 				},
 				Tty: false,
-				Cmd: metadata.Cmd{
+				Cmd: executor.Cmd{
 					// test relative path
 					Path: "date",
 					Args: []string{"date", "--reference=/"},

--- a/cmd/vic-init/tether_test.go
+++ b/cmd/vic-init/tether_test.go
@@ -30,7 +30,7 @@ import (
 	"golang.org/x/net/context"
 
 	"github.com/vmware/govmomi/vim25/types"
-	"github.com/vmware/vic/lib/metadata"
+	"github.com/vmware/vic/lib/config/executor"
 	"github.com/vmware/vic/lib/tether"
 	"github.com/vmware/vic/pkg/dio"
 	"github.com/vmware/vic/pkg/trace"
@@ -134,7 +134,7 @@ func (t *Mocker) SetHostname(hostname string, aliases ...string) error {
 }
 
 // Apply takes the network endpoint configuration and applies it to the system
-func (t *Mocker) Apply(endpoint *metadata.NetworkEndpoint) error {
+func (t *Mocker) Apply(endpoint *executor.NetworkEndpoint) error {
 	defer trace.End(trace.Begin("mocking endpoint configuration for " + endpoint.Network.Name))
 	t.IPs[endpoint.Network.Name] = endpoint.Assigned
 
@@ -171,7 +171,7 @@ func TestMain(m *testing.M) {
 	os.Exit(retCode)
 }
 
-func StartTether(t *testing.T, cfg *metadata.ExecutorConfig) (tether.Tether, extraconfig.DataSource) {
+func StartTether(t *testing.T, cfg *executor.ExecutorConfig) (tether.Tether, extraconfig.DataSource) {
 	store := map[string]string{}
 	sink := extraconfig.MapSink(store)
 	src := extraconfig.MapSource(store)
@@ -192,7 +192,7 @@ func StartTether(t *testing.T, cfg *metadata.ExecutorConfig) (tether.Tether, ext
 	return tthr, src
 }
 
-func RunTether(t *testing.T, cfg *metadata.ExecutorConfig) (tether.Tether, extraconfig.DataSource, error) {
+func RunTether(t *testing.T, cfg *executor.ExecutorConfig) (tether.Tether, extraconfig.DataSource, error) {
 	store := map[string]string{}
 	sink := extraconfig.MapSink(store)
 	src := extraconfig.MapSource(store)

--- a/cmd/vicadmin/vicadm.go
+++ b/cmd/vicadmin/vicadm.go
@@ -37,7 +37,7 @@ import (
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/vim25/types"
 
-	"github.com/vmware/vic/lib/metadata"
+	vchconfig "github.com/vmware/vic/lib/config"
 	"github.com/vmware/vic/lib/pprof"
 	"github.com/vmware/vic/pkg/trace"
 	"github.com/vmware/vic/pkg/version"
@@ -64,7 +64,7 @@ var (
 	// VMFiles is the set of files to collect per VM associated with the VCH
 	vmFiles = []string{
 		"vmware.log",
-		string(metadata.VM + ".debug"),
+		string(vchconfig.VM + ".debug"),
 	}
 
 	config struct {
@@ -79,9 +79,9 @@ var (
 		tls          bool
 	}
 
-	resources metadata.Resources
+	resources vchconfig.Resources
 
-	vchConfig metadata.VirtualContainerHostConfigSpec
+	vchConfig vchconfig.VirtualContainerHostConfigSpec
 
 	defaultReaders map[string]entryReader
 
@@ -334,7 +334,7 @@ func findDatastoreLogs(c *session.Session) (map[string]entryReader, error) {
 		// generate the full paths to collect
 		for _, file := range vmFiles {
 			// replace the VM token in file name with the VM name
-			processed := strings.Replace(file, string(metadata.VM), path.Base(vmpath.Path), -1)
+			processed := strings.Replace(file, string(vchconfig.VM), path.Base(vmpath.Path), -1)
 			rpath := fmt.Sprintf("%s/%s", vmpath.Path, processed)
 			readers[rpath] = datastoreReader{
 				ds:   ds,

--- a/cmd/vicadmin/vicadm_test.go
+++ b/cmd/vicadmin/vicadm_test.go
@@ -32,7 +32,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/vmware/vic/lib/config"
+
+	vchconfig "github.com/vmware/vic/lib/config"
 	"github.com/vmware/vic/pkg/vsphere/test/env"
 )
 
@@ -70,7 +71,7 @@ func init() {
 	if kerr != nil || cerr != nil {
 		panic("unable to load test certificate")
 	}
-	vchConfig.HostCertificate = &config.RawCertificate{
+	vchConfig.HostCertificate = &vchconfig.RawCertificate{
 		Cert: cert,
 		Key:  key,
 	}

--- a/cmd/vicadmin/vicadm_test.go
+++ b/cmd/vicadmin/vicadm_test.go
@@ -32,7 +32,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/vmware/vic/lib/metadata"
+	"github.com/vmware/vic/lib/config"
 	"github.com/vmware/vic/pkg/vsphere/test/env"
 )
 
@@ -70,7 +70,7 @@ func init() {
 	if kerr != nil || cerr != nil {
 		panic("unable to load test certificate")
 	}
-	vchConfig.HostCertificate = &metadata.RawCertificate{
+	vchConfig.HostCertificate = &config.RawCertificate{
 		Cert: cert,
 		Key:  key,
 	}

--- a/isos/appliance.sh
+++ b/isos/appliance.sh
@@ -91,7 +91,7 @@ cp ${DIR}/appliance/imagec.sh $(rootfs_dir $PKGDIR)/sbin/imagec
 cp ${BIN}/vic-init $(rootfs_dir $PKGDIR)/sbin/vic-init
 
 cp ${BIN}/imagec $(rootfs_dir $PKGDIR)/sbin/imagec.bin
-cp ${BIN}/{docker-engine-server,port-layer-server,rpctool,vicadmin} $(rootfs_dir $PKGDIR)/sbin/
+cp ${BIN}/{docker-engine-server,port-layer-server,vicadmin} $(rootfs_dir $PKGDIR)/sbin/
 
 echo "net.ipv4.ip_forward = 1" > $(rootfs_dir $PKGDIR)/usr/lib/sysctl.d/50-vic.conf
 

--- a/isos/appliance/imagec.sh
+++ b/isos/appliance/imagec.sh
@@ -16,8 +16,4 @@
 
 # imagec wrapper file - furnish the pretence of rpctool based default args
 
-debuglevel="$(rpctool -get guestinfo./init/common/diagnostics/debug)"
-if [ "$debuglevel" != "0" -a "$debuglevel" != "" ]; then
-    debug="-debug"
-fi
-/sbin/imagec.bin $debug -logfile=/var/log/vic/imagec.log --insecure-allow-http --insecure-skip-verify "$@"
+/sbin/imagec.bin -debug -logfile=/var/log/vic/imagec.log --insecure-allow-http --insecure-skip-verify "$@"

--- a/isos/base.sh
+++ b/isos/base.sh
@@ -68,7 +68,7 @@ cp $DIR/base/*.repo $(rootfs_dir $PKGDIR)/etc/yum.repos.d/
 cp $DIR/base/yum.conf $(rootfs_dir $PKGDIR)/etc/yum/
 
 # install the core packages
-yum_cached -c $cache -u -p $PKGDIR install filesystem coreutils bash linux-esx --nogpgcheck -y
+yum_cached -c $cache -u -p $PKGDIR install filesystem coreutils linux-esx --nogpgcheck -y
 # strip the cache from the resulting image
 yum_cached -c $cache -p $PKGDIR clean all
 

--- a/isos/bootstrap-staging.sh
+++ b/isos/bootstrap-staging.sh
@@ -102,9 +102,6 @@ fi
 #   libtirpc  # due to a previous package reliance on rpc
 #
 yum_cached -c $cache -u -p $PKGDIR install \
-    iproute2 \
-    libtirpc \
-    grep \
     haveged \
     systemd \
     -y --nogpgcheck

--- a/isos/bootstrap.sh
+++ b/isos/bootstrap.sh
@@ -74,6 +74,7 @@ unpack $package $PKGDIR
 if [ -v debug ]; then
     export ISONAME="bootstrap-debug.iso"
     cp ${DIR}/bootstrap/bootstrap.debug $(rootfs_dir $PKGDIR)/bin/bootstrap
+    cp ${BIN}/rpctool $(rootfs_dir $PKGDIR)/sbin/
 else
     export ISONAME="bootstrap.iso"
     cp ${DIR}/bootstrap/bootstrap $(rootfs_dir $PKGDIR)/bin/bootstrap
@@ -81,7 +82,6 @@ fi
 
 # copy in our components
 cp ${BIN}/tether-linux $(rootfs_dir $PKGDIR)/bin/tether
-cp ${BIN}/rpctool $(rootfs_dir $PKGDIR)/sbin/
 
 # kick off our components at boot time
 cp ${DIR}/bootstrap/tether.service $(rootfs_dir $PKGDIR)/etc/systemd/system/

--- a/isos/bootstrap/bootstrap
+++ b/isos/bootstrap/bootstrap
@@ -1,39 +1,22 @@
 #!/bin/bash
 
+set -x
+
 MOUNTPOINT="/mnt/containerfs"
 
 mkdir -p /mnt/containerfs
 
-# see if we should bail to the bootstrap or pivot into the container
-# do this before the fork so we don't have a backdoor call in the hot path
-# NOTE: this is moved after the fork during debugging so we can chose on a per VM basis
-SHELL=`/sbin/rpctool -get bootstrap-shell 2>/dev/null`
-
 echo "Waiting for rootfs"
 while [ ! -e /dev/disk/by-label/containerfs ]; do :;done
 if mount -t ext4 /dev/disk/by-label/containerfs ${MOUNTPOINT}; then
-    # make the required directory structure, but presume that something in the daemon
-    # has done the *right* thing for /.tether* and created them where it won't show in a diff
-    # we do this to ensure that subsequent commands don't fail if the daemon hasn't prepped
-    # the structure
-    mkdir -p ${MOUNTPOINT}/.tether ${MOUNTPOINT}/.tether-init
-
+    # ensure mountpoint exists
+    mkdir -p ${MOUNTPOINT}/.tether
+ 
     # ensure that no matter what we have access to required devices
     # WARNING WARNING WARNING WARNING WARNING
     # if the tmpfs is not large enough odd hangs can occur and the ESX event log will
     # report the guest disabling the CPU
     mount -t tmpfs -o size=64m tmpfs ${MOUNTPOINT}/.tether/
-
-    # if we don't have a populated init layer, pull from guestinfo
-    if [ ! -f ${MOUNTPOINT}/.tether-init/docker-id ]; then
-        mount -t tmpfs -o size=1m tmpfs ${MOUNTPOINT}/.tether-init/
-        # create the assumed structure
-        # TODO: this cannot be in guest and still not show up in diffs
-        mkdir -p ${MOUNTPOINT}/dev ${MOUNTPOINT}/proc ${MOUNTPOINT}/sys ${MOUNTPOINT}/etc
-    fi
-
-    # this is so we're not exposing the raw container disk if we wouldn't be otherwise
-    #	rm -f /mnt/.tether/volumes/containerfs
 
     # enable full system functionality in the container
     echo "Publishing modules within container"
@@ -46,13 +29,7 @@ if mount -t ext4 /dev/disk/by-label/containerfs ${MOUNTPOINT}; then
     cp /bin/tether ${MOUNTPOINT}/.tether/tether
 
     echo "switching to the new mount"
-    if [ "$SHELL" != "true" ]; then
-        systemctl switch-root ${MOUNTPOINT} /.tether/tether 2>&1
-    else
-        systemctl switch-root ${MOUNTPOINT} /bin/sh 2>&1
-        # fail back to shell in bootstrap image without switch_root
-        /bin/ash
-    fi
+    systemctl switch-root ${MOUNTPOINT} /.tether/tether 2>&1
 else
     # TODO: what do we do here? we really need to somehow report an error
     # fail hard

--- a/lib/apiservers/engine/backends/vicbackends.go
+++ b/lib/apiservers/engine/backends/vicbackends.go
@@ -22,7 +22,7 @@ import (
 	httptransport "github.com/go-swagger/go-swagger/httpkit/client"
 	"github.com/vmware/vic/lib/apiservers/engine/backends/cache"
 	"github.com/vmware/vic/lib/apiservers/portlayer/client"
-	"github.com/vmware/vic/lib/metadata"
+	"github.com/vmware/vic/lib/config"
 )
 
 const (
@@ -44,10 +44,10 @@ var (
 	productName         string
 	productVersion      string
 
-	vchConfig *metadata.VirtualContainerHostConfigSpec
+	vchConfig *config.VirtualContainerHostConfigSpec
 )
 
-func Init(portLayerAddr, product string, config *metadata.VirtualContainerHostConfigSpec) error {
+func Init(portLayerAddr, product string, config *config.VirtualContainerHostConfigSpec) error {
 	_, _, err := net.SplitHostPort(portLayerAddr)
 	if err != nil {
 		return err
@@ -111,6 +111,6 @@ func ProductVersion() string {
 	return productVersion
 }
 
-func VchConfig() *metadata.VirtualContainerHostConfigSpec {
+func VchConfig() *config.VirtualContainerHostConfigSpec {
 	return vchConfig
 }

--- a/lib/apiservers/portlayer/restapi/handlers/containers_handlers.go
+++ b/lib/apiservers/portlayer/restapi/handlers/containers_handlers.go
@@ -32,7 +32,7 @@ import (
 	"github.com/vmware/vic/lib/apiservers/portlayer/restapi/operations"
 	"github.com/vmware/vic/lib/apiservers/portlayer/restapi/operations/containers"
 	"github.com/vmware/vic/lib/apiservers/portlayer/restapi/options"
-	"github.com/vmware/vic/lib/metadata"
+	"github.com/vmware/vic/lib/config/executor"
 	"github.com/vmware/vic/lib/portlayer/exec"
 	"github.com/vmware/vic/pkg/trace"
 )
@@ -83,21 +83,21 @@ func (handler *ContainersHandlersImpl) CreateHandler(params containers.CreatePar
 		Bytes:   x509.MarshalPKCS1PrivateKey(privateKey),
 	}
 
-	m := metadata.ExecutorConfig{
-		Common: metadata.Common{
+	m := executor.ExecutorConfig{
+		Common: executor.Common{
 			ID:   id,
 			Name: *params.CreateConfig.Name,
 		},
-		Sessions: map[string]metadata.SessionConfig{
-			id: metadata.SessionConfig{
-				Common: metadata.Common{
+		Sessions: map[string]executor.SessionConfig{
+			id: executor.SessionConfig{
+				Common: executor.Common{
 					ID:   id,
 					Name: *params.CreateConfig.Name,
 				},
 				Tty: *params.CreateConfig.Tty,
 				// FIXME: default to true for now until we can have a more sophisticated approach
 				Attach: true,
-				Cmd: metadata.Cmd{
+				Cmd: executor.Cmd{
 					Env:  params.CreateConfig.Env,
 					Dir:  *params.CreateConfig.WorkingDir,
 					Path: *params.CreateConfig.Path,

--- a/lib/config/executor/container_vm.go
+++ b/lib/config/executor/container_vm.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package metadata
+package executor
 
 import (
 	"net/url"

--- a/lib/config/executor/network_interface.go
+++ b/lib/config/executor/network_interface.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package metadata
+package executor
 
 import (
 	"net"

--- a/lib/config/virtual_container_host.go
+++ b/lib/config/virtual_container_host.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package metadata
+package config
 
 import (
 	"crypto/tls"
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/vmware/govmomi/vim25/types"
+	"github.com/vmware/vic/lib/config/executor"
 )
 
 // PatternToken is a set of tokens that can be placed into string constants
@@ -51,7 +52,7 @@ type VirtualContainerHostConfigSpec struct {
 	// The base config for the appliance. This includes the networks that are to be attached
 	// and disks to be mounted.
 	// Networks are keyed by interface name
-	ExecutorConfig `vic:"0.1" scope:"read-only" key:"init"`
+	executor.ExecutorConfig `vic:"0.1" scope:"read-only" key:"init"`
 
 	////////////// vSphere connection configuration
 	// The sdk URL
@@ -99,7 +100,7 @@ type VirtualContainerHostConfigSpec struct {
 	BridgeNetwork       string `vic:"0.1" scope:"read-only" key:"bridge_network"`
 	CreateBridgeNetwork bool   `vic:"0.1" scope:"read-only" key:"create_bridge_network"`
 	// Published networks available for containers to join, keyed by consumption name
-	ContainerNetworks map[string]*ContainerNetwork `vic:"0.1" scope:"read-only" key:"container_networks"`
+	ContainerNetworks map[string]*executor.ContainerNetwork `vic:"0.1" scope:"read-only" key:"container_networks"`
 	// The IP range for the bridge networks
 	BridgeIPRange *net.IPNet `vic:"0.1" scope:"read-only" key:"bridge-ip-range"`
 
@@ -173,10 +174,10 @@ func (t *VirtualContainerHostConfigSpec) SetMoref(moref *types.ManagedObjectRefe
 }
 
 // AddNetwork adds a network that will be configured on the appliance VM
-func (t *VirtualContainerHostConfigSpec) AddNetwork(net *NetworkEndpoint) {
+func (t *VirtualContainerHostConfigSpec) AddNetwork(net *executor.NetworkEndpoint) {
 	if net != nil {
 		if t.ExecutorConfig.Networks == nil {
-			t.ExecutorConfig.Networks = make(map[string]*NetworkEndpoint)
+			t.ExecutorConfig.Networks = make(map[string]*executor.NetworkEndpoint)
 		}
 
 		t.ExecutorConfig.Networks[net.Network.Name] = net
@@ -184,20 +185,20 @@ func (t *VirtualContainerHostConfigSpec) AddNetwork(net *NetworkEndpoint) {
 }
 
 // AddContainerNetwork adds a network that will be configured on the appliance VM
-func (t *VirtualContainerHostConfigSpec) AddContainerNetwork(net *ContainerNetwork) {
+func (t *VirtualContainerHostConfigSpec) AddContainerNetwork(net *executor.ContainerNetwork) {
 	if net != nil {
 		if t.ContainerNetworks == nil {
-			t.ContainerNetworks = make(map[string]*ContainerNetwork)
+			t.ContainerNetworks = make(map[string]*executor.ContainerNetwork)
 		}
 
 		t.ContainerNetworks[net.Name] = net
 	}
 }
 
-func (t *VirtualContainerHostConfigSpec) AddComponent(name string, component *SessionConfig) {
+func (t *VirtualContainerHostConfigSpec) AddComponent(name string, component *executor.SessionConfig) {
 	if component != nil {
 		if t.ExecutorConfig.Sessions == nil {
-			t.ExecutorConfig.Sessions = make(map[string]SessionConfig)
+			t.ExecutorConfig.Sessions = make(map[string]executor.SessionConfig)
 		}
 
 		if component.Name == "" {
@@ -241,9 +242,9 @@ func (t *VirtualContainerHostConfigSpec) SetvSphereTarget(url *url.URL) {
 	}
 }
 
-func CreateSession(cmd string, args ...string) *SessionConfig {
-	cfg := &SessionConfig{
-		Cmd: Cmd{
+func CreateSession(cmd string, args ...string) *executor.SessionConfig {
+	cfg := &executor.SessionConfig{
+		Cmd: executor.Cmd{
 			Path: cmd,
 			Args: []string{
 				cmd,

--- a/lib/dns/dns_test.go
+++ b/lib/dns/dns_test.go
@@ -21,7 +21,7 @@ import (
 	log "github.com/Sirupsen/logrus"
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/vim25/types"
-	"github.com/vmware/vic/lib/metadata"
+	"github.com/vmware/vic/lib/config/executor"
 	"github.com/vmware/vic/lib/portlayer/exec"
 	"github.com/vmware/vic/lib/portlayer/network"
 
@@ -96,7 +96,7 @@ func TestVIC(t *testing.T) {
 		BridgeNetwork: "bridge",
 		ContainerNetworks: map[string]*network.ContainerNetwork{
 			"bridge": &network.ContainerNetwork{
-				Common: metadata.Common{
+				Common: executor.Common{
 					Name: "testBridge",
 				},
 				PortGroup: bridgeNetwork,

--- a/lib/install/data/data.go
+++ b/lib/install/data/data.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/vmware/govmomi/vim25/types"
 	"github.com/vmware/vic/cmd/vic-machine/common"
-	"github.com/vmware/vic/lib/metadata"
+	"github.com/vmware/vic/lib/config"
 	"github.com/vmware/vic/pkg/ip"
 )
 
@@ -75,9 +75,9 @@ type Data struct {
 // InstallerData is used to hold the transient installation configuration that shouldn't be serialized
 type InstallerData struct {
 	// Virtual Container Host capacity
-	VCHSize metadata.Resources
+	VCHSize config.Resources
 	// Appliance capacity
-	ApplianceSize metadata.Resources
+	ApplianceSize config.Resources
 
 	KeyPEM  string
 	CertPEM string

--- a/lib/install/management/create.go
+++ b/lib/install/management/create.go
@@ -22,8 +22,8 @@ import (
 
 	log "github.com/Sirupsen/logrus"
 
+	"github.com/vmware/vic/lib/config"
 	"github.com/vmware/vic/lib/install/data"
-	"github.com/vmware/vic/lib/metadata"
 	"github.com/vmware/vic/pkg/errors"
 	"github.com/vmware/vic/pkg/trace"
 	"github.com/vmware/vic/pkg/vsphere/tasks"
@@ -34,7 +34,7 @@ import (
 	"golang.org/x/net/context"
 )
 
-func (d *Dispatcher) CreateVCH(conf *metadata.VirtualContainerHostConfigSpec, settings *data.InstallerData) error {
+func (d *Dispatcher) CreateVCH(conf *config.VirtualContainerHostConfigSpec, settings *data.InstallerData) error {
 	defer trace.End(trace.Begin(conf.Name))
 
 	var err error
@@ -146,7 +146,7 @@ func (d *Dispatcher) uploadImages(files []string) error {
 	return nil
 }
 
-func (d *Dispatcher) RegisterExtension(conf *metadata.VirtualContainerHostConfigSpec, extension types.Extension) error {
+func (d *Dispatcher) RegisterExtension(conf *config.VirtualContainerHostConfigSpec, extension types.Extension) error {
 	defer trace.End(trace.Begin(conf.ExtensionName))
 
 	log.Infoln("Registering VCH as a vSphere extension")

--- a/lib/install/management/create_test.go
+++ b/lib/install/management/create_test.go
@@ -21,9 +21,9 @@ import (
 
 	log "github.com/Sirupsen/logrus"
 
+	"github.com/vmware/vic/lib/config"
 	"github.com/vmware/vic/lib/install/data"
 	"github.com/vmware/vic/lib/install/validate"
-	"github.com/vmware/vic/lib/metadata"
 	"github.com/vmware/vic/pkg/vsphere/session"
 	"github.com/vmware/vic/pkg/vsphere/simulator"
 
@@ -81,7 +81,7 @@ func TestMain(t *testing.T) {
 
 		testCreateVolumeStores(ctx, validator.Session, conf, false, t)
 		testDeleteVolumeStores(ctx, validator.Session, conf, 1, t)
-		errConf := &metadata.VirtualContainerHostConfigSpec{}
+		errConf := &config.VirtualContainerHostConfigSpec{}
 		*errConf = *conf
 		errConf.VolumeLocations = make(map[string]*url.URL)
 		errConf.VolumeLocations["volume-store"], _ = url.Parse("ds://store_not_exist/volumes/test")
@@ -155,7 +155,7 @@ func getVPXSession(ctx context.Context, service string) (*session.Session, error
 	return s, nil
 }
 
-func testCreateNetwork(ctx context.Context, sess *session.Session, conf *metadata.VirtualContainerHostConfigSpec, t *testing.T) {
+func testCreateNetwork(ctx context.Context, sess *session.Session, conf *config.VirtualContainerHostConfigSpec, t *testing.T) {
 	d := &Dispatcher{
 		session: sess,
 		ctx:     ctx,
@@ -177,7 +177,7 @@ func testCreateNetwork(ctx context.Context, sess *session.Session, conf *metadat
 	}
 }
 
-func testCreateVolumeStores(ctx context.Context, sess *session.Session, conf *metadata.VirtualContainerHostConfigSpec, hasErr bool, t *testing.T) {
+func testCreateVolumeStores(ctx context.Context, sess *session.Session, conf *config.VirtualContainerHostConfigSpec, hasErr bool, t *testing.T) {
 	d := &Dispatcher{
 		session: sess,
 		ctx:     ctx,
@@ -214,7 +214,7 @@ func testDeleteVolumeStores(ctx context.Context, sess *session.Session, conf *me
 }
 
 // FIXME: Failed to find IDE controller in simulator, so create appliance failed
-func testCreateAppliance(ctx context.Context, sess *session.Session, conf *metadata.VirtualContainerHostConfigSpec, vConf *data.InstallerData, hasErr bool, t *testing.T) {
+func testCreateAppliance(ctx context.Context, sess *session.Session, conf *config.VirtualContainerHostConfigSpec, vConf *data.InstallerData, hasErr bool, t *testing.T) {
 	d := &Dispatcher{
 		session: sess,
 		ctx:     ctx,

--- a/lib/install/management/create_test.go
+++ b/lib/install/management/create_test.go
@@ -199,7 +199,7 @@ func testCreateVolumeStores(ctx context.Context, sess *session.Session, conf *co
 	}
 }
 
-func testDeleteVolumeStores(ctx context.Context, sess *session.Session, conf *metadata.VirtualContainerHostConfigSpec, numVols int, t *testing.T) {
+func testDeleteVolumeStores(ctx context.Context, sess *session.Session, conf *config.VirtualContainerHostConfigSpec, numVols int, t *testing.T) {
 	d := &Dispatcher{
 		session: sess,
 		ctx:     ctx,

--- a/lib/install/management/delete.go
+++ b/lib/install/management/delete.go
@@ -20,7 +20,7 @@ import (
 	log "github.com/Sirupsen/logrus"
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/vim25/types"
-	"github.com/vmware/vic/lib/metadata"
+	"github.com/vmware/vic/lib/config"
 	"github.com/vmware/vic/pkg/errors"
 	"github.com/vmware/vic/pkg/trace"
 	"github.com/vmware/vic/pkg/vsphere/compute"
@@ -30,7 +30,7 @@ import (
 	"golang.org/x/net/context"
 )
 
-func (d *Dispatcher) DeleteVCH(conf *metadata.VirtualContainerHostConfigSpec) error {
+func (d *Dispatcher) DeleteVCH(conf *config.VirtualContainerHostConfigSpec) error {
 	defer trace.End(trace.Begin(conf.Name))
 
 	var errs []string
@@ -89,7 +89,7 @@ func (d *Dispatcher) DeleteVCH(conf *metadata.VirtualContainerHostConfigSpec) er
 	return nil
 }
 
-func (d *Dispatcher) DeleteVCHInstances(vmm *vm.VirtualMachine, conf *metadata.VirtualContainerHostConfigSpec) error {
+func (d *Dispatcher) DeleteVCHInstances(vmm *vm.VirtualMachine, conf *config.VirtualContainerHostConfigSpec) error {
 	defer trace.End(trace.Begin(""))
 
 	log.Infof("Removing VMs")
@@ -148,7 +148,7 @@ func (d *Dispatcher) DeleteVCHInstances(vmm *vm.VirtualMachine, conf *metadata.V
 	return nil
 }
 
-func (d *Dispatcher) deleteNetworkDevices(vmm *vm.VirtualMachine, conf *metadata.VirtualContainerHostConfigSpec) error {
+func (d *Dispatcher) deleteNetworkDevices(vmm *vm.VirtualMachine, conf *config.VirtualContainerHostConfigSpec) error {
 	defer trace.End(trace.Begin(""))
 
 	log.Infof("Removing appliance VM network devices")

--- a/lib/install/management/delete_test.go
+++ b/lib/install/management/delete_test.go
@@ -26,9 +26,9 @@ import (
 
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/vim25/types"
+	"github.com/vmware/vic/lib/config"
 	"github.com/vmware/vic/lib/install/data"
 	"github.com/vmware/vic/lib/install/validate"
-	"github.com/vmware/vic/lib/metadata"
 	"github.com/vmware/vic/pkg/trace"
 	"github.com/vmware/vic/pkg/vsphere/session"
 	"github.com/vmware/vic/pkg/vsphere/simulator"
@@ -95,7 +95,7 @@ func TestDelete(t *testing.T) {
 	}
 }
 
-func createAppliance(ctx context.Context, sess *session.Session, conf *metadata.VirtualContainerHostConfigSpec, vConf *data.InstallerData, hasErr bool, t *testing.T) {
+func createAppliance(ctx context.Context, sess *session.Session, conf *config.VirtualContainerHostConfigSpec, vConf *data.InstallerData, hasErr bool, t *testing.T) {
 	var err error
 
 	d := &Dispatcher{
@@ -172,7 +172,7 @@ func testNewVCHFromCompute(computePath string, name string, v *validate.Validato
 	t.Logf("Got VCH %s, path %s", vch, path)
 }
 
-func testDeleteVCH(v *validate.Validator, conf *metadata.VirtualContainerHostConfigSpec, t *testing.T) {
+func testDeleteVCH(v *validate.Validator, conf *config.VirtualContainerHostConfigSpec, t *testing.T) {
 	d := &Dispatcher{
 		session: v.Session,
 		ctx:     v.Context,

--- a/lib/install/management/dispatcher.go
+++ b/lib/install/management/dispatcher.go
@@ -22,7 +22,7 @@ import (
 	log "github.com/Sirupsen/logrus"
 
 	"github.com/vmware/govmomi/object"
-	"github.com/vmware/vic/lib/metadata"
+	"github.com/vmware/vic/lib/config"
 	"github.com/vmware/vic/pkg/trace"
 	"github.com/vmware/vic/pkg/vsphere/compute"
 	"github.com/vmware/vic/pkg/vsphere/diagnostic"
@@ -61,7 +61,7 @@ type diagnosticLog struct {
 var diagnosticLogs = make(map[string]*diagnosticLog)
 
 func NewDispatcher(ctx context.Context, s *session.Session,
-	conf *metadata.VirtualContainerHostConfigSpec, force bool) *Dispatcher {
+	conf *config.VirtualContainerHostConfigSpec, force bool) *Dispatcher {
 	defer trace.End(trace.Begin(""))
 	isVC := s.IsVC()
 	e := &Dispatcher{
@@ -78,7 +78,7 @@ func NewDispatcher(ctx context.Context, s *session.Session,
 
 // Get the current log header LineEnd of the hostd/vpxd logs.
 // With this we avoid collecting log file data that existed prior to install.
-func (d *Dispatcher) InitDiagnosticLogs(conf *metadata.VirtualContainerHostConfigSpec) {
+func (d *Dispatcher) InitDiagnosticLogs(conf *config.VirtualContainerHostConfigSpec) {
 	defer trace.End(trace.Begin(""))
 
 	if d.isVC {

--- a/lib/install/management/finder.go
+++ b/lib/install/management/finder.go
@@ -23,8 +23,8 @@ import (
 	"github.com/vmware/govmomi/find"
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/vim25/types"
+	"github.com/vmware/vic/lib/config"
 	"github.com/vmware/vic/lib/install/validate"
-	"github.com/vmware/vic/lib/metadata"
 	"github.com/vmware/vic/pkg/errors"
 	"github.com/vmware/vic/pkg/trace"
 	"github.com/vmware/vic/pkg/vsphere/compute"
@@ -128,7 +128,7 @@ func (d *Dispatcher) NewVCHFromComputePath(computePath string, name string, v *v
 	return vmm, d.vchPoolPath, nil
 }
 
-func (d *Dispatcher) GetVCHConfig(vm *vm.VirtualMachine) (*metadata.VirtualContainerHostConfigSpec, error) {
+func (d *Dispatcher) GetVCHConfig(vm *vm.VirtualMachine) (*config.VirtualContainerHostConfigSpec, error) {
 	defer trace.End(trace.Begin(""))
 
 	//this is the appliance vm
@@ -139,7 +139,7 @@ func (d *Dispatcher) GetVCHConfig(vm *vm.VirtualMachine) (*metadata.VirtualConta
 		return nil, err
 	}
 	data := extraconfig.MapSource(mapConfig)
-	vchConfig := &metadata.VirtualContainerHostConfigSpec{}
+	vchConfig := &config.VirtualContainerHostConfigSpec{}
 	result := extraconfig.Decode(data, vchConfig)
 	if result == nil {
 		err = errors.Errorf("Failed to decode VM configuration %q: %s", vm.Reference(), err)

--- a/lib/install/management/inspect.go
+++ b/lib/install/management/inspect.go
@@ -20,14 +20,14 @@ import (
 	log "github.com/Sirupsen/logrus"
 
 	"github.com/vmware/govmomi/vim25/types"
-	"github.com/vmware/vic/lib/metadata"
+	"github.com/vmware/vic/lib/config"
 	"github.com/vmware/vic/pkg/errors"
 	"github.com/vmware/vic/pkg/ip"
 	"github.com/vmware/vic/pkg/trace"
 	"github.com/vmware/vic/pkg/vsphere/vm"
 )
 
-func (d *Dispatcher) InspectVCH(vch *vm.VirtualMachine, conf *metadata.VirtualContainerHostConfigSpec) error {
+func (d *Dispatcher) InspectVCH(vch *vm.VirtualMachine, conf *config.VirtualContainerHostConfigSpec) error {
 	defer trace.End(trace.Begin(conf.Name))
 
 	state, err := vch.PowerState(d.ctx)
@@ -58,7 +58,7 @@ func (d *Dispatcher) InspectVCH(vch *vm.VirtualMachine, conf *metadata.VirtualCo
 	return nil
 }
 
-func (d *Dispatcher) ShowVCH(conf *metadata.VirtualContainerHostConfigSpec, key string, cert string) {
+func (d *Dispatcher) ShowVCH(conf *config.VirtualContainerHostConfigSpec, key string, cert string) {
 	// #1218: Temporarily disable SSH access for TP3
 	//	log.Infof("")
 	//	log.Infof("SSH to appliance (default=root:password)")

--- a/lib/install/management/network.go
+++ b/lib/install/management/network.go
@@ -19,12 +19,12 @@ import (
 
 	"github.com/vmware/govmomi/find"
 	"github.com/vmware/govmomi/vim25/types"
-	"github.com/vmware/vic/lib/metadata"
+	"github.com/vmware/vic/lib/config"
 	"github.com/vmware/vic/pkg/errors"
 	"github.com/vmware/vic/pkg/trace"
 )
 
-func (d *Dispatcher) createBridgeNetwork(conf *metadata.VirtualContainerHostConfigSpec) error {
+func (d *Dispatcher) createBridgeNetwork(conf *config.VirtualContainerHostConfigSpec) error {
 	defer trace.End(trace.Begin(""))
 
 	// if the bridge network is already extant there's nothing to do
@@ -83,7 +83,7 @@ func (d *Dispatcher) createBridgeNetwork(conf *metadata.VirtualContainerHostConf
 	return nil
 }
 
-func (d *Dispatcher) removeNetwork(conf *metadata.VirtualContainerHostConfigSpec) error {
+func (d *Dispatcher) removeNetwork(conf *config.VirtualContainerHostConfigSpec) error {
 	defer trace.End(trace.Begin(conf.Name))
 
 	if d.session.IsVC() {

--- a/lib/install/management/resource_pool.go
+++ b/lib/install/management/resource_pool.go
@@ -22,8 +22,8 @@ import (
 	"github.com/vmware/govmomi/find"
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/vim25/types"
+	"github.com/vmware/vic/lib/config"
 	"github.com/vmware/vic/lib/install/data"
-	"github.com/vmware/vic/lib/metadata"
 	"github.com/vmware/vic/pkg/errors"
 	"github.com/vmware/vic/pkg/trace"
 	"github.com/vmware/vic/pkg/vsphere/compute"
@@ -33,7 +33,7 @@ import (
 	"golang.org/x/net/context"
 )
 
-func (d *Dispatcher) createResourcePool(conf *metadata.VirtualContainerHostConfigSpec, settings *data.InstallerData) (*object.ResourcePool, error) {
+func (d *Dispatcher) createResourcePool(conf *config.VirtualContainerHostConfigSpec, settings *data.InstallerData) (*object.ResourcePool, error) {
 	defer trace.End(trace.Begin(""))
 
 	d.vchPoolPath = path.Join(settings.ResourcePoolPath, conf.Name)
@@ -104,7 +104,7 @@ func (d *Dispatcher) createResourcePool(conf *metadata.VirtualContainerHostConfi
 	return rp, nil
 }
 
-func (d *Dispatcher) destroyResourcePoolIfEmpty(conf *metadata.VirtualContainerHostConfigSpec) error {
+func (d *Dispatcher) destroyResourcePoolIfEmpty(conf *config.VirtualContainerHostConfigSpec) error {
 	defer trace.End(trace.Begin(""))
 
 	log.Infof("Removing Resource Pool %q", conf.Name)

--- a/lib/install/management/store_files.go
+++ b/lib/install/management/store_files.go
@@ -263,7 +263,7 @@ func (d *Dispatcher) createVolumeStores(conf *config.VirtualContainerHostConfigS
 }
 
 // returns # of removed stores
-func (d *Dispatcher) deleteVolumeStoreIfForced(conf *metadata.VirtualContainerHostConfigSpec) (removed int) {
+func (d *Dispatcher) deleteVolumeStoreIfForced(conf *config.VirtualContainerHostConfigSpec) (removed int) {
 	defer trace.End(trace.Begin(""))
 	removed = 0
 

--- a/lib/install/management/store_files.go
+++ b/lib/install/management/store_files.go
@@ -25,7 +25,7 @@ import (
 
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/vim25/types"
-	"github.com/vmware/vic/lib/metadata"
+	"github.com/vmware/vic/lib/config"
 	"github.com/vmware/vic/lib/portlayer/storage/vsphere"
 	"github.com/vmware/vic/pkg/errors"
 	"github.com/vmware/vic/pkg/trace"
@@ -40,7 +40,7 @@ const (
 	volumeRoot = "volumes"
 )
 
-func (d *Dispatcher) DeleteStores(vchVM *vm.VirtualMachine, conf *metadata.VirtualContainerHostConfigSpec) error {
+func (d *Dispatcher) DeleteStores(vchVM *vm.VirtualMachine, conf *config.VirtualContainerHostConfigSpec) error {
 	defer trace.End(trace.Begin(""))
 
 	ds := d.session.Datastore
@@ -246,7 +246,7 @@ func (d *Dispatcher) getVCHRootDir(vchVM *vm.VirtualMachine) (string, error) {
 	return path.Join(parent, uuid), nil
 }
 
-func (d *Dispatcher) createVolumeStores(conf *metadata.VirtualContainerHostConfigSpec) error {
+func (d *Dispatcher) createVolumeStores(conf *config.VirtualContainerHostConfigSpec) error {
 	for _, url := range conf.VolumeLocations {
 		ds, err := d.session.Finder.Datastore(d.ctx, url.Host)
 		if err != nil {

--- a/lib/install/management/virtual_app.go
+++ b/lib/install/management/virtual_app.go
@@ -20,13 +20,13 @@ import (
 	"github.com/vmware/govmomi/find"
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/vim25/types"
+	"github.com/vmware/vic/lib/config"
 	"github.com/vmware/vic/lib/install/data"
-	"github.com/vmware/vic/lib/metadata"
 	"github.com/vmware/vic/pkg/errors"
 	"github.com/vmware/vic/pkg/trace"
 )
 
-func (d *Dispatcher) createVApp(conf *metadata.VirtualContainerHostConfigSpec, settings *data.InstallerData) (*object.VirtualApp, error) {
+func (d *Dispatcher) createVApp(conf *config.VirtualContainerHostConfigSpec, settings *data.InstallerData) (*object.VirtualApp, error) {
 	defer trace.End(trace.Begin(""))
 	var err error
 

--- a/lib/install/validate/validator_test.go
+++ b/lib/install/validate/validator_test.go
@@ -22,8 +22,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/vmware/govmomi/vim25/types"
+	"github.com/vmware/vic/lib/config"
 	"github.com/vmware/vic/lib/install/data"
-	"github.com/vmware/vic/lib/metadata"
 	"github.com/vmware/vic/pkg/trace"
 	"github.com/vmware/vic/pkg/vsphere/session"
 	"github.com/vmware/vic/pkg/vsphere/simulator"
@@ -184,7 +184,7 @@ func createPool(ctx context.Context, sess *session.Session, poolPath string, nam
 	return nil
 }
 
-func testCompute(v *Validator, input *data.Data, t *testing.T) *metadata.VirtualContainerHostConfigSpec {
+func testCompute(v *Validator, input *data.Data, t *testing.T) *config.VirtualContainerHostConfigSpec {
 	tests := []struct {
 		path   string
 		vc     bool
@@ -206,7 +206,7 @@ func testCompute(v *Validator, input *data.Data, t *testing.T) *metadata.Virtual
 		{"test", false, true},
 		{"/ha-datacenter/host/localhost.localdomain/Resources/validator", false, false},
 	}
-	conf := &metadata.VirtualContainerHostConfigSpec{}
+	conf := &config.VirtualContainerHostConfigSpec{}
 
 	for _, test := range tests {
 		if v.isVC && !test.vc {
@@ -229,7 +229,7 @@ func testCompute(v *Validator, input *data.Data, t *testing.T) *metadata.Virtual
 	return conf
 }
 
-func testTargets(v *Validator, input *data.Data, conf *metadata.VirtualContainerHostConfigSpec, t *testing.T) {
+func testTargets(v *Validator, input *data.Data, conf *config.VirtualContainerHostConfigSpec, t *testing.T) {
 	v.target(v.Context, input, conf)
 	pass, set := conf.Target.User.Password()
 	t.Logf("target: %+v", conf.Target)
@@ -242,7 +242,7 @@ func testTargets(v *Validator, input *data.Data, conf *metadata.VirtualContainer
 	}
 }
 
-func testStorage(v *Validator, input *data.Data, conf *metadata.VirtualContainerHostConfigSpec, t *testing.T) {
+func testStorage(v *Validator, input *data.Data, conf *config.VirtualContainerHostConfigSpec, t *testing.T) {
 	tests := []struct {
 		image         string
 		volumes       map[string]string

--- a/lib/portlayer/attach/client.go
+++ b/lib/portlayer/attach/client.go
@@ -20,6 +20,8 @@ import (
 
 	log "github.com/Sirupsen/logrus"
 	"golang.org/x/crypto/ssh"
+
+	"github.com/vmware/vic/cmd/tether/msgs"
 )
 
 const (
@@ -49,12 +51,12 @@ type attachSSH struct {
 }
 
 func SSHls(client *ssh.Client) ([]string, error) {
-	ok, reply, err := client.SendRequest(ContainersReq, true, nil)
+	ok, reply, err := client.SendRequest(msgs.ContainersReq, true, nil)
 	if !ok || err != nil {
 		return nil, fmt.Errorf("failed to get container IDs from remote: %s", err)
 	}
 
-	ids := ContainersMsg{}
+	ids := msgs.ContainersMsg{}
 
 	if err = ids.Unmarshal(reply); err != nil {
 		log.Debugf("raw IDs response: %+v", reply)
@@ -89,8 +91,8 @@ func SSHAttach(client *ssh.Client, id string) (SessionInteraction, error) {
 }
 
 func (t *attachSSH) Signal(signal ssh.Signal) error {
-	msg := SignalMsg{signal}
-	ok, err := t.channel.SendRequest(SignalReq, true, msg.Marshal())
+	msg := msgs.SignalMsg{signal}
+	ok, err := t.channel.SendRequest(msgs.SignalReq, true, msg.Marshal())
 	if err == nil && !ok {
 		return fmt.Errorf("unknown error")
 	}
@@ -120,8 +122,8 @@ func (t *attachSSH) Close() error {
 
 // Resize resizes the terminal.
 func (t *attachSSH) Resize(cols, rows, widthpx, heightpx uint32) error {
-	msg := WindowChangeMsg{cols, rows, widthpx, heightpx}
-	ok, err := t.channel.SendRequest(WindowChangeReq, true, msg.Marshal())
+	msg := msgs.WindowChangeMsg{cols, rows, widthpx, heightpx}
+	ok, err := t.channel.SendRequest(msgs.WindowChangeReq, true, msg.Marshal())
 	if err == nil && !ok {
 		return fmt.Errorf("unknown error")
 	}

--- a/lib/portlayer/attach/server_test.go
+++ b/lib/portlayer/attach/server_test.go
@@ -26,6 +26,7 @@ import (
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
+	"github.com/vmware/vic/cmd/tether/msgs"
 	"github.com/vmware/vic/pkg/serial"
 )
 
@@ -130,8 +131,8 @@ func TestAttachSshSession(t *testing.T) {
 		wg.Add(1)
 		defer wg.Done()
 		for req := range reqs {
-			if req.Type == ContainersReq {
-				msg := ContainersMsg{IDs: []string{expectedID}}
+			if req.Type == msgs.ContainersReq {
+				msg := msgs.ContainersMsg{IDs: []string{expectedID}}
 				req.Reply(true, msg.Marshal())
 				break
 			}

--- a/lib/portlayer/exec/config.go
+++ b/lib/portlayer/exec/config.go
@@ -19,7 +19,8 @@ import (
 
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/vim25/types"
-	"github.com/vmware/vic/lib/metadata"
+	"github.com/vmware/vic/lib/config"
+	"github.com/vmware/vic/lib/config/executor"
 )
 
 var VCHConfig Configuration
@@ -31,7 +32,7 @@ type Configuration struct {
 
 	// Port Layer - exec
 	// Default containerVM capacity
-	ContainerVMSize metadata.Resources `vic:"0.1" scope:"read-only" recurse:"depth=0"`
+	ContainerVMSize config.Resources `vic:"0.1" scope:"read-only" recurse:"depth=0"`
 
 	// Permitted datastore URLs for container storage for this virtual container host
 	ContainerStores []url.URL `vic:"0.1" scope:"read-only" recurse:"depth=0"`
@@ -50,7 +51,7 @@ type Configuration struct {
 	ContainerNameConvention string
 
 	// FIXME: temporary work around for injecting network path of debug nic
-	Networks     map[string]*metadata.NetworkEndpoint `vic:"0.1" scope:"read-only" key:"init/networks"`
+	Networks     map[string]*executor.NetworkEndpoint `vic:"0.1" scope:"read-only" key:"init/networks"`
 	DebugNetwork object.NetworkReference
 
 	// Information about the VCH resource pool and about the real host that we want

--- a/lib/portlayer/exec/container.go
+++ b/lib/portlayer/exec/container.go
@@ -280,7 +280,7 @@ func (c *Container) Remove(ctx context.Context, sess *session.Session) error {
 	return nil
 }
 
-func (c *Container) Update(ctx context.Context, sess *session.Session) (*metadata.ExecutorConfig, error) {
+func (c *Container) Update(ctx context.Context, sess *session.Session) (*executor.ExecutorConfig, error) {
 	defer trace.End(trace.Begin("Container.Update"))
 	c.Lock()
 	defer c.Unlock()
@@ -295,7 +295,7 @@ func (c *Container) Update(ctx context.Context, sess *session.Session) (*metadat
 		return nil, err
 	}
 
-	extraconfig.Decode(extraconfig.OptionValueSource(vm[0].Config.ExtraConfig), c.ExecConfig)
+	extraconfig.Decode(vmomi.OptionValueSource(vm[0].Config.ExtraConfig), c.ExecConfig)
 	return c.ExecConfig, nil
 }
 

--- a/lib/portlayer/exec/container.go
+++ b/lib/portlayer/exec/container.go
@@ -24,9 +24,10 @@ import (
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/vim25/mo"
 	"github.com/vmware/govmomi/vim25/types"
-	"github.com/vmware/vic/lib/metadata"
+	"github.com/vmware/vic/lib/config/executor"
 	"github.com/vmware/vic/pkg/trace"
 	"github.com/vmware/vic/pkg/vsphere/extraconfig"
+	"github.com/vmware/vic/pkg/vsphere/extraconfig/vmomi"
 	"github.com/vmware/vic/pkg/vsphere/session"
 	"github.com/vmware/vic/pkg/vsphere/tasks"
 	"github.com/vmware/vic/pkg/vsphere/vm"
@@ -50,7 +51,7 @@ const (
 type Container struct {
 	sync.Mutex
 
-	ExecConfig *metadata.ExecutorConfig
+	ExecConfig *executor.ExecutorConfig
 	State      State
 
 	// friendly description of state
@@ -63,7 +64,7 @@ type Container struct {
 
 func NewContainer(id ID) *Handle {
 	con := &Container{
-		ExecConfig: &metadata.ExecutorConfig{},
+		ExecConfig: &executor.ExecutorConfig{},
 		State:      StateStopped,
 	}
 	con.ExecConfig.ID = id.String()
@@ -85,7 +86,7 @@ func (c *Container) newHandle() *Handle {
 }
 
 // TODO: Is this used anywhere?
-func (c *Container) cacheExecConfig(ec *metadata.ExecutorConfig) {
+func (c *Container) cacheExecConfig(ec *executor.ExecutorConfig) {
 	c.Lock()
 	defer c.Unlock()
 
@@ -409,8 +410,8 @@ func convertInfraContainers(vms []mo.VirtualMachine, all *bool) []*Container {
 			continue
 		}
 
-		container := &Container{ExecConfig: &metadata.ExecutorConfig{}}
-		source := extraconfig.OptionValueSource(vms[i].Config.ExtraConfig)
+		container := &Container{ExecConfig: &executor.ExecutorConfig{}}
+		source := vmomi.OptionValueSource(vms[i].Config.ExtraConfig)
 		extraconfig.Decode(source, container.ExecConfig)
 
 		// check extraConfig to see if we have a containerVM -- assumes

--- a/lib/portlayer/exec/container_cache_test.go
+++ b/lib/portlayer/exec/container_cache_test.go
@@ -18,7 +18,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/vmware/vic/lib/metadata"
+	"github.com/vmware/vic/lib/config/executor"
 )
 
 func TestContainerCache(t *testing.T) {
@@ -32,7 +32,7 @@ func TestContainerCache(t *testing.T) {
 	assert.Equal(t, len(containers.cache), 0)
 
 	// create a new container
-	container := &Container{ExecConfig: &metadata.ExecutorConfig{}}
+	container := &Container{ExecConfig: &executor.ExecutorConfig{}}
 	container.ExecConfig.ID = containerID
 	// put it in the cache
 	containers.Put(container)

--- a/lib/portlayer/exec/handle.go
+++ b/lib/portlayer/exec/handle.go
@@ -28,11 +28,12 @@ import (
 	log "github.com/Sirupsen/logrus"
 	"github.com/golang/groupcache/lru"
 	"github.com/vmware/govmomi/vim25/types"
+	"github.com/vmware/vic/lib/config/executor"
 	"github.com/vmware/vic/lib/guest"
-	"github.com/vmware/vic/lib/metadata"
 	"github.com/vmware/vic/lib/spec"
 	"github.com/vmware/vic/pkg/trace"
 	"github.com/vmware/vic/pkg/vsphere/extraconfig"
+	"github.com/vmware/vic/pkg/vsphere/extraconfig/vmomi"
 	"github.com/vmware/vic/pkg/vsphere/session"
 )
 
@@ -43,7 +44,7 @@ const (
 
 // ContainerCreateConfig defines the parameters for Create call
 type ContainerCreateConfig struct {
-	Metadata metadata.ExecutorConfig
+	Metadata executor.ExecutorConfig
 
 	ParentImageID  string
 	ImageStoreName string
@@ -62,7 +63,7 @@ func init() {
 
 type Handle struct {
 	Spec       *spec.VirtualMachineConfigSpec
-	ExecConfig metadata.ExecutorConfig
+	ExecConfig executor.ExecutorConfig
 	Container  *Container
 	State      *State
 
@@ -149,7 +150,7 @@ func (h *Handle) Commit(ctx context.Context, sess *session.Session) error {
 	cfg := make(map[string]string)
 	extraconfig.Encode(extraconfig.MapSink(cfg), h.ExecConfig)
 	s := h.Spec.Spec()
-	s.ExtraConfig = append(s.ExtraConfig, extraconfig.OptionValueFromMap(cfg)...)
+	s.ExtraConfig = append(s.ExtraConfig, vmomi.OptionValueFromMap(cfg)...)
 
 	if err := h.Container.Commit(ctx, sess, h); err != nil {
 		return err

--- a/lib/portlayer/exec/handle.go
+++ b/lib/portlayer/exec/handle.go
@@ -242,7 +242,7 @@ func (h *Handle) Create(ctx context.Context, sess *session.Session, config *Cont
 	return nil
 }
 
-func (h *Handle) Update(ctx context.Context, sess *session.Session) (*metadata.ExecutorConfig, error) {
+func (h *Handle) Update(ctx context.Context, sess *session.Session) (*executor.ExecutorConfig, error) {
 	defer trace.End(trace.Begin("Handle.Create"))
 
 	ec, err := h.Container.Update(ctx, sess)

--- a/lib/portlayer/network/config.go
+++ b/lib/portlayer/network/config.go
@@ -18,7 +18,7 @@ import (
 	"net"
 
 	"github.com/vmware/govmomi/object"
-	"github.com/vmware/vic/lib/metadata"
+	"github.com/vmware/vic/lib/config/executor"
 	"github.com/vmware/vic/pkg/ip"
 )
 
@@ -40,7 +40,7 @@ type Configuration struct {
 type ContainerNetwork struct {
 	// Common.Name - the symbolic name for the network, e.g. web or backend
 	// Common.ID - identifier of the underlay for the network
-	metadata.Common
+	executor.Common
 
 	// The network scope the IP belongs to.
 	// The IP address is the default gateway

--- a/lib/portlayer/network/context.go
+++ b/lib/portlayer/network/context.go
@@ -29,7 +29,7 @@ import (
 	log "github.com/Sirupsen/logrus"
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/vim25/types"
-	"github.com/vmware/vic/lib/metadata"
+	"github.com/vmware/vic/lib/config/executor"
 	"github.com/vmware/vic/lib/portlayer/exec"
 	"github.com/vmware/vic/lib/spec"
 	"github.com/vmware/vic/pkg/ip"
@@ -863,16 +863,16 @@ func (c *Context) AddContainer(h *exec.Handle, options *AddContainerOptions) err
 	}
 
 	if h.ExecConfig.Networks == nil {
-		h.ExecConfig.Networks = make(map[string]*metadata.NetworkEndpoint)
+		h.ExecConfig.Networks = make(map[string]*executor.NetworkEndpoint)
 	}
 
-	ne := &metadata.NetworkEndpoint{
-		Common: metadata.Common{
+	ne := &executor.NetworkEndpoint{
+		Common: executor.Common{
 			ID: strconv.Itoa(int(pciSlot)),
 			// Name: this would cause NIC renaming if uncommented
 		},
-		Network: metadata.ContainerNetwork{
-			Common: metadata.Common{
+		Network: executor.ContainerNetwork{
+			Common: executor.Common{
 				Name: s.Name(),
 			},
 			Aliases: options.Aliases,
@@ -909,7 +909,7 @@ func (c *Context) RemoveContainer(h *exec.Handle, scope string) error {
 		return err
 	}
 
-	var ne *metadata.NetworkEndpoint
+	var ne *executor.NetworkEndpoint
 	ne, ok := h.ExecConfig.Networks[s.Name()]
 	if !ok {
 		return fmt.Errorf("container %s not part of network %s", h.ExecConfig.ID, s.Name())

--- a/lib/portlayer/network/context_test.go
+++ b/lib/portlayer/network/context_test.go
@@ -119,7 +119,7 @@ func TestMain(m *testing.M) {
 				PortGroup:   testExternalNetwork,
 			},
 			"bar71": &ContainerNetwork{
-				Common: metadata.Common{
+				Common: executor.Common{
 					Name: "external",
 				},
 				Gateway:     net.IPNet{IP: net.ParseIP("10.131.0.1"), Mask: net.CIDRMask(16, 32)},
@@ -128,13 +128,13 @@ func TestMain(m *testing.M) {
 				PortGroup:   testExternalNetwork,
 			},
 			"bar72": &ContainerNetwork{
-				Common: metadata.Common{
+				Common: executor.Common{
 					Name: "external",
 				},
 				PortGroup: testExternalNetwork,
 			},
 			"bar73": &ContainerNetwork{
-				Common: metadata.Common{
+				Common: executor.Common{
 					Name: "external",
 				},
 				Gateway:   net.IPNet{IP: net.ParseIP("10.133.0.1"), Mask: net.CIDRMask(16, 32)},

--- a/lib/portlayer/network/context_test.go
+++ b/lib/portlayer/network/context_test.go
@@ -26,7 +26,7 @@ import (
 
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/vim25/types"
-	"github.com/vmware/vic/lib/metadata"
+	"github.com/vmware/vic/lib/config/executor"
 	"github.com/vmware/vic/lib/portlayer/exec"
 	"github.com/vmware/vic/lib/spec"
 	"github.com/vmware/vic/pkg/ip"
@@ -110,7 +110,7 @@ func TestMain(m *testing.M) {
 				PortGroup: testBridgeNetwork,
 			},
 			"bar7": &ContainerNetwork{
-				Common: metadata.Common{
+				Common: executor.Common{
 					Name: "external",
 				},
 				Gateway:     net.IPNet{IP: net.ParseIP("10.13.0.1"), Mask: net.CIDRMask(16, 32)},
@@ -889,7 +889,7 @@ func TestContextRemoveContainer(t *testing.T) {
 	}
 
 	for i, te := range tests {
-		var ne *metadata.NetworkEndpoint
+		var ne *executor.NetworkEndpoint
 		if te.h != nil && te.h.ExecConfig.Networks != nil {
 			ne = te.h.ExecConfig.Networks[te.scope]
 		}

--- a/lib/portlayer/storage/vsphere/vm.go
+++ b/lib/portlayer/storage/vsphere/vm.go
@@ -19,7 +19,7 @@ import (
 	"net/url"
 
 	"github.com/vmware/govmomi/vim25/types"
-	"github.com/vmware/vic/lib/metadata"
+	"github.com/vmware/vic/lib/config/executor"
 	"github.com/vmware/vic/lib/portlayer/exec"
 	"github.com/vmware/vic/lib/portlayer/storage"
 	"github.com/vmware/vic/pkg/trace"
@@ -34,7 +34,7 @@ func VolumeJoin(ctx context.Context, handle *exec.Handle, volume *storage.Volume
 		return nil, fmt.Errorf("Volume with ID %s is already in container %s's mountspec'", volume.ID, handle.Container.ExecConfig.ID)
 	}
 
-	newMountSpec := metadata.MountSpec{
+	newMountSpec := executor.MountSpec{
 		Source: url.URL{
 			Scheme: "label",
 			Path:   volume.Label,
@@ -67,7 +67,7 @@ func VolumeJoin(ctx context.Context, handle *exec.Handle, volume *storage.Volume
 
 	handle.Spec.DeviceChange = append(handle.Spec.DeviceChange, config)
 	if handle.ExecConfig.Mounts == nil {
-		handle.ExecConfig.Mounts = make(map[string]metadata.MountSpec)
+		handle.ExecConfig.Mounts = make(map[string]executor.MountSpec)
 	}
 	handle.ExecConfig.Mounts[volume.ID] = newMountSpec
 

--- a/lib/pprof/pprof.go
+++ b/lib/pprof/pprof.go
@@ -23,7 +23,7 @@ import (
 	"net/url"
 
 	log "github.com/Sirupsen/logrus"
-	"github.com/vmware/vic/lib/metadata"
+	"github.com/vmware/vic/lib/config"
 	"github.com/vmware/vic/pkg/vsphere/extraconfig"
 )
 
@@ -40,7 +40,7 @@ const (
 )
 
 var (
-	vchConfig metadata.VirtualContainerHostConfigSpec
+	vchConfig config.VirtualContainerHostConfigSpec
 )
 
 func init() {

--- a/lib/spec/spec.go
+++ b/lib/spec/spec.go
@@ -21,9 +21,10 @@ import (
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/vmware/govmomi/vim25/types"
-	"github.com/vmware/vic/lib/metadata"
+	"github.com/vmware/vic/lib/config/executor"
 	"github.com/vmware/vic/pkg/trace"
 	"github.com/vmware/vic/pkg/vsphere/extraconfig"
+	"github.com/vmware/vic/pkg/vsphere/extraconfig/vmomi"
 	"github.com/vmware/vic/pkg/vsphere/session"
 )
 
@@ -70,7 +71,7 @@ type VirtualMachineConfigSpecConfig struct {
 	ImageStoreName string
 
 	// Temporary
-	Metadata metadata.ExecutorConfig
+	Metadata executor.ExecutorConfig
 }
 
 // VirtualMachineConfigSpec type
@@ -136,7 +137,7 @@ func NewVirtualMachineConfigSpec(ctx context.Context, session *session.Session, 
 	// encode the config as optionvalues
 	cfg := map[string]string{}
 	extraconfig.Encode(extraconfig.MapSink(cfg), config.Metadata)
-	metaCfg := extraconfig.OptionValueFromMap(cfg)
+	metaCfg := vmomi.OptionValueFromMap(cfg)
 
 	// merge it with the sec
 	s.ExtraConfig = append(s.ExtraConfig, metaCfg...)

--- a/lib/tether/cmd_test.go
+++ b/lib/tether/cmd_test.go
@@ -16,11 +16,10 @@ package tether
 
 import (
 	"fmt"
-	"os/exec"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/vmware/vic/lib/metadata"
+	"github.com/vmware/vic/lib/config/executor"
 	"github.com/vmware/vic/pkg/vsphere/extraconfig"
 )
 
@@ -34,20 +33,20 @@ func TestPathLookup(t *testing.T) {
 	testSetup(t)
 	defer testTeardown(t)
 
-	cfg := metadata.ExecutorConfig{
-		Common: metadata.Common{
+	cfg := executor.ExecutorConfig{
+		Common: executor.Common{
 			ID:   "pathlookup",
 			Name: "tether_test_executor",
 		},
 
-		Sessions: map[string]metadata.SessionConfig{
-			"pathlookup": metadata.SessionConfig{
-				Common: metadata.Common{
+		Sessions: map[string]executor.SessionConfig{
+			"pathlookup": executor.SessionConfig{
+				Common: executor.Common{
 					ID:   "pathlookup",
 					Name: "tether_test_session",
 				},
 				Tty: false,
-				Cmd: metadata.Cmd{
+				Cmd: executor.Cmd{
 					// test relative path
 					Path: "date",
 					Args: []string{"date", "--reference=/"},
@@ -72,20 +71,20 @@ func TestRelativePath(t *testing.T) {
 	testSetup(t)
 	defer testTeardown(t)
 
-	cfg := metadata.ExecutorConfig{
-		Common: metadata.Common{
+	cfg := executor.ExecutorConfig{
+		Common: executor.Common{
 			ID:   "relpath",
 			Name: "tether_test_executor",
 		},
 
-		Sessions: map[string]metadata.SessionConfig{
-			"relpath": metadata.SessionConfig{
-				Common: metadata.Common{
+		Sessions: map[string]executor.SessionConfig{
+			"relpath": executor.SessionConfig{
+				Common: executor.Common{
 					ID:   "relpath",
 					Name: "tether_test_session",
 				},
 				Tty: false,
-				Cmd: metadata.Cmd{
+				Cmd: executor.Cmd{
 					// test relative path
 					Path: "./date",
 					Args: []string{"./date", "--reference=/"},
@@ -110,20 +109,20 @@ func TestAbsPath(t *testing.T) {
 	testSetup(t)
 	defer testTeardown(t)
 
-	cfg := metadata.ExecutorConfig{
-		Common: metadata.Common{
+	cfg := executor.ExecutorConfig{
+		Common: executor.Common{
 			ID:   "abspath",
 			Name: "tether_test_executor",
 		},
 
-		Sessions: map[string]metadata.SessionConfig{
-			"abspath": metadata.SessionConfig{
-				Common: metadata.Common{
+		Sessions: map[string]executor.SessionConfig{
+			"abspath": executor.SessionConfig{
+				Common: executor.Common{
 					ID:   "abspath",
 					Name: "tether_test_session",
 				},
 				Tty: false,
-				Cmd: metadata.Cmd{
+				Cmd: executor.Cmd{
 					// test abs path
 					Path: "/bin/date",
 					Args: []string{"date", "--reference=/"},
@@ -147,7 +146,7 @@ func TestAbsPath(t *testing.T) {
 	log := Mocked.SessionLogBuffer.Bytes()
 
 	// run the command directly
-	out, err := exec.Command("/bin/date", "--reference=/").Output()
+	out, err := executor.Command("/bin/date", "--reference=/").Output()
 	if err != nil {
 		fmt.Printf("Failed to run date for comparison data: %s", err)
 		t.Error(err)
@@ -163,20 +162,20 @@ func TestHalt(t *testing.T) {
 	testSetup(t)
 	defer testTeardown(t)
 
-	cfg := metadata.ExecutorConfig{
-		Common: metadata.Common{
+	cfg := executor.ExecutorConfig{
+		Common: executor.Common{
 			ID:   "abspath",
 			Name: "tether_test_executor",
 		},
 
-		Sessions: map[string]metadata.SessionConfig{
-			"abspath": metadata.SessionConfig{
-				Common: metadata.Common{
+		Sessions: map[string]executor.SessionConfig{
+			"abspath": executor.SessionConfig{
+				Common: executor.Common{
 					ID:   "abspath",
 					Name: "tether_test_session",
 				},
 				Tty: false,
-				Cmd: metadata.Cmd{
+				Cmd: executor.Cmd{
 					// test abs path
 					Path: "/bin/date",
 					Args: []string{"date", "--reference=/"},
@@ -203,7 +202,7 @@ func TestHalt(t *testing.T) {
 	log := Mocked.SessionLogBuffer.Bytes()
 
 	// run the command directly
-	out, err := exec.Command("/bin/date", "--reference=/").Output()
+	out, err := executor.Command("/bin/date", "--reference=/").Output()
 	if err != nil {
 		fmt.Printf("Failed to run date for comparison data: %s", err)
 		t.Error(err)
@@ -234,20 +233,20 @@ func TestMissingBinary(t *testing.T) {
 	testSetup(t)
 	defer testTeardown(t)
 
-	cfg := metadata.ExecutorConfig{
-		Common: metadata.Common{
+	cfg := executor.ExecutorConfig{
+		Common: executor.Common{
 			ID:   "missing",
 			Name: "tether_test_executor",
 		},
 
-		Sessions: map[string]metadata.SessionConfig{
-			"missing": metadata.SessionConfig{
-				Common: metadata.Common{
+		Sessions: map[string]executor.SessionConfig{
+			"missing": executor.SessionConfig{
+				Common: executor.Common{
 					ID:   "missing",
 					Name: "tether_test_session",
 				},
 				Tty: false,
-				Cmd: metadata.Cmd{
+				Cmd: executor.Cmd{
 					// test relative path
 					Path: "/not/there",
 					Args: []string{"/not/there"},
@@ -281,20 +280,20 @@ func TestMissingRelativeBinary(t *testing.T) {
 	testSetup(t)
 	defer testTeardown(t)
 
-	cfg := metadata.ExecutorConfig{
-		Common: metadata.Common{
+	cfg := executor.ExecutorConfig{
+		Common: executor.Common{
 			ID:   "missing",
 			Name: "tether_test_executor",
 		},
 
-		Sessions: map[string]metadata.SessionConfig{
-			"missing": metadata.SessionConfig{
-				Common: metadata.Common{
+		Sessions: map[string]executor.SessionConfig{
+			"missing": executor.SessionConfig{
+				Common: executor.Common{
 					ID:   "missing",
 					Name: "tether_test_session",
 				},
 				Tty: false,
-				Cmd: metadata.Cmd{
+				Cmd: executor.Cmd{
 					// test relative path
 					Path: "notthere",
 					Args: []string{"notthere"},

--- a/lib/tether/config.go
+++ b/lib/tether/config.go
@@ -20,7 +20,7 @@ import (
 	"os/exec"
 	"sync"
 
-	"github.com/vmware/vic/lib/metadata"
+	"github.com/vmware/vic/lib/config/executor"
 	"github.com/vmware/vic/pkg/dio"
 )
 
@@ -45,7 +45,7 @@ type ExecutorConfig struct {
 	Sessions map[string]*SessionConfig `vic:"0.1" scope:"read-only" key:"sessions"`
 
 	// Maps the mount name to the detail mount specification
-	Mounts map[string]metadata.MountSpec `vic:"0.1" scope:"read-only" key:"mounts"`
+	Mounts map[string]executor.MountSpec `vic:"0.1" scope:"read-only" key:"mounts"`
 
 	// This describes an executors presence on a network, and contains sufficient
 	// information to configure the interface in the guest.
@@ -61,10 +61,10 @@ type ExecutorConfig struct {
 // This is close to but not perfectly aligned with the new docker/docker/daemon/execdriver/driver:CommonProcessConfig
 type SessionConfig struct {
 	// The primary session may have the same ID as the executor owning it
-	metadata.Common `vic:"0.1" scope:"read-only" key:"common"`
+	executor.Common `vic:"0.1" scope:"read-only" key:"common"`
 
 	// Diagnostics holds basic diagnostics data
-	Diagnostics metadata.Diagnostics `vic:"0.1" scope:"read-write" key:"diagnostics"`
+	Diagnostics executor.Diagnostics `vic:"0.1" scope:"read-write" key:"diagnostics"`
 
 	// The primary process for the session
 	Cmd exec.Cmd `vic:"0.1" scope:"read-only" key:"cmd" recurse:"depth=2,nofollow"`
@@ -97,7 +97,7 @@ type SessionConfig struct {
 type NetworkEndpoint struct {
 	// Common.Name - the nic alias requested (only one name and one alias possible in linux)
 	// Common.ID - pci slot of the vnic allowing for interface identifcation in-guest
-	metadata.Common
+	executor.Common
 
 	// IP address to assign - nil if DHCP
 	Static *net.IPNet `vic:"0.1" scope:"read-only" key:"staticip"`
@@ -107,7 +107,7 @@ type NetworkEndpoint struct {
 
 	// The network in which this information should be interpreted. This is embedded directly rather than
 	// as a pointer so that we can ensure the data is consistent
-	Network metadata.ContainerNetwork `vic:"0.1" scope:"read-only" key:"network"`
+	Network executor.ContainerNetwork `vic:"0.1" scope:"read-only" key:"network"`
 
 	// DHCP runtime info
 	DHCP *DHCPInfo `vic:"0.1" scope:"read-only" recurse:"depth=0"`

--- a/lib/tether/config_test.go
+++ b/lib/tether/config_test.go
@@ -19,7 +19,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/vmware/vic/lib/metadata"
+	"github.com/vmware/vic/lib/config/executor"
 	"github.com/vmware/vic/pkg/ip"
 	"github.com/vmware/vic/pkg/vsphere/extraconfig"
 )
@@ -30,22 +30,22 @@ var (
 )
 
 func TestToExtraConfig(t *testing.T) {
-	exec := metadata.ExecutorConfig{
-		Common: metadata.Common{
+	exec := executor.ExecutorConfig{
+		Common: executor.Common{
 			ID:   "deadbeef",
 			Name: "configtest",
 		},
-		Sessions: map[string]metadata.SessionConfig{
-			"deadbeef": metadata.SessionConfig{
-				Cmd: metadata.Cmd{
+		Sessions: map[string]executor.SessionConfig{
+			"deadbeef": executor.SessionConfig{
+				Cmd: executor.Cmd{
 					Path: "/bin/bash",
 					Args: []string{"/bin/bash", "-c", "echo hello"},
 					Dir:  "/",
 					Env:  []string{"HOME=/", "PATH=/bin"},
 				},
 			},
-			"beefed": metadata.SessionConfig{
-				Cmd: metadata.Cmd{
+			"beefed": executor.SessionConfig{
+				Cmd: executor.Cmd{
 					Path: "/bin/bash",
 					Args: []string{"/bin/bash", "-c", "echo goodbye"},
 					Dir:  "/",
@@ -53,11 +53,11 @@ func TestToExtraConfig(t *testing.T) {
 				},
 			},
 		},
-		Networks: map[string]*metadata.NetworkEndpoint{
-			"eth0": &metadata.NetworkEndpoint{
+		Networks: map[string]*executor.NetworkEndpoint{
+			"eth0": &executor.NetworkEndpoint{
 				Static: &net.IPNet{IP: localhost, Mask: lmask.Mask},
-				Network: metadata.ContainerNetwork{
-					Common: metadata.Common{
+				Network: executor.ContainerNetwork{
+					Common: executor.Common{
 						Name: "notsure",
 					},
 					Gateway:     net.IPNet{IP: gateway, Mask: gmask.Mask},
@@ -68,7 +68,7 @@ func TestToExtraConfig(t *testing.T) {
 		},
 	}
 
-	// encode metadata package's ExecutorConfig
+	// encode exec package's ExecutorConfig
 	encoded := map[string]string{}
 	extraconfig.Encode(extraconfig.MapSink(encoded), exec)
 
@@ -77,10 +77,10 @@ func TestToExtraConfig(t *testing.T) {
 	extraconfig.Decode(extraconfig.MapSource(encoded), &decoded)
 
 	// the networks should be identical
-	assert.Equal(t, exec.Networks["eth0"], decoded.Networks["eth0"])
+	assert.Equal(t, executor.Networks["eth0"], decoded.Networks["eth0"])
 
 	// the source and destination structs are different - we're doing a sparse comparison
-	expected := exec.Sessions["deadbeef"]
+	expected := executor.Sessions["deadbeef"]
 	actual := *decoded.Sessions["deadbeef"]
 
 	assert.Equal(t, expected.Cmd.Path, actual.Cmd.Path)

--- a/lib/tether/net_linux_test.go
+++ b/lib/tether/net_linux_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/vishvananda/netlink"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/vmware/vic/lib/metadata"
+	"github.com/vmware/vic/lib/config/executor"
 )
 
 // Utility method to add an interface to Mocked
@@ -71,20 +71,20 @@ func TestSetIpAddress(t *testing.T) {
 
 	secondIP, _ := netlink.ParseIPNet("172.16.0.10/24")
 	gwIP, _ := netlink.ParseIPNet("172.16.0.1/24")
-	cfg := metadata.ExecutorConfig{
-		Common: metadata.Common{
+	cfg := executor.ExecutorConfig{
+		Common: executor.Common{
 			ID:   "ipconfig",
 			Name: "tether_test_executor",
 		},
-		Networks: map[string]*metadata.NetworkEndpoint{
-			"bridge": &metadata.NetworkEndpoint{
-				Common: metadata.Common{
+		Networks: map[string]*executor.NetworkEndpoint{
+			"bridge": &executor.NetworkEndpoint{
+				Common: executor.Common{
 					ID: bridge,
 					// interface rename
 					Name: "bridge",
 				},
-				Network: metadata.ContainerNetwork{
-					Common: metadata.Common{
+				Network: executor.ContainerNetwork{
+					Common: executor.Common{
 						Name: "bridge",
 					},
 					Default: true,
@@ -95,26 +95,26 @@ func TestSetIpAddress(t *testing.T) {
 					Mask: lmask.Mask,
 				},
 			},
-			"cnet": &metadata.NetworkEndpoint{
-				Common: metadata.Common{
+			"cnet": &executor.NetworkEndpoint{
+				Common: executor.Common{
 					ID: bridge,
 					// no interface rename
 				},
-				Network: metadata.ContainerNetwork{
-					Common: metadata.Common{
+				Network: executor.ContainerNetwork{
+					Common: executor.Common{
 						Name: "cnet",
 					},
 				},
 				Static: secondIP,
 			},
-			"external": &metadata.NetworkEndpoint{
-				Common: metadata.Common{
+			"external": &executor.NetworkEndpoint{
+				Common: executor.Common{
 					ID: external,
 					// interface rename
 					Name: "external",
 				},
-				Network: metadata.ContainerNetwork{
-					Common: metadata.Common{
+				Network: executor.ContainerNetwork{
+					Common: executor.Common{
 						Name: "external",
 					},
 				},

--- a/lib/tether/net_test.go
+++ b/lib/tether/net_test.go
@@ -18,15 +18,15 @@ import (
 	"testing"
 
 	"github.com/docker/docker/pkg/stringid"
-	"github.com/vmware/vic/lib/metadata"
+	"github.com/vmware/vic/lib/config/executor"
 )
 
 func TestSetHostname(t *testing.T) {
 	testSetup(t)
 	defer testTeardown(t)
 
-	cfg := metadata.ExecutorConfig{
-		Common: metadata.Common{
+	cfg := executor.ExecutorConfig{
+		Common: executor.Common{
 			ID:   "sethostname",
 			Name: "tether_test_executor",
 		},
@@ -52,8 +52,8 @@ func TestNoNetwork(t *testing.T) {
 	testSetup(t)
 	defer testTeardown(t)
 
-	cfg := metadata.ExecutorConfig{
-		Common: metadata.Common{
+	cfg := executor.ExecutorConfig{
+		Common: executor.Common{
 			ID:   "ipconfig",
 			Name: "tether_test_executor",
 		},

--- a/lib/tether/tether_darwin.go
+++ b/lib/tether/tether_darwin.go
@@ -21,7 +21,6 @@ import (
 
 	"golang.org/x/crypto/ssh"
 
-	"github.com/vmware/vic/lib/portlayer/attach"
 	"github.com/vmware/vic/pkg/trace"
 )
 
@@ -68,20 +67,6 @@ func lookPath(file string, env []string, dir string) (string, error) {
 
 func establishPty(session *SessionConfig) error {
 	defer trace.End(trace.Begin("initializing pty handling for session " + session.ID))
-
-	return errors.New("unimplemented on OSX")
-}
-
-// The syscall struct
-type winsize struct {
-	wsRow    uint16
-	wsCol    uint16
-	wsXpixel uint16
-	wsYpixel uint16
-}
-
-func resizePty(pty uintptr, winSize *attach.WindowChangeMsg) error {
-	defer trace.End(trace.Begin("resize pty"))
 
 	return errors.New("unimplemented on OSX")
 }

--- a/lib/tether/tether_linux.go
+++ b/lib/tether/tether_linux.go
@@ -17,7 +17,6 @@ package tether
 import (
 	"fmt"
 	"io"
-	_ "net/http/pprof"
 	"os"
 	"os/signal"
 	"path/filepath"

--- a/lib/tether/tether_test.go
+++ b/lib/tether/tether_test.go
@@ -30,7 +30,7 @@ import (
 	"golang.org/x/net/context"
 
 	"github.com/vmware/govmomi/vim25/types"
-	"github.com/vmware/vic/lib/metadata"
+	"github.com/vmware/vic/lib/config/executor"
 	"github.com/vmware/vic/pkg/dio"
 	"github.com/vmware/vic/pkg/trace"
 	"github.com/vmware/vic/pkg/vsphere/extraconfig"
@@ -172,7 +172,7 @@ func TestMain(m *testing.M) {
 	os.Exit(retCode)
 }
 
-func StartTether(t *testing.T, cfg *metadata.ExecutorConfig) (Tether, extraconfig.DataSource) {
+func StartTether(t *testing.T, cfg *executor.ExecutorConfig) (Tether, extraconfig.DataSource) {
 	store := map[string]string{}
 	sink := extraconfig.MapSink(store)
 	src := extraconfig.MapSource(store)
@@ -193,7 +193,7 @@ func StartTether(t *testing.T, cfg *metadata.ExecutorConfig) (Tether, extraconfi
 	return tthr, src
 }
 
-func RunTether(t *testing.T, cfg *metadata.ExecutorConfig) (Tether, extraconfig.DataSource, error) {
+func RunTether(t *testing.T, cfg *executor.ExecutorConfig) (Tether, extraconfig.DataSource, error) {
 	store := map[string]string{}
 	sink := extraconfig.MapSink(store)
 	src := extraconfig.MapSource(store)

--- a/lib/tether/tether_windows.go
+++ b/lib/tether/tether_windows.go
@@ -20,7 +20,6 @@ import (
 
 	"golang.org/x/crypto/ssh"
 
-	"github.com/vmware/vic/lib/portlayer/attach"
 	"github.com/vmware/vic/pkg/trace"
 )
 
@@ -42,9 +41,5 @@ func signalProcess(process *os.Process, sig ssh.Signal) error {
 }
 
 func establishPty(session *SessionConfig) error {
-	return errors.New("unimplemented on windows")
-}
-
-func resizePty(pty uintptr, winSize *attach.WindowChangeMsg) error {
 	return errors.New("unimplemented on windows")
 }

--- a/lib/vicadmin/validate.go
+++ b/lib/vicadmin/validate.go
@@ -20,7 +20,8 @@ import (
 
 	log "github.com/Sirupsen/logrus"
 	// "github.com/vmware/govmomi/vim25/types"
-	"github.com/vmware/vic/lib/metadata"
+
+	"github.com/vmware/vic/lib/config"
 	"github.com/vmware/vic/pkg/trace"
 	// "github.com/vmware/vic/pkg/vsphere/session"
 	"golang.org/x/net/context"
@@ -32,7 +33,7 @@ type Validator struct {
 	FirewallErrors []string
 }
 
-func NewValidator(ctx context.Context, vch metadata.VirtualContainerHostConfigSpec) *Validator {
+func NewValidator(ctx context.Context, vch config.VirtualContainerHostConfigSpec) *Validator {
 	defer trace.End(trace.Begin(""))
 	log.Infof("Creating new validator")
 	v := new(Validator)
@@ -46,7 +47,7 @@ func NewValidator(ctx context.Context, vch metadata.VirtualContainerHostConfigSp
 	return v
 }
 
-func (v *Validator) checkFirewall(ctx context.Context, vch metadata.VirtualContainerHostConfigSpec) {
+func (v *Validator) checkFirewall(ctx context.Context, vch config.VirtualContainerHostConfigSpec) {
 	defer trace.End(trace.Begin(""))
 	log.Infof("Checking firewall rules")
 	//rule := types.HostFirewallRule{

--- a/pkg/vsphere/extraconfig/decode.go
+++ b/pkg/vsphere/extraconfig/decode.go
@@ -24,7 +24,6 @@ import (
 	"time"
 
 	log "github.com/Sirupsen/logrus"
-	"github.com/vmware/govmomi/vim25/types"
 )
 
 var (
@@ -475,21 +474,4 @@ func MapSource(src map[string]string) DataSource {
 		}
 		return val, nil
 	}
-}
-
-// OptionValueSource is a convenience method to generate a MapSource source from
-// and array of OptionValue's
-func OptionValueSource(src []types.BaseOptionValue) DataSource {
-	// create the key/value store from the extraconfig slice for lookups
-	kv := make(map[string]string)
-	for i := range src {
-		k := src[i].GetOptionValue().Key
-		v := src[i].GetOptionValue().Value.(string)
-		if v == "<nil>" {
-			v = ""
-		}
-		kv[k] = v
-	}
-
-	return MapSource(kv)
 }

--- a/pkg/vsphere/extraconfig/encode.go
+++ b/pkg/vsphere/extraconfig/encode.go
@@ -24,8 +24,6 @@ import (
 	"time"
 
 	log "github.com/Sirupsen/logrus"
-
-	"github.com/vmware/govmomi/vim25/types"
 )
 
 var (
@@ -272,24 +270,4 @@ func MapSink(sink map[string]string) DataSink {
 		sink[key] = value
 		return nil
 	}
-}
-
-// OptionValueFromMap is a convenience method to convert a map into a BaseOptionValue array
-func OptionValueFromMap(data map[string]string) []types.BaseOptionValue {
-	if len(data) == 0 {
-		return nil
-	}
-
-	array := make([]types.BaseOptionValue, len(data))
-
-	i := 0
-	for k, v := range data {
-		if v == "" {
-			v = "<nil>"
-		}
-		array[i] = &types.OptionValue{Key: k, Value: v}
-		i++
-	}
-
-	return array
 }

--- a/pkg/vsphere/extraconfig/vmomi/optionvalue.go
+++ b/pkg/vsphere/extraconfig/vmomi/optionvalue.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package extraconfig is in a separate package to avoid the transitive inclusion of govmomi
+// Package vmomi is in a separate package to avoid the transitive inclusion of govmomi
 // as a fundamental dependency of the main extraconfig
 package vmomi
 

--- a/pkg/vsphere/extraconfig/vmomi/optionvalue.go
+++ b/pkg/vsphere/extraconfig/vmomi/optionvalue.go
@@ -1,0 +1,74 @@
+// Copyright 2016 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package extraconfig is in a separate package to avoid the transitive inclusion of govmomi
+// as a fundamental dependency of the main extraconfig
+package vmomi
+
+import (
+	"fmt"
+
+	"github.com/vmware/govmomi/vim25/types"
+	"github.com/vmware/vic/pkg/vsphere/extraconfig"
+)
+
+// OptionValueSource is a convenience method to generate a MapSource source from
+// and array of OptionValue's
+func OptionValueSource(src []types.BaseOptionValue) extraconfig.DataSource {
+	// create the key/value store from the extraconfig slice for lookups
+	kv := make(map[string]string)
+	for i := range src {
+		k := src[i].GetOptionValue().Key
+		v := src[i].GetOptionValue().Value.(string)
+		if v == "<nil>" {
+			v = ""
+		}
+		kv[k] = v
+	}
+
+	return extraconfig.MapSource(kv)
+}
+
+// OptionValueFromMap is a convenience method to convert a map into a BaseOptionValue array
+func OptionValueFromMap(data map[string]string) []types.BaseOptionValue {
+	if len(data) == 0 {
+		return nil
+	}
+
+	array := make([]types.BaseOptionValue, len(data))
+
+	i := 0
+	for k, v := range data {
+		if v == "" {
+			v = "<nil>"
+		}
+		array[i] = &types.OptionValue{Key: k, Value: v}
+		i++
+	}
+
+	return array
+}
+
+// OptionValueArrayToString translates the options array in to a Go formatted structure dump
+func OptionValueArrayToString(options []types.BaseOptionValue) string {
+	// create the key/value store from the extraconfig slice for lookups
+	kv := make(map[string]string)
+	for i := range options {
+		k := options[i].GetOptionValue().Key
+		v := options[i].GetOptionValue().Value.(string)
+		kv[k] = v
+	}
+
+	return fmt.Sprintf("%#v", kv)
+}

--- a/pkg/vsphere/session/session.go
+++ b/pkg/vsphere/session/session.go
@@ -41,7 +41,7 @@ import (
 	"github.com/vmware/govmomi/vim25"
 	"github.com/vmware/govmomi/vim25/soap"
 	"github.com/vmware/govmomi/vim25/types"
-	"github.com/vmware/vic/lib/metadata"
+	"github.com/vmware/vic/lib/config"
 	"github.com/vmware/vic/pkg/errors"
 	"github.com/vmware/vic/pkg/vsphere/extraconfig"
 )
@@ -118,7 +118,7 @@ func (s *Session) IsVSAN(ctx context.Context) bool {
 
 // Create accepts a Config and returns a Session with the cached vSphere resources.
 func (s *Session) Create(ctx context.Context) (*Session, error) {
-	var vchExtraConfig metadata.VirtualContainerHostConfigSpec
+	var vchExtraConfig config.VirtualContainerHostConfigSpec
 	source, err := extraconfig.GuestInfoSource()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This removes the transitive inclusion of govmomi and docker code from the
tether, reducing its size from 43MB to 12MB. Given the Go compiler mandated package restructuring needed for this I also renamed the core configuration structures to lib/config given the much maligned metadata name.
Also changes the appliance binaries to be dynamically linked (#1190) although not assessed actual impact there.