### PR TITLE
Move log message out of for loop

### DIFF
--- a/lib/install/management/store_files.go
+++ b/lib/install/management/store_files.go
@@ -181,6 +181,7 @@ func (d *Dispatcher) createVolumeStores(conf *metadata.VirtualContainerHostConfi
 
 // returns # of removed stores
 func (d *Dispatcher) deleteVolumeStoreIfForced(conf *metadata.VirtualContainerHostConfigSpec) (removed int) {
+	defer trace.End(trace.Begin(""))
 	removed = 0
 
 	if !d.force {
@@ -196,8 +197,8 @@ func (d *Dispatcher) deleteVolumeStoreIfForced(conf *metadata.VirtualContainerHo
 		return 0
 	}
 
+	log.Infoln("Removing volume stores...")
 	for label, url := range conf.VolumeLocations {
-		log.Infoln("Removing volume stores...")
 		// FIXME: url is being encoded by the portlayer incorrectly, so we have to convert url.Path to the right url.URL object
 
 		dsURL, err := vsphere.DatastoreToURL(url.Path)

--- a/lib/portlayer/storage/vsphere/datastore.go
+++ b/lib/portlayer/storage/vsphere/datastore.go
@@ -28,6 +28,7 @@ import (
 	"github.com/vmware/govmomi/vim25/mo"
 	"github.com/vmware/govmomi/vim25/soap"
 	"github.com/vmware/govmomi/vim25/types"
+	"github.com/vmware/vic/pkg/trace"
 	"github.com/vmware/vic/pkg/vsphere/session"
 	"github.com/vmware/vic/pkg/vsphere/tasks"
 	"golang.org/x/net/context"
@@ -311,6 +312,7 @@ var pathFormat = regexp.MustCompile(`\s([\/\w]+$)`)
 
 // Converts `[datastore] /path` to URL
 func DatastoreToURL(ds string) (*url.URL, error) {
+	defer trace.End(trace.Begin(""))
 	u := new(url.URL)
 	var matches []string
 	if matches = datastoreFormat.FindStringSubmatch(ds); len(matches) != 2 {
@@ -329,6 +331,7 @@ func DatastoreToURL(ds string) (*url.URL, error) {
 
 // Converts URL for datastores to datastore format ([datastore1] /path/to/thing)
 func URLtoDatastore(u *url.URL) (string, error) {
+	defer trace.End(trace.Begin(""))
 	scheme := "ds"
 	if u.Scheme != scheme {
 		return "", fmt.Errorf("url (%s) is not a datastore", u.String())

--- a/lib/portlayer/storage/vsphere/datastore.go
+++ b/lib/portlayer/storage/vsphere/datastore.go
@@ -312,7 +312,7 @@ var pathFormat = regexp.MustCompile(`\s([\/\w]+$)`)
 
 // Converts `[datastore] /path` to URL
 func DatastoreToURL(ds string) (*url.URL, error) {
-	defer trace.End(trace.Begin(""))
+	defer trace.End(trace.Begin(ds))
 	u := new(url.URL)
 	var matches []string
 	if matches = datastoreFormat.FindStringSubmatch(ds); len(matches) != 2 {
@@ -331,7 +331,7 @@ func DatastoreToURL(ds string) (*url.URL, error) {
 
 // Converts URL for datastores to datastore format ([datastore1] /path/to/thing)
 func URLtoDatastore(u *url.URL) (string, error) {
-	defer trace.End(trace.Begin(""))
+	defer trace.End(trace.Begin(u.String()))
 	scheme := "ds"
 	if u.Scheme != scheme {
 		return "", fmt.Errorf("url (%s) is not a datastore", u.String())


### PR DESCRIPTION
This informational log message should only get printed once, and I erroneously put it inside of the for loop below where it should be.

This PR fixes that. Also adds some traces for debug.