### PR TITLE
vapp for VCH in VC

### DIFF
--- a/cmd/vic-machine/create/create.go
+++ b/cmd/vic-machine/create/create.go
@@ -103,6 +103,11 @@ func (c *Create) Flags() []cli.Flag {
 			Usage:       "Container datastore name - not supported yet, default to image datastore",
 			Destination: &c.ContainerDatastoreName,
 		},
+		cli.StringSliceFlag{
+			Name:  "volume-store",
+			Value: &c.volumeStores,
+			Usage: "Specify location and label for volume store; path optional: \"datastore/path:label\" or \"datastore:label\"",
+		},
 		cli.StringFlag{
 			Name:        "bridge-network, b",
 			Value:       "",
@@ -199,10 +204,10 @@ func (c *Create) Flags() []cli.Flag {
 			Usage:       "vCPUs for the appliance VM",
 			Destination: &c.NumCPUs,
 		},
-		cli.StringSliceFlag{
-			Name:  "volume-store",
-			Value: &c.volumeStores,
-			Usage: "Specify location and label for volume store; path optional: \"datastore/path:label\" or \"datastore:label\"",
+		cli.BoolFlag{
+			Name:        "use-rp",
+			Usage:       "Use resource pool for vch parent in VC",
+			Destination: &c.UseRP,
 		},
 	}
 	preFlags := append(c.TargetFlags(), c.ComputeFlags()...)

--- a/lib/install/data/data.go
+++ b/lib/install/data/data.go
@@ -59,6 +59,7 @@ type Data struct {
 	Timeout time.Duration
 
 	Force bool
+	UseRP bool
 }
 
 // InstallerData is used to hold the transient installation configuration that shouldn't be serialized
@@ -83,6 +84,7 @@ type InstallerData struct {
 	ImageFiles []string
 
 	Extension types.Extension
+	UseRP     bool
 }
 
 func NewData() *Data {

--- a/lib/install/management/appliance.go
+++ b/lib/install/management/appliance.go
@@ -16,6 +16,7 @@ package management
 
 import (
 	"fmt"
+	"path"
 	"strconv"
 	"time"
 
@@ -53,7 +54,7 @@ func (d *Dispatcher) isVCH(vm *vm.VirtualMachine) (bool, error) {
 
 	info, err := vm.FetchExtraConfig(d.ctx)
 	if err != nil {
-		err = errors.Errorf("Failed to fetch guest info of appliance vm, %s", err)
+		err = errors.Errorf("Failed to fetch guest info of appliance vm: %s", err)
 		return false, err
 	}
 
@@ -72,7 +73,7 @@ func (d *Dispatcher) checkExistence(conf *metadata.VirtualContainerHostConfigSpe
 	defer trace.End(trace.Begin(""))
 
 	var err error
-	d.vchPoolPath = fmt.Sprintf("%s/%s", settings.ResourcePoolPath, conf.Name)
+	d.vchPoolPath = path.Join(settings.ResourcePoolPath, conf.Name)
 	var orp *object.ResourcePool
 	var vapp *object.VirtualApp
 	if d.isVC {
@@ -100,8 +101,8 @@ func (d *Dispatcher) checkExistence(conf *metadata.VirtualContainerHostConfigSpe
 	}
 	if vm == nil {
 		if vapp != nil {
-			err = errors.Errorf("virtual app %s is found, but is not VCH, please choose different name", d.vchPoolPath)
-			log.Errorf("%s", err)
+			err = errors.Errorf("virtual app %q is found, but is not VCH, please choose different name", d.vchPoolPath)
+			log.Error(err)
 			return err
 		}
 		return nil
@@ -109,10 +110,10 @@ func (d *Dispatcher) checkExistence(conf *metadata.VirtualContainerHostConfigSpe
 
 	log.Debugf("Appliance is found")
 	if ok, verr := d.isVCH(vm); !ok {
-		verr = errors.Errorf("VM %s is found, but is not VCH appliance, please choose different name", conf.Name)
+		verr = errors.Errorf("VM %q is found, but is not VCH appliance, please choose different name", conf.Name)
 		return verr
 	}
-	err = errors.Errorf("Appliance %s exists, to install with same name, please delete it first.", conf.Name)
+	err = errors.Errorf("Appliance %q exists, to install with same name, please delete it first.", conf.Name)
 	return err
 }
 
@@ -123,7 +124,7 @@ func (d *Dispatcher) deleteVM(vm *vm.VirtualMachine, force bool) error {
 	power, err := vm.PowerState(d.ctx)
 	if err != nil || power != types.VirtualMachinePowerStatePoweredOff {
 		if err != nil {
-			log.Warnf("Failed to get vm power status %s: %s", vm.Reference(), err)
+			log.Warnf("Failed to get vm power status %q: %s", vm.Reference(), err)
 		}
 		if !force {
 			if err != nil {
@@ -131,12 +132,12 @@ func (d *Dispatcher) deleteVM(vm *vm.VirtualMachine, force bool) error {
 			}
 			name, err := vm.Name(d.ctx)
 			if err != nil {
-				log.Errorf("VM name is not found, %s", err)
+				log.Errorf("VM name is not found: %s", err)
 			}
 			if name != "" {
-				err = errors.Errorf("VM %s is powered on", name)
+				err = errors.Errorf("VM %q is powered on", name)
 			} else {
-				err = errors.Errorf("VM %s is powered on", vm.Reference())
+				err = errors.Errorf("VM %q is powered on", vm.Reference())
 			}
 			return err
 		}
@@ -156,11 +157,11 @@ func (d *Dispatcher) deleteVM(vm *vm.VirtualMachine, force bool) error {
 		return vm.Destroy(ctx)
 	})
 	if err != nil {
-		err = errors.Errorf("Failed to destroy vm %s: %s", vm.Reference(), err)
+		err = errors.Errorf("Failed to destroy vm %q: %s", vm.Reference(), err)
 		return err
 	}
 	if _, err = d.deleteDatastoreFiles(d.session.Datastore, folder, true); err != nil {
-		log.Warnf("VM path %s is not removed, %s", folder, err)
+		log.Warnf("VM path %q is not removed: %s", folder, err)
 	}
 
 	return nil
@@ -177,26 +178,26 @@ func (d *Dispatcher) addNetworkDevices(conf *metadata.VirtualContainerHostConfig
 		if pnic, ok := nets[endpoint.Network.Common.ID]; ok {
 			// there's already a NIC on this network
 			endpoint.Common.ID = pnic.Common.ID
-			log.Infof("Network role %s is sharing NIC with %s", name, pnic.Network.Common.Name)
+			log.Infof("Network role %q is sharing NIC with %q", name, pnic.Network.Common.Name)
 			continue
 		}
 
 		moref := new(types.ManagedObjectReference)
 		if ok := moref.FromString(endpoint.Network.ID); !ok {
-			return nil, fmt.Errorf("serialized managed object reference in unexpected format: %s", endpoint.Network.ID)
+			return nil, fmt.Errorf("serialized managed object reference in unexpected format: %q", endpoint.Network.ID)
 		}
 		obj, err := d.session.Finder.ObjectReference(d.ctx, *moref)
 		if err != nil {
-			return nil, fmt.Errorf("unable to reacquire reference for network %s from serialized form: %s", endpoint.Network.Name, endpoint.Network.ID)
+			return nil, fmt.Errorf("unable to reacquire reference for network %q from serialized form: %q", endpoint.Network.Name, endpoint.Network.ID)
 		}
 		network, ok := obj.(object.NetworkReference)
 		if !ok {
-			return nil, fmt.Errorf("reacquired reference for network %s, from serialized form %s, was not a network: %T", endpoint.Network.Name, endpoint.Network.ID, obj)
+			return nil, fmt.Errorf("reacquired reference for network %q, from serialized form %q, was not a network: %T", endpoint.Network.Name, endpoint.Network.ID, obj)
 		}
 
 		backing, err := network.EthernetCardBackingInfo(d.ctx)
 		if err != nil {
-			err = errors.Errorf("Failed to get network backing info for %s: %s", network, err)
+			err = errors.Errorf("Failed to get network backing info for %q: %s", network, err)
 			return nil, err
 		}
 
@@ -208,12 +209,12 @@ func (d *Dispatcher) addNetworkDevices(conf *metadata.VirtualContainerHostConfig
 
 		slot := cspec.AssignSlotNumber(nic, slots)
 		if slot == spec.NilSlot {
-			err = errors.Errorf("Failed to assign stable PCI slot for %s network card", name)
+			err = errors.Errorf("Failed to assign stable PCI slot for %q network card", name)
 		}
 
 		endpoint.Common.ID = strconv.Itoa(int(slot))
 		slots[slot] = true
-		log.Debugf("Setting %s to slot %d", name, slot)
+		log.Debugf("Setting %q to slot %d", name, slot)
 
 		devices = append(devices, nic)
 
@@ -304,7 +305,7 @@ func (d *Dispatcher) findApplianceByID(conf *metadata.VirtualContainerHostConfig
 	ref, err := d.session.Finder.ObjectReference(d.ctx, *moref)
 	if err != nil {
 		if _, ok := err.(*find.NotFoundError); !ok {
-			err = errors.Errorf("Failed to query appliance (%s): %s", moref, err)
+			err = errors.Errorf("Failed to query appliance (%q): %s", moref, err)
 			return nil, err
 		}
 		log.Debugf("Appliance is not found")
@@ -313,7 +314,7 @@ func (d *Dispatcher) findApplianceByID(conf *metadata.VirtualContainerHostConfig
 	}
 	ovm, ok := ref.(*object.VirtualMachine)
 	if !ok {
-		log.Errorf("Failed to find VM %s, %s", moref, err)
+		log.Errorf("Failed to find VM %q: %s", moref, err)
 		return nil, err
 	}
 	vmm = vm.NewVirtualMachine(d.ctx, d.session, ovm.Reference())
@@ -411,8 +412,8 @@ func (d *Dispatcher) createAppliance(conf *metadata.VirtualContainerHostConfigSp
 		log.Errorf("Failed to get canonical name for appliance: %s", err)
 		return err
 	}
-	log.Debugf("vm folder name: %s", d.vmPathName)
-	log.Debugf("vm inventory path: %s", vm2.InventoryPath)
+	log.Debugf("vm folder name: %q", d.vmPathName)
+	log.Debugf("vm inventory path: %q", vm2.InventoryPath)
 
 	// create an extension to register the appliance as
 	if err = d.GenerateExtensionName(conf, vm2); err != nil {
@@ -603,7 +604,7 @@ func (d *Dispatcher) makeSureApplianceRuns(conf *metadata.VirtualContainerHostCo
 	// but instead...
 	if !ip.IsUnspecifiedIP(conf.ExecutorConfig.Networks["client"].Assigned.IP) {
 		d.HostIP = conf.ExecutorConfig.Networks["client"].Assigned.IP.String()
-		log.Debug("Obtained IP address for client interface: %s", d.HostIP)
+		log.Debug("Obtained IP address for client interface: %q", d.HostIP)
 		return nil
 	}
 
@@ -627,7 +628,7 @@ func (d *Dispatcher) makeSureApplianceRuns(conf *metadata.VirtualContainerHostCo
 			if ip.IsUnspecifiedIP(net.Assigned.IP) {
 				addr = "waiting for IP"
 			}
-			log.Infof("    %s IP: %s", name, addr)
+			log.Infof("    %q IP: %q", name, addr)
 		}
 
 		// if we timed out, then report status - if cancelled this doesn't need reporting
@@ -639,7 +640,7 @@ func (d *Dispatcher) makeSureApplianceRuns(conf *metadata.VirtualContainerHostCo
 			} else if session.Started != "" {
 				status = session.Started
 			}
-			log.Infof("    %s: %s", name, status)
+			log.Infof("    %q: %q", name, status)
 		}
 
 		return errors.New("timed out waiting for IP address information from appliance")

--- a/lib/install/management/create.go
+++ b/lib/install/management/create.go
@@ -51,7 +51,7 @@ func (d *Dispatcher) CreateVCH(conf *metadata.VirtualContainerHostConfigSpec, se
 			}
 
 			log.Error(detail)
-			log.Errorf("Deploying vch under parent pool %s, cause --force is provided", settings.ResourcePoolPath)
+			log.Errorf("Deploying vch under parent pool %q, (--force=true)", settings.ResourcePoolPath)
 			d.vchPool = d.session.Pool
 			conf.ComputeResources = append(conf.ComputeResources, d.vchPool.Reference())
 		}
@@ -63,7 +63,7 @@ func (d *Dispatcher) CreateVCH(conf *metadata.VirtualContainerHostConfigSpec, se
 			}
 
 			log.Error(detail)
-			log.Errorf("Deploying vch under parent pool %s, , cause --force is provided", settings.ResourcePoolPath)
+			log.Errorf("Deploying vch under parent pool %q, (--force=true)", settings.ResourcePoolPath)
 			d.vchPool = d.session.Pool
 			conf.ComputeResources = append(conf.ComputeResources, d.vchPool.Reference())
 		}
@@ -118,14 +118,14 @@ func (d *Dispatcher) uploadImages(files []string) error {
 		go func(image string) {
 			defer wg.Done()
 
-			log.Infof("\t%s", image)
+			log.Infof("\t%q", image)
 			base := filepath.Base(image)
 			err = d.session.Datastore.UploadFile(d.ctx, image, d.vmPathName+"/"+base, nil)
 			if err != nil {
-				log.Errorf("\t\tUpload failed for %s, %s", image, err)
+				log.Errorf("\t\tUpload failed for %q: %s", image, err)
 				if d.force {
 					log.Warnf("\t\tContinuing despite failures (due to --force option)")
-					log.Warnf("\t\tNote: The VCH will not function without %s...", image)
+					log.Warnf("\t\tNote: The VCH will not function without %q...", image)
 					results <- nil
 				} else {
 					results <- err

--- a/lib/install/management/create.go
+++ b/lib/install/management/create.go
@@ -43,7 +43,7 @@ func (d *Dispatcher) CreateVCH(conf *metadata.VirtualContainerHostConfigSpec, se
 		return err
 	}
 
-	if d.isVC {
+	if d.isVC && !settings.UseRP {
 		if d.vchVapp, err = d.createVApp(conf, settings); err != nil {
 			detail := fmt.Sprintf("Creating virtual app failed: %s", err)
 			if !d.force {

--- a/lib/install/management/create_test.go
+++ b/lib/install/management/create_test.go
@@ -64,7 +64,7 @@ func TestMain(t *testing.T) {
 
 		validator, err := validate.NewValidator(ctx, input)
 		if err != nil {
-			t.Errorf("Failed to validator, %s", err)
+			t.Errorf("Failed to validator: %s", err)
 		}
 
 		validator.DisableFirewallCheck = true
@@ -72,7 +72,7 @@ func TestMain(t *testing.T) {
 
 		conf, err := validator.Validate(ctx, input)
 		if err != nil {
-			log.Errorf("Failed to validate conf, %s", err)
+			log.Errorf("Failed to validate conf: %s", err)
 			validator.ListIssues()
 		}
 

--- a/lib/install/management/delete.go
+++ b/lib/install/management/delete.go
@@ -74,7 +74,7 @@ func (d *Dispatcher) DeleteVCH(conf *metadata.VirtualContainerHostConfigSpec) er
 			log.Warnf("Failed to get extension name during VCH deletion: %s", err)
 		}
 		if err = d.UnregisterExtension(conf.ExtensionName); err != nil {
-			log.Warnf("Failed to remove extension %s: %s", conf.ExtensionName, err)
+			log.Warnf("Failed to remove extension %q: %s", conf.ExtensionName, err)
 		}
 	}
 
@@ -84,7 +84,7 @@ func (d *Dispatcher) DeleteVCH(conf *metadata.VirtualContainerHostConfigSpec) er
 		return err
 	}
 	if err = d.destroyResourcePoolIfEmpty(conf); err != nil {
-		log.Warnf("VCH resource pool is not removed, %s", err)
+		log.Warnf("VCH resource pool is not removed: %s", err)
 	}
 	return nil
 }
@@ -101,15 +101,16 @@ func (d *Dispatcher) DeleteVCHInstances(vmm *vm.VirtualMachine, conf *metadata.V
 	rpRef := conf.ComputeResources[len(conf.ComputeResources)-1]
 	ref, err := d.session.Finder.ObjectReference(d.ctx, rpRef)
 	if err != nil {
-		err = errors.Errorf("Failed to get VCH resource pool (%s): %s", rpRef, err)
+		err = errors.Errorf("Failed to get VCH resource pool %q: %s", rpRef, err)
 		return err
 	}
 	switch ref.(type) {
 	case *object.VirtualApp:
 	case *object.ResourcePool:
-		break
+		//		ok
 	default:
-		log.Errorf("Failed to find virtual app or resource pool %s, %s", rpRef, err)
+		log.Errorf("Failed to find virtual app or resource pool %q: %s", rpRef, err)
+		return err
 	}
 
 	rp := compute.NewResourcePool(d.ctx, d.session, ref.Reference())
@@ -119,7 +120,7 @@ func (d *Dispatcher) DeleteVCHInstances(vmm *vm.VirtualMachine, conf *metadata.V
 
 	ds, err := d.session.Finder.Datastore(d.ctx, conf.ImageStores[0].Host)
 	if err != nil {
-		err = errors.Errorf("Failed to find image datastore %s", conf.ImageStores[0].Host)
+		err = errors.Errorf("Failed to find image datastore %q", conf.ImageStores[0].Host)
 		return err
 	}
 	d.session.Datastore = ds
@@ -154,7 +155,7 @@ func (d *Dispatcher) deleteNetworkDevices(vmm *vm.VirtualMachine, conf *metadata
 
 	power, err := vmm.PowerState(d.ctx)
 	if err != nil {
-		log.Errorf("Failed to get vm power status %s: %s", vmm.Reference(), err)
+		log.Errorf("Failed to get vm power status %q: %s", vmm.Reference(), err)
 		return err
 
 	}
@@ -204,7 +205,7 @@ func (d *Dispatcher) UnregisterExtension(name string) error {
 
 	extensionManager := object.NewExtensionManager(d.session.Vim25())
 	if err := extensionManager.Unregister(d.ctx, name); err != nil {
-		return errors.Errorf("Failed to remove extension w/ name %s due to error: %s", name, err)
+		return errors.Errorf("Failed to remove extension w/ name %q due to error: %s", name, err)
 	}
 	return nil
 }

--- a/lib/install/management/delete_test.go
+++ b/lib/install/management/delete_test.go
@@ -100,6 +100,12 @@ func createAppliance(ctx context.Context, sess *session.Session, conf *metadata.
 		force:   false,
 	}
 	delete(conf.Networks, "bridge") // FIXME: cannot create bridge network in simulator
+	if d.isVC {
+		if d.vchVapp, err = d.createVApp(conf, vConf); err != nil {
+			// FIXME: Got error: ServerFaultCode: ResourcePool:resourcepool-14 does not implement: CreateVApp. Simulator need to implement CreateVApp
+			//			t.Errorf("Unable to create virtual app: %s", err)
+		}
+	}
 	if d.vchPool, err = d.createResourcePool(conf, vConf); err != nil {
 		t.Errorf("Unable to create resource pool: %s", err)
 	}

--- a/lib/install/management/delete_test.go
+++ b/lib/install/management/delete_test.go
@@ -17,6 +17,7 @@ package management
 import (
 	"fmt"
 	"net/url"
+	"path"
 	"testing"
 
 	log "github.com/Sirupsen/logrus"
@@ -67,11 +68,11 @@ func TestDelete(t *testing.T) {
 		installSettings := &data.InstallerData{}
 		installSettings.ApplianceSize.CPU.Limit = 1
 		installSettings.ApplianceSize.Memory.Limit = 1024
-		installSettings.ResourcePoolPath = fmt.Sprintf("%s/%s", input.ComputeResourcePath, input.DisplayName)
+		installSettings.ResourcePoolPath = path.Join(input.ComputeResourcePath, input.DisplayName)
 
 		validator, err := validate.NewValidator(ctx, input)
 		if err != nil {
-			t.Errorf("Failed to validator, %s", err)
+			t.Errorf("Failed to validator: %s", err)
 		}
 
 		validator.DisableFirewallCheck = true
@@ -79,7 +80,7 @@ func TestDelete(t *testing.T) {
 
 		conf, err := validator.Validate(ctx, input)
 		if err != nil {
-			log.Errorf("Failed to validate conf, %s", err)
+			log.Errorf("Failed to validate conf: %s", err)
 			validator.ListIssues()
 		}
 
@@ -161,7 +162,7 @@ func testNewVCHFromCompute(computePath string, name string, v *validate.Validato
 	}
 	vch, path, err := d.NewVCHFromComputePath(computePath, name, v)
 	if err != nil {
-		t.Errorf("Failed to get VCH, %s", err)
+		t.Errorf("Failed to get VCH: %s", err)
 		return
 	}
 	t.Logf("Got VCH %s, path %s", vch, path)
@@ -176,7 +177,7 @@ func testDeleteVCH(v *validate.Validator, conf *metadata.VirtualContainerHostCon
 	}
 	// failed to get vm FolderName, that will eventually cause panic in simulator to delete empty datastore file
 	if err := d.DeleteVCH(conf); err != nil {
-		t.Errorf("Failed to get VCH, %s", err)
+		t.Errorf("Failed to get VCH: %s", err)
 		return
 	}
 	t.Logf("Successfully deleted VCH")
@@ -185,7 +186,7 @@ func testDeleteVCH(v *validate.Validator, conf *metadata.VirtualContainerHostCon
 	if err != nil {
 		// FIXME: simulator didn't return FileNotFound error here
 		//		if !types.IsFileNotFound(err) {
-		//			t.Errorf("Failed to browse folder %s, %s", "VIC", errors.ErrorStack(err))
+		//			t.Errorf("Failed to browse folder %s: %s", "VIC", errors.ErrorStack(err))
 		//			return
 		//		}
 		t.Logf("Images Folder is not found")
@@ -198,7 +199,7 @@ func testDeleteVCH(v *validate.Validator, conf *metadata.VirtualContainerHostCon
 	}
 	// FIXME: simulator didn't return NotFoundError
 	//	if err != nil {
-	//		t.Errorf("Unexpected error to get appliance VM, %s", err)
+	//		t.Errorf("Unexpected error to get appliance VM: %s", err)
 	//	}
 	// delete VM does not clean up resource pool after VM is removed, so resource pool could not be removed
 }

--- a/lib/install/management/dispatcher.go
+++ b/lib/install/management/dispatcher.go
@@ -46,6 +46,7 @@ type Dispatcher struct {
 	VICAdminProto string
 
 	vchPool   *object.ResourcePool
+	vchVapp   *object.VirtualApp
 	appliance *vm.VirtualMachine
 }
 

--- a/lib/install/management/finder.go
+++ b/lib/install/management/finder.go
@@ -16,6 +16,7 @@ package management
 
 import (
 	"fmt"
+	"path"
 
 	log "github.com/Sirupsen/logrus"
 
@@ -46,7 +47,7 @@ func (d *Dispatcher) NewVCHFromID(id string) (*vm.VirtualMachine, error) {
 	ref, err := d.session.Finder.ObjectReference(d.ctx, *moref)
 	if err != nil {
 		if _, ok := err.(*find.NotFoundError); !ok {
-			err = errors.Errorf("Failed to query appliance (%s): %s", moref, err)
+			err = errors.Errorf("Failed to query appliance (%q): %s", moref, err)
 			return nil, err
 		}
 		log.Debugf("Appliance is not found")
@@ -54,26 +55,26 @@ func (d *Dispatcher) NewVCHFromID(id string) (*vm.VirtualMachine, error) {
 	}
 	ovm, ok := ref.(*object.VirtualMachine)
 	if !ok {
-		log.Errorf("Failed to find VM %s, %s", moref, err)
+		log.Errorf("Failed to find VM %q: %s", moref, err)
 		return nil, err
 	}
 	vmm = vm.NewVirtualMachine(d.ctx, d.session, ovm.Reference())
 
 	// check if it's VCH
 	if ok, err = d.isVCH(vmm); err != nil {
-		log.Errorf("%s", err)
+		log.Error(err)
 		return nil, err
 	}
 	if !ok {
 		err = errors.Errorf("Not a VCH")
-		log.Errorf("%s", err)
+		log.Error(err)
 		return nil, err
 	}
 	return vmm, nil
 }
 
 func (d *Dispatcher) NewVCHFromComputePath(computePath string, name string, v *validate.Validator) (*vm.VirtualMachine, string, error) {
-	defer trace.End(trace.Begin(fmt.Sprintf("path %s, name %s", computePath, name)))
+	defer trace.End(trace.Begin(fmt.Sprintf("path %q, name %q", computePath, name)))
 
 	var err error
 
@@ -81,12 +82,12 @@ func (d *Dispatcher) NewVCHFromComputePath(computePath string, name string, v *v
 	if err != nil {
 		return nil, "", err
 	}
-	d.vchPoolPath = fmt.Sprintf("%s/%s", parent.InventoryPath, name)
+	d.vchPoolPath = path.Join(parent.InventoryPath, name)
 	var vchPool *object.ResourcePool
 	if d.isVC {
 		vapp, err := d.findVirtualApp(d.vchPoolPath)
 		if err != nil {
-			log.Errorf("Failed to get VCH virtual app %s, %s", d.vchPoolPath, err)
+			log.Errorf("Failed to get VCH virtual app %q: %s", d.vchPoolPath, err)
 			return nil, d.vchPoolPath, err
 		}
 		if vapp != nil {
@@ -96,7 +97,7 @@ func (d *Dispatcher) NewVCHFromComputePath(computePath string, name string, v *v
 	if vchPool == nil {
 		vchPool, err = d.session.Finder.ResourcePool(d.ctx, d.vchPoolPath)
 		if err != nil {
-			log.Errorf("Failed to get VCH resource pool %s, %s", d.vchPoolPath, err)
+			log.Errorf("Failed to get VCH resource pool %q: %s", d.vchPoolPath, err)
 			return nil, d.vchPoolPath, err
 		}
 	}
@@ -104,24 +105,24 @@ func (d *Dispatcher) NewVCHFromComputePath(computePath string, name string, v *v
 	rp := compute.NewResourcePool(d.ctx, d.session, vchPool.Reference())
 	var vmm *vm.VirtualMachine
 	if vmm, err = rp.GetChildVM(d.ctx, d.session, name); err != nil {
-		log.Errorf("Failed to get VCH VM, %s", err)
+		log.Errorf("Failed to get VCH VM: %s", err)
 		return nil, d.vchPoolPath, err
 	}
 	if vmm == nil {
-		err = errors.Errorf("Didn't find VM %s in resource pool %s", name, rp.Name())
-		log.Errorf("%s", err)
+		err = errors.Errorf("Didn't find VM %q in resource pool %q", name, rp.Name())
+		log.Error(err)
 		return nil, d.vchPoolPath, err
 	}
 
 	// check if it's VCH
 	var ok bool
 	if ok, err = d.isVCH(vmm); err != nil {
-		log.Errorf("%s", err)
+		log.Error(err)
 		return nil, d.vchPoolPath, err
 	}
 	if !ok {
 		err = errors.Errorf("Not a VCH")
-		log.Errorf("%s", err)
+		log.Error(err)
 		return nil, d.vchPoolPath, err
 	}
 	return vmm, d.vchPoolPath, nil
@@ -133,16 +134,16 @@ func (d *Dispatcher) GetVCHConfig(vm *vm.VirtualMachine) (*metadata.VirtualConta
 	//this is the appliance vm
 	mapConfig, err := vm.FetchExtraConfig(d.ctx)
 	if err != nil {
-		err = errors.Errorf("Failed to get VM extra config of %s, %s", vm.Reference(), err)
-		log.Errorf("%s", err)
+		err = errors.Errorf("Failed to get VM extra config of %q: %s", vm.Reference(), err)
+		log.Error(err)
 		return nil, err
 	}
 	data := extraconfig.MapSource(mapConfig)
 	vchConfig := &metadata.VirtualContainerHostConfigSpec{}
 	result := extraconfig.Decode(data, vchConfig)
 	if result == nil {
-		err = errors.Errorf("Failed to decode VM configuration %s, %s", vm.Reference(), err)
-		log.Errorf("%s", err)
+		err = errors.Errorf("Failed to decode VM configuration %q: %s", vm.Reference(), err)
+		log.Error(err)
 		return nil, err
 	}
 

--- a/lib/install/management/network.go
+++ b/lib/install/management/network.go
@@ -52,7 +52,7 @@ func (d *Dispatcher) createBridgeNetwork(conf *metadata.VirtualContainerHostConf
 	if err = hostNetSystem.AddVirtualSwitch(d.ctx, name, &types.HostVirtualSwitchSpec{
 		NumPorts: 1024,
 	}); err != nil {
-		err = errors.Errorf("Failed to add virtual switch (%s): %s", name, err)
+		err = errors.Errorf("Failed to add virtual switch (%q): %s", name, err)
 		return err
 	}
 
@@ -63,7 +63,7 @@ func (d *Dispatcher) createBridgeNetwork(conf *metadata.VirtualContainerHostConf
 		VswitchName: name,
 		Policy:      types.HostNetworkPolicy{},
 	}); err != nil {
-		err = errors.Errorf("Failed to add port group (%s): %s", name, err)
+		err = errors.Errorf("Failed to add port group (%q): %s", name, err)
 		return err
 	}
 
@@ -71,7 +71,7 @@ func (d *Dispatcher) createBridgeNetwork(conf *metadata.VirtualContainerHostConf
 	if err != nil {
 		_, ok := err.(*find.NotFoundError)
 		if !ok {
-			err = errors.Errorf("Failed to query virtual switch (%s): %s", name, err)
+			err = errors.Errorf("Failed to query virtual switch (%q): %s", name, err)
 			return err
 		}
 	}
@@ -97,12 +97,12 @@ func (d *Dispatcher) removeNetwork(conf *metadata.VirtualContainerHostConfigSpec
 
 	name := conf.Name
 	if network, err := d.session.Finder.Network(d.ctx, name); err != nil || network == nil {
-		log.Infof("Didn't find network %s", name)
+		log.Infof("Didn't find network %q", name)
 		log.Debugf("Didn't find network for %s", err)
 		return nil
 	}
 
-	log.Infof("Removing Portgroup %s", name)
+	log.Infof("Removing Portgroup %q", name)
 	hostNetSystem, err := d.session.Host.ConfigManager().NetworkSystem(d.ctx)
 	if err != nil {
 		return err
@@ -113,7 +113,7 @@ func (d *Dispatcher) removeNetwork(conf *metadata.VirtualContainerHostConfigSpec
 		return err
 	}
 
-	log.Infof("Removing VirtualSwitch %s", name)
+	log.Infof("Removing VirtualSwitch %q", name)
 	err = hostNetSystem.RemoveVirtualSwitch(d.ctx, name)
 	if err != nil {
 		return err

--- a/lib/install/management/resource_pool.go
+++ b/lib/install/management/resource_pool.go
@@ -15,7 +15,7 @@
 package management
 
 import (
-	"fmt"
+	"path"
 
 	log "github.com/Sirupsen/logrus"
 
@@ -36,13 +36,13 @@ import (
 func (d *Dispatcher) createResourcePool(conf *metadata.VirtualContainerHostConfigSpec, settings *data.InstallerData) (*object.ResourcePool, error) {
 	defer trace.End(trace.Begin(""))
 
-	d.vchPoolPath = fmt.Sprintf("%s/%s", settings.ResourcePoolPath, conf.Name)
+	d.vchPoolPath = path.Join(settings.ResourcePoolPath, conf.Name)
 
 	rp, err := d.session.Finder.ResourcePool(d.ctx, d.vchPoolPath)
 	if err != nil {
 		_, ok := err.(*find.NotFoundError)
 		if !ok {
-			err = errors.Errorf("Failed to query compute resource (%s): %s", d.vchPoolPath, err)
+			err = errors.Errorf("Failed to query compute resource (%q): %q", d.vchPoolPath, err)
 			return nil, err
 		}
 	} else {
@@ -50,7 +50,7 @@ func (d *Dispatcher) createResourcePool(conf *metadata.VirtualContainerHostConfi
 		return rp, nil
 	}
 
-	log.Infof("Creating Resource Pool %s", conf.Name)
+	log.Infof("Creating Resource Pool %q", conf.Name)
 	// TODO: expose the limits and reservation here via options
 	resSpec := types.ResourceConfigSpec{
 		CpuAllocation: &types.ResourceAllocationInfo{
@@ -75,7 +75,7 @@ func (d *Dispatcher) createResourcePool(conf *metadata.VirtualContainerHostConfi
 
 	rp, err = d.session.Pool.Create(d.ctx, conf.Name, resSpec)
 	if err != nil {
-		log.Debugf("Failed to create resource pool %s: %s", d.vchPoolPath, err)
+		log.Debugf("Failed to create resource pool %q: %s", d.vchPoolPath, err)
 		return nil, err
 	}
 
@@ -86,7 +86,7 @@ func (d *Dispatcher) createResourcePool(conf *metadata.VirtualContainerHostConfi
 func (d *Dispatcher) destroyResourcePoolIfEmpty(conf *metadata.VirtualContainerHostConfigSpec) error {
 	defer trace.End(trace.Begin(""))
 
-	log.Infof("Removing Resource Pool %s", conf.Name)
+	log.Infof("Removing Resource Pool %q", conf.Name)
 
 	rpRef := conf.ComputeResources[len(conf.ComputeResources)-1]
 	rp := compute.NewResourcePool(d.ctx, d.session, rpRef)
@@ -94,11 +94,11 @@ func (d *Dispatcher) destroyResourcePoolIfEmpty(conf *metadata.VirtualContainerH
 	var vms []*vm.VirtualMachine
 	var err error
 	if vms, err = rp.GetChildrenVMs(d.ctx, d.session); err != nil {
-		err = errors.Errorf("Unable to get children vm of resource pool %s: %s", rp.Name(), err)
+		err = errors.Errorf("Unable to get children vm of resource pool %q: %s", rp.Name(), err)
 		return err
 	}
 	if len(vms) != 0 {
-		err = errors.Errorf("Resource pool is not empty: %s", rp.Name())
+		err = errors.Errorf("Resource pool is not empty: %q", rp.Name())
 		return err
 	}
 	if _, err := tasks.WaitForResult(d.ctx, func(ctx context.Context) (tasks.ResultWaiter, error) {
@@ -115,7 +115,7 @@ func (d *Dispatcher) findResourcePool(path string) (*object.ResourcePool, error)
 	if err != nil {
 		_, ok := err.(*find.NotFoundError)
 		if !ok {
-			err = errors.Errorf("Failed to query resource pool (%s): %s", path, err)
+			err = errors.Errorf("Failed to query resource pool %q: %s", path, err)
 			return nil, err
 		}
 		return nil, nil

--- a/lib/install/management/resource_pool.go
+++ b/lib/install/management/resource_pool.go
@@ -108,3 +108,17 @@ func (d *Dispatcher) destroyResourcePoolIfEmpty(conf *metadata.VirtualContainerH
 	}
 	return nil
 }
+
+func (d *Dispatcher) findResourcePool(path string) (*object.ResourcePool, error) {
+	defer trace.End(trace.Begin(path))
+	rp, err := d.session.Finder.ResourcePool(d.ctx, path)
+	if err != nil {
+		_, ok := err.(*find.NotFoundError)
+		if !ok {
+			err = errors.Errorf("Failed to query resource pool (%s): %s", path, err)
+			return nil, err
+		}
+		return nil, nil
+	}
+	return rp, nil
+}

--- a/lib/install/management/store_files.go
+++ b/lib/install/management/store_files.go
@@ -200,7 +200,6 @@ func (d *Dispatcher) deleteVolumeStoreIfForced(conf *metadata.VirtualContainerHo
 	log.Infoln("Removing volume stores...")
 	for label, url := range conf.VolumeLocations {
 		// FIXME: url is being encoded by the portlayer incorrectly, so we have to convert url.Path to the right url.URL object
-
 		dsURL, err := vsphere.DatastoreToURL(url.Path)
 
 		if err != nil {

--- a/lib/install/management/store_files.go
+++ b/lib/install/management/store_files.go
@@ -15,6 +15,7 @@
 package management
 
 import (
+	"bytes"
 	"fmt"
 	"path"
 	"strings"
@@ -29,8 +30,6 @@ import (
 	"github.com/vmware/vic/pkg/trace"
 	"github.com/vmware/vic/pkg/vsphere/tasks"
 	"github.com/vmware/vic/pkg/vsphere/vm"
-
-	"bytes"
 
 	"golang.org/x/net/context"
 )
@@ -87,7 +86,7 @@ func (d *Dispatcher) deleteImages(ds *object.Datastore, root string) (bool, erro
 }
 
 func (d *Dispatcher) deleteDatastoreFiles(ds *object.Datastore, path string, force bool) (bool, error) {
-	defer trace.End(trace.Begin(fmt.Sprintf("path %s, force %t", path, force)))
+	defer trace.End(trace.Begin(fmt.Sprintf("path %q, force %t", path, force)))
 
 	var empty bool
 	dsPath := ds.Path(path)
@@ -95,15 +94,15 @@ func (d *Dispatcher) deleteDatastoreFiles(ds *object.Datastore, path string, for
 	res, err := d.lsFolder(ds, dsPath)
 	if err != nil {
 		if !types.IsFileNotFound(err) {
-			err = errors.Errorf("Failed to browse folder %s, %s", dsPath, err)
+			err = errors.Errorf("Failed to browse folder %q: %s", dsPath, err)
 			return empty, err
 		}
-		log.Debugf("Folder %s is not found", dsPath)
+		log.Debugf("Folder %q is not found", dsPath)
 		empty = true
 		return empty, nil
 	}
 	if len(res.File) > 0 && !force {
-		log.Debugf("Folder %s is not empty, leave it there", dsPath)
+		log.Debugf("Folder %q is not empty, leave it there", dsPath)
 		return empty, nil
 	}
 	if err = d.deleteVMFSFiles(ds, dsPath, d.force); err == nil {
@@ -120,7 +119,7 @@ func (d *Dispatcher) deleteVMFSFiles(ds *object.Datastore, dsPath string, force 
 	if _, err := tasks.WaitForResult(d.ctx, func(ctx context.Context) (tasks.ResultWaiter, error) {
 		return m.DeleteDatastoreFile(ctx, dsPath, d.session.Datacenter)
 	}); err != nil {
-		log.Debugf("Failed to delete %s, %s", dsPath, err)
+		log.Debugf("Failed to delete %q: %s", dsPath, err)
 	}
 	return nil
 }
@@ -157,7 +156,7 @@ func (d *Dispatcher) getVCHRootDir(vchVM *vm.VirtualMachine) (string, error) {
 	parent := vsphere.StorageParentDir
 	uuid, err := vchVM.UUID(d.ctx)
 	if err != nil {
-		err = errors.Errorf("Failed to get VCH UUID, %s", err)
+		err = errors.Errorf("Failed to get VCH UUID: %s", err)
 		return "", err
 	}
 	return path.Join(parent, uuid), nil
@@ -167,7 +166,7 @@ func (d *Dispatcher) createVolumeStores(conf *metadata.VirtualContainerHostConfi
 	for _, url := range conf.VolumeLocations {
 		ds, err := d.session.Finder.Datastore(d.ctx, url.Host)
 		if err != nil {
-			return errors.Errorf("Could not retrieve datastore with host %s due to error %s", url.Host, err)
+			return errors.Errorf("Could not retrieve datastore with host %q due to error %s", url.Host, err)
 		}
 		nds, err := vsphere.NewDatastore(d.ctx, d.session, ds, url.Path)
 		if err != nil {
@@ -193,7 +192,7 @@ func (d *Dispatcher) deleteVolumeStoreIfForced(conf *metadata.VirtualContainerHo
 		for label, url := range conf.VolumeLocations {
 			volumeStores.WriteString(fmt.Sprintf("\t%s: %s\n", label, url.Path))
 		}
-		log.Warnf("Since --force was not specified, the following volume stores will not be removed. Use the vSphere UI to delete content you do not wish to keep.\n%s", volumeStores.String())
+		log.Warnf("Since --force was not specified, the following volume stores will not be removed. Use the vSphere UI to delete content you do not wish to keep.\n%q", volumeStores.String())
 		return 0
 	}
 
@@ -203,18 +202,18 @@ func (d *Dispatcher) deleteVolumeStoreIfForced(conf *metadata.VirtualContainerHo
 		dsURL, err := vsphere.DatastoreToURL(url.Path)
 
 		if err != nil {
-			log.Warnf("Didn't receive an expected volume store path format: %s", url.Path)
+			log.Warnf("Didn't receive an expected volume store path format: %q", url.Path)
 			continue
 		}
 
-		log.Debugf("Provided datastore URL: %s\nParsed volume store path: %s", url.Path, dsURL.Path)
+		log.Debugf("Provided datastore URL: %q\nParsed volume store path: %q", url.Path, dsURL.Path)
 
-		log.Infof("Deleting volume store %s on Datastore %s at path %s", label, dsURL.Host, dsURL.Path)
+		log.Infof("Deleting volume store %q on Datastore %q at path %q", label, dsURL.Host, dsURL.Path)
 
 		datastores, err := d.session.Finder.DatastoreList(d.ctx, dsURL.Host)
 
 		if err != nil {
-			log.Errorf("Error finding datastore %s: %s", dsURL.Host, err)
+			log.Errorf("Error finding datastore %q: %s", dsURL.Host, err)
 			continue
 		}
 		if len(datastores) > 1 {
@@ -222,13 +221,13 @@ func (d *Dispatcher) deleteVolumeStoreIfForced(conf *metadata.VirtualContainerHo
 			for _, d := range datastores {
 				foundDatastores.WriteString(fmt.Sprintf("\n%s\n", d.InventoryPath))
 			}
-			log.Errorf("Ambiguous datastore name (%s) provided. Results were: %s", dsURL.Host, foundDatastores)
+			log.Errorf("Ambiguous datastore name (%q) provided. Results were: %q", dsURL.Host, foundDatastores)
 			continue
 		}
 
 		datastore := datastores[0]
 		if _, err := d.deleteDatastoreFiles(datastore, dsURL.Path, d.force); err != nil {
-			log.Errorf("Failed to delete volume store %s on Datastore %s at path %s", label, dsURL.Host, dsURL.Path)
+			log.Errorf("Failed to delete volume store %q on Datastore %q at path %q", label, dsURL.Host, dsURL.Path)
 		} else {
 			removed++
 		}

--- a/lib/install/management/virtual_app.go
+++ b/lib/install/management/virtual_app.go
@@ -30,7 +30,7 @@ func (d *Dispatcher) createVApp(conf *metadata.VirtualContainerHostConfigSpec, s
 	defer trace.End(trace.Begin(""))
 	var err error
 
-	log.Infof("Creating virtual app %s", conf.Name)
+	log.Infof("Creating virtual app %q", conf.Name)
 
 	resSpec := types.ResourceConfigSpec{
 		CpuAllocation: &types.ResourceAllocationInfo{
@@ -74,7 +74,7 @@ func (d *Dispatcher) createVApp(conf *metadata.VirtualContainerHostConfigSpec, s
 
 	app, err := d.session.Pool.CreateVApp(d.ctx, conf.Name, resSpec, configSpec, d.session.Folders(d.ctx).VmFolder)
 	if err != nil {
-		log.Debugf("Failed to create virtual app %s: %s", conf.Name, err)
+		log.Debugf("Failed to create virtual app %q: %s", conf.Name, err)
 		return nil, err
 	}
 	conf.ComputeResources = append(conf.ComputeResources, app.Reference())
@@ -87,7 +87,7 @@ func (d *Dispatcher) findVirtualApp(path string) (*object.VirtualApp, error) {
 	if err != nil {
 		_, ok := err.(*find.NotFoundError)
 		if !ok {
-			err = errors.Errorf("Failed to query virtual app (%s): %s", path, err)
+			err = errors.Errorf("Failed to query virtual app %q: %s", path, err)
 			return nil, err
 		}
 		return nil, nil

--- a/lib/install/management/virtual_app.go
+++ b/lib/install/management/virtual_app.go
@@ -1,0 +1,96 @@
+// Copyright 2016 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package management
+
+import (
+	log "github.com/Sirupsen/logrus"
+
+	"github.com/vmware/govmomi/find"
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25/types"
+	"github.com/vmware/vic/lib/install/data"
+	"github.com/vmware/vic/lib/metadata"
+	"github.com/vmware/vic/pkg/errors"
+	"github.com/vmware/vic/pkg/trace"
+)
+
+func (d *Dispatcher) createVApp(conf *metadata.VirtualContainerHostConfigSpec, settings *data.InstallerData) (*object.VirtualApp, error) {
+	defer trace.End(trace.Begin(""))
+	var err error
+
+	log.Infof("Creating virtual app %s", conf.Name)
+
+	resSpec := types.ResourceConfigSpec{
+		CpuAllocation: &types.ResourceAllocationInfo{
+			Shares: &types.SharesInfo{
+				Level: types.SharesLevelNormal,
+			},
+			ExpandableReservation: types.NewBool(true),
+			Limit: -1,
+			// FIXME: govmomi omitempty
+			Reservation: 1,
+		},
+		MemoryAllocation: &types.ResourceAllocationInfo{
+			Shares: &types.SharesInfo{
+				Level: types.SharesLevelNormal,
+			},
+			ExpandableReservation: types.NewBool(true),
+			Limit: -1,
+			// FIXME: govmomi omitempty
+			Reservation: 1,
+		},
+	}
+
+	prodSpec := types.VAppProductSpec{
+		Info: &types.VAppProductInfo{
+			Name:      "vSphere Integrated Containers",
+			Vendor:    "VMware",
+			VendorUrl: "http://www.vmware.com/",
+			Version:   "0.0.1",
+		},
+		ArrayUpdateSpec: types.ArrayUpdateSpec{
+			Operation: types.ArrayUpdateOperationAdd,
+		},
+	}
+
+	configSpec := types.VAppConfigSpec{
+		Annotation: "vSphere Integrated Containers",
+		VmConfigSpec: types.VmConfigSpec{
+			Product: []types.VAppProductSpec{prodSpec},
+		},
+	}
+
+	app, err := d.session.Pool.CreateVApp(d.ctx, conf.Name, resSpec, configSpec, d.session.Folders(d.ctx).VmFolder)
+	if err != nil {
+		log.Debugf("Failed to create virtual app %s: %s", conf.Name, err)
+		return nil, err
+	}
+	conf.ComputeResources = append(conf.ComputeResources, app.Reference())
+	return app, nil
+}
+
+func (d *Dispatcher) findVirtualApp(path string) (*object.VirtualApp, error) {
+	defer trace.End(trace.Begin(path))
+	vapp, err := d.session.Finder.VirtualApp(d.ctx, path)
+	if err != nil {
+		_, ok := err.(*find.NotFoundError)
+		if !ok {
+			err = errors.Errorf("Failed to query virtual app (%s): %s", path, err)
+			return nil, err
+		}
+		return nil, nil
+	}
+	return vapp, nil
+}

--- a/lib/install/validate/validator.go
+++ b/lib/install/validate/validator.go
@@ -1191,6 +1191,7 @@ func (v *Validator) AddDeprecatedFields(ctx context.Context, conf *metadata.Virt
 	dconfig.ClusterPath = v.Session.Cluster.InventoryPath
 
 	dconfig.ResourcePoolPath = v.ResourcePoolPath
+	dconfig.UseRP = input.UseRP
 
 	log.Debugf("Datacenter: %s, Cluster: %s, Resource Pool: %s", dconfig.DatacenterName, dconfig.ClusterPath, dconfig.ResourcePoolPath)
 

--- a/lib/install/validate/validator.go
+++ b/lib/install/validate/validator.go
@@ -217,13 +217,13 @@ func (v *Validator) compute(ctx context.Context, input *data.Data, conf *metadat
 
 	clusters, err := v.Session.Finder.ComputeResourceList(v.Context, v.Session.ClusterPath)
 	if err != nil {
-		log.Errorf("Unable to acquire reference to cluster %s: %s", path.Base(v.Session.ClusterPath), err)
+		log.Errorf("Unable to acquire reference to cluster %q: %s", path.Base(v.Session.ClusterPath), err)
 		v.NoteIssue(err)
 		return
 	}
 
 	if len(clusters) != 1 {
-		err := fmt.Errorf("Unable to acquire unambiguous reference to cluster %s", path.Base(v.Session.ClusterPath))
+		err := fmt.Errorf("Unable to acquire unambiguous reference to cluster %q", path.Base(v.Session.ClusterPath))
 		log.Error(err)
 		v.NoteIssue(err)
 	}
@@ -285,7 +285,7 @@ func (v *Validator) network(ctx context.Context, input *data.Data, conf *metadat
 	})
 	// Bridge network should be different with all other networks
 	if input.BridgeNetworkName == input.ExternalNetworkName {
-		v.NoteIssue(errors.Errorf("the bridge network must not be shared with another network role - external also uses %s", input.BridgeNetworkName))
+		v.NoteIssue(errors.Errorf("the bridge network must not be shared with another network role - external also uses %q", input.BridgeNetworkName))
 	}
 
 	// Client net
@@ -306,7 +306,7 @@ func (v *Validator) network(ctx context.Context, input *data.Data, conf *metadat
 		},
 	})
 	if input.BridgeNetworkName == input.ClientNetworkName {
-		v.NoteIssue(errors.Errorf("the bridge network must not be shared with another network role - client also uses %s", input.BridgeNetworkName))
+		v.NoteIssue(errors.Errorf("the bridge network must not be shared with another network role - client also uses %q", input.BridgeNetworkName))
 	}
 
 	// Management net
@@ -324,7 +324,7 @@ func (v *Validator) network(ctx context.Context, input *data.Data, conf *metadat
 		},
 	})
 	if input.BridgeNetworkName == input.ManagementNetworkName {
-		v.NoteIssue(errors.Errorf("the bridge network must not be shared with another network role - management also uses %s", input.BridgeNetworkName))
+		v.NoteIssue(errors.Errorf("the bridge network must not be shared with another network role - management also uses %q", input.BridgeNetworkName))
 	}
 
 	// Bridge net -
@@ -379,7 +379,7 @@ func (v *Validator) network(ctx context.Context, input *data.Data, conf *metadat
 		pools := input.MappedNetworksIPRanges[name]
 		dns := input.MappedNetworksDNS[name]
 		if len(pools) != 0 && nilIPNet(gw) {
-			v.NoteIssue(fmt.Errorf("IP range specified without gateway for container network %s", name))
+			v.NoteIssue(fmt.Errorf("IP range specified without gateway for container network %q", name))
 			continue
 		}
 
@@ -388,13 +388,13 @@ func (v *Validator) network(ctx context.Context, input *data.Data, conf *metadat
 		// and don't overlap with each other
 		for i, r := range pools {
 			if !gw.Contains(r.FirstIP) || !gw.Contains(r.LastIP) {
-				err = fmt.Errorf("IP range %s is not in subnet %s", r, gw)
+				err = fmt.Errorf("IP range %q is not in subnet %q", r, gw)
 				break
 			}
 
 			for _, r2 := range pools[i+1:] {
 				if r2.Overlaps(r) {
-					err = fmt.Errorf("Overlapping ip ranges: %s %s", r2, r)
+					err = fmt.Errorf("Overlapping ip ranges: %q %q", r2, r)
 					break
 				}
 			}
@@ -421,7 +421,7 @@ func (v *Validator) network(ctx context.Context, input *data.Data, conf *metadat
 			Pools:       pools,
 		}
 		if input.BridgeNetworkName == net {
-			v.NoteIssue(errors.Errorf("the bridge network must not be shared with another network role - %s also mapped as container network %s", input.BridgeNetworkName, name))
+			v.NoteIssue(errors.Errorf("the bridge network must not be shared with another network role - %q also mapped as container network %q", input.BridgeNetworkName, name))
 		}
 
 		conf.AddContainerNetwork(mappedNet)
@@ -506,9 +506,9 @@ func (v *Validator) firewall(ctx context.Context) {
 		}
 		if !esxfw.Enabled {
 			disabled = true
-			log.Infof("Firewall status: DISABLED on %s", host.InventoryPath)
+			log.Infof("Firewall status: DISABLED on %q", host.InventoryPath)
 		} else {
-			log.Infof("Firewall status: ENABLED on %s", host.InventoryPath)
+			log.Infof("Firewall status: ENABLED on %q", host.InventoryPath)
 		}
 
 		info, err := fs.Info(ctx)
@@ -533,13 +533,13 @@ func (v *Validator) firewall(ctx context.Context) {
 	if len(correct) > 0 {
 		log.Info("Firewall configuration OK on hosts:")
 		for _, h := range correct {
-			log.Infof("  %s", h)
+			log.Infof("  %q", h)
 		}
 	}
 	if len(misconfiguredEnabled) > 0 {
 		log.Error("Firewall configuration incorrect on hosts:")
 		for _, h := range misconfiguredEnabled {
-			log.Errorf("  %s", h)
+			log.Errorf("  %q", h)
 		}
 		// TODO: when we can intelligently place containerVMs on hosts with proper config, install
 		// can proceed if there is at least one host properly configured. For now this prevents install.
@@ -551,7 +551,7 @@ func (v *Validator) firewall(ctx context.Context) {
 	if len(misconfiguredDisabled) > 0 {
 		log.Warning("Firewall configuration will be incorrect if firewall is reenabled on hosts:")
 		for _, h := range misconfiguredDisabled {
-			log.Warningf("  %s", h)
+			log.Warningf("  %q", h)
 		}
 		log.Warning("Firewall must permit 8080/tcp outbound if firewall is reenabled")
 	}
@@ -618,7 +618,7 @@ func (v *Validator) checkAssignedLicenses(ctx context.Context) error {
 		for _, feature := range features {
 			if !v.assignedLicenseHasFeature(la, feature) {
 				valid = false
-				msg := fmt.Sprintf("%s - license missing feature '%s'", host.InventoryPath, feature)
+				msg := fmt.Sprintf("%q - license missing feature %q", host.InventoryPath, feature)
 				invalidLic = append(invalidLic, msg)
 			}
 		}
@@ -631,13 +631,13 @@ func (v *Validator) checkAssignedLicenses(ctx context.Context) error {
 	if len(validLic) > 0 {
 		log.Infof("License check OK on hosts:")
 		for _, h := range validLic {
-			log.Infof("  %s", h)
+			log.Infof("  %q", h)
 		}
 	}
 	if len(invalidLic) > 0 {
 		log.Errorf("License check FAILED on hosts:")
 		for _, h := range invalidLic {
-			log.Errorf("  %s", h)
+			log.Errorf("  %q", h)
 		}
 		msg := "License does not meet minimum requirements to use VIC"
 		return errors.New(msg)
@@ -660,7 +660,7 @@ func (v *Validator) checkLicense(ctx context.Context) error {
 
 	for _, feature := range features {
 		if len(licenses.WithFeature(feature)) == 0 {
-			msg := fmt.Sprintf("Host license missing feature '%s'", feature)
+			msg := fmt.Sprintf("Host license missing feature %q", feature)
 			invalidLic = append(invalidLic, msg)
 		}
 	}
@@ -668,7 +668,7 @@ func (v *Validator) checkLicense(ctx context.Context) error {
 	if len(invalidLic) > 0 {
 		log.Errorf("License check FAILED:")
 		for _, h := range invalidLic {
-			log.Errorf("  %s", h)
+			log.Errorf("  %q", h)
 		}
 		msg := "License does not meet minimum requirements to use VIC"
 		return errors.New(msg)
@@ -728,12 +728,12 @@ func (v *Validator) drs(ctx context.Context) {
 
 	if !(*z.Enabled) {
 		log.Error("DRS check FAILED")
-		log.Errorf("  DRS must be enabled on cluster %s", v.Session.Pool.InventoryPath)
+		log.Errorf("  DRS must be enabled on cluster %q", v.Session.Pool.InventoryPath)
 		v.NoteIssue(errors.New("DRS must be enabled to use VIC"))
 		return
 	}
 	log.Info("DRS check OK on:")
-	log.Infof("  %s", v.Session.Pool.InventoryPath)
+	log.Infof("  %q", v.Session.Pool.InventoryPath)
 }
 
 func (v *Validator) target(ctx context.Context, input *data.Data, conf *metadata.VirtualContainerHostConfigSpec) {
@@ -744,7 +744,7 @@ func (v *Validator) target(ctx context.Context, input *data.Data, conf *metadata
 		var err error
 		targetURL, err = url.Parse(v.Session.Service)
 		if err != nil {
-			v.NoteIssue(fmt.Errorf("Error processing target after transformation to SOAP endpoint: %s, %s", v.Session.Service, err))
+			v.NoteIssue(fmt.Errorf("Error processing target after transformation to SOAP endpoint: %q: %s", v.Session.Service, err))
 			return
 		}
 	}
@@ -792,7 +792,7 @@ func (v *Validator) networkHelper(ctx context.Context, path string) (string, err
 
 	nets, err := v.Session.Finder.NetworkList(ctx, path)
 	if err != nil {
-		log.Debugf("no such network %s", path)
+		log.Debugf("no such network %q", path)
 		// TODO: error message about no such match and how to get a network list
 		// we return err directly here so we can check the type
 		return "", err
@@ -827,7 +827,7 @@ func (v *Validator) dpgMorefHelper(ctx context.Context, ref string) (string, err
 	if v.IsVC() {
 		_, dpg := net.(*object.DistributedVirtualPortgroup)
 		if !dpg {
-			return "", fmt.Errorf("%s is not a Distributed Port Group", ref)
+			return "", fmt.Errorf("%q is not a Distributed Port Group", ref)
 		}
 	}
 
@@ -839,7 +839,7 @@ func (v *Validator) dpgHelper(ctx context.Context, path string) (string, error) 
 
 	nets, err := v.Session.Finder.NetworkList(ctx, path)
 	if err != nil {
-		log.Debugf("no such network %s", path)
+		log.Debugf("no such network %q", path)
 		// TODO: error message about no such match and how to get a network list
 		// we return err directly here so we can check the type
 		return "", err
@@ -854,7 +854,7 @@ func (v *Validator) dpgHelper(ctx context.Context, path string) (string, error) 
 	if v.IsVC() {
 		_, dpg := nets[0].(*object.DistributedVirtualPortgroup)
 		if !dpg {
-			return "", fmt.Errorf("%s is not a Distributed Port Group", path)
+			return "", fmt.Errorf("%q is not a Distributed Port Group", path)
 		}
 	}
 
@@ -872,7 +872,7 @@ func (v *Validator) DatastoreHelper(ctx context.Context, path string) (*url.URL,
 
 	// url scheme does not contain ://, so remove it to make url work
 	if dsURL.Scheme != "" && dsURL.Scheme != "ds" {
-		return nil, nil, errors.Errorf("bad scheme %s provided for datastore", dsURL.Scheme)
+		return nil, nil, errors.Errorf("bad scheme %q provided for datastore", dsURL.Scheme)
 	}
 
 	dsURL.Scheme = "ds"
@@ -922,7 +922,7 @@ func (v *Validator) ResourcePoolHelper(ctx context.Context, path string) (*objec
 	// if compute-resource is unspecified is there a default
 	if path == "" || path == "/" {
 		if v.Session.Pool != nil {
-			log.Debugf("Using default resource pool for compute resource: %s", v.Session.Pool.InventoryPath)
+			log.Debugf("Using default resource pool for compute resource: %q", v.Session.Pool.InventoryPath)
 			return v.Session.Pool, nil
 		}
 
@@ -932,12 +932,12 @@ func (v *Validator) ResourcePoolHelper(ctx context.Context, path string) (*objec
 	}
 
 	ipath := v.computePathToInventoryPath(path)
-	log.Debugf("Converted original path %s to %s", path, ipath)
+	log.Debugf("Converted original path %q to %q", path, ipath)
 
 	// first try the path directly without any processing
 	pools, err := v.Session.Finder.ResourcePoolList(ctx, path)
 	if err != nil {
-		log.Debugf("Failed to look up compute resource as absolute path %s: %s", path, err)
+		log.Debugf("Failed to look up compute resource as absolute path %q: %s", path, err)
 		if _, ok := err.(*find.NotFoundError); !ok {
 			// we return err directly here so we can check the type
 			return nil, err
@@ -957,7 +957,7 @@ func (v *Validator) ResourcePoolHelper(ctx context.Context, path string) (*objec
 
 		pools, err = v.Session.Finder.ResourcePoolList(ctx, ipath)
 		if err != nil {
-			log.Debugf("failed to look up compute resource as cluster path %s: %s", ipath, err)
+			log.Debugf("failed to look up compute resource as cluster path %q: %s", ipath, err)
 			if _, ok := err.(*find.NotFoundError); !ok {
 				// we return err directly here so we can check the type
 				return nil, err
@@ -966,7 +966,7 @@ func (v *Validator) ResourcePoolHelper(ctx context.Context, path string) (*objec
 	}
 
 	if len(pools) == 1 {
-		log.Debugf("Selected compute resource %s", pools[0].InventoryPath)
+		log.Debugf("Selected compute resource %q", pools[0].InventoryPath)
 		return pools[0], nil
 	}
 
@@ -974,7 +974,7 @@ func (v *Validator) ResourcePoolHelper(ctx context.Context, path string) (*objec
 	v.suggestComputeResource(ipath)
 
 	if len(pools) == 0 {
-		log.Debugf("no such compute resource %s", path)
+		log.Debugf("no such compute resource %q", path)
 		// we return err directly here so we can check the type
 		return nil, err
 	}
@@ -986,7 +986,7 @@ func (v *Validator) ResourcePoolHelper(ctx context.Context, path string) (*objec
 func (v *Validator) suggestComputeResource(path string) {
 	defer trace.End(trace.Begin(path))
 
-	log.Infof("Suggesting valid values for --compute-resource based on %s", path)
+	log.Infof("Suggesting valid values for --compute-resource based on %q", path)
 
 	// allow us to work on inventory paths
 	path = v.computePathToInventoryPath(path)
@@ -1015,7 +1015,7 @@ func (v *Validator) suggestComputeResource(path string) {
 		// we've collected recommendations - displayname
 		log.Info("Suggested values for --compute-resource:")
 		for _, p := range matches {
-			log.Infof("  %s", v.inventoryPathToComputePath(p))
+			log.Infof("  %q", v.inventoryPathToComputePath(p))
 		}
 		return
 	}
@@ -1037,7 +1037,7 @@ func (v *Validator) findValidPool(path string) []string {
 	clusters, err := v.Session.Finder.ComputeResourceList(v.Context, path)
 	if len(clusters) == 0 {
 		// not a cluster
-		log.Debugf("Path %s does not identify a cluster (or clusters) or the list could not be obtained: %s", path, err)
+		log.Debugf("Path %q does not identify a cluster (or clusters) or the list could not be obtained: %s", path, err)
 		return nil
 	}
 
@@ -1051,7 +1051,7 @@ func (v *Validator) findValidPool(path string) []string {
 		return matches
 	}
 
-	log.Debugf("Suggesting pools for cluster %s", clusters[0].Name())
+	log.Debugf("Suggesting pools for cluster %q", clusters[0].Name())
 	matches = v.listResourcePools(fmt.Sprintf("%s/Resources/*", clusters[0].InventoryPath))
 	if matches == nil {
 		// no child pools so recommend cluster directly
@@ -1066,7 +1066,7 @@ func (v *Validator) listResourcePools(path string) []string {
 
 	pools, err := v.Session.Finder.ResourcePoolList(v.Context, path+"/*")
 	if err != nil {
-		log.Debugf("Unable to list pools for %s: %s", path, err)
+		log.Debugf("Unable to list pools for %q: %s", path, err)
 		return nil
 	}
 
@@ -1087,7 +1087,7 @@ func (v *Validator) computePathToInventoryPath(path string) string {
 
 	// if it opens with the datacenter prefix the assume it's an absolute
 	if strings.HasPrefix(path, v.DatacenterPath) {
-		log.Debugf("Path is treated as absolute given datacenter prefix %s", v.DatacenterPath)
+		log.Debugf("Path is treated as absolute given datacenter prefix %q", v.DatacenterPath)
 		return path
 	}
 
@@ -1123,7 +1123,7 @@ func (v *Validator) inventoryPathToComputePath(path string) string {
 
 	// sanity check datacenter
 	if !strings.HasPrefix(path, v.DatacenterPath) {
-		log.Debugf("Expected path to be within target datacenter %s: %s", v.DatacenterPath, path)
+		log.Debugf("Expected path to be within target datacenter %q: %q", v.DatacenterPath, path)
 		v.NoteIssue(errors.New("inventory path was not in datacenter scope"))
 		return ""
 	}
@@ -1193,7 +1193,7 @@ func (v *Validator) AddDeprecatedFields(ctx context.Context, conf *metadata.Virt
 	dconfig.ResourcePoolPath = v.ResourcePoolPath
 	dconfig.UseRP = input.UseRP
 
-	log.Debugf("Datacenter: %s, Cluster: %s, Resource Pool: %s", dconfig.DatacenterName, dconfig.ClusterPath, dconfig.ResourcePoolPath)
+	log.Debugf("Datacenter: %q, Cluster: %q, Resource Pool: %q", dconfig.DatacenterName, dconfig.ClusterPath, dconfig.ResourcePoolPath)
 
 	return &dconfig
 }

--- a/lib/install/validate/validator_test.go
+++ b/lib/install/validate/validator_test.go
@@ -100,7 +100,7 @@ func TestMain(t *testing.T) {
 
 		validator, err := NewValidator(ctx, input)
 		if err != nil {
-			t.Errorf("Failed to new validator, %s", err)
+			t.Errorf("Failed to new validator: %s", err)
 		}
 
 		validator.DisableFirewallCheck = true
@@ -151,7 +151,7 @@ func getVPXData(url *url.URL) *data.Data {
 func createPool(ctx context.Context, sess *session.Session, poolPath string, name string, t *testing.T) error {
 	rp, err := sess.Finder.ResourcePool(ctx, poolPath)
 	if err != nil {
-		t.Logf("Failed to get parent pool, %s", err)
+		t.Logf("Failed to get parent pool: %s", err)
 		return err
 	}
 	t.Logf("Creating Resource Pool %s", name)

--- a/lib/portlayer/exec/config.go
+++ b/lib/portlayer/exec/config.go
@@ -40,6 +40,8 @@ type Configuration struct {
 	ComputeResources []types.ManagedObjectReference `vic:"0.1" scope:"read-only"`
 	// Resource pool is the working version of the compute resource config
 	ResourcePool *object.ResourcePool
+	// Parent resource will be a VirtualApp on VC
+	VirtualApp *object.VirtualApp
 
 	// Path of the ISO to use for bootstrapping containers
 	BootstrapImagePath string `vic:"0.1" scope:"read-only" key:"bootstrap_image_path"`

--- a/lib/portlayer/portlayer.go
+++ b/lib/portlayer/portlayer.go
@@ -65,7 +65,7 @@ func Init(ctx context.Context, sess *session.Session) error {
 	cr := exec.VCHConfig.ComputeResources[0]
 	r, err := f.ObjectReference(ctx, cr)
 	if err != nil {
-		detail := fmt.Sprintf("could not get resource pool or vitual app reference from %s: %s", cr.String(), err)
+		detail := fmt.Sprintf("could not get resource pool or virtual app reference from %q: %s", cr.String(), err)
 		log.Errorf(detail)
 		return err
 	}
@@ -76,7 +76,7 @@ func Init(ctx context.Context, sess *session.Session) error {
 	case *object.ResourcePool:
 		exec.VCHConfig.ResourcePool = o
 	default:
-		detail := fmt.Sprintf("could not get resource pool or virtual app from reference %s: object type is wrong", cr.String())
+		detail := fmt.Sprintf("could not get resource pool or virtual app from reference %q: object type is wrong", cr.String())
 		log.Errorf(detail)
 		return errors.New(detail)
 	}

--- a/lib/portlayer/portlayer.go
+++ b/lib/portlayer/portlayer.go
@@ -25,6 +25,7 @@ import (
 	"github.com/vmware/vic/lib/portlayer/exec"
 	"github.com/vmware/vic/lib/portlayer/network"
 	"github.com/vmware/vic/lib/portlayer/storage"
+	"github.com/vmware/vic/pkg/errors"
 	"github.com/vmware/vic/pkg/vsphere/extraconfig"
 	"github.com/vmware/vic/pkg/vsphere/session"
 	"golang.org/x/net/context"
@@ -64,11 +65,22 @@ func Init(ctx context.Context, sess *session.Session) error {
 	cr := exec.VCHConfig.ComputeResources[0]
 	r, err := f.ObjectReference(ctx, cr)
 	if err != nil {
-		detail := fmt.Sprintf("could not get resource pool reference from %s: %s", cr.String(), err)
+		detail := fmt.Sprintf("could not get resource pool or vitual app reference from %s: %s", cr.String(), err)
 		log.Errorf(detail)
 		return err
 	}
-	exec.VCHConfig.ResourcePool = r.(*object.ResourcePool)
+	switch o := r.(type) {
+	case *object.VirtualApp:
+		exec.VCHConfig.VirtualApp = o
+		exec.VCHConfig.ResourcePool = o.ResourcePool
+	case *object.ResourcePool:
+		exec.VCHConfig.ResourcePool = o
+	default:
+		detail := fmt.Sprintf("could not get resource pool or virtual app from reference %s: object type is wrong", cr.String())
+		log.Errorf(detail)
+		return errors.New(detail)
+	}
+
 	//FIXME: temporary injection of debug network for debug nic
 	ne := exec.VCHConfig.Networks["client"]
 	if ne == nil {

--- a/pkg/vsphere/compute/rp.go
+++ b/pkg/vsphere/compute/rp.go
@@ -103,9 +103,7 @@ func (rp *ResourcePool) GetChildVM(ctx context.Context, s *session.Session, name
 			return vmm, nil
 		}
 	}
-	err = errors.Errorf("Didn't find VM %s in resource pool %s", name, rp.Name())
-	log.Errorf("%s", err)
-	return nil, err
+	return nil, nil
 }
 
 func (rp *ResourcePool) GetCluster(ctx context.Context) (*object.ComputeResource, error) {


### PR DESCRIPTION
Fixes #1350 

  Create vApp in VC while deploy VCH, and then create every VM under vApp. In ESX, still keep resource pool.
  As vApp is one special resource pool, except creation, all the other operation based on resource pool is left, for example, to  query child VMs under the resource pool.