### PR TITLE
Make datastore path parsing more robust

### DIFF
--- a/lib/install/management/store_files.go
+++ b/lib/install/management/store_files.go
@@ -203,12 +203,13 @@ func (d *Dispatcher) deleteVolumeStoreIfForced(conf *metadata.VirtualContainerHo
 
 		dsURL, err := vsphere.DatastoreToURL(url.Path)
 
-		log.Debugf("Provided datastore URL: %s\nParsed volume store path: %s", url.Path, dsURL.Path)
-
 		if err != nil {
 			log.Warnf("Didn't receive an expected volume store path format: %s", url.Path)
 			continue
 		}
+
+		log.Debugf("Provided datastore URL: %s\nParsed volume store path: %s", url.Path, dsURL.Path)
+
 		log.Infof("Deleting volume store %s on Datastore %s at path %s", label, dsURL.Host, dsURL.Path)
 
 		datastores, err := d.session.Finder.DatastoreList(d.ctx, dsURL.Host)

--- a/lib/portlayer/storage/vsphere/datastore.go
+++ b/lib/portlayer/storage/vsphere/datastore.go
@@ -308,7 +308,7 @@ func (d *Datastore) rootDir() string {
 
 // Parse the datastore format ([datastore1] /path/to/thing) to groups.
 var datastoreFormat = regexp.MustCompile(`^\[([\w\d\(\)\s]+)\]`)
-var pathFormat = regexp.MustCompile(`\s([\/\w]+$)`)
+var pathFormat = regexp.MustCompile(`\s([\/\w-_]+$)`)
 
 // Converts `[datastore] /path` to URL
 func DatastoreToURL(ds string) (*url.URL, error) {

--- a/lib/portlayer/storage/vsphere/datastore_test.go
+++ b/lib/portlayer/storage/vsphere/datastore_test.go
@@ -136,6 +136,8 @@ func TestDatastoreToURLParsing(t *testing.T) {
 		{"[datastore1] ///path////to/thing", expectedURL},
 		{"[Datastore (1)] /path/to/thing", "ds://Datastore%20(1)/path/to/thing"},
 		{"[datastore1] path", "ds://datastore1/path"},
+		{"[datastore1] pa-th", "ds://datastore1/pa-th"},
+		{"[datastore1] pa_th", "ds://datastore1/pa_th"},
 	}
 
 	dsoutputs := []string{
@@ -144,6 +146,8 @@ func TestDatastoreToURLParsing(t *testing.T) {
 		"[datastore1] /path/to/thing",
 		"[Datastore (1)] /path/to/thing",
 		"[datastore1] path",
+		"[datastore1] pa-th",
+		"[datastore1] pa_th",
 	}
 
 	for i, in := range input {


### PR DESCRIPTION
Adds legality for - and _ in datastore paths. **Please comment if there are other special characters that should be allowed** as there does not seem to be a canonical list of vSphere-allowed characters for datastore names & paths

Also moves a call to log.Debug to _after_ the error checking when calling DatastoreToURL so that we get an error message instead of a nil pointer if DatastoreToURL returns nil.

Fixes #1535

(also at this time this includes some changes from another PR I have open, in the first commit, those are (mostly) unrelated)

