### PR TITLE
Provide sane default PATH when not specified in image

### DIFF
--- a/lib/apiservers/engine/backends/container.go
+++ b/lib/apiservers/engine/backends/container.go
@@ -214,22 +214,8 @@ func (c *Container) ContainerCreate(config types.ContainerCreateConfig) (types.C
 	container.ID = image.ID
 	container.Config = image.Config
 
-	// Overwrite or append the image's config from the CLI with the metadata from the image's
-	// layer metadata where appropriate
-	if len(config.Config.Cmd) == 0 {
-		config.Config.Cmd = container.Config.Cmd
-	}
-	if config.Config.WorkingDir == "" {
-		config.Config.WorkingDir = container.Config.WorkingDir
-	}
-	if len(config.Config.Entrypoint) == 0 {
-		config.Config.Entrypoint = container.Config.Entrypoint
-	}
-	// Set TERM to xterm if tty is set
-	if config.Config.Tty {
-		config.Config.Env = append(config.Config.Env, "TERM=xterm")
-	}
-	config.Config.Env = append(config.Config.Env, container.Config.Env...)
+	// set default configuration values and those supplied by image where needed
+	container.SetConfigOptions(config.Config)
 
 	// TODO(jzt): users other than root are not currently supported
 	// We should check for USER in config.Config.Env once we support Dockerfiles.

--- a/tests/test-cases/Group1-Docker-Commands/1-5-Docker-Start.md
+++ b/tests/test-cases/Group1-Docker-Commands/1-5-Docker-Start.md
@@ -16,12 +16,14 @@ This test requires that a vSphere server is running and available
 3. Issue docker start <containerID>
 4. Issue docker create -it busybox /bin/top to VIC appliance
 5. Issue docker start -ai <containerID>
-6. Issue docker start fakeContainer
+6. Issue docker create vmware/photon
+7. Issue docker start vmware/photon <containerID>
+8. Issue docker start fakeContainer
 
 #Expected Outcome:
-* Commands 1-5 should all return without error and respond with the container ID
-* After command 3 and 5 verify that the containers are running
-* Step 6 should result in the VIC applaiance returning the following error:  
+* Commands 1-7 should all return without error and respond with the container ID
+* After commands 3, 5, and 7 verify that the containers are running
+* Step 8 should result in the VIC applaiance returning the following error:  
 ```
 Error response from daemon: No such container: fakeContainer  
 Error: failed to start containers: fakeContainer  

--- a/tests/test-cases/Group1-Docker-Commands/1-5-Docker-Start.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-5-Docker-Start.robot
@@ -25,6 +25,13 @@ Start with attach and interactive
     ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} start -ai ${output}
     Should Be Equal As Integers  ${rc}  0
     Should Not Contain  ${output}  Error:
+Start from image that has no PATH
+    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} pull vmware/photon
+    Should Be Equal As Integers  ${rc}  0
+    Should Not Contain  ${output}  Error:
+    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} create -it vmware/photon
+    Should Be Equal As Integers  ${rc}  0
+    Should Not Contain  ${output}  Error:
 Start non-existent container
     ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} start fakeContainer
     Should Be Equal As Integers  ${rc}  1


### PR DESCRIPTION
This change:

- Adds a default `PATH` when one is not configured by the user or does not exist in the image that the container was created from.
- Refactors container configuration at create time to protect against duplicate environment variable keys and overwrite of creation-time user-specified configuration by image configuration.
- Fixes #1594, `ENV` being overwritten by `ExecParams` during container create

Fixes #1509, #1594 
