### PR TITLE
Stopping a stopped container throws an error

### DIFF
--- a/lib/apiservers/engine/backends/container.go
+++ b/lib/apiservers/engine/backends/container.go
@@ -787,6 +787,14 @@ func (c *Container) containerStop(name string, seconds int, unbound bool) error 
 
 	handle := getResponse.Payload
 
+	// we have a container on the PL side lets check the state before proceeding
+	// ignore the error  since others will be checking below..this is an attempt to short circuit the op
+	// TODO: can be replaced with simple cache check once power events are propigated to persona
+	infoResponse, _ := client.Containers.GetContainerInfo(containers.NewGetContainerInfoParams().WithID(name))
+	if *infoResponse.Payload.ContainerConfig.State == "Stopped" {
+		return nil
+	}
+
 	if unbound {
 		// get the endpoints for the container
 		conEpsRes, err := client.Scopes.GetContainerEndpoints(scopes.NewGetContainerEndpointsParams().WithHandleOrID(handle))

--- a/tests/test-cases/Group1-Docker-Commands/1-7-Docker-Stop.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-7-Docker-Stop.robot
@@ -6,16 +6,13 @@ Suite Teardown  Cleanup VIC Appliance On Test Server
 
 *** Test Cases ***
 Stop an already stopped container
-    ${status}=  Get State Of Github Issue  1319
-    Run Keyword If  '${status}' == 'closed'  Fail  Test 1-7-Docker-Stop.robot needs to be updated now that Issue #1319 has been resolved
-    Log  Issue \#1319 is blocking implementation  WARN
-    #${rc}  ${output}=  Run And Return Rc And Output  docker ${params} pull busybox
-    #Should Be Equal As Integers  ${rc}  0
-    #${rc}  ${container}=  Run And Return Rc And Output  docker ${params} create busybox sleep 30
-    #Should Be Equal As Integers  ${rc}  0
-    #${rc}  ${output}=  Run And Return Rc And Output  docker ${params} stop ${container}
-    #Should Be Equal As Integers  ${rc}  0
-    
+    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} pull busybox
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${container}=  Run And Return Rc And Output  docker ${params} create busybox sleep 30
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} stop ${container}
+    Should Be Equal As Integers  ${rc}  0
+
 Basic docker container stop
     ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} pull busybox
     Should Be Equal As Integers  ${rc}  0


### PR DESCRIPTION
This fixes two bugs -- both around attempting to stop a stopped
container.  The first is when a container was created, but
never started and a stop command is issued.  Additionally, when a
started container is stopped and a subsequent stop is issued the
infra layer will throw a vSphere error.

Fixes #1319