### PR TITLE
Make go 1.7 happy

### DIFF
--- a/cmd/vicadmin/vicadm_test.go
+++ b/cmd/vicadmin/vicadm_test.go
@@ -253,7 +253,7 @@ func TestLogTail(t *testing.T) {
 
 	for _, path := range paths {
 		u.Path = path
-		log.Printf("GET %s:\n", u)
+		log.Printf("GET %s:\n", u.String())
 		res, err := insecureClient.Get(u.String())
 		if err != nil {
 			t.Fatal(err)

--- a/lib/apiservers/engine/backends/image_test.go
+++ b/lib/apiservers/engine/backends/image_test.go
@@ -62,7 +62,7 @@ func TestConvertV1ImageToDockerImage(t *testing.T) {
 	assert.Equal(t, tag, dockerImage.RepoTags[0], "Error: expected tag %s, got %s", tag, dockerImage.RepoTags[0])
 }
 
-func TestclientFriendlyTags(t *testing.T) {
+func TestClientFriendlyTags(t *testing.T) {
 	imageName := "busybox"
 	tags := []string{"1.24.2", "latest"}
 
@@ -77,7 +77,7 @@ func TestclientFriendlyTags(t *testing.T) {
 
 }
 
-func TestclientFriendlyDigests(t *testing.T) {
+func TestClientFriendlyDigests(t *testing.T) {
 	imageName := "busybox"
 	digests := []string{"12345", "6789"}
 

--- a/lib/portlayer/exec/container.go
+++ b/lib/portlayer/exec/container.go
@@ -327,7 +327,7 @@ func ContainerInfo(ctx context.Context, sess *session.Session, containerID ID) (
 		return nil, fmt.Errorf("%s does not appear to be a container", containerID)
 	case 1:
 		// we have a winner
-		return &cc[0], nil
+		return cc[0], nil
 	default:
 		// we manged to find multiple vms
 		return nil, fmt.Errorf("multiple containers named %s found", containerID)
@@ -335,7 +335,7 @@ func ContainerInfo(ctx context.Context, sess *session.Session, containerID ID) (
 }
 
 // return a list of container attributes
-func List(ctx context.Context, sess *session.Session, all *bool) ([]Container, error) {
+func List(ctx context.Context, sess *session.Session, all *bool) ([]*Container, error) {
 
 	// for now we'll go to the infrastructure
 	// future iteration will utilize cache & event stream
@@ -392,8 +392,8 @@ func populateVMAttributes(ctx context.Context, sess *session.Session, refs []typ
 }
 
 // convert the infra containers to a container object
-func convertInfraContainers(vms []mo.VirtualMachine, all *bool) []Container {
-	var containerVMs []Container
+func convertInfraContainers(vms []mo.VirtualMachine, all *bool) []*Container {
+	var containerVMs []*Container
 
 	for i := range vms {
 		// poweredOn or all states
@@ -424,7 +424,7 @@ func convertInfraContainers(vms []mo.VirtualMachine, all *bool) []Container {
 		}
 		container.VMUnsharedDisk = vms[i].Summary.Storage.Unshared
 
-		containerVMs = append(containerVMs, *container)
+		containerVMs = append(containerVMs, container)
 
 	}
 


### PR DESCRIPTION
```
cmd/vicadmin/vicadm_test.go:256: arg u for printf verb %s of wrong type: net/url.URL
lib/apiservers/engine/backends/image_test.go:65: TestclientFriendlyTags has malformed name: first letter after 'Test' must not be lowercase
lib/apiservers/engine/backends/image_test.go:80: TestclientFriendlyDigests has malformed name: first letter after 'Test' must not be lowercase
lib/portlayer/exec/container.go:427: function call copies lock value: exec.Container
```