### PR TITLE
Enable sshd again on VCH (with default pw: changeme)

### DIFF
--- a/isos/appliance-staging.sh
+++ b/isos/appliance-staging.sh
@@ -110,11 +110,8 @@ yum_cached -p $PKGDIR clean all
 # configure us for autologin of root
 #COPY override.conf $ROOTFS/etc/systemd/system/getty@.service.d/
 # HACK until the issues with override.conf above are dealt with
-pwhash=$(openssl passwd -1 -salt vic password)
+pwhash=$(openssl passwd -1 -salt vic changeme)
 sed -i -e "s/^root:[^:]*:/root:${pwhash}:/" $(rootfs_dir $PKGDIR)/etc/shadow
-
-# 1218: Temporarily disable SSH for TP3
-rm $(rootfs_dir $PKGDIR)/usr/lib/systemd/system/sshd@.service
 
 # Allow root login via ssh
 sed -i -e "s/\#*PermitRootLogin\s.*/PermitRootLogin yes/" $(rootfs_dir $PKGDIR)/etc/ssh/sshd_config


### PR DESCRIPTION
This reverts @corrieb's commit which titled as 

```
Temporarily remove default SSH access from appliance for TP3 (#1456)
```

