### PR TITLE
Allow custom paths for image store

### DIFF
--- a/lib/apiservers/portlayer/restapi/handlers/storage_handlers.go
+++ b/lib/apiservers/portlayer/restapi/handlers/storage_handlers.go
@@ -68,8 +68,15 @@ func (handler *StorageHandlersImpl) Configure(api *operations.PortLayerAPI, hand
 	if err != nil {
 		log.Fatalf("StorageHandler ERROR: %s", err)
 	}
-
-	ds, err := vsphereSpl.NewImageStore(ctx, storageSession)
+	if len(spl.Config.ImageStores) == 0 {
+		log.Panicf("No image stores provided; unable to instantiate storage layer")
+	}
+	imageStoreURL := spl.Config.ImageStores[0]
+	// TODO: support multiple image stores. Right now we only support the first one
+	if len(spl.Config.ImageStores) > 1 {
+		log.Warningf("Multiple image stores found. Multiple image stores are not yet supported. Using [%s] %s", imageStoreURL.Host, imageStoreURL.Path)
+	}
+	ds, err := vsphereSpl.NewImageStore(ctx, storageSession, &imageStoreURL)
 	if err != nil {
 		log.Panicf("Cannot instantiate storage layer: %s", err)
 	}

--- a/lib/portlayer/storage/vsphere/image.go
+++ b/lib/portlayer/storage/vsphere/image.go
@@ -16,6 +16,7 @@ package vsphere
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -61,7 +62,7 @@ type ImageStore struct {
 	parents *parentM
 }
 
-func NewImageStore(ctx context.Context, s *session.Session) (*ImageStore, error) {
+func NewImageStore(ctx context.Context, s *session.Session, u *url.URL) (*ImageStore, error) {
 	dm, err := disk.NewDiskManager(ctx, s)
 	if err != nil {
 		return nil, err
@@ -70,7 +71,16 @@ func NewImageStore(ctx context.Context, s *session.Session) (*ImageStore, error)
 	// Currently using the datastore associated with the session which is not
 	// ideal.  This should be passed in via the config.  The datastore need not
 	// be the same datastore used for the rest of the system.
-	ds, err := datastore.NewHelper(ctx, s, s.Datastore, StorageParentDir)
+	datastores, err := s.Finder.DatastoreList(ctx, u.Host)
+	if err != nil {
+		// TODO: real error beyond whatever DatastoreList returns
+		return nil, err
+	}
+	if len(datastores) != 1 {
+		return nil, errors.New("Datastore not found or ambiguous name provided.")
+	}
+
+	ds, err := datastore.NewHelper(ctx, s, datastores[0], path.Join(u.Path, StorageParentDir))
 	if err != nil {
 		return nil, err
 	}

--- a/lib/portlayer/storage/vsphere/image_test.go
+++ b/lib/portlayer/storage/vsphere/image_test.go
@@ -20,6 +20,7 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"io/ioutil"
+	"net/url"
 	"os"
 	"path"
 	"path/filepath"
@@ -44,7 +45,11 @@ func setup(t *testing.T) (*portlayer.NameLookupCache, *session.Session, error) {
 		return nil, nil, fmt.Errorf("skip")
 	}
 
-	vsImageStore, err := NewImageStore(context.TODO(), client)
+	storeURL := &url.URL{
+		Path: StorageParentDir,
+		Host: client.DatastorePath}
+
+	vsImageStore, err := NewImageStore(context.TODO(), client, storeURL)
 	if err != nil {
 		if err.Error() == "can't find the hosting vm" {
 			t.Skip("Skipping: test must be run in a VM")
@@ -67,8 +72,11 @@ func TestRestartImageStore(t *testing.T) {
 
 	origVsStore := cacheStore.DataStore.(*ImageStore)
 
+	imageStoreURL := &url.URL{
+		Path: client.Datastore.Path(StorageParentDir),
+		Host: client.DatastorePath}
 	// now start it again
-	restartedVsStore, err := NewImageStore(context.TODO(), client)
+	restartedVsStore, err := NewImageStore(context.TODO(), client, imageStoreURL)
 	if !assert.NoError(t, err) || !assert.NotNil(t, restartedVsStore) {
 		return
 	}


### PR DESCRIPTION
Allows users to specify a specific directory in a datastore to use for their image store.
Only supports the first one specified, for the time being. TODO in place to that effect. Addresses #925 -- note that despite the title of the issue in question, the changes needed in vic-machine were already in place & so I just did the wiring in the port layer.