### PR TITLE
make sure /etc/{hosts|resolv.conf} are readable

### DIFF
--- a/lib/etcconf/hosts.go
+++ b/lib/etcconf/hosts.go
@@ -17,6 +17,7 @@ package etcconf
 import (
 	"fmt"
 	"net"
+	"os"
 	"strings"
 	"sync"
 
@@ -129,6 +130,11 @@ func (h *hosts) Save() error {
 	}
 
 	if err := save(h.path, &hostsWalker{entries: entries}); err != nil {
+		return err
+	}
+
+	// make sure the file is readable
+	if err := os.Chmod(h.path, 0644); err != nil {
 		return err
 	}
 

--- a/lib/etcconf/resolvconf.go
+++ b/lib/etcconf/resolvconf.go
@@ -17,6 +17,7 @@ package etcconf
 import (
 	"fmt"
 	"net"
+	"os"
 	"strings"
 	"sync"
 
@@ -114,6 +115,11 @@ func (r *resolvConf) Save() error {
 	walker := &resolvConfWalker{nameservers: r.nameservers}
 	log.Debugf("%+v", walker)
 	if err := save(r.path, walker); err != nil {
+		return err
+	}
+
+	// make sure the file is readable
+	if err := os.Chmod(r.path, 0644); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
by non-root users. Without this postgres fails to start with

LOG:  could not translate host name "localhost", service "5432" to address: Name or service not known
WARNING:  could not create listen socket for "localhost"
FATAL:  could not create any TCP/IP sockets