### PR TITLE
Fix login to VC

### DIFF
--- a/cmd/vicadmin/vicadm.go
+++ b/cmd/vicadmin/vicadm.go
@@ -101,11 +101,8 @@ func init() {
 
 	flag.StringVar(&config.addr, "l", ":2378", "Listen address")
 	flag.StringVar(&config.dockerHost, "docker-host", "127.0.0.1:2376", "Docker host")
-	flag.StringVar(&config.ExtensionCert, "cert", "", "VMOMI Client certificate file")
 	flag.StringVar(&config.hostCertFile, "hostcert", "", "Host certificate file")
-	flag.StringVar(&config.ExtensionKey, "key", "", "VMOMI Client private key file")
 	flag.StringVar(&config.hostKeyFile, "hostkey", "", "Host private key file")
-	flag.StringVar(&config.Service, "sdk", "", "The ESXi or vCenter URL")
 	flag.StringVar(&config.DatacenterPath, "dc", "", "Name of the Datacenter")
 	flag.StringVar(&config.DatastorePath, "ds", "", "Name of the Datastore")
 	flag.StringVar(&config.ClusterPath, "cluster", "", "Path of the cluster")
@@ -842,6 +839,14 @@ func main() {
 	defer trace.End(trace.Begin(""))
 
 	flag.Parse()
+
+	config.Service = vchConfig.Target.String()
+	config.ExtensionCert = vchConfig.ExtensionCert
+	config.ExtensionKey = vchConfig.ExtensionKey
+	config.ExtensionName = vchConfig.ExtensionName
+
+	log.Infof("VCH datastorePath: %+v", vchConfig.ImageStores)
+	log.Infof("From command-line: %+v", config.DatastorePath)
 
 	s := &server{
 		addr: config.addr,

--- a/lib/install/management/appliance.go
+++ b/lib/install/management/appliance.go
@@ -438,7 +438,6 @@ func (d *Dispatcher) createAppliance(conf *metadata.VirtualContainerHostConfigSp
 				"-docker-host=unix:///var/run/docker.sock",
 				// FIXME: hack during config migration
 				"-insecure",
-				"-sdk=" + conf.Target.String(),
 				"-ds=" + conf.ImageStores[0].Host,
 				"-cluster=" + settings.ClusterPath,
 				"-pool=" + settings.ResourcePoolPath,


### PR DESCRIPTION

Fixes #1626 and #597 

It turns out that the reason @cormachogan wasn't seeing container logs is that the vicadmin page was not authenticating correctly against a VC environment.  Therefore, instead of specifying the SDK on the command-line, this PR forces vicadmin to pull its SDK endpoint from the metadata.VirtualContainerHostConfigSpec.  

