### PR TITLE
Tether: Symlink /proc/mounts to /etc/mtab

### DIFF
--- a/lib/tether/ops_linux.go
+++ b/lib/tether/ops_linux.go
@@ -711,6 +711,11 @@ func (t *BaseOperations) Setup(config Config) error {
 	t.hosts = h
 	t.resolvConf = rc
 	t.config = config
+
+	// support the df command (#1642)
+	if err = os.Symlink("/proc/mounts", "/etc/mtab"); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/tests/test-cases/Group1-Docker-Commands/1-6-Docker-Run.md
+++ b/tests/test-cases/Group1-Docker-Commands/1-6-Docker-Run.md
@@ -21,6 +21,7 @@ This test requires that a vSphere server is running and available
 8. Issue docker run fakeImage /bin/bash to the VIC appliance
 9. Issue docker run -d --name busy3 busybox /bin/top to the VIC appliance
 10. Issue docker run --link busy3:busy3 busybox ping -c2 busy3 to the VIC appliance
+11. Issue docker run -it busybox /bin/df to the VIC appliance
 
 #Expected Outcome:
 * Step 2 and 3 should result in success and print the dmesg of the container
@@ -37,6 +38,7 @@ docker: Error response from daemon: Container command not found or does not exis
 docker: Error parsing reference: "fakeImage" is not a valid repository/tag.
 ```
 * Step 10 should result in success and the output should indicate that the ping succeeded across containers just using the linked name
+* Step 11 should result in success with exit code 0
 
 #Possible Problems:
 None

--- a/tests/test-cases/Group1-Docker-Commands/1-6-Docker-Run.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-6-Docker-Run.robot
@@ -61,3 +61,7 @@ Docker run linked containers
     Log  Issue \#384 is blocking implementation  WARN
     #${rc}  ${output}=  Run And Return Rc And Output  docker ${params} run --link busy3:busy3 busybox ping -c2 busy3 
     #Should Be Equal As Integers  ${rc}  0
+
+Docker run df command
+    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} run -it busybox /bin/df
+    Should Be Equal As Integers  ${rc}  0


### PR DESCRIPTION
Fixes #1642 

Symlinks `/proc/mounts` to `/etc/mtab` to support the `df` command in containers. Verified the fix manually on a busybox container.

Integration testing is WIP.
