### PR TITLE
Allow custom image store paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Project Bonneville was research aimed at determining best approaches to enabling
 Once built, pick up the correct binary based on your OS, and then the result can be installed with the following command.
 
 ```
-bin/vic-machine-linux create --target target-host[/datacenter] --image-datastore <datastore name> --name <vch-name> --user <username> --password <password> --compute-resource <cluster/a/resource/pool/path>
+bin/vic-machine-linux create --target target-host[/datacenter] --image-store <datastore name> --name <vch-name> --user <username> --password <password> --compute-resource <cluster/a/resource/pool/path>
 ```
 
 See `vic-machine-XXX create --help` for usage information.

--- a/cmd/imagec/storage.go
+++ b/cmd/imagec/storage.go
@@ -60,7 +60,7 @@ func CreateImageStore(storename string) error {
 	transport := httptransport.New(options.host, "/", []string{"http"})
 	client := apiclient.New(transport, nil)
 
-	log.Debugf("Creating a store")
+	log.Debugf("Creating a store from input %s", storename)
 
 	body := &models.ImageStore{Name: storename}
 

--- a/cmd/vic-machine/create/create.go
+++ b/cmd/vic-machine/create/create.go
@@ -117,8 +117,8 @@ func (c *Create) Flags() []cli.Flag {
 		cli.StringFlag{
 			Name:        "image-datastore, i",
 			Value:       "",
-			Usage:       "REQUIRED. Image datastore name",
-			Destination: &c.ImageDatastoreName,
+			Usage:       "Image datastore path",
+			Destination: &c.ImageDatastorePath,
 		},
 		cli.StringFlag{
 			Name:        "container-datastore, cs",
@@ -309,8 +309,8 @@ func (c *Create) processParams() error {
 		return err
 	}
 
-	if c.ImageDatastoreName == "" {
-		return cli.NewExitError("--image-datastore Image datastore name must be specified", 1)
+	if c.ImageDatastorePath == "" {
+		return cli.NewExitError("--image-datastore Image datastore path must be specified", 1)
 	}
 
 	if c.cert != "" && c.key == "" {

--- a/cmd/vic-machine/create/create.go
+++ b/cmd/vic-machine/create/create.go
@@ -115,9 +115,9 @@ func NewCreate() *Create {
 func (c *Create) Flags() []cli.Flag {
 	flags := []cli.Flag{
 		cli.StringFlag{
-			Name:        "image-datastore, i",
+			Name:        "image-store, i",
 			Value:       "",
-			Usage:       "Image datastore path",
+			Usage:       "Image datastore path in format \"datastore/path\"",
 			Destination: &c.ImageDatastorePath,
 		},
 		cli.StringFlag{
@@ -293,7 +293,7 @@ func (c *Create) processVolumeStores() error {
 	for _, arg := range c.volumeStores {
 		splitMeta := strings.SplitN(arg, ":", 2)
 		if len(splitMeta) != 2 {
-			return errors.New("Volume store input must be in format datastore-path:label")
+			return errors.New("Volume store input must be in format datastore-name/path:label")
 		}
 		c.VolumeLocations[splitMeta[1]] = splitMeta[0]
 	}
@@ -310,7 +310,7 @@ func (c *Create) processParams() error {
 	}
 
 	if c.ImageDatastorePath == "" {
-		return cli.NewExitError("--image-datastore Image datastore path must be specified", 1)
+		return cli.NewExitError("--image-store Image datastore path must be specified", 1)
 	}
 
 	if c.cert != "" && c.key == "" {

--- a/cmd/vic-machine/create/create.go
+++ b/cmd/vic-machine/create/create.go
@@ -293,7 +293,7 @@ func (c *Create) processVolumeStores() error {
 	for _, arg := range c.volumeStores {
 		splitMeta := strings.SplitN(arg, ":", 2)
 		if len(splitMeta) != 2 {
-			return errors.New("Volume store input must be in format datastore-name/path:label")
+			return errors.New("Volume store input must be in format datastore/path:label")
 		}
 		c.VolumeLocations[splitMeta[1]] = splitMeta[0]
 	}
@@ -310,7 +310,7 @@ func (c *Create) processParams() error {
 	}
 
 	if c.ImageDatastorePath == "" {
-		return cli.NewExitError("--image-store Image datastore path must be specified", 1)
+		return cli.NewExitError("--image-store Image datastore path must be specified; use format datastore/path", 1)
 	}
 
 	if c.cert != "" && c.key == "" {

--- a/doc/user_doc/vic_installation/install_vic_cli.md
+++ b/doc/user_doc/vic_installation/install_vic_cli.md
@@ -41,7 +41,7 @@ The virtual container host allows you to use an ESXi host or vCenter Server inst
 
    <pre>$ vic-machine-darwin create
 --target <i>vcenter_server_address</i>
---image-datastore <i>datastore_name</i> 
+--image-store <i>datastore_name</i> 
 --user <i>username</i>
 --bridge-network <i>network_name</i></pre>  
 
@@ -49,7 +49,7 @@ The virtual container host allows you to use an ESXi host or vCenter Server inst
 
    <pre>$ vic-machine-linux create
 --target <i>vcenter_server_address</i>
---image-datastore <i>datastore_name</i> 
+--image-store <i>datastore_name</i> 
 --user <i>username</i>
 --bridge-network <i>network_name</i></pre> 
 
@@ -57,7 +57,7 @@ The virtual container host allows you to use an ESXi host or vCenter Server inst
 
    <pre>$ vic-machine-windows create
 --target <i>vcenter_server_address</i>
---image-datastore <i>datastore_name</i> 
+--image-store <i>datastore_name</i> 
 --user <i>username</i>
 --bridge-network <i>network_name</i></pre> 
 

--- a/doc/user_doc/vic_installation/vch_installer_examples.md
+++ b/doc/user_doc/vic_installation/vch_installer_examples.md
@@ -21,7 +21,7 @@ You can install vSphere Integrated Containers directly on an ESXi host that is n
 <pre>vic-machine<i>-darwin</i><i>-linux</i><i>-windows</i> create
 --target <i>esxi_host_IPv4_address_or_FQDN</i>
 --user root
---image-datastore <i>datastore_name</i>
+--image-store <i>datastore_name</i>
 </pre>
 
 <a name="cluster"></a>
@@ -38,7 +38,7 @@ In addition to the mandatory options for deployment to a cluster, this example s
 --user Administrator@vsphere.local
 --password <i>vcenter_sso_password</i>
 --compute-resource <i>cluster_name</i>
---image-datastore <i>datastore_name</i>
+--image-store <i>datastore_name</i>
 --bridge-network <i>distributed_port_group_name</i>
 --name vch1
 </pre>
@@ -61,7 +61,7 @@ In addition to the mandatory options for deployment to a cluster, this example s
 --user Administrator@vsphere.local
 --password <i>vcenter_sso_password</i>
 --compute-resource <i>cluster_name</i>
---image-datastore <i>datastore_name</i>
+--image-store <i>datastore_name</i>
 --bridge-network <i>network_1_name</i>
 --management-network <i>network_2_name</i>
 --external-network <i>network_3_name</i>
@@ -80,7 +80,7 @@ In addition to the mandatory options for deployment to a cluster, this example s
 --user Administrator@vsphere.local
 --password <i>vcenter_sso_password</i>
 --compute-resource <i>cluster_name</i>
---image-datastore <i>datastore_1_name</i>
+--image-store <i>datastore_1_name</i>
 --container-datastore <i>datastore_2_name</i>
 --bridge-network <i>network_1_name</i>
 --name vch1
@@ -98,7 +98,7 @@ In addition to the mandatory options, this example specifies the vCenter Single 
 --user Administrator@vsphere.local
 --password <i>vcenter_sso_password</i>
 --compute-resource <i>host_IPv4_address_or_FQDN</i>
---image-datastore <i>datastore_name</i>
+--image-store <i>datastore_name</i>
 --bridge-network <i>network_name</i>
 --name vch1
 </pre>
@@ -114,7 +114,7 @@ This example uses the minimum required options.
 --target <i>esxi_host_IPv4_address_or_FQDN</i>
 --user root
 --compute-resource <i>resource_pool_name</i>
---image-datastore <i>datastore_name</i>
+--image-store <i>datastore_name</i>
 </pre>
 
 <a name="rp_cluster"></a>
@@ -129,7 +129,7 @@ In addition to the mandatory options, this example sets the vCenter Single Sign-
 --user Administrator@vsphere.local
 --password <i>vcenter_sso_password</i>
 --compute-resource <i>cluster_name</i>/<i>resource_pool_name</i>
---image-datastore <i>datastore_name</i>
+--image-store <i>datastore_name</i>
 --bridge-network <i>network_name</i>
 --name vch1
 </pre>
@@ -146,7 +146,7 @@ In addition to the mandatory options for deployment to a cluster, this example s
 --user Administrator@vsphere.local
 --password <i>vcenter_sso_password</i>
 --compute-resource <i>cluster_name</i>
---image-datastore <i>datastore_name</i>
+--image-store <i>datastore_name</i>
 --bridge-network <i>network_name</i>
 --cert <i>path_to_certificate_file</i>
 --key <i>path_to_certificate_file</i>
@@ -165,7 +165,7 @@ In addition to the mandatory options for deployment to a cluster, this example s
 --user Administrator@vsphere.local
 --password <i>vcenter_sso_password</i>
 --compute-resource <i>cluster_name</i>
---image-datastore <i>datastore_name</i>
+--image-store <i>datastore_name</i>
 --bridge-network <i>network_name</i>
 --name vch1
 --no-tls
@@ -183,7 +183,7 @@ In addition to the mandatory options for deployment to a cluster, this example s
 --user Administrator@vsphere.local
 --password <i>vcenter_sso_password</i>
 --compute-resource <i>cluster_name</i>
---image-datastore <i>datastore_name</i>
+--image-store <i>datastore_name</i>
 --bridge-network <i>network_name</i>
 --name vch1
 --appliance-cpu <i>number_of_CPUs</i>

--- a/doc/user_doc/vic_installation/vch_installer_examples.md
+++ b/doc/user_doc/vic_installation/vch_installer_examples.md
@@ -86,6 +86,19 @@ In addition to the mandatory options for deployment to a cluster, this example s
 --name vch1
 </pre>
 
+It is also possible to specify a specific folder in which to store your images, instead of just a datastore. This can be done by providing a path following the `image-store` option:
+
+<pre>vic-machine<i>-darwin</i><i>-linux</i><i>-windows</i> create
+--target <i>vcenter_server_IPv4_address_or_FQDN</i>
+--user Administrator@vsphere.local
+--password <i>vcenter_sso_password</i>
+--compute-resource <i>cluster_name</i>
+--image-store <i>datastore_1_name/path/to/some/specific/location</i>
+--container-datastore <i>datastore_2_name</i>
+--bridge-network <i>network_1_name</i>
+--name vch1
+</pre>
+
 <a name="standalone"></a> 
 ## Deploy a Virtual Container Host on a Standalone Host in vCenter Server ##
 

--- a/doc/user_doc/vic_installation/vch_installer_options.md
+++ b/doc/user_doc/vic_installation/vch_installer_options.md
@@ -46,13 +46,12 @@ You can also specify the username in the URL that you pass to `vic-machine creat
 
 Short name: `-i`
 
-The datastore in which to store container image files. When you deploy a virtual container host, `vic-machine` creates a folder named `VIC` on the target datastore,  in which to store all of the container images that you pull into a virtual container host. The `vic-machine` utility also places the VM files for the virtual container host in the datastore that you designate as the image store, in a folder that has the same name as the virtual container host.
+The datastore in which to store container image files. When you deploy a virtual container host, `vic-machine` creates a folder named `VIC` on the target datastore,  in which to store all of the container images that you pull into a virtual container host. The `vic-machine` utility also places the VM files for the virtual container host in the datastore that you designate as the image store, in a folder that has the same name as the virtual container host. If you specify an image store in the format `datastore/some/path`, `/some/path` will be used as your image store instead of the folder with the same name as the virtual container host.
 
 You can designate the same datastore as the image store for multiple virtual container hosts. In this case, only one `VIC` folder is created in the datastore and the container image files are made available to all of the virtual container hosts that use that image store. 
 
 **NOTES**: 
 - vSphere Integrated Containers supports all alphanumeric characters, hyphens, and underscores in datastore paths and datastore names.
-- In the current builds the `image-store` option does not support datastore folders. If you specify a datastore folder in the `image-store` option, `vic-machine` does not return an error, but creates all of the necessary folders at the root level of the datastore.
 - In the current builds the `container-datastore` option is not enabled. As a consequence, container VM files are also stored in the datastore that you designate as the image store.
 
 <pre>--image-store <i>datastore_name</i></pre> 

--- a/doc/user_doc/vic_installation/vch_installer_options.md
+++ b/doc/user_doc/vic_installation/vch_installer_options.md
@@ -42,7 +42,7 @@ If you are deploying vSphere Integrated Containers on vCenter Server, specify a 
 You can also specify the username in the URL that you pass to `vic-machine create` in the `target` option.
 
 <a name="image"></a>
-### `image-datastore` ###
+### `image-store` ###
 
 Short name: `-i`
 
@@ -52,10 +52,10 @@ You can designate the same datastore as the image store for multiple virtual con
 
 **NOTES**: 
 - vSphere Integrated Containers supports all alphanumeric characters, hyphens, and underscores in datastore paths and datastore names.
-- In the current builds the `image-datastore` option does not support datastore folders. If you specify a datastore folder in the `image-datastore` option, `vic-machine` does not return an error, but creates all of the necessary folders at the root level of the datastore.
+- In the current builds the `image-store` option does not support datastore folders. If you specify a datastore folder in the `image-store` option, `vic-machine` does not return an error, but creates all of the necessary folders at the root level of the datastore.
 - In the current builds the `container-datastore` option is not enabled. As a consequence, container VM files are also stored in the datastore that you designate as the image store.
 
-<pre>--image-datastore <i>datastore_name</i></pre> 
+<pre>--image-store <i>datastore_name</i></pre> 
 
 <a name="bridge"></a>
 ### `bridge-network` ###
@@ -208,9 +208,9 @@ The `vic-machine` utility allows you to specify the datastores in which to store
 - vSphere Integrated Containers fully supports VMware Virtual SAN datastores. 
 - vSphere Integrated Containers supports all alphanumeric characters, hyphens, and underscores in datastore paths and datastore names.
 
-### `image-datastore` ###
+### `image-store` ###
 
-See [image-datastore](#image) in the section on mandatory options.
+See [image-store](#image) in the section on mandatory options.
 
 ### `container-datastore` ###
 
@@ -218,7 +218,7 @@ Short name: `--cs`
 
 The datastore in which to store container VM files. When you run a container, container VM files are stored in folders at the top level of the designated datastore. If multiple virtual container hosts use the same container store, all of the container VM files appear at the top level of the container store. You cannot currently designate a specific datastore folder for the VM files of the containers that run in a particular virtual container host.
 
-If you do not specify the `container-datastore` option, vSphere Integrated Containers stores container VM files in the same datastore that you specify in the mandatory `image-datastore` option.
+If you do not specify the `container-datastore` option, vSphere Integrated Containers stores container VM files in the same datastore that you specify in the mandatory `image-store` option.
 
 **NOTE**: In the current builds the `container-datastore` option is not enabled. Container VM files are stored in the datastore that you designate as the image store.
 

--- a/lib/apiservers/portlayer/restapi/handlers/containers_handlers.go
+++ b/lib/apiservers/portlayer/restapi/handlers/containers_handlers.go
@@ -127,8 +127,7 @@ func (handler *ContainersHandlersImpl) CreateHandler(params containers.CreatePar
 	h := exec.NewContainer(exec.ParseID(id))
 	// Create the executor.ExecutorCreateConfig
 	c := &exec.ContainerCreateConfig{
-		Metadata: m,
-
+		Metadata:       m,
 		ParentImageID:  *params.CreateConfig.Image,
 		ImageStoreName: params.CreateConfig.ImageStore.Name,
 		VCHName:        options.PortLayerOptions.VCHName,

--- a/lib/apiservers/portlayer/restapi/handlers/storage_handlers.go
+++ b/lib/apiservers/portlayer/restapi/handlers/storage_handlers.go
@@ -67,8 +67,15 @@ func (handler *StorageHandlersImpl) Configure(api *operations.PortLayerAPI, hand
 	if err != nil {
 		log.Fatalf("StorageHandler ERROR: %s", err)
 	}
-
-	ds, err := vsphereSpl.NewImageStore(ctx, storageSession)
+	if len(spl.Config.ImageStores) == 0 {
+		log.Panicf("No image stores provided; unable to instantiate storage layer")
+	}
+	imageStoreURL := spl.Config.ImageStores[0]
+	// TODO: support multiple image stores. Right now we only support the first one
+	if len(spl.Config.ImageStores) > 1 {
+		log.Warningf("Multiple image stores found. Multiple image stores are not yet supported. Using [%s] %s", imageStoreURL.Host, imageStoreURL.Path)
+	}
+	ds, err := vsphereSpl.NewImageStore(ctx, storageSession, &imageStoreURL)
 	if err != nil {
 		log.Panicf("Cannot instantiate storage layer: %s", err)
 	}

--- a/lib/install/data/data.go
+++ b/lib/install/data/data.go
@@ -39,7 +39,7 @@ type Data struct {
 	ApplianceISO string
 	BootstrapISO string
 
-	ImageDatastoreName     string
+	ImageDatastorePath     string
 	VolumeLocations        map[string]string
 	ContainerDatastoreName string
 

--- a/lib/install/management/create_test.go
+++ b/lib/install/management/create_test.go
@@ -95,7 +95,7 @@ func getESXData(url *url.URL) *data.Data {
 	result.URL = url
 	result.DisplayName = "test001"
 	result.ComputeResourcePath = "/ha-datacenter/host/localhost.localdomain/Resources"
-	result.ImageDatastoreName = "LocalDS_0"
+	result.ImageDatastorePath = "LocalDS_0"
 	result.BridgeNetworkName = "bridge"
 	result.ManagementNetworkName = "VM Network"
 	result.ExternalNetworkName = "VM Network"
@@ -110,7 +110,7 @@ func getVPXData(url *url.URL) *data.Data {
 	result.URL = url
 	result.DisplayName = "test001"
 	result.ComputeResourcePath = "/DC0/host/DC0_C0/Resources"
-	result.ImageDatastoreName = "LocalDS_0"
+	result.ImageDatastorePath = "LocalDS_0"
 	result.ExternalNetworkName = "VM Network"
 	result.BridgeNetworkName = "bridge"
 	result.VolumeLocations = make(map[string]string)

--- a/lib/install/management/delete.go
+++ b/lib/install/management/delete.go
@@ -51,7 +51,7 @@ func (d *Dispatcher) DeleteVCH(conf *config.VirtualContainerHostConfigSpec) erro
 		return err
 	}
 
-	if err = d.DeleteStores(vmm, conf); err != nil {
+	if err = d.deleteImages(conf); err != nil {
 		errs = append(errs, err.Error())
 	}
 

--- a/lib/install/management/store_files.go
+++ b/lib/install/management/store_files.go
@@ -26,12 +26,10 @@ import (
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/vim25/types"
 	"github.com/vmware/vic/lib/config"
-	"github.com/vmware/vic/lib/portlayer/storage/vsphere"
 	"github.com/vmware/vic/pkg/errors"
 	"github.com/vmware/vic/pkg/trace"
 	"github.com/vmware/vic/pkg/vsphere/datastore"
 	"github.com/vmware/vic/pkg/vsphere/tasks"
-	"github.com/vmware/vic/pkg/vsphere/vm"
 
 	"golang.org/x/net/context"
 )
@@ -39,37 +37,6 @@ import (
 const (
 	volumeRoot = "volumes"
 )
-
-func (d *Dispatcher) DeleteStores(vchVM *vm.VirtualMachine, conf *config.VirtualContainerHostConfigSpec) error {
-	defer trace.End(trace.Begin(""))
-
-	ds := d.session.Datastore
-
-	p, err := d.getVCHRootDir(vchVM) // p would be path but there's an imported package called path
-	if err != nil {
-		return err
-	}
-
-	var errs []string
-	var emptyVolumes bool
-	log.Infof("Removing images")
-	if err = d.deleteImages(conf); err != nil {
-		errs = append(errs, err.Error())
-	}
-	emptyVolumes, err = d.deleteDatastoreFiles(ds, path.Join(p, volumeRoot), d.force)
-
-	if emptyVolumes {
-		// if not empty, don't try to delete parent directory here
-		log.Debugf("Removing stores directory")
-		if _, err = d.deleteParent(ds, p); err != nil {
-			errs = append(errs, err.Error())
-		}
-	}
-	if len(errs) > 0 {
-		return errors.New(strings.Join(errs, "\n"))
-	}
-	return nil
-}
 
 func (d *Dispatcher) deleteImages(conf *config.VirtualContainerHostConfigSpec) error {
 	var emptyImages bool
@@ -261,18 +228,6 @@ func (d *Dispatcher) lsFolder(ds *object.Datastore, dsPath string) (*types.HostD
 	return &res, nil
 }
 
-func (d *Dispatcher) getVCHRootDir(vchVM *vm.VirtualMachine) (string, error) {
-	defer trace.End(trace.Begin(""))
-
-	parent := vsphere.StorageParentDir
-	uuid, err := vchVM.UUID(d.ctx)
-	if err != nil {
-		err = errors.Errorf("Failed to get VCH UUID: %s", err)
-		return "", err
-	}
-	return path.Join(parent, uuid), nil
-}
-
 func (d *Dispatcher) createVolumeStores(conf *config.VirtualContainerHostConfigSpec) error {
 	for _, url := range conf.VolumeLocations {
 		ds, err := d.session.Finder.Datastore(d.ctx, url.Host)
@@ -303,7 +258,7 @@ func (d *Dispatcher) deleteVolumeStoreIfForced(conf *config.VirtualContainerHost
 		for label, url := range conf.VolumeLocations {
 			volumeStores.WriteString(fmt.Sprintf("\t%s: %s\n", label, url.Path))
 		}
-		log.Warnf("Since --force was not specified, the following volume stores will not be removed. Use the vSphere UI to delete content you do not wish to keep.\n%q", volumeStores.String())
+		log.Warnf("Since --force was not specified, the following volume stores will not be removed. Use the vSphere UI to delete content you do not wish to keep.\n%s", volumeStores.String())
 		return 0
 	}
 

--- a/lib/install/management/store_files.go
+++ b/lib/install/management/store_files.go
@@ -71,7 +71,7 @@ func (d *Dispatcher) DeleteStores(vchVM *vm.VirtualMachine, conf *config.Virtual
 	return nil
 }
 
-func (d *Dispatcher) deleteImages(conf *metadata.VirtualContainerHostConfigSpec) error {
+func (d *Dispatcher) deleteImages(conf *config.VirtualContainerHostConfigSpec) error {
 	var emptyImages bool
 	var errs []string
 

--- a/lib/install/management/store_files.go
+++ b/lib/install/management/store_files.go
@@ -54,7 +54,7 @@ func (d *Dispatcher) DeleteStores(vchVM *vm.VirtualMachine, conf *config.Virtual
 	var emptyVolumes bool
 	log.Infof("Removing images")
 	if err = d.deleteImages(conf); err != nil {
-		return err
+		errs = append(errs, err.Error())
 	}
 	emptyVolumes, err = d.deleteDatastoreFiles(ds, path.Join(p, volumeRoot), d.force)
 
@@ -83,7 +83,10 @@ func (d *Dispatcher) deleteImages(conf *config.VirtualContainerHostConfigSpec) e
 		}
 
 		if len(imageDSes) != 1 {
-			errs = append(errs, fmt.Sprintf("Invalid or ambiguous datastore name %s provided while attempting to remove image stores", imageDir.Host))
+			errs = append(errs, fmt.Sprintf("Found %d datastores with provided datastore path %s. Provided datastore path must identify exactly one datastore.",
+				len(imageDSes),
+				imageDir.String()))
+
 			continue
 		}
 

--- a/lib/install/validate/storage.go
+++ b/lib/install/validate/storage.go
@@ -35,6 +35,11 @@ func (v *Validator) storage(ctx context.Context, input *data.Data, conf *config.
 	// Image Store
 	imageDSpath, ds, err := v.DatastoreHelper(ctx, input.ImageDatastorePath, "", "--image-datastore")
 
+	if imageDSpath == nil {
+		v.NoteIssue(err)
+		return
+	}
+
 	// provide a default path if only a DS name is provided
 	if imageDSpath.Path == "" {
 		imageDSpath.Path = path.Join(input.DisplayName, "images")

--- a/lib/install/validate/storage.go
+++ b/lib/install/validate/storage.go
@@ -17,6 +17,7 @@ package validate
 import (
 	"fmt"
 	"net/url"
+	"path"
 	"strings"
 
 	log "github.com/Sirupsen/logrus"

--- a/lib/install/validate/storage.go
+++ b/lib/install/validate/storage.go
@@ -32,7 +32,13 @@ func (v *Validator) storage(ctx context.Context, input *data.Data, conf *config.
 	defer trace.End(trace.Begin(""))
 
 	// Image Store
-	imageDSpath, ds, err := v.DatastoreHelper(ctx, input.ImageDatastoreName, "", "--image-datastore")
+	imageDSpath, ds, err := v.DatastoreHelper(ctx, input.ImageDatastorePath, "", "--image-datastore")
+
+	// provide a default path if only a DS name is provided
+	if imageDSpath.Path == "" {
+		imageDSpath.Path = path.Join(input.DisplayName, "images")
+	}
+
 	v.NoteIssue(err)
 	if ds != nil {
 		v.SetDatastore(ds, imageDSpath)
@@ -40,6 +46,12 @@ func (v *Validator) storage(ctx context.Context, input *data.Data, conf *config.
 	}
 
 	// Volume Store(s)
+	conf.BootstrapImagePath = fmt.Sprintf("[%s] %s/%s",
+		imageDSpath.Host,
+		input.DisplayName,
+		path.Base(input.BootstrapISO),
+	)
+
 	if conf.VolumeLocations == nil {
 		conf.VolumeLocations = make(map[string]*url.URL)
 	}

--- a/lib/install/validate/storage.go
+++ b/lib/install/validate/storage.go
@@ -51,13 +51,6 @@ func (v *Validator) storage(ctx context.Context, input *data.Data, conf *config.
 		conf.AddImageStore(imageDSpath)
 	}
 
-	// Volume Store(s)
-	conf.BootstrapImagePath = fmt.Sprintf("[%s] %s/%s",
-		imageDSpath.Host,
-		input.DisplayName,
-		path.Base(input.BootstrapISO),
-	)
-
 	if conf.VolumeLocations == nil {
 		conf.VolumeLocations = make(map[string]*url.URL)
 	}

--- a/lib/install/validate/storage.go
+++ b/lib/install/validate/storage.go
@@ -33,7 +33,7 @@ func (v *Validator) storage(ctx context.Context, input *data.Data, conf *config.
 	defer trace.End(trace.Begin(""))
 
 	// Image Store
-	imageDSpath, ds, err := v.DatastoreHelper(ctx, input.ImageDatastorePath, "", "--image-datastore")
+	imageDSpath, ds, err := v.DatastoreHelper(ctx, input.ImageDatastorePath, "", "--image-store")
 
 	if imageDSpath == nil {
 		v.NoteIssue(err)

--- a/lib/install/validate/storage.go
+++ b/lib/install/validate/storage.go
@@ -26,6 +26,7 @@ import (
 	"github.com/vmware/vic/lib/install/data"
 	"github.com/vmware/vic/pkg/errors"
 	"github.com/vmware/vic/pkg/trace"
+	"github.com/vmware/vic/pkg/vsphere/datastore"
 	"golang.org/x/net/context"
 )
 
@@ -113,6 +114,11 @@ func (v *Validator) DatastoreHelper(ctx context.Context, path string, label stri
 	// temporary until session is extracted
 	// FIXME: commented out until components can consume moid
 	// dsURL.Host = stores[0].Reference().Value
+
+	// make sure the vsphere ds format fits the right format
+	if _, err := datastore.ToURL(fmt.Sprintf("[%s] %s", dsURL.Host, dsURL.Path)); err != nil {
+		return nil, nil, err
+	}
 
 	return dsURL, stores[0], nil
 }

--- a/lib/install/validate/validator.go
+++ b/lib/install/validate/validator.go
@@ -193,7 +193,6 @@ func (v *Validator) basics(ctx context.Context, input *data.Data, conf *config.V
 	// TODO: ensure that displayname doesn't violate constraints (length, characters, etc)
 	conf.SetName(input.DisplayName)
 	conf.SetDebug(input.Debug.Debug)
-
 	conf.Name = input.DisplayName
 }
 

--- a/lib/install/validate/validator_test.go
+++ b/lib/install/validate/validator_test.go
@@ -111,7 +111,6 @@ func TestMain(t *testing.T) {
 		}
 
 		conf := testCompute(validator, input, t)
-		testDatastoreHelper(validator, t)
 		testTargets(validator, input, conf, t)
 		testStorage(validator, input, conf, t)
 		//		testNetwork() need dvs support
@@ -243,21 +242,6 @@ func testTargets(v *Validator, input *data.Data, conf *config.VirtualContainerHo
 	}
 }
 
-func testDatastoreHelper(v *Validator, t *testing.T) {
-	tests := []struct {
-		path     string
-		expected string
-	}{{"ds://LocalDS_0/path",
-		"ds://LocalDS_0/path"}}
-	for _, test := range tests {
-		output, _, err := v.DatastoreHelper(v.Context, test.path)
-
-		if err != nil {
-			log.Errorln(err)
-		}
-		assert.Equal(t, test.expected, output.String())
-	}
-}
 func testStorage(v *Validator, input *data.Data, conf *config.VirtualContainerHostConfigSpec, t *testing.T) {
 	tests := []struct {
 		image         string

--- a/lib/install/validate/validator_test.go
+++ b/lib/install/validate/validator_test.go
@@ -123,7 +123,7 @@ func getESXData(url *url.URL) *data.Data {
 	result.URL = url
 	result.DisplayName = "test001"
 	result.ComputeResourcePath = "/ha-datacenter/host/localhost.localdomain/Resources"
-	result.ImageDatastoreName = "LocalDS_0"
+	result.ImageDatastorePath = "LocalDS_0"
 	result.BridgeNetworkName = "bridge"
 	result.BridgeIPRange = "172.16.0.0/12"
 	result.ManagementNetworkName = "VM Network"
@@ -140,7 +140,7 @@ func getVPXData(url *url.URL) *data.Data {
 	result.URL = url
 	result.DisplayName = "test001"
 	result.ComputeResourcePath = "/DC0/host/DC0_C0/Resources"
-	result.ImageDatastoreName = "LocalDS_0"
+	result.ImageDatastorePath = "LocalDS_0"
 	result.ExternalNetworkName = "VM Network"
 	result.BridgeNetworkName = "bridge"
 	result.BridgeIPRange = "172.16.0.0/12"
@@ -250,19 +250,70 @@ func testStorage(v *Validator, input *data.Data, conf *config.VirtualContainerHo
 		expectImage   string
 		expectVolumes map[string]string
 	}{
-		{"LocalDS_0", map[string]string{"volume1": "LocalDS_0/volumes/volume1", "volume2": "ds://LocalDS_0/volumes/volume2"}, false, "ds://LocalDS_0", map[string]string{"volume1": "ds://LocalDS_0/volumes/volume1", "volume2": "ds://LocalDS_0/volumes/volume2"}},
-		{"ds://LocalDS_0/images", map[string]string{"volume1": "LocalDS_0/volumes/volume1", "volume2": "ds://LocalDS_0/volumes/volume2"}, false, "ds://LocalDS_0", map[string]string{"volume1": "ds://LocalDS_0/volumes/volume1", "volume2": "ds://LocalDS_0/volumes/volume2"}},
-		{"LocalDS_0/images", map[string]string{"volume1": "LocalDS_0/volumes/volume1", "volume2": "ds://LocalDS_0/volumes/volume2"}, false, "ds://LocalDS_0", map[string]string{"volume1": "ds://LocalDS_0/volumes/volume1", "volume2": "ds://LocalDS_0/volumes/volume2"}},
-		{"ds://LocalDS_0/images/xyz", map[string]string{"volume1": "LocalDS_0/volumes/volume1", "volume2": "ds://LocalDS_0/volumes/volume2"}, false, "ds://LocalDS_0", map[string]string{"volume1": "ds://LocalDS_0/volumes/volume1", "volume2": "ds://LocalDS_0/volumes/volume2"}},
-		{"LocalDS_0", map[string]string{"volume1": "LocalDS_1/volumes/volume1", "volume2": "ds://LocalDS_1/volumes/volume2"}, true, "", nil},
-		{"ds://LocalDS_0", map[string]string{"volume1": "LocalDS_1/volumes/volume1", "volume2": "ds://LocalDS_1/volumes/volume2"}, true, "", nil},
-		{"", map[string]string{"volume1": "", "volume2": "ds://"}, true, "", nil},
-		{"ds://", map[string]string{"volume1": "", "volume2": "ds://"}, true, "", nil},
+		{"LocalDS_0",
+			map[string]string{"volume1": "LocalDS_0/volumes/volume1",
+				"volume2": "ds://LocalDS_0/volumes/volume2"},
+			false,
+			"ds://LocalDS_0",
+			map[string]string{"volume1": "ds://LocalDS_0/volumes/volume1",
+				"volume2": "ds://LocalDS_0/volumes/volume2"}},
+
+		{"ds://LocalDS_0/images",
+			map[string]string{"volume1": "LocalDS_0/volumes/volume1",
+				"volume2": "ds://LocalDS_0/volumes/volume2"},
+			false,
+			"ds://LocalDS_0/images",
+			map[string]string{"volume1": "ds://LocalDS_0/volumes/volume1",
+				"volume2": "ds://LocalDS_0/volumes/volume2"}},
+
+		{"LocalDS_0/images",
+			map[string]string{"volume1": "LocalDS_0/volumes/volume1",
+				"volume2": "ds://LocalDS_0/volumes/volume2"},
+			false,
+			"ds://LocalDS_0/images",
+			map[string]string{"volume1": "ds://LocalDS_0/volumes/volume1",
+				"volume2": "ds://LocalDS_0/volumes/volume2"}},
+
+		{"ds://LocalDS_0/images/xyz",
+			map[string]string{"volume1": "LocalDS_0/volumes/volume1",
+				"volume2": "ds://LocalDS_0/volumes/volume2"},
+			false,
+			"ds://LocalDS_0/images/xyz",
+			map[string]string{"volume1": "ds://LocalDS_0/volumes/volume1",
+				"volume2": "ds://LocalDS_0/volumes/volume2"}},
+
+		{"LocalDS_0",
+			map[string]string{"volume1": "LocalDS_1/volumes/volume1",
+				"volume2": "ds://LocalDS_1/volumes/volume2"},
+			true,
+			"",
+			nil},
+
+		{"ds://LocalDS_0",
+			map[string]string{"volume1": "LocalDS_1/volumes/volume1",
+				"volume2": "ds://LocalDS_1/volumes/volume2"},
+			true,
+			"LocalDS_0",
+			nil},
+
+		{"",
+			map[string]string{"volume1": "",
+				"volume2": "ds://"},
+			true,
+			"",
+			nil},
+
+		{"ds://",
+			map[string]string{"volume1": "",
+				"volume2": "ds://"},
+			true,
+			"",
+			nil},
 	}
 
 	for _, test := range tests {
 		t.Logf("%+v", test)
-		input.ImageDatastoreName = test.image
+		input.ImageDatastorePath = test.image
 		input.VolumeLocations = test.volumes
 		v.storage(v.Context, input, conf)
 		v.ListIssues()

--- a/lib/portlayer/exec/config.go
+++ b/lib/portlayer/exec/config.go
@@ -61,4 +61,7 @@ type Configuration struct {
 	HostOS          string
 	HostOSVersion   string
 	HostProductName string //'VMware vCenter Server' or 'VMare ESXi'
+
+	// Datastore URLs for image stores - the top layer is [0], the bottom layer is [len-1]
+	ImageStores []url.URL `vic:"0.1" scope:"read-only" key:"image_stores"`
 }

--- a/lib/portlayer/exec/container.go
+++ b/lib/portlayer/exec/container.go
@@ -126,6 +126,7 @@ func (c *Container) Commit(ctx context.Context, sess *session.Session, h *Handle
 			var folders *object.DatacenterFolders
 			folders, err = sess.Datacenter.Folders(ctx)
 			if err != nil {
+				log.Errorf("Could not get folders")
 				return err
 			}
 			parent := folders.VmFolder
@@ -140,6 +141,7 @@ func (c *Container) Commit(ctx context.Context, sess *session.Session, h *Handle
 		}
 
 		if err != nil {
+			log.Errorf("Something failed. Spec was %s", *h.Spec.Spec())
 			return err
 		}
 

--- a/lib/portlayer/exec/handle.go
+++ b/lib/portlayer/exec/handle.go
@@ -233,6 +233,7 @@ func (h *Handle) Create(ctx context.Context, sess *session.Session, config *Cont
 		DebugNetwork:  backing,
 
 		ImageStoreName: config.ImageStoreName,
+		ImageStorePath: &VCHConfig.ImageStores[0],
 
 		Metadata: config.Metadata,
 	}

--- a/lib/portlayer/storage/image_cache.go
+++ b/lib/portlayer/storage/image_cache.go
@@ -190,6 +190,7 @@ func (c *NameLookupCache) WriteImage(ctx context.Context, parent *Image, ID stri
 
 // GetImage gets the specified image from the given store by retreiving it from the cache.
 func (c *NameLookupCache) GetImage(ctx context.Context, store *url.URL, ID string) (*Image, error) {
+	log.Debugf("Getting image from %#v", store)
 	storeName, err := util.ImageStoreName(store)
 	if err != nil {
 		return nil, err

--- a/lib/portlayer/storage/vsphere/image.go
+++ b/lib/portlayer/storage/vsphere/image.go
@@ -15,7 +15,6 @@
 package vsphere
 
 import (
-	"bytes"
 	"crypto/sha256"
 	"errors"
 	"fmt"

--- a/lib/portlayer/storage/vsphere/image.go
+++ b/lib/portlayer/storage/vsphere/image.go
@@ -69,9 +69,6 @@ func NewImageStore(ctx context.Context, s *session.Session, u *url.URL) (*ImageS
 		return nil, err
 	}
 
-	// Currently using the datastore associated with the session which is not
-	// ideal.  This should be passed in via the config.  The datastore need not
-	// be the same datastore used for the rest of the system.
 	datastores, err := s.Finder.DatastoreList(ctx, u.Host)
 	if err != nil {
 		// TODO: real error beyond whatever DatastoreList returns

--- a/lib/portlayer/storage/vsphere/image.go
+++ b/lib/portlayer/storage/vsphere/image.go
@@ -30,6 +30,7 @@ import (
 	"github.com/vmware/govmomi/vim25/types"
 	portlayer "github.com/vmware/vic/lib/portlayer/storage"
 	"github.com/vmware/vic/lib/portlayer/util"
+	"github.com/vmware/vic/pkg/trace"
 	"github.com/vmware/vic/pkg/vsphere/datastore"
 	"github.com/vmware/vic/pkg/vsphere/disk"
 	"github.com/vmware/vic/pkg/vsphere/session"
@@ -294,6 +295,7 @@ func (v *ImageStore) WriteImage(ctx context.Context, parent *portlayer.Image, ID
 
 func (v *ImageStore) GetImage(ctx context.Context, store *url.URL, ID string) (*portlayer.Image, error) {
 
+	defer trace.End(trace.Begin(store.String()))
 	storeName, err := util.ImageStoreName(store)
 	if err != nil {
 		return nil, err
@@ -341,6 +343,7 @@ func (v *ImageStore) GetImage(ctx context.Context, store *url.URL, ID string) (*
 		Metadata: meta,
 	}
 
+	log.Debugf("Returning image from location %s with parent url %s", newImage.SelfLink, newImage.Parent)
 	return newImage, nil
 }
 

--- a/lib/portlayer/storage/vsphere/image.go
+++ b/lib/portlayer/storage/vsphere/image.go
@@ -15,7 +15,6 @@
 package vsphere
 
 import (
-	"crypto/sha256"
 	"errors"
 	"fmt"
 	"io"
@@ -75,7 +74,7 @@ func NewImageStore(ctx context.Context, s *session.Session, u *url.URL) (*ImageS
 	}
 
 	if len(datastores) != 1 {
-		return nil, errors.New(fmt.Sprintf("Found %d datastores with provided datastore path %s. Installation will not continue, as provided datastore path must identify exactly one datastore.", len(datastores), u.String()))
+		return nil, errors.New(fmt.Sprintf("Found %d datastores with provided datastore path %s. Cannot create image store.", len(datastores), u.String()))
 	}
 
 	ds, err := datastore.NewHelper(ctx, s, datastores[0], path.Join(u.Path, StorageParentDir))

--- a/lib/portlayer/storage/vsphere/image.go
+++ b/lib/portlayer/storage/vsphere/image.go
@@ -71,11 +71,11 @@ func NewImageStore(ctx context.Context, s *session.Session, u *url.URL) (*ImageS
 
 	datastores, err := s.Finder.DatastoreList(ctx, u.Host)
 	if err != nil {
-		// TODO: real error beyond whatever DatastoreList returns
-		return nil, err
+		return nil, errors.New(fmt.Sprintf("Host returned error when trying to locate provided datastore %s: %s", u.String(), err.Error()))
 	}
+
 	if len(datastores) != 1 {
-		return nil, errors.New("Datastore not found or ambiguous name provided.")
+		return nil, errors.New(fmt.Sprintf("Found %d datastores with provided datastore path %s. Installation will not continue, as provided datastore path must identify exactly one datastore.", len(datastores), u.String()))
 	}
 
 	ds, err := datastore.NewHelper(ctx, s, datastores[0], path.Join(u.Path, StorageParentDir))

--- a/lib/portlayer/storage/vsphere/image_test.go
+++ b/lib/portlayer/storage/vsphere/image_test.go
@@ -20,6 +20,7 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"io/ioutil"
+	"net/url"
 	"os"
 	"path"
 	"path/filepath"
@@ -44,7 +45,11 @@ func setup(t *testing.T) (*portlayer.NameLookupCache, *session.Session, error) {
 		return nil, nil, fmt.Errorf("skip")
 	}
 
-	vsImageStore, err := NewImageStore(context.TODO(), client)
+	storeURL := &url.URL{
+		Path: StorageParentDir,
+		Host: client.DatastorePath}
+
+	vsImageStore, err := NewImageStore(context.TODO(), client, storeURL)
 	if err != nil {
 		if err.Error() == "can't find the hosting vm" {
 			t.Skip("Skipping: test must be run in a VM")
@@ -67,8 +72,11 @@ func TestRestartImageStore(t *testing.T) {
 
 	origVsStore := cacheStore.DataStore.(*ImageStore)
 
+	imageStoreURL := &url.URL{
+		Path: client.Datastore.Path(StorageParentDir),
+		Host: client.DatastorePath}
 	// now start it again
-	restartedVsStore, err := NewImageStore(context.TODO(), client)
+	restartedVsStore, err := NewImageStore(context.TODO(), client, imageStoreURL)
 	if !assert.NoError(t, err) || !assert.NotNil(t, restartedVsStore) {
 		return
 	}

--- a/lib/spec/disk.go
+++ b/lib/spec/disk.go
@@ -80,7 +80,9 @@ func (s *VirtualMachineConfigSpec) AddVirtualDisk(device *types.VirtualDisk) *Vi
 			VirtualDeviceFileBackingInfo: types.VirtualDeviceFileBackingInfo{
 				// XXX This needs to come from a storage helper in the future
 				// and should not be computed here like this.
-				FileName: s.Datastore.Path(fmt.Sprintf("VIC/%s/images/%s/%[2]s.vmdk",
+
+				FileName: s.Datastore.Path(fmt.Sprintf("%s/VIC/%s/images/%s/%[3]s.vmdk",
+					s.ImageStorePath().Path,
 					s.ImageStoreName(),
 					s.ParentImageID())),
 			},

--- a/lib/spec/spec.go
+++ b/lib/spec/spec.go
@@ -26,6 +26,7 @@ import (
 	"github.com/vmware/vic/pkg/vsphere/extraconfig"
 	"github.com/vmware/vic/pkg/vsphere/extraconfig/vmomi"
 	"github.com/vmware/vic/pkg/vsphere/session"
+	"net/url"
 )
 
 // NilSlot is an invalid PCI slot number
@@ -72,6 +73,9 @@ type VirtualMachineConfigSpecConfig struct {
 
 	// Name of the image store
 	ImageStoreName string
+
+	// url path to image store
+	ImageStorePath *url.URL
 
 	// Temporary
 	Metadata executor.ExecutorConfig
@@ -155,11 +159,14 @@ func NewVirtualMachineConfigSpec(ctx context.Context, session *session.Session, 
 	// merge it with the sec
 	s.ExtraConfig = append(s.ExtraConfig, metaCfg...)
 
-	return &VirtualMachineConfigSpec{
+	vmcs := &VirtualMachineConfigSpec{
 		Session:                  session,
 		VirtualMachineConfigSpec: s,
 		config: config,
-	}, nil
+	}
+
+	log.Debugf("Virtual machine config spec created: %+v", vmcs)
+	return vmcs, nil
 }
 
 // AddVirtualDevice appends an Add operation to the DeviceChange list

--- a/lib/spec/spec.go
+++ b/lib/spec/spec.go
@@ -272,6 +272,13 @@ func (s *VirtualMachineConfigSpec) ImageStoreName() string {
 	return s.config.ImageStoreName
 }
 
+// ImageStorePath returns the image store url
+func (s *VirtualMachineConfigSpec) ImageStorePath() *url.URL {
+	defer trace.End(trace.Begin(s.config.ID))
+
+	return s.config.ImageStorePath
+}
+
 func (s *VirtualMachineConfigSpec) generateNextKey() int32 {
 
 	s.key -= 10

--- a/pkg/vsphere/datastore/datastore.go
+++ b/pkg/vsphere/datastore/datastore.go
@@ -15,7 +15,6 @@
 package datastore
 
 import (
-	"errors"
 	"fmt"
 	"io"
 	"net/url"
@@ -307,19 +306,19 @@ func (d *Helper) rootDir() string {
 }
 
 // Parse the datastore format ([datastore1] /path/to/thing) to groups.
-var datastoreFormat = regexp.MustCompile(`^\[([\w\d\(\)-_\s]+)\]`)
-var pathFormat = regexp.MustCompile(`\s([\/\w-_]+$)`)
+var datastoreFormat = regexp.MustCompile(`^\[([\w\d\(\)-_\.\s]+)\]`)
+var pathFormat = regexp.MustCompile(`\s([\/\w-_\.]*$)`)
 
 // Converts `[datastore] /path` to ds:// URL
 func ToURL(ds string) (*url.URL, error) {
 	u := new(url.URL)
 	var matches []string
 	if matches = datastoreFormat.FindStringSubmatch(ds); len(matches) != 2 {
-		return nil, errors.New("Ambiguous datastore format encountered.")
+		return nil, fmt.Errorf("Ambiguous datastore hostname format encountered from input: %s.", ds)
 	}
 	u.Host = matches[1]
 	if matches = pathFormat.FindStringSubmatch(ds); len(matches) != 2 {
-		return nil, errors.New("Ambiguous datastore path format encountered.")
+		return nil, fmt.Errorf("Ambiguous datastore path format encountered from input: %s.", ds)
 	}
 
 	u.Path = path.Clean(matches[1])

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-1-Distributed-Switch.md
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-1-Distributed-Switch.md
@@ -31,7 +31,7 @@ This test requires access to VMWare Nimbus cluster for dynamic ESXi and vCenter 
 ```govc dvs.add -dvs=test-ds -pnic=vmnic1 <ESXi IP2>```  
 ```govc dvs.add -dvs=test-ds -pnic=vmnic1 <ESXi IP3>```
 8. Deploy VCH Appliance to the new vCenter:  
-```bin/vic-machine-linux create --target=<VC IP> --user=Administrator@vsphere.local --image-datastore=datastore1 --appliance-iso=bin/appliance.iso --bootstrap-iso=bin/bootstrap.iso --generate-cert=false --password=Admin\!23 --force=true --bridge-network=bridge --compute-resource=/ha-datacenter/host/<ESXi IP 1>/Resources --external-network=vm-network --name=VCH-test```
+```bin/vic-machine-linux create --target=<VC IP> --user=Administrator@vsphere.local --image-store=datastore1 --appliance-iso=bin/appliance.iso --bootstrap-iso=bin/bootstrap.iso --generate-cert=false --password=Admin\!23 --force=true --bridge-network=bridge --compute-resource=/ha-datacenter/host/<ESXi IP 1>/Resources --external-network=vm-network --name=VCH-test```
 9. Run a variety of docker commands on the VCH appliance
 
 #Expected Outcome:

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-2-Cluster.md
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-2-Cluster.md
@@ -19,7 +19,7 @@ This test requires access to VMWare Nimbus cluster for dynamic ESXi and vCenter 
 4. Add 2 ESXi hosts to the cluster:  
 ```govc cluster.add -hostname=<ESXi IP> -username=<USER> -cluster=cluster1 -password=<PW> -noverify=true```
 5. Deploy VCH Appliance to the new vCenter cluster:    
-```bin/vic-machine-linux create --target=<VC IP> --user=Administrator@vsphere.local --image-datastore=datastore1 --appliance-iso=bin/appliance.iso --bootstrap-iso=bin/bootstrap.iso --generate-cert=false --password=Admin\!23 --force=true --bridge-network=bridge --compute-resource=/ha-datacenter/host/cluster1/<ESXi IP 1>/Resources --external-network=vm-network --name=VCH-test```
+```bin/vic-machine-linux create --target=<VC IP> --user=Administrator@vsphere.local --image-store=datastore1 --appliance-iso=bin/appliance.iso --bootstrap-iso=bin/bootstrap.iso --generate-cert=false --password=Admin\!23 --force=true --bridge-network=bridge --compute-resource=/ha-datacenter/host/cluster1/<ESXi IP 1>/Resources --external-network=vm-network --name=VCH-test```
 6. Run a variety of docker commands on the VCH appliance
 
 #Expected Outcome:

--- a/tests/resources/Util.robot
+++ b/tests/resources/Util.robot
@@ -80,11 +80,11 @@ Run VIC Machine Command
     [Arguments]  ${certs}  ${vol}  ${bridge}  ${external}
 	${proto}=  Set Variable If  ${certs}  "https"  "http"
 	Set Suite Variable  ${proto}
-    ${output}=  Run Keyword If  ${certs}  Run  bin/vic-machine-linux create --name=${vch-name} --target=%{TEST_URL} --user=%{TEST_USERNAME} --image-datastore=%{TEST_DATASTORE} --appliance-iso=bin/appliance.iso --bootstrap-iso=bin/bootstrap.iso --password=%{TEST_PASSWORD} --force=true --bridge-network=${bridge} --external-network=${external} --compute-resource=%{TEST_RESOURCE} --timeout %{TEST_TIMEOUT} --volume-store=%{TEST_DATASTORE}/test:${vol}
+    ${output}=  Run Keyword If  ${certs}  Run  bin/vic-machine-linux create --name=${vch-name} --target=%{TEST_URL} --user=%{TEST_USERNAME} --image-store=%{TEST_DATASTORE} --appliance-iso=bin/appliance.iso --bootstrap-iso=bin/bootstrap.iso --password=%{TEST_PASSWORD} --force=true --bridge-network=${bridge} --external-network=${external} --compute-resource=%{TEST_RESOURCE} --timeout %{TEST_TIMEOUT} --volume-store=%{TEST_DATASTORE}/test:${vol}
     Run Keyword If  ${certs}  Should Contain  ${output}  Installer completed successfully
     Return From Keyword If  ${certs}  ${output}
 
-    ${output}=  Run Keyword Unless  ${certs}  Run  bin/vic-machine-linux create --name=${vch-name} --target=%{TEST_URL} --user=%{TEST_USERNAME} --image-datastore=%{TEST_DATASTORE} --appliance-iso=bin/appliance.iso --bootstrap-iso=bin/bootstrap.iso --password=%{TEST_PASSWORD} --no-tls --force=true --bridge-network=${bridge} --external-network=${external} --compute-resource=%{TEST_RESOURCE} --timeout %{TEST_TIMEOUT} --volume-store=%{TEST_DATASTORE}/test:${vol}
+    ${output}=  Run Keyword Unless  ${certs}  Run  bin/vic-machine-linux create --name=${vch-name} --target=%{TEST_URL} --user=%{TEST_USERNAME} --image-store=%{TEST_DATASTORE} --appliance-iso=bin/appliance.iso --bootstrap-iso=bin/bootstrap.iso --password=%{TEST_PASSWORD} --no-tls --force=true --bridge-network=${bridge} --external-network=${external} --compute-resource=%{TEST_RESOURCE} --timeout %{TEST_TIMEOUT} --volume-store=%{TEST_DATASTORE}/test:${vol}
     Run Keyword Unless  ${certs}  Should Contain  ${output}  Installer completed successfully
     [Return]  ${output}
 

--- a/tests/test-cases/Group6-VIC-Machine/6-4-Create-Basic.md
+++ b/tests/test-cases/Group6-VIC-Machine/6-4-Create-Basic.md
@@ -49,7 +49,7 @@ This test requires that a vSphere server is running and available
 1. Issue the following command:
 ```
 vic-machine create --name=<VCH_NAME> --target=<TEST_URL> \
-    --user=<TEST_USERNAME> --image-datastore=<TEST_DATASTORE> --password=<TEST_PASSWORD> \
+    --user=<TEST_USERNAME> --image-store=<TEST_DATASTORE> --password=<TEST_PASSWORD> \
     --bridge-network=<NETWORK> --compute-resource=<TEST_RESOURCE>
 ```
 2. Run regression tests
@@ -65,7 +65,7 @@ vic-machine create --name=<VCH_NAME> --target=<TEST_URL> \
 2. Issue the following command:
 ```
 vic-machine-linux create --name=<VCH_NAME> --target="<TEST_USERNAME>:<TEST_PASSWORD>@<TEST_URL>" \
-    --image-datastore=<TEST_DATASTORE>
+    --image-store=<TEST_DATASTORE>
 ```
 3. Run regression tests
 
@@ -78,7 +78,7 @@ vic-machine-linux create --name=<VCH_NAME> --target="<TEST_USERNAME>:<TEST_PASSW
 ## Create VCH - full params
 1. Issue the following command:
 ```
-vic-machine-linux create --name=<VCH_NAME> --target=<TEST_URL> --user=<TEST_USERNAME> --image-datastore=<TEST_DATASTORE> --appliance-iso=bin/appliance.iso --bootstrap-iso=bin/bootstrap.iso --password=<TEST_PASSWORD> --force=true --bridge-network=network --compute-resource=<TEST_RESOURCE> --timeout <TEST_TIMEOUT> --volume-store=<TEST_DATASTORE>/test:default
+vic-machine-linux create --name=<VCH_NAME> --target=<TEST_URL> --user=<TEST_USERNAME> --image-store=<TEST_DATASTORE> --appliance-iso=bin/appliance.iso --bootstrap-iso=bin/bootstrap.iso --password=<TEST_PASSWORD> --force=true --bridge-network=network --compute-resource=<TEST_RESOURCE> --timeout <TEST_TIMEOUT> --volume-store=<TEST_DATASTORE>/test:default
 ```
 2. Run regression tests
 

--- a/tests/test-cases/Group6-VIC-Machine/6-4-Create-Basic.robot
+++ b/tests/test-cases/Group6-VIC-Machine/6-4-Create-Basic.robot
@@ -63,3 +63,28 @@ Create VCH - full params
     Run Keyword If  '${status}' == 'closed'  Fail  6-4-Create-Basic.robot needs to be updated now that Issue #1109 has been resolved
     Run Regression Tests
     Cleanup VIC Appliance On Test Server
+
+Create VCH - custom image store directory
+    Log To Console  \nRunning vic-machine create
+    # Attempt to cleanup old/canceled tests
+    Run Keyword And Ignore Error  Cleanup Dangling VMs On Test Server
+    Run Keyword And Ignore Error  Cleanup Datastore On Test Server
+    Set Test Environment Variables  ${true}  default  network  'VM Network'
+    Set Test VCH Name
+
+    Log To Console  \nInstalling VCH to test server...
+    ${output}=  Run  bin/vic-machine-linux create --name=${vch-name} --target=%{TEST_URL} --user=%{TEST_USERNAME} --image-store %{TEST_DATASTORE}/vic-machine-test-images --appliance-iso=bin/appliance.iso --bootstrap-iso=bin/bootstrap.iso --password=%{TEST_PASSWORD} --force=true --bridge-network=network --compute-resource=%{TEST_RESOURCE} --timeout %{TEST_TIMEOUT}
+
+    Should Contain  ${output}  Installer completed successfully
+    Get Docker Params  ${output}  ${true}
+    Log To Console  Installer completed successfully: ${vch-name}...
+    Sleep  10 seconds
+    ${output}=  Run  GOVC_DATASTORE=%{TEST_DATASTORE} govc datastore.ls
+    Should Contain  ${output}  vic-machine-test-images
+
+    ${status}=  Get State Of Github Issue  1109
+    Run Keyword If  '${status}' == 'closed'  Fail  6-4-Create-Basic.robot needs to be updated now that Issue #1109 has been resolved
+    Run Regression Tests
+    Cleanup VIC Appliance On Test Server
+    ${output}=  Run  GOVC_DATASTORE=%{TEST_DATASTORE} govc datastore.ls
+    Should Not Contain  ${output}  vic-machine-test-images

--- a/tests/test-cases/Group6-VIC-Machine/6-4-Create-Basic.robot
+++ b/tests/test-cases/Group6-VIC-Machine/6-4-Create-Basic.robot
@@ -13,7 +13,7 @@ Create VCH - defaults
     Set Test VCH Name
 
     Log To Console  \nInstalling VCH to test server...
-    ${output}=  Run  bin/vic-machine-linux create --name=${vch-name} --target=%{TEST_URL} --user=%{TEST_USERNAME} --image-datastore=%{TEST_DATASTORE} --password=%{TEST_PASSWORD}
+    ${output}=  Run  bin/vic-machine-linux create --name=${vch-name} --target=%{TEST_URL} --user=%{TEST_USERNAME} --image-store=%{TEST_DATASTORE} --password=%{TEST_PASSWORD}
     Should Contain  ${output}  Installer completed successfully
     Get Docker Params  ${output}  ${true}
     Log To Console  Installer completed successfully: ${vch-name}...
@@ -33,7 +33,7 @@ Create VCH - target URL
     Set Test VCH Name
 
     Log To Console  \nInstalling VCH to test server...
-    ${output}=  Run  bin/vic-machine-linux create --name=${vch-name} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --image-datastore=%{TEST_DATASTORE}
+    ${output}=  Run  bin/vic-machine-linux create --name=${vch-name} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --image-store=%{TEST_DATASTORE}
     Should Contain  ${output}  Installer completed successfully
     Get Docker Params  ${output}  ${true}
     Log To Console  Installer completed successfully: ${vch-name}...
@@ -53,7 +53,7 @@ Create VCH - full params
     Set Test VCH Name
 
     Log To Console  \nInstalling VCH to test server...
-    ${output}=  Run  bin/vic-machine-linux create --name=${vch-name} --target=%{TEST_URL} --user=%{TEST_USERNAME} --image-datastore=%{TEST_DATASTORE} --appliance-iso=bin/appliance.iso --bootstrap-iso=bin/bootstrap.iso --password=%{TEST_PASSWORD} --force=true --bridge-network=network --compute-resource=%{TEST_RESOURCE} --timeout %{TEST_TIMEOUT} --volume-store=%{TEST_DATASTORE}/test:default
+    ${output}=  Run  bin/vic-machine-linux create --name=${vch-name} --target=%{TEST_URL} --user=%{TEST_USERNAME} --image-store=%{TEST_DATASTORE} --appliance-iso=bin/appliance.iso --bootstrap-iso=bin/bootstrap.iso --password=%{TEST_PASSWORD} --force=true --bridge-network=network --compute-resource=%{TEST_RESOURCE} --timeout %{TEST_TIMEOUT} --volume-store=%{TEST_DATASTORE}/test:default
     Should Contain  ${output}  Installer completed successfully
     Get Docker Params  ${output}  ${true}
     Log To Console  Installer completed successfully: ${vch-name}...

--- a/tests/test-cases/Group6-VIC-Machine/6-5-Create-Validation.md
+++ b/tests/test-cases/Group6-VIC-Machine/6-5-Create-Validation.md
@@ -53,7 +53,7 @@ This test requires that a vSphere server is running and available
 2. Issue the following command:
 ```
 vic-machine create --name=<VCH_NAME> --target=<TEST_URL> \
-    --user=<TEST_USERNAME> --image-datastore=<TEST_DATASTORE> --password=<TEST_PASSWORD> \
+    --user=<TEST_USERNAME> --image-store=<TEST_DATASTORE> --password=<TEST_PASSWORD> \
     --bridge-network=<NETWORK> --compute-resource=<TEST_RESOURCE>
 ```
 3. Run regression tests
@@ -68,7 +68,7 @@ vic-machine create --name=<VCH_NAME> --target=<TEST_URL> \
 2. Issue the following command:
 ```
 vic-machine create --name=<VCH_NAME> --target=<TEST_URL> \
-    --user=<TEST_USERNAME> --image-datastore=<TEST_DATASTORE> --password=<TEST_PASSWORD> \
+    --user=<TEST_USERNAME> --image-store=<TEST_DATASTORE> --password=<TEST_PASSWORD> \
     --bridge-network=<NETWORK> --compute-resource=<TEST_RESOURCE>
 ```
 


### PR DESCRIPTION
Creating a new PR because this one is more expansive. Previous reviewers ( @hmahmood @emlin @fdawg4l ) may wish to take another gander.

This modifies the portlayer as well as vic-machine to allow custom image store locations. If one is not provided, a directory called images/ inside of the normal vch storage directory (where the ISOs go) is used

During delete, only the final directory in the path is removed -- during create, the path is created if it does not exist.

Comments more than welcome. Emma I expect you specifically to have some input about some functions / variables I've renamed.

Addresses the last of the functionality described in #1210 