### PR TITLE
Adds VolumeStore to the name portion of Volume ls output

### DIFF
--- a/lib/apiservers/engine/backends/volume.go
+++ b/lib/apiservers/engine/backends/volume.go
@@ -81,6 +81,7 @@ func (v *Volume) Volumes(filter string) ([]*types.Volume, []string, error) {
 			return nil, nil, fmt.Errorf("error unmarshalling docker metadata: %s", err)
 		}
 		volume := NewVolumeModel(vol, volumeMetadata.Labels)
+		volume.Name = fmt.Sprintf("[%s]:%s", vol.Store, vol.Name)
 		volumes = append(volumes, volume)
 	}
 	return volumes, nil, nil


### PR DESCRIPTION
Fixes #1679 

Cormac brought up the fact that after making a volume there is no way to tell what volume store a specfic volume belonged to. He recommended providing a prefix to the name field in `volume ls` so the output of the said function was much more useful. 

sample output:
```
 % docker -H 10.17.109.84:2376 --tls volume ls                                                                   
DRIVER              VOLUME NAME
vsphere             [default]:newTestVol
vsphere             [test-store]:testVol
```