### PR TITLE
Show correct output while pulling fake image (#757)

### DIFF
--- a/cmd/imagec/imagec.go
+++ b/cmd/imagec/imagec.go
@@ -694,16 +694,20 @@ func main() {
 		options.token = token
 	}
 
-	// Get the manifest
-	manifest, err := FetchImageManifest(options)
-	if err != nil {
-		log.Fatalf("Error while pulling image manifest: %s", err)
-	}
-
 	// HACK: Required to learn the name of the vmdk from given reference
 	// Used by docker personality until metadata support lands
 	if !options.resolv {
 		progress.Message(po, options.tag, "Pulling from "+options.image)
+	}
+
+	// Get the manifest
+	manifest, err := FetchImageManifest(options)
+	if err != nil {
+		if strings.Contains(err.Error(), "image not found") {
+			log.Fatalf("Error: image %s not found", options.image)
+		} else {
+			log.Fatalf("Error while pulling image manifest: %s", err)
+		}
 	}
 
 	// Create the ImageWithMeta slice to hold Image structs

--- a/tests/test-cases/Group1-Docker-Commands/1-2-Docker-Pull.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-2-Docker-Pull.robot
@@ -51,9 +51,7 @@ Pull non-existent image
     ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} pull fakebadimage
     Log  ${output}
     Should Be Equal As Integers  ${rc}  1
-    ${status}=  Get State Of Github Issue  757
-    Run Keyword If  '${status}' == 'closed'  Fail  Test 1-2-Docker-Pull.robot needs to be updated now that Issue #757 has been resolved
-    #Should contain  ${output}  image library/fakebadimage not found
+    Should contain  ${output}  image library/fakebadimage not found
 
 Pull image from non-existent repo
     ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} pull fakebadrepo.com:9999/ubuntu


### PR DESCRIPTION
* Fixes output while pulling a non-existent image

Vanilla docker:
```
$ sudo docker pull foo/bar
Using default tag: latest
Pulling repository docker.io/foo/bar
Error: image foo/bar not found
```

VIC:
```
$ docker -H <host> --tls pull foo/bar
Using default tag: latest
latest: Pulling from foo/bar
Error: image foo/bar not found
```
* Enables related integration test for `docker pull`

Fixes #757