### PR TITLE
Unify metadata functions for images and volumes

### DIFF
--- a/lib/portlayer/storage/image.go
+++ b/lib/portlayer/storage/image.go
@@ -76,13 +76,6 @@ type ImageStorer interface {
 	WriteImage(ctx context.Context, parent *Image, ID string, meta map[string][]byte, r io.Reader) (*Image,
 		error)
 
-	// WriteMetadata will write the provided metadata to the image store
-	//
-	// storeName - The image store to query name - The name of the image (optional)
-	// ID - textual ID for the image
-	// meta - metadata associated with the image
-	WriteMetadata(ctx context.Context, storeName string, ID string, meta map[string][]byte) error
-
 	// GetImage queries the image store for the specified image.
 	//
 	// store - The image store to query name - The name of the image (optional)

--- a/lib/portlayer/storage/image_cache.go
+++ b/lib/portlayer/storage/image_cache.go
@@ -164,19 +164,6 @@ func (c *NameLookupCache) WriteImage(ctx context.Context, parent *Image, ID stri
 	if err == nil && i != nil {
 		// TODO(FA) check sums to make sure this is the right image
 
-		// if meta supplied write it
-		if meta != nil && len(meta) != 0 {
-			// get the storename from the url
-			storeName, err := util.ImageStoreName(p.Store)
-			if err != nil {
-				return nil, err
-			}
-
-			c.DataStore.WriteMetadata(ctx, storeName, i.ID, meta)
-			i.Metadata = meta
-			c.AddImageToStore(*p.Store, i.ID, *i)
-		}
-
 		return i, nil
 	}
 

--- a/lib/portlayer/storage/image_cache_test.go
+++ b/lib/portlayer/storage/image_cache_test.go
@@ -72,10 +72,6 @@ func (c *MockDataStore) WriteImage(ctx context.Context, parent *Image, ID string
 	return i, nil
 }
 
-func (c *MockDataStore) WriteMetadata(ctx context.Context, storeName string, ID string, meta map[string][]byte) error {
-	return nil
-}
-
 // GetImage gets the specified image from the given store by retreiving it from the cache.
 func (c *MockDataStore) GetImage(ctx context.Context, store *url.URL, ID string) (*Image, error) {
 	i, ok := c.db[*store][ID]

--- a/lib/portlayer/storage/vsphere/image_test.go
+++ b/lib/portlayer/storage/vsphere/image_test.go
@@ -189,7 +189,6 @@ func TestCreateImageLayers(t *testing.T) {
 	if !assert.NoError(t, err) {
 		return
 	}
-	parent.Metadata = make(map[string][]byte)
 
 	// Keep a list of all files we're extracting via layers so we can verify
 	// they exist in the leaf layer.  Ext adds lost+found, so add it here.
@@ -221,7 +220,7 @@ func TestCreateImageLayers(t *testing.T) {
 		meta[dirName+"_scorpions"] = []byte("Here I am, rock you like a hurricane")
 
 		// Tar the files
-		buf, terr := tarFiles(files, meta)
+		buf, terr := tarFiles(files)
 		if !assert.NoError(t, terr) {
 			return
 		}
@@ -309,7 +308,7 @@ type tarFile struct {
 	Body string
 }
 
-func tarFiles(files []tarFile, meta map[string][]byte) (*bytes.Buffer, error) {
+func tarFiles(files []tarFile) (*bytes.Buffer, error) {
 	// Create a buffer to write our archive to.
 	buf := new(bytes.Buffer)
 

--- a/lib/portlayer/storage/vsphere/metadata.go
+++ b/lib/portlayer/storage/vsphere/metadata.go
@@ -1,0 +1,91 @@
+// Copyright 2016 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vsphere
+
+import (
+	"bytes"
+	"io/ioutil"
+	"path"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/vmware/govmomi/vim25/types"
+	"github.com/vmware/vic/pkg/vsphere/datastore"
+	"golang.org/x/net/context"
+)
+
+// Write the opaque metadata blobs (by name).
+// Each blob in the metadata map is written to a file with the corresponding
+// name.  Likewise, when we read it back (on restart) we populate the map
+// accordingly.
+func writeMetadata(ctx context.Context, ds *datastore.Helper, dir string, meta map[string][]byte) error {
+	// XXX this should be done via disklib so this meta follows the disk in
+	// case of motion.
+
+	if meta != nil && len(meta) != 0 {
+		for name, value := range meta {
+			r := bytes.NewReader(value)
+			pth := path.Join(dir, name)
+			log.Infof("Writing metadata %s", pth)
+			if err := ds.Upload(ctx, r, pth); err != nil {
+				return err
+			}
+		}
+	} else {
+		if _, err := ds.Mkdir(ctx, false, dir); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// Read the metadata from the given dir
+func getMetadata(ctx context.Context, ds *datastore.Helper, dir string) (map[string][]byte, error) {
+
+	res, err := ds.Ls(ctx, dir)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(res.File) == 0 {
+		log.Infof("No meta found for %s", dir)
+		return nil, nil
+	}
+
+	meta := make(map[string][]byte)
+	for _, f := range res.File {
+		finfo, ok := f.(*types.FileInfo)
+		if !ok {
+			continue
+		}
+
+		p := path.Join(dir, finfo.Path)
+		log.Infof("Getting metadata %s", p)
+		rc, err := ds.Download(ctx, p)
+		if err != nil {
+			return nil, err
+		}
+		defer rc.Close()
+
+		buf, err := ioutil.ReadAll(rc)
+		if err != nil {
+			return nil, err
+		}
+
+		meta[finfo.Path] = buf
+	}
+
+	return meta, nil
+}


### PR DESCRIPTION
This is just code cleanup.  We need to store metadata for volumes as
well as images.  Might as well use the same routines for both.