### PR TITLE
Refactored ContainerCreate

### DIFF
--- a/cmd/docker/main.go
+++ b/cmd/docker/main.go
@@ -213,7 +213,7 @@ func startServerWithOptions(cli *CliOptions) *apiserver.Server {
 
 func setAPIRoutes(api *apiserver.Server) {
 	imageHandler := &vicbackends.Image{}
-	containerHandler := &vicbackends.Container{}
+	containerHandler := vicbackends.NewContainerBackend()
 	volumeHandler := &vicbackends.Volume{}
 	networkHandler := &vicbackends.Network{}
 	systemHandler := vicbackends.NewSystemBackend()

--- a/lib/apiservers/engine/backends/container_test.go
+++ b/lib/apiservers/engine/backends/container_test.go
@@ -15,54 +15,355 @@
 package vicbackends
 
 import (
+	"fmt"
+	"net/http"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/go-swagger/go-swagger/client"
+
+	derr "github.com/docker/docker/errors"
+	"github.com/docker/engine-api/types"
+	"github.com/docker/engine-api/types/container"
+	dnetwork "github.com/docker/engine-api/types/network"
+
+	"github.com/vmware/vic/lib/apiservers/engine/backends/cache"
+	plscopes "github.com/vmware/vic/lib/apiservers/portlayer/client/scopes"
+	plmodels "github.com/vmware/vic/lib/apiservers/portlayer/models"
+	"github.com/vmware/vic/lib/metadata"
 )
 
-func TestProcessVolumeParams(t *testing.T) {
-	rawTestVolumes := []string{"/blah", "testVolume:/mount", "testVolume:/mount/path:r"}
-	var processedTestVolumes []volumeFields
+//***********
+// Mock proxy
+//***********
 
-	for _, testString := range rawTestVolumes {
-		processedFields, err := processVolumeParam(testString)
-		assert.Nil(t, err)
-		processedTestVolumes = append(processedTestVolumes, processedFields)
-	}
-	assert.Equal(t, 3, len(processedTestVolumes))
-
-	assert.NotEmpty(t, processedTestVolumes[0].ID)
-	assert.Equal(t, "/blah", processedTestVolumes[0].Dest)
-	assert.Equal(t, "rw", processedTestVolumes[0].Flags)
-
-	assert.Equal(t, "testVolume", processedTestVolumes[1].ID)
-	assert.Equal(t, "/mount", processedTestVolumes[1].Dest)
-	assert.Equal(t, "rw", processedTestVolumes[1].Flags)
-
-	assert.Equal(t, "testVolume", processedTestVolumes[2].ID)
-	assert.Equal(t, "/mount/path", processedTestVolumes[2].Dest)
-	assert.Equal(t, "r", processedTestVolumes[2].Flags)
+type CreateHandleMockData struct {
+	createInputID   string
+	retID           string
+	retHandle       string
+	retErr          error
+	createErrSubstr string
 }
 
-func TestProcessSpecifiedVolumes(t *testing.T) {
-	rawTestVolumes := []string{"masterVolume:/blah", "testVolume:/mount:r", "specVol:/mount/path:r"}
-	var processedTestVolumes []volumeFields
+type AddToScopeMockData struct {
+	createInputID   string
+	retHandle       string
+	retErr          error
+	createErrSubstr string
+}
 
-	processedFields, err := processSpecifiedVolumes(rawTestVolumes)
-	assert.Nil(t, err)
-	processedTestVolumes = append(processedTestVolumes, processedFields...)
+type AddVolumesMockData struct {
+	retHandle       string
+	retErr          error
+	createErrSubstr string
+}
 
-	assert.Len(t, processedFields, 3)
+type CommitHandleMockData struct {
+	createInputID   string
+	createErrSubstr string
 
-	assert.Equal(t, "masterVolume", processedTestVolumes[0].ID)
-	assert.Equal(t, "/blah", processedTestVolumes[0].Dest)
-	assert.Equal(t, "rw", processedTestVolumes[0].Flags)
+	retErr error
+}
 
-	assert.Equal(t, "testVolume", processedTestVolumes[1].ID)
-	assert.Equal(t, "/mount", processedTestVolumes[1].Dest)
-	assert.Equal(t, "r", processedTestVolumes[1].Flags)
+type MockContainerProxy struct {
+	mockRespIndices      []int
+	mockCreateHandleData []CreateHandleMockData
+	mockAddToScopeData   []AddToScopeMockData
+	mockAddVolumesData   []AddVolumesMockData
+	mockCommitData       []CommitHandleMockData
+}
 
-	assert.Equal(t, "specVol", processedTestVolumes[2].ID)
-	assert.Equal(t, "/mount/path", processedTestVolumes[2].Dest)
-	assert.Equal(t, "r", processedTestVolumes[2].Flags)
+const SUCCESS = 0
+
+func NewMockContainerProxy() *MockContainerProxy {
+	return &MockContainerProxy{
+		mockRespIndices:      make([]int, 4),
+		mockCreateHandleData: MockCreateHandleData(),
+		mockAddToScopeData:   MockAddToScopeData(),
+		mockAddVolumesData:   MockAddVolumesData(),
+		mockCommitData:       MockCommitData(),
+	}
+}
+
+func MockCreateHandleData() []CreateHandleMockData {
+	createHandleTimeoutErr := client.NewAPIError("unknown error", "context deadline exceeded", http.StatusServiceUnavailable)
+
+	mockCreateHandleData := []CreateHandleMockData{
+		{"busybox", "321cba", "handle", nil, ""},
+		{"busybox", "", "", derr.NewRequestNotFoundError(fmt.Errorf("No such image: abc123")), "No such image"},
+		{"busybox", "", "", derr.NewErrorWithStatusCode(createHandleTimeoutErr, http.StatusInternalServerError), "context deadline exceeded"},
+	}
+
+	return mockCreateHandleData
+}
+
+func MockAddToScopeData() []AddToScopeMockData {
+	addToScopeNotFound := plscopes.AddContainerNotFound{
+		Payload: &plmodels.Error{
+			Message: "Scope not found",
+		},
+	}
+
+	addToScopeNotFoundErr := fmt.Errorf("ContainerProxy.AddContainerToScope: Scopes error: %s", addToScopeNotFound.Error())
+
+	addToScopeTimeout := plscopes.AddContainerInternalServerError{
+		Payload: &plmodels.Error{
+			Message: "context deadline exceeded",
+		},
+	}
+
+	addToScopeTimeoutErr := fmt.Errorf("ContainerProxy.AddContainerToScope: Scopes error: %s", addToScopeTimeout.Error())
+
+	mockAddToScopeData := []AddToScopeMockData{
+		{"busybox", "handle", nil, ""},
+		{"busybox", "handle", derr.NewErrorWithStatusCode(fmt.Errorf("container.ContainerCreate failed to create a portlayer client"), http.StatusInternalServerError), "failed to create a portlayer"},
+		{"busybox", "handle", derr.NewErrorWithStatusCode(addToScopeNotFoundErr, http.StatusInternalServerError), "Scope not found"},
+		{"busybox", "handle", derr.NewErrorWithStatusCode(addToScopeTimeoutErr, http.StatusInternalServerError), "context deadline exceeded"},
+	}
+
+	return mockAddToScopeData
+}
+
+func MockAddVolumesData() []AddVolumesMockData {
+	return nil
+}
+
+func MockCommitData() []CommitHandleMockData {
+	noSuchImageErr := fmt.Errorf("No such image: busybox")
+
+	mockCommitData := []CommitHandleMockData{
+		{"buxybox", "", nil},
+		{"busybox", "failed to create a portlayer", derr.NewErrorWithStatusCode(fmt.Errorf("container.ContainerCreate failed to create a portlayer client"), http.StatusInternalServerError)},
+		{"busybox", "No such image", derr.NewRequestNotFoundError(noSuchImageErr)},
+	}
+
+	return mockCommitData
+}
+
+func (m *MockContainerProxy) GetMockDataCount() (int, int, int, int) {
+	return len(m.mockCreateHandleData), len(m.mockAddToScopeData), len(m.mockAddVolumesData), len(m.mockCommitData)
+}
+
+func (m *MockContainerProxy) SetMockDataResponse(createHandleResp int, addToScopeResp int, addVolumeResp int, commitContainerResp int) {
+	m.mockRespIndices[0] = createHandleResp
+	m.mockRespIndices[1] = addToScopeResp
+	m.mockRespIndices[2] = addVolumeResp
+	m.mockRespIndices[3] = commitContainerResp
+}
+
+func (m *MockContainerProxy) CreateContainerHandle(imageID string, config types.ContainerCreateConfig) (string, string, error) {
+	respIdx := m.mockRespIndices[0]
+
+	if respIdx >= len(m.mockCreateHandleData) {
+		return "", "", nil
+	}
+	return m.mockCreateHandleData[respIdx].retID, m.mockCreateHandleData[respIdx].retHandle, m.mockCreateHandleData[respIdx].retErr
+}
+
+func (m *MockContainerProxy) AddContainerToScope(handle string, config types.ContainerCreateConfig) (string, error) {
+	respIdx := m.mockRespIndices[1]
+
+	if respIdx >= len(m.mockAddToScopeData) {
+		return "", nil
+	}
+
+	return m.mockAddToScopeData[respIdx].retHandle, m.mockAddToScopeData[respIdx].retErr
+}
+
+func (m *MockContainerProxy) AddVolumesToContainer(handle string, config types.ContainerCreateConfig) (string, error) {
+	respIdx := m.mockRespIndices[2]
+
+	if respIdx >= len(m.mockAddVolumesData) {
+		return "", nil
+	}
+
+	return m.mockAddVolumesData[respIdx].retHandle, m.mockAddVolumesData[respIdx].retErr
+}
+
+func (m *MockContainerProxy) CommitContainerHandle(handle, imageID string) error {
+	respIdx := m.mockRespIndices[3]
+
+	if respIdx >= len(m.mockCommitData) {
+		return nil
+	}
+
+	return m.mockCommitData[respIdx].retErr
+}
+
+func AddMockImageToCache() {
+	mockImage := &metadata.ImageConfig{
+		ImageID: "e732471cb81a564575aad46b9510161c5945deaf18e9be3db344333d72f0b4b2",
+		Name:    "busybox",
+		Tags:    []string{"latest"},
+	}
+	mockImage.Config = &container.Config{
+		Hostname:     "55cd1f8f6e5b",
+		Domainname:   "",
+		User:         "",
+		AttachStdin:  false,
+		AttachStdout: false,
+		AttachStderr: false,
+		Tty:          false,
+		OpenStdin:    false,
+		StdinOnce:    false,
+		Env:          []string{"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"},
+		Cmd:          []string{"sh"},
+		Image:        "sha256:e732471cb81a564575aad46b9510161c5945deaf18e9be3db344333d72f0b4b2",
+		Volumes:      nil,
+		WorkingDir:   "",
+		Entrypoint:   nil,
+		OnBuild:      nil,
+	}
+
+	cache.ImageCache().AddImage(mockImage)
+}
+
+//***********
+// Tests
+//***********
+
+// TestContainerCreateEmptyImageCache() attempts a ContainerCreate() with an empty image
+// cache
+func TestContainerCreateEmptyImageCache(t *testing.T) {
+	mockContainerProxy := NewMockContainerProxy()
+
+	// Create our personality Container backend
+	cb := &Container{
+		containerProxy: mockContainerProxy,
+	}
+
+	// mock a container create config
+	var config types.ContainerCreateConfig
+
+	config.HostConfig = &container.HostConfig{}
+	config.Config = &container.Config{}
+	config.NetworkingConfig = &dnetwork.NetworkingConfig{}
+	config.Config.Image = "busybox"
+
+	_, err := cb.ContainerCreate(config)
+
+	assert.Contains(t, err.Error(), "No such image", "Error (%s) should have 'No such image' for an empty image cache", err.Error())
+}
+
+//func TestContainerCreateEmptyImageCache(t *testing.T) {
+//}
+
+// TestCreateHandle() cycles through all possible input/outputs for creating a handle
+// and calls vicbackends.ContainerCreate().  The idea is that if creating handle fails
+// then vicbackends.ContainerCreate() should return errors from that.
+func TestCreateHandle(t *testing.T) {
+	mockContainerProxy := NewMockContainerProxy()
+
+	// Create our personality Container backend
+	cb := &Container{
+		containerProxy: mockContainerProxy,
+	}
+
+	AddMockImageToCache()
+
+	// mock a container create config
+	var config types.ContainerCreateConfig
+
+	config.HostConfig = &container.HostConfig{}
+	config.Config = &container.Config{}
+	config.NetworkingConfig = &dnetwork.NetworkingConfig{}
+
+	mockCreateHandleData := MockCreateHandleData()
+
+	// Iterate over create handler responses and see what the composite ContainerCreate()
+	// returns.  Since the handle is the first operation, we expect to receive a create handle
+	// error.
+	count, _, _, _ := mockContainerProxy.GetMockDataCount()
+
+	for i := 0; i < count; i++ {
+		if i == SUCCESS { //skip success case
+			continue
+		}
+
+		mockContainerProxy.SetMockDataResponse(i, 0, 0, 0)
+		config.Config.Image = mockCreateHandleData[i].createInputID
+		_, err := cb.ContainerCreate(config)
+
+		assert.Contains(t, err.Error(), mockCreateHandleData[i].createErrSubstr)
+	}
+}
+
+// TestContainerAddToScope() assumes container handle create succeeded and cycles through all
+// possible input/outputs for adding container to scope and calls vicbackends.ContainerCreate()
+func TestContainerAddToScope(t *testing.T) {
+	mockContainerProxy := NewMockContainerProxy()
+
+	// Create our personality Container backend
+	cb := &Container{
+		containerProxy: mockContainerProxy,
+	}
+
+	AddMockImageToCache()
+
+	// mock a container create config
+	var config types.ContainerCreateConfig
+
+	config.HostConfig = &container.HostConfig{}
+	config.Config = &container.Config{}
+	config.NetworkingConfig = &dnetwork.NetworkingConfig{}
+
+	mockAddToScopeData := MockAddToScopeData()
+
+	// Iterate over create handler responses and see what the composite ContainerCreate()
+	// returns.  Since the handle is the first operation, we expect to receive a create handle
+	// error.
+	_, count, _, _ := mockContainerProxy.GetMockDataCount()
+
+	for i := 0; i < count; i++ {
+		if i == SUCCESS { //skip success case
+			continue
+		}
+
+		mockContainerProxy.SetMockDataResponse(0, i, 0, 0)
+		config.Config.Image = mockAddToScopeData[i].createInputID
+		_, err := cb.ContainerCreate(config)
+
+		assert.Contains(t, err.Error(), mockAddToScopeData[i].createErrSubstr)
+	}
+}
+
+// TestContainerAddVolumes() assumes container handle create succeeded and cycles through all
+// possible input/outputs for committing the handle and calls vicbackends.ContainerCreate()
+func TestCommitHandle(t *testing.T) {
+	mockContainerProxy := NewMockContainerProxy()
+
+	// Create our personality Container backend
+	cb := &Container{
+		containerProxy: mockContainerProxy,
+	}
+
+	AddMockImageToCache()
+
+	// mock a container create config
+	var config types.ContainerCreateConfig
+
+	config.HostConfig = &container.HostConfig{}
+	config.Config = &container.Config{}
+	config.NetworkingConfig = &dnetwork.NetworkingConfig{}
+
+	mockCommitHandleData := MockCommitData()
+
+	// Iterate over create handler responses and see what the composite ContainerCreate()
+	// returns.  Since the handle is the first operation, we expect to receive a create handle
+	// error.
+	_, _, _, count := mockContainerProxy.GetMockDataCount()
+
+	for i := 0; i < count; i++ {
+		if i == SUCCESS { //skip success case
+			continue
+		}
+
+		mockContainerProxy.SetMockDataResponse(0, 0, 0, i)
+		config.Config.Image = mockCommitHandleData[i].createInputID
+		_, err := cb.ContainerCreate(config)
+
+		assert.Contains(t, err.Error(), mockCommitHandleData[i].createErrSubstr)
+	}
+
 }

--- a/lib/apiservers/engine/backends/endpoint/endpoint.go
+++ b/lib/apiservers/engine/backends/endpoint/endpoint.go
@@ -12,24 +12,27 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package container
+package endpoint
 
 import (
-	containertypes "github.com/docker/engine-api/types/container"
+	"fmt"
+
+	log "github.com/Sirupsen/logrus"
+	apinet "github.com/docker/engine-api/types/network"
 )
 
-// VicContainer is VIC's abridged version of Docker's container object.
-type VicContainer struct {
-	Name        string
-	ImageID     string
-	ContainerID string
-	Config      *containertypes.Config //Working copy of config (with overrides from container create)
-	HostConfig  *containertypes.HostConfig
-}
+func Alias(endpointConfig *apinet.EndpointSettings) []string {
+	var aliases []string
 
-// NewVicContainer returns a reference to a new VicContainer
-func NewVicContainer() *VicContainer {
-	return &VicContainer{
-		Config: &containertypes.Config{},
+	log.Debugf("EndpointsConfig: %#v", endpointConfig)
+	log.Debugf("Aliases: %s", endpointConfig.Aliases)
+	log.Debugf("Links: %s", endpointConfig.Links)
+
+	// Links are already in CONTAINERNAME:ALIAS format
+	aliases = endpointConfig.Links
+	// Converts aliases to ":ALIAS" format
+	for i := range endpointConfig.Aliases {
+		aliases = append(aliases, fmt.Sprintf(":%s", endpointConfig.Aliases[i]))
 	}
+	return aliases
 }

--- a/lib/apiservers/engine/backends/portlayer/container_proxy.go
+++ b/lib/apiservers/engine/backends/portlayer/container_proxy.go
@@ -1,0 +1,423 @@
+// Copyright 2016 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package portlayer
+
+//****
+// container_proxy.go
+//
+// Contains all code that touches the portlayer for container operations and all
+// code that converts swagger based returns to docker personality backend structs.
+// The goal is to make the backend code that implements the docker engine-api
+// interfaces be as simple as possible and contain no swagger or portlayer code.
+//
+// Rule for code to be in here:
+// 1. touches VIC portlayer
+// 2. converts swagger to docker engine-api structs
+// 3. errors MUST be docker engine-api compatible errors.  DO NOT return arbitrary errors!
+//		- Do NOT return portlayer errors
+//		- Do NOT return fmt.Errorf()
+//		- Do NOT return errors.New()
+//		- Please USE the aliased docker error package 'derr'
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/google/uuid"
+
+	derr "github.com/docker/docker/errors"
+	"github.com/docker/engine-api/types"
+	"github.com/docker/engine-api/types/strslice"
+
+	"github.com/vmware/vic/lib/apiservers/engine/backends/endpoint"
+	"github.com/vmware/vic/lib/apiservers/portlayer/client"
+	"github.com/vmware/vic/lib/apiservers/portlayer/client/containers"
+	"github.com/vmware/vic/lib/apiservers/portlayer/client/scopes"
+	"github.com/vmware/vic/lib/apiservers/portlayer/client/storage"
+	"github.com/vmware/vic/lib/apiservers/portlayer/models"
+	"github.com/vmware/vic/pkg/trace"
+	"github.com/vmware/vic/pkg/vsphere/sys"
+)
+
+type VicContainerProxy interface {
+	CreateContainerHandle(imageID string, config types.ContainerCreateConfig) (string, string, error)
+	AddContainerToScope(handle string, config types.ContainerCreateConfig) (string, error)
+	AddVolumesToContainer(handle string, config types.ContainerCreateConfig) (string, error)
+	CommitContainerHandle(handle, imageID string) error
+}
+
+type ContainerProxy struct {
+	client *client.PortLayer
+}
+
+type volumeFields struct {
+	ID    string
+	Dest  string
+	Flags string
+}
+
+func NewContainerProxy(plClient *client.PortLayer) *ContainerProxy {
+	return &ContainerProxy{client: plClient}
+}
+
+// containerCreateHandle() creates a new VIC container by calling the portlayer
+//
+// returns:
+// 	(containerID, containerHandle, error)
+func (c *ContainerProxy) CreateContainerHandle(imageID string, config types.ContainerCreateConfig) (string, string, error) {
+	defer trace.End(trace.Begin("ContainerProxy.containerCreateHandle"))
+
+	if c.client == nil {
+		return "", "",
+			derr.NewErrorWithStatusCode(fmt.Errorf("ContainerProxy.CreateContainerHandle failed to create a portlayer client"),
+				http.StatusInternalServerError)
+	}
+
+	if imageID == "" {
+		return "", "",
+			derr.NewRequestNotFoundError(fmt.Errorf("No image specified"))
+	}
+
+	// Call the Exec port layer to create the container
+	host, err := sys.UUID()
+	if err != nil {
+		return "", "",
+			derr.NewErrorWithStatusCode(fmt.Errorf("ContainerProxy.CreateContainerHandle got unexpected error getting VCH UUID"),
+				http.StatusInternalServerError)
+	}
+
+	plCreateParams := dockerContainerCreateParamsToPortlayer(config, imageID, host)
+	createResults, err := c.client.Containers.Create(plCreateParams)
+	if err != nil {
+		if _, ok := err.(*containers.CreateNotFound); ok {
+			err = fmt.Errorf("No such image: %s", imageID)
+			log.Errorf(err.Error())
+			return "", "", derr.NewRequestNotFoundError(err)
+		}
+
+		// If we get here, most likely something went wrong with the port layer API server
+		return "", "",
+			derr.NewErrorWithStatusCode(err, http.StatusInternalServerError)
+	}
+
+	id := createResults.Payload.ID
+	h := createResults.Payload.Handle
+
+	return id, h, nil
+}
+
+// AddContainerToScope() adds a container, referenced by handle, to a scope.
+// If an error is return, the returned handle should not be used.
+//
+// returns:
+//	modified handle
+func (c *ContainerProxy) AddContainerToScope(handle string, config types.ContainerCreateConfig) (string, error) {
+	defer trace.End(trace.Begin("ContainerProxy.AddContainerToScope"))
+
+	if c.client == nil {
+		return "",
+			derr.NewErrorWithStatusCode(fmt.Errorf("ContainerProxy.AddContainerToScope failed to create a portlayer client"),
+				http.StatusInternalServerError)
+	}
+
+	log.Debugf("Network Configuration Section - Container Create")
+	// configure networking
+	netConf := toModelsNetworkConfig(config)
+	if netConf != nil {
+		addContRes, err := c.client.Scopes.AddContainer(scopes.NewAddContainerParams().
+			WithScope(netConf.NetworkName).
+			WithConfig(&models.ScopesAddContainerConfig{
+				Handle:        handle,
+				NetworkConfig: netConf,
+			}))
+
+		if err != nil {
+			log.Errorf("ContainerProxy.AddContainerToScope: Scopes error: %s", err.Error())
+			return handle, derr.NewErrorWithStatusCode(err, http.StatusInternalServerError)
+		}
+
+		defer func() {
+			if err == nil {
+				return
+			}
+			// roll back the AddContainer call
+			if _, err2 := c.client.Scopes.RemoveContainer(scopes.NewRemoveContainerParams().WithHandle(handle).WithScope(netConf.NetworkName)); err2 != nil {
+				log.Warnf("could not roll back container add: %s", err2)
+			}
+		}()
+
+		handle = addContRes.Payload
+	}
+
+	return handle, nil
+}
+
+// AddVolumesToContainer() adds volumes to a container, referenced by handle.
+// If an error is return, the returned handle should not be used.
+//
+// returns:
+//	modified handle
+func (c *ContainerProxy) AddVolumesToContainer(handle string, config types.ContainerCreateConfig) (string, error) {
+	defer trace.End(trace.Begin("ContainerProxy.AddVolumesToContainer"))
+
+	if c.client == nil {
+		return "",
+			derr.NewErrorWithStatusCode(fmt.Errorf("ContainerProxy.AddVolumesToContainer failed to create a portlayer client"),
+				http.StatusInternalServerError)
+	}
+
+	//Volume Attachment Section
+	log.Debugf("ContainerProxy.AddVolumesToContainer - VolumeSection")
+	log.Debugf("Raw Volume arguments : binds:  %#v : volumes : %#v", config.HostConfig.Binds, config.Config.Volumes)
+	var joinList []volumeFields
+	var err error
+
+	joinList, err = processAnonymousVolumes(&handle, config.Config.Volumes, c.client)
+	if err != nil {
+		return handle, derr.NewErrorWithStatusCode(fmt.Errorf("%s", err), http.StatusBadRequest)
+	}
+
+	volumeSubset, err := processSpecifiedVolumes(config.HostConfig.Binds)
+	if err != nil {
+		return handle, derr.NewErrorWithStatusCode(fmt.Errorf("%s", err), http.StatusBadRequest)
+	}
+	joinList = append(joinList, volumeSubset...)
+
+	for _, fields := range joinList {
+		flags := make(map[string]string)
+		//NOTE: for now we are passing the flags directly through. This is NOT SAFE and only a stop gap.
+		flags["Mode"] = fields.Flags
+		joinParams := storage.NewVolumeJoinParams().WithJoinArgs(&models.VolumeJoinConfig{
+			Flags:     flags,
+			Handle:    handle,
+			MountPath: fields.Dest,
+		}).WithName(fields.ID)
+
+		res, err := c.client.Storage.VolumeJoin(joinParams)
+		if err != nil {
+			switch err := err.(type) {
+			case *storage.VolumeJoinInternalServerError:
+				return handle, derr.NewErrorWithStatusCode(fmt.Errorf(err.Payload.Message), http.StatusInternalServerError)
+			case *storage.VolumeJoinDefault:
+				return handle, derr.NewErrorWithStatusCode(fmt.Errorf(err.Payload.Message), http.StatusInternalServerError)
+			default:
+				return handle, derr.NewErrorWithStatusCode(err, http.StatusInternalServerError)
+			}
+		}
+
+		handle = res.Payload
+	}
+
+	return handle, nil
+}
+
+// CommitContainerHandle() commits any changes to container handle.
+//
+func (c *ContainerProxy) CommitContainerHandle(handle, imageID string) error {
+	defer trace.End(trace.Begin("ContainerProxy.CommitContainerHandle"))
+
+	if c.client == nil {
+		return derr.NewErrorWithStatusCode(fmt.Errorf("ContainerProxy.CommitContainerHandle failed to create a portlayer client"),
+			http.StatusInternalServerError)
+	}
+
+	_, err := c.client.Containers.Commit(containers.NewCommitParams().WithHandle(handle))
+	if err != nil {
+		err = fmt.Errorf("No such image: %s", imageID)
+		log.Errorf("%s", err.Error())
+		// FIXME: Containers.Commit returns more errors than it's swagger spec says.
+		// When no image exist, it also sends back non swagger errors.  We should fix
+		// this once Commit returns correct error codes.
+		return derr.NewRequestNotFoundError(err)
+	}
+
+	return nil
+}
+
+//----------
+// Utility Functions
+//----------
+
+func dockerContainerCreateParamsToPortlayer(cc types.ContainerCreateConfig, layerID string, imageStore string) *containers.CreateParams {
+	config := &models.ContainerCreateConfig{}
+
+	// Image
+	config.Image = new(string)
+	*config.Image = layerID
+
+	// Repo Requested
+	config.RepoName = new(string)
+	*config.RepoName = cc.Config.Image
+
+	var path string
+	var args []string
+
+	// Expand cmd into entrypoint and args
+	cmd := strslice.StrSlice(cc.Config.Cmd)
+	if len(cc.Config.Entrypoint) != 0 {
+		path, args = cc.Config.Entrypoint[0], append(cc.Config.Entrypoint[1:], cmd...)
+	} else {
+		path, args = cmd[0], cmd[1:]
+	}
+
+	//copy friendly name
+	config.Name = new(string)
+	*config.Name = cc.Name
+
+	// copy the path
+	config.Path = new(string)
+	*config.Path = path
+
+	// copy the args
+	config.Args = make([]string, len(args))
+	copy(config.Args, args)
+
+	// copy the env array
+	config.Env = make([]string, len(cc.Config.Env))
+	copy(config.Env, cc.Config.Env)
+
+	// image store
+	config.ImageStore = &models.ImageStore{Name: imageStore}
+
+	// network
+	config.NetworkDisabled = new(bool)
+	*config.NetworkDisabled = cc.Config.NetworkDisabled
+
+	// working dir
+	config.WorkingDir = new(string)
+	*config.WorkingDir = cc.Config.WorkingDir
+
+	// tty
+	config.Tty = new(bool)
+	*config.Tty = cc.Config.Tty
+
+	log.Debugf("dockerContainerCreateParamsToPortlayer = %+v", config)
+
+	return containers.NewCreateParams().WithCreateConfig(config)
+}
+
+func toModelsNetworkConfig(cc types.ContainerCreateConfig) *models.NetworkConfig {
+	if cc.Config.NetworkDisabled {
+		return nil
+	}
+
+	nc := &models.NetworkConfig{
+		NetworkName: cc.HostConfig.NetworkMode.NetworkName(),
+	}
+	if cc.NetworkingConfig != nil {
+		log.Debugf("EndpointsConfig: %#v", cc.NetworkingConfig)
+
+		es, ok := cc.NetworkingConfig.EndpointsConfig[nc.NetworkName]
+		if ok {
+			if es.IPAMConfig != nil {
+				nc.Address = &es.IPAMConfig.IPv4Address
+			}
+
+			// Docker copies Links to NetworkConfig only if it is a UserDefined network, handle that
+			// https://github.com/docker/docker/blame/master/runconfig/opts/parse.go#L598
+			if !cc.HostConfig.NetworkMode.IsUserDefined() && len(cc.HostConfig.Links) > 0 {
+				es.Links = make([]string, len(cc.HostConfig.Links))
+				copy(es.Links, cc.HostConfig.Links)
+			}
+			// Pass Links and Aliases to PL
+			nc.Aliases = endpoint.Alias(es)
+
+		}
+	}
+
+	nc.Ports = make([]string, len(cc.HostConfig.PortBindings))
+	i := 0
+	for p := range cc.HostConfig.PortBindings {
+		nc.Ports[i] = string(p)
+		i++
+	}
+
+	return nc
+}
+
+//This function is used to turn any call from docker create -v <stuff> into a volumeFields object.
+//the -v has 3 forms. 1: -v <anonymouse mount path>, -v <Volume Name>:<Destination Mount Path>, and -v <Volume Name>:<Destination Mount Path>:<mount flags>
+func processVolumeParam(volString string) (volumeFields, error) {
+	volumeStrings := strings.Split(volString, ":")
+	fields := volumeFields{}
+
+	//This switch determines which type of -v was invoked.
+	switch len(volumeStrings) {
+	case 1:
+		VolumeID, err := uuid.NewUUID()
+		if err != nil {
+			return volumeFields{}, nil
+		}
+		fields.ID = VolumeID.String()
+		fields.Dest = volumeStrings[0]
+		fields.Flags = "rw"
+	case 2:
+		fields.ID = volumeStrings[0]
+		fields.Dest = volumeStrings[1]
+		fields.Flags = "rw"
+	case 3:
+		fields.ID = volumeStrings[0]
+		fields.Dest = volumeStrings[1]
+		fields.Flags = volumeStrings[2]
+	default:
+		//NOTE: the docker cli should cover this case. This is here for posterity.
+		return volumeFields{}, fmt.Errorf("Volume bind input is invalid : -v %s", volString)
+	}
+	return fields, nil
+}
+
+func processAnonymousVolumes(h *string, volumes map[string]struct{}, client *client.PortLayer) ([]volumeFields, error) {
+	var volumeFields []volumeFields
+
+	for v := range volumes {
+		fields, err := processVolumeParam(v)
+		log.Infof("Processed Volume arguments : %#v", fields)
+		if err != nil {
+			return nil, err
+		}
+		//NOTE: This should be the guard for the case of an anonymous volume.
+		//NOTE: we should not expect any driver args if the drive is anonymous.
+		log.Infof("anonymous volume being created - Container Create - volume mount section ID: %s ", fields.ID)
+		metadata := make(map[string]string)
+		metadata["flags"] = fields.Flags
+		volumeRequest := models.VolumeRequest{
+			Capacity: -1,
+			Driver:   "vsphere",
+			Store:    "default",
+			Name:     fields.ID,
+			Metadata: metadata,
+		}
+		_, err = client.Storage.CreateVolume(storage.NewCreateVolumeParams().WithVolumeRequest(&volumeRequest))
+		if err != nil {
+			return nil, err
+		}
+		volumeFields = append(volumeFields, fields)
+	}
+	return volumeFields, nil
+}
+
+func processSpecifiedVolumes(volumes []string) ([]volumeFields, error) {
+	var volumeFields []volumeFields
+	for _, v := range volumes {
+		fields, err := processVolumeParam(v)
+		if err != nil {
+			return volumeFields, err
+		}
+		volumeFields = append(volumeFields, fields)
+	}
+	return volumeFields, nil
+}

--- a/lib/apiservers/engine/backends/portlayer/container_proxy_test.go
+++ b/lib/apiservers/engine/backends/portlayer/container_proxy_test.go
@@ -1,0 +1,68 @@
+// Copyright 2016 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package portlayer
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestProcessVolumeParams(t *testing.T) {
+	rawTestVolumes := []string{"/blah", "testVolume:/mount", "testVolume:/mount/path:r"}
+	var processedTestVolumes []volumeFields
+
+	for _, testString := range rawTestVolumes {
+		processedFields, err := processVolumeParam(testString)
+		assert.Nil(t, err)
+		processedTestVolumes = append(processedTestVolumes, processedFields)
+	}
+	assert.Equal(t, 3, len(processedTestVolumes))
+
+	assert.NotEmpty(t, processedTestVolumes[0].ID)
+	assert.Equal(t, "/blah", processedTestVolumes[0].Dest)
+	assert.Equal(t, "rw", processedTestVolumes[0].Flags)
+
+	assert.Equal(t, "testVolume", processedTestVolumes[1].ID)
+	assert.Equal(t, "/mount", processedTestVolumes[1].Dest)
+	assert.Equal(t, "rw", processedTestVolumes[1].Flags)
+
+	assert.Equal(t, "testVolume", processedTestVolumes[2].ID)
+	assert.Equal(t, "/mount/path", processedTestVolumes[2].Dest)
+	assert.Equal(t, "r", processedTestVolumes[2].Flags)
+}
+
+func TestProcessSpecifiedVolumes(t *testing.T) {
+	rawTestVolumes := []string{"masterVolume:/blah", "testVolume:/mount:r", "specVol:/mount/path:r"}
+	var processedTestVolumes []volumeFields
+
+	processedFields, err := processSpecifiedVolumes(rawTestVolumes)
+	assert.Nil(t, err)
+	processedTestVolumes = append(processedTestVolumes, processedFields...)
+
+	assert.Len(t, processedFields, 3)
+
+	assert.Equal(t, "masterVolume", processedTestVolumes[0].ID)
+	assert.Equal(t, "/blah", processedTestVolumes[0].Dest)
+	assert.Equal(t, "rw", processedTestVolumes[0].Flags)
+
+	assert.Equal(t, "testVolume", processedTestVolumes[1].ID)
+	assert.Equal(t, "/mount", processedTestVolumes[1].Dest)
+	assert.Equal(t, "r", processedTestVolumes[1].Flags)
+
+	assert.Equal(t, "specVol", processedTestVolumes[2].ID)
+	assert.Equal(t, "/mount/path", processedTestVolumes[2].Dest)
+	assert.Equal(t, "r", processedTestVolumes[2].Flags)
+}


### PR DESCRIPTION
Refactored ContainerCreate().  Simplified the function.  Moved all
remoting code out to ../backends/portlayer/container_proxy.go.  Also
added some infrastructure to do unit testing on the personality server
and perform some error injection.