### PR TITLE
Allow hyphens and underscores in datastore names

### DIFF
--- a/pkg/vsphere/datastore/datastore.go
+++ b/pkg/vsphere/datastore/datastore.go
@@ -307,7 +307,7 @@ func (d *Helper) rootDir() string {
 }
 
 // Parse the datastore format ([datastore1] /path/to/thing) to groups.
-var datastoreFormat = regexp.MustCompile(`^\[([\w\d\(\)\s]+)\]`)
+var datastoreFormat = regexp.MustCompile(`^\[([\w\d\(\)-_\s]+)\]`)
 var pathFormat = regexp.MustCompile(`\s([\/\w-_]+$)`)
 
 // Converts `[datastore] /path` to ds:// URL

--- a/pkg/vsphere/datastore/datastore_test.go
+++ b/pkg/vsphere/datastore/datastore_test.go
@@ -115,6 +115,7 @@ func TestDatastoreToURLParsing(t *testing.T) {
 		{"[datastore1] path", "ds://datastore1/path"},
 		{"[datastore1] pa-th", "ds://datastore1/pa-th"},
 		{"[datastore1] pa_th", "ds://datastore1/pa_th"},
+		{"[data_store1] pa_th", "ds://data_store1/pa_th"},
 	}
 
 	dsoutputs := []string{
@@ -125,6 +126,7 @@ func TestDatastoreToURLParsing(t *testing.T) {
 		"[datastore1] path",
 		"[datastore1] pa-th",
 		"[datastore1] pa_th",
+		"[data_store1] pa_th",
 	}
 
 	for i, in := range input {


### PR DESCRIPTION
Allows users to use hyphens and underscores in datastore names

The valid symbols in paths and names are now: alphanumeric characters, hyphens, and underscores, spaces in *names* but not in paths, and _that's all_. It's using a whitelist.

If there should be more allowed characters, we can build them in. But for now, barring further comment, that's it. Things like `*` and `@` seem like a bad idea to allow.

Fixes #1652 
