### PR TITLE
Docker info

### DIFF
--- a/lib/apiservers/engine/backends/system.go
+++ b/lib/apiservers/engine/backends/system.go
@@ -130,7 +130,6 @@ func (s *System) SystemInfo() (*types.Info, error) {
 		info.Plugins.Network = append(info.Plugins.Network, network.Name)
 	}
 
-	// Check if portlayer server is up
 	info.SystemStatus = make([][2]string, 0)
 
 	// Add in volume label from the VCH via guestinfo

--- a/lib/apiservers/engine/backends/system.go
+++ b/lib/apiservers/engine/backends/system.go
@@ -26,6 +26,7 @@ package vicbackends
 //		- It is OK to return errors returned from functions in system_portlayer.go
 
 import (
+	"bytes"
 	"fmt"
 	"runtime"
 	"time"
@@ -54,6 +55,7 @@ const (
 	systemOS           = " VMware OS"
 	systemOSVersion    = " VMware OS version"
 	systemProductName  = " VMware Product"
+	volumeStores       = "VolumeStores"
 )
 
 func NewSystemBackend() *System {
@@ -170,6 +172,14 @@ func (s *System) SystemInfo() (*types.Info, error) {
 		}
 		if vchInfo.HostOSVersion != nil {
 			customInfo := [2]string{systemOSVersion, *vchInfo.HostOSVersion}
+			info.SystemStatus = append(info.SystemStatus, customInfo)
+		}
+		if vchConfig.VolumeLocations != nil {
+			var locationsBuffer bytes.Buffer
+			for label := range vchConfig.VolumeLocations {
+				locationsBuffer.WriteString(fmt.Sprintf("[%s] ", label))
+			}
+			customInfo := [2]string{volumeStores, locationsBuffer.String()}
 			info.SystemStatus = append(info.SystemStatus, customInfo)
 		}
 	}


### PR DESCRIPTION
Fixes #1679 

This changes the way we get the volume stores from listing them from `vchConfig.VolumeLocations` to making a call to the portlayer to ask for the volume stores list. 

sample output(new line bolded): 
```
  % docker -H 10.17.109.164:2376 --tls info
Containers: 0
 Running: 0
 Paused: 0
 Stopped: 0
Images: 0
Storage Driver: vSphere Integrated Containers Backend Engine
```
__VolumeStores: test-store default__ 
```
vSphere Integrated Containers Backend Engine: RUNNING
 VCH mhz limit: 12559 Mhz
 VCH memory limit: 66.06 GiB
 VMware Product: VMware vCenter Server
 VMware OS: linux-x64
 VMware OS version: 6.0.0
Execution Driver: vSphere Integrated Containers Backend Engine
Plugins: 
 Volume: 
 Network: bridge
Operating System: linux-x64
OSType: linux-x64
Architecture: x86_64
CPUs: 12559
Total Memory: 66.06 GiB
Name: mavery-vch-1
ID: vSphere Integrated Containers
Docker Root Dir: 
Debug mode (client): false
Debug mode (server): false
Registry: registry-1.docker.io
```