### PR TITLE
Initial docker kill functionality

### DIFF
--- a/lib/apiservers/portlayer/restapi/handlers/containers_handlers.go
+++ b/lib/apiservers/portlayer/restapi/handlers/containers_handlers.go
@@ -52,6 +52,7 @@ func (handler *ContainersHandlersImpl) Configure(api *operations.PortLayerAPI, h
 	api.ContainersContainerRemoveHandler = containers.ContainerRemoveHandlerFunc(handler.RemoveContainerHandler)
 	api.ContainersGetContainerInfoHandler = containers.GetContainerInfoHandlerFunc(handler.GetContainerInfoHandler)
 	api.ContainersGetContainerListHandler = containers.GetContainerListHandlerFunc(handler.GetContainerListHandler)
+	api.ContainersContainerSignalHandler = containers.ContainerSignalHandlerFunc(handler.ContainerSignalHandler)
 
 	handler.handlerCtx = handlerCtx
 }
@@ -267,6 +268,12 @@ func (handler *ContainersHandlersImpl) GetContainerListHandler(params containers
 		vmList = append(vmList, info)
 	}
 	return containers.NewGetContainerListOK().WithPayload(vmList)
+}
+
+func (handler *ContainersHandlersImpl) ContainerSignalHandler(params containers.ContainerSignalParams) middleware.Responder {
+	defer trace.End(trace.Begin("Containers.ContainerSignal"))
+
+	return containers.NewContainerSignalOK()
 }
 
 // utility function to convert from a Container type to the API Model ContainerInfo (which should prob be called ContainerDetail)

--- a/lib/apiservers/portlayer/swagger.yml
+++ b/lib/apiservers/portlayer/swagger.yml
@@ -819,6 +819,27 @@ paths:
           description: "Error"
           schema:
             $ref: "#/definitions/Error"
+  /containers/{id}/signal:
+    post:
+      description: "Sends a signal to a container by id"
+      summary: "Signal a running container"
+      operationId: ContainerSignal
+      tags: ["containers"]
+      consumes:
+        - application/octet-stream
+      parameters:
+        - name: id
+          in: path
+          type: string
+          required: true
+        - name: signal
+          in: query
+          type: integer
+          format: int64
+          required: true
+      responses:
+        '200':
+          description: "OK"
   /interaction/{id}/resize:
     post:
       description: "Resize the container's tty session"


### PR DESCRIPTION
Add docker kill to personality server and added PostContainerSignal
to the portlayer rest server to support it.  Needs portlayer vSphere
support and Docker Wait infrastructure to complete the full functionality.

Part of #378