### PR TITLE
Add container stop signal support

### DIFF
--- a/cmd/tether/main_linux.go
+++ b/cmd/tether/main_linux.go
@@ -80,7 +80,7 @@ func main() {
 	tthr.Register("Attach", sshserver)
 
 	// register the toolbox extension
-	tthr.Register("Toolbox", tether.NewToolbox())
+	tthr.Register("Toolbox", tether.NewToolbox().InContainer())
 
 	err = tthr.Start()
 	if err != nil {

--- a/cmd/tether/msgs/messages.go
+++ b/cmd/tether/msgs/messages.go
@@ -14,7 +14,13 @@
 
 package msgs
 
-import "golang.org/x/crypto/ssh"
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"golang.org/x/crypto/ssh"
+)
 
 // All of the messages passed over the ssh channel/global mux are (or will be)
 // defined here.
@@ -91,6 +97,28 @@ func (s *SignalMsg) Unmarshal(payload []byte) error {
 
 func (s *SignalMsg) Signum() int {
 	return Signals[s.Signal]
+}
+
+func (s *SignalMsg) FromString(name string) error {
+	num, err := strconv.Atoi(name)
+	if err == nil {
+		for sig, val := range Signals {
+			if num == val {
+				s.Signal = sig
+				return nil
+			}
+		}
+	}
+
+	name = strings.TrimPrefix(strings.ToUpper(name), "SIG")
+
+	s.Signal = ssh.Signal(name)
+	_, ok := Signals[s.Signal]
+	if !ok {
+		return fmt.Errorf("unsupported signal name: %q", name)
+	}
+
+	return nil
 }
 
 // ContainersMsg

--- a/cmd/tether/msgs/messages_test.go
+++ b/cmd/tether/msgs/messages_test.go
@@ -42,6 +42,20 @@ func TestSignal(t *testing.T) {
 	out.Unmarshal(tmp)
 
 	assert.Equal(t, s, out)
+
+	for _, name := range []string{"SIGQUIT", "QUIT", "quit", "3"} {
+		err := out.FromString(name)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	for _, name := range []string{"SIGNOPE", "nope", "0", "-1"} {
+		err := out.FromString(name)
+		if err == nil {
+			t.Errorf("expected error parsing %q", name)
+		}
+	}
 }
 
 func TestContainers(t *testing.T) {

--- a/cmd/toolbox/main.go
+++ b/cmd/toolbox/main.go
@@ -34,18 +34,15 @@ func main() {
 
 	service := toolbox.NewService(in, out)
 
-	vix := toolbox.RegisterVixRelayedCommandHandler(service)
-
 	// Trigger a command start, for example:
 	// govc guest.start -vm vm-name kill SIGHUP
-	vix.ProcessStartCommand = func(r *toolbox.VixMsgStartProgramRequest) (int, error) {
+	service.VixCommand.ProcessStartCommand = func(r *toolbox.VixMsgStartProgramRequest) (int, error) {
 		fmt.Fprintf(os.Stderr, "guest-command: %s %s\n", r.ProgramPath, r.Arguments)
 		return -1, nil
 	}
 
-	power := toolbox.RegisterPowerCommandHandler(service)
-
 	if os.Getuid() == 0 {
+		power := service.PowerCommand
 		power.Halt.Handler = toolbox.Halt
 		power.Reboot.Handler = toolbox.Reboot
 	}

--- a/lib/apiservers/engine/backends/container.go
+++ b/lib/apiservers/engine/backends/container.go
@@ -1680,6 +1680,7 @@ func copyConfigOverrides(vc *viccontainer.VicContainer, config types.ContainerCr
 	vc.Config.Tty = config.Config.Tty
 	vc.Config.OpenStdin = config.Config.OpenStdin
 	vc.Config.StdinOnce = config.Config.StdinOnce
+	vc.Config.StopSignal = config.Config.StopSignal
 	vc.HostConfig = config.HostConfig
 }
 

--- a/lib/apiservers/engine/backends/portlayer/container_proxy.go
+++ b/lib/apiservers/engine/backends/portlayer/container_proxy.go
@@ -305,6 +305,10 @@ func dockerContainerCreateParamsToPortlayer(cc types.ContainerCreateConfig, laye
 	config.Tty = new(bool)
 	*config.Tty = cc.Config.Tty
 
+	// container stop signal
+	config.StopSignal = new(string)
+	*config.StopSignal = cc.Config.StopSignal
+
 	log.Debugf("dockerContainerCreateParamsToPortlayer = %+v", config)
 
 	return containers.NewCreateParams().WithCreateConfig(config)

--- a/lib/apiservers/portlayer/restapi/handlers/containers_handlers.go
+++ b/lib/apiservers/portlayer/restapi/handlers/containers_handlers.go
@@ -107,9 +107,10 @@ func (handler *ContainersHandlersImpl) CreateHandler(params containers.CreatePar
 				},
 			},
 		},
-		Key:      pem.EncodeToMemory(&privateKeyBlock),
-		LayerID:  *params.CreateConfig.Image,
-		RepoName: *params.CreateConfig.RepoName,
+		Key:        pem.EncodeToMemory(&privateKeyBlock),
+		LayerID:    *params.CreateConfig.Image,
+		RepoName:   *params.CreateConfig.RepoName,
+		StopSignal: *params.CreateConfig.StopSignal,
 	}
 	log.Infof("CreateHandler Metadata: %#v", m)
 

--- a/lib/apiservers/portlayer/swagger.yml
+++ b/lib/apiservers/portlayer/swagger.yml
@@ -1174,6 +1174,8 @@ definitions:
       tty:
         type: boolean
         default: false
+      stopSignal:
+        type: string
   ContainerCreatedInfo:
     type: object
     required:

--- a/lib/config/executor/container_vm.go
+++ b/lib/config/executor/container_vm.go
@@ -135,6 +135,9 @@ type ExecutorConfig struct {
 	// Repository requested by user
 	// TODO: a bit docker specific
 	RepoName string `vic:"0.1" scope:"read-only" key:"repo"`
+
+	// StopSignal is the signal name or number used to stop a container
+	StopSignal string `vic:"0.1" scope:"read-only" key:"stopSignal"`
 }
 
 // Cmd is here because the encoding packages seem to have issues with the full exec.Cmd struct

--- a/lib/tether/config.go
+++ b/lib/tether/config.go
@@ -54,6 +54,9 @@ type ExecutorConfig struct {
 	// Key is the host key used during communicate back with the Interaction endpoint if any
 	// Used if the in-guest tether is responsible for authenticating the connection
 	Key []byte `vic:"0.1" scope:"read-only" key:"key"`
+
+	// StopSignal is the signal name or number used to stop a container
+	StopSignal string `vic:"0.1" scope:"read-only" key:"stopSignal"`
 }
 
 // SessionConfig defines the content of a session - this maps to the root of a process tree
@@ -92,6 +95,9 @@ type SessionConfig struct {
 	Outwriter dio.DynamicMultiWriter
 	Errwriter dio.DynamicMultiWriter
 	Reader    dio.DynamicMultiReader
+
+	// This channel is closed on session exit
+	exit chan struct{}
 }
 
 type NetworkEndpoint struct {

--- a/lib/tether/tether.go
+++ b/lib/tether/tether.go
@@ -322,6 +322,9 @@ func (t *tether) handleSessionExit(session *SessionConfig) {
 	if f != nil {
 		f()
 	}
+
+	// notify guest shutdown waiter this process has gone away
+	close(session.exit)
 }
 
 // launch will launch the command defined in the session.
@@ -348,6 +351,8 @@ func (t *tether) launch(session *SessionConfig) error {
 	session.Outwriter = logwriter
 	session.Errwriter = logwriter
 	session.Reader = dio.MultiReader()
+
+	session.exit = make(chan struct{})
 
 	// Special case here because UID/GID lookup need to be done
 	// on the appliance...

--- a/lib/tether/toolbox.go
+++ b/lib/tether/toolbox.go
@@ -17,14 +17,23 @@
 package tether
 
 import (
+	"fmt"
 	"net"
+	"syscall"
+	"time"
 
+	"golang.org/x/crypto/ssh"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/vmware/vic/cmd/tether/msgs"
 	"github.com/vmware/vic/pkg/vsphere/toolbox"
 )
 
 // Toolbox is a tether extension that wraps toolbox.Service
 type Toolbox struct {
 	*toolbox.Service
+
+	config *ExecutorConfig
 }
 
 // NewToolbox returns a tether.Extension that wraps the vsphere/toolbox service
@@ -52,8 +61,60 @@ func (t *Toolbox) Stop() error {
 }
 
 // Reload implementation of the tether.Extension interface
-func (*Toolbox) Reload(config *ExecutorConfig) error {
+func (t *Toolbox) Reload(config *ExecutorConfig) error {
+	t.config = config
 	return nil
+}
+
+// InContainer configures the toolbox to run within a container VM
+func (t *Toolbox) InContainer() *Toolbox {
+	t.PowerCommand.Halt.Handler = t.halt
+
+	return t
+}
+
+func (t *Toolbox) kill(name string) error {
+	session := t.config.Sessions[t.config.ID]
+
+	if name == "" {
+		name = string(ssh.SIGTERM)
+	}
+
+	sig := new(msgs.SignalMsg)
+	err := sig.FromString(name)
+	if err != nil {
+		return err
+	}
+
+	num := syscall.Signal(sig.Signum())
+
+	log.Infof("sending signal %s (%d) to %s", sig.Signal, num, session.ID)
+
+	if err := session.Cmd.Process.Signal(num); err != nil {
+		return fmt.Errorf("failed to signal %s: %s", session.ID, err)
+	}
+
+	return nil
+}
+
+func (t *Toolbox) halt() error {
+	session := t.config.Sessions[t.config.ID]
+	log.Infof("stopping %s", session.ID)
+
+	if err := t.kill(t.config.StopSignal); err != nil {
+		return err
+	}
+
+	select {
+	case <-session.exit:
+		log.Infof("%s has stopped", session.ID)
+		return nil
+	case <-time.After(time.Second * 10): // TODO: honor -t flag from docker stop
+	}
+
+	log.Warnf("killing %s", session.ID)
+
+	return session.Cmd.Process.Kill()
 }
 
 // externalIP attempts to find an external IP to be reported as the guest IP

--- a/lib/tether/toolbox.go
+++ b/lib/tether/toolbox.go
@@ -34,10 +34,6 @@ func NewToolbox() *Toolbox {
 
 	service := toolbox.NewService(in, out)
 
-	toolbox.RegisterVixRelayedCommandHandler(service)
-
-	toolbox.RegisterPowerCommandHandler(service)
-
 	return &Toolbox{Service: service}
 }
 

--- a/pkg/vsphere/toolbox/power.go
+++ b/pkg/vsphere/toolbox/power.go
@@ -50,7 +50,7 @@ type PowerCommandHandler struct {
 	Suspend PowerCommand
 }
 
-func RegisterPowerCommandHandler(service *Service) *PowerCommandHandler {
+func registerPowerCommandHandler(service *Service) *PowerCommandHandler {
 	handler := new(PowerCommandHandler)
 
 	handlers := map[string]struct {

--- a/pkg/vsphere/toolbox/power_test.go
+++ b/pkg/vsphere/toolbox/power_test.go
@@ -26,7 +26,7 @@ func TestPowerCommandHandler(t *testing.T) {
 	out := new(mockChannelOut)
 
 	service := NewService(in, out)
-	power := RegisterPowerCommandHandler(service)
+	power := service.PowerCommand
 
 	// cover nil Handler and out.Receive paths
 	_, _ = power.Halt.Dispatch(nil)

--- a/pkg/vsphere/toolbox/service.go
+++ b/pkg/vsphere/toolbox/service.go
@@ -54,6 +54,9 @@ type Service struct {
 	wg       *sync.WaitGroup
 	delay    time.Duration
 
+	VixCommand   *VixRelayedCommandHandler
+	PowerCommand *PowerCommandHandler
+
 	PrimaryIP func() string
 }
 
@@ -74,6 +77,9 @@ func NewService(rpcIn Channel, rpcOut Channel) *Service {
 	s.RegisterHandler("ping", s.Ping)
 	s.RegisterHandler("Set_Option", s.SetOption)
 	s.RegisterHandler("Capabilities_Register", s.CapabilitiesRegister)
+
+	s.VixCommand = registerVixRelayedCommandHandler(s)
+	s.PowerCommand = registerPowerCommandHandler(s)
 
 	return s
 }

--- a/pkg/vsphere/toolbox/service_test.go
+++ b/pkg/vsphere/toolbox/service_test.go
@@ -288,11 +288,9 @@ func TestServiceRunESX(t *testing.T) {
 		}
 	}
 
-	vix := RegisterVixRelayedCommandHandler(service)
-
 	if *testPID != 0 {
 		wg.Add(1)
-		vix.ProcessStartCommand = func(r *VixMsgStartProgramRequest) (int, error) {
+		service.VixCommand.ProcessStartCommand = func(r *VixMsgStartProgramRequest) (int, error) {
 			defer wg.Done()
 
 			if r.ProgramPath != "/bin/date" {

--- a/pkg/vsphere/toolbox/vix_command.go
+++ b/pkg/vsphere/toolbox/vix_command.go
@@ -109,7 +109,7 @@ type VixUserCredentialNamePassword struct {
 	Password string
 }
 
-func RegisterVixRelayedCommandHandler(service *Service) *VixRelayedCommandHandler {
+func registerVixRelayedCommandHandler(service *Service) *VixRelayedCommandHandler {
 	handler := &VixRelayedCommandHandler{
 		Out:      service.out,
 		handlers: make(map[uint32]VixCommandHandler),

--- a/pkg/vsphere/toolbox/vix_command_test.go
+++ b/pkg/vsphere/toolbox/vix_command_test.go
@@ -91,7 +91,7 @@ func TestVixRelayedCommandHandler(t *testing.T) {
 
 	service := NewService(in, out)
 
-	vix := RegisterVixRelayedCommandHandler(service)
+	vix := service.VixCommand
 
 	msg := []byte("\"reqname\"\x00")
 

--- a/tests/test-cases/Group1-Docker-Commands/1-7-Docker-Stop.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-7-Docker-Stop.robot
@@ -4,6 +4,20 @@ Resource  ../../resources/Util.robot
 Suite Setup  Install VIC Appliance To Test Server
 Suite Teardown  Cleanup VIC Appliance On Test Server
 
+*** Keywords ***
+Trap Signal Command
+    # Container command runs an infinite loop, trapping and logging the given signal name
+    [Arguments]  ${sig}
+    [Return]  busybox sh -c "trap 'echo StopSignal${sig}' ${sig}; while true; do sleep 1; done"
+
+Assert Stop Signal
+    # Assert the docker stop signal was trapped by checking the container output log file
+    [Arguments]  ${id}  ${sig}
+    ${rc}=  Run And Return Rc  govc datastore.download ${id}/${id}.log ${TEMPDIR}/${id}.log
+    Should Be Equal As Integers  ${rc}  0
+    ${output}=  OperatingSystem.Get File  ${TEMPDIR}/${id}.log
+    Should Contain  ${output}  StopSignal${sig}
+
 *** Test Cases ***
 Stop an already stopped container
     ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} pull busybox
@@ -20,18 +34,29 @@ Basic docker container stop
     Should Be Equal As Integers  ${rc}  0
     ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} start ${container}
     Should Be Equal As Integers  ${rc}  0
-    ${before}=  Get Current Date
     ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} stop ${container}
-    ${after}=  Get Current Date
     Should Be Equal As Integers  ${rc}  0
-    ${result}=  Subtract Date From Date  ${after}  ${before}
 
-    ${status}=  Get State Of Github Issue  1320
-    Run Keyword If  '${status}' == 'closed'  Fail  Test 1-7-Docker-Stop.robot needs to be updated now that Issue #1320 has been resolved
-    Log  Issue \#1320 is blocking implementation  WARN
-    #Should Be True  ${9} < ${result} < ${11}
+Stop a container with SIGKILL using default grace period
+    ${rc}=  Run And Return Rc  docker ${params} pull busybox
+    Should Be Equal As Integers  ${rc}  0
+    ${trap}=  Trap Signal Command  TERM
+    ${rc}  ${container}=  Run And Return Rc And Output  docker ${params} run -d ${trap}
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}=  Run And Return Rc  docker ${params} stop ${container}
+    Should Be Equal As Integers  ${rc}  0
 
-Stop a container with a time limit
+Stop a container with SIGKILL using specific stop signal
+    ${rc}=  Run And Return Rc  docker ${params} pull busybox
+    Should Be Equal As Integers  ${rc}  0
+    ${trap}=  Trap Signal Command  USR1
+    ${rc}  ${container}=  Run And Return Rc And Output  docker ${params} run -d --stop-signal USR1 ${trap}
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}=  Run And Return Rc  docker ${params} stop ${container}
+    Should Be Equal As Integers  ${rc}  0
+    Assert Stop Signal  ${container}  USR1
+
+Stop a container with SIGKILL using specific grace period
     ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} pull busybox
     Should Be Equal As Integers  ${rc}  0
     ${rc}  ${container}=  Run And Return Rc And Output  docker ${params} create busybox sleep 30

--- a/tests/test-cases/Group8-vSphere-Integration/8-1-GuestTools.robot
+++ b/tests/test-cases/Group8-vSphere-Integration/8-1-GuestTools.robot
@@ -18,3 +18,12 @@ Verify container VM guest IP is reported
     Should Be Equal As Integers  ${rc}  0
     Should Not Contain  ${id}  Error
     Run  govc vm.ip ${id}
+
+Stop container VM using guest shutdown
+    ${rc}=  Run And Return Rc  docker ${params} pull busybox
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${id}=  Run And Return Rc And Output  docker ${params} run -d busybox /bin/top
+    Should Be Equal As Integers  ${rc}  0
+    Run  govc vm.ip ${id}
+    ${rc}=  Run And Return Rc  govc vm.power -s ${id}
+    Should Be Equal As Integers  ${rc}  0


### PR DESCRIPTION
The stop signal can be specified in the Dockerfile or docker run cli.

The toolbox now has support for the VirtualMachine.ShutdownGuest API
and 'docker stop' behaves the same as guest shutdown from the vSphere
side.

Fixes #1268