### PR TITLE
Fix nil pointer dereferences in vicadm_test.go

### DIFF
--- a/cmd/vicadmin/logs.go
+++ b/cmd/vicadmin/logs.go
@@ -36,6 +36,7 @@ import (
 
 const (
 	uint32max = (1 << 32) - 1
+	tailLines = 8
 )
 
 type dlogReader struct {
@@ -301,7 +302,7 @@ func zipEntries(readers map[string]entryReader, out *zip.Writer) error {
 }
 
 func tailFile(wr io.Writer, file string, done *chan bool) error {
-	nlines := 8
+	nlines := tailLines
 	f, err := os.Open(file)
 	if err != nil {
 		return err

--- a/cmd/vicadmin/logs.go
+++ b/cmd/vicadmin/logs.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io"
 	"math"
+	"os"
 	"path"
 	"sync"
 	"time"
@@ -295,6 +296,60 @@ func zipEntries(readers map[string]entryReader, out *zip.Writer) error {
 			continue
 		}
 		log.Infof("Wrote %d bytes to %s", sz, header.Name)
+	}
+	return nil
+}
+
+func tailFile(wr io.Writer, file string, done *chan bool) error {
+	nlines := 8
+	f, err := os.Open(file)
+	if err != nil {
+		return err
+	}
+
+	pos, err := f.Seek(0, 2)
+	if err != nil {
+		return err
+	}
+	b := make([]byte, 1)
+	for pos > 0 && nlines >= 0 {
+		pos--
+		_, err := f.ReadAt(b, pos)
+		if err != nil && err != io.EOF {
+			return err
+		}
+		if b[0] == '\n' {
+			nlines--
+		}
+	}
+
+	pos++
+	if _, err = f.Seek(pos, 0); err != nil {
+		return err
+	}
+
+	b = make([]byte, 1024)
+	// We KNOW there's a data race here.
+	// But it doesn't break anything, so we just trap it.
+	defer func() {
+		_ = recover()
+	}()
+	var n int
+	for true {
+		for err != io.EOF {
+			n, err = f.Read(b)
+			if err != nil && err != io.EOF {
+				return err
+			}
+			fmt.Fprint(wr, string(b[:n]))
+		}
+		select {
+		case _ = <-*done:
+			return nil
+		default:
+		}
+		time.Sleep(50 * time.Millisecond)
+		err = nil
 	}
 	return nil
 }

--- a/cmd/vicadmin/server.go
+++ b/cmd/vicadmin/server.go
@@ -23,7 +23,7 @@ import (
 	"html/template"
 	"net"
 	"net/http"
-	"os/exec"
+	// "os/exec"
 	"path/filepath"
 
 	"golang.org/x/net/context"
@@ -248,21 +248,25 @@ func (s *server) tailFiles(res http.ResponseWriter, req *http.Request, names []s
 		w: res,
 	}
 
-	// TODO: tail in Go, rather than shelling out
+	/* // TODO: tail in Go, rather than shelling out
 	cmd := exec.Command("tail", append([]string{"-F"}, names...)...)
 	cmd.Stdout = fw
 	cmd.Stderr = fw
+	*/
 
-	if err := cmd.Start(); err != nil {
+	done := make(chan bool)
+	go tailFile(fw, names[0], &done)
+
+	/* if err := cmd.Start(); err != nil {
 		log.Errorf("error tailing logs: %s", err)
 		return
 	}
-
-	defer cmd.Process.Kill()
-
-	go cmd.Wait()
+	*/
+	// defer cmd.Process.Kill()
+	// go cmd.Wait()
 
 	<-cc
+	done <- true
 }
 
 func (s *server) index(res http.ResponseWriter, req *http.Request) {

--- a/cmd/vicadmin/server.go
+++ b/cmd/vicadmin/server.go
@@ -248,22 +248,8 @@ func (s *server) tailFiles(res http.ResponseWriter, req *http.Request, names []s
 		w: res,
 	}
 
-	/* // TODO: tail in Go, rather than shelling out
-	cmd := exec.Command("tail", append([]string{"-F"}, names...)...)
-	cmd.Stdout = fw
-	cmd.Stderr = fw
-	*/
-
 	done := make(chan bool)
 	go tailFile(fw, names[0], &done)
-
-	/* if err := cmd.Start(); err != nil {
-		log.Errorf("error tailing logs: %s", err)
-		return
-	}
-	*/
-	// defer cmd.Process.Kill()
-	// go cmd.Wait()
 
 	<-cc
 	done <- true
@@ -273,11 +259,6 @@ func (s *server) index(res http.ResponseWriter, req *http.Request) {
 	defer trace.End(trace.Begin(""))
 	ctx := context.Background()
 	v := vicadmin.NewValidator(ctx, vchConfig)
-
-	// version := vchConfig.Version
-	// vchName := vchConfig.ContainerNameConvention
-	//cr := vchConfig.ComputeResources[0]
-	//cpu := resources.CPU
 
 	tmpl, err := template.ParseFiles("dashboard.html")
 	err = tmpl.ExecuteTemplate(res, "dashboard.html", v)

--- a/cmd/vicadmin/server.go
+++ b/cmd/vicadmin/server.go
@@ -16,14 +16,11 @@ package main
 
 import (
 	"archive/zip"
-	// "archive/tar"
 	"compress/gzip"
 	"crypto/tls"
-	// "fmt"
 	"html/template"
 	"net"
 	"net/http"
-	// "os/exec"
 	"path/filepath"
 
 	"golang.org/x/net/context"

--- a/cmd/vicadmin/vicadm.go
+++ b/cmd/vicadmin/vicadm.go
@@ -432,8 +432,6 @@ func main() {
 		} else {
 			vchConfig.Target.User = url.User(upw[0])
 		}
-		log.Infof("vSphere UserInfo = %s", vchConfig.UserPassword)
-		log.Infof("vSphere target = %s", vchConfig.Target.String())
 	}
 	config.Service = vchConfig.Target.String()
 	config.ExtensionCert = vchConfig.ExtensionCert

--- a/cmd/vicadmin/vicadm.go
+++ b/cmd/vicadmin/vicadm.go
@@ -423,6 +423,18 @@ func main() {
 
 	flag.Parse()
 
+	// If we're in an ESXi environment, then we need
+	// to extract the userid/password from UserPassword
+	if vchConfig.UserPassword != "" {
+		upw := strings.Split(vchConfig.UserPassword, ":")
+		if len(upw) == 2 {
+			vchConfig.Target.User = url.UserPassword(upw[0], upw[1])
+		} else {
+			vchConfig.Target.User = url.User(upw[0])
+		}
+		log.Infof("vSphere UserInfo = %s", vchConfig.UserPassword)
+		log.Infof("vSphere target = %s", vchConfig.Target.String())
+	}
 	config.Service = vchConfig.Target.String()
 	config.ExtensionCert = vchConfig.ExtensionCert
 	config.ExtensionKey = vchConfig.ExtensionKey

--- a/cmd/vicadmin/vicadm_test.go
+++ b/cmd/vicadmin/vicadm_test.go
@@ -264,6 +264,7 @@ func TestLogTail(t *testing.T) {
 		u.Path = path
 		log.Printf("GET %s:\n", u.String())
 		res, err := insecureClient.Get(u.String())
+		defer res.Body.Close()
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -278,7 +279,6 @@ func TestLogTail(t *testing.T) {
 		size := int64(256)
 		n, _ := io.CopyN(out, res.Body, size)
 		out.Write([]byte("...\n"))
-		res.Body.Close()
 
 		assert.Equal(t, size, n)
 	}

--- a/cmd/vicadmin/vicadm_test.go
+++ b/cmd/vicadmin/vicadm_test.go
@@ -248,7 +248,6 @@ func TestLogTail(t *testing.T) {
 
 	paths := []string{
 		"/logs/tail/" + name,
-		"/logs/" + name,
 	}
 
 	i := 0

--- a/lib/config/virtual_container_host.go
+++ b/lib/config/virtual_container_host.go
@@ -57,6 +57,9 @@ type VirtualContainerHostConfigSpec struct {
 	////////////// vSphere connection configuration
 	// The sdk URL
 	Target url.URL `vic:"0.1" scope:"read-only" key:"target"`
+	// User/Password (For ESXi only)
+	// Required because url.URL does not Marshal the UserInfo field
+	UserPassword string `vic:"0.1" scope:"read-only" key:"userpw"`
 	// Certificate for authentication as vSphere Extension
 	ExtensionCert string `vic:"0.1" scope:"read-only" key:"extension_cert"`
 	ExtensionKey  string `vic:"0.1" scope:"read-only" key:"extension_key"`

--- a/lib/install/validate/validator.go
+++ b/lib/install/validate/validator.go
@@ -754,6 +754,8 @@ func (v *Validator) target(ctx context.Context, input *data.Data, conf *config.V
 			v.NoteIssue(fmt.Errorf("Error processing target after transformation to SOAP endpoint: %q: %s", v.Session.Service, err))
 			return
 		}
+		conf.UserPassword = targetURL.User.String()
+		log.Info("Saving User/Password as conf.UserPassword")
 	}
 
 	// bridge network params

--- a/lib/install/validate/validator.go
+++ b/lib/install/validate/validator.go
@@ -755,7 +755,6 @@ func (v *Validator) target(ctx context.Context, input *data.Data, conf *config.V
 			return
 		}
 		conf.UserPassword = targetURL.User.String()
-		log.Info("Saving User/Password as conf.UserPassword")
 	}
 
 	// bridge network params


### PR DESCRIPTION
The associated panic() occurs periodically when running "go test":
2016/07/28 17:08:32 GET https://localhost:33160/logs/vicadmin.log:
time="2016-07-28T17:08:32Z" level=debug msg="[ END ] [github.com/vmware/vic/cmd/vicadmin.(*server).tailFiles] [28.04363ms] " 
panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xb code=0x1 addr=0x20 pc=0xb0685a]

goroutine 69 [running]:
panic(0x1026cc0, 0xc820012110)
    /usr/local/go/src/runtime/panic.go:481 +0x3e6
bufio.(*Writer).flush(0xc8201cc200, 0x0, 0x0)
    /usr/local/go/src/bufio/bufio.go:562 +0xda
bufio.(*Writer).Flush(0xc8201cc200, 0x0, 0x0)
    /usr/local/go/src/bufio/bufio.go:551 +0x2d
net/http.(*response).Flush(0xc8201d1e10)
    /usr/local/go/src/net/http/server.go:1301 +0x45
github.com/vmware/vic/cmd/vicadmin.(*flushWriter).Write(0xc8203cfa00, 0xc820396000, 0x183, 0x8000, 0x183, 0x0, 0x0)
    github.com/vmware/vic/cmd/vicadmin/_test/_obj_test/vicadm.go:458 +0xcd
io.copyBuffer(0x7fa4f9b81bc0, 0xc8203cfa00, 0x7fa4f9b79590, 0xc820026028, 0xc820396000, 0x8000, 0x8000, 0x2023, 0x0, 0x0)
    /usr/local/go/src/io/io.go:382 +0x2c9
io.Copy(0x7fa4f9b81bc0, 0xc8203cfa00, 0x7fa4f9b79590, 0xc820026028, 0x0, 0x0, 0x0)
    /usr/local/go/src/io/io.go:350 +0x64
os/exec.(*Cmd).writerDescriptor.func1(0x0, 0x0)
    /usr/local/go/src/os/exec/exec.go:236 +0x8b
os/exec.(*Cmd).Start.func1(0xc8201dcc80, 0xc8203cfb80)
    /usr/local/go/src/os/exec/exec.go:344 +0x1d
created by os/exec.(*Cmd).Start
    /usr/local/go/src/os/exec/exec.go:345 +0x967
exit status 2
FAIL    github.com/vmware/vic/cmd/vicadmin    0.248s
Makefile:217: recipe for target 'test' failed
make: *** [test] Error 1
[info] build failed (exit code 2)

It turns out that there is currently a race condition in tailFiles, where the following sequence of events happens:
    The http connection is closed and the runtime begins tearing down the connection
    The http CloseNotifier sends a signal on a channel
    The main thread receives from the channel and exits
    The deferred cmd.Kill() kills the "tail -f" command

The race condition occurs when the "tail -f" command writes (and flushes) to the flushWriter after the runtime has torn down the endpoint, resulting in a nil pointer dereference.  This PR moves the "tail -f" functionality into a "tailFile" function which runs as a goroutine and explicitly accepts that there may be data races, and does an explicit recover() from any panic() which may arise from this.
    
Fixes nil pointer dereferences in vicadm_test.go.

