### PR TITLE
Fix test logic

### DIFF
--- a/tests/test-cases/Group1-Docker-Commands/1-10-Docker-PS.md
+++ b/tests/test-cases/Group1-Docker-Commands/1-10-Docker-PS.md
@@ -15,9 +15,9 @@ This test requires that a vSphere server is running and available
 2. Issue docker ps to the VIC appliance
 3. Issue docker create busybox /bin/top to the VIC appliance
 4. Issue docker start <containerID> to the VIC appliance
-5. Issue docker create busybox dmesg to the VIC appliance
+5. Issue docker create busybox ls to the VIC appliance
 6. Issue docker start <containerID> to the VIC appliance
-7. Issue docker create busybox ls to the VIC appliance
+7. Issue docker create busybox dmesg to the VIC appliance
 8. Issue docker ps to the VIC appliance
 9. Issue docker ps -a to the VIC appliance
 10. Issue docker ps -l to the VIC appliance
@@ -31,11 +31,11 @@ This test requires that a vSphere server is running and available
 * Step 2 should return with only the printed ps command header and no containers
 * Step 8 should return with only the information for the /bin/top container
 * Step 9 should return with the information for all 3 containers
-* Step 10 should return with the information for only the 'ls' container
+* Step 10 should return with the information for only the 'dmesg' container
 * Step 11 should return with the information for both the 'ls' and the 'dmesg' containers
-* Step 12 should return with the information in addition to the size information of the 'ls' container
+* Step 12 should return with the information in addition to the size information of the 'dmesg' container
 * Step 13 should return with only the three container IDs
-* Step 14 should return with only the information for the 'ls' container
+* Step 14 should return with only the information for the 'dmesg' container
 
 #Possible Problems:
 None

--- a/tests/test-cases/Group1-Docker-Commands/1-10-Docker-PS.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-10-Docker-PS.robot
@@ -21,7 +21,7 @@ Empty docker ps command
 Docker ps only running containers
     ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} pull busybox
     Should Be Equal As Integers  ${rc}  0
-    ${rc}  ${container2}=  Run And Return Rc And Output  docker ${params} create busybox dmesg
+    ${rc}  ${container2}=  Run And Return Rc And Output  docker ${params} create busybox ls
     Should Be Equal As Integers  ${rc}  0
     ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} start ${container2}
     Should Be Equal As Integers  ${rc}  0
@@ -29,14 +29,14 @@ Docker ps only running containers
     Should Be Equal As Integers  ${rc}  0
     ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} start ${container1}
     Should Be Equal As Integers  ${rc}  0
-    ${rc}  ${container3}=  Run And Return Rc And Output  docker ${params} create busybox ls
+    ${rc}  ${container3}=  Run And Return Rc And Output  docker ${params} create busybox dmesg
     Should Be Equal As Integers  ${rc}  0
     Sleep  5 seconds
     ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} ps
     Should Be Equal As Integers  ${rc}  0
     Should Contain  ${output}  /bin/top
     ${output}=  Split To Lines  ${output}
-    Length Should Be  ${output}  3
+    Length Should Be  ${output}  2
     
 Docker ps all containers
     ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} ps -a

--- a/tests/test-cases/Group1-Docker-Commands/1-10-Docker-PS.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-10-Docker-PS.robot
@@ -36,7 +36,7 @@ Docker ps only running containers
     Should Be Equal As Integers  ${rc}  0
     Should Contain  ${output}  /bin/top
     ${output}=  Split To Lines  ${output}
-    Length Should Be  ${output}  2
+    Length Should Be  ${output}  3
     
 Docker ps all containers
     ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} ps -a


### PR DESCRIPTION
Alleviate a race condition in the ps test, when the sleep and the other creates are not enough to let the first container finish it's output.