### PR TITLE
Show correct output during rm on a running container

### DIFF
--- a/lib/apiservers/engine/backends/container.go
+++ b/lib/apiservers/engine/backends/container.go
@@ -409,20 +409,19 @@ func (c *Container) ContainerRm(name string, config *types.ContainerRmConfig) er
 	//call the remove directly on the name. No need for using a handle.
 	_, err := client.Containers.ContainerRemove(containers.NewContainerRemoveParams().WithID(name))
 	if err != nil {
-		if _, ok := err.(*containers.ContainerRemoveNotFound); ok {
+		switch err := err.(type) {
+		case *containers.ContainerRemoveNotFound:
 			return derr.NewRequestNotFoundError(fmt.Errorf("No such container: %s", name))
+		case *containers.ContainerRemoveDefault:
+			return derr.NewErrorWithStatusCode(fmt.Errorf("server error from portlayer : %s", err.Payload.Message), http.StatusInternalServerError)
+		case *containers.ContainerRemoveConflict:
+			return derr.NewErrorWithStatusCode(fmt.Errorf(err.Payload.Message), http.StatusConflict)
+		default:
+			return derr.NewErrorWithStatusCode(fmt.Errorf("server error from portlayer : %s", err), http.StatusInternalServerError)
 		}
-		if errModel, ok := err.(*containers.ContainerRemoveDefault); ok {
-			return derr.NewErrorWithStatusCode(fmt.Errorf("server error from portlayer : %s", errModel.Payload.Message), http.StatusInternalServerError)
-		}
-		if _, ok := err.(*containers.ContainerRemoveConflict); ok {
-			return derr.NewErrorWithStatusCode(fmt.Errorf("You cannot remove a running container. Stop the container before attempting removal or use -f"), http.StatusConflict)
-		}
-		return derr.NewErrorWithStatusCode(fmt.Errorf("server error from portlayer : %s", err), http.StatusInternalServerError)
 	}
 	// delete container from the cache
 	cache.ContainerCache().DeleteContainer(name)
-
 	return nil
 }
 

--- a/lib/apiservers/engine/backends/container.go
+++ b/lib/apiservers/engine/backends/container.go
@@ -415,7 +415,7 @@ func (c *Container) ContainerRm(name string, config *types.ContainerRmConfig) er
 		case *containers.ContainerRemoveDefault:
 			return derr.NewErrorWithStatusCode(fmt.Errorf("server error from portlayer : %s", err.Payload.Message), http.StatusInternalServerError)
 		case *containers.ContainerRemoveConflict:
-			return derr.NewErrorWithStatusCode(fmt.Errorf(err.Payload.Message), http.StatusConflict)
+			return derr.NewErrorWithStatusCode(fmt.Errorf("You cannot remove a running container. Stop the container before attempting removal or use -f"), http.StatusConflict)
 		default:
 			return derr.NewErrorWithStatusCode(fmt.Errorf("server error from portlayer : %s", err), http.StatusInternalServerError)
 		}

--- a/lib/apiservers/engine/backends/container.go
+++ b/lib/apiservers/engine/backends/container.go
@@ -416,7 +416,7 @@ func (c *Container) ContainerRm(name string, config *types.ContainerRmConfig) er
 			return derr.NewErrorWithStatusCode(fmt.Errorf("server error from portlayer : %s", errModel.Payload.Message), http.StatusInternalServerError)
 		}
 		if _, ok := err.(*containers.ContainerRemoveConflict); ok {
-			return derr.NewErrorWithStatusCode(fmt.Errorf("Conflict, You cannot remove a running container. Stop the container before attempting removal or use -f"), http.StatusConflict)
+			return derr.NewErrorWithStatusCode(fmt.Errorf("You cannot remove a running container. Stop the container before attempting removal or use -f"), http.StatusConflict)
 		}
 		return derr.NewErrorWithStatusCode(fmt.Errorf("server error from portlayer : %s", err), http.StatusInternalServerError)
 	}

--- a/lib/apiservers/engine/backends/container.go
+++ b/lib/apiservers/engine/backends/container.go
@@ -415,6 +415,9 @@ func (c *Container) ContainerRm(name string, config *types.ContainerRmConfig) er
 		if errModel, ok := err.(*containers.ContainerRemoveDefault); ok {
 			return derr.NewErrorWithStatusCode(fmt.Errorf("server error from portlayer : %s", errModel.Payload.Message), http.StatusInternalServerError)
 		}
+		if _, ok := err.(*containers.ContainerRemoveConflict); ok {
+			return derr.NewErrorWithStatusCode(fmt.Errorf("Conflict, You cannot remove a running container. Stop the container before attempting removal or use -f"), http.StatusConflict)
+		}
 		return derr.NewErrorWithStatusCode(fmt.Errorf("server error from portlayer : %s", err), http.StatusInternalServerError)
 	}
 	// delete container from the cache

--- a/lib/apiservers/portlayer/restapi/handlers/containers_handlers.go
+++ b/lib/apiservers/portlayer/restapi/handlers/containers_handlers.go
@@ -20,6 +20,7 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
+	"strings"
 
 	middleware "github.com/go-swagger/go-swagger/httpkit/middleware"
 	"golang.org/x/net/context"
@@ -225,6 +226,9 @@ func (handler *ContainersHandlersImpl) RemoveContainerHandler(params containers.
 
 	err := h.Container.Remove(context.Background(), handler.handlerCtx.Session)
 	if err != nil {
+		if strings.Contains(err.Error(), "The attempted operation cannot be performed in the current state (Powered on)") {
+			return containers.NewContainerRemoveConflict()
+		}
 		return containers.NewContainerRemoveInternalServerError()
 	}
 

--- a/lib/apiservers/portlayer/swagger.yml
+++ b/lib/apiservers/portlayer/swagger.yml
@@ -726,6 +726,8 @@ paths:
           description: "bad parameter"
         '404':
           description: "no such container"
+        '409':
+          description: "conflict"
         '500':
           description: "server error"
         default:

--- a/lib/apiservers/portlayer/swagger.yml
+++ b/lib/apiservers/portlayer/swagger.yml
@@ -728,6 +728,8 @@ paths:
           description: "no such container"
         '409':
           description: "conflict"
+          schema:
+            $ref: "#/definitions/Error"
         '500':
           description: "server error"
         default:

--- a/lib/portlayer/exec/container.go
+++ b/lib/portlayer/exec/container.go
@@ -273,7 +273,7 @@ func (c *Container) Remove(ctx context.Context, sess *session.Session) error {
 
 	// don't remove the containerVM if it is powered on
 	if state == types.VirtualMachinePowerStatePoweredOn {
-		return RemovePowerError{fmt.Errorf("You cannot remove a running container. Stop the container before attempting removal or use -f")}
+		return RemovePowerError{fmt.Errorf("Container is powered on")}
 	}
 
 	//removes the vm from vsphere, but detaches the disks first

--- a/lib/portlayer/exec/container.go
+++ b/lib/portlayer/exec/container.go
@@ -239,6 +239,14 @@ func (c *Container) stop(ctx context.Context) error {
 	return nil
 }
 
+type RemovePowerError struct {
+	err error
+}
+
+func (r RemovePowerError) Error() string {
+	return r.err.Error()
+}
+
 func (c *Container) Remove(ctx context.Context, sess *session.Session) error {
 	defer trace.End(trace.Begin("Container.Remove"))
 	c.Lock()
@@ -257,6 +265,16 @@ func (c *Container) Remove(ctx context.Context, sess *session.Session) error {
 	// FIXME: was expecting to find a utility function to convert to/from datastore/url given
 	// how widely it's used but couldn't - will ask around.
 	dsPath := fmt.Sprintf("[%s] %s", url.Host, url.Path)
+
+	state, err := c.vm.PowerState(ctx)
+	if err != nil {
+		return fmt.Errorf("Failed to get vm power status %q: %s", c.vm.Reference(), err)
+	}
+
+	// don't remove the containerVM if it is powered on
+	if state == types.VirtualMachinePowerStatePoweredOn {
+		return RemovePowerError{fmt.Errorf("You cannot remove a running container. Stop the container before attempting removal or use -f")}
+	}
 
 	//removes the vm from vsphere, but detaches the disks first
 	_, err = tasks.WaitForResult(ctx, func(ctx context.Context) (tasks.ResultWaiter, error) {

--- a/tests/test-cases/Group1-Docker-Commands/1-11-Docker-RM.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-11-Docker-RM.robot
@@ -46,7 +46,7 @@ Remove a running container
     Should Be Equal As Integers  ${rc}  0
     ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} rm ${container}
     Should Be Equal As Integers  ${rc}  1
-    Should Contain  ${output}  Error response from daemon: Conflict, You cannot remove a running container. Stop the container before attempting removal or use -f
+    Should Contain  ${output}  Error response from daemon: You cannot remove a running container. Stop the container before attempting removal or use -f
     
 Force remove a running container
     ${status}=  Get State Of Github Issue  1312

--- a/tests/test-cases/Group1-Docker-Commands/1-11-Docker-RM.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-11-Docker-RM.robot
@@ -40,16 +40,13 @@ Remove a stopped container
     #Should Not Contain  ${output}  ${container}
 
 Remove a running container
-    ${status}=  Get State Of Github Issue  1311
-    Run Keyword If  '${status}' == 'closed'  Fail  Test 1-11-Docker-RM.robot needs to be updated now that Issue #1311 has been resolved
-    Log  Issue \#1311 is blocking implementation  WARN
-    #${rc}  ${container}=  Run And Return Rc And Output  docker ${params} create busybox /bin/top
-    #Should Be Equal As Integers  ${rc}  0
-    #${rc}  ${output}=  Run And Return Rc And Output  docker ${params} start ${container}
-    #Should Be Equal As Integers  ${rc}  0
-    #${rc}  ${output}=  Run And Return Rc And Output  docker ${params} rm ${container}
-    #Should Be Equal As Integers  ${rc}  1
-    #Should Contain  ${output}  Error response from daemon: Conflict, You cannot remove a running container. Stop the container before attempting removal or use -f
+    ${rc}  ${container}=  Run And Return Rc And Output  docker ${params} create busybox /bin/top
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} start ${container}
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} rm ${container}
+    Should Be Equal As Integers  ${rc}  1
+    Should Contain  ${output}  Error response from daemon: Conflict, You cannot remove a running container. Stop the container before attempting removal or use -f
     
 Force remove a running container
     ${status}=  Get State Of Github Issue  1312


### PR DESCRIPTION
* Fixes output during a `docker rm` on a running container

Vanilla docker:
```
$ sudo docker create busybox /bin/top
<container-id>
$ sudo docker start <container-id>
<container-id>
$ sudo docker rm <container-id>
Error response from daemon: You cannot remove a running container <container-id>. Stop the container before attempting removal or use -f
```

VIC:
```
$ docker -H <host> --tls create busybox /bin/top
<container-id>
$ docker -H <host> --tls start <container-id>
<container-id>
$ docker -H <host> --tls rm <container-id>
Error response from daemon: You cannot remove a running container. Stop the container before attempting removal or use -f
```

* Enables the related integration test in the `docker rm` suite

Fixes #1311