### PR TITLE
Docker volume rm storage handler implementation

### DIFF
--- a/lib/apiservers/portlayer/restapi/handlers/storage_handlers.go
+++ b/lib/apiservers/portlayer/restapi/handlers/storage_handlers.go
@@ -295,7 +295,7 @@ func (handler *StorageHandlersImpl) CreateVolume(params storage.CreateVolumePara
 func (handler *StorageHandlersImpl) RemoveVolume(params storage.RemoveVolumeParams) middleware.Responder {
 	defer trace.End(trace.Begin("storage_handlers.RemoveVolume"))
 
-	err := storageVolumeLayer.VolumeGet(context.TODO(), params.Name)
+	_, err := storageVolumeLayer.VolumeGet(context.TODO(), params.Name)
 	if err != nil {
 		return storage.NewRemoveVolumeNotFound().WithPayload(&models.Error{
 			Message: err.Error(),

--- a/lib/apiservers/portlayer/restapi/handlers/storage_handlers.go
+++ b/lib/apiservers/portlayer/restapi/handlers/storage_handlers.go
@@ -292,9 +292,23 @@ func (handler *StorageHandlersImpl) CreateVolume(params storage.CreateVolumePara
 }
 
 //RemoveVolume : Remove a Volume from existence
-func (handler *StorageHandlersImpl) RemoveVolume(storage.RemoveVolumeParams) middleware.Responder {
+func (handler *StorageHandlersImpl) RemoveVolume(params storage.RemoveVolumeParams) middleware.Responder {
 	defer trace.End(trace.Begin("storage_handlers.RemoveVolume"))
-	return storage.NewRemoveVolumeOK() //TODO: this is just a stub for now.
+
+	err := storageVolumeLayer.VolumeGet(context.TODO(), params.Name)
+	if err != nil {
+		return storage.NewRemoveVolumeNotFound().WithPayload(&models.Error{
+			Message: err.Error(),
+		})
+	}
+
+	err = storageVolumeLayer.VolumeDestroy(context.TODO(), params.Name)
+	if err != nil {
+		return storage.NewRemoveVolumeInternalServerError().WithPayload(&models.Error{
+			Message: err.Error(),
+		})
+	}
+	return storage.NewRemoveVolumeOK()
 }
 
 //VolumesList : Lists available volumes for use

--- a/lib/apiservers/portlayer/restapi/handlers/storage_handlers.go
+++ b/lib/apiservers/portlayer/restapi/handlers/storage_handlers.go
@@ -295,18 +295,14 @@ func (handler *StorageHandlersImpl) CreateVolume(params storage.CreateVolumePara
 func (handler *StorageHandlersImpl) RemoveVolume(params storage.RemoveVolumeParams) middleware.Responder {
 	defer trace.End(trace.Begin("storage_handlers.RemoveVolume"))
 
-	_, err := storageVolumeLayer.VolumeGet(context.TODO(), params.Name)
+	err := storageVolumeLayer.VolumeDestroy(context.TODO(), params.Name)
 	if err != nil {
-		return storage.NewRemoveVolumeNotFound().WithPayload(&models.Error{
-			Message: err.Error(),
-		})
-	}
-
-	err = storageVolumeLayer.VolumeDestroy(context.TODO(), params.Name)
-	if err != nil {
-		return storage.NewRemoveVolumeInternalServerError().WithPayload(&models.Error{
-			Message: err.Error(),
-		})
+		switch err := err.(type) {
+		default:
+			return storage.NewRemoveVolumeInternalServerError().WithPayload(&models.Error{
+				Message: err.Error(),
+			})
+		}
 	}
 	return storage.NewRemoveVolumeOK()
 }


### PR DESCRIPTION
references #1720 #1511 #1508 

1720 - Volume rm not removing the volume
1511 - Support `docker volume delete`
1508 - Add support for `volume delete`

This is the implementation of the handler which is to call `VolumeDestroy` right now that function is `TBD` and once that is complete further work can be done on this PR. 