### PR TITLE
Abandon images if checksums don't match on pull

### DIFF
--- a/lib/apiservers/portlayer/restapi/handlers/storage_handlers_test.go
+++ b/lib/apiservers/portlayer/restapi/handlers/storage_handlers_test.go
@@ -145,7 +145,7 @@ func (c *MockDataStore) ListImageStores(ctx context.Context) ([]*url.URL, error)
 	return nil, nil
 }
 
-func (c *MockDataStore) WriteImage(ctx context.Context, parent *spl.Image, ID string, meta map[string][]byte, r io.Reader) (*spl.Image, error) {
+func (c *MockDataStore) WriteImage(ctx context.Context, parent *spl.Image, ID string, meta map[string][]byte, sum string, r io.Reader) (*spl.Image, error) {
 	i := spl.Image{
 		ID:       ID,
 		Store:    parent.Store,

--- a/lib/portlayer/storage/image.go
+++ b/lib/portlayer/storage/image.go
@@ -72,9 +72,9 @@ type ImageStorer interface {
 	// parent - The parent image to create the new image from.
 	// ID - textual ID for the image to be written
 	// meta - metadata associated with the image
+	// sum - expected sha266 sum of the image content.
 	// r - the image tar to be written
-	WriteImage(ctx context.Context, parent *Image, ID string, meta map[string][]byte, r io.Reader) (*Image,
-		error)
+	WriteImage(ctx context.Context, parent *Image, ID string, meta map[string][]byte, sum string, r io.Reader) (*Image, error)
 
 	// GetImage queries the image store for the specified image.
 	//

--- a/lib/portlayer/storage/image_cache.go
+++ b/lib/portlayer/storage/image_cache.go
@@ -15,7 +15,6 @@
 package storage
 
 import (
-	"crypto/sha256"
 	"fmt"
 	"io"
 	"net/url"
@@ -123,7 +122,7 @@ func (c *NameLookupCache) CreateImageStore(ctx context.Context, storeName string
 	defer c.storeCacheLock.Unlock()
 
 	// Create the root image
-	scratch, err := c.DataStore.WriteImage(ctx, &Image{Store: u}, Scratch.ID, nil, nil)
+	scratch, err := c.DataStore.WriteImage(ctx, &Image{Store: u}, Scratch.ID, nil, "", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -168,18 +167,9 @@ func (c *NameLookupCache) WriteImage(ctx context.Context, parent *Image, ID stri
 	}
 
 	// Definitely not in cache or image store, create image.
-	h := sha256.New()
-	t := io.TeeReader(r, h)
-
-	i, err = c.DataStore.WriteImage(ctx, p, ID, meta, t)
+	i, err = c.DataStore.WriteImage(ctx, p, ID, meta, sum, r)
 	if err != nil {
 		return nil, err
-	}
-
-	actualSum := fmt.Sprintf("sha256:%x", h.Sum(nil))
-	if actualSum != sum {
-		// TODO(jzt): cleanup?
-		return nil, fmt.Errorf("Failed to validate image checksum. Expected %s, got %s", sum, actualSum)
 	}
 
 	// Add the new image to the cache

--- a/lib/portlayer/storage/image_cache_test.go
+++ b/lib/portlayer/storage/image_cache_test.go
@@ -59,7 +59,7 @@ func (c *MockDataStore) ListImageStores(ctx context.Context) ([]*url.URL, error)
 	return nil, nil
 }
 
-func (c *MockDataStore) WriteImage(ctx context.Context, parent *Image, ID string, meta map[string][]byte, r io.Reader) (*Image, error) {
+func (c *MockDataStore) WriteImage(ctx context.Context, parent *Image, ID string, meta map[string][]byte, sum string, r io.Reader) (*Image, error) {
 	i := &Image{
 		ID:       ID,
 		Store:    parent.Store,
@@ -177,7 +177,7 @@ func TestOutsideCacheWriteImage(t *testing.T) {
 		id := fmt.Sprintf("ID-%d", i)
 
 		// Write to the datastore creating images
-		img, werr := s.DataStore.WriteImage(context.TODO(), &parent, id, nil, nil)
+		img, werr := s.DataStore.WriteImage(context.TODO(), &parent, id, nil, "", nil)
 		if !assert.NoError(t, werr) {
 			return
 		}

--- a/lib/portlayer/storage/vsphere/image.go
+++ b/lib/portlayer/storage/vsphere/image.go
@@ -15,6 +15,7 @@
 package vsphere
 
 import (
+	"crypto/sha256"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -24,12 +25,14 @@ import (
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/docker/docker/pkg/archive"
+	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/vim25/types"
 	portlayer "github.com/vmware/vic/lib/portlayer/storage"
 	"github.com/vmware/vic/lib/portlayer/util"
 	"github.com/vmware/vic/pkg/vsphere/datastore"
 	"github.com/vmware/vic/pkg/vsphere/disk"
 	"github.com/vmware/vic/pkg/vsphere/session"
+	"github.com/vmware/vic/pkg/vsphere/tasks"
 	"golang.org/x/net/context"
 )
 
@@ -187,7 +190,7 @@ func (v *ImageStore) ListImageStores(ctx context.Context) ([]*url.URL, error) {
 // ID - textual ID for the image to be written
 // meta - metadata associated with the image
 // Tag - the tag of the image to be written
-func (v *ImageStore) WriteImage(ctx context.Context, parent *portlayer.Image, ID string, meta map[string][]byte,
+func (v *ImageStore) WriteImage(ctx context.Context, parent *portlayer.Image, ID string, meta map[string][]byte, sum string,
 	r io.Reader) (*portlayer.Image, error) {
 
 	storeName, err := util.ImageStoreName(parent.Store)
@@ -200,29 +203,12 @@ func (v *ImageStore) WriteImage(ctx context.Context, parent *portlayer.Image, ID
 		return nil, err
 	}
 
-	// Create the image directory in the store.
-	imageDir := v.imageDirPath(storeName, ID)
-	_, err = v.ds.Mkdir(ctx, false, imageDir)
-	if err != nil {
-		return nil, err
-	}
-
-	imageDiskDsURI := v.imageDiskPath(storeName, ID)
-	log.Infof("Creating image %s (%s)", ID, imageDiskDsURI)
-
 	// If this is scratch, then it's the root of the image store.  All images
 	// will be descended from this created and prepared fs.
 	if ID == portlayer.Scratch.ID {
-		// Create the disk
-		vmdisk, cerr := v.dm.CreateAndAttach(ctx, imageDiskDsURI, "", defaultDiskSize, os.O_RDWR)
-		if cerr != nil {
-			return nil, cerr
-		}
-		defer v.dm.Detach(ctx, vmdisk)
-
-		// Make the filesystem and set its label to defaultDiskLabel
-		if cerr = vmdisk.Mkfs(defaultDiskLabel); cerr != nil {
-			return nil, cerr
+		// Create the scratch layer
+		if err := v.scratch(ctx, storeName); err != nil {
+			return nil, err
 		}
 	} else {
 
@@ -230,38 +216,15 @@ func (v *ImageStore) WriteImage(ctx context.Context, parent *portlayer.Image, ID
 			return nil, fmt.Errorf("parent ID is empty")
 		}
 
-		// datastore path to the parent
-		parentDiskDsURI := v.imageDiskPath(storeName, parent.ID)
-
-		// Create the disk
-		vmdisk, cerr := v.dm.CreateAndAttach(ctx, imageDiskDsURI, parentDiskDsURI, 0, os.O_RDWR)
-		if cerr != nil {
-			return nil, cerr
-		}
-		defer v.dm.Detach(ctx, vmdisk)
-
-		dir, cerr := ioutil.TempDir("", "mnt-"+ID)
-		if cerr != nil {
-			return nil, cerr
-		}
-		defer os.RemoveAll(dir)
-
-		if merr := vmdisk.Mount(dir, nil); merr != nil {
-			return nil, merr
-		}
-		defer vmdisk.Unmount()
-
-		// Untar the archive
-		cerr = archive.Untar(r, dir, &archive.TarOptions{})
-		if cerr != nil {
-			return nil, cerr
+		if err := v.writeImage(ctx, storeName, parent.ID, ID, sum, r); err != nil {
+			return nil, err
 		}
 
 		// persist the relationship
 		v.parents.Add(ID, parent.ID)
 
-		if cerr = v.parents.Save(ctx); cerr != nil {
-			return nil, cerr
+		if err := v.parents.Save(ctx); err != nil {
+			return nil, err
 		}
 	}
 
@@ -281,6 +244,124 @@ func (v *ImageStore) WriteImage(ctx context.Context, parent *portlayer.Image, ID
 	}
 
 	return newImage, nil
+}
+
+// Create a temporary directory, create a vmdk in this directory, attach/mount
+// the disk, unpack the tar, check the checksum.  If the data doesn't match the
+// expected checksum, abort by nuking the tempdir.  If everything matches, move
+// the tmpdir to the expected location (with the vmdk inside it).  The unwind
+// path is a bit convoluted here;  we need to clean up on the way out in the
+// error case (using the tmpdir).
+func (v *ImageStore) writeImage(ctx context.Context, storeName, parentID, ID,
+	sum string, r io.Reader) error {
+
+	// Create a temp image directory in the store.
+	tmpImageDir := v.imageDirPath(storeName, ID+"inprogress")
+	_, err := v.ds.Mkdir(ctx, true, tmpImageDir)
+	if err != nil {
+		return err
+	}
+
+	// datastore path to the parent
+	parentDiskDsURI := v.imageDiskPath(storeName, parentID)
+
+	// datastore path to the disk we're creating
+	imageDiskDsURI := path.Join(v.ds.RootURL, tmpImageDir, ID+".vmdk")
+	log.Infof("Creating image %s (%s)", ID, imageDiskDsURI)
+
+	// Create the disk
+	vmdisk, err := v.dm.CreateAndAttach(ctx, imageDiskDsURI, parentDiskDsURI, 0, os.O_RDWR)
+	if err != nil {
+		return err
+	}
+
+	defer func() {
+		if vmdisk.Mounted() {
+			log.Debugf("Unmounting abandonned disk")
+			vmdisk.Unmount()
+		}
+		if vmdisk.Attached() {
+			log.Debugf("Detaching abandonned disk")
+			v.dm.Detach(ctx, vmdisk)
+		}
+
+		v.ds.Rm(ctx, tmpImageDir)
+	}()
+
+	// tmp dir to mount the disk
+	dir, err := ioutil.TempDir("", "mnt-"+ID)
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(dir)
+
+	if err := vmdisk.Mount(dir, nil); err != nil {
+		return err
+	}
+
+	h := sha256.New()
+	t := io.TeeReader(r, h)
+
+	// Untar the archive
+	if err = archive.Untar(t, dir, &archive.TarOptions{}); err != nil {
+		return err
+	}
+
+	actualSum := fmt.Sprintf("sha256:%x", h.Sum(nil))
+	if actualSum != sum {
+		return fmt.Errorf("Failed to validate image checksum. Expected %s, got %s", sum, actualSum)
+	}
+
+	if err = vmdisk.Unmount(); err != nil {
+		return err
+	}
+
+	if err = v.dm.Detach(ctx, vmdisk); err != nil {
+		return err
+	}
+
+	// If we've gotten here, prepare the final location for the image
+	imageDir := v.imageDirPath(storeName, ID)
+	_, err = v.ds.Mkdir(ctx, true, imageDir)
+	if err != nil {
+		return err
+	}
+
+	// Move the disk to it's proper directory
+	vdm := object.NewVirtualDiskManager(v.s.Vim25())
+	return tasks.Wait(ctx, func(context.Context) (tasks.Waiter, error) {
+		dest := v.imageDiskPath(storeName, ID)
+		log.Infof("Moving disk %s to %s", imageDiskDsURI, dest)
+		t, err := vdm.MoveVirtualDisk(ctx, imageDiskDsURI, v.s.Datacenter, dest, v.s.Datacenter, true)
+		log.Infof("move task = %s", t)
+		return t, err
+	})
+}
+
+func (v *ImageStore) scratch(ctx context.Context, storeName string) error {
+
+	// Create the image directory in the store.
+	imageDir := v.imageDirPath(storeName, portlayer.Scratch.ID)
+	if _, err := v.ds.Mkdir(ctx, false, imageDir); err != nil {
+		return err
+	}
+
+	imageDiskDsURI := v.imageDiskPath(storeName, portlayer.Scratch.ID)
+	log.Infof("Creating image %s (%s)", portlayer.Scratch.ID, imageDiskDsURI)
+
+	// Create the disk
+	vmdisk, err := v.dm.CreateAndAttach(ctx, imageDiskDsURI, "", defaultDiskSize, os.O_RDWR)
+	if err != nil {
+		return err
+	}
+	defer v.dm.Detach(ctx, vmdisk)
+
+	// Make the filesystem and set its label to defaultDiskLabel
+	if err := vmdisk.Mkfs(defaultDiskLabel); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func (v *ImageStore) GetImage(ctx context.Context, store *url.URL, ID string) (*portlayer.Image, error) {

--- a/pkg/vsphere/datastore/datastore.go
+++ b/pkg/vsphere/datastore/datastore.go
@@ -235,11 +235,19 @@ func (d *Helper) Stat(ctx context.Context, pth string) (types.BaseFileInfo, erro
 func (d *Helper) Mv(ctx context.Context, fromPath, toPath string) error {
 	from := path.Join(d.RootURL, fromPath)
 	to := path.Join(d.RootURL, toPath)
+	log.Infof("Moving %s to %s", from, to)
 	err := tasks.Wait(ctx, func(context.Context) (tasks.Waiter, error) {
 		return d.fm.MoveDatastoreFile(ctx, from, d.s.Datacenter, to, d.s.Datacenter, true)
 	})
 
 	return err
+}
+
+func (d *Helper) Rm(ctx context.Context, pth string) error {
+	f := path.Join(d.RootURL, pth)
+	return tasks.Wait(context.TODO(), func(ctx context.Context) (tasks.Waiter, error) {
+		return d.fm.DeleteDatastoreFile(ctx, f, d.s.Datacenter)
+	})
 }
 
 func (d *Helper) IsVSAN(ctx context.Context) bool {

--- a/pkg/vsphere/datastore/datastore.go
+++ b/pkg/vsphere/datastore/datastore.go
@@ -196,7 +196,7 @@ func (d *Helper) Ls(ctx context.Context, p string) (*types.HostDatastoreBrowserS
 
 // LsDirs returns a list of dirents at the given path (relative to root)
 func (d *Helper) LsDirs(ctx context.Context, p string) (*types.ArrayOfHostDatastoreBrowserSearchResults, error) {
-	spec := types.HostDatastoreBrowserSearchSpec{
+	spec := &types.HostDatastoreBrowserSearchSpec{
 		MatchPattern: []string{"*"},
 	}
 
@@ -205,7 +205,7 @@ func (d *Helper) LsDirs(ctx context.Context, p string) (*types.ArrayOfHostDatast
 		return nil, err
 	}
 
-	task, err := b.SearchDatastoreSubFolders(ctx, path.Join(d.RootURL, p), &spec)
+	task, err := b.SearchDatastoreSubFolders(ctx, path.Join(d.RootURL, p), spec)
 	if err != nil {
 		return nil, err
 	}
@@ -245,6 +245,7 @@ func (d *Helper) Mv(ctx context.Context, fromPath, toPath string) error {
 
 func (d *Helper) Rm(ctx context.Context, pth string) error {
 	f := path.Join(d.RootURL, pth)
+	log.Infof("Removing %s", pth)
 	return tasks.Wait(context.TODO(), func(ctx context.Context) (tasks.Waiter, error) {
 		return d.fm.DeleteDatastoreFile(ctx, f, d.s.Datacenter)
 	})

--- a/pkg/vsphere/disk/disk.go
+++ b/pkg/vsphere/disk/disk.go
@@ -85,7 +85,7 @@ func (d *VirtualDisk) unlock() {
 }
 
 func (d *VirtualDisk) setAttached(devicePath string) error {
-	if d.isAttached() {
+	if d.Attached() {
 		return fmt.Errorf("%s is already attached (%s)", d.DatastoreURI, devicePath)
 	}
 
@@ -98,11 +98,11 @@ func (d *VirtualDisk) setAttached(devicePath string) error {
 }
 
 func (d *VirtualDisk) canBeDetached() error {
-	if !d.isAttached() {
+	if !d.Attached() {
 		return fmt.Errorf("%s is already detached", d.DatastoreURI)
 	}
 
-	if d.isMounted() {
+	if d.Mounted() {
 		return fmt.Errorf("%s is mounted (%s)", d.DatastoreURI, d.mountPath)
 	}
 
@@ -110,11 +110,11 @@ func (d *VirtualDisk) canBeDetached() error {
 }
 
 func (d *VirtualDisk) setDetached() error {
-	if !d.isAttached() {
+	if !d.Attached() {
 		return fmt.Errorf("%s is already dettached", d.DatastoreURI)
 	}
 
-	if d.isMounted() {
+	if d.Mounted() {
 		return fmt.Errorf("%s is still mounted (%s)", d.DatastoreURI, d.mountPath)
 	}
 
@@ -126,11 +126,11 @@ func (d *VirtualDisk) Mkfs(labelName string) error {
 	d.lock()
 	defer d.unlock()
 
-	if !d.isAttached() {
+	if !d.Attached() {
 		return fmt.Errorf("%s isn't attached", d.DatastoreURI)
 	}
 
-	if d.isMounted() {
+	if d.Mounted() {
 		return fmt.Errorf("%s is mounted mounted", d.DatastoreURI)
 	}
 
@@ -141,14 +141,14 @@ func (d *VirtualDisk) SetLabel(labelName string) error {
 	d.lock()
 	defer d.unlock()
 
-	if !d.isAttached() {
+	if !d.Attached() {
 		return fmt.Errorf("%s isn't attached", d.DatastoreURI)
 	}
 
 	return d.fs.SetLabel(d.DevicePath, labelName)
 }
 
-func (d *VirtualDisk) isAttached() bool {
+func (d *VirtualDisk) Attached() bool {
 	return d.DevicePath != ""
 }
 
@@ -156,11 +156,11 @@ func (d *VirtualDisk) Mount(mountPath string, options []string) error {
 	d.lock()
 	defer d.unlock()
 
-	if !d.isAttached() {
+	if !d.Attached() {
 		return fmt.Errorf("%s isn't attached", d.DatastoreURI)
 	}
 
-	if d.isMounted() {
+	if d.Mounted() {
 		return fmt.Errorf("%s already mounted", d.DatastoreURI)
 	}
 
@@ -176,7 +176,7 @@ func (d *VirtualDisk) Unmount() error {
 	d.lock()
 	defer d.unlock()
 
-	if !d.isMounted() {
+	if !d.Mounted() {
 		return fmt.Errorf("%s already unmounted", d.DatastoreURI)
 	}
 
@@ -189,7 +189,7 @@ func (d *VirtualDisk) Unmount() error {
 }
 
 func (d *VirtualDisk) MountPath() (string, error) {
-	if !d.isMounted() {
+	if !d.Mounted() {
 		return "", fmt.Errorf("%s isn't mounted", d.DatastoreURI)
 	}
 
@@ -200,16 +200,16 @@ func (d *VirtualDisk) DiskPath() string {
 	return d.DatastoreURI
 }
 
-func (d *VirtualDisk) isMounted() bool {
+func (d *VirtualDisk) Mounted() bool {
 	return d.mountPath != ""
 }
 
 func (d *VirtualDisk) canBeUnmounted() error {
-	if !d.isAttached() {
+	if !d.Attached() {
 		return fmt.Errorf("%s is detached", d.DatastoreURI)
 	}
 
-	if !d.isMounted() {
+	if !d.Mounted() {
 		return fmt.Errorf("%s is unmounted", d.DatastoreURI)
 	}
 
@@ -217,7 +217,7 @@ func (d *VirtualDisk) canBeUnmounted() error {
 }
 
 func (d *VirtualDisk) setUmounted() error {
-	if !d.isMounted() {
+	if !d.Mounted() {
 		return fmt.Errorf("%s already unmounted", d.DatastoreURI)
 	}
 

--- a/pkg/vsphere/disk/disk_manager.go
+++ b/pkg/vsphere/disk/disk_manager.go
@@ -230,6 +230,11 @@ func (m *Manager) Detach(ctx context.Context, d *VirtualDisk) error {
 	d.lock()
 	defer d.unlock()
 
+	if !d.Attached() {
+		log.Infof("Disk %s is already detached", d.DevicePath)
+		return nil
+	}
+
 	if err := d.canBeDetached(); err != nil {
 		return errors.Trace(err)
 	}


### PR DESCRIPTION
Fixes #933 

This change writes the image to a temporary directory, compares the
computed checksum with the expected checksum, and moves the disk to the
image store if they match.  Otherwise the temporary directory is
removed.  Subsequent pulls should complete without an issue.