### PR TITLE
Implement docker log in personality and portlayer rest

### DIFF
--- a/lib/apiservers/engine/backends/container.go
+++ b/lib/apiservers/engine/backends/container.go
@@ -36,14 +36,14 @@ import (
 	"github.com/docker/docker/api/types/backend"
 	derr "github.com/docker/docker/errors"
 	"github.com/docker/docker/pkg/archive"
+	"github.com/docker/docker/pkg/ioutils"
 	"github.com/docker/docker/pkg/namesgenerator"
 	"github.com/docker/docker/pkg/stdcopy"
-	"github.com/docker/docker/pkg/stringid"
 	"github.com/docker/docker/pkg/version"
 	"github.com/docker/engine-api/types"
 	"github.com/docker/engine-api/types/container"
 	containertypes "github.com/docker/engine-api/types/container"
-	dnetwork "github.com/docker/engine-api/types/network"
+	timetypes "github.com/docker/engine-api/types/time"
 	"github.com/docker/go-connections/nat"
 
 	"github.com/vishvananda/netlink"
@@ -115,7 +115,7 @@ const (
 
 func NewContainerBackend() *Container {
 	return &Container{
-		containerProxy: portlayer.NewContainerProxy(PortLayerClient()),
+		containerProxy: portlayer.NewContainerProxy(PortLayerClient(), PortLayerServer(), PortLayerName()),
 	}
 }
 
@@ -817,7 +817,7 @@ func (c *Container) ContainerInspect(name string, size bool, version version.Ver
 		}
 	}
 
-	inspectJSON, err := containerInfoToDockerContainerInspect(vc, results.Payload)
+	inspectJSON, err := portlayer.ContainerInfoToDockerContainerInspect(vc, results.Payload, PortLayerName())
 	if err != nil {
 		log.Errorf("containerInfoToDockerContainerInspect failed with %s", err)
 		return nil, err
@@ -836,7 +836,40 @@ func (c *Container) ContainerInspect(name string, size bool, version version.Ver
 // ContainerLogs hooks up a container's stdout and stderr streams
 // configured with the given struct.
 func (c *Container) ContainerLogs(name string, config *backend.ContainerLogsConfig, started chan struct{}) error {
-	return fmt.Errorf("%s does not implement container.ContainerLogs", ProductName())
+	//FIXME:  Doug, remove following 3 lines once integration is added
+	if true {
+		return fmt.Errorf("%s does not implement container.ContainerLogs", ProductName())
+	}
+	defer trace.End(trace.Begin(""))
+
+	// Look up the container name in the metadata cache to get long ID
+	vc := cache.ContainerCache().GetContainer(name)
+	if vc == nil {
+		return derr.NewRequestNotFoundError(fmt.Errorf("No such container: %s", name))
+	}
+	name = vc.ContainerID
+
+	tailLines, since, err := c.validateContainerLogsConfig(vc, config)
+	if err != nil {
+		return err
+	}
+
+	// Outstream modification (from Docker's code) so the stream is streamed with the
+	// necessary headers that the CLI expects.  This is Docker's scheme.
+	wf := ioutils.NewWriteFlusher(config.OutStream)
+	defer wf.Close()
+	close(started)
+	wf.Flush()
+
+	var outStream io.Writer = wf
+	if !vc.Config.Tty {
+		outStream = stdcopy.NewStdWriter(outStream, stdcopy.Stdout)
+	}
+
+	// Make a call to our proxy to handle the remoting
+	err = c.containerProxy.StreamContainerLogs(name, outStream, started, config.Timestamps, config.Follow, since, tailLines)
+
+	return err
 }
 
 // ContainerStats writes information about the container to the stream
@@ -932,347 +965,6 @@ func (c *Container) ContainerAttach(name string, ca *backend.ContainerAttachConf
 	err = attachStreams(context.Background(), vc, clStdin, clStdout, clStderr, ca)
 
 	return err
-}
-
-//-------------------------------------
-// ContainerInspect() Utility Functions
-//-------------------------------------
-
-// containerInfoToDockerContainerInspect() takes a ContainerInfo swagger-based struct
-// returned from VIC's port layer and creates an engine-api based container inspect struct.
-// There maybe other asset gathering if ContainerInfo does not have all the information
-func containerInfoToDockerContainerInspect(vc *viccontainer.VicContainer, info *models.ContainerInfo) (*types.ContainerJSON, error) {
-	if vc == nil || info == nil || info.ContainerConfig == nil {
-		return nil, derr.NewRequestNotFoundError(fmt.Errorf("No such container: %s", vc.ContainerID))
-	}
-
-	// Set default container state attributes
-	containerState := &types.ContainerState{}
-
-	if info.ProcessConfig != nil {
-		if info.ProcessConfig.Pid != nil {
-			containerState.Pid = int(*info.ProcessConfig.Pid)
-		}
-		if info.ProcessConfig.ExitCode != nil {
-			containerState.ExitCode = int(*info.ProcessConfig.ExitCode)
-		}
-		if info.ProcessConfig.ErrorMsg != nil {
-			containerState.Error = *info.ProcessConfig.ErrorMsg
-		}
-		if info.ProcessConfig.Started != nil {
-			swaggerTime := time.Time(*info.ProcessConfig.Started)
-			containerState.StartedAt = swaggerTime.Format(time.RFC3339Nano)
-		}
-
-		if info.ProcessConfig.Finished != nil {
-			swaggerTime := time.Time(*info.ProcessConfig.Finished)
-			containerState.FinishedAt = swaggerTime.Format(time.RFC3339Nano)
-		}
-	}
-
-	inspectJSON := &types.ContainerJSON{
-		ContainerJSONBase: &types.ContainerJSONBase{
-			State:           containerState,
-			ResolvConfPath:  "",
-			HostnamePath:    "",
-			HostsPath:       "",
-			Driver:          PortLayerName(),
-			MountLabel:      "",
-			ProcessLabel:    "",
-			AppArmorProfile: "",
-			ExecIDs:         nil,
-			HostConfig:      hostConfigFromContainerInfo(vc, info),
-			GraphDriver:     types.GraphDriverData{Name: PortLayerName()},
-			SizeRw:          nil,
-			SizeRootFs:      nil,
-		},
-		Mounts:          mountsFromContainerInfo(vc, info),
-		Config:          containerConfigFromContainerInfo(vc, info),
-		NetworkSettings: networkFromContainerInfo(vc, info),
-	}
-
-	if inspectJSON.NetworkSettings != nil {
-		log.Debugf("Docker inspect - network settings = %#v", inspectJSON.NetworkSettings)
-	} else {
-		log.Debug("Docker inspect - network settings = nil")
-	}
-
-	if info.ProcessConfig != nil {
-		if info.ProcessConfig.ExecPath != nil {
-			inspectJSON.Path = *info.ProcessConfig.ExecPath
-		}
-		if info.ProcessConfig.ExecArgs != nil {
-			// args[0] is the command and should not appear in the args list here
-			inspectJSON.Args = info.ProcessConfig.ExecArgs[1:]
-		}
-	}
-
-	if info.ContainerConfig != nil {
-		if info.ContainerConfig.State != nil {
-			containerState.Status = strings.ToLower(*info.ContainerConfig.State)
-
-			// https://github.com/docker/docker/blob/master/container/state.go#L77
-			if containerState.Status == "stopped" {
-				containerState.Status = "exited"
-			}
-			if containerState.Status == "running" {
-				containerState.Running = true
-			}
-		}
-		if info.ContainerConfig.LayerID != nil {
-			inspectJSON.Image = *info.ContainerConfig.LayerID
-		}
-		if info.ContainerConfig.LogPath != nil {
-			inspectJSON.LogPath = *info.ContainerConfig.LogPath
-		}
-		if info.ContainerConfig.RestartCount != nil {
-			inspectJSON.RestartCount = int(*info.ContainerConfig.RestartCount)
-		}
-		if info.ContainerConfig.ContainerID != nil {
-			inspectJSON.ID = *info.ContainerConfig.ContainerID
-		}
-		if info.ContainerConfig.Created != nil {
-			inspectJSON.Created = time.Unix(*info.ContainerConfig.Created, 0).String()
-		}
-		if len(info.ContainerConfig.Names) > 0 {
-			inspectJSON.Name = info.ContainerConfig.Names[0]
-		}
-	}
-
-	return inspectJSON, nil
-}
-
-// hostConfigFromContainerInfo() gets the hostconfig that is passed to the backend during
-// docker create and updates any needed info
-func hostConfigFromContainerInfo(vc *viccontainer.VicContainer, info *models.ContainerInfo) *container.HostConfig {
-	if vc == nil || vc.HostConfig == nil || info == nil {
-		return nil
-	}
-
-	// Create a copy of the created container's hostconfig.  This is passed in during
-	// container create
-	hostConfig := *vc.HostConfig
-
-	// Resources don't really map well to VIC so we leave most of them empty. If we look
-	// at the struct in engine-api/types/container/host_config.go, Microsoft added
-	// additional attributes to the struct that are applicable to Windows containers.
-	// If understanding VIC's host resources are desireable, we should go down this
-	// same route.
-	//
-	// The values we fill out below is an abridged list of the original struct.
-	resourceConfig := container.Resources{
-	// Applicable to all platforms
-	//			CPUShares int64 `json:"CpuShares"` // CPU shares (relative weight vs. other containers)
-	//			Memory    int64 // Memory limit (in bytes)
-
-	//			// Applicable to UNIX platforms
-	//			DiskQuota            int64           // Disk limit (in bytes)
-	}
-
-	hostConfig.VolumeDriver = PortLayerName()
-	hostConfig.Resources = resourceConfig
-
-	if len(info.ScopeConfig) > 0 {
-		if info.ScopeConfig[0].DNS != nil {
-			hostConfig.DNS = info.ScopeConfig[0].DNS
-		}
-
-		hostConfig.NetworkMode = container.NetworkMode(info.ScopeConfig[0].ScopeType)
-	}
-
-	return &hostConfig
-}
-
-// mountsFromContainerInfo()
-func mountsFromContainerInfo(vc *viccontainer.VicContainer, info *models.ContainerInfo) []types.MountPoint {
-	if vc == nil || info == nil {
-		return nil
-	}
-
-	var mounts []types.MountPoint
-
-	for _, vConfig := range info.VolumeConfig {
-		// Fill with defaults
-		mountConfig := types.MountPoint{
-			Destination: "",
-			Driver:      PortLayerName(),
-			Mode:        "",
-			Propagation: "",
-		}
-
-		// Fill with info from portlayer
-		if vConfig.MountPoint != nil {
-			mountConfig.Name = *vConfig.MountPoint
-		}
-		if vConfig.MountPoint != nil {
-			mountConfig.Source = *vConfig.MountPoint
-		}
-		if vConfig.ReadWrite != nil {
-			mountConfig.RW = *vConfig.ReadWrite
-		}
-
-		mounts = append(mounts, mountConfig)
-	}
-
-	return mounts
-}
-
-// containerConfigFromContainerInfo() returns a container.Config that has attributes
-// overridden at create or start time.  This is important.  This function is called
-// to help build the Container Inspect struct.  That struct contains the original
-// container config that is part of the image metadata AND the overriden container
-// config.  The user can override these via the remote API or the docker CLI.
-func containerConfigFromContainerInfo(vc *viccontainer.VicContainer, info *models.ContainerInfo) *container.Config {
-	if vc == nil || vc.Config == nil || info == nil || info.ContainerConfig == nil || info.ProcessConfig == nil {
-		return nil
-	}
-
-	// Copy the working copy of our container's config
-	container := *vc.Config
-
-	if info.ContainerConfig.ContainerID != nil {
-		container.Hostname = stringid.TruncateID(*info.ContainerConfig.ContainerID) // Hostname
-	}
-	if info.ContainerConfig.AttachStdin != nil {
-		container.AttachStdin = *info.ContainerConfig.AttachStdin // Attach the standard input, makes possible user interaction
-	}
-	if info.ContainerConfig.AttachStdout != nil {
-		container.AttachStdout = *info.ContainerConfig.AttachStdout // Attach the standard output
-	}
-	if info.ContainerConfig.AttachStderr != nil {
-		container.AttachStderr = *info.ContainerConfig.AttachStderr // Attach the standard error
-	}
-	if info.ContainerConfig.Tty != nil {
-		container.Tty = *info.ContainerConfig.Tty // Attach standard streams to a tty, including stdin if it is not closed.
-	}
-	// They are not coming from PL so set them to true unconditionally
-	container.OpenStdin = true // Open stdin
-	container.StdinOnce = true
-
-	if info.ContainerConfig.LayerID != nil {
-		container.Image = *info.ContainerConfig.LayerID // Name of the image as it was passed by the operator (eg. could be symbolic)
-	}
-	if info.ContainerConfig.Labels != nil {
-		container.Labels = info.ContainerConfig.Labels // List of labels set to this container
-	}
-
-	// Fill in information about the process
-	if info.ProcessConfig.Env != nil {
-		container.Env = info.ProcessConfig.Env // List of environment variable to set in the container
-	}
-	if info.ProcessConfig.ExecPath != nil {
-		container.Cmd = append(container.Cmd, *info.ProcessConfig.ExecPath) // Command to run when starting the container
-	}
-	if info.ProcessConfig.ExecArgs != nil {
-		container.Cmd = append(container.Cmd, info.ProcessConfig.ExecArgs[1:]...)
-	}
-	if info.ProcessConfig.WorkingDir != nil {
-		container.WorkingDir = *info.ProcessConfig.WorkingDir // Current directory (PWD) in the command will be launched
-	}
-
-	// Fill in information about the container network
-	if info.ScopeConfig == nil {
-		container.NetworkDisabled = true
-	} else {
-		container.NetworkDisabled = false
-		container.MacAddress = ""
-		container.ExposedPorts = vc.Config.ExposedPorts
-		container.PublishService = "" // Name of the network service exposed by the container
-	}
-
-	// Get the original container config from the image's metadata in our image cache.
-	var imageConfig *metadata.ImageConfig
-
-	if info.ContainerConfig.LayerID != nil {
-		imageConfig, _ = cache.ImageCache().GetImage(*info.ContainerConfig.LayerID)
-	}
-
-	// Fill in the values with defaults from the original image's container config
-	// structure
-	if imageConfig != nil {
-		container.StopSignal = imageConfig.ContainerConfig.StopSignal // Signal to stop a container
-
-		container.OnBuild = imageConfig.ContainerConfig.OnBuild // ONBUILD metadata that were defined on the image Dockerfile
-
-		// Fill in information about the container's volumes
-		// FIXME:  Why does types.ContainerJSON have Mounts and also ContainerConfig,
-		// which also has Volumes?  Assuming this is a copy from image's container
-		// config till we figure this out.
-		container.Volumes = imageConfig.ContainerConfig.Volumes
-	}
-
-	return &container
-}
-
-func networkFromContainerInfo(vc *viccontainer.VicContainer, info *models.ContainerInfo) *types.NetworkSettings {
-	networks := &types.NetworkSettings{
-		NetworkSettingsBase: types.NetworkSettingsBase{
-			Bridge:                 "",
-			SandboxID:              "",
-			HairpinMode:            false,
-			LinkLocalIPv6Address:   "",
-			LinkLocalIPv6PrefixLen: 0,
-			Ports:                  portMapFromVicContainer(vc),
-			SandboxKey:             "",
-			SecondaryIPAddresses:   nil,
-			SecondaryIPv6Addresses: nil,
-		},
-		Networks: make(map[string]*dnetwork.EndpointSettings),
-	}
-
-	return networks
-}
-
-// portMapFromVicContainer() constructs a docker portmap from both the container's
-// hostconfig and config (both stored in VicContainer).  They are added and modified
-// during docker create.  This function creates a new map that is adhere's to docker's
-// structure for types.NetworkSettings.Ports.
-func portMapFromVicContainer(vc *viccontainer.VicContainer) nat.PortMap {
-	var portMap nat.PortMap
-
-	if vc == nil {
-		return portMap
-	}
-
-	portMap = make(nat.PortMap)
-
-	// Iterate over the hostconfig that was set in docker create.  Get non-nil
-	// bindings and fix up ip addr and add to networks
-	if vc.HostConfig != nil && vc.HostConfig.PortBindings != nil {
-		//		networks.Ports = vc.HostConfig.PortBindings
-		for port, portbindings := range vc.HostConfig.PortBindings {
-
-			var newbindings []nat.PortBinding
-
-			for _, binding := range portbindings {
-				nb := binding
-
-				// Check host IP.  VIC only support 0.0.0.0
-				if nb.HostIP == "" {
-					nb.HostIP = "0.0.0.0"
-				}
-
-				newbindings = append(newbindings, nb)
-			}
-
-			portMap[port] = newbindings
-		}
-	}
-
-	// Iterate over the container's original image config.  This is the set of
-	// exposed ports.  For ports that were not in hostConfig, we assign value of
-	// nil.  This appears to be the behavior of regular docker.
-	if vc.Config != nil {
-		for port := range vc.Config.ExposedPorts {
-			if _, ok := portMap[port]; ok {
-				continue
-			}
-
-			portMap[port] = nil
-		}
-	}
-
-	return portMap
 }
 
 //------------------------------------
@@ -1698,4 +1390,41 @@ func ContainerSignal(containerID string, sig uint64) error {
 	}
 
 	return nil
+}
+
+//----------------------------------
+// ContainerLogs() utility functions
+//----------------------------------
+
+// validateContainerLogsConfig() validates and extracts options for logging from the
+// backend.ContainerLogsConfig object we're given.
+//
+// returns:
+//	tail lines, since (in unix time), error
+func (c *Container) validateContainerLogsConfig(vc *viccontainer.VicContainer, config *backend.ContainerLogsConfig) (int64, int64, error) {
+	if !(config.ShowStdout || config.ShowStderr) {
+		return 0, 0, fmt.Errorf("You must choose at least one stream")
+	}
+
+	// Validate tail lines and since params for future purposes, but VIC
+	// does not yet support them.
+	tailLines, err := strconv.ParseInt(config.Tail, 10, 64)
+	if err != nil {
+		tailLines = -1
+	}
+
+	var since time.Time
+	if config.Since != "" {
+		s, n, err := timetypes.ParseTimestamps(config.Since, 0)
+		if err != nil {
+			return 0, 0, err
+		}
+		since = time.Unix(s, n)
+	}
+
+	if config.Timestamps || config.Since != "" {
+		return 0, 0, fmt.Errorf("%s does not yet support timestampped logs.", ProductName())
+	}
+
+	return tailLines, since.Unix(), nil
 }

--- a/lib/apiservers/engine/backends/portlayer/container_proxy.go
+++ b/lib/apiservers/engine/backends/portlayer/container_proxy.go
@@ -33,22 +33,35 @@ package portlayer
 
 import (
 	"fmt"
+	"io"
 	"net/http"
 	"strings"
+	"time"
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/google/uuid"
+	"github.com/mreiferson/go-httpclient"
+
+	"github.com/go-swagger/go-swagger/httpkit"
+	httptransport "github.com/go-swagger/go-swagger/httpkit/client"
 
 	derr "github.com/docker/docker/errors"
+	"github.com/docker/docker/pkg/stringid"
 	"github.com/docker/engine-api/types"
+	"github.com/docker/engine-api/types/container"
+	dnetwork "github.com/docker/engine-api/types/network"
 	"github.com/docker/engine-api/types/strslice"
+	"github.com/docker/go-connections/nat"
 
+	"github.com/vmware/vic/lib/apiservers/engine/backends/cache"
+	viccontainer "github.com/vmware/vic/lib/apiservers/engine/backends/container"
 	"github.com/vmware/vic/lib/apiservers/engine/backends/endpoint"
 	"github.com/vmware/vic/lib/apiservers/portlayer/client"
 	"github.com/vmware/vic/lib/apiservers/portlayer/client/containers"
 	"github.com/vmware/vic/lib/apiservers/portlayer/client/scopes"
 	"github.com/vmware/vic/lib/apiservers/portlayer/client/storage"
 	"github.com/vmware/vic/lib/apiservers/portlayer/models"
+	"github.com/vmware/vic/lib/metadata"
 	"github.com/vmware/vic/pkg/trace"
 	"github.com/vmware/vic/pkg/vsphere/sys"
 )
@@ -58,10 +71,14 @@ type VicContainerProxy interface {
 	AddContainerToScope(handle string, config types.ContainerCreateConfig) (string, error)
 	AddVolumesToContainer(handle string, config types.ContainerCreateConfig) (string, error)
 	CommitContainerHandle(handle, imageID string) error
+	StreamContainerLogs(name string, out io.Writer, started chan struct{}, showTimestamps bool, followLogs bool, since int64, tailLines int64) error
+	ContainerRunning(vc *viccontainer.VicContainer) (bool, error)
 }
 
 type ContainerProxy struct {
-	client *client.PortLayer
+	client        *client.PortLayer
+	portlayerAddr string
+	portlayerName string
 }
 
 type volumeFields struct {
@@ -70,8 +87,18 @@ type volumeFields struct {
 	Flags string
 }
 
-func NewContainerProxy(plClient *client.PortLayer) *ContainerProxy {
-	return &ContainerProxy{client: plClient}
+const (
+	attachConnectTimeout   time.Duration = 15 * time.Second //timeout for the connection
+	attachAttemptTimeout   time.Duration = 40 * time.Second //timeout before we ditch an attach attempt
+	attachPLAttemptDiff    time.Duration = 10 * time.Second
+	attachPLAttemptTimeout time.Duration = attachAttemptTimeout - attachPLAttemptDiff //timeout for the portlayer before ditching an attempt
+	attachRequestTimeout   time.Duration = 2 * time.Hour                              //timeout to hold onto the attach connection
+	swaggerSubstringEOF                  = "EOF"
+	forceLogType                         = "json-file"	//Use in inspect to allow docker logs to work
+)
+
+func NewContainerProxy(plClient *client.PortLayer, portlayerAddr string, portlayerName string) *ContainerProxy {
+	return &ContainerProxy{client: plClient, portlayerAddr: portlayerAddr, portlayerName: portlayerName}
 }
 
 // containerCreateHandle() creates a new VIC container by calling the portlayer
@@ -246,6 +273,91 @@ func (c *ContainerProxy) CommitContainerHandle(handle, imageID string) error {
 	}
 
 	return nil
+}
+
+// StreamContainerlogs() reads the log stream from the portlayer rest server and writes
+// it directly to the io.Writer that is passed in.
+func (c *ContainerProxy) StreamContainerLogs(name string, out io.Writer, started chan struct{}, showTimestamps bool, followLogs bool, since int64, tailLines int64) error {
+	defer trace.End(trace.Begin(""))
+
+	plClient, transport := c.createNewAttachClientWithTimeouts(attachConnectTimeout, 0, attachAttemptTimeout)
+	defer transport.Close()
+	close(started)
+
+	params := containers.NewGetContainerLogsParams().
+		WithID(name).
+		WithFollow(&followLogs).
+		WithTimestamp(&showTimestamps).
+		WithSince(&since).
+		WithTaillines(&tailLines)
+	_, err := plClient.Containers.GetContainerLogs(params, out)
+	if err != nil {
+		switch err := err.(type) {
+		case *containers.GetContainerLogsNotFound:
+			return derr.NewRequestNotFoundError(fmt.Errorf("No such container: %s", name))
+
+		case *containers.GetContainerLogsInternalServerError:
+			return derr.NewErrorWithStatusCode(fmt.Errorf("Server error from the interaction port layer"),
+				http.StatusInternalServerError)
+
+		default:
+			//Check for EOF.  Since the connection, transport, and data handling are
+			//encapsulated inisde of Swagger, we can only detect EOF by checking the
+			//error string
+			if strings.Contains(err.Error(), swaggerSubstringEOF) {
+				return nil
+			}
+			unknownErrMsg := fmt.Errorf("Unknown error from the interaction port layer: %s", err)
+			return derr.NewErrorWithStatusCode(unknownErrMsg, http.StatusInternalServerError)
+		}
+	}
+
+	return nil
+}
+
+func (c *ContainerProxy) ContainerRunning(vc *viccontainer.VicContainer) (bool, error) {
+	defer trace.End(trace.Begin(""))
+
+	if c.client == nil {
+		return false, derr.NewErrorWithStatusCode(fmt.Errorf("ContainerProxy.CommitContainerHandle failed to create a portlayer client"),
+			http.StatusInternalServerError)
+	}
+
+	results, err := c.client.Containers.GetContainerInfo(containers.NewGetContainerInfoParams().WithID(vc.ContainerID))
+	if err != nil {
+		switch err := err.(type) {
+		case *containers.GetContainerInfoNotFound:
+			return false, derr.NewRequestNotFoundError(fmt.Errorf("No such container: %s", vc.ContainerID))
+		case *containers.GetContainerInfoInternalServerError:
+			return false, derr.NewErrorWithStatusCode(fmt.Errorf("Error from portlayer: %#v", err.Payload), http.StatusInternalServerError)
+		default:
+			return false, derr.NewErrorWithStatusCode(fmt.Errorf("Unknown error from the container portlayer"), http.StatusInternalServerError)
+		}
+	}
+
+	inspectJSON, err := ContainerInfoToDockerContainerInspect(vc, results.Payload, c.portlayerName)
+	if err != nil {
+		log.Errorf("containerInfoToDockerContainerInspect failed with %s", err)
+		return false, err
+	}
+
+	return inspectJSON.State.Running, nil
+}
+
+func (c *ContainerProxy) createNewAttachClientWithTimeouts(connectTimeout, responseTimeout, responseHeaderTimeout time.Duration) (*client.PortLayer, *httpclient.Transport) {
+	runtime := httptransport.New(c.portlayerAddr, "/", []string{"http"})
+	transport := &httpclient.Transport{
+		ConnectTimeout:        connectTimeout,
+		ResponseHeaderTimeout: responseHeaderTimeout,
+		RequestTimeout:        responseTimeout,
+	}
+	runtime.Transport = transport
+
+	plClient := client.New(runtime, nil)
+	runtime.Consumers["application/octet-stream"] = httpkit.ByteStreamConsumer()
+	runtime.Producers["application/octet-stream"] = httpkit.ByteStreamProducer()
+
+	return plClient, transport
 }
 
 //----------
@@ -424,4 +536,348 @@ func processSpecifiedVolumes(volumes []string) ([]volumeFields, error) {
 		volumeFields = append(volumeFields, fields)
 	}
 	return volumeFields, nil
+}
+
+//-------------------------------------
+// Inspect Utility Functions
+//-------------------------------------
+
+// ContainerInfoToDockerContainerInspect() takes a ContainerInfo swagger-based struct
+// returned from VIC's port layer and creates an engine-api based container inspect struct.
+// There maybe other asset gathering if ContainerInfo does not have all the information
+func ContainerInfoToDockerContainerInspect(vc *viccontainer.VicContainer, info *models.ContainerInfo, portlayerName string) (*types.ContainerJSON, error) {
+	if vc == nil || info == nil || info.ContainerConfig == nil {
+		return nil, derr.NewRequestNotFoundError(fmt.Errorf("No such container: %s", vc.ContainerID))
+	}
+
+	// Set default container state attributes
+	containerState := &types.ContainerState{}
+
+	if info.ProcessConfig != nil {
+		if info.ProcessConfig.Pid != nil {
+			containerState.Pid = int(*info.ProcessConfig.Pid)
+		}
+		if info.ProcessConfig.ExitCode != nil {
+			containerState.ExitCode = int(*info.ProcessConfig.ExitCode)
+		}
+		if info.ProcessConfig.ErrorMsg != nil {
+			containerState.Error = *info.ProcessConfig.ErrorMsg
+		}
+		if info.ProcessConfig.Started != nil {
+			swaggerTime := time.Time(*info.ProcessConfig.Started)
+			containerState.StartedAt = swaggerTime.Format(time.RFC3339Nano)
+		}
+
+		if info.ProcessConfig.Finished != nil {
+			swaggerTime := time.Time(*info.ProcessConfig.Finished)
+			containerState.FinishedAt = swaggerTime.Format(time.RFC3339Nano)
+		}
+	}
+
+	inspectJSON := &types.ContainerJSON{
+		ContainerJSONBase: &types.ContainerJSONBase{
+			State:           containerState,
+			ResolvConfPath:  "",
+			HostnamePath:    "",
+			HostsPath:       "",
+			Driver:          portlayerName,
+			MountLabel:      "",
+			ProcessLabel:    "",
+			AppArmorProfile: "",
+			ExecIDs:         nil,
+			HostConfig:      hostConfigFromContainerInfo(vc, info, portlayerName),
+			GraphDriver:     types.GraphDriverData{Name: portlayerName},
+			SizeRw:          nil,
+			SizeRootFs:      nil,
+		},
+		Mounts:          mountsFromContainerInfo(vc, info, portlayerName),
+		Config:          containerConfigFromContainerInfo(vc, info),
+		NetworkSettings: networkFromContainerInfo(vc, info),
+	}
+
+	if inspectJSON.NetworkSettings != nil {
+		log.Debugf("Docker inspect - network settings = %#v", inspectJSON.NetworkSettings)
+	} else {
+		log.Debug("Docker inspect - network settings = nil")
+	}
+
+	if info.ProcessConfig != nil {
+		if info.ProcessConfig.ExecPath != nil {
+			inspectJSON.Path = *info.ProcessConfig.ExecPath
+		}
+		if info.ProcessConfig.ExecArgs != nil {
+			// args[0] is the command and should not appear in the args list here
+			inspectJSON.Args = info.ProcessConfig.ExecArgs[1:]
+		}
+	}
+
+	if info.ContainerConfig != nil {
+		if info.ContainerConfig.State != nil {
+			containerState.Status = strings.ToLower(*info.ContainerConfig.State)
+
+			// https://github.com/docker/docker/blob/master/container/state.go#L77
+			if containerState.Status == "stopped" {
+				containerState.Status = "exited"
+			}
+			if containerState.Status == "running" {
+				containerState.Running = true
+			}
+		}
+		if info.ContainerConfig.LayerID != nil {
+			inspectJSON.Image = *info.ContainerConfig.LayerID
+		}
+		if info.ContainerConfig.LogPath != nil {
+			inspectJSON.LogPath = *info.ContainerConfig.LogPath
+		}
+		if info.ContainerConfig.RestartCount != nil {
+			inspectJSON.RestartCount = int(*info.ContainerConfig.RestartCount)
+		}
+		if info.ContainerConfig.ContainerID != nil {
+			inspectJSON.ID = *info.ContainerConfig.ContainerID
+		}
+		if info.ContainerConfig.Created != nil {
+			inspectJSON.Created = time.Unix(*info.ContainerConfig.Created, 0).String()
+		}
+		if len(info.ContainerConfig.Names) > 0 {
+			inspectJSON.Name = info.ContainerConfig.Names[0]
+		}
+	}
+
+	return inspectJSON, nil
+}
+
+// hostConfigFromContainerInfo() gets the hostconfig that is passed to the backend during
+// docker create and updates any needed info
+func hostConfigFromContainerInfo(vc *viccontainer.VicContainer, info *models.ContainerInfo, portlayerName string) *container.HostConfig {
+	if vc == nil || vc.HostConfig == nil || info == nil {
+		return nil
+	}
+
+	// Create a copy of the created container's hostconfig.  This is passed in during
+	// container create
+	hostConfig := *vc.HostConfig
+
+	// Resources don't really map well to VIC so we leave most of them empty. If we look
+	// at the struct in engine-api/types/container/host_config.go, Microsoft added
+	// additional attributes to the struct that are applicable to Windows containers.
+	// If understanding VIC's host resources are desireable, we should go down this
+	// same route.
+	//
+	// The values we fill out below is an abridged list of the original struct.
+	resourceConfig := container.Resources{
+	// Applicable to all platforms
+	//			CPUShares int64 `json:"CpuShares"` // CPU shares (relative weight vs. other containers)
+	//			Memory    int64 // Memory limit (in bytes)
+
+	//			// Applicable to UNIX platforms
+	//			DiskQuota            int64           // Disk limit (in bytes)
+	}
+
+	hostConfig.VolumeDriver = portlayerName
+	hostConfig.Resources = resourceConfig
+
+	if len(info.ScopeConfig) > 0 {
+		if info.ScopeConfig[0].DNS != nil {
+			hostConfig.DNS = info.ScopeConfig[0].DNS
+		}
+
+		hostConfig.NetworkMode = container.NetworkMode(info.ScopeConfig[0].ScopeType)
+	}
+
+	// Set this to json-file to force the docker CLI to allow us to use docker logs
+	hostConfig.LogConfig.Type = forceLogType
+
+	return &hostConfig
+}
+
+// mountsFromContainerInfo()
+func mountsFromContainerInfo(vc *viccontainer.VicContainer, info *models.ContainerInfo, portlayerName string) []types.MountPoint {
+	if vc == nil || info == nil {
+		return nil
+	}
+
+	var mounts []types.MountPoint
+
+	for _, vConfig := range info.VolumeConfig {
+		// Fill with defaults
+		mountConfig := types.MountPoint{
+			Destination: "",
+			Driver:      portlayerName,
+			Mode:        "",
+			Propagation: "",
+		}
+
+		// Fill with info from portlayer
+		if vConfig.MountPoint != nil {
+			mountConfig.Name = *vConfig.MountPoint
+		}
+		if vConfig.MountPoint != nil {
+			mountConfig.Source = *vConfig.MountPoint
+		}
+		if vConfig.ReadWrite != nil {
+			mountConfig.RW = *vConfig.ReadWrite
+		}
+
+		mounts = append(mounts, mountConfig)
+	}
+
+	return mounts
+}
+
+// containerConfigFromContainerInfo() returns a container.Config that has attributes
+// overridden at create or start time.  This is important.  This function is called
+// to help build the Container Inspect struct.  That struct contains the original
+// container config that is part of the image metadata AND the overriden container
+// config.  The user can override these via the remote API or the docker CLI.
+func containerConfigFromContainerInfo(vc *viccontainer.VicContainer, info *models.ContainerInfo) *container.Config {
+	if vc == nil || vc.Config == nil || info == nil || info.ContainerConfig == nil || info.ProcessConfig == nil {
+		return nil
+	}
+
+	// Copy the working copy of our container's config
+	container := *vc.Config
+
+	if info.ContainerConfig.ContainerID != nil {
+		container.Hostname = stringid.TruncateID(*info.ContainerConfig.ContainerID) // Hostname
+	}
+	if info.ContainerConfig.AttachStdin != nil {
+		container.AttachStdin = *info.ContainerConfig.AttachStdin // Attach the standard input, makes possible user interaction
+	}
+	if info.ContainerConfig.AttachStdout != nil {
+		container.AttachStdout = *info.ContainerConfig.AttachStdout // Attach the standard output
+	}
+	if info.ContainerConfig.AttachStderr != nil {
+		container.AttachStderr = *info.ContainerConfig.AttachStderr // Attach the standard error
+	}
+	if info.ContainerConfig.Tty != nil {
+		container.Tty = *info.ContainerConfig.Tty // Attach standard streams to a tty, including stdin if it is not closed.
+	}
+	// They are not coming from PL so set them to true unconditionally
+	container.OpenStdin = true // Open stdin
+	container.StdinOnce = true
+
+	if info.ContainerConfig.LayerID != nil {
+		container.Image = *info.ContainerConfig.LayerID // Name of the image as it was passed by the operator (eg. could be symbolic)
+	}
+	if info.ContainerConfig.Labels != nil {
+		container.Labels = info.ContainerConfig.Labels // List of labels set to this container
+	}
+
+	// Fill in information about the process
+	if info.ProcessConfig.Env != nil {
+		container.Env = info.ProcessConfig.Env // List of environment variable to set in the container
+	}
+	if info.ProcessConfig.ExecPath != nil {
+		container.Cmd = append(container.Cmd, *info.ProcessConfig.ExecPath) // Command to run when starting the container
+	}
+	if info.ProcessConfig.ExecArgs != nil {
+		container.Cmd = append(container.Cmd, info.ProcessConfig.ExecArgs[1:]...)
+	}
+	if info.ProcessConfig.WorkingDir != nil {
+		container.WorkingDir = *info.ProcessConfig.WorkingDir // Current directory (PWD) in the command will be launched
+	}
+
+	// Fill in information about the container network
+	if info.ScopeConfig == nil {
+		container.NetworkDisabled = true
+	} else {
+		container.NetworkDisabled = false
+		container.MacAddress = ""
+		container.ExposedPorts = vc.Config.ExposedPorts
+		container.PublishService = "" // Name of the network service exposed by the container
+	}
+
+	// Get the original container config from the image's metadata in our image cache.
+	var imageConfig *metadata.ImageConfig
+
+	if info.ContainerConfig.LayerID != nil {
+		imageConfig, _ = cache.ImageCache().GetImage(*info.ContainerConfig.LayerID)
+	}
+
+	// Fill in the values with defaults from the original image's container config
+	// structure
+	if imageConfig != nil {
+		container.StopSignal = imageConfig.ContainerConfig.StopSignal // Signal to stop a container
+
+		container.OnBuild = imageConfig.ContainerConfig.OnBuild // ONBUILD metadata that were defined on the image Dockerfile
+
+		// Fill in information about the container's volumes
+		// FIXME:  Why does types.ContainerJSON have Mounts and also ContainerConfig,
+		// which also has Volumes?  Assuming this is a copy from image's container
+		// config till we figure this out.
+		container.Volumes = imageConfig.ContainerConfig.Volumes
+	}
+
+	return &container
+}
+
+func networkFromContainerInfo(vc *viccontainer.VicContainer, info *models.ContainerInfo) *types.NetworkSettings {
+	networks := &types.NetworkSettings{
+		NetworkSettingsBase: types.NetworkSettingsBase{
+			Bridge:                 "",
+			SandboxID:              "",
+			HairpinMode:            false,
+			LinkLocalIPv6Address:   "",
+			LinkLocalIPv6PrefixLen: 0,
+			Ports:                  portMapFromVicContainer(vc),
+			SandboxKey:             "",
+			SecondaryIPAddresses:   nil,
+			SecondaryIPv6Addresses: nil,
+		},
+		Networks: make(map[string]*dnetwork.EndpointSettings),
+	}
+
+	return networks
+}
+
+// portMapFromVicContainer() constructs a docker portmap from both the container's
+// hostconfig and config (both stored in VicContainer).  They are added and modified
+// during docker create.  This function creates a new map that is adhere's to docker's
+// structure for types.NetworkSettings.Ports.
+func portMapFromVicContainer(vc *viccontainer.VicContainer) nat.PortMap {
+	var portMap nat.PortMap
+
+	if vc == nil {
+		return portMap
+	}
+
+	portMap = make(nat.PortMap)
+
+	// Iterate over the hostconfig that was set in docker create.  Get non-nil
+	// bindings and fix up ip addr and add to networks
+	if vc.HostConfig != nil && vc.HostConfig.PortBindings != nil {
+		//		networks.Ports = vc.HostConfig.PortBindings
+		for port, portbindings := range vc.HostConfig.PortBindings {
+
+			var newbindings []nat.PortBinding
+
+			for _, binding := range portbindings {
+				nb := binding
+
+				// Check host IP.  VIC only support 0.0.0.0
+				if nb.HostIP == "" {
+					nb.HostIP = "0.0.0.0"
+				}
+
+				newbindings = append(newbindings, nb)
+			}
+
+			portMap[port] = newbindings
+		}
+	}
+
+	// Iterate over the container's original image config.  This is the set of
+	// exposed ports.  For ports that were not in hostConfig, we assign value of
+	// nil.  This appears to be the behavior of regular docker.
+	if vc.Config != nil {
+		for port := range vc.Config.ExposedPorts {
+			if _, ok := portMap[port]; ok {
+				continue
+			}
+
+			portMap[port] = nil
+		}
+	}
+
+	return portMap
 }

--- a/tests/test-cases/Group1-Docker-Commands/1-8-Docker-Logs.md
+++ b/tests/test-cases/Group1-Docker-Commands/1-8-Docker-Logs.md
@@ -12,25 +12,40 @@ This test requires that a vSphere server is running and available
 
 #Test Steps:
 1. Deploy VIC appliance to vSphere server
-2. Issue docker create busybox dmesg to the VIC appliance
+2. Issue docker create busybox /bin/sh -c 'a=0; while [ $a -lt 5 ]; do echo "line $a"; a=`expr $a + 1`; sleep 1; done;' to the VIC appliance
 3. Issue docker start <containerID> to the VIC appliance
-4. Issue docker logs <containerID> to the VIC appliance
-5. Issue docker logs -t <containerID> to the VIC appliance
-6. Issue docker logs --since="<timeStamp from Step 5>" <containerID> to the VIC appliance
-7. Issue docker logs --tail="3" <containerID> to the VIC appliance
-8. Issue docker create busybox /bin/top to the VIC appliance
-9. Issue docker start <containerID> to the VIC appliance
-10. Issue docker logs -f <containerID> to the VIC appliance
-11. Issue docker logs fakeContainer
+4. Sleep 6 seconds
+5. Issue docker logs <containerID> to the VIC appliance
+6. Issue docker logs --tail=all <containerID> to the VIC appliance
+7. Issue docker logs --tail=2 <containerID> to the VIC appliance
+8. Issue docker logs --tail=0 <containerID> to the VIC appliance
+9. Issue docker create -t busybox /bin/sh -c 'a=0; while [ $a -lt 5 ]; do echo "line $a"; a=`expr $a + 1`; sleep 1; done;' to the VIC appliance
+10. Issue docker start <containerID> to the VIC appliance
+11. Sleep 2 seconds
+12. Issue docker logs --follow <containerID> to the VIC appliance
+13. Issue docker create busybox /bin/sh -c 'a=0; while [ $a -lt 5 ]; do echo "line $a"; a=`expr $a + 1`; sleep 1; done;' to the VIC appliance
+14. Issue docker start <containerID> to the VIC appliance
+15. Sleep 2.5 seconds
+16. Issue docker logs --tail=1 --follow <containerID> to the VIC appliance
+17. Issue docker logs --since=1s <containerID> to the VIC appliance
+18. Issue docker logs --timestamps <containerID> to the VIC appliance
+19. Issue docker logs fakeContainer
 
 #Expected Outcome:
-* Steps 2-10 should all complete without error
-* Step 4 should return the result of the dmesg output
-* Step 5 should return the result of the dmesg output with timestamps on each of the lines
-* Step 6 should return a set of results limited to only messages after that timestamp
-* Step 7 should return only the last 3 lines of output from the dmesg command
-* Step 10 should show the live running output from the top command
-* Step 11 should result in an error with the following message:    
+* Steps 2-16 should all complete without error
+* Step 6 should output 5 lines
+* Step 7 should output 2 lines
+* Step 8 should output 0 lines
+* Step 12 should have last line be
+```
+line 5
+```
+* Step 16 should output 3 lines
+* Step 17 and 18 should result in an error with the following message:
+```
+Error: vSphere Integrated Containers does not yet support timestampped logs.
+```
+* Step 19 should result in an error with the following message:
 ```
 Error: No such container: fakeContainer
 ```

--- a/tests/test-cases/Group1-Docker-Commands/1-8-Docker-Logs.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-8-Docker-Logs.robot
@@ -5,75 +5,80 @@ Suite Setup  Install VIC Appliance To Test Server
 Suite Teardown  Cleanup VIC Appliance On Test Server
 
 *** Test Cases ***
-Basic docker logs
+Docker logs with tail
     ${status}=  Get State Of Github Issue  366
     Run Keyword If  '${status}' == 'closed'  Fail  Test 1-8-Docker-Logs.robot needs to be updated now that Issue #366 has been resolved
     Log  Issue \#366 is blocking implementation  WARN
     #${rc}  ${output}=  Run And Return Rc And Output  docker ${params} pull busybox
     #Should Be Equal As Integers  ${rc}  0
-    #${rc}  ${containerID}=  Run And Return Rc And Output  docker ${params} create busybox dmesg
+    #${rc}  ${containerID}=  Run And Return Rc And Output  docker ${params} create busybox /bin/sh -c 'a=0; while [ $a -lt 5 ]; do echo "line $a"; a=`expr $a + 1`; sleep 1; done;'
     #Should Be Equal As Integers  ${rc}  0
     #${rc}  ${output}=  Run And Return Rc And Output  docker ${params} start ${containerID}
     #Should Be Equal As Integers  ${rc}  0
-    #${rc}  ${output}=  Run And Return Rc And Output  docker ${params} logs ${containerID}
+	#Run  Sleep 6
+    #${rc}  ${output}=  Run And Return Rc And Output  docker ${params} logs --tail=all ${containerID}
+	#${linecount}=  Get Line Count  ${output}
     #Should Be Equal As Integers  ${rc}  0
+	#Should Be Equal As Integers  ${linecount}  5
+    #${rc}  ${output}=  Run And Return Rc And Output  docker ${params} logs --tail=2 ${containerID}
+	#${linecount}=  Get Line Count  ${output}
+    #Should Be Equal As Integers  ${rc}  0
+	#Should Be Equal As Integers  ${linecount}  2
+    #${rc}  ${output}=  Run And Return Rc And Output  docker ${params} logs --tail=0 ${containerID}
+    #Should Be Equal As Integers  ${rc}  0
+	#${linecount}=  Get Line Count  ${output}
+	#Should Be Equal As Integers  ${linecount}  0
     
-Docker logs with timestamps
+Docker logs with follow
     ${status}=  Get State Of Github Issue  366
     Run Keyword If  '${status}' == 'closed'  Fail  Test 1-8-Docker-Logs.robot needs to be updated now that Issue #366 has been resolved
     Log  Issue \#366 is blocking implementation  WARN
     #${rc}  ${output}=  Run And Return Rc And Output  docker ${params} pull busybox
     #Should Be Equal As Integers  ${rc}  0
-    #${rc}  ${containerID}=  Run And Return Rc And Output  docker ${params} create busybox dmesg
+    #${rc}  ${containerID}=  Run And Return Rc And Output  docker ${params} create busybox /bin/sh -c 'a=0; while [ $a -lt 5 ]; do echo "line $a"; a=`expr $a + 1`; sleep 1; done;'
     #Should Be Equal As Integers  ${rc}  0
     #${rc}  ${output}=  Run And Return Rc And Output  docker ${params} start ${containerID}
     #Should Be Equal As Integers  ${rc}  0
-    #${rc}  ${time}=  Run And Return Rc And Output  docker ${params} logs -t ${containerID}
+	#Run  Sleep 2
+    #${rc}  ${output}=  Run And Return Rc And Output  docker ${params} logs --follow ${containerID}
     #Should Be Equal As Integers  ${rc}  0
+	#${linecount}=  Get Line Count  ${output}
+	#${lastline}=  Get Line  ${output}  ${linecount}-1
+	#Should Contain  ${lastline}  line 5
+
+Docker logs with follow and tail
+    ${status}=  Get State Of Github Issue  366
+    Run Keyword If  '${status}' == 'closed'  Fail  Test 1-8-Docker-Logs.robot needs to be updated now that Issue #366 has been resolved
+    Log  Issue \#366 is blocking implementation  WARN
+    #${rc}  ${output}=  Run And Return Rc And Output  docker ${params} pull busybox
+    #Should Be Equal As Integers  ${rc}  0
+    #${rc}  ${containerID}=  Run And Return Rc And Output  docker ${params} create busybox /bin/sh -c 'a=0; while [ $a -lt 5 ]; do echo "line $a"; a=`expr $a + 1`; sleep 1; done;'
+    #Should Be Equal As Integers  ${rc}  0
+    #${rc}  ${output}=  Run And Return Rc And Output  docker ${params} start ${containerID}
+    #Should Be Equal As Integers  ${rc}  0
+	#Run  Sleep 2.5, wait for first 2 lines to output
+	#${rc}  ${output}=  Run and Return Rc And Output  docker ${params} logs --tail=1 --follow ${containerID}
+	#Should Be Equal As Integers  ${rc}  0
+	#${linecount}=  Get Line Count  ${Output}
+	#Should Be Equal As Integers  ${linecount}  3
     
 Docker logs with timestamps and since certain time
     ${status}=  Get State Of Github Issue  366
     Run Keyword If  '${status}' == 'closed'  Fail  Test 1-8-Docker-Logs.robot needs to be updated now that Issue #366 has been resolved
     Log  Issue \#366 is blocking implementation  WARN
-    #${rc}  ${output}=  Run And Return Rc And Output  docker ${params} pull busybox
-    #Should Be Equal As Integers  ${rc}  0
-    #${rc}  ${containerID}=  Run And Return Rc And Output  docker ${params} create busybox dmesg
-    #Should Be Equal As Integers  ${rc}  0
-    #${rc}  ${output}=  Run And Return Rc And Output  docker ${params} start ${containerID}
-    #Should Be Equal As Integers  ${rc}  0
-    #${rc}  ${time}=  Run And Return Rc And Output  docker ${params} logs -t ${containerID}
-    #Should Be Equal As Integers  ${rc}  0
-    #${time}=  Split To Lines  ${time}
-    #${len}=  Get Length  ${time}
-    #${time}=  Fetch From Left  @{time}[${len-5}]  ${SPACE}
-    #${rc}  ${output}=  Run And Return Rc And Output  docker ${params} logs --since=@{time} ${containerID}
-    #Should Be Equal As Integers  ${rc}  0
-    
-Docker logs last three
-    ${status}=  Get State Of Github Issue  366
-    Run Keyword If  '${status}' == 'closed'  Fail  Test 1-8-Docker-Logs.robot needs to be updated now that Issue #366 has been resolved
-    Log  Issue \#366 is blocking implementation  WARN
-    #${rc}  ${output}=  Run And Return Rc And Output  docker ${params} pull busybox
-    #Should Be Equal As Integers  ${rc}  0
-    #${rc}  ${containerID}=  Run And Return Rc And Output  docker ${params} create busybox dmesg
-    #Should Be Equal As Integers  ${rc}  0
-    #${rc}  ${output}=  Run And Return Rc And Output  docker ${params} start ${containerID}
-    #Should Be Equal As Integers  ${rc}  0
-    #${rc}  ${time}=  Run And Return Rc And Output  docker ${params} logs --tail="3" ${containerID}
-    #Should Be Equal As Integers  ${rc}  0
-    
-Docker logs live output
-    ${status}=  Get State Of Github Issue  366
-    Run Keyword If  '${status}' == 'closed'  Fail  Test 1-8-Docker-Logs.robot needs to be updated now that Issue #366 has been resolved
-    Log  Issue \#366 is blocking implementation  WARN
-    #${rc}  ${output}=  Run And Return Rc And Output  docker ${params} pull busybox
-    #Should Be Equal As Integers  ${rc}  0
-    #${rc}  ${containerID}=  Run And Return Rc And Output  docker ${params} create busybox /bin/top
-    #Should Be Equal As Integers  ${rc}  0
-    #${rc}  ${output}=  Run And Return Rc And Output  docker ${params} start ${containerID}
-    #Should Be Equal As Integers  ${rc}  0
-    #${rc}  ${output}=  Run And Return Rc And Output  docker ${params} logs -f ${containerID}
-    #Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} pull busybox
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${containerID}=  Run And Return Rc And Output  docker ${params} create busybox /bin/sh -c 'a=0; while [ $a -lt 5 ]; do echo "line $a"; a=`expr $a + 1`; sleep 1; done;'
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} start ${containerID}
+    Should Be Equal As Integers  ${rc}  0
+	Run  Sleep 6, wait for container to finish
+    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} logs --since=1s ${containerID}
+	Should Be Equal As Integers  ${rc}  1
+    Should Contain  ${output}  does not yet support timestampped logs
+    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} logs --timestamps ${containerID}
+	Should Be Equal As Integers  ${rc}  1
+    Should Contain  ${output}  does not yet support timestampped logs
     
 Docker logs non-existent container
     ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} logs fakeContainer


### PR DESCRIPTION
Implment the streaming support in the docker personality server and portlayer
rest server.  Added some unit testing for container logs.  Also moved some
docker inspect code to container_proxy.go so we can fully mock container logs.
Logs needs to make a container inspect call to check on the container's
running state.  We can't mock that state test without moving some of the
inspect code to container_proxy.go.