### PR TITLE
Add container signal delivery

### DIFF
--- a/lib/apiservers/portlayer/restapi/handlers/containers_handlers.go
+++ b/lib/apiservers/portlayer/restapi/handlers/containers_handlers.go
@@ -280,6 +280,16 @@ func (handler *ContainersHandlersImpl) GetContainerListHandler(params containers
 func (handler *ContainersHandlersImpl) ContainerSignalHandler(params containers.ContainerSignalParams) middleware.Responder {
 	defer trace.End(trace.Begin("Containers.ContainerSignal"))
 
+	h := exec.GetContainer(exec.ParseID(params.ID))
+	if h == nil {
+		return containers.NewContainerSignalNotFound().WithPayload(&models.Error{Message: fmt.Sprintf("container %s not found", params.ID)})
+	}
+
+	err := h.Container.Signal(context.Background(), params.Signal)
+	if err != nil {
+		return containers.NewContainerSignalInternalServerError().WithPayload(&models.Error{Message: err.Error()})
+	}
+
 	return containers.NewContainerSignalOK()
 }
 

--- a/lib/apiservers/portlayer/swagger.yml
+++ b/lib/apiservers/portlayer/swagger.yml
@@ -842,6 +842,14 @@ paths:
           format: int64
           required: true
       responses:
+        '500':
+          description: "Failed to signal container"
+          schema:
+            $ref: "#/definitions/Error"
+        '404':
+          description: "Container not found"
+          schema:
+            $ref: "#/definitions/Error"
         '200':
           description: "OK"
   /containers/{id}/logs:

--- a/lib/portlayer/exec/container.go
+++ b/lib/portlayer/exec/container.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	log "github.com/Sirupsen/logrus"
+	"github.com/vmware/govmomi/guest"
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/vim25/mo"
 	"github.com/vmware/govmomi/vim25/types"
@@ -238,6 +239,37 @@ func (c *Container) stop(ctx context.Context) error {
 
 	// ShutdownGuest does not wait for PowerOff state, so we need to do that ourselves
 	return c.vm.WaitForPowerState(ctx, types.VirtualMachinePowerStatePoweredOff)
+}
+
+func (c *Container) startGuestProgram(ctx context.Context, name string, args string) error {
+	o := guest.NewOperationsManager(c.vm.Client.Client, c.vm.Reference())
+	m, err := o.ProcessManager(ctx)
+	if err != nil {
+		return err
+	}
+
+	spec := types.GuestProgramSpec{
+		ProgramPath: name,
+		Arguments:   args,
+	}
+
+	auth := types.NamePasswordAuthentication{
+		Username: c.ExecConfig.ID,
+	}
+
+	_, err = m.StartProgram(ctx, &auth, &spec)
+
+	return err
+}
+
+func (c *Container) Signal(ctx context.Context, num int64) error {
+	defer trace.End(trace.Begin("Container.Signal"))
+
+	if c.vm == nil {
+		return fmt.Errorf("vm not set")
+	}
+
+	return c.startGuestProgram(ctx, "kill", fmt.Sprintf("%d", num))
 }
 
 type RemovePowerError struct {

--- a/tests/test-cases/Group1-Docker-Commands/1-14-Docker-Kill.md
+++ b/tests/test-cases/Group1-Docker-Commands/1-14-Docker-Kill.md
@@ -12,12 +12,12 @@ This test requires that a vSphere server is running and available
 
 #Test Steps:
 1. Deploy VIC appliance to vSphere server
-2. Issue docker create busybox sleep 30 to the VIC appliance
+2. Issue docker create busybox sleep 300 to the VIC appliance
 3. Issue docker start <containerID> to the VIC appliance
 4. Issue docker kill <containerID> to the VIC appliance
 5. Issue docker start <containerID> to the VIC appliance
-6. Issue docker kill -s 2 <containerID> to the VIC appliance
-7. Issue docker kill -s 9 <containerID> to the VIC appliance
+6. Issue docker kill -s HUP <containerID> to the VIC appliance
+7. Issue docker kill -s TERM <containerID> to the VIC appliance
 8. Issue docker kill fakeContainer to the VIC appliance
 
 #Expected Outcome:
@@ -25,7 +25,7 @@ This test requires that a vSphere server is running and available
 * Step 4 should result in the container stopping immediately
 * Step 6 should result in the container continuing to run
 * Step 7 should result in the container stopping immediately
-* Step 8 should result in an error and the following message:  
+* Step 8 should result in an error and the following message:
 ```
 Failed to kill container (fakeContainer): Error response from daemon: Cannot kill container fakeContainer: No such container: fakeContainer
 ```

--- a/tests/test-cases/Group1-Docker-Commands/1-14-Docker-Kill.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-14-Docker-Kill.robot
@@ -1,0 +1,66 @@
+*** Settings ***
+Documentation  Test 1-14 - Docker Kill
+Resource  ../../resources/Util.robot
+Suite Setup  Install VIC Appliance To Test Server
+Suite Teardown  Cleanup VIC Appliance On Test Server
+
+*** Keywords ***
+Trap Signal Command
+    # Container command runs an infinite loop, trapping and logging the given signal name
+    [Arguments]  ${sig}
+    [Return]  busybox sh -c "trap 'echo KillSignal${sig}' ${sig}; while true; do date && sleep 1; done"
+
+Assert Kill Signal
+    # Assert the docker kill signal was trapped by checking the container output log file
+    [Arguments]  ${id}  ${sig}
+    ${rc}=  Run And Return Rc  govc datastore.download ${id}/${id}.log ${TEMPDIR}/${id}.log
+    Should Be Equal As Integers  ${rc}  0
+    ${output}=  OperatingSystem.Get File  ${TEMPDIR}/${id}.log
+    Remove File  ${TEMPDIR}/${id}.log
+    Should Contain  ${output}  KillSignal${sig}
+
+Inspect State Running
+    [Arguments]  ${id}  ${expected}
+    ${rc}  ${state}=  Run And Return Rc And Output  docker ${params} inspect --format="{{ .State.Running }}" ${id}
+    Should Be Equal As Integers  ${rc}  0
+    Should Be Equal  ${state}  ${expected}
+
+*** Test Cases ***
+Signal a container with default kill signal
+    ${rc}=  Run And Return Rc  docker ${params} pull busybox
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${id}=  Run And Return Rc And Output  docker ${params} create busybox sleep 300
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}=  Run And Return Rc  docker ${params} start ${id}
+    Should Be Equal As Integers  ${rc}  0
+    Inspect State Running  ${id}  true
+    ${rc}=  Run And Return Rc  docker ${params} kill ${id}
+    Should Be Equal As Integers  ${rc}  0
+    # Wait for container VM to stop/powerOff
+    Wait Until Keyword Succeeds  5x  200 milliseconds  Inspect State Running  ${id}  false
+    # Cannot send signal to a powered off container VM
+    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} kill ${id}
+    Should Be Equal As Integers  ${rc}  1
+    Should Contain  ${output}  Cannot kill container ${id}
+
+Signal a container with SIGHUP
+    ${rc}=  Run And Return Rc  docker ${params} pull busybox
+    Should Be Equal As Integers  ${rc}  0
+    ${trap}=  Trap Signal Command  HUP
+    ${rc}  ${id}=  Run And Return Rc And Output  docker ${params} run -d ${trap}
+    Should Be Equal As Integers  ${rc}  0
+    # Expect failure with unknown signal name
+    ${rc}=  Run And Return Rc  docker ${params} kill -s NOPE ${id}
+    Should Be Equal As Integers  ${rc}  1
+    ${rc}=  Run And Return Rc  docker ${params} kill -s HUP ${id}
+    Should Be Equal As Integers  ${rc}  0
+    Wait Until Keyword Succeeds  5x  1 seconds  Assert Kill Signal  ${id}  HUP
+    Inspect State Running  ${id}  true
+    ${rc}=  Run And Return Rc  docker ${params} kill -s TERM ${id}
+    Should Be Equal As Integers  ${rc}  0
+    Wait Until Keyword Succeeds  5x  200 milliseconds  Inspect State Running  ${id}  false
+
+Signal a non-existent container
+    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} kill fakeContainer
+    Should Be Equal As Integers  ${rc}  1
+    Should Contain  ${output}  No such container: fakeContainer

--- a/tests/test-cases/Group8-vSphere-Integration/8-1-GuestTools.robot
+++ b/tests/test-cases/Group8-vSphere-Integration/8-1-GuestTools.robot
@@ -27,3 +27,19 @@ Stop container VM using guest shutdown
     Run  govc vm.ip ${id}
     ${rc}=  Run And Return Rc  govc vm.power -s ${id}
     Should Be Equal As Integers  ${rc}  0
+
+Signal container VM using vix command
+    ${rc}=  Run And Return Rc  docker ${params} pull busybox
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${id}=  Run And Return Rc And Output  docker ${params} run -d busybox /bin/top
+    Should Be Equal As Integers  ${rc}  0
+    Run  govc vm.ip ${id}
+    # Invalid command
+    ${rc}=  Run And Return Rc  govc guest.start -vm ${id} -l ${id} hello world
+    Should Be Equal As Integers  ${rc}  1
+    # Invalid id (via auth user)
+    ${rc}=  Run And Return Rc  govc guest.start -vm ${id} kill USR1
+    Should Be Equal As Integers  ${rc}  1
+    # OK
+    ${rc}=  Run And Return Rc  govc guest.start -vm ${id} -l ${id} kill USR1
+    Should Be Equal As Integers  ${rc}  0


### PR DESCRIPTION
Port layer now uses the vSphere API to send the "kill" command to the
container VM guest toolbox.

Closes #1267