### PR TITLE
Enable Firewall Checking in vicadmin

### DIFF
--- a/cmd/vicadmin/server.go
+++ b/cmd/vicadmin/server.go
@@ -255,7 +255,8 @@ func (s *server) tailFiles(res http.ResponseWriter, req *http.Request, names []s
 func (s *server) index(res http.ResponseWriter, req *http.Request) {
 	defer trace.End(trace.Begin(""))
 	ctx := context.Background()
-	v := vicadmin.NewValidator(ctx, vchConfig)
+	sess, err := client()
+	v := vicadmin.NewValidator(ctx, &vchConfig, sess)
 
 	tmpl, err := template.ParseFiles("dashboard.html")
 	err = tmpl.ExecuteTemplate(res, "dashboard.html", v)

--- a/cmd/vicadmin/vicadm.go
+++ b/cmd/vicadmin/vicadm.go
@@ -433,6 +433,7 @@ func main() {
 			vchConfig.Target.User = url.User(upw[0])
 		}
 	}
+
 	config.Service = vchConfig.Target.String()
 	config.ExtensionCert = vchConfig.ExtensionCert
 	config.ExtensionKey = vchConfig.ExtensionKey

--- a/isos/vicadmin/dashboard.html
+++ b/isos/vicadmin/dashboard.html
@@ -42,16 +42,15 @@
                     Containers
                   </li>
                   <li>
-                    <span class="right warning">
-                      <i class="fa fa-exclamation-triangle"></i>
+                    <span class="right">
+                      <i class="fa fa-check"></i>
                     </span>
                     Network Connectivity
                   </li>
                   <li>
-                    <span class="right">
-                      <i class="fa fa-check"></i>
-                    </span>
+                    {{.FirewallStatus}}
                     Firewall
+                    {{.FirewallIssues}}
                   </li>
                   <li>
                     <span class="right">

--- a/lib/install/validate/config.go
+++ b/lib/install/validate/config.go
@@ -52,7 +52,7 @@ func (v *Validator) CheckFirewall(ctx context.Context) []error {
 
 	if hosts, err = v.Session.Datastore.AttachedClusterHosts(ctx, v.Session.Cluster); err != nil {
 		log.Errorf("Unable to get the list of hosts attached to given storage: %s", err)
-		return append(issues, err)
+		return append(fwissues, err)
 	}
 
 	var misconfiguredEnabled []string
@@ -62,14 +62,14 @@ func (v *Validator) CheckFirewall(ctx context.Context) []error {
 	for _, host := range hosts {
 		fs, err := host.ConfigManager().FirewallSystem(ctx)
 		if err != nil {
-			issues = append(issues, err)
+			fwissues = append(fwissues, err)
 			break
 		}
 
 		disabled := false
 		esxfw, err := esxcli.GetFirewallInfo(host)
 		if err != nil {
-			issues = append(issues, err)
+			fwissues = append(fwissues, err)
 			break
 		}
 		if !esxfw.Enabled {
@@ -81,7 +81,7 @@ func (v *Validator) CheckFirewall(ctx context.Context) []error {
 
 		info, err := fs.Info(ctx)
 		if err != nil {
-			issues = append(issues, err)
+			fwissues = append(fwissues, err)
 			break
 		}
 

--- a/lib/install/validate/config.go
+++ b/lib/install/validate/config.go
@@ -29,9 +29,9 @@ import (
 )
 
 func (v *Validator) CheckFirewall(ctx context.Context) []error {
-	issues := []error{}
+	fwissues := []error{}
 	if v.DisableFirewallCheck {
-		return issues
+		return fwissues
 	}
 	defer trace.End(trace.Begin(""))
 
@@ -47,7 +47,7 @@ func (v *Validator) CheckFirewall(ctx context.Context) []error {
 
 	errMsg := "Firewall check SKIPPED"
 	if !v.sessionValid(errMsg) {
-		return issues
+		return fwissues
 	}
 
 	if hosts, err = v.Session.Datastore.AttachedClusterHosts(ctx, v.Session.Cluster); err != nil {
@@ -113,7 +113,7 @@ func (v *Validator) CheckFirewall(ctx context.Context) []error {
 		// can proceed if there is at least one host properly configured. For now this prevents install.
 		msg := "Firewall must permit 8080/tcp outbound to use VIC"
 		log.Error(msg)
-		issues = append(issues, errors.New(msg))
+		fwissues = append(fwissues, errors.New(msg))
 	}
 	if len(misconfiguredDisabled) > 0 {
 		log.Warning("Firewall configuration will be incorrect if firewall is reenabled on hosts:")
@@ -122,7 +122,7 @@ func (v *Validator) CheckFirewall(ctx context.Context) []error {
 		}
 		log.Warning("Firewall must permit 8080/tcp outbound if firewall is reenabled")
 	}
-	return issues
+	return fwissues
 }
 
 func (v *Validator) license(ctx context.Context) {

--- a/lib/vicadmin/validate.go
+++ b/lib/vicadmin/validate.go
@@ -54,9 +54,8 @@ func NewValidator(ctx context.Context, vch *config.VirtualContainerHostConfigSpe
 	log.Info(fmt.Sprintf("Setting hostname to %s", v.Hostname))
 
 	v2, _ := validate.CreateFromVCHConfig(ctx, vch, sess)
-	v2.ReValidate(ctx)
 
-	firewallIssues := v2.GetFirewallIssues()
+	firewallIssues := v2.CheckFirewall()
 	if len(firewallIssues) == 0 {
 		v.FirewallStatus = GoodStatus
 		v.FirewallIssues = template.HTML("")

--- a/lib/vicadmin/validate.go
+++ b/lib/vicadmin/validate.go
@@ -54,7 +54,8 @@ func NewValidator(ctx context.Context, vch *config.VirtualContainerHostConfigSpe
 	log.Info(fmt.Sprintf("Setting hostname to %s", v.Hostname))
 
 	v2, _ := validate.CreateFromVCHConfig(ctx, vch, sess)
-	firewallIssues := v2.CheckFirewall(ctx)
+	v2.CheckFirewall(ctx)
+	firewallIssues := v2.GetIssues()
 
 	if len(firewallIssues) == 0 {
 		v.FirewallStatus = GoodStatus

--- a/lib/vicadmin/validate.go
+++ b/lib/vicadmin/validate.go
@@ -54,8 +54,8 @@ func NewValidator(ctx context.Context, vch *config.VirtualContainerHostConfigSpe
 	log.Info(fmt.Sprintf("Setting hostname to %s", v.Hostname))
 
 	v2, _ := validate.CreateFromVCHConfig(ctx, vch, sess)
+	firewallIssues := v2.CheckFirewall(ctx)
 
-	firewallIssues := v2.CheckFirewall()
 	if len(firewallIssues) == 0 {
 		v.FirewallStatus = GoodStatus
 		v.FirewallIssues = template.HTML("")

--- a/lib/vicadmin/validate.go
+++ b/lib/vicadmin/validate.go
@@ -16,44 +16,58 @@ package vicadmin
 
 import (
 	"fmt"
+	"html/template"
 	"os"
+	"strings"
 
 	log "github.com/Sirupsen/logrus"
 	// "github.com/vmware/govmomi/vim25/types"
 
 	"github.com/vmware/vic/lib/config"
+	"github.com/vmware/vic/lib/install/validate"
 	"github.com/vmware/vic/pkg/trace"
-	// "github.com/vmware/vic/pkg/vsphere/session"
+	"github.com/vmware/vic/pkg/vsphere/session"
 	"golang.org/x/net/context"
 )
 
 type Validator struct {
 	Hostname       string
 	Version        string
-	FirewallErrors []string
+	FirewallStatus template.HTML
+	FirewallIssues template.HTML
 }
 
-func NewValidator(ctx context.Context, vch config.VirtualContainerHostConfigSpec) *Validator {
+const (
+	GoodStatus = template.HTML(`<span class="right"><i class="fa fa-check"></i></span>`)
+	BadStatus  = template.HTML(`<span class="right warning"><i class="fa fa-exclamation-triangle"></i></span>`)
+)
+
+func NewValidator(ctx context.Context, vch *config.VirtualContainerHostConfigSpec, sess *session.Session) *Validator {
 	defer trace.End(trace.Begin(""))
 	log.Infof("Creating new validator")
-	v := new(Validator)
-	v.checkFirewall(ctx, vch)
-	v.FirewallErrors = nil
+	v := &Validator{}
 	v.Version = vch.Version
 	log.Info(fmt.Sprintf("Setting version to %s", v.Version))
 
 	v.Hostname, _ = os.Hostname()
+	v.Hostname = strings.Title(v.Hostname)
+	log.Info(fmt.Sprintf("Setting hostname to %s", v.Hostname))
+
+	v2, _ := validate.CreateFromVCHConfig(ctx, vch, sess)
+	v2.ReValidate(ctx)
+
+	firewallIssues := v2.GetFirewallIssues()
+	if len(firewallIssues) == 0 {
+		v.FirewallStatus = GoodStatus
+		v.FirewallIssues = template.HTML("")
+	} else {
+		v.FirewallStatus = BadStatus
+		for _, err := range firewallIssues {
+			v.FirewallIssues = template.HTML(fmt.Sprintf("%s<span class=\"error-message\">%s</span>\n", v.FirewallIssues, err))
+		}
+	}
+	log.Info(fmt.Sprintf("FirewallStatus set to: %s", v.FirewallStatus))
+	log.Info(fmt.Sprintf("FirewallIssues set to: %s", v.FirewallIssues))
 
 	return v
-}
-
-func (v *Validator) checkFirewall(ctx context.Context, vch config.VirtualContainerHostConfigSpec) {
-	defer trace.End(trace.Begin(""))
-	log.Infof("Checking firewall rules")
-	//rule := types.HostFirewallRule{
-	//Port:      8080, // serialOverLANPort
-	//PortType:  types.HostFirewallRulePortTypeDst,
-	//Protocol:  string(types.HostFirewallRuleProtocolTcp),
-	//Direction: types.HostFirewallRuleDirectionOutbound,
-	//}
 }


### PR DESCRIPTION
Enables the "Firewall" checkbox on the vicadmin portal.  In the event the firewall is enabled and misconfigured on a host, the checkbox will change from a green check to orange warning triangle, and an appropriate warning message will be posted.  Partially addresses #1229.
