### PR TITLE
Better handling of the capacity driver arg for volume create

### DIFF
--- a/lib/apiservers/engine/backends/volume.go
+++ b/lib/apiservers/engine/backends/volume.go
@@ -215,7 +215,7 @@ func validateDriverArgs(args map[string]string, model *models.VolumeRequest) err
 
 	capacity, err := validateCapacityArg(capstr)
 	if err != nil {
-		return derr.NewBadRequestError(err)
+		return err
 	}
 	model.Capacity = int64(capacity)
 

--- a/lib/apiservers/engine/backends/volume.go
+++ b/lib/apiservers/engine/backends/volume.go
@@ -26,6 +26,7 @@ import (
 	derr "github.com/docker/docker/errors"
 
 	"github.com/docker/engine-api/types"
+	"github.com/docker/go-units"
 	"github.com/google/uuid"
 	"github.com/vmware/vic/lib/apiservers/portlayer/client/storage"
 	"github.com/vmware/vic/lib/apiservers/portlayer/models"
@@ -213,37 +214,13 @@ func validateDriverArgs(args map[string]string, model *models.VolumeRequest) err
 		return nil
 	}
 
-	capacity, err := validateCapacityArg(capstr)
+	capacity, err := units.FromHumanSize(capstr)
 	if err != nil {
 		return err
 	}
 	model.Capacity = int64(capacity)
 
 	return nil
-}
-
-func validateCapacityArg(capacityInput string) (int64, error) {
-	validationPattern, _ := regexp.Compile("^[0-9]+[mMgGtT][bB]$")
-	numberPattern, _ := regexp.Compile("[0-9]+")
-	unitPattern, _ := regexp.Compile("[mMgGtT][bB]")
-
-	if !validationPattern.MatchString(capacityInput) {
-		return -1, fmt.Errorf("invalid value for capacity argument supplied. format is <int64><unit>. where units are MB, GB, TB and the value is positive. e.g. --opt Capacity=1024GB")
-	}
-
-	numberString := numberPattern.FindString(capacityInput)
-	unit := strings.ToUpper(unitPattern.FindString(capacityInput))
-	number, _ := strconv.ParseInt(numberString, 10, 64)
-
-	switch unit {
-	case "MB": //Capacity is already correct
-	case "GB":
-		number = number * 1024
-	case "TB":
-		number = number * 1024 * 1024
-	}
-
-	return number, nil
 }
 
 func translateInputsToPortlayerRequestModel(name, driverName string, opts, labels map[string]string) (*models.VolumeRequest, error) {

--- a/lib/apiservers/engine/backends/volume.go
+++ b/lib/apiservers/engine/backends/volume.go
@@ -18,9 +18,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"regexp"
-	"strconv"
-	"strings"
 
 	log "github.com/Sirupsen/logrus"
 	derr "github.com/docker/docker/errors"

--- a/lib/apiservers/engine/backends/volume.go
+++ b/lib/apiservers/engine/backends/volume.go
@@ -35,6 +35,7 @@ const (
 	OptsVolumeStoreKey     string = "VolumeStore"
 	OptsCapacityKey        string = "Capacity"
 	dockerMetadataModelKey string = "DockerMetaData"
+	bytesToMegabyte               = int64(1000000)
 )
 
 func NewVolumeModel(volume *models.VolumeResponse, labels map[string]string) *types.Volume {
@@ -215,7 +216,7 @@ func validateDriverArgs(args map[string]string, model *models.VolumeRequest) err
 	if err != nil {
 		return err
 	}
-	model.Capacity = int64(capacity)
+	model.Capacity = int64(capacity) / bytesToMegabyte
 
 	return nil
 }

--- a/lib/apiservers/engine/backends/volume_test.go
+++ b/lib/apiservers/engine/backends/volume_test.go
@@ -132,51 +132,6 @@ func TestValidateDriverArgs(t *testing.T) {
 	}
 }
 
-func TestValidateCapacityArg(t *testing.T) {
-	testBadString1 := "HelloWorld"
-	testBadString2 := "123HelloWorld"
-	testBadString3 := "-123TB"
-	testGoodString1 := "1024MB"
-	testGoodString2 := "512gB"
-	testGoodString3 := "2tb"
-
-	testNumber, err := validateCapacityArg(testBadString1)
-	if !assert.Equal(t, int64(-1), testNumber) ||
-		!assert.NotNil(t, err) {
-		return
-	}
-
-	testNumber, err = validateCapacityArg(testBadString2)
-	if !assert.Equal(t, int64(-1), testNumber) ||
-		!assert.NotNil(t, err) {
-		return
-	}
-
-	testNumber, err = validateCapacityArg(testBadString3)
-	if !assert.Equal(t, int64(-1), testNumber) ||
-		!assert.NotNil(t, err) {
-		return
-	}
-
-	testNumber, err = validateCapacityArg(testGoodString1)
-	if !assert.Equal(t, int64(1024), testNumber) ||
-		!assert.Nil(t, err) {
-		return
-	}
-
-	testNumber, err = validateCapacityArg(testGoodString2)
-	if !assert.Equal(t, int64(524288), testNumber) ||
-		!assert.Nil(t, err) {
-		return
-	}
-
-	testNumber, err = validateCapacityArg(testGoodString3)
-	if !assert.Equal(t, int64(2097152), testNumber) ||
-		!assert.Nil(t, err) {
-		return
-	}
-}
-
 func TestExtractDockerMetadata(t *testing.T) {
 	driver := "vsphere"
 	volumeName := "testVolume"

--- a/lib/apiservers/engine/backends/volume_test.go
+++ b/lib/apiservers/engine/backends/volume_test.go
@@ -16,7 +16,6 @@ package vicbackends
 
 import (
 	"encoding/json"
-	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -47,7 +46,7 @@ func TestTranslatVolumeRequestModel(t *testing.T) {
 	testDriverArgs := make(map[string]string)
 	testDriverArgs["testArg"] = "important driver stuff"
 	testDriverArgs[OptsVolumeStoreKey] = "testStore"
-	testDriverArgs[OptsCapacityKey] = "12"
+	testDriverArgs[OptsCapacityKey] = "12MB"
 
 	testRequest, err := translateInputsToPortlayerRequestModel("testName", "vsphere", testDriverArgs, testLabels)
 	if !assert.NoError(t, err) {
@@ -98,7 +97,7 @@ func TestCreateVolumeMetada(t *testing.T) {
 func TestValidateDriverArgs(t *testing.T) {
 	testMap := make(map[string]string)
 	testStore := "Mystore"
-	testCap := int64(12)
+	testCap := "12MB"
 	testBadCap := "This is not valid!"
 	testModel := models.VolumeRequest{
 		Driver:     "vsphere",
@@ -112,23 +111,68 @@ func TestValidateDriverArgs(t *testing.T) {
 	}
 
 	testMap[OptsVolumeStoreKey] = testStore
-	testMap[OptsCapacityKey] = strconv.FormatInt(testCap, 10)
+	testMap[OptsCapacityKey] = testCap
 	err = validateDriverArgs(testMap, &testModel)
-	if !assert.Equal(t, testStore, testModel.Store) || !assert.Equal(t, testCap, testModel.Capacity) || !assert.NoError(t, err) {
+	if !assert.Equal(t, testStore, testModel.Store) || !assert.Equal(t, int64(12), testModel.Capacity) || !assert.NoError(t, err) {
 		return
 	}
 
 	//This is a negative test case. We want an error
 	testMap[OptsCapacityKey] = testBadCap
 	err = validateDriverArgs(testMap, &testModel)
-	if !assert.Equal(t, testStore, testModel.Store) || !assert.Equal(t, int64(-1), testModel.Capacity) || !assert.Error(t, err) {
+	if !assert.Equal(t, testStore, testModel.Store) || !assert.Equal(t, int64(12), testModel.Capacity) || !assert.Error(t, err) {
 		return
 	}
 
-	testMap[OptsCapacityKey] = strconv.FormatInt(testCap, 10)
+	testMap[OptsCapacityKey] = testCap
 	delete(testMap, OptsVolumeStoreKey)
 	err = validateDriverArgs(testMap, &testModel)
 	if !assert.Equal(t, "default", testModel.Store) || !assert.Equal(t, int64(12), testModel.Capacity) || !assert.NoError(t, err) {
+		return
+	}
+}
+
+func TestValidateCapacityArg(t *testing.T) {
+	testBadString1 := "HelloWorld"
+	testBadString2 := "123HelloWorld"
+	testBadString3 := "-123TB"
+	testGoodString1 := "1024MB"
+	testGoodString2 := "512gB"
+	testGoodString3 := "2tb"
+
+	testNumber, err := validateCapacityArg(testBadString1)
+	if !assert.Equal(t, int64(-1), testNumber) ||
+		!assert.NotNil(t, err) {
+		return
+	}
+
+	testNumber, err = validateCapacityArg(testBadString2)
+	if !assert.Equal(t, int64(-1), testNumber) ||
+		!assert.NotNil(t, err) {
+		return
+	}
+
+	testNumber, err = validateCapacityArg(testBadString3)
+	if !assert.Equal(t, int64(-1), testNumber) ||
+		!assert.NotNil(t, err) {
+		return
+	}
+
+	testNumber, err = validateCapacityArg(testGoodString1)
+	if !assert.Equal(t, int64(1024), testNumber) ||
+		!assert.Nil(t, err) {
+		return
+	}
+
+	testNumber, err = validateCapacityArg(testGoodString2)
+	if !assert.Equal(t, int64(524288), testNumber) ||
+		!assert.Nil(t, err) {
+		return
+	}
+
+	testNumber, err = validateCapacityArg(testGoodString3)
+	if !assert.Equal(t, int64(2097152), testNumber) ||
+		!assert.Nil(t, err) {
 		return
 	}
 }


### PR DESCRIPTION
Fixes #1562 #1503 

Implements the `validateCapacityArg` helper function which now looks for a unit and a value. negative values are rejected. A strict pattern is used for verifying a proper format. Unit tests have been updated and a new unit test added for the new helper function. 

