### PR TITLE
Handle tether exit in the toolbox

### DIFF
--- a/lib/tether/config.go
+++ b/lib/tether/config.go
@@ -95,9 +95,6 @@ type SessionConfig struct {
 	Outwriter dio.DynamicMultiWriter
 	Errwriter dio.DynamicMultiWriter
 	Reader    dio.DynamicMultiReader
-
-	// This channel is closed on session exit
-	exit chan struct{}
 }
 
 type NetworkEndpoint struct {

--- a/lib/tether/tether.go
+++ b/lib/tether/tether.go
@@ -320,9 +320,6 @@ func (t *tether) handleSessionExit(session *SessionConfig) {
 	if f != nil {
 		f()
 	}
-
-	// notify guest shutdown waiter this process has gone away
-	close(session.exit)
 }
 
 // launch will launch the command defined in the session.
@@ -349,8 +346,6 @@ func (t *tether) launch(session *SessionConfig) error {
 	session.Outwriter = logwriter
 	session.Errwriter = logwriter
 	session.Reader = dio.MultiReader()
-
-	session.exit = make(chan struct{})
 
 	// Special case here because UID/GID lookup need to be done
 	// on the appliance...


### PR DESCRIPTION
We are only concerned with StopSignal / ShutdownGuest when running
within a container VM.  No need for an exit channel when running within
the VCH.  So move the exit channel logic to the tether toolbox
extension.

Fixes #1790