### PR TITLE
Implements uuid naming for volumes without a specified name on create…

### DIFF
--- a/lib/apiservers/engine/backends/volume.go
+++ b/lib/apiservers/engine/backends/volume.go
@@ -24,6 +24,7 @@ import (
 	derr "github.com/docker/docker/errors"
 
 	"github.com/docker/engine-api/types"
+	"github.com/google/uuid"
 	"github.com/vmware/vic/lib/apiservers/portlayer/client/storage"
 	"github.com/vmware/vic/lib/apiservers/portlayer/models"
 	"github.com/vmware/vic/pkg/trace"
@@ -96,8 +97,6 @@ func (v *Volume) VolumeCreate(name, driverName string, opts, labels map[string]s
 	defer trace.End(trace.Begin("Volume.VolumeCreate"))
 	result := &types.Volume{}
 
-	// TODO: design a way to have better error returns.
-
 	client := PortLayerClient()
 	if client == nil {
 		return nil, derr.NewErrorWithStatusCode(fmt.Errorf("Failed to get a portlayer client"), http.StatusInternalServerError)
@@ -110,7 +109,10 @@ func (v *Volume) VolumeCreate(name, driverName string, opts, labels map[string]s
 		return result, derr.NewErrorWithStatusCode(fmt.Errorf("Bad Driver Arg: %s", varErr), http.StatusBadRequest)
 	}
 
-	// TODO: setup name randomization if name == nil
+	if model.Name == "" {
+		volumeUUID, _ := uuid.NewUUID()
+		model.Name = volumeUUID.String()
+	}
 
 	res, err := client.Storage.CreateVolume(storage.NewCreateVolumeParams().WithVolumeRequest(model))
 	if err != nil {
@@ -118,13 +120,13 @@ func (v *Volume) VolumeCreate(name, driverName string, opts, labels map[string]s
 
 		case *storage.CreateVolumeInternalServerError:
 			// FIXME: right now this does not return an error model...
-			return result, derr.NewErrorWithStatusCode(fmt.Errorf("Server error from Portlayer: %s", err.Error()), http.StatusInternalServerError)
+			return result, derr.NewErrorWithStatusCode(fmt.Errorf("%s", err.Error()), http.StatusInternalServerError)
 
 		case *storage.CreateVolumeDefault:
-			return result, derr.NewErrorWithStatusCode(fmt.Errorf("Server error from Portlayer: %s", err.Payload.Message), http.StatusInternalServerError)
+			return result, derr.NewErrorWithStatusCode(fmt.Errorf("%s", err.Payload.Message), http.StatusInternalServerError)
 
 		default:
-			return result, derr.NewErrorWithStatusCode(fmt.Errorf("Server error from Portlayer: %s", err), http.StatusInternalServerError)
+			return result, derr.NewErrorWithStatusCode(fmt.Errorf("%s", err), http.StatusInternalServerError)
 		}
 	}
 

--- a/lib/apiservers/engine/backends/volume.go
+++ b/lib/apiservers/engine/backends/volume.go
@@ -110,8 +110,7 @@ func (v *Volume) VolumeCreate(name, driverName string, opts, labels map[string]s
 	}
 
 	if model.Name == "" {
-		volumeUUID, _ := uuid.NewUUID()
-		model.Name = volumeUUID.String()
+		model.Name = uuid.New().String()
 	}
 
 	res, err := client.Storage.CreateVolume(storage.NewCreateVolumeParams().WithVolumeRequest(model))


### PR DESCRIPTION
Fixes #1548 

This adds a simple uuid generation for the name of a volume if `docker volume create` is invoked without the `--name` option. Currently we fail the operation and return a swagger error. Instead we will return a uuid. Or if we want a random name if we so choose. 