### PR TITLE
Support network rm using network ID

### DIFF
--- a/lib/portlayer/network/context.go
+++ b/lib/portlayer/network/context.go
@@ -984,15 +984,18 @@ func (c *Context) DeleteScope(name string) error {
 
 	// remove gateway ip from bridge interface
 	addr := net.IPNet{IP: s.Gateway(), Mask: s.Subnet().Mask}
-	if err = Config.BridgeLink.AddrDel(addr); err != nil {
-		if errno, ok := err.(syscall.Errno); !ok || errno != syscall.EADDRNOTAVAIL {
-			log.Warnf("could not remove gateway address %s for scope %s on link %s: %s", addr, s.Name(), Config.BridgeLink.Attrs().Name, err)
-		}
 
-		err = nil
+	if s.Type() != BridgeScopeType {
+		if err = Config.BridgeLink.AddrDel(addr); err != nil {
+			if errno, ok := err.(syscall.Errno); !ok || errno != syscall.EADDRNOTAVAIL {
+				log.Warnf("could not remove gateway address %s for scope %s on link %s: %s", addr, s.Name(), Config.BridgeLink.Attrs().Name, err)
+			}
+
+			err = nil
+		}
 	}
 
-	delete(c.scopes, name)
+	delete(c.scopes, s.Name())
 	return nil
 }
 

--- a/lib/portlayer/network/context.go
+++ b/lib/portlayer/network/context.go
@@ -982,11 +982,11 @@ func (c *Context) DeleteScope(name string) error {
 		return fmt.Errorf("scope has bound endpoints")
 	}
 
-	// remove gateway ip from bridge interface
-	addr := net.IPNet{IP: s.Gateway(), Mask: s.Subnet().Mask}
+	if s.Type() == BridgeScopeType {
 
-	if s.Type() != BridgeScopeType {
-		if err = Config.BridgeLink.AddrDel(addr); err != nil {
+		// remove gateway ip from bridge interface
+		addr := net.IPNet{IP: s.Gateway(), Mask: s.Subnet().Mask}
+		if err := Config.BridgeLink.AddrDel(addr); err != nil {
 			if errno, ok := err.(syscall.Errno); !ok || errno != syscall.EADDRNOTAVAIL {
 				log.Warnf("could not remove gateway address %s for scope %s on link %s: %s", addr, s.Name(), Config.BridgeLink.Attrs().Name, err)
 			}

--- a/lib/portlayer/network/context_test.go
+++ b/lib/portlayer/network/context_test.go
@@ -993,6 +993,16 @@ func TestDeleteScope(t *testing.T) {
 	ctx.AddContainer(h, options)
 	ctx.BindContainer(h)
 
+	baz, err := ctx.NewScope(BridgeScopeType, "bazScope", nil, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("ctx.NewScope(%s, \"bazScope\", nil, nil, nil, nil) => (nil, %#v), want (baz, nil)", BridgeScopeType, err)
+	}
+
+	qux, err := ctx.NewScope(BridgeScopeType, "quxScope", nil, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("ctx.NewScope(%s, \"quxScope\", nil, nil, nil, nil) => (nil, %#v), want (qux, nil)", BridgeScopeType, err)
+	}
+
 	var tests = []struct {
 		name string
 		err  error
@@ -1000,7 +1010,12 @@ func TestDeleteScope(t *testing.T) {
 		{"", ResourceNotFoundError{}},
 		{ctx.DefaultScope().Name(), fmt.Errorf("cannot delete builtin scopes")},
 		{bar.Name(), fmt.Errorf("cannot delete scope with bound endpoints")},
+		// full name
 		{foo.Name(), nil},
+		// full id
+		{baz.ID(), nil},
+		// partial id
+		{qux.ID()[:6], nil},
 	}
 
 	for _, te := range tests {

--- a/tests/test-cases/Group1-Docker-Commands/1-18-Docker-Network-RM.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-18-Docker-Network-RM.robot
@@ -24,10 +24,7 @@ Multiple network remove
     ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} network ls
     Should Be Equal As Integers  ${rc}  0
     Should Not Contain  ${output}  test-network2
-    ${status}=  Get State Of Github Issue  1318
-    Run Keyword If  '${status}' == 'closed'  Fail  Test 1-18-Docker-Network-RM.robot needs to be updated now that Issue #1318 has been resolved
-    Log  Issue \#1318 is blocking implementation  WARN
-    #Should Not Contain  ${output}  test-network3
+    Should Not Contain  ${output}  test-network3
 
 Remove already removed network
     ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} network rm test-network


### PR DESCRIPTION
* Fixes `DeleteScope` to support `network rm` using the network ID and remove the gateway IP only for bridge networks
* Adds unit test cases for `network rm` using full and partial network ID
* Enables related integration test in the `network rm` suite

Fixes #1318
