### PR TITLE
Add script to run integration tests locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ drone exec -trusted -cache -e VIC_ESX_TEST_URL=""
 
 To build without modifying the local system:
 ```
-docker run -v $(pwd):/go/src/github.com/vmware/vic -w /go/src/github.com/vmware/vic golang:1.6 make all
+docker run -v $(pwd):/go/src/github.com/vmware/vic -w /go/src/github.com/vmware/vic golang:1.6.3 make all
 ```
 
 To build directly:
@@ -120,7 +120,7 @@ $ make isos
 The appliance and bootstrap ISOs are bootable CD images used to start the VMs that make up VIC. To build the image using [docker](https://www.docker.com/), ensure `GOPATH` is set and `docker` is installed, then issue the following.
 
 ```
-docker run -v $(pwd):/go/src/github.com/vmware/vic -w /go/src/github.com/vmware/vic golang:1.6 make isos
+docker run -v $(pwd):/go/src/github.com/vmware/vic -w /go/src/github.com/vmware/vic golang:1.6.3 make isos
 ```
 
 Alternatively, the iso image can be built locally.  Again, ensure `GOPATH` is set, but also ensure the following packages are installed. This will attempt to install the following packages if not present using apt-get:

--- a/doc/user_doc/vic_installation/set_up_devbox.md
+++ b/doc/user_doc/vic_installation/set_up_devbox.md
@@ -21,5 +21,5 @@ The current builds of vSphere Integrated Containers only run on a Linux OS syste
 14. Install Docker in the DevBox VM.<pre>apt install docker.io</pre>
 15. Clone the vSphere Integrated Containers repository from GitHub into the DevBox VM.<pre>git clone https://github.com/vmware/vic.git</pre>
 16. Go to the `/vic` folder.<pre>cd vic</pre>
-17. Run the `make` command to build the vSphere Integrated Containers binaries. <pre>docker run -v $(pwd):/go/src/github.com/vmware/vic -w /go/src/github.com/vmware/vic golang:1.6 make all</pre> This command uses containers and golang to build vSphere Integrated Containers. Copy the command as is into the Vagrant terminal. The build takes approximately 10 minutes.
+17. Run the `make` command to build the vSphere Integrated Containers binaries. <pre>docker run -v $(pwd):/go/src/github.com/vmware/vic -w /go/src/github.com/vmware/vic golang:1.6.3 make all</pre> This command uses containers and golang to build vSphere Integrated Containers. Copy the command as is into the Vagrant terminal. The build takes approximately 10 minutes.
 18. Add the `vic-machine` executable to the path of the DevBox VM.<pre>PATH=$PATH:/home/vagrant/vic/bin</pre>

--- a/tests/README.md
+++ b/tests/README.md
@@ -17,11 +17,11 @@ To run the integration tests locally:
     VIC_ESX_TEST_DATASTORE: <datastore path, e.g. /ha-datacenter/datastore/datastore1>
     VIC_ESX_TEST_URL: <user:password@IP address of your test server>
   ```
-  
+
 If you are using a vSAN environment or non-default ESX install, then you can also specify the two networks to use with the following command (make sure to add them to the yaml file in Step 2 below as well):
 
   ```
-    BRIDGE_NETWORK: bridge  
+    BRIDGE_NETWORK: bridge
     EXTERNAL_NETWORK: external
   ```
 
@@ -67,12 +67,13 @@ If you are using a vSAN environment or non-default ESX install, then you can als
 
 3. Execute drone from the projects root directory:
 
-To run only the regression tests:  
+To run only the regression tests:
 `drone exec --trusted -E "test_secrets.yml" --yaml ".drone.local.yml" --payload '{"build": {"branch":"regression", "event":"push"}, "repo": {"full_name":"regression"}}'`
 
-To run the full suite:  
+To run the full suite:
 `drone exec --trusted -E "test_secrets.yml" --yaml ".drone.local.yml" --payload '{"build": {"branch":"master", "event":"push"}, "repo": {"full_name":"vmware/vic"}}'`
 
+4. Forget about all that and use ./local-integration-test.sh
 
 ## Find the documentation for each of the tests here:
 

--- a/tests/local-integration-test.sh
+++ b/tests/local-integration-test.sh
@@ -1,0 +1,56 @@
+#!/bin/bash -e
+# Copyright 2016 VMware, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Run robot integration tests locally, no .yml files required.
+# Set GITHUB_TOKEN once and switch environments just by changing GOVC_URL
+
+if [ -z "$GITHUB_TOKEN" ] || [ -z "$GOVC_URL" ]; then
+    echo "usage: GITHUB_TOKEN=... GOVC_URL=... $0 test.robot..."
+    exit 1
+fi
+
+cd "$(git rev-parse --show-toplevel)"
+
+tests=${*#${PWD}/}
+
+drone exec --trusted --yaml <(cat <<CONFIG
+---
+clone:
+  path: github.com/vmware/vic
+  tags: true
+
+build:
+  integration-test:
+    image: vmware-docker-ci-repo.bintray.io/integration/vic-test:1.1
+    pull: true
+    environment:
+      GITHUB_AUTOMATION_API_KEY: $GITHUB_TOKEN
+      TEST_URL_ARRAY:   $(govc env -x GOVC_URL_HOST)
+      TEST_USERNAME:    $(govc env GOVC_USERNAME)
+      TEST_PASSWORD:    $(govc env GOVC_PASSWORD)
+      TEST_DATASTORE:   ${GOVC_DATASTORE:-$(basename "$(govc ls datastore)")}
+      TEST_RESOURCE:    ${GOVC_RESOURCE_POOL:-$(govc ls host/*/Resources)}
+      BRIDGE_NETWORK:   $BRIDGE_NETWORK
+      EXTERNAL_NETWORK: $EXTERNAL_NETWORK
+      BIN: bin
+      GOPATH: /drone
+      SHELL: /bin/bash
+      DOCKER_API_VERSION: "1.21"
+      TEST_TIMEOUT: 60s
+      GOVC_INSECURE: true
+    commands:
+      - pybot ${tests:-tests/test-cases}
+CONFIG
+)


### PR DESCRIPTION
Requires 2 env variables and no messing with yaml files.

Set GITHUB_TOKEN once and switch environments just by changing GOVC_URL