### PR TITLE
Feature/disable cleanup temporarily

### DIFF
--- a/tests/resources/Util.robot
+++ b/tests/resources/Util.robot
@@ -26,6 +26,7 @@ Set Test Environment Variables
     ${IDX}=  Evaluate  %{DRONE_BUILD_NUMBER} \% ${len}
 
     Set Environment Variable  TEST_URL  @{URLs}[${IDX}]
+    Log To Console  %{TEST_URL}
     Set Environment Variable  GOVC_URL  %{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}
 
     ${host}=  Run  govc ls host

--- a/tests/resources/Util.robot
+++ b/tests/resources/Util.robot
@@ -26,7 +26,6 @@ Set Test Environment Variables
     ${IDX}=  Evaluate  %{DRONE_BUILD_NUMBER} \% ${len}
 
     Set Environment Variable  TEST_URL  @{URLs}[${IDX}]
-    Log To Console  %{TEST_URL}
     Set Environment Variable  GOVC_URL  %{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}
 
     ${host}=  Run  govc ls host

--- a/tests/resources/Util.robot
+++ b/tests/resources/Util.robot
@@ -59,8 +59,8 @@ Install VIC Appliance To Test Server
     [Arguments]  ${certs}=${false}  ${vol}=default
     Set Test Environment Variables  ${certs}  ${vol}  network  'VM Network'
     # Attempt to cleanup old/canceled tests
-    Run Keyword And Ignore Error  Cleanup Dangling VMs On Test Server
-    Run Keyword And Ignore Error  Cleanup Datastore On Test Server
+    #Run Keyword And Ignore Error  Cleanup Dangling VMs On Test Server
+    #Run Keyword And Ignore Error  Cleanup Datastore On Test Server
     Set Test VCH Name
 
     # Install the VCH now
@@ -88,7 +88,7 @@ Run VIC Machine Command
 
 Cleanup VIC Appliance On Test Server
     [Tags]  secret
-    Run Keyword And Ignore Error  Gather Logs From Test Server
+    Gather Logs From Test Server
     ${output}=  Run  bin/vic-machine-linux delete --name=${vch-name} --target=%{TEST_URL} --user=%{TEST_USERNAME} --password=%{TEST_PASSWORD} --force=true --compute-resource=%{TEST_RESOURCE} --timeout %{TEST_TIMEOUT}
     Run Keyword And Ignore Error  Should Contain  ${output}  Completed successfully
     ${output}=  Run  rm -f ${vch-name}-*.pem

--- a/tests/resources/Util.robot
+++ b/tests/resources/Util.robot
@@ -86,8 +86,12 @@ Run VIC Machine Command
     [Return]  ${output}
 
 Cleanup VIC Appliance On Test Server
-    [Tags]  secret
     Gather Logs From Test Server
+    ${output}=  Run VIC Machine Delete Command
+    [Return]  ${output}
+    
+Run VIC Machine Delete Command
+    [Tags]  secret
     ${output}=  Run  bin/vic-machine-linux delete --name=${vch-name} --target=%{TEST_URL} --user=%{TEST_USERNAME} --password=%{TEST_PASSWORD} --force=true --compute-resource=%{TEST_RESOURCE} --timeout %{TEST_TIMEOUT}
     Run Keyword And Ignore Error  Should Contain  ${output}  Completed successfully
     ${output}=  Run  rm -f ${vch-name}-*.pem


### PR DESCRIPTION
Need to keep VCHs around if we hit the issue of not being able to gather logs.