### PR TITLE
Remove systemd-networkd from appliance

### DIFF
--- a/isos/appliance.sh
+++ b/isos/appliance.sh
@@ -71,17 +71,25 @@ cp ${DIR}/appliance/nat.service $(rootfs_dir $PKGDIR)/etc/systemd/system/
 cp ${DIR}/appliance/nat-setup $(rootfs_dir $PKGDIR)/etc/systemd/scripts
 
 mkdir -p $(rootfs_dir $PKGDIR)/etc/systemd/system/vic.target.wants
-ln -s /etc/systemd/system/vic-init.service $(rootfs_dir $PKGDIR)/etc/systemd/system/vic.target.wants/vic-init.service
-ln -s /etc/systemd/system/nat.service $(rootfs_dir $PKGDIR)/etc/systemd/system/vic.target.wants/nat.service
+ln -s /etc/systemd/system/vic-init.service $(rootfs_dir $PKGDIR)/etc/systemd/system/vic.target.wants/
+ln -s /etc/systemd/system/nat.service $(rootfs_dir $PKGDIR)/etc/systemd/system/vic.target.wants/
+ln -s /etc/systemd/system/multi-user.target $(rootfs_dir $PKGDIR)/etc/systemd/system/vic.target.wants/
+
+# disable networkd given we manage the link state directly
+rm -f $(rootfs_dir $PKGDIR)/etc/systemd/system/multi-user.target.wants/systemd-networkd.service
+rm -f $(rootfs_dir $PKGDIR)/etc/systemd/system/sockets.target.wants/systemd-networkd.socket
 
 # change the default systemd target to launch VIC
-# ln -sf /etc/systemd/system/vic.target $(rootfs_dir $PKGDIR)/etc/systemd/system/default.target
+ln -sf /etc/systemd/system/vic.target $(rootfs_dir $PKGDIR)/etc/systemd/system/default.target
 # update the multi-user target to launch VIC - this launches sshd as well
-ln -s /etc/systemd/system/vic.target $(rootfs_dir $PKGDIR)/etc/systemd/system/multi-user.target.wants/vic.target
+#ln -s /etc/systemd/system/vic.target $(rootfs_dir $PKGDIR)/etc/systemd/system/multi-user.target.wants/vic.target
 
 # do not use the systemd dhcp client
 rm -f $(rootfs_dir $PKGDIR)/etc/systemd/network/*
 cp ${DIR}/base/no-dhcp.network $(rootfs_dir $PKGDIR)/etc/systemd/network/
+
+# do not use the default iptables rules - nat-setup supplants this
+rm -f $(rootfs_dir $PKGDIR)/etc/systemd/network/*
 
 
 ## main VIC components

--- a/isos/appliance/nat.service
+++ b/isos/appliance/nat.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=NAT setup for bridge network
-After=vic-init.service
+After=iptables.service
 
 [Service]
 Type=oneshot

--- a/isos/appliance/vic-init.service
+++ b/isos/appliance/vic-init.service
@@ -1,7 +1,6 @@
 [Unit]
 Description=Init process for VIC components
-After=network-online.target
-Wants=network-online.target
+After=basic.target
 
 [Service]
 Type=idle
@@ -13,3 +12,5 @@ ExecStart=/sbin/vic-init
 
 [Install]
 WantedBy=vic.target
+Wants=basic.target
+Wants=multi-user.target

--- a/isos/appliance/vic.target
+++ b/isos/appliance/vic.target
@@ -1,5 +1,5 @@
 [Unit]
 Description=vSphere Integrated Containers
-Requires=network-online.target
-After=network-online.target
+Requires=basic.target
+After=basic.target
 AllowIsolate=yes


### PR DESCRIPTION
Removes the dependency on systemd-networkd which seems to have been
disrupting our link management in the appliance and causing "network
unreachable" errors

Fixes #1791 
