### PR TITLE
[skip ci] Adding documentation about volume usage.

### DIFF
--- a/doc/user_doc/vic_admin/delete_vch_options.md
+++ b/doc/user_doc/vic_admin/delete_vch_options.md
@@ -70,6 +70,9 @@ Forces `vic-machine delete` to ignore warnings and continue with the deletion of
 <pre>--force</pre>
 
 ### `timeout` ###
+
+Short name: none
+
 The timeout period for deleting the virtual container host. Specify a value in the format `XmYs` if the default timeout of 3m0s is insufficient.
 
 <pre>--timeout 5m0s</pre> 

--- a/doc/user_doc/vic_app_dev/SUMMARY.md
+++ b/doc/user_doc/vic_app_dev/SUMMARY.md
@@ -3,3 +3,5 @@
 * [Introduction](README.md)
 * [Supported Docker Commands](container_operations.md)
 * [Use and Limitations of Containers in vSphere Integrated Containers](container_limitations.md)
+* [Using Volumes with vSphere Integrated Containers](using_volumes_with_vic.md)
+* [Docker Commands Fail with a Docker API Version Error](ts_docker_version_error.md)

--- a/doc/user_doc/vic_app_dev/ts_docker_version_error.md
+++ b/doc/user_doc/vic_app_dev/ts_docker_version_error.md
@@ -1,0 +1,21 @@
+# Docker Commands Fail with a Docker API Version Error #
+
+After a successful deployment of a vSphere Integrated Containers virtual container host, attempting to run a Docker command fails with a Docker version error.
+
+## Problem ##
+When you attempt to run a Docker command from a Docker client that is connecting to a virtual container host, the command fails with the error `Error response from daemon: client is newer than server (client API version: 1.24, server API version: 1.23)`.
+
+## Cause ##
+
+vSphere Integrated Containers supports Docker 1.11, that includes version 1.23 of the Docker API. You are using version 1.12 of the Docker client, that uses version 1.24 of the Docker API, which is incompatible.
+
+## Solution ##
+1. Open a Docker client terminal.
+2. Set the Docker client API to the same version as is used by vSphere Integrated Containers.
+
+ <pre>export DOCKER_API_VERSION=1.23</pre> 
+4. Check that your Docker client can now connect to the virtual container host by running a Docker command. 
+
+ <pre>docker -H <i>virtual_container_host_address</i>:2376 --tls info</pre>
+
+ The `docker info` command should succeed and you should see information about the virtual container host.

--- a/doc/user_doc/vic_app_dev/using_volumes_with_vic.md
+++ b/doc/user_doc/vic_app_dev/using_volumes_with_vic.md
@@ -1,0 +1,75 @@
+# Using Volumes with vSphere Integrated Containers #
+
+vSphere Integrated Containers supports the use of container volumes. When you create or the vSphere Administrator creates a virtual container host, you or the Administrator specify the datastore to use to store container volumes in the `vic-machine create --volume-store` option. For information about how to use the `vic-machine create --volume-store` option, see the section on `volume-store` in [Virtual Container Host Deployment Options](../vic_installation/vch_installer_options.html#volume-store) in *vSphere Integrated Containers Installation and Configuration*.   
+
+## Obtain the List of Available Volume Stores ##
+
+To obtain the list of volume stores that are available on a virtual container host, run `docker info`.
+
+<pre>docker -H <i>virtual_container_host_address</i>:2376 --tls info</pre>
+
+The list of available volume stores for this virtual container host appears in the `docker info` output under `VolumeStores`.
+
+<pre>[...]
+Storage Driver: vSphere Integrated Containers Backend Engine
+VolumeStores: <i>volume_store_1</i> <i>volume_store_2</i> ... <i>volume_store_n</i>
+vSphere Integrated Containers Backend Engine: RUNNING
+[...]</pre>
+
+## Create a Volume in a Volume Store ##
+
+When you use the `docker volume create` command to create a volume, you can optionally provide a name for the volume by specifying the `--name` option. If you do not specify `--name`, `docker volume create` assigns a random UUID to the volume.
+
+- If the volume store label is anything other than `default`, you must specify the `--opt VolumeStore` option and pass the name of an existing volume store to it. If you do not specify `--opt VolumeStore`, `docker volume create` searches for a volume store named `default`, and returns an error if no such volume store exists. 
+
+  <pre>docker -H <i>virtual_container_host_address</i>:2376 --tls volume create 
+--opt VolumeStore=<i>volume_store_label</i> 
+--name <i>volume_name</i></pre>
+
+- If you or the vSphere Administrator set the volume store label to `default` when running `vic-machine create`, you do not need to specify `--opt VolumeStore`.
+
+  <pre>docker -H <i>virtual_container_host_address</i>:2376 --tls volume create 
+--name <i>volume_name</i></pre>
+
+- If you intend to create anonymous volumes by using `docker create -v`, a volume store named `default` must exist. In this case, you include the path to the destination at which you want to mount an anonymous volume in the `docker create -v` command. Docker creates the volume in the `default` volume store, if it exists.
+
+  <pre>docker -H <i>virtual_container_host_address</i>:2376 --tls create 
+-v <i>destination_path_for_anonymous_volume</i> busybox</pre>
+
+  **NOTE**: If you use `docker create -v`, vSphere Integrated Containers only supports the `-r` and `-rw` options.
+
+- You can optionally set the capacity of a volume by specifying the `--opt Capacity` option when you run `docker volume create`. If you do not specify the `--opt Capacity` option, the volume is created with the default capacity of 1024MB. 
+
+  If you do not specify a unit for the capacity, the volume is created with a capacity in megabytes.
+  <pre>docker -H <i>virtual_container_host_address</i>:2376 --tls volume create 
+--opt VolumeStore=<i>volume_store_label</i> 
+--opt Capacity=2048
+--name <i>volume_name</i></pre>
+- To create a volume with a capacity in gigabytes or terabytes, include `GB`, or `TB` in the value that you pass to `--opt Capacity`. The unit is case insensitive.
+
+  <pre>docker -H <i>virtual_container_host_address</i>:2376 --tls volume create 
+--opt VolumeStore=<i>volume_store_label</i> 
+--opt Capacity=10GB
+--name <i>volume_name</i></pre>
+
+
+**NOTE**: When using a vSphere Integrated Containers virtual container host as your Docker endpoint, the storage driver is always the vSphere Integrated Containers Backend Engine. If you specify the `docker volume create --driver` option, it is ignored.  
+
+## Obtain the List of Available Volumes ##
+
+To obtain a list of volumes that are available on a virtual container host, run `docker volume ls`.
+
+<pre>docker -H <i>virtual_container_host_address</i>:2376 --tls volume ls
+
+DRIVER         VOLUME NAME
+vsphere        <i>volume_1</i>
+vsphere        <i>volume_2</i>
+[...]          [...]
+vsphere        <i>volume_n</i></pre>
+
+## Delete a Named Volume from a Volume Store ##
+To delete a volume, run `docker volume rm` and specify the name of the volume to delete.
+<pre>docker -H <i>virtual_container_host_address</i>:2376 --tls 
+volume rm <i>volume_name</i></pre>
+
+**NOTE**: In the current builds, `docker volume rm` is not yet supported.

--- a/doc/user_doc/vic_installation/install_vic_cli.md
+++ b/doc/user_doc/vic_installation/install_vic_cli.md
@@ -64,9 +64,7 @@ The virtual container host allows you to use an ESXi host or vCenter Server inst
    At the end of a successful installation, `vic-machine` displays a success message:
    
    <pre>Initialization of appliance successful
-SSH to appliance (default=root:password)
-ssh root@<i>vch_address</i>
-Log server:
+vic-admin portal:
 https://<i>vch_address</i>:2378
 DOCKER_HOST=<i>vch_address</i>:2376
 Connect to docker:

--- a/doc/user_doc/vic_installation/vch_installer_options.md
+++ b/doc/user_doc/vic_installation/vch_installer_options.md
@@ -50,9 +50,12 @@ The datastore in which to store container image files. When you deploy a virtual
 
 You can designate the same datastore as the image store for multiple virtual container hosts. In this case, only one `VIC` folder is created in the datastore and the container image files are made available to all of the virtual container hosts that use that image store. 
 
-**NOTE**: In the current builds the `container-store` option is not enabled. As a consequence, container VM files are also stored in the datastore that you designate as the image store.
+**NOTES**: 
+- vSphere Integrated Containers supports all alphanumeric characters, hyphens, and underscores in datastore paths and datastore names.
+- In the current builds the `image-datastore` option does not support datastore folders. If you specify a datastore folder in the `image-datastore` option, `vic-machine` does not return an error, but creates all of the necessary folders at the root level of the datastore.
+- In the current builds the `container-datastore` option is not enabled. As a consequence, container VM files are also stored in the datastore that you designate as the image store.
 
-<pre>--image-store <i>datastore_name</i></pre> 
+<pre>--image-datastore <i>datastore_name</i></pre> 
 
 <a name="bridge"></a>
 ### `bridge-network` ###
@@ -81,7 +84,19 @@ The `vic-machine create` utility allows you to specify different networks for th
 
 See [bridge-network](#bridge) in the section on mandatory options.
 
+### `bridge-network-range` ###
+
+Short name: `--bnr`
+
+The range of IP addresses that additional bridge networks can use when container application developers use `docker network create` to create new bridge networks. If you do not specify the `bridge-network-range` option, the IP range for bridge networks is 172.16.0.0/12.
+
+When you specify the bridge network IP range, you specify the IP range as a CIDR.
+
+<pre>--bridge-network-range 192.168.100.0/24</pre>
+
 ### `external-network` ###
+
+Short name: `--en`
 
 The network for containers to use to connect to the Internet. Containers use the external network to pull container images, for example from https://hub.docker.com/, and to publish network services. If you define the external network, you can deploy containers directly on the external interface. 
 
@@ -91,6 +106,8 @@ If not specified, containers use the default VM Network for external traffic.
 
 ### `management-network` ###
 
+Short name: `--mn`
+
 The network that the virtual container host uses to communicate with vCenter Server and ESXi hosts. Container VMs use this network to communicate with the virtual container host. 
 
 If not specified, the virtual container host uses the external network for management traffic.
@@ -99,6 +116,8 @@ If not specified, the virtual container host uses the external network for manag
 
 ### `client-network` ###
 
+Short name: `--cln`
+
 The network that the virtual container host uses to generate the Docker API. The Docker API only uses this network.
 
 If not specified, the virtual container host uses the external network for client traffic.
@@ -106,6 +125,8 @@ If not specified, the virtual container host uses the external network for clien
 <pre>--client-network <i>network_name</i></pre>
 
 ### `container-network` ###
+
+Short name: `--cn`
 
 A network for container VMs to use for external communication when you  run `docker run` or `docker create` with the `--net` option. 
 
@@ -125,6 +146,8 @@ If the network that you specify does not support DHCP, you must also specify the
 
 ### `container-network-gateway` ###
 
+Short name: `--cng`
+
 The gateway for the subnet of the container network. This option is required if the network that you specify in the `container-network` option does not support DHCP. Specify the gateway in the format <code><i>container_network</i>:<i>subnet</i></code>. If you specify this option, it is recommended that you also specify the  `container-network-dns` option.
 
  When you specify the container network gateway, you use the distributed port group that you specify in the `container-network `option.
@@ -133,6 +156,8 @@ The gateway for the subnet of the container network. This option is required if 
 
 ### `container-network-dns` ###
 
+Short name: `--cnd`
+
 The address of the DNS server for the container network. This option is recommended if the network that you specify in the `container-network` option does not support DHCP. 
 
 When you specify the container network DNS server, you use the distributed port group that you specify in the `container-network` option.
@@ -140,6 +165,8 @@ When you specify the container network DNS server, you use the distributed port 
 <pre>--container-network-dns <i>distributed_port_group_name</i>:8.8.8.8</pre>
 
 ### `container-network-ip-range` ###
+
+Short name: `--cnr`
 
 The range of IP addresses that container VMs can use if the network that you specify in the `container-network` option does not support DHCP. If you do not specify this option, the IP range for container VMs is the entire subnet that you specify in `container-network-gateway`.
 
@@ -179,8 +206,7 @@ If you do not specify the `compute-resource` option and multiple possible resour
 The `vic-machine` utility allows you to specify the datastores in which to store container VM files, container image files, and the files for the virtual container host appliance. 
 
 - vSphere Integrated Containers fully supports VMware Virtual SAN datastores. 
-- vSphere Integrated Containers supports all alphanumeric characters, hyphens, and underscores in datastore paths. 
-- vSphere Integrated Containers supports all alphanumeric characters, spaces, and parentheses in datastore names. vSphere Integrated Containers does not support hyphens and underscores in datastore names.
+- vSphere Integrated Containers supports all alphanumeric characters, hyphens, and underscores in datastore paths and datastore names.
 
 ### `image-datastore` ###
 
@@ -188,19 +214,43 @@ See [image-datastore](#image) in the section on mandatory options.
 
 ### `container-datastore` ###
 
+Short name: `--cs`
+
 The datastore in which to store container VM files. When you run a container, container VM files are stored in folders at the top level of the designated datastore. If multiple virtual container hosts use the same container store, all of the container VM files appear at the top level of the container store. You cannot currently designate a specific datastore folder for the VM files of the containers that run in a particular virtual container host.
 
-If you do not specify the `container-store` option, vSphere Integrated Containers stores container VM files in the same datastore that you specify in the mandatory `image-store` option.
+If you do not specify the `container-datastore` option, vSphere Integrated Containers stores container VM files in the same datastore that you specify in the mandatory `image-datastore` option.
 
-**NOTE**: In the current builds the `container-store` option is not enabled. Container VM files are stored in the datastore that you designate as the image store.
+**NOTE**: In the current builds the `container-datastore` option is not enabled. Container VM files are stored in the datastore that you designate as the image store.
 
 <pre>--container-datastore <i>datastore_name</i></pre> 
 
+<a name="volume-store"></a>
 ### `volume-store` ###
 
-The datastore in which to create named volumes when using the `docker volume create` command.
+Short name: `--vs`
 
-<pre>--volume-store <i>datastore_name</i>/<i>path</i>:<i>volume_store_name</i></pre>
+The datastore in which to create volumes when using the `docker volume create` command. When you specify the `volume-store` option, you  provide the name of the target datastore and a label for the volume store. You can optionally provide a path to a specific folder in the datastore in which to create the volume store. 
+
+The label that you specify is the volume store name that Docker uses. For example, the volume store label appears in the information for a virtual container host when container application developers run `docker info`. Container application developers also specify the volume store label in the <code>docker volume create --opt VolumeStore=<i>volume_store_label</i></code> option when they create a  volume.
+
+- If you only require one volume store, you can set the volume store label to `default`. If you set the volume store label to `default`, container application developers do not need to specify the <code>--opt VolumeStore=<i>volume_store_label</i></code> option when they run `docker volume create`. 
+
+  **NOTE**: If container application developers intend to create anonymous volumes by using `docker create -v`, you must create a volume store with a label of `default`.
+
+  <pre>--volume-store <i>datastore_name</i>:default</pre>
+- If you specify the target datastore and the volume store label, `vic-machine create` creates a folder named `volumes` under the `VIC` folder on the target datastore. Any volumes that container application developers create will appear in the `volumes` folder.
+
+  <pre>--volume-store <i>datastore_name</i>:<i>volume_store_label</i></pre>
+- If you specify the target datastore, a datastore path, and the volume store label, `vic-machine create` creates a folder named `VIC/volumes` in the location that you specify in the datastore path. If the folders that you specify in the path do not already exist on the datastore, `vic-machine create` creates the appropriate folder structure. Any volumes that container application developers create will appear in the <code><i>path</i>/VIC/volumes</code> folder.
+
+  <pre>--volume-store <i>datastore_name</i>/<i>path</i>:<i>volume_store_label</i></pre>
+- You can specify the `volume-store` option multiple times, to create multiple volume stores on the virtual container host.
+
+  <pre>--volume-store <i>datastore_name</i>/path:<i>volume_store_label_1</i>
+--volume-store <i>datastore_name</i>/<i>path</i>:<i>volume_store_label_2</i>
+[...]
+--volume-store <i>datastore_name</i>/<i>path</i>:<i>volume_store_label_n</i>
+</pre>
 
 <a name="security"></a>
 ## Security Options ##
@@ -209,11 +259,15 @@ You can configure a virtual container host to use an automatically generated cer
 
 ### `no-tls` ###
 
+Short name: `-k`
+
 If you do not set the `no-tls` option, `vic-machine` by default generates a TLS certificate and key for the virtual container host to  use to authenticate with a Docker client. Set the `no-tls` option if you do not require certificate-based authentication between the virtual container host and the Docker client. If you use the `cert` and `key` options to upload a custom CA certificate, `vic-machine` does not auto-generate a certificate, without requiring you to set `no-tls` to `false`.
 
 <pre>--no-tls</pre>
 
 ### `cert` ###
+
+Short name: none
 
 The path to an X.509 certificate for the Docker API to use to authenticate the virtual container host with a Docker client.
 
@@ -225,6 +279,9 @@ If you use the `cert` and `key` options, `vic-machine` does not automatically ge
 <pre>--cert <i>path_to_vcenter_server_certificate</i> --key <i>path_to_vcenter_server_key</i></pre> 
 
 ### `key` ###
+
+Short name: none
+
 The path to the private key file for use with a custom CA certificate. This option is mandatory if your Docker environment uses certificates that are signed by a CA. For information about how to set up a Docker client to use CA certificates, see https://docs.docker.com/engine/security/https/.
 
 Use this option in combination with the `cert` option, that provides the path to an X.509 certificate file. 
@@ -263,11 +320,16 @@ Forces `vic-machine create` to ignore warnings and non-fatal errors and continue
 <pre>--force</pre>
 
 ### `timeout` ###
+
+Short name: none
+
 The timeout period for uploading the vSphere Integrated Containers  appliance and container images to the ESXi host, and for powering on the appliance. Specify a value in the format `XmYs` if the default timeout of 3m0s is insufficient.
 
 <pre>--timeout 5m0s</pre> 
 
 ### `appliance-iso` ###
+
+Short name: `--ai`
 
 The ISO image from which the virtual container host appliance boots. Omit this option to boot the appliance from the default ISO that is included with `vic-machine`. Set this option to boot the appliance from a different ISO file, for example to reinstall an existing virtual container host or to update it to a newer version.
 
@@ -275,21 +337,31 @@ The ISO image from which the virtual container host appliance boots. Omit this o
 
 ### `bootstrap-iso` ###
 
+Short name: `--bi`
+
 The ISO image from which container VMs boot. Omit this option to boot container VMs from the default Photon OS ISO that is included with `vic-machine`. Set this option to a different ISO file to boot container VMs with an operating system other than Photon OS.
 
 <pre>--bootstrap-iso <i>path_to_ISO_file</i></pre>
 
 ### `appliance-cpu ` ###
-The number of virtual CPUs for the virtual container host appliance VM. The default is 1. Set this option to increase the number of CPUs in the virtual container host VM, for example if the virtual container host will handle large volumes of containers, or containers that require a lot of processing power.
+
+Short name: none
+
+The number of virtual CPUs for the virtual container host VM. The default is 1. Set this option to increase the number of CPUs in the virtual container host VM, for example if the virtual container host will handle large volumes of containers, or containers that require a lot of processing power.
 
 <pre>--appliance-cpu <i>number_of_CPUs</i></pre>
 
 ### `appliance-memory ` ###
-The amount of memory for the virtual container host appliance VM. The default is 2048MB. Set this option to increase the amount of memory in the virtual container host VM, for example if the virtual container host will handle large volumes of containers, or containers that consume a lot of memory.
+
+Short name: none
+
+The amount of memory for the virtual container host VM. The default is 2048MB. Set this option to increase the amount of memory in the virtual container host VM, for example if the virtual container host will handle large volumes of containers, or containers that consume a lot of memory.
 
 <pre>--appliance-memory <i>amount_of_memory</i></pre>
 
 ### `use-rp` ###
+
+Short name: none
 
 Deploy the virtual container host to a resource pool rather than to a vApp. If you specify this option, `vic-machine create` creates a resource pool with the same name as the virtual container host.
 
@@ -297,37 +369,49 @@ Deploy the virtual container host to a resource pool rather than to a vApp. If y
 
 ### `pool-memory-reservation` ###
 
-Reserve a quantity of memory for use by the vApp or resource pool that contains the virtual container host. Specify the memory reservation value in MB. If not specified, `vic-machine create` sets the reservation to 0 (unlimited).
+Short name: `--pmr`
+
+Reserve a quantity of memory for use by the vApp or resource pool that contains the virtual container host and container VMs. Specify the memory reservation value in MB. If not specified, `vic-machine create` sets the reservation to 1.
 
 <pre>--pool-memory-reservation 1024</pre>
 
 ### `pool-memory-limit` ###
 
-Limit the amount of memory that the vApp or resource pool that contains the virtual container host can use. Specify the memory limit value in MB. If not specified, `vic-machine create` sets the limit to 0 (unlimited).
+Short name: `--pml`
+
+Limit the amount of memory that is available for use by the vApp or resource pool that contains the virtual container host and container VMs. Specify the memory limit value in MB. If not specified, `vic-machine create` sets the limit to 0 (unlimited).
 
 <pre>--pool-memory-limit 1024</pre>
 
 ### `pool-memory-shares` ###
 
-Set memory shares on the vApp or resource pool that contains the virtual container host. Specify the share value as a level or a number, for example `high`, `normal`, `low`, or `163840`. If not specified, `vic-machine create` sets the share to `nil` (unlimited).
+Short name: `--pms`
+
+Set memory shares on the vApp or resource pool that contains the virtual container host and container VMs. Specify the share value as a level or a number, for example `high`, `normal`, `low`, or `163840`. If not specified, `vic-machine create` sets the share to `normal`.
 
 <pre>--pool-memory-shares low</pre>
 
 ### `pool-cpu-reservation` ###
 
-Reserve a quantity of CPU capacity for use by the vApp or resource pool that contains the virtual container host.  Specify the CPU reservation value in MHz. If not specified, `vic-machine create` sets the reservation to 0 (unlimited).
+Short name: `--pcr`
+
+Reserve a quantity of CPU capacity for use by the vApp or resource pool that contains the virtual container host and container VMs.  Specify the CPU reservation value in MHz. If not specified, `vic-machine create` sets the reservation to 1.
 
 <pre>--pool-cpu-reservation 1024</pre>
 
 ### `pool-cpu-limit` ###
 
-Limit the amount of CPU capacity that the vApp or resource pool that contains the virtual container host can use. Specify the CPU limit value in MHz. If not specified, `vic-machine create` sets the reservation to 0 (unlimited).
+Short name: `--pcl`
+
+Limit the amount of CPU capacity that is available for use by the vApp or resource pool that contains the virtual container host and container VMs. Specify the CPU limit value in MHz. If not specified, `vic-machine create` sets the reservation to 0 (unlimited).
 
 <pre>--pool-cpu-limit 1024</pre>
 
 ### `pool-cpu-shares` ###
 
-Set CPU shares on the vApp or resource pool that contains the virtual container host. Specify the share value as a level or a number, for example `high`, `normal`, `low`, or `163840`. If not specified, `vic-machine create` sets the share to `nil` (unlimited).
+Short name: `--pcs`
+
+Set CPU shares on the vApp or resource pool that contains the virtual container host and container VMs. Specify the share value as a level or a number, for example `high`, `normal`, `low`, or `163840`. If not specified, `vic-machine create` sets the share to `normal`.
 
 <pre>--pool-cpu-shares low</pre>
 

--- a/doc/user_doc/vic_installation/vic_installation_prereqs.md
+++ b/doc/user_doc/vic_installation/vic_installation_prereqs.md
@@ -1,18 +1,18 @@
-# Environment Prerequisites for vSphere Integrated Containers Installation
+# Environment Prerequisites for vSphere Integrated Containers Installation #
 
 Before you install vSphere Integrated Containers, you must ensure that your infrastructure meets certain requirements.
 
-## Supported Platforms for `vic-machine`
+## Supported Platforms for `vic-machine` ##
 
-The current builds of the vSphere Integrated Containers installation and management utility, `vic-machine`, have been tested and verified on the following Linux OS, Windows, and Mac OS systems.
+The vSphere Integrated Containers installation and management utility, `vic-machine`, has been tested and verified on the following Linux OS, Windows, and Mac OS systems.
 
 |**Platform**|**Supported Versions**|
 |---|---|
 |Windows|7, 10|
-|Mac OS X |10.11 (TBC)|
+|Mac OS X |10.11 (El Capitan)|
 |Linux|Ubuntu 15.04, others TBD|
 
-## Supported vSphere Configurations
+## Supported vSphere Configurations ##
 
 You can install vSphere Integrated Containers in the following vSphere setups:
 
@@ -20,11 +20,20 @@ You can install vSphere Integrated Containers in the following vSphere setups:
 * vCenter Server 6.0, managing one or more standalone ESXi 6.0 hosts.
 * vCenter Server 6.0, managing a cluster of ESXi 6.0 hosts, with DRS enabled.
 
-In all cases, your ESXi hosts must have at least 8GB of memory.
-
 Deploying vSphere Integrated Containers to a vCenter Server instance that is running in Enhanced Linked Mode is fully supported.  
 
-## License Requirements
+## ESXi Host Requirements ##
+
+To be valid targets for virtual container hosts and container VMs, standalone ESXi hosts and all ESXi hosts in vCenter Server clusters must meet the following criteria:
+
+- All ESXi hosts must be attached to shared storage for use as container datastores, image datastores, and volume stores.
+- The firewall on all ESXi hosts must be configured to allow connections on the back channel.
+- All ESXi hosts must be attached to the distributed virtual switch for the bridge network in vCenter Server. For more information about distributed virtual switches, see [Network Requirements](#networkreqs) below.
+- All ESXi hosts must be attached to any mapped vSphere networks.
+
+During deployment of virtual container hosts, the `vic-machine` utilty checks that the target ESXi hosts meet the requirements, and issues warnings if they do not.
+
+## License Requirements ##
 The type of license that vSphere Integrated Containers requires depends on the way in which you deploy the software.
 
 | **Type of Installation** | **vSphere Feature Used** | **Required License** |


### PR DESCRIPTION
[skip ci] This PR addresses the following doc issues: 
- https://github.com/vmware/vic/issues/932
- https://github.com/vmware/vic/issues/1523
- https://github.com/vmware/vic/issues/1526
- https://github.com/vmware/vic/issues/1522
- https://github.com/vmware/vic/issues/1521

The changes related to volumes are in two files:
- Fleshed out the description of the `vic-machine create --volume-store` option in [Virtual Container Host Deployment Options](https://github.com/stuclem/vic/blob/master/doc/user_doc/vic_installation/vch_installer_options.md#volume-store). @gigawhitlocks, please can you review this section?
- Added a new topic on [Using Volumes with vSphere Integrated Containers](https://github.com/stuclem/vic/blob/master/doc/user_doc/vic_app_dev/using_volumes_with_vic.md), which is intended for container app developers. @matthewavery, please can you take a look?

There are also a couple of minor changes relating to the `vic-machine create --pool-xxx` options in [Virtual Container Host Deployment Options](https://github.com/stuclem/vic/blob/master/doc/user_doc/vic_installation/vch_installer_options.md#use-rp). @emlin, can you please check these ones?

Thanks!