### PR TITLE
Show server and build info in docker version output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -266,7 +266,7 @@ $(imagec): $(call godeps,cmd/imagec/*.go) $(portlayerapi-client)
 $(docker-engine-api): $(call godeps,cmd/docker/*.go) $(portlayerapi-client)
 ifeq ($(OS),linux)
 	@echo Building docker-engine-api server...
-	@$(TIME) $(GO) build $(RACE) -o $@ ./cmd/docker
+	@$(TIME) $(GO) build $(RACE) $(ldflags) -o $@ ./cmd/docker
 else
 	@echo skipping docker-engine-api server, cannot build on non-linux
 endif

--- a/lib/apiservers/engine/backends/system.go
+++ b/lib/apiservers/engine/backends/system.go
@@ -39,6 +39,7 @@ import (
 	"github.com/vmware/vic/lib/apiservers/portlayer/client"
 	"github.com/vmware/vic/lib/apiservers/portlayer/client/storage"
 	"github.com/vmware/vic/pkg/trace"
+	"github.com/vmware/vic/pkg/version"
 
 	"github.com/docker/docker/pkg/platform"
 	"github.com/docker/engine-api/types"
@@ -186,19 +187,30 @@ func (s *System) SystemInfo() (*types.Info, error) {
 	return info, nil
 }
 
+// layout for build time as per constants defined in https://golang.org/src/time/format.go
+const buildTimeLayout = "2006/01/02@15:04:05"
+
 func (s *System) SystemVersion() types.Version {
 	APIVersion := "1.22"
 	Arch := runtime.GOARCH
-	// FIXME: fill with real build time
-	BuildTime := "-"
+
+	BuildTime := version.BuildDate
+	if t, err := time.Parse(buildTimeLayout, BuildTime); err == nil {
+		// match time format from docker version's output
+		BuildTime = t.Format(time.ANSIC)
+	}
+
 	Experimental := true
-	// FIXME: fill with real commit id
-	GitCommit := "-"
+	GitCommit := version.GitCommit
 	GoVersion := runtime.Version()
 	// FIXME: fill with real kernel version
 	KernelVersion := "-"
 	Os := runtime.GOOS
-	Version := "0.0.1"
+	Version := version.Version
+	if Version != "" && Version[0] == 'v' {
+		// match version format from docker version's output
+		Version = Version[1:]
+	}
 
 	// go runtime panics without this so keep this here
 	// until we find a repro case and report it to upstream


### PR DESCRIPTION
Populates the build time, commit and version fields for the server portion of the `docker version` output

Server portion output:

Vanilla docker
```
Server:
 Version:      1.11.2
 API version:  1.23
 Go version:   go1.5.4
 Git commit:   b9f10c9
 Built:        Wed Jun  1 22:00:43 2016
 OS/Arch:      linux/amd64
```
VIC
```
Server:
 Version:      0.4.0
 API version:  1.23
 Go version:   go1.6.3
 Git commit:   5622735
 Built:        Thu Aug  4 17:14:53 2016
 OS/Arch:      linux/amd64
 Experimental: true
```
Fixes #856

