### PR TITLE
Show cleaner output during docker pull

### DIFF
--- a/cmd/imagec/imagec.go
+++ b/cmd/imagec/imagec.go
@@ -703,7 +703,7 @@ func main() {
 	// HACK: Required to learn the name of the vmdk from given reference
 	// Used by docker personality until metadata support lands
 	if !options.resolv {
-		progress.Message(po, options.tag, "Pulling from "+options.image)
+		progress.Message(po, "", "Pulling from "+options.image)
 	}
 
 	// Get the manifest


### PR DESCRIPTION
Minor change that removes the image tag from the output of `docker pull`

Vanilla docker
```
$ sudo docker pull foo/bar
Using default tag: latest
Pulling repository docker.io/foo/bar
Error: image foo/bar not found
```

VIC
```
$ docker -H <host> --tls pull foo/bar
Using default tag: latest
Pulling from foo/bar
Error: image foo/bar not found
```

Fixes #1717

