### PR TITLE
Just big sleep to allow VM to shut off and hopefully avoid intermitte…

### DIFF
--- a/tests/resources/Util.robot
+++ b/tests/resources/Util.robot
@@ -267,6 +267,7 @@ Run Regression Tests
     ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} ps -a
     Should Be Equal As Integers  ${rc}  0
     Should Contain  ${output}  Stopped
+    Sleep  30
     ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} rm ${container}
     Should Be Equal As Integers  ${rc}  0
     ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} ps -a

--- a/tests/resources/Util.robot
+++ b/tests/resources/Util.robot
@@ -267,6 +267,8 @@ Run Regression Tests
     ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} ps -a
     Should Be Equal As Integers  ${rc}  0
     Should Contain  ${output}  Stopped
+    ${status}=  Get State Of Github Issue  1870
+    Run Keyword If  '${status}' == 'closed'  Fail  Remove the big sleep from Util.robot now that Issue #1870 has been resolved
     Sleep  30
     ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} rm ${container}
     Should Be Equal As Integers  ${rc}  0

--- a/tests/resources/Util.robot
+++ b/tests/resources/Util.robot
@@ -248,6 +248,15 @@ Wait Until Container Stops
     \   Sleep  1
     Fail  Container did not stop within 10 seconds
 
+Wait Until VM Stops
+    [Arguments]  ${vm}
+    :FOR  ${idx}  IN RANGE  0  20
+    \   ${out}=  Run  govc vm.info ${vm}
+    \   ${status}=  Run Keyword And Return Status  Should Contain  ${out}  poweredOff
+    \   Return From Keyword If  ${status}
+    \   Sleep  1
+    Fail  VM did not stop within 20 seconds
+
 Run Regression Tests
     ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} pull busybox
     Should Be Equal As Integers  ${rc}  0
@@ -268,8 +277,8 @@ Run Regression Tests
     Should Be Equal As Integers  ${rc}  0
     Should Contain  ${output}  Stopped
     ${status}=  Get State Of Github Issue  1870
-    Run Keyword If  '${status}' == 'closed'  Fail  Remove the big sleep from Util.robot now that Issue #1870 has been resolved
-    Sleep  30
+    Run Keyword If  '${status}' == 'closed'  Fail  Remove the wait until vm stops from Util.robot now that Issue #1870 has been resolved
+    Wait Until VM Stops  *${container}
     ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} rm ${container}
     Should Be Equal As Integers  ${rc}  0
     ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} ps -a

--- a/tests/test-cases/Group1-Docker-Commands/1-11-Docker-RM.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-11-Docker-RM.robot
@@ -27,6 +27,9 @@ Remove a stopped container
     ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} start ${container}
     Should Be Equal As Integers  ${rc}  0
     Wait Until Container Stops  ${container}
+    ${status}=  Get State Of Github Issue  1870
+    Run Keyword If  '${status}' == 'closed'  Fail  Remove the wait until vm stops from 1-11-Docker-RM.robot now that Issue #1870 has been resolved
+    Wait Until VM Stops  *${container}
     ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} rm ${container}
     Should Be Equal As Integers  ${rc}  0
     ${rc}  ${output}=  Run And Return Rc And Output  govc ls vm


### PR DESCRIPTION
We believe that there is a race between docker stop and docker rm. Because we have not implemented containerWait yet, our docker rm implementation immediately tries to rm a vm that might still be powered on.