### PR TITLE
Updated integration test for docker logs

### DIFF
--- a/tests/test-cases/Group1-Docker-Commands/1-8-Docker-Logs.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-8-Docker-Logs.robot
@@ -75,10 +75,10 @@ Docker logs with timestamps and since certain time
 	Run  Sleep 6, wait for container to finish
     ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} logs --since=1s ${containerID}
 	Should Be Equal As Integers  ${rc}  1
-    Should Contain  ${output}  does not yet support timestampped logs
+    Should Contain  ${output}  vSphere Integrated Containers does not implement container.ContainerLogs
     ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} logs --timestamps ${containerID}
 	Should Be Equal As Integers  ${rc}  1
-    Should Contain  ${output}  does not yet support timestampped logs
+    Should Contain  ${output}  vSphere Integrated Containers does not implement container.ContainerLogs
     
 Docker logs non-existent container
     ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} logs fakeContainer


### PR DESCRIPTION
Fixed error that CI looks for durin logs with timestamps and certain
time outputs.

Fixes #1871 