### PR TITLE
Support unspecified host port for port mapping

### DIFF
--- a/lib/apiservers/engine/backends/container.go
+++ b/lib/apiservers/engine/backends/container.go
@@ -587,9 +587,9 @@ func (c *Container) mapPorts(op portmap.Operation, hostconfig *container.HostCon
 			continue
 		}
 
-		for _, pb := range pbs {
+		for i := range pbs {
 			var hostPort int
-			if pb.HostPort == "" {
+			if pbs[i].HostPort == "" {
 				// use a random port since no host port is specified
 				hostPort, err = requestHostPort(proto)
 				if err != nil {
@@ -597,11 +597,10 @@ func (c *Container) mapPorts(op portmap.Operation, hostconfig *container.HostCon
 					return err
 				}
 				// update the hostconfig
-				hostpb := nat.PortBinding{HostIP: "", HostPort: strconv.Itoa(hostPort)}
-				hostconfig.PortBindings[nport] = []nat.PortBinding{hostpb}
+				pbs[i].HostPort = strconv.Itoa(hostPort)
 
 			} else {
-				hostPort, err = strconv.Atoi(pb.HostPort)
+				hostPort, err = strconv.Atoi(pbs[i].HostPort)
 				if err != nil {
 					return err
 				}

--- a/tests/test-cases/Group1-Docker-Commands/1-25-Docker-Port-Map.md
+++ b/tests/test-cases/Group1-Docker-Commands/1-25-Docker-Port-Map.md
@@ -25,12 +25,16 @@ This test requires that a vSphere server is running and available
 12. Issue docker start webserver3
 13. Issue docker create -it -p 8081-8088:80 --name webserver5 nginx
 14. Issue docker create -it -p 10.10.10.10:8088:80 --name webserver5 nginx
+15. Issue docker create -it -p 6379 --name test-redis redis:alpine
+16. Issue docker start test-redis
+17. Issue docker stop test-redis
 
 #Expected Outcome:
 * Steps 2-6 should all return without error
 * Steps 7-8 should both return error
 * Steps 9-11 should all return without error
 * Steps 12-14 should return error
+* Steps 15-17 should return without error
 
 #Possible Problems:
 None

--- a/tests/test-cases/Group1-Docker-Commands/1-25-Docker-Port-Map.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-25-Docker-Port-Map.robot
@@ -47,3 +47,13 @@ Create container with host ip
     ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} create -it -p 10.10.10.10:8088:80 --name webserver5 nginx
     Should Not Be Equal As Integers  ${rc}  0
     Should Contain  ${output}  host IP is not supported for port bindings
+
+Create container without specifying host port
+    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} create -it -p 6379 --name test-redis redis:alpine
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} start test-redis
+    Should Be Equal As Integers  ${rc}  0
+    Should Not Contain  ${output}  Error
+    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} stop test-redis
+    Should Be Equal As Integers  ${rc}  0
+    Should Not Contain  ${output}  Error

--- a/tests/test-cases/Group1-Docker-Commands/1-6-Docker-Run.md
+++ b/tests/test-cases/Group1-Docker-Commands/1-6-Docker-Run.md
@@ -22,7 +22,7 @@ This test requires that a vSphere server is running and available
 9. Issue docker run -d --name busy3 busybox /bin/top to the VIC appliance
 10. Issue docker run --link busy3:busy3 busybox ping -c2 busy3 to the VIC appliance
 11. Issue docker run -it busybox /bin/df to the VIC appliance
-
+12. Issue docker run -d -p 6379 redis:alpine to the VIC appliance
 #Expected Outcome:
 * Step 2 and 3 should result in success and print the dmesg of the container
 * Step 4 should result in the top command starting and printing it's results to the screen
@@ -39,6 +39,7 @@ docker: Error parsing reference: "fakeImage" is not a valid repository/tag.
 ```
 * Step 10 should result in success and the output should indicate that the ping succeeded across containers just using the linked name
 * Step 11 should result in success with exit code 0 and show the output of the df command
+* Step 12 should result in success with exit code 0
 
 #Possible Problems:
 None

--- a/tests/test-cases/Group1-Docker-Commands/1-6-Docker-Run.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-6-Docker-Run.robot
@@ -69,3 +69,8 @@ Docker run df command
     #${rc}  ${output}=  Run And Return Rc And Output  docker ${params} run -it busybox /bin/df
     #Should Be Equal As Integers  ${rc}  0
     #Should Contain  ${output}  Filesystem           1K-blocks      Used Available Use% Mounted on
+
+Docker run -d unspecified host port
+    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} run -d -p 6379 redis:alpine
+    Should Be Equal As Integers  ${rc}  0
+    Should Not Contain  ${output}  Error


### PR DESCRIPTION
* Adds support for mapping a random host port to the container when the host port in not specified in the CLI
* Adds integration tests in the `docker port map` and `docker run` suites

Integration tests verified locally.

Fixes #1735 
