### PR TITLE
Fix incorrect assumption for bootstrap.iso path

### DIFF
--- a/cmd/vic-machine/create/create.go
+++ b/cmd/vic-machine/create/create.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 	"time"
@@ -514,6 +515,8 @@ func (c *Create) Run(cliContext *cli.Context) error {
 
 	vConfig := validator.AddDeprecatedFields(ctx, vchConfig, c.Data)
 	vConfig.ImageFiles = images
+	vConfig.ApplianceISO = path.Base(c.ApplianceISO)
+	vConfig.BootstrapISO = path.Base(c.BootstrapISO)
 
 	{ // create certificates for VCH extension
 		var certbuffer, keybuffer bytes.Buffer

--- a/lib/install/data/data.go
+++ b/lib/install/data/data.go
@@ -93,6 +93,9 @@ type InstallerData struct {
 
 	ImageFiles []string
 
+	ApplianceISO string
+	BootstrapISO string
+
 	Extension types.Extension
 	UseRP     bool
 }

--- a/lib/install/validate/validator.go
+++ b/lib/install/validate/validator.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"net"
 	"net/url"
-	"path"
 	"path/filepath"
 	"strings"
 
@@ -196,12 +195,6 @@ func (v *Validator) basics(ctx context.Context, input *data.Data, conf *config.V
 	conf.SetDebug(input.Debug.Debug)
 
 	conf.Name = input.DisplayName
-
-	conf.BootstrapImagePath = fmt.Sprintf("[%s] %s/%s",
-		input.ImageDatastoreName,
-		input.DisplayName,
-		path.Base(input.BootstrapISO),
-	)
 }
 
 func (v *Validator) checkSessionSet() []string {


### PR DESCRIPTION
The ISO path that's generated is based off the display name, not the
actual VM folder path. This pr fixes that also removes the hardcoded
appliance.iso file name.

Fixes #1351 2nd time