### PR TITLE
Make VIC UI support vCenter 5.5

### DIFF
--- a/ui/installer/VCSA/uninstall.sh
+++ b/ui/installer/VCSA/uninstall.sh
@@ -35,11 +35,18 @@ echo -n "Enter your vCenter Administrator Password: "
 read -s VCENTER_ADMIN_PASSWORD
 echo ""
 
+read -p "Are you running vCenter 5.5? (y/n): " IS_VCENTER_5_5
+if [[ $(echo $IS_VCENTER_5_5 | grep -i "y") ]] ; then
+    IS_VCENTER_5_5=1
+    WEBCLIENT_PLUGINS_FOLDER="/var/lib/vmware/vsphere-client/vc-packages/vsphere-client-serenity/"
+else
+    WEBCLIENT_PLUGINS_FOLDER="/etc/vmware/vsphere-client/vc-packages/vsphere-client-serenity/"
+fi
+
 OS=$(uname)
 PLUGIN_BUNDLES=''
 VCENTER_SDK_URL="https://${VCENTER_IP}/sdk/"
 COMMONFLAGS="--target $VCENTER_SDK_URL --user $VCENTER_ADMIN_USERNAME --password $VCENTER_ADMIN_PASSWORD"
-WEBCLIENT_PLUGINS_FOLDER="/etc/vmware/vsphere-client/vc-packages/vsphere-client-serenity/"
 PLUGIN_FOLDERS=''
 
 if [[ $(echo $OS | grep -i "darwin") ]] ; then
@@ -80,7 +87,7 @@ parse_and_unregister_plugins () {
     echo "Deleting plugin contents..."
     echo "Please enter the root password for your machine running VCSA"
     echo "-------------------------------------------------------------"
-    ssh -t root@$VCENTER_IP "cd $WEBCLIENT_PLUGINS_FOLDER; rm -rf $PLUGIN_FOLDERS" 
+    ssh -t root@$VCENTER_IP "cd $WEBCLIENT_PLUGINS_FOLDER; rm -rf $PLUGIN_FOLDERS"
 }
 
 rename_package_folder () {

--- a/ui/vic-ui/plugin-package.xml
+++ b/ui/vic-ui/plugin-package.xml
@@ -4,7 +4,7 @@
       description="VicUI" vendor="VMware">
    <dependencies>
       <!-- Minimum vSphere Client version compatible with this plugin -->
-      <pluginPackage id="com.vmware.vsphere.client" version="6.0.0" />
+      <pluginPackage id="com.vmware.vsphere.client" version="5.5.0" />
    </dependencies>
 
    <bundlesOrder>

--- a/ui/vic-ui/swf/src/main/flex/com/vmware/vicui/views/VchPortletMediator.as
+++ b/ui/vic-ui/swf/src/main/flex/com/vmware/vicui/views/VchPortletMediator.as
@@ -7,14 +7,14 @@ package com.vmware.vicui.views {
 	import com.vmware.ui.IContextObjectHolder;
 	import com.vmware.vicui.constants.AppConstants;
 	import com.vmware.vicui.model.VchInfo;
-	
+
 	import flash.events.EventDispatcher;
 	import flash.utils.ByteArray;
-	
+
 	import mx.logging.ILogger;
 	import mx.logging.Log;
 	import mx.utils.Base64Decoder;
-	
+
 	[Event(name="{com.vmware.data.query.events.DataByModelRequest.REQUEST_ID}",
    type="com.vmware.data.query.events.DataByModelRequest")]
 
@@ -25,115 +25,112 @@ package com.vmware.vicui.views {
 	{
 	   private var _contextObject:IResourceReference;
 	   private var _view:VchPortletView;
-	
+
 	   private static var _logger:ILogger = Log.getLogger('VchMediator');
-	
+
 	   [View]
 	   /** The view associated with this mediator. */
 	   public function set view(value:VchPortletView):void {
 		   _view = value;
 	   }
-	   
+
 	   /**
 		* Returns the view.
 		*/
 	   public function get view():VchPortletView {
 		   return _view;
 	   }
-	
-	
+
 	   [Bindable]
 	   /** Returns the inventory object handled in this view (IContextObjectHolder interface) */
 	   public function get contextObject():Object {
 	      return _contextObject;
 	   }
-	
+
 	   /** Called by the framework with the current inventory object or null */
 	   public function set contextObject(value:Object):void {
 	      _contextObject = IResourceReference(value);
-	
+
 	      if (_contextObject == null) {
 	         // A null contextObject means that the view is being cleared
 	         clearData();
 	         return;
 	      }
-	
+
 	      // Once contextObject is set the view can be initialized with the object data.
 	      requestData();
 	   }
-	
+
 	   private function requestData():void {
-	   	   // Default data request option allowing implicit updates of the view
-	   	   var requestInfo:DataRequestInfo = new DataRequestInfo(DataUpdateSpec.newImplicitInstance());
+		   // Default data request option allowing implicit updates of the view
+		   var requestInfo:DataRequestInfo = new DataRequestInfo(DataUpdateSpec.newImplicitInstance());
 
 		   // Dispatch an event to fetch the _contextObject data from the server along the specified model.
 		   dispatchEvent(DataByModelRequest.newInstance(_contextObject, VchInfo, requestInfo));
 	   }
-	   
+
 	   [ResponseHandler(name="{com.vmware.data.query.events.DataByModelRequest.RESPONSE_ID}")]
 	   public function onData(event:DataByModelRequest, result:VchInfo):void {
 		   _logger.info("Vch summary data retrieved.");
 
 		   if (_view != null) {
-			   
+
 			   //set default placeholder data
 			   _view.isVch = new Boolean(false);
 			   _view.dockerApiEndpoint.text = new String("-");
 			   _view.dockerLog.label = new String("-");
-		   	   
+
 			   if (result != null) {
-				   
+
 				   var config:Array = new Array();
-				   
+
 				   //extraConfig data from vm config
 				   config = result.extraConfig;
-				   
+
 				   if (config != null) {
-					   
+
 					   var keyName:String = new String();
 					   var keyVal:String = new String();
 					   var key:String = new String();
 
 					   for (key in config ) {
-						  
-							keyName = config[key].key.value as String;
-							keyVal = config[key].value as String;
-							
-							//determine if its a vch
-							if (keyName == AppConstants.VCH_NAME_PATH) {
-							    _view.isVch = true;
-							    continue;
-							}
-							
-							//get container ip and decode to correct format
-							if (keyName == AppConstants.VCH_CLIENT_IP_PATH ) {
-								var base64Decoder:Base64Decoder = new Base64Decoder();
-							    base64Decoder.decode(keyVal);
-								   
-								var bytes:ByteArray = new ByteArray();
-								var ip_raw:String = new String();
-								var ip_ipv4:String = new String();
-		
-							    bytes = base64Decoder.toByteArray();
-							    ip_raw = bytes.toString();
-							    ip_ipv4 = ip_raw.charCodeAt(0) + "." + ip_raw.charCodeAt(1) + "." + ip_raw.charCodeAt(2) + "." + ip_raw.charCodeAt(3);
-							       
-							    _view.dockerApiEndpoint.text = "DOCKER_HOST=tcp://" + ip_ipv4 + AppConstants.VCH_ENDPOINT_PORT;
-							    _view.dockerLog.label = "http://" + ip_ipv4 + AppConstants.VCH_LOG_PORT;
-							    continue;
-		
-							}
+
+						   keyName = config[key].key.value as String;
+						   keyVal = config[key].value as String;
+
+						   //determine if its a vch
+						   if (keyName == AppConstants.VCH_NAME_PATH) {
+							   _view.isVch = true;
+							   continue;
+						   }
+
+						   //get container ip and decode to correct format
+						   if (keyName == AppConstants.VCH_CLIENT_IP_PATH ) {
+							   var base64Decoder:Base64Decoder = new Base64Decoder();
+							   base64Decoder.decode(keyVal);
+
+							   var bytes:ByteArray = new ByteArray();
+							   var ip_ipv4:String = new String();
+
+							   bytes = base64Decoder.toByteArray();
+							   ip_ipv4 = bytes.readUnsignedByte() + "." + bytes.readUnsignedByte() + "." + bytes.readUnsignedByte() + "." + bytes.readUnsignedByte();
+
+							   _view.dockerApiEndpoint.text = "DOCKER_HOST=tcp://" + ip_ipv4 + AppConstants.VCH_ENDPOINT_PORT;
+							   _view.dockerLog.label = "https://" + ip_ipv4 + AppConstants.VCH_LOG_PORT;
+							   continue;
+
+						   }
 					   }
 				   }
 			   } else {
 				   _view.isVch = false;
 			   }
-	   	   }
+		   }
 	   }
-	   
+
 	   private function clearData() : void {
-	   	   if(_view != null) {  
-		      // clear the UI data
+		   if(_view != null) {
+			   // clear the UI data
 			   _view.isVch = false;
 			   _view.dockerApiEndpoint.text = new String("-");
 			   _view.dockerLog.label = new String("-");

--- a/ui/vic-ui/war/src/main/webapp/plugin.xml
+++ b/ui/vic-ui/war/src/main/webapp/plugin.xml
@@ -26,10 +26,11 @@
                      <propertyName>isContainer</propertyName>
                      <comparator>EQUALS</comparator>
                      <comparableValue>
-                        <string>true</string>
+                        <Boolean>true</Boolean>
                      </comparableValue>
                   </com.vmware.data.query.PropertyConstraint>
                </nestedConstraints>
+	       <conjoiner>AND</conjoiner>
             </com.vmware.data.query.CompositeConstraint>
          </propertyConditions>
       </metadata>
@@ -50,10 +51,11 @@
                      <propertyName>isVCH</propertyName>
                      <comparator>EQUALS</comparator>
                      <comparableValue>
-                        <string>true</string>
+                        <Boolean>true</Boolean>
                      </comparableValue>
                   </com.vmware.data.query.PropertyConstraint>
                </nestedConstraints>
+               <conjoiner>AND</conjoiner>
             </com.vmware.data.query.CompositeConstraint>
          </propertyConditions>
       </metadata>


### PR DESCRIPTION
This PR makes VIC UI (VCH and container VM portlets) work across three different versions of vCenter (5.5, 6.0 and 6.5). I have confirmed the VCH VM portlet behaves as expected for the three versions, but could test the container VM portlet only on 6.0, as I couldn't get `docker run` to run on 6.5 which is an already raised issue.

Fixes #1856.