### PR TITLE
Refactor stop command

### DIFF
--- a/lib/apiservers/engine/backends/container.go
+++ b/lib/apiservers/engine/backends/container.go
@@ -789,8 +789,9 @@ func (c *Container) containerStop(name string, seconds int, unbound bool) error 
 	}
 
 	handle = stateChangeResponse.Payload
+	wait := int32(seconds)
 
-	_, err = client.Containers.Commit(containers.NewCommitParamsWithContext(ctx).WithHandle(handle))
+	_, err = client.Containers.Commit(containers.NewCommitParamsWithContext(ctx).WithHandle(handle).WithWaitTime(&wait))
 	if err != nil {
 		// delete from cache since all cases are 404's
 		cache.ContainerCache().DeleteContainer(name)

--- a/lib/apiservers/engine/backends/portlayer/container_proxy.go
+++ b/lib/apiservers/engine/backends/portlayer/container_proxy.go
@@ -138,9 +138,9 @@ func (c *ContainerProxy) CreateContainerHandle(imageID string, config types.Cont
 	createResults, err := c.client.Containers.Create(plCreateParams)
 	if err != nil {
 		if _, ok := err.(*containers.CreateNotFound); ok {
-			err = fmt.Errorf("No such image: %s", imageID)
-			log.Errorf(err.Error())
-			return "", "", derr.NewRequestNotFoundError(err)
+			cerr := fmt.Errorf("No such image: %s", imageID)
+			log.Errorf("%s (%s)", cerr, err)
+			return "", "", derr.NewRequestNotFoundError(cerr)
 		}
 
 		// If we get here, most likely something went wrong with the port layer API server
@@ -271,12 +271,12 @@ func (c *ContainerProxy) CommitContainerHandle(handle, imageID string) error {
 
 	_, err := c.client.Containers.Commit(containers.NewCommitParamsWithContext(ctx).WithHandle(handle))
 	if err != nil {
-		err = fmt.Errorf("No such image: %s", imageID)
-		log.Errorf("%s", err.Error())
+		cerr := fmt.Errorf("No such image: %s", imageID)
+		log.Errorf("%s (%s)", cerr, err)
 		// FIXME: Containers.Commit returns more errors than it's swagger spec says.
 		// When no image exist, it also sends back non swagger errors.  We should fix
 		// this once Commit returns correct error codes.
-		return derr.NewRequestNotFoundError(err)
+		return derr.NewRequestNotFoundError(cerr)
 	}
 
 	return nil

--- a/lib/apiservers/portlayer/restapi/handlers/containers_handlers.go
+++ b/lib/apiservers/portlayer/restapi/handlers/containers_handlers.go
@@ -215,7 +215,7 @@ func (handler *ContainersHandlersImpl) CommitHandler(params containers.CommitPar
 		return containers.NewCommitNotFound().WithPayload(&models.Error{Message: "container not found"})
 	}
 
-	if err := h.Commit(context.Background(), handler.handlerCtx.Session); err != nil {
+	if err := h.Commit(context.Background(), handler.handlerCtx.Session, params.WaitTime); err != nil {
 		log.Errorf("CommitHandler error (%s): %s", h.String(), err)
 		return containers.NewCommitDefault(http.StatusServiceUnavailable).WithPayload(&models.Error{Message: err.Error()})
 	}

--- a/lib/apiservers/portlayer/swagger.json
+++ b/lib/apiservers/portlayer/swagger.json
@@ -1161,7 +1161,14 @@
 						"in": "path",
 						"required": true,
 						"type": "string"
+					},
+                                        {
+						"name": "wait_time",
+						"in": "query",
+					        "type": "integer",
+                                                "format": "int32"
 					}
+
 				],
 				"responses": {
 					"200": {

--- a/lib/portlayer/exec/container.go
+++ b/lib/portlayer/exec/container.go
@@ -35,6 +35,7 @@ import (
 	"github.com/vmware/vic/pkg/vsphere/sys"
 	"github.com/vmware/vic/pkg/vsphere/tasks"
 	"github.com/vmware/vic/pkg/vsphere/vm"
+	"golang.org/x/crypto/ssh"
 	"golang.org/x/net/context"
 )
 
@@ -97,7 +98,7 @@ func (c *Container) cacheExecConfig(ec *executor.ExecutorConfig) {
 	c.ExecConfig = ec
 }
 
-func (c *Container) Commit(ctx context.Context, sess *session.Session, h *Handle) error {
+func (c *Container) Commit(ctx context.Context, sess *session.Session, h *Handle, waitTime *int32) error {
 	defer trace.End(trace.Begin("Committing handle"))
 
 	c.Lock()
@@ -150,7 +151,7 @@ func (c *Container) Commit(ctx context.Context, sess *session.Session, h *Handle
 	// if we're stopping the VM, do so before the reconfigure to preserve the extraconfig
 	if h.State != nil && *h.State == StateStopped {
 		// stop the container
-		if err := h.Container.stop(ctx); err != nil {
+		if err := h.Container.stop(ctx, waitTime); err != nil {
 			return err
 		}
 
@@ -223,25 +224,73 @@ func (c *Container) start(ctx context.Context) error {
 	return nil
 }
 
-func (c *Container) stop(ctx context.Context) error {
+func (c *Container) waitForPowerState(ctx context.Context, max time.Duration, state types.VirtualMachinePowerState) (bool, error) {
+	timeout, cancel := context.WithTimeout(ctx, max)
+	defer cancel()
+
+	err := c.vm.WaitForPowerState(timeout, state)
+	if err != nil {
+		return timeout.Err() == err, err
+	}
+
+	return false, nil
+}
+
+func (c *Container) shutdown(ctx context.Context, waitTime *int32) error {
+	wait := 10 * time.Second // default
+	if waitTime != nil && *waitTime > 0 {
+		wait = time.Duration(*waitTime) * time.Second
+	}
+
+	stop := []string{c.ExecConfig.StopSignal, string(ssh.SIGKILL)}
+	if stop[0] == "" {
+		stop[0] = string(ssh.SIGTERM)
+	}
+
+	for _, sig := range stop {
+		msg := fmt.Sprintf("sending kill -%s %s", sig, c.ExecConfig.ID)
+		log.Info(msg)
+
+		err := c.startGuestProgram(ctx, "kill", sig)
+		if err != nil {
+			return fmt.Errorf("%s: %s", msg, err)
+		}
+
+		log.Infof("waiting %s for %s to power off", wait, c.ExecConfig.ID)
+		timeout, err := c.waitForPowerState(ctx, wait, types.VirtualMachinePowerStatePoweredOff)
+		if err == nil {
+			return nil // VM has powered off
+		}
+
+		if !timeout {
+			return err // error other than timeout
+		}
+
+		log.Warnf("timeout (%s) waiting for %s to power off via SIG%s", wait, c.ExecConfig.ID, sig)
+	}
+
+	return fmt.Errorf("failed to shutdown %s via kill signals %s", c.ExecConfig.ID, stop)
+}
+
+func (c *Container) stop(ctx context.Context, waitTime *int32) error {
 	defer trace.End(trace.Begin("Container.stop"))
 
 	if c.vm == nil {
 		return fmt.Errorf("vm not set")
 	}
 
-	err := c.vm.ShutdownGuest(ctx)
-	if err != nil {
-		log.Warnf("ShutdownGuest %s failed: %s", c.ExecConfig.ID, err)
-		// Fallback to PowerOff in the event that tools may not be running
-		_, err = tasks.WaitForResult(ctx, func(ctx context.Context) (tasks.ResultWaiter, error) {
-			return c.vm.PowerOff(ctx)
-		})
-		return err
+	err := c.shutdown(ctx, waitTime)
+	if err == nil {
+		return nil
 	}
 
-	// ShutdownGuest does not wait for PowerOff state, so we need to do that ourselves
-	return c.vm.WaitForPowerState(ctx, types.VirtualMachinePowerStatePoweredOff)
+	log.Warnf("stopping %s via hard power off due to: %s", c.ExecConfig.ID, err)
+
+	_, err = tasks.WaitForResult(ctx, func(ctx context.Context) (tasks.ResultWaiter, error) {
+		return c.vm.PowerOff(ctx)
+	})
+
+	return err
 }
 
 func (c *Container) startGuestProgram(ctx context.Context, name string, args string) error {

--- a/lib/portlayer/exec/handle.go
+++ b/lib/portlayer/exec/handle.go
@@ -140,7 +140,7 @@ func (h *Handle) String() string {
 	return h.key
 }
 
-func (h *Handle) Commit(ctx context.Context, sess *session.Session) error {
+func (h *Handle) Commit(ctx context.Context, sess *session.Session, waitTime *int32) error {
 	if h.committed {
 		return nil // already committed
 	}
@@ -152,7 +152,7 @@ func (h *Handle) Commit(ctx context.Context, sess *session.Session) error {
 	s := h.Spec.Spec()
 	s.ExtraConfig = append(s.ExtraConfig, vmomi.OptionValueFromMap(cfg)...)
 
-	if err := h.Container.Commit(ctx, sess, h); err != nil {
+	if err := h.Container.Commit(ctx, sess, h, waitTime); err != nil {
 		return err
 	}
 

--- a/lib/tether/toolbox.go
+++ b/lib/tether/toolbox.go
@@ -83,6 +83,8 @@ func (t *Toolbox) Start() error {
 func (t *Toolbox) Stop() error {
 	t.Service.Stop()
 
+	t.Service.Wait()
+
 	close(t.stop)
 
 	return nil
@@ -165,7 +167,7 @@ func (t *Toolbox) halt() error {
 	case <-t.stop:
 		log.Infof("%s has stopped", session.ID)
 		return nil
-	case <-time.After(time.Second * 10): // TODO: honor -t flag from docker stop
+	case <-time.After(time.Second * 10):
 	}
 
 	log.Warnf("killing %s", session.ID)

--- a/pkg/vsphere/toolbox/service.go
+++ b/pkg/vsphere/toolbox/service.go
@@ -68,7 +68,7 @@ func NewService(rpcIn Channel, rpcOut Channel) *Service {
 		out:      &ChannelOut{NewTraceChannel(rpcOut)},
 		handlers: make(map[string]Handler),
 		wg:       new(sync.WaitGroup),
-		stop:     make(chan struct{}, 1),
+		stop:     make(chan struct{}),
 
 		PrimaryIP: DefaultIP,
 	}
@@ -149,13 +149,13 @@ func (s *Service) Start() error {
 
 // Stop cancels the RPC listener routine created via Start
 func (s *Service) Stop() {
-	s.stop <- struct{}{}
+	close(s.stop)
 
 	_ = s.in.Stop()
 	_ = s.out.Stop()
 }
 
-// Wait blocks until Start returns
+// Wait blocks until Start returns, allowing any current RPC in progress to complete.
 func (s *Service) Wait() {
 	s.wg.Wait()
 }

--- a/tests/README.md
+++ b/tests/README.md
@@ -35,7 +35,7 @@ If you are using a vSAN environment or non-default ESX install, then you can als
 
   build:
     integration-test:
-      image: $${TEST_BUILD_IMAGE=vmware-docker-ci-repo.bintray.io/integration/vic-test:1.1}
+      image: $${TEST_BUILD_IMAGE=vmware-docker-ci-repo.bintray.io/integration/vic-test:1.4}
       pull: true
       environment:
         BIN: bin

--- a/tests/local-integration-test.sh
+++ b/tests/local-integration-test.sh
@@ -33,7 +33,7 @@ clone:
 
 build:
   integration-test:
-    image: vmware-docker-ci-repo.bintray.io/integration/vic-test:1.1
+    image: vmware-docker-ci-repo.bintray.io/integration/vic-test:1.4
     pull: true
     environment:
       GITHUB_AUTOMATION_API_KEY: $GITHUB_TOKEN

--- a/tests/test-cases/Group1-Docker-Commands/1-7-Docker-Stop.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-7-Docker-Stop.robot
@@ -18,6 +18,15 @@ Assert Stop Signal
     ${output}=  OperatingSystem.Get File  ${TEMPDIR}/${id}.log
     Should Contain  ${output}  StopSignal${sig}
 
+Assert Kill Signal
+    # Assert SIGKILL was sent or not by checking the tether debug log file
+    [Arguments]  ${id}  ${expect}
+    ${rc}=  Run And Return Rc  govc datastore.download ${id}/${id}.debug ${TEMPDIR}/${id}.debug
+    Should Be Equal As Integers  ${rc}  0
+    ${output}=  OperatingSystem.Get File  ${TEMPDIR}/${id}.debug
+    Run Keyword If  ${expect}  Should Contain  ${output}  sending signal KILL
+    Run Keyword Unless  ${expect}  Should Not Contain  ${output}  sending signal KILL
+
 *** Test Cases ***
 Stop an already stopped container
     ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} pull busybox
@@ -36,15 +45,17 @@ Basic docker container stop
     Should Be Equal As Integers  ${rc}  0
     ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} stop ${container}
     Should Be Equal As Integers  ${rc}  0
+    Assert Kill Signal  ${container}  False
 
 Stop a container with SIGKILL using default grace period
     ${rc}=  Run And Return Rc  docker ${params} pull busybox
     Should Be Equal As Integers  ${rc}  0
-    ${trap}=  Trap Signal Command  TERM
+    ${trap}=  Trap Signal Command  HUP
     ${rc}  ${container}=  Run And Return Rc And Output  docker ${params} run -d ${trap}
     Should Be Equal As Integers  ${rc}  0
     ${rc}=  Run And Return Rc  docker ${params} stop ${container}
     Should Be Equal As Integers  ${rc}  0
+    Assert Kill Signal  ${container}  False
 
 Stop a container with SIGKILL using specific stop signal
     ${rc}=  Run And Return Rc  docker ${params} pull busybox
@@ -57,22 +68,15 @@ Stop a container with SIGKILL using specific stop signal
     Assert Stop Signal  ${container}  USR1
 
 Stop a container with SIGKILL using specific grace period
-    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} pull busybox
+    ${rc}=  Run And Return Rc  docker ${params} pull busybox
     Should Be Equal As Integers  ${rc}  0
-    ${rc}  ${container}=  Run And Return Rc And Output  docker ${params} create busybox sleep 30
+    ${trap}=  Trap Signal Command  HUP
+    ${rc}  ${container}=  Run And Return Rc And Output  docker ${params} run -d --stop-signal HUP ${trap}
     Should Be Equal As Integers  ${rc}  0
-    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} start ${container}
+    ${rc}=  Run And Return Rc  docker ${params} stop -t 2 ${container}
     Should Be Equal As Integers  ${rc}  0
-    ${before}=  Get Current Date
-    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} stop -t 2 ${container}
-    ${after}=  Get Current Date
-    Should Be Equal As Integers  ${rc}  0
-    ${result}=  Subtract Date From Date  ${after}  ${before}
-
-    ${status}=  Get State Of Github Issue  1321
-    Run Keyword If  '${status}' == 'closed'  Fail  Test 1-7-Docker-Stop.robot needs to be updated now that Issue #1321 has been resolved
-    Log  Issue \#1321 is blocking implementation  WARN
-    #Should Be True  ${1} < ${result} < ${3}
+    Assert Stop Signal  ${container}  HUP
+    Assert Kill Signal  ${container}  True
 
 Stop a non-existent container
     ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} stop fakeContainer

--- a/tests/test-cases/Group1-Docker-Commands/1-7-Docker-Stop.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-7-Docker-Stop.robot
@@ -21,6 +21,9 @@ Assert Stop Signal
 Assert Kill Signal
     # Assert SIGKILL was sent or not by checking the tether debug log file
     [Arguments]  ${id}  ${expect}
+    ${rc}  ${output}=  Run And Return Rc And Output  govc vm.info -json -vm.path "[%{TEST_DATASTORE}] ${id}/${id}.vmx" | jq -r .VirtualMachines[].Runtime.PowerState
+    Should Be Equal As Integers  ${rc}  0
+    Should Be Equal  ${output}  poweredOff
     ${rc}=  Run And Return Rc  govc datastore.download ${id}/${id}.debug ${TEMPDIR}/${id}.debug
     Should Be Equal As Integers  ${rc}  0
     ${output}=  OperatingSystem.Get File  ${TEMPDIR}/${id}.debug
@@ -66,6 +69,7 @@ Stop a container with SIGKILL using specific stop signal
     ${rc}=  Run And Return Rc  docker ${params} stop ${container}
     Should Be Equal As Integers  ${rc}  0
     Assert Stop Signal  ${container}  USR1
+    Assert Kill Signal  ${container}  True
 
 Stop a container with SIGKILL using specific grace period
     ${rc}=  Run And Return Rc  docker ${params} pull busybox
@@ -93,3 +97,4 @@ Attempt to stop a container that has been started out of band
     Should Be Equal As Integers  ${rc}  0
     ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} stop ${container}
     Should Be Equal As Integers  ${rc}  0
+    Assert Kill Signal  ${container}  False

--- a/tests/test-cases/Group8-vSphere-Integration/8-1-GuestTools.robot
+++ b/tests/test-cases/Group8-vSphere-Integration/8-1-GuestTools.robot
@@ -35,7 +35,7 @@ Stop container VM using guest shutdown
     Should Be Equal As Integers  ${rc}  0
     ${rc}  ${output}=  Run And Return Rc And Output  govc vm.power -s ${name}-*
     Should Be Equal As Integers  ${rc}  0
-    Wait Until Keyword Succeeds  5x  200 milliseconds  Assert VM Power State  ${name}  poweredOff
+    Wait Until Keyword Succeeds  20x  500 milliseconds  Assert VM Power State  ${name}  poweredOff
 
 Signal container VM using vix command
     ${rc}=  Run And Return Rc  docker ${params} pull busybox


### PR DESCRIPTION
Change the port layer to use the toolbox kill command instead of
ShutdownGuest to stop a container VM.  This is required to support the
'-t' flag, as ShutdownGuest does not take any parameters.

- Wait for vsphere/toolbox service to exit the main loop, allowing
  any in-flight RPC to complete.

- Fix a few cases where "No such image" errors swallowed the original
  error, logging the original.

Fixes #1321
Fixes #1870