### PR TITLE
Add the commit hash into the bundle

### DIFF
--- a/tests/integration-test.sh
+++ b/tests/integration-test.sh
@@ -29,7 +29,7 @@ fi
 rc="$?"
 
 timestamp=$(date +%s)
-outfile="integration_test_logs_"$DRONE_BUILD_NUMBER"_$timestamp.tar"
+outfile="integration_logs_"$DRONE_BUILD_NUMBER"_"$DRONE_COMMIT"_$timestamp.tar"
 
 tar cf $outfile log.html package.list *container-logs.tar.gz *.log vmsupport-*.tgz
 


### PR DESCRIPTION
Add the commit hash so that we can cross reference a git commit to the logs bundle that is created on the build for it.