### PR TITLE
Add tests to VICadmin

### DIFF
--- a/cmd/vicadmin/vicadm.go
+++ b/cmd/vicadmin/vicadm.go
@@ -375,13 +375,14 @@ func client() (*session.Session, error) {
 	session := session.NewSession(&config.Config)
 	_, err := session.Connect(ctx)
 	if err != nil {
+		log.Warnf("Unable to connect: %s", err)
 		return nil, err
 	}
 
 	_, err = session.Populate(ctx)
 	if err != nil {
 		// no a critical error for vicadmin
-		log.Warn(err)
+		log.Warnf("Unable to populate session: %s", err)
 	}
 
 	return session, nil
@@ -426,12 +427,12 @@ func main() {
 	// If we're in an ESXi environment, then we need
 	// to extract the userid/password from UserPassword
 	if vchConfig.UserPassword != "" {
-		upw := strings.Split(vchConfig.UserPassword, ":")
-		if len(upw) == 2 {
-			vchConfig.Target.User = url.UserPassword(upw[0], upw[1])
-		} else {
-			vchConfig.Target.User = url.User(upw[0])
-		}
+		newurl, _ := url.Parse(fmt.Sprintf("%s://%s@%s%s",
+					vchConfig.Target.Scheme,
+					vchConfig.UserPassword,
+					vchConfig.Target.Host,
+					vchConfig.Target.Path))
+		vchConfig.Target = *newurl
 	}
 
 	config.Service = vchConfig.Target.String()

--- a/isos/vicadmin/dashboard.html
+++ b/isos/vicadmin/dashboard.html
@@ -42,10 +42,9 @@
                     Containers
                   </li>
                   <li>
-                    <span class="right">
-                      <i class="fa fa-check"></i>
-                    </span>
+					{{.NetworkStatus}}
                     Network Connectivity
+                    {{.NetworkIssues}}
                   </li>
                   <li>
                     {{.FirewallStatus}}
@@ -59,10 +58,9 @@
                     Virtual Container Host (VCH)
                   </li>
                   <li>
-                    <span class="right">
-                      <i class="fa fa-check"></i>
-                    </span>
+                    {{.LicenseStatus}}
                     License
+                    {{.LicenseIssues}}
                   </li>
                 </ul>
               </div>
@@ -95,7 +93,7 @@
                         <a href="/logs/tail/imagec.log">Live Log</a>
                       </li>
                   <li><a href="/logs/port-layer.log">
-                      VCH Services (Low-Level)
+                      Port-Layer Service
                       </a>
                       <span class="right">
                         <a href="/logs/tail/port-layer.log">Live Log</a>

--- a/lib/vicadmin/validate.go
+++ b/lib/vicadmin/validate.go
@@ -17,6 +17,7 @@ package vicadmin
 import (
 	"fmt"
 	"html/template"
+	"net"
 	"os"
 	"strings"
 
@@ -36,6 +37,10 @@ type Validator struct {
 	Version        string
 	FirewallStatus template.HTML
 	FirewallIssues template.HTML
+	LicenseStatus  template.HTML
+	LicenseIssues  template.HTML
+	NetworkStatus  template.HTML
+	NetworkIssues  template.HTML
 	HostIP         string
 	DockerPort     string
 }
@@ -57,7 +62,7 @@ func NewValidator(ctx context.Context, vch *config.VirtualContainerHostConfigSpe
 	v.Hostname = strings.Title(v.Hostname)
 	log.Info(fmt.Sprintf("Setting hostname to %s", v.Hostname))
 
-
+	//Firewall Status Check
 	v2, _ := validate.CreateFromVCHConfig(ctx, vch, sess)
 	v2.CheckFirewall(ctx)
 	firewallIssues := v2.GetIssues()
@@ -73,6 +78,48 @@ func NewValidator(ctx context.Context, vch *config.VirtualContainerHostConfigSpe
 	}
 	log.Info(fmt.Sprintf("FirewallStatus set to: %s", v.FirewallStatus))
 	log.Info(fmt.Sprintf("FirewallIssues set to: %s", v.FirewallIssues))
+
+	//License Check
+	v2.ClearIssues()
+	v2.CheckLicense(ctx)
+	licenseIssues := v2.GetIssues()
+
+	if len(licenseIssues) == 0 {
+		v.LicenseStatus = GoodStatus
+		v.LicenseIssues = template.HTML("")
+	} else {
+		v.LicenseStatus = BadStatus
+		for _, err := range licenseIssues {
+			v.LicenseIssues = template.HTML(fmt.Sprintf("%s<span class=\"error-message\">%s</span>\n", v.LicenseIssues, err))
+		}
+	}
+
+	//Network Connection Check
+	hosts := []string{
+		"google.com:80",
+		"docker.io:443",
+	}
+	nwErrors := []error{}
+
+	for _, host := range hosts {
+		conn, err := net.Dial("tcp", host)
+		if err != nil {
+			nwErrors = append(nwErrors, err)
+		} else {
+			conn.Close()
+		}
+	}
+
+	if len(nwErrors) > 0 {
+		v.NetworkStatus = BadStatus
+		for _, err := range nwErrors {
+			v.NetworkIssues = template.HTML(fmt.Sprintf("%s<span class=\"error-message\">%s</span>\n", v.NetworkIssues, err))
+		}
+	} else {
+		v.NetworkStatus = GoodStatus
+		v.NetworkIssues = template.HTML("")
+
+	}
 
 	//Retrieve Host IP Information and Set Docker Endpoint
 	v.HostIP = vch.ExecutorConfig.Networks["client"].Assigned.IP.String()

--- a/tests/test-cases/Group7-Regression/7-1-Regression.md
+++ b/tests/test-cases/Group7-Regression/7-1-Regression.md
@@ -20,10 +20,11 @@ This test requires that a vSphere server is running and available
 7. Issue a docker stop <containerID>
 8. Issue a docker ps, verify that the container is stopped
 9. Issue a docker rm <containerID>
-10. Issue a docker ps, verify that the container is removed
-11. Issue a docker rmi busybox
-12. Issue a docker images, verify that busybox image is gone
-13. Remove the VIC appliance with vic-machine delete command, verify that the appliance was removed
+10. Pull container log bundle from VICadmin and ensure that the container's vmware.log is present
+11. Issue a docker ps, verify that the container is removed
+12. Issue a docker rmi busybox
+13. Issue a docker images, verify that busybox image is gone
+14. Remove the VIC appliance with vic-machine delete command, verify that the appliance was removed
 
 #Expected Outcome:
 VIC appliance should respond without error to each of the commands

--- a/tests/test-cases/Group9-VIC-Admin/9-1-VICAdmin-ShowHTML.md
+++ b/tests/test-cases/Group9-VIC-Admin/9-1-VICAdmin-ShowHTML.md
@@ -1,0 +1,24 @@
+Test 9-1 - VIC Admin ShowHTML
+=======
+
+#Purpose:
+To verify that the VIC Administration appliance can display HTML
+
+#Environment:
+This test requires that a vSphere environment be running and available
+
+#Test Steps:
+1. Deploy VIC appliance to the vSphere server
+2. Pull the VICadmin web page and verify that it contains valid HTML
+3. Pull the Portlayer log file and verify that it contains valid data
+4. Pull the VCH-Init log and verify that it contains valid data
+5. Pull the Docker Personality log and verify that it contains valid data
+6. Create a container via the appliance
+7. Pull the container log bundle from the appliance and verify that it contains the new container's logs
+
+#Expected Outcomes:
+* VICadmin should display a web page that at a minimum includes <title>VIC Admin</title>
+* VICadmin responds with a log file indicating that the portlayer sever has started
+* VICadmin responds with a log file indicating VCH init has begun reaping processes
+* VICadmin responds with log file indicating docker personality service has started
+* VICadmin responds with a ZIP file containing at a minimum the vmware.log file from the new container

--- a/tests/test-cases/Group9-VIC-Admin/9-1-VICAdmin-ShowHTML.robot
+++ b/tests/test-cases/Group9-VIC-Admin/9-1-VICAdmin-ShowHTML.robot
@@ -1,0 +1,43 @@
+*** Settings ***
+Documentation  Test 9-1 - VICAdmin DisplayHTML
+Resource  ../../resources/Util.robot
+Suite Setup  Install VIC Appliance To Test Server  ${true}
+Suite Teardown  Cleanup VIC Appliance On Test Server
+Default Tags
+
+*** Test Cases ***
+Display HTML
+    ${rc}  ${output}=  Run And Return Rc And Output  curl -k ${proto}://${vch-ip}:2378/
+    Should contain  ${output}  <title>VCH Admin</title>
+
+Get Portlayer Log
+    ${rc}  ${output}=  Run And Return Rc And Output  curl -k ${proto}://${vch-ip}:2378/logs/port-layer.log
+    Should contain  ${output}  Launching portlayer server
+
+Get VCH-Init Log
+    ${rc}  ${output}=  Run And Return Rc And Output  curl -k ${proto}://${vch-ip}:2378/logs/init.log
+    Should contain  ${output}  reaping child processes
+
+Get Docker Personality Log
+    ${rc}  ${output}=  Run And Return Rc And Output  curl -k ${proto}://${vch-ip}:2378/logs/docker-personality.log
+    Should contain  ${output}  docker personality
+
+Get Container Logs
+    ${rc}  ${output}=  Run And Return Rc and Output  docker ${params} pull busybox
+    Should Be Equal As Integers  ${rc}  0
+    Should Not Contain  ${output}  Error
+    ${rc}  ${container}=  Run And Return Rc and Output  docker ${params} create busybox /bin/top
+    Should Be Equal As Integers  ${rc}  0
+    Should Not Contain  ${container}  Error
+    ${rc}  ${output}=  Run And Return Rc and Output  docker ${params} start ${container}
+    Should Be Equal As Integers  ${rc}  0
+    Should Not Contain  ${output}  Error
+    ${rc}  ${output}=  Run And Return Rc and Output  curl -k ${proto}://${vch-ip}:2378/container-logs.tar.gz | tar tvzf -
+    Should Be Equal As Integers  ${rc}  0
+    Log  ${output}
+    Should Contain  ${output}  ${container}/vmware.log
+
+Get VICAdmin Log
+    ${rc}  ${output}=  Run And Return Rc And Output  curl -k ${proto}://${vch-ip}:2378/logs/vicadmin.log
+    Log  ${output}
+    Should contain  ${output}  Launching vicadmin server

--- a/tests/test-cases/Group9-VIC-Admin/9-1-VICAdmin-ShowHTML.robot
+++ b/tests/test-cases/Group9-VIC-Admin/9-1-VICAdmin-ShowHTML.robot
@@ -1,5 +1,5 @@
 *** Settings ***
-Documentation  Test 9-1 - VICAdmin DisplayHTML
+Documentation  Test 9-1 - VICAdmin ShowHTML
 Resource  ../../resources/Util.robot
 Suite Setup  Install VIC Appliance To Test Server  ${true}
 Suite Teardown  Cleanup VIC Appliance On Test Server

--- a/tests/test-cases/Group9-VIC-Admin/TestCases.md
+++ b/tests/test-cases/Group9-VIC-Admin/TestCases.md
@@ -1,0 +1,5 @@
+Group 9 - VIC Admin
+=======
+
+
+[Test 9-1 - VICAdmin ShowHTML](9-1-VICAdmin-ShowHTML.md)

--- a/tests/test-cases/TestGroups.md
+++ b/tests/test-cases/TestGroups.md
@@ -12,3 +12,5 @@ VIC Integration Test Suite
 -
 [Group 6 - VIC Machine](Group6-VIC-Machine/TestCases.md)
 -
+[Group 9 - VIC Admin](Group9-VIC-Admin/TestCases.md)
+-


### PR DESCRIPTION
Fixes #1834 
Fixes #1836 
It turns out that when assigning the Userid/Password to the vchConfig.Target field, if either field contains special characters (that have been escaped with %XX), the % in the password gets re-escaped into "%".  Therefore, when assigning User/Password in cmd/vicadmin/vicadm.go, we just rebuild the field and use url.Parse() to parse it.

This PR adds in integration tests (Group9-VICadmin) marked as "regression" tests that will verify the ability for vicadmin to pull container logs.  If VICadmin breaks and generates nil pointer exceptions, they will be exposed in this integration test suite.

Additional features added in VICadmin include:

* Populates Network Health
* Populates License Check field

These will be squashed upon merge to master.