### PR TITLE
PortLayer event stream

### DIFF
--- a/lib/portlayer/event/event_manager.go
+++ b/lib/portlayer/event/event_manager.go
@@ -1,0 +1,52 @@
+// Copyright 2016 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package event
+
+import (
+	"github.com/vmware/vic/pkg/vsphere/session"
+)
+
+type EventManager interface {
+
+	// AddMonitoredObject will add the object for event listening
+	AddMonitoredObject(ref string) error
+
+	// RemoveMonitoredObject will remove the object from event listening
+	RemoveMonitoredObject(ref string)
+
+	// Register will for event callbacks
+	Register(caller string, callback func(Event, *session.Session))
+
+	// Unregsiter from event callbacks
+	Unregister(caller string)
+
+	// Registry will return the callback map
+	Registry() map[string]func(Event, *session.Session)
+
+	// RegistryCount returns the count of callbacks
+	RegistryCount() int
+
+	// Start listening for events
+	Start() error
+
+	// Stop listening for events
+	Stop()
+
+	// Blacklist will identify an object to be omitted from event callbacks
+	Blacklist(ref string) error
+
+	// Unblacklist will remove an object that was previously blacklisted
+	Unblacklist(ref string)
+}

--- a/lib/portlayer/event/events.go
+++ b/lib/portlayer/event/events.go
@@ -1,0 +1,37 @@
+// Copyright 2016 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package event
+
+const (
+	ContainerCreated      = "Created"
+	ContainerShutdown     = "Shutdown"
+	ContainerPoweredOn    = "PoweredOn"
+	ContainerPoweredOff   = "PoweredOff"
+	ContainerSuspended    = "Suspended"
+	ContainerResumed      = "Resumed"
+	ContainerRemoved      = "Removed"
+	ContainerReconfigured = "Reconfigured"
+)
+
+type Event interface {
+	// id of event
+	EventID() int
+	// event (PowerOn, PowerOff, etc)
+	String() string
+	// reference evented object
+	Reference() string
+	// event message
+	Message() string
+}

--- a/lib/portlayer/event/vsphere/manager.go
+++ b/lib/portlayer/event/vsphere/manager.go
@@ -1,0 +1,225 @@
+// Copyright 2016 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vsphere
+
+import (
+	"fmt"
+
+	"github.com/vmware/vic/lib/portlayer/event"
+	"github.com/vmware/vic/pkg/vsphere/session"
+
+	vmwEvents "github.com/vmware/govmomi/event"
+	"github.com/vmware/govmomi/vim25/types"
+
+	log "github.com/Sirupsen/logrus"
+	"golang.org/x/net/context"
+)
+
+type vSphereManager struct {
+	vmwManager *vmwEvents.Manager
+	callbacks  map[string]func(event.Event, *session.Session)
+	blacklist  map[types.ManagedObjectReference]string
+	objects    map[string]types.ManagedObjectReference
+	session    *session.Session
+}
+
+func NewEventManager(s *session.Session) *vSphereManager {
+	return &vSphereManager{
+		callbacks: make(map[string]func(event.Event, *session.Session)),
+		blacklist: make(map[types.ManagedObjectReference]string),
+		objects:   make(map[string]types.ManagedObjectReference),
+		session:   s,
+	}
+
+}
+
+func (mgr *vSphereManager) AddMonitoredObject(ref string) error {
+	log.Debugf("EventManager added (%s) to monitor", ref)
+	moRef := types.ManagedObjectReference{}
+	if !moRef.FromString(ref) {
+		return fmt.Errorf("Invalid Managed Object provided for Montioring(%s)", ref)
+	}
+	mgr.objects[ref] = moRef
+	return nil
+}
+
+func (mgr *vSphereManager) RemoveMonitoredObject(ref string) {
+	delete(mgr.objects, ref)
+}
+
+func (mgr *vSphereManager) monitoredObjects() []types.ManagedObjectReference {
+	refs := make([]types.ManagedObjectReference, 0, len(mgr.objects))
+	for k := range mgr.objects {
+		refs = append(refs, mgr.objects[k])
+	}
+	return refs
+}
+
+// Blacklist object from callbacks
+func (mgr *vSphereManager) Blacklist(ref string) error {
+	moRef := types.ManagedObjectReference{}
+	if !moRef.FromString(ref) {
+		return fmt.Errorf("Invalid Managed Object provided to Blacklist(%s)", ref)
+	}
+	mgr.blacklist[moRef] = ref
+	return nil
+}
+
+// Unblacklist removes object blacklisting and will allow callbacks to occur
+func (mgr *vSphereManager) Unblacklist(ref string) {
+	moRef := types.ManagedObjectReference{}
+	moRef.FromString(ref)
+	delete(mgr.blacklist, moRef)
+}
+
+// BlacklistCount
+func (mgr *vSphereManager) BlacklistCount() int {
+	return len(mgr.blacklist)
+}
+
+func (mgr *vSphereManager) blacklisted(ref types.ManagedObjectReference) bool {
+	if _, ok := mgr.blacklist[ref]; ok {
+		log.Debugf("EventManager skipping blacklisted object (%s)", ref.String())
+		return true
+	}
+	return false
+}
+
+// Register the callback
+func (mgr *vSphereManager) Register(caller string, callback func(event.Event, *session.Session)) {
+	log.Debugf("Registering %s with EventManager", caller)
+	mgr.callbacks[caller] = callback
+}
+
+// Unregister call back
+func (mgr *vSphereManager) Unregister(caller string) {
+	delete(mgr.callbacks, caller)
+}
+
+// Registry eturns map of callbacks
+func (mgr *vSphereManager) Registry() map[string]func(event.Event, *session.Session) {
+	return mgr.callbacks
+}
+
+// RegistryCount returns the callback count
+func (mgr *vSphereManager) RegistryCount() int {
+	return len(mgr.callbacks)
+}
+
+// Stop listening by destroying the manager
+// this will be best effort -- as event manager will
+// be killed when session is killed
+func (mgr *vSphereManager) Stop() {
+	_, err := mgr.vmwManager.Destroy(context.Background())
+	if err != nil {
+		log.Warnf("EventManger failed to destroy the govmomi manager: %s", err.Error())
+	}
+}
+
+// Start the event listener
+func (mgr *vSphereManager) Start() error {
+	// array of managed objects
+	refs := mgr.monitoredObjects()
+
+	// only continue if objects were added to monitor
+	if len(refs) == 0 {
+		return fmt.Errorf("EventManager requires at least one ManagedObject for monitoring, currently %d have been added", 0)
+	}
+
+	log.Debugf("EventManager starting event listener for %d managed objects...", len(refs))
+
+	// create the govmomi view manager
+	mgr.vmwManager = vmwEvents.NewManager(mgr.session.Client.Client)
+
+	// we don't want the event listener to timeout
+	ctx := context.Background()
+
+	// vars used for clarity
+	// page size of lastest page of events
+	// setting to 1 to avoid having to track last event
+	// processed -- this may change in future if too chatty
+
+	// TODO: need to create an "event storm" to ensure we can handle
+	// a 1 event page
+	pageSize := int32(1)
+	// bool to follow the stream
+	followStream := true
+	// don't exceed the govmomi object limit
+	force := false
+
+	//TODO: need a proper way to handle failures / status
+	go func(page int32, follow bool, ff bool, refs []types.ManagedObjectReference) error {
+		// the govmomi event listener can only be configured once per session -- so if it's already listening it
+		// will be replaced
+		//
+		// the manager & listener will be closed with the session
+		err := mgr.vmwManager.Events(ctx, refs, 1, followStream, force, func(page []types.BaseEvent) error {
+			evented(mgr, page)
+			return nil
+		})
+		// TODO: this will disappear in the ether
+		if err != nil {
+			log.Debugf("Error configuring event manager %s \n", err.Error())
+			return err
+		}
+		return nil
+	}(pageSize, followStream, force, refs)
+
+	return nil
+}
+
+// evented will process the event and call registered callbacks
+//
+// Initial implmentation will only act on certain events -- future implementations
+// may provide more flexibilty
+func evented(mgr *vSphereManager, page []types.BaseEvent) {
+
+	if mgr.RegistryCount() == 0 {
+		log.Debug("EventManager has no callbacks configured...")
+	}
+
+	for i := range page {
+		var vmwEve event.Event
+		// reference to object evented
+		var ref types.ManagedObjectReference
+
+		e := page[i].GetEvent()
+
+		// what type of event do we have
+		switch page[i].(type) {
+		case *types.VmGuestShutdownEvent,
+			*types.VmPoweredOnEvent,
+			*types.VmPoweredOffEvent,
+			*types.VmRemovedEvent,
+			*types.VmSuspendedEvent:
+			vmwEve = NewVMEvent(page[i])
+			ref = e.Vm.Vm
+		}
+
+		// if we have event and it's not blacklisted
+		if vmwEve != nil && !mgr.blacklisted(ref) {
+			action(mgr, vmwEve)
+		}
+	}
+
+}
+
+// action will execute the callbacks
+func action(mgr *vSphereManager, vmwEve event.Event) {
+	for caller, callback := range mgr.callbacks {
+		log.Debugf("EventManager callling back to %s on %s for Event(%s)", caller, vmwEve.Reference(), vmwEve.String())
+		callback(vmwEve, mgr.session)
+	}
+}

--- a/lib/portlayer/event/vsphere/manager_test.go
+++ b/lib/portlayer/event/vsphere/manager_test.go
@@ -1,0 +1,143 @@
+// Copyright 2016 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vsphere
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/vmware/govmomi/vim25/types"
+	"github.com/vmware/vic/lib/portlayer/event"
+	"github.com/vmware/vic/pkg/vsphere/session"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// used to test callbacks
+var callcount int
+
+func newVMMO() *types.ManagedObjectReference {
+	return &types.ManagedObjectReference{Value: "101", Type: "vm"}
+}
+
+func TestNewEventManager(t *testing.T) {
+	// TODO: use simulator
+	// for now create uninitilized session
+	s := &session.Session{}
+	mgr := NewEventManager(s)
+	assert.NotNil(t, mgr)
+}
+
+func TestMonitoredObject(t *testing.T) {
+
+	s := &session.Session{}
+	mgr := NewEventManager(s)
+	mo := newVMMO()
+
+	mgr.AddMonitoredObject(mo.String())
+	mos := mgr.monitoredObjects()
+	assert.Equal(t, 1, len(mos))
+	mgr.RemoveMonitoredObject(mo.String())
+	mos = mgr.monitoredObjects()
+	assert.Equal(t, 0, len(mos))
+}
+
+func TestBlacklist(t *testing.T) {
+
+	s := &session.Session{}
+	mgr := NewEventManager(s)
+	mo := newVMMO()
+	mos := mo.String()
+
+	mgr.Blacklist(mos)
+	assert.Equal(t, 1, mgr.BlacklistCount())
+	assert.True(t, mgr.blacklisted(*mo))
+	mgr.Unblacklist(mos)
+	assert.Equal(t, 0, mgr.BlacklistCount())
+	assert.False(t, mgr.blacklisted(*mo))
+}
+
+func TestRegistration(t *testing.T) {
+	s := &session.Session{}
+	mgr := NewEventManager(s)
+
+	mgr.Register("test", callMe)
+	assert.Equal(t, 1, mgr.RegistryCount())
+	assert.NotNil(t, mgr.Registry())
+	assert.Equal(t, 1, len(mgr.Registry()))
+	mgr.Unregister("FooBar")
+	assert.Equal(t, 1, mgr.RegistryCount())
+	mgr.Unregister("test")
+	assert.Equal(t, 0, mgr.RegistryCount())
+
+}
+
+func TestEvented(t *testing.T) {
+	s := &session.Session{}
+	mgr := NewEventManager(s)
+	callcount = 0
+
+	// register local callback
+	mgr.Register("test", callMe)
+
+	// test lifecycle events
+	page := eventPage(3, true)
+	evented(mgr, page)
+	assert.Equal(t, 3, callcount)
+
+	// non-lifecycle events
+	page = eventPage(2, false)
+	evented(mgr, page)
+	assert.Equal(t, 3, callcount)
+
+}
+
+// will test basic failure of no callbacks configured
+// additional testing requires additions to the simulator
+func TestStartFailure(t *testing.T) {
+	s := &session.Session{}
+	mgr := NewEventManager(s)
+	assert.Error(t, mgr.Start())
+
+}
+
+// simple callback counter
+func callMe(ie event.Event, s *session.Session) {
+	callcount++
+}
+
+// utility function to mock a vsphere event
+//
+// size is the number of events to create
+// lifeCycle is true when we want to generate state events
+// lifeCycle events == poweredOn, poweredOff, etc..
+func eventPage(size int, lifeCycle bool) []types.BaseEvent {
+	page := make([]types.BaseEvent, 0, size)
+	moid := 100
+	for i := 0; i < size; i++ {
+		var eve types.BaseEvent
+		moid++
+		vm := types.ManagedObjectReference{Value: strconv.Itoa(moid), Type: "vm"}
+		if lifeCycle {
+			eve = types.BaseEvent(&types.VmPoweredOnEvent{VmEvent: types.VmEvent{Event: types.Event{Vm: &types.VmEventArgument{Vm: vm}}}})
+		} else {
+			eve = types.BaseEvent(&types.VmReconfiguredEvent{VmEvent: types.VmEvent{Event: types.Event{Vm: &types.VmEventArgument{Vm: vm}}}})
+		}
+
+		page = append(page, eve)
+	}
+
+	return page
+}

--- a/lib/portlayer/event/vsphere/vm_event.go
+++ b/lib/portlayer/event/vsphere/vm_event.go
@@ -1,0 +1,69 @@
+// Copyright 2016 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vsphere
+
+import (
+	"github.com/vmware/vic/lib/portlayer/event"
+
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type VMEvent struct {
+	eventType string
+	eventID   int
+	message   string
+	ref       string
+}
+
+func NewVMEvent(be types.BaseEvent) *VMEvent {
+	var eventType string
+	// vm events that we care about
+	switch be.(type) {
+	case *types.VmPoweredOnEvent:
+		eventType = event.ContainerPoweredOn
+	case *types.VmPoweredOffEvent:
+		eventType = event.ContainerPoweredOff
+	case *types.VmSuspendedEvent:
+		eventType = event.ContainerSuspended
+	case *types.VmRemovedEvent:
+		eventType = event.ContainerRemoved
+	case *types.VmGuestShutdownEvent:
+		eventType = event.ContainerShutdown
+	}
+	e := be.GetEvent()
+	return &VMEvent{
+		eventType: eventType,
+		eventID:   int(e.Key),
+		message:   e.FullFormattedMessage,
+		ref:       e.Vm.Vm.String(),
+	}
+}
+
+func (vme *VMEvent) EventID() int {
+	return vme.eventID
+}
+
+// return event type / description
+func (vme *VMEvent) String() string {
+	return vme.eventType
+}
+
+func (vme *VMEvent) Message() string {
+	return vme.message
+}
+
+func (vme *VMEvent) Reference() string {
+	return vme.ref
+}

--- a/lib/portlayer/event/vsphere/vm_event_test.go
+++ b/lib/portlayer/event/vsphere/vm_event_test.go
@@ -1,0 +1,37 @@
+// Copyright 2016 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vsphere
+
+import (
+	"testing"
+
+	"github.com/vmware/govmomi/vim25/types"
+	"github.com/vmware/vic/lib/portlayer/event"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewEvent(t *testing.T) {
+	vm := newVMMO()
+	k := 1
+	msg := "jojo the idiot circus boy"
+	vmwEve := &types.VmPoweredOnEvent{VmEvent: types.VmEvent{Event: types.Event{FullFormattedMessage: msg, Key: int32(k), Vm: &types.VmEventArgument{Vm: *vm}}}}
+	vme := NewVMEvent(vmwEve)
+	assert.NotNil(t, vme)
+	assert.Equal(t, event.ContainerPoweredOn, vme.String())
+	assert.Equal(t, vm.String(), vme.Reference())
+	assert.Equal(t, k, vme.EventID())
+	assert.Equal(t, msg, vme.Message())
+}

--- a/lib/portlayer/exec/config.go
+++ b/lib/portlayer/exec/config.go
@@ -21,6 +21,7 @@ import (
 	"github.com/vmware/govmomi/vim25/types"
 	"github.com/vmware/vic/lib/config"
 	"github.com/vmware/vic/lib/config/executor"
+	"github.com/vmware/vic/lib/portlayer/event"
 )
 
 var VCHConfig Configuration
@@ -53,6 +54,9 @@ type Configuration struct {
 	// FIXME: temporary work around for injecting network path of debug nic
 	Networks     map[string]*executor.NetworkEndpoint `vic:"0.1" scope:"read-only" key:"init/networks"`
 	DebugNetwork object.NetworkReference
+
+	// For now throw the Event Manager here
+	EventManager event.EventManager
 
 	// Information about the VCH resource pool and about the real host that we want
 	// tol retrieve just once.

--- a/lib/portlayer/exec/container.go
+++ b/lib/portlayer/exec/container.go
@@ -42,16 +42,19 @@ import (
 	"golang.org/x/net/context"
 )
 
-func init() {
-	NewContainerCache()
-}
-
 type State int
 
 const (
-	StateRunning = iota + 1
+	StateStarting = iota + 1
+	StateRunning
+	StateStopping
 	StateStopped
+	StateSuspending
+	StateSuspended
 	StateCreated
+	StateRemoving
+	StateRemoved
+	StateUnknown
 
 	propertyCollectorTimeout = 3 * time.Minute
 )
@@ -61,9 +64,6 @@ type Container struct {
 
 	ExecConfig *executor.ExecutorConfig
 	State      State
-
-	// friendly description of state
-	Status string
 
 	VMUnsharedDisk int64
 
@@ -89,16 +89,27 @@ func GetContainer(id uid.UID) *Handle {
 
 }
 
-func (c *Container) newHandle() *Handle {
-	return newHandle(c)
+func (s State) String() string {
+	switch s {
+	case StateCreated:
+		return "Created"
+	case StateStarting:
+		return "Starting"
+	case StateRunning:
+		return "Running"
+	case StateRemoving:
+		return "Removing"
+	case StateStopping:
+		return "Stopping"
+	case StateStopped:
+		return "Stopped"
+
+	}
+	return ""
 }
 
-// TODO: Is this used anywhere?
-func (c *Container) cacheExecConfig(ec *executor.ExecutorConfig) {
-	c.Lock()
-	defer c.Unlock()
-
-	c.ExecConfig = ec
+func (c *Container) newHandle() *Handle {
+	return newHandle(c)
 }
 
 func (c *Container) Commit(ctx context.Context, sess *session.Session, h *Handle, waitTime *int32) error {
@@ -121,7 +132,7 @@ func (c *Container) Commit(ctx context.Context, sess *session.Session, h *Handle
 			res, err = tasks.WaitForResult(ctx, func(ctx context.Context) (tasks.ResultWaiter, error) {
 				return VCHConfig.VirtualApp.CreateChildVM_Task(ctx, *h.Spec.Spec(), nil)
 			})
-			// set the status to created
+
 			c.State = StateCreated
 		} else {
 			// Find the Virtual Machine folder that we use
@@ -138,7 +149,6 @@ func (c *Container) Commit(ctx context.Context, sess *session.Session, h *Handle
 				return parent.CreateVM(ctx, *h.Spec.Spec(), VCHConfig.ResourcePool, nil)
 			})
 
-			// set the status to created
 			c.State = StateCreated
 		}
 
@@ -200,12 +210,17 @@ func (c *Container) start(ctx context.Context) error {
 	if c.vm == nil {
 		return fmt.Errorf("vm not set")
 	}
+	// get existing state and set to starting
+	// if there's a failure we'll revert to existing
+	existingState := c.State
+	c.State = StateStarting
 
 	// Power on
 	_, err := tasks.WaitForResult(ctx, func(ctx context.Context) (tasks.ResultWaiter, error) {
 		return c.vm.PowerOn(ctx)
 	})
 	if err != nil {
+		c.State = existingState
 		return err
 	}
 
@@ -219,10 +234,12 @@ func (c *Container) start(ctx context.Context) error {
 
 	detail, err = c.vm.WaitForKeyInExtraConfig(ctx, key)
 	if err != nil {
+		c.State = existingState
 		return fmt.Errorf("unable to wait for process launch status: %s", err.Error())
 	}
 
 	if detail != "true" {
+		c.State = existingState
 		return errors.New(detail)
 	}
 
@@ -283,6 +300,10 @@ func (c *Container) stop(ctx context.Context, waitTime *int32) error {
 	if c.vm == nil {
 		return fmt.Errorf("vm not set")
 	}
+	// get existing state and set to stopping
+	// if there's a failure we'll revert to existing
+	existingState := c.State
+	c.State = StateStopping
 
 	err := c.shutdown(ctx, waitTime)
 	if err == nil {
@@ -305,8 +326,8 @@ func (c *Container) stop(ctx context.Context, waitTime *int32) error {
 				}
 			}
 		}
+		c.State = existingState
 	}
-
 	return err
 }
 
@@ -394,6 +415,16 @@ func (c *Container) Remove(ctx context.Context, sess *session.Session) error {
 		return NotFoundError{}
 	}
 
+	// check state first
+	if c.State == StateRunning {
+		return RemovePowerError{fmt.Errorf("Container is powered on")}
+	}
+
+	// get existing state and set to removing
+	// if there's a failure we'll revert to existing
+	existingState := c.State
+	c.State = StateRemoving
+
 	// get the folder the VM is in
 	url, err := c.vm.DSPath(ctx)
 	if err != nil {
@@ -408,27 +439,19 @@ func (c *Container) Remove(ctx context.Context, sess *session.Session) error {
 		}
 
 		log.Errorf("Failed to get datastore path for %s: %s", c.ExecConfig.ID, err)
+		c.State = existingState
 		return err
 	}
 	// FIXME: was expecting to find a utility function to convert to/from datastore/url given
 	// how widely it's used but couldn't - will ask around.
 	dsPath := fmt.Sprintf("[%s] %s", url.Host, url.Path)
 
-	state, err := c.vm.PowerState(ctx)
-	if err != nil {
-		return fmt.Errorf("Failed to get vm power status %q: %s", c.vm.Reference(), err)
-	}
-
-	// don't remove the containerVM if it is powered on
-	if state == types.VirtualMachinePowerStatePoweredOn {
-		return RemovePowerError{fmt.Errorf("Container is powered on")}
-	}
-
 	//removes the vm from vsphere, but detaches the disks first
 	_, err = tasks.WaitForResult(ctx, func(ctx context.Context) (tasks.ResultWaiter, error) {
 		return c.vm.DeleteExceptDisks(ctx)
 	})
 	if err != nil {
+		c.State = existingState
 		return err
 	}
 
@@ -438,6 +461,7 @@ func (c *Container) Remove(ctx context.Context, sess *session.Session) error {
 	if _, err = tasks.WaitForResult(ctx, func(ctx context.Context) (tasks.ResultWaiter, error) {
 		return fm.DeleteDatastoreFile(ctx, dsPath, sess.Datacenter)
 	}); err != nil {
+		c.State = existingState
 		log.Debugf("Failed to delete %s, %s", dsPath, err)
 	}
 
@@ -465,61 +489,13 @@ func (c *Container) Update(ctx context.Context, sess *session.Session) (*executo
 	return c.ExecConfig, nil
 }
 
-// Grab the info for the requested container
-// TODO:  Possibly change so that handler requests a handle to the
-// container and if it's not present then search and return a handle
-func ContainerInfo(ctx context.Context, sess *session.Session, containerID uid.UID) (*Container, error) {
-	// first  lets see if we have it in the cache
-	container := containers.Container(containerID.String())
-	// if we missed search for it...
-	if container == nil {
-		// search
-		vm, err := childVM(ctx, sess, containerID.String())
-		if err != nil || vm == nil {
-			log.Debugf("ContainerInfo failed to find childVM: %s", err.Error())
-			return nil, fmt.Errorf("Container Not Found: %s", containerID)
-		}
-		container = &Container{vm: vm}
-	}
-
-	// get properties for specific containerVMs
-	// we must do this since we don't know that we have a valid state
-	// This will be refactored when event streaming hits
-	vms, err := populateVMAttributes(ctx, sess, []types.ManagedObjectReference{container.vm.Reference()})
-	if err != nil {
-		return nil, err
-	}
-	// convert the VMs to container objects -- include
-	// powered off vms
-	all := true
-	cc := convertInfraContainers(vms, &all)
-
-	switch len(cc) {
-	case 0:
-		// we found a vm, but it doesn't appear to be a container VM
-		containers.Remove(containerID.String())
-		return nil, fmt.Errorf("%s does not appear to be a container", containerID)
-	case 1:
-		// we have a winner
-		return cc[0], nil
-	default:
-		// we manged to find multiple vms
-		return nil, fmt.Errorf("multiple containers named %s found", containerID)
-	}
+// return specific container to caller
+func ContainerInfo(containerID string) *Container {
+	return containers.Container(containerID)
 }
 
-// return a list of container attributes
-func List(ctx context.Context, sess *session.Session, all *bool) ([]*Container, error) {
-
-	// for now we'll go to the infrastructure
-	// future iteration will utilize cache & event stream
-	moVMs, err := infraContainers(ctx, sess)
-	if err != nil {
-		return nil, err
-	}
-	// convert to container
-	containers := convertInfraContainers(moVMs, all)
-	return containers, nil
+func Containers(all bool) []*Container {
+	return containers.Containers(all)
 }
 
 // get the containerVMs from infrastructure for this resource pool
@@ -611,21 +587,18 @@ func convertInfraContainers(vms []mo.VirtualMachine, all *bool) []*Container {
 			continue
 		}
 
-		// set state & friendly status
+		// set state
 		if vms[i].Runtime.PowerState == types.VirtualMachinePowerStatePoweredOn {
 			container.State = StateRunning
-			container.Status = "Running"
 		} else {
-			// look in the container cache and check status
+			// look in the container cache and check state
 			// if it's created we'll take that as it's been created, but
 			// not started
 			cached := containers.Container(container.ExecConfig.ID)
 			if cached != nil && cached.State == StateCreated {
 				container.State = StateCreated
-				container.Status = "Created"
 			} else {
 				container.State = StateStopped
-				container.Status = "Stopped"
 			}
 		}
 		if vms[i].Summary.Storage != nil {

--- a/lib/portlayer/exec/container_cache_test.go
+++ b/lib/portlayer/exec/container_cache_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/vmware/vic/lib/config/executor"
+	"github.com/vmware/vic/lib/portlayer/event"
 	"github.com/vmware/vic/pkg/uid"
 )
 
@@ -48,4 +49,44 @@ func TestContainerCache(t *testing.T) {
 	assert.Equal(t, len(containers.cache), 0)
 	// remove non-existent container
 	containers.Remove("blahblah")
+}
+
+func TestIsContainerID(t *testing.T) {
+	validID := "aba122943"
+	invalidID := "ABC-XZ_@"
+
+	assert.True(t, isContainerID(validID))
+	assert.False(t, isContainerID(invalidID))
+}
+
+func TestPoweredOnEvents(t *testing.T) {
+	// if container is starting then viewed that poweredOn event is part of PL activity
+	po := event.ContainerPoweredOn
+	assert.EqualValues(t, StateStarting, eventedState(po, StateStarting))
+	// if container is running and poweredOn event then it's either PL activity or it's been handled
+	assert.EqualValues(t, StateRunning, eventedState(po, StateRunning))
+	// if container stopped and then poweredOn event recieved then return state running
+	assert.EqualValues(t, StateRunning, eventedState(po, StateStopped))
+	// if container suspended and then poweredOn event recieved then return state running
+	assert.EqualValues(t, StateRunning, eventedState(po, StateSuspended))
+}
+
+func TestPoweredOffEvents(t *testing.T) {
+	// if container is stopping then viewed that poweredOff event is part of PL activity
+	po := event.ContainerPoweredOff
+	assert.EqualValues(t, StateStopping, eventedState(po, StateStopping))
+	// if container is stopped and poweredOff event then it's either PL activity or it's been handled
+	assert.EqualValues(t, StateStopped, eventedState(po, StateStopped))
+	// if container running and then poweredOff event recieved then return state stopped
+	assert.EqualValues(t, StateStopped, eventedState(po, StateRunning))
+}
+
+func TestSuspendedEvents(t *testing.T) {
+	// if container is suspending (pause) then viewed that suspended event is part of PL activity
+	se := event.ContainerSuspended
+	assert.EqualValues(t, StateSuspending, eventedState(se, StateSuspending))
+	// if container is suspeded (paused) and suspended event then it's either PL activity or it's been handled
+	assert.EqualValues(t, StateSuspended, eventedState(se, StateSuspended))
+	// if container running and then suspended event recieved then return state stopped
+	assert.EqualValues(t, StateSuspended, eventedState(se, StateRunning))
 }

--- a/lib/portlayer/exec/container_test.go
+++ b/lib/portlayer/exec/container_test.go
@@ -1,0 +1,38 @@
+// Copyright 2016 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package exec
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStateStringer(t *testing.T) {
+
+	c := &Container{State: StateRunning}
+
+	assert.Equal(t, "Running", c.State.String())
+	c.State = StateStopped
+	assert.Equal(t, "Stopped", c.State.String())
+	c.State = StateStopping
+	assert.Equal(t, "Stopping", c.State.String())
+	c.State = StateRemoving
+	assert.Equal(t, "Removing", c.State.String())
+	c.State = StateStarting
+	assert.Equal(t, "Starting", c.State.String())
+	c.State = StateCreated
+	assert.Equal(t, "Created", c.State.String())
+}

--- a/tests/test-cases/Group1-Docker-Commands/1-10-Docker-PS.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-10-Docker-PS.robot
@@ -47,6 +47,47 @@ Docker ps all containers
     ${output}=  Split To Lines  ${output}
     Length Should Be  ${output}  4
     
+Docker ps powerOn container OOB
+    ${rc}  ${container}=  Run And Return Rc And Output  docker ${params} create --name jojo busybox /bin/top
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} ps -q
+    Should Be Equal As Integers  ${rc}  0
+    ${output}=  Split To Lines  ${output}
+    Length Should Be  ${output}  1
+    # Remove container VM out-of-band
+    ${rc}  ${output}=  Run And Return Rc And Output  govc vm.power -on "jojo*"
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} ps -q
+    Should Be Equal As Integers  ${rc}  0
+    ${output}=  Split To Lines  ${output}
+    Length Should Be  ${output}  2
+
+Docker ps powerOff container OOB
+    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} ps -q
+    Should Be Equal As Integers  ${rc}  0
+    ${output}=  Split To Lines  ${output}
+    Length Should Be  ${output}  2
+    # Remove container VM out-of-band
+    ${rc}  ${output}=  Run And Return Rc And Output  govc vm.power -off "jojo*"
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} ps -q
+    Should Be Equal As Integers  ${rc}  0
+    ${output}=  Split To Lines  ${output}
+    Length Should Be  ${output}  1
+
+Docker ps Remove container OOB
+    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} ps -aq
+    Should Be Equal As Integers  ${rc}  0
+    ${output}=  Split To Lines  ${output}
+    Length Should Be  ${output}  4
+    # Remove container VM out-of-band
+    ${rc}  ${output}=  Run And Return Rc And Output  govc vm.destroy "jojo*"
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} ps -aq
+    Should Be Equal As Integers  ${rc}  0
+    ${output}=  Split To Lines  ${output}
+    Length Should Be  ${output}  3
+
 Docker ps last container
     ${status}=  Get State Of Github Issue  1545
     Run Keyword If  '${status}' == 'closed'  Fail  Test 1-10-Docker-PS.robot needs to be updated now that Issue #1545 has been resolved


### PR DESCRIPTION
Initial event stream for PortLayer

Change is focused on exec and will update the container cache with out of band activity.  ContainerList (utilized by docker ps) & ContainerInfo (utilized by docker inspect) have been refactored to take advantage of an up to date container cache.  

This change does not encompass network and will not release network resources
for containers are acted on out of band.  That will be addressed in a future
change.

Fixes: #1329

