### PR TITLE
Check if cluster is set before checking VDS membership

### DIFF
--- a/lib/install/validate/network.go
+++ b/lib/install/validate/network.go
@@ -318,7 +318,7 @@ func (v *Validator) checkVDSMembership(ctx context.Context, network types.Manage
 	}
 
 	if v.Session.Cluster == nil {
-		return errors.New("cluster not set")
+		return errors.New("Invalid cluster. Check --compute-resource")
 	}
 	clusterHosts, err := v.Session.Cluster.Hosts(ctx)
 	if err != nil {

--- a/lib/install/validate/network.go
+++ b/lib/install/validate/network.go
@@ -317,6 +317,9 @@ func (v *Validator) checkVDSMembership(ctx context.Context, network types.Manage
 		return nil
 	}
 
+	if v.Session.Cluster == nil {
+		return errors.New("cluster not set")
+	}
 	clusterHosts, err := v.Session.Cluster.Hosts(ctx)
 	if err != nil {
 		return err


### PR DESCRIPTION
Fixes #1860 

Before:
```
⇒  bin/vic-machine-linux create --target 10.17.109.115 --image-datastore vsanDatastore --name chin-vic-18 --user administrator@vsphere.local --password password --compute-resource chin --bridge-network vch-test --timeout 10m                                                                                                                                  
INFO[2016-08-10T14:06:29-07:00] ### Installing VCH ####                      
INFO[2016-08-10T14:06:29-07:00] Generating certificate/key pair - private key in ./chin-vic-18-key.pem 
INFO[2016-08-10T14:06:30-07:00] Validating supplied configuration            
INFO[2016-08-10T14:06:30-07:00] Suggesting valid values for --compute-resource based on "/dc1/host/chin/Resources" 
INFO[2016-08-10T14:06:30-07:00] Suggested values for --compute-resource:     
INFO[2016-08-10T14:06:30-07:00]   "cluster1"                                 
INFO[2016-08-10T14:06:30-07:00]   "cluster2"                                 
ERRO[2016-08-10T14:06:31-07:00] --------------------                         
ERRO[2016-08-10T14:06:31-07:00] vic-machine-linux failed: runtime error: invalid memory address or nil pointer dereference
```

Now:
```
⇒  bin/vic-machine-linux create --target 10.17.109.115 --image-datastore vsanDatastore --name chin-vic-18 --user administrator@vsphere.local --password password --compute-resource chin --bridge-network vch-test --timeout 10m
INFO[2016-08-11T07:06:15-07:00] ### Installing VCH ####                      
INFO[2016-08-11T07:06:15-07:00] Generating certificate/key pair - private key in ./chin-vic-18-key.pem 
INFO[2016-08-11T07:06:16-07:00] Validating supplied configuration            
INFO[2016-08-11T07:06:16-07:00] Suggesting valid values for --compute-resource based on "/dc1/host/chin/Resources" 
INFO[2016-08-11T07:06:17-07:00] Suggested values for --compute-resource:     
INFO[2016-08-11T07:06:17-07:00]   "cluster1"                                 
INFO[2016-08-11T07:06:17-07:00]   "cluster2"                                 
ERRO[2016-08-11T07:06:17-07:00] Firewall check SKIPPED                       
ERRO[2016-08-11T07:06:17-07:00]   cluster not set                            
ERRO[2016-08-11T07:06:17-07:00] License check SKIPPED                        
ERRO[2016-08-11T07:06:17-07:00]   cluster not set                            
ERRO[2016-08-11T07:06:17-07:00] DRS check SKIPPED                            
ERRO[2016-08-11T07:06:17-07:00]   cluster not set                            
ERRO[2016-08-11T07:06:17-07:00] Compatibility check SKIPPED                  
ERRO[2016-08-11T07:06:17-07:00]   cluster not set                            
ERRO[2016-08-11T07:06:17-07:00] --------------------                         
ERRO[2016-08-11T07:06:17-07:00] resource pool '/dc1/host/chin/Resources' not found 
ERRO[2016-08-11T07:06:17-07:00] Unable to check hosts in vDS for "vch-test": cluster not set 
ERRO[2016-08-11T07:06:17-07:00] Firewall check SKIPPED                       
ERRO[2016-08-11T07:06:17-07:00] License check SKIPPED                        
ERRO[2016-08-11T07:06:17-07:00] DRS check SKIPPED                            
ERRO[2016-08-11T07:06:17-07:00] Compatibility check SKIPPED                  
ERRO[2016-08-11T07:06:17-07:00] Create cannot continue: configuration validation failed 
ERRO[2016-08-11T07:06:17-07:00] --------------------                         
ERRO[2016-08-11T07:06:17-07:00] vic-machine-linux failed: validation of configuration failed
```