### PR TITLE
WIP confirming fix of p0 bug #1823 in the CI

### DIFF
--- a/tests/integration-test.sh
+++ b/tests/integration-test.sh
@@ -20,11 +20,7 @@ gsutil version -l
 
 dpkg -l > package.list
 
-if [ $DRONE_BRANCH = "master" ] && [ $DRONE_REPO = "vmware/vic" ]; then
-    pybot --removekeywords TAG:secret tests/test-cases
-else
-    pybot --removekeywords TAG:secret --include regression tests/test-cases
-fi
+pybot --removekeywords TAG:secret tests/test-cases
 
 rc="$?"
 


### PR DESCRIPTION
Fixes #1823 
There was a p0 bug on `docker stop` in the past where a vm would not actually poweroff. This was due in part because we were not waiting long enough for a signal to potentially propagate. Also due in part for a nil pointer exception coming from `vicadmin`. This PR enables integration tests to see if the 1823 error appears or not. 