### PR TITLE
Add protection against regression #1778

### DIFF
--- a/tests/test-cases/Group1-Docker-Commands/1-2-Docker-Pull.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-2-Docker-Pull.robot
@@ -13,6 +13,7 @@ Pull image
     Should Be Equal As Integers  ${rc}  0
     Should Contain  ${output}  Digest:
     Should Contain  ${output}  Status:
+    Should Not Contain  ${output}  No such image:
 
 *** Test Cases ***
 Pull nginx


### PR DESCRIPTION
Small change; expected it to take more but this should address the final bit in #1778 which is to add a regression test to protect against that issue arising again; namely, where the image pull appears to succeed but finally states `no such image`

Instead of writing a new test, I've modified the `pull` integration tests to ensure that this message is not output at the end of a pull