### PR TITLE
Abandon inconsistent images and purge images without a manifest file

### DIFF
--- a/lib/apiservers/portlayer/restapi/handlers/storage_handlers_test.go
+++ b/lib/apiservers/portlayer/restapi/handlers/storage_handlers_test.go
@@ -145,7 +145,7 @@ func (c *MockDataStore) ListImageStores(ctx context.Context) ([]*url.URL, error)
 	return nil, nil
 }
 
-func (c *MockDataStore) WriteImage(ctx context.Context, parent *spl.Image, ID string, meta map[string][]byte, r io.Reader) (*spl.Image, error) {
+func (c *MockDataStore) WriteImage(ctx context.Context, parent *spl.Image, ID string, meta map[string][]byte, sum string, r io.Reader) (*spl.Image, error) {
 	i := spl.Image{
 		ID:       ID,
 		Store:    parent.Store,

--- a/lib/portlayer/storage/image.go
+++ b/lib/portlayer/storage/image.go
@@ -72,9 +72,9 @@ type ImageStorer interface {
 	// parent - The parent image to create the new image from.
 	// ID - textual ID for the image to be written
 	// meta - metadata associated with the image
+	// sum - expected sha266 sum of the image content.
 	// r - the image tar to be written
-	WriteImage(ctx context.Context, parent *Image, ID string, meta map[string][]byte, r io.Reader) (*Image,
-		error)
+	WriteImage(ctx context.Context, parent *Image, ID string, meta map[string][]byte, sum string, r io.Reader) (*Image, error)
 
 	// GetImage queries the image store for the specified image.
 	//

--- a/lib/portlayer/storage/image_cache.go
+++ b/lib/portlayer/storage/image_cache.go
@@ -15,7 +15,6 @@
 package storage
 
 import (
-	"crypto/sha256"
 	"fmt"
 	"io"
 	"net/url"
@@ -123,7 +122,7 @@ func (c *NameLookupCache) CreateImageStore(ctx context.Context, storeName string
 	defer c.storeCacheLock.Unlock()
 
 	// Create the root image
-	scratch, err := c.DataStore.WriteImage(ctx, &Image{Store: u}, Scratch.ID, nil, nil)
+	scratch, err := c.DataStore.WriteImage(ctx, &Image{Store: u}, Scratch.ID, nil, "", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -168,18 +167,9 @@ func (c *NameLookupCache) WriteImage(ctx context.Context, parent *Image, ID stri
 	}
 
 	// Definitely not in cache or image store, create image.
-	h := sha256.New()
-	t := io.TeeReader(r, h)
-
-	i, err = c.DataStore.WriteImage(ctx, p, ID, meta, t)
+	i, err = c.DataStore.WriteImage(ctx, p, ID, meta, sum, r)
 	if err != nil {
 		return nil, err
-	}
-
-	actualSum := fmt.Sprintf("sha256:%x", h.Sum(nil))
-	if actualSum != sum {
-		// TODO(jzt): cleanup?
-		return nil, fmt.Errorf("Failed to validate image checksum. Expected %s, got %s", sum, actualSum)
 	}
 
 	// Add the new image to the cache

--- a/lib/portlayer/storage/image_cache_test.go
+++ b/lib/portlayer/storage/image_cache_test.go
@@ -59,7 +59,7 @@ func (c *MockDataStore) ListImageStores(ctx context.Context) ([]*url.URL, error)
 	return nil, nil
 }
 
-func (c *MockDataStore) WriteImage(ctx context.Context, parent *Image, ID string, meta map[string][]byte, r io.Reader) (*Image, error) {
+func (c *MockDataStore) WriteImage(ctx context.Context, parent *Image, ID string, meta map[string][]byte, sum string, r io.Reader) (*Image, error) {
 	i := &Image{
 		ID:       ID,
 		Store:    parent.Store,
@@ -177,7 +177,7 @@ func TestOutsideCacheWriteImage(t *testing.T) {
 		id := fmt.Sprintf("ID-%d", i)
 
 		// Write to the datastore creating images
-		img, werr := s.DataStore.WriteImage(context.TODO(), &parent, id, nil, nil)
+		img, werr := s.DataStore.WriteImage(context.TODO(), &parent, id, nil, "", nil)
 		if !assert.NoError(t, werr) {
 			return
 		}

--- a/lib/portlayer/storage/vsphere/image.go
+++ b/lib/portlayer/storage/vsphere/image.go
@@ -15,6 +15,7 @@
 package vsphere
 
 import (
+	"crypto/sha256"
 	"errors"
 	"fmt"
 	"io"
@@ -195,7 +196,7 @@ func (v *ImageStore) ListImageStores(ctx context.Context) ([]*url.URL, error) {
 // ID - textual ID for the image to be written
 // meta - metadata associated with the image
 // Tag - the tag of the image to be written
-func (v *ImageStore) WriteImage(ctx context.Context, parent *portlayer.Image, ID string, meta map[string][]byte,
+func (v *ImageStore) WriteImage(ctx context.Context, parent *portlayer.Image, ID string, meta map[string][]byte, sum string,
 	r io.Reader) (*portlayer.Image, error) {
 
 	storeName, err := util.ImageStoreName(parent.Store)
@@ -208,29 +209,12 @@ func (v *ImageStore) WriteImage(ctx context.Context, parent *portlayer.Image, ID
 		return nil, err
 	}
 
-	// Create the image directory in the store.
-	imageDir := v.imageDirPath(storeName, ID)
-	_, err = v.ds.Mkdir(ctx, false, imageDir)
-	if err != nil {
-		return nil, err
-	}
-
-	imageDiskDsURI := v.imageDiskPath(storeName, ID)
-	log.Infof("Creating image %s (%s)", ID, imageDiskDsURI)
-
 	// If this is scratch, then it's the root of the image store.  All images
 	// will be descended from this created and prepared fs.
 	if ID == portlayer.Scratch.ID {
-		// Create the disk
-		vmdisk, cerr := v.dm.CreateAndAttach(ctx, imageDiskDsURI, "", defaultDiskSize, os.O_RDWR)
-		if cerr != nil {
-			return nil, cerr
-		}
-		defer v.dm.Detach(ctx, vmdisk)
-
-		// Make the filesystem and set its label to defaultDiskLabel
-		if cerr = vmdisk.Mkfs(defaultDiskLabel); cerr != nil {
-			return nil, cerr
+		// Create the scratch layer
+		if err := v.scratch(ctx, storeName); err != nil {
+			return nil, err
 		}
 	} else {
 
@@ -238,46 +222,17 @@ func (v *ImageStore) WriteImage(ctx context.Context, parent *portlayer.Image, ID
 			return nil, fmt.Errorf("parent ID is empty")
 		}
 
-		// datastore path to the parent
-		parentDiskDsURI := v.imageDiskPath(storeName, parent.ID)
-
-		// Create the disk
-		vmdisk, cerr := v.dm.CreateAndAttach(ctx, imageDiskDsURI, parentDiskDsURI, 0, os.O_RDWR)
-		if cerr != nil {
-			return nil, cerr
-		}
-		defer v.dm.Detach(ctx, vmdisk)
-
-		dir, cerr := ioutil.TempDir("", "mnt-"+ID)
-		if cerr != nil {
-			return nil, cerr
-		}
-		defer os.RemoveAll(dir)
-
-		if merr := vmdisk.Mount(dir, nil); merr != nil {
-			return nil, merr
-		}
-		defer vmdisk.Unmount()
-
-		// Untar the archive
-		cerr = archive.Untar(r, dir, &archive.TarOptions{})
-		if cerr != nil {
-			return nil, cerr
-		}
-
 		// persist the relationship
 		v.parents.Add(ID, parent.ID)
 
-		if cerr = v.parents.Save(ctx); cerr != nil {
-			return nil, cerr
+		if err := v.parents.Save(ctx); err != nil {
+			return nil, err
 		}
-	}
 
-	// Write the metadata to the datastore
-	metaDataDir := v.imageMetadataDirPath(storeName, ID)
-	err = writeMetadata(ctx, v.ds, metaDataDir, meta)
-	if err != nil {
-		return nil, err
+		if err := v.writeImage(ctx, storeName, parent.ID, ID, meta, sum, r); err != nil {
+			return nil, err
+		}
+
 	}
 
 	newImage := &portlayer.Image{
@@ -289,6 +244,126 @@ func (v *ImageStore) WriteImage(ctx context.Context, parent *portlayer.Image, ID
 	}
 
 	return newImage, nil
+}
+
+// Create the image directory, create a temp vmdk in this directory,
+// attach/mount the disk, unpack the tar, check the checksum.  If the data
+// doesn't match the expected checksum, abort by nuking the image directory.
+// If everything matches, move the tmp vmdk to ID.vmdk.  The unwind path is a
+// bit convoluted here;  we need to clean up on the way out in the error case
+func (v *ImageStore) writeImage(ctx context.Context, storeName, parentID, ID string, meta map[string][]byte,
+	sum string, r io.Reader) error {
+
+	// Create a temp image directory in the store.
+	imageDir := v.imageDirPath(storeName, ID)
+	_, err := v.ds.Mkdir(ctx, true, imageDir)
+	if err != nil {
+		return err
+	}
+
+	// Write the metadata to the datastore
+	metaDataDir := v.imageMetadataDirPath(storeName, ID)
+	err = writeMetadata(ctx, v.ds, metaDataDir, meta)
+	if err != nil {
+		return err
+	}
+
+	// datastore path to the parent
+	parentDiskDsURI := v.imageDiskPath(storeName, parentID)
+
+	// datastore path to the disk we're creating
+	diskDsURI := v.imageDiskPath(storeName, ID)
+	log.Infof("Creating image %s (%s)", ID, diskDsURI)
+
+	// Create the disk
+	vmdisk, err := v.dm.CreateAndAttach(ctx, diskDsURI, parentDiskDsURI, 0, os.O_RDWR)
+	if err != nil {
+		return err
+	}
+
+	defer func() {
+		var cleanup bool
+		if vmdisk.Mounted() {
+			cleanup = true
+			log.Debugf("Unmounting abandonned disk")
+			vmdisk.Unmount()
+		}
+		if vmdisk.Attached() {
+			cleanup = true
+			log.Debugf("Detaching abandonned disk")
+			v.dm.Detach(ctx, vmdisk)
+		}
+
+		if cleanup {
+			v.ds.Rm(ctx, imageDir)
+		}
+	}()
+
+	// tmp dir to mount the disk
+	dir, err := ioutil.TempDir("", "mnt-"+ID)
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(dir)
+
+	if err := vmdisk.Mount(dir, nil); err != nil {
+		return err
+	}
+
+	h := sha256.New()
+	t := io.TeeReader(r, h)
+
+	// Untar the archive
+	if err = archive.Untar(t, dir, &archive.TarOptions{}); err != nil {
+		return err
+	}
+
+	actualSum := fmt.Sprintf("sha256:%x", h.Sum(nil))
+	if actualSum != sum {
+		return fmt.Errorf("Failed to validate image checksum. Expected %s, got %s", sum, actualSum)
+	}
+
+	if err = vmdisk.Unmount(); err != nil {
+		return err
+	}
+
+	if err = v.dm.Detach(ctx, vmdisk); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (v *ImageStore) scratch(ctx context.Context, storeName string) error {
+
+	// Create the image directory in the store.
+	imageDir := v.imageDirPath(storeName, portlayer.Scratch.ID)
+	if _, err := v.ds.Mkdir(ctx, false, imageDir); err != nil {
+		return err
+	}
+
+	// Write the metadata to the datastore
+	metaDataDir := v.imageMetadataDirPath(storeName, portlayer.Scratch.ID)
+	if err := writeMetadata(ctx, v.ds, metaDataDir, nil); err != nil {
+		return err
+	}
+
+	imageDiskDsURI := v.imageDiskPath(storeName, portlayer.Scratch.ID)
+	log.Infof("Creating image %s (%s)", portlayer.Scratch.ID, imageDiskDsURI)
+
+	// Create the disk
+	vmdisk, err := v.dm.CreateAndAttach(ctx, imageDiskDsURI, "", defaultDiskSize, os.O_RDWR)
+	if err != nil {
+		return err
+	}
+	defer v.dm.Detach(ctx, vmdisk)
+
+	// Make the filesystem and set its label to defaultDiskLabel
+	if err := vmdisk.Mkfs(defaultDiskLabel); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func (v *ImageStore) GetImage(ctx context.Context, store *url.URL, ID string) (*portlayer.Image, error) {

--- a/lib/portlayer/storage/vsphere/image_test.go
+++ b/lib/portlayer/storage/vsphere/image_test.go
@@ -74,9 +74,16 @@ func TestRestartImageStore(t *testing.T) {
 
 	origVsStore := cacheStore.DataStore.(*ImageStore)
 
+	storeName := "bogusStoreName"
+	origStore, err := cacheStore.CreateImageStore(context.TODO(), storeName)
+	if !assert.NoError(t, err) || !assert.NotNil(t, origStore) {
+		return
+	}
+
 	imageStoreURL := &url.URL{
-		Path: client.Datastore.Path(StorageParentDir),
+		Path: StorageParentDir,
 		Host: client.DatastorePath}
+
 	// now start it again
 	restartedVsStore, err := NewImageStore(context.TODO(), client, imageStoreURL)
 	if !assert.NoError(t, err) || !assert.NotNil(t, restartedVsStore) {
@@ -85,6 +92,15 @@ func TestRestartImageStore(t *testing.T) {
 
 	// Check we didn't create a new UUID directory (relevant if vsan)
 	if !assert.Equal(t, origVsStore.ds.RootURL, restartedVsStore.ds.RootURL) {
+		return
+	}
+
+	restartedStore, err := restartedVsStore.GetImageStore(context.TODO(), storeName)
+	if !assert.NoError(t, err) || !assert.NotNil(t, restartedStore) {
+		return
+	}
+
+	if !assert.Equal(t, origStore.String(), restartedStore.String()) {
 		return
 	}
 }

--- a/lib/portlayer/storage/vsphere/image_test.go
+++ b/lib/portlayer/storage/vsphere/image_test.go
@@ -367,7 +367,6 @@ func TestBrokenPull(t *testing.T) {
 }
 
 func TestInProgressCleanup(t *testing.T) {
-	t.Skipf("not ready for testing")
 
 	cacheStore, client, err := setup(t)
 	if !assert.NoError(t, err) {
@@ -412,15 +411,13 @@ func TestInProgressCleanup(t *testing.T) {
 		return
 	}
 
-	// nuke the vmdk
-	rm(t, client, vsStore.imageDiskPath("testStore", imageID))
-	//
-	//
-	//	// call cleanup
-	//	if err = vsStore.cleanup(context.TODO(), storeURL); !assert.NoError(t, err) {
-	//		return
-	//	}
-	//
+	// nuke the done file.
+	rm(t, client, path.Join(vsStore.ds.RootURL, vsStore.imageDirPath("testStore", imageID), manifest))
+
+	// call cleanup
+	if err = vsStore.cleanup(context.TODO(), storeURL); !assert.NoError(t, err) {
+		return
+	}
 
 	// Make sure list is now empty.
 	listedImages, err := vsStore.ListImages(context.TODO(), parent.Store, nil)

--- a/lib/portlayer/storage/vsphere/image_test.go
+++ b/lib/portlayer/storage/vsphere/image_test.go
@@ -27,6 +27,7 @@ import (
 	"sort"
 	"testing"
 
+	"github.com/Sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/vim25/types"
@@ -38,6 +39,7 @@ import (
 )
 
 func setup(t *testing.T) (*portlayer.NameLookupCache, *session.Session, error) {
+	logrus.SetLevel(logrus.DebugLevel)
 	StorageParentDir = datastore.TestName("imageTests")
 
 	client := datastore.Session(context.TODO(), t)
@@ -155,31 +157,7 @@ func TestCreateImageLayers(t *testing.T) {
 	}
 
 	vsStore := cacheStore.DataStore.(*ImageStore)
-
-	// Nuke the files and then the parent dir.  Unfortunately, because this is
-	// vsan, we need to delete the files in the directories first (maybe
-	// because they're linked vmkds) before we can delete the parent directory.
-	defer func() {
-		res, err := vsStore.ds.LsDirs(context.TODO(), "")
-		if err != nil {
-			t.Logf("error: %s", err)
-			return
-		}
-
-		for _, dir := range res.HostDatastoreBrowserSearchResults {
-			for _, f := range dir.File {
-				file, ok := f.(*types.FileInfo)
-				if !ok {
-					continue
-				}
-
-				rm(t, client, path.Join(dir.FolderPath, file.Path))
-			}
-			rm(t, client, dir.FolderPath)
-		}
-
-		rm(t, client, client.Datastore.Path(StorageParentDir))
-	}()
+	defer cleanup(t, client, vsStore)
 
 	storeURL, err := cacheStore.CreateImageStore(context.TODO(), "testStore")
 	if !assert.NoError(t, err) {
@@ -310,6 +288,131 @@ func TestCreateImageLayers(t *testing.T) {
 	}
 }
 
+func TestBrokenPull(t *testing.T) {
+
+	cacheStore, client, err := setup(t)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	vsStore := cacheStore.DataStore.(*ImageStore)
+
+	defer cleanup(t, client, vsStore)
+
+	storeURL, err := cacheStore.CreateImageStore(context.TODO(), "testStore")
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	// base this image off scratch
+	parent, err := cacheStore.GetImage(context.TODO(), storeURL, portlayer.Scratch.ID)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	imageID := "dir0"
+
+	// Add some files to the archive.
+	var files = []tarFile{
+		{imageID, tar.TypeDir, ""},
+		{imageID + "/readme.txt", tar.TypeReg, "This archive contains some text files."},
+		{imageID + "/gopher.txt", tar.TypeReg, "Gopher names:\nGeorge\nGeoffrey\nGonzo"},
+		{imageID + "/todo.txt", tar.TypeReg, "Get animal handling license."},
+	}
+
+	// meta for the image
+	meta := make(map[string][]byte)
+	meta[imageID+"_meta"] = []byte("Some Meta")
+	meta[imageID+"_moreMeta"] = []byte("Some More Meta")
+	meta[imageID+"_scorpions"] = []byte("Here I am, rock you like a hurricane")
+
+	// Tar the files
+	buf, terr := tarFiles(files)
+	if !assert.NoError(t, terr) {
+		return
+	}
+
+	// Calculate the checksum
+	h := sha256.New()
+	h.Write(buf.Bytes())
+	actualsum := fmt.Sprintf("sha256:%x", h.Sum(nil))
+
+	// Write the image via the cache (which writes to the vsphere impl).  We're passing a bogus sum so the image should fail to save.
+	writtenImage, err := cacheStore.WriteImage(context.TODO(), parent, imageID, meta, "bogusSum", new(bytes.Buffer))
+	if !assert.Error(t, err) || !assert.Nil(t, writtenImage) {
+		return
+	}
+
+	// Now try again with the right sum and there shouldn't be an error.
+	writtenImage, err = cacheStore.WriteImage(context.TODO(), parent, imageID, meta, actualsum, buf)
+	if !assert.NoError(t, err) || !assert.NotNil(t, writtenImage) {
+		return
+	}
+}
+
+func TestInProgressCleanup(t *testing.T) {
+	t.Skipf("not ready for testing")
+
+	cacheStore, client, err := setup(t)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	vsStore := cacheStore.DataStore.(*ImageStore)
+
+	defer cleanup(t, client, vsStore)
+
+	storeURL, err := cacheStore.CreateImageStore(context.TODO(), "testStore")
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	// base this image off scratch
+	parent, err := cacheStore.GetImage(context.TODO(), storeURL, portlayer.Scratch.ID)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	// create a test image
+	imageID := "testImage"
+
+	// meta for the image
+	meta := make(map[string][]byte)
+	meta[imageID+"_meta"] = []byte("Some Meta")
+
+	// Tar the files
+	buf, err := tarFiles([]tarFile{})
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	// Calculate the checksum
+	h := sha256.New()
+	h.Write(buf.Bytes())
+	sum := fmt.Sprintf("sha256:%x", h.Sum(nil))
+
+	writtenImage, err := cacheStore.WriteImage(context.TODO(), parent, imageID, meta, sum, buf)
+	if !assert.NoError(t, err) || !assert.NotNil(t, writtenImage) {
+		return
+	}
+
+	// nuke the vmdk
+	rm(t, client, vsStore.imageDiskPath("testStore", imageID))
+	//
+	//
+	//	// call cleanup
+	//	if err = vsStore.cleanup(context.TODO(), storeURL); !assert.NoError(t, err) {
+	//		return
+	//	}
+	//
+
+	// Make sure list is now empty.
+	listedImages, err := vsStore.ListImages(context.TODO(), parent.Store, nil)
+	if !assert.NoError(t, err) || !assert.Equal(t, len(listedImages), 1) || !assert.Equal(t, listedImages[0].ID, portlayer.Scratch.ID) {
+		return
+	}
+}
+
 type tarFile struct {
 	Name string
 	Type byte
@@ -375,10 +478,36 @@ func mountLayerRO(v *ImageStore, parent *portlayer.Image) (*disk.VirtualDisk, er
 }
 
 func rm(t *testing.T, client *session.Session, name string) {
+	t.Logf("deleting %s", name)
 	fm := object.NewFileManager(client.Vim25())
 	task, err := fm.DeleteDatastoreFile(context.TODO(), name, client.Datacenter)
 	if !assert.NoError(t, err) {
 		return
 	}
 	_, _ = task.WaitForResult(context.TODO(), nil)
+}
+
+// Nuke the files and then the parent dir.  Unfortunately, because this is
+// vsan, we need to delete the files in the directories first (maybe
+// because they're linked vmkds) before we can delete the parent directory.
+func cleanup(t *testing.T, client *session.Session, vsStore *ImageStore) {
+	res, err := vsStore.ds.LsDirs(context.TODO(), "")
+	if err != nil {
+		t.Logf("error: %s", err)
+		return
+	}
+
+	for _, dir := range res.HostDatastoreBrowserSearchResults {
+		for _, f := range dir.File {
+			file, ok := f.(*types.FileInfo)
+			if !ok {
+				continue
+			}
+
+			rm(t, client, path.Join(dir.FolderPath, file.Path))
+		}
+		rm(t, client, dir.FolderPath)
+	}
+
+	rm(t, client, client.Datastore.Path(StorageParentDir))
 }

--- a/pkg/vsphere/datastore/datastore.go
+++ b/pkg/vsphere/datastore/datastore.go
@@ -195,7 +195,7 @@ func (d *Helper) Ls(ctx context.Context, p string) (*types.HostDatastoreBrowserS
 
 // LsDirs returns a list of dirents at the given path (relative to root)
 func (d *Helper) LsDirs(ctx context.Context, p string) (*types.ArrayOfHostDatastoreBrowserSearchResults, error) {
-	spec := types.HostDatastoreBrowserSearchSpec{
+	spec := &types.HostDatastoreBrowserSearchSpec{
 		MatchPattern: []string{"*"},
 	}
 
@@ -204,7 +204,7 @@ func (d *Helper) LsDirs(ctx context.Context, p string) (*types.ArrayOfHostDatast
 		return nil, err
 	}
 
-	task, err := b.SearchDatastoreSubFolders(ctx, path.Join(d.RootURL, p), &spec)
+	task, err := b.SearchDatastoreSubFolders(ctx, path.Join(d.RootURL, p), spec)
 	if err != nil {
 		return nil, err
 	}
@@ -234,11 +234,20 @@ func (d *Helper) Stat(ctx context.Context, pth string) (types.BaseFileInfo, erro
 func (d *Helper) Mv(ctx context.Context, fromPath, toPath string) error {
 	from := path.Join(d.RootURL, fromPath)
 	to := path.Join(d.RootURL, toPath)
+	log.Infof("Moving %s to %s", from, to)
 	err := tasks.Wait(ctx, func(context.Context) (tasks.Waiter, error) {
 		return d.fm.MoveDatastoreFile(ctx, from, d.s.Datacenter, to, d.s.Datacenter, true)
 	})
 
 	return err
+}
+
+func (d *Helper) Rm(ctx context.Context, pth string) error {
+	f := path.Join(d.RootURL, pth)
+	log.Infof("Removing %s", pth)
+	return tasks.Wait(context.TODO(), func(ctx context.Context) (tasks.Waiter, error) {
+		return d.fm.DeleteDatastoreFile(ctx, f, d.s.Datacenter)
+	})
 }
 
 func (d *Helper) IsVSAN(ctx context.Context) bool {

--- a/pkg/vsphere/disk/disk.go
+++ b/pkg/vsphere/disk/disk.go
@@ -85,7 +85,7 @@ func (d *VirtualDisk) unlock() {
 }
 
 func (d *VirtualDisk) setAttached(devicePath string) error {
-	if d.isAttached() {
+	if d.Attached() {
 		return fmt.Errorf("%s is already attached (%s)", d.DatastoreURI, devicePath)
 	}
 
@@ -98,11 +98,11 @@ func (d *VirtualDisk) setAttached(devicePath string) error {
 }
 
 func (d *VirtualDisk) canBeDetached() error {
-	if !d.isAttached() {
+	if !d.Attached() {
 		return fmt.Errorf("%s is already detached", d.DatastoreURI)
 	}
 
-	if d.isMounted() {
+	if d.Mounted() {
 		return fmt.Errorf("%s is mounted (%s)", d.DatastoreURI, d.mountPath)
 	}
 
@@ -110,11 +110,11 @@ func (d *VirtualDisk) canBeDetached() error {
 }
 
 func (d *VirtualDisk) setDetached() error {
-	if !d.isAttached() {
+	if !d.Attached() {
 		return fmt.Errorf("%s is already dettached", d.DatastoreURI)
 	}
 
-	if d.isMounted() {
+	if d.Mounted() {
 		return fmt.Errorf("%s is still mounted (%s)", d.DatastoreURI, d.mountPath)
 	}
 
@@ -126,11 +126,11 @@ func (d *VirtualDisk) Mkfs(labelName string) error {
 	d.lock()
 	defer d.unlock()
 
-	if !d.isAttached() {
+	if !d.Attached() {
 		return fmt.Errorf("%s isn't attached", d.DatastoreURI)
 	}
 
-	if d.isMounted() {
+	if d.Mounted() {
 		return fmt.Errorf("%s is mounted mounted", d.DatastoreURI)
 	}
 
@@ -141,14 +141,14 @@ func (d *VirtualDisk) SetLabel(labelName string) error {
 	d.lock()
 	defer d.unlock()
 
-	if !d.isAttached() {
+	if !d.Attached() {
 		return fmt.Errorf("%s isn't attached", d.DatastoreURI)
 	}
 
 	return d.fs.SetLabel(d.DevicePath, labelName)
 }
 
-func (d *VirtualDisk) isAttached() bool {
+func (d *VirtualDisk) Attached() bool {
 	return d.DevicePath != ""
 }
 
@@ -156,11 +156,11 @@ func (d *VirtualDisk) Mount(mountPath string, options []string) error {
 	d.lock()
 	defer d.unlock()
 
-	if !d.isAttached() {
+	if !d.Attached() {
 		return fmt.Errorf("%s isn't attached", d.DatastoreURI)
 	}
 
-	if d.isMounted() {
+	if d.Mounted() {
 		return fmt.Errorf("%s already mounted", d.DatastoreURI)
 	}
 
@@ -176,7 +176,7 @@ func (d *VirtualDisk) Unmount() error {
 	d.lock()
 	defer d.unlock()
 
-	if !d.isMounted() {
+	if !d.Mounted() {
 		return fmt.Errorf("%s already unmounted", d.DatastoreURI)
 	}
 
@@ -189,7 +189,7 @@ func (d *VirtualDisk) Unmount() error {
 }
 
 func (d *VirtualDisk) MountPath() (string, error) {
-	if !d.isMounted() {
+	if !d.Mounted() {
 		return "", fmt.Errorf("%s isn't mounted", d.DatastoreURI)
 	}
 
@@ -200,16 +200,16 @@ func (d *VirtualDisk) DiskPath() string {
 	return d.DatastoreURI
 }
 
-func (d *VirtualDisk) isMounted() bool {
+func (d *VirtualDisk) Mounted() bool {
 	return d.mountPath != ""
 }
 
 func (d *VirtualDisk) canBeUnmounted() error {
-	if !d.isAttached() {
+	if !d.Attached() {
 		return fmt.Errorf("%s is detached", d.DatastoreURI)
 	}
 
-	if !d.isMounted() {
+	if !d.Mounted() {
 		return fmt.Errorf("%s is unmounted", d.DatastoreURI)
 	}
 
@@ -217,7 +217,7 @@ func (d *VirtualDisk) canBeUnmounted() error {
 }
 
 func (d *VirtualDisk) setUmounted() error {
-	if !d.isMounted() {
+	if !d.Mounted() {
 		return fmt.Errorf("%s already unmounted", d.DatastoreURI)
 	}
 

--- a/pkg/vsphere/disk/disk_manager.go
+++ b/pkg/vsphere/disk/disk_manager.go
@@ -230,6 +230,11 @@ func (m *Manager) Detach(ctx context.Context, d *VirtualDisk) error {
 	d.lock()
 	defer d.unlock()
 
+	if !d.Attached() {
+		log.Infof("Disk %s is already detached", d.DevicePath)
+		return nil
+	}
+
 	if err := d.canBeDetached(); err != nil {
 		return errors.Trace(err)
 	}


### PR DESCRIPTION
    Write manifest file to signify doneness for images
    
    Write a manifest file (currently empty but free to use for future
    stashing of important stuff) for each image after the checksum matches.
    This is the last step in a WriteImage so we can use this to know when an
    image is complete and consistent.

    Abandon images if checksums don't match on pull
    
    This change writes the image compares the computed checksum with the
    expected checksum, and moves the disk to the image store if they match.
    Otherwise the image's directory is removed.  Subsequent pulls should
    complete without an issue.

Fixes #933
