### PR TITLE
Make installer wait for portlayer to initialize

### DIFF
--- a/lib/install/management/create.go
+++ b/lib/install/management/create.go
@@ -98,9 +98,15 @@ func (d *Dispatcher) CreateVCH(conf *config.VirtualContainerHostConfigSpec, sett
 		return errors.Errorf("Failed to power on appliance %s. Exiting...", err)
 	}
 
-	if err = d.makeSureApplianceRuns(conf); err != nil {
+	if err = d.ensureApplianceInitializes(conf); err != nil {
 		return errors.Errorf("%s. Exiting...", err)
 	}
+
+	// wait till the appliance components are fully initialized
+	if err = d.ensureComponentsInitialize(conf); err != nil {
+		return errors.Errorf("%s. Exiting...", err)
+	}
+
 	return nil
 }
 

--- a/tests/resources/Util.robot
+++ b/tests/resources/Util.robot
@@ -82,11 +82,6 @@ Install VIC Appliance To Test Server
     Get Docker Params  ${output}  ${certs}
     Log To Console  Installer completed successfully: ${vch-name}...
 
-    # Required due to #1109
-    Sleep  10 seconds
-    ${status}=  Get State Of Github Issue  1109
-    Run Keyword If  '${status}' == 'closed'  Fail  Util.robot needs to be updated now that Issue #1109 has been resolved
-
 Run VIC Machine Command
     [Tags]  secret
     [Arguments]  ${certs}  ${vol}

--- a/tests/test-cases/Group6-VIC-Machine/6-4-Create-Basic.md
+++ b/tests/test-cases/Group6-VIC-Machine/6-4-Create-Basic.md
@@ -58,6 +58,7 @@ vic-machine create --name=<VCH_NAME> --target=<TEST_URL> \
 * Deployment succeed
 * Regression test pass
 
+#Test Steps
 ## Create VCH - defaults with --no-tls
 1. Issue the following command:
 ```

--- a/tests/test-cases/Group6-VIC-Machine/6-4-Create-Basic.md
+++ b/tests/test-cases/Group6-VIC-Machine/6-4-Create-Basic.md
@@ -58,6 +58,21 @@ vic-machine create --name=<VCH_NAME> --target=<TEST_URL> \
 * Deployment succeed
 * Regression test pass
 
+## Create VCH - defaults with --no-tls
+1. Issue the following command:
+```
+vic-machine-linux create --name=${vch-name} --target=%{TEST_URL} \
+    --user=%{TEST_USERNAME} --image-store=%{TEST_DATASTORE} --appliance-iso=bin/appliance.iso \
+    --bootstrap-iso=bin/bootstrap.iso --password=%{TEST_PASSWORD} --no-tls --force=true \
+    --bridge-network=%{BRIDGE_NETWORK} --external-network=%{EXTERNAL_NETWORK} \
+    --compute-resource=%{TEST_RESOURCE} --timeout %{TEST_TIMEOUT} \
+    --volume-store=%{TEST_DATASTORE}/test:${vol}
+```
+2. Run regression tests
+
+#Expected Outcome:
+* Deployment succeeds
+* Regression tests pass
 
 #Test Steps
 ## Create VCH - target URL

--- a/tests/test-cases/Group6-VIC-Machine/6-4-Create-Basic.robot
+++ b/tests/test-cases/Group6-VIC-Machine/6-4-Create-Basic.robot
@@ -22,6 +22,18 @@ Create VCH - defaults
     Run Regression Tests
     Cleanup VIC Appliance On Test Server
 
+Create VCH - defaults with --no-tls
+    Log To Console  \nRunning vic-machine create - defaults with --no-tls
+    Set Test Environment Variables  ${true}  default  network  'VM Network'
+    # Attempt to cleanup old/canceled tests
+    Run Keyword And Ignore Error  Cleanup Dangling VMs On Test Server
+    Run Keyword And Ignore Error  Cleanup Datastore On Test Server
+    Set Test VCH Name
+
+    Install VIC Appliance To Test Server
+    Run Regression Tests
+    Cleanup VIC Appliance On Test Server
+
 Create VCH - target URL
     Log To Console  \nRunning vic-machine create - target URL
     Set Test Environment Variables  ${true}  default

--- a/tests/test-cases/Group6-VIC-Machine/6-4-Create-Basic.robot
+++ b/tests/test-cases/Group6-VIC-Machine/6-4-Create-Basic.robot
@@ -24,7 +24,7 @@ Create VCH - defaults
 
 Create VCH - defaults with --no-tls
     Log To Console  \nRunning vic-machine create - defaults with --no-tls
-    Set Test Environment Variables  ${true}  default  network  'VM Network'
+    Set Test Environment Variables  ${true}  default
     # Attempt to cleanup old/canceled tests
     Run Keyword And Ignore Error  Cleanup Dangling VMs On Test Server
     Run Keyword And Ignore Error  Cleanup Datastore On Test Server

--- a/tests/test-cases/Group6-VIC-Machine/6-4-Create-Basic.robot
+++ b/tests/test-cases/Group6-VIC-Machine/6-4-Create-Basic.robot
@@ -19,9 +19,6 @@ Create VCH - defaults
     Get Docker Params  ${output}  ${true}
     Log To Console  Installer completed successfully: ${vch-name}...
 
-    Sleep  10 seconds
-    ${status}=  Get State Of Github Issue  1109
-    Run Keyword If  '${status}' == 'closed'  Fail  6-4-Create-Basic.robot needs to be updated now that Issue #1109 has been resolved
     Run Regression Tests
     Cleanup VIC Appliance On Test Server
 
@@ -39,9 +36,6 @@ Create VCH - target URL
     Get Docker Params  ${output}  ${true}
     Log To Console  Installer completed successfully: ${vch-name}...
 
-    Sleep  10 seconds
-    ${status}=  Get State Of Github Issue  1109
-    Run Keyword If  '${status}' == 'closed'  Fail  6-4-Create-Basic.robot needs to be updated now that Issue #1109 has been resolved
     Run Regression Tests
     Cleanup VIC Appliance On Test Server
 
@@ -59,9 +53,6 @@ Create VCH - full params
     Get Docker Params  ${output}  ${true}
     Log To Console  Installer completed successfully: ${vch-name}...
 
-    Sleep  10 seconds
-    ${status}=  Get State Of Github Issue  1109
-    Run Keyword If  '${status}' == 'closed'  Fail  6-4-Create-Basic.robot needs to be updated now that Issue #1109 has been resolved
     Run Regression Tests
     Cleanup VIC Appliance On Test Server
 
@@ -79,12 +70,9 @@ Create VCH - custom image store directory
     Should Contain  ${output}  Installer completed successfully
     Get Docker Params  ${output}  ${true}
     Log To Console  Installer completed successfully: ${vch-name}...
-    Sleep  10 seconds
     ${output}=  Run  GOVC_DATASTORE=%{TEST_DATASTORE} govc datastore.ls
     Should Contain  ${output}  vic-machine-test-images
 
-    ${status}=  Get State Of Github Issue  1109
-    Run Keyword If  '${status}' == 'closed'  Fail  6-4-Create-Basic.robot needs to be updated now that Issue #1109 has been resolved
     Run Regression Tests
     Cleanup VIC Appliance On Test Server
     ${output}=  Run  GOVC_DATASTORE=%{TEST_DATASTORE} govc datastore.ls

--- a/tests/test-cases/Group6-VIC-Machine/6-5-Create-Validation.robot
+++ b/tests/test-cases/Group6-VIC-Machine/6-5-Create-Validation.robot
@@ -46,8 +46,5 @@ Default image datastore
     Should Contain  ${output}  Installer completed successfully
     Get Docker Params  ${output}  ${true}
     Log To Console  Installer completed successfully: ${vch-name}...
-    Sleep  10 seconds
-    ${status}=  Get State Of Github Issue  1109
-    Run Keyword If  '${status}' == 'closed'  Fail  6-5-Create-Validation.robot needs to be updated now that Issue #1109 has been resolved
     Run Regression Tests
     Cleanup VIC Appliance On Test Server


### PR DESCRIPTION
* Adds logic to make the installer wait for the portlayer to start serving requests
* Removes `sleep` in the integration tests
* Adds an integration test for `vic-machine create --no-tls`

Fixes #1109 