### PR TITLE
Add profiling data to log bundle

### DIFF
--- a/cmd/vicadmin/logs.go
+++ b/cmd/vicadmin/logs.go
@@ -106,6 +106,7 @@ func configureReaders() map[string]entryReader {
 		"concise": "/debug/pprof/goroutine?debug=1",
 		"block":   "/debug/pprof/block?debug=1",
 		"heap":    "/debug/pprof/heap?debug=1",
+		"profile": "/debug/pprof/profile",
 	}
 
 	pprofSources := map[string]string{


### PR DESCRIPTION
This PR adds profiling data to the log bundle gathered by the VCH appliance, per @hickeng's suggestion.

