### PR TITLE
Fix typo visible on vic admin page

### DIFF
--- a/isos/vicadmin/dashboard.html
+++ b/isos/vicadmin/dashboard.html
@@ -93,7 +93,7 @@
                   <div class="fourty"><a href="/logs/tail/port-layer.log">Live Log</a></div>
                 </div>
                 <div class="row">
-                  <div class="sixty"><a href="/logs/init.log">VCH Initializaation & Startup</a></div>
+                  <div class="sixty"><a href="/logs/init.log">VCH Initialization & Startup</a></div>
                   <div class="fourty"><a href="/logs/tail/init.log">Live Log</a></div>
                 </div>
                 <div class="row">


### PR DESCRIPTION
I found an errant `a` on the vic admin page while I was inspecting some logs.

