### PR TITLE
Fix erroneous layout in vicadmin

### DIFF
--- a/isos/vicadmin/dashboard.html
+++ b/isos/vicadmin/dashboard.html
@@ -25,7 +25,7 @@
           <span class="title">vSphere Integrated Containers</span>
         </div>
         <a role="button" class="btn btn-primary" href="http://www.github.com/vmware/vic">
-          <i class="fa fa-github"></i>
+          <i class="icon-github-circled"></i>
           View on Github
         </a>
       </header>

--- a/lib/vicadmin/validate.go
+++ b/lib/vicadmin/validate.go
@@ -52,7 +52,7 @@ type Validator struct {
 
 const (
 	GoodStatus = template.HTML(`<i class="icon-ok"></i>`)
-	BadStatus  = template.HTML(`<i class="icon-attention></i>`)
+	BadStatus  = template.HTML(`<i class="icon-attention"></i>`)
 )
 
 func NewValidator(ctx context.Context, vch *config.VirtualContainerHostConfigSpec, sess *session.Session) *Validator {


### PR DESCRIPTION
Fixes #2008 

Incorrect dynamically generated HTML would cause errors when displaying the vicadmin page.  This PR addresses that issue.

