### PR TITLE
Add Operations to trace contexts [full-ci]

### DIFF
--- a/pkg/trace/context.go
+++ b/pkg/trace/context.go
@@ -1,0 +1,162 @@
+// Copyright 2016 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package trace
+
+import (
+	"fmt"
+	"os"
+	"sync/atomic"
+	"time"
+
+	"github.com/Sirupsen/logrus"
+
+	"golang.org/x/net/context"
+)
+
+const OpTraceKey = "traceKey"
+
+var opIDPrefix = os.Getpid()
+
+// monotonic counter which inrements on Start()
+var opCount uint64
+
+type Operation struct {
+	context.Context
+	operation
+}
+
+type operation struct {
+	t  []Message
+	id string
+}
+
+func newOperation(ctx context.Context, id string, skip int, msg string) Operation {
+	op := operation{
+
+		// Can be used to trace based on this number which is unique per chain
+		// of operations
+		id: id,
+
+		// Start the trace.
+		t: []Message{*newTrace(msg, skip)},
+	}
+
+	// We need to be able to identify this operation across API (and process)
+	// boundaries.  So add the trace as a value to the embedded context.  We
+	// stash the values individually in the context because we can't assign
+	// the operation itself as a value to the embedded context (it's circular)
+	ctx = context.WithValue(ctx, OpTraceKey, op)
+
+	o := Operation{
+		Context:   ctx,
+		operation: op,
+	}
+
+	o.Debugf(o.t[0].beginHdr())
+	return o
+}
+
+// Creates a header string to be printed.
+func (o *Operation) header() string {
+	if Logger.Level >= logrus.DebugLevel {
+		return fmt.Sprintf("op=%s (delta:%s)", o.id, o.t[0].delta())
+	} else {
+		return fmt.Sprintf("op=%s", o.id)
+	}
+}
+
+// Err returns a non-nil error value after Done is closed.  Err returns
+// Canceled if the context was canceled or DeadlineExceeded if the
+// context's deadline passed.  No other values for Err are defined.
+// After Done is closed, successive calls to Err return the same value.
+func (o Operation) Err() error {
+
+	// Walk up the contexts from which this context was created and get their errors
+	if err := o.Context.Err(); err != nil {
+		// Print the error
+		o.Errorf("%s: %s error: %s", o.t[0].endHdr(), o.t[0].msg, err)
+
+		// Walk the stack and end with where this was called from
+		for _, t := range append(o.t, *newTrace("Err", 2)) {
+			Logger.Errorf("\t%s:%d %s", t.funcName, t.lineNo, t.msg)
+		}
+
+		return err
+	}
+
+	return nil
+}
+
+func (o *Operation) Infof(format string, args ...interface{}) {
+	Logger.Infof("%s: %s", o.header(), fmt.Sprintf(format, args...))
+}
+
+func (o *Operation) Debugf(format string, args ...interface{}) {
+	Logger.Debugf("%s: %s", o.header(), fmt.Sprintf(format, args...))
+}
+
+func (o *Operation) Errorf(format string, args ...interface{}) {
+	Logger.Errorf("%s: %s", o.header(), fmt.Sprintf(format, args...))
+}
+
+func (o *Operation) newChild(ctx context.Context, msg string) Operation {
+	child := newOperation(ctx, o.id, 4, msg)
+	t := child.t[0]
+	child.t = append(o.t, t)
+	return child
+}
+
+func opID(opNum uint64) string {
+	return fmt.Sprintf("%d%d", opIDPrefix, opNum)
+}
+
+// Add tracing info to the context.
+func NewOperation(ctx context.Context, msg string) Operation {
+	return newOperation(ctx, opID(atomic.AddUint64(&opCount, 1)), 3, msg)
+}
+
+// WithTimeout
+func WithTimeout(parent *Operation, timeout time.Duration, msg string) (Operation, context.CancelFunc) {
+	ctx, cancelFunc := context.WithTimeout(parent.Context, timeout)
+	op := parent.newChild(ctx, msg)
+
+	return op, cancelFunc
+}
+
+// WithDeadline
+func WithDeadline(parent *Operation, expiration time.Time, msg string) (Operation, context.CancelFunc) {
+	ctx, cancelFunc := context.WithDeadline(parent.Context, expiration)
+	op := parent.newChild(ctx, msg)
+
+	return op, cancelFunc
+}
+
+// FromContext unpacks the values in the ctx to create an Operation
+func FromContext(ctx context.Context) (Operation, error) {
+
+	o := Operation{
+		Context: ctx,
+	}
+
+	op := ctx.Value(OpTraceKey)
+	switch val := op.(type) {
+	case operation:
+		o.operation = val
+	default:
+		return Operation{}, fmt.Errorf("not an Operation")
+	}
+
+	return o, nil
+}

--- a/pkg/trace/context.go
+++ b/pkg/trace/context.go
@@ -119,7 +119,7 @@ func (o *Operation) newChild(ctx context.Context, msg string) Operation {
 }
 
 func opID(opNum uint64) string {
-	return fmt.Sprintf("%d%d", opIDPrefix, opNum)
+	return fmt.Sprintf("%d.%d", opIDPrefix, opNum)
 }
 
 // Add tracing info to the context.

--- a/pkg/trace/context_test.go
+++ b/pkg/trace/context_test.go
@@ -1,0 +1,141 @@
+// Copyright 2016 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package trace
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+
+	"golang.org/x/net/context"
+)
+
+func TestContextUnpack(t *testing.T) {
+	Logger.Level = logrus.DebugLevel
+
+	cnt := 100
+	wg := &sync.WaitGroup{}
+	wg.Add(cnt)
+	for i := 0; i < cnt; i++ {
+		go func() {
+			defer wg.Done()
+			ctx := NewOperation(context.TODO(), "testmsg")
+
+			// unpack an Operation via the context using it's Values fields
+			c, err := FromContext(ctx)
+
+			if !assert.NoError(t, err) || !assert.NotNil(t, c) {
+				return
+			}
+			c.Infof("test info message %d", i)
+		}()
+	}
+	wg.Wait()
+}
+
+// If we timeout a child, test a stack is printed of contexts
+func TestNestedLogging(t *testing.T) {
+	// create a buf to check the log
+	buf := new(bytes.Buffer)
+	Logger = logrus.StandardLogger()
+	logrus.SetOutput(buf)
+
+	root := NewOperation(context.Background(), "root")
+
+	var ctxFunc func(parent Operation, level int) Operation
+
+	levels := 10
+	ctxFunc = func(parent Operation, level int) Operation {
+		if level == levels {
+			return parent
+		}
+
+		child, _ := WithDeadline(&parent, time.Time{}, fmt.Sprintf("level %d", level))
+
+		return ctxFunc(child, level+1)
+	}
+
+	child := ctxFunc(root, 0)
+
+	// Assert the child has an error and prints a stack.  The parent doesn't
+	// see this and should not have an error.  Only cancelation trickles up the
+	// stack to the parent.
+	if !assert.NoError(t, root.Err()) || !assert.Error(t, child.Err()) {
+		return
+	}
+
+	// Assert we got a stack trace in the log
+	lines := strings.Count(buf.String(), "\n")
+	t.Log(buf.String())
+
+	// Sample stack
+	//
+	// ERRO[0000] op=1: [ END ] [github.com/vmware/vic/pkg/trace.TestNestedLogging:60]: root error: context deadline exceeded
+	// ERRO[0000]      github.com/vmware/vic/pkg/trace.TestNestedLogging:60 root
+	// ERRO[0000]      github.com/vmware/vic/pkg/trace.TestNestedLogging.func1:70 level 0
+	// ERRO[0000]      github.com/vmware/vic/pkg/trace.TestNestedLogging.func1:70 level 1
+	// ERRO[0000]      github.com/vmware/vic/pkg/trace.TestNestedLogging.func1:70 level 2
+	// ERRO[0000]      github.com/vmware/vic/pkg/trace.TestNestedLogging.func1:70 level 3
+	// ERRO[0000]      github.com/vmware/vic/pkg/trace.TestNestedLogging.func1:70 level 4
+	// ERRO[0000]      github.com/vmware/vic/pkg/trace.TestNestedLogging.func1:70 level 5
+	// ERRO[0000]      github.com/vmware/vic/pkg/trace.TestNestedLogging.func1:70 level 6
+	// ERRO[0000]      github.com/vmware/vic/pkg/trace.TestNestedLogging.func1:70 level 7
+	// ERRO[0000]      github.com/vmware/vic/pkg/trace.TestNestedLogging.func1:70 level 8
+	// ERRO[0000]      github.com/vmware/vic/pkg/trace.TestNestedLogging.func1:70 level 9
+	// ERRO[0000]      github.com/vmware/vic/pkg/trace.TestNestedLogging:80 Err
+
+	// We arrive at 3 because we have the err line (line 0), then the root
+	// (line 1), the then final "Err" line.
+	if !assert.Equal(t, lines, levels+3) {
+		return
+	}
+}
+
+// Just checking behavior of the context package
+func TestSanity(t *testing.T) {
+	Logger.Level = logrus.InfoLevel
+	levels := 10
+
+	root, _ := context.WithDeadline(context.Background(), time.Time{})
+
+	var ctxFunc func(parent context.Context, level int) context.Context
+
+	ctxFunc = func(parent context.Context, level int) context.Context {
+		if level == levels {
+			return parent
+		}
+
+		child, _ := context.WithDeadline(parent, time.Now().Add(time.Hour))
+
+		return ctxFunc(child, level+1)
+	}
+
+	child := ctxFunc(root, 0)
+
+	if !assert.Error(t, child.Err()) {
+		t.FailNow()
+	}
+
+	err := root.Err()
+	if !assert.Error(t, err) {
+		return
+	}
+}


### PR DESCRIPTION
WIP.

Add debugging information in contexts via Operations.

```
=== RUN   TestDeadlineLogging
ERRO[0000] op=101: [ END ] [github.com/vmware/vic/pkg/trace.TestDeadlineLogging:55]: testmsg error: context deadline exceeded 
--- PASS: TestDeadlineLogging (0.00s)
```