### PR TITLE
[skip ci] Updated procedures for VIC UI plugin installation

### DIFF
--- a/doc/user_doc/vic_installation/plugin_vc_no_sftp_or_web.md
+++ b/doc/user_doc/vic_installation/plugin_vc_no_sftp_or_web.md
@@ -1,29 +1,28 @@
 # Install the vSphere Integrated Containers Plug-In on vCenter Server For Windows, without SFTP or a Web Server #
 
-You can install the vSphere Web Client plug-in for vSphere Integrated Containers on a vCenter Server instance that has neither access to an SFTP service nor to a Web Server.
+You can install the vSphere Web Client plug-in for vSphere Integrated Containers on a vCenter Server instance for Windows that has neither access to an SFTP service nor to a Web Server.
 
 **Prerequisites**
 
-- You deployed at least one virtual container host to a vCenter Server instance.
-- Download the latest build of the vSphere Integrated Containers plug-in bundle from https://bintray.com/vmware/vic-repo/build-deps/installer-onsite-beta#files.
+You deployed at least one virtual container host to a vCenter Server instance that runs on Windows.
 
 **Procedure**
 
-1. Unpack the `vic-ui-installer.zip` bundle on the Windows machine on which vCenter Server is running.
-2. Copy the `com.vmware.vicui.Vicui-0.0.1` folder into the folder that contains the vSphere Web Client packages.
+1. On the system on which you run `vic-machine`, navigate to the folder that contains the `vic-machine` utility and open the `ui` folder.
+2. Copy the `com.vmware.vicui.Vicui-0.0.1` folder into the folder on the vCenter Server system that contains the vSphere Web Client packages.
   
-  - Source folder: <pre><i>unpack_dir</i>\installer\vsphere-client-serenity</pre>
-  - Destination folder: <pre><i>instl_dir</i>\vCenterServer\cfg\vsphere-client\vc-packages\vsphere-client-serenity</pre>
+  - Source location on `vic-machine` system: <pre><i>vic_unpack_dir</i>\vic\ui\vsphere-client-serenity</pre>
+  - Destination location on vCenter Server Windows system: <pre><i>instl_dir</i>\vCenterServer\cfg\vsphere-client\vc-packages\vsphere-client-serenity</pre>
 
     <code><i>instl_dir</i></code> is the location in which vCenter Server is installed. If the `vc-packages\vsphere-client-serenity` folders do not exist under the <code>vsphere-client</code> folder, create them manually.
-3. Open the <code><i>unpack_dir</i>\installer\vCenterForWindows\configs</code> file in a text editor.
+3. On the `vic-machine` system, open the <code><i>vic_unpack_dir</i>\vic\ui\vCenterForWindows\configs</code> file in a text editor.
 4. Enter the IPv4 address or FQDN of the vCenter Server instance on which to install the plug-in.<pre>SET target_vcenter_ip=<i>vcenter_server_address</i></pre>
 5. Deactivate SFTP by changing the value of `sftp_supported` to 0.<pre>SET sftp_supported=0</pre>
 6. Save and close the `configs` file.
-7. Open a command prompt and navigate to <code><i>unpack_dir</i>\installer\vCenterForWindows</code>.
+7. Open a command prompt and navigate to <code><i>vic_unpack_dir</i>\vic\ui\vCenterForWindows</code>.
 8. Run the installer.<pre>install.bat</pre>
   Make sure that you use the correct account to run `install.bat`. 
   - If vCenter Server uses the local system account, run `install.bat` with the local system account.
   - If vCenter Server uses a different user account, run `install.bat` with that account.
-9. Enter the password for the vCenter Server administrator account.
+9. Enter the user name and password for the vCenter Server administrator account.
 10. When installation finishes, if you are logged into the vSphere Web Client, log out then log back in again.

--- a/doc/user_doc/vic_installation/plugin_vc_sftp.md
+++ b/doc/user_doc/vic_installation/plugin_vc_sftp.md
@@ -4,17 +4,18 @@ If your vCenter Server instance runs on a Windows system that has access to an S
 
 **Prerequisites**
 
-- You deployed at least one virtual container host to a vCenter Server instance.
-- Download the latest build of the vSphere Integrated Containers plug-in bundle from https://bintray.com/vmware/vic-repo/build-deps/installer-onsite-beta#files.
+- You deployed at least one virtual container host to a vCenter Server instance that runs on Windows.
 - Your vCenter Server instance is running on a Windows system that has an SFTP service.
 
 **Procedure**
 
-1. Unpack the `vic-ui-installer.zip` bundle on a Windows system that has access to an SFTP service.
-3. Open the <code><i>unpack_dir</i>\installer\vCenterForWindow\configs</code> file in a text editor.
-4. Enter the IPv4 address or FQDN of the vCenter Server instance on which to install the plug-in.<pre>target_vcenter_ip=<i>vcenter_server_address</i></pre>
-5. Make sure that `sftp_supported` is set to 1.<pre>sftp_supported=1</pre>
-6. Provide the SFTP user name and password.<pre>sftp_username=<i>username</i>sftp_password=<i>password</i></pre> 
+1. On the system on which you run `vic-machine`, navigate to the folder that contains the `vic-machine` utility and open the `ui` folder.
+3. Open the <code><i>vic_unpack_dir</i>\vic\ui\vCenterForWindows\configs</code> file in a text editor.
+4. Enter the IPv4 address or FQDN of the vCenter Server instance on which to install the plug-in.<pre>SET target_vcenter_ip=<i>vcenter_server_address</i></pre>
+5. Make sure that `sftp_supported` is set to 1.<pre>SET sftp_supported=1</pre>
+6. Provide the SFTP user name and password.
+  <pre>SET sftp_username=<i>username</i>
+SET sftp_password=<i>password</i></pre> 
 6. Provide the location of the `vsphere-client-serenity` folder on the vCenter Server Windows system relative to the root folder of the SFTP connection.
 
   For example, if the root folder of the SFTP connection is <code><i>vcenter_server_install_dir</i>\vCenterServer\cfg</code>, set the relative path as follows:  
@@ -22,10 +23,10 @@ If your vCenter Server instance runs on a Windows system that has access to an S
   <pre>target_vc_packages_path=/vsphere-client/vc-packages/vsphere-client-serenity/</pre>
 
 7. Save and close the `configs` file.
-7. Open a command prompt and navigate to <code><i>unpack_dir</i>\installer\vCenterForWindows</code>.
+7. Open a command prompt and navigate to <code><i>vic_unpack_dir</i>\vic\ui\vCenterForWindows</code>.
 8. Run the installer.<pre>install.bat</pre>
   Make sure that you use the correct account to run `install.bat`. 
   - If vCenter Server uses the local system account, run `install.bat` with the local system account.
   - If vCenter Server uses a different user account, run `install.bat` with that account.
-9. Enter the password for the vCenter Server administrator account.
+9. Enter the user name and password for the vCenter Server administrator account.
 10. When installation finishes, if you are logged into the vSphere Web Client, log out then log back in again.

--- a/doc/user_doc/vic_installation/plugin_vc_web.md
+++ b/doc/user_doc/vic_installation/plugin_vc_web.md
@@ -4,24 +4,23 @@ If your vCenter Server instance runs on Windows, you can use a Web server to hos
 
 **Prerequisites**
 
-- You deployed at least one virtual container host to a vCenter Server instance.
-- Download the latest build of the vSphere Integrated Containers plug-in bundle from https://bintray.com/vmware/vic-repo/build-deps/installer-onsite-beta#files.
+- You deployed at least one virtual container host to a vCenter Server instance that runs on Windows.
 - You are running a Web server that your vCenter Server instance can access.
 
 **Procedure**
 
-1. Unpack the `vic-ui-installer.zip` bundle on the Windows machine on which vCenter Server is running.
+1. On the system on which you run `vic-machine`, navigate to the folder that contains the `vic-machine` utility and open the `ui` folder.
 2. Upload the plug-in bundle to your Web server.
-  <pre><i>unpack_dir</i>\installer\vsphere-client-serenity\com.vmware.vicui.Vicui-0.0.1.zip</pre>
-3. Open the <code><i>unpack_dir</i>\installer\vCenterForWindows\configs</code> file in a text editor.
-4. Enter the IPv4 address or FQDN of the vCenter Server instance on which to install the plug-in.<pre>target_vcenter_ip=<i>vcenter_server_address</i></pre>
-5. Enter the URL of the ZIP file on your Web server.<pre>vic_ui_host_url=<i>vic_web_server_location</i></pre>
-6. (Optional) If you used an HTTPS address in `vic_ui_host_url`, provide the SHA-1 thumbprint of the Web server.<pre>vic_ui_host_thumbprint=<i>thumbprint</i></pre> 
+  <pre><i>vic_unpack_dir</i>\vic\ui\vsphere-client-serenity\com.vmware.vicui.Vicui-0.0.1.zip</pre>
+3. On the `vic-machine` system, open the <code><i>vic_unpack_dir</i>\vic\ui\vCenterForWindows\configs</code> file in a text editor.
+4. Enter the IPv4 address or FQDN of the vCenter Server instance on which to install the plug-in.<pre>SET target_vcenter_ip=<i>vcenter_server_address</i></pre>
+5. Enter the URL of the ZIP file on your Web server.<pre>SET vic_ui_host_url=<i>vic_web_server_location</i></pre>
+6. (Optional) If you used an HTTPS address in `vic_ui_host_url`, provide the SHA-1 thumbprint of the Web server.<pre>SET vic_ui_host_thumbprint=<i>thumbprint</i></pre> 
 6. Save and close the `configs` file.
-7. Open a command prompt and navigate to <code><i>unpack_dir</i>\installer\vCenterForWindows</code>.
+7. Open a command prompt and navigate to <code><i>vic_unpack_dir</i>\vic\ui\vCenterForWindows</code>.
 8. Run the installer.<pre>install.bat</pre>
   Make sure that you use the correct account to run `install.bat`. 
   - If vCenter Server uses the local system account, run `install.bat` with the local system account.
   - If vCenter Server uses a different user account, run `install.bat` with that account.
-9. Enter the password for the vCenter Server administrator account.
+9. Enter the user name and password for the vCenter Server administrator account.
 10. When installation finishes, if you are logged into the vSphere Web Client, log out then log back in again.

--- a/doc/user_doc/vic_installation/plugin_vcsa_no_web.md
+++ b/doc/user_doc/vic_installation/plugin_vcsa_no_web.md
@@ -15,7 +15,13 @@ You deployed at least one virtual container host to a vCenter Server Appliance i
 7. Open a command prompt and navigate to <code><i>vic_unpack_dir</i>/vic/ui/VCSA</code>.
 8. Run the installer.<pre>./install.sh</pre>Make sure that `install.sh` is executable by running `chmod` before you run it.
 9. Enter the user name and password for the vCenter Server administrator account.
-10. Enter the root password for the vCenter Server Appliance twice.
+10. Answer the question about the version of vCenter Server that you are using.
+  - Answer `y` if you are using vCenter Server 5.5.
+  - Answer `n` if you are using vCenter Server 6.0.
+10. Enter the root password for the vCenter Server Appliance.
 
-  The installer requires the root password of the vCenter Server Appliance twice: once to copy the files to the appliance over SSH, and once to set the correct ownership on the files and folders.
+  The installer requires the root password of the vCenter Server Appliance three times: 
+   - Once to check whether the Bash shell is enabled on the vCenter Server Appliance. If the Bash shell is not enabled, the installation fails and the installer provides remedial instructions.
+   - Once to copy the files to the appliance over SSH.
+   - Once to set the correct ownership on the files and folders.
 10. When installation finishes, if you are logged into the vSphere Web Client, log out then log back in again.

--- a/doc/user_doc/vic_installation/plugin_vcsa_no_web.md
+++ b/doc/user_doc/vic_installation/plugin_vcsa_no_web.md
@@ -4,21 +4,17 @@ If you are running the vCenter Server Appliance and you do not have access to a 
 
 **Prerequisites**
 
-- You deployed at least one virtual container host to a vCenter Server instance.
-- Download the latest build of the vSphere Integrated Containers plug-in bundle from https://bintray.com/vmware/vic-repo/build-deps/installer-onsite-beta#files.
+You deployed at least one virtual container host to a vCenter Server Appliance instance.
 
 **Procedure**
 
-1. Unpack the `vic-ui-installer.zip` bundle on any system.
-2. (Optional) Connect to the vCenter Server Appliance via SSH and copy the contents of the `vic-ui-installer.zip` bundle to a temporary location on the vCenter Server Appliance. 
-
-  Perform this step if you unpacked the `vic-ui-installer.zip` bundle on a Windows system. If you unpacked `vic-ui-installer.zip` on a Mac OS or Linux system, you do not need to copy the files to the vCenter Server Appliance.
-3. Open the <code><i>unpack_dir</i>\installer\VCSA\configs</code> file in a text editor.
+1. On the system on which you run `vic-machine`, navigate to the folder that contains the `vic-machine` utility and open the `ui` folder.
+3. Open the  <code><i>vic_unpack_dir</i>/vic/ui/VCSA/configs</code> file in a text editor.
 4. Enter the IPv4 address or FQDN of the vCenter Server instance on which to install the plug-in. <pre>VCENTER_IP="<i>vcenter_server_address</i>"</pre>
 6. Save and close the `configs` file.
-7. Navigate to <code><i>unpack_dir</i>/installer/VCSA</code>.
+7. Open a command prompt and navigate to <code><i>vic_unpack_dir</i>/vic/ui/VCSA</code>.
 8. Run the installer.<pre>./install.sh</pre>Make sure that `install.sh` is executable by running `chmod` before you run it.
-9. Enter the password for the vCenter Server administrator account.
+9. Enter the user name and password for the vCenter Server administrator account.
 10. Enter the root password for the vCenter Server Appliance twice.
 
   The installer requires the root password of the vCenter Server Appliance twice: once to copy the files to the appliance over SSH, and once to set the correct ownership on the files and folders.

--- a/doc/user_doc/vic_installation/plugin_vcsa_web.md
+++ b/doc/user_doc/vic_installation/plugin_vcsa_web.md
@@ -20,4 +20,7 @@ If you are running the vCenter Server Appliance, you can use a Web server to hos
 7. Open a command prompt and navigate to <code><i>vic_unpack_dir</i>/vic/ui/VCSA</code>.
 8. Run the installer.<pre>./install.sh</pre>Make sure that `install.sh` is executable by running `chmod` before you run it.
 9. Enter the user name and password for the vCenter Server administrator account.
+10. Answer the question about the version of vCenter Server that you are using.
+  - Answer `y` if you are using vCenter Server 5.5.
+  - Answer `n` if you are using vCenter Server 6.0.
 10. When installation finishes, if you are logged into the vSphere Web Client, log out then log back in again.

--- a/doc/user_doc/vic_installation/plugin_vcsa_web.md
+++ b/doc/user_doc/vic_installation/plugin_vcsa_web.md
@@ -11,7 +11,7 @@ If you are running the vCenter Server Appliance, you can use a Web server to hos
 
 1. On the system on which you run `vic-machine`, navigate to the folder that contains the `vic-machine` utility and open the `ui` folder.
 2. Upload the plug-in bundle to your Web server.
-  <pre><i>vic_unpack_dir</i>/vic/ui/vsphere-client-serenity\com.vmware.vicui.Vicui-0.0.1.zip</pre>
+  <pre><i>vic_unpack_dir</i>/vic/ui/vsphere-client-serenity/com.vmware.vicui.Vicui-0.0.1.zip</pre>
 3. Open the  <code><i>vic_unpack_dir</i>/vic/ui/VCSA/configs</code> file in a text editor.
 4. Enter the IPv4 address or FQDN of the vCenter Server instance on which to install the plug-in.<pre>VCENTER_IP="<i>vcenter_server_address</i>"</pre>
 5. Enter the URL of the ZIP file on your Web server.<pre>VIC_UI_HOST_URL="<i>vic_web_server_location</i>"</pre>

--- a/doc/user_doc/vic_installation/plugin_vcsa_web.md
+++ b/doc/user_doc/vic_installation/plugin_vcsa_web.md
@@ -5,23 +5,19 @@ If you are running the vCenter Server Appliance, you can use a Web server to hos
 **Prerequisites**
 
 - You deployed at least one virtual container host to a vCenter Server Appliance instance.
-- Download the latest build of the vSphere Integrated Containers plug-in bundle from https://bintray.com/vmware/vic-repo/build-deps/installer-onsite-beta#files.
 - You are running a Web server that the vCenter Server Appliance can access.
 
 **Procedure**
 
-1. Unpack the `vic-ui-installer.zip` bundle on any system.
+1. On the system on which you run `vic-machine`, navigate to the folder that contains the `vic-machine` utility and open the `ui` folder.
 2. Upload the plug-in bundle to your Web server.
-  <pre><i>unpack_dir</i>\installer\vsphere-client-serenity\com.vmware.vicui.Vicui-0.0.1.zip</pre>
-2. (Optional) Connect to the vCenter Server Appliance via SSH and copy the contents of the `vic-ui-installer.zip` bundle to a temporary location on the vCenter Server Appliance. 
-
-  Perform this step if you unpacked the `vic-ui-installer.zip` bundle on a Windows system. If you unpacked `vic-ui-installer.zip` on a Mac OS or Linux system, you do not need to copy the files to the vCenter Server Appliance.
-3. Open the <code><i>unpack_dir</i>\installer\VCSA\configs</code> file in a text editor.
+  <pre><i>vic_unpack_dir</i>/vic/ui/vsphere-client-serenity\com.vmware.vicui.Vicui-0.0.1.zip</pre>
+3. Open the  <code><i>vic_unpack_dir</i>/vic/ui/VCSA/configs</code> file in a text editor.
 4. Enter the IPv4 address or FQDN of the vCenter Server instance on which to install the plug-in.<pre>VCENTER_IP="<i>vcenter_server_address</i>"</pre>
 5. Enter the URL of the ZIP file on your Web server.<pre>VIC_UI_HOST_URL="<i>vic_web_server_location</i>"</pre>
 6. (Optional) If you used an HTTPS address in `vic_ui_host_url`, provide the SHA-1 thumbprint of the Web server.<pre>VIC_UI_HOST_THUMBPRINT="<i>thumbprint</i>"</pre> 
 6. Save and close the `configs` file.
-7. Navigate to <code><i>unpack_dir</i>/installer/VCSA</code>.
+7. Open a command prompt and navigate to <code><i>vic_unpack_dir</i>/vic/ui/VCSA</code>.
 8. Run the installer.<pre>./install.sh</pre>Make sure that `install.sh` is executable by running `chmod` before you run it.
-9. Enter the password for the vCenter Server administrator account.
+9. Enter the user name and password for the vCenter Server administrator account.
 10. When installation finishes, if you are logged into the vSphere Web Client, log out then log back in again.


### PR DESCRIPTION
[skip ci]

Fixes https://github.com/vmware/vic/issues/924. 

Affects the following topics:

- [Install the vSphere Integrated Containers Plug-In on vCenter Server For Windows, without SFTP or a Web Server](https://github.com/stuclem/vic/blob/master/doc/user_doc/vic_installation/plugin_vc_no_sftp_or_web.md)
- [Install the vSphere Integrated Containers Plug-In on vCenter Server For Windows by Using SFTP](https://github.com/stuclem/vic/blob/master/doc/user_doc/vic_installation/plugin_vc_sftp.md)
- [Install the vSphere Integrated Containers Plug-In on vCenter Server For Windows by Using a Web Server](https://github.com/stuclem/vic/blob/master/doc/user_doc/vic_installation/plugin_vc_web.md)
- [Install the vSphere Integrated Containers Plug-In on a vCenter Server Appliance Without Access to a Web Server](https://github.com/stuclem/vic/blob/master/doc/user_doc/vic_installation/plugin_vcsa_no_web.md)
- [Install the vSphere Integrated Containers Plug-In on a vCenter Server Appliance by Using a Web Server](https://github.com/stuclem/vic/blob/master/doc/user_doc/vic_installation/plugin_vcsa_web.md)

I will address deployment to VC 5.5 in a future PR in the context of https://github.com/vmware/vic/issues/1900.

@jooskim, can you please review the 5 topics above? Thanks!