### PR TITLE
upgrade versioning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -326,15 +326,15 @@ $(bootstrap-staging-debug): isos/bootstrap-staging.sh $(iso-base)
 
 $(vic-machine-linux): $(call godeps,cmd/vic-machine/*.go)
 	@echo building vic-machine linux...
-	@GOARCH=amd64 GOOS=linux $(TIME) $(GO) build $(RACE) -ldflags "-X main.BuildID=${BUILD_NUMBER} -X main.CommitID=${COMMIT}" -o ./$@ ./$(dir $<)
+	@GOARCH=amd64 GOOS=linux $(TIME) $(GO) build $(RACE) $(ldflags) -o ./$@ ./$(dir $<)
 
 $(vic-machine-windows): $(call godeps,cmd/vic-machine/*.go)
 	@echo building vic-machine windows...
-	@GOARCH=amd64 GOOS=windows $(TIME) $(GO) build $(RACE) -ldflags "-X main.BuildID=${BUILD_NUMBER} -X main.CommitID=${COMMIT}" -o ./$@ ./$(dir $<)
+	@GOARCH=amd64 GOOS=windows $(TIME) $(GO) build $(RACE) $(ldflags) -o ./$@ ./$(dir $<)
 
 $(vic-machine-darwin): $(call godeps,cmd/vic-machine/*.go)
 	@echo building vic-machine darwin...
-	@GOARCH=amd64 GOOS=darwin $(TIME) $(GO) build $(RACE) -ldflags "-X main.BuildID=${BUILD_NUMBER} -X main.CommitID=${COMMIT}" -o ./$@ ./$(dir $<)
+	@GOARCH=amd64 GOOS=darwin $(TIME) $(GO) build $(RACE) $(ldflags) -o ./$@ ./$(dir $<)
 
 $(vic-ui-linux): $(call godeps,cmd/vic-ui/*.go)
 	@echo building vic-ui linux...

--- a/cmd/vic-machine/create/create.go
+++ b/cmd/vic-machine/create/create.go
@@ -50,6 +50,11 @@ const (
 	LinuxImageKey      = "linux"
 	ApplianceImageName = "appliance.iso"
 	LinuxImageName     = "bootstrap.iso"
+
+	// An ISO 9660 sector is normally 2 KiB long. Although the specification allows for alternative sector sizes, you will rarely find anything other than 2 KiB.
+	ISO9660SectorSize = 2048
+	ISOVolumeSector   = 0x10
+	PublisherOffset   = 318
 )
 
 var EntireOptionHelpTemplate = `NAME:
@@ -408,7 +413,7 @@ func (c *Create) loadCertificate() (*certificate.Keypair, error) {
 	return keypair, nil
 }
 
-func (c *Create) checkImagesFiles() ([]string, error) {
+func (c *Create) checkImagesFiles(cliContext *cli.Context) (map[string]string, error) {
 	defer trace.End(trace.Begin(""))
 
 	// detect images files
@@ -417,20 +422,20 @@ func (c *Create) checkImagesFiles() ([]string, error) {
 		return nil, fmt.Errorf("Specified OS \"%s\" is not known to this installer", c.osType)
 	}
 
-	var imgs []string
-	var result []string
+	imgs := make(map[string]string)
+	result := make(map[string]string)
 	if c.ApplianceISO == "" {
 		c.ApplianceISO = images[ApplianceImageKey][0]
 	}
-	imgs = append(imgs, c.ApplianceISO)
+	imgs[ApplianceImageName] = c.ApplianceISO
 
 	if c.BootstrapISO == "" {
 		c.BootstrapISO = osImgs[0]
 	}
-	imgs = append(imgs, c.BootstrapISO)
+	imgs[LinuxImageName] = c.BootstrapISO
 
-	for _, img := range imgs {
-		_, err := os.Stat(img)
+	for name, img := range imgs {
+		_, err := os.Open(img)
 		if os.IsNotExist(err) {
 			var dir string
 			dir, err = filepath.Abs(filepath.Dir(os.Args[0]))
@@ -444,9 +449,59 @@ func (c *Create) checkImagesFiles() ([]string, error) {
 			log.Warnf("\t\tUnable to locate %s in the current or installer directory.", img)
 			return nil, err
 		}
-		result = append(result, img)
+
+		version, err := c.getImageVersion(cliContext, img)
+		if err != nil {
+			log.Error(err)
+			return nil, err
+		}
+		versionedName := fmt.Sprintf("%s-%s", version, name)
+		result[versionedName] = img
+		if name == ApplianceImageName {
+			c.ApplianceISO = versionedName
+		} else {
+			c.BootstrapISO = versionedName
+		}
 	}
+
 	return result, nil
+}
+
+// checkImageVersion will read iso file version from Primary Volume Descriptor, field "Publisher Identifier"
+func (c *Create) getImageVersion(cliContext *cli.Context, img string) (string, error) {
+	f, err := os.Open(img)
+	if err != nil {
+		return "", errors.Errorf("failed to open iso file %q: %s", img, err)
+	}
+	defer f.Close()
+
+	// System area goes from sectors 0x00 to 0x0F. Volume descriptors can be
+	// found starting at sector 0x10
+
+	_, err = f.Seek(int64(ISOVolumeSector*ISO9660SectorSize)+PublisherOffset, 0)
+	if err != nil {
+		return "", errors.Errorf("failed to locate iso version section in file %q: %s", img, err)
+	}
+	publisherBytes := make([]byte, 128)
+	size, err := f.Read(publisherBytes)
+	if err != nil {
+		return "", errors.Errorf("failed to read iso version in file %q: %s", img, err)
+	}
+	if size == 0 {
+		return "", errors.Errorf("version is not set in iso file %q", img)
+	}
+
+	versions := strings.Fields(string(publisherBytes[:size]))
+	version := versions[len(versions)-1]
+
+	if !strings.EqualFold(cliContext.App.Version, version) {
+		message := fmt.Sprintf("iso file %q has inconsistent version with installer %q != %q.", img, version, cliContext.App.Version)
+		if !c.Force {
+			return "", errors.Errorf("%s. Specify --force to force create. ", message)
+		}
+		log.Warn(message)
+	}
+	return version, nil
 }
 
 func (c *Create) Run(cliContext *cli.Context) (err error) {
@@ -463,8 +518,8 @@ func (c *Create) Run(cliContext *cli.Context) (err error) {
 		return err
 	}
 
-	var images []string
-	if images, err = c.checkImagesFiles(); err != nil {
+	var images map[string]string
+	if images, err = c.checkImagesFiles(cliContext); err != nil {
 		return err
 	}
 
@@ -516,7 +571,6 @@ func (c *Create) Run(cliContext *cli.Context) (err error) {
 	vConfig.ImageFiles = images
 	vConfig.ApplianceISO = path.Base(c.ApplianceISO)
 	vConfig.BootstrapISO = path.Base(c.BootstrapISO)
-
 	{ // create certificates for VCH extension
 		var certbuffer, keybuffer bytes.Buffer
 		if certbuffer, keybuffer, err = certificate.CreateRawKeyPair(); err != nil {

--- a/cmd/vic-machine/create/install_test.go
+++ b/cmd/vic-machine/create/install_test.go
@@ -22,6 +22,8 @@ import (
 	"testing"
 
 	log "github.com/Sirupsen/logrus"
+
+	"github.com/urfave/cli"
 )
 
 var (
@@ -41,9 +43,24 @@ func TestImageNotFound(t *testing.T) {
 	flag.Parse()
 	create.ApplianceISO = tmpfile.Name()
 	create.osType = "linux"
-	if _, err = create.checkImagesFiles(); err == nil {
+	if _, err = create.checkImagesFiles(nil); err == nil {
 		t.Errorf("Error is expected for boot iso file is not found.")
 	}
+}
+
+func writeImageVersion(fileName string, version string) error {
+	f, err := os.OpenFile(fileName, os.O_APPEND|os.O_WRONLY, os.ModeAppend)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	if err := f.Truncate(int64(0x10*2048) + 318); err != nil {
+		return err
+	}
+	if _, err := f.WriteAt([]byte(version), int64(0x10*2048)+318); err != nil {
+		return err
+	}
+	return nil
 }
 
 func TestImageChecks(t *testing.T) {
@@ -67,8 +84,29 @@ func TestImageChecks(t *testing.T) {
 	create.BootstrapISO = tmpfile.Name()
 	create.osType = "linux"
 	var imageFiles []string
-	if imageFiles, err = create.checkImagesFiles(); err != nil {
-		t.Errorf("Error returned: %s", err)
+	if _, err = create.checkImagesFiles(nil); err == nil {
+		t.Errorf("Error is expected")
+	}
+
+	if err = writeImageVersion("appliance.iso", "Inc. 0.1-000-abcd"); err != nil {
+		t.Error(err)
+	}
+	if err = writeImageVersion(tmpfile.Name(), "Inc. 0.1-000-abcd"); err != nil {
+		t.Error(err)
+	}
+
+	cliContext := &cli.Context{
+		App: &cli.App{
+			Version: "Inconsistent",
+		},
+	}
+	if _, err = create.checkImagesFiles(cliContext); err == nil {
+		t.Errorf("Error is expected")
+	}
+
+	cliContext.App.Version = "0.1-000-abcd"
+	if imageFiles, err = create.checkImagesFiles(cliContext); err != nil {
+		t.Errorf("Error is returned: %s", err)
 	}
 	found := false
 	for _, file := range imageFiles {

--- a/cmd/vic-machine/create/install_test.go
+++ b/cmd/vic-machine/create/install_test.go
@@ -83,7 +83,7 @@ func TestImageChecks(t *testing.T) {
 	create.ApplianceISO = ""
 	create.BootstrapISO = tmpfile.Name()
 	create.osType = "linux"
-	var imageFiles []string
+	var imageFiles map[string]string
 	if _, err = create.checkImagesFiles(nil); err == nil {
 		t.Errorf("Error is expected")
 	}

--- a/cmd/vic-machine/main.go
+++ b/cmd/vic-machine/main.go
@@ -28,12 +28,7 @@ import (
 	"github.com/vmware/vic/cmd/vic-machine/inspect"
 	"github.com/vmware/vic/cmd/vic-machine/list"
 	"github.com/vmware/vic/pkg/errors"
-)
-
-var (
-	Version  string
-	BuildID  string
-	CommitID string
+	"github.com/vmware/vic/pkg/version"
 )
 
 const (
@@ -82,11 +77,8 @@ func main() {
 			Action: showVersion,
 		},
 	}
-	if Version != "" {
-		app.Version = fmt.Sprintf("%s-%s-%s", Version, BuildID, CommitID)
-	} else {
-		app.Version = fmt.Sprintf("%s-%s", BuildID, CommitID)
-	}
+
+	app.Version = fmt.Sprintf("%s-%s-%s", version.Version, version.BuildNumber, version.GitCommit)
 
 	logs := []io.Writer{app.Writer}
 	// Open log file

--- a/isos/base/utils.sh
+++ b/isos/base/utils.sh
@@ -17,13 +17,13 @@
 # utility functions for staged authoring of ISOs
 [ -n "$DEBUG" ] && set -x
 BASE_DIR=$(dirname $(readlink -f "$BASH_SOURCE"))
+VERSION=`git describe --abbrev=0 --tags`-${BUILD_NUMBER}-`git rev-parse --short HEAD`
 
 # initialize a directory with the assumptions we make for authoring
 # 1: target directory
 initialize_bundle() {
     mkdir -p $1
-
-    cp $BASE_DIR/xorriso-options.cfg $1
+    sed -e "s/\${VERSION}/${VERSION}/" $BASE_DIR/xorriso-options.cfg > $1/xorriso-options.cfg
 
     mkdir -p $1/rootfs/var/lib/rpm $1/bootfs/boot
 

--- a/isos/base/xorriso-options.cfg
+++ b/isos/base/xorriso-options.cfg
@@ -1,3 +1,3 @@
-publisher 'VMware Inc.'
+publisher 'VMware Inc. ${VERSION}'
 map bootfs /
 boot_image isolinux dir=/boot/isolinux

--- a/lib/install/data/data.go
+++ b/lib/install/data/data.go
@@ -91,7 +91,7 @@ type InstallerData struct {
 	Datacenter types.ManagedObjectReference
 	Cluster    types.ManagedObjectReference
 
-	ImageFiles []string
+	ImageFiles map[string]string
 
 	ApplianceISO string
 	BootstrapISO string


### PR DESCRIPTION
This PR add version information to iso files, and check the version during vic-machine create.
If the version does not match, create will fail, to ignore this failure, need to specify --force

For #812 

Note: this force installation should be fore developer only. Customer should be careful if they have this version mismatch issue, that means they are using binaries from different build.

