### PR TITLE
Wait and Retry implementation for TaskInProgressFaults during calls to vsphere

### DIFF
--- a/lib/apiservers/engine/backends/volume.go
+++ b/lib/apiservers/engine/backends/volume.go
@@ -35,7 +35,6 @@ const (
 	OptsVolumeStoreKey     string = "VolumeStore"
 	OptsCapacityKey        string = "Capacity"
 	dockerMetadataModelKey string = "DockerMetaData"
-	bytesToMegabyte               = int64(1000000)
 )
 
 func NewVolumeModel(volume *models.VolumeResponse, labels map[string]string) *types.Volume {
@@ -216,8 +215,7 @@ func validateDriverArgs(args map[string]string, model *models.VolumeRequest) err
 	if err != nil {
 		return err
 	}
-	model.Capacity = int64(capacity) / bytesToMegabyte
-
+	model.Capacity = int64(capacity) / int64(units.MB)
 	return nil
 }
 

--- a/pkg/vsphere/disk/disk_manager.go
+++ b/pkg/vsphere/disk/disk_manager.go
@@ -224,7 +224,6 @@ func (m *Manager) Create(ctx context.Context, newDiskURI string,
 // }
 
 func (m *Manager) Attach(ctx context.Context, disk *types.VirtualDisk) error {
-
 	deviceList := object.VirtualDeviceList{}
 	deviceList = append(deviceList, disk)
 

--- a/pkg/vsphere/disk/disk_manager.go
+++ b/pkg/vsphere/disk/disk_manager.go
@@ -228,13 +228,15 @@ func (m *Manager) Attach(ctx context.Context, disk *types.VirtualDisk) error {
 	deviceList := object.VirtualDeviceList{}
 	deviceList = append(deviceList, disk)
 
-	_, err := tasks.Retry(ctx, func(ctx context.Context) (tasks.ResultWaiter, error) {
-		changeSpec, err := deviceList.ConfigSpec(types.VirtualDeviceConfigSpecOperationAdd)
-		if err != nil {
-			return nil, err
-		}
-		machineSpec := types.VirtualMachineConfigSpec{}
-		machineSpec.DeviceChange = append(machineSpec.DeviceChange, changeSpec...)
+	changeSpec, err := deviceList.ConfigSpec(types.VirtualDeviceConfigSpecOperationAdd)
+	if err != nil {
+		return err
+	}
+
+	machineSpec := types.VirtualMachineConfigSpec{}
+	machineSpec.DeviceChange = append(machineSpec.DeviceChange, changeSpec...)
+
+	_, err = tasks.Retry(ctx, func(ctx context.Context) (tasks.ResultWaiter, error) {
 		return m.vm.Reconfigure(ctx, machineSpec)
 	})
 

--- a/pkg/vsphere/disk/disk_manager.go
+++ b/pkg/vsphere/disk/disk_manager.go
@@ -226,7 +226,7 @@ func (m *Manager) Create(ctx context.Context, newDiskURI string,
 func (m *Manager) Attach(ctx context.Context, spec *types.VirtualDisk) error {
 	machineSpec := configureDeviceSpec(ctx, *m.vm, types.VirtualDeviceConfigSpecOperationAdd, types.VirtualDeviceConfigSpecFileOperationCreate, spec)
 
-	_, err := tasks.WaitAndRetryForResult(ctx, func(ctx context.Context) (tasks.ResultWaiter, error) {
+	_, err := tasks.Retry(ctx, func(ctx context.Context) (tasks.ResultWaiter, error) {
 		return m.vm.Reconfigure(ctx, machineSpec)
 	})
 
@@ -269,7 +269,7 @@ func (m *Manager) Detach(ctx context.Context, d *VirtualDisk) error {
 
 	spec.DeviceChange = config
 
-	_, err = tasks.WaitAndRetryForResult(ctx, func(ctx context.Context) (tasks.ResultWaiter, error) {
+	_, err = tasks.Retry(ctx, func(ctx context.Context) (tasks.ResultWaiter, error) {
 		return m.vm.Reconfigure(ctx, spec)
 	})
 	if err != nil {

--- a/pkg/vsphere/tasks/waiter.go
+++ b/pkg/vsphere/tasks/waiter.go
@@ -104,7 +104,12 @@ func Retry(ctx context.Context, f func(context.Context) (ResultWaiter, error)) (
 
 	for {
 		taskInfo, err = WaitForResult(ctx, f)
-		if err == nil && taskInfo.Error == nil {
+
+		if err != nil {
+			return nil, err
+		}
+
+		if taskInfo.Error == nil {
 			break
 		}
 

--- a/pkg/vsphere/tasks/waiter.go
+++ b/pkg/vsphere/tasks/waiter.go
@@ -121,7 +121,9 @@ func Retry(ctx context.Context, f func(context.Context) (ResultWaiter, error)) (
 				backoffFactor *= 2
 			}
 		case <-ctx.Done():
-			timer.Stop()
+			if !timer.Stop() {
+				<-timer.C
+			}
 			return nil, ctx.Err()
 		}
 		log.Debugf("Retrying Task due to TaskInProgressFault: %s", taskInfo.Task.Reference())

--- a/pkg/vsphere/tasks/waiter.go
+++ b/pkg/vsphere/tasks/waiter.go
@@ -30,7 +30,7 @@ import (
 )
 
 const (
-	maxBackoffFactor = int64(8)
+	maxBackoffFactor = int64(16)
 )
 
 type Waiter interface {
@@ -120,6 +120,7 @@ func Retry(ctx context.Context, f func(context.Context) (ResultWaiter, error)) (
 				backoffFactor *= 2
 			}
 		case <-ctx.Done():
+			log.Errorf("Context Deadline Exceeded while trying to Retry task : %#v", taskInfo)
 			return nil, ctx.Err()
 		}
 		log.Infof("Retrying Task due to TaskInProgressFault: %s", taskInfo.Task.Reference())

--- a/pkg/vsphere/tasks/waiter.go
+++ b/pkg/vsphere/tasks/waiter.go
@@ -96,12 +96,6 @@ func Retry(ctx context.Context, f func(context.Context) (ResultWaiter, error)) (
 	var taskInfo *types.TaskInfo
 	backoffFactor := int64(1)
 
-	//setting up timer
-	timer := time.NewTimer(time.Duration(100) * time.Millisecond)
-	if !timer.Stop() {
-		<-timer.C
-	}
-
 	for {
 		taskInfo, err = WaitForResult(ctx, f)
 		if err != nil {
@@ -109,7 +103,7 @@ func Retry(ctx context.Context, f func(context.Context) (ResultWaiter, error)) (
 		}
 
 		if taskInfo.Error == nil {
-			break
+			return taskInfo, nil
 		}
 
 		if _, ok := taskInfo.Error.Fault.(types.TaskInProgressFault); !ok {
@@ -130,10 +124,4 @@ func Retry(ctx context.Context, f func(context.Context) (ResultWaiter, error)) (
 		}
 		log.Infof("Retrying Task due to TaskInProgressFault: %s", taskInfo.Task.Reference())
 	}
-
-	if err != nil {
-		return nil, err
-	}
-
-	return taskInfo, nil
 }

--- a/tests/test-cases/Group1-Docker-Commands/1-19-Docker-Volume-Create.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-19-Docker-Volume-Create.robot
@@ -2,16 +2,12 @@
 Documentation  Test 1-19 - Docker Volume Create
 Resource  ../../resources/Util.robot
 Suite Setup  Install VIC Appliance To Test Server
-Suite Teardown  Cleanup VIC Appliance On Test Server
+suite Teardown  Cleanup VIC Appliance On Test Server
 
 *** Test Cases ***
 Simple docker volume create
-    ${status}=  Get State Of Github Issue  1560
-    Run Keyword If  '${status}' == 'closed'  Fail  Test 1-19-Docker-Volume-Create.robot needs to be updated now that Issue #1560 has been resolved
-    Log  Issue \#1560 is blocking implementation  WARN
-    # Auto-named volumes not supported yet
-    #${rc}  ${output}=  Run And Return Rc And Output  docker ${params} volume create
-    #Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} volume create
+    Should Be Equal As Integers  ${rc}  0
 
 Docker volume create named volume
     ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} volume create --name=test

--- a/tests/test-cases/Group1-Docker-Commands/1-19-Docker-Volume-Create.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-19-Docker-Volume-Create.robot
@@ -2,7 +2,7 @@
 Documentation  Test 1-19 - Docker Volume Create
 Resource  ../../resources/Util.robot
 Suite Setup  Install VIC Appliance To Test Server
-suite Teardown  Cleanup VIC Appliance On Test Server
+Suite Teardown  Cleanup VIC Appliance On Test Server
 
 *** Test Cases ***
 Simple docker volume create
@@ -15,71 +15,47 @@ Docker volume create named volume
     Should Be Equal As Strings  ${output}  test
 
 Docker volume create already named volume
-    ${status}=  Get State Of Github Issue  1562
-    Run Keyword If  '${status}' == 'closed'  Fail  Test 1-19-Docker-Volume-Create.robot needs to be updated now that Issue #1562 has been resolved
-    Log  Issue \#1562 is blocking implementation  WARN
-    #${rc}  ${output}=  Run And Return Rc And Output  docker ${params} volume create --name=test
-    #Should Be Equal As Integers  ${rc}  1
-    #Should Contain  ${output}  Error response from daemon: A volume named test already exists. Choose a different volume name.
+    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} volume create --name=test
+    Should Be Equal As Integers  ${rc}  1
+    Should Contain  ${output}  Error response from daemon: A volume named test already exists. Choose a different volume name.
     
 Docker volume create volume with bad driver
-    ${status}=  Get State Of Github Issue  1564
-    Run Keyword If  '${status}' == 'closed'  Fail  Test 1-19-Docker-Volume-Create.robot needs to be updated now that Issue #1564 has been resolved
-    Log  Issue \#1564 is blocking implementation  WARN
-    #${rc}  ${output}=  Run And Return Rc And Output  docker ${params} volume create -d fakeDriver --name=test2
-    #Should Be Equal As Integers  ${rc}  1
-    #Should Contain  ${output}  Error looking up volume plugin fakeDriver: plugin not found
+    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} volume create -d fakeDriver --name=test2
+    Should Be Equal As Integers  ${rc}  1
+    Should Contain  ${output}  Error looking up volume plugin fakeDriver: plugin not found
     
 Docker volume create with bad datastore
-    ${status}=  Get State Of Github Issue  1561
-    Run Keyword If  '${status}' == 'closed'  Fail  Test 1-19-Docker-Volume-Create.robot needs to be updated now that Issue #1561 has been resolved
-    Log  Issue \#1561 is blocking implementation  WARN
-    #${rc}  ${output}=  Run And Return Rc And Output  docker ${params} volume create --name=test3 --opt VolumeStore=fakeStore
-    #Should Be Equal As Integers  ${rc}  1
-    #Should Contain  ${output}  Error looking up volume store fakeStore: datastore not found
+    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} volume create --name=test3 --opt VolumeStore=fakeStore
+    Should Be Equal As Integers  ${rc}  1
+    Should Contain  ${output}  Error looking up volume store fakeStore: datastore not found
 
 Docker volume create with specific capacity
-    ${status}=  Get State Of Github Issue  1565
-    Run Keyword If  '${status}' == 'closed'  Fail  Test 1-19-Docker-Volume-Create.robot needs to be updated now that Issue #1565 has been resolved
-    Log  Issue \#1565 is blocking implementation  WARN
-    #${rc}  ${output}=  Run And Return Rc And Output  docker ${params} volume create --name=test4 --opt Capacity=100
-    #Should Be Equal As Integers  ${rc}  0
-    #Should Be Equal As Strings  ${output}  test4
-    #${rc}  ${output}=  Run And Return Rc And Output  govc datastore.ls -json=true test/VIC/volumes/test4
-    #Should Be Equal As Integers  ${rc}  0
-    #Should Contain  ${output}  "FileSize":100
+    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} volume create --name=test4 --opt Capacity=100
+    Should Be Equal As Integers  ${rc}  0
+    Should Be Equal As Strings  ${output}  test4
+    ${rc}  ${output}=  Run And Return Rc And Output  govc datastore.ls -json=true test/VIC/volumes/test4
+    Should Be Equal As Integers  ${rc}  0
+    Should Contain  ${output}  "FileSize":100
     
 Docker volume create with zero capacity
-    ${status}=  Get State Of Github Issue  1562
-    Run Keyword If  '${status}' == 'closed'  Fail  Test 1-19-Docker-Volume-Create.robot needs to be updated now that Issue #1562 has been resolved
-    Log  Issue \#1562 is blocking implementation  WARN
-    #${rc}  ${output}=  Run And Return Rc And Output  docker ${params} volume create --name=test5 --opt Capacity=0
-    #Should Be Equal As Integers  ${rc}  1
-    #Should Contain  ${output}  Error
+    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} volume create --name=test5 --opt Capacity=0
+    Should Be Equal As Integers  ${rc}  1
+    Should Contain  ${output}  Error
     
 Docker volume create with negative one capacity
-    ${status}=  Get State Of Github Issue  1562
-    Run Keyword If  '${status}' == 'closed'  Fail  Test 1-19-Docker-Volume-Create.robot needs to be updated now that Issue #1562 has been resolved
-    Log  Issue \#1562 is blocking implementation  WARN
-    #${rc}  ${output}=  Run And Return Rc And Output  docker ${params} volume create --name=test6 --opt Capacity=-1
-    #Should Be Equal As Integers  ${rc}  1
-    #Should Contain  ${output}  Error    
+    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} volume create --name=test6 --opt Capacity=-1
+    Should Be Equal As Integers  ${rc}  1
+    Should Contain  ${output}  Error
     
 Docker volume create with capacity too big
-    ${status}=  Get State Of Github Issue  1562
-    Run Keyword If  '${status}' == 'closed'  Fail  Test 1-19-Docker-Volume-Create.robot needs to be updated now that Issue #1562 has been resolved
-    Log  Issue \#1562 is blocking implementation  WARN
-    #${rc}  ${output}=  Run And Return Rc And Output  docker ${params} volume create --name=test7 --opt Capacity=2147483647
-    #Should Be Equal As Integers  ${rc}  1
-    #Should Contain  ${output}  Error
+    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} volume create --name=test7 --opt Capacity=2147483647
+    Should Be Equal As Integers  ${rc}  1
+    Should Contain  ${output}  Error
     
 Docker volume create with capacity exceeding int size
-    ${status}=  Get State Of Github Issue  1562
-    Run Keyword If  '${status}' == 'closed'  Fail  Test 1-19-Docker-Volume-Create.robot needs to be updated now that Issue #1562 has been resolved
-    Log  Issue \#1562 is blocking implementation  WARN
-    #${rc}  ${output}=  Run And Return Rc And Output  docker ${params} volume create --name=test8 --opt Capacity=9999999999
-    #Should Be Equal As Integers  ${rc}  1
-    #Should Contain  ${output}  Error
+    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} volume create --name=test8 --opt Capacity=9999999999
+    Should Be Equal As Integers  ${rc}  1
+    Should Contain  ${output}  Error
     
 Docker volume create with possibly invalid name
     ${status}=  Get State Of Github Issue  1563
@@ -105,3 +81,4 @@ Docker volume create 10 volumes rapidly
     #\   ${res}=  Wait For Process  ${pid}
     #\   Log  ${res.stdout} ${res.stderr}
     #\   Should Be Equal As Integers  ${res.rc}  0
+

--- a/tests/test-cases/Group1-Docker-Commands/1-19-Docker-Volume-Create.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-19-Docker-Volume-Create.robot
@@ -15,47 +15,71 @@ Docker volume create named volume
     Should Be Equal As Strings  ${output}  test
 
 Docker volume create already named volume
-    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} volume create --name=test
-    Should Be Equal As Integers  ${rc}  1
-    Should Contain  ${output}  Error response from daemon: A volume named test already exists. Choose a different volume name.
+    ${status}=  Get State Of Github Issue  1562
+    Run Keyword If  '${status}' == 'closed'  Fail  Test 1-19-Docker-Volume-Create.robot needs to be updated now that Issue #1562 has been resolved
+    Log  Issue \#1562 is blocking implementation  WARN
+    #${rc}  ${output}=  Run And Return Rc And Output  docker ${params} volume create --name=test
+    #Should Be Equal As Integers  ${rc}  1
+    #Should Contain  ${output}  Error response from daemon: A volume named test already exists. Choose a different volume name.
     
 Docker volume create volume with bad driver
-    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} volume create -d fakeDriver --name=test2
-    Should Be Equal As Integers  ${rc}  1
-    Should Contain  ${output}  Error looking up volume plugin fakeDriver: plugin not found
+    ${status}=  Get State Of Github Issue  1564
+    Run Keyword If  '${status}' == 'closed'  Fail  Test 1-19-Docker-Volume-Create.robot needs to be updated now that Issue #1564 has been resolved
+    Log  Issue \#1564 is blocking implementation  WARN
+    #${rc}  ${output}=  Run And Return Rc And Output  docker ${params} volume create -d fakeDriver --name=test2
+    #Should Be Equal As Integers  ${rc}  1
+    #Should Contain  ${output}  Error looking up volume plugin fakeDriver: plugin not found
     
-Docker volume create with bad datastore
-    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} volume create --name=test3 --opt VolumeStore=fakeStore
-    Should Be Equal As Integers  ${rc}  1
-    Should Contain  ${output}  Error looking up volume store fakeStore: datastore not found
+Docker volume create with bad volumestore
+    ${status}=  Get State Of Github Issue  1561
+    Run Keyword If  '${status}' == 'closed'  Fail  Test 1-19-Docker-Volume-Create.robot needs to be updated now that Issue #1561 has been resolved
+    Log  Issue \#1561 is blocking implementation  WARN
+    #${rc}  ${output}=  Run And Return Rc And Output  docker ${params} volume create --name=test3 --opt VolumeStore=fakeStore
+    #Should Be Equal As Integers  ${rc}  1
+    #Should Contain  ${output}  Error looking up volume store fakeStore: datastore not found
 
 Docker volume create with specific capacity
-    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} volume create --name=test4 --opt Capacity=100
-    Should Be Equal As Integers  ${rc}  0
-    Should Be Equal As Strings  ${output}  test4
-    ${rc}  ${output}=  Run And Return Rc And Output  govc datastore.ls -json=true test/VIC/volumes/test4
-    Should Be Equal As Integers  ${rc}  0
-    Should Contain  ${output}  "FileSize":100
+    ${status}=  Get State Of Github Issue  1565
+    Run Keyword If  '${status}' == 'closed'  Fail  Test 1-19-Docker-Volume-Create.robot needs to be updated now that Issue #1565 has been resolved
+    Log  Issue \#1565 is blocking implementation  WARN
+    #${rc}  ${output}=  Run And Return Rc And Output  docker ${params} volume create --name=test4 --opt Capacity=100
+    #Should Be Equal As Integers  ${rc}  0
+    #Should Be Equal As Strings  ${output}  test4
+    #${rc}  ${output}=  Run And Return Rc And Output  govc datastore.ls -json=true test/VIC/volumes/test4
+    #Should Be Equal As Integers  ${rc}  0
+    #Should Contain  ${output}  "FileSize":100
     
 Docker volume create with zero capacity
-    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} volume create --name=test5 --opt Capacity=0
-    Should Be Equal As Integers  ${rc}  1
-    Should Contain  ${output}  Error
+    ${status}=  Get State Of Github Issue  1562
+    Run Keyword If  '${status}' == 'closed'  Fail  Test 1-19-Docker-Volume-Create.robot needs to be updated now that Issue #1562 has been resolved
+    Log  Issue \#1562 is blocking implementation  WARN
+    #${rc}  ${output}=  Run And Return Rc And Output  docker ${params} volume create --name=test5 --opt Capacity=0
+    #Should Be Equal As Integers  ${rc}  1
+    #Should Contain  ${output}  Error
     
 Docker volume create with negative one capacity
-    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} volume create --name=test6 --opt Capacity=-1
-    Should Be Equal As Integers  ${rc}  1
-    Should Contain  ${output}  Error
+    ${status}=  Get State Of Github Issue  1562
+    Run Keyword If  '${status}' == 'closed'  Fail  Test 1-19-Docker-Volume-Create.robot needs to be updated now that Issue #1562 has been resolved
+    Log  Issue \#1562 is blocking implementation  WARN
+    #${rc}  ${output}=  Run And Return Rc And Output  docker ${params} volume create --name=test6 --opt Capacity=-1
+    #Should Be Equal As Integers  ${rc}  1
+    #Should Contain  ${output}  Error    
     
 Docker volume create with capacity too big
-    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} volume create --name=test7 --opt Capacity=2147483647
-    Should Be Equal As Integers  ${rc}  1
-    Should Contain  ${output}  Error
+    ${status}=  Get State Of Github Issue  1562
+    Run Keyword If  '${status}' == 'closed'  Fail  Test 1-19-Docker-Volume-Create.robot needs to be updated now that Issue #1562 has been resolved
+    Log  Issue \#1562 is blocking implementation  WARN
+    #${rc}  ${output}=  Run And Return Rc And Output  docker ${params} volume create --name=test7 --opt Capacity=2147483647
+    #Should Be Equal As Integers  ${rc}  1
+    #Should Contain  ${output}  Error
     
 Docker volume create with capacity exceeding int size
-    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} volume create --name=test8 --opt Capacity=9999999999
-    Should Be Equal As Integers  ${rc}  1
-    Should Contain  ${output}  Error
+    ${status}=  Get State Of Github Issue  1562
+    Run Keyword If  '${status}' == 'closed'  Fail  Test 1-19-Docker-Volume-Create.robot needs to be updated now that Issue #1562 has been resolved
+    Log  Issue \#1562 is blocking implementation  WARN
+    #${rc}  ${output}=  Run And Return Rc And Output  docker ${params} volume create --name=test8 --opt Capacity=9999999999
+    #Should Be Equal As Integers  ${rc}  1
+    #Should Contain  ${output}  Error
     
 Docker volume create with possibly invalid name
     ${status}=  Get State Of Github Issue  1563
@@ -65,20 +89,16 @@ Docker volume create with possibly invalid name
     #Should Be Equal As Integers  ${rc}  1
     #Should Be Equal As Strings  ${output}  Error response from daemon: create test???: "test???" includes invalid characters for a local volume name, only "[a-zA-Z0-9][a-zA-Z0-9_.-]" are allowed
     
-Docker volume create 10 volumes rapidly
-    ${status}=  Get State Of Github Issue  2013
-    Run Keyword If  '${status}' == 'closed'  Fail  Test 1-19-Docker-Volume-Create.robot needs to be updated now that Issue #2013 has been resolved
-    Log  Issue \#2013 is blocking implementation  WARN
-    #${pids}=  Create List
+Docker volume create 100 volumes rapidly
+    ${pids}=  Create List
 
-    # Create 10 volumes rapidly
-    #:FOR  ${idx}  IN RANGE  0  10
-    #\   ${pid}=  Start Process  docker ${params} volume create --name\=multiple${idx} --opt Capacity\=2MB  shell=True
-    #\   Append To List  ${pids}  ${pid}
+    # Create 100 volumes rapidly
+    :FOR  ${idx}  IN RANGE  0  100
+    \   ${pid}=  Start Process  docker ${params} volume create --name\=multiple${idx} --opt Capacity\=512MB  shell=True
+    \   Append To List  ${pids}  ${pid}
 
     # Wait for them to finish and check their RC
-    #:FOR  ${pid}  IN  @{pids}
-    #\   ${res}=  Wait For Process  ${pid}
-    #\   Log  ${res.stdout} ${res.stderr}
-    #\   Should Be Equal As Integers  ${res.rc}  0
-
+    :FOR  ${pid}  IN  @{pids}
+    \   ${res}=  Wait For Process  ${pid}
+    \   Log  ${res.stdout} ${res.stderr}
+    \   Should Be Equal As Integers  ${res.rc}  0

--- a/tests/test-cases/Group1-Docker-Commands/1-21-Docker-Volume-LS.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-21-Docker-Volume-LS.robot
@@ -25,12 +25,15 @@ Volume ls quiet
     Should Not Contain  ${output}  VOLUME NAME
     
 Volume ls dangling volumes
-    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} volume ls -f dangling=true
-    Should Be Equal As Integers  ${rc}  0
-    Should Contain  ${output}  vsphere
-    Should Contain  ${output}  test
-    Should Contain  ${output}  DRIVER
-    Should Contain  ${output}  VOLUME NAME
+    ${status}=  Get State Of Github Issue  1718
+    Run Keyword If  '${status}' == 'closed'  Fail  Test 1-21-Docker-Volume-LS.robot needs to be updated now that Issue #1718 has been resolved
+    Log  Issue \#1718 is blocking implementation  WARN
+    #${rc}  ${output}=  Run And Return Rc And Output  docker ${params} volume ls -f dangling=true
+    #Should Be Equal As Integers  ${rc}  0
+    #Should Contain  ${output}  vsphere
+    #Should Contain  ${output}  test
+    #Should Contain  ${output}  DRIVER
+    #Should Contain  ${output}  VOLUME NAME
     
 Volume ls invalid filter
     ${status}=  Get State Of Github Issue  1718

--- a/tests/test-cases/Group1-Docker-Commands/1-21-Docker-Volume-LS.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-21-Docker-Volume-LS.robot
@@ -6,40 +6,31 @@ Suite Teardown  Cleanup VIC Appliance On Test Server
 
 *** Test Cases ***
 Simple volume ls
-    ${status}=  Get State Of Github Issue  1896
-    Run Keyword If  '${status}' == 'closed'  Fail  Test 1-21-Docker-Volume-LS.robot needs to be updated now that Issue #1896 has been resolved
-    Log  Issue \#1896 is blocking implementation  WARN
-    #${rc}  ${output}=  Run And Return Rc And Output  docker ${params} volume create --name=test
-    #Should Be Equal As Integers  ${rc}  0
-    #Should Be Equal As Strings  ${output}  test
-    #${rc}  ${output}=  Run And Return Rc And Output  docker ${params} volume ls
-    #Should Be Equal As Integers  ${rc}  0
-    #Should Contain  ${output}  vsphere
-    #Should Contain  ${output}  test
-    #Should Contain  ${output}  DRIVER
-    #Should Contain  ${output}  VOLUME NAME
+    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} volume create --name=test
+    Should Be Equal As Integers  ${rc}  0
+    Should Be Equal As Strings  ${output}  test
+    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} volume ls
+    Should Be Equal As Integers  ${rc}  0
+    Should Contain  ${output}  vsphere
+    Should Contain  ${output}  test
+    Should Contain  ${output}  DRIVER
+    Should Contain  ${output}  VOLUME NAME
     
 Volume ls quiet
-    ${status}=  Get State Of Github Issue  1896
-    Run Keyword If  '${status}' == 'closed'  Fail  Test 1-21-Docker-Volume-LS.robot needs to be updated now that Issue #1896 has been resolved
-    Log  Issue \#1896 is blocking implementation  WARN
-    #${rc}  ${output}=  Run And Return Rc And Output  docker ${params} volume ls -q
-    #Should Be Equal As Integers  ${rc}  0
-    #Should Not Contain  ${output}  vsphere
-    #Should Contain  ${output}  test
-    #Should Not Contain  ${output}  DRIVER
-    #Should Not Contain  ${output}  VOLUME NAME
+    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} volume ls -q
+    Should Be Equal As Integers  ${rc}  0
+    Should Not Contain  ${output}  vsphere
+    Should Contain  ${output}  test
+    Should Not Contain  ${output}  DRIVER
+    Should Not Contain  ${output}  VOLUME NAME
     
 Volume ls dangling volumes
-    ${status}=  Get State Of Github Issue  1718
-    Run Keyword If  '${status}' == 'closed'  Fail  Test 1-21-Docker-Volume-LS.robot needs to be updated now that Issue #1718 has been resolved
-    Log  Issue \#1718 is blocking implementation  WARN
-    #${rc}  ${output}=  Run And Return Rc And Output  docker ${params} volume ls -f dangling=true
-    #Should Be Equal As Integers  ${rc}  0
-    #Should Contain  ${output}  vsphere
-    #Should Contain  ${output}  test
-    #Should Contain  ${output}  DRIVER
-    #Should Contain  ${output}  VOLUME NAME
+    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} volume ls -f dangling=true
+    Should Be Equal As Integers  ${rc}  0
+    Should Contain  ${output}  vsphere
+    Should Contain  ${output}  test
+    Should Contain  ${output}  DRIVER
+    Should Contain  ${output}  VOLUME NAME
     
 Volume ls invalid filter
     ${status}=  Get State Of Github Issue  1718


### PR DESCRIPTION
Fixes #2013 #1725 #1896 #1560 

This PR will be a simple implementation of a wait and retry to solve issues where we get a `TaskInProgressFault` from vsphere when trying to attempt multiple "long running" tasks. Currently we have only seen this on `attach` and `detach` requests for disk devices to the same vm(our appliance). 

Additionally the test for a randomly named volume has been fixed up to reflect that the issue for that has been addressed in the past. this has also been noted in #1560 

