### PR TITLE
Use RFC3339 timestamp format for created field in image

### DIFF
--- a/lib/apiservers/engine/backends/image.go
+++ b/lib/apiservers/engine/backends/image.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"os/exec"
 	"sort"
+	"time"
 
 	log "github.com/Sirupsen/logrus"
 
@@ -211,7 +212,7 @@ func imageConfigToDockerImageInspect(imageConfig *metadata.ImageConfig, productN
 		RepoDigests:     clientFriendlyDigests(imageConfig.Name, imageConfig.Digests),
 		Parent:          imageConfig.Parent,
 		Comment:         imageConfig.Comment,
-		Created:         imageConfig.Created.String(),
+		Created:         imageConfig.Created.Format(time.RFC3339Nano),
 		Container:       imageConfig.Container,
 		ContainerConfig: &imageConfig.ContainerConfig,
 		DockerVersion:   imageConfig.DockerVersion,


### PR DESCRIPTION
While evaluating VIC 0.5.0 with Docker Tooling For Eclipse (which uses the Docker Spotify Client), I was getting image inspection failures. Error message:

Caused by: com.fasterxml.jackson.databind.exc.InvalidFormatException: Can not construct instance of java.util.Date from String value '2016-06-23 23:23:37.198943461 +0000 UTC': not a valid representation (error: Failed to parse Date value '2016-06-23 23:23:37.198943461 +0000 UTC': Can not parse date "2016-06-23 23:23:37.198943461 +0000 UTC": not compatible with any of standard forms ("yyyy-MM-dd'T'HH:mm:ss.SSSZ", "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", "EEE, dd MMM yyyy HH:mm:ss zzz", "yyyy-MM-dd"))

Comparison of docker inspect output on busybox:latest:

Docker For Mac:

$ docker inspect 2b8fd9751c4c | grep Created
        "Created": "2016-06-23T23:23:37.198943461Z",`

VIC 0.5.0:

$ docker -H 192.168.0.114 inspect 332de81782ef | grep Created
        "Created": "2016-06-23 23:23:37.198943461 +0000 UTC",

VIC with patch:

$ docker -H 192.168.0.104:2375 inspect 332de81782ef | grep Created
        "Created": "2016-06-23T23:23:37.198943461Z",

Image inspection with Spotify Docker Client succeeds now.