### PR TITLE
[skip ci] Doc update about when to use quotes in vic-machine options

### DIFF
--- a/doc/user_doc/vic_admin/delete_vch_options.md
+++ b/doc/user_doc/vic_admin/delete_vch_options.md
@@ -12,7 +12,7 @@ The IPv4 address, fully qualified domain name (FQDN), or URL of the ESXi host or
 - If the target ESXi host is managed by vCenter Server, or if you deployed the virtual container host to a cluster, provide the address of vCenter Server.<pre>--target <i>vcenter_server_address</i></pre>
 - You can optionally include the user name and password of the ESXi host or vCenter Server in the target URL. Wrap the user name or password in single quotes (Linux or Mac OS) or double quotes (Windows) if they include special characters.<pre>--target <i>username</i>:<i>password</i>@<i>esxi_or_vcenter_server_address</i></pre>
 - If you deployed the virtual container host on a vCenter Server instance that includes more than one datacenter, include the datacenter name in the target URL. If you include an invalid datacenter name, `vic-machine delete` fails and suggests the available datacenters that you can specify.<pre>--target <i>vcenter_server_address</i>/<i>datacenter_name</i></pre>
-- If you do not specify the `passwd` option or include the password in the target URL, `vic-machine inspect` prompts you to enter the password.
+- If you do not specify the `password` option or include the password in the target URL, `vic-machine inspect` prompts you to enter the password.
 
 ### `user` ###
 

--- a/doc/user_doc/vic_admin/inspect_vch_options.md
+++ b/doc/user_doc/vic_admin/inspect_vch_options.md
@@ -12,7 +12,7 @@ The IPv4 address, fully qualified domain name (FQDN), or URL of the ESXi host or
 - If the target ESXi host is managed by vCenter Server, or if you deployed the virtual container host to a cluster, provide the address of vCenter Server.<pre>--target <i>vcenter_server_address</i></pre>
 - You can optionally include the user name and password of the ESXi host or vCenter Server in the target URL. Wrap the user name or password in single quotes (Linux or Mac OS) or double quotes (Windows) if they include special characters.<pre>--target <i>username</i>:<i>password</i>@<i>esxi_or_vcenter_server_address</i></pre>
 - If you deployed the virtual container host on a vCenter Server instance that includes more than one datacenter, include the datacenter name in the target URL. If you omit the datacenter name or include an invalid datacenter, `vic-machine inspect` fails and suggests the available datacenters that you can specify.<pre>--target <i>vcenter_server_address</i>/<i>datacenter_name</i></pre>
-- If you do not specify the `passwd` option or include the password in the target URL, `vic-machine inspect` prompts you to enter the password.
+- If you do not specify the `password` option or include the password in the target URL, `vic-machine inspect` prompts you to enter the password.
 
 ### `user` ###
 

--- a/doc/user_doc/vic_admin/list_vch_options.md
+++ b/doc/user_doc/vic_admin/list_vch_options.md
@@ -13,7 +13,7 @@ The IPv4 address, fully qualified domain name (FQDN), or URL of the ESXi host or
 - You can optionally include the user name and password of the ESXi host or vCenter Server in the target URL. Wrap the user name or password in single quotes (Linux or Mac OS) or double quotes (Windows) if they include special characters.<pre>--target <i>username</i>:<i>password</i>@<i>esxi_or_vcenter_server_address</i></pre>
 - If you deployed the virtual container hosts on a vCenter Server instance that includes more than one datacenter, you can include the datacenter name in the target URL. If you include a datacenter name, `vic-machine ls` lists all of the virtual container hosts that are running in that datacenter. If you do not include a datacenter name, `vic-machine ls` lists all of the virtual container hosts that are running on that vCenter Server instance, for all datacenters.<pre>--target <i>vcenter_server_address</i></pre>
 - <pre>--target <i>vcenter_server_address</i>/<i>datacenter_name</i></pre>
-- If you do not specify the `passwd` option or include the password in the target URL, `vic-machine ls` prompts you to enter the password.
+- If you do not specify the `password` option or include the password in the target URL, `vic-machine ls` prompts you to enter the password.
 
 ### `user` ###
 

--- a/doc/user_doc/vic_installation/vch_installer_options.md
+++ b/doc/user_doc/vic_installation/vch_installer_options.md
@@ -27,7 +27,7 @@ To facilitate IP address changes in your infrastructure, provide an FQDN wheneve
 - If you are deploying a virtual container host directly on an ESXi host, you must specify the `user` option, or include the user name and password in the target URL. Wrap the user name or password in single quotes (Linux or Mac OS) or double quotes (Windows) if they include special characters.<pre>--target <i>esxi_host_username</i>:<i>password</i>@<i>esxi_host_address</i></pre>
 - If you are deploying a virtual container host on a vCenter Server instance, you must specify the `user` option, or include the user name and password in the target URL. Wrap the user name or password in single quotes (Linux or Mac OS) or double quotes (Windows) if they include special characters.<pre>--target <i>vcenter_server_username</i>:<i>password</i>@<i>vcenter_server_address</i></pre>
 - If you are deploying a virtual container host on a vCenter Server instance that includes more than one datacenter, include the datacenter name in the target URL. If you include an invalid datacenter name, `vic-machine create` fails and suggests the available datacenters that you can specify. <pre>--target <i>vcenter_server_address</i>/<i>datacenter_name</i></pre>
-- If you do not specify the `passwd` option or include the password in the target URL, `vic-machine create` prompts you to enter the password.
+- If you do not specify the `password` option or include the password in the target URL, `vic-machine create` prompts you to enter the password.
 
 ### `user` ###
 


### PR DESCRIPTION
Fixes https://github.com/vmware/vic/issues/2073, which resulted from this [SocialCast posting](https://vmware-com.socialcast.com/messages/31466650).

Updates the following doc topics to describe when to wrap options in quotes:
- [Virtual Container Host Deployment Options](https://github.com/stuclem/vic/blob/master/doc/user_doc/vic_installation/vch_installer_options.md)
- [Virtual Container Host Inspect Options](https://github.com/stuclem/vic/blob/master/doc/user_doc/vic_admin/inspect_vch_options.md)
- [Virtual Container Host Delete Options](https://github.com/stuclem/vic/blob/master/doc/user_doc/vic_admin/delete_vch_options.md)
- [Virtual Container Host List Options](https://github.com/stuclem/vic/blob/master/doc/user_doc/vic_admin/list_vch_options.md)

Adds [VCH Deployment Fails with Unknown or Non-Specified Argument Error or Incorrect User Name Error](https://github.com/stuclem/vic/blob/master/doc/user_doc/vic_installation/ts_cli_argument_error.md) 

@emlin and @gigawhitlocks, please can you take a look?

Thanks!

