### PR TITLE
Implement an index to track tree nodes

### DIFF
--- a/pkg/index/index.go
+++ b/pkg/index/index.go
@@ -103,6 +103,19 @@ func (i *Index) Get(nodeId string) (Node, error) {
 	return n.Copy(), nil
 }
 
+func (i *Index) List() ([]Node, error) {
+	i.l.Lock()
+	defer i.l.Unlock()
+
+	nodes := make([]Node, 0, len(i.lookupTable))
+
+	for _, v := range i.lookupTable {
+		nodes = append(nodes, v.Copy())
+	}
+
+	return nodes, nil
+}
+
 // Delete deletes a leaf node
 func (i *Index) Delete(nodeId string) (Node, error) {
 	i.l.Lock()

--- a/pkg/index/index.go
+++ b/pkg/index/index.go
@@ -1,0 +1,192 @@
+// Copyright 2016 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package index
+
+import (
+	"container/list"
+	"fmt"
+	"sync"
+
+	log "github.com/Sirupsen/logrus"
+)
+
+type Node interface {
+	// Returns the string representation (usually the ID) of the node
+	String() string
+
+	// Deep copy of the node
+	Copy() Node
+}
+
+type node struct {
+	Node
+	parent   *node
+	children []*node
+	mask     uint32
+}
+
+func (n *node) addChild(child *node) {
+	n.children = append(n.children, child)
+}
+
+type Index struct {
+	root        *node
+	lookupTable map[string]*node
+	l           sync.Mutex
+}
+
+func NewIndex() *Index {
+	i := &Index{
+		lookupTable: make(map[string]*node),
+	}
+
+	return i
+}
+
+// Insert inserts a copy of the given node to the tree under the given parent.
+func (i *Index) Insert(parent string, n Node) error {
+	i.l.Lock()
+	defer i.l.Unlock()
+
+	_, ok := i.lookupTable[n.String()]
+	if ok {
+		return fmt.Errorf("node %s already exists in index", n.String())
+	}
+
+	newNode := &node{
+		Node: n.Copy(),
+	}
+
+	if parent == n.String() {
+		if i.root != nil {
+			return fmt.Errorf("node cannot point to self unless it's root")
+		}
+
+		// set root
+		i.root = newNode
+
+	} else {
+		p, ok := i.lookupTable[parent]
+		if !ok {
+			return fmt.Errorf("Can't find parent %s", parent)
+		}
+		newNode.parent = p
+		p.addChild(newNode)
+	}
+
+	i.lookupTable[n.String()] = newNode
+	return nil
+}
+
+// Get returns a Copy of the named node.
+func (i *Index) Get(nodeId string) (Node, error) {
+	i.l.Lock()
+	defer i.l.Unlock()
+
+	n, ok := i.lookupTable[nodeId]
+	if !ok {
+		return nil, fmt.Errorf("Node %s not found", nodeId)
+	}
+
+	return n.Copy(), nil
+}
+
+// Delete deletes a leaf node
+func (i *Index) Delete(nodeId string) (Node, error) {
+	i.l.Lock()
+	defer i.l.Unlock()
+
+	n, ok := i.lookupTable[nodeId]
+	if !ok {
+		return nil, fmt.Errorf("Node %s not found", nodeId)
+	}
+
+	if len(n.children) != 0 {
+		return nil, fmt.Errorf("Node %s has children %#q", nodeId, n.children)
+	}
+
+	// remove the reference to the node from its parent
+	var deleted bool
+	err := i.bfsworker(i.root, func(needle *node) (iterflag, error) {
+		for idx, child := range needle.children {
+			if child.String() == nodeId {
+				// remove the child
+				needle.children = append(needle.children[:idx], needle.children[idx+1:]...)
+				log.Debugf("Removing %s from parent (%s children : %#q)", nodeId, needle.String(), needle.children)
+				deleted = true
+				return STOP, nil
+			}
+		}
+
+		// continue iterating
+		return NOOP, nil
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	if !deleted {
+		err = fmt.Errorf("%s not found in tree", nodeId)
+		log.Errorf("%s", err)
+		return nil, err
+	}
+
+	delete(i.lookupTable, nodeId)
+
+	return n.Node, nil
+}
+
+type iterflag int
+
+const (
+	NOOP iterflag = iota
+	STOP
+)
+
+type visitor func(Node) (iterflag, error)
+
+func (i *Index) bfs(root *node, visitFunc visitor) error {
+	i.l.Lock()
+	defer i.l.Unlock()
+
+	// XXX Look into parallelizing this without breaking API boundaries.
+	return i.bfsworker(root, func(n *node) (iterflag, error) { return visitFunc(n.Node) })
+}
+
+func (i *Index) bfsworker(root *node, visitFunc func(*node) (iterflag, error)) error {
+
+	queue := list.New()
+	queue.PushBack(root)
+
+	for queue.Len() > 0 {
+		n := queue.Remove(queue.Front()).(*node)
+
+		flag, err := visitFunc(n)
+		if err != nil {
+			return err
+		}
+
+		if flag == STOP {
+			return nil
+		}
+
+		for _, child := range n.children {
+			queue.PushBack(child)
+		}
+	}
+
+	return nil
+}

--- a/pkg/index/index.go
+++ b/pkg/index/index.go
@@ -131,33 +131,24 @@ func (i *Index) Delete(nodeId string) (Node, error) {
 	}
 
 	// remove the reference to the node from its parent
+	parent := n.parent
 	var deleted bool
-	err := i.bfsworker(i.root, func(needle *node) (iterflag, error) {
-		for idx, child := range needle.children {
-			if child.String() == nodeId {
-				// remove the child
-				needle.children = append(needle.children[:idx], needle.children[idx+1:]...)
-				log.Debugf("Removing %s from parent (%s children : %#q)", nodeId, needle.String(), needle.children)
-				deleted = true
-				return STOP, nil
-			}
+	for idx, child := range parent.children {
+		if child.String() == nodeId {
+			parent.children = append(parent.children[:idx], parent.children[idx+1:]...)
+			deleted = true
 		}
-
-		// continue iterating
-		return NOOP, nil
-	})
-
-	if err != nil {
-		return nil, err
 	}
 
 	if !deleted {
-		err = fmt.Errorf("%s not found in tree", nodeId)
+		err := fmt.Errorf("%s not found in tree", nodeId)
 		log.Errorf("%s", err)
 		return nil, err
 	}
 
+	// remove from the lookup table
 	delete(i.lookupTable, nodeId)
+	n.parent = nil
 
 	return n.Node, nil
 }

--- a/pkg/index/index_test.go
+++ b/pkg/index/index_test.go
@@ -1,0 +1,183 @@
+// Copyright 2016 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package index
+
+import (
+	"strconv"
+	"sync"
+	"testing"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+)
+
+type mockEntry struct {
+	number int
+}
+
+func newMockEntry(n int) *mockEntry {
+	return &mockEntry{
+		number: n,
+	}
+}
+
+func (m *mockEntry) String() string {
+	return strconv.Itoa(m.number)
+}
+
+func (m *mockEntry) Copy() Node {
+	return &mockEntry{
+		number: m.number,
+	}
+}
+
+func TestInsertAndGet(t *testing.T) {
+	i := NewIndex()
+	root := newMockEntry(0)
+	err := i.Insert(root.String(), root)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	max := 10
+
+	// insert
+	for n := 1; n < max; n++ {
+		err = i.Insert(strconv.Itoa(n-1), newMockEntry(n))
+		if !assert.NoError(t, err) {
+			return
+		}
+	}
+
+	// add an entry that already exists
+	err = i.Insert("1", newMockEntry(1))
+	if !assert.Error(t, err) {
+		return
+	}
+
+	// check children
+	for _, node := range i.lookupTable {
+		if node.String() != "9" && !assert.True(t, len(node.children) > 0) {
+			return
+		}
+	}
+
+	// Now get
+	wg := sync.WaitGroup{}
+	wg.Add(max)
+	for idx := 0; idx < max; idx++ {
+		go func(idx int) {
+			defer wg.Done()
+			_, err := i.Get(strconv.Itoa(idx))
+			if !assert.NoError(t, err) {
+				return
+			}
+		}(idx)
+	}
+	wg.Wait()
+}
+
+func TestBFS(t *testing.T) {
+	i := NewIndex()
+
+	root := newMockEntry(0)
+
+	i.Insert(root.String(), root)
+
+	branches := 10
+	expectedNodes := createTree(t, i, branches)
+	expectedNodes[0] = root
+
+	var count int
+	err := i.bfs(i.root, func(n Node) (iterflag, error) {
+		mynode := n.(*mockEntry)
+		t.Logf("%#v\n", mynode)
+
+		// will point to different elements but check their values
+		assert.Equal(t, expectedNodes[mynode.number], mynode)
+		count++
+		return NOOP, nil
+	})
+
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	if !assert.Equal(t, (4*(branches-1))+1, count) {
+		return
+	}
+}
+
+func TestDelete(t *testing.T) {
+	logrus.SetLevel(logrus.DebugLevel)
+	i := NewIndex()
+
+	root := newMockEntry(0)
+
+	i.Insert(root.String(), root)
+
+	branches := 10
+	expectedNodes := createTree(t, i, branches)
+	expectedNodes[0] = root
+
+	// is a leaf, should delete without issue
+	n, err := i.Delete("9000")
+	if !assert.NoError(t, err) || !assert.NotNil(t, n) {
+		return
+	}
+
+	// check it's gone
+	_, ok := i.lookupTable["9000"]
+	if !assert.False(t, ok) {
+		return
+	}
+
+	// isn't a leaf, should throw an error
+	n, err = i.Delete("9")
+	if !assert.Error(t, err) || !assert.Nil(t, n) {
+		return
+	}
+
+	// isn't in the index
+	n, err = i.Delete("foo")
+	if !assert.Error(t, err) || !assert.Nil(t, n) {
+		return
+	}
+}
+
+func createTree(t *testing.T, i *Index, count int) map[int]*mockEntry {
+	expectedNodes := make(map[int]*mockEntry)
+
+	insert := func(id int, n *mockEntry) {
+		if !assert.NoError(t, i.Insert(strconv.Itoa(id), n)) {
+			return
+		}
+	}
+
+	// insert and create 3 children for each branch
+	for n := 1; n < count; n++ {
+		expectedNodes[n] = newMockEntry(n)
+		expectedNodes[n*10] = newMockEntry(n * 10)
+		expectedNodes[n*100] = newMockEntry(n * 100)
+		expectedNodes[n*1000] = newMockEntry(n * 1000)
+
+		insert(0, expectedNodes[n])
+		insert(n, expectedNodes[n*10])
+		insert(n, expectedNodes[n*100])
+		insert(n, expectedNodes[n*1000])
+	}
+
+	return expectedNodes
+}

--- a/pkg/index/index_test.go
+++ b/pkg/index/index_test.go
@@ -35,7 +35,7 @@ func newMockEntry(n, parent int) *mockEntry {
 	}
 }
 
-func (m *mockEntry) String() string {
+func (m *mockEntry) Self() string {
 	return strconv.Itoa(m.number)
 }
 
@@ -43,7 +43,7 @@ func (m *mockEntry) Parent() string {
 	return strconv.Itoa(m.parent)
 }
 
-func (m *mockEntry) Copy() Node {
+func (m *mockEntry) Copy() Element {
 	return &mockEntry{
 		number: m.number,
 		parent: m.parent,
@@ -76,7 +76,7 @@ func TestInsertAndGet(t *testing.T) {
 
 	// check children
 	for _, node := range i.lookupTable {
-		if node.String() != "9" && !assert.True(t, len(node.children) > 0) {
+		if node.Self() != "9" && !assert.True(t, len(node.children) > 0) {
 			return
 		}
 	}
@@ -109,7 +109,7 @@ func TestBFS(t *testing.T) {
 	expectedNodes[0] = root
 
 	var count int
-	err := i.bfs(i.root, func(n Node) (iterflag, error) {
+	err := i.bfs(i.root, func(n Element) (iterflag, error) {
 		mynode := n.(*mockEntry)
 		t.Logf("%#v\n", mynode)
 

--- a/pkg/index/index_test.go
+++ b/pkg/index/index_test.go
@@ -132,6 +132,12 @@ func TestDelete(t *testing.T) {
 	expectedNodes := createTree(t, i, branches)
 	expectedNodes[0] = root
 
+	// list what we added
+	before, err := i.List()
+	if !assert.NoError(t, err) || !assert.True(t, len(before) > 0) {
+		return
+	}
+
 	// is a leaf, should delete without issue
 	n, err := i.Delete("9000")
 	if !assert.NoError(t, err) || !assert.NotNil(t, n) {
@@ -153,6 +159,12 @@ func TestDelete(t *testing.T) {
 	// isn't in the index
 	n, err = i.Delete("foo")
 	if !assert.Error(t, err) || !assert.Nil(t, n) {
+		return
+	}
+
+	// list once more and make sure we nuked the image
+	after, err := i.List()
+	if !assert.NoError(t, err) || !assert.Equal(t, len(before), len(after)+1) {
 		return
 	}
 }


### PR DESCRIPTION
This index will replace the map in the storage layer used to cache images.  By replacing the map with this index, we'll be able to support `rmi`.