### PR TITLE
Improve UI installer

### DIFF
--- a/ui/installer/vCenterForWindows/configs
+++ b/ui/installer/vCenterForWindows/configs
@@ -17,4 +17,5 @@ SET sftp_username=
 SET sftp_password=
 
 REM Location of C:\ProgramData\VMware\vCenterServer\cfg\vsphere-client\vc-packages\vsphere-serenity relative to the root of SFTP connection
+REM Note: If you are running vCenter 5.5 Windows, the location should point to C:\ProgramData\VMware\vSphere Web Client\vc-packages\vsphere-serenity
 SET target_vc_packages_path=/vsphere-client/vc-packages/vsphere-client-serenity/

--- a/ui/installer/vCenterForWindows/install.bat
+++ b/ui/installer/vCenterForWindows/install.bat
@@ -44,7 +44,7 @@ IF [%1] == [--force] (
 
 IF /I %vic_ui_host_url% NEQ NOURL (
     IF /I %vic_ui_host_url:~0,5%==https (
-        SET vcenter_reg_common_flags=%vcenter_reg_common_flags% --serverThumbprint %vic_ui_host_thumbprint%
+        SET vcenter_reg_common_flags=%vcenter_reg_common_flags% --server-thumbprint %vic_ui_host_thumbprint%
     )
 
     IF %vic_ui_host_url:~-1,1% NEQ / (
@@ -56,6 +56,7 @@ IF /I %vic_ui_host_url% NEQ NOURL (
         "%utils_path%winscp.com" /command "open -hostkey=* sftp://%sftp_username%:%sftp_password%@%target_vcenter_ip%" "put -filemask=|*.zip ..\vsphere-client-serenity\* %target_vc_packages_path%" "exit"
     ) ELSE (
         ECHO SFTP not enabled. You have to manually copy the com.vmware.vicui.* folder in \ui\vsphere-client-serenity to %VMWARE_CFG_DIR%\vsphere-client\vc-packages\vsphere-client-serenity
+        ECHO Note: If you are running vCenter 5.5 Windows, copy the folder to %PROGRAMDATA%\VMware\vSphere Web Client\vc-packages\vsphere-client-serenity
     )
 )
 


### PR DESCRIPTION
This PR improves the UI installer in that:

1. It does not ask whether or not the VC version is 5.5 when installing VIC UI through the standard plugin deployment procedure (using a web server) The reason for checking the VC version is that 5.5 has a different folder structure for storing Web Client plugin contents than in 6.0+, and the user doesn't need to care about this when deploying the plugin with the standard method.
2. The flag used for specifying a server thumbprint flag in VIC UI registration is changed from --serverThumbprint to --server-thumbprint. (See #2048)
3. Removed an unnecessary check on whether the plugin extension was registered successfully with VC