### PR TITLE
Move image store creation to docker persona startup

### DIFF
--- a/cmd/imagec/imagec.go
+++ b/cmd/imagec/imagec.go
@@ -270,12 +270,6 @@ func ImagesToDownload(manifest *Manifest, storeName string) ([]*ImageWithMeta, *
 		return images, nil, nil
 	}
 
-	// Create the image store just in case
-	err := CreateImageStore(storeName)
-	if err != nil {
-		return nil, nil, fmt.Errorf("Failed to create image store: %s", err)
-	}
-
 	// Get the list of known images from the storage layer
 	existingImages, err := ListImages(storeName, images)
 	if err != nil {
@@ -333,7 +327,7 @@ func updateImageMetadata(imageLayer *ImageWithMeta, manifest *Manifest) error {
 
 		imageMeta := &metadata.ImageConfig{}
 		// tag / digest info only resides in the metadata so must unmarshall meta to determine
-		if err := json.Unmarshal([]byte(existingImage.Metadata[MetaDataKey]), imageMeta); err != nil {
+		if err := json.Unmarshal([]byte(existingImage.Metadata[metadata.MetaDataKey]), imageMeta); err != nil {
 			return fmt.Errorf("updateImageMetadata failed to get existing metadata: Layer(%s) %s", id, err)
 		}
 

--- a/cmd/imagec/imagec_test.go
+++ b/cmd/imagec/imagec_test.go
@@ -348,29 +348,6 @@ func TestPingPortLayer(t *testing.T) {
 	}
 }
 
-func TestCreateImageStore(t *testing.T) {
-	s := httptest.NewServer(
-		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(http.StatusCreated)
-
-			resp := `
-			{
-				"code":201,"url":"http://Photon/storage/PetStore"
-			}
-			`
-			w.Write([]byte(resp))
-		}))
-	defer s.Close()
-
-	options.host = s.URL[7:]
-
-	err := CreateImageStore(Storename)
-	if err != nil {
-		t.Errorf(err.Error())
-	}
-}
-
 func TestListImages(t *testing.T) {
 	s := httptest.NewServer(
 		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/cmd/imagec/storage.go
+++ b/cmd/imagec/storage.go
@@ -28,11 +28,8 @@ import (
 	"github.com/vmware/vic/lib/apiservers/portlayer/client/misc"
 	"github.com/vmware/vic/lib/apiservers/portlayer/client/storage"
 	"github.com/vmware/vic/lib/apiservers/portlayer/models"
+	"github.com/vmware/vic/lib/metadata"
 	"github.com/vmware/vic/pkg/trace"
-)
-
-const (
-	MetaDataKey = "metaData"
 )
 
 var (
@@ -51,34 +48,6 @@ func PingPortLayer() (bool, error) {
 		return false, err
 	}
 	return ok.Payload == "OK", nil
-}
-
-// CreateImageStore creates an image store
-func CreateImageStore(storename string) error {
-	defer trace.End(trace.Begin(storename))
-
-	transport := httptransport.New(options.host, "/", []string{"http"})
-	client := apiclient.New(transport, nil)
-
-	log.Debugf("Creating a store from input %s", storename)
-
-	body := &models.ImageStore{Name: storename}
-
-	_, err := client.Storage.CreateImageStore(
-		storage.NewCreateImageStoreParamsWithContext(ctx).WithBody(body),
-	)
-	if _, ok := err.(*storage.CreateImageStoreConflict); ok {
-		log.Debugf("Store already exists")
-		return nil
-	}
-	if err != nil {
-		log.Debugf("Creating a store failed: %s", err)
-
-		return err
-	}
-	log.Debugf("Created a store %#v", body)
-
-	return nil
 }
 
 // ListImages lists the images from given image store
@@ -124,7 +93,7 @@ func WriteImage(image *ImageWithMeta, data io.ReadCloser) error {
 	key := new(string)
 	blob := new(string)
 
-	*key = MetaDataKey
+	*key = metadata.MetaDataKey
 	*blob = image.meta
 
 	r, err := client.Storage.WriteImage(

--- a/lib/metadata/image_config.go
+++ b/lib/metadata/image_config.go
@@ -18,6 +18,11 @@ import (
 	docker "github.com/docker/docker/image"
 )
 
+const (
+	// MetaDataKey specifies the key that maps to metadata blobs in the portlayer
+	MetaDataKey = "metaData"
+)
+
 // ImageConfig contains configuration data describing images and their layers
 type ImageConfig struct {
 	docker.V1Image


### PR DESCRIPTION
This removes the image store creation step from imagec and the image cache's `Update()` and places it at the persona startup. It will retry 5 times for a total of 10 seconds, and will move on if the store already exists (in the case of a persona restart, for example). The image store must be created before the persona can start serving requests.

Paging @fdawg4l, @mhagen-vmware 

Fixes #2092, #2069 