### PR TITLE
Populate VCH status on VIC admin page

### DIFF
--- a/isos/vicadmin/dashboard.html
+++ b/isos/vicadmin/dashboard.html
@@ -44,8 +44,8 @@
               <div class="card card-block">
                 <h3 class="card-title">Status</h3>
                 <div class="row">
-                  <div class="sixty">Containers</div>
-                  <div class="fourty"><i class="icon-ok"></i></div>
+                  <div class="sixty">Virtual Container Host (VCH){{.VCHIssues}}</div>
+                  <div class="fourty">{{.VCHStatus}}</i></div>
                 </div>
                 <div class="row">
                   <div class="sixty">Network Connectivity{{.NetworkIssues}}</div>
@@ -54,10 +54,6 @@
                 <div class="row">
                   <div class="sixty">Firewall{{.FirewallIssues}}</div>
                   <div class="fourty">{{.FirewallStatus}}</div>
-                </div>
-                <div class="row">
-                  <div class="sixty">Virtual Container Host (VCH)</div>
-                  <div class="fourty"><i class="icon-ok"></i></div>
                 </div>
                 <div class="row">
                   <div class="sixty">License{{.LicenseIssues}}</div>

--- a/lib/tether/tether_darwin.go
+++ b/lib/tether/tether_darwin.go
@@ -24,6 +24,10 @@ import (
 	"github.com/vmware/vic/pkg/trace"
 )
 
+const (
+	PIDFileDir = "/var/run"
+)
+
 // Mkdev will hopefully get rolled into go.sys at some point
 func Mkdev(majorNumber int, minorNumber int) int {
 	return (majorNumber << 8) | (minorNumber & 0xff) | ((minorNumber & 0xfff00) << 12)

--- a/lib/tether/tether_linux.go
+++ b/lib/tether/tether_linux.go
@@ -31,6 +31,7 @@ import (
 const (
 	//https://github.com/golang/go/blob/master/src/syscall/zerrors_linux_arm64.go#L919
 	SetChildSubreaper = 0x24
+	PIDFileDir        = "/var/run"
 )
 
 // Mkdev will hopefully get rolled into go.sys at some point

--- a/lib/tether/tether_windows.go
+++ b/lib/tether/tether_windows.go
@@ -23,6 +23,10 @@ import (
 	"github.com/vmware/vic/pkg/trace"
 )
 
+const (
+	PIDFileDir = "C:\\Temp"
+)
+
 func (t *tether) childReaper() error {
 	// TODO: windows child process notifications
 	return errors.New("Child reaping unimplemented on windows")


### PR DESCRIPTION
Fixes #1229

This populates the "VCH Status" health check on the VICadmin page by verifying that "vic-init" and all proceses defined in the VirtualContainerHostConfigSpec.ExecutorConfig are currently running.  If any processes are not running, the green check changes to an orange warning triangle, and a warning message indicating that that particular process is not running is published on the vicadmin page.

