### PR TITLE
Prevent childreaper reaping comparison execs

### DIFF
--- a/cmd/vic-init/restart_test.go
+++ b/cmd/vic-init/restart_test.go
@@ -90,6 +90,10 @@ func TestRestart(t *testing.T) {
 	// read the output from the session
 	log := Mocked.SessionLogBuffer.Bytes()
 
+	// the tether has to be stopped before comparison on the reaper may swaller exec.Wait
+	tthr.Stop()
+	<-Mocked.Cleaned
+
 	// run the command directly
 	out, err := exec.Command("/bin/date", "--reference=/").Output()
 	if err != nil {

--- a/lib/tether/cmd_test.go
+++ b/lib/tether/cmd_test.go
@@ -147,6 +147,9 @@ func TestAbsPath(t *testing.T) {
 	// read the output from the session
 	log := mocker.SessionLogBuffer.Bytes()
 
+	// block until tether exits
+	<-mocker.Cleaned
+
 	// run the command directly
 	out, err := exec.Command("/bin/date", "--reference=/").Output()
 	if err != nil {


### PR DESCRIPTION
The child reaper portion of the tether could reap the comparison
executions as zombies before the os.Wait call was invoked.
This resulted in "wait: no child processes" errors.

We simply ensure that the tether is stopped before running the comparison

Fixes #2090 #2095
