### PR TITLE
WIP: Support docker run from custom registries [full ci]

### DIFF
--- a/cmd/imagec/imagec.go
+++ b/cmd/imagec/imagec.go
@@ -674,12 +674,7 @@ func main() {
 		log.Debugf("Running standalone")
 	}
 
-	// track whether the image is from a custom registry or not
 	registryURL := fmt.Sprintf("%s/", options.registry)
-	defaultRegistry := true
-	if options.registry != DefaultDockerURL {
-		defaultRegistry = false
-	}
 
 	// Calculate (and overwrite) the registry URL and make sure that it responds to requests
 	options.registry, err = LearnRegistryURL(options)
@@ -705,12 +700,7 @@ func main() {
 	// HACK: Required to learn the name of the vmdk from given reference
 	// Used by docker personality until metadata support lands
 	if !options.resolv {
-		if defaultRegistry {
-			progress.Message(po, "", "Pulling from "+options.image)
-		} else {
-			// prepend the custom registry URL
-			progress.Message(po, "", "Pulling from "+registryURL+options.image)
-		}
+		progress.Message(po, "", "Pulling from "+options.image)
 	}
 
 	// Get the manifest

--- a/lib/apiservers/engine/backends/cache/image_cache.go
+++ b/lib/apiservers/engine/backends/cache/image_cache.go
@@ -211,24 +211,25 @@ func (ic *ICache) AddImage(imageConfig *metadata.ImageConfig) {
 
 	for _, tag := range imageConfig.Tags {
 		ref, err = reference.WithTag(ref, tag)
-
 		if err != nil {
 			log.Errorf("Tried to create tagged reference from %s and tag %s: %s", imageConfig.Name, tag, err.Error())
 			return
 		}
 
 		if tagged, ok := ref.(reference.NamedTagged); ok {
-			taggedName := fmt.Sprintf("%s:%s", tagged.Name(), tagged.Tag())
 			if imageConfig.Registry == DefaultDockerRegistry {
+				taggedName := fmt.Sprintf("%s:%s", tagged.Name(), tagged.Tag())
 				ic.cacheByName[taggedName] = imageConfig
 			} else {
 				// prepend the registry URL for a custom registry image
-				ic.cacheByName[imageConfig.Registry+taggedName] = imageConfig
+				fullTaggedName := fmt.Sprintf("%s%s:%s", imageConfig.Registry, tagged.RemoteName(), tagged.Tag())
+				ic.cacheByName[fullTaggedName] = imageConfig
 			}
 		} else {
 			ic.cacheByName[ref.Name()] = imageConfig
 		}
 	}
+
 }
 
 // copyImageConfig performs and returns deep copy of an ImageConfig struct

--- a/lib/apiservers/engine/backends/image.go
+++ b/lib/apiservers/engine/backends/image.go
@@ -180,7 +180,7 @@ func convertV1ImageToDockerImage(image *metadata.ImageConfig) *types.Image {
 	return &types.Image{
 		ID:          image.ImageID,
 		ParentID:    image.Parent,
-		RepoTags:    clientFriendlyTags(image.Name, image.Tags),
+		RepoTags:    clientFriendlyTags(image.Registry, image.Name, image.Tags),
 		RepoDigests: clientFriendlyDigests(image.Name, image.Digests),
 		Created:     image.Created.Unix(),
 		Size:        image.Size,
@@ -208,7 +208,7 @@ func imageConfigToDockerImageInspect(imageConfig *metadata.ImageConfig, productN
 	}
 
 	inspectData := &types.ImageInspect{
-		RepoTags:        clientFriendlyTags(imageConfig.Name, imageConfig.Tags),
+		RepoTags:        clientFriendlyTags(imageConfig.Registry, imageConfig.Name, imageConfig.Tags),
 		RepoDigests:     clientFriendlyDigests(imageConfig.Name, imageConfig.Digests),
 		Parent:          imageConfig.Parent,
 		Comment:         imageConfig.Comment,
@@ -234,6 +234,8 @@ func imageConfigToDockerImageInspect(imageConfig *metadata.ImageConfig, productN
 	return inspectData
 }
 
+const DefaultDockerRegistry = "registry-1.docker.io/"
+
 /*
 	function will take the array of image tags (1.24,1.24.1,latest, etc)
 	and create a new array of tags that are supported by the docker client
@@ -247,11 +249,16 @@ func imageConfigToDockerImageInspect(imageConfig *metadata.ImageConfig, productN
 	image
 */
 
-func clientFriendlyTags(imageName string, tags []string) []string {
+func clientFriendlyTags(registryURL string, imageName string, tags []string) []string {
 	clientTags := make([]string, len(tags))
 	if len(tags) > 0 {
 		for index, tag := range tags {
-			clientTags[index] = fmt.Sprintf("%s:%s", imageName, tag)
+			if registryURL == DefaultDockerRegistry {
+				clientTags[index] = fmt.Sprintf("%s:%s", imageName, tag)
+			} else {
+				// prepend the registry URL for a custom registry image
+				clientTags[index] = fmt.Sprintf("%s%s:%s", registryURL, imageName, tag)
+			}
 		}
 	} else {
 		clientTags = append(clientTags, fmt.Sprintf("%s:%s", "<none>", "<none>"))

--- a/lib/apiservers/engine/backends/image.go
+++ b/lib/apiservers/engine/backends/image.go
@@ -234,8 +234,6 @@ func imageConfigToDockerImageInspect(imageConfig *metadata.ImageConfig, productN
 	return inspectData
 }
 
-const DefaultDockerRegistry = "registry-1.docker.io/"
-
 /*
 	function will take the array of image tags (1.24,1.24.1,latest, etc)
 	and create a new array of tags that are supported by the docker client
@@ -253,7 +251,7 @@ func clientFriendlyTags(registryURL string, imageName string, tags []string) []s
 	clientTags := make([]string, len(tags))
 	if len(tags) > 0 {
 		for index, tag := range tags {
-			if registryURL == DefaultDockerRegistry {
+			if registryURL == cache.DefaultDockerRegistry {
 				clientTags[index] = fmt.Sprintf("%s:%s", imageName, tag)
 			} else {
 				// prepend the registry URL for a custom registry image

--- a/lib/apiservers/engine/backends/image_test.go
+++ b/lib/apiservers/engine/backends/image_test.go
@@ -65,13 +65,20 @@ func TestConvertV1ImageToDockerImage(t *testing.T) {
 func TestClientFriendlyTags(t *testing.T) {
 	imageName := "busybox"
 	tags := []string{"1.24.2", "latest"}
+	defaultRegistry := "registry-1.docker.io/"
+	customRegistry := "custom.reg.com/"
 
-	friendlyTags := clientFriendlyTags(imageName, tags)
-	assert.Equal(t, len(friendlyTags), len(tags), "Error: expected %d tags, got %d", len(tags), len(friendlyTags))
-	assert.Equal(t, friendlyTags[0], "busybox:1.24.2", "Error: expected %s, got %s", "busybox:1.24.2", friendlyTags[0])
-	assert.Equal(t, friendlyTags[1], "busybox:latest", "Error: expected %s, got %s", "busybox:latest", friendlyTags[1])
+	defaultFriendlyTags := clientFriendlyTags(defaultRegistry, imageName, tags)
+	assert.Equal(t, len(defaultFriendlyTags), len(tags), "Error: expected %d tags, got %d", len(tags), len(defaultFriendlyTags))
+	assert.Equal(t, defaultFriendlyTags[0], "busybox:1.24.2", "Error: expected %s, got %s", "busybox:1.24.2", defaultFriendlyTags[0])
+	assert.Equal(t, defaultFriendlyTags[1], "busybox:latest", "Error: expected %s, got %s", "busybox:latest", defaultFriendlyTags[1])
 
-	emptyTags := clientFriendlyTags(imageName, []string{})
+	customFriendlyTags := clientFriendlyTags(customRegistry, imageName, tags)
+	assert.Equal(t, len(customFriendlyTags), len(tags), "Error: expected %d tags, got %d", len(tags), len(customFriendlyTags))
+	assert.Equal(t, customFriendlyTags[0], "custom.reg.com/busybox:1.24.2", "Error: expected %s, got %s", "custom.reg.com/busybox:1.24.2", customFriendlyTags[0])
+	assert.Equal(t, customFriendlyTags[1], "custom.reg.com/busybox:latest", "Error: expected %s, got %s", "custom.reg.com/busybox:latest", customFriendlyTags[1])
+
+	emptyTags := clientFriendlyTags(defaultRegistry, imageName, []string{})
 	assert.Equal(t, len(emptyTags), 1, "Error: expected %d tags, got %d", 1, len(emptyTags))
 	assert.Equal(t, emptyTags[0], "<none>:<none>", "Error: expected %s tags, got %s", "<none>:<none>", emptyTags[0])
 

--- a/lib/metadata/image_config.go
+++ b/lib/metadata/image_config.go
@@ -28,10 +28,11 @@ type ImageConfig struct {
 	docker.V1Image
 
 	// image specific data
-	ImageID string            `json:"image_id"`
-	Digests []string          `json:"digests,omitempty"`
-	Tags    []string          `json:"tags,omitempty"`
-	Name    string            `json:"name,omitempty"`
-	DiffIDs map[string]string `json:"diff_ids,omitempty"`
-	History []docker.History  `json:"history,omitempty"`
+	ImageID  string            `json:"image_id"`
+	Digests  []string          `json:"digests,omitempty"`
+	Tags     []string          `json:"tags,omitempty"`
+	Name     string            `json:"name,omitempty"`
+	DiffIDs  map[string]string `json:"diff_ids,omitempty"`
+	History  []docker.History  `json:"history,omitempty"`
+	Registry string            `json:"registry"`
 }

--- a/tests/test-cases/Group1-Docker-Commands/1-2-Docker-Pull.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-2-Docker-Pull.robot
@@ -31,6 +31,9 @@ Pull non-default tag
 Pull an image based on digest
     Wait Until Keyword Succeeds  5x  15 seconds  Pull image  nginx@sha256:7281cf7c854b0dfc7c68a6a4de9a785a973a14f1481bc028e2022bcd6a8d9f64
 
+Pull an image with the full docker registry URL
+    Wait Until Keyword Succeeds  5x  15 seconds  Pull image  registry.hub.docker.com/library/hello-world
+
 Pull an image from non-default repo
     #${result}=  Run Process  docker run -d -p 5000:5000 --name registry registry:2  shell=True
     #Log to console  ${result.stdout}


### PR DESCRIPTION
Changes the image cache's `cacheByName` index to pull and run images from private registries. 

**Limitation - doesn't yet support pulling and running the same image from different registries.**

Tested VIC output:
```
$ docker -H 192.168.77.130:2376 --tls pull 192.168.77.128:5000/busybox
Using default tag: latest
Pulling from 192.168.77.128:5000/busybox
a3ed95caeb02: Pull complete 
8ddc19f16526: Pull complete 
Digest: sha256:2130edda90b78fc58d77ecb1c4a512b08942dd7156fafcd5f9890bc08b1dc954
Status: Downloaded newer image for busybox:latest
anchala@ubuntu:~/go/src/github.com/vmware/vic$ docker -H 192.168.77.130:2376 --tls pull hello-world
Using default tag: latest
Pulling from library/hello-world
a3ed95caeb02: Pull complete 
c04b14da8d14: Pull complete 
Digest: sha256:548e9719abe62684ac7f01eea38cb5b0cf467cfe67c58b83fe87ba96674a4cdd
Status: Downloaded newer image for library/hello-world:latest
anchala@ubuntu:~/go/src/github.com/vmware/vic$ docker -H 192.168.77.130:2376 --tls images
REPOSITORY                    TAG                 IMAGE ID            CREATED             SIZE
hello-world                   latest              723aa7d39e9d        7 weeks ago         1.848 kB
192.168.77.128:5000/busybox   latest              332de81782ef        8 weeks ago         1.093 MB
anchala@ubuntu:~/go/src/github.com/vmware/vic$ docker -H 192.168.77.130:2376 --tls run -it 192.168.77.128:5000/busybox
/ # exit
anchala@ubuntu:~/go/src/github.com/vmware/vic$ docker -H 192.168.77.130:2376 --tls run -d hello-world
6fc6453d16678c48bc9ae04713c0ca3605e0a7667704040937bef036fde4e253
```

Partially fixes #1638

