### PR TITLE
Makes sure valid volume/image stores provided

### DIFF
--- a/lib/install/validate/storage.go
+++ b/lib/install/validate/storage.go
@@ -58,14 +58,10 @@ func (v *Validator) storage(ctx context.Context, input *data.Data, conf *config.
 
 	// TODO: add volume locations
 	for label, volDSpath := range input.VolumeLocations {
-		dsURL, vds, err := v.DatastoreHelper(ctx, volDSpath, label, "--volume-store")
+		dsURL, _, err := v.DatastoreHelper(ctx, volDSpath, label, "--volume-store")
 		v.NoteIssue(err)
 		if dsURL != nil {
 			conf.VolumeLocations[label] = dsURL
-		}
-
-		if !v.targetDatastoreIsWriteable(ctx, vds) {
-			return
 		}
 	}
 }

--- a/lib/install/validate/storage.go
+++ b/lib/install/validate/storage.go
@@ -52,11 +52,6 @@ func (v *Validator) storage(ctx context.Context, input *data.Data, conf *config.
 		v.SetDatastore(ds, imageDSpath)
 		conf.AddImageStore(imageDSpath)
 	}
-
-	if !v.targetDatastoreIsWriteable(ctx, ds) {
-		return
-	}
-
 	if conf.VolumeLocations == nil {
 		conf.VolumeLocations = make(map[string]*url.URL)
 	}
@@ -183,62 +178,4 @@ func (v *Validator) suggestDatastore(path string, label string, flag string) {
 			log.Infof("  %q", d)
 		}
 	}
-}
-
-// checks if a given datastore ds is writeable by compute resource specified on cmd line --compute-resource
-func (v *Validator) targetDatastoreIsWriteable(ctx context.Context, ds *object.Datastore) bool {
-	defer trace.End(trace.Begin(ds.String()))
-
-	// get compute hosts if we haven't run this method on this object before
-	if len(v.computeHosts) == 0 {
-		var err error
-		v.computeHosts, err = v.Session.Cluster.Hosts(ctx)
-		if err != nil {
-			v.NoteIssue(err)
-			return false
-		}
-		// v.computeHosts shouldn't be zero anymore; if it still is, there's a problem
-		if len(v.computeHosts) == 0 {
-			v.NoteIssue(errors.New("Couldn't get list of hosts connected to target cluster"))
-			return false
-		}
-	}
-
-	// now get hosts connected to ds
-	attachedHosts, err := ds.AttachedClusterHosts(ctx, v.Session.Cluster)
-	if err != nil {
-		v.NoteIssue(err)
-		return false
-	}
-
-	if len(attachedHosts) == 0 {
-		// this could mean that we're not operating on a cluster..
-		log.Debugf("AttachedClusterHosts returned nothing; searching for unclustered hosts connected to datastore %s", ds.String())
-		attachedHosts, err := ds.AttachedHosts(ctx)
-
-		if err != nil {
-			v.NoteIssue(err)
-			return false
-		}
-
-		if len(attachedHosts) == 0 {
-			// shouldn't be possible to wind up here, but we should get an error message if we do ¯\_(ツ)_/¯
-			v.NoteIssue(errors.Errorf("No attached hosts found for datastore %s", ds.String()))
-			return false
-		}
-	}
-
-	// find a common host in the two lists
-	for _, c := range v.computeHosts {
-		for _, a := range attachedHosts {
-			if c.Reference() == a.Reference() {
-				return true
-			}
-		}
-	}
-
-	// no common host found -- erroneous user input
-	v.NoteIssue(errors.Errorf("Datastore %s is not writeable from the compute resource specified under --compute-resource", ds.String()))
-	return false
-
 }

--- a/lib/install/validate/storage.go
+++ b/lib/install/validate/storage.go
@@ -39,16 +39,22 @@ func (v *Validator) storage(ctx context.Context, input *data.Data, conf *config.
 		v.NoteIssue(err)
 		return
 	}
+	if err != nil {
+		v.NoteIssue(err)
+	}
 
 	// provide a default path if only a DS name is provided
 	if imageDSpath.Path == "" {
 		imageDSpath.Path = input.DisplayName
 	}
 
-	v.NoteIssue(err)
 	if ds != nil {
 		v.SetDatastore(ds, imageDSpath)
 		conf.AddImageStore(imageDSpath)
+	}
+
+	if !v.targetDatastoreIsWriteable(ctx, ds) {
+		return
 	}
 
 	if conf.VolumeLocations == nil {
@@ -57,10 +63,14 @@ func (v *Validator) storage(ctx context.Context, input *data.Data, conf *config.
 
 	// TODO: add volume locations
 	for label, volDSpath := range input.VolumeLocations {
-		dsURL, _, err := v.DatastoreHelper(ctx, volDSpath, label, "--volume-store")
+		dsURL, vds, err := v.DatastoreHelper(ctx, volDSpath, label, "--volume-store")
 		v.NoteIssue(err)
 		if dsURL != nil {
 			conf.VolumeLocations[label] = dsURL
+		}
+
+		if !v.targetDatastoreIsWriteable(ctx, vds) {
+			return
 		}
 	}
 }
@@ -173,4 +183,62 @@ func (v *Validator) suggestDatastore(path string, label string, flag string) {
 			log.Infof("  %q", d)
 		}
 	}
+}
+
+// checks if a given datastore ds is writeable by compute resource specified on cmd line --compute-resource
+func (v *Validator) targetDatastoreIsWriteable(ctx context.Context, ds *object.Datastore) bool {
+	defer trace.End(trace.Begin(ds.String()))
+
+	// get compute hosts if we haven't run this method on this object before
+	if len(v.computeHosts) == 0 {
+		var err error
+		v.computeHosts, err = v.Session.Cluster.Hosts(ctx)
+		if err != nil {
+			v.NoteIssue(err)
+			return false
+		}
+		// v.computeHosts shouldn't be zero anymore; if it still is, there's a problem
+		if len(v.computeHosts) == 0 {
+			v.NoteIssue(errors.New("Couldn't get list of hosts connected to target cluster"))
+			return false
+		}
+	}
+
+	// now get hosts connected to ds
+	attachedHosts, err := ds.AttachedClusterHosts(ctx, v.Session.Cluster)
+	if err != nil {
+		v.NoteIssue(err)
+		return false
+	}
+
+	if len(attachedHosts) == 0 {
+		// this could mean that we're not operating on a cluster..
+		log.Debugf("AttachedClusterHosts returned nothing; searching for unclustered hosts connected to datastore %s", ds.String())
+		attachedHosts, err := ds.AttachedHosts(ctx)
+
+		if err != nil {
+			v.NoteIssue(err)
+			return false
+		}
+
+		if len(attachedHosts) == 0 {
+			// shouldn't be possible to wind up here, but we should get an error message if we do ¯\_(ツ)_/¯
+			v.NoteIssue(errors.Errorf("No attached hosts found for datastore %s", ds.String()))
+			return false
+		}
+	}
+
+	// find a common host in the two lists
+	for _, c := range v.computeHosts {
+		for _, a := range attachedHosts {
+			if c.Reference() == a.Reference() {
+				return true
+			}
+		}
+	}
+
+	// no common host found -- erroneous user input
+	v.NoteIssue(errors.Errorf("Datastore %s is not writeable from the compute resource specified under --compute-resource", ds.String()))
+	return false
+
 }

--- a/lib/install/validate/storage.go
+++ b/lib/install/validate/storage.go
@@ -39,19 +39,18 @@ func (v *Validator) storage(ctx context.Context, input *data.Data, conf *config.
 		v.NoteIssue(err)
 		return
 	}
-	if err != nil {
-		v.NoteIssue(err)
-	}
 
 	// provide a default path if only a DS name is provided
 	if imageDSpath.Path == "" {
 		imageDSpath.Path = input.DisplayName
 	}
 
+	v.NoteIssue(err)
 	if ds != nil {
 		v.SetDatastore(ds, imageDSpath)
 		conf.AddImageStore(imageDSpath)
 	}
+
 	if conf.VolumeLocations == nil {
 		conf.VolumeLocations = make(map[string]*url.URL)
 	}

--- a/lib/install/validate/validator.go
+++ b/lib/install/validate/validator.go
@@ -23,6 +23,7 @@ import (
 	log "github.com/Sirupsen/logrus"
 	units "github.com/docker/go-units"
 	"github.com/vmware/govmomi/find"
+	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/vim25/mo"
 	"github.com/vmware/vic/lib/config"
 	"github.com/vmware/vic/lib/install/data"
@@ -48,8 +49,9 @@ type Validator struct {
 	Session *session.Session
 	Context context.Context
 
-	isVC   bool
-	issues []error
+	isVC         bool
+	issues       []error
+	computeHosts []*object.HostSystem
 
 	DisableFirewallCheck bool
 	DisableDRSCheck      bool

--- a/lib/install/validate/validator.go
+++ b/lib/install/validate/validator.go
@@ -376,20 +376,20 @@ func (v *Validator) compatibility(ctx context.Context, conf *config.VirtualConta
 			v.NoteIssue(err)
 		}
 		if len(datastores) != 1 {
-			// this is basically an assert, at this point DatastoreList should absolutely only return one result
+			// this is basically an assert; at this point DatastoreList should absolutely only return one result
 			v.NoteIssue(errors.Errorf("Looking up datastore %s returned %d results.", u.String(), len(datastores)))
 		}
 		if !v.isTargetDatastoreWriteable(ctx, datastores[0]) {
-			v.NoteIssue(error.Errorf("Datastore %s is not writeable by the compute resource provided by --compute-resource", u.String()))
+			v.NoteIssue(errors.Errorf("Datastore %s is not writeable by the compute resource provided by --compute-resource", u.String()))
 		}
 	}
 
 	// call above closure on each of the collections of datastores that we have in the config
 	for _, u := range conf.ImageStores {
-		checkDS(u)
+		checkDS(&u)
 	}
 	for _, u := range conf.ContainerStores {
-		checkDS(u)
+		checkDS(&u)
 	}
 
 	for _, u := range conf.VolumeLocations {


### PR DESCRIPTION
Right now, `vic-machine` will happily allow the user to create an image or volume store on a datastore that is not actually writable by the compute-resource. This change adds checks to `validator` to make sure that the datastore can be seen and written to by the compute-resource.

The bulk of the work here is done but I'm still in the process of verifying that everything works as expected in the three cases: VC w/o a cluster (works), VC w/ a cluster (pending), ESX (works)

Comments welcome while I work on testing :)

Fixes #1974 #2000 

