### PR TITLE
[skip ci] Doc updates for firewall, 5.5 support, shared storage

### DIFF
--- a/doc/user_doc/vic_installation/SUMMARY.md
+++ b/doc/user_doc/vic_installation/SUMMARY.md
@@ -18,3 +18,4 @@
 * [Troubleshooting vSphere Integrated Containers Installation](troubleshoot_vic_install.md)
   * [VCH Deployment Fails with Resource Pool Creation Error](ts_resource_pool_error.md)
   * [VCH Deployment Fails with Unknown or Non-Specified Argument Error or Incorrect User Name Error](ts_cli_argument_error.md)
+  * [VCH Deployment Fails with Firewall Validation Error](ts_firewall_error.md)

--- a/doc/user_doc/vic_installation/ts_firewall_error.md
+++ b/doc/user_doc/vic_installation/ts_firewall_error.md
@@ -1,0 +1,37 @@
+# VCH Deployment Fails with Firewall Validation Error #
+When you use `vic-machine create` to deploy a virtual container host, deployment fails because a firewall port 2377 is not open.
+
+## Problem ##
+Deployment fails with an error during the validation phase: 
+
+<pre>Firewall must permit 2377/tcp outbound to use VIC.</pre>
+
+## Cause ##
+ESXi hosts communicate with the virtual container hosts via port 2377. For deployment of a virtual container host to succeed, port 2377 must be open for outgoing connections on all all ESXi hosts before you run vic-machine create. Opening port 2377 for outgoing connections on ESXi hosts opens port 2377 for inbound connections on the virtual container hosts.
+
+## Solution ##
+
+In test environments, you can disable the firewalls on the ESXi hosts instead of opening port 2377. To disable the firewall, log into the ESXi hosts as ```root```, and run the following command: 
+   
+   ```$ esxcli network firewall set --enabled false``` 
+
+In production environments, if you are deploying to a standalone ESXi host, set a firewall ruleset on that ESXi host. If you are deploying to a cluster, set the firewall ruleset on all of the ESXi hosts in the cluster.
+
+**IMPORTANT**: Firewall rules that you set manually are not persistent. If you reboot the ESXi hosts, any firewall rules that you set are lost. You must recreate firewall rules each time you reboot a host.
+
+To set a firewall rule manually, log into each ESXi host via SSH and following the instructions in [VMware KB 2008226]( http://kb.vmware.com/selfservice/microsites/search.do?language=en_US&cmd=displayKC&externalId=2008226) to add the following rule after the last rule in the file ```/etc/vmware/firewall/service.xml```.
+<pre>
+&lt;service id='<i>id_number</i>'&gt;
+  &lt;id&gt;vicoutgoing&lt;/id&gt;
+  &lt;rule id='0000'&gt;
+    &lt;direction&gt;outbound&lt;/direction&gt;
+    &lt;protocol&gt;tcp&lt;/protocol&gt;
+    &lt;port type='dst'&gt;2377&lt;/port&gt;
+  &lt;/rule&gt;
+  &lt;enabled&gt;true&lt;/enabled&gt;
+  &lt;required&gt;true&lt;/required&gt;
+&lt;/service&gt;
+</pre>
+
+  
+In this example, *id_number* is the number of the preceding ruleset in ```service.xml```, incremented by 1.

--- a/doc/user_doc/vic_installation/vch_installer_options.md
+++ b/doc/user_doc/vic_installation/vch_installer_options.md
@@ -60,6 +60,8 @@ Short name: `-i`
 
 The datastore in which to store container image files. When you deploy a virtual container host, `vic-machine` creates a folder named `VIC` on the target datastore,  in which to store all of the container images that you pull into a virtual container host. The `vic-machine` utility also places the VM files for the virtual container host in the datastore that you designate as the image store, in a folder that has the same name as the virtual container host. 
 
+If you are deploying the virtual container host to a vCenter Server cluster, the datastore that you designate in the `image-store` option must be shared by all of the ESXi hosts in the cluster. Using non-shared datastores is possible, but limits the use of vSphere features such as DRS and High Availability.
+
 You can designate the same datastore as the image store for multiple virtual container hosts. In this case, only one `VIC` folder is created in the datastore and the container image files are made available to all of the virtual container hosts that use that image store.
 
 vSphere Integrated Containers supports all alphanumeric characters, hyphens, and underscores in datastore paths and datastore names, but no other special characters. 

--- a/doc/user_doc/vic_installation/vic_installation_prereqs.md
+++ b/doc/user_doc/vic_installation/vic_installation_prereqs.md
@@ -26,8 +26,8 @@ Deploying vSphere Integrated Containers to a vCenter Server instance that is run
 
 To be valid targets for virtual container hosts and container VMs, standalone ESXi hosts and all ESXi hosts in vCenter Server clusters must meet the following criteria:
 
-- All ESXi hosts must be attached to shared storage for use as container datastores, image datastores, and volume stores.
-- The firewall on all ESXi hosts must be configured to allow connections on the back channel.
+- All ESXi hosts must be attached to shared storage for use as container datastores, image datastores, and volume stores. Using non-shared datastores is possible, but limits the use of vSphere features such as DRS and High Availability. The use of VMware Virtual SAN datastores is fully supported.
+- The firewall on all ESXi hosts must be configured to allow connections on the back channel and to allow outbound connections on port 2377. For instruction about how to open port 2377 on ESXi hosts, see [VCH Deployment Fails with Firewall Validation Error](ts_firewall_error.md).
 - All ESXi hosts must be attached to the distributed virtual switch for the bridge network in vCenter Server. For more information about distributed virtual switches, see [Network Requirements](#networkreqs) below.
 - All ESXi hosts must be attached to any mapped vSphere networks.
 
@@ -45,10 +45,6 @@ All of the ESXi hosts in a cluster require an appropriate license. Installation 
 
 ## Role and Permissions Requirements
 You must use an account with the vSphere Administrator role when you install vSphere Integrated Containers.
-
-<a name="datastorereqs"></a>
-## Datastore Requirements
-All of the hosts in a vCenter Server cluster must have access to a shared datastore, in which to store container images. Using non-shared datastores is possible, but limits the use of vSphere features such as DRS and High Availability.
 
 <a name="networkreqs"></a>
 ## Network Requirements

--- a/doc/user_doc/vic_installation/vic_installation_prereqs.md
+++ b/doc/user_doc/vic_installation/vic_installation_prereqs.md
@@ -46,6 +46,10 @@ All of the ESXi hosts in a cluster require an appropriate license. Installation 
 ## Role and Permissions Requirements
 You must use an account with the vSphere Administrator role when you install vSphere Integrated Containers.
 
+<a name="datastorereqs"></a>
+## Datastore Requirements
+All of the hosts in a vCenter Server cluster must have access to a shared datastore, in which to store container images. Using non-shared datastores is possible, but limits the use of vSphere features such as DRS and High Availability.
+
 <a name="networkreqs"></a>
 ## Network Requirements
 * Use a trusted network for the deployment and use of vSphere Integrated Containers.
@@ -54,6 +58,7 @@ You must use an account with the vSphere Administrator role when you install vSp
  * One IP address, that can be either static or set by using DHCP.
  * One VLAN, if you use VLAN for network isolation.
  * One IP address for each container that you run with the `docker run --net=host` option.
-* In a vCenter Server environment, before you deploy a virtual container host, you must create a distributed virtual switch and a distributed port group. You must add the target ESXi host or hosts to the distributed virtual switch. 
+* Virtual container hosts require a network with DHCP for use as the external network. You can share this network between multiple virtual container hosts.
+* In a vCenter Server environment, before you deploy a virtual container host, you must create a distributed virtual switch with a distributed port group for each virtual container host. Container VMs that the virtual container host provisions connect to the port groups. You must add the target ESXi host or hosts to the distributed virtual switch. You can create multiple port groups on the same distributed virtual switch, but each virtual container host requires its own port group. 
  - For information about how to create a distributed port group, see [Create a vSphere Distributed Switch](https://pubs.vmware.com/vsphere-60/topic/com.vmware.vsphere.networking.doc/GUID-D21B3241-0AC9-437C-80B1-0C8043CC1D7D.html) in the vSphere 6.0 documentation.
  - For information about how to add hosts to a distributed virtual switch, see [Add Hosts to a vSphere Distributed Switch](https://pubs.vmware.com/vsphere-60/topic/com.vmware.vsphere.networking.doc/GUID-E90C1B0D-82CB-4A3D-BE1B-0FDCD6575725.html) in the vSphere 6.0 documentation.

--- a/doc/user_doc/vic_installation/vic_installation_prereqs.md
+++ b/doc/user_doc/vic_installation/vic_installation_prereqs.md
@@ -4,21 +4,22 @@ Before you install vSphere Integrated Containers, you must ensure that your infr
 
 ## Supported Platforms for `vic-machine` ##
 
-The vSphere Integrated Containers installation and management utility, `vic-machine`, has been tested and verified on the following Linux OS, Windows, and Mac OS systems.
+The vSphere Integrated Containers installation and management utility, `vic-machine`, has been tested and verified on the following Linux OS, Windows, Mac OS, and Photon OS systems. It is possible to use `vic-machine` on other platforms, but results are not guaranteed.
 
 |**Platform**|**Supported Versions**|
 |---|---|
 |Windows|7, 10|
 |Mac OS X |10.11 (El Capitan)|
-|Linux|Ubuntu 15.04, others TBD|
+|Linux|Ubuntu 15.04|
+|Photon OS|1.0|
 
 ## Supported vSphere Configurations ##
 
 You can install vSphere Integrated Containers in the following vSphere setups:
 
-* Standalone ESXi 6.0 host that is not managed by a vCenter Server instance.
-* vCenter Server 6.0, managing one or more standalone ESXi 6.0 hosts.
-* vCenter Server 6.0, managing a cluster of ESXi 6.0 hosts, with DRS enabled.
+* Standalone ESXi 5.5 or 6.0 host that is not managed by a vCenter Server instance.
+* vCenter Server 5.5 or 6.0, managing one or more standalone ESXi 5.5 or 6.0 hosts.
+* vCenter Server 5.5 or 6.0, managing a cluster of ESXi 5.5 or 6.0 hosts, with DRS enabled.
 
 Deploying vSphere Integrated Containers to a vCenter Server instance that is running in Enhanced Linked Mode is fully supported.  
 


### PR DESCRIPTION
- Fixes https://github.com/vmware/vic/issues/2135, VIC requires firewall port 2377.
- Fixes https://github.com/vmware/vic/issues/1996, image-store must be shared between all hosts in a cluster.
- Fixes https://github.com/vmware/vic/issues/1900, support for vCenter Server 5.5. 

@hmahmood, for the info about port 2377, could you please look at the section on [ESX Host Requirements](https://github.com/stuclem/vic/blob/master/doc/user_doc/vic_installation/vic_installation_prereqs.md#esxi-host-requirements) and [VCH Deployment Fails with Firewall Validation Error](https://github.com/stuclem/vic/blob/master/doc/user_doc/vic_installation/ts_firewall_error.md)?

@emlin, can you please check the info on shared datastores in [ESX Host Requirements](https://github.com/stuclem/vic/blob/master/doc/user_doc/vic_installation/vic_installation_prereqs.md#esxi-host-requirements) and in the doc for the [image-store](https://github.com/stuclem/vic/blob/master/doc/user_doc/vic_installation/vch_installer_options.md#image-store) option?

@mhagen-vmware can you also please take a look at all of [Environment Prerequisites for vSphere Integrated Containers Installation](https://github.com/stuclem/vic/blob/master/doc/user_doc/vic_installation/vic_installation_prereqs.md)? 

Thanks all! 
