### PR TITLE
Only delete container from cache on a NotFound error from PL

### DIFF
--- a/lib/apiservers/engine/backends/container.go
+++ b/lib/apiservers/engine/backends/container.go
@@ -564,9 +564,9 @@ func (c *Container) containerStart(name string, hostConfig *container.HostConfig
 	// commit the handle; this will reconfigure and start the vm
 	_, err = client.Containers.Commit(containers.NewCommitParamsWithTimeout(commitTimeout).WithHandle(handle))
 	if err != nil {
-		cache.ContainerCache().DeleteContainer(name)
 		switch err := err.(type) {
 		case *containers.CommitNotFound:
+			cache.ContainerCache().DeleteContainer(name)
 			return NotFoundError(paramName)
 		case *containers.CommitDefault:
 			return InternalServerError(err.Payload.Message)


### PR DESCRIPTION
```
vagrant@devbox /U/z/g/s/g/v/vic ❯❯❯ docker -H 192.168.218.235:2376 --tls run busybox xxxx
Unable to find image 'busybox:latest' locally
Pulling from library/busybox
a3ed95caeb02: Pull complete
8ddc19f16526: Pull complete
Digest: sha256:65ce39ce3eb0997074a460adfb568d0b9f0f6a4392d97b6035630c9d7bf92402
Status: Downloaded newer image for library/busybox:latest
docker: Error response from daemon: server error from portlayer : xxxx: no such executable in PATH.
vagrant@devbox /U/z/g/s/g/v/vic ❯❯❯ docker -H 192.168.218.235:2376 --tls ps -a
CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS              PORTS               NAMES
8c7d2a742e40        busybox             "xxxx"              3 months ago        Stopped                                 drunk_rosalind
vagrant@devbox /U/z/g/s/g/v/vic ❯❯❯ docker -H 192.168.218.235:2376 --tls rm 8c
8c
vagrant@devbox /U/z/g/s/g/v/vic ❯❯❯ docker -H 192.168.218.235:2376 --tls ps -a
CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS              PORTS               NAMES
```

Drink one for me, Rosalind.

Fixes #2113.

