### PR TITLE
Fix datastore helper to mkdir nested root directories

### DIFF
--- a/pkg/vsphere/datastore/datastore_util.go
+++ b/pkg/vsphere/datastore/datastore_util.go
@@ -48,6 +48,7 @@ func Session(ctx context.Context, t *testing.T) *session.Session {
 }
 
 func DSsetup(t *testing.T) (context.Context, *Helper, func()) {
+	log.SetLevel(log.DebugLevel)
 	ctx := context.Background()
 	sess := Session(ctx, t)
 


### PR DESCRIPTION

Fixes #2145

If the root directory was greater than 1 path element, we'd ignore the
nested directory if it existed.  A path existing isn't an error
condition in this case.  Set the root to the existing dir and move on.

Added test to exercise this restart condition.