### PR TITLE
[full ci] Support pull and run from custom registries

### DIFF
--- a/cmd/imagec/imagec.go
+++ b/cmd/imagec/imagec.go
@@ -496,7 +496,7 @@ func WriteImageBlobs(images []*ImageWithMeta) error {
 }
 
 // CreateImageConfig constructs the image metadata from layers that compose the image
-func CreateImageConfig(images []*ImageWithMeta, manifest *Manifest) error {
+func CreateImageConfig(images []*ImageWithMeta, manifest *Manifest, reference string) error {
 
 	if len(images) == 0 {
 		return nil
@@ -562,11 +562,12 @@ func CreateImageConfig(images []*ImageWithMeta, manifest *Manifest) error {
 		ImageID: sum,
 		// TODO: this will change when issue 1186 is
 		// implemented -- only populate the digests when pulled by digest
-		Digests: []string{manifest.Digest},
-		Tags:    []string{options.tag},
-		Name:    manifest.Name,
-		DiffIDs: diffIDs,
-		History: history,
+		Digests:   []string{manifest.Digest},
+		Tags:      []string{options.tag},
+		Name:      manifest.Name,
+		DiffIDs:   diffIDs,
+		History:   history,
+		Reference: reference,
 	}
 
 	blob, err := json.Marshal(metaData)
@@ -731,7 +732,7 @@ func main() {
 		log.Fatalf(err.Error())
 	}
 
-	if err := CreateImageConfig(images, manifest); err != nil {
+	if err := CreateImageConfig(images, manifest, options.reference); err != nil {
 		log.Fatalf(err.Error())
 	}
 

--- a/lib/apiservers/engine/backends/container_test.go
+++ b/lib/apiservers/engine/backends/container_test.go
@@ -245,9 +245,10 @@ func (m *MockContainerProxy) ContainerRunning(vc *viccontainer.VicContainer) (bo
 
 func AddMockImageToCache() {
 	mockImage := &metadata.ImageConfig{
-		ImageID: "e732471cb81a564575aad46b9510161c5945deaf18e9be3db344333d72f0b4b2",
-		Name:    "busybox",
-		Tags:    []string{"latest"},
+		ImageID:   "e732471cb81a564575aad46b9510161c5945deaf18e9be3db344333d72f0b4b2",
+		Name:      "busybox",
+		Tags:      []string{"latest"},
+		Reference: "busybox:latest",
 	}
 	mockImage.Config = &container.Config{
 		Hostname:     "55cd1f8f6e5b",

--- a/lib/apiservers/engine/backends/image.go
+++ b/lib/apiservers/engine/backends/image.go
@@ -188,7 +188,7 @@ func convertV1ImageToDockerImage(image *metadata.ImageConfig) *types.Image {
 	return &types.Image{
 		ID:          image.ImageID,
 		ParentID:    image.Parent,
-		RepoTags:    clientFriendlyTags(image.Name, image.Tags),
+		RepoTags:    clientFriendlyTags(image.Reference, image.Tags),
 		RepoDigests: clientFriendlyDigests(image.Name, image.Digests),
 		Created:     image.Created.Unix(),
 		Size:        image.Size,
@@ -216,7 +216,7 @@ func imageConfigToDockerImageInspect(imageConfig *metadata.ImageConfig, productN
 	}
 
 	inspectData := &types.ImageInspect{
-		RepoTags:        clientFriendlyTags(imageConfig.Name, imageConfig.Tags),
+		RepoTags:        clientFriendlyTags(imageConfig.Reference, imageConfig.Tags),
 		RepoDigests:     clientFriendlyDigests(imageConfig.Name, imageConfig.Digests),
 		Parent:          imageConfig.Parent,
 		Comment:         imageConfig.Comment,
@@ -255,15 +255,14 @@ func imageConfigToDockerImageInspect(imageConfig *metadata.ImageConfig, productN
 	image
 */
 
-func clientFriendlyTags(imageName string, tags []string) []string {
+func clientFriendlyTags(reference string, tags []string) []string {
 	clientTags := make([]string, len(tags))
 	if len(tags) > 0 {
-		for index, tag := range tags {
-			clientTags[index] = fmt.Sprintf("%s:%s", imageName, tag)
+		for index := range tags {
+			clientTags[index] = fmt.Sprintf("%s", reference)
 		}
 	} else {
 		clientTags = append(clientTags, fmt.Sprintf("%s:%s", "<none>", "<none>"))
-
 	}
 	return clientTags
 }

--- a/lib/apiservers/engine/backends/image_test.go
+++ b/lib/apiservers/engine/backends/image_test.go
@@ -65,13 +65,20 @@ func TestConvertV1ImageToDockerImage(t *testing.T) {
 func TestClientFriendlyTags(t *testing.T) {
 	imageName := "busybox"
 	tags := []string{"1.24.2", "latest"}
+	defaultRegistry := "registry-1.docker.io/"
+	customRegistry := "custom.reg.com/"
 
-	friendlyTags := clientFriendlyTags(imageName, tags)
-	assert.Equal(t, len(friendlyTags), len(tags), "Error: expected %d tags, got %d", len(tags), len(friendlyTags))
-	assert.Equal(t, friendlyTags[0], "busybox:1.24.2", "Error: expected %s, got %s", "busybox:1.24.2", friendlyTags[0])
-	assert.Equal(t, friendlyTags[1], "busybox:latest", "Error: expected %s, got %s", "busybox:latest", friendlyTags[1])
+	defaultFriendlyTags := clientFriendlyTags(defaultRegistry, imageName, tags)
+	assert.Equal(t, len(defaultFriendlyTags), len(tags), "Error: expected %d tags, got %d", len(tags), len(defaultFriendlyTags))
+	assert.Equal(t, defaultFriendlyTags[0], "busybox:1.24.2", "Error: expected %s, got %s", "busybox:1.24.2", defaultFriendlyTags[0])
+	assert.Equal(t, defaultFriendlyTags[1], "busybox:latest", "Error: expected %s, got %s", "busybox:latest", defaultFriendlyTags[1])
 
-	emptyTags := clientFriendlyTags(imageName, []string{})
+	customFriendlyTags := clientFriendlyTags(customRegistry, imageName, tags)
+	assert.Equal(t, len(customFriendlyTags), len(tags), "Error: expected %d tags, got %d", len(tags), len(customFriendlyTags))
+	assert.Equal(t, customFriendlyTags[0], "custom.reg.com/busybox:1.24.2", "Error: expected %s, got %s", "custom.reg.com/busybox:1.24.2", customFriendlyTags[0])
+	assert.Equal(t, customFriendlyTags[1], "custom.reg.com/busybox:latest", "Error: expected %s, got %s", "custom.reg.com/busybox:latest", customFriendlyTags[1])
+
+	emptyTags := clientFriendlyTags(defaultRegistry, imageName, []string{})
 	assert.Equal(t, len(emptyTags), 1, "Error: expected %d tags, got %d", 1, len(emptyTags))
 	assert.Equal(t, emptyTags[0], "<none>:<none>", "Error: expected %s tags, got %s", "<none>:<none>", emptyTags[0])
 

--- a/lib/apiservers/engine/backends/image_test.go
+++ b/lib/apiservers/engine/backends/image_test.go
@@ -40,12 +40,13 @@ func TestConvertV1ImageToDockerImage(t *testing.T) {
 				Labels: map[string]string{},
 			},
 		},
-		ImageID: "test_id",
-		Digests: []string{"12345"},
-		Tags:    []string{"test_tag"},
-		Name:    "test_name",
-		DiffIDs: map[string]string{"test_diffid": "test_layerid"},
-		History: []v1.History{},
+		ImageID:   "test_id",
+		Digests:   []string{"12345"},
+		Tags:      []string{"test_tag"},
+		Name:      "test_name",
+		DiffIDs:   map[string]string{"test_diffid": "test_layerid"},
+		History:   []v1.History{},
+		Reference: "test_name:test_tag",
 	}
 	digest := fmt.Sprintf("%s@sha:%s", image.Name, "12345")
 	tag := fmt.Sprintf("%s:%s", image.Name, "test_tag")
@@ -63,22 +64,19 @@ func TestConvertV1ImageToDockerImage(t *testing.T) {
 }
 
 func TestClientFriendlyTags(t *testing.T) {
-	imageName := "busybox"
-	tags := []string{"1.24.2", "latest"}
-	defaultRegistry := "registry-1.docker.io/"
-	customRegistry := "custom.reg.com/"
+	tags := []string{"latest"}
+	defaultReference := "busybox:latest"
+	customReference := "custom.reg.com/busybox:latest"
 
-	defaultFriendlyTags := clientFriendlyTags(defaultRegistry, imageName, tags)
+	defaultFriendlyTags := clientFriendlyTags(defaultReference, tags)
 	assert.Equal(t, len(defaultFriendlyTags), len(tags), "Error: expected %d tags, got %d", len(tags), len(defaultFriendlyTags))
-	assert.Equal(t, defaultFriendlyTags[0], "busybox:1.24.2", "Error: expected %s, got %s", "busybox:1.24.2", defaultFriendlyTags[0])
-	assert.Equal(t, defaultFriendlyTags[1], "busybox:latest", "Error: expected %s, got %s", "busybox:latest", defaultFriendlyTags[1])
+	assert.Equal(t, defaultFriendlyTags[0], "busybox:latest", "Error: expected %s, got %s", "busybox:latest", defaultFriendlyTags[0])
 
-	customFriendlyTags := clientFriendlyTags(customRegistry, imageName, tags)
+	customFriendlyTags := clientFriendlyTags(customReference, tags)
 	assert.Equal(t, len(customFriendlyTags), len(tags), "Error: expected %d tags, got %d", len(tags), len(customFriendlyTags))
-	assert.Equal(t, customFriendlyTags[0], "custom.reg.com/busybox:1.24.2", "Error: expected %s, got %s", "custom.reg.com/busybox:1.24.2", customFriendlyTags[0])
-	assert.Equal(t, customFriendlyTags[1], "custom.reg.com/busybox:latest", "Error: expected %s, got %s", "custom.reg.com/busybox:latest", customFriendlyTags[1])
+	assert.Equal(t, customFriendlyTags[0], "custom.reg.com/busybox:latest", "Error: expected %s, got %s", "custom.reg.com/busybox:latest", customFriendlyTags[0])
 
-	emptyTags := clientFriendlyTags(defaultRegistry, imageName, []string{})
+	emptyTags := clientFriendlyTags(defaultReference, []string{})
 	assert.Equal(t, len(emptyTags), 1, "Error: expected %d tags, got %d", 1, len(emptyTags))
 	assert.Equal(t, emptyTags[0], "<none>:<none>", "Error: expected %s tags, got %s", "<none>:<none>", emptyTags[0])
 

--- a/lib/metadata/image_config.go
+++ b/lib/metadata/image_config.go
@@ -28,10 +28,11 @@ type ImageConfig struct {
 	docker.V1Image
 
 	// image specific data
-	ImageID string            `json:"image_id"`
-	Digests []string          `json:"digests,omitempty"`
-	Tags    []string          `json:"tags,omitempty"`
-	Name    string            `json:"name,omitempty"`
-	DiffIDs map[string]string `json:"diff_ids,omitempty"`
-	History []docker.History  `json:"history,omitempty"`
+	ImageID   string            `json:"image_id"`
+	Digests   []string          `json:"digests,omitempty"`
+	Tags      []string          `json:"tags,omitempty"`
+	Name      string            `json:"name,omitempty"`
+	DiffIDs   map[string]string `json:"diff_ids,omitempty"`
+	History   []docker.History  `json:"history,omitempty"`
+	Reference string            `json:"registry"`
 }

--- a/tests/test-cases/Group1-Docker-Commands/1-2-Docker-Pull.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-2-Docker-Pull.robot
@@ -31,6 +31,9 @@ Pull non-default tag
 Pull an image based on digest
     Wait Until Keyword Succeeds  5x  15 seconds  Pull image  nginx@sha256:7281cf7c854b0dfc7c68a6a4de9a785a973a14f1481bc028e2022bcd6a8d9f64
 
+Pull an image with the full docker registry URL
+    Wait Until Keyword Succeeds  5x  15 seconds  Pull image  registry.hub.docker.com/library/hello-world
+
 Pull an image from non-default repo
     #${result}=  Run Process  docker run -d -p 5000:5000 --name registry registry:2  shell=True
     #Log to console  ${result.stdout}


### PR DESCRIPTION
Follow-up of #2118 

* Changes the image cache's `cacheByName` index to pull and run images from private registries.
* Adds an integration test in `1-2-Docker-Pull`

**Limitation - doesn't yet support pulling and running the same image from different registries.**

Tested VIC output with 3 registry formats:
```
# full docker registry path
$ docker -H 192.168.77.130:2376 --tls run -it registry.hub.docker.com/library/busybox
Unable to find image 'registry.hub.docker.com/library/busybox:latest' locally
Pulling from library/busybox
a3ed95caeb02: Pull complete 
8ddc19f16526: Pull complete 
Digest: sha256:65ce39ce3eb0997074a460adfb568d0b9f0f6a4392d97b6035630c9d7bf92402
Status: Downloaded newer image for library/busybox:latest
/ # exit

# custom local registry
$ docker -H 192.168.77.130:2376 --tls run -it 192.168.77.128:5000/ubuntu /bin/bash
Unable to find image '192.168.77.128:5000/ubuntu:latest' locally
Pulling from ubuntu
a3ed95caeb02: Pull complete 
2f0243478e1f: Pull complete 
d8909ae88469: Pull complete 
820f09abed29: Pull complete 
01193a8f3d88: Pull complete 
Digest: sha256:56c7e84239cf43f15664ee0b7fa6ce9bc19d27c1cf9359daabeaa791f6934e50
Status: Downloaded newer image for ubuntu:latest
root@b06bd6eafaa0:/# exit

# simple use case
$ docker -H 192.168.77.130:2376 --tls run -d hello-world
Unable to find image 'hello-world:latest' locally
Pulling from library/hello-world
a3ed95caeb02: Pull complete 
c04b14da8d14: Pull complete 
Digest: sha256:548e9719abe62684ac7f01eea38cb5b0cf467cfe67c58b83fe87ba96674a4cdd
Status: Downloaded newer image for library/hello-world:latest
f5ee907137c6bc459ecadaaaf74109f1a3acae7dec1042f9bb0e13a16db94bc7

$ docker -H 192.168.77.130:2376 --tls images
REPOSITORY                                TAG                 IMAGE ID            CREATED             SIZE
192.168.77.128:5000/ubuntu                latest              7420cee32676        2 weeks ago         126.4 MB
hello-world                               latest              723aa7d39e9d        7 weeks ago         1.848 kB
registry.hub.docker.com/library/busybox   latest              332de81782ef        9 weeks ago         1.093 MB
```

Ping @jzt @sflxn @corrieb 

Addresses #1638

