### PR TITLE
Populate image name in docker inspect

### DIFF
--- a/lib/apiservers/engine/backends/portlayer/container_proxy.go
+++ b/lib/apiservers/engine/backends/portlayer/container_proxy.go
@@ -770,8 +770,8 @@ func containerConfigFromContainerInfo(vc *viccontainer.VicContainer, info *model
 	container.OpenStdin = true // Open stdin
 	container.StdinOnce = true
 
-	if info.ContainerConfig.LayerID != nil {
-		container.Image = *info.ContainerConfig.LayerID // Name of the image as it was passed by the operator (eg. could be symbolic)
+	if info.ContainerConfig.RepoName != nil {
+		container.Image = *info.ContainerConfig.RepoName // Name of the image as it was passed by the operator (eg. could be symbolic)
 	}
 	if info.ContainerConfig.Labels != nil {
 		container.Labels = info.ContainerConfig.Labels // List of labels set to this container

--- a/tests/test-cases/Group1-Docker-Commands/1-23-Docker-Inspect.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-23-Docker-Inspect.robot
@@ -40,6 +40,16 @@ Docker inspect container specifying type
     ${output}=  Evaluate  json.loads(r'''${output}''')  json
     ${id}=  Get From Dictionary  ${output[0]}  Id
 
+Docker inspect container check image name
+    ${rc}  ${container}=  Run And Return Rc And Output  docker ${params} create busybox
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} inspect --type=container ${container}
+    Should Be Equal As Integers  ${rc}  0
+    ${output}=  Evaluate  json.loads(r'''${output}''')  json
+    ${config}=  Get From Dictionary  ${output[0]}  Config
+    ${image}=  Get From Dictionary  ${config}  Image
+    Should Contain  ${image}  busybox
+
 Docker inspect container specifying incorrect type
     ${rc}  ${container}=  Run And Return Rc And Output  docker ${params} create busybox
     Should Be Equal As Integers  ${rc}  0


### PR DESCRIPTION
* Changes `Config.Image` in the output of `docker inspect` to show the image name instead of the layer ID
* Adds an integration test in `1-23-Docker-Inspect`

Fixes #2089

