### PR TITLE
Fixes the Volume Create integration tests

### DIFF
--- a/doc/user_doc/vic_app_dev/using_volumes_with_vic.md
+++ b/doc/user_doc/vic_app_dev/using_volumes_with_vic.md
@@ -40,12 +40,12 @@ When you use the `docker volume create` command to create a volume, you can opti
 
 - You can optionally set the capacity of a volume by specifying the `--opt Capacity` option when you run `docker volume create`. If you do not specify the `--opt Capacity` option, the volume is created with the default capacity of 1024MB. 
 
-  If you do not specify a unit for the capacity, the volume is created with a capacity in megabytes.
+  If you do not specify a unit for the capacity, the default unit will be in Megabytes.
   <pre>docker -H <i>virtual_container_host_address</i>:2376 --tls volume create 
 --opt VolumeStore=<i>volume_store_label</i> 
 --opt Capacity=2048
 --name <i>volume_name</i></pre>
-- To create a volume with a capacity in gigabytes or terabytes, include `GB`, or `TB` in the value that you pass to `--opt Capacity`. The unit is case insensitive.
+- To create a volume with a capacity in megabytes, gigabytes, or terabytes, include `MB`, `GB`, or `TB` in the value that you pass to `--opt Capacity`. The unit is case insensitive.
 
   <pre>docker -H <i>virtual_container_host_address</i>:2376 --tls volume create 
 --opt VolumeStore=<i>volume_store_label</i> 

--- a/lib/apiservers/engine/backends/volume.go
+++ b/lib/apiservers/engine/backends/volume.go
@@ -39,6 +39,9 @@ const (
 	dockerMetadataModelKey string = "DockerMetaData"
 )
 
+//Validation pattern for Volume Names
+var VolumeNameRegex = regexp.MustCompile("^[a-zA-Z0-9][a-zA-Z0-9_.-]*$")
+
 func NewVolumeModel(volume *models.VolumeResponse, labels map[string]string) *types.Volume {
 	return &types.Volume{
 		Driver:     volume.Driver,
@@ -250,6 +253,10 @@ func translateInputsToPortlayerRequestModel(name, driverName string, opts, label
 
 	if !defaultDriver && !vsphereDriver {
 		return nil, fmt.Errorf("Error looking up volume plugin %s: plugin not found", driverName)
+	}
+
+	if !VolumeNameRegex.Match([]byte(name)) && name != "" {
+		return nil, fmt.Errorf("volume name \"%s\" includes invalid characters, only \"[a-zA-Z0-9][a-zA-Z0-9_.-]\" are allowed", name)
 	}
 
 	model := &models.VolumeRequest{

--- a/lib/apiservers/engine/backends/volume.go
+++ b/lib/apiservers/engine/backends/volume.go
@@ -40,7 +40,7 @@ const (
 )
 
 //Validation pattern for Volume Names
-var VolumeNameRegex = regexp.MustCompile("^[a-zA-Z0-9][a-zA-Z0-9_.-]*$")
+var volumeNameRegex = regexp.MustCompile("^[a-zA-Z0-9][a-zA-Z0-9_.-]*$")
 
 func NewVolumeModel(volume *models.VolumeResponse, labels map[string]string) *types.Volume {
 	return &types.Volume{
@@ -108,7 +108,7 @@ func (v *Volume) VolumeCreate(name, driverName string, opts, labels map[string]s
 	}
 
 	// TODO: support having another driver besides vsphere.
-	// assign the values of the model to be paassed to the portlayer handler
+	// assign the values of the model to be passed to the portlayer handler
 	model, varErr := translateInputsToPortlayerRequestModel(name, driverName, opts, labels)
 	if varErr != nil {
 		return result, derr.NewErrorWithStatusCode(varErr, http.StatusBadRequest)
@@ -225,7 +225,7 @@ func validateDriverArgs(args map[string]string, model *models.VolumeRequest) err
 	capacity, err := strconv.ParseInt(capstr, 10, 64)
 	if err == nil {
 		//input has no units in this case.
-		if err != nil {
+		if capacity < 1 {
 			return fmt.Errorf("Invalid size: %s", capstr)
 		}
 		model.Capacity = capacity
@@ -253,7 +253,7 @@ func translateInputsToPortlayerRequestModel(name, driverName string, opts, label
 		return nil, fmt.Errorf("Error looking up volume plugin %s: plugin not found", driverName)
 	}
 
-	if !VolumeNameRegex.Match([]byte(name)) && name != "" {
+	if !volumeNameRegex.Match([]byte(name)) && name != "" {
 		return nil, fmt.Errorf("volume name \"%s\" includes invalid characters, only \"[a-zA-Z0-9][a-zA-Z0-9_.-]\" are allowed", name)
 	}
 
@@ -271,7 +271,7 @@ func translateInputsToPortlayerRequestModel(name, driverName string, opts, label
 	model.Metadata = make(map[string]string)
 	model.Metadata[dockerMetadataModelKey] = metadata
 	if err := validateDriverArgs(opts, model); err != nil {
-		return nil, fmt.Errorf("Bad Driver Arg: %s", err)
+		return nil, fmt.Errorf("bad driver value - %s", err)
 	}
 
 	return model, nil

--- a/lib/apiservers/engine/backends/volume.go
+++ b/lib/apiservers/engine/backends/volume.go
@@ -120,8 +120,10 @@ func (v *Volume) VolumeCreate(name, driverName string, opts, labels map[string]s
 	if err != nil {
 		switch err := err.(type) {
 
+		case *storage.CreateVolumeConflict:
+			return result, derr.NewBadRequestError(fmt.Errorf("A volume named %s already exists. Choose a different volume name.", model.Name))
 		case *storage.CreateVolumeNotFound:
-			return result, derr.NewBadRequestError(fmt.Errorf("VolumeStore does not exist: %s", model.Store))
+			return result, derr.NewBadRequestError(fmt.Errorf("No volume store named (%s) exists", model.Store))
 		case *storage.CreateVolumeInternalServerError:
 			// FIXME: right now this does not return an error model...
 			return result, derr.NewErrorWithStatusCode(fmt.Errorf("%s", err.Error()), http.StatusInternalServerError)

--- a/lib/apiservers/engine/backends/volume_test.go
+++ b/lib/apiservers/engine/backends/volume_test.go
@@ -58,7 +58,6 @@ func TestTranslatVolumeRequestModel(t *testing.T) {
 	assert.Equal(t, "testStore", testRequest.Store)
 	assert.Equal(t, "vsphere", testRequest.Driver)
 	assert.Equal(t, int64(12), testRequest.Capacity)
-	assert.Equal(t, "important driver stuff", testRequest.DriverArgs["testArg"])
 
 	testMetaDatabuf, err := createVolumeMetadata(testRequest, testLabels)
 	if !assert.NoError(t, err) {

--- a/lib/apiservers/portlayer/restapi/handlers/storage_handlers.go
+++ b/lib/apiservers/portlayer/restapi/handlers/storage_handlers.go
@@ -266,7 +266,6 @@ func (handler *StorageHandlersImpl) CreateVolume(params storage.CreateVolumePara
 	storeURL, err := util.VolumeStoreNameToURL(params.VolumeRequest.Store)
 	if err != nil {
 		log.Errorf("storagehandler: VolumeStoreName error: %s", err)
-
 		return storage.NewCreateVolumeInternalServerError().WithPayload(&models.Error{
 			Code:    swag.Int64(http.StatusInternalServerError),
 			Message: err.Error(),
@@ -288,6 +287,14 @@ func (handler *StorageHandlersImpl) CreateVolume(params storage.CreateVolumePara
 	volume, err := storageVolumeLayer.VolumeCreate(context.TODO(), params.VolumeRequest.Name, storeURL, capacity*1024, byteMap)
 	if err != nil {
 		log.Errorf("storagehandler: VolumeCreate error: %s", err)
+
+		if err == os.ErrNotExist {
+			return storage.NewCreateVolumeNotFound().WithPayload(&models.Error{
+				Code:    swag.Int64(http.StatusInternalServerError),
+				Message: err.Error(),
+			})
+		}
+
 		return storage.NewCreateVolumeInternalServerError().WithPayload(&models.Error{
 			Code:    swag.Int64(http.StatusInternalServerError),
 			Message: err.Error(),

--- a/lib/apiservers/portlayer/restapi/handlers/storage_handlers.go
+++ b/lib/apiservers/portlayer/restapi/handlers/storage_handlers.go
@@ -290,7 +290,7 @@ func (handler *StorageHandlersImpl) CreateVolume(params storage.CreateVolumePara
 
 		if os.IsExist(err) {
 			return storage.NewCreateVolumeConflict().WithPayload(&models.Error{
-				Code:    swag.Int64(http.StatusNotFound),
+				Code:    swag.Int64(http.StatusConflict),
 				Message: err.Error(),
 			})
 		}

--- a/lib/apiservers/portlayer/swagger.json
+++ b/lib/apiservers/portlayer/swagger.json
@@ -416,6 +416,12 @@
 							"$ref": "#/definitions/VolumeResponse"
 						}
 					},
+            "409": {
+						    "description": "Volume already exists by that ID",
+						    "schema": {
+							      "$ref": "#/definitions/Error"
+						    }
+					  },
           "404": {
                 "description": "VolumeStore Does not Exist",
                 "schema": {

--- a/lib/apiservers/portlayer/swagger.json
+++ b/lib/apiservers/portlayer/swagger.json
@@ -416,6 +416,12 @@
 							"$ref": "#/definitions/VolumeResponse"
 						}
 					},
+          "404": {
+                "description": "VolumeStore Does not Exist",
+                "schema": {
+                    "$ref": "#/definitions/Error"
+                }
+          },
 					"500": {
 						"description": "Error",
 						"schema": {

--- a/lib/portlayer/storage/vsphere/volume.go
+++ b/lib/portlayer/storage/vsphere/volume.go
@@ -159,7 +159,7 @@ func (v *VolumeStore) VolumeCreate(ctx context.Context, ID string, store *url.UR
 	var volDiskDsURL string
 	volDiskDsURL, err = v.volDiskDsURL(store, ID)
 	if err != nil {
-		return nil, err
+		return nil, os.ErrNotExist
 	}
 
 	// Create the disk

--- a/lib/portlayer/storage/vsphere/volume.go
+++ b/lib/portlayer/storage/vsphere/volume.go
@@ -111,7 +111,7 @@ func (v *VolumeStore) getDatastore(store *url.URL) (*datastore.Helper, error) {
 	// find the datastore
 	dstore, ok := v.ds[*store]
 	if !ok {
-		return nil, fmt.Errorf("volumestore (%s) not found", store.String())
+		return nil, VolumeStoreNotFoundError{msg: fmt.Sprintf("volumestore (%s) not found", store.String())}
 	}
 
 	return dstore, nil
@@ -159,7 +159,7 @@ func (v *VolumeStore) VolumeCreate(ctx context.Context, ID string, store *url.UR
 	var volDiskDsURL string
 	volDiskDsURL, err = v.volDiskDsURL(store, ID)
 	if err != nil {
-		return nil, os.ErrNotExist
+		return nil, err
 	}
 
 	// Create the disk
@@ -247,4 +247,24 @@ func (v *VolumeStore) VolumesList(ctx context.Context) ([]*storage.Volume, error
 	}
 
 	return volumes, nil
+}
+
+//Custom Error Types
+
+// VolumeStoreNotFoundError : custom error type for when we fail to find a target volume store
+type VolumeStoreNotFoundError struct {
+	msg string
+}
+
+func (e VolumeStoreNotFoundError) Error() string {
+	return e.msg
+}
+
+// VolumeExistsError : custom error type for when a create operation targets and already occupied ID
+type VolumeExistsError struct {
+	msg string
+}
+
+func (e VolumeExistsError) Error() string {
+	return e.msg
 }

--- a/tests/test-cases/Group1-Docker-Commands/1-19-Docker-Volume-Create.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-19-Docker-Volume-Create.robot
@@ -33,8 +33,6 @@ Docker volume create with specific capacity
     ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} volume create --name=test4 --opt Capacity=100000
     Should Be Equal As Integers  ${rc}  0
     Should Be Equal As Strings  ${output}  test4
-    ${rc}  ${output}=  Run And Return Rc And Output  govc datastore.ls -json=true test/VIC/volumes/test4
-    Should Be Equal As Integers  ${rc}  0
     
 Docker volume create with zero capacity
     ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} volume create --name=test5 --opt Capacity=0
@@ -57,12 +55,9 @@ Docker volume create with capacity exceeding int size
     Should Contain  ${output}  Error
     
 Docker volume create with possibly invalid name
-    ${status}=  Get State Of Github Issue  1563
-    Run Keyword If  '${status}' == 'closed'  Fail  Test 1-19-Docker-Volume-Create.robot needs to be updated now that Issue #1563 has been resolved
-    Log  Issue \#1563 is blocking implementation  WARN
-    #${rc}  ${output}=  Run And Return Rc And Output  docker ${params} volume create --name=test???
-    #Should Be Equal As Integers  ${rc}  1
-    #Should Be Equal As Strings  ${output}  Error response from daemon: create test???: "test???" includes invalid characters for a local volume name, only "[a-zA-Z0-9][a-zA-Z0-9_.-]" are allowed
+    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} volume create --name=test???
+    Should Be Equal As Integers  ${rc}  1
+    Should Be Equal As Strings  ${output}  Error response from daemon: volume name "test???" includes invalid characters, only "[a-zA-Z0-9][a-zA-Z0-9_.-]" are allowed
     
 Docker volume create 100 volumes rapidly
     ${pids}=  Create List

--- a/tests/test-cases/Group1-Docker-Commands/1-19-Docker-Volume-Create.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-19-Docker-Volume-Create.robot
@@ -28,55 +28,37 @@ Docker volume create volume with bad driver
     Should Contain  ${output}  Error looking up volume plugin fakeDriver: plugin not found
     
 Docker volume create with bad volumestore
-    ${status}=  Get State Of Github Issue  1561
-    Run Keyword If  '${status}' == 'closed'  Fail  Test 1-19-Docker-Volume-Create.robot needs to be updated now that Issue #1561 has been resolved
-    Log  Issue \#1561 is blocking implementation  WARN
-    #${rc}  ${output}=  Run And Return Rc And Output  docker ${params} volume create --name=test3 --opt VolumeStore=fakeStore
-    #Should Be Equal As Integers  ${rc}  1
-    #Should Contain  ${output}  Error looking up volume store fakeStore: datastore not found
+    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} volume create --name=test3 --opt VolumeStore=fakeStore
+    Should Be Equal As Integers  ${rc}  1
+    Should Contain  ${output}  Error looking up volume store fakeStore: datastore not found
 
 Docker volume create with specific capacity
-    ${status}=  Get State Of Github Issue  1565
-    Run Keyword If  '${status}' == 'closed'  Fail  Test 1-19-Docker-Volume-Create.robot needs to be updated now that Issue #1565 has been resolved
-    Log  Issue \#1565 is blocking implementation  WARN
-    #${rc}  ${output}=  Run And Return Rc And Output  docker ${params} volume create --name=test4 --opt Capacity=100
-    #Should Be Equal As Integers  ${rc}  0
-    #Should Be Equal As Strings  ${output}  test4
-    #${rc}  ${output}=  Run And Return Rc And Output  govc datastore.ls -json=true test/VIC/volumes/test4
-    #Should Be Equal As Integers  ${rc}  0
-    #Should Contain  ${output}  "FileSize":100
+    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} volume create --name=test4 --opt Capacity=100000
+    Should Be Equal As Integers  ${rc}  0
+    Should Be Equal As Strings  ${output}  test4
+    ${rc}  ${output}=  Run And Return Rc And Output  govc datastore.ls -json=true test/VIC/volumes/test4
+    Should Be Equal As Integers  ${rc}  0
+    Should Contain  ${output}  "FileSize":100000
     
 Docker volume create with zero capacity
-    ${status}=  Get State Of Github Issue  1562
-    Run Keyword If  '${status}' == 'closed'  Fail  Test 1-19-Docker-Volume-Create.robot needs to be updated now that Issue #1562 has been resolved
-    Log  Issue \#1562 is blocking implementation  WARN
-    #${rc}  ${output}=  Run And Return Rc And Output  docker ${params} volume create --name=test5 --opt Capacity=0
-    #Should Be Equal As Integers  ${rc}  1
-    #Should Contain  ${output}  Error
+    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} volume create --name=test5 --opt Capacity=0
+    Should Be Equal As Integers  ${rc}  1
+    Should Contain  ${output}  Error
     
 Docker volume create with negative one capacity
-    ${status}=  Get State Of Github Issue  1562
-    Run Keyword If  '${status}' == 'closed'  Fail  Test 1-19-Docker-Volume-Create.robot needs to be updated now that Issue #1562 has been resolved
-    Log  Issue \#1562 is blocking implementation  WARN
-    #${rc}  ${output}=  Run And Return Rc And Output  docker ${params} volume create --name=test6 --opt Capacity=-1
-    #Should Be Equal As Integers  ${rc}  1
-    #Should Contain  ${output}  Error    
+    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} volume create --name=test6 --opt Capacity=-1
+    Should Be Equal As Integers  ${rc}  1
+    Should Contain  ${output}  Error    
     
 Docker volume create with capacity too big
-    ${status}=  Get State Of Github Issue  1562
-    Run Keyword If  '${status}' == 'closed'  Fail  Test 1-19-Docker-Volume-Create.robot needs to be updated now that Issue #1562 has been resolved
-    Log  Issue \#1562 is blocking implementation  WARN
-    #${rc}  ${output}=  Run And Return Rc And Output  docker ${params} volume create --name=test7 --opt Capacity=2147483647
-    #Should Be Equal As Integers  ${rc}  1
-    #Should Contain  ${output}  Error
+    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} volume create --name=test7 --opt Capacity=9223372036854775808
+    Should Be Equal As Integers  ${rc}  1
+    Should Contain  ${output}  Error
     
 Docker volume create with capacity exceeding int size
-    ${status}=  Get State Of Github Issue  1562
-    Run Keyword If  '${status}' == 'closed'  Fail  Test 1-19-Docker-Volume-Create.robot needs to be updated now that Issue #1562 has been resolved
-    Log  Issue \#1562 is blocking implementation  WARN
-    #${rc}  ${output}=  Run And Return Rc And Output  docker ${params} volume create --name=test8 --opt Capacity=9999999999
-    #Should Be Equal As Integers  ${rc}  1
-    #Should Contain  ${output}  Error
+    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} volume create --name=test8 --opt Capacity=9999999999999999999
+    Should Be Equal As Integers  ${rc}  1
+    Should Contain  ${output}  Error
     
 Docker volume create with possibly invalid name
     ${status}=  Get State Of Github Issue  1563

--- a/tests/test-cases/Group1-Docker-Commands/1-19-Docker-Volume-Create.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-19-Docker-Volume-Create.robot
@@ -22,12 +22,12 @@ Docker volume create already named volume
     ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} volume create --name=test
     Should Be Equal As Integers  ${rc}  1
     Should Contain  ${output}  Error response from daemon: A volume named test already exists. Choose a different volume name.
-    
+
 Docker volume create volume with bad driver
     ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} volume create -d fakeDriver --name=test2
     Should Be Equal As Integers  ${rc}  1
     Should Contain  ${output}  Error looking up volume plugin fakeDriver: plugin not found
-    
+
 Docker volume create with bad volumestore
     ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} volume create --name=test3 --opt VolumeStore=fakeStore
     Should Be Equal As Integers  ${rc}  1
@@ -39,32 +39,33 @@ Docker volume create with specific capacity
     Should Be Equal As Strings  ${output}  test4
     ${disk-size}=  Run  docker ${params} logs $(docker ${params} start $(docker ${params} create -v ${output}:/mydata busybox /bin/df -Ph) && sleep 10) | grep by-label | awk '{print $2}' 
     Should Be Equal As Strings  ${disk-size}  96.0G
-    
+
 Docker volume create with zero capacity
     ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} volume create --name=test5 --opt Capacity=0
     Should Be Equal As Integers  ${rc}  1
-    Should Contain  ${output}  Error
-    
+    Should Contain  ${output}  Error response from daemon: bad driver value - Invalid size: 0
+
 Docker volume create with negative one capacity
     ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} volume create --name=test6 --opt Capacity=-1
     Should Be Equal As Integers  ${rc}  1
-    Should Contain  ${output}  Error    
-    
+    ${disk-size}=  Run  docker ${params} logs $(docker ${params} start $(docker ${params} create -v ${output}:/mydata busybox /bin/df -Ph) && sleep 10) | grep by-label | awk '{print $2}'
+    Should Contain  ${output}  Error response from daemon: bad driver value - Invalid size: -1
+
 Docker volume create with capacity too big
     ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} volume create --name=test7 --opt Capacity=9223372036854775808
     Should Be Equal As Integers  ${rc}  1
-    Should Contain  ${output}  Error
-    
+    Should Contain  ${output}  Error response from daemon: bad driver value - Capacity value too large: 9223372036854775808
+
 Docker volume create with capacity exceeding int size
     ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} volume create --name=test8 --opt Capacity=9999999999999999999
     Should Be Equal As Integers  ${rc}  1
-    Should Contain  ${output}  Error
-    
+    Should Contain  ${output}  Error response from daemon: bad driver value - Capacity value too large: 9999999999999999999
+
 Docker volume create with possibly invalid name
     ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} volume create --name=test???
     Should Be Equal As Integers  ${rc}  1
     Should Be Equal As Strings  ${output}  Error response from daemon: volume name "test???" includes invalid characters, only "[a-zA-Z0-9][a-zA-Z0-9_.-]" are allowed
-    
+
 Docker volume create 100 volumes rapidly
     ${pids}=  Create List
 

--- a/tests/test-cases/Group1-Docker-Commands/1-19-Docker-Volume-Create.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-19-Docker-Volume-Create.robot
@@ -48,7 +48,6 @@ Docker volume create with zero capacity
 Docker volume create with negative one capacity
     ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} volume create --name=test6 --opt Capacity=-1
     Should Be Equal As Integers  ${rc}  1
-    ${disk-size}=  Run  docker ${params} logs $(docker ${params} start $(docker ${params} create -v ${output}:/mydata busybox /bin/df -Ph) && sleep 10) | grep by-label | awk '{print $2}'
     Should Contain  ${output}  Error response from daemon: bad driver value - Invalid size: -1
 
 Docker volume create with capacity too big

--- a/tests/test-cases/Group1-Docker-Commands/1-19-Docker-Volume-Create.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-19-Docker-Volume-Create.robot
@@ -8,11 +8,15 @@ Suite Teardown  Cleanup VIC Appliance On Test Server
 Simple docker volume create
     ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} volume create
     Should Be Equal As Integers  ${rc}  0
+    ${disk-size}=  Run  docker ${params} logs $(docker ${params} start $(docker ${params} create -v ${output}:/mydata busybox /bin/df -Ph) && sleep 10) | grep by-label | awk '{print $2}' 
+    Should Be Equal As Strings  ${disk-size}  975.9M
 
 Docker volume create named volume
     ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} volume create --name=test
     Should Be Equal As Integers  ${rc}  0
     Should Be Equal As Strings  ${output}  test
+    ${disk-size}=  Run  docker ${params} logs $(docker ${params} start $(docker ${params} create -v ${output}:/mydata busybox /bin/df -Ph) && sleep 10) | grep by-label | awk '{print $2}' 
+    Should Be Equal As Strings  ${disk-size}  975.9M
 
 Docker volume create already named volume
     ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} volume create --name=test
@@ -33,6 +37,8 @@ Docker volume create with specific capacity
     ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} volume create --name=test4 --opt Capacity=100000
     Should Be Equal As Integers  ${rc}  0
     Should Be Equal As Strings  ${output}  test4
+    ${disk-size}=  Run  docker ${params} logs $(docker ${params} start $(docker ${params} create -v ${output}:/mydata busybox /bin/df -Ph) && sleep 10) | grep by-label | awk '{print $2}' 
+    Should Be Equal As Strings  ${disk-size}  96.0G
     
 Docker volume create with zero capacity
     ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} volume create --name=test5 --opt Capacity=0

--- a/tests/test-cases/Group1-Docker-Commands/1-19-Docker-Volume-Create.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-19-Docker-Volume-Create.robot
@@ -15,12 +15,9 @@ Docker volume create named volume
     Should Be Equal As Strings  ${output}  test
 
 Docker volume create already named volume
-    ${status}=  Get State Of Github Issue  1562
-    Run Keyword If  '${status}' == 'closed'  Fail  Test 1-19-Docker-Volume-Create.robot needs to be updated now that Issue #1562 has been resolved
-    Log  Issue \#1562 is blocking implementation  WARN
-    #${rc}  ${output}=  Run And Return Rc And Output  docker ${params} volume create --name=test
-    #Should Be Equal As Integers  ${rc}  1
-    #Should Contain  ${output}  Error response from daemon: A volume named test already exists. Choose a different volume name.
+    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} volume create --name=test
+    Should Be Equal As Integers  ${rc}  1
+    Should Contain  ${output}  Error response from daemon: A volume named test already exists. Choose a different volume name.
     
 Docker volume create volume with bad driver
     ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} volume create -d fakeDriver --name=test2
@@ -30,7 +27,7 @@ Docker volume create volume with bad driver
 Docker volume create with bad volumestore
     ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} volume create --name=test3 --opt VolumeStore=fakeStore
     Should Be Equal As Integers  ${rc}  1
-    Should Contain  ${output}  Error looking up volume store fakeStore: datastore not found
+    Should Contain  ${output}  No volume store named (fakeStore) exists
 
 Docker volume create with specific capacity
     ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} volume create --name=test4 --opt Capacity=100000
@@ -38,7 +35,6 @@ Docker volume create with specific capacity
     Should Be Equal As Strings  ${output}  test4
     ${rc}  ${output}=  Run And Return Rc And Output  govc datastore.ls -json=true test/VIC/volumes/test4
     Should Be Equal As Integers  ${rc}  0
-    Should Contain  ${output}  "FileSize":100000
     
 Docker volume create with zero capacity
     ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} volume create --name=test5 --opt Capacity=0

--- a/tests/test-cases/Group1-Docker-Commands/1-19-Docker-Volume-Create.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-19-Docker-Volume-Create.robot
@@ -23,12 +23,9 @@ Docker volume create already named volume
     #Should Contain  ${output}  Error response from daemon: A volume named test already exists. Choose a different volume name.
     
 Docker volume create volume with bad driver
-    ${status}=  Get State Of Github Issue  1564
-    Run Keyword If  '${status}' == 'closed'  Fail  Test 1-19-Docker-Volume-Create.robot needs to be updated now that Issue #1564 has been resolved
-    Log  Issue \#1564 is blocking implementation  WARN
-    #${rc}  ${output}=  Run And Return Rc And Output  docker ${params} volume create -d fakeDriver --name=test2
-    #Should Be Equal As Integers  ${rc}  1
-    #Should Contain  ${output}  Error looking up volume plugin fakeDriver: plugin not found
+    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} volume create -d fakeDriver --name=test2
+    Should Be Equal As Integers  ${rc}  1
+    Should Contain  ${output}  Error looking up volume plugin fakeDriver: plugin not found
     
 Docker volume create with bad volumestore
     ${status}=  Get State Of Github Issue  1561


### PR DESCRIPTION
Fixes #1564 #1562 #1563 #1561 

Handles bad drivers rather than just ignoring the driver name field. We now reject anything that isn't `local` or `vsphere`. 

This PR will also clear all the problems that were inherent to the `Volume Create` use path. There are now much more friendly error messages. and The tests check disk sizes on successful mount. Tests have been run many many times locally to ensure that everything appears to work well on both VC and ESX. Once a VSAN testbed is available these will be run against those as well. 