### PR TITLE
Show cmd only once in docker inspect

### DIFF
--- a/lib/apiservers/engine/backends/portlayer/container_proxy.go
+++ b/lib/apiservers/engine/backends/portlayer/container_proxy.go
@@ -781,12 +781,7 @@ func containerConfigFromContainerInfo(vc *viccontainer.VicContainer, info *model
 	if info.ProcessConfig.Env != nil {
 		container.Env = info.ProcessConfig.Env // List of environment variable to set in the container
 	}
-	if info.ProcessConfig.ExecPath != nil {
-		container.Cmd = append(container.Cmd, *info.ProcessConfig.ExecPath) // Command to run when starting the container
-	}
-	if info.ProcessConfig.ExecArgs != nil {
-		container.Cmd = append(container.Cmd, info.ProcessConfig.ExecArgs[1:]...)
-	}
+
 	if info.ProcessConfig.WorkingDir != nil {
 		container.WorkingDir = *info.ProcessConfig.WorkingDir // Current directory (PWD) in the command will be launched
 	}

--- a/tests/test-cases/Group1-Docker-Commands/1-23-Docker-Inspect.md
+++ b/tests/test-cases/Group1-Docker-Commands/1-23-Docker-Inspect.md
@@ -19,8 +19,9 @@ This test requires that a vSphere server is running and available
 6. Issue docker create busybox to the VIC appliance
 7. Issue docker inspect <containerID> to the VIC appliance
 8. Issue docker inspect --type=container <containerID> to the VIC appliance
-9. Issue docker inspect --type=image <containerID> to the VIC appliance
-10. Issue docker inspect fake to the VIC appliance
+9. Issue docker inspect <containerID> to the VIC appliance and verify the Cmd and Image fields
+10. Issue docker inspect --type=image <containerID> to the VIC appliance
+11. Issue docker inspect fake to the VIC appliance
 
 #Expected Outcome:
 * Step 3,4,7,8 should result in success and a properly formatted JSON response
@@ -28,11 +29,12 @@ This test requires that a vSphere server is running and available
 ```
 Error: No such container: busybox
 ```
-* Step 9 should result in an error with the following message:  
+* Step 9 should result in success with the correct values in the Cmd and Image fields
+* Step 10 should result in an error with the following message:
 ```
 Error: No such image: <containerID>
 ```
-* Step 10 should result in an error with the following message:  
+* Step 11 should result in an error with the following message:
 ```
 Error: No such image or container: fake
 ```

--- a/tests/test-cases/Group1-Docker-Commands/1-23-Docker-Inspect.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-23-Docker-Inspect.robot
@@ -40,15 +40,17 @@ Docker inspect container specifying type
     ${output}=  Evaluate  json.loads(r'''${output}''')  json
     ${id}=  Get From Dictionary  ${output[0]}  Id
 
-Docker inspect container check image name
-    ${rc}  ${container}=  Run And Return Rc And Output  docker ${params} create busybox
+Docker inspect container check cmd and image name
+    ${rc}  ${container}=  Run And Return Rc And Output  docker ${params} create busybox /bin/bash
     Should Be Equal As Integers  ${rc}  0
-    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} inspect --type=container ${container}
+    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} inspect ${container}
     Should Be Equal As Integers  ${rc}  0
     ${output}=  Evaluate  json.loads(r'''${output}''')  json
     ${config}=  Get From Dictionary  ${output[0]}  Config
     ${image}=  Get From Dictionary  ${config}  Image
     Should Contain  ${image}  busybox
+    ${cmd}=  Get From Dictionary  ${config}  Cmd
+    Should Be Equal As Strings  ${cmd}  [u'/bin/bash']
 
 Docker inspect container specifying incorrect type
     ${rc}  ${container}=  Run And Return Rc And Output  docker ${params} create busybox


### PR DESCRIPTION
* Fixes the `Config.Cmd` value in the output of `docker inspect` to show the command only once

Earlier:
```
$ docker -H 192.168.77.131:2376 run -it -d --name cont1 alpine sh -c 'echo string'
$ docker -H 192.168.77.131:2376 --tls inspect cont1 | grep -4 Cmd
"Cmd": [
                "sh",
                "-c",
                "echo string",
                "sh",
                "-c",
                "echo string"
            ],
```

Now:
```
$ docker -H 192.168.77.131:2376 run -it -d --name cont1 alpine sh -c 'echo string'
$ docker -H 192.168.77.131:2376 --tls inspect cont1 | grep -4 Cmd
"Cmd": [
                "sh",
                "-c",
                "echo string"
            ],
```

* Adds an integration test in `1-23-Docker-Inspect`

Fixes #2091 
