### PR TITLE
Assign error for cleanup lambda to remove inconsistent image

### DIFF
--- a/lib/portlayer/storage/image_cache.go
+++ b/lib/portlayer/storage/image_cache.go
@@ -169,6 +169,7 @@ func (c *NameLookupCache) WriteImage(ctx context.Context, parent *Image, ID stri
 	// Definitely not in cache or image store, create image.
 	i, err = c.DataStore.WriteImage(ctx, p, ID, meta, sum, r)
 	if err != nil {
+		log.Errorf("WriteImage of %s failed with: %s", ID, err)
 		return nil, err
 	}
 

--- a/lib/portlayer/storage/vsphere/image.go
+++ b/lib/portlayer/storage/vsphere/image.go
@@ -335,7 +335,8 @@ func (v *ImageStore) writeImage(ctx context.Context, storeName, parentID, ID str
 
 	actualSum := fmt.Sprintf("sha256:%x", h.Sum(nil))
 	if actualSum != sum {
-		return fmt.Errorf("Failed to validate image checksum. Expected %s, got %s", sum, actualSum)
+		err = fmt.Errorf("Failed to validate image checksum. Expected %s, got %s", sum, actualSum)
+		return err
 	}
 
 	if err = vmdisk.Unmount(); err != nil {


### PR DESCRIPTION
Errors thrown by the checksum not matching weren't triggering the cleanup lambda since `err` was unset.
