### PR TITLE
[full ci] Use pkg/index for storage image cache

### DIFF
--- a/lib/apiservers/portlayer/restapi/handlers/storage_handlers.go
+++ b/lib/apiservers/portlayer/restapi/handlers/storage_handlers.go
@@ -382,7 +382,7 @@ func convertImage(image *spl.Image) *models.Image {
 
 	// scratch image
 	if image.Parent != nil {
-		s := image.Parent.String()
+		s := image.ParentLink.String()
 		parent = &s
 	}
 

--- a/lib/portlayer/storage/image.go
+++ b/lib/portlayer/storage/image.go
@@ -24,29 +24,8 @@ import (
 	"golang.org/x/net/context"
 
 	"github.com/vmware/vic/lib/portlayer/util"
+	"github.com/vmware/vic/pkg/index"
 )
-
-// Image is the handle to identify an image layer on the backing store.  The
-// URI namespace used to identify the Image in the storage layer has the
-// following path scheme:
-//
-// `/storage/<image store identifier, usually the vch uuid>/<image id>`
-//
-type Image struct {
-	// Identifer for this layer.  Usually a SHA
-	ID string
-
-	// location of the layer.  Filled in by the runtime.
-	SelfLink *url.URL
-
-	// Parent's location.  It's the VMDK this snapshot inerits from.
-	Parent *url.URL
-
-	Store *url.URL
-
-	// Metadata associated with the image.
-	Metadata map[string][]byte
-}
 
 // ImageStorer is an interface to store images in the Image Store
 type ImageStorer interface {
@@ -85,6 +64,72 @@ type ImageStorer interface {
 	// ListImages returns a list of Images given a list of image IDs, or all
 	// images in the image store if no param is passed.
 	ListImages(ctx context.Context, store *url.URL, IDs []string) ([]*Image, error)
+}
+
+// Image is the handle to identify an image layer on the backing store.  The
+// URI namespace used to identify the Image in the storage layer has the
+// following path scheme:
+//
+// `/storage/<image store identifier, usually the vch uuid>/<image id>`
+//
+type Image struct {
+	// Identifer for this layer.  Usually a SHA
+	ID string
+
+	// location of the layer.  Filled in by the runtime.
+	SelfLink *url.URL
+
+	// Parent's location.  It's the VMDK this snapshot inerits from.
+	ParentLink *url.URL
+
+	Store *url.URL
+
+	// Metadata associated with the image.
+	Metadata map[string][]byte
+}
+
+func (i *Image) Copy() index.Element {
+
+	selflink, _ := url.Parse(i.SelfLink.String())
+	store, _ := url.Parse(i.Store.String())
+
+	var parent *url.URL
+	if i.ParentLink != nil {
+		parent, _ = url.Parse(i.ParentLink.String())
+	}
+
+	c := &Image{
+		ID:         i.ID,
+		SelfLink:   selflink,
+		ParentLink: parent,
+		Store:      store,
+	}
+
+	if i.Metadata != nil {
+
+		c.Metadata = make(map[string][]byte)
+
+		for k, v := range i.Metadata {
+			buf := make([]byte, len(v))
+			copy(buf, v)
+			c.Metadata[k] = buf
+		}
+	}
+	return c
+}
+
+// Returns the Selflink of the image
+func (i *Image) Self() string {
+	return i.SelfLink.String()
+}
+
+// Returns a link to the parent.  Returns link to self if there is no parent
+func (i *Image) Parent() string {
+	if i.ParentLink != nil {
+		return i.ParentLink.String()
+	} else {
+		return i.Self()
+	}
 }
 
 func Parse(u *url.URL) (*Image, error) {

--- a/lib/portlayer/storage/image.go
+++ b/lib/portlayer/storage/image.go
@@ -73,15 +73,16 @@ type ImageStorer interface {
 // `/storage/<image store identifier, usually the vch uuid>/<image id>`
 //
 type Image struct {
-	// Identifer for this layer.  Usually a SHA
+	// ID is the identifer for this layer.  Usually a SHA
 	ID string
 
-	// location of the layer.  Filled in by the runtime.
+	// SelfLink is the URL for this layer.  Filled in by the runtime.
 	SelfLink *url.URL
 
-	// Parent's location.  It's the VMDK this snapshot inerits from.
+	// ParentLink is the URL for the parent.  It's the VMDK this snapshot inerits from.
 	ParentLink *url.URL
 
+	// Store is the URL for the image store the image can be found on.
 	Store *url.URL
 
 	// Metadata associated with the image.
@@ -106,7 +107,6 @@ func (i *Image) Copy() index.Element {
 	}
 
 	if i.Metadata != nil {
-
 		c.Metadata = make(map[string][]byte)
 
 		for k, v := range i.Metadata {

--- a/lib/portlayer/storage/image_cache.go
+++ b/lib/portlayer/storage/image_cache.go
@@ -25,6 +25,7 @@ import (
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/vmware/vic/lib/portlayer/util"
+	"github.com/vmware/vic/pkg/index"
 )
 
 var Scratch = Image{
@@ -36,13 +37,9 @@ var Scratch = Image{
 // of images on disk.
 type NameLookupCache struct {
 
-	// The individual store locations
-	//
-	// We want to map a store to a list of images.  Images are resolveable by
-	// ID (string) and resolve to an Image.  The keys/values in the map should
-	// be immuteable, so we're passing by value here.  We don't want things
-	// changing outside of the API calls.
-	storeCache     map[url.URL]map[string]Image
+	// The individual store locations -> Index
+	storeCache map[url.URL]*index.Index
+	// Guard against concurrent writes to the storeCache map
 	storeCacheLock sync.Mutex
 
 	// The image store implementation.  This mutates the actual disk images.
@@ -52,7 +49,7 @@ type NameLookupCache struct {
 func NewLookupCache(ds ImageStorer) *NameLookupCache {
 	return &NameLookupCache{
 		DataStore:  ds,
-		storeCache: make(map[url.URL]map[string]Image),
+		storeCache: make(map[url.URL]*index.Index),
 	}
 }
 
@@ -69,6 +66,7 @@ func (c *NameLookupCache) GetImageStore(ctx context.Context, storeName string) (
 
 	// check the cache
 	_, ok := c.storeCache[*store]
+
 	if !ok {
 		log.Info("Refreshing image cache from datastore.")
 		// Store isn't in the cache.  Look it up in the datastore.
@@ -83,7 +81,22 @@ func (c *NameLookupCache) GetImageStore(ctx context.Context, storeName string) (
 			return nil, err
 		}
 
-		c.storeCache[*store] = make(map[string]Image)
+		indx := index.NewIndex()
+
+		c.storeCache[*store] = indx
+
+		// Add Scratch
+		scratch, err := c.DataStore.GetImage(ctx, store, Scratch.ID)
+		if err != nil {
+			log.Errorf("Error looking up scratch on %s: %s", store.String(), err)
+			return nil, fmt.Errorf("Scratch does not exist.  Imagestore is corrrupt.")
+		}
+
+		if err = indx.Insert(scratch); err != nil {
+			return nil, err
+		}
+
+		// XXX after creating the indx and populating the map, we can put the rest in a go routine
 
 		// Fall out here if there are no images.  We should at least have a scratch.
 		images, err := c.DataStore.ListImages(ctx, store, nil)
@@ -92,14 +105,16 @@ func (c *NameLookupCache) GetImageStore(ctx context.Context, storeName string) (
 		}
 
 		// add the images we retrieved to the cache.
-		for _, v := range images {
-			log.Infof("Imagestore: Found image %s on datastore.", v.ID)
-			c.storeCache[*store][v.ID] = *v
-		}
+		for _, image := range images {
+			if image.ID == Scratch.ID {
+				continue
+			}
 
-		// Assert there's a scratch
-		if _, ok = c.storeCache[*store][Scratch.ID]; !ok {
-			return nil, fmt.Errorf("Scratch does not exist.  Imagestore is corrrupt.")
+			log.Infof("Imagestore: Found image %s on datastore.", image.ID)
+
+			if err := indx.Insert(image); err != nil {
+				return nil, err
+			}
 		}
 	}
 
@@ -107,29 +122,39 @@ func (c *NameLookupCache) GetImageStore(ctx context.Context, storeName string) (
 }
 
 func (c *NameLookupCache) CreateImageStore(ctx context.Context, storeName string) (*url.URL, error) {
-	u, err := c.GetImageStore(ctx, storeName)
+	store, err := util.ImageStoreNameToURL(storeName)
+	if err != nil {
+		return nil, err
+	}
+
+	// Check for existance and rehydrate the cache if it exists on disk.
+	_, err = c.GetImageStore(ctx, storeName)
 	// we expect this not to exist.
 	if err == nil {
 		return nil, os.ErrExist
 	}
 
-	u, err = c.DataStore.CreateImageStore(ctx, storeName)
-	if err != nil {
-		return nil, err
-	}
-
 	c.storeCacheLock.Lock()
 	defer c.storeCacheLock.Unlock()
 
-	// Create the root image
-	scratch, err := c.DataStore.WriteImage(ctx, &Image{Store: u}, Scratch.ID, nil, "", nil)
+	store, err = c.DataStore.CreateImageStore(ctx, storeName)
 	if err != nil {
 		return nil, err
 	}
 
-	c.storeCache[*u] = make(map[string]Image)
-	c.storeCache[*u][scratch.ID] = *scratch
-	return u, nil
+	// Create the root image
+	scratch, err := c.DataStore.WriteImage(ctx, &Image{Store: store}, Scratch.ID, nil, "", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	indx := index.NewIndex()
+	c.storeCache[*store] = indx
+	if err = indx.Insert(scratch); err != nil {
+		return nil, err
+	}
+
+	return store, nil
 }
 
 // ListImageStores returns a list of strings representing all existing image stores
@@ -142,13 +167,6 @@ func (c *NameLookupCache) ListImageStores(ctx context.Context) ([]*url.URL, erro
 		stores = append(stores, &key)
 	}
 	return stores, nil
-}
-
-// add to store cache
-func (c *NameLookupCache) AddImageToStore(storeURL url.URL, imageID string, image Image) {
-	c.storeCacheLock.Lock()
-	defer c.storeCacheLock.Unlock()
-	c.storeCache[storeURL][imageID] = image
 }
 
 func (c *NameLookupCache) WriteImage(ctx context.Context, parent *Image, ID string, meta map[string][]byte, sum string, r io.Reader) (*Image, error) {
@@ -173,15 +191,23 @@ func (c *NameLookupCache) WriteImage(ctx context.Context, parent *Image, ID stri
 		return nil, err
 	}
 
+	c.storeCacheLock.Lock()
+	indx := c.storeCache[*parent.Store]
+	c.storeCacheLock.Unlock()
+
 	// Add the new image to the cache
-	c.AddImageToStore(*p.Store, i.ID, *i)
+	if err = indx.Insert(i); err != nil {
+		return nil, err
+	}
 
 	return i, nil
 }
 
 // GetImage gets the specified image from the given store by retreiving it from the cache.
 func (c *NameLookupCache) GetImage(ctx context.Context, store *url.URL, ID string) (*Image, error) {
-	log.Debugf("Getting image from %#v", store)
+
+	log.Debugf("Getting image %s from %s", ID, store.String())
+
 	storeName, err := util.ImageStoreName(store)
 	if err != nil {
 		return nil, err
@@ -193,57 +219,83 @@ func (c *NameLookupCache) GetImage(ctx context.Context, store *url.URL, ID strin
 	}
 
 	c.storeCacheLock.Lock()
-	defer c.storeCacheLock.Unlock()
+	indx := c.storeCache[*store]
+	c.storeCacheLock.Unlock()
 
-	var ok bool
-	i := &Image{}
-	*i, ok = c.storeCache[*store][ID]
-	if !ok {
-		log.Infof("Image %s not in cache, retreiving from datastore", ID)
-		// Not in the cache.  Try to load it.
-		i, err = c.DataStore.GetImage(ctx, store, ID)
-		if err != nil {
-			return nil, err
-		}
-
-		c.storeCache[*store][ID] = *i
-	}
-
-	return i, nil
-}
-
-// ListImages resturns a list of Images for a list of IDs, or all if no IDs are passed
-func (c *NameLookupCache) ListImages(ctx context.Context, store *url.URL, IDs []string) ([]*Image, error) {
-	storeName, err := util.ImageStoreName(store)
+	imgUrl, err := util.ImageURL(storeName, ID)
 	if err != nil {
 		return nil, err
 	}
 
-	// Check the store exists before we start iterating it.  This will populate the cache if it's empty.
-	if _, err := c.GetImageStore(ctx, storeName); err != nil {
-		return nil, err
-	}
+	node, err := c.storeCache[*store].Get(imgUrl.String())
 
-	c.storeCacheLock.Lock()
-	defer c.storeCacheLock.Unlock()
-
-	// Filter the results
-	var imageList []*Image
-	if len(IDs) > 0 {
-		for _, id := range IDs {
-			if i, ok := c.storeCache[*store][id]; ok {
-				newImage := i
-				imageList = append(imageList, &newImage)
+	var img *Image
+	if err != nil {
+		if err == index.ErrNodeNotFound {
+			log.Infof("Image %s not in cache, retreiving from datastore", ID)
+			// Not in the cache.  Try to load it.
+			img, err = c.DataStore.GetImage(ctx, store, ID)
+			if err != nil {
+				return nil, err
 			}
+
+			if err = indx.Insert(img); err != nil {
+				return nil, err
+			}
+		} else {
+			return nil, err
 		}
 	} else {
-		for _, v := range c.storeCache[*store] {
+		img, _ = node.(*Image)
+	}
+
+	return img, nil
+}
+
+// ListImages resturns a list of Images for a list of IDs, or all if no IDs are passed
+func (c *NameLookupCache) ListImages(ctx context.Context, store *url.URL, IDs []string) ([]*Image, error) {
+	// Filter the results
+	imageList := make([]*Image, 0, len(IDs))
+
+	if len(IDs) > 0 {
+		for _, id := range IDs {
+			i, err := c.GetImage(ctx, store, id)
+
+			if err == nil {
+				imageList = append(imageList, i)
+			}
+		}
+
+	} else {
+
+		storeName, err := util.ImageStoreName(store)
+		if err != nil {
+			return nil, err
+		}
+		// Check the store exists before we start iterating it.  This will populate the cache if it's empty.
+		if _, err := c.GetImageStore(ctx, storeName); err != nil {
+			return nil, err
+		}
+
+		// get the relevant cache
+		c.storeCacheLock.Lock()
+		indx := c.storeCache[*store]
+		c.storeCacheLock.Unlock()
+
+		images, err := indx.List()
+		if err != nil {
+			return nil, err
+		}
+
+		for _, v := range images {
+
+			img, _ := v.(*Image)
 			// filter out scratch
-			if v.ID == Scratch.ID {
+			if img.ID == Scratch.ID {
 				continue
 			}
-			newImage := v
-			imageList = append(imageList, &newImage)
+
+			imageList = append(imageList, img)
 		}
 	}
 

--- a/lib/portlayer/storage/image_cache.go
+++ b/lib/portlayer/storage/image_cache.go
@@ -288,7 +288,6 @@ func (c *NameLookupCache) ListImages(ctx context.Context, store *url.URL, IDs []
 		}
 
 		for _, v := range images {
-
 			img, _ := v.(*Image)
 			// filter out scratch
 			if img.ID == Scratch.ID {

--- a/lib/portlayer/storage/image_cache_test.go
+++ b/lib/portlayer/storage/image_cache_test.go
@@ -22,6 +22,7 @@ import (
 
 	"golang.org/x/net/context"
 
+	"github.com/Sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/vmware/vic/lib/portlayer/util"
 )
@@ -249,14 +250,16 @@ func TestImageStoreRestart(t *testing.T) {
 	// Create a set of images
 	expectedImages := make(map[string]*Image)
 
-	parent := Scratch
-	parent.Store = storeURL
+	parent, err := firstCache.GetImage(context.TODO(), storeURL, Scratch.ID)
+	if !assert.NoError(t, err) {
+		return
+	}
 
 	testSum := "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
 	for i := 1; i < 50; i++ {
 		id := fmt.Sprintf("ID-%d", i)
 
-		img, werr := firstCache.WriteImage(context.TODO(), &parent, id, nil, testSum, nil)
+		img, werr := firstCache.WriteImage(context.TODO(), parent, id, nil, testSum, nil)
 		if !assert.NoError(t, werr) {
 			return
 		}

--- a/lib/portlayer/storage/image_test.go
+++ b/lib/portlayer/storage/image_test.go
@@ -1,0 +1,66 @@
+// Copyright 2016 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storage
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/vmware/vic/lib/portlayer/util"
+)
+
+func TestImageCopy(t *testing.T) {
+	storeName := "testStore"
+	ID := "testImageID"
+
+	imageURL, err := util.ImageURL(storeName, ID)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	parentURL, err := util.ImageURL(storeName, Scratch.ID)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	storeURL, err := util.ImageStoreNameToURL(storeName)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	expected := &Image{
+		ID:         ID,
+		SelfLink:   imageURL,
+		ParentLink: parentURL,
+		Store:      storeURL,
+		Metadata: map[string][]byte{
+			"1": []byte{byte(1)},
+			"2": []byte{byte(2)},
+			"3": []byte("three"),
+		},
+	}
+
+	actual := expected.Copy().(*Image)
+
+	if !assert.Equal(t, expected, actual) {
+		return
+	}
+
+	actual.Metadata["4"] = []byte("four")
+
+	if !assert.NotEqual(t, expected, actual) {
+		return
+	}
+}

--- a/lib/portlayer/storage/vsphere/image.go
+++ b/lib/portlayer/storage/vsphere/image.go
@@ -247,11 +247,11 @@ func (v *ImageStore) WriteImage(ctx context.Context, parent *portlayer.Image, ID
 	}
 
 	newImage := &portlayer.Image{
-		ID:       ID,
-		SelfLink: imageURL,
-		Parent:   parent.SelfLink,
-		Store:    parent.Store,
-		Metadata: meta,
+		ID:         ID,
+		SelfLink:   imageURL,
+		ParentLink: parent.SelfLink,
+		Store:      parent.Store,
+		Metadata:   meta,
 	}
 
 	return newImage, nil
@@ -439,9 +439,9 @@ func (v *ImageStore) GetImage(ctx context.Context, store *url.URL, ID string) (*
 		// We're relying on the parent map for this since we don't currently have a
 		// way to get the disk's spec.  See VIC #482 for details.  Parent:
 		// parent.SelfLink,
-		Store:    &s,
-		Parent:   parentURL,
-		Metadata: meta,
+		Store:      &s,
+		ParentLink: parentURL,
+		Metadata:   meta,
 	}
 
 	log.Debugf("Returning image from location %s with parent url %s", newImage.SelfLink, newImage.Parent)

--- a/lib/portlayer/util/paths.go
+++ b/lib/portlayer/util/paths.go
@@ -16,6 +16,7 @@ package util
 
 import (
 	"errors"
+	"fmt"
 	"net/url"
 	"path"
 	"path/filepath"
@@ -60,6 +61,10 @@ func ImageStoreName(u *url.URL) (string, error) {
 }
 
 func ImageURL(storeName, imageName string) (*url.URL, error) {
+	if imageName == "" {
+		return nil, fmt.Errorf("image ID missing")
+	}
+
 	u, err := ImageStoreNameToURL(storeName)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This is in support of `rmi` (#437).  We need to keep images in b+trees so we can tell what can be deleted and what can't.
