### PR TITLE
Append the suite name to the log bundle file name

### DIFF
--- a/tests/resources/Util.robot
+++ b/tests/resources/Util.robot
@@ -156,7 +156,7 @@ Gather Logs From Test Server
     ${status}  ${message}=  Run Keyword And Ignore Error  Should Not Contain  ${params}  --tls
     # Non-certificate case
     ${ip}=  Run Keyword If  '${status}'=='PASS'  Split String  ${params}  :
-    Run Keyword If  '${status}'=='PASS'  Run  wget ${vic-admin}/container-logs.zip -O ${vch-name}-container-logs.zip
+    Run Keyword If  '${status}'=='PASS'  Run  wget ${vic-admin}/container-logs.zip -O ${SUITE NAME}-${vch-name}-container-logs.zip
     # Certificate case
     ${ip}=  Run Keyword If  '${status}'=='FAIL'  Split String  ${params}  ${SPACE}
     ${ip}=  Run Keyword If  '${status}'=='FAIL'  Split String  @{ip}[1]  :


### PR DESCRIPTION
Fixes #2062 

Looks like this now:
7-1-Regression-VCH-0-2100-container-logs.zip