### PR TITLE
WIP: Use poll instead of inotify for tailing logs

### DIFF
--- a/cmd/vicadmin/logs.go
+++ b/cmd/vicadmin/logs.go
@@ -329,6 +329,7 @@ func tailFile(wr io.Writer, file string, done *chan bool) error {
 		Location:  &spos,
 		ReOpen:    true,
 		MustExist: false,
+		Poll:      true,
 		Follow:    true,
 	}
 


### PR DESCRIPTION
There are known issues with the hpcloud/tail pkg that we're using for tailing vicadmin logs: 
hpcloud/tail#90
hpcloud/tail#21
hpcloud/tail#97

Using `poll` instead of `inotify` resolves the issue in some cases.

I can't repro #2096 locally. I'm using the WIP tag here to see if I can repro the issue on CI with this change. I'll update the PR once I've root-caused the issue.

Addresses #2096 #2203 

