### PR TITLE
Fix version.ShortVersion formatting

### DIFF
--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -75,5 +75,8 @@ func (v *Build) String() string {
 }
 
 func (v *Build) ShortVersion() string {
+	if v.BuildNumber == "" {
+		v.BuildNumber = "0"
+	}
 	return fmt.Sprintf("%s-%s-%s", v.Version, v.BuildNumber, v.GitCommit)
 }


### PR DESCRIPTION
now shows
```
Server Version: v0.5.5-c775037
```
instead of
```
Server Version: v0.5.5--c775037
```
when the BuildNumber is omitted