### PR TITLE
Add DeleteImage to storage image cache

### DIFF
--- a/lib/apiservers/portlayer/restapi/handlers/storage_handlers_test.go
+++ b/lib/apiservers/portlayer/restapi/handlers/storage_handlers_test.go
@@ -184,6 +184,10 @@ func (c *MockDataStore) ListImages(ctx context.Context, store *url.URL, IDs []st
 	return nil, fmt.Errorf("store (%s) doesn't exist", store.String())
 }
 
+func (c *MockDataStore) DeleteImage(ctx context.Context, image *spl.Image) error {
+	return nil
+}
+
 func TestCreateImageStore(t *testing.T) {
 	storageImageLayer = spl.NewLookupCache(&MockDataStore{})
 

--- a/lib/portlayer/storage/errors.go
+++ b/lib/portlayer/storage/errors.go
@@ -1,0 +1,23 @@
+// Copyright 2016 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storage
+
+type ErrImageInUse struct {
+	msg string
+}
+
+func (e *ErrImageInUse) Error() string {
+	return e.msg
+}

--- a/lib/portlayer/storage/image.go
+++ b/lib/portlayer/storage/image.go
@@ -64,6 +64,11 @@ type ImageStorer interface {
 	// ListImages returns a list of Images given a list of image IDs, or all
 	// images in the image store if no param is passed.
 	ListImages(ctx context.Context, store *url.URL, IDs []string) ([]*Image, error)
+
+	// DeleteImage deletes an image from the image store.  If the image is in
+	// use either by way of inheritence or because it's attached to a
+	// container, this will return an error.
+	DeleteImage(ctx context.Context, image *Image) error
 }
 
 // Image is the handle to identify an image layer on the backing store.  The

--- a/lib/portlayer/storage/image_cache_test.go
+++ b/lib/portlayer/storage/image_cache_test.go
@@ -329,7 +329,7 @@ func TestDeleteImage(t *testing.T) {
 		return
 	}
 
-	// create a 3 level tree with 9 branches
+	// create a 3 level tree with 4 branches
 	branches := 4
 	images := make(map[int]*Image)
 	for branch := 1; branch < branches; branch++ {

--- a/lib/portlayer/storage/image_cache_test.go
+++ b/lib/portlayer/storage/image_cache_test.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"io"
 	"net/url"
+	"strconv"
 	"testing"
 
 	"golang.org/x/net/context"
@@ -108,6 +109,12 @@ func (c *MockDataStore) ListImages(ctx context.Context, store *url.URL, IDs []st
 		imageList = append(imageList, i)
 	}
 	return imageList, nil
+}
+
+// DeleteImage removes an image from the image store
+func (c *MockDataStore) DeleteImage(ctx context.Context, image *Image) error {
+	delete(c.db[*image.Store], image.ID)
+	return nil
 }
 
 func TestListImages(t *testing.T) {
@@ -304,5 +311,91 @@ func TestImageStoreRestart(t *testing.T) {
 		if !assert.NoError(t, err) || !assert.Equal(t, expectedImg, img) {
 			return
 		}
+	}
+}
+
+func TestDeleteImage(t *testing.T) {
+	logrus.SetLevel(logrus.DebugLevel)
+	imageCache := NewLookupCache(NewMockDataStore())
+	ctx := context.Background()
+
+	storeURL, err := imageCache.CreateImageStore(ctx, "testStore")
+	if !assert.NoError(t, err) || !assert.NotNil(t, storeURL) {
+		return
+	}
+
+	scratch, err := imageCache.GetImage(ctx, storeURL, Scratch.ID)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	// create a 3 level tree with 9 branches
+	branches := 4
+	images := make(map[int]*Image)
+	for branch := 1; branch < branches; branch++ {
+		// level 1
+		img, err := imageCache.WriteImage(ctx, scratch, strconv.Itoa(branch), nil, "", nil)
+		if !assert.NoError(t, err) || !assert.NotNil(t, img) {
+			return
+		}
+		images[branch] = img
+
+		// level 2
+		i, err := imageCache.WriteImage(ctx, img, strconv.Itoa(branch*10), nil, "", nil)
+		if !assert.NoError(t, err) || !assert.NotNil(t, i) {
+			return
+		}
+		images[branch*10] = i
+
+		// level 3
+		i, err = imageCache.WriteImage(ctx, img, strconv.Itoa(branch*100), nil, "", nil)
+		if !assert.NoError(t, err) || !assert.NotNil(t, i) {
+			return
+		}
+		images[branch*100] = i
+	}
+
+	// Deletion of an intermediate node should fail
+	err = imageCache.DeleteImage(ctx, images[1])
+	if !assert.Error(t, err) {
+		return
+	}
+
+	imageList, err := imageCache.ListImages(ctx, storeURL, nil)
+	if !assert.NoError(t, err) || !assert.NotNil(t, imageList) {
+		return
+	}
+
+	// image list should be uneffected
+	if !assert.Equal(t, len(images), len(imageList)) {
+		return
+	}
+
+	// Deletion of leaves should be fine
+	for branch := 1; branch < branches; branch++ {
+		// range up the branch
+		for _, img := range []*Image{images[branch*100], images[branch*10], images[branch]} {
+
+			err = imageCache.DeleteImage(ctx, img)
+			if !assert.NoError(t, err) {
+				return
+			}
+
+			// the image should be gone
+			i, err := imageCache.GetImage(ctx, storeURL, img.ID)
+			if !assert.Error(t, err) || !assert.Nil(t, i) {
+				return
+			}
+		}
+	}
+
+	// List images should be empty (because we filter out scratch)
+	imageList, err = imageCache.ListImages(ctx, storeURL, nil)
+	if !assert.NoError(t, err) || !assert.NotNil(t, imageList) {
+		return
+	}
+
+	if !assert.True(t, len(imageList) == 0) {
+		return
 	}
 }

--- a/lib/portlayer/storage/vsphere/image.go
+++ b/lib/portlayer/storage/vsphere/image.go
@@ -481,6 +481,13 @@ func (v *ImageStore) ListImages(ctx context.Context, store *url.URL, IDs []strin
 	return images, nil
 }
 
+// DeleteImage deletes an image from the image store.  If the image is in
+// use either by way of inheritence or because it's attached to a
+// container, this will return an error.
+func (v *ImageStore) DeleteImage(ctx context.Context, image *portlayer.Image) error {
+	return fmt.Errorf("not implemented")
+}
+
 // Find any image directories without the manifest file and remove them.
 func (v *ImageStore) cleanup(ctx context.Context, store *url.URL) error {
 	log.Infof("Checking for inconsistent images on %s", store.String())

--- a/lib/portlayer/storage/vsphere/image.go
+++ b/lib/portlayer/storage/vsphere/image.go
@@ -541,6 +541,7 @@ func (v *ImageStore) writeManifest(ctx context.Context, storeName, ID string, r 
 func (v *ImageStore) verifyImage(ctx context.Context, storeName, ID string) error {
 	imageDir := v.imageDirPath(storeName, ID)
 
+	// Check for teh manifiest file and the vmdk
 	for _, p := range []string{path.Join(imageDir, manifest), v.imageDiskPath(storeName, ID)} {
 		if _, err := v.ds.Stat(ctx, p); err != nil {
 			return err

--- a/pkg/index/index.go
+++ b/pkg/index/index.go
@@ -71,7 +71,7 @@ func (i *Index) Insert(n Element) error {
 		return fmt.Errorf("node %s already exists in index", n.Self())
 	}
 
-	log.Debugf("Inserting %s (parent: %s) in index", n.Self(), n.Parent())
+	log.Debugf("Index: inserting %s (parent: %s) in index", n.Self(), n.Parent())
 
 	newNode := &node{
 		Element: n.Copy(),
@@ -108,6 +108,19 @@ func (i *Index) Get(nodeId string) (Element, error) {
 	}
 
 	return n.Copy(), nil
+}
+
+// HasChildren returns whether a node has children or not
+func (i *Index) HasChildren(nodeId string) (bool, error) {
+	i.m.Lock()
+	defer i.m.Unlock()
+
+	n, ok := i.lookupTable[nodeId]
+	if !ok {
+		return false, ErrNodeNotFound
+	}
+
+	return (len(n.children) > 0), nil
 }
 
 func (i *Index) List() ([]Element, error) {

--- a/pkg/vsphere/datastore/datastore.go
+++ b/pkg/vsphere/datastore/datastore.go
@@ -218,7 +218,17 @@ func (d *Helper) Download(ctx context.Context, pth string) (io.ReadCloser, error
 }
 
 func (d *Helper) Stat(ctx context.Context, pth string) (types.BaseFileInfo, error) {
-	return d.ds.Stat(ctx, path.Join(d.rootDir(), pth))
+	i, err := d.ds.Stat(ctx, path.Join(d.rootDir(), pth))
+	if err != nil {
+		switch err.(type) {
+		case object.DatastoreNoSuchDirectoryError:
+			return nil, os.ErrNotExist
+		default:
+			return nil, err
+		}
+	}
+
+	return i, nil
 }
 
 func (d *Helper) Mv(ctx context.Context, fromPath, toPath string) error {


### PR DESCRIPTION
This change implements image deletion from the image cache.  The vsphere impl which actually removes it from the datastore (after checking if it is attached) will come in next.  

Only allows deletes of images which have no children.  Deletes of
unused branches will come in at a later date if at all.

