### PR TITLE
Adding the rm container regression for invalid command

### DIFF
--- a/tests/test-cases/Group1-Docker-Commands/1-11-Docker-RM.md
+++ b/tests/test-cases/Group1-Docker-Commands/1-11-Docker-RM.md
@@ -25,9 +25,10 @@ This test requires that a vSphere server is running and available
 12. Issue docker create --name test busybox to the VIC appliance
 13. Remove the containerVM out-of-band using govc
 14. Issue docker rm test to the VIC appliance
+15. Issue docker rm to container created with an unknown executable
 
 #Expected Outcome:
-* Steps 2-8,12 should complete without error
+* Steps 2-8,12,15 should complete without error
 * Step 3,6,10 should result in the container being removed from the VIC appliance
 * Step 9 should result in the following error:  
 ```

--- a/tests/test-cases/Group1-Docker-Commands/1-11-Docker-RM.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-11-Docker-RM.robot
@@ -73,4 +73,10 @@ Remove a container deleted out of band
     ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} rm test
     Should Be Equal As Integers  ${rc}  1
     Should Contain  ${output}  Error response from daemon: No such container: test
+
+Remove a container created with unknown executable
+    ${rc}  ${container}=  Run And Return Rc And Output  docker ${params} create busybox xxxx
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} rm ${container}
+    Should Be Equal As Integers  ${rc}  0
     


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[  ] There is an associated issue that is labelled
[  ] Code is up-to-date with the `master` branch
[  ] You've successfully run `make test` locally
[  ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/vmware/vic/blob/master/.github/CONTRIBUTING.md
-->

Create regression test for #2113 (#2123)