### PR TITLE
Log failures from ParseReference, run imagec tests in debug mode

### DIFF
--- a/cmd/imagec/imagec.go
+++ b/cmd/imagec/imagec.go
@@ -172,6 +172,7 @@ func ParseReference() error {
 	// Validate and parse reference name
 	ref, err := reference.ParseNamed(options.reference)
 	if err != nil {
+		log.Warn("Error while parsing reference %s: %#v", options.reference, err)
 		return err
 	}
 

--- a/tests/test-cases/Group2-Imagec/2-10-Verify-Logfile.robot
+++ b/tests/test-cases/Group2-Imagec/2-10-Verify-Logfile.robot
@@ -3,7 +3,7 @@ Resource  ../../resources/Util.robot
 
 *** Test Cases ***
 Test
-    ${result}=  Run Process  ${bin-dir}/imagec -standalone -reference photon -logfile /tmp/foo.log -destination /tmp/images  shell=True 
+    ${result}=  Run Process  ${bin-dir}/imagec -debug -standalone -reference photon -logfile /tmp/foo.log -destination /tmp/images  shell=True 
     Should Be Equal As Integers  0  ${result.rc}
     OperatingSystem.File Should Exist  /tmp/foo.log
     File Should Not Be Empty  /tmp/foo.log


### PR DESCRIPTION
This is not a fix for #2219 but should give us some visibility into it next time it occurs.
