### PR TITLE
[full ci] Fix the wrong version info in vApp

### DIFF
--- a/lib/install/management/virtual_app.go
+++ b/lib/install/management/virtual_app.go
@@ -24,6 +24,7 @@ import (
 	"github.com/vmware/vic/lib/install/data"
 	"github.com/vmware/vic/pkg/errors"
 	"github.com/vmware/vic/pkg/trace"
+	"github.com/vmware/vic/pkg/version"
 )
 
 func (d *Dispatcher) createVApp(conf *config.VirtualContainerHostConfigSpec, settings *data.InstallerData) (*object.VirtualApp, error) {
@@ -79,7 +80,7 @@ func (d *Dispatcher) createVApp(conf *config.VirtualContainerHostConfigSpec, set
 			Name:      "vSphere Integrated Containers",
 			Vendor:    "VMware",
 			VendorUrl: "http://www.vmware.com/",
-			Version:   "0.0.1",
+			Version:   version.Version,
 		},
 		ArrayUpdateSpec: types.ArrayUpdateSpec{
 			Operation: types.ArrayUpdateOperationAdd,


### PR DESCRIPTION
This simple PR fixes #2158 in that the version of vApp in vSphere Web Client currently showing 0.0.1 is corrected to 0.5.5.

After fix:
![image](https://cloud.githubusercontent.com/assets/3834071/18291906/30043256-7450-11e6-8760-b600205cb585.png)
