### PR TITLE
Refactor imagec error handling

### DIFF
--- a/cmd/imagec/docker.go
+++ b/cmd/imagec/docker.go
@@ -138,7 +138,7 @@ func LearnAuthURL(options ImageCOptions) (*url.URL, error) {
 
 	// Do we even have the image on that registry
 	if err != nil && fetcher.IsStatusNotFound() {
-		return nil, fmt.Errorf("%s:%s does not exists at %s", options.image, options.tag, options.registry)
+		return nil, fmt.Errorf("%s:%s does not exist at %s", options.image, options.tag, options.registry)
 	}
 
 	return nil, fmt.Errorf("%s returned an unexpected response: %s", url, err)

--- a/cmd/imagec/errors.go
+++ b/cmd/imagec/errors.go
@@ -14,6 +14,8 @@
 
 package main
 
+import "fmt"
+
 // DoNotRetry is an error wrapper indicating that the error cannot be resolved with a retry.
 type DoNotRetry struct {
 	Err error
@@ -21,5 +23,23 @@ type DoNotRetry struct {
 
 // Error returns the stringified representation of the encapsulated error.
 func (e DoNotRetry) Error() string {
-	return e.Err.Error()
+	return fmt.Sprintf("download failed: %s", e.Err.Error())
+}
+
+// ImageNotFoundError is returned when an image is not found.
+type ImageNotFoundError struct {
+	Err error
+}
+
+func (e ImageNotFoundError) Error() string {
+	return fmt.Sprintf("image not found: %s", e.Err.Error())
+}
+
+// TagNotFoundError is returned when an image's tag doesn't exist.
+type TagNotFoundError struct {
+	Err error
+}
+
+func (e TagNotFoundError) Error() string {
+	return fmt.Sprintf("image tag not found: %s", e.Err.Error())
 }

--- a/cmd/imagec/imagec.go
+++ b/cmd/imagec/imagec.go
@@ -705,9 +705,12 @@ func main() {
 	// Get the manifest
 	manifest, err := FetchImageManifest(options)
 	if err != nil {
-		if strings.Contains(err.Error(), "image not found") {
+		switch err := err.(type) {
+		case ImageNotFoundError:
 			log.Fatalf("Error: image %s not found", options.image)
-		} else {
+		case TagNotFoundError:
+			log.Fatalf("Tag %s not found in repository %s", options.tag, options.image)
+		default:
 			log.Fatalf("Error while pulling image manifest: %s", err)
 		}
 	}

--- a/cmd/imagec/imagec_test.go
+++ b/cmd/imagec/imagec_test.go
@@ -509,8 +509,8 @@ func TestFetchScenarios(t *testing.T) {
 	// valid token but image is missing we shouldn't retry
 	_, err = FetchImageManifest(options)
 	if err != nil {
-		// we should get a DNR error
-		if _, isDNR := err.(DoNotRetry); !isDNR {
+		// we should get a ImageNotFoundError
+		if _, imageErr := err.(ImageNotFoundError); !imageErr {
 			t.Errorf(err.Error())
 		}
 	}

--- a/tests/test-cases/Group1-Docker-Commands/1-2-Docker-Pull.md
+++ b/tests/test-cases/Group1-Docker-Commands/1-2-Docker-Pull.md
@@ -21,12 +21,14 @@ This test requires that an vSphere server is running and available.
 5. Issue a docker pull command to the new VIC appliance using a different repo than the default
     * myregistry.local:5000/testing/test-image
 6. Issue a docker pull command to the new VIC appliance using all tags option
-    * --all-tags fedora
+    * --all-tags nginx
 7. Issue a docker pull command to the new VIC appliance using an image that doesn't exist
 8. Issue a docker pull command to the new VIC appliance using a non-default repository that doesn't exist
+9. Issue a docker pull command for an image with a tag that doesn't exist
+10. Issue a docker pull command for an image that has already been pulled
 
 #Expected Outcome:
-VIC appliance should respond with a properly formatted pull response to each command issued to it. No errors should be seen, except in the case of step 7 and 8.
+VIC appliance should respond with a properly formatted pull response to each command issued to it. No errors should be seen, except in the case of step 7, 8 and 9.
 
 #Possible Problems:
 None

--- a/tests/test-cases/Group1-Docker-Commands/1-2-Docker-Pull.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-2-Docker-Pull.robot
@@ -63,6 +63,12 @@ Pull image from non-existent repo
     Should Be Equal As Integers  ${rc}  1
     Should Contain  ${output}  no such host
 
+Pull image with a tag that doesn't exist
+    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} pull busybox:faketag
+    Log  ${output}
+    Should Be Equal As Integers  ${rc}  1
+    Should Contain  ${output}  Tag faketag not found in repository library/busybox
+
 Pull image that already has been pulled
     Wait Until Keyword Succeeds  5x  15 seconds  Pull image  alpine
     Wait Until Keyword Succeeds  5x  15 seconds  Pull image  alpine


### PR DESCRIPTION
* Shows correct output for an invalid image tag:
```
$ docker -H 192.168.77.130:2376 --tls pull hello-world:faketag
Pulling from library/hello-world
Tag faketag not found in repository library/hello-world
```
* Introduces typed errors in imagec for invalid images/tags
* Adds an integration test in `1-2-Docker-Pull`

Fixes #2117, addresses #1710
Fixes #2093
