### PR TITLE
Use imagec fetcher for login [full ci]

### DIFF
--- a/cmd/imagec/imagec.go
+++ b/cmd/imagec/imagec.go
@@ -43,6 +43,7 @@ import (
 
 	"github.com/vmware/vic/lib/apiservers/portlayer/models"
 	"github.com/vmware/vic/lib/metadata"
+	urlfetcher "github.com/vmware/vic/pkg/fetcher"
 	"github.com/vmware/vic/pkg/i18n"
 	"github.com/vmware/vic/pkg/version"
 	"github.com/vmware/vic/pkg/vsphere/sys"
@@ -75,7 +76,7 @@ type ImageCOptions struct {
 	username string
 	password string
 
-	token *Token
+	token *urlfetcher.Token
 
 	timeout time.Duration
 
@@ -121,9 +122,6 @@ const (
 
 	// DefaultHTTPTimeout specifies the default HTTP timeout
 	DefaultHTTPTimeout = 3600 * time.Second
-
-	// DefaultTokenExpirationDuration specifies the default token expiration
-	DefaultTokenExpirationDuration = 60 * time.Second
 
 	// attribute update actions
 	Add = iota + 1
@@ -201,14 +199,14 @@ func DestinationDirectory() string {
 	/*
 		https/
 		├── 192.168.218.5:5000
-		│   └── v2
-		│       └── busybox
-		│           └── latest
+		│   └── v2
+		│       └── busybox
+		│           └── latest
 		...
-		│               ├── fef924a0204a00b3ec67318e2ed337b189c99ea19e2bf10ed30a13b87c5e17ab
-		│               │   ├── fef924a0204a00b3ec67318e2ed337b189c99ea19e2bf10ed30a13b87c5e17ab.json
-		│               │   └── fef924a0204a00b3ec67318e2ed337b189c99ea19e2bf10ed30a13b87c5e17ab.tar
-		│               └── manifest.json
+		│               ├── fef924a0204a00b3ec67318e2ed337b189c99ea19e2bf10ed30a13b87c5e17ab
+		│               │   ├── fef924a0204a00b3ec67318e2ed337b189c99ea19e2bf10ed30a13b87c5e17ab.json
+		│               │   └── fef924a0204a00b3ec67318e2ed337b189c99ea19e2bf10ed30a13b87c5e17ab.tar
+		│               └── manifest.json
 		└── registry-1.docker.io
 		    └── v2
 		        └── library
@@ -216,8 +214,8 @@ func DestinationDirectory() string {
 		                └── latest
 		                    ...
 		                    ├── f61ebe2817bb4e6a7f0a4cf249a5316223f7ecc886feac24b9887a490feaed57
-		                    │   ├── f61ebe2817bb4e6a7f0a4cf249a5316223f7ecc886feac24b9887a490feaed57.json
-		                    │   └── f61ebe2817bb4e6a7f0a4cf249a5316223f7ecc886feac24b9887a490feaed57.tar
+		                    │   ├── f61ebe2817bb4e6a7f0a4cf249a5316223f7ecc886feac24b9887a490feaed57.json
+		                    │   └── f61ebe2817bb4e6a7f0a4cf249a5316223f7ecc886feac24b9887a490feaed57.tar
 		                    └── manifest.json
 
 	*/
@@ -685,7 +683,7 @@ func main() {
 	url, err := LearnAuthURL(options)
 	if err != nil {
 		switch err := err.(type) {
-		case ImageNotFoundError:
+		case urlfetcher.ImageNotFoundError:
 			log.Fatalf("Error: image %s not found", options.reference)
 		default:
 			log.Fatalf("Failed to obtain OAuth endpoint: %s", err)
@@ -711,9 +709,9 @@ func main() {
 	manifest, err := FetchImageManifest(options)
 	if err != nil {
 		switch err := err.(type) {
-		case ImageNotFoundError:
+		case urlfetcher.ImageNotFoundError:
 			log.Fatalf("Error: image %s not found", options.image)
-		case TagNotFoundError:
+		case urlfetcher.TagNotFoundError:
 			log.Fatalf("Tag %s not found in repository %s", options.tag, options.image)
 		default:
 			log.Fatalf("Error while pulling image manifest: %s", err)

--- a/cmd/imagec/imagec_test.go
+++ b/cmd/imagec/imagec_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/Sirupsen/logrus"
 
 	"github.com/vmware/vic/lib/apiservers/portlayer/models"
+	urlfetcher "github.com/vmware/vic/pkg/fetcher"
 )
 
 const (
@@ -168,7 +169,7 @@ func TestFetchToken(t *testing.T) {
 		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
 
-			body, err := json.Marshal(&Token{Token: OAuthToken})
+			body, err := json.Marshal(&urlfetcher.Token{Token: OAuthToken})
 			if err != nil {
 				t.Errorf(err.Error())
 			}
@@ -206,7 +207,7 @@ func TestFetchImageManifest(t *testing.T) {
 	options.registry = s.URL
 	options.image = Image
 	options.tag = Tag
-	options.token = &Token{Token: OAuthToken}
+	options.token = &urlfetcher.Token{Token: OAuthToken}
 
 	// create a temporary directory
 	dir, err := ioutil.TempDir("", "imagec")
@@ -267,7 +268,7 @@ func TestFetchImageBlob(t *testing.T) {
 	options.registry = s.URL
 	options.image = Image
 	options.tag = Tag
-	options.token = &Token{Token: OAuthToken}
+	options.token = &urlfetcher.Token{Token: OAuthToken}
 
 	// create a temporary directory
 	dir, err := ioutil.TempDir("", "imagec")
@@ -487,14 +488,14 @@ func TestFetchScenarios(t *testing.T) {
 	_, err = FetchImageManifest(options)
 	if err != nil {
 		// we should get a DNR error
-		if _, isDNR := err.(DoNotRetry); !isDNR {
+		if _, isDNR := err.(urlfetcher.DoNotRetry); !isDNR {
 			t.Errorf(err.Error())
 		}
 	}
 	wwwAuthenticate = false
 
 	// set a valid token
-	options.token = &Token{Token: OAuthToken}
+	options.token = &urlfetcher.Token{Token: OAuthToken}
 
 	// enable invalid token test
 	invalidToken = true
@@ -511,7 +512,7 @@ func TestFetchScenarios(t *testing.T) {
 	_, err = FetchImageManifest(options)
 	if err != nil {
 		// we should get a ImageNotFoundError
-		if _, imageErr := err.(ImageNotFoundError); !imageErr {
+		if _, imageErr := err.(urlfetcher.ImageNotFoundError); !imageErr {
 			t.Errorf(err.Error())
 		}
 	}

--- a/pkg/fetcher/errors.go
+++ b/pkg/fetcher/errors.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package fetcher
 
 import "fmt"
 


### PR DESCRIPTION
Refactored fetcher to separate auth and layer fetching. Moved
it to pkg/registry.  Updated the personality server's login to
use the fetcher code for login to match up the login and pull
auth code.