### PR TITLE
upgrade workflow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -291,7 +291,7 @@ $(portlayerapi-server): $(PORTLAYER_DEPS) $(SWAGGER)
 
 $(portlayerapi): $(call godeps,cmd/port-layer-server/*.go) $(portlayerapi-server) $(portlayerapi-client)
 	@echo building Portlayer API server...
-	@$(TIME) $(GO) build $(RACE) -o $@ ./cmd/port-layer-server
+	@$(TIME) $(GO) build $(RACE) $(ldflags) -o $@ ./cmd/port-layer-server
 
 $(iso-base): isos/base.sh isos/base/*.repo isos/base/isolinux/** isos/base/xorriso-options.cfg
 	@echo building iso-base docker image

--- a/cmd/vic-machine/common/images.go
+++ b/cmd/vic-machine/common/images.go
@@ -1,0 +1,192 @@
+// Copyright 2016 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	log "github.com/Sirupsen/logrus"
+
+	"github.com/urfave/cli"
+	"github.com/vmware/vic/pkg/errors"
+	"github.com/vmware/vic/pkg/trace"
+	"github.com/vmware/vic/pkg/version"
+)
+
+const (
+	ApplianceImageKey  = "core"
+	LinuxImageKey      = "linux"
+	ApplianceImageName = "appliance.iso"
+	LinuxImageName     = "bootstrap.iso"
+
+	// An ISO 9660 sector is normally 2 KiB long. Although the specification allows for alternative sector sizes, you will rarely find anything other than 2 KiB.
+	ISO9660SectorSize = 2048
+	ISOVolumeSector   = 0x10
+	PublisherOffset   = 318
+)
+
+var (
+	images = map[string][]string{
+		ApplianceImageKey: {ApplianceImageName},
+		LinuxImageKey:     {LinuxImageName},
+	}
+)
+
+type Images struct {
+	ApplianceISO string
+	BootstrapISO string
+	OSType       string
+}
+
+func (i *Images) ImageFlags() []cli.Flag {
+	return []cli.Flag{
+		cli.StringFlag{
+			Name:        "appliance-iso, ai",
+			Value:       "",
+			Usage:       "The appliance iso",
+			Destination: &i.ApplianceISO,
+		},
+		cli.StringFlag{
+			Name:        "bootstrap-iso, bi",
+			Value:       "",
+			Usage:       "The bootstrap iso",
+			Destination: &i.BootstrapISO,
+		},
+	}
+}
+
+func (i *Images) CheckImagesFiles(force bool) (map[string]string, error) {
+	defer trace.End(trace.Begin(""))
+
+	i.OSType = "linux"
+	// detect images files
+	osImgs, ok := images[i.OSType]
+	if !ok {
+		return nil, fmt.Errorf("Specified OS \"%s\" is not known to this installer", i.OSType)
+	}
+
+	imgs := make(map[string]string)
+	result := make(map[string]string)
+	if i.ApplianceISO == "" {
+		i.ApplianceISO = images[ApplianceImageKey][0]
+	}
+	imgs[ApplianceImageName] = i.ApplianceISO
+
+	if i.BootstrapISO == "" {
+		i.BootstrapISO = osImgs[0]
+	}
+	imgs[LinuxImageName] = i.BootstrapISO
+
+	for name, img := range imgs {
+		_, err := os.Stat(img)
+		if os.IsNotExist(err) {
+			var dir string
+			dir, err = filepath.Abs(filepath.Dir(os.Args[0]))
+			_, err = os.Stat(filepath.Join(dir, img))
+			if err == nil {
+				img = filepath.Join(dir, img)
+			}
+		}
+
+		if os.IsNotExist(err) {
+			log.Warnf("\t\tUnable to locate %s in the current or installer directory.", img)
+			return nil, err
+		}
+
+		version, err := i.checkImageVersion(img, force)
+		if err != nil {
+			log.Error(err)
+			return nil, err
+		}
+		versionedName := fmt.Sprintf("%s-%s", version, name)
+		result[versionedName] = img
+		if name == ApplianceImageName {
+			i.ApplianceISO = versionedName
+		} else {
+			i.BootstrapISO = versionedName
+		}
+	}
+
+	return result, nil
+}
+
+// GetImageVersion will read iso file version from Primary Volume Descriptor, field "Publisher Identifier"
+func (i *Images) GetImageVersion(img string) (string, error) {
+	defer trace.End(trace.Begin(""))
+
+	f, err := os.Open(img)
+	if err != nil {
+		return "", errors.Errorf("failed to open iso file %q: %s", img, err)
+	}
+	defer f.Close()
+
+	// System area goes from sectors 0x00 to 0x0F. Volume descriptors can be
+	// found starting at sector 0x10
+
+	_, err = f.Seek(int64(ISOVolumeSector*ISO9660SectorSize)+PublisherOffset, 0)
+	if err != nil {
+		return "", errors.Errorf("failed to locate iso version section in file %q: %s", img, err)
+	}
+	publisherBytes := make([]byte, 128)
+	size, err := f.Read(publisherBytes)
+	if err != nil {
+		return "", errors.Errorf("failed to read iso version in file %q: %s", img, err)
+	}
+	if size == 0 {
+		return "", errors.Errorf("version is not set in iso file %q", img)
+	}
+
+	versions := strings.Fields(string(publisherBytes[:size]))
+	return versions[len(versions)-1], nil
+}
+
+func (i *Images) checkImageVersion(img string, force bool) (string, error) {
+	defer trace.End(trace.Begin(""))
+
+	ver, err := i.GetImageVersion(img)
+	if err != nil {
+		return "", err
+	}
+	sv := i.getNoCommitHashVersion(ver)
+	if sv == "" {
+		log.Debugf("Version is not set in %q", img)
+		ver = ""
+	}
+
+	installerSV := i.getNoCommitHashVersion(version.GetBuild().ShortVersion())
+
+	// here compare version without last commit hash, to make developer life easier
+	if !strings.EqualFold(installerSV, sv) {
+		message := fmt.Sprintf("iso file %q has inconsistent version with installer %q != %q.", img, strings.ToLower(ver), version.GetBuild().ShortVersion())
+		if !force {
+			return "", errors.Errorf("%s. Specify --force to force create. ", message)
+		}
+		log.Warn(message)
+	}
+	return ver, nil
+}
+
+func (i *Images) getNoCommitHashVersion(version string) string {
+	defer trace.End(trace.Begin(""))
+
+	j := strings.LastIndex(version, "-")
+	if j == -1 {
+		return ""
+	}
+	return version[:j]
+}

--- a/cmd/vic-machine/common/images_test.go
+++ b/cmd/vic-machine/common/images_test.go
@@ -1,0 +1,115 @@
+// Copyright 2016 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/urfave/cli"
+
+	log "github.com/Sirupsen/logrus"
+)
+
+var (
+	image = &Images{}
+)
+
+func TestImageNotFound(t *testing.T) {
+	log.SetLevel(log.InfoLevel)
+	tmpfile, err := ioutil.TempFile("", "appIso")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	defer os.Remove(tmpfile.Name()) // clean up
+
+	image.ApplianceISO = tmpfile.Name()
+	image.OSType = "linux"
+	if _, err = image.CheckImagesFiles(false); err == nil {
+		t.Errorf("Error is expected for boot iso file is not found.")
+	}
+}
+
+func writeImageVersion(fileName string, version string) error {
+	f, err := os.OpenFile(fileName, os.O_APPEND|os.O_WRONLY, os.ModeAppend)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	if err := f.Truncate(int64(0x10*2048) + 318); err != nil {
+		return err
+	}
+	if _, err := f.WriteAt([]byte(version), int64(0x10*2048)+318); err != nil {
+		return err
+	}
+	return nil
+}
+
+func TestImageChecks(t *testing.T) {
+	log.SetLevel(log.InfoLevel)
+	tmpfile, err := ioutil.TempFile("", "bootIso")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	defer os.Remove(tmpfile.Name()) // clean up
+
+	_, err = os.Create("appliance.iso")
+	if err != nil {
+		t.Errorf("Failed to create default appliance iso file")
+	}
+	defer os.Remove("appliance.iso")
+
+	image.ApplianceISO = ""
+	image.BootstrapISO = tmpfile.Name()
+	image.OSType = "linux"
+	var imageFiles map[string]string
+	if _, err = image.CheckImagesFiles(false); err == nil {
+		t.Errorf("Error is expected")
+	}
+
+	if err = writeImageVersion("appliance.iso", "Inc. 0.1-000-abcd"); err != nil {
+		t.Error(err)
+	}
+	if err = writeImageVersion(tmpfile.Name(), "Inc. 0.1-000-abcd"); err != nil {
+		t.Error(err)
+	}
+
+	cliContext := &cli.Context{
+		App: &cli.App{
+			Version: "Inconsistent",
+		},
+	}
+	if _, err = image.CheckImagesFiles(false); err == nil {
+		t.Errorf("Error is expected")
+	}
+
+	cliContext.App.Version = "0.1-000-abcd"
+	if imageFiles, err = image.CheckImagesFiles(true); err != nil {
+		t.Errorf("Error is returned: %s", err)
+	}
+	found := false
+	for _, file := range imageFiles {
+		if file == tmpfile.Name() {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("Image file list does not contain input, %s", imageFiles)
+	}
+}

--- a/cmd/vic-machine/create/install_test.go
+++ b/cmd/vic-machine/create/install_test.go
@@ -16,109 +16,15 @@ package create
 
 import (
 	"flag"
-	"fmt"
-	"io/ioutil"
 	"os"
 	"testing"
 
 	log "github.com/Sirupsen/logrus"
-
-	"github.com/urfave/cli"
 )
 
 var (
 	create = NewCreate()
 )
-
-func TestImageNotFound(t *testing.T) {
-	log.SetLevel(log.InfoLevel)
-	tmpfile, err := ioutil.TempFile("", "appIso")
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	defer os.Remove(tmpfile.Name()) // clean up
-
-	os.Args = []string{"cmd", "create", fmt.Sprintf("-appliance-iso=%s", tmpfile.Name())}
-	flag.Parse()
-	create.ApplianceISO = tmpfile.Name()
-	create.osType = "linux"
-	if _, err = create.checkImagesFiles(nil); err == nil {
-		t.Errorf("Error is expected for boot iso file is not found.")
-	}
-}
-
-func writeImageVersion(fileName string, version string) error {
-	f, err := os.OpenFile(fileName, os.O_APPEND|os.O_WRONLY, os.ModeAppend)
-	if err != nil {
-		return err
-	}
-	defer f.Close()
-	if err := f.Truncate(int64(0x10*2048) + 318); err != nil {
-		return err
-	}
-	if _, err := f.WriteAt([]byte(version), int64(0x10*2048)+318); err != nil {
-		return err
-	}
-	return nil
-}
-
-func TestImageChecks(t *testing.T) {
-	log.SetLevel(log.InfoLevel)
-	tmpfile, err := ioutil.TempFile("", "bootIso")
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	defer os.Remove(tmpfile.Name()) // clean up
-
-	_, err = os.Create("appliance.iso")
-	if err != nil {
-		t.Errorf("Failed to create default appliance iso file")
-	}
-	defer os.Remove("appliance.iso")
-
-	os.Args = []string{"cmd", "create", fmt.Sprintf("-bootstrap-iso=%s", tmpfile.Name())}
-	flag.Parse()
-	create.ApplianceISO = ""
-	create.BootstrapISO = tmpfile.Name()
-	create.osType = "linux"
-	var imageFiles map[string]string
-	if _, err = create.checkImagesFiles(nil); err == nil {
-		t.Errorf("Error is expected")
-	}
-
-	if err = writeImageVersion("appliance.iso", "Inc. 0.1-000-abcd"); err != nil {
-		t.Error(err)
-	}
-	if err = writeImageVersion(tmpfile.Name(), "Inc. 0.1-000-abcd"); err != nil {
-		t.Error(err)
-	}
-
-	cliContext := &cli.Context{
-		App: &cli.App{
-			Version: "Inconsistent",
-		},
-	}
-	if _, err = create.checkImagesFiles(cliContext); err == nil {
-		t.Errorf("Error is expected")
-	}
-
-	cliContext.App.Version = "0.1-000-abcd"
-	if imageFiles, err = create.checkImagesFiles(cliContext); err != nil {
-		t.Errorf("Error is returned: %s", err)
-	}
-	found := false
-	for _, file := range imageFiles {
-		if file == tmpfile.Name() {
-			found = true
-			break
-		}
-	}
-	if !found {
-		t.Errorf("Image file list does not contain input, %s", imageFiles)
-	}
-}
 
 func TestLoadKey(t *testing.T) {
 	log.SetLevel(log.InfoLevel)

--- a/cmd/vic-machine/inspect/inspect.go
+++ b/cmd/vic-machine/inspect/inspect.go
@@ -28,7 +28,7 @@ import (
 	"golang.org/x/net/context"
 )
 
-// Delete has all input parameters for vic-machine delete command
+// Inspect has all input parameters for vic-machine inspect command
 type Inspect struct {
 	*data.Data
 
@@ -41,7 +41,7 @@ func NewInspect() *Inspect {
 	return d
 }
 
-// Flags return all cli flags for delete
+// Flags return all cli flags for inspect
 func (i *Inspect) Flags() []cli.Flag {
 	preFlags := append(i.TargetFlags(), i.IDFlags()...)
 	preFlags = append(preFlags, i.ComputeFlags()...)

--- a/cmd/vic-machine/main.go
+++ b/cmd/vic-machine/main.go
@@ -27,6 +27,7 @@ import (
 	uninstall "github.com/vmware/vic/cmd/vic-machine/delete"
 	"github.com/vmware/vic/cmd/vic-machine/inspect"
 	"github.com/vmware/vic/cmd/vic-machine/list"
+	"github.com/vmware/vic/cmd/vic-machine/upgrade"
 	"github.com/vmware/vic/pkg/errors"
 	"github.com/vmware/vic/pkg/version"
 )
@@ -46,6 +47,7 @@ func main() {
 	uninstall := uninstall.NewUninstall()
 	inspect := inspect.NewInspect()
 	list := list.NewList()
+	upgrade := upgrade.NewUpgrade()
 	app.Commands = []cli.Command{
 		{
 			Name:   "create",
@@ -70,6 +72,13 @@ func main() {
 			Usage:  "Inspect VCH",
 			Action: inspect.Run,
 			Flags:  inspect.Flags(),
+		},
+		{
+			Name:   "upgrade",
+			Usage:  "Upgrade VCH to latest version - test only",
+			Action: upgrade.Run,
+			Flags:  upgrade.Flags(),
+			Hidden: true,
 		},
 		{
 			Name:   "version",

--- a/cmd/vic-machine/upgrade/upgrade.go
+++ b/cmd/vic-machine/upgrade/upgrade.go
@@ -1,0 +1,159 @@
+// Copyright 2016 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package upgrade
+
+import (
+	"path"
+	"time"
+
+	log "github.com/Sirupsen/logrus"
+
+	"github.com/urfave/cli"
+	"github.com/vmware/vic/lib/install/data"
+	"github.com/vmware/vic/lib/install/management"
+	"github.com/vmware/vic/lib/install/validate"
+	"github.com/vmware/vic/pkg/errors"
+	"github.com/vmware/vic/pkg/trace"
+	"github.com/vmware/vic/pkg/vsphere/vm"
+
+	"golang.org/x/net/context"
+)
+
+// Upgrade has all input parameters for vic-machine upgrade command
+type Upgrade struct {
+	*data.Data
+
+	executor *management.Dispatcher
+}
+
+func NewUpgrade() *Upgrade {
+	upgrade := &Upgrade{}
+	upgrade.Data = data.NewData()
+
+	return upgrade
+}
+
+// Flags return all cli flags for upgrade
+func (u *Upgrade) Flags() []cli.Flag {
+	flags := []cli.Flag{
+		cli.DurationFlag{
+			Name:        "timeout",
+			Value:       3 * time.Minute,
+			Usage:       "Time to wait for upgrade",
+			Destination: &u.Timeout,
+		},
+	}
+	flags = append(
+		append(
+			append(
+				append(
+					append(
+						u.TargetFlags(),
+						u.IDFlags()...,
+					), u.ComputeFlags()...,
+				), u.ImageFlags()...,
+			), flags...),
+		u.DebugFlags()...,
+	)
+	return flags
+}
+
+func (u *Upgrade) processParams() error {
+	defer trace.End(trace.Begin(""))
+
+	if err := u.HasCredentials(); err != nil {
+		return err
+	}
+
+	u.Insecure = true
+	return nil
+}
+
+func (u *Upgrade) Run(cli *cli.Context) error {
+	var err error
+	if err = u.processParams(); err != nil {
+		return err
+	}
+
+	if u.Debug.Debug > 0 {
+		log.SetLevel(log.DebugLevel)
+		trace.Logger.Level = log.DebugLevel
+	}
+
+	if len(cli.Args()) > 0 {
+		log.Errorf("Unknown argument: %s", cli.Args()[0])
+		return errors.New("invalid CLI arguments")
+	}
+
+	var images map[string]string
+	if images, err = u.CheckImagesFiles(u.Force); err != nil {
+		return err
+	}
+
+	log.Infof("### Upgrading VCH ####")
+
+	ctx, cancel := context.WithTimeout(context.Background(), u.Timeout)
+	defer cancel()
+
+	validator, err := validate.NewValidator(ctx, u.Data)
+	if err != nil {
+		log.Errorf("Upgrade cannot continue - failed to create validator: %s", err)
+		return errors.New("upgrade failed")
+	}
+	executor := management.NewDispatcher(validator.Context, validator.Session, nil, u.Force)
+
+	var vch *vm.VirtualMachine
+	if u.Data.ID != "" {
+		vch, err = executor.NewVCHFromID(u.Data.ID)
+	} else {
+		vch, err = executor.NewVCHFromComputePath(u.Data.ComputeResourcePath, u.Data.DisplayName, validator)
+	}
+	if err != nil {
+		log.Errorf("Failed to get Virtual Container Host %s", u.DisplayName)
+		log.Error(err)
+		return errors.New("upgrade failed")
+	}
+
+	log.Infof("")
+	log.Infof("VCH ID: %s", vch.Reference().String())
+
+	vchConfig, err := executor.GetVCHConfig(vch)
+	if err != nil {
+		log.Error("Failed to get Virtual Container Host configuration")
+		log.Error(err)
+		return errors.New("upgrade failed")
+	}
+	executor.InitDiagnosticLogs(vchConfig)
+
+	// FIXME: add vchConfig validation here, to make the old vch config is compatible with new version
+
+	vConfig := validator.AddDeprecatedFields(ctx, vchConfig, u.Data)
+	vConfig.ImageFiles = images
+	vConfig.ApplianceISO = path.Base(u.ApplianceISO)
+	vConfig.BootstrapISO = path.Base(u.BootstrapISO)
+	vConfig.RollbackTimeout = u.Timeout
+
+	if err = executor.Upgrade(vch, vchConfig, vConfig); err != nil {
+		// upgrade failed
+		executor.CollectDiagnosticLogs()
+		if err == nil {
+			err = errors.New("upgrade failed")
+		}
+		return err
+	}
+	log.Infof("Completed successfully")
+
+	return nil
+}

--- a/lib/install/data/data.go
+++ b/lib/install/data/data.go
@@ -37,8 +37,7 @@ type Data struct {
 	CertPEM []byte
 	KeyPEM  []byte
 
-	ApplianceISO string
-	BootstrapISO string
+	common.Images
 
 	ImageDatastorePath     string
 	VolumeLocations        map[string]string
@@ -98,8 +97,11 @@ type InstallerData struct {
 
 	ImageFiles map[string]string
 
-	ApplianceISO string
-	BootstrapISO string
+	ApplianceISO      string
+	BootstrapISO      string
+	ISOVersion        string
+	PreUpgradeVersion string
+	RollbackTimeout   time.Duration
 
 	Extension types.Extension
 	UseRP     bool

--- a/lib/install/management/create.go
+++ b/lib/install/management/create.go
@@ -90,6 +90,13 @@ func (d *Dispatcher) CreateVCH(conf *config.VirtualContainerHostConfigSpec, sett
 			return errors.Errorf("Error registering VCH vSphere extension: %s", err)
 		}
 	}
+	return d.startAppliance(conf)
+}
+
+func (d *Dispatcher) startAppliance(conf *config.VirtualContainerHostConfigSpec) error {
+	defer trace.End(trace.Begin(""))
+
+	var err error
 	_, err = tasks.WaitForResult(d.ctx, func(ctx context.Context) (tasks.Task, error) {
 		return d.appliance.PowerOn(ctx)
 	})
@@ -106,7 +113,6 @@ func (d *Dispatcher) CreateVCH(conf *config.VirtualContainerHostConfigSpec, sett
 	if err = d.ensureComponentsInitialize(conf); err != nil {
 		return errors.Errorf("%s. Exiting...", err)
 	}
-
 	return nil
 }
 

--- a/lib/install/management/dispatcher.go
+++ b/lib/install/management/dispatcher.go
@@ -48,6 +48,8 @@ type Dispatcher struct {
 	vchPool   *object.ResourcePool
 	vchVapp   *object.VirtualApp
 	appliance *vm.VirtualMachine
+
+	oldApplianceISO string
 }
 
 type diagnosticLog struct {

--- a/lib/install/management/upgrade.go
+++ b/lib/install/management/upgrade.go
@@ -1,0 +1,303 @@
+// Copyright 2016 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package management
+
+import (
+	"fmt"
+	"path"
+	"strings"
+
+	log "github.com/Sirupsen/logrus"
+
+	"github.com/vmware/govmomi/object"
+	//	"github.com/vmware/govmomi/task"
+	"github.com/vmware/govmomi/vim25/types"
+	"github.com/vmware/vic/lib/config"
+	"github.com/vmware/vic/lib/install/data"
+	"github.com/vmware/vic/pkg/errors"
+	"github.com/vmware/vic/pkg/trace"
+	"github.com/vmware/vic/pkg/vsphere/extraconfig"
+	"github.com/vmware/vic/pkg/vsphere/extraconfig/vmomi"
+	"github.com/vmware/vic/pkg/vsphere/tasks"
+	"github.com/vmware/vic/pkg/vsphere/vm"
+
+	"golang.org/x/net/context"
+)
+
+const (
+	UpgradePrefix = "upgrade for"
+)
+
+// Upgrade will try to upgrade vch appliance to new version. If failed will try to roll back to original status.
+func (d *Dispatcher) Upgrade(vch *vm.VirtualMachine, conf *config.VirtualContainerHostConfigSpec, settings *data.InstallerData) (err error) {
+	defer trace.End(trace.Begin(conf.Name))
+
+	d.appliance = vch
+
+	// update the displayname to the actual folder name used
+	if d.vmPathName, err = d.appliance.FolderName(d.ctx); err != nil {
+		log.Errorf("Failed to get canonical name for appliance: %s", err)
+		return err
+	}
+
+	ds, err := d.session.Finder.Datastore(d.ctx, conf.ImageStores[0].Host)
+	if err != nil {
+		err = errors.Errorf("Failed to find image datastore %q", conf.ImageStores[0].Host)
+		return err
+	}
+	d.session.Datastore = ds
+
+	snapshotName := fmt.Sprintf("upgrade for %s", conf.Version.BuildNumber)
+	snapshotRefID, err := d.createSnapshot(snapshotName, "upgrade snapshot")
+	if err != nil {
+		return err
+	}
+
+	if err = d.update(conf, settings); err == nil {
+		return nil
+	}
+	log.Errorf("Failed to upgrade: %s", err)
+	log.Infof("Rolling back upgrade")
+
+	// reset timeout, to make sure rollback still happens in case of deadline exceeded error in previous step
+	var cancel context.CancelFunc
+	d.ctx, cancel = context.WithTimeout(context.Background(), settings.RollbackTimeout)
+	defer cancel()
+
+	if rerr := d.rollback(conf, snapshotName); rerr != nil {
+		log.Errorf("Failed to revert appliance to snapshot: %s", rerr)
+		// return the error message for upgrade, instead of rollback
+		return err
+	}
+
+	// do clean up aggressively, even the previous operation failed with context deadline excceeded.
+	d.ctx = context.Background()
+	d.cleanSnapshot(*snapshotRefID, snapshotName, conf.Name)
+	d.deleteUpgradeImages(ds, settings)
+	log.Infof("Appliance is rollback to old version")
+	return err
+}
+
+func (d *Dispatcher) cleanSnapshot(id types.ManagedObjectReference, snapshotName string, applianceName string) error {
+	log.Infof("Deleting upgrade snapshot %q", snapshotName)
+	if _, err := tasks.WaitForResult(d.ctx, func(ctx context.Context) (tasks.Task, error) {
+		return d.appliance.RemoveSnapshot(ctx, id, true, true)
+	}); err != nil {
+		log.Errorf("Failed to clean up appliance upgrade snapshot %q: %s.", snapshotName, err)
+		log.Errorf("Snapshot %q of appliance virtual machine %q MUST be removed manually before upgrade again", snapshotName, applianceName)
+		return err
+	}
+	return nil
+}
+
+func (d *Dispatcher) createSnapshot(name string, desc string) (*types.ManagedObjectReference, error) {
+	defer trace.End(trace.Begin(name))
+	log.Infof("Creating snapshot %s", name)
+
+	snapRefID, err := d.tryCreateSnapshot(name, desc)
+	if err == nil {
+		log.Infof("created snapshot %s", snapRefID)
+		return snapRefID, nil
+	}
+	log.Error(err)
+	return nil, err
+}
+
+// tryCreateSnapshot try to create upgrade snapshot. It will check if upgrade snapshot already exists. If exists, return error.
+// if succeed, return snapshot refID
+func (d *Dispatcher) tryCreateSnapshot(name, desc string) (*types.ManagedObjectReference, error) {
+	defer trace.End(trace.Begin(name))
+
+	node, err := d.appliance.GetCurrentSnapshotTree(d.ctx)
+	if err != nil {
+		return nil, errors.Errorf("Failed to get current snapshot: %s", err)
+	}
+
+	if node != nil && strings.HasPrefix(node.Name, UpgradePrefix) {
+		return nil, errors.Errorf("Another upgrade process is in progress. If not remove appliance snapshot %q and try again", node.Name)
+	}
+	taskInfo, err := tasks.WaitForResult(d.ctx, func(ctx context.Context) (tasks.Task, error) {
+		return d.appliance.CreateSnapshot(d.ctx, name, desc, true, true)
+	})
+	if err != nil {
+		return nil, errors.Errorf("Failed to create upgrade snapshot %q: %s.", name, err)
+	}
+	return taskInfo.Entity, nil
+}
+
+func (d *Dispatcher) deleteUpgradeImages(ds *object.Datastore, settings *data.InstallerData) {
+	defer trace.End(trace.Begin(""))
+
+	log.Infof("Deleting upgrade images")
+
+	m := object.NewFileManager(ds.Client())
+
+	file := path.Join(d.vmPathName, settings.ApplianceISO)
+	if err := d.deleteVMFSFiles(m, ds, file); err != nil {
+		log.Warnf("Image file %q is not removed for %s. Use the vSphere UI to delete content", file, err)
+	}
+
+	file = path.Join(d.vmPathName, settings.BootstrapISO)
+	if err := d.deleteVMFSFiles(m, ds, file); err != nil {
+		log.Warnf("Image file %q is not removed for %s. Use the vSphere UI to delete content", file, err)
+	}
+}
+
+func (d *Dispatcher) update(conf *config.VirtualContainerHostConfigSpec, settings *data.InstallerData) error {
+	defer trace.End(trace.Begin(conf.Name))
+
+	power, err := d.appliance.PowerState(d.ctx)
+	if err != nil {
+		log.Errorf("Failed to get vm power status %q: %s", d.appliance.Reference(), err)
+		return err
+	}
+	if power != types.VirtualMachinePowerStatePoweredOff {
+		if _, err = tasks.WaitForResult(d.ctx, func(ctx context.Context) (tasks.Task, error) {
+			return d.appliance.PowerOff(ctx)
+		}); err != nil {
+			log.Errorf("Failed to power off appliance: %s", err)
+			return err
+		}
+	}
+
+	if err = d.uploadImages(settings.ImageFiles); err != nil {
+		return errors.Errorf("Uploading images failed with %s. Exiting...", err)
+	}
+
+	// FIXME: move to existing configuration validation func
+	paths := strings.Split(conf.BootstrapImagePath, "/")
+	if len(paths) != 2 {
+		err = errors.Errorf("Old bootstrap image path %q is incorrect", conf.BootstrapImagePath)
+		log.Error(err)
+		return err
+	}
+	conf.BootstrapImagePath = fmt.Sprintf("[%s] %s/%s", conf.ImageStores[0].Host, d.vmPathName, settings.BootstrapISO)
+
+	if err = d.reconfigVCH(conf, fmt.Sprintf("[%s] %s/%s", conf.ImageStores[0].Host, d.vmPathName, settings.ApplianceISO)); err != nil {
+		return err
+	}
+
+	return d.startAppliance(conf)
+}
+
+func (d *Dispatcher) rollback(conf *config.VirtualContainerHostConfigSpec, snapshot string) error {
+	defer trace.End(trace.Begin(fmt.Sprintf("old appliance iso: %q, snapshot: %q", d.oldApplianceISO, snapshot)))
+
+	power, err := d.appliance.PowerState(d.ctx)
+	if err != nil {
+		log.Errorf("Failed to get vm power status %q: %s", d.appliance.Reference(), err)
+		return err
+	}
+	if power != types.VirtualMachinePowerStatePoweredOff {
+		if _, err = tasks.WaitForResult(d.ctx, func(ctx context.Context) (tasks.Task, error) {
+			return d.appliance.PowerOff(ctx)
+		}); err != nil {
+			log.Errorf("Failed to power off appliance: %s", err)
+			return err
+		}
+	}
+	// switch back appliance iso file, cause snapshot does not take care of it
+	if err = d.reconfigVCH(nil, d.oldApplianceISO); err != nil {
+		return err
+	}
+
+	// do not power on appliance in this snapsthot revert
+	log.Infof("Reverting to snapshot %s", snapshot)
+	if _, err = tasks.WaitForResult(d.ctx, func(ctx context.Context) (tasks.Task, error) {
+		return d.appliance.RevertToSnapshot(d.ctx, snapshot, true)
+	}); err != nil {
+		return errors.Errorf("Failed to roll back upgrade: %s.", err)
+	}
+
+	return d.startAppliance(conf)
+}
+
+func (d *Dispatcher) reconfigVCH(conf *config.VirtualContainerHostConfigSpec, isoFile string) error {
+	defer trace.End(trace.Begin(isoFile))
+
+	spec := &types.VirtualMachineConfigSpec{}
+
+	deviceChange, err := d.switchISO(isoFile)
+	if err != nil {
+		return err
+	}
+
+	spec.DeviceChange = deviceChange
+
+	if conf != nil {
+		cfg := make(map[string]string)
+		extraconfig.Encode(extraconfig.MapSink(cfg), conf)
+		spec.ExtraConfig = append(spec.ExtraConfig, vmomi.OptionValueFromMap(cfg)...)
+	}
+
+	if spec.DeviceChange == nil && spec.ExtraConfig == nil {
+		// nothing need to do
+		log.Debugf("Nothing changed, no need to reconfigure appliance")
+		return nil
+	}
+
+	// reconfig
+	log.Infof("Setting VM configuration")
+	info, err := tasks.WaitForResult(d.ctx, func(ctx context.Context) (tasks.Task, error) {
+		return d.appliance.Reconfigure(ctx, *spec)
+	})
+
+	if err != nil {
+		log.Errorf("Error while reconfiguring appliance: %s", err)
+		return err
+	}
+	if info.State != types.TaskInfoStateSuccess {
+		log.Errorf("Reconfiguring appliance reported: %s", info.Error.LocalizedMessage)
+		return err
+	}
+	return nil
+}
+
+func (d *Dispatcher) switchISO(filePath string) ([]types.BaseVirtualDeviceConfigSpec, error) {
+	defer trace.End(trace.Begin(filePath))
+
+	var devices object.VirtualDeviceList
+	var err error
+
+	log.Infof("Switching appliance iso to %s", filePath)
+	devices, err = d.appliance.Device(d.ctx)
+	if err != nil {
+		log.Errorf("Failed to get vm devices for appliance: %s", err)
+		return nil, err
+	}
+	// find the single cdrom
+	cd, err := devices.FindCdrom("")
+	if err != nil {
+		log.Errorf("Failed to get CD rom device from appliance: %s", err)
+		return nil, err
+	}
+
+	oldApplianceISO := cd.Backing.(*types.VirtualCdromIsoBackingInfo).FileName
+	if oldApplianceISO == filePath {
+		log.Debugf("Target file name %q is same to old one, no need to change.")
+		return nil, nil
+	}
+	cd = devices.InsertIso(cd, filePath)
+	changedDevices := object.VirtualDeviceList([]types.BaseVirtualDevice{cd})
+
+	deviceChange, err := changedDevices.ConfigSpec(types.VirtualDeviceConfigSpecOperationEdit)
+	if err != nil {
+		log.Errorf("Failed to create config spec for appliance: %s", err)
+		return nil, err
+	}
+
+	d.oldApplianceISO = oldApplianceISO
+	return deviceChange, nil
+}


### PR DESCRIPTION
Fixes #2171 

create snapshot, upload new iso files, switch appliance VM iso files, and then update configuration. If failed, rollback to snapshot, and clean up everything created.

upgrade is not finished in this change. So upgrade command will not be shown in command help