### PR TITLE
exec event handling

### DIFF
--- a/lib/portlayer/event/collector/vsphere/vm_event.go
+++ b/lib/portlayer/event/collector/vsphere/vm_event.go
@@ -42,10 +42,11 @@ func NewVMEvent(be types.BaseEvent) *VmEvent {
 	e := be.GetEvent()
 	return &VmEvent{
 		&events.BaseEvent{
-			Event:  ee,
-			ID:     int(e.Key),
-			Detail: e.FullFormattedMessage,
-			Ref:    e.Vm.Vm.String(),
+			Event:       ee,
+			ID:          int(e.Key),
+			Detail:      e.FullFormattedMessage,
+			Ref:         e.Vm.Vm.String(),
+			CreatedTime: e.CreatedTime,
 		},
 	}
 

--- a/lib/portlayer/event/collector/vsphere/vm_event_test.go
+++ b/lib/portlayer/event/collector/vsphere/vm_event_test.go
@@ -16,6 +16,7 @@ package vsphere
 
 import (
 	"testing"
+	"time"
 
 	"github.com/vmware/govmomi/vim25/types"
 	"github.com/vmware/vic/lib/portlayer/event/events"
@@ -27,12 +28,15 @@ func TestNewEvent(t *testing.T) {
 	vm := newVMMO()
 	k := 1
 	msg := "jojo the idiot circus boy"
-	vmwEve := &types.VmPoweredOnEvent{VmEvent: types.VmEvent{Event: types.Event{FullFormattedMessage: msg, Key: int32(k), Vm: &types.VmEventArgument{Vm: *vm}}}}
+	tt := time.Now().UTC()
+	vmwEve := &types.VmPoweredOnEvent{VmEvent: types.VmEvent{Event: types.Event{CreatedTime: tt, FullFormattedMessage: msg, Key: int32(k), Vm: &types.VmEventArgument{Vm: *vm}}}}
 	vme := NewVMEvent(vmwEve)
 	assert.NotNil(t, vme)
 	assert.Equal(t, events.ContainerPoweredOn, vme.String())
 	assert.Equal(t, vm.String(), vme.Reference())
 	assert.Equal(t, k, vme.EventID())
 	assert.Equal(t, msg, vme.Message())
-	assert.Equal(t, vme.Topic(), "vsphere.VmEvent")
+	assert.Equal(t, "vsphere.VmEvent", vme.Topic())
+	assert.Equal(t, tt, vme.Created())
+
 }

--- a/lib/portlayer/event/events/base_event.go
+++ b/lib/portlayer/event/events/base_event.go
@@ -18,16 +18,18 @@ import (
 	"fmt"
 	"path"
 	"reflect"
+	"time"
 )
 
 type EventType string
 
 type BaseEvent struct {
-	Type   EventType
-	Event  string
-	ID     int
-	Detail string
-	Ref    string
+	Type        EventType
+	Event       string
+	ID          int
+	Detail      string
+	Ref         string
+	CreatedTime time.Time
 }
 
 func (be *BaseEvent) EventID() int {
@@ -45,6 +47,9 @@ func (be *BaseEvent) Message() string {
 
 func (be *BaseEvent) Reference() string {
 	return be.Ref
+}
+func (be *BaseEvent) Created() time.Time {
+	return be.CreatedTime
 }
 
 // NewEventType utility function that uses reflection to return

--- a/lib/portlayer/event/events/container_event.go
+++ b/lib/portlayer/event/events/container_event.go
@@ -14,24 +14,26 @@
 
 package events
 
-import (
-	"time"
+const (
+	ContainerCreated      = "Created"
+	ContainerShutdown     = "Shutdown"
+	ContainerPoweredOn    = "PoweredOn"
+	ContainerPoweredOff   = "PoweredOff"
+	ContainerSuspended    = "Suspended"
+	ContainerResumed      = "Resumed"
+	ContainerRemoved      = "Removed"
+	ContainerReconfigured = "Reconfigured"
+	ContainerStarted      = "Started"
+	ContainerStopped      = "Stopped"
 )
 
-type Event interface {
-	EventTopic
-	// id of event
-	EventID() int
-	// event (PowerOn, PowerOff, etc)
-	String() string
-	// reference evented object
-	Reference() string
-	// event message
-	Message() string
-
-	Created() time.Time
+type ContainerEvent struct {
+	*BaseEvent
 }
 
-type EventTopic interface {
-	Topic() string
+func (ce *ContainerEvent) Topic() string {
+	if ce.Type == "" {
+		ce.Type = NewEventType(ce)
+	}
+	return ce.Type.Topic()
 }

--- a/lib/portlayer/exec/exec.go
+++ b/lib/portlayer/exec/exec.go
@@ -1,0 +1,173 @@
+// Copyright 2016 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package exec
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/vmware/govmomi/find"
+	"github.com/vmware/govmomi/object"
+
+	"github.com/vmware/vic/lib/portlayer/event"
+	"github.com/vmware/vic/lib/portlayer/event/collector/vsphere"
+	"github.com/vmware/vic/lib/portlayer/event/events"
+	"github.com/vmware/vic/pkg/errors"
+
+	"github.com/vmware/vic/pkg/vsphere/session"
+
+	log "github.com/Sirupsen/logrus"
+	"golang.org/x/net/context"
+)
+
+func Init(ctx context.Context, f *find.Finder, session *session.Session) error {
+
+	ccount := len(VCHConfig.ComputeResources)
+	if ccount != 1 {
+		detail := fmt.Sprintf("expected singular compute resource element, found %d", ccount)
+		log.Errorf(detail)
+		return errors.New(detail)
+	}
+
+	cr := VCHConfig.ComputeResources[0]
+
+	r, err := f.ObjectReference(ctx, cr)
+	if err != nil {
+		detail := fmt.Sprintf("could not get resource pool or virtual app reference from %q: %s", cr.String(), err)
+		log.Errorf(detail)
+		return err
+	}
+	switch o := r.(type) {
+	case *object.VirtualApp:
+		VCHConfig.VirtualApp = o
+		VCHConfig.ResourcePool = o.ResourcePool
+	case *object.ResourcePool:
+		VCHConfig.ResourcePool = o
+	default:
+		detail := fmt.Sprintf("could not get resource pool or virtual app from reference %q: object type is wrong", cr.String())
+		log.Errorf(detail)
+		return errors.New(detail)
+	}
+
+	// we want to monitor the resource pool, so create a vSphere Event Collector
+	ec := vsphere.NewCollector(session.Vim25(), VCHConfig.ResourcePool.Reference().String())
+
+	// start the collection of vsphere events
+	err = ec.Start()
+	if err != nil {
+		detail := fmt.Sprintf("%s failed to start: %s", ec.Name(), err.Error())
+		log.Error(detail)
+		return err
+	}
+
+	// create the event manager &  register the existing collector
+	VCHConfig.EventManager = event.NewEventManager(ec)
+
+	// subscribe the exec layer to the event stream for Vm events
+	VCHConfig.EventManager.Subscribe(events.NewEventType(vsphere.VmEvent{}).Topic(), "exec", eventCallback)
+
+	// instantiate the container cache now
+	NewContainerCache()
+
+	// Grab the AboutInfo about our host environment
+	about := session.Vim25().ServiceContent.About
+	VCHConfig.VCHMhz = NCPU(ctx)
+	VCHConfig.VCHMemoryLimit = MemTotal(ctx)
+	VCHConfig.HostOS = about.OsType
+	VCHConfig.HostOSVersion = about.Version
+	VCHConfig.HostProductName = about.Name
+	log.Debugf("Host - OS (%s), version (%s), name (%s)", about.OsType, about.Version, about.Name)
+	log.Debugf("VCH limits - %d Mhz, %d MB", VCHConfig.VCHMhz, VCHConfig.VCHMemoryLimit)
+
+	return nil
+}
+
+// eventCallback will process events
+func eventCallback(ie events.Event) {
+	// grab the container from the cache
+	container := containers.Container(ie.Reference())
+	if container != nil {
+
+		newState := eventedState(ie.String(), container.State)
+		// do we have a state change
+		if newState != container.State {
+			switch newState {
+			case StateStopping,
+				StateRunning,
+				StateStopped,
+				StateSuspended:
+				log.Debugf("Container(%s) state set to %s via event activity", container.ExecConfig.ID, newState.String())
+				container.State = newState
+				publishContainerEvent(container.ExecConfig.ID, ie.Created(), ie.String())
+			case StateRemoved:
+				log.Debugf("Container(%s) %s via event activity", container.ExecConfig.ID, newState.String())
+				containers.Remove(container.ExecConfig.ID)
+				publishContainerEvent(container.ExecConfig.ID, ie.Created(), ie.String())
+
+			}
+		}
+	}
+
+	return
+}
+
+// eventedState will determine the target container
+// state based on the current container state and the vsphere event
+func eventedState(e string, current State) State {
+	switch e {
+	case events.ContainerShutdown:
+		// no need to worry about existing state
+		return StateStopping
+	case events.ContainerPoweredOn:
+		// are we in the process of starting
+		if current != StateStarting {
+			return StateRunning
+		}
+	case events.ContainerPoweredOff:
+		// are we in the process of stopping
+		if current != StateStopping {
+			return StateStopped
+		}
+	case events.ContainerSuspended:
+		// are we in the process of suspending
+		if current != StateSuspending {
+			return StateSuspended
+		}
+	case events.ContainerRemoved:
+		if current != StateRemoving {
+			return StateRemoved
+		}
+	}
+	return current
+}
+
+// publishContainerEvent will publish a ContainerEvent to the vic event stream
+func publishContainerEvent(id string, created time.Time, eventType string) {
+	if VCHConfig.EventManager == nil || eventType == "" {
+		return
+	}
+
+	ce := &events.ContainerEvent{
+		&events.BaseEvent{
+			Ref:         id,
+			CreatedTime: created,
+			Event:       eventType,
+			Detail:      fmt.Sprintf("Container %s %s", id, eventType),
+		},
+	}
+
+	VCHConfig.EventManager.Publish(ce)
+
+}

--- a/lib/portlayer/exec/exec_test.go
+++ b/lib/portlayer/exec/exec_test.go
@@ -1,0 +1,94 @@
+// Copyright 2016 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package exec
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/vmware/vic/lib/portlayer/event"
+	"github.com/vmware/vic/lib/portlayer/event/collector/vsphere"
+	"github.com/vmware/vic/lib/portlayer/event/events"
+)
+
+var containerEvents []events.Event
+
+func TestEventedState(t *testing.T) {
+	// poweredOn event
+	event := events.ContainerPoweredOn
+	assert.EqualValues(t, StateStarting, eventedState(event, StateStarting))
+	assert.EqualValues(t, StateRunning, eventedState(event, StateRunning))
+	assert.EqualValues(t, StateRunning, eventedState(event, StateStopped))
+	assert.EqualValues(t, StateRunning, eventedState(event, StateSuspended))
+
+	// powerOff event
+	event = events.ContainerPoweredOff
+	assert.EqualValues(t, StateStopping, eventedState(event, StateStopping))
+	assert.EqualValues(t, StateStopped, eventedState(event, StateStopped))
+	assert.EqualValues(t, StateStopped, eventedState(event, StateRunning))
+
+	// suspended event
+	event = events.ContainerSuspended
+	assert.EqualValues(t, StateSuspending, eventedState(event, StateSuspending))
+	assert.EqualValues(t, StateSuspended, eventedState(event, StateSuspended))
+	assert.EqualValues(t, StateSuspended, eventedState(event, StateRunning))
+
+	// removed event
+	event = events.ContainerRemoved
+	assert.EqualValues(t, StateRemoved, eventedState(event, StateRunning))
+	assert.EqualValues(t, StateRemoved, eventedState(event, StateStopped))
+	assert.EqualValues(t, StateRemoving, eventedState(event, StateRemoving))
+}
+
+func TestPublishContainerEvent(t *testing.T) {
+
+	NewContainerCache()
+	containerEvents = make([]events.Event, 0)
+	VCHConfig = Configuration{}
+
+	mgr := event.NewEventManager()
+	VCHConfig.EventManager = mgr
+	mgr.Subscribe(events.NewEventType(events.ContainerEvent{}).Topic(), "testing", containerCallback)
+	mgr.Subscribe(events.NewEventType(vsphere.VmEvent{}).Topic(), "infra", eventCallback)
+
+	// create new running container and place in cache
+	id := "123439"
+	container := newTestContainer(id)
+	addTestVM(container)
+	container.State = StateRunning
+	containers.Put(container)
+
+	// create vm PoweredOff event and publish
+	ve := &vsphere.VmEvent{
+		&events.BaseEvent{
+			Event: events.ContainerPoweredOff,
+			Ref:   container.vm.Reference().String(),
+		},
+	}
+	mgr.Publish(ve)
+	time.Sleep(time.Millisecond * 30)
+
+	assert.Equal(t, 1, len(containerEvents))
+	assert.Equal(t, id, containerEvents[0].Reference())
+	assert.Equal(t, events.ContainerPoweredOff, containerEvents[0].String())
+	assert.EqualValues(t, StateStopped, containers.Container(id).State)
+
+}
+
+func containerCallback(ee events.Event) {
+	containerEvents = append(containerEvents, ee)
+}

--- a/lib/portlayer/portlayer.go
+++ b/lib/portlayer/portlayer.go
@@ -22,12 +22,11 @@ import (
 	"github.com/vmware/govmomi/find"
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/vim25/types"
-	"github.com/vmware/vic/lib/portlayer/event"
-	"github.com/vmware/vic/lib/portlayer/event/collector/vsphere"
+
 	"github.com/vmware/vic/lib/portlayer/exec"
 	"github.com/vmware/vic/lib/portlayer/network"
 	"github.com/vmware/vic/lib/portlayer/storage"
-	"github.com/vmware/vic/pkg/errors"
+
 	"github.com/vmware/vic/pkg/vsphere/extraconfig"
 	"github.com/vmware/vic/pkg/vsphere/session"
 	"golang.org/x/net/context"
@@ -59,41 +58,7 @@ func Init(ctx context.Context, sess *session.Session) error {
 		return err
 	}
 
-	cr := exec.VCHConfig.ComputeResources[0]
-	r, err := f.ObjectReference(ctx, cr)
-	if err != nil {
-		detail := fmt.Sprintf("could not get resource pool or virtual app reference from %q: %s", cr.String(), err)
-		log.Errorf(detail)
-		return err
-	}
-	switch o := r.(type) {
-	case *object.VirtualApp:
-		exec.VCHConfig.VirtualApp = o
-		exec.VCHConfig.ResourcePool = o.ResourcePool
-	case *object.ResourcePool:
-		exec.VCHConfig.ResourcePool = o
-	default:
-		detail := fmt.Sprintf("could not get resource pool or virtual app from reference %q: object type is wrong", cr.String())
-		log.Errorf(detail)
-		return errors.New(detail)
-	}
-
-	// we want to monitor the resource pool, so create a vSphere Event Collector
-	ec := vsphere.NewCollector(sess.Vim25(), exec.VCHConfig.ResourcePool.Reference().String())
-
-	// start the collection of vsphere events
-	err = ec.Start()
-	if err != nil {
-		detail := fmt.Sprintf("%s failed to start: %s", ec.Name(), err.Error())
-		log.Error(detail)
-		return err
-	}
-
-	// create the event manager &  register the existing collector
-	exec.VCHConfig.EventManager = event.NewEventManager(ec)
-
-	// instantiate the container cache now
-	exec.NewContainerCache()
+	exec.Init(ctx, f, sess)
 
 	//FIXME: temporary injection of debug network for debug nic
 	ne := exec.VCHConfig.Networks["client"]
@@ -104,7 +69,7 @@ func Init(ctx context.Context, sess *session.Session) error {
 	}
 	nr := new(types.ManagedObjectReference)
 	nr.FromString(ne.Network.ID)
-	r, err = f.ObjectReference(ctx, *nr)
+	r, err := f.ObjectReference(ctx, *nr)
 	if err != nil {
 		detail := fmt.Sprintf("could not get client network reference from %s: %s", nr.String(), err)
 		log.Errorf(detail)
@@ -133,14 +98,5 @@ func Init(ctx context.Context, sess *session.Session) error {
 	extraconfig.Decode(source, &storage.Config)
 	log.Debugf("Decoded VCH config for storage: %#v", storage.Config)
 
-	// Grab the AboutInfo about our host environment
-	about := sess.Vim25().ServiceContent.About
-	exec.VCHConfig.VCHMhz = exec.NCPU(ctx)
-	exec.VCHConfig.VCHMemoryLimit = exec.MemTotal(ctx)
-	exec.VCHConfig.HostOS = about.OsType
-	exec.VCHConfig.HostOSVersion = about.Version
-	exec.VCHConfig.HostProductName = about.Name
-	log.Debugf("Host - OS (%s), version (%s), name (%s)", about.OsType, about.Version, about.Name)
-	log.Debugf("VCH limits - %d Mhz, %d MB", exec.VCHConfig.VCHMhz, exec.VCHConfig.VCHMemoryLimit)
 	return nil
 }


### PR DESCRIPTION
Implements ContainerEvent publishing from the exec layer and
removes event handling from the container cache.

Finally, the publishing to the event stream is non-blocking via
a go routine.

Fixes #2208, Fixes #2240