### PR TITLE
[skip ci] Remove WinSCP from package

### DIFF
--- a/ui/installer/vCenterForWindows/configs
+++ b/ui/installer/vCenterForWindows/configs
@@ -8,14 +8,3 @@ SET vic_ui_host_url=NOURL
 
 REM If line 10 starts with "https", enter the SHA-1 thumbprint of the web server hosting the zip files
 SET vic_ui_host_thumbprint=
-
-REM Enter 1 if your server has the SFTP service enabled or 0 if not
-SET sftp_supported=1
-
-REM Enter SFTP username and password
-SET sftp_username=
-SET sftp_password=
-
-REM Location of C:\ProgramData\VMware\vCenterServer\cfg\vsphere-client\vc-packages\vsphere-serenity relative to the root of SFTP connection
-REM Note: If you are running vCenter 5.5 Windows, the location should point to C:\ProgramData\VMware\vSphere Web Client\vc-packages\vsphere-serenity
-SET target_vc_packages_path=/vsphere-client/vc-packages/vsphere-client-serenity/

--- a/ui/installer/vCenterForWindows/install.bat
+++ b/ui/installer/vCenterForWindows/install.bat
@@ -49,20 +49,7 @@ IF /I %vic_ui_host_url% NEQ NOURL (
 
     IF %vic_ui_host_url:~-1,1% NEQ / (
         SET vic_ui_host_url=%vic_ui_host_url%/
-    )    
-) ELSE (
-    IF %sftp_supported% EQU 1 (
-        ECHO Copying plugins...
-        "%utils_path%winscp.com" /command "open -hostkey=* sftp://%sftp_username%:%sftp_password%@%target_vcenter_ip%" "put -filemask=|*.zip ..\vsphere-client-serenity\* %target_vc_packages_path%" "exit"
-    ) ELSE (
-        ECHO SFTP not enabled. You have to manually copy the com.vmware.vicui.* folder in \ui\vsphere-client-serenity to %VMWARE_CFG_DIR%\vsphere-client\vc-packages\vsphere-client-serenity
-        ECHO Note: If you are running vCenter 5.5 Windows, copy the folder to %PROGRAMDATA%\VMware\vSphere Web Client\vc-packages\vsphere-client-serenity
     )
-)
-
-IF %ERRORLEVEL% GTR 0 (
-    ECHO Error: Failed uploading plugin files! Check the configs file for correct connection credentials
-    GOTO:EOF
 )
 
 IF EXIST _scratch_flags.txt (
@@ -92,4 +79,12 @@ FOR /F "tokens=*" %%A IN (..\vCenterForWindows\_scratch_flags.txt) DO (
 cd ..\vCenterForWindows
 DEL _scratch_flags.txt
 
-ECHO VIC UI was successfully installed. Make sure to log out of vSphere Web Client if you are logged in, and log back in.
+IF /I %vic_ui_host_url% EQU NOURL (
+    ECHO =============================
+    ECHO With the current version of VIC, you have to manually copy the com.vmware.vicui.* folder in \ui\vsphere-client-serenity to %VMWARE_CFG_DIR%\vsphere-client\vc-packages\vsphere-client-serenity
+    ECHO Note: If you are running vCenter Server 5.5, copy the folder to %PROGRAMDATA%\VMware\vSphere Web Client\vc-packages\vsphere-client-serenity instead
+    ECHO After that, log out of vSphere Web Client and then log back in.
+    ECHO =============================
+) ELSE (
+    ECHO VIC UI was successfully installed. Make sure to log out of vSphere Web Client and log back in.
+)

--- a/ui/installer/vCenterForWindows/uninstall.bat
+++ b/ui/installer/vCenterForWindows/uninstall.bat
@@ -56,11 +56,6 @@ FOR /F "tokens=*" %%A IN (..\vCenterForWindows\_scratch_flags.txt) DO (
             GOTO:EOF
         )
     )
-    IF %sftp_supported% EQU 1 (
-        "%utils_path%winscp.com" /command "open -hostkey=* sftp://%sftp_username%:%sftp_password%@%target_vcenter_ip%" "cd %target_vc_packages_path%" "rm com.vmware.vicui.*" "exit"
-    ) ELSE (
-        ECHO SFTP not enabled. You have to manually delete %target_vc_packages_path%\com.vmware.vicui.Vicui
-    )
 )
 
 cd ..\vCenterForWindows


### PR DESCRIPTION
This PR fixes #2204 in that it removes the WinSCP binary and updates the affected scripts for vCenter Windows. This will require @stuclem to update the current documentation on UI installation via PR #2261.