### PR TITLE
Show clearer error on a non-existent image pull from a custom repo 

### DIFF
--- a/cmd/imagec/docker.go
+++ b/cmd/imagec/docker.go
@@ -138,7 +138,8 @@ func LearnAuthURL(options ImageCOptions) (*url.URL, error) {
 
 	// Do we even have the image on that registry
 	if err != nil && fetcher.IsStatusNotFound() {
-		return nil, fmt.Errorf("%s:%s does not exist at %s", options.image, options.tag, options.registry)
+		err = fmt.Errorf("image not found")
+		return nil, ImageNotFoundError{Err: err}
 	}
 
 	return nil, fmt.Errorf("%s returned an unexpected response: %s", url, err)

--- a/cmd/imagec/imagec.go
+++ b/cmd/imagec/imagec.go
@@ -684,7 +684,12 @@ func main() {
 	// Get the URL of the OAuth endpoint
 	url, err := LearnAuthURL(options)
 	if err != nil {
-		log.Fatalf("Failed to obtain OAuth endpoint: %s", err)
+		switch err := err.(type) {
+		case ImageNotFoundError:
+			log.Fatalf("Error: image %s not found", options.reference)
+		default:
+			log.Fatalf("Failed to obtain OAuth endpoint: %s", err)
+		}
 	}
 
 	// Get the OAuth token - if only we have a URL


### PR DESCRIPTION
Minor change that displays a more helpful error message.

Fixes #2276

