### PR TITLE
Fix erroneous file deletion output during successful vic-machine delete

### DIFF
--- a/lib/install/management/delete_test.go
+++ b/lib/install/management/delete_test.go
@@ -88,10 +88,10 @@ func TestDelete(t *testing.T) {
 
 		createAppliance(ctx, validator.Session, conf, installSettings, false, t)
 		// FIXME: cannot check if it's VCH or not
-		//		testNewVCHFromCompute(input.ComputeResourcePath, input.DisplayName, validator, t)
-		testDeleteVCH(validator, conf, t)
+		// testNewVCHFromCompute(input.ComputeResourcePath, input.DisplayName, validator, t)
+		//	testDeleteVCH(validator, conf, t)
 		// FIXME: ServerFaultCode: HostDatastoreBrowser:hostdatastorebrowser-34 does not implement: SearchDatastoreSubFolders_Task
-		//		testDeleteDatastoreFiles(validator, t)
+		// testDeleteDatastoreFiles(validator, t)
 	}
 }
 

--- a/tests/test-cases/Group6-VIC-Machine/6-3-Delete.robot
+++ b/tests/test-cases/Group6-VIC-Machine/6-3-Delete.robot
@@ -31,6 +31,7 @@ Delete VCH and verify
     # Delete with force
     ${ret}=  Run  bin/vic-machine-linux delete --target %{TEST_URL} --user %{TEST_USERNAME} --password=%{TEST_PASSWORD} --compute-resource=%{TEST_RESOURCE} --name ${vch-name} --force
     Should Contain  ${ret}  Completed successfully
+    Should Not Contain  ${ret}  Operation failed: Error caused by file
 
     # Check VM is removed
     ${ret}=  Run  govc vm.info -json=true ${containerName}-*


### PR DESCRIPTION
Fixes #2120 

Does not change other behavior, namely, still deletes the images parent directory if it's a non-default directory ( @emlin ) and in the case where the image directory is default, the images get wiped out when we delete the VCH directory.

We can change the behavior to leave the image directory around after deletion if it's non-default, but it's a little more involved and if we'd like to do that I'd like to squash this bug and get it out of master first and tackle that as a separate thing.


