### PR TITLE
Init empty NetworkingConfig if not specified in container create

### DIFF
--- a/lib/apiservers/engine/backends/portlayer/container_proxy.go
+++ b/lib/apiservers/engine/backends/portlayer/container_proxy.go
@@ -515,7 +515,7 @@ func processAnonymousVolumes(h *string, volumes map[string]struct{}, client *cli
 
 	for v := range volumes {
 		fields, err := processVolumeParam(v)
-		log.Infof("Processed Volume arguments : %#v", fields)
+		log.Infof("Processed anonymous volume arguments: %#v", fields)
 		if err != nil {
 			return nil, err
 		}
@@ -544,6 +544,7 @@ func processSpecifiedVolumes(volumes []string) ([]volumeFields, error) {
 	var volumeFields []volumeFields
 	for _, v := range volumes {
 		fields, err := processVolumeParam(v)
+		log.Infof("Processed specified volume arguments: %#v", fields)
 		if err != nil {
 			return volumeFields, err
 		}


### PR DESCRIPTION
The `invalid config` error in #2281 occurs because drone doesn't specify `NetworkingConfig` for `ContainerCreate`. This PR fixes that by initializing an empty `NetworkingConfig` if it doesn't exist.

The [dogfood test](https://github.com/vmware/vic/blob/master/tests/manual-test-cases/Group15-Dogfood/15-1-Drone-Continuous-Integration.robot#L11) now fails with

```
$ drone exec --docker-host 192.168.77.130:2375 --trusted -e .drone.sec -yaml .drone.yml

[DRONE] starting job #1
INFO[0000] Pulling image drone/drone-exec:latest        
ERRO[0006] Error creating drone/drone-exec:latest. 500 Internal Server Error: path /storage/volumes/var/run/docker.sock was not found

 
500 Internal Server Error: path /storage/volumes/var/run/docker.sock was not found
``` 

The logs show that drone is trying to mount `/var/run/docker.sock`: 

```
time="2016-08-24T02:32:32Z" level=debug msg="[BEGIN] [github.com/vmware/vic/lib/apiservers/engine/backends/portlayer.(*ContainerProxy).AddVolumesToContainer] 80b8c8070b0f88ae8ede031d1688c77a" 
time="2016-08-24T02:32:32Z" level=info msg="Processed anonymous volume arguments: portlayer.volumeFields{ID:\"02d766d1-69a3-11e6-b997-000c299ae23b\", Dest:\"/var/run/docker.sock\", Flags:\"rw\"}" 
time="2016-08-24T02:32:32Z" level=info msg="anonymous volume being created - Container Create - volume mount section ID: 02d766d1-69a3-11e6-b997-000c299ae23b " 
time="2016-08-24T02:32:33Z" level=info msg="Processed specified volume arguments: portlayer.volumeFields{ID:\"/var/run/docker.sock\", Dest:\"/var/run/docker.sock\", Flags:\"rw\"}" 
time="2016-08-24T02:32:33Z" level=debug msg="[ END ] [github.com/vmware/vic/lib/apiservers/engine/backends/portlayer.(*ContainerProxy).AddVolumesToContainer] [419.147081ms] 80b8c8070b0f88ae8ede031d1688c77a
```

Filesystem mounting is currently unsupported.

This PR also removes a duplicate import of `github.com/docker/engine-api/types/container`.

Addresses #2281

