### PR TITLE
vic-machine ls shows version and upgrade status

### DIFF
--- a/cmd/vic-machine/common/images.go
+++ b/cmd/vic-machine/common/images.go
@@ -172,7 +172,7 @@ func (i *Images) checkImageVersion(img string, force bool) (string, error) {
 
 	// here compare version without last commit hash, to make developer life easier
 	if !strings.EqualFold(installerSV, sv) {
-		message := fmt.Sprintf("iso file %q has inconsistent version with installer %q != %q.", img, strings.ToLower(ver), version.GetBuild().ShortVersion())
+		message := fmt.Sprintf("iso file %q has inconsistent version with installer %q != %q", img, strings.ToLower(ver), version.GetBuild().ShortVersion())
 		if !force {
 			return "", errors.Errorf("%s. Specify --force to force create. ", message)
 		}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -94,7 +94,7 @@ func (v *Build) IsOlder(b *Build) (bool, error) {
 	}
 
 	if v.BuildNumber == "" || b.BuildNumber == "" {
-		return false, fmt.Errorf("invalid BuildNumber - comparing %s to %s", v.BuildNumber, b.BuildNumber)
+		return false, fmt.Errorf("invalid BuildNumber - comparing %q to %q", v.BuildNumber, b.BuildNumber)
 	}
 
 	vi, errv := strconv.Atoi(v.BuildNumber)


### PR DESCRIPTION
Fixes #2180 

```
⇒  bin/vic-machine-linux ls --target 192.168.218.177 --user root --password password
INFO[2016-09-13T12:06:25-07:00] ### Listing VCHs ####                        
INFO[2016-09-13T12:06:26-07:00] Validating target                            

ID        PATH                                                       NAME                VERSION                   UPGRADE STATUS
94        /ha-datacenter/host/localhost.localdomain/Resources        chin-vic-255        v0.5.5-124-216f97c        VCH has newer version


⇒  bin/vic-machine-linux ls --target 192.168.218.177 --user root --password password
INFO[2016-09-13T12:07:19-07:00] ### Listing VCHs ####                        
INFO[2016-09-13T12:07:19-07:00] Validating target                            

ID        PATH                                                       NAME                VERSION                   UPGRADE STATUS
94        /ha-datacenter/host/localhost.localdomain/Resources        chin-vic-255        v0.5.5-124-216f97c        Upgrade in progress

⇒  bin/vic-machine-linux ls --target 192.168.218.177 --user root --password password
INFO[2016-09-13T12:08:41-07:00] ### Listing VCHs ####                        
INFO[2016-09-13T12:08:41-07:00] Validating target                            

ID        PATH                                                       NAME                VERSION                   UPGRADE STATUS
94        /ha-datacenter/host/localhost.localdomain/Resources        chin-vic-255        v0.5.5-124-216f97c        Up to date


⇒  bin/vic-machine-linux ls --target 192.168.218.177 --user root --password password
INFO[2016-09-13T12:10:20-07:00] ### Listing VCHs ####                        
INFO[2016-09-13T12:10:20-07:00] Validating target                            

ID        PATH                                                       NAME                VERSION                   UPGRADE STATUS
94        /ha-datacenter/host/localhost.localdomain/Resources        chin-vic-255        v0.5.5-124-216f97c        Upgradeable to v0.5.5-125-c689df9
```
passed local regression tests