### PR TITLE
Better errors if a user leaves volume datastore path blank or tries to use /

### DIFF
--- a/cmd/vic-machine/create/create.go
+++ b/cmd/vic-machine/create/create.go
@@ -279,10 +279,20 @@ func (c *Create) processVolumeStores() error {
 	c.VolumeLocations = make(map[string]string)
 	for _, arg := range c.volumeStores {
 		splitMeta := strings.SplitN(arg, ":", 2)
+		// splitMeta[0] is "name/path" and splitMeta[1] is "label"
+
 		if len(splitMeta) != 2 {
 			return errors.New("Volume store input must be in format datastore/path:label")
 		}
 		c.VolumeLocations[splitMeta[1]] = splitMeta[0]
+		if !strings.ContainsRune(splitMeta[0], '/') {
+			// path is left empty
+			return errors.New("Must provide a path to the volume store argument; no default location is provided. The destination directory will be created if it does not exist.")
+		}
+		if strings.HasSuffix(splitMeta[0], "/") && len(strings.Split(splitMeta[0], "/")) == 2 {
+			// path is /
+			return errors.New("Cannot use root directory for storing volumes. Specify a path to a containing directory for your volumes e.g. 'Datastore1/volumes:default' if the default volume store should be at path /volumes on datastore \"Datastore1\" and the destination directory will be created for you if it does not already exist.")
+		}
 	}
 
 	return nil


### PR DESCRIPTION
Fixes #2302

The behavior reported by @caglar10ur  is correct, since we do not (currently) provide a default location for volume stores if this is not specified on the command line.

However, the error output received in those cases is not helpful, so I've added a little more sanity checking and better error messages to the validator to help the user out in these cases.

Looks like this in practice:
<pre>~/go/src/github.com/vmware/vic master*
❯ ./bin/vic-machine-linux create --target xxxx --user administrator@vsphere.local --password xxxxx --bridge-network vch-test --name ian-best-vch --compute-resource /Datacenter/host/Austin/Resources --timeout=1h --image-store=Datastore --volume-store=Datastore:default
ERRO[2016-09-13T16:00:47-05:00] --------------------                         
ERRO[2016-09-13T16:00:47-05:00] vic-machine-linux failed: Error occurred while processing volume stores: Must provide a path to the volume store argument, as no default location currently exists. The destination directory will be created if it does not exist.
 

~/go/src/github.com/vmware/vic master*
❯ ./bin/vic-machine-linux create --target xxxx --user administrator@vsphere.local --password xxxxx --bridge-network vch-test --name ian-best-vch --compute-resource /Datacenter/host/Austin/Resources --timeout=1h --image-store=Datastore --volume-store=Datastore/:default
ERRO[2016-09-13T16:00:55-05:00] --------------------                         
ERRO[2016-09-13T16:00:55-05:00] vic-machine-linux failed: Error occurred while processing volume stores: Cannot use root directory for storing volumes. Specify a name for your volumes directory e.g. 'datastore/volumes:default' and the destination directory will be created for you if it does not already exist.
</pre>