### PR TITLE
Remove start context, change commit timeout to 3 minutes [full ci]

### DIFF
--- a/lib/apiservers/engine/backends/container.go
+++ b/lib/apiservers/engine/backends/container.go
@@ -108,8 +108,7 @@ type Container struct {
 }
 
 const (
-	commitTimeout  = 1 * time.Minute
-	DefaultEnvPath = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+	defaultEnvPath = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 )
 
 func NotFoundError(msg string) error {
@@ -555,7 +554,7 @@ func (c *Container) containerStart(name string, hostConfig *containertypes.HostC
 	}
 
 	// commit the handle; this will reconfigure and start the vm
-	_, err = client.Containers.Commit(containers.NewCommitParamsWithTimeout(commitTimeout).WithHandle(handle))
+	_, err = client.Containers.Commit(containers.NewCommitParamsWithContext(ctx).WithHandle(handle))
 	if err != nil {
 		switch err := err.(type) {
 		case *containers.CommitNotFound:
@@ -1318,7 +1317,7 @@ func setPathFromImageConfig(config, imageConfig *containertypes.Config) {
 	}
 
 	// no PATH set, use the default
-	config.Env = append(config.Env, fmt.Sprintf("PATH=%s", DefaultEnvPath))
+	config.Env = append(config.Env, fmt.Sprintf("PATH=%s", defaultEnvPath))
 }
 
 // validateCreateConfig() checks the parameters for ContainerCreate().

--- a/lib/portlayer/exec/container.go
+++ b/lib/portlayer/exec/container.go
@@ -57,8 +57,6 @@ const (
 	StateRemoving
 	StateRemoved
 	StateUnknown
-
-	propertyCollectorTimeout = 3 * time.Minute
 )
 
 type Container struct {
@@ -242,10 +240,6 @@ func (c *Container) start(ctx context.Context) error {
 	// guestinfo key that we want to wait for
 	key := fmt.Sprintf("guestinfo..sessions|%s.started", c.ExecConfig.ID)
 	var detail string
-
-	// Wait some before giving up...
-	ctx, cancel := context.WithTimeout(ctx, propertyCollectorTimeout)
-	defer cancel()
 
 	detail, err = c.vm.WaitForKeyInExtraConfig(ctx, key)
 	if err != nil {


### PR DESCRIPTION
I've removed the timeouts used in container commit and start. These should hopefully clear up any CDE's during CI builds. Users are now responsible for cancelling long-running requests themselves.

See #1822 for discussion around this.