### PR TITLE
Rename vicbackends package to backends

### DIFF
--- a/cmd/docker/main.go
+++ b/cmd/docker/main.go
@@ -31,7 +31,7 @@ import (
 	"github.com/docker/docker/docker/listeners"
 	"github.com/docker/docker/pkg/signal"
 	"github.com/docker/go-connections/tlsconfig"
-	"github.com/vmware/vic/lib/apiservers/engine/backends"
+	vicbackends "github.com/vmware/vic/lib/apiservers/engine/backends"
 	"github.com/vmware/vic/lib/config"
 	"github.com/vmware/vic/lib/pprof"
 	"github.com/vmware/vic/pkg/trace"

--- a/lib/apiservers/engine/backends/backends.go
+++ b/lib/apiservers/engine/backends/backends.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package vicbackends
+package backends
 
 import (
 	"context"

--- a/lib/apiservers/engine/backends/container.go
+++ b/lib/apiservers/engine/backends/container.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package vicbackends
+package backends
 
 import (
 	"fmt"

--- a/lib/apiservers/engine/backends/container_test.go
+++ b/lib/apiservers/engine/backends/container_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package vicbackends
+package backends
 
 import (
 	"bytes"

--- a/lib/apiservers/engine/backends/endpoint.go
+++ b/lib/apiservers/engine/backends/endpoint.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package vicbackends
+package backends
 
 import (
 	"fmt"

--- a/lib/apiservers/engine/backends/image.go
+++ b/lib/apiservers/engine/backends/image.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package vicbackends
+package backends
 
 import (
 	"fmt"

--- a/lib/apiservers/engine/backends/image_test.go
+++ b/lib/apiservers/engine/backends/image_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package vicbackends
+package backends
 
 import (
 	"fmt"

--- a/lib/apiservers/engine/backends/network.go
+++ b/lib/apiservers/engine/backends/network.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package vicbackends
+package backends
 
 import (
 	"fmt"

--- a/lib/apiservers/engine/backends/sandbox.go
+++ b/lib/apiservers/engine/backends/sandbox.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package vicbackends
+package backends
 
 import (
 	"net"

--- a/lib/apiservers/engine/backends/system.go
+++ b/lib/apiservers/engine/backends/system.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package vicbackends
+package backends
 
 //****
 // system.go

--- a/lib/apiservers/engine/backends/system_portlayer.go
+++ b/lib/apiservers/engine/backends/system_portlayer.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package vicbackends
+package backends
 
 //****
 // system_portlayer.go

--- a/lib/apiservers/engine/backends/volume.go
+++ b/lib/apiservers/engine/backends/volume.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package vicbackends
+package backends
 
 import (
 	"encoding/json"

--- a/lib/apiservers/engine/backends/volume_test.go
+++ b/lib/apiservers/engine/backends/volume_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package vicbackends
+package backends
 
 import (
 	"encoding/json"


### PR DESCRIPTION
Go convention is to name the directory the same as the pacakge.  Also
vicbackends stutters.