### PR TITLE
Enables tests which were disabled due to tickets 1313 and 1312

### DIFF
--- a/tests/test-cases/Group1-Docker-Commands/1-11-Docker-RM.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-11-Docker-RM.robot
@@ -33,11 +33,9 @@ Remove a stopped container
     Should Be Equal As Integers  ${rc}  0
     Should Not Contain  ${output}  ${container}
     ${status}=  Get State Of Github Issue  1313
-    Run Keyword If  '${status}' == 'closed'  Fail  Test 1-11-Docker-RM.robot needs to be updated now that Issue #1313 has been resolved
-    Log  Issue \#1313 is blocking implementation  WARN
-    #${rc}  ${output}=  Run And Return Rc And Output  govc datastore.ls
-    #Should Be Equal As Integers  ${rc}  0
-    #Should Not Contain  ${output}  ${container}
+    ${rc}  ${output}=  Run And Return Rc And Output  govc datastore.ls
+    Should Be Equal As Integers  ${rc}  0
+    Should Not Contain  ${output}  ${container}
 
 Remove a running container
     ${rc}  ${container}=  Run And Return Rc And Output  docker ${params} create busybox /bin/top
@@ -49,15 +47,12 @@ Remove a running container
     Should Contain  ${output}  Error response from daemon: You cannot remove a running container. Stop the container before attempting removal or use -f
     
 Force remove a running container
-    ${status}=  Get State Of Github Issue  1312
-    Run Keyword If  '${status}' == 'closed'  Fail  Test 1-11-Docker-RM.robot needs to be updated now that Issue #1312 has been resolved
-    Log  Issue \#1312 is blocking implementation  WARN
-    #${rc}  ${container}=  Run And Return Rc And Output  docker ${params} create busybox /bin/top
-    #Should Be Equal As Integers  ${rc}  0
-    #${rc}  ${output}=  Run And Return Rc And Output  docker ${params} start ${container}
-    #Should Be Equal As Integers  ${rc}  0
-    #${rc}  ${output}=  Run And Return Rc And Output  docker ${params} rm -f ${container}
-    #Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${container}=  Run And Return Rc And Output  docker ${params} create busybox /bin/top
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} start ${container}
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} rm -f ${container}
+    Should Be Equal As Integers  ${rc}  0
     
 Remove a fake container
     ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} rm fakeContainer


### PR DESCRIPTION
Fixes #1312 #1313 

Both #1312 and #1313 were solved when other p0s were solved. 

#1312 : this was solved by @gigawhitlocks fix for the `container stop` issue where stop would not work and was not updating state. The fix was #2309 since rebasing past this PR. 

#1313 : this was solved by @hickeng with pr #1441

After re enabling the test, it was confirmed that the tests now pass on both VC and ESX.
