### PR TITLE
Use DefaultHTTPTimeout when fetching image manifest

### DIFF
--- a/cmd/imagec/docker.go
+++ b/cmd/imagec/docker.go
@@ -335,7 +335,7 @@ func FetchImageManifest(options ImageCOptions) (*Manifest, error) {
 	log.Debugf("URL: %s", url)
 
 	fetcher := NewURLFetcher(FetcherOptions{
-		Timeout:            10 * time.Second,
+		Timeout:            options.timeout,
 		Username:           options.username,
 		Password:           options.password,
 		Token:              options.token,


### PR DESCRIPTION
Addresses timeout issues seen in CI, related to #2219 .

