### PR TITLE
Support creating named volumes

### DIFF
--- a/tests/test-cases/Group1-Docker-Commands/1-4-Docker-Create.md
+++ b/tests/test-cases/Group1-Docker-Commands/1-4-Docker-Create.md
@@ -16,31 +16,35 @@ This test requires that a vSphere server is running and available
 3. Issue docker create busybox to the new VIC appliance
 4. Issue docker create -t -i busybox to the new VIC appliance
 5. Issue docker create --name test1 busybox to the new VIC appliance
-6. Issue docker create -v /var/log:/var/log busybox ls /var/log to the new VIC appliance
+6. Issue docker create -v /var/log busybox ls /var/log to the new VIC appliance
 7. Issue docker start <containerID> to the new VIC appliance
 8. Issue docker logs <containerID> to the new VIC appliance
-9. Issue docker create busybox /bin/top to the new VIC appliance
-10. Issue docker create fakeimage to the new VIC appliance
-11. Issue docker create fakeImage to the new VIC appliance
-12. Issue docker create --name busy1 busybox /bin/top to the new VIC appliance
-13. Issue docker start busy1 to the new VIC appliance
-14. Issue docker create --link busy1:busy1 --name busy2 busybox ping -c2 busy1 to the new VIC appliance
-15. Issue docker start busy2 to the new VIC appliance
-16. Issue docker logs busy2 to the new VIC appliance
-17. Create a container, rm the container, then create another container
-18. Create a container directly without pulling the image first for an image that hasn't been pulled yet
-19. Create a container without specifying a command
+9. Issue docker create -v test-named-vol:/testdir busybox
+10. Issue docker start <containerID>
+11. Issue docker volume ls
+12. Issue docker create busybox /bin/top to the new VIC appliance
+13. Issue docker create fakeimage to the new VIC appliance
+14. Issue docker create fakeImage to the new VIC appliance
+15. Issue docker create --name busy1 busybox /bin/top to the new VIC appliance
+16. Issue docker start busy1 to the new VIC appliance
+17. Issue docker create --link busy1:busy1 --name busy2 busybox ping -c2 busy1 to the new VIC appliance
+18. Issue docker start busy2 to the new VIC appliance
+19. Issue docker logs busy2 to the new VIC appliance
+20. Create a container, rm the container, then create another container
+21. Create a container directly without pulling the image first for an image that hasn't been pulled yet
+22. Create a container without specifying a command
 
 #Expected Outcome:
 * Steps 3-7 should all return without error and printing the container ID on return
 * Step 8 should show that the contents of the containers /var/log matches the contents of the hosts /var/log
-* Step 10 should return with the error message - Error: image library/fakeimage not found
-* Step 11 should return with the error message - Error parsing reference: "fakeImage" is not a valid repository/tag
-* Step 14 should result in success and the busy2 container should exist
-* Step 16 should show that busy2 was able to successfully ping busy1 just using the linked name
-* Step 17 should result in success for all three parts
-* Step 18 should return without error
-* Step 19 should return with the following error message - Error response from daemon: No command specified
+* Steps 9, 10 and 11 should return without errors and should successfully create a new volume called `test-named-vol`
+* Step 13 should return with the error message - Error: image library/fakeimage not found
+* Step 14 should return with the error message - Error parsing reference: "fakeImage" is not a valid repository/tag
+* Step 17 should result in success and the busy2 container should exist
+* Step 19 should show that busy2 was able to successfully ping busy1 just using the linked name
+* Step 20 should result in success for all three parts
+* Step 21 should return without error
+* Step 22 should return with the following error message - Error response from daemon: No command specified
 
 #Possible Problems:
 None

--- a/tests/test-cases/Group1-Docker-Commands/1-4-Docker-Create.md
+++ b/tests/test-cases/Group1-Docker-Commands/1-4-Docker-Create.md
@@ -21,7 +21,7 @@ This test requires that a vSphere server is running and available
 8. Issue docker logs <containerID> to the new VIC appliance
 9. Issue docker create -v test-named-vol:/testdir busybox
 10. Issue docker start <containerID>
-11. Issue docker volume ls
+11. Issue docker logs <containerID> to grab the disk size of the volume
 12. Issue docker create busybox /bin/top to the new VIC appliance
 13. Issue docker create fakeimage to the new VIC appliance
 14. Issue docker create fakeImage to the new VIC appliance
@@ -37,7 +37,7 @@ This test requires that a vSphere server is running and available
 #Expected Outcome:
 * Steps 3-7 should all return without error and printing the container ID on return
 * Step 8 should show that the contents of the containers /var/log matches the contents of the hosts /var/log
-* Steps 9, 10 and 11 should return without errors and should successfully create a new volume called `test-named-vol`
+* Steps 9, 10 and 11 should return without errors and should successfully create a new volume called `test-named-vol` with disk size 975.9M
 * Step 13 should return with the error message - Error: image library/fakeimage not found
 * Step 14 should return with the error message - Error parsing reference: "fakeImage" is not a valid repository/tag
 * Step 17 should result in success and the busy2 container should exist

--- a/tests/test-cases/Group1-Docker-Commands/1-4-Docker-Create.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-4-Docker-Create.robot
@@ -19,7 +19,7 @@ Simple creates
     Should Be Equal As Integers  ${rc}  0
     Should Not Contain  ${output}  Error
 
-Create with volume
+Create with anonymous volume
     ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} create -v /var/log busybox ls /var/log
     Should Be Equal As Integers  ${rc}  0
     Should Not Contain  ${output}  Error
@@ -32,6 +32,21 @@ Create with volume
     #${rc}  ${output}=  Run And Return Rc And Output  docker ${params} logs ${output}
     #Should Be Equal As Integers  ${rc}  0
     #Should Not Contain  ${output}  Error
+
+Create with named volume
+    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} create -v test-named-vol:/testdir busybox
+    Should Be Equal As Integers  ${rc}  0
+    Should Not Contain  ${output}  Error
+    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} start ${output}
+    Should Be Equal As Integers  ${rc}  0
+    Should Not Contain  ${output}  Error
+
+    ${status}=  Get State Of Github Issue  1718
+    Run Keyword If  '${status}' == 'closed'  Log  Test `Create with named volume` can be improved with volume name filtering, now that #1718 has been resolved  WARN
+    #${rc}  ${output}=  Run And Return Rc And Output  docker ${params} volume ls -f name=test-named-vol
+    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} volume ls
+    Should Be Equal As Integers  ${rc}  0
+    Should Contain  ${output}  test-named-vol
 
 Create simple top example
     ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} create busybox /bin/top

--- a/tests/test-cases/Group1-Docker-Commands/1-4-Docker-Create.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-4-Docker-Create.robot
@@ -34,19 +34,8 @@ Create with anonymous volume
     #Should Not Contain  ${output}  Error
 
 Create with named volume
-    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} create -v test-named-vol:/testdir busybox
-    Should Be Equal As Integers  ${rc}  0
-    Should Not Contain  ${output}  Error
-    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} start ${output}
-    Should Be Equal As Integers  ${rc}  0
-    Should Not Contain  ${output}  Error
-
-    ${status}=  Get State Of Github Issue  1718
-    Run Keyword If  '${status}' == 'closed'  Log  Test `Create with named volume` can be improved with volume name filtering, now that #1718 has been resolved  WARN
-    #${rc}  ${output}=  Run And Return Rc And Output  docker ${params} volume ls -f name=test-named-vol
-    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} volume ls
-    Should Be Equal As Integers  ${rc}  0
-    Should Contain  ${output}  test-named-vol
+    ${disk-size}=  Run  docker ${params} logs $(docker ${params} start $(docker ${params} create -v test-named-vol:/testdir busybox /bin/df -Ph) && sleep 10) | grep by-label | awk '{print $2}'
+    Should Be Equal As Strings  ${disk-size}  975.9M
 
 Create simple top example
     ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} create busybox /bin/top


### PR DESCRIPTION
* Adds support for creating named volumes with `docker create -v` and `docker run -v`
* Adds an integration test in `1-4-Docker-Create`

Also cleans up unneeded params in `processAnonymousVolumes` and typos.

`1-4-Docker-Create` and `1-19-Docker-Volume-Create` pass locally.

Fixes #2317 

