### PR TITLE
Add script to automate ci log downloads [full ci]

### DIFF
--- a/infra/scripts/ci-logs.sh
+++ b/infra/scripts/ci-logs.sh
@@ -1,0 +1,134 @@
+#!/bin/bash -e
+# Copyright 2016 VMware, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Requirements
+# ############
+# - gcloud SDK: https://cloud.google.com/sdk/docs/
+# - drone cli 0.5: https://github.com/drone/drone#from-source
+#
+# Examples
+# ########
+# Grab the logs for your current branch:
+# $ ./ci-logs.sh
+#
+# If the build is running you can stream the logs using the '-s' option:
+# $ ./ci-logs.sh -s
+#
+# Grab logs for a specific build:
+# $ ./ci-logs.sh 4835
+#
+# Grab logs for recent failures on the master branch:
+# $ drone build list --format {{.Number}}-{{.Branch}}-{{.Status}} vmware/vic | grep master-failure | cut -d- -f1 | xargs -n1 ./ci-logs.sh
+#
+# Find container log zip files for failed tests:
+# $ grep FAIL ci.log | grep Test-Cases.Group | grep :: | awk '{print $1}' | xargs -n1 -I% bash -c "ls %*.zip"
+
+top=$(git rev-parse --show-toplevel)
+repo="vmware/$(basename "$top")"
+dir="$top/ci-logs"
+drone=${DRONE_CLI:-drone}
+
+while getopts s flag
+do
+    case $flag in
+        d)
+            dir="$OPTARG"
+            ;;
+        s)
+            stream=true
+            ;;
+        *)
+            echo "invalid option '$flag'"
+            exit 1
+            ;;
+    esac
+done
+
+shift $((OPTIND-1))
+
+build="$1"
+job="$2"
+
+export DRONE_SERVER=${DRONE_SERVER:-https://ci.vmware.run}
+
+if [ -z "$DRONE_TOKEN" ] ; then
+    echo "DRONE_TOKEN not set (available at $DRONE_SERVER/settings/profile)"
+fi
+
+if [ -z "$build" ] ; then
+    commit=$(git rev-parse HEAD)
+    builds=$($drone build list --format "{{.Number}}-{{.Commit}}" "$repo" | grep "$commit")
+    build=$(cut -d- -f1 <<<"$builds")
+fi
+
+if [ -z "$job" ] ; then
+    job=1
+fi
+
+info=$($drone build info "$repo" "$build")
+state=$(grep Status: <<<"$info" | awk '{print $2}')
+
+echo "$info"
+
+case "$state" in
+    running)
+        if [ -z "$stream" ] ; then
+            exit
+        fi
+        ;;
+    success|failure|killed)
+        stream=""
+        ;;
+    pending|error)
+        exit
+        ;;
+esac
+
+if [ ! -d "$dir" ] ; then
+    mkdir "$dir"
+fi
+
+logs="$dir/$build"
+mkdir "$logs"
+
+if [ -n "$stream" ] ; then
+    echo "Streaming CI log..."
+
+    curl --silent "$DRONE_SERVER/api/stream/$repo/$build/$job?access_token=$DRONE_TOKEN" | \
+        grep data: | cut -d: -f2- | grep -v '^$' | tee "$logs/ci.log"
+else
+    echo "Downloading CI log..."
+    curl --silent "$DRONE_SERVER/api/repos/$repo/logs/$build/$job?access_token=$DRONE_TOKEN" > "$logs/ci.log"
+fi
+
+url=$(grep https://console.cloud.google.com/ "$logs/ci.log")
+if [ -z "$url" ] ; then
+    echo "No integration logs link found for build ${build}"
+    exit
+fi
+
+name=$(basename "$url" | cut -d? -f1)
+bucket=$(basename "$(dirname "$(dirname "$url")")")
+
+echo "Downloading integration logs ($name)..."
+
+gsutil cp "gs://$bucket/$name" "$logs/$name"
+
+unzip -d "$logs" "$logs/$name" >/dev/null
+
+if [ "$state" = "failure" ] ; then
+    echo "Container logs for failed tests:"
+    grep FAIL "$logs/ci.log" | grep Test-Cases.Group | grep :: | awk '{print $1}' | xargs -n1 -I% bash -c "ls $logs/%*.zip" 2>/dev/null
+fi

--- a/tests/integration-test.sh
+++ b/tests/integration-test.sh
@@ -34,7 +34,7 @@ timestamp=$(date +%s)
 outfile="integration_logs_"$DRONE_BUILD_NUMBER"_"$DRONE_COMMIT"_$timestamp.zip"
 export LOGLINK="https://console.cloud.google.com/m/cloudstorage/b/vic-ci-logs/o/$outfile?authuser=1"
 
-zip -9 $outfile log.html package.list *container-logs.zip *.log
+zip -9 $outfile output.xml log.html package.list *container-logs.zip *.log
 
 # GC credentials
 keyfile="/root/vic-ci-logs.key"


### PR DESCRIPTION
Example, for the build of your current branch, no build number required optionally use `-s` flag to stream the log output:

```
$ ./ci-logs.sh -s
Number: 4870
Status: running
Event: pull_request
Commit: d1e2a9ce27bb1b45510b80d569a5785bbdd2aa9c
Branch: ci
Ref: refs/pull/2348/merge
Message: Add script to automate ci log downloads
Author: dougm
Streaming CI log...
[info] Pulling image plugins/drone-git:latest
Drone Git Plugin built from 43dcd64
...
```

Example, for a specific build:
```
$ ./ci-logs.sh 4829
Number: 4829
Status: failure
Event: push
Commit: 25ae6cbdc4a0e4586af8ace73966be0847482114
Branch: master
Ref: refs/heads/master
Message: Add DeleteImage to storage image cache

Author: fdawg4l
Downloading CI log...
Downloading integration logs (integration_logs_4829_25ae6cbdc4a0e4586af8ace73966be0847482114_1473970920.zip)...
Container logs for failed tests:
/.../4829/Test-Cases.Group1-Docker-Commands.1-24-Docker-Link-VCH-4829-7302-container-logs.zip
/.../4829/Test-Cases.Group1-Docker-Commands.1-6-Docker-Run-VCH-4829-9308-container-logs.zip
/.../4829/Test-Cases.Group6-VIC-Machine.6-4-Create-Basic-VCH-4829-1673-container-logs.zip
```