### PR TITLE
Enable robot tests using log based assertions [full ci]

### DIFF
--- a/tests/test-cases/Group1-Docker-Commands/1-17-Docker-Network-Connect.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-17-Docker-Network-Connect.robot
@@ -10,19 +10,17 @@ Connect container to a new network
     Should Be Equal As Integers  ${rc}  0
     ${rc}  ${containerID}=  Run And Return Rc And Output  docker ${params} pull busybox
     Should Be Equal As Integers  ${rc}  0
-    ${rc}  ${containerID}=  Run And Return Rc And Output  docker ${params} create busybox ifconfig
+    ${rc}  ${containerID}=  Run And Return Rc And Output  docker ${params} create busybox ip -4 addr show eth0
     Should Be Equal As Integers  ${rc}  0
     ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} network connect test-network ${containerID}
     Should Be Equal As Integers  ${rc}  0
     ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} start ${containerID}
     Should Be Equal As Integers  ${rc}  0
-    ${status}=  Get State Of Github Issue  366
-    Run Keyword If  '${status}' == 'closed'  Fail  Test 1-17-Docker-Network-Connect.robot needs to be updated now that Issue #366 has been resolved
-    Log  Issue \#366 is blocking implementation  WARN
-    #${rc}  ${output}=  Run And Return Rc And Output  docker ${params} logs ${containerID}
-    #Should Be Equal As Integers  ${rc}  0
-    #Should Contain  ${output}  eth0
-    #Should Contain  ${output}  eth1
+    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} logs --follow ${containerID}
+    Should Be Equal As Integers  ${rc}  0
+    ${ips}=  Get Lines Containing String  ${output}  inet
+    @{lines}=  Split To Lines  ${ips}
+    Length Should Be  ${lines}  2
 
 Connect to non-existent container
     ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} network connect test-network fakeContainer

--- a/tests/test-cases/Group1-Docker-Commands/1-4-Docker-Create.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-4-Docker-Create.robot
@@ -26,12 +26,9 @@ Create with anonymous volume
     ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} start ${output}
     Should Be Equal As Integers  ${rc}  0
     Should Not Contain  ${output}  Error
-    ${status}=  Get State Of Github Issue  366
-    Run Keyword If  '${status}' == 'closed'  Fail  Test 1-4-Docker-Create.robot needs to be updated now that Issue #366 has been resolved
-    Log  Issue \#366 is blocking implementation  WARN
-    #${rc}  ${output}=  Run And Return Rc And Output  docker ${params} logs ${output}
-    #Should Be Equal As Integers  ${rc}  0
-    #Should Not Contain  ${output}  Error
+    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} logs --follow ${output}
+    Should Be Equal As Integers  ${rc}  0
+    Should Not Contain  ${output}  Error
 
 Create with named volume
     ${disk-size}=  Run  docker ${params} logs $(docker ${params} start $(docker ${params} create -v test-named-vol:/testdir busybox /bin/df -Ph) && sleep 10) | grep by-label | awk '{print $2}'
@@ -67,12 +64,11 @@ Create linked containers that can ping
     ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} start busy2
     Should Be Equal As Integers  ${rc}  0
     Should Not Contain  ${output}  Error
-    ${status}=  Get State Of Github Issue  366
-    Run Keyword If  '${status}' == 'closed'  Fail  Test 1-4-Docker-Create.robot needs to be updated now that Issue #366 has been resolved
-    Log  Issue \#366 is blocking implementation  WARN
-    #${rc}  ${output}=  Run And Return Rc And Output  docker ${params} logs busy2
-    #Should Be Equal As Integers  ${rc}  0
-    #Should Not Contain  ${output}  Error
+    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} logs --follow busy2
+    Should Be Equal As Integers  ${rc}  0
+    ${status}=  Get State Of Github Issue  1459
+    Run Keyword If  '${status}' == 'closed'  Fail  Test 1-4-Docker-Create.robot needs to be updated now that Issue #1459 has been resolved
+    Log  Issue \#1459 is blocking implementation  WARN
     #Should Contain  ${output}  2 packets transmitted, 2 received
 
 Create a container after the last container is removed


### PR DESCRIPTION
A few tests were using 'docker logs' to assert container command output
but were disabled.

Note that the tests needed additional changes other just enabling the
use of logs.

Closes #366