### PR TITLE
Add docker wait to docker kill [full ci]

### DIFF
--- a/lib/apiservers/engine/backends/container_test.go
+++ b/lib/apiservers/engine/backends/container_test.go
@@ -292,6 +292,14 @@ func (m *MockContainerProxy) ContainerRunning(vc *viccontainer.VicContainer) (bo
 	return true, nil
 }
 
+func (m *MockContainerProxy) Wait(vc *viccontainer.VicContainer, timeout time.Duration) (exitCode int32, processStatus string, containerState string, reterr error) {
+	return 0, "", "", nil
+}
+
+func (m *MockContainerProxy) Signal(vc *viccontainer.VicContainer, sig uint64) error {
+	return nil
+}
+
 func AddMockImageToCache() {
 	mockImage := &metadata.ImageConfig{
 		ImageID:   "e732471cb81a564575aad46b9510161c5945deaf18e9be3db344333d72f0b4b2",


### PR DESCRIPTION
Finish up docker kill implementation by adding support for
docker wait if the signal is 0 or sigkill.  Also moved all the
swagger related code for docker kill and docker wait to
container_proxy.go.

Resolves #378