### PR TITLE
[full ci] Refactor volume create/join error handling

### DIFF
--- a/lib/apiservers/engine/backends/container.go
+++ b/lib/apiservers/engine/backends/container.go
@@ -111,18 +111,6 @@ const (
 	defaultEnvPath = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 )
 
-func NotFoundError(msg string) error {
-	return derr.NewRequestNotFoundError(fmt.Errorf("No such container: %s", msg))
-}
-
-func InternalServerError(msg string) error {
-	return derr.NewErrorWithStatusCode(fmt.Errorf("Server error from portlayer: %s", msg), http.StatusInternalServerError)
-}
-
-func BadRequestError(msg string) error {
-	return derr.NewErrorWithStatusCode(fmt.Errorf("Bad request error from portlayer: %s", msg), http.StatusBadRequest)
-}
-
 func (c *Container) Handle(id, name string) (string, error) {
 	resp, err := c.containerProxy.Client().Containers.Get(containers.NewGetParamsWithContext(ctx).WithID(id))
 	if err != nil {

--- a/lib/apiservers/engine/backends/container_proxy.go
+++ b/lib/apiservers/engine/backends/container_proxy.go
@@ -191,7 +191,7 @@ func (c *ContainerProxy) AddContainerToScope(handle string, config types.Contain
 }
 
 // AddVolumesToContainer adds volumes to a container, referenced by handle.
-// If an error is return, the returned handle should not be used.
+// If an error is returned, the returned handle should not be used.
 //
 // returns:
 //	modified handle
@@ -205,21 +205,42 @@ func (c *ContainerProxy) AddVolumesToContainer(handle string, config types.Conta
 	//Volume Attachment Section
 	log.Debugf("ContainerProxy.AddVolumesToContainer - VolumeSection")
 	log.Debugf("Raw Volume arguments : binds:  %#v : volumes : %#v", config.HostConfig.Binds, config.Config.Volumes)
-	var joinList []volumeFields
-	var err error
 
-	joinList, err = processAnonymousVolumes(config.Config.Volumes)
+	// Collect all volume mappings. In a docker create/run, they
+	// can be anonymous (-v /dir) or specific (-v vol-name:/dir).
+	volumes := config.HostConfig.Binds
+	for anonVol := range config.Config.Volumes {
+		volumes = append(volumes, anonVol)
+	}
+
+	volList, err := processVolumeFields(volumes)
 	if err != nil {
 		return handle, BadRequestError(err.Error())
 	}
 
-	volumeSubset, err := processSpecifiedVolumes(config.HostConfig.Binds)
-	if err != nil {
-		return handle, BadRequestError(err.Error())
-	}
-	joinList = append(joinList, volumeSubset...)
+	// Create and join volumes.
+	for _, fields := range volList {
 
-	for _, fields := range joinList {
+		driverArgs := make(map[string]string)
+		driverArgs["flags"] = fields.Flags
+
+		vol := &Volume{}
+		_, req, err := vol.volumeCreate(fields.ID, "vsphere", driverArgs, nil)
+		if err != nil {
+			switch err := err.(type) {
+			case *storage.CreateVolumeConflict:
+				// Implicitly ignore the error where a volume with the same name
+				// already exists. We can just join the said volume to the container.
+				log.Infof("a volume with the name %s already exists", fields.ID)
+			case *storage.CreateVolumeNotFound:
+				return handle, VolumeCreateNotFoundError(req.Store) //derr.NewErrorWithStatusCode(fmt.Errorf("No volume store named (%s) exists", volRequest.Store), http.StatusInternalServerError)
+			default:
+				return handle, InternalServerError(err.Error()) //derr.NewErrorWithStatusCode(fmt.Errorf("%s", err), http.StatusInternalServerError)
+			}
+		} else {
+			log.Infof("volumeCreate succeeded. Volume mount section ID: %s", fields.ID)
+		}
+
 		flags := make(map[string]string)
 		//NOTE: for now we are passing the flags directly through. This is NOT SAFE and only a stop gap.
 		flags["Mode"] = fields.Flags
@@ -236,6 +257,8 @@ func (c *ContainerProxy) AddVolumesToContainer(handle string, config types.Conta
 				return handle, InternalServerError(err.Payload.Message)
 			case *storage.VolumeJoinDefault:
 				return handle, InternalServerError(err.Payload.Message)
+			case *storage.VolumeJoinNotFound:
+				return handle, VolumeJoinNotFoundError(err.Payload.Message) //derr.NewErrorWithStatusCode(fmt.Errorf(err.Payload.Message), http.StatusNotFound)
 			default:
 				return handle, InternalServerError(err.Error())
 			}
@@ -248,7 +271,6 @@ func (c *ContainerProxy) AddVolumesToContainer(handle string, config types.Conta
 }
 
 // CommitContainerHandle() commits any changes to container handle.
-//
 func (c *ContainerProxy) CommitContainerHandle(handle, imageID string) error {
 	defer trace.End(trace.Begin(handle))
 
@@ -455,14 +477,21 @@ func toModelsNetworkConfig(cc types.ContainerCreateConfig) *models.NetworkConfig
 	return nc
 }
 
-//This function is used to turn any call from docker create -v <stuff> into a volumeFields object.
-//the -v has 3 forms. 1: -v <anonymous mount path>, -v <Volume Name>:<Destination Mount Path>, and -v <Volume Name>:<Destination Mount Path>:<mount flags>
+// processVolumeParam is used to turn any call from docker create -v <stuff> into a volumeFields object.
+// The -v has 3 forms. -v <anonymous mount path>, -v <Volume Name>:<Destination Mount Path> and
+// -v <Volume Name>:<Destination Mount Path>:<mount flags>
 func processVolumeParam(volString string) (volumeFields, error) {
 	volumeStrings := strings.Split(volString, ":")
 	fields := volumeFields{}
 
-	//This switch determines which type of -v was invoked.
-	switch len(volumeStrings) {
+	// Error out if the intended volume is a directory on the client filesystem.
+	numVolParams := len(volumeStrings)
+	if numVolParams > 1 && strings.HasPrefix(volumeStrings[0], "/") {
+		return volumeFields{}, InvalidVolumeError{}
+	}
+
+	// This switch determines which type of -v was invoked.
+	switch numVolParams {
 	case 1:
 		VolumeID, err := uuid.NewUUID()
 		if err != nil {
@@ -480,63 +509,22 @@ func processVolumeParam(volString string) (volumeFields, error) {
 		fields.Dest = volumeStrings[1]
 		fields.Flags = volumeStrings[2]
 	default:
-		//NOTE: the docker cli should cover this case. This is here for posterity.
-		return volumeFields{}, fmt.Errorf("Volume bind input is invalid : -v %s", volString)
+		// NOTE: the docker cli should cover this case. This is here for posterity.
+		return volumeFields{}, InvalidBindError{volume: volString}
 	}
 	return fields, nil
 }
 
-// processAnonymousVolumes parses fields for implicit volume mappings in a
-// create/run (such as -v /dir) and creates volumes for them.
-func processAnonymousVolumes(volumes map[string]struct{}) ([]volumeFields, error) {
+// processVolumeFields parses fields for volume mappings specified in a create/run -v.
+func processVolumeFields(volumes []string) ([]volumeFields, error) {
 	var volumeFields []volumeFields
-
-	for v := range volumes {
-		fields, err := processVolumeParam(v)
-		log.Infof("Processed anonymous volume arguments: %#v", fields)
-		if err != nil {
-			return nil, err
-		}
-		//NOTE: This should be the guard for the case of an anonymous volume.
-		//NOTE: we should not expect any driver args if the drive is anonymous.
-		log.Infof("anonymous volume being created - Container Create - volume mount section ID: %s ", fields.ID)
-
-		driverArgs := make(map[string]string)
-		driverArgs["flags"] = fields.Flags
-
-		vol := &Volume{}
-		_, err = vol.VolumeCreate(fields.ID, "vsphere", driverArgs, nil)
-
-		volumeFields = append(volumeFields, fields)
-	}
-	return volumeFields, nil
-}
-
-// processSpecifiedVolumes parses fields for volumes specified explicitly during a
-// create/run (such as -v volume-name:/dir) and creates them if they don't already exist.
-func processSpecifiedVolumes(volumes []string) ([]volumeFields, error) {
-	var volumeFields []volumeFields
-	vol := &Volume{}
 
 	for _, v := range volumes {
 		fields, err := processVolumeParam(v)
-		log.Infof("Processed specified volume arguments: %#v", fields)
+		log.Infof("Processed volume arguments: %#v", fields)
 		if err != nil {
-			return volumeFields, err
+			return nil, err
 		}
-
-		// Error out if the intended volume is a directory on the client filesystem.
-		if strings.HasPrefix(fields.ID, "/") {
-			return nil, fmt.Errorf("%s does not support mounting directories as a data volume.", ProductName())
-		}
-
-		driverArgs := make(map[string]string)
-		driverArgs["flags"] = fields.Flags
-		_, err = vol.VolumeCreate(fields.ID, "vsphere", driverArgs, nil)
-		if err == nil {
-			log.Infof("named volume created - Container Create - volume mount section ID: %s ", fields.ID)
-		}
-
 		volumeFields = append(volumeFields, fields)
 	}
 	return volumeFields, nil

--- a/lib/apiservers/engine/backends/container_proxy.go
+++ b/lib/apiservers/engine/backends/container_proxy.go
@@ -228,7 +228,7 @@ func (c *ContainerProxy) AddVolumesToContainer(handle string, config types.Conta
 		// present can be avoided by adding an extra optional param to VolumeJoin,
 		// which would then call volumeCreate if the volume does not exist.
 		vol := &Volume{}
-		_, req, err := vol.volumeCreate(fields.ID, "vsphere", driverArgs, nil)
+		_, err := vol.volumeCreate(fields.ID, "vsphere", driverArgs, nil)
 		if err != nil {
 			switch err := err.(type) {
 			case *storage.CreateVolumeConflict:
@@ -236,7 +236,7 @@ func (c *ContainerProxy) AddVolumesToContainer(handle string, config types.Conta
 				// already exists. We can just join the said volume to the container.
 				log.Infof("a volume with the name %s already exists", fields.ID)
 			case *storage.CreateVolumeNotFound:
-				return handle, VolumeCreateNotFoundError(req.Store)
+				return handle, VolumeCreateNotFoundError(volumeStore(driverArgs))
 			default:
 				return handle, InternalServerError(err.Error())
 			}

--- a/lib/apiservers/engine/backends/container_proxy.go
+++ b/lib/apiservers/engine/backends/container_proxy.go
@@ -224,6 +224,9 @@ func (c *ContainerProxy) AddVolumesToContainer(handle string, config types.Conta
 		driverArgs := make(map[string]string)
 		driverArgs["flags"] = fields.Flags
 
+		// NOTE: calling volumeCreate regardless of whether the volume is already
+		// present can be avoided by adding an extra optional param to VolumeJoin,
+		// which would then call volumeCreate if the volume does not exist.
 		vol := &Volume{}
 		_, req, err := vol.volumeCreate(fields.ID, "vsphere", driverArgs, nil)
 		if err != nil {

--- a/lib/apiservers/engine/backends/container_proxy.go
+++ b/lib/apiservers/engine/backends/container_proxy.go
@@ -236,9 +236,9 @@ func (c *ContainerProxy) AddVolumesToContainer(handle string, config types.Conta
 				// already exists. We can just join the said volume to the container.
 				log.Infof("a volume with the name %s already exists", fields.ID)
 			case *storage.CreateVolumeNotFound:
-				return handle, VolumeCreateNotFoundError(req.Store) //derr.NewErrorWithStatusCode(fmt.Errorf("No volume store named (%s) exists", volRequest.Store), http.StatusInternalServerError)
+				return handle, VolumeCreateNotFoundError(req.Store)
 			default:
-				return handle, InternalServerError(err.Error()) //derr.NewErrorWithStatusCode(fmt.Errorf("%s", err), http.StatusInternalServerError)
+				return handle, InternalServerError(err.Error())
 			}
 		} else {
 			log.Infof("volumeCreate succeeded. Volume mount section ID: %s", fields.ID)
@@ -261,7 +261,7 @@ func (c *ContainerProxy) AddVolumesToContainer(handle string, config types.Conta
 			case *storage.VolumeJoinDefault:
 				return handle, InternalServerError(err.Payload.Message)
 			case *storage.VolumeJoinNotFound:
-				return handle, VolumeJoinNotFoundError(err.Payload.Message) //derr.NewErrorWithStatusCode(fmt.Errorf(err.Payload.Message), http.StatusNotFound)
+				return handle, VolumeJoinNotFoundError(err.Payload.Message)
 			default:
 				return handle, InternalServerError(err.Error())
 			}

--- a/lib/apiservers/engine/backends/container_proxy_test.go
+++ b/lib/apiservers/engine/backends/container_proxy_test.go
@@ -22,6 +22,7 @@ import (
 
 func TestProcessVolumeParams(t *testing.T) {
 	rawTestVolumes := []string{"/blah", "testVolume:/mount", "testVolume:/mount/path:r"}
+	invalidVolume := "/dir:/dir"
 	var processedTestVolumes []volumeFields
 
 	for _, testString := range rawTestVolumes {
@@ -42,27 +43,7 @@ func TestProcessVolumeParams(t *testing.T) {
 	assert.Equal(t, "testVolume", processedTestVolumes[2].ID)
 	assert.Equal(t, "/mount/path", processedTestVolumes[2].Dest)
 	assert.Equal(t, "r", processedTestVolumes[2].Flags)
-}
 
-func TestProcessSpecifiedVolumes(t *testing.T) {
-	rawTestVolumes := []string{"masterVolume:/blah", "testVolume:/mount:r", "specVol:/mount/path:r"}
-	var processedTestVolumes []volumeFields
-
-	processedFields, err := processSpecifiedVolumes(rawTestVolumes)
-	assert.Nil(t, err)
-	processedTestVolumes = append(processedTestVolumes, processedFields...)
-
-	assert.Len(t, processedFields, 3)
-
-	assert.Equal(t, "masterVolume", processedTestVolumes[0].ID)
-	assert.Equal(t, "/blah", processedTestVolumes[0].Dest)
-	assert.Equal(t, "rw", processedTestVolumes[0].Flags)
-
-	assert.Equal(t, "testVolume", processedTestVolumes[1].ID)
-	assert.Equal(t, "/mount", processedTestVolumes[1].Dest)
-	assert.Equal(t, "r", processedTestVolumes[1].Flags)
-
-	assert.Equal(t, "specVol", processedTestVolumes[2].ID)
-	assert.Equal(t, "/mount/path", processedTestVolumes[2].Dest)
-	assert.Equal(t, "r", processedTestVolumes[2].Flags)
+	invalidFields, _ := processVolumeParam(invalidVolume)
+	assert.Equal(t, volumeFields{}, invalidFields)
 }

--- a/lib/apiservers/engine/backends/errors.go
+++ b/lib/apiservers/engine/backends/errors.go
@@ -46,3 +46,18 @@ func VolumeJoinNotFoundError(msg string) error {
 func VolumeCreateNotFoundError(msg string) error {
 	return derr.NewErrorWithStatusCode(fmt.Errorf("No volume store named (%s) exists", msg), http.StatusInternalServerError)
 }
+
+// NotFoundError returns a 404 docker error when a container is not found.
+func NotFoundError(msg string) error {
+	return derr.NewRequestNotFoundError(fmt.Errorf("No such container: %s", msg))
+}
+
+// InternalServerError returns a 500 docker error on a portlayer error.
+func InternalServerError(msg string) error {
+	return derr.NewErrorWithStatusCode(fmt.Errorf("Server error from portlayer: %s", msg), http.StatusInternalServerError)
+}
+
+// BadRequestError returns a 400 docker error on a bad request.
+func BadRequestError(msg string) error {
+	return derr.NewErrorWithStatusCode(fmt.Errorf("Bad request error from portlayer: %s", msg), http.StatusBadRequest)
+}

--- a/lib/apiservers/engine/backends/errors.go
+++ b/lib/apiservers/engine/backends/errors.go
@@ -1,0 +1,48 @@
+// Copyright 2016 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package backends
+
+import (
+	"fmt"
+	derr "github.com/docker/docker/errors"
+	"net/http"
+)
+
+// InvalidVolumeError is returned when the user specifies a client directory as a volume.
+type InvalidVolumeError struct {
+}
+
+func (e InvalidVolumeError) Error() string {
+	return fmt.Sprintf("%s does not support mounting directories as a data volume.", ProductName())
+}
+
+// InvalidBindError is returned when create/run -v has more params than allowed.
+type InvalidBindError struct {
+	volume string
+}
+
+func (e InvalidBindError) Error() string {
+	return fmt.Sprintf("volume bind input is invalid: -v %s", e.volume)
+}
+
+// VolumeJoinNotFoundError returns a 404 docker error for a volume join request.
+func VolumeJoinNotFoundError(msg string) error {
+	return derr.NewRequestNotFoundError(fmt.Errorf(msg))
+}
+
+// VolumeCreateNotFoundError returns a 404 docker error for a volume create request.
+func VolumeCreateNotFoundError(msg string) error {
+	return derr.NewErrorWithStatusCode(fmt.Errorf("No volume store named (%s) exists", msg), http.StatusInternalServerError)
+}

--- a/lib/apiservers/engine/backends/volume.go
+++ b/lib/apiservers/engine/backends/volume.go
@@ -105,9 +105,8 @@ func (v *Volume) volumeCreate(name, driverName string, driverArgs, labels map[st
 
 	client := PortLayerClient()
 	if client == nil {
-		return nil, nil, derr.NewErrorWithStatusCode(fmt.Errorf("Failed to get a portlayer client"), http.StatusInternalServerError)
+		return nil, nil, fmt.Errorf("failed to get a portlayer client")
 	}
-
 	if name == "" {
 		name = uuid.New().String()
 	}
@@ -116,7 +115,7 @@ func (v *Volume) volumeCreate(name, driverName string, driverArgs, labels map[st
 	// assign the values of the model to be passed to the portlayer handler
 	req, varErr := newVolumeCreateReq(name, driverName, driverArgs, labels)
 	if varErr != nil {
-		return result, req, derr.NewErrorWithStatusCode(varErr, http.StatusBadRequest)
+		return result, req, varErr
 	}
 	log.Infof("Finalized model for volume create request to portlayer: %#v", req)
 
@@ -143,10 +142,8 @@ func (v *Volume) VolumeCreate(name, driverName string, driverArgs, labels map[st
 		case *storage.CreateVolumeInternalServerError:
 			// FIXME: right now this does not return an error model...
 			return result, derr.NewErrorWithStatusCode(fmt.Errorf("%s", err.Error()), http.StatusInternalServerError)
-
 		case *storage.CreateVolumeDefault:
 			return result, derr.NewErrorWithStatusCode(fmt.Errorf("%s", err.Payload.Message), http.StatusInternalServerError)
-
 		default:
 			return result, derr.NewErrorWithStatusCode(fmt.Errorf("%s", err), http.StatusInternalServerError)
 		}

--- a/lib/apiservers/engine/backends/volume.go
+++ b/lib/apiservers/engine/backends/volume.go
@@ -99,14 +99,15 @@ func (v *Volume) VolumeInspect(name string) (*types.Volume, error) {
 }
 
 // volumeCreate issues a CreateVolume request to the portlayer
-func (v *Volume) volumeCreate(name, driverName string, driverArgs, labels map[string]string) (*types.Volume, *models.VolumeRequest, error) {
+func (v *Volume) volumeCreate(name, driverName string, driverArgs, labels map[string]string) (*types.Volume, error) {
 	defer trace.End(trace.Begin(""))
 	result := &types.Volume{}
 
 	client := PortLayerClient()
 	if client == nil {
-		return nil, nil, fmt.Errorf("failed to get a portlayer client")
+		return nil, fmt.Errorf("failed to get a portlayer client")
 	}
+
 	if name == "" {
 		name = uuid.New().String()
 	}
@@ -115,30 +116,29 @@ func (v *Volume) volumeCreate(name, driverName string, driverArgs, labels map[st
 	// assign the values of the model to be passed to the portlayer handler
 	req, varErr := newVolumeCreateReq(name, driverName, driverArgs, labels)
 	if varErr != nil {
-		return result, req, varErr
+		return result, varErr
 	}
 	log.Infof("Finalized model for volume create request to portlayer: %#v", req)
 
 	res, err := client.Storage.CreateVolume(storage.NewCreateVolumeParamsWithContext(ctx).WithVolumeRequest(req))
 	if err != nil {
-		return result, req, err
+		return result, err
 	}
 	result = NewVolumeModel(res.Payload, labels)
-	return result, req, nil
+	return result, nil
 }
 
 // VolumeCreate : docker personality implementation for VIC
 func (v *Volume) VolumeCreate(name, driverName string, driverArgs, labels map[string]string) (*types.Volume, error) {
 	defer trace.End(trace.Begin("Volume.VolumeCreate"))
 
-	result, req, err := v.volumeCreate(name, driverName, driverArgs, labels)
+	result, err := v.volumeCreate(name, driverName, driverArgs, labels)
 	if err != nil {
 		switch err := err.(type) {
-
 		case *storage.CreateVolumeConflict:
-			return result, derr.NewErrorWithStatusCode(fmt.Errorf("A volume named %s already exists. Choose a different volume name.", req.Name), http.StatusInternalServerError)
+			return result, derr.NewErrorWithStatusCode(fmt.Errorf("A volume named %s already exists. Choose a different volume name.", name), http.StatusInternalServerError)
 		case *storage.CreateVolumeNotFound:
-			return result, derr.NewErrorWithStatusCode(fmt.Errorf("No volume store named (%s) exists", req.Store), http.StatusInternalServerError)
+			return result, derr.NewErrorWithStatusCode(fmt.Errorf("No volume store named (%s) exists", volumeStore(driverArgs)), http.StatusInternalServerError)
 		case *storage.CreateVolumeInternalServerError:
 			// FIXME: right now this does not return an error model...
 			return result, derr.NewErrorWithStatusCode(fmt.Errorf("%s", err.Error()), http.StatusInternalServerError)
@@ -247,13 +247,18 @@ func newVolumeCreateReq(name, driverName string, driverArgs, labels map[string]s
 	return req, nil
 }
 
-func validateDriverArgs(args map[string]string, req *models.VolumeRequest) error {
-	// volumestore name validation
+// volumeStore returns the value of the optional volume store param specified in the CLI.
+func volumeStore(args map[string]string) string {
 	storeName, ok := args[OptsVolumeStoreKey]
 	if !ok {
-		storeName = "default"
+		return "default"
 	}
-	req.Store = storeName
+	return storeName
+}
+
+func validateDriverArgs(args map[string]string, req *models.VolumeRequest) error {
+	// volumestore name validation
+	req.Store = volumeStore(args)
 
 	// capacity validation
 	capstr, ok := args[OptsCapacityKey]

--- a/lib/apiservers/portlayer/restapi/handlers/storage_handlers.go
+++ b/lib/apiservers/portlayer/restapi/handlers/storage_handlers.go
@@ -402,7 +402,7 @@ func (handler *StorageHandlersImpl) VolumesList(params storage.ListVolumesParams
 
 //VolumeJoin : modifies the config spec of a container to mount the specified container
 func (handler *StorageHandlersImpl) VolumeJoin(params storage.VolumeJoinParams) middleware.Responder {
-	defer trace.End(trace.Begin("storage_handlers.RemoveVolume"))
+	defer trace.End(trace.Begin(""))
 	actualHandle := epl.GetHandle(params.JoinArgs.Handle)
 
 	//Note: Name should already be populated by now.

--- a/lib/apiservers/portlayer/swagger.json
+++ b/lib/apiservers/portlayer/swagger.json
@@ -605,6 +605,12 @@
 							"type": "string"
 						}
 					},
+					"404": {
+						"description": "Volume not found",
+						"schema": {
+							"$ref": "#/definitions/Error"
+						}
+                                        },
 					"500": {
 						"description": "ServerError",
 						"schema": {

--- a/lib/portlayer/storage/vsphere/volume.go
+++ b/lib/portlayer/storage/vsphere/volume.go
@@ -111,7 +111,7 @@ func (v *VolumeStore) getDatastore(store *url.URL) (*datastore.Helper, error) {
 	// find the datastore
 	dstore, ok := v.ds[*store]
 	if !ok {
-		return nil, VolumeStoreNotFoundError{msg: fmt.Sprintf("volumestore (%s) not found", store.String())}
+		return nil, VolumeStoreNotFoundError{msg: fmt.Sprintf("volume store (%s) not found", store.String())}
 	}
 
 	return dstore, nil

--- a/tests/test-cases/Group1-Docker-Commands/1-4-Docker-Create.md
+++ b/tests/test-cases/Group1-Docker-Commands/1-4-Docker-Create.md
@@ -22,29 +22,31 @@ This test requires that a vSphere server is running and available
 9. Issue docker create -v test-named-vol:/testdir busybox
 10. Issue docker start <containerID>
 11. Issue docker logs <containerID> to grab the disk size of the volume
-12. Issue docker create busybox /bin/top to the new VIC appliance
-13. Issue docker create fakeimage to the new VIC appliance
-14. Issue docker create fakeImage to the new VIC appliance
-15. Issue docker create --name busy1 busybox /bin/top to the new VIC appliance
-16. Issue docker start busy1 to the new VIC appliance
-17. Issue docker create --link busy1:busy1 --name busy2 busybox ping -c2 busy1 to the new VIC appliance
-18. Issue docker start busy2 to the new VIC appliance
-19. Issue docker logs busy2 to the new VIC appliance
-20. Create a container, rm the container, then create another container
-21. Create a container directly without pulling the image first for an image that hasn't been pulled yet
-22. Create a container without specifying a command
+12. Issue docker create -v /dir:/dir busybox
+13. Issue docker create busybox /bin/top to the new VIC appliance
+14. Issue docker create fakeimage to the new VIC appliance
+15. Issue docker create fakeImage to the new VIC appliance
+16. Issue docker create --name busy1 busybox /bin/top to the new VIC appliance
+17. Issue docker start busy1 to the new VIC appliance
+18. Issue docker create --link busy1:busy1 --name busy2 busybox ping -c2 busy1 to the new VIC appliance
+19. Issue docker start busy2 to the new VIC appliance
+20. Issue docker logs busy2 to the new VIC appliance
+21. Create a container, rm the container, then create another container
+22. Create a container directly without pulling the image first for an image that hasn't been pulled yet
+23. Create a container without specifying a command
 
 #Expected Outcome:
 * Steps 3-7 should all return without error and printing the container ID on return
 * Step 8 should show that the contents of the containers /var/log matches the contents of the hosts /var/log
 * Steps 9, 10 and 11 should return without errors and should successfully create a new volume called `test-named-vol` with disk size 975.9M
-* Step 13 should return with the error message - Error: image library/fakeimage not found
-* Step 14 should return with the error message - Error parsing reference: "fakeImage" is not a valid repository/tag
-* Step 17 should result in success and the busy2 container should exist
-* Step 19 should show that busy2 was able to successfully ping busy1 just using the linked name
-* Step 20 should result in success for all three parts
-* Step 21 should return without error
-* Step 22 should return with the following error message - Error response from daemon: No command specified
+* Step 12 should return with the error message - Error response from daemon: vSphere Integrated Containers does not support mounting directories as a data volume.
+* Step 14 should return with the error message - Error: image library/fakeimage not found
+* Step 15 should return with the error message - Error parsing reference: "fakeImage" is not a valid repository/tag
+* Step 18 should result in success and the busy2 container should exist
+* Step 20 should show that busy2 was able to successfully ping busy1 just using the linked name
+* Step 21 should result in success for all three parts
+* Step 22 should return without error
+* Step 23 should return with the following error message - Error response from daemon: No command specified
 
 #Possible Problems:
 None

--- a/tests/test-cases/Group1-Docker-Commands/1-4-Docker-Create.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-4-Docker-Create.robot
@@ -34,6 +34,11 @@ Create with named volume
     ${disk-size}=  Run  docker ${params} logs $(docker ${params} start $(docker ${params} create -v test-named-vol:/testdir busybox /bin/df -Ph) && sleep 10) | grep by-label | awk '{print $2}'
     Should Be Equal As Strings  ${disk-size}  975.9M
 
+Create with a directory as a volume
+    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} create -v /dir:/dir busybox
+    Should Be Equal As Integers  ${rc}  1
+    Should Contain  ${output}  Error response from daemon: vSphere Integrated Containers does not support mounting directories as a data volume.
+
 Create simple top example
     ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} create busybox /bin/top
     Should Be Equal As Integers  ${rc}  0

--- a/tests/test-cases/Group1-Docker-Commands/1-4-Docker-Create.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-4-Docker-Create.robot
@@ -37,7 +37,7 @@ Create with named volume
 Create with a directory as a volume
     ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} create -v /dir:/dir busybox
     Should Be Equal As Integers  ${rc}  1
-    Should Contain  ${output}  Error response from daemon: vSphere Integrated Containers does not support mounting directories as a data volume.
+    Should Contain  ${output}  Error response from daemon: Bad request error from portlayer: vSphere Integrated Containers does not support mounting directories as a data volume.
 
 Create simple top example
     ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} create busybox /bin/top


### PR DESCRIPTION
Follow-up of #2339

* Moves invalid volume create check to `processVolumeParam` func
* Condenses `processAnonymousVolumes` and `processSpecifiedVolumes` into one func, `processVolumeFields`
* Per @hmahmood, adds a helper func `volumeCreate` to separate the error handling between the `create`/`run` and `volume create` paths
* Adds a 404 response in swagger for a `VolumeJoin` to check if volume was not found
* Adds unit test improvements

`1-4-Docker-Create` and `1-19-Docker-Volume-Create` pass locally.
