### PR TITLE
Fix already bound error on container restart

### DIFF
--- a/tests/resources/Util.robot
+++ b/tests/resources/Util.robot
@@ -209,7 +209,7 @@ Get State Of Drone Build
     ${out}=  Run  drone build info vmware/vic ${num}
     ${lines}=  Split To Lines  ${out}
     [Return]  @{lines}[2]
-    
+
 Get Title of Drone Build
     [Arguments]  ${num}
     ${out}=  Run  drone build info vmware/vic ${num}
@@ -419,7 +419,7 @@ Run Regression Tests
 Put Host Into Maintenance Mode
     ${rc}  ${output}=  Run And Return Rc And Output  govc host.maintenance.enter -host.ip=%{TEST_URL}
     Should Contain  ${output}  entering maintenance mode... OK
-    
+
 Remove Host From Maintenance Mode
     ${rc}  ${output}=  Run And Return Rc And Output  govc host.maintenance.exit -host.ip=%{TEST_URL}
     Should Contain  ${output}  exiting maintenance mode... OK

--- a/tests/test-cases/Group1-Docker-Commands/1-5-Docker-Start.md
+++ b/tests/test-cases/Group1-Docker-Commands/1-5-Docker-Start.md
@@ -19,14 +19,15 @@ This test requires that a vSphere server is running and available
 6. Issue docker create vmware/photon
 7. Issue docker start vmware/photon <containerID>
 8. Issue docker start fakeContainer
+9. Issue docker start to a previously started ans stopped container
 
 #Expected Outcome:
-* Commands 1-7 should all return without error and respond with the container ID
+* Commands 1-7 and 9 should all return without error and respond with the container ID
 * After commands 3, 5, and 7 verify that the containers are running
-* Step 8 should result in the VIC applaiance returning the following error:  
+* Step 8 should result in the VIC applaiance returning the following error:
 ```
-Error response from daemon: No such container: fakeContainer  
-Error: failed to start containers: fakeContainer  
+Error response from daemon: No such container: fakeContainer
+Error: failed to start containers: fakeContainer
 ```
 
 #Possible Problems:

--- a/tests/test-cases/Group1-Docker-Commands/1-5-Docker-Start.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-5-Docker-Start.robot
@@ -50,3 +50,13 @@ Start with no ethernet card
     Should Be Equal As Integers  ${rc}  1
     Should Contain  ${output}  unable to wait for process launch status
     Should Not Contain  ${output}  context deadline exceeded
+Restart a stopped container
+    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} create -it busybox /bin/ls
+    Should Be Equal As Integers  ${rc}  0
+    Should Not Contain  ${output}  Error:
+    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} start ${output}
+    Should Be Equal As Integers  ${rc}  0
+    Should Not Contain  ${output}  Error:
+    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} start ${output}
+    Should Be Equal As Integers  ${rc}  0
+    Should Not Contain  ${output}  Error:


### PR DESCRIPTION
Fixes #1086 

```
chin@ubuntu:~/go/src/github.com/vmware/vic|1086/already-bound 
⇒  docker -H 192.168.218.141:2376 --tls create -it golang
Unable to find image 'golang:latest' locally
Pulling from library/golang
a79803310595: Pull complete 
8ad8b3f87b37: Pull complete 
a3ed95caeb02: Pull complete 
751fe39c4d34: Pull complete 
ae3b77eefc06: Pull complete 
92c7f8737c98: Pull complete 
bf37bbda794c: Pull complete 
6e9d2df2553b: Pull complete 
Digest: sha256:ddf30fb99905cf90292825504d453289ccbc3f6b0ff4e087c1c4d0e487ee3314
Status: Downloaded newer image for library/golang:latest
da897d227c6c18209abbb66c15702d78db6fc8bdea02ae61b3e3d104d1cff351
chin@ubuntu:~/go/src/github.com/vmware/vic|1086/already-bound 
⇒  docker -H 192.168.218.141:2376 --tls start da         
da
chin@ubuntu:~/go/src/github.com/vmware/vic|1086/already-bound 
⇒  docker -H 192.168.218.141:2376 --tls ps -a      
CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS              PORTS               NAMES
da897d227c6c        golang              "/bin/bash"         4 months ago        Running                                 determined_bhaskara
chin@ubuntu:~/go/src/github.com/vmware/vic|1086/already-bound 
⇒  docker -H 192.168.218.141:2376 --tls attach da
root@da897d227c6c:/go# 
root@da897d227c6c:/go# ls
bin  src
root@da897d227c6c:/go# exit%                                                                                                                                                                                                                                                                                                                                                                                                      chin@ubuntu:~/go/src/github.com/vmware/vic|1086/already-bound 
⇒  docker -H 192.168.218.141:2376 --tls ps -a    
CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS              PORTS               NAMES
da897d227c6c        golang              "/bin/bash"         4 months ago        Exited (0)                              determined_bhaskara
chin@ubuntu:~/go/src/github.com/vmware/vic|1086/already-bound 
⇒  docker -H 192.168.218.141:2376 --tls start da   
da
chin@ubuntu:~/go/src/github.com/vmware/vic|1086/already-bound 
⇒  docker -H 192.168.218.141:2376 --tls ps -a      
CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS              PORTS               NAMES
da897d227c6c        golang              "/bin/bash"         4 months ago        Running                                 determined_bhaskara
chin@ubuntu:~/go/src/github.com/vmware/vic|1086/already-bound 
⇒  docker -H 192.168.218.141:2376 --tls attach da
root@da897d227c6c:/go# 
root@da897d227c6c:/go# ls
bin  src
root@da897d227c6c:/go# exit
exit
```

passed local regression tests