### PR TITLE
Align handle and container state during container create

### DIFF
--- a/lib/portlayer/exec/container.go
+++ b/lib/portlayer/exec/container.go
@@ -174,6 +174,10 @@ func (c *Container) Commit(ctx context.Context, sess *session.Session, h *Handle
 
 		c.vm = vm.NewVirtualMachine(ctx, sess, res.Result.(types.ManagedObjectReference))
 		c.State = StateCreated
+
+		// align the handle state w/the container
+		h.State = &c.State
+
 		commitEvent = events.ContainerCreated
 
 		// clear the spec as we've acted on it


### PR DESCRIPTION
Container Create will create the VM and then immediately call stop on the newly created VM.  This fixes that behavior by aligning the handle & container state. 

Fixes #2403