### PR TITLE
Avoid waiting on guestinfo if vm powered off

### DIFF
--- a/lib/tether/ops_linux.go
+++ b/lib/tether/ops_linux.go
@@ -200,7 +200,7 @@ func pciToLinkName(pciPath string) (string, error) {
 	}
 
 	if len(matches) != 1 {
-		return "", fmt.Errorf("more than one eth interface matches %s", p)
+		return "", fmt.Errorf("%d eth interfaces match %s (%v)", len(matches), p, matches)
 	}
 
 	return path.Base(matches[0]), nil

--- a/pkg/vsphere/compute/rp_test.go
+++ b/pkg/vsphere/compute/rp_test.go
@@ -20,7 +20,6 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/vmware/govmomi/find"
 	"github.com/vmware/vic/pkg/vsphere/session"
 	"github.com/vmware/vic/pkg/vsphere/simulator"
 
@@ -77,7 +76,7 @@ func getESXSession(ctx context.Context, service string) (*session.Session, error
 	if err != nil {
 		return nil, err
 	}
-	s.Finder = find.NewFinder(s.Client.Client, false)
+
 	if s, err = s.Populate(ctx); err != nil {
 		return nil, err
 	}
@@ -99,7 +98,7 @@ func getVPXSession(ctx context.Context, service string) (*session.Session, error
 	if err != nil {
 		return nil, err
 	}
-	s.Finder = find.NewFinder(s.Client.Client, false)
+
 	if s, err = s.Populate(ctx); err != nil {
 		return nil, err
 	}

--- a/pkg/vsphere/session/session.go
+++ b/pkg/vsphere/session/session.go
@@ -202,7 +202,7 @@ func (s *Session) Connect(ctx context.Context) (*Session, error) {
 		return nil, errors.Errorf("Failed to log in to %s: %s", soapURL.String(), err)
 	}
 
-	s.Finder = find.NewFinder(s.Vim25(), true)
+	s.Finder = find.NewFinder(s.Vim25(), false)
 	// log high-level environement information
 	s.logEnvironmentInfo()
 	return s, nil

--- a/pkg/vsphere/simulator/simulator.go
+++ b/pkg/vsphere/simulator/simulator.go
@@ -271,6 +271,7 @@ func (s *Service) NewServer() *Server {
 		Scheme: "http",
 		Host:   ts.Listener.Addr().String(),
 		Path:   path,
+		User:   url.UserPassword("user", "pass"),
 	}
 
 	// Enable use of SessionManagerGenericServiceTicket.HostName in govmomi, disabled by default.

--- a/pkg/vsphere/simulator/simulator_test.go
+++ b/pkg/vsphere/simulator/simulator_test.go
@@ -20,7 +20,6 @@ import (
 	"io"
 	"log"
 	"net/http"
-	"net/url"
 	"reflect"
 	"testing"
 	"time"
@@ -236,7 +235,7 @@ func TestServeHTTP(t *testing.T) {
 			t.Fatal("expected invalid login error")
 		}
 
-		err = client.Login(ctx, url.UserPassword("user", "pass"))
+		err = client.Login(ctx, ts.URL.User)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/vsphere/vm/vm_test.go
+++ b/pkg/vsphere/vm/vm_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/vmware/govmomi/vim25/types"
 	"github.com/vmware/vic/lib/guest"
 	"github.com/vmware/vic/pkg/vsphere/session"
+	"github.com/vmware/vic/pkg/vsphere/simulator"
 	"github.com/vmware/vic/pkg/vsphere/sys"
 
 	"github.com/vmware/vic/pkg/vsphere/tasks"
@@ -271,6 +272,61 @@ func TestVMAttributes(t *testing.T) {
 			t.Fatalf("ERROR: %s", err)
 		}
 	}()
+}
+
+func TestWaitForKeyInExtraConfig(t *testing.T) {
+	ctx := context.Background()
+
+	m := simulator.ESX()
+	defer m.Remove()
+	err := m.Create()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	server := m.Service.NewServer()
+	defer server.Close()
+
+	config := &session.Config{
+		Service: server.URL.String(),
+	}
+
+	s, err := session.NewSession(config).Connect(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if s, err = s.Populate(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	vms, err := s.Finder.VirtualMachineList(ctx, "*")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	vm := NewVirtualMachineFromVM(ctx, s, vms[0])
+
+	opt := &types.OptionValue{Key: "foo", Value: "bar"}
+	obj := simulator.Map.Get(vm.Reference()).(*simulator.VirtualMachine)
+	obj.Config.ExtraConfig = append(obj.Config.ExtraConfig, opt)
+
+	val, err := vm.WaitForKeyInExtraConfig(ctx, opt.Key)
+
+	if err == nil {
+		t.Error("expected error")
+	}
+
+	obj.Summary.Runtime.PowerState = types.VirtualMachinePowerStatePoweredOn
+
+	val, err = vm.WaitForKeyInExtraConfig(ctx, opt.Key)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if val != opt.Value {
+		t.Errorf("%s != %s", val, opt.Value)
+	}
 }
 
 func createSnapshotTree(prefix string, deep int, wide int) []types.VirtualMachineSnapshotTree {

--- a/tests/test-cases/Group1-Docker-Commands/1-5-Docker-Start.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-5-Docker-Start.robot
@@ -37,3 +37,16 @@ Start non-existent container
     Should Be Equal As Integers  ${rc}  1
     Should Contain  ${output}  Error response from daemon: No such container: fakeContainer
     Should Contain  ${output}  Error: failed to start containers: fakeContainer
+Start with no ethernet card
+    # Testing that port layer doesn't hang forever if tether fails to initialize (see issue #2327)
+    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} pull busybox
+    Should Be Equal As Integers  ${rc}  0
+    ${name}=  Generate Random String  15
+    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} create --name ${name} busybox date
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${output}=  Run And Return Rc And Output  govc device.remove -vm ${name}-* ethernet-0
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} start ${name}
+    Should Be Equal As Integers  ${rc}  1
+    Should Contain  ${output}  unable to wait for process launch status
+    Should Not Contain  ${output}  context deadline exceeded

--- a/vendor/github.com/vmware/govmomi/vim25/xml/extras.go
+++ b/vendor/github.com/vmware/govmomi/vim25/xml/extras.go
@@ -71,7 +71,11 @@ func typeToString(typ reflect.Type) string {
 	case reflect.Float64:
 		return "xsd:double"
 	case reflect.String:
-		return "xsd:string"
+		name := typ.Name()
+		if name == "string" {
+			return "xsd:string"
+		}
+		return name
 	case reflect.Struct:
 		if typ == stringToTypeMap["xsd:dateTime"] {
 			return "xsd:dateTime"

--- a/vendor/manifest
+++ b/vendor/manifest
@@ -674,7 +674,7 @@
 			"importpath": "github.com/vmware/govmomi",
 			"repository": "https://github.com/vmware/govmomi",
 			"vcs": "git",
-			"revision": "f9184c1d704efa615d419dd8d1dae1ade94701d1",
+			"revision": "46ab2a7cb16a3f2d5f46e30d49c2365ed746a0a6",
 			"branch": "master"
 		},
 		{


### PR DESCRIPTION
If the tether fails to initialize, for example when no ethernet card is
found, the container VM will power off.  With this change we stop
waiting on guestinfo keys in such an event.

Issue #2327
