### PR TITLE
Establish stdin connection immediately after attach [full ci]

### DIFF
--- a/lib/apiservers/engine/backends/container_test.go
+++ b/lib/apiservers/engine/backends/container_test.go
@@ -22,6 +22,8 @@ import (
 	"testing"
 	"time"
 
+	"golang.org/x/net/context"
+
 	"github.com/docker/docker/api/types/backend"
 	derr "github.com/docker/docker/errors"
 	"github.com/docker/engine-api/types"
@@ -277,7 +279,7 @@ func (m *MockContainerProxy) StreamContainerLogs(name string, out io.Writer, sta
 	return nil
 }
 
-func (m *MockContainerProxy) ContainerRunning(vc *viccontainer.VicContainer) (bool, error) {
+func (m *MockContainerProxy) IsRunning(vc *viccontainer.VicContainer) (bool, error) {
 	// Assume container is running if container in cache.  If we need other conditions
 	// in the future, we can add it, but for now, just assume running.
 	c := cache.ContainerCache().GetContainer(vc.ContainerID)
@@ -294,6 +296,14 @@ func (m *MockContainerProxy) Wait(vc *viccontainer.VicContainer, timeout time.Du
 }
 
 func (m *MockContainerProxy) Signal(vc *viccontainer.VicContainer, sig uint64) error {
+	return nil
+}
+
+func (m *MockContainerProxy) Resize(vc *viccontainer.VicContainer, height, width int32) error {
+	return nil
+}
+
+func (m *MockContainerProxy) AttachStreams(ctx context.Context, vc *viccontainer.VicContainer, clStdin io.ReadCloser, clStdout, clStderr io.Writer, ca *backend.ContainerAttachConfig) error {
 	return nil
 }
 


### PR DESCRIPTION
Formerly, the attach performed a lazy connection between the personality
and the portlayer servers for the stdin stream.  The reason is the
Swagger client will not make the initial connection unless there is data
present in the ReaderCloser given to the client.  We force the connection
by sending over an init byte sequence, which causes an immediate connection
to the portlayer.  The interaction portlayer was updated to ignore the initial byte
sequence.

Also, since I touched the attach code again, I went ahead and moved
all the attach and resize swagger related code to the _proxy.go file.

Resolves #2353

**NOTE!!!: A lot of this code is the moving swagger code for resize and attach over to the _proxy.go file.  The relevant code is in container_proxy.go:copyStdIn() and in interaction_handler.go.**