### PR TITLE
Re-enable docker kill tests [full ci]

### DIFF
--- a/isos/bootstrap/bootstrap
+++ b/isos/bootstrap/bootstrap
@@ -2,6 +2,9 @@
 
 set -x
 
+echo "Loading drivers"
+/usr/sbin/modprobe vmxnet3
+
 MOUNTPOINT="/mnt/containerfs"
 
 mkdir -p /mnt/containerfs
@@ -11,7 +14,7 @@ while [ ! -e /dev/disk/by-label/containerfs ]; do :;done
 if mount -t ext4 /dev/disk/by-label/containerfs ${MOUNTPOINT}; then
     # ensure mountpoint exists
     mkdir -p ${MOUNTPOINT}/.tether
- 
+
     # ensure that no matter what we have access to required devices
     # WARNING WARNING WARNING WARNING WARNING
     # if the tmpfs is not large enough odd hangs can occur and the ESX event log will

--- a/tests/test-cases/Group1-Docker-Commands/1-14-Docker-Kill.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-14-Docker-Kill.robot
@@ -8,65 +8,51 @@ Suite Teardown  Cleanup VIC Appliance On Test Server
 Trap Signal Command
     # Container command runs an infinite loop, trapping and logging the given signal name
     [Arguments]  ${sig}
-    [Return]  busybox sh -c "trap 'echo KillSignal${sig}' ${sig}; while true; do date && sleep 1; done"
+    [Return]  busybox sh -c "trap 'echo KillSignal${sig}' ${sig}; echo READY; while true; do date && sleep 1; done"
 
-Assert Kill Signal
-    # Assert the docker kill signal was trapped by checking the container output log file
-    [Arguments]  ${id}  ${sig}
-	${rc}  ${dir}=  Run And Return Rc And Output  govc datastore.ls *-${id}
+Assert Container Output
+    [Arguments]  ${id}  ${match}
+    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} logs ${id}
     Should Be Equal As Integers  ${rc}  0
-    ${rc}=  Run And Return Rc  govc datastore.download ${dir}/${id}.log ${TEMPDIR}/${id}.log
-    Should Be Equal As Integers  ${rc}  0
-    ${output}=  OperatingSystem.Get File  ${TEMPDIR}/${id}.log
-    Remove File  ${TEMPDIR}/${id}.log
-    Should Contain  ${output}  KillSignal${sig}
-
-Inspect State Running
-    [Arguments]  ${id}  ${expected}
-    ${rc}  ${state}=  Run And Return Rc And Output  docker ${params} inspect --format="{{ .State.Running }}" ${id}
-    Should Be Equal As Integers  ${rc}  0
-    Should Be Equal  ${state}  ${expected}
+    Should Contain  ${output}  ${match}
 
 *** Test Cases ***
 Signal a container with default kill signal
-    ${status}=  Get State Of Github Issue  1946
-    Run Keyword If  '${status}' == 'closed'  Fail  Test 1-14-Docker-Kill.robot needs to be updated now that Issue #1946 has been resolved
-    Log  Issue \#1946 is blocking implementation  WARN
-    #${rc}=  Run And Return Rc  docker ${params} pull busybox
-    #Should Be Equal As Integers  ${rc}  0
-    #${rc}  ${id}=  Run And Return Rc And Output  docker ${params} create busybox sleep 300
-    #Should Be Equal As Integers  ${rc}  0
-    #${rc}=  Run And Return Rc  docker ${params} start ${id}
-    #Should Be Equal As Integers  ${rc}  0
-    #Inspect State Running  ${id}  true
-    #${rc}=  Run And Return Rc  docker ${params} kill ${id}
-    #Should Be Equal As Integers  ${rc}  0
+    ${rc}=  Run And Return Rc  docker ${params} pull busybox
+    Should Be Equal As Integers  ${rc}  0
+    ${trap}=  Trap Signal Command  HUP
+    ${rc}  ${id}=  Run And Return Rc And Output  docker ${params} create ${trap}
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} start ${id}
+    Should Be Equal As Integers  ${rc}  0
+    Wait Until Keyword Succeeds  20x  200 milliseconds  Assert Container Output  ${id}  READY
+    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} kill ${id}
+    Should Be Equal As Integers  ${rc}  0
     # Wait for container VM to stop/powerOff
-    #Wait Until Keyword Succeeds  20x  500 milliseconds  Inspect State Running  ${id}  false
+    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} logs --follow ${id}
     # Cannot send signal to a powered off container VM
-    #${rc}  ${output}=  Run And Return Rc And Output  docker ${params} kill ${id}
-    #Should Be Equal As Integers  ${rc}  1
-    #Should Contain  ${output}  Cannot kill container ${id}
+    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} kill ${id}
+    Should Be Equal As Integers  ${rc}  1
+    Should Contain  ${output}  Cannot kill container ${id}
 
 Signal a container with SIGHUP
-    ${status}=  Get State Of Github Issue  1946
-    Run Keyword If  '${status}' == 'closed'  Fail  Test 1-14-Docker-Kill.robot needs to be updated now that Issue #1946 has been resolved
-    Log  Issue \#1946 is blocking implementation  WARN
-    #${rc}=  Run And Return Rc  docker ${params} pull busybox
-    #Should Be Equal As Integers  ${rc}  0
-    #${trap}=  Trap Signal Command  HUP
-    #${rc}  ${id}=  Run And Return Rc And Output  docker ${params} run -d ${trap}
-    #Should Be Equal As Integers  ${rc}  0
-    ## Expect failure with unknown signal name
-    #${rc}=  Run And Return Rc  docker ${params} kill -s NOPE ${id}
-    #Should Be Equal As Integers  ${rc}  1
-    #${rc}=  Run And Return Rc  docker ${params} kill -s HUP ${id}
-    #Should Be Equal As Integers  ${rc}  0
-    #Wait Until Keyword Succeeds  5x  1 seconds  Assert Kill Signal  ${id}  HUP
-    #Inspect State Running  ${id}  true
-    #${rc}=  Run And Return Rc  docker ${params} kill -s TERM ${id}
-    #Should Be Equal As Integers  ${rc}  0
-    #Wait Until Keyword Succeeds  20x  500 milliseconds  Inspect State Running  ${id}  false
+    ${rc}=  Run And Return Rc  docker ${params} pull busybox
+    Should Be Equal As Integers  ${rc}  0
+    ${trap}=  Trap Signal Command  HUP
+    ${rc}  ${id}=  Run And Return Rc And Output  docker ${params} create ${trap}
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} start ${id}
+    Should Be Equal As Integers  ${rc}  0
+    Wait Until Keyword Succeeds  20x  200 milliseconds  Assert Container Output  ${id}  READY
+    # Expect failure with unknown signal name
+    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} kill -s NOPE ${id}
+    Should Be Equal As Integers  ${rc}  1
+    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} kill -s HUP ${id}
+    Should Be Equal As Integers  ${rc}  0
+    Wait Until Keyword Succeeds  20x  200 milliseconds  Assert Container Output  ${id}  KillSignalHUP
+    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} kill -s TERM ${id}
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} logs --follow ${id}
 
 Signal a non-existent container
     ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} kill fakeContainer


### PR DESCRIPTION
Adds an explicit "modprobe vmxnet3" to the tether (see issue #2327)

Fixes #1946