### PR TITLE
Update UI with regards to 'vice' prefix

### DIFF
--- a/ui/vic-ui-service/src/main/java/com/vmware/vicui/VicUIServiceImpl.java
+++ b/ui/vic-ui-service/src/main/java/com/vmware/vicui/VicUIServiceImpl.java
@@ -44,8 +44,8 @@ import com.vmware.vise.vim.data.VimObjectReferenceService;
 public class VicUIServiceImpl implements VicUIService, ClientSessionEndListener {
 	private static final Log _logger = LogFactory.getLog(VicUIServiceImpl.class);
 	private static final String[] VIC_VM_TYPES = {"isVCH", "isContainer"};
-	private static final String EXTRACONFIG_VCH_PATH = "guestinfo./init/common/name";
-	private static final String EXTRACONFIG_CONTAINER_PATH = "guestinfo./common/name";
+	private static final String EXTRACONFIG_VCH_PATH = "guestinfo.vice./init/common/name";
+	private static final String EXTRACONFIG_CONTAINER_PATH = "guestinfo.vice./common/name";
 	private static final String SERVICE_INSTANCE = "ServiceInstance";
 	private final VimObjectReferenceService _vimObjRefService;
 	private final UserSessionService _userSessionService;

--- a/ui/vic-ui/swf/src/main/flex/com/vmware/vicui/constants/AppConstants.as
+++ b/ui/vic-ui/swf/src/main/flex/com/vmware/vicui/constants/AppConstants.as
@@ -2,11 +2,11 @@ package com.vmware.vicui.constants {
 	
 	public class AppConstants {
 		
-		public static const VM_CONTAINER_NAME_PATH:String = "guestinfo./common/name";
-		public static const VM_CONTAINER_IMAGE_PATH:String = "guestinfo./repo";
-		public static const VM_CONTAINER_PORTMAPPING:String = "guestinfo./networks|bridge/ports~";
-		public static const VCH_NAME_PATH:String = "guestinfo./init/common/name";
-		public static const VCH_CLIENT_IP_PATH:String = "guestinfo..init.networks|client.ip.IP";
+		public static const VM_CONTAINER_NAME_PATH:String = "guestinfo.vice./common/name";
+		public static const VM_CONTAINER_IMAGE_PATH:String = "guestinfo.vice./repo";
+		public static const VM_CONTAINER_PORTMAPPING:String = "guestinfo.vice./networks|bridge/ports~";
+		public static const VCH_NAME_PATH:String = "guestinfo.vice./init/common/name";
+		public static const VCH_CLIENT_IP_PATH:String = "guestinfo.vice..init.networks|client.ip.IP";
 		public static const VCH_ENDPOINT_PORT:String = ":2376";
 		public static const VCH_LOG_PORT:String = ":2378";	
 		


### PR DESCRIPTION
This PR updates UI and UI service code that was making references to old extraConfig keys for VCH and Container VM portlets.

Fixes #2410

