### PR TITLE
Fix guestinfo wait poweroff shortcut

### DIFF
--- a/pkg/vsphere/vm/vm.go
+++ b/pkg/vsphere/vm/vm.go
@@ -225,7 +225,10 @@ func (vm *VirtualMachine) WaitForKeyInExtraConfig(ctx context.Context, key strin
 					// check the status of the key and return true if it's been set to non-nil
 					if key == value.GetOptionValue().Key {
 						detail = value.GetOptionValue().Value.(string)
-						return detail != "" && detail != "<nil>"
+						if detail != "" && detail != "<nil>" {
+							return true
+						}
+						break // continue the outer loop as we may have a powerState change too
 					}
 				}
 			case types.VirtualMachinePowerState:


### PR DESCRIPTION
Shortcut was added in PR #2405 - possible for the update callback
included both properties.  In that case, we'd miss the powerState change.