### PR TITLE
VIC does not support host IP in port bindings, but allow 0.0.0.0

### DIFF
--- a/lib/apiservers/engine/backends/container.go
+++ b/lib/apiservers/engine/backends/container.go
@@ -1417,7 +1417,7 @@ func validateCreateConfig(config *types.ContainerCreateConfig) error {
 	if config.HostConfig != nil {
 		for _, pbs := range config.HostConfig.PortBindings {
 			for _, pb := range pbs {
-				if pb.HostIP != "" {
+				if pb.HostIP != "" && pb.HostIP != "0.0.0.0" {
 					return InternalServerError("host IP is not supported for port bindings")
 				}
 


### PR DESCRIPTION
Fixes #2104

Although VIC does not support specifying the host IP to be using when doing port bindings, allow 0.0.0.0 to be specified since this is the default behavior anyway.

When using Jenkins with Docker Plug-in (https://wiki.jenkins-ci.org/display/JENKINS/Docker+Plugin), Jenkins will send a container create API call with the following JSON for HostConfig:

```
   "HostConfig":{
      "Binds":null,
      "Links":null,
      "LxcConf":null,
      "LogConfig":null,
      "PortBindings":{
         "22/tcp":[
            {
               "HostIp":"0.0.0.0",
               "HostPort":""
            }
         ]
      },
```

Without this patch, provisioning the build slave fails with the following error message even though it is a valid configuration that should work with VIC:

`host IP is not supported for port bindings`

With this patch, everything works as expected. Here is an example build output from a dynamically provisioned Jenkins slave container running on VIC:

```
Building remotely on VIC-33a7e3b8f890 (docker-slave) in workspace /home/jenkins/workspace/vic-test
[vic-test] $ /bin/sh -xe /tmp/hudson4730172276331220303.sh
+ printenv
<output truncated>
JENKINS_HOME=/Users/Shared/Jenkins/Home
SSH_CLIENT=172.16.0.1 65089 22
JENKINS_CLOUD_ID=VIC
USER=jenkins
<output truncated>
DOCKER_HOST=tcp://10.115.68.105:2375
<output truncated>
SSH_CONNECTION=172.16.0.1 65089 172.16.0.2 22
DOCKER_CONTAINER_ID=33a7e3b8f8900e31d9541f54ef94953f39d22263f25e11037df7f1003dee6c28
Finished: SUCCESS
```
