### PR TITLE
Container Start / Stop time

### DIFF
--- a/lib/apiservers/engine/backends/container_proxy.go
+++ b/lib/apiservers/engine/backends/container_proxy.go
@@ -567,14 +567,12 @@ func ContainerInfoToDockerContainerInspect(vc *viccontainer.VicContainer, info *
 		if info.ProcessConfig.ErrorMsg != nil {
 			containerState.Error = *info.ProcessConfig.ErrorMsg
 		}
-		if info.ProcessConfig.Started != nil {
-			swaggerTime := time.Time(*info.ProcessConfig.Started)
-			containerState.StartedAt = swaggerTime.Format(time.RFC3339Nano)
+		if info.ProcessConfig.StartTime != nil && *info.ProcessConfig.StartTime != 0 {
+			containerState.StartedAt = time.Unix(*info.ProcessConfig.StartTime, 0).Format(time.RFC3339Nano)
 		}
 
-		if info.ProcessConfig.Finished != nil {
-			swaggerTime := time.Time(*info.ProcessConfig.Finished)
-			containerState.FinishedAt = swaggerTime.Format(time.RFC3339Nano)
+		if info.ProcessConfig.StopTime != nil && *info.ProcessConfig.StopTime != 0 {
+			containerState.FinishedAt = time.Unix(*info.ProcessConfig.StopTime, 0).Format(time.RFC3339Nano)
 		}
 	}
 
@@ -639,8 +637,8 @@ func ContainerInfoToDockerContainerInspect(vc *viccontainer.VicContainer, info *
 		if info.ContainerConfig.ContainerID != nil {
 			inspectJSON.ID = *info.ContainerConfig.ContainerID
 		}
-		if info.ContainerConfig.Created != nil {
-			inspectJSON.Created = time.Unix(*info.ContainerConfig.Created, 0).Format(time.RFC3339Nano)
+		if info.ContainerConfig.CreateTime != nil {
+			inspectJSON.Created = time.Unix(*info.ContainerConfig.CreateTime, 0).Format(time.RFC3339Nano)
 		}
 		if len(info.ContainerConfig.Names) > 0 {
 			inspectJSON.Name = info.ContainerConfig.Names[0]

--- a/lib/apiservers/portlayer/swagger.json
+++ b/lib/apiservers/portlayer/swagger.json
@@ -2175,7 +2175,15 @@
 					"type": "integer",
 					"format": "int32"
 				},
-				"created": {
+				"createTime": {
+					"type": "integer",
+					"format": "int64"
+				},
+				"startTime": {
+					"type": "integer",
+					"format": "int64"
+				},
+				"stopTime": {
 					"type": "integer",
 					"format": "int64"
 				},
@@ -2215,7 +2223,7 @@
 				"repoName": {
 					"type": "string"
 				},
-				"created": {
+				"createTime": {
 					"type": "integer",
 					"format": "int64"
 				},
@@ -2331,13 +2339,13 @@
 				"status": {
 					"type": "string"
 				},
-				"started": {
-					"type": "string",
-					"format": "datetime"
+				"startTime": {
+					"type": "integer",
+					"format": "int64"
 				},
-				"finished": {
-					"type": "string",
-					"format": "datetime"
+				"stopTime": {
+					"type": "integer",
+					"format": "int64"
 				},
 				"exitCode": {
 					"type": "integer",

--- a/lib/config/executor/container_vm.go
+++ b/lib/config/executor/container_vm.go
@@ -40,9 +40,6 @@ type Common struct {
 	// Convenience field to record a human readable name
 	Name string `vic:"0.1" scope:"read-only" key:"name"`
 
-	// creation timestamp
-	Created int64 `vic:"0.1" scope:"read-only" key:"created"`
-
 	// Freeform notes related to the entity
 	Notes string `vic:"0.1" scope:"hidden" key:"notes"`
 }
@@ -113,6 +110,9 @@ type ContainerVM struct {
 type ExecutorConfig struct {
 	Common `vic:"0.1" scope:"read-only" key:"common"`
 
+	// CreateTime stamp
+	CreateTime int64 `vic:"0.1" scope:"read-write" key:"createtime"`
+
 	// Diagnostics holds basic diagnostics data
 	Diagnostics Diagnostics `vic:"0.1" scope:"read-only" key:"diagnostics"`
 
@@ -166,6 +166,7 @@ type Cmd struct {
 type SessionConfig struct {
 	// The primary session may have the same ID as the executor owning it
 	Common `vic:"0.1" scope:"read-only" key:"common"`
+	Detail `vic:"0.1" scope:"read-write" key:"detail"`
 
 	// The primary process for the session
 	Cmd Cmd `vic:"0.1" scope:"read-only" key:"cmd"`
@@ -198,4 +199,12 @@ type SessionConfig struct {
 	// Need to go here since UID/GID resolution must be done on appliance
 	User  string `vic:"0.1" scope:"read-only" key:"User"`
 	Group string `vic:"0.1" scope:"read-only" key:"Group"`
+}
+
+type Detail struct {
+
+	// creation, started & stopped timestamps
+	CreateTime int64 `vic:"0.1" scope:"read-write" key:"createtime"`
+	StartTime  int64 `vic:"0.1" scope:"read-write" key:"starttime"`
+	StopTime   int64 `vic:"0.1" scope:"read-write" key:"stoptime"`
 }

--- a/lib/portlayer/exec/container.go
+++ b/lib/portlayer/exec/container.go
@@ -55,6 +55,7 @@ const (
 	StateSuspending
 	StateSuspended
 	StateCreated
+	StateCreating
 	StateRemoving
 	StateRemoved
 
@@ -77,7 +78,7 @@ type Container struct {
 func NewContainer(id uid.UID) *Handle {
 	con := &Container{
 		ExecConfig: &executor.ExecutorConfig{},
-		State:      StateStopped,
+		State:      StateCreating,
 	}
 	con.ExecConfig.ID = id.String()
 	return con.NewHandle()
@@ -173,9 +174,6 @@ func (c *Container) Commit(ctx context.Context, sess *session.Session, h *Handle
 
 		c.vm = vm.NewVirtualMachine(ctx, sess, res.Result.(types.ManagedObjectReference))
 		c.State = StateCreated
-
-		// align the handle state w/the container
-		h.State = &c.State
 
 		commitEvent = events.ContainerCreated
 

--- a/lib/tether/config.go
+++ b/lib/tether/config.go
@@ -65,6 +65,7 @@ type ExecutorConfig struct {
 type SessionConfig struct {
 	// The primary session may have the same ID as the executor owning it
 	executor.Common `vic:"0.1" scope:"read-only" key:"common"`
+	executor.Detail `vic:"0.1" scope:"read-write" key:"detail"`
 
 	// Diagnostics holds basic diagnostics data
 	Diagnostics executor.Diagnostics `vic:"0.1" scope:"read-write" key:"diagnostics"`


### PR DESCRIPTION
Container start / stop time persisted to the container vmx.  The following docker commands have been updated with this information:

- ps
```
vic ps -a
CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS                            PORTS               NAMES
55ab3a4adfc5        busybox             "/bin/top"          28 seconds ago      Up 25 seconds                                         insane_poitras
df7d0a04de20        busybox             "/bin/top"          3 minutes ago       Exited (143) About a minute ago                       elegant_albattani
```
- inspect
```
{
        "Id": "df7d0a04de20fa47eb6371a7189ec3013673ab12625e65728c658109e5b8e46f",
        "Created": "2016-09-22T15:12:40Z",
        "Path": "/bin/top",
        "Args": [],
        "State": {
            "Status": "exited",
            "Running": false,
            "Paused": false,
            "Restarting": false,
            "OOMKilled": false,
            "Dead": false,
            "Pid": 0,
            "ExitCode": 143,
            "Error": "",
            "StartedAt": "2016-09-22T15:13:06Z",
            "FinishedAt": "2016-09-22T15:14:32Z"
        }
```

Known issue:

- Out of Band powerOn, powerOff result in incorrect time, so no time will be shown


fixes #1899 