### PR TITLE
Move vCenter version check to configs

### DIFF
--- a/ui/installer/VCSA/configs
+++ b/ui/installer/VCSA/configs
@@ -9,4 +9,8 @@ VCENTER_IP=""
 VIC_UI_HOST_URL="NOURL"
 
 # If VIC_UI_HOST_URL starts with "https", enter SHA-1 thumbprint of the web server hosting the vic-ui.zip file
+# The fingerprint should be in the format of A0:B1:C2:... In case you retrieved the fingerprint from Google Chrome make sure to replace spaces with colons (:)
 VIC_UI_HOST_THUMBPRINT=""
+
+# WARNING: VIC UI can run on a vCenter 5.5 setup, but is not officially supported. Use it with your own risk. If you wish to continue change the value from 0 to 1
+IS_VCENTER_5_5=0

--- a/ui/installer/vCenterForWindows/configs
+++ b/ui/installer/vCenterForWindows/configs
@@ -6,5 +6,6 @@ REM For example, if vic-ui.zip is available at https://192.168.1.5/vic-ui-plugin
 REM Note: each uploaded zip file will be accessed only once when the user logs into vSphere Web Client for the first time after successful installation
 SET vic_ui_host_url=NOURL
 
-REM If line 10 starts with "https", enter the SHA-1 thumbprint of the web server hosting the zip files
+REM If line 11 starts with "https", enter the SHA-1 thumbprint of the web server hosting the zip files
+REM The fingerprint should be in the format of A0:B1:C2:... In case you retrieved the fingerprint from Google Chrome make sure to replace spaces with colons (:)
 SET vic_ui_host_thumbprint=

--- a/ui/installer/vCenterForWindows/install.bat
+++ b/ui/installer/vCenterForWindows/install.bat
@@ -82,8 +82,11 @@ DEL _scratch_flags.txt
 IF /I %vic_ui_host_url% EQU NOURL (
     ECHO =============================
     ECHO With the current version of VIC, you have to manually copy the com.vmware.vicui.* folder in \ui\vsphere-client-serenity to %VMWARE_CFG_DIR%\vsphere-client\vc-packages\vsphere-client-serenity
-    ECHO Note: If you are running vCenter Server 5.5, copy the folder to %PROGRAMDATA%\VMware\vSphere Web Client\vc-packages\vsphere-client-serenity instead
-    ECHO After that, log out of vSphere Web Client and then log back in.
+    ECHO
+    ECHO Note for vCenter 5.5 users:
+    ECHO VIC UI may run on a vCenter 5.5 setup, but is not officially supported. Use it with your own risk. To proceed, copy the aforementioned folder to %PROGRAMDATA%\VMware\vSphere Web Client\vc-packages\vsphere-client-serenity instead
+    ECHO
+    ECHO Once you've copied the folder, log out of vSphere Web Client and then log back in.
     ECHO =============================
 ) ELSE (
     ECHO VIC UI was successfully installed. Make sure to log out of vSphere Web Client and log back in.


### PR DESCRIPTION
Made a change to the UI installer in a way that vCenter 5.5 support is still there, but needs to be configured in the `configs` file which comes with a warning message that VC 5.5 is not officially supported.

Addresses #2416.