### PR TITLE
populate container cache in docker personality during init

### DIFF
--- a/lib/apiservers/engine/backends/container.go
+++ b/lib/apiservers/engine/backends/container.go
@@ -1006,32 +1006,32 @@ func (c *Container) Containers(config *types.ContainerListOptions) ([]*types.Con
 	// TODO: move to conversion function
 	containers := make([]*types.Container, 0, len(containme.Payload))
 	for _, t := range containme.Payload {
-		cmd := strings.Join(t.ExecArgs, " ")
+		cmd := strings.Join(t.ProcessConfig.ExecArgs, " ")
 		// the docker client expects the friendly name to be prefixed
 		// with a forward slash -- create a new slice and add here
-		names := make([]string, 0, len(t.Names))
-		for i := range t.Names {
-			names = append(names, clientFriendlyContainerName(t.Names[i]))
+		names := make([]string, 0, len(t.ContainerConfig.Names))
+		for i := range t.ContainerConfig.Names {
+			names = append(names, clientFriendlyContainerName(t.ContainerConfig.Names[i]))
 		}
 		var started time.Time
 		var stopped time.Time
-		if t.StartTime != nil && *t.StartTime > 0 {
+		if t.ProcessConfig.StartTime != nil && *t.ProcessConfig.StartTime > 0 {
 			started = time.Unix(*t.StartTime, 0)
 		}
-		if t.StopTime != nil && *t.StopTime > 0 {
+		if t.ProcessConfig.StopTime != nil && *t.ProcessConfig.StopTime > 0 {
 			stopped = time.Unix(*t.StopTime, 0)
 		}
 		// get the docker friendly status
-		_, status := dockerStatus(int(*t.ExitCode), *t.Status, *t.State, started, stopped)
+		_, status := dockerStatus(int(*t.ProcessConfig.ExitCode), *t.ProcessConfig.Status, *t.ContainerConfig.State, started, stopped)
 
 		c := &types.Container{
-			ID:      *t.ContainerID,
-			Image:   *t.RepoName,
-			Created: *t.CreateTime,
+			ID:      *t.ContainerConfig.ContainerID,
+			Image:   *t.ContainerConfig.RepoName,
+			Created: *t.ContainerConfig.CreateTime,
 			Status:  status,
 			Names:   names,
 			Command: cmd,
-			SizeRw:  *t.StorageSize,
+			SizeRw:  *t.ContainerConfig.StorageSize,
 		}
 		containers = append(containers, c)
 	}

--- a/lib/apiservers/engine/backends/container.go
+++ b/lib/apiservers/engine/backends/container.go
@@ -1016,10 +1016,10 @@ func (c *Container) Containers(config *types.ContainerListOptions) ([]*types.Con
 		var started time.Time
 		var stopped time.Time
 		if t.ProcessConfig.StartTime != nil && *t.ProcessConfig.StartTime > 0 {
-			started = time.Unix(*t.StartTime, 0)
+			started = time.Unix(*t.ProcessConfig.StartTime, 0)
 		}
 		if t.ProcessConfig.StopTime != nil && *t.ProcessConfig.StopTime > 0 {
-			stopped = time.Unix(*t.StopTime, 0)
+			stopped = time.Unix(*t.ProcessConfig.StopTime, 0)
 		}
 		// get the docker friendly status
 		_, status := dockerStatus(int(*t.ProcessConfig.ExitCode), *t.ProcessConfig.Status, *t.ContainerConfig.State, started, stopped)

--- a/lib/apiservers/engine/backends/container_proxy.go
+++ b/lib/apiservers/engine/backends/container_proxy.go
@@ -875,3 +875,29 @@ func portMapFromVicContainer(vc *viccontainer.VicContainer) nat.PortMap {
 
 	return portMap
 }
+
+func ContainerInfoToVicContainer(info models.ContainerInfo) *viccontainer.VicContainer {
+	log.Debugf("Convert container info to vic container")
+
+	vc := viccontainer.NewVicContainer()
+
+	var name string
+	if len(info.ContainerConfig.Names) > 0 {
+		vc.Name = info.ContainerConfig.Names[0]
+	}
+	log.Debugf("Container %q", name)
+
+	if info.ContainerConfig.LayerID != nil {
+		vc.ImageID = *info.ContainerConfig.LayerID
+	}
+
+	if info.ContainerConfig.ContainerID != nil {
+		vc.ContainerID = *info.ContainerConfig.ContainerID
+	}
+
+	tempVC := viccontainer.NewVicContainer()
+	tempVC.HostConfig = &container.HostConfig{}
+	vc.Config = containerConfigFromContainerInfo(tempVC, &info)
+	vc.HostConfig = hostConfigFromContainerInfo(tempVC, &info, PortLayerName())
+	return vc
+}

--- a/lib/apiservers/engine/backends/system_portlayer.go
+++ b/lib/apiservers/engine/backends/system_portlayer.go
@@ -94,9 +94,9 @@ func (s *SystemProxy) ContainerCount() (int, int, int, error) {
 	}
 
 	for _, t := range containList.Payload {
-		if *t.State == "Running" {
+		if *t.ContainerConfig.State == "Running" {
 			running++
-		} else if *t.State == "Stopped" || *t.State == "Created" {
+		} else if *t.ContainerConfig.State == "Stopped" || *t.ContainerConfig.State == "Created" {
 			stopped++
 		}
 	}

--- a/lib/apiservers/portlayer/swagger.json
+++ b/lib/apiservers/portlayer/swagger.json
@@ -1088,7 +1088,7 @@
 						"schema": {
 							"type": "array",
 							"items": {
-								"$ref": "#definitions/ContainerListInfo"
+								"$ref": "#definitions/ContainerInfo"
 							}
 						}
 					},
@@ -2280,6 +2280,10 @@
 				},
 				"reservation": {
 					"$ref": "#/definitions/ReservationConfig"
+				},
+				"storageSize": {
+					"type": "integer",
+					"format": "int64"
 				}
 			}
 		},

--- a/tests/test-cases/Group10-VCH-Restart/Group10-VCH-Restart.md
+++ b/tests/test-cases/Group10-VCH-Restart/Group10-VCH-Restart.md
@@ -12,10 +12,13 @@ This test requires that a vSphere server is running and available
 2. Issue docker network create bar, creating a new network called "bar"
 3. Reboot VCH
 4. Issue a docker network ls
+5. Issue docker inspect
+6. Issue docker stop, start and ls
 
 #Expected Outcome:
 * VCH should reboot within a reasonable amount of time
 * After VCH restart, network ls should have the previously created network listed
+* Step 5, 6 should result in success
 
 #Possible Problems:
 None

--- a/tests/test-cases/Group10-VCH-Restart/Group10-VCH-Restart.robot
+++ b/tests/test-cases/Group10-VCH-Restart/Group10-VCH-Restart.robot
@@ -48,4 +48,16 @@ Created Network Persists And Containers Are Discovered With Correct IPs
     Should Be Equal  ${ip}  ${ip1}
     ${ip}=  Get Container IP  ${id2}  bridge
     Should Be Equal  ${ip}  ${ip2}
-     
+    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} inspect vch-restart-test1
+    Should Be Equal As Integers  ${rc}  0
+    Should Contain  ${output}  "Id"
+    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} stop vch-restart-test1
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} ps -a
+    Should Be Equal As Integers  ${rc}  0
+    Should Contain  ${output}  Exited (0)
+    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} start vch-restart-test1
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} ps -a
+    Should Be Equal As Integers  ${rc}  0
+    Should Not Contain  ${output}  Exited (0)


### PR DESCRIPTION
Fixes #2382 

In this change, I unified the response object of container list and container inspect in portlayer API. So container list will return enough information to rebuild container cache.

Another thing is that the container repopulated method end up in backend.go, instead of container cache file. The reason is that @sflxn is refactoring container_proxy file, I don't want to move that file around at this moment.