### PR TITLE
Persist Docker's per container labels [full ci]

### DIFF
--- a/lib/apiservers/engine/backends/container.go
+++ b/lib/apiservers/engine/backends/container.go
@@ -1526,7 +1526,6 @@ func copyConfigOverrides(vc *viccontainer.VicContainer, config types.ContainerCr
 	vc.Config.OpenStdin = config.Config.OpenStdin
 	vc.Config.StdinOnce = config.Config.StdinOnce
 	vc.Config.StopSignal = config.Config.StopSignal
-	vc.Config.Labels = config.Config.Labels
 	vc.HostConfig = config.HostConfig
 }
 

--- a/lib/apiservers/portlayer/restapi/handlers/containers_handlers.go
+++ b/lib/apiservers/portlayer/restapi/handlers/containers_handlers.go
@@ -120,6 +120,13 @@ func (handler *ContainersHandlersImpl) CreateHandler(params containers.CreatePar
 		RepoName:   *params.CreateConfig.RepoName,
 		StopSignal: *params.CreateConfig.StopSignal,
 	}
+	if params.CreateConfig.Annotations != nil && len(params.CreateConfig.Annotations) > 0 {
+		m.Annotations = make(map[string]string)
+		for k, v := range params.CreateConfig.Annotations {
+			m.Annotations[k] = v
+		}
+	}
+
 	log.Infof("CreateHandler Metadata: %#v", m)
 
 	// Create new portlayer executor and call Create on it
@@ -393,6 +400,14 @@ func convertContainerToContainerInfo(container *exec.Container) *models.Containe
 	info.ContainerConfig.AttachStderr = &attach
 
 	info.ContainerConfig.StorageSize = &container.VMUnsharedDisk
+
+	if container.ExecConfig.Annotations != nil && len(container.ExecConfig.Annotations) > 0 {
+		info.ContainerConfig.Annotations = make(map[string]string)
+
+		for k, v := range container.ExecConfig.Annotations {
+			info.ContainerConfig.Annotations[k] = v
+		}
+	}
 
 	path := container.ExecConfig.Sessions[ccid].Cmd.Path
 	info.ProcessConfig.ExecPath = &path

--- a/lib/apiservers/portlayer/swagger.json
+++ b/lib/apiservers/portlayer/swagger.json
@@ -1950,6 +1950,12 @@
 				},
 				"stopSignal": {
 					"type": "string"
+				},
+				"annotations": {
+					"type": "object",
+					"additionalProperties": {
+						"type": "string"
+					}
 				}
 			}
 		},
@@ -2239,7 +2245,7 @@
 						"type": "string"
 					}
 				},
-				"labels": {
+				"annotations": {
 					"type": "object",
 					"additionalProperties": {
 						"type": "string"

--- a/lib/config/executor/container_vm.go
+++ b/lib/config/executor/container_vm.go
@@ -134,6 +134,9 @@ type ExecutorConfig struct {
 	// Layer id that is backing this container VM
 	LayerID string `vic:"0.1" scope:"read-only" key:"layerid"`
 
+	// Blob metadata for the caller
+	Annotations map[string]string `vic:"0.1" scope:"hidden" key:"annotation"`
+
 	// Repository requested by user
 	// TODO: a bit docker specific
 	RepoName string `vic:"0.1" scope:"read-only" key:"repo"`


### PR DESCRIPTION
Persist Docker's per container labels so to handle restarts of
the personality server and to allow containers to be moved.

Resolves #2355