### PR TITLE
Update vendor/govmomi

### DIFF
--- a/vendor/manifest
+++ b/vendor/manifest
@@ -674,7 +674,7 @@
 			"importpath": "github.com/vmware/govmomi",
 			"repository": "https://github.com/vmware/govmomi",
 			"vcs": "git",
-			"revision": "46ab2a7cb16a3f2d5f46e30d49c2365ed746a0a6",
+			"revision": "b932baf416e9101c762b7075f12af5a6fb364627",
 			"branch": "master"
 		},
 		{


### PR DESCRIPTION
From vmware/govmomi@9f0e9654 :

  Treat DatastoreFile follower Close as "stop"
  Rather than close right away, wake up and return io.EOF after 1 final
  Read().  The main point of follow.DatastoreFile.Close is to break out of
  the blocking Read() call.  We still do that, but also give the
  caller any other data that may have come in while we were waiting on the
  poll interval ticker.

Fixes #2380
Fixes #2445