### PR TITLE
Fixes the failing test that looks for the tether debug logs

### DIFF
--- a/tests/test-cases/Group9-VIC-Admin/9-1-VICAdmin-ShowHTML.robot
+++ b/tests/test-cases/Group9-VIC-Admin/9-1-VICAdmin-ShowHTML.robot
@@ -36,7 +36,7 @@ Get Container Logs
     Should Be Equal As Integers  ${rc}  0
     Log  ${output}
     Should Contain  ${output}  ${container}/vmware.log
-    Should Contain  ${output}  ${container}/*.debug
+    Should Match Regexp  ${output}  ${container}/*.debug
 
 Get VICAdmin Log
     ${rc}  ${output}=  Run And Return Rc And Output  curl -sk ${vic-admin}/logs/vicadmin.log


### PR DESCRIPTION
This fixes a small integration test failure that was introduced due to the incorrect robot keyword being used when attempting to apply a regex match. Now the lookup on the name of the tether debug file for robot test group 9-1 should pass. This has been tested on VC and ESX. Not on VSAN though. 