### PR TITLE
Fixes vic-machine delete removing attached disks to powered off VMs

### DIFF
--- a/lib/install/management/appliance.go
+++ b/lib/install/management/appliance.go
@@ -177,7 +177,8 @@ func (d *Dispatcher) deleteVM(vm *vm.VirtualMachine, force bool) error {
 	}
 
 	_, err = tasks.WaitForResult(d.ctx, func(ctx context.Context) (tasks.Task, error) {
-		return vm.Destroy(ctx)
+
+		return vm.DeleteExceptDisks(ctx)
 	})
 	if err != nil {
 		err = errors.Errorf("Failed to destroy VM %q: %s", vm.Reference(), err)

--- a/lib/install/management/appliance.go
+++ b/lib/install/management/appliance.go
@@ -177,7 +177,6 @@ func (d *Dispatcher) deleteVM(vm *vm.VirtualMachine, force bool) error {
 	}
 
 	_, err = tasks.WaitForResult(d.ctx, func(ctx context.Context) (tasks.Task, error) {
-
 		return vm.DeleteExceptDisks(ctx)
 	})
 	if err != nil {


### PR DESCRIPTION
Previously we were calling the heavy handed vm.Destroy which removes the vm and any devices attached to it. Now we will be calling DeleteExceptDisks which removes disks from the VM before calling Destroy on it. 

Fixes #2114 

