### PR TITLE
Fix port-mapping integration test

### DIFF
--- a/tests/test-cases/Group1-Docker-Commands/1-25-Docker-Port-Map.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-25-Docker-Port-Map.robot
@@ -12,10 +12,9 @@ Create container with port mappings
     ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} start webserver
     Should Be Equal As Integers  ${rc}  0
     Should Not Contain  ${output}  Error
-    Sleep  20  Wait for nginx to start
-    ${rc}  ${output}=  Run And Return Rc And Output  curl ${vch-ip}:10000 --connect-timeout 10
+    ${rc}  ${output}=  Run And Return Rc And Output  wget ${vch-ip}:10000 --retry-connrefused --timeout=10 --tries=10
     Should Be Equal As Integers  ${rc}  0
-    ${rc}  ${output}=  Run And Return Rc And Output  curl ${vch-ip}:10001 --connect-timeout 10
+    ${rc}  ${output}=  Run And Return Rc And Output  wget ${vch-ip}:10001 --retry-connrefused --timeout=10 --tries=10
     Should Be Equal As Integers  ${rc}  0
     ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} stop webserver
     Should Be Equal As Integers  ${rc}  0


### PR DESCRIPTION
The first integration test in [`1-25-Docker-Port-Map`](https://github.com/vmware/vic/blob/master/tests/test-cases/Group1-Docker-Commands/1-25-Docker-Port-Map.robot#L8) has a transient failure where nginx isn't running when we hit its endpoint with `curl`. This PR fixes the issue by using `wget` instead, which supports retries when the server isn't fully up.

More details in the commit message.

Fixes #2354 

