### PR TITLE
Implement imagec private registry test[skip ci]

### DIFF
--- a/tests/manual-test-cases/Group5-Functional-Tests/5-9-Private-Registry.md
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-9-Private-Registry.md
@@ -20,9 +20,11 @@ This test requires access to a vSphere Server
 ```docker push localhost:5000/busybox```
 5. Attempt to pull the local registry image using the VCH appliance:  
 ```docker pull ${params} 172.17.0.1:5000/busybox```
+6. Use imagec binary standalone to pull the image from the local registry:  
+```imagec -standalone -insecure-allow-http -reference localhost:5000/busybox```
 
 #Expected Outcome:
-The VCH appliance should be able to successfully pull the image from a local registry without error
+The VCH appliance should be able to successfully pull the image from a local registry without error and imagec should be able to pull the image as well directly
 
 #Possible Problems:
 The default network on VCH containers is in the 172.17.0.x space, but this could potentially change. If you are having issues running the tests make sure that the container has an IP address in that network space. 

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-9-Private-Registry.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-9-Private-Registry.robot
@@ -1,10 +1,26 @@
 *** Settings ***
 Documentation  Test 5-9 - Private Registry
 Resource  ../../resources/Util.robot
-Suite Setup  Install VIC Appliance To Test Server
-Suite Teardown  Cleanup VIC Appliance On Test Server
+Suite Setup  Private Registry Setup
+Suite Teardown  Private Registry Cleanup
 
 *** Keywords ***
+Private Registry Setup
+    Install VIC Appliance To Test Server
+    ${rc}  ${output}=  Run And Return Rc And Output  docker run -d -p 5000:5000 --name registry registry
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${output}=  Run And Return Rc And Output  docker pull busybox
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${output}=  Run And Return Rc And Output  docker tag busybox localhost:5000/busybox:latest
+    Should Be Equal As Integers  ${rc}  0  
+    ${rc}  ${output}=  Run And Return Rc And Output  docker push localhost:5000/busybox
+    Should Be Equal As Integers  ${rc}  0
+    
+Private Registry Cleanup
+    Cleanup VIC Appliance On Test Server
+    ${rc}  ${output}=  Run And Return Rc And Output  docker rm -f registry
+    Should Be Equal As Integers  ${rc}  0
+
 Pull image
     [Arguments]  ${image}
     Log To Console  \nRunning docker pull ${image}...
@@ -17,12 +33,11 @@ Pull image
 
 *** Test Cases ***
 Pull an image from non-default repo
-    ${output}=  Run  docker run -d -p 5000:5000 --name registry registry
-    Log  ${output}
-    ${output}=  Run  docker pull busybox
-    Log  ${output}
-    ${output}=  Run  docker tag busybox localhost:5000/busybox:latest
-    Log  ${output}
-    ${output}=  Run  docker push localhost:5000/busybox
-    Log  ${output}
     Wait Until Keyword Succeeds  5x  15 seconds  Pull image  172.17.0.1:5000/busybox
+    
+Standalone imagec pull from private registry
+    ${result}=  Run Process  ${bin-dir}/imagec -standalone -insecure-allow-http -reference localhost:5000/busybox  shell=True  cwd=/
+    Log  ${result.stdout}
+    Log  ${result.stderr}
+    Should Contain  ${result.stdout}  "status":"Download complete"
+    Should Contain  ${result.stdout}  "status":"Digest: sha256:


### PR DESCRIPTION
Fixes #250

This needs to be a manual test case as well, until we can get a private registry hooked up in the CI. Then we can move this over.