### PR TITLE
Disable device monitoring for vsan in create esxi script

### DIFF
--- a/infra/machines/vcsa/create-esxi-vm.sh
+++ b/infra/machines/vcsa/create-esxi-vm.sh
@@ -180,6 +180,9 @@ else
     action="create"
 fi
 
+echo "Disabling VSAN device monitoring"
+govc host.esxcli system settings advanced set -o /LSOM/VSANDeviceMonitoring -i 0
+
 echo "ESX host account $action for user $username..."
 govc host.account.$action -id $username -password "$password"
 


### PR DESCRIPTION
VSAN device monitoring on nested environments leads to nodes being
marked as unavailable because performance is below some threshold.  See
http://cormachogan.com/2015/09/22/vsan-6-1-new-feature-problematic-disk-handling/
for details.