### PR TITLE
Use unsigned 16-bit int to enable full TCP port range

### DIFF
--- a/lib/portlayer/network/port.go
+++ b/lib/portlayer/network/port.go
@@ -26,9 +26,11 @@ type Port string
 const NilPort = Port("")
 
 func ParsePort(p string) (Port, error) {
-	port := Port(p).Port()
+	if _, err := Port(p).Port(); err != nil {
+		return NilPort, err
+	}
 	proto := Port(p).Proto()
-	if proto == "" || port < 0 {
+	if proto == "" {
 		return NilPort, fmt.Errorf("bad port spec %s", p)
 	}
 
@@ -40,18 +42,18 @@ func (p Port) Proto() string {
 	return proto
 }
 
-func (p Port) Port() int16 {
+func (p Port) Port() (uint16, error) {
 	_, port := nat.SplitProtoPort(string(p))
 	if port == "" {
-		return -1
+		return 0, fmt.Errorf("bad port spec %s", p)
 	}
 
 	pout, err := strconv.Atoi(port)
 	if err != nil {
-		return -1
+		return 0, fmt.Errorf("bad port spec %s", p)
 	}
 
-	return int16(pout)
+	return uint16(pout), nil
 }
 
 func (p Port) String() string {


### PR DESCRIPTION
This change allows containers to map ports from 0 to 65535, instead of to just 32767.

Previously, the command below would return "bad port spec 50000/tcp"

```
$ docker -H 10.115.68.105:2375 run -d -p 8080:8080 -p 50000:50000 aus-dc-test.eng.vmware.com/jenkins-interop/jenkins
bef7c5015dc00e386384b9b091230d0248faf7e715548870dc3e6eba8f3c2b57
```
