### PR TITLE
Improve port-mapping integration test

### DIFF
--- a/tests/test-cases/Group1-Docker-Commands/1-25-Docker-Port-Map.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-25-Docker-Port-Map.robot
@@ -12,9 +12,11 @@ Create container with port mappings
     ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} start webserver
     Should Be Equal As Integers  ${rc}  0
     Should Not Contain  ${output}  Error
-    ${rc}  ${output}=  Run And Return Rc And Output  wget ${vch-ip}:10000 --retry-connrefused --timeout=10 --tries=10
+    ${rc}  ${output}=  Run And Return Rc And Output  wget ${vch-ip}:10000 --retry-connrefused --timeout=10
+    Log To Console  ${output}
     Should Be Equal As Integers  ${rc}  0
-    ${rc}  ${output}=  Run And Return Rc And Output  wget ${vch-ip}:10001 --retry-connrefused --timeout=10 --tries=10
+    ${rc}  ${output}=  Run And Return Rc And Output  wget ${vch-ip}:10001 --retry-connrefused --timeout=10
+    Log To Console  ${output}
     Should Be Equal As Integers  ${rc}  0
     ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} stop webserver
     Should Be Equal As Integers  ${rc}  0

--- a/tests/test-cases/Group1-Docker-Commands/1-25-Docker-Port-Map.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-25-Docker-Port-Map.robot
@@ -4,6 +4,12 @@ Resource  ../../resources/Util.robot
 Suite Setup  Install VIC Appliance To Test Server
 Suite Teardown  Cleanup VIC Appliance On Test Server
 
+*** Keywords ***
+Hit Nginx Endpoint
+    [Arguments]  ${vch-ip}  ${port}
+    ${rc}  ${output}=  Run And Return Rc And Output  wget ${vch-ip}:${port}
+    Should Be Equal As Integers  ${rc}  0
+
 *** Test Cases ***
 Create container with port mappings
     ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} create -it -p 10000:80 -p 10001:80 --name webserver nginx
@@ -12,12 +18,9 @@ Create container with port mappings
     ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} start webserver
     Should Be Equal As Integers  ${rc}  0
     Should Not Contain  ${output}  Error
-    ${rc}  ${output}=  Run And Return Rc And Output  wget ${vch-ip}:10000 --retry-connrefused --timeout=10
-    Log To Console  ${output}
-    Should Be Equal As Integers  ${rc}  0
-    ${rc}  ${output}=  Run And Return Rc And Output  wget ${vch-ip}:10001 --retry-connrefused --timeout=10
-    Log To Console  ${output}
-    Should Be Equal As Integers  ${rc}  0
+    Wait Until Keyword Succeeds  20x  5 seconds  Hit Nginx Endpoint  ${vch-ip}  10000
+    Wait Until Keyword Succeeds  20x  5 seconds  Hit Nginx Endpoint  ${vch-ip}  10001
+
     ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} stop webserver
     Should Be Equal As Integers  ${rc}  0
     ${rc}  ${output}=  Run And Return Rc And Output  curl ${vch-ip}:10000 --connect-timeout 5


### PR DESCRIPTION
The first integration test in [1-25-Docker-Port-Map](https://github.com/vmware/vic/blob/master/tests/test-cases/Group1-Docker-Commands/1-25-Docker-Port-Map.robot#L8) has an intermittent failure where nginx isn't fully initialized when we hit its endpoint. #2480 addressed this by retrying the connection request if we get a `Connection refused` error, but we've seen this test fail in CI again.

This PR aims to resolve the issue by increasing the number of connection retries to give nginx more time to finish initializing. It also logs the output of `wget` during the test run.

Fixes #2354