### PR TITLE
Fix 'Equivalent path already exists: /containers/{handle}'

### DIFF
--- a/lib/apiservers/portlayer/swagger.json
+++ b/lib/apiservers/portlayer/swagger.json
@@ -1207,7 +1207,7 @@
 				}
 			}
 		},
-		"/containers/{handle}": {
+		"/containers/handle/{handle}": {
 			"put": {
 				"description": "Commit and close a container handle",
 				"operationId": "Commit",

--- a/lib/apiservers/portlayer/swagger.json
+++ b/lib/apiservers/portlayer/swagger.json
@@ -1,2778 +1,2778 @@
 {
-	"swagger": "2.0",
-	"info": {
-		"description": "Port Layer API",
-		"title": "Port Layer API",
-		"version": "v0.0.1"
-	},
-	"produces": [
-		"application/json"
-	],
-	"consumes": [
-		"application/json"
-	],
-	"schemes": [
-		"http"
-	],
-	"paths": {
-		"/_ping": {
-			"get": {
-				"description": "Pings the server to see if it's running",
-				"summary": "ping the portlayer server",
-				"tags": [
-					"misc"
-				],
-				"operationId": "Ping",
-				"produces": [
-					"text/plain"
-				],
-				"responses": {
-					"200": {
-						"description": "OK",
-						"schema": {
-							"type": "string"
-						}
-					}
-				}
-			}
-		},
-		"/vch/info": {
-			"get": {
-				"description": "Gets vital information about the vch",
-				"tags": [
-					"misc"
-				],
-				"operationId": "GetVCHInfo",
-				"consumes": [
-					"application/json"
-				],
-				"produces": [
-					"application/json"
-				],
-				"responses": {
-					"200": {
-						"description": "retrieval success",
-						"schema": {
-							"$ref": "#/definitions/VCHInfo"
-						}
-					}
-				}
-			}
-		},
-		"/storage": {
-			"post": {
-				"description": "Creates a location to store images",
-				"summary": "creates an image store",
-				"tags": [
-					"storage"
-				],
-				"operationId": "CreateImageStore",
-				"parameters": [
-					{
-						"name": "body",
-						"in": "body",
-						"schema": {
-							"$ref": "#/definitions/ImageStore"
-						}
-					}
-				],
-				"responses": {
-					"201": {
-						"description": "Created",
-						"schema": {
-							"$ref": "#/definitions/StoreUrl"
-						}
-					},
-					"409": {
-						"description": "An image store with that name already exists.",
-						"schema": {
-							"$ref": "#/definitions/Error"
-						}
-					},
-					"default": {
-						"description": "error",
-						"schema": {
-							"$ref": "#/definitions/Error"
-						}
-					}
-				}
-			}
-		},
-		"/storage/{store_name}": {
-			"get": {
-				"description": "Retrieves a list of images given a list of image IDs, or all images in the image store if no param is passed.",
-				"summary": "Retrieve a list of images in an image store",
-				"tags": [
-					"storage"
-				],
-				"operationId": "ListImages",
-				"parameters": [
-					{
-						"name": "store_name",
-						"type": "string",
-						"in": "path",
-						"required": true
-					},
-					{
-						"name": "ids",
-						"type": "array",
-						"in": "query",
-						"items": {
-							"type": "string",
-							"collectionFormat": "csv"
-						}
-					}
-				],
-				"responses": {
-					"200": {
-						"description": "OK",
-						"schema": {
-							"type": "array",
-							"items": {
-								"$ref": "#/definitions/Image"
-							}
-						}
-					},
-					"404": {
-						"description": "Not found",
-						"schema": {
-							"$ref": "#/definitions/Error"
-						}
-					},
-					"default": {
-						"description": "error",
-						"schema": {
-							"$ref": "#/definitions/Error"
-						}
-					}
-				}
-			},
-			"post": {
-				"description": "Creates a new image layer in an image store",
-				"summary": "Creates a new image layer",
-				"tags": [
-					"storage"
-				],
-				"operationId": "WriteImage",
-				"consumes": [
-					"application/octet-stream"
-				],
-				"parameters": [
-					{
-						"name": "image_file",
-						"in": "body",
-						"schema": {
-							"type": "string",
-							"format": "binary"
-						}
-					},
-					{
-						"name": "store_name",
-						"type": "string",
-						"in": "path",
-						"required": true
-					},
-					{
-						"name": "image_id",
-						"type": "string",
-						"in": "query",
-						"required": true
-					},
-					{
-						"name": "parent_id",
-						"type": "string",
-						"in": "query",
-						"required": true
-					},
-					{
-						"name": "sum",
-						"type": "string",
-						"in": "query",
-						"required": true
-					},
-					{
-						"name": "metadatakey",
-						"type": "string",
-						"in": "query"
-					},
-					{
-						"name": "metadataval",
-						"type": "string",
-						"in": "query"
-					}
-				],
-				"responses": {
-					"201": {
-						"description": "Created",
-						"schema": {
-							"$ref": "#/definitions/Image"
-						}
-					},
-					"default": {
-						"description": "error",
-						"schema": {
-							"$ref": "#/definitions/Error"
-						}
-					}
-				}
-			}
-		},
-		"/storage/{store_name}/info/{id}": {
-			"get": {
-				"description": "Inspect an image by id in an image store",
-				"summary": "Inspect an image",
-				"tags": [
-					"storage"
-				],
-				"operationId": "GetImage",
-				"parameters": [
-					{
-						"name": "store_name",
-						"type": "string",
-						"in": "path",
-						"required": true
-					},
-					{
-						"name": "id",
-						"type": "string",
-						"in": "path",
-						"required": true
-					}
-				],
-				"responses": {
-					"200": {
-						"description": "OK",
-						"schema": {
-							"$ref": "#/definitions/Image"
-						}
-					},
-					"404": {
-						"description": "Not found",
-						"schema": {
-							"$ref": "#/definitions/Error"
-						}
-					},
-					"default": {
-						"description": "error",
-						"schema": {
-							"$ref": "#/definitions/Error"
-						}
-					}
-				}
-			},
-			"delete" : {
-				"description": "Delete an image by id in an image store",
-				"summary": "Delete an image",
-				"tags": [
-					"storage"
-				],
-				"operationId": "DeleteImage",
-				"parameters": [
-					{
-						"name": "store_name",
-						"type": "string",
-						"in": "path",
-						"required": true
-					},
-					{
-						"name": "id",
-						"type": "string",
-						"in": "path",
-						"required": true
-					}
-				],
-				"responses": {
-					"200": {
-						"description": "OK",
-						"schema": {
-							"type": "string"
-						}
-					},
-					"404": {
-						"description": "Not found",
-						"schema": {
-							"$ref": "#/definitions/Error"
-						}
-					},
-					"423": {
-						"description": "In use",
-						"schema": {
-							"$ref": "#/definitions/Error"
-						}
-					},
-					"default": {
-						"description": "error",
-						"schema": {
-							"$ref": "#/definitions/Error"
-						}
-					}
-				}
-			}
-		},
-		"/storage/{store_name}/tar/{id}": {
-			"get": {
-				"description": "Get an image by id in an image store as a tar file",
-				"summary": "Get an image as a tar file",
-				"tags": [
-					"storage"
-				],
-				"operationId": "GetImageTar",
-				"parameters": [
-					{
-						"name": "store_name",
-						"type": "string",
-						"in": "path",
-						"required": true
-					},
-					{
-						"name": "id",
-						"type": "string",
-						"in": "path",
-						"required": true
-					}
-				],
-				"responses": {
-					"200": {
-						"description": "OK",
-						"schema": {
-							"type": "string",
-							"format": "binary"
-						}
-					},
-					"404": {
-						"description": "Not found"
-					},
-					"default": {
-						"description": "error",
-						"schema": {
-							"$ref": "#/definitions/Error"
-						}
-					}
-				}
-			}
-		},
-		"/storage/volumestores/": {
-			"get": {
-				"description": "Get a list of available volume store locations",
-				"operationId": "VolumeStoresList",
-				"tags": [
-					"storage"
-				],
-				"consumes": [
-					"application/json",
-					"application/octet-stream"
-				],
-				"produces": [
-					"application/json"
-				],
-				"responses": {
-					"200": {
-						"description": "OK",
-						"schema": {
-							"$ref": "#/definitions/VolumeStoresListResponse"
-						}
-					},
-					"404": {
-						"description": "Not found",
-						"schema": {
-							"$ref": "#/definitions/Error"
-						}
-					},
-					"500": {
-						"description": "error",
-						"schema": {
-							"$ref": "#/definitions/Error"
-						}
-					}
-				}
-			}
-		},
-		"/storage/volumes/": {
-			"get": {
-				"description": "Get a list of available volumes",
-				"operationId": "ListVolumes",
-				"tags": [
-					"storage"
-				],
-				"consumes": [
-					"application/json",
-					"application/octet-stream"
-				],
-				"produces": [
-					"application/json"
-				],
-				"parameters": [
-					{
-						"name": "filterString",
-						"type": "string",
-						"in": "query",
-						"required": false
-					}
-				],
-				"responses": {
-					"200": {
-						"description": "OK",
-						"schema": {
-							"type": "array",
-							"items": {
-								"$ref": "#/definitions/VolumeResponse"
-							}
-						}
-					},
-					"500": {
-						"description": "Not found",
-						"schema": {
-							"$ref": "#/definitions/Error"
-						}
-					},
-					"default": {
-						"description": "error",
-						"schema": {
-							"$ref": "#/definitions/Error"
-						}
-					}
-				}
-			},
-			"post": {
-				"description": "Create a volume",
-				"operationId": "CreateVolume",
-				"summary": "Creates a Volume with metadata that is provided from the personality",
-				"tags": [
-					"storage"
-				],
-				"consumes": [
-					"application/json",
-					"application/octet-stream"
-				],
-				"produces": [
-					"application/json"
-				],
-				"parameters": [
-					{
-						"name": "VolumeRequest",
-						"required": true,
-						"in": "body",
-						"schema": {
-							"$ref": "#/definitions/VolumeRequest"
-						}
-					}
-				],
-				"responses": {
-					"201": {
-						"description": "Created",
-						"schema": {
-							"$ref": "#/definitions/VolumeResponse"
-						}
-					},
-            "409": {
-						    "description": "Volume already exists by that ID",
-						    "schema": {
-							      "$ref": "#/definitions/Error"
-						    }
-					  },
-          "404": {
-                "description": "VolumeStore Does not Exist",
-                "schema": {
-                    "$ref": "#/definitions/Error"
+    "swagger": "2.0",
+    "info": {
+        "description": "Port Layer API",
+        "title": "Port Layer API",
+        "version": "v0.0.1"
+    },
+    "produces": [
+        "application/json"
+    ],
+    "consumes": [
+        "application/json"
+    ],
+    "schemes": [
+        "http"
+    ],
+    "paths": {
+        "/_ping": {
+            "get": {
+                "description": "Pings the server to see if it's running",
+                "summary": "ping the portlayer server",
+                "tags": [
+                    "misc"
+                ],
+                "operationId": "Ping",
+                "produces": [
+                    "text/plain"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
                 }
-          },
-					"500": {
-						"description": "Error",
-						"schema": {
-							"$ref": "#/definitions/Error"
-						}
-					},
-					"default": {
-						"description": "error",
-						"schema": {
-							"$ref": "#/definitions/Error"
-						}
-					}
-				}
-			}
-		},
-		"/storage/volumes/{name}": {
-			"get": {
-				"description": "Get a Volume Handle",
-				"operationId": "GetVolume",
-				"tags": [
-					"storage"
-				],
-				"consumes": [
-					"application/json",
-					"application/octet-stream"
-				],
-				"produces": [
-					"application/json"
-				],
-				"parameters": [
-					{
-						"name": "name",
-						"required": true,
-						"in": "path",
-						"type": "string"
-					}
-				],
-				"responses": {
-					"200": {
-						"description": "OK",
-						"schema": {
-							"type": "string"
-						}
-					},
-					"404": {
-						"description": "Volume not found",
-						"schema": {
-							"$ref": "#/definitions/Error"
-						}
-					}
-				}
-			},
-			"delete": {
-				"summary": "Remove a volume",
-				"tags": [
-					"storage"
-				],
-				"operationId": "RemoveVolume",
-				"parameters": [
-					{
-						"name": "name",
-						"type": "string",
-						"in": "path",
-						"required": true
-					}
-				],
-				"responses": {
-					"200": {
-						"description": "Volume successfully removed",
-						"schema": {
-							"$ref": "#/definitions/Error"
-						}
-					},
-					"404": {
-						"description": "Volume not found",
-						"schema": {
-							"$ref": "#/definitions/Error"
-						}
-					},
-					"409": {
-						"description": "Volume in use",
-						"schema": {
-							"$ref": "#/definitions/Error"
-						}
-					},
-					"500": {
-						"description": "Server Error",
-						"schema": {
-							"$ref": "#/definitions/Error"
-						}
-					}
-				}
-			},
-			"post": {
-				"description": "Attach a volume to a container",
-				"operationId": "VolumeJoin",
-				"tags": [
-					"storage"
-				],
-				"consumes": [
-					"application/json",
-					"application/octet-stream"
-				],
-				"produces": [
-					"application/json"
-				],
-				"parameters": [
-					{
-						"name": "name",
-						"required": true,
-						"type": "string",
-						"in": "path"
-					},
-					{
-						"name": "JoinArgs",
-						"in": "body",
-						"required": true,
-						"schema": {
-							"$ref": "#/definitions/VolumeJoinConfig"
-						}
-					}
-				],
-				"responses": {
-					"200": {
-						"description": "OK",
-						"schema": {
-							"type": "string"
-						}
-					},
-					"404": {
-						"description": "Volume not found",
-						"schema": {
-							"$ref": "#/definitions/Error"
-						}
-                                        },
-					"500": {
-						"description": "ServerError",
-						"schema": {
-							"$ref": "#/definitions/Error"
-						}
-					},
-					"default": {
-						"description": "error",
-						"schema": {
-							"$ref": "#/definitions/Error"
-						}
-					}
-				}
-			}
-		},
-		"/scopes": {
-			"post": {
-				"summary": "Create a new scope",
-				"tags": [
-					"scopes"
-				],
-				"operationId": "CreateScope",
-				"parameters": [
-					{
-						"name": "config",
-						"in": "body",
-						"schema": {
-							"$ref": "#/definitions/ScopeConfig"
-						}
-					}
-				],
-				"responses": {
-					"201": {
-						"description": "Created",
-						"schema": {
-							"$ref": "#/definitions/ScopeConfig"
-						}
-					},
-					"409": {
-						"description": "A scope with that name exists.",
-						"schema": {
-							"$ref": "#/definitions/Error"
-						}
-					},
-					"default": {
-						"description": "error",
-						"schema": {
-							"$ref": "#/definitions/Error"
-						}
-					}
-				}
-			},
-			"get": {
-				"tags": [
-					"scopes"
-				],
-				"operationId": "ListAll",
-				"responses": {
-					"200": {
-						"description": "OK",
-						"schema": {
-							"type": "array",
-							"items": {
-								"$ref": "#/definitions/ScopeConfig"
-							}
-						}
-					},
-					"default": {
-						"description": "error",
-						"schema": {
-							"$ref": "#/definitions/Error"
-						}
-					}
-				}
-			}
-		},
-		"/scopes/{idName}": {
-			"get": {
-				"tags": [
-					"scopes"
-				],
-				"operationId": "List",
-				"parameters": [
-					{
-						"name": "idName",
-						"type": "string",
-						"in": "path",
-						"required": true
-					}
-				],
-				"responses": {
-					"200": {
-						"description": "OK",
-						"schema": {
-							"type": "array",
-							"items": {
-								"$ref": "#/definitions/ScopeConfig"
-							}
-						}
-					},
-					"404": {
-						"description": "Not found",
-						"schema": {
-							"$ref": "#/definitions/Error"
-						}
-					},
-					"default": {
-						"description": "error",
-						"schema": {
-							"$ref": "#/definitions/Error"
-						}
-					}
-				}
-			},
-			"delete": {
-				"tags": [
-					"scopes"
-				],
-				"operationId": "DeleteScope",
-				"parameters": [
-					{
-						"name": "idName",
-						"type": "string",
-						"in": "path",
-						"required": true
-					}
-				],
-				"responses": {
-					"200": {
-						"description": "OK"
-					},
-					"404": {
-						"description": "Not found",
-						"schema": {
-							"$ref": "#/definitions/Error"
-						}
-					},
-					"500": {
-						"description": "Internal server error",
-						"schema": {
-							"$ref": "#/definitions/Error"
-						}
-					}
-				}
-			}
-		},
-		"/scopes/{scope}/containers": {
-			"post": {
-				"description": "Add a container to scopes modifying the container VM's config as necessary",
-				"tags": [
-					"scopes"
-				],
-				"operationId": "AddContainer",
-				"parameters": [
-					{
-						"name": "scope",
-						"required": true,
-						"in": "path",
-						"type": "string"
-					},
-					{
-						"name": "config",
-						"in": "body",
-						"schema": {
-							"$ref": "#/definitions/ScopesAddContainerConfig"
-						},
-						"required": true
-					}
-				],
-				"responses": {
-					"200": {
-						"description": "OK",
-						"schema": {
-							"type": "string"
-						}
-					},
-					"404": {
-						"description": "Not found",
-						"schema": {
-							"$ref": "#/definitions/Error"
-						}
-					},
-					"500": {
-						"description": "error",
-						"schema": {
-							"$ref": "#/definitions/Error"
-						}
-					}
-				}
-			}
-		},
-		"/scopes/{scope}/containers/{handle}": {
-			"delete": {
-				"description": "Remove a container from a scope",
-				"tags": [
-					"scopes"
-				],
-				"operationId": "RemoveContainer",
-				"parameters": [
-					{
-						"name": "handle",
-						"required": true,
-						"in": "path",
-						"type": "string"
-					},
-					{
-						"name": "scope",
-						"in": "path",
-						"required": true,
-						"type": "string"
-					}
-				],
-				"responses": {
-					"200": {
-						"description": "OK",
-						"schema": {
-							"type": "string"
-						}
-					},
-					"404": {
-						"description": "Not found",
-						"schema": {
-							"$ref": "#/definitions/Error"
-						}
-					},
-					"500": {
-						"description": "error",
-						"schema": {
-							"$ref": "#/definitions/Error"
-						}
-					}
-				}
-			}
-		},
-		"/scopes/containers/{handleOrId}": {
-			"get": {
-				"tags": [
-					"scopes"
-				],
-				"description": "Get a list of the endpoints for a container",
-				"operationId": "GetContainerEndpoints",
-				"consumes": [
-					"application/octet-stream",
-					"application/json"
-				],
-				"produces": [
-					"application/json"
-				],
-				"parameters": [
-					{
-						"name": "handleOrId",
-						"required": true,
-						"in": "path",
-						"type": "string"
-					}
-				],
-				"responses": {
-					"200": {
-						"description": "OK",
-						"schema": {
-							"type": "array",
-							"items": {
-								"$ref": "#/definitions/EndpointConfig"
-							}
-						}
-					},
-					"404": {
-						"description": "Not found",
-						"schema": {
-							"$ref": "#/definitions/Error"
-						}
-					},
-					"500": {
-						"description": "error",
-						"schema": {
-							"$ref": "#/definitions/Error"
-						}
-					}
-				}
-			}
-		},
-		"/scopes/containers/{handle}/binding": {
-			"post": {
-				"tags": [
-					"scopes"
-				],
-				"description": "Perform scope initialization for each of the scopes the container belongs to. Network initialization may include, for example, assigning addresses on a scope.",
-				"operationId": "BindContainer",
-				"consumes": [
-					"application/octet-stream",
-					"application/json"
-				],
-				"produces": [
-					"application/json"
-				],
-				"parameters": [
-					{
-						"name": "handle",
-						"required": true,
-						"in": "path",
-						"type": "string"
-					}
-				],
-				"responses": {
-					"200": {
-						"description": "OK",
-						"schema": {
-							"$ref": "#/definitions/BindContainerResponse"
-						}
-					},
-					"404": {
-						"description": "Not found",
-						"schema": {
-							"$ref": "#/definitions/Error"
-						}
-					},
-					"500": {
-						"description": "error",
-						"schema": {
-							"$ref": "#/definitions/Error"
-						}
-					}
-				}
-			},
-			"delete": {
-				"tags": [
-					"scopes"
-				],
-				"operationId": "UnbindContainer",
-				"consumes": [
-					"application/octet-stream",
-					"application/json"
-				],
-				"produces": [
-					"application/json"
-				],
-				"parameters": [
-					{
-						"name": "handle",
-						"required": true,
-						"in": "path",
-						"type": "string"
-					}
-				],
-				"responses": {
-					"200": {
-						"description": "OK",
-						"schema": {
-							"$ref": "#/definitions/UnbindContainerResponse"
-						}
-					},
-					"404": {
-						"description": "Not found",
-						"schema": {
-							"$ref": "#/definitions/Error"
-						}
-					},
-					"500": {
-						"description": "error",
-						"schema": {
-							"$ref": "#/definitions/Error"
-						}
-					}
-				}
-			}
-		},
-		"/containers": {
-			"post": {
-				"description": "Initiates a container create operation",
-				"summary": "Initiates a container create operation",
-				"operationId": "Create",
-				"tags": [
-					"containers"
-				],
-				"consumes": [
-					"application/json",
-					"application/octet-stream"
-				],
-				"produces": [
-					"application/json"
-				],
-				"parameters": [
-					{
-						"name": "name",
-						"in": "query",
-						"type": "string",
-						"pattern": "/?[a-zA-Z0-9_-]+"
-					},
-					{
-						"name": "createConfig",
-						"in": "body",
-						"required": true,
-						"schema": {
-							"$ref": "#/definitions/ContainerCreateConfig"
-						}
-					}
-				],
-				"responses": {
-					"200": {
-						"description": "OK",
-						"schema": {
-							"$ref": "#/definitions/ContainerCreatedInfo"
-						}
-					},
-					"404": {
-						"description": "Create failed",
-						"schema": {
-							"$ref": "#/definitions/Error"
-						}
-					}
-				}
-			}
-		},
-		"/containers/info/{id}": {
-			"get": {
-				"description": "Gets information about a container by id",
-				"operationId": "GetContainerInfo",
-				"tags": [
-					"containers"
-				],
-				"consumes": [
-					"application/octet-stream"
-				],
-				"produces": [
-					"application/json"
-				],
-				"parameters": [
-					{
-						"name": "id",
-						"required": true,
-						"in": "path",
-						"type": "string"
-					}
-				],
-				"responses": {
-					"200": {
-						"description": "OK",
-						"schema": {
-							"$ref": "#/definitions/ContainerInfo"
-						}
-					},
-					"404": {
-						"description": "not found",
-						"schema": {
-							"$ref": "#/definitions/Error"
-						}
-					},
-					"500": {
-						"description": "server error",
-						"schema": {
-							"$ref": "#/definitions/Error"
-						}
-					}
-				}
-			}
-		},
-		"/containers/list": {
-			"get": {
-				"description": "Gets a list of all containers",
-				"operationId": "GetContainerList",
-				"tags": [
-					"containers"
-				],
-				"consumes": [
-					"application/octet-stream"
-				],
-				"produces": [
-					"application/json"
-				],
-				"parameters": [
-					{
-						"name": "all",
-						"required": false,
-						"in": "query",
-						"type": "boolean"
-					}
-				],
-				"responses": {
-					"200": {
-						"description": "OK",
-						"schema": {
-							"type": "array",
-							"items": {
-								"$ref": "#/definitions/ContainerInfo"
-							}
-						}
-					},
-					"500": {
-						"description": "server error",
-						"schema": {
-							"$ref": "#/definitions/Error"
-						}
-					}
-				}
-			}
-		},
-		"/containers/{id}": {
-			"get": {
-				"description": "Get a container handle",
-				"operationId": "Get",
-				"tags": [
-					"containers"
-				],
-				"consumes": [
-					"application/json",
-					"application/octet-stream"
-				],
-				"produces": [
-					"application/json"
-				],
-				"parameters": [
-					{
-						"name": "id",
-						"required": true,
-						"in": "path",
-						"type": "string"
-					}
-				],
-				"responses": {
-					"200": {
-						"description": "OK",
-						"schema": {
-							"type": "string"
-						}
-					},
-					"404": {
-						"description": "not found",
-						"schema": {
-							"$ref": "#/definitions/Error"
-						}
-					},
-					"default": {
-						"description": "Error",
-						"schema": {
-							"$ref": "#/definitions/Error"
-						}
-					}
-				}
-			},
-			"delete": {
-				"description": "Remove a container from existence",
-				"operationId": "ContainerRemove",
-				"tags": [
-					"containers"
-				],
-				"consumes": [
-					"application/octet-stream"
-				],
-				"parameters": [
-					{
-						"name": "id",
-						"required": true,
-						"in": "path",
-						"type": "string"
-					},
-					{
-						"name": "force",
-						"in": "query",
-						"type": "boolean",
-						"default": false
-					},
-					{
-						"name": "v",
-						"in": "query",
-						"type": "boolean",
-						"default": false
-					}
-				],
-				"responses": {
-					"200": {
-						"description": "OK"
-					},
-					"400": {
-						"description": "bad parameter"
-					},
-					"404": {
-						"description": "no such container"
-					},
-					"409": {
-						"description": "conflict",
-						"schema": {
-							"$ref": "#/definitions/Error"
-						}
-					},
-					"500": {
-						"description": "server error"
-					},
-					"default": {
-						"description": "Error",
-						"schema": {
-							"$ref": "#/definitions/Error"
-						}
-					}
-				}
-			}
-		},
-		"/containers/handle/{handle}": {
-			"put": {
-				"description": "Commit and close a container handle",
-				"operationId": "Commit",
-				"tags": [
-					"containers"
-				],
-				"consumes": [
-					"application/json",
-					"application/octet-stream"
-				],
-				"produces": [
-					"application/json"
-				],
-				"parameters": [
-					{
-						"name": "handle",
-						"in": "path",
-						"required": true,
-						"type": "string"
-					},
-                                        {
-						"name": "wait_time",
-						"in": "query",
-						"type": "integer",
-						"format": "int32"
-					}
+            }
+        },
+        "/vch/info": {
+            "get": {
+                "description": "Gets vital information about the vch",
+                "tags": [
+                    "misc"
+                ],
+                "operationId": "GetVCHInfo",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "retrieval success",
+                        "schema": {
+                            "$ref": "#/definitions/VCHInfo"
+                        }
+                    }
+                }
+            }
+        },
+        "/storage": {
+            "post": {
+                "description": "Creates a location to store images",
+                "summary": "creates an image store",
+                "tags": [
+                    "storage"
+                ],
+                "operationId": "CreateImageStore",
+                "parameters": [
+                    {
+                        "name": "body",
+                        "in": "body",
+                        "schema": {
+                            "$ref": "#/definitions/ImageStore"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/StoreUrl"
+                        }
+                    },
+                    "409": {
+                        "description": "An image store with that name already exists.",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "default": {
+                        "description": "error",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    }
+                }
+            }
+        },
+        "/storage/{store_name}": {
+            "get": {
+                "description": "Retrieves a list of images given a list of image IDs, or all images in the image store if no param is passed.",
+                "summary": "Retrieve a list of images in an image store",
+                "tags": [
+                    "storage"
+                ],
+                "operationId": "ListImages",
+                "parameters": [
+                    {
+                        "name": "store_name",
+                        "type": "string",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "name": "ids",
+                        "type": "array",
+                        "in": "query",
+                        "items": {
+                            "type": "string",
+                            "collectionFormat": "csv"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Image"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not found",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "default": {
+                        "description": "error",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "description": "Creates a new image layer in an image store",
+                "summary": "Creates a new image layer",
+                "tags": [
+                    "storage"
+                ],
+                "operationId": "WriteImage",
+                "consumes": [
+                    "application/octet-stream"
+                ],
+                "parameters": [
+                    {
+                        "name": "image_file",
+                        "in": "body",
+                        "schema": {
+                            "type": "string",
+                            "format": "binary"
+                        }
+                    },
+                    {
+                        "name": "store_name",
+                        "type": "string",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "name": "image_id",
+                        "type": "string",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "name": "parent_id",
+                        "type": "string",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "name": "sum",
+                        "type": "string",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "name": "metadatakey",
+                        "type": "string",
+                        "in": "query"
+                    },
+                    {
+                        "name": "metadataval",
+                        "type": "string",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/Image"
+                        }
+                    },
+                    "default": {
+                        "description": "error",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    }
+                }
+            }
+        },
+        "/storage/{store_name}/info/{id}": {
+            "get": {
+                "description": "Inspect an image by id in an image store",
+                "summary": "Inspect an image",
+                "tags": [
+                    "storage"
+                ],
+                "operationId": "GetImage",
+                "parameters": [
+                    {
+                        "name": "store_name",
+                        "type": "string",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "name": "id",
+                        "type": "string",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/Image"
+                        }
+                    },
+                    "404": {
+                        "description": "Not found",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "default": {
+                        "description": "error",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    }
+                }
+            },
+            "delete" : {
+                "description": "Delete an image by id in an image store",
+                "summary": "Delete an image",
+                "tags": [
+                    "storage"
+                ],
+                "operationId": "DeleteImage",
+                "parameters": [
+                    {
+                        "name": "store_name",
+                        "type": "string",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "name": "id",
+                        "type": "string",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "404": {
+                        "description": "Not found",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "423": {
+                        "description": "In use",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "default": {
+                        "description": "error",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    }
+                }
+            }
+        },
+        "/storage/{store_name}/tar/{id}": {
+            "get": {
+                "description": "Get an image by id in an image store as a tar file",
+                "summary": "Get an image as a tar file",
+                "tags": [
+                    "storage"
+                ],
+                "operationId": "GetImageTar",
+                "parameters": [
+                    {
+                        "name": "store_name",
+                        "type": "string",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "name": "id",
+                        "type": "string",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "string",
+                            "format": "binary"
+                        }
+                    },
+                    "404": {
+                        "description": "Not found"
+                    },
+                    "default": {
+                        "description": "error",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    }
+                }
+            }
+        },
+        "/storage/volumestores/": {
+            "get": {
+                "description": "Get a list of available volume store locations",
+                "operationId": "VolumeStoresList",
+                "tags": [
+                    "storage"
+                ],
+                "consumes": [
+                    "application/json",
+                    "application/octet-stream"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/VolumeStoresListResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not found",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "500": {
+                        "description": "error",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    }
+                }
+            }
+        },
+        "/storage/volumes/": {
+            "get": {
+                "description": "Get a list of available volumes",
+                "operationId": "ListVolumes",
+                "tags": [
+                    "storage"
+                ],
+                "consumes": [
+                    "application/json",
+                    "application/octet-stream"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "filterString",
+                        "type": "string",
+                        "in": "query",
+                        "required": false
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/VolumeResponse"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Not found",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "default": {
+                        "description": "error",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "description": "Create a volume",
+                "operationId": "CreateVolume",
+                "summary": "Creates a Volume with metadata that is provided from the personality",
+                "tags": [
+                    "storage"
+                ],
+                "consumes": [
+                    "application/json",
+                    "application/octet-stream"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "VolumeRequest",
+                        "required": true,
+                        "in": "body",
+                        "schema": {
+                            "$ref": "#/definitions/VolumeRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/VolumeResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Volume already exists by that ID",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "404": {
+                        "description": "VolumeStore Does not Exist",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "500": {
+                        "description": "Error",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "default": {
+                        "description": "error",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    }
+                }
+            }
+        },
+        "/storage/volumes/{name}": {
+            "get": {
+                "description": "Get a Volume Handle",
+                "operationId": "GetVolume",
+                "tags": [
+                    "storage"
+                ],
+                "consumes": [
+                    "application/json",
+                    "application/octet-stream"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "name",
+                        "required": true,
+                        "in": "path",
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "404": {
+                        "description": "Volume not found",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "summary": "Remove a volume",
+                "tags": [
+                    "storage"
+                ],
+                "operationId": "RemoveVolume",
+                "parameters": [
+                    {
+                        "name": "name",
+                        "type": "string",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Volume successfully removed",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "404": {
+                        "description": "Volume not found",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "409": {
+                        "description": "Volume in use",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "500": {
+                        "description": "Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "description": "Attach a volume to a container",
+                "operationId": "VolumeJoin",
+                "tags": [
+                    "storage"
+                ],
+                "consumes": [
+                    "application/json",
+                    "application/octet-stream"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "name",
+                        "required": true,
+                        "type": "string",
+                        "in": "path"
+                    },
+                    {
+                        "name": "JoinArgs",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/VolumeJoinConfig"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "404": {
+                        "description": "Volume not found",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "500": {
+                        "description": "ServerError",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "default": {
+                        "description": "error",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    }
+                }
+            }
+        },
+        "/scopes": {
+            "post": {
+                "summary": "Create a new scope",
+                "tags": [
+                    "scopes"
+                ],
+                "operationId": "CreateScope",
+                "parameters": [
+                    {
+                        "name": "config",
+                        "in": "body",
+                        "schema": {
+                            "$ref": "#/definitions/ScopeConfig"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/ScopeConfig"
+                        }
+                    },
+                    "409": {
+                        "description": "A scope with that name exists.",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "default": {
+                        "description": "error",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    }
+                }
+            },
+            "get": {
+                "tags": [
+                    "scopes"
+                ],
+                "operationId": "ListAll",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ScopeConfig"
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "error",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    }
+                }
+            }
+        },
+        "/scopes/{idName}": {
+            "get": {
+                "tags": [
+                    "scopes"
+                ],
+                "operationId": "List",
+                "parameters": [
+                    {
+                        "name": "idName",
+                        "type": "string",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ScopeConfig"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not found",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "default": {
+                        "description": "error",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "tags": [
+                    "scopes"
+                ],
+                "operationId": "DeleteScope",
+                "parameters": [
+                    {
+                        "name": "idName",
+                        "type": "string",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    },
+                    "404": {
+                        "description": "Not found",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    }
+                }
+            }
+        },
+        "/scopes/{scope}/containers": {
+            "post": {
+                "description": "Add a container to scopes modifying the container VM's config as necessary",
+                "tags": [
+                    "scopes"
+                ],
+                "operationId": "AddContainer",
+                "parameters": [
+                    {
+                        "name": "scope",
+                        "required": true,
+                        "in": "path",
+                        "type": "string"
+                    },
+                    {
+                        "name": "config",
+                        "in": "body",
+                        "schema": {
+                            "$ref": "#/definitions/ScopesAddContainerConfig"
+                        },
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "404": {
+                        "description": "Not found",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "500": {
+                        "description": "error",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    }
+                }
+            }
+        },
+        "/scopes/{scope}/containers/{handle}": {
+            "delete": {
+                "description": "Remove a container from a scope",
+                "tags": [
+                    "scopes"
+                ],
+                "operationId": "RemoveContainer",
+                "parameters": [
+                    {
+                        "name": "handle",
+                        "required": true,
+                        "in": "path",
+                        "type": "string"
+                    },
+                    {
+                        "name": "scope",
+                        "in": "path",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "404": {
+                        "description": "Not found",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "500": {
+                        "description": "error",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    }
+                }
+            }
+        },
+        "/scopes/containers/{handleOrId}": {
+            "get": {
+                "tags": [
+                    "scopes"
+                ],
+                "description": "Get a list of the endpoints for a container",
+                "operationId": "GetContainerEndpoints",
+                "consumes": [
+                    "application/octet-stream",
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "handleOrId",
+                        "required": true,
+                        "in": "path",
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/EndpointConfig"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not found",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "500": {
+                        "description": "error",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    }
+                }
+            }
+        },
+        "/scopes/containers/{handle}/binding": {
+            "post": {
+                "tags": [
+                    "scopes"
+                ],
+                "description": "Perform scope initialization for each of the scopes the container belongs to. Network initialization may include, for example, assigning addresses on a scope.",
+                "operationId": "BindContainer",
+                "consumes": [
+                    "application/octet-stream",
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "handle",
+                        "required": true,
+                        "in": "path",
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/BindContainerResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not found",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "500": {
+                        "description": "error",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "tags": [
+                    "scopes"
+                ],
+                "operationId": "UnbindContainer",
+                "consumes": [
+                    "application/octet-stream",
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "handle",
+                        "required": true,
+                        "in": "path",
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/UnbindContainerResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not found",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "500": {
+                        "description": "error",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    }
+                }
+            }
+        },
+        "/containers": {
+            "post": {
+                "description": "Initiates a container create operation",
+                "summary": "Initiates a container create operation",
+                "operationId": "Create",
+                "tags": [
+                    "containers"
+                ],
+                "consumes": [
+                    "application/json",
+                    "application/octet-stream"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "name",
+                        "in": "query",
+                        "type": "string",
+                        "pattern": "/?[a-zA-Z0-9_-]+"
+                    },
+                    {
+                        "name": "createConfig",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/ContainerCreateConfig"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/ContainerCreatedInfo"
+                        }
+                    },
+                    "404": {
+                        "description": "Create failed",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    }
+                }
+            }
+        },
+        "/containers/info/{id}": {
+            "get": {
+                "description": "Gets information about a container by id",
+                "operationId": "GetContainerInfo",
+                "tags": [
+                    "containers"
+                ],
+                "consumes": [
+                    "application/octet-stream"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "id",
+                        "required": true,
+                        "in": "path",
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/ContainerInfo"
+                        }
+                    },
+                    "404": {
+                        "description": "not found",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "500": {
+                        "description": "server error",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    }
+                }
+            }
+        },
+        "/containers/list": {
+            "get": {
+                "description": "Gets a list of all containers",
+                "operationId": "GetContainerList",
+                "tags": [
+                    "containers"
+                ],
+                "consumes": [
+                    "application/octet-stream"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "all",
+                        "required": false,
+                        "in": "query",
+                        "type": "boolean"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ContainerInfo"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "server error",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    }
+                }
+            }
+        },
+        "/containers/{id}": {
+            "get": {
+                "description": "Get a container handle",
+                "operationId": "Get",
+                "tags": [
+                    "containers"
+                ],
+                "consumes": [
+                    "application/json",
+                    "application/octet-stream"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "id",
+                        "required": true,
+                        "in": "path",
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "404": {
+                        "description": "not found",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "description": "Remove a container from existence",
+                "operationId": "ContainerRemove",
+                "tags": [
+                    "containers"
+                ],
+                "consumes": [
+                    "application/octet-stream"
+                ],
+                "parameters": [
+                    {
+                        "name": "id",
+                        "required": true,
+                        "in": "path",
+                        "type": "string"
+                    },
+                    {
+                        "name": "force",
+                        "in": "query",
+                        "type": "boolean",
+                        "default": false
+                    },
+                    {
+                        "name": "v",
+                        "in": "query",
+                        "type": "boolean",
+                        "default": false
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    },
+                    "400": {
+                        "description": "bad parameter"
+                    },
+                    "404": {
+                        "description": "no such container"
+                    },
+                    "409": {
+                        "description": "conflict",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "500": {
+                        "description": "server error"
+                    },
+                    "default": {
+                        "description": "Error",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    }
+                }
+            }
+        },
+        "/containers/handle/{handle}": {
+            "put": {
+                "description": "Commit and close a container handle",
+                "operationId": "Commit",
+                "tags": [
+                    "containers"
+                ],
+                "consumes": [
+                    "application/json",
+                    "application/octet-stream"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "handle",
+                        "in": "path",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "name": "wait_time",
+                        "in": "query",
+                        "type": "integer",
+                        "format": "int32"
+                    }
 
-				],
-				"responses": {
-					"200": {
-						"description": "OK"
-					},
-					"404": {
-						"description": "not found",
-						"schema": {
-							"$ref": "#/definitions/Error"
-						}
-					},
-					"default": {
-						"description": "Error",
-						"schema": {
-							"$ref": "#/definitions/Error"
-						}
-					}
-				}
-			}
-		},
-		"/containers/{handle}/state": {
-			"put": {
-				"description": "Changes the state of a container",
-				"operationId": "StateChange",
-				"tags": [
-					"containers"
-				],
-				"consumes": [
-					"application/octet-stream",
-					"application/json"
-				],
-				"produces": [
-					"application/json"
-				],
-				"parameters": [
-					{
-						"name": "handle",
-						"required": true,
-						"in": "path",
-						"type": "string"
-					},
-					{
-						"name": "state",
-						"required": true,
-						"in": "body",
-						"schema": {
-							"type": "string",
-							"enum": [
-								"RUNNING",
-								"STOPPED"
-							]
-						}
-					}
-				],
-				"responses": {
-					"200": {
-						"description": "OK",
-						"schema": {
-							"type": "string"
-						}
-					},
-					"404": {
-						"description": "not found",
-						"schema": {
-							"$ref": "#/definitions/Error"
-						}
-					},
-					"default": {
-						"description": "Error",
-						"schema": {
-							"$ref": "#/definitions/Error"
-						}
-					}
-				}
-			},
-			"get": {
-				"description": "Get the current state of the a container",
-				"operationId": "GetState",
-				"tags": [
-					"containers"
-				],
-				"consumes": [
-					"application/octet-stream",
-					"application/json"
-				],
-				"produces": [
-					"application/json"
-				],
-				"parameters": [
-					{
-						"name": "handle",
-						"required": true,
-						"in": "path",
-						"type": "string"
-					}
-				],
-				"responses": {
-					"200": {
-						"description": "OK",
-						"schema": {
-							"$ref": "#/definitions/ContainerGetStateResponse"
-						}
-					},
-					"404": {
-						"description": "not found",
-						"schema": {
-							"$ref": "#/definitions/Error"
-						}
-					},
-					"default": {
-						"description": "Error",
-						"schema": {
-							"$ref": "#/definitions/Error"
-						}
-					}
-				}
-			}
-		},
-		"/containers/{id}/signal": {
-			"post": {
-				"description": "Sends a signal to a container by id",
-				"summary": "Signal a running container",
-				"operationId": "ContainerSignal",
-				"tags": [
-					"containers"
-				],
-				"consumes": [
-					"application/octet-stream"
-				],
-				"parameters": [
-					{
-						"name": "id",
-						"in": "path",
-						"type": "string",
-						"required": true
-					},
-					{
-						"name": "signal",
-						"in": "query",
-						"type": "integer",
-						"format": "int64",
-						"required": true
-					}
-				],
-				"responses": {
-					"200": {
-						"description": "OK"
-					},
-					"404": {
-						"description": "Container not found",
-						"schema": {
-							"$ref": "#/definitions/Error"
-						}
-					},
-					"500": {
-						"description": "Failed to signal container",
-						"schema": {
-							"$ref": "#/definitions/Error"
-						}
-					}
-				}
-			}
-		},
-		"/containers/{id}/logs": {
-			"get": {
-				"description": "Gets the container logs by id",
-				"summary": "Gets the container logs",
-				"operationId": "GetContainerLogs",
-				"tags": [
-					"containers"
-				],
-				"consumes": [
-					"application/octet-stream"
-				],
-				"produces": [
-					"application/octet-stream"
-				],
-				"parameters": [
-					{
-						"name": "id",
-						"in": "path",
-						"type": "string",
-						"required": true
-					},
-					{
-						"name": "follow",
-						"in": "query",
-						"type": "boolean",
-						"default": false,
-						"required": false
-					},
-					{
-						"name": "since",
-						"in": "query",
-						"type": "integer",
-						"format": "int64",
-						"required": false
-					},
-					{
-						"name": "timestamp",
-						"in": "query",
-						"type": "boolean",
-						"default": false,
-						"required": false
-					},
-					{
-						"name": "taillines",
-						"in": "query",
-						"type": "integer",
-						"format": "int64",
-						"required": false
-					},
-					{
-						"name": "deadline",
-						"in": "query",
-						"type": "integer",
-						"format": "int64",
-						"required": false
-					}
-				],
-				"responses": {
-					"200": {
-						"description": "OK",
-						"schema": {
-							"format": "binary"
-						}
-					},
-					"404": {
-						"description": "Logs not found",
-						"schema": {
-							"$ref": "#/definitions/Error"
-						}
-					},
-					"500": {
-						"description": "Failed to get logs",
-						"schema": {
-							"$ref": "#/definitions/Error"
-						}
-					}
-				}
-			}
-		},
-		"/logging": {
-			"post": {
-				"description": "Adds logging capabilities to given handle",
-				"summary": "Add logging capability",
-				"operationId": "LoggingJoin",
-				"tags": [
-					"logging"
-				],
-				"consumes": [
-					"application/octet-stream",
-					"application/json"
-				],
-				"produces": [
-					"application/json"
-				],
-				"parameters": [
-					{
-						"name": "config",
-						"in": "body",
-						"schema": {
-							"$ref": "#/definitions/LoggingJoinConfig"
-						},
-						"required": true
-					}
-				],
-				"responses": {
-					"200": {
-						"description": "OK",
-						"schema": {
-							"$ref": "#/definitions/LoggingJoinResponse"
-						}
-					},
-					"404": {
-						"description": "VirtualDevice not found",
-						"schema": {
-							"$ref": "#/definitions/Error"
-						}
-					},
-					"500": {
-						"description": "Adding a VirtualDevice failed",
-						"schema": {
-							"$ref": "#/definitions/Error"
-						}
-					}
-				}
-			}
-		},
-		"/logging/binding": {
-			"post": {
-				"description": "Enable/bind/activate the VirtualDevice",
-				"summary": "Enable/bind/activate the VirtualDevice",
-				"operationId": "LoggingBind",
-				"tags": [
-					"logging"
-				],
-				"consumes": [
-					"application/octet-stream",
-					"application/json"
-				],
-				"produces": [
-					"application/json"
-				],
-				"parameters": [
-					{
-						"name": "config",
-						"in": "body",
-						"schema": {
-							"$ref": "#/definitions/LoggingBindConfig"
-						},
-						"required": true
-					}
-				],
-				"responses": {
-					"200": {
-						"description": "OK",
-						"schema": {
-							"$ref": "#/definitions/LoggingBindResponse"
-						}
-					},
-					"404": {
-						"description": "VirtualDevice not found",
-						"schema": {
-							"$ref": "#/definitions/Error"
-						}
-					},
-					"500": {
-						"description": "Connecting VirtualDevice failed",
-						"schema": {
-							"$ref": "#/definitions/Error"
-						}
-					}
-				}
-			},
-			"delete": {
-				"description": "Disable/unbind/deactivate the VirtualDevice",
-				"summary": "Disable/unbind/deactivate the VirtualDevice",
-				"operationId": "LoggingUnbind",
-				"tags": [
-					"logging"
-				],
-				"consumes": [
-					"application/octet-stream",
-					"application/json"
-				],
-				"produces": [
-					"application/json"
-				],
-				"parameters": [
-					{
-						"name": "config",
-						"in": "body",
-						"schema": {
-							"$ref": "#/definitions/LoggingUnbindConfig"
-						},
-						"required": true
-					}
-				],
-				"responses": {
-					"200": {
-						"description": "OK",
-						"schema": {
-							"$ref": "#/definitions/LoggingUnbindResponse"
-						}
-					},
-					"404": {
-						"description": "VirtualDevice not found",
-						"schema": {
-							"$ref": "#/definitions/Error"
-						}
-					},
-					"500": {
-						"description": "Disconnecting VirtualDevice failed",
-						"schema": {
-							"$ref": "#/definitions/Error"
-						}
-					}
-				}
-			}
-		},
-		"/interaction": {
-			"post": {
-				"description": "Adds interaction capabilities to given handle",
-				"summary": "Add interaction capability",
-				"operationId": "InteractionJoin",
-				"tags": [
-					"interaction"
-				],
-				"consumes": [
-					"application/octet-stream",
-					"application/json"
-				],
-				"produces": [
-					"application/json"
-				],
-				"parameters": [
-					{
-						"name": "config",
-						"in": "body",
-						"schema": {
-							"$ref": "#/definitions/InteractionJoinConfig"
-						},
-						"required": true
-					}
-				],
-				"responses": {
-					"200": {
-						"description": "OK",
-						"schema": {
-							"$ref": "#/definitions/InteractionJoinResponse"
-						}
-					},
-					"404": {
-						"description": "VirtualDevice not found",
-						"schema": {
-							"$ref": "#/definitions/Error"
-						}
-					},
-					"500": {
-						"description": "Adding a VirtualDevice failed",
-						"schema": {
-							"$ref": "#/definitions/Error"
-						}
-					}
-				}
-			}
-		},
-		"/interaction/binding": {
-			"post": {
-				"description": "Enable/bind/activate the VirtualDevice",
-				"summary": "Enable/bind/activate the VirtualDevice",
-				"operationId": "InteractionBind",
-				"tags": [
-					"interaction"
-				],
-				"consumes": [
-					"application/octet-stream",
-					"application/json"
-				],
-				"produces": [
-					"application/json"
-				],
-				"parameters": [
-					{
-						"name": "config",
-						"in": "body",
-						"schema": {
-							"$ref": "#/definitions/InteractionBindConfig"
-						},
-						"required": true
-					}
-				],
-				"responses": {
-					"200": {
-						"description": "OK",
-						"schema": {
-							"$ref": "#/definitions/InteractionBindResponse"
-						}
-					},
-					"404": {
-						"description": "VirtualDevice not found",
-						"schema": {
-							"$ref": "#/definitions/Error"
-						}
-					},
-					"500": {
-						"description": "Connecting VirtualDevice failed",
-						"schema": {
-							"$ref": "#/definitions/Error"
-						}
-					}
-				}
-			},
-			"delete": {
-				"description": "Disable/unbind/deactivate the VirtualDevice",
-				"summary": "Disable/unbind/deactivate the VirtualDevice",
-				"operationId": "InteractionUnbind",
-				"tags": [
-					"interaction"
-				],
-				"consumes": [
-					"application/octet-stream",
-					"application/json"
-				],
-				"produces": [
-					"application/json"
-				],
-				"parameters": [
-					{
-						"name": "config",
-						"in": "body",
-						"schema": {
-							"$ref": "#/definitions/InteractionUnbindConfig"
-						},
-						"required": true
-					}
-				],
-				"responses": {
-					"200": {
-						"description": "OK",
-						"schema": {
-							"$ref": "#/definitions/InteractionUnbindResponse"
-						}
-					},
-					"404": {
-						"description": "VirtualDevice not found",
-						"schema": {
-							"$ref": "#/definitions/Error"
-						}
-					},
-					"500": {
-						"description": "Disconnecting VirtualDevice failed",
-						"schema": {
-							"$ref": "#/definitions/Error"
-						}
-					}
-				}
-			}
-		},
-		"/containers/{id}/wait": {
-			"get": {
-				"description": "Wait for the container to stop",
-				"operationId": "ContainerWait",
-				"tags": [
-					"containers"
-				],
-				"consumes": [
-					"application/octet-stream",
-					"application/json"
-				],
-				"produces": [
-					"application/json"
-				],
-				"parameters": [
-					{
-						"name": "id",
-						"in": "path",
-						"type": "string",
-						"required": true
-					},
-					{
-						"name": "timeout",
-						"in": "query",
-						"type": "integer",
-						"format": "int64",
-						"required": true
-					}
-				],
-				"responses": {
-					"200": {
-						"description": "OK",
-						"schema": {
-							"$ref": "#/definitions/ContainerInfo"
-						}
-					},
-					"404": {
-						"description": "Container not found",
-						"schema": {
-							"$ref": "#/definitions/Error"
-						}
-					},
-					"500": {
-						"description": "Failed to wait on Container",
-						"schema": {
-							"$ref": "#/definitions/Error"
-						}
-					}
-				}
-			}
-		},
-		"/interaction/{id}/resize": {
-			"post": {
-				"description": "Resize the container's tty session",
-				"summary": "Resize tty session",
-				"operationId": "ContainerResize",
-				"tags": [
-					"interaction"
-				],
-				"consumes": [
-					"application/octet-stream",
-					"application/json"
-				],
-				"produces": [
-					"application/json"
-				],
-				"parameters": [
-					{
-						"name": "id",
-						"in": "path",
-						"type": "string",
-						"required": true
-					},
-					{
-						"name": "height",
-						"in": "query",
-						"type": "integer",
-						"format": "int32",
-						"required": true
-					},
-					{
-						"name": "width",
-						"in": "query",
-						"type": "integer",
-						"format": "int32",
-						"required": true
-					}
-				],
-				"responses": {
-					"200": {
-						"description": "OK"
-					},
-					"404": {
-						"description": "Container not found",
-						"schema": {
-							"$ref": "#/definitions/Error"
-						}
-					},
-					"500": {
-						"description": "Container resize failed",
-						"schema": {
-							"$ref": "#/definitions/Error"
-						}
-					}
-				}
-			}
-		},
-		"/interaction/{id}/stdin": {
-			"post": {
-				"description": "Set a stdin for the container",
-				"summary": "Set stdin",
-				"operationId": "ContainerSetStdin",
-				"tags": [
-					"interaction"
-				],
-				"consumes": [
-					"application/raw-stream"
-				],
-				"parameters": [
-					{
-						"name": "id",
-						"in": "path",
-						"type": "string",
-						"required": true
-					},
-					{
-						"name": "deadline",
-						"in": "query",
-						"type": "string",
-						"format": "datetime"
-					},
-					{
-						"name": "raw_stream",
-						"in": "body",
-						"schema": {
-							"type": "string",
-							"format": "binary"
-						}
-					}
-				],
-				"responses": {
-					"200": {
-						"description": "OK"
-					},
-					"404": {
-						"description": "Container not found",
-						"schema": {
-							"$ref": "#/definitions/Error"
-						}
-					},
-					"500": {
-						"description": "Failed to Set stdin",
-						"schema": {
-							"$ref": "#/definitions/Error"
-						}
-					}
-				}
-			}
-		},
-		"/interaction/{id}/stdout": {
-			"get": {
-				"description": "Get a stdout for the container",
-				"summary": "Get stdout",
-				"operationId": "ContainerGetStdout",
-				"tags": [
-					"interaction"
-				],
-				"consumes": [
-					"application/octet-stream"
-				],
-				"produces": [
-					"application/octet-stream"
-				],
-				"parameters": [
-					{
-						"name": "id",
-						"in": "path",
-						"type": "string",
-						"required": true
-					},
-					{
-						"name": "deadline",
-						"in": "query",
-						"type": "string",
-						"format": "datetime"
-					}
-				],
-				"responses": {
-					"200": {
-						"description": "OK",
-						"schema": {
-							"format": "binary"
-						}
-					},
-					"404": {
-						"description": "Container not found",
-						"schema": {
-							"$ref": "#/definitions/Error"
-						}
-					},
-					"500": {
-						"description": "Failed to get stdout",
-						"schema": {
-							"$ref": "#/definitions/Error"
-						}
-					}
-				}
-			}
-		},
-		"/interaction/{id}/stderr": {
-			"get": {
-				"description": "Get a stderr for the container",
-				"summary": "Get stderr",
-				"operationId": "ContainerGetStderr",
-				"tags": [
-					"interaction"
-				],
-				"consumes": [
-					"application/octet-stream"
-				],
-				"produces": [
-					"application/octet-stream"
-				],
-				"parameters": [
-					{
-						"name": "id",
-						"in": "path",
-						"type": "string",
-						"required": true
-					},
-					{
-						"name": "deadline",
-						"in": "query",
-						"type": "string",
-						"format": "datetime"
-					}
-				],
-				"responses": {
-					"200": {
-						"description": "OK",
-						"schema": {
-							"format": "binary"
-						}
-					},
-					"404": {
-						"description": "Container not found",
-						"schema": {
-							"$ref": "#/definitions/Error"
-						}
-					},
-					"500": {
-						"description": "Failed to get stderr",
-						"schema": {
-							"$ref": "#/definitions/Error"
-						}
-					}
-				}
-			}
-		}
-	},
-	"definitions": {
-		"Error": {
-			"type": "object",
-			"required": [
-				"message"
-			],
-			"properties": {
-				"code": {
-					"type": "integer",
-					"format": "int64"
-				},
-				"message": {
-					"type": "string"
-				}
-			}
-		},
-		"VCHInfo": {
-			"type": "object",
-			"properties": {
-				"cpuMhz": {
-					"type": "integer",
-					"format": "int64"
-				},
-				"memory": {
-					"type": "integer",
-					"format": "int64"
-				},
-				"hostProductName": {
-					"type": "string"
-				},
-				"hostOS": {
-					"type": "string"
-				},
-				"hostOSVersion": {
-					"type": "string"
-				}
-			}
-		},
-		"StoreUrl": {
-			"type": "object",
-			"required": [
-				"url"
-			],
-			"properties": {
-				"code": {
-					"type": "integer",
-					"format": "int64"
-				},
-				"url": {
-					"type": "string"
-				}
-			}
-		},
-		"ImageStore": {
-			"type": "object",
-			"required": [
-				"name"
-			],
-			"properties": {
-				"name": {
-					"type": "string"
-				}
-			}
-		},
-		"Image": {
-			"type": "object",
-			"required": [
-				"ID",
-				"Store"
-			],
-			"properties": {
-				"ID": {
-					"type": "string"
-				},
-				"SelfLink": {
-					"type": "string"
-				},
-				"Parent": {
-					"type": "string"
-				},
-				"Store": {
-					"type": "string"
-				},
-				"Metadata": {
-					"type": "object",
-					"additionalProperties": {
-						"type": "string"
-					}
-				}
-			}
-		},
-		"ScopeConfig": {
-			"type": "object",
-			"required": [
-				"name",
-				"scopeType"
-			],
-			"properties": {
-				"id": {
-					"type": "string"
-				},
-				"name": {
-					"type": "string"
-				},
-				"scopeType": {
-					"type": "string"
-				},
-				"subnet": {
-					"type": "string"
-				},
-				"gateway": {
-					"type": "string"
-				},
-				"dns": {
-					"type": "array",
-					"items": {
-						"type": "string"
-					}
-				},
-				"ipam": {
-					"type": "array",
-					"items": {
-						"type": "string"
-					}
-				},
-				"endpoints": {
-					"type": "array",
-					"items": {
-						"$ref": "#/definitions/EndpointConfig"
-					}
-				}
-			}
-		},
-		"EndpointConfig": {
-			"type": "object",
-			"required": [
-				"id",
-				"name",
-				"scope",
-				"address",
-				"gateway",
-				"container",
-				"ports"
-			],
-			"properties": {
-				"id": {
-					"type": "string"
-				},
-				"name": {
-					"type": "string"
-				},
-				"scope": {
-					"type": "string"
-				},
-				"address": {
-					"type": "string"
-				},
-				"gateway": {
-					"type": "string"
-				},
-				"container": {
-					"type": "string"
-				},
-				"ports": {
-					"type": "array",
-					"items": {
-						"type": "string"
-					}
-				}
-			}
-		},
-		"ContainerCreateConfig": {
-			"type": "object",
-			"properties": {
-				"name": {
-					"type": "string"
-				},
-				"imageStore": {
-					"$ref": "#/definitions/ImageStore"
-				},
-				"image": {
-					"type": "string"
-				},
-				"repoName": {
-					"type": "string"
-				},
-				"path": {
-					"type": "string"
-				},
-				"args": {
-					"type": "array",
-					"items": {
-						"type": "string"
-					}
-				},
-				"workingDir": {
-					"type": "string"
-				},
-				"env": {
-					"type": "array",
-					"items": {
-						"type": "string"
-					}
-				},
-				"networkDisabled": {
-					"type": "boolean"
-				},
-				"tty": {
-					"type": "boolean",
-					"default": false
-				},
-				"stopSignal": {
-					"type": "string"
-				},
-				"annotations": {
-					"type": "object",
-					"additionalProperties": {
-						"type": "string"
-					}
-				}
-			}
-		},
-		"ContainerCreatedInfo": {
-			"type": "object",
-			"required": [
-				"handle",
-				"id"
-			],
-			"properties": {
-				"handle": {
-					"type": "string"
-				},
-				"id": {
-					"type": "string"
-				}
-			}
-		},
-		"ScopesAddContainerConfig": {
-			"type": "object",
-			"required": [
-				"networkConfig",
-				"handle"
-			],
-			"properties": {
-				"networkConfig": {
-					"$ref": "#/definitions/NetworkConfig"
-				},
-				"handle": {
-					"type": "string"
-				}
-			}
-		},
-		"NetworkConfig": {
-			"type": "object",
-			"required": [
-				"networkName"
-			],
-			"properties": {
-				"networkName": {
-					"type": "string"
-				},
-				"address": {
-					"type": "string"
-				},
-				"aliases": {
-					"type": "array",
-					"items": {
-						"type": "string"
-					}
-				},
-				"ports": {
-					"type": "array",
-					"items": {
-						"type": "string"
-					}
-				}
-			}
-		},
-		"ContainerGetStateResponse": {
-			"type": "object",
-			"required": [
-				"handle",
-				"state"
-			],
-			"properties": {
-				"handle": {
-					"type": "string"
-				},
-				"state": {
-					"type": "string",
-					"enum": [
-						"RUNNING",
-						"STOPPED"
-					]
-				}
-			}
-		},
-		"VolumeRequest": {
-			"type": "object",
-			"required": [
-				"Name",
-				"Store",
-				"Capacity",
-				"Driver"
-			],
-			"properties": {
-				"Name": {
-					"type": "string"
-				},
-				"Driver": {
-					"type": "string"
-				},
-				"DriverArgs": {
-					"type": "object",
-					"additionalProperties": {
-						"type": "string"
-					}
-				},
-				"Store": {
-					"type": "string"
-				},
-				"Capacity": {
-					"type": "integer",
-					"format": "int64"
-				},
-				"Metadata": {
-					"type": "object",
-					"additionalProperties": {
-						"type": "string"
-					}
-				}
-			}
-		},
-		"VolumeResponse": {
-			"type": "object",
-			"required": [
-				"Name",
-				"Label",
-				"Store",
-				"Driver"
-			],
-			"properties": {
-				"Name": {
-					"type": "string"
-				},
-				"Label": {
-					"description": "this is the label used to mount the block device",
-					"type": "string"
-				},
-				"Driver": {
-					"type": "string"
-				},
-				"Store": {
-					"type": "string"
-				},
-				"Metadata": {
-					"type": "object",
-					"additionalProperties": {
-						"type": "string"
-					}
-				}
-			}
-		},
-		"VolumeJoinConfig": {
-			"type": "object",
-			"required": [
-				"Handle",
-				"MountPath",
-				"Flags"
-			],
-			"properties": {
-				"Handle": {
-					"type": "string"
-				},
-				"MountPath": {
-					"type": "string"
-				},
-				"Flags": {
-					"type": "object",
-					"additionalProperties": {
-						"type": "string"
-					}
-				}
-			}
-		},
-		"VolumeStoresListResponse": {
-			"type": "object",
-			"required": [
-				"Stores"
-			],
-			"properties": {
-				"Stores": {
-					"type": "object",
-					"additionalProperties": {
-						"type": "string"
-					}
-				}
-			}
-		},
-		"ContainerInfo": {
-			"type": "object",
-			"properties": {
-				"containerConfig": {
-					"$ref": "#/definitions/ContainerConfig"
-				},
-				"HostConfig": {
-					"$ref": "#/definitions/HostConfig"
-				},
-				"processConfig": {
-					"$ref": "#/definitions/ProcessConfig"
-				},
-				"volumeConfig": {
-					"type": "array",
-					"items": {
-						"$ref": "#/definitions/VolumeConfig"
-					}
-				},
-				"scopeConfig": {
-					"type": "array",
-					"items": {
-						"$ref": "#/definitions/ScopeConfig"
-					}
-				}
-			}
-		},
-		"ContainerConfig": {
-			"type": "object",
-			"properties": {
-				"containerId": {
-					"type": "string"
-				},
-				"layerId": {
-					"type": "string"
-				},
-				"repoName": {
-					"type": "string"
-				},
-				"createTime": {
-					"type": "integer",
-					"format": "int64"
-				},
-				"names": {
-					"type": "array",
-					"items": {
-						"type": "string"
-					}
-				},
-				"annotations": {
-					"type": "object",
-					"additionalProperties": {
-						"type": "string"
-					}
-				},
-				"state": {
-					"type": "string"
-				},
-				"restartCount": {
-					"type": "integer",
-					"format": "int32"
-				},
-				"hostName": {
-					"type": "string"
-				},
-				"attachStdin": {
-					"type": "boolean"
-				},
-				"attachStdout": {
-					"type": "boolean"
-				},
-				"attachStderr": {
-					"type": "boolean"
-				},
-				"tty": {
-					"type": "boolean"
-				},
-				"consoleSize": {
-					"type": "object",
-					"properties": {
-						"width": {
-							"type": "integer"
-						},
-						"height": {
-							"type": "integer"
-						}
-					}
-				},
-				"openStdin": {
-					"type": "boolean"
-				},
-				"logPath": {
-					"type": "string"
-				},
-				"reservation": {
-					"$ref": "#/definitions/ReservationConfig"
-				},
-				"storageSize": {
-					"type": "integer",
-					"format": "int64"
-				}
-			}
-		},
-		"ReservationConfig": {
-			"type": "object",
-			"properties": {
-				"cpuCount": {
-					"type": "integer"
-				},
-				"memoryLimit": {
-					"type": "integer"
-				}
-			}
-		},
-		"HostConfig": {
-			"description": "Information about the virtual container host (VCH)",
-			"type": "object",
-			"properties": {
-				"architecture": {
-					"type": "string"
-				},
-				"ostype": {
-					"type": "string"
-				},
-				"kernelVersion": {
-					"type": "string"
-				},
-				"reservation": {
-					"$ref": "#/definitions/ReservationConfig"
-				}
-			}
-		},
-		"ProcessConfig": {
-			"type": "object",
-			"properties": {
-				"pid": {
-					"type": "integer"
-				},
-				"execPath": {
-					"type": "string"
-				},
-				"execArgs": {
-					"type": "array",
-					"items": {
-						"type": "string"
-					}
-				},
-				"workingDir": {
-					"type": "string"
-				},
-				"env": {
-					"type": "array",
-					"items": {
-						"type": "string"
-					}
-				},
-				"status": {
-					"type": "string"
-				},
-				"startTime": {
-					"type": "integer",
-					"format": "int64"
-				},
-				"stopTime": {
-					"type": "integer",
-					"format": "int64"
-				},
-				"exitCode": {
-					"type": "integer",
-					"format": "int32"
-				},
-				"errorMsg": {
-					"type": "string"
-				}
-			}
-		},
-		"VolumeConfig": {
-			"type": "object",
-			"properties": {
-				"label": {
-					"type": "array",
-					"items": {
-						"type": "string"
-					}
-				},
-				"mountPoint": {
-					"type": "string"
-				},
-				"readWrite": {
-					"type": "boolean"
-				}
-			}
-		},
-		"BindContainerResponse": {
-			"type": "object",
-			"required": [
-				"handle",
-				"endpoints"
-			],
-			"properties": {
-				"handle": {
-					"type": "string"
-				},
-				"endpoints": {
-					"type": "array",
-					"items": {
-						"$ref": "#/definitions/EndpointConfig"
-					}
-				}
-			}
-		},
-		"UnbindContainerResponse": {
-			"type": "object",
-			"required": [
-				"handle",
-				"endpoints"
-			],
-			"properties": {
-				"handle": {
-					"type": "string"
-				},
-				"endpoints": {
-					"type": "array",
-					"items": {
-						"$ref": "#/definitions/EndpointConfig"
-					}
-				}
-			}
-		},
-		"LoggingJoinConfig": {
-			"type": "object",
-			"required": [
-				"handle"
-			],
-			"properties": {
-				"handle": {
-					"type": "object"
-				}
-			}
-		},
-		"LoggingBindConfig": {
-			"type": "object",
-			"required": [
-				"handle"
-			],
-			"properties": {
-				"handle": {
-					"type": "object"
-				}
-			}
-		},
-		"LoggingUnbindConfig": {
-			"type": "object",
-			"required": [
-				"handle"
-			],
-			"properties": {
-				"handle": {
-					"type": "object"
-				}
-			}
-		},
-		"LoggingJoinResponse": {
-			"type": "object",
-			"required": [
-				"handle"
-			],
-			"properties": {
-				"handle": {
-					"type": "object"
-				}
-			}
-		},
-		"LoggingBindResponse": {
-			"type": "object",
-			"required": [
-				"handle"
-			],
-			"properties": {
-				"handle": {
-					"type": "object"
-				}
-			}
-		},
-		"LoggingUnbindResponse": {
-			"type": "object",
-			"required": [
-				"handle"
-			],
-			"properties": {
-				"handle": {
-					"type": "object"
-				}
-			}
-		},
-		"InteractionJoinConfig": {
-			"type": "object",
-			"required": [
-				"handle"
-			],
-			"properties": {
-				"handle": {
-					"type": "object"
-				}
-			}
-		},
-		"InteractionBindConfig": {
-			"type": "object",
-			"required": [
-				"handle"
-			],
-			"properties": {
-				"handle": {
-					"type": "object"
-				}
-			}
-		},
-		"InteractionUnbindConfig": {
-			"type": "object",
-			"required": [
-				"handle"
-			],
-			"properties": {
-				"handle": {
-					"type": "object"
-				}
-			}
-		},
-		"InteractionJoinResponse": {
-			"type": "object",
-			"required": [
-				"handle"
-			],
-			"properties": {
-				"handle": {
-					"type": "object"
-				}
-			}
-		},
-		"InteractionBindResponse": {
-			"type": "object",
-			"required": [
-				"handle"
-			],
-			"properties": {
-				"handle": {
-					"type": "object"
-				}
-			}
-		},
-		"InteractionUnbindResponse": {
-			"type": "object",
-			"required": [
-				"handle"
-			],
-			"properties": {
-				"handle": {
-					"type": "object"
-				}
-			}
-		}
-	}
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    },
+                    "404": {
+                        "description": "not found",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    }
+                }
+            }
+        },
+        "/containers/{handle}/state": {
+            "put": {
+                "description": "Changes the state of a container",
+                "operationId": "StateChange",
+                "tags": [
+                    "containers"
+                ],
+                "consumes": [
+                    "application/octet-stream",
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "handle",
+                        "required": true,
+                        "in": "path",
+                        "type": "string"
+                    },
+                    {
+                        "name": "state",
+                        "required": true,
+                        "in": "body",
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "RUNNING",
+                                "STOPPED"
+                            ]
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "404": {
+                        "description": "not found",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    }
+                }
+            },
+            "get": {
+                "description": "Get the current state of the a container",
+                "operationId": "GetState",
+                "tags": [
+                    "containers"
+                ],
+                "consumes": [
+                    "application/octet-stream",
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "handle",
+                        "required": true,
+                        "in": "path",
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/ContainerGetStateResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "not found",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    }
+                }
+            }
+        },
+        "/containers/{id}/signal": {
+            "post": {
+                "description": "Sends a signal to a container by id",
+                "summary": "Signal a running container",
+                "operationId": "ContainerSignal",
+                "tags": [
+                    "containers"
+                ],
+                "consumes": [
+                    "application/octet-stream"
+                ],
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "name": "signal",
+                        "in": "query",
+                        "type": "integer",
+                        "format": "int64",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    },
+                    "404": {
+                        "description": "Container not found",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "500": {
+                        "description": "Failed to signal container",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    }
+                }
+            }
+        },
+        "/containers/{id}/logs": {
+            "get": {
+                "description": "Gets the container logs by id",
+                "summary": "Gets the container logs",
+                "operationId": "GetContainerLogs",
+                "tags": [
+                    "containers"
+                ],
+                "consumes": [
+                    "application/octet-stream"
+                ],
+                "produces": [
+                    "application/octet-stream"
+                ],
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "name": "follow",
+                        "in": "query",
+                        "type": "boolean",
+                        "default": false,
+                        "required": false
+                    },
+                    {
+                        "name": "since",
+                        "in": "query",
+                        "type": "integer",
+                        "format": "int64",
+                        "required": false
+                    },
+                    {
+                        "name": "timestamp",
+                        "in": "query",
+                        "type": "boolean",
+                        "default": false,
+                        "required": false
+                    },
+                    {
+                        "name": "taillines",
+                        "in": "query",
+                        "type": "integer",
+                        "format": "int64",
+                        "required": false
+                    },
+                    {
+                        "name": "deadline",
+                        "in": "query",
+                        "type": "integer",
+                        "format": "int64",
+                        "required": false
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "format": "binary"
+                        }
+                    },
+                    "404": {
+                        "description": "Logs not found",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "500": {
+                        "description": "Failed to get logs",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    }
+                }
+            }
+        },
+        "/logging": {
+            "post": {
+                "description": "Adds logging capabilities to given handle",
+                "summary": "Add logging capability",
+                "operationId": "LoggingJoin",
+                "tags": [
+                    "logging"
+                ],
+                "consumes": [
+                    "application/octet-stream",
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "config",
+                        "in": "body",
+                        "schema": {
+                            "$ref": "#/definitions/LoggingJoinConfig"
+                        },
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/LoggingJoinResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "VirtualDevice not found",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "500": {
+                        "description": "Adding a VirtualDevice failed",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    }
+                }
+            }
+        },
+        "/logging/binding": {
+            "post": {
+                "description": "Enable/bind/activate the VirtualDevice",
+                "summary": "Enable/bind/activate the VirtualDevice",
+                "operationId": "LoggingBind",
+                "tags": [
+                    "logging"
+                ],
+                "consumes": [
+                    "application/octet-stream",
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "config",
+                        "in": "body",
+                        "schema": {
+                            "$ref": "#/definitions/LoggingBindConfig"
+                        },
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/LoggingBindResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "VirtualDevice not found",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "500": {
+                        "description": "Connecting VirtualDevice failed",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "description": "Disable/unbind/deactivate the VirtualDevice",
+                "summary": "Disable/unbind/deactivate the VirtualDevice",
+                "operationId": "LoggingUnbind",
+                "tags": [
+                    "logging"
+                ],
+                "consumes": [
+                    "application/octet-stream",
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "config",
+                        "in": "body",
+                        "schema": {
+                            "$ref": "#/definitions/LoggingUnbindConfig"
+                        },
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/LoggingUnbindResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "VirtualDevice not found",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "500": {
+                        "description": "Disconnecting VirtualDevice failed",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    }
+                }
+            }
+        },
+        "/interaction": {
+            "post": {
+                "description": "Adds interaction capabilities to given handle",
+                "summary": "Add interaction capability",
+                "operationId": "InteractionJoin",
+                "tags": [
+                    "interaction"
+                ],
+                "consumes": [
+                    "application/octet-stream",
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "config",
+                        "in": "body",
+                        "schema": {
+                            "$ref": "#/definitions/InteractionJoinConfig"
+                        },
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/InteractionJoinResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "VirtualDevice not found",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "500": {
+                        "description": "Adding a VirtualDevice failed",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    }
+                }
+            }
+        },
+        "/interaction/binding": {
+            "post": {
+                "description": "Enable/bind/activate the VirtualDevice",
+                "summary": "Enable/bind/activate the VirtualDevice",
+                "operationId": "InteractionBind",
+                "tags": [
+                    "interaction"
+                ],
+                "consumes": [
+                    "application/octet-stream",
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "config",
+                        "in": "body",
+                        "schema": {
+                            "$ref": "#/definitions/InteractionBindConfig"
+                        },
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/InteractionBindResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "VirtualDevice not found",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "500": {
+                        "description": "Connecting VirtualDevice failed",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "description": "Disable/unbind/deactivate the VirtualDevice",
+                "summary": "Disable/unbind/deactivate the VirtualDevice",
+                "operationId": "InteractionUnbind",
+                "tags": [
+                    "interaction"
+                ],
+                "consumes": [
+                    "application/octet-stream",
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "config",
+                        "in": "body",
+                        "schema": {
+                            "$ref": "#/definitions/InteractionUnbindConfig"
+                        },
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/InteractionUnbindResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "VirtualDevice not found",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "500": {
+                        "description": "Disconnecting VirtualDevice failed",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    }
+                }
+            }
+        },
+        "/containers/{id}/wait": {
+            "get": {
+                "description": "Wait for the container to stop",
+                "operationId": "ContainerWait",
+                "tags": [
+                    "containers"
+                ],
+                "consumes": [
+                    "application/octet-stream",
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "name": "timeout",
+                        "in": "query",
+                        "type": "integer",
+                        "format": "int64",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/ContainerInfo"
+                        }
+                    },
+                    "404": {
+                        "description": "Container not found",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "500": {
+                        "description": "Failed to wait on Container",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    }
+                }
+            }
+        },
+        "/interaction/{id}/resize": {
+            "post": {
+                "description": "Resize the container's tty session",
+                "summary": "Resize tty session",
+                "operationId": "ContainerResize",
+                "tags": [
+                    "interaction"
+                ],
+                "consumes": [
+                    "application/octet-stream",
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "name": "height",
+                        "in": "query",
+                        "type": "integer",
+                        "format": "int32",
+                        "required": true
+                    },
+                    {
+                        "name": "width",
+                        "in": "query",
+                        "type": "integer",
+                        "format": "int32",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    },
+                    "404": {
+                        "description": "Container not found",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "500": {
+                        "description": "Container resize failed",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    }
+                }
+            }
+        },
+        "/interaction/{id}/stdin": {
+            "post": {
+                "description": "Set a stdin for the container",
+                "summary": "Set stdin",
+                "operationId": "ContainerSetStdin",
+                "tags": [
+                    "interaction"
+                ],
+                "consumes": [
+                    "application/raw-stream"
+                ],
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "name": "deadline",
+                        "in": "query",
+                        "type": "string",
+                        "format": "datetime"
+                    },
+                    {
+                        "name": "raw_stream",
+                        "in": "body",
+                        "schema": {
+                            "type": "string",
+                            "format": "binary"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    },
+                    "404": {
+                        "description": "Container not found",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "500": {
+                        "description": "Failed to Set stdin",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    }
+                }
+            }
+        },
+        "/interaction/{id}/stdout": {
+            "get": {
+                "description": "Get a stdout for the container",
+                "summary": "Get stdout",
+                "operationId": "ContainerGetStdout",
+                "tags": [
+                    "interaction"
+                ],
+                "consumes": [
+                    "application/octet-stream"
+                ],
+                "produces": [
+                    "application/octet-stream"
+                ],
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "name": "deadline",
+                        "in": "query",
+                        "type": "string",
+                        "format": "datetime"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "format": "binary"
+                        }
+                    },
+                    "404": {
+                        "description": "Container not found",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "500": {
+                        "description": "Failed to get stdout",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    }
+                }
+            }
+        },
+        "/interaction/{id}/stderr": {
+            "get": {
+                "description": "Get a stderr for the container",
+                "summary": "Get stderr",
+                "operationId": "ContainerGetStderr",
+                "tags": [
+                    "interaction"
+                ],
+                "consumes": [
+                    "application/octet-stream"
+                ],
+                "produces": [
+                    "application/octet-stream"
+                ],
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "name": "deadline",
+                        "in": "query",
+                        "type": "string",
+                        "format": "datetime"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "format": "binary"
+                        }
+                    },
+                    "404": {
+                        "description": "Container not found",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "500": {
+                        "description": "Failed to get stderr",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "definitions": {
+        "Error": {
+            "type": "object",
+            "required": [
+                "message"
+            ],
+            "properties": {
+                "code": {
+                    "type": "integer",
+                    "format": "int64"
+                },
+                "message": {
+                    "type": "string"
+                }
+            }
+        },
+        "VCHInfo": {
+            "type": "object",
+            "properties": {
+                "cpuMhz": {
+                    "type": "integer",
+                    "format": "int64"
+                },
+                "memory": {
+                    "type": "integer",
+                    "format": "int64"
+                },
+                "hostProductName": {
+                    "type": "string"
+                },
+                "hostOS": {
+                    "type": "string"
+                },
+                "hostOSVersion": {
+                    "type": "string"
+                }
+            }
+        },
+        "StoreUrl": {
+            "type": "object",
+            "required": [
+                "url"
+            ],
+            "properties": {
+                "code": {
+                    "type": "integer",
+                    "format": "int64"
+                },
+                "url": {
+                    "type": "string"
+                }
+            }
+        },
+        "ImageStore": {
+            "type": "object",
+            "required": [
+                "name"
+            ],
+            "properties": {
+                "name": {
+                    "type": "string"
+                }
+            }
+        },
+        "Image": {
+            "type": "object",
+            "required": [
+                "ID",
+                "Store"
+            ],
+            "properties": {
+                "ID": {
+                    "type": "string"
+                },
+                "SelfLink": {
+                    "type": "string"
+                },
+                "Parent": {
+                    "type": "string"
+                },
+                "Store": {
+                    "type": "string"
+                },
+                "Metadata": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "ScopeConfig": {
+            "type": "object",
+            "required": [
+                "name",
+                "scopeType"
+            ],
+            "properties": {
+                "id": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "scopeType": {
+                    "type": "string"
+                },
+                "subnet": {
+                    "type": "string"
+                },
+                "gateway": {
+                    "type": "string"
+                },
+                "dns": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "ipam": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "endpoints": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/EndpointConfig"
+                    }
+                }
+            }
+        },
+        "EndpointConfig": {
+            "type": "object",
+            "required": [
+                "id",
+                "name",
+                "scope",
+                "address",
+                "gateway",
+                "container",
+                "ports"
+            ],
+            "properties": {
+                "id": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "scope": {
+                    "type": "string"
+                },
+                "address": {
+                    "type": "string"
+                },
+                "gateway": {
+                    "type": "string"
+                },
+                "container": {
+                    "type": "string"
+                },
+                "ports": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "ContainerCreateConfig": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "imageStore": {
+                    "$ref": "#/definitions/ImageStore"
+                },
+                "image": {
+                    "type": "string"
+                },
+                "repoName": {
+                    "type": "string"
+                },
+                "path": {
+                    "type": "string"
+                },
+                "args": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "workingDir": {
+                    "type": "string"
+                },
+                "env": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "networkDisabled": {
+                    "type": "boolean"
+                },
+                "tty": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "stopSignal": {
+                    "type": "string"
+                },
+                "annotations": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "ContainerCreatedInfo": {
+            "type": "object",
+            "required": [
+                "handle",
+                "id"
+            ],
+            "properties": {
+                "handle": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                }
+            }
+        },
+        "ScopesAddContainerConfig": {
+            "type": "object",
+            "required": [
+                "networkConfig",
+                "handle"
+            ],
+            "properties": {
+                "networkConfig": {
+                    "$ref": "#/definitions/NetworkConfig"
+                },
+                "handle": {
+                    "type": "string"
+                }
+            }
+        },
+        "NetworkConfig": {
+            "type": "object",
+            "required": [
+                "networkName"
+            ],
+            "properties": {
+                "networkName": {
+                    "type": "string"
+                },
+                "address": {
+                    "type": "string"
+                },
+                "aliases": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "ports": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "ContainerGetStateResponse": {
+            "type": "object",
+            "required": [
+                "handle",
+                "state"
+            ],
+            "properties": {
+                "handle": {
+                    "type": "string"
+                },
+                "state": {
+                    "type": "string",
+                    "enum": [
+                        "RUNNING",
+                        "STOPPED"
+                    ]
+                }
+            }
+        },
+        "VolumeRequest": {
+            "type": "object",
+            "required": [
+                "Name",
+                "Store",
+                "Capacity",
+                "Driver"
+            ],
+            "properties": {
+                "Name": {
+                    "type": "string"
+                },
+                "Driver": {
+                    "type": "string"
+                },
+                "DriverArgs": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
+                "Store": {
+                    "type": "string"
+                },
+                "Capacity": {
+                    "type": "integer",
+                    "format": "int64"
+                },
+                "Metadata": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "VolumeResponse": {
+            "type": "object",
+            "required": [
+                "Name",
+                "Label",
+                "Store",
+                "Driver"
+            ],
+            "properties": {
+                "Name": {
+                    "type": "string"
+                },
+                "Label": {
+                    "description": "this is the label used to mount the block device",
+                    "type": "string"
+                },
+                "Driver": {
+                    "type": "string"
+                },
+                "Store": {
+                    "type": "string"
+                },
+                "Metadata": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "VolumeJoinConfig": {
+            "type": "object",
+            "required": [
+                "Handle",
+                "MountPath",
+                "Flags"
+            ],
+            "properties": {
+                "Handle": {
+                    "type": "string"
+                },
+                "MountPath": {
+                    "type": "string"
+                },
+                "Flags": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "VolumeStoresListResponse": {
+            "type": "object",
+            "required": [
+                "Stores"
+            ],
+            "properties": {
+                "Stores": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "ContainerInfo": {
+            "type": "object",
+            "properties": {
+                "containerConfig": {
+                    "$ref": "#/definitions/ContainerConfig"
+                },
+                "HostConfig": {
+                    "$ref": "#/definitions/HostConfig"
+                },
+                "processConfig": {
+                    "$ref": "#/definitions/ProcessConfig"
+                },
+                "volumeConfig": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/VolumeConfig"
+                    }
+                },
+                "scopeConfig": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/ScopeConfig"
+                    }
+                }
+            }
+        },
+        "ContainerConfig": {
+            "type": "object",
+            "properties": {
+                "containerId": {
+                    "type": "string"
+                },
+                "layerId": {
+                    "type": "string"
+                },
+                "repoName": {
+                    "type": "string"
+                },
+                "createTime": {
+                    "type": "integer",
+                    "format": "int64"
+                },
+                "names": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "annotations": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
+                "state": {
+                    "type": "string"
+                },
+                "restartCount": {
+                    "type": "integer",
+                    "format": "int32"
+                },
+                "hostName": {
+                    "type": "string"
+                },
+                "attachStdin": {
+                    "type": "boolean"
+                },
+                "attachStdout": {
+                    "type": "boolean"
+                },
+                "attachStderr": {
+                    "type": "boolean"
+                },
+                "tty": {
+                    "type": "boolean"
+                },
+                "consoleSize": {
+                    "type": "object",
+                    "properties": {
+                        "width": {
+                            "type": "integer"
+                        },
+                        "height": {
+                            "type": "integer"
+                        }
+                    }
+                },
+                "openStdin": {
+                    "type": "boolean"
+                },
+                "logPath": {
+                    "type": "string"
+                },
+                "reservation": {
+                    "$ref": "#/definitions/ReservationConfig"
+                },
+                "storageSize": {
+                    "type": "integer",
+                    "format": "int64"
+                }
+            }
+        },
+        "ReservationConfig": {
+            "type": "object",
+            "properties": {
+                "cpuCount": {
+                    "type": "integer"
+                },
+                "memoryLimit": {
+                    "type": "integer"
+                }
+            }
+        },
+        "HostConfig": {
+            "description": "Information about the virtual container host (VCH)",
+            "type": "object",
+            "properties": {
+                "architecture": {
+                    "type": "string"
+                },
+                "ostype": {
+                    "type": "string"
+                },
+                "kernelVersion": {
+                    "type": "string"
+                },
+                "reservation": {
+                    "$ref": "#/definitions/ReservationConfig"
+                }
+            }
+        },
+        "ProcessConfig": {
+            "type": "object",
+            "properties": {
+                "pid": {
+                    "type": "integer"
+                },
+                "execPath": {
+                    "type": "string"
+                },
+                "execArgs": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "workingDir": {
+                    "type": "string"
+                },
+                "env": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "status": {
+                    "type": "string"
+                },
+                "startTime": {
+                    "type": "integer",
+                    "format": "int64"
+                },
+                "stopTime": {
+                    "type": "integer",
+                    "format": "int64"
+                },
+                "exitCode": {
+                    "type": "integer",
+                    "format": "int32"
+                },
+                "errorMsg": {
+                    "type": "string"
+                }
+            }
+        },
+        "VolumeConfig": {
+            "type": "object",
+            "properties": {
+                "label": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "mountPoint": {
+                    "type": "string"
+                },
+                "readWrite": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "BindContainerResponse": {
+            "type": "object",
+            "required": [
+                "handle",
+                "endpoints"
+            ],
+            "properties": {
+                "handle": {
+                    "type": "string"
+                },
+                "endpoints": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/EndpointConfig"
+                    }
+                }
+            }
+        },
+        "UnbindContainerResponse": {
+            "type": "object",
+            "required": [
+                "handle",
+                "endpoints"
+            ],
+            "properties": {
+                "handle": {
+                    "type": "string"
+                },
+                "endpoints": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/EndpointConfig"
+                    }
+                }
+            }
+        },
+        "LoggingJoinConfig": {
+            "type": "object",
+            "required": [
+                "handle"
+            ],
+            "properties": {
+                "handle": {
+                    "type": "object"
+                }
+            }
+        },
+        "LoggingBindConfig": {
+            "type": "object",
+            "required": [
+                "handle"
+            ],
+            "properties": {
+                "handle": {
+                    "type": "object"
+                }
+            }
+        },
+        "LoggingUnbindConfig": {
+            "type": "object",
+            "required": [
+                "handle"
+            ],
+            "properties": {
+                "handle": {
+                    "type": "object"
+                }
+            }
+        },
+        "LoggingJoinResponse": {
+            "type": "object",
+            "required": [
+                "handle"
+            ],
+            "properties": {
+                "handle": {
+                    "type": "object"
+                }
+            }
+        },
+        "LoggingBindResponse": {
+            "type": "object",
+            "required": [
+                "handle"
+            ],
+            "properties": {
+                "handle": {
+                    "type": "object"
+                }
+            }
+        },
+        "LoggingUnbindResponse": {
+            "type": "object",
+            "required": [
+                "handle"
+            ],
+            "properties": {
+                "handle": {
+                    "type": "object"
+                }
+            }
+        },
+        "InteractionJoinConfig": {
+            "type": "object",
+            "required": [
+                "handle"
+            ],
+            "properties": {
+                "handle": {
+                    "type": "object"
+                }
+            }
+        },
+        "InteractionBindConfig": {
+            "type": "object",
+            "required": [
+                "handle"
+            ],
+            "properties": {
+                "handle": {
+                    "type": "object"
+                }
+            }
+        },
+        "InteractionUnbindConfig": {
+            "type": "object",
+            "required": [
+                "handle"
+            ],
+            "properties": {
+                "handle": {
+                    "type": "object"
+                }
+            }
+        },
+        "InteractionJoinResponse": {
+            "type": "object",
+            "required": [
+                "handle"
+            ],
+            "properties": {
+                "handle": {
+                    "type": "object"
+                }
+            }
+        },
+        "InteractionBindResponse": {
+            "type": "object",
+            "required": [
+                "handle"
+            ],
+            "properties": {
+                "handle": {
+                    "type": "object"
+                }
+            }
+        },
+        "InteractionUnbindResponse": {
+            "type": "object",
+            "required": [
+                "handle"
+            ],
+            "properties": {
+                "handle": {
+                    "type": "object"
+                }
+            }
+        }
+    }
 }


### PR DESCRIPTION
```
       "/containers/{id}": {
and
        "/containers/{handle}": {
```

are the same endpoint and validators not happy about it.

Reindent the file while at it...