### PR TITLE
Fix 0->0 docker ps port binding bug

### DIFF
--- a/lib/apiservers/engine/backends/container.go
+++ b/lib/apiservers/engine/backends/container.go
@@ -1026,7 +1026,7 @@ func (c *Container) Containers(config *types.ContainerListOptions) ([]*types.Con
 
 		ips, err := clientIPv4Addrs()
 		var ports []types.Port
-		if err == nil {
+		if err != nil {
 			log.Errorf("Couldn't get IP information from connected client for reporting port bindings.")
 		} else {
 			ports = portInformation(t, ips)

--- a/lib/apiservers/engine/backends/container.go
+++ b/lib/apiservers/engine/backends/container.go
@@ -1024,6 +1024,14 @@ func (c *Container) Containers(config *types.ContainerListOptions) ([]*types.Con
 		// get the docker friendly status
 		_, status := dockerStatus(int(*t.ProcessConfig.ExitCode), *t.ProcessConfig.Status, *t.ContainerConfig.State, started, stopped)
 
+		ips, err := clientIPv4Addrs()
+		var ports []types.Port
+		if err == nil {
+			log.Errorf("Couldn't get IP information from connected client for reporting port bindings.")
+		} else {
+			ports = portInformation(t, ips)
+		}
+
 		c := &types.Container{
 			ID:      *t.ContainerConfig.ContainerID,
 			Image:   *t.ContainerConfig.RepoName,
@@ -1032,7 +1040,7 @@ func (c *Container) Containers(config *types.ContainerListOptions) ([]*types.Con
 			Names:   names,
 			Command: cmd,
 			SizeRw:  *t.ContainerConfig.StorageSize,
-			Ports:   portInformation(t),
+			Ports:   ports,
 		}
 		containers = append(containers, c)
 	}
@@ -1605,26 +1613,23 @@ func clientIPv4Addrs() ([]netlink.Addr, error) {
 
 // returns port bindings as a list of Docker Ports for return to the client
 // returns empty slice on error
-func portInformation(t *models.ContainerInfo) []types.Port {
+func portInformation(t *models.ContainerInfo, ips []netlink.Addr) []types.Port {
 	// create a port for each IP on the interface (usually only 1, if netlink.FAMILY_ALL then usually 2)
 	var ports []types.Port
 
-	ips, err := clientIPv4Addrs()
-	if err != nil {
-		log.Errorf("Problem getting client IP address: %s", err.Error())
-		return ports
-	}
-	for _, ip := range ips {
-		ports = append(ports, types.Port{IP: ip.IP.String()})
-	}
 	container := cache.ContainerCache().GetContainer(*t.ContainerConfig.ContainerID)
 	if container == nil {
 		log.Errorf("Could not find container with ID %s", *t.ContainerConfig.ContainerID)
 		return ports
 	}
 
+	for _, ip := range ips {
+		ports = append(ports, types.Port{IP: ip.IP.String()})
+	}
+
 	portBindings := container.HostConfig.PortBindings
 	var resultPorts []types.Port
+	var err error
 
 	for _, port := range ports {
 		for portBindingPrivatePort, hostPortBindings := range portBindings {
@@ -1635,6 +1640,7 @@ func portInformation(t *models.ContainerInfo) []types.Port {
 				continue
 			}
 			port.Type = portAndType[1]
+			log.Infof("%d", len(hostPortBindings))
 
 			for i := 0; i < len(hostPortBindings); i++ {
 				newport := port
@@ -1643,7 +1649,11 @@ func portInformation(t *models.ContainerInfo) []types.Port {
 					log.Infof("Got an error trying to convert public port number to an int")
 					continue
 				}
-				resultPorts = append(resultPorts, newport)
+				// sanity check -- sometimes these come back as 0 which doesn't make sense
+				// so in that case we don't want to report these bindings
+				if newport.PublicPort != 0 && newport.PrivatePort != 0 {
+					resultPorts = append(resultPorts, newport)
+				}
 			}
 		}
 	}

--- a/lib/apiservers/engine/backends/container_test.go
+++ b/lib/apiservers/engine/backends/container_test.go
@@ -584,7 +584,6 @@ func TestContainerLogs(t *testing.T) {
 }
 
 func TestPortInformation(t *testing.T) {
-	// I could refactor this to have a loop and an array or whatever but eh
 	mockContainerInfo := &plmodels.ContainerInfo{}
 	mockContainerConfig := &plmodels.ContainerConfig{}
 	containerID := "foo"
@@ -618,9 +617,6 @@ func TestPortInformation(t *testing.T) {
 	assert.NotEmpty(t, ports, "There should be bound IPs")
 	assert.Equal(t, len(ports), 1, "Expected 1 port binding, found %d", len(ports))
 
-	// add another port, 0->0 binding to check that it doesn't get added
-	// add another port valid->valid and check that we get both
-	// remove things and make sure it comes back empty
 	port, _ = nat.NewPort("tcp", "80")
 	portBinding = nat.PortBinding{
 		HostIP:   "127.0.0.1",

--- a/lib/apiservers/engine/backends/container_test.go
+++ b/lib/apiservers/engine/backends/container_test.go
@@ -584,6 +584,7 @@ func TestContainerLogs(t *testing.T) {
 }
 
 func TestPortInformation(t *testing.T) {
+	// I could refactor this to have a loop and an array or whatever but eh
 	mockContainerInfo := &plmodels.ContainerInfo{}
 	mockContainerConfig := &plmodels.ContainerConfig{}
 	containerID := "foo"
@@ -619,9 +620,27 @@ func TestPortInformation(t *testing.T) {
 
 	// ports = portInformation(mockContainerInfo, ips)
 	assert.NotEmpty(t, ports, "There should be bound IPs")
-	assert.Equal(len(ports), 1)
+	assert.Equal(t, len(ports), 1, "Expected 1 port binding, found %d", len(ports))
 
 	// add another port, 0->0 binding to check that it doesn't get added
 	// add another port valid->valid and check that we get both
 	// remove things and make sure it comes back empty
+	port, _ = nat.NewPort("tcp", "80")
+	portBinding = nat.PortBinding{
+		HostIP:   "127.0.0.1",
+		HostPort: "00",
+	}
+	portMap[port] = portBindings
+	ports = portInformation(mockContainerInfo, ips)
+	assert.NotEmpty(t, ports, "There should be 1 bound IP")
+	assert.Equal(t, len(ports), 1, "Expected 1 port binding, found %d", len(ports))
+
+	port, _ = nat.NewPort("tcp", "800")
+	portBinding = nat.PortBinding{
+		HostIP:   "127.0.0.1",
+		HostPort: "800",
+	}
+	portMap[port] = portBindings
+	ports = portInformation(mockContainerInfo, ips)
+	assert.Equal(t, len(ports), 2, "Expected 2 port binding, found %d", len(ports))
 }

--- a/lib/apiservers/engine/backends/container_test.go
+++ b/lib/apiservers/engine/backends/container_test.go
@@ -606,8 +606,6 @@ func TestPortInformation(t *testing.T) {
 
 	ip, _ := netlink.ParseAddr("192.168.1.1/24")
 	ips := []netlink.Addr{*ip}
-	// ports := portInformation(mockContainerInfo, ips)
-	// assert.Empty(t, ports, "There should be no bound IPs")
 
 	co := viccontainer.NewVicContainer()
 	co.HostConfig = mockHostConfig
@@ -616,9 +614,7 @@ func TestPortInformation(t *testing.T) {
 	cache.ContainerCache().AddContainer(co)
 
 	ports := portInformation(mockContainerInfo, ips)
-	// assert.Empty(t, ports, "There should still be no bound IPs")
 
-	// ports = portInformation(mockContainerInfo, ips)
 	assert.NotEmpty(t, ports, "There should be bound IPs")
 	assert.Equal(t, len(ports), 1, "Expected 1 port binding, found %d", len(ports))
 


### PR DESCRIPTION
Yesterday @hmahmood found a bug where sometimes when there's no ports bound to a container, docker ps shows `0->0` as being bound. This makes zero sense, so I've added a check so that we don't report an impossible `0->0` binding & also added a unit test for the method .