### PR TITLE
Creates new block device package to remove our reliance on udev for volume mounting WIP

### DIFF
--- a/cmd/tether/tether_test.go
+++ b/cmd/tether/tether_test.go
@@ -141,14 +141,14 @@ func (t *Mocker) Apply(endpoint *tether.NetworkEndpoint) error {
 }
 
 // MountLabel performs a mount with the source treated as a disk label
-func (t *Mocker) MountLabel(ctx context.Context, label, target string) error {
-	defer trace.End(trace.Begin(fmt.Sprintf("mocking mounting %s on %s", label, target)))
+func (t *Mocker) MountLabel(ctx context.Context, devicePath string, target string) error {
+	defer trace.End(trace.Begin(fmt.Sprintf("mocking mounting %s on %s", devicePath, target)))
 
 	if t.Mounts == nil {
 		t.Mounts = make(map[string]string)
 	}
 
-	t.Mounts[label] = target
+	t.Mounts[devicePath] = target
 	return nil
 }
 

--- a/cmd/tether/tether_test.go
+++ b/cmd/tether/tether_test.go
@@ -141,7 +141,6 @@ func (t *Mocker) Apply(endpoint *tether.NetworkEndpoint) error {
 }
 
 // MountLabel performs a mount with the source treated as a disk label
-// This assumes that /dev/disk/by-label is being populated, probably by udev
 func (t *Mocker) MountLabel(ctx context.Context, label, target string) error {
 	defer trace.End(trace.Begin(fmt.Sprintf("mocking mounting %s on %s", label, target)))
 

--- a/lib/tether/interfaces.go
+++ b/lib/tether/interfaces.go
@@ -18,7 +18,6 @@ import (
 	"io"
 
 	"github.com/vmware/vic/pkg/dio"
-	"github.com/vmware/vic/pkg/fs"
 	"golang.org/x/net/context"
 
 	"github.com/vmware/vic/pkg/dio"
@@ -36,7 +35,7 @@ type Operations interface {
 
 	SetHostname(hostname string, aliases ...string) error
 	Apply(endpoint *NetworkEndpoint) error
-	MountLabel(ctx context.Context, devicePath, target string) error
+	MountLabel(ctx context.Context, devicePath string, target string) error
 	Fork() error
 
 	SessionLog(session *SessionConfig) (dio.DynamicMultiWriter, error)

--- a/lib/tether/interfaces.go
+++ b/lib/tether/interfaces.go
@@ -17,6 +17,8 @@ package tether
 import (
 	"io"
 
+	"github.com/vmware/vic/pkg/dio"
+	"github.com/vmware/vic/pkg/fs"
 	"golang.org/x/net/context"
 
 	"github.com/vmware/vic/pkg/dio"
@@ -34,7 +36,7 @@ type Operations interface {
 
 	SetHostname(hostname string, aliases ...string) error
 	Apply(endpoint *NetworkEndpoint) error
-	MountLabel(ctx context.Context, label, target string) error
+	MountLabel(ctx context.Context, label, target string, BlockDeviceMap map[string]fs.Fsinfo) error
 	Fork() error
 
 	SessionLog(session *SessionConfig) (dio.DynamicMultiWriter, error)

--- a/lib/tether/interfaces.go
+++ b/lib/tether/interfaces.go
@@ -36,7 +36,7 @@ type Operations interface {
 
 	SetHostname(hostname string, aliases ...string) error
 	Apply(endpoint *NetworkEndpoint) error
-	MountLabel(ctx context.Context, label, target string, BlockDeviceMap map[string]fs.Fsinfo) error
+	MountLabel(ctx context.Context, devicePath, target string) error
 	Fork() error
 
 	SessionLog(session *SessionConfig) (dio.DynamicMultiWriter, error)

--- a/lib/tether/ops_linux.go
+++ b/lib/tether/ops_linux.go
@@ -584,25 +584,20 @@ func (t *BaseOperations) dhcpLoop(stop chan bool, e *NetworkEndpoint, ack *dhcp.
 
 // MountLabel performs a mount by looking up a fsinfo from the device map using the volume label
 // the value of the map is the fsinfo object which has the device path.
-func (t *BaseOperations) MountLabel(ctx context.Context, label, target string, BlockDeviceMap map[string]fs.Fsinfo) error {
-	defer trace.End(trace.Begin(fmt.Sprintf("Mounting %s on %s", label, target)))
+func (t *BaseOperations) MountLabel(ctx context.Context, devicepath, target string) error {
+	defer trace.End(trace.Begin(fmt.Sprintf("Mounting %s on %s", devicepath, target)))
 
 	if err := os.MkdirAll(target, 0600); err != nil {
 		return fmt.Errorf("unable to create mount point %s: %s", target, err)
 	}
 
-	blockInfo, ok := BlockDeviceMap[label]
-	if !ok {
-		return fmt.Errorf(fmt.Sprintf("Could not find block device (%s) when attempting to perform mount operation", label))
-	}
-
-	sourcePath, err := filepath.EvalSymlinks(blockInfo.DevicePath)
+	sourcePath, err := filepath.EvalSymlinks(blockInfo.DevPath())
 	if err != nil {
-		return fmt.Errorf("error attempting to follow the symlink in (%s)", blockInfo.DevicePath)
+		return fmt.Errorf("error attempting to follow the symlink in (%s)", devicepath)
 	}
 
 	if err := Sys.Syscall.Mount(sourcePath, target, "ext4", syscall.MS_NOATIME, ""); err != nil {
-		detail := fmt.Sprintf("mounting %s on %s failed: %s", label, target, err)
+		detail := fmt.Sprintf("mounting %s on %s failed: %s", devicepath, target, err)
 		return errors.New(detail)
 	}
 

--- a/lib/tether/ops_linux.go
+++ b/lib/tether/ops_linux.go
@@ -596,9 +596,7 @@ func (t *BaseOperations) MountLabel(ctx context.Context, label, target string, B
 		return fmt.Errorf(fmt.Sprintf("Could not find block device (%s) when attempting to perform mount operation", label))
 	}
 
-	log.Infof("Found device %#v for label %s", blockInfo, label)
 	sourcePath, err := filepath.EvalSymlinks(blockInfo.DevicePath)
-	log.Infof("Followed symlink to device %s", sourcePath)
 	if err != nil {
 		return fmt.Errorf("error attempting to follow the symlink in (%s)", blockInfo.DevicePath)
 	}

--- a/lib/tether/ops_linux.go
+++ b/lib/tether/ops_linux.go
@@ -35,7 +35,6 @@ import (
 
 	"github.com/vmware/vic/lib/dhcp"
 	"github.com/vmware/vic/lib/dhcp/client"
-	"github.com/vmware/vic/pkg/fs"
 	"github.com/vmware/vic/pkg/ip"
 	"github.com/vmware/vic/pkg/trace"
 	"github.com/vmware/vmw-guestinfo/rpcout"
@@ -584,14 +583,14 @@ func (t *BaseOperations) dhcpLoop(stop chan bool, e *NetworkEndpoint, ack *dhcp.
 
 // MountLabel performs a mount by looking up a fsinfo from the device map using the volume label
 // the value of the map is the fsinfo object which has the device path.
-func (t *BaseOperations) MountLabel(ctx context.Context, devicepath, target string) error {
+func (t *BaseOperations) MountLabel(ctx context.Context, devicepath string, target string) error {
 	defer trace.End(trace.Begin(fmt.Sprintf("Mounting %s on %s", devicepath, target)))
 
 	if err := os.MkdirAll(target, 0600); err != nil {
 		return fmt.Errorf("unable to create mount point %s: %s", target, err)
 	}
 
-	sourcePath, err := filepath.EvalSymlinks(blockInfo.DevPath())
+	sourcePath, err := filepath.EvalSymlinks(devicepath)
 	if err != nil {
 		return fmt.Errorf("error attempting to follow the symlink in (%s)", devicepath)
 	}

--- a/lib/tether/ops_linux.go
+++ b/lib/tether/ops_linux.go
@@ -35,6 +35,7 @@ import (
 
 	"github.com/vmware/vic/lib/dhcp"
 	"github.com/vmware/vic/lib/dhcp/client"
+	"github.com/vmware/vic/pkg/fs"
 	"github.com/vmware/vic/pkg/ip"
 	"github.com/vmware/vic/pkg/trace"
 	"github.com/vmware/vmw-guestinfo/rpcout"
@@ -583,14 +584,14 @@ func (t *BaseOperations) dhcpLoop(stop chan bool, e *NetworkEndpoint, ack *dhcp.
 
 // MountLabel performs a mount by looking up a fsinfo from the device map using the volume label
 // the value of the map is the fsinfo object which has the device path.
-func (t *BaseOperations) MountLabel(ctx context.Context, label, target string) error {
+func (t *BaseOperations) MountLabel(ctx context.Context, label, target string, BlockDeviceMap map[string]fs.Fsinfo) error {
 	defer trace.End(trace.Begin(fmt.Sprintf("Mounting %s on %s", label, target)))
 
 	if err := os.MkdirAll(target, 0600); err != nil {
 		return fmt.Errorf("unable to create mount point %s: %s", target, err)
 	}
 
-	blockInfo, ok := DeviceMap[label]
+	blockInfo, ok := BlockDeviceMap[label]
 	if !ok {
 		return fmt.Errorf(fmt.Sprintf("Could not find block device (%s) when attempting to perform mount operation", label))
 	}

--- a/lib/tether/tether.go
+++ b/lib/tether/tether.go
@@ -214,6 +214,8 @@ func (t *tether) Start() error {
 		log.Info("Populating ext4 block device list now.")
 		deviceManager := fs.Ext4DeviceManager{}
 		DeviceMap, err := deviceManager.GetDeviceByLbel(linuxBlockDevicePath)
+		log.Infof("Found ext4 block devices : %s", DeviceMap)
+
 		if err != nil {
 			log.Errorf("error while trying to identify mountable volumes: %s", err)
 		}

--- a/lib/tether/tether.go
+++ b/lib/tether/tether.go
@@ -48,7 +48,7 @@ const (
 
 var Sys = system.New()
 
-//this map contains the found bock devices native to the containerVM
+//this map contains the found block devices native to the containerVM
 var DeviceMap = make(map[string]fs.Fsinfo)
 
 type tether struct {

--- a/lib/tether/tether.go
+++ b/lib/tether/tether.go
@@ -228,8 +228,12 @@ func (t *tether) Start() error {
 				return errors.New(detail)
 			}
 
+			log.Infof("attempting to mount %s to %s", v.Source.Path, v.Path)
 			// this could block indefinitely while waiting for a volume to present
-			t.ops.MountLabel(context.Background(), v.Source.Path, v.Path)
+			mountErr := t.ops.MountLabel(context.Background(), v.Source.Path, v.Path, DeviceMap)
+			if mountErr != nil {
+				log.Error(mountErr.Error())
+			}
 		}
 
 		// process the sessions and launch if needed

--- a/lib/tether/tether.go
+++ b/lib/tether/tether.go
@@ -26,9 +26,8 @@ import (
 	"syscall"
 	"time"
 
-	"golang.org/x/net/context"
-
 	log "github.com/Sirupsen/logrus"
+	"golang.org/x/net/context"
 
 	"github.com/vmware/vic/lib/system"
 	"github.com/vmware/vic/pkg/dio"
@@ -49,7 +48,7 @@ const (
 var Sys = system.New()
 
 //this map contains the found block devices native to the containerVM
-var DeviceMap = make(map[string]fs.Fsinfo)
+var DeviceMap = make(map[string]fs.DeviceInfo)
 
 type tether struct {
 	// the implementation to use for tailored operations
@@ -213,8 +212,8 @@ func (t *tether) Start() error {
 
 		log.Info("Populating block device list now.")
 		BlockDevices, err := fs.NewBlockDevices(linuxBlockDevicePath)
-		DeviceMap := BlockDevices.DevicesByLabel()
-		log.Infof("Found ext4 block devices : %s", DeviceMap)
+		labeledDevices := BlockDevices.DevicesByLabel()
+		log.Infof("Found block devices : %s", labeledDevices)
 
 		if err != nil {
 			log.Errorf("error while trying to identify mountable volumes: %s", err)
@@ -228,10 +227,7 @@ func (t *tether) Start() error {
 				return errors.New(detail)
 			}
 
-			log.Infof("attempting to mount %s to %s", v.Source.Path, v.Path)
-			// this could block indefinitely while waiting for a volume to present
-
-			filesystem, ok := DeviceMap[v.Source.Path]
+			filesystem, ok := labeledDevices[v.Source.Path]
 			if !ok {
 				log.Warnf("Could not find Mount Label (%s) during a mount operation", v.Source.Path)
 				continue

--- a/pkg/fs/block.go
+++ b/pkg/fs/block.go
@@ -23,7 +23,7 @@ import (
 )
 
 //this contains the fs block info that we are interested in.
-type Fsinfo struct {
+type DeviceInfo struct {
 	DevicePath  string
 	UUID        string
 	VolumeLabel string
@@ -33,11 +33,11 @@ type FileSystem interface {
 	DevPath() string
 	UUID() string
 	Label() string
-	Info() Fsinfo
+	Info() DeviceInfo
 }
 
 type Ext4FileSystem struct {
-	FilesystemInfo Fsinfo
+	FilesystemInfo DeviceInfo
 }
 
 func (fs Ext4FileSystem) DevPath() string {
@@ -52,7 +52,7 @@ func (fs Ext4FileSystem) Label() string {
 	return fs.FilesystemInfo.VolumeLabel
 }
 
-func (fs Ext4FileSystem) Info() Fsinfo {
+func (fs Ext4FileSystem) Info() DeviceInfo {
 	return fs.FilesystemInfo
 }
 
@@ -120,7 +120,7 @@ func (m Ext4SuperBlock) Read(devicesPath string) ([]FileSystem, error) {
 		blockPath := fmt.Sprintf("%s/%s", devicesPath, block.Name())
 		info, berr := sbinfo.ReadExt2Superblock(blockPath)
 		fs := Ext4FileSystem{
-			FilesystemInfo: m.newExt4Fsinfo(info, blockPath),
+			FilesystemInfo: m.newExt4DeviceInfo(info, blockPath),
 		}
 
 		if berr != nil {
@@ -134,8 +134,8 @@ func (m Ext4SuperBlock) Read(devicesPath string) ([]FileSystem, error) {
 	return ext4BlockDevices, nil
 }
 
-func (m *Ext4SuperBlock) newExt4Fsinfo(info *sbinfo.Ext2Sb, devicePath string) Fsinfo {
-	ext4info := Fsinfo{
+func (m *Ext4SuperBlock) newExt4DeviceInfo(info *sbinfo.Ext2Sb, devicePath string) DeviceInfo {
+	ext4info := DeviceInfo{
 		DevicePath:  devicePath,
 		UUID:        string(info.SUUID[:]),
 		VolumeLabel: string(info.SVolumeName[:]),

--- a/pkg/fs/block.go
+++ b/pkg/fs/block.go
@@ -1,3 +1,17 @@
+// Copyright 2016 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package fs
 
 import (

--- a/pkg/fs/block.go
+++ b/pkg/fs/block.go
@@ -1,0 +1,78 @@
+package fs
+
+import (
+	"fmt"
+	"github.com/ctdk/sbinfo"
+	"io/ioutil"
+	"os"
+)
+
+//this contains the fs block info that we are interested in.
+type Fsinfo struct {
+	DevicePath  string
+	UUID        string
+	VolumeLabel string
+}
+
+type fsDeviceManager interface {
+	FindMountableBlockDevices(devicesPath string) ([]Fsinfo, error)
+	GetDevicesByLabel(devicesPath string) (map[string]Fsinfo, error)
+}
+
+type Ext4DeviceManager struct{}
+
+func (m *Ext4DeviceManager) FindMountableBlockDevices(devicesPath string) ([]Fsinfo, error) {
+	ext4BlockDevices := make([]Fsinfo, 1, 1)
+
+	//first make sure devicesPath is valid
+	devicesDir, err := os.Stat(devicesPath)
+	if err != nil {
+		return nil, err
+	}
+
+	if !devicesDir.IsDir() {
+		return nil, fmt.Errorf("Supplied device path is not a directory")
+	}
+
+	blockDevices, err := ioutil.ReadDir(devicesPath)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, block := range blockDevices {
+		blockPath := fmt.Sprintf("%s/%s", devicesPath, block.Name())
+		info, berr := sbinfo.ReadExt2Superblock(blockPath)
+
+		if berr != nil {
+			//ignore this block, it is probably not ext4
+			continue
+		}
+
+		ext4BlockDevices = append(ext4BlockDevices, m.newExt4Fsinfo(info, blockPath))
+	}
+
+	return ext4BlockDevices, nil
+}
+
+func (m *Ext4DeviceManager) GetDeviceByLbel(devicesPath string) (map[string]Fsinfo, error) {
+	deviceLabelMap := make(map[string]Fsinfo)
+
+	devices, err := m.FindMountableBlockDevices(devicesPath)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, device := range devices {
+		deviceLabelMap[device.VolumeLabel] = device
+	}
+	return deviceLabelMap, nil
+}
+
+func (m *Ext4DeviceManager) newExt4Fsinfo(info *sbinfo.Ext2Sb, devicePath string) Fsinfo {
+	ext4info := Fsinfo{
+		DevicePath:  devicePath,
+		UUID:        string(info.SUUID[:]),
+		VolumeLabel: string(info.SVolumeName[:]),
+	}
+	return ext4info
+}

--- a/pkg/fs/ext4.go
+++ b/pkg/fs/ext4.go
@@ -32,7 +32,7 @@ func NewExt4() *Ext4 {
 	return &Ext4{}
 }
 
-// Mkfs creates an ext4 fs on the given device and applices the given label
+// Mkfs creates an ext4 fs on the given device and applies the given label
 func (e *Ext4) Mkfs(devPath, label string) error {
 	defer trace.End(trace.Begin(devPath))
 

--- a/vendor/github.com/ctdk/sbinfo/LICENSE
+++ b/vendor/github.com/ctdk/sbinfo/LICENSE
@@ -1,0 +1,201 @@
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets "[]"
+   replaced with your own identifying information. (Don't include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same "printed page" as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/vendor/github.com/ctdk/sbinfo/ext2.go
+++ b/vendor/github.com/ctdk/sbinfo/ext2.go
@@ -1,0 +1,154 @@
+package sbinfo
+
+// Ext2Sb represents an ext2/3/4 superblock.
+type Ext2Sb struct {
+	SInodesCount          uint32
+	SBlocksCount          uint32
+	SRBlocksCount         uint32
+	SFreeBlocksCount      uint32
+	SFreeInodesCount      uint32
+	SFirstDataBlock       uint32
+	SLogBlockSize         uint32
+	SLogClusterSize       uint32
+	SBlocksPerGroup       uint32
+	SClustersPerGroup     uint32
+	SInodesPerGroup       uint32
+	SMtime                uint32
+	SWtime                uint32
+	SMntCount             uint16
+	SMaxMntCount          uint16
+	SMagic                uint16
+	SState                uint16
+	SErrors               uint16
+	SMinorRevLevel        uint16
+	SLastcheck            uint32
+	SCheckinterval        uint32
+	SCreatorOs            uint32
+	SRevLevel             uint32
+	SDefResUID            uint16
+	SDefResGID            uint16
+	SFirstIno             uint32
+	SInodeSize            uint16
+	SBlockGroupNr         uint16
+	SFeatureCompat        uint32
+	SFeatureIncompat      uint32
+	SFeatureROCompat      uint32
+	SUUID                 [16]byte
+	SVolumeName           [16]byte
+	SLastMounted          [64]byte
+	SAlgorithmUsageBitmap uint32
+	SPreallocBlocks       uint8
+	SPreallocDirBlocks    uint8
+	SReservedGdtBlocks    uint16
+	SJournalUUID          [16]byte
+	SJournalInum          uint32
+	SJournalDev           uint32
+	SLastOrphan           uint32
+	SHashSeed             [4]uint32
+	SDefHashVersion       byte
+	SJnlBackupType        byte
+	SDefaultMountOpts     uint32
+	SFirstMetaBg          uint32
+	SMkfsTime             uint32
+	SJnlBlocks            [17]uint32
+	SBlocksCountHi        uint32
+	SRBlocksCountHi       uint32
+	SFreeBlocksCountHi    uint32
+	SMinExtraIsize        uint16
+	SWantExtraIsize       uint16
+	SFlags                uint32
+	SRaidStride           uint16
+	SMmpInterval          uint16
+	SMmpBlock             uint64
+	SRaidStripeWidth      uint32
+	SLogGroupsPerFlex     byte
+	SChecksumType         byte
+	SReservedPad          uint16
+	SKbytesWritten        uint64
+	SSnapshotInum         uint32
+	SSnapshotId           uint32
+	SSnapshotRBlocksCount uint64
+	SSnapshotList         uint32
+	SErrorCount           uint32
+	SFirstErrorTime       uint32
+	SFirstErrorIno        uint32
+	SFirstErrorBlock      uint64
+	SFirstErrorFunc       [32]byte
+	SFirstErrorLine       uint32
+	SLastErrorTime        uint32
+	SLastErrorIno         uint32
+	SLastErrorLine        uint32
+	SLastErrorBlock       uint64
+	SLastErrorFunc        [32]byte
+	SMountOpts            [64]byte
+	SUsrQuotaInum         uint32
+	SGrpQuotaInum         uint32
+	SOverheadBlocks       uint32
+	SBackupBgs            [2]uint32
+	SReserved             [106]uint32
+	SChecksum             uint32
+}
+
+const (
+	EXT3_FEATURE_COMPAT_HAS_JOURNAL    uint32 = 0x0004
+	EXT2_FEATURE_RO_COMPAT_SPARSE_SUPER uint32 = 0x0001
+	EXT2_FEATURE_RO_COMPAT_LARGE_FILE   uint32 = 0x0002
+	EXT2_FEATURE_RO_COMPAT_BTREE_DIR    uint32 = 0x0004
+	EXT4_FEATURE_RO_COMPAT_HUGE_FILE    uint32 = 0x0008
+	EXT4_FEATURE_RO_COMPAT_GDT_CSUM     uint32 = 0x0010
+	EXT4_FEATURE_RO_COMPAT_DIR_NLINK    uint32 = 0x0020
+	EXT4_FEATURE_RO_COMPAT_EXTRA_ISIZE  uint32 = 0x0040
+	EXT2_FEATURE_INCOMPAT_FILETYPE    uint32 = 0x0002
+	EXT3_FEATURE_INCOMPAT_RECOVER     uint32 = 0x0004
+	EXT3_FEATURE_INCOMPAT_JOURNAL_DEV  uint32 = 0x0008
+	EXT2_FEATURE_INCOMPAT_META_BG      uint32 = 0x0010
+	EXT4_FEATURE_INCOMPAT_EXTENTS     uint32 = 0x0040
+	EXT4_FEATURE_INCOMPAT_64BIT       uint32 = 0x0080
+	EXT4_FEATURE_INCOMPAT_MMP         uint32 = 0x0100
+	EXT4_FEATURE_INCOMPAT_FLEX_BG      uint32 = 0x0200
+)
+
+const EXT2_FEATURE_RO_COMPAT_SUPP uint32 = EXT2_FEATURE_RO_COMPAT_SPARSE_SUPER | EXT2_FEATURE_RO_COMPAT_LARGE_FILE | EXT2_FEATURE_RO_COMPAT_BTREE_DIR
+const EXT2_FEATURE_INCOMPAT_SUPP uint32 = EXT2_FEATURE_INCOMPAT_FILETYPE | EXT2_FEATURE_INCOMPAT_META_BG
+const EXT2_FEATURE_RO_COMPAT_UNSUPPORTED uint32 = ^EXT2_FEATURE_RO_COMPAT_SUPP
+const EXT2_FEATURE_INCOMPAT_UNSUPPORTED uint32 = ^EXT2_FEATURE_INCOMPAT_SUPP
+const EXT3_FEATURE_RO_COMPAT_SUPP uint32 = EXT2_FEATURE_RO_COMPAT_SPARSE_SUPER |  EXT2_FEATURE_RO_COMPAT_LARGE_FILE | EXT2_FEATURE_RO_COMPAT_BTREE_DIR
+const EXT3_FEATURE_INCOMPAT_SUPP uint32 = EXT2_FEATURE_INCOMPAT_SUPP | EXT3_FEATURE_INCOMPAT_RECOVER
+const EXT3_FEATURE_RO_COMPAT_UNSUPPORTED uint32 = ^EXT3_FEATURE_RO_COMPAT_SUPP
+const EXT3_FEATURE_INCOMPAT_UNSUPPORTED uint32 = ^EXT3_FEATURE_INCOMPAT_SUPP
+
+func (sb *Ext2Sb) IsExt4() bool {
+	ext3 := sb.SFeatureIncompat & EXT3_FEATURE_INCOMPAT_UNSUPPORTED
+	ext2 := sb.SFeatureIncompat & EXT2_FEATURE_INCOMPAT_UNSUPPORTED
+	if ext3 > 0 && ext2 > 0 {
+		return true
+	}
+	return false
+}
+
+func (sb *Ext2Sb) IsExt3() bool {
+	j := sb.SFeatureCompat & EXT3_FEATURE_COMPAT_HAS_JOURNAL
+	if j == 0 {
+		return false
+	}
+	y := sb.SFeatureROCompat & EXT3_FEATURE_RO_COMPAT_UNSUPPORTED
+	z := sb.SFeatureIncompat & EXT3_FEATURE_INCOMPAT_UNSUPPORTED
+	
+	if z == 0 && y == 0{
+		return true
+	}
+	return false
+}
+
+func (sb *Ext2Sb) IsExt2() bool {
+	j := sb.SFeatureCompat & EXT3_FEATURE_COMPAT_HAS_JOURNAL
+	if j > 0 {
+		return false
+	}
+	y := sb.SFeatureROCompat & EXT2_FEATURE_RO_COMPAT_UNSUPPORTED
+	z := sb.SFeatureIncompat & EXT2_FEATURE_INCOMPAT_UNSUPPORTED
+	if z == 0 && y == 0 {
+		return true
+	}
+	return false
+}

--- a/vendor/github.com/ctdk/sbinfo/sbinfo.go
+++ b/vendor/github.com/ctdk/sbinfo/sbinfo.go
@@ -1,0 +1,39 @@
+//Package sbinfo reads information from a filesystem's superblock and returns a
+// struct representing that superblock. At the moment only works with ext2/3/4.
+package sbinfo
+
+import (
+	"fmt"
+	"os"
+	"unsafe"
+)
+
+const ext2Magic uint16 = 0xef53
+
+// ReadExt2Superblock reads the superblock from the given device or file and
+// returns a struct representing the superblock, or an error on failure.
+func ReadExt2Superblock(devPath string) (*Ext2Sb, error) {
+	fp, err := os.Open(devPath)
+	if err != nil {
+		return nil, err
+	}
+	// read in the first 2k bytes
+	buf := make([]byte, 2048)
+	n, err := fp.Read(buf)
+	if n != 2048 {
+		nerr := fmt.Errorf("Expected 2048 bytes, only read %d from %s", n, devPath)
+		return nil, nerr
+	}
+	if err != nil {
+		return nil, err
+	}
+	sbRaw := buf[1024:]
+	sb := (*Ext2Sb)(unsafe.Pointer(&sbRaw[0]))
+	// This needs to be able to check if it's running on a bigendian system
+	// and switch up the sb values as needed.
+	if sb.SMagic != ext2Magic {
+		sbErr := fmt.Errorf("Bad magic number for %s", devPath)
+		return nil, sbErr
+	}
+	return sb, nil
+}

--- a/vendor/manifest
+++ b/vendor/manifest
@@ -146,6 +146,14 @@
 			"path": "/util"
 		},
 		{
+			"importpath": "github.com/ctdk/sbinfo",
+			"repository": "https://github.com/ctdk/sbinfo",
+			"vcs": "git",
+			"revision": "6eaed7001b5a904ad86e3598ddd797eb82050e18",
+			"branch": "master",
+			"notests": true
+		},
+		{
 			"importpath": "github.com/d2g/dhcp4",
 			"repository": "https://github.com/d2g/dhcp4",
 			"vcs": "git",


### PR DESCRIPTION
This Commit uses a new vendored package to inspect attached block devices and create a map which is then used to look up(by label) all of the mounts that are expected for the container. We need this in order to strip out udev and more of systemd. It will also keeps us from having the race condition where udev has not finished sym linking block devices when we `switch-root` which then breaks udev causing us to lose any labeled devices that we intend to mount. 


Fixes #2485 
Fixes #2472 
