### PR TITLE
[full ci] VCH static IPs for client, external, and management networks

### DIFF
--- a/lib/install/data/data.go
+++ b/lib/install/data/data.go
@@ -25,7 +25,7 @@ import (
 	"github.com/vmware/vic/pkg/ip"
 )
 
-// Data wrapps all parameters required by value validation
+// Data wraps all parameters required by value validation
 type Data struct {
 	*common.Target
 	common.Debug
@@ -43,10 +43,11 @@ type Data struct {
 	VolumeLocations        map[string]string
 	ContainerDatastoreName string
 
-	ExternalNetworkName   string
-	ManagementNetworkName string
-	BridgeNetworkName     string
-	ClientNetworkName     string
+	BridgeNetworkName string
+	ClientNetwork     NetworkConfig
+	ExternalNetwork   NetworkConfig
+	ManagementNetwork NetworkConfig
+	DNS               []net.IP
 
 	MappedNetworks         map[string]string
 	MappedNetworksGateways map[string]net.IPNet
@@ -74,6 +75,18 @@ type Data struct {
 	UseRP bool
 
 	ScratchSize string
+}
+
+// NetworkConfig is used to set IP addr for each network
+type NetworkConfig struct {
+	Name    string
+	Gateway net.IPNet
+	IP      net.IPNet
+}
+
+// Empty determines if ip and gateway are unset
+func (n *NetworkConfig) Empty() bool {
+	return ip.Empty(n.Gateway) && ip.Empty(n.IP)
 }
 
 // InstallerData is used to hold the transient installation configuration that shouldn't be serialized

--- a/lib/install/management/create_test.go
+++ b/lib/install/management/create_test.go
@@ -97,8 +97,8 @@ func getESXData(url *url.URL) *data.Data {
 	result.ComputeResourcePath = "/ha-datacenter/host/localhost.localdomain/Resources"
 	result.ImageDatastorePath = "LocalDS_0"
 	result.BridgeNetworkName = "bridge"
-	result.ManagementNetworkName = "VM Network"
-	result.ExternalNetworkName = "VM Network"
+	result.ManagementNetwork.Name = "VM Network"
+	result.ExternalNetwork.Name = "VM Network"
 	result.VolumeLocations = make(map[string]string)
 	result.VolumeLocations["volume-store"] = "LocalDS_0/volumes/test"
 
@@ -111,7 +111,7 @@ func getVPXData(url *url.URL) *data.Data {
 	result.DisplayName = "test001"
 	result.ComputeResourcePath = "/DC0/host/DC0_C0/Resources"
 	result.ImageDatastorePath = "LocalDS_0"
-	result.ExternalNetworkName = "VM Network"
+	result.ExternalNetwork.Name = "VM Network"
 	result.BridgeNetworkName = "bridge"
 	result.VolumeLocations = make(map[string]string)
 	result.VolumeLocations["volume-store"] = "LocalDS_0/volumes/test"

--- a/lib/install/validate/network.go
+++ b/lib/install/validate/network.go
@@ -34,38 +34,40 @@ import (
 	"golang.org/x/net/context"
 )
 
-func (v *Validator) addNetworkHelper(ctx context.Context, conf *config.VirtualContainerHostConfigSpec, netName, epName, contNetName string, def bool) error {
+func (v *Validator) getEndpoint(ctx context.Context, conf *config.VirtualContainerHostConfigSpec, network data.NetworkConfig, epName, contNetName string, def bool, ns []net.IP) (*executor.NetworkEndpoint, error) {
 	defer trace.End(trace.Begin(""))
+	var gw net.IPNet
+	var staticIP *net.IPNet
 
-	moid, err := v.networkHelper(ctx, netName)
+	if !network.Empty() {
+		log.Debugf("Setting static IP for %q on port group %q", contNetName, network.Name)
+		gw = network.Gateway
+		staticIP = &network.IP
+	}
+
+	moid, err := v.networkHelper(ctx, network.Name)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	if epName != "" {
-		conf.AddNetwork(&executor.NetworkEndpoint{
+	e := &executor.NetworkEndpoint{
+		Common: executor.Common{
+			Name: epName,
+		},
+		Network: executor.ContainerNetwork{
 			Common: executor.Common{
-				Name: epName,
+				Name: contNetName,
+				ID:   moid,
 			},
-			Network: executor.ContainerNetwork{
-				Common: executor.Common{
-					Name: contNetName,
-					ID:   moid,
-				},
-				Default: def,
-			},
-		})
-	} else {
-		conf.AddNetwork(&executor.NetworkEndpoint{
-			Network: executor.ContainerNetwork{
-				Common: executor.Common{
-					Name: contNetName,
-					ID:   moid,
-				},
-			},
-		})
+			Default:     def,
+			Gateway:     gw,
+			Nameservers: ns,
+		},
+		Static: staticIP,
 	}
-	return nil
+	log.Debugf("NetworkEndpoint: %v", e)
+
+	return e, nil
 }
 
 func (v *Validator) checkNetworkConflict(bridgeNetName, otherNetName, otherNetType string) {
@@ -74,40 +76,148 @@ func (v *Validator) checkNetworkConflict(bridgeNetName, otherNetName, otherNetTy
 	}
 }
 
+// portGroupConfig gets the input config for all networks
+// for use in checking that the config is valid
+func (v *Validator) portGroupConfig(input *data.Data, counts map[string]int, ips map[string][]data.NetworkConfig) {
+	defer trace.End(trace.Begin(""))
+
+	if input.ManagementNetwork.Name != "" {
+		counts[input.ManagementNetwork.Name]++
+		if !input.ManagementNetwork.Empty() {
+			ips[input.ManagementNetwork.Name] = append(ips[input.ManagementNetwork.Name], input.ManagementNetwork)
+		}
+	}
+	if input.ClientNetwork.Name != "" {
+		counts[input.ClientNetwork.Name]++
+		if !input.ClientNetwork.Empty() {
+			ips[input.ClientNetwork.Name] = append(ips[input.ClientNetwork.Name], input.ClientNetwork)
+		}
+	}
+	if input.ExternalNetwork.Name != "" {
+		counts[input.ExternalNetwork.Name]++
+		if !input.ExternalNetwork.Empty() {
+			ips[input.ExternalNetwork.Name] = append(ips[input.ExternalNetwork.Name], input.ExternalNetwork)
+		}
+	}
+}
+
+// checkPortGroups checks that network config is valid
+// prevent assigning > 1 static IP to the same port group
+// warn if assigning addresses in the same subnet to > 1 port group
+func (v *Validator) checkPortGroups(counts map[string]int, ips map[string][]data.NetworkConfig) error {
+	defer trace.End(trace.Begin(""))
+
+	for pg := range ips {
+		if len(ips[pg]) > 1 {
+			var msgIPs []string
+			for _, v := range ips[pg] {
+				msgIPs = append(msgIPs, v.IP.IP.String())
+			}
+			log.Errorf("Port group %q is configured for networks with more than one static IP: %s", pg, msgIPs)
+			log.Error("All VCH networks on the same port group must have the same IP address")
+			log.Error("To resolve this, configure static IP for one network and assign other networks to same port group.")
+			log.Error("The static IP will be automatically configured for networks sharing the port group.")
+			return fmt.Errorf("Incorrect static IP configuration for networks on port group %q", pg)
+		}
+	}
+
+	// check if same subnet assigned to multiple portgroups - this can cause routing problems
+	networks := make(map[string]string)
+	for n, config := range ips {
+		_, net, _ := net.ParseCIDR(config[0].IP.String())
+		netAddr := net.String()
+		if networks[netAddr] != "" {
+			log.Warnf("Unsupported static IP configuration: Same subnet %q is assigned to multiple port groups %q and %q", netAddr, networks[netAddr], n)
+		} else {
+			networks[netAddr] = n
+		}
+	}
+
+	return nil
+}
+
+// configureSharedPortGroups sets VCH static IP for networks that share a
+// portgroup with another network that has a configured static IP
+func (v *Validator) configureSharedPortGroups(input *data.Data, counts map[string]int, ips map[string][]data.NetworkConfig) error {
+	defer trace.End(trace.Begin(""))
+
+	// find other networks using same portgroup and copy the NetworkConfig to them
+	for name, config := range ips {
+		if len(config) != 1 {
+			return fmt.Errorf("Failed to configure static IP for additional networks using port group %q", name)
+		}
+		log.Infof("Configuring static IP for additional networks using port group %q", name)
+		if input.ClientNetwork.Name == name && input.ClientNetwork.Empty() {
+			input.ClientNetwork = config[0]
+		}
+		if input.ExternalNetwork.Name == name && input.ExternalNetwork.Empty() {
+			input.ExternalNetwork = config[0]
+		}
+		if input.ManagementNetwork.Name == name && input.ManagementNetwork.Empty() {
+			input.ManagementNetwork = config[0]
+		}
+	}
+
+	return nil
+}
+
 func (v *Validator) network(ctx context.Context, input *data.Data, conf *config.VirtualContainerHostConfigSpec) {
 	defer trace.End(trace.Begin(""))
 
+	var e *executor.NetworkEndpoint
+	var err error
+
+	// set default portgroup if user input not provided
+	if input.ClientNetwork.Name == "" {
+		input.ClientNetwork.Name = input.ExternalNetwork.Name
+	}
+	if input.ManagementNetwork.Name == "" {
+		input.ManagementNetwork.Name = input.ClientNetwork.Name
+	}
+
+	c := make(map[string]int)                  // number of VCH networks using portgroup
+	i := make(map[string][]data.NetworkConfig) // user configured IPs for portgroup
+	v.portGroupConfig(input, c, i)
+
+	err = v.checkPortGroups(c, i)
+	v.NoteIssue(err)
+
+	err = v.configureSharedPortGroups(input, c, i)
+	v.NoteIssue(err)
+
 	// External net
 	// external network is default for appliance
-	err := v.addNetworkHelper(ctx, conf, input.ExternalNetworkName, "external", "external", true)
+	e, err = v.getEndpoint(ctx, conf, input.ExternalNetwork, "external", "external", true, input.DNS)
 	if err != nil {
 		v.NoteIssue(fmt.Errorf("Error checking network for --external-network: %s", err))
 		v.suggestNetwork("--external-network", true)
 	}
 	// Bridge network should be different than all other networks
-	v.checkNetworkConflict(input.BridgeNetworkName, input.ExternalNetworkName, "external")
+	v.checkNetworkConflict(input.BridgeNetworkName, input.ExternalNetwork.Name, "external")
+	conf.AddNetwork(e)
 
-	// Client net
-	if input.ClientNetworkName == "" {
-		input.ClientNetworkName = input.ExternalNetworkName
-	}
-	err = v.addNetworkHelper(ctx, conf, input.ClientNetworkName, "client", "client", false)
+	// Client net - defaults to connect to same portgroup as external
+	e, err = v.getEndpoint(ctx, conf, input.ClientNetwork, "client", "client", false, input.DNS)
 	if err != nil {
 		v.NoteIssue(fmt.Errorf("Error checking network for --client-network: %s", err))
 		v.suggestNetwork("--client-network", true)
 	}
-	v.checkNetworkConflict(input.BridgeNetworkName, input.ClientNetworkName, "client")
+	v.checkNetworkConflict(input.BridgeNetworkName, input.ClientNetwork.Name, "client")
+	conf.AddNetwork(e)
 
-	// Management net
-	if input.ManagementNetworkName == "" {
-		input.ManagementNetworkName = input.ClientNetworkName
-	}
-	err = v.addNetworkHelper(ctx, conf, input.ManagementNetworkName, "", "management", false)
+	// Management net - defaults to connect to the same portgroup as client
+	e, err = v.getEndpoint(ctx, conf, input.ManagementNetwork, "", "management", false, input.DNS)
 	if err != nil {
 		v.NoteIssue(fmt.Errorf("Error checking network for --management-network: %s", err))
 		v.suggestNetwork("--management-network", true)
 	}
-	v.checkNetworkConflict(input.BridgeNetworkName, input.ManagementNetworkName, "management")
+	v.checkNetworkConflict(input.BridgeNetworkName, input.ManagementNetwork.Name, "management")
+	conf.AddNetwork(e)
+
+	log.Debug("Network configuration:")
+	for net, val := range conf.ExecutorConfig.Networks {
+		log.Debugf("\tNetwork: %s NetworkEndpoint: %v", net, val)
+	}
 
 	// Bridge net -
 	//   vCenter: must exist and must be a DPG
@@ -255,27 +365,29 @@ func (v *Validator) generateBridgeName(ctx, input *data.Data, conf *config.Virtu
 	return input.DisplayName
 }
 
-func (v *Validator) getNetwork(ctx context.Context, path string) (object.NetworkReference, error) {
-	defer trace.End(trace.Begin(path))
+// getNetwork gets a moref based on the network name
+func (v *Validator) getNetwork(ctx context.Context, name string) (object.NetworkReference, error) {
+	defer trace.End(trace.Begin(name))
 
-	nets, err := v.Session.Finder.NetworkList(ctx, path)
+	nets, err := v.Session.Finder.NetworkList(ctx, name)
 	if err != nil {
-		log.Debugf("no such network %q", path)
+		log.Debugf("no such network %q", name)
 		// TODO: error message about no such match and how to get a network list
 		// we return err directly here so we can check the type
 		return nil, err
 	}
 	if len(nets) > 1 {
 		// TODO: error about required disabmiguation and list entries in nets
-		return nil, errors.New("ambiguous network " + path)
+		return nil, errors.New("ambiguous network " + name)
 	}
 	return nets[0], nil
 }
 
-func (v *Validator) networkHelper(ctx context.Context, path string) (string, error) {
-	defer trace.End(trace.Begin(path))
+// networkHelper gets a moid based on the network name
+func (v *Validator) networkHelper(ctx context.Context, name string) (string, error) {
+	defer trace.End(trace.Begin(name))
 
-	net, err := v.getNetwork(ctx, path)
+	net, err := v.getNetwork(ctx, name)
 	if err != nil {
 		return "", err
 	}

--- a/lib/install/validate/validator.go
+++ b/lib/install/validate/validator.go
@@ -36,16 +36,14 @@ import (
 )
 
 type Validator struct {
-	TargetPath            string
-	DatacenterPath        string
-	ClusterPath           string
-	ResourcePoolPath      string
-	ImageStorePath        string
-	ExternalNetworkPath   string
-	BridgeNetworkPath     string
-	BridgeNetworkName     string
-	ManagementNetworkPath string
-	ManagementNetworkName string
+	TargetPath          string
+	DatacenterPath      string
+	ClusterPath         string
+	ResourcePoolPath    string
+	ImageStorePath      string
+	ExternalNetworkPath string
+	BridgeNetworkPath   string
+	BridgeNetworkName   string
 
 	Session *session.Session
 	Context context.Context

--- a/lib/install/validate/validator_test.go
+++ b/lib/install/validate/validator_test.go
@@ -134,8 +134,8 @@ func getESXData(url *url.URL) *data.Data {
 	result.ImageDatastorePath = "LocalDS_0"
 	result.BridgeNetworkName = "bridge"
 	_, result.BridgeIPRange, _ = net.ParseCIDR("172.16.0.0/12")
-	result.ManagementNetworkName = "VM Network"
-	result.ExternalNetworkName = "VM Network"
+	result.ManagementNetwork.Name = "VM Network"
+	result.ExternalNetwork.Name = "VM Network"
 	result.VolumeLocations = make(map[string]string)
 	result.VolumeLocations["volume-store"] = "LocalDS_0/volumes/test"
 
@@ -149,7 +149,7 @@ func getVPXData(url *url.URL) *data.Data {
 	result.DisplayName = "test001"
 	result.ComputeResourcePath = "/DC0/host/DC0_C0/Resources"
 	result.ImageDatastorePath = "LocalDS_0"
-	result.ExternalNetworkName = "VM Network"
+	result.ExternalNetwork.Name = "VM Network"
 	result.BridgeNetworkName = "bridge"
 	_, result.BridgeIPRange, _ = net.ParseCIDR("172.16.0.0/12")
 	result.VolumeLocations = make(map[string]string)

--- a/lib/portlayer/storage/vsphere/volume.go
+++ b/lib/portlayer/storage/vsphere/volume.go
@@ -125,7 +125,7 @@ func (v *VolumeStore) getDatastore(store *url.URL) (*datastore.Helper, error) {
 	// find the datastore
 	dstore, ok := v.ds[*store]
 	if !ok {
-		return nil, storage.VolumeStoreNotFoundError{fmt.Sprintf("volume store (%s) not found", store.String())}
+		return nil, storage.VolumeStoreNotFoundError{Msg: fmt.Sprintf("volume store (%s) not found", store.String())}
 	}
 
 	return dstore, nil

--- a/pkg/ip/ip.go
+++ b/pkg/ip/ip.go
@@ -159,6 +159,24 @@ func (i *Range) UnmarshalText(text []byte) error {
 	return nil
 }
 
+// ParseIPandMask parses a CIDR format address (e.g. 1.1.1.1/8)
+func ParseIPandMask(s string) (net.IPNet, error) {
+	var i net.IPNet
+	ip, ipnet, err := net.ParseCIDR(s)
+	if err != nil {
+		return i, err
+	}
+
+	i.IP = ip
+	i.Mask = ipnet.Mask
+	return i, nil
+}
+
+// Empty determines if net.IPNet is empty
+func Empty(i net.IPNet) bool {
+	return i.IP == nil && i.Mask == nil
+}
+
 func IsUnspecifiedIP(ip net.IP) bool {
 	return len(ip) == 0 || ip.IsUnspecified()
 }

--- a/tests/test-cases/Group6-VIC-Machine/6-7-Create-Network.md
+++ b/tests/test-cases/Group6-VIC-Machine/6-7-Create-Network.md
@@ -15,7 +15,7 @@ This test requires that a vSphere server is running and available
 #Test Steps
 1. Create without external network provided
 2. Verify "VM Network" is connected in VCH VM
-3. Integration test passed 
+3. Integration test passed
 
 #Test Steps
 1. Create with wrong network name provided for external network
@@ -39,7 +39,7 @@ This test requires that a vSphere server is running and available
 1. Create without management network provided, but external network correctly set
 2. Verify warning message set for management network and client network sharing the same network
 3. No multiple attachement in VM network to same vSphere virtual switch (or DPG)
-4. Integration test passed 
+4. Integration test passed
 
 #Test Steps
 1. Create with wrong network name provided for management network
@@ -83,7 +83,7 @@ This test requires that a vSphere server is running and available
 3. Verify integration test passed
 
 #Test Steps
-1. Create with same network for bridige and external network 
+1. Create with same network for bridge and external network
 2. Verify create failed for same network with external network
 3. Same case with management network
 4. Same case with container network
@@ -159,3 +159,47 @@ This test requires that a vSphere server is running and available
 7. Docker network ls show net1
 8. Docker container created with network attached with net1, got ip address inside of network range
 9. Docker create another container, and link to previous one, can talk to the the first container successfully
+
+
+# Test Cases: VCH static IP
+
+# Test Steps
+1. Create with static IP address for external network (client and management networks unspecified
+   default to same port group as external network)
+2. Verify debug output shows specified static IP address correctly assigned and copied to client and
+   management networks
+
+# Test Steps
+1. Create with static IP address for client network and specify client, external, and management
+   networks to be on same port group
+2. Verify debug output shows specified static IP address correctly assigned and copied to external
+   and management networks
+
+# Test Steps
+1. Create with static IP address for managment network and specify client, external, and management
+   networks to be on the same port group
+2. Verify debug output shows specified static IP address correctly assigned and copied to client
+   and external management networks
+
+# Test Steps
+1. Create with static IP address for external network and specify client and management networks to
+   be on different port group
+2. Verify debug output shows specified static IP address correctly assigned
+3. Verify debug output shows client and management networks set to DHCP
+
+# Test Steps
+1. Create with static IP address for external network on `external-network` port group and a static
+   IP address for client network on `client-network` port group
+2. Verify debug output shows correct IP address assigned to each interface
+
+# Test Steps
+1. Create with static IP address for each external network and client network and specify both to be
+   on the same port group
+2. Verify output shows configuration error and install does not proceed
+
+# Test Steps
+1. Create with static IP address for external network and a static IP address for client network.
+   Specify the addresses to be on the same subnet, but assign each network to a different port
+   group
+2. Verify output shows warning that assigning the same subnet to different port groups is
+   unsupported


### PR DESCRIPTION
Allows the user to specify static IP address and gateway for client, external, and management (CEM) networks.
Allows the user to specify DNS servers to use for CEM networks.
If the same port group is specified for more than one of the CEM networks, only one static IP may be specified for the networks sharing the port group. 

Fixes #1184 

passed local regression tests
