### PR TITLE
[full ci] allow ssh and shell enable via vic-machine

### DIFF
--- a/cmd/vic-init/main_linux.go
+++ b/cmd/vic-init/main_linux.go
@@ -76,8 +76,9 @@ func main() {
 	// create the tether
 	tthr = tether.New(src, sink, &operations{})
 
-	// register the toolbox extension
-	tthr.Register("Toolbox", tether.NewToolbox())
+	// register the toolbox extension and configure for appliance
+	toolbox := configureToolbox(tether.NewToolbox())
+	tthr.Register("Toolbox", toolbox)
 
 	err = tthr.Start()
 	if err != nil {
@@ -109,4 +110,11 @@ func reboot() {
 
 	syscall.Sync()
 	syscall.Reboot(syscall.LINUX_REBOOT_CMD_RESTART)
+}
+
+func configureToolbox(t *tether.Toolbox) *tether.Toolbox {
+	vix := t.Service.VixCommand
+	vix.ProcessStartCommand = startCommand
+
+	return t
 }

--- a/cmd/vic-init/toolbox.go
+++ b/cmd/vic-init/toolbox.go
@@ -1,0 +1,178 @@
+// Copyright 2016 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !windows,!darwin
+
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"strings"
+
+	log "github.com/Sirupsen/logrus"
+
+	"github.com/vmware/vic/pkg/trace"
+	"github.com/vmware/vic/pkg/vsphere/toolbox"
+)
+
+// startCommand is the switch for the synthetic commands that are permitted within the appliance.
+// This is not intended to allow arbitrary commands to be executed.
+func startCommand(r *toolbox.VixMsgStartProgramRequest) (int, error) {
+	switch r.ProgramPath {
+	case "enable-ssh":
+		return -1, enableSSH(r.Arguments)
+	case "passwd":
+		return -1, passwd(r.Arguments)
+	default:
+		return -1, fmt.Errorf("unknown command %q", r.ProgramPath)
+	}
+}
+
+// enableShell changes the root shell from /bin/false to /bin/bash
+func enableShell() error {
+	defer trace.End(trace.Begin(""))
+
+	chsh := exec.Command("/bin/chsh", "-s", "/bin/bash", "root")
+	err := chsh.Start()
+	if err != nil {
+		err := fmt.Errorf("Failed to launch chsh: %s", err)
+		log.Error(err)
+		return err
+	}
+
+	// ignore the error - it's likely raced with child reaper, we just want to make sure
+	// that it's exited by the time we pass this point
+	chsh.Wait()
+
+	// confirm the change
+	file, err := os.Open("/etc/passwd")
+	if err != nil {
+		err := fmt.Errorf("Failed to open file to confirm change: %s", err)
+		log.Error(err)
+		return err
+	}
+
+	reader := bufio.NewReader(file)
+	line, err := reader.ReadString('\n')
+	if err != nil {
+		err := fmt.Errorf("Failed to read line from file to confirm change: %s", err)
+		log.Error(err)
+		return err
+	}
+
+	// assert that first line is root
+	if !strings.HasPrefix(line, "root") {
+		err := fmt.Errorf("Expected line to start with root: %s", line)
+		log.Error(err)
+		return err
+	}
+
+	// assert that first line is root
+	if !strings.HasSuffix(line, "/bin/bash\n") {
+		err := fmt.Errorf("Expected line to end with /bin/bash: %s", line)
+		log.Error(err)
+		return err
+	}
+
+	return nil
+}
+
+// passwd sets the password for the root user to that provided as an argument
+func passwd(pass string) error {
+	defer trace.End(trace.Begin(""))
+
+	err := enableShell()
+	if err != nil {
+		err := fmt.Errorf("Failed to enable shell: %s", err)
+		log.Error(err)
+		// continue anyway as people may be able to get something useful
+	}
+
+	setPasswd := exec.Command("/sbin/chpasswd")
+	stdin, err := setPasswd.StdinPipe()
+	if err != nil {
+		err := fmt.Errorf("Failed to create stdin pipe for chpasswd: %s", err)
+		log.Error(err)
+		return err
+	}
+
+	err = setPasswd.Start()
+	if err != nil {
+		err := fmt.Errorf("Failed to launch chpasswd: %s", err)
+		log.Error(err)
+		return err
+	}
+
+	_, err = stdin.Write([]byte("root:" + pass))
+
+	// so that we're actively waiting when the process exits, or we'll race (and lose) to child reaper
+	var waitErr error
+	go func() {
+		waitErr = setPasswd.Wait()
+	}()
+
+	err = stdin.Close()
+	if err != nil {
+		err := fmt.Errorf("Failed to close input to chpasswd: %s", err)
+		log.Error(err)
+
+		// fire and forget as we're already on error path
+		setPasswd.Process.Kill()
+
+		return err
+	}
+
+	return nil
+}
+
+// enableSSH receives a key as an argument
+func enableSSH(key string) error {
+	defer trace.End(trace.Begin(""))
+
+	err := enableShell()
+	if err != nil {
+		err := fmt.Errorf("Failed to enable shell: %s", err)
+		log.Error(err)
+		// continue anyway as people may be able to get something useful
+	}
+
+	// basic sanity check for args - we don't bother validating it's a key
+	if len(key) != 0 {
+		err = os.MkdirAll("/root/.ssh", 0700)
+		if err != nil {
+			err := fmt.Errorf("unable to create path for keys: %s", err)
+			log.Error(err)
+			return err
+		}
+
+		err = ioutil.WriteFile("/root/.ssh/authorized_keys", []byte(key), 0600)
+		if err != nil {
+			err := fmt.Errorf("unable to create authorized_keys: %s", err)
+			log.Error(err)
+			return err
+		}
+	}
+
+	// because init is explicitly reaping child processes we cannot use simple
+	// exec commands to gather status
+	startSSH := exec.Command("/usr/bin/systemctl", "start", "sshd")
+	out, err := startSSH.CombinedOutput()
+	log.Info("Attempted to start ssh service:\n %s", out)
+
+	return nil
+}

--- a/cmd/vic-init/toolbox.go
+++ b/cmd/vic-init/toolbox.go
@@ -32,7 +32,12 @@ import (
 
 // startCommand is the switch for the synthetic commands that are permitted within the appliance.
 // This is not intended to allow arbitrary commands to be executed.
+// returns:
+//  pid: we return -1 as this is a synthetic command
+//  error
 func startCommand(r *toolbox.VixMsgStartProgramRequest) (int, error) {
+	defer trace.End(trace.Begin(r.ProgramPath))
+
 	switch r.ProgramPath {
 	case "enable-ssh":
 		return -1, enableSSH(r.Arguments)
@@ -121,9 +126,8 @@ func passwd(pass string) error {
 	_, err = stdin.Write([]byte("root:" + pass))
 
 	// so that we're actively waiting when the process exits, or we'll race (and lose) to child reaper
-	var waitErr error
 	go func() {
-		waitErr = setPasswd.Wait()
+		setPasswd.Wait()
 	}()
 
 	err = stdin.Close()

--- a/cmd/vic-machine/debug/debug.go
+++ b/cmd/vic-machine/debug/debug.go
@@ -1,0 +1,163 @@
+// Copyright 2016 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package debug
+
+import (
+	log "github.com/Sirupsen/logrus"
+
+	"github.com/urfave/cli"
+	"github.com/vmware/vic/lib/install/data"
+	"github.com/vmware/vic/lib/install/management"
+	"github.com/vmware/vic/lib/install/validate"
+	"github.com/vmware/vic/pkg/errors"
+	"github.com/vmware/vic/pkg/trace"
+	"github.com/vmware/vic/pkg/version"
+	"github.com/vmware/vic/pkg/vsphere/vm"
+
+	"golang.org/x/net/context"
+)
+
+// Debug has all input parameters for vic-machine Debug command
+type Debug struct {
+	*data.Data
+
+	executor *management.Dispatcher
+
+	enableSSH     bool
+	password      string
+	authorizedKey string
+}
+
+func NewDebug() *Debug {
+	d := &Debug{}
+	d.Data = data.NewData()
+	return d
+}
+
+// Flags return all cli flags for Debug
+func (d *Debug) Flags() []cli.Flag {
+	preFlags := append(d.TargetFlags(), d.IDFlags()...)
+	preFlags = append(preFlags, d.ComputeFlags()...)
+
+	flags := []cli.Flag{
+		cli.BoolFlag{
+			Name:        "enable-ssh, ssh",
+			Usage:       "Enable SSH server within appliance VM",
+			Destination: &d.enableSSH,
+		},
+		cli.StringFlag{
+			Name:        "authorized-key, key",
+			Value:       "",
+			Usage:       "Key to place as /root/.ssh/authorized_keys",
+			Destination: &d.authorizedKey,
+		},
+		cli.StringFlag{
+			Name:        "rootpw, pw",
+			Value:       "",
+			Usage:       "Password to set for root user (non-persistent over reboots)",
+			Destination: &d.password,
+		},
+	}
+
+	flags = append(preFlags, flags...)
+
+	return append(flags, d.DebugFlags()...)
+}
+
+func (d *Debug) processParams() error {
+	defer trace.End(trace.Begin(""))
+
+	if err := d.HasCredentials(); err != nil {
+		return err
+	}
+
+	d.Insecure = true
+	return nil
+}
+
+func (d *Debug) Run(cli *cli.Context) error {
+	var err error
+	if err = d.processParams(); err != nil {
+		return err
+	}
+
+	if d.Debug.Debug > 0 {
+		log.SetLevel(log.DebugLevel)
+		trace.Logger.Level = log.DebugLevel
+	}
+
+	if len(cli.Args()) > 0 {
+		log.Errorf("Unknown argument: %s", cli.Args()[0])
+		return errors.New("invalid CLI arguments")
+	}
+
+	log.Infof("### Configuring VCH for debug ####")
+
+	ctx, cancel := context.WithTimeout(context.Background(), d.Timeout)
+	defer cancel()
+
+	validator, err := validate.NewValidator(ctx, d.Data)
+	if err != nil {
+		log.Errorf("Debug cannot continue - failed to create validator: %s", err)
+		return errors.New("Debug failed")
+	}
+	executor := management.NewDispatcher(validator.Context, validator.Session, nil, d.Force)
+
+	var vch *vm.VirtualMachine
+	if d.Data.ID != "" {
+		vch, err = executor.NewVCHFromID(d.Data.ID)
+	} else {
+		vch, err = executor.NewVCHFromComputePath(d.Data.ComputeResourcePath, d.Data.DisplayName, validator)
+	}
+	if err != nil {
+		log.Errorf("Failed to get Virtual Container Host %s", d.DisplayName)
+		log.Error(err)
+		return errors.New("Debug failed")
+	}
+
+	log.Infof("")
+	log.Infof("VCH ID: %s", vch.Reference().String())
+
+	vchConfig, err := executor.GetVCHConfig(vch)
+	if err != nil {
+		log.Error("Failed to get Virtual Container Host configuration")
+		log.Error(err)
+		return errors.New("Debug failed")
+	}
+	executor.InitDiagnosticLogs(vchConfig)
+
+	installerVer := version.GetBuild()
+
+	log.Info("")
+	log.Infof("Installer version: %s", installerVer.ShortVersion())
+	log.Infof("VCH version: %s", vchConfig.Version.ShortVersion())
+
+	if err = executor.DebugVCH(vch, vchConfig, d.password, d.authorizedKey); err != nil {
+		executor.CollectDiagnosticLogs()
+		log.Errorf("%s", err)
+		return errors.New("Debug failed")
+	}
+
+	// display the VCH endpoints again for convenience
+	if err = executor.InspectVCH(vch, vchConfig); err != nil {
+		executor.CollectDiagnosticLogs()
+		log.Errorf("%s", err)
+		return errors.New("inspect failed")
+	}
+
+	log.Infof("Completed successfully")
+
+	return nil
+}

--- a/cmd/vic-machine/main.go
+++ b/cmd/vic-machine/main.go
@@ -25,6 +25,7 @@ import (
 	"github.com/urfave/cli"
 
 	"github.com/vmware/vic/cmd/vic-machine/create"
+	"github.com/vmware/vic/cmd/vic-machine/debug"
 	uninstall "github.com/vmware/vic/cmd/vic-machine/delete"
 	"github.com/vmware/vic/cmd/vic-machine/inspect"
 	"github.com/vmware/vic/cmd/vic-machine/list"
@@ -49,6 +50,7 @@ func main() {
 	inspect := inspect.NewInspect()
 	list := list.NewList()
 	upgrade := upgrade.NewUpgrade()
+	debug := debug.NewDebug()
 	app.Commands = []cli.Command{
 		{
 			Name:   "create",
@@ -84,6 +86,12 @@ func main() {
 			Name:   "version",
 			Usage:  "Show VIC version information",
 			Action: showVersion,
+		},
+		{
+			Name:   "debug",
+			Usage:  "Debug VCH",
+			Action: debug.Run,
+			Flags:  debug.Flags(),
 		},
 	}
 

--- a/isos/appliance-staging.sh
+++ b/isos/appliance-staging.sh
@@ -113,11 +113,16 @@ yum_cached -p $PKGDIR clean all
 pwhash=$(openssl passwd -1 -salt vic password)
 sed -i -e "s/^root:[^:]*:/root:${pwhash}:/" $(rootfs_dir $PKGDIR)/etc/shadow
 
-# 1218: Temporarily disable SSH for TP3
+
+# Disable SSH by default - this can be enabled via guest operations
 rm $(rootfs_dir $PKGDIR)/usr/lib/systemd/system/sshd@.service
+rm $(rootfs_dir $PKGDIR)/etc/systemd/system/multi-user.target.wants/sshd.service
 
 # Allow root login via ssh
 sed -i -e "s/\#*PermitRootLogin\s.*/PermitRootLogin yes/" $(rootfs_dir $PKGDIR)/etc/ssh/sshd_config
+
+# Disable root login
+sed -i -e 's@:/bin/bash$@:/bin/false@' $(rootfs_dir $PKGDIR)/etc/passwd
 
 # package up the result
 pack $PKGDIR $OUT

--- a/lib/install/management/debug.go
+++ b/lib/install/management/debug.go
@@ -1,0 +1,116 @@
+// Copyright 2016 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package management
+
+import (
+	"context"
+
+	log "github.com/Sirupsen/logrus"
+
+	"github.com/vmware/govmomi/guest"
+	"github.com/vmware/govmomi/vim25/types"
+	"github.com/vmware/vic/lib/config"
+	"github.com/vmware/vic/pkg/errors"
+	"github.com/vmware/vic/pkg/trace"
+	"github.com/vmware/vic/pkg/vsphere/vm"
+)
+
+func (d *Dispatcher) DebugVCH(vch *vm.VirtualMachine, conf *config.VirtualContainerHostConfigSpec, password, authorized_key string) error {
+	defer trace.End(trace.Begin(conf.Name))
+
+	op, err := trace.FromContext(d.ctx)
+	if err != nil {
+		op = trace.NewOperation(d.ctx, "enable appliance debug")
+	}
+
+	err = d.enableSSH(op, vch, password, authorized_key)
+	if err != nil {
+		op.Errorf("Unable to enable ssh on the VCH appliance VM: %s", err)
+		return err
+	}
+
+	d.sshEnabled = true
+
+	return nil
+}
+
+func (d *Dispatcher) enableSSH(ctx context.Context, vch *vm.VirtualMachine, password, authorized_key string) error {
+	op, err := trace.FromContext(ctx)
+	if err != nil {
+		op = trace.NewOperation(ctx, "enable ssh in appliance")
+	}
+
+	state, err := vch.PowerState(op)
+	if err != nil {
+		log.Errorf("Failed to get appliance power state, service might not be available at this moment.")
+	}
+	if state != types.VirtualMachinePowerStatePoweredOn {
+		err = errors.Errorf("VCH appliance is not powered on, state %s", state)
+		op.Errorf("%s", err)
+		return err
+	}
+
+	running, err := vch.IsToolsRunning(op)
+	if err != nil || !running {
+		err = errors.New("Tools is not running in the appliance, unable to continue")
+		op.Errorf("%s", err)
+		return err
+	}
+
+	manager := guest.NewOperationsManager(d.session.Client.Client, vch.Reference())
+	processManager, err := manager.ProcessManager(op)
+	if err != nil {
+		err = errors.Errorf("Unable to manage processes in appliance VM: %s", err)
+		op.Errorf("%s", err)
+		return err
+	}
+
+	auth := types.NamePasswordAuthentication{}
+
+	spec := types.GuestProgramSpec{
+		ProgramPath:      "enable-ssh",
+		Arguments:        string(authorized_key),
+		WorkingDirectory: "/",
+		EnvVariables:     []string{},
+	}
+
+	_, err = processManager.StartProgram(op, &auth, &spec)
+	if err != nil {
+		err = errors.Errorf("Unable to enable SSH in appliance VM: %s", err)
+		op.Errorf("%s", err)
+		return err
+	}
+
+	if password == "" {
+		return nil
+	}
+
+	// set the password as well
+	spec = types.GuestProgramSpec{
+		ProgramPath:      "passwd",
+		Arguments:        password,
+		WorkingDirectory: "/",
+		EnvVariables:     []string{},
+	}
+
+	_, err = processManager.StartProgram(op, &auth, &spec)
+	if err != nil {
+		err = errors.Errorf("Unable to enable in appliance VM: %s", err)
+		op.Errorf("%s", err)
+		return err
+	}
+
+	return nil
+}

--- a/lib/install/management/dispatcher.go
+++ b/lib/install/management/dispatcher.go
@@ -50,6 +50,8 @@ type Dispatcher struct {
 	appliance *vm.VirtualMachine
 
 	oldApplianceISO string
+
+	sshEnabled bool
 }
 
 type diagnosticLog struct {

--- a/lib/install/management/inspect.go
+++ b/lib/install/management/inspect.go
@@ -61,10 +61,12 @@ func (d *Dispatcher) InspectVCH(vch *vm.VirtualMachine, conf *config.VirtualCont
 }
 
 func (d *Dispatcher) ShowVCH(conf *config.VirtualContainerHostConfigSpec, key string, cert string) {
-	// #1218: Temporarily disable SSH access for TP3
-	//	log.Infof("")
-	//	log.Infof("SSH to appliance (default=root:password)")
-	//	log.Infof("ssh root@%s", d.HostIP)
+	if d.sshEnabled {
+		log.Infof("")
+		log.Infof("SSH to appliance")
+		log.Infof("ssh root@%s", d.HostIP)
+	}
+
 	log.Infof("")
 	log.Infof("vic-admin portal:")
 	log.Infof("%s://%s:2378", d.VICAdminProto, d.HostIP)

--- a/tests/test-cases/Group6-VIC-Machine/6-11-Debug.robot
+++ b/tests/test-cases/Group6-VIC-Machine/6-11-Debug.robot
@@ -1,0 +1,23 @@
+*** Settings ***
+Documentation  Test 6-11 - Verify enable of ssh in the appliance
+Resource  ../../resources/Util.robot
+Test Setup  Install VIC Appliance To Test Server
+Test Teardown  Run Keyword If Test Failed  Cleanup VIC Appliance On Test Server
+
+*** Test Cases ***
+Enable SSH and verify
+    # generate a key to use for the Test
+    ${rc}=  Run And Return Rc  ssh-keygen -t rsa -N "" -f ${vch-name}.key
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}=  Run And Return Rc  chmod 600 ${vch-name}.key
+    Should Be Equal As Integers  ${rc}  0
+
+    ${rc}=  Run And Return Rc  bin/vic-machine-linux debug --target %{TEST_URL} --user %{TEST_USERNAME} --password=%{TEST_PASSWORD} --compute-resource=%{TEST_RESOURCE} --name ${vch-name} --enable-ssh --authorized-key=${vch-name}.key.pub
+    Should Be Equal As Integers  ${rc}  0
+
+    # check the ssh
+    ${rc}=  Run And Return Rc  ssh -vv -o StrictHostKeyChecking=no -i ${vch-name}.key root@${vch-ip} /bin/true
+    Should Be Equal As Integers  ${rc}  0
+
+    # delete the keys
+    Remove Files  ${vch-name}.key  ${vch-name}.key.pub 


### PR DESCRIPTION
This disables console and ssh access to the appliance VM by default.
Access can be restored by running vic-machine debug, with password and/or
ssh authorized key

This is something of a kludge on the vic-machine side at the moment as I
fully expect it to be merged into `vic-machine configure` when that's available.

Fixes #1218 
