### PR TITLE
VCH restart for network port layer

### DIFF
--- a/lib/apiservers/portlayer/restapi/handlers/containers_handlers.go
+++ b/lib/apiservers/portlayer/restapi/handlers/containers_handlers.go
@@ -201,7 +201,8 @@ func (handler *ContainersHandlersImpl) GetStateHandler(params containers.GetStat
 func (handler *ContainersHandlersImpl) GetHandler(params containers.GetParams) middleware.Responder {
 	defer trace.End(trace.Begin(params.ID))
 
-	h := exec.GetContainer(uid.Parse(params.ID))
+	ctx := context.Background()
+	h := exec.GetContainer(ctx, uid.Parse(params.ID))
 	if h == nil {
 		return containers.NewGetNotFound().WithPayload(&models.Error{Message: fmt.Sprintf("container %s not found", params.ID)})
 	}
@@ -235,7 +236,7 @@ func (handler *ContainersHandlersImpl) RemoveContainerHandler(params containers.
 
 	// get the indicated container for removal
 	cID := uid.Parse(params.ID)
-	h := exec.GetContainer(cID)
+	h := exec.GetContainer(context.Background(), cID)
 	if h == nil {
 		return containers.NewContainerRemoveNotFound()
 	}
@@ -292,7 +293,7 @@ func (handler *ContainersHandlersImpl) GetContainerListHandler(params containers
 func (handler *ContainersHandlersImpl) ContainerSignalHandler(params containers.ContainerSignalParams) middleware.Responder {
 	defer trace.End(trace.Begin(params.ID))
 
-	h := exec.GetContainer(uid.Parse(params.ID))
+	h := exec.GetContainer(context.Background(), uid.Parse(params.ID))
 	if h == nil {
 		return containers.NewContainerSignalNotFound().WithPayload(&models.Error{Message: fmt.Sprintf("container %s not found", params.ID)})
 	}
@@ -308,7 +309,7 @@ func (handler *ContainersHandlersImpl) ContainerSignalHandler(params containers.
 func (handler *ContainersHandlersImpl) GetContainerLogsHandler(params containers.GetContainerLogsParams) middleware.Responder {
 	defer trace.End(trace.Begin(params.ID))
 
-	h := exec.GetContainer(uid.Parse(params.ID))
+	h := exec.GetContainer(context.Background(), uid.Parse(params.ID))
 	if h == nil {
 		return containers.NewGetContainerLogsNotFound().WithPayload(&models.Error{
 			Message: fmt.Sprintf("container %s not found", params.ID),

--- a/lib/apiservers/portlayer/restapi/handlers/scopes_handlers.go
+++ b/lib/apiservers/portlayer/restapi/handlers/scopes_handlers.go
@@ -15,6 +15,7 @@
 package handlers
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"net/http"
@@ -110,7 +111,7 @@ func (handler *ScopesHandlersImpl) listScopes(idName string) ([]*models.ScopeCon
 
 				// this will "refresh" the container executor config that contains
 				// the current ip addresses
-				h := exec.GetContainer(cid)
+				h := exec.GetContainer(context.Background(), cid)
 				if h == nil {
 					return nil, fmt.Errorf("could not find container %s", cid)
 				}

--- a/lib/config/executor/network_interface.go
+++ b/lib/config/executor/network_interface.go
@@ -29,8 +29,11 @@ type NetworkEndpoint struct {
 	// Common.ID - pci slot of the vnic allowing for interface identifcation in-guest
 	Common
 
-	// IP address to assign - nil if DHCP
-	Static *net.IPNet `vic:"0.1" scope:"read-only" key:"staticip"`
+	// Whether this endpoint's IP was specified by the client (true if it was)
+	Static bool `vic:"0.1" scope:"read-only" key:"static"`
+
+	// IP address to assign
+	IP *net.IPNet `vic:"0.1" scope:"read-only" key:"eip"`
 
 	// Actual IP address assigned
 	Assigned net.IPNet `vic:"0.1" scope:"read-write" key:"ip"`

--- a/lib/config/virtual_container_host.go
+++ b/lib/config/virtual_container_host.go
@@ -101,7 +101,7 @@ type VirtualContainerHostConfigSpec struct {
 	BridgeNetwork       string `vic:"0.1" scope:"read-only" key:"bridge_network"`
 	CreateBridgeNetwork bool   `vic:"0.1" scope:"read-only" key:"create_bridge_network"`
 	// Published networks available for containers to join, keyed by consumption name
-	ContainerNetworks map[string]*executor.ContainerNetwork `vic:"0.1" scope:"read-write" key:"container_networks"`
+	ContainerNetworks map[string]*executor.ContainerNetwork `vic:"0.1" scope:"read-only" key:"container_networks"`
 	// The IP range for the bridge networks
 	BridgeIPRange *net.IPNet `vic:"0.1" scope:"read-only" key:"bridge-ip-range"`
 

--- a/lib/dns/dns_test.go
+++ b/lib/dns/dns_test.go
@@ -111,7 +111,7 @@ func TestVIC(t *testing.T) {
 	}
 
 	// initialize the context
-	ctx, err := network.NewContext(net.IPNet{IP: net.IPv4(172, 16, 0, 0), Mask: net.CIDRMask(12, 32)}, net.CIDRMask(16, 32), config)
+	ctx, err := network.NewContext(config)
 	if err != nil {
 		t.Fatalf("%s", err)
 	}

--- a/lib/install/validate/network.go
+++ b/lib/install/validate/network.go
@@ -145,7 +145,8 @@ func (v *Validator) network(ctx context.Context, input *data.Data, conf *config.
 			Name: "bridge",
 			ID:   bridgeID,
 		},
-		Static: &net.IPNet{IP: net.IPv4zero}, // static but managed externally
+		Static: true,
+		IP:     &net.IPNet{IP: net.IPv4zero}, // static but managed externally
 		Network: executor.ContainerNetwork{
 			Common: executor.Common{
 				Name: "bridge",

--- a/lib/install/validate/network.go
+++ b/lib/install/validate/network.go
@@ -28,6 +28,7 @@ import (
 	"github.com/vmware/vic/lib/config"
 	"github.com/vmware/vic/lib/config/executor"
 	"github.com/vmware/vic/lib/install/data"
+	"github.com/vmware/vic/lib/portlayer/constants"
 	"github.com/vmware/vic/pkg/errors"
 	"github.com/vmware/vic/pkg/ip"
 	"github.com/vmware/vic/pkg/trace"
@@ -151,7 +152,7 @@ func (v *Validator) network(ctx context.Context, input *data.Data, conf *config.
 				Name: "bridge",
 				ID:   netMoid,
 			},
-			Type: "bridge",
+			Type: constants.BridgeScopeType,
 		},
 	}
 	// we need to have the bridge network identified as an available container network
@@ -160,6 +161,10 @@ func (v *Validator) network(ctx context.Context, input *data.Data, conf *config.
 	// port forwarding
 	conf.AddNetwork(bridgeNet)
 	conf.BridgeIPRange = input.BridgeIPRange
+
+	externalNet := conf.Networks["external"].Network
+	externalNet.Type = constants.ExternalScopeType
+	conf.AddContainerNetwork(&externalNet)
 
 	err = v.checkVDSMembership(ctx, endpointMoref, input.BridgeNetworkName)
 	if err != nil && checkBridgeVDS {
@@ -230,7 +235,7 @@ func (v *Validator) network(ctx context.Context, input *data.Data, conf *config.
 				Name: name,
 				ID:   moref.String(),
 			},
-			Type:        "external",
+			Type:        constants.ExternalScopeType,
 			Gateway:     gw,
 			Nameservers: dns,
 			Pools:       pools,

--- a/lib/install/validate/network.go
+++ b/lib/install/validate/network.go
@@ -28,7 +28,6 @@ import (
 	"github.com/vmware/vic/lib/config"
 	"github.com/vmware/vic/lib/config/executor"
 	"github.com/vmware/vic/lib/install/data"
-	"github.com/vmware/vic/lib/portlayer/constants"
 	"github.com/vmware/vic/pkg/errors"
 	"github.com/vmware/vic/pkg/ip"
 	"github.com/vmware/vic/pkg/trace"
@@ -152,7 +151,7 @@ func (v *Validator) network(ctx context.Context, input *data.Data, conf *config.
 				Name: "bridge",
 				ID:   netMoid,
 			},
-			Type: constants.BridgeScopeType,
+			Type: "bridge",
 		},
 	}
 	// we need to have the bridge network identified as an available container network
@@ -161,10 +160,6 @@ func (v *Validator) network(ctx context.Context, input *data.Data, conf *config.
 	// port forwarding
 	conf.AddNetwork(bridgeNet)
 	conf.BridgeIPRange = input.BridgeIPRange
-
-	externalNet := conf.Networks["external"].Network
-	externalNet.Type = constants.ExternalScopeType
-	conf.AddContainerNetwork(&externalNet)
 
 	err = v.checkVDSMembership(ctx, endpointMoref, input.BridgeNetworkName)
 	if err != nil && checkBridgeVDS {
@@ -235,7 +230,7 @@ func (v *Validator) network(ctx context.Context, input *data.Data, conf *config.
 				Name: name,
 				ID:   moref.String(),
 			},
-			Type:        constants.ExternalScopeType,
+			Type:        "external",
 			Gateway:     gw,
 			Nameservers: dns,
 			Pools:       pools,

--- a/lib/portlayer/exec/container.go
+++ b/lib/portlayer/exec/container.go
@@ -329,8 +329,6 @@ func (c *Container) Commit(ctx context.Context, sess *session.Session, h *Handle
 		}
 	}
 
-	c.ExecConfig = &h.ExecConfig
-
 	return nil
 }
 

--- a/lib/portlayer/exec/container.go
+++ b/lib/portlayer/exec/container.go
@@ -121,12 +121,10 @@ func GetContainer(id uid.UID) *Handle {
 	// get from the cache
 	container := Containers.Container(id.String())
 	if container != nil {
-		// Call property collector to fill the data
-		container.Refresh(context.TODO())
 		return container.NewHandle()
 	}
-	return nil
 
+	return nil
 }
 
 func (s State) String() string {
@@ -151,18 +149,36 @@ func (s State) String() string {
 }
 
 func (c *Container) NewHandle() *Handle {
+	c.m.Lock()
+	defer c.m.Unlock()
+
+	// Call property collector to fill the data
+	if c.vm != nil {
+		if err := c.refresh(context.TODO()); err != nil {
+			log.Errorf("refreshing container %s failed: %s", c.ExecConfig.ID, err)
+			return nil
+		}
+	}
+
 	return newHandle(c)
 }
 
 // Refresh calls the propery collector to get config and runtime info and Guest RPC for ExtraConfig
 func (c *Container) Refresh(ctx context.Context) error {
+	c.m.Lock()
+	defer c.m.Unlock()
+
+	return c.refresh(ctx)
+}
+
+func (c *Container) refresh(ctx context.Context) error {
 	var o mo.VirtualMachine
 
 	// make sure we have vm
 	if c.vm == nil {
 		return fmt.Errorf("There is no backing VirtualMachine %#v", c)
 	}
-	if err := c.vm.Properties(ctx, c.vm.Reference(), []string{"config", "runtime"}, &o); err != nil {
+	if err := c.vm.Properties(ctx, c.vm.Reference(), []string{"config", "config.extraConfig", "runtime"}, &o); err != nil {
 		return err
 	}
 
@@ -170,11 +186,7 @@ func (c *Container) Refresh(ctx context.Context) error {
 	c.Runtime = &o.Runtime
 
 	// Get the ExtraConfig
-	src, err := extraconfig.GuestInfoSource()
-	if err != nil {
-		return err
-	}
-	extraconfig.Decode(src, c.ExecConfig)
+	extraconfig.Decode(vmomi.OptionValueSource(o.Config.ExtraConfig), c.ExecConfig)
 
 	return nil
 }
@@ -242,7 +254,7 @@ func (c *Container) Commit(ctx context.Context, sess *session.Session, h *Handle
 		h.Spec = nil
 
 		// refresh the struct with what propery collector provides
-		if err = c.Refresh(ctx); err != nil {
+		if err = c.refresh(ctx); err != nil {
 			return err
 		}
 	}
@@ -259,7 +271,7 @@ func (c *Container) Commit(ctx context.Context, sess *session.Session, h *Handle
 		commitEvent = events.ContainerStopped
 
 		// refresh the struct with what propery collector provides
-		if err := c.Refresh(ctx); err != nil {
+		if err := c.refresh(ctx); err != nil {
 			return err
 		}
 	}
@@ -296,7 +308,7 @@ func (c *Container) Commit(ctx context.Context, sess *session.Session, h *Handle
 		}
 
 		// refresh the struct with what propery collector provides
-		if err = c.Refresh(ctx); err != nil {
+		if err = c.refresh(ctx); err != nil {
 			return err
 		}
 	}
@@ -312,7 +324,7 @@ func (c *Container) Commit(ctx context.Context, sess *session.Session, h *Handle
 		commitEvent = events.ContainerStarted
 
 		// refresh the struct with what propery collector provides
-		if err := c.Refresh(ctx); err != nil {
+		if err := c.refresh(ctx); err != nil {
 			return err
 		}
 	}

--- a/lib/portlayer/exec/container_cache.go
+++ b/lib/portlayer/exec/container_cache.go
@@ -105,13 +105,13 @@ func (conCache *containerCache) Remove(idOrRef string) {
 }
 
 func (conCache *containerCache) sync(ctx context.Context, sess *session.Session) error {
+	conCache.m.Lock()
+	defer conCache.m.Unlock()
+
 	cons, err := infraContainers(ctx, sess)
 	if err != nil {
 		return err
 	}
-
-	conCache.m.Lock()
-	defer conCache.m.Unlock()
 
 	conCache.cache = make(map[string]*Container)
 	for _, c := range cons {

--- a/lib/portlayer/exec/exec.go
+++ b/lib/portlayer/exec/exec.go
@@ -156,7 +156,7 @@ func eventCallback(ie events.Event) {
 					ctx, cancel := context.WithTimeout(context.Background(), propertyCollectorTimeout)
 					defer cancel()
 
-					_, err := container.Update(ctx, container.vm.Session)
+					err := container.Refresh(ctx)
 					if err != nil {
 						log.Errorf("Event driven container update failed: %s", err.Error())
 					}

--- a/lib/portlayer/exec/handle.go
+++ b/lib/portlayer/exec/handle.go
@@ -180,15 +180,17 @@ func (h *Handle) Commit(ctx context.Context, sess *session.Session, waitTime *in
 	cfg := make(map[string]string)
 
 	// Set timestamps based on target state
-	switch *h.State {
-	case StateRunning:
-		se := h.ExecConfig.Sessions[h.ExecConfig.ID]
-		se.StartTime = time.Now().UTC().Unix()
-		h.ExecConfig.Sessions[h.ExecConfig.ID] = se
-	case StateStopped:
-		se := h.ExecConfig.Sessions[h.ExecConfig.ID]
-		se.StopTime = time.Now().UTC().Unix()
-		h.ExecConfig.Sessions[h.ExecConfig.ID] = se
+	if h.State != nil {
+		switch *h.State {
+		case StateRunning:
+			se := h.ExecConfig.Sessions[h.ExecConfig.ID]
+			se.StartTime = time.Now().UTC().Unix()
+			h.ExecConfig.Sessions[h.ExecConfig.ID] = se
+		case StateStopped:
+			se := h.ExecConfig.Sessions[h.ExecConfig.ID]
+			se.StopTime = time.Now().UTC().Unix()
+			h.ExecConfig.Sessions[h.ExecConfig.ID] = se
+		}
 	}
 
 	extraconfig.Encode(extraconfig.MapSink(cfg), h.ExecConfig)

--- a/lib/portlayer/exec/handle.go
+++ b/lib/portlayer/exec/handle.go
@@ -286,15 +286,3 @@ func (h *Handle) Create(ctx context.Context, sess *session.Session, config *Cont
 	h.SetSpec(linux.Spec())
 	return nil
 }
-
-func (h *Handle) Update(ctx context.Context, sess *session.Session) (*executor.ExecutorConfig, error) {
-	defer trace.End(trace.Begin("Handle.Create"))
-
-	ec, err := h.Container.Update(ctx, sess)
-	if err != nil {
-		return nil, err
-	}
-
-	h.ExecConfig = *ec
-	return ec, nil
-}

--- a/lib/portlayer/network/config.go
+++ b/lib/portlayer/network/config.go
@@ -30,7 +30,7 @@ type Configuration struct {
 	// The default bridge network supplied for the Virtual Container Host
 	BridgeNetwork string `vic:"0.1" scope:"read-only" key:"bridge_network"`
 	// Published networks available for containers to join, keyed by consumption name
-	ContainerNetworks map[string]*ContainerNetwork `vic:"0.1" scope:"read-write" key:"container_networks"`
+	ContainerNetworks map[string]*ContainerNetwork `vic:"0.1" scope:"read-only" key:"container_networks"`
 	// The bridge link
 	BridgeLink Link
 	// The IP range for the bridge networks

--- a/lib/portlayer/network/context.go
+++ b/lib/portlayer/network/context.go
@@ -124,7 +124,8 @@ func NewContext(config *Configuration) (*Context, error) {
 			pools[i] = p.String()
 		}
 
-		s, err := ctx.NewScope(n.Type, nn, &n.Gateway, n.Gateway.IP, n.Nameservers, pools)
+		subnet := net.IPNet{IP: n.Gateway.IP.Mask(n.Gateway.Mask), Mask: n.Gateway.Mask}
+		s, err := ctx.NewScope(n.Type, nn, &subnet, n.Gateway.IP, n.Nameservers, pools)
 		if err != nil {
 			return nil, err
 		}

--- a/lib/portlayer/network/context.go
+++ b/lib/portlayer/network/context.go
@@ -44,8 +44,6 @@ const (
 	DefaultBridgeName = "bridge"
 )
 
-var UnspecifiedIP = &net.IPNet{IP: net.IPv4zero}
-
 // Context denotes a networking context that represents a set of scopes, endpoints,
 // and containers. Each context has its own separate IPAM.
 type Context struct {

--- a/lib/portlayer/network/context.go
+++ b/lib/portlayer/network/context.go
@@ -44,6 +44,8 @@ const (
 	DefaultBridgeName = "bridge"
 )
 
+var UnspecifiedIP = &net.IPNet{IP: net.IPv4zero}
+
 // Context denotes a networking context that represents a set of scopes, endpoints,
 // and containers. Each context has its own separate IPAM.
 type Context struct {
@@ -547,13 +549,22 @@ func (c *Context) bindContainer(h *exec.Handle) ([]*Endpoint, error) {
 			s.removeContainer(con)
 		}()
 
-		var ip *net.IP
-		if ne.Static != nil {
-			ip = &ne.Static.IP
+		var eip *net.IP
+		if ne.Static {
+			eip = &ne.IP.IP
+		} else if !ip.IsUnspecifiedIP(ne.Assigned.IP) {
+			// for VCH restart, we need to reserve
+			// the IP of the running container
+			//
+			// this may be a DHCP assigned IP, however, the
+			// addContainer call below will ignore reserving
+			// an IP if the scope is "dynamic"
+			eip = &ne.Assigned.IP
 		}
 
-		var e *Endpoint
-		if e, err = s.addContainer(con, ip); err != nil {
+		e := newEndpoint(con, s, eip, s.subnet, s.gateway, nil)
+		e.static = ne.Static
+		if err = s.addContainer(con, e); err != nil {
 			return nil, err
 		}
 
@@ -568,10 +579,9 @@ func (c *Context) bindContainer(h *exec.Handle) ([]*Endpoint, error) {
 			}
 		}
 
-		eip := e.IP()
-		if eip != nil && !eip.IsUnspecified() {
-			ne.Static = &net.IPNet{
-				IP:   eip,
+		if !ip.IsUnspecifiedIP(e.IP()) {
+			ne.IP = &net.IPNet{
+				IP:   e.IP(),
 				Mask: e.Scope().Subnet().Mask,
 			}
 		}
@@ -705,18 +715,6 @@ func (c *Context) UnbindContainer(h *exec.Handle) ([]*Endpoint, error) {
 			return nil, &ResourceNotFoundError{}
 		}
 
-		defer func() {
-			if err == nil {
-				return
-			}
-
-			var ip *net.IP
-			if ne.Static != nil {
-				ip = &ne.Static.IP
-			}
-			s.addContainer(con, ip)
-		}()
-
 		// save the endpoint info
 		e := con.Endpoint(s).copy()
 
@@ -724,9 +722,8 @@ func (c *Context) UnbindContainer(h *exec.Handle) ([]*Endpoint, error) {
 			return nil, err
 		}
 
-		if !e.static {
-			ne.Static = nil
-		}
+		// clear out assigned ip
+		ne.Assigned.IP = net.IPv4zero
 
 		// aliases to remove
 		// name for dns lookup
@@ -931,8 +928,10 @@ func (c *Context) AddContainer(h *exec.Handle, options *AddContainerOptions) err
 		Ports: options.Ports,
 	}
 
-	if options.IP != nil && !options.IP.IsUnspecified() {
-		ne.Static = &net.IPNet{
+	ne.Static = false
+	if options.IP != nil && !ip.IsUnspecifiedIP(*options.IP) {
+		ne.Static = true
+		ne.IP = &net.IPNet{
 			IP:   *options.IP,
 			Mask: s.Subnet().Mask,
 		}

--- a/lib/portlayer/network/context.go
+++ b/lib/portlayer/network/context.go
@@ -437,22 +437,6 @@ func (c *Context) NewScope(scopeType, name string, subnet *net.IPNet, gateway ne
 		return nil, err
 	}
 
-	// add the new scope to the config
-	c.config.ContainerNetworks[s.Name()] = &ContainerNetwork{
-		Common: executor.Common{
-			ID:   s.ID().String(),
-			Name: s.Name(),
-		},
-		Type:        s.Type(),
-		Gateway:     net.IPNet{IP: s.Gateway(), Mask: s.Subnet().Mask},
-		Nameservers: s.DNS(),
-		Pools:       s.IPAM().Pools(),
-		PortGroup:   s.network,
-	}
-
-	// write config
-	c.config.Encode()
-
 	return s, nil
 }
 
@@ -917,6 +901,7 @@ func (c *Context) AddContainer(h *exec.Handle, options *AddContainerOptions) err
 			},
 			Aliases: options.Aliases,
 			Pools:   s.IPAM().Pools(),
+			Type:    s.Type(),
 		},
 		Ports: options.Ports,
 	}

--- a/lib/portlayer/network/context.go
+++ b/lib/portlayer/network/context.go
@@ -469,10 +469,15 @@ func (c *Context) findScopes(idName *string) ([]*Scope, error) {
 		}
 
 		// search by id or partial id
+		var ss []*Scope
 		for _, s := range c.scopes {
 			if strings.HasPrefix(s.id.String(), *idName) {
-				return []*Scope{s}, nil
+				ss = append(ss, s)
 			}
+		}
+
+		if len(ss) > 0 {
+			return ss, nil
 		}
 
 		return nil, ResourceNotFoundError{error: fmt.Errorf("scope %s not found", *idName)}
@@ -1087,6 +1092,11 @@ func (c *Context) UpdateContainer(h *exec.Handle) error {
 
 		e := con.Endpoint(s)
 		e.ip = ne.Assigned.IP
+		if ip.IsUnspecifiedSubnet(&ne.Network.Gateway) {
+			log.Warnf("updating container %s: gateway not present for scope %s", con.ID(), s.Name())
+			continue
+		}
+
 		gw, snet, err := net.ParseCIDR(ne.Network.Gateway.String())
 		if err != nil {
 			return err

--- a/lib/portlayer/network/context.go
+++ b/lib/portlayer/network/context.go
@@ -66,38 +66,57 @@ type AddContainerOptions struct {
 	Ports   []string
 }
 
-func NewContext(bridgePool net.IPNet, bridgeMask net.IPMask, config *Configuration) (*Context, error) {
+func NewContext(config *Configuration) (*Context, error) {
 	defer trace.End(trace.Begin(""))
 	if config == nil {
 		return nil, fmt.Errorf("missing config")
 	}
 
-	pones, pbits := bridgePool.Mask.Size()
-	mones, mbits := bridgeMask.Size()
+	bridgeRange := config.BridgeIPRange
+	if bridgeRange == nil || len(bridgeRange.IP) == 0 || bridgeRange.IP.IsUnspecified() {
+		var err error
+		_, bridgeRange, err = net.ParseCIDR("172.16.0.0/12")
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	bridgeWidth := config.BridgeNetworkWidth
+	if bridgeWidth == nil || len(*bridgeWidth) == 0 {
+		w := net.CIDRMask(16, 32)
+		bridgeWidth = &w
+	}
+
+	pones, pbits := bridgeRange.Mask.Size()
+	mones, mbits := bridgeWidth.Size()
 	if pbits != mbits || mones < pones {
 		return nil, fmt.Errorf("bridge mask is not compatible with bridge pool mask")
 	}
 
 	ctx := &Context{
 		config:            config,
-		defaultBridgeMask: bridgeMask,
-		defaultBridgePool: NewAddressSpaceFromNetwork(&bridgePool),
+		defaultBridgeMask: *bridgeWidth,
+		defaultBridgePool: NewAddressSpaceFromNetwork(bridgeRange),
 		scopes:            make(map[string]*Scope),
 		containers:        make(map[string]*Container),
 	}
 
-	s, err := ctx.newBridgeScope(uid.New(), DefaultBridgeName, nil, net.IPv4(0, 0, 0, 0), nil, &IPAM{})
+	n := ctx.config.ContainerNetworks[ctx.config.BridgeNetwork]
+	if n == nil {
+		return nil, fmt.Errorf("default bridge network %s not present in config", ctx.config.BridgeNetwork)
+	}
+
+	s, err := ctx.NewScope(n.Type, n.Name, nil, nil, nil, nil)
 	if err != nil {
 		return nil, err
 	}
 	s.builtin = true
-	s.dns = []net.IP{s.gateway}
 	ctx.defaultScope = s
 
 	// add any bridge/external networks
 	for nn, n := range ctx.config.ContainerNetworks {
-		if nn == DefaultBridgeName {
-			continue
+		if nn == ctx.config.BridgeNetwork {
+			continue // already added above
 		}
 
 		pools := make([]string, len(n.Pools))
@@ -105,14 +124,12 @@ func NewContext(bridgePool net.IPNet, bridgeMask net.IPMask, config *Configurati
 			pools[i] = p.String()
 		}
 
-		s, err := ctx.NewScope(n.Type, nn, &net.IPNet{IP: n.Gateway.IP.Mask(n.Gateway.Mask), Mask: n.Gateway.Mask}, n.Gateway.IP, n.Nameservers, pools)
+		s, err := ctx.NewScope(n.Type, nn, &n.Gateway, n.Gateway.IP, n.Nameservers, pools)
 		if err != nil {
 			return nil, err
 		}
 
-		if n.Type == constants.ExternalScopeType {
-			s.builtin = true
-		}
+		s.builtin = true
 	}
 
 	return ctx, nil

--- a/lib/portlayer/network/context_test.go
+++ b/lib/portlayer/network/context_test.go
@@ -104,8 +104,12 @@ func testConfig() *Configuration {
 		sink:          extraconfig.MapSink(map[string]string{}),
 		BridgeLink:    &mockLink{},
 		BridgeNetwork: "bridge",
+		BridgeIPRange: &net.IPNet{IP: net.ParseIP("172.16.0.0"), Mask: net.CIDRMask(12, 32)},
 		ContainerNetworks: map[string]*ContainerNetwork{
 			"bridge": {
+				Common: executor.Common{
+					Name: "bridge",
+				},
 				PortGroup: testBridgeNetwork,
 				Type:      constants.BridgeScopeType,
 			},
@@ -164,7 +168,7 @@ func TestMain(m *testing.M) {
 
 func TestMapExternalNetworks(t *testing.T) {
 	conf := testConfig()
-	ctx, err := NewContext(net.IPNet{IP: net.IPv4(172, 16, 0, 0), Mask: net.CIDRMask(12, 32)}, net.CIDRMask(16, 32), conf)
+	ctx, err := NewContext(conf)
 	if err != nil {
 		t.Fatalf("NewContext() => (nil, %s), want (ctx, nil)", err)
 	}
@@ -227,7 +231,7 @@ func TestMapExternalNetworks(t *testing.T) {
 }
 
 func TestContextNewScope(t *testing.T) {
-	ctx, err := NewContext(net.IPNet{IP: net.IPv4(172, 16, 0, 0), Mask: net.CIDRMask(12, 32)}, net.CIDRMask(16, 32), testConfig())
+	ctx, err := NewContext(testConfig())
 	if err != nil {
 		t.Fatalf("NewContext() => (nil, %s), want (ctx, nil)", err)
 	}
@@ -384,7 +388,7 @@ func TestContextNewScope(t *testing.T) {
 }
 
 func TestScopes(t *testing.T) {
-	ctx, err := NewContext(net.IPNet{IP: net.IPv4(172, 16, 0, 0), Mask: net.CIDRMask(12, 32)}, net.CIDRMask(16, 32), testConfig())
+	ctx, err := NewContext(testConfig())
 	if err != nil {
 		t.Fatalf("NewContext() => (nil, %s), want (ctx, nil)", err)
 		return
@@ -479,7 +483,7 @@ func TestScopes(t *testing.T) {
 }
 
 func TestContextAddContainer(t *testing.T) {
-	ctx, err := NewContext(net.IPNet{IP: net.IPv4(172, 16, 0, 0), Mask: net.CIDRMask(12, 32)}, net.CIDRMask(16, 32), testConfig())
+	ctx, err := NewContext(testConfig())
 	if err != nil {
 		t.Fatalf("NewContext() => (nil, %s), want (ctx, nil)", err)
 		return
@@ -645,7 +649,7 @@ func newContainer(name string) *exec.Handle {
 }
 
 func TestContextBindUnbindContainer(t *testing.T) {
-	ctx, err := NewContext(net.IPNet{IP: net.IPv4(172, 16, 0, 0), Mask: net.CIDRMask(12, 32)}, net.CIDRMask(16, 32), testConfig())
+	ctx, err := NewContext(testConfig())
 	if err != nil {
 		t.Fatalf("NewContext() => (nil, %s), want (ctx, nil)", err)
 	}
@@ -863,7 +867,7 @@ func TestContextRemoveContainer(t *testing.T) {
 
 	hFoo := newContainer("foo")
 
-	ctx, err := NewContext(net.IPNet{IP: net.IPv4(172, 16, 0, 0), Mask: net.CIDRMask(12, 32)}, net.CIDRMask(16, 32), testConfig())
+	ctx, err := NewContext(testConfig())
 	if err != nil {
 		t.Fatalf("NewContext() => (nil, %s), want (ctx, nil)", err)
 	}
@@ -967,7 +971,7 @@ func TestContextRemoveContainer(t *testing.T) {
 }
 
 func TestDeleteScope(t *testing.T) {
-	ctx, err := NewContext(net.IPNet{IP: net.IPv4(172, 16, 0, 0), Mask: net.CIDRMask(12, 32)}, net.CIDRMask(16, 32), testConfig())
+	ctx, err := NewContext(testConfig())
 	if err != nil {
 		t.Fatalf("NewContext() => (nil, %s), want (ctx, nil)", err)
 	}
@@ -1040,7 +1044,7 @@ func TestDeleteScope(t *testing.T) {
 }
 
 func TestAliases(t *testing.T) {
-	ctx, err := NewContext(net.IPNet{IP: net.IPv4(172, 16, 0, 0), Mask: net.CIDRMask(12, 32)}, net.CIDRMask(16, 32), testConfig())
+	ctx, err := NewContext(testConfig())
 	assert.NoError(t, err)
 	assert.NotNil(t, ctx)
 

--- a/lib/portlayer/network/context_test.go
+++ b/lib/portlayer/network/context_test.go
@@ -178,7 +178,7 @@ func TestMapExternalNetworks(t *testing.T) {
 
 	// check if external networks were loaded
 	for n, nn := range conf.ContainerNetworks {
-		scopes, err := ctx.Scopes(&n)
+		scopes, err := ctx.findScopes(&n)
 		if err != nil || len(scopes) != 1 {
 			t.Fatalf("external network %s was not loaded", n)
 		}
@@ -442,7 +442,7 @@ func TestScopes(t *testing.T) {
 	}
 
 	for _, te := range tests {
-		l, err := ctx.Scopes(te.in)
+		l, err := ctx.Scopes(context.TODO(), te.in)
 		if te.out == nil {
 			if err == nil {
 				t.Fatalf("Scopes() => (_, nil), want (_, err)")
@@ -839,7 +839,7 @@ func TestContextBindUnbindContainer(t *testing.T) {
 			}
 
 			// container should not be part of scope
-			scopes, err := ctx.Scopes(&s)
+			scopes, err := ctx.findScopes(&s)
 			if err != nil || len(scopes) != 1 {
 				t.Fatalf("%d: ctx.Scopes(%s) => (%#v, %#v)", i, s, scopes, err)
 			}
@@ -1033,7 +1033,7 @@ func TestDeleteScope(t *testing.T) {
 			continue
 		}
 
-		scopes, err := ctx.Scopes(&te.name)
+		scopes, err := ctx.findScopes(&te.name)
 		if _, ok := err.(ResourceNotFoundError); !ok || len(scopes) != 0 {
 			t.Fatalf("scope %s not deleted", te.name)
 		}

--- a/lib/portlayer/network/endpoint.go
+++ b/lib/portlayer/network/endpoint.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"net"
 
+	"github.com/vmware/vic/pkg/ip"
 	"github.com/vmware/vic/pkg/uid"
 )
 
@@ -54,7 +55,7 @@ func (a alias) scopedName() string {
 	return fmt.Sprintf("%s:%s:%s", a.ep.Scope().Name(), a.ep.Container().Name(), a.Name)
 }
 
-func newEndpoint(container *Container, scope *Scope, ip *net.IP, subnet net.IPNet, gateway net.IP, pciSlot *int32) *Endpoint {
+func newEndpoint(container *Container, scope *Scope, eip *net.IP, subnet net.IPNet, gateway net.IP, pciSlot *int32) *Endpoint {
 	e := &Endpoint{
 		container: container,
 		scope:     scope,
@@ -66,10 +67,8 @@ func newEndpoint(container *Container, scope *Scope, ip *net.IP, subnet net.IPNe
 		aliases:   make(map[string][]alias),
 	}
 
-	if ip != nil {
-		e.ip = *ip
-	}
-	if !e.ip.IsUnspecified() {
+	if eip != nil && !ip.IsUnspecifiedIP(*eip) {
+		e.ip = *eip
 		e.static = true
 	}
 

--- a/lib/portlayer/network/endpoint.go
+++ b/lib/portlayer/network/endpoint.go
@@ -35,8 +35,6 @@ type Endpoint struct {
 	container *Container
 	scope     *Scope
 	ip        net.IP
-	gateway   net.IP
-	subnet    net.IPNet
 	static    bool
 	ports     map[Port]interface{} // exposed ports
 	aliases   map[string][]alias
@@ -55,12 +53,10 @@ func (a alias) scopedName() string {
 	return fmt.Sprintf("%s:%s:%s", a.ep.Scope().Name(), a.ep.Container().Name(), a.Name)
 }
 
-func newEndpoint(container *Container, scope *Scope, eip *net.IP, subnet net.IPNet, gateway net.IP, pciSlot *int32) *Endpoint {
+func newEndpoint(container *Container, scope *Scope, eip *net.IP, pciSlot *int32) *Endpoint {
 	e := &Endpoint{
 		container: container,
 		scope:     scope,
-		gateway:   gateway,
-		subnet:    subnet,
 		ip:        net.IPv4(0, 0, 0, 0),
 		static:    false,
 		ports:     make(map[Port]interface{}),
@@ -105,7 +101,7 @@ func (e *Endpoint) Scope() *Scope {
 }
 
 func (e *Endpoint) Subnet() *net.IPNet {
-	return &e.subnet
+	return e.Scope().Subnet()
 }
 
 func (e *Endpoint) Container() *Container {
@@ -121,7 +117,7 @@ func (e *Endpoint) Name() string {
 }
 
 func (e *Endpoint) Gateway() net.IP {
-	return e.gateway
+	return e.Scope().Gateway()
 }
 
 func (e *Endpoint) Ports() []Port {

--- a/lib/portlayer/network/endpoint_test.go
+++ b/lib/portlayer/network/endpoint_test.go
@@ -23,13 +23,14 @@ import (
 
 func TestEndpointNameID(t *testing.T) {
 	c := &Container{id: "foo", name: "bar"}
-	s := &Scope{}
+	s := &Scope{
+		gateway: net.ParseIP("10.10.10.1"),
+		subnet:  net.IPNet{IP: net.ParseIP("10.10.10.0"), Mask: net.CIDRMask(24, 32)},
+	}
 	e := Endpoint{
 		container: c,
 		scope:     s,
 		ip:        net.ParseIP("10.10.10.10"),
-		gateway:   net.ParseIP("10.10.10.1"),
-		subnet:    net.IPNet{IP: net.ParseIP("10.10.10.0"), Mask: net.CIDRMask(24, 32)},
 		static:    true,
 		ports:     make(map[Port]interface{}),
 	}
@@ -40,13 +41,14 @@ func TestEndpointNameID(t *testing.T) {
 
 func TestEndpointCopy(t *testing.T) {
 	c := &Container{id: "foo"}
-	s := &Scope{}
+	s := &Scope{
+		gateway: net.ParseIP("10.10.10.1"),
+		subnet:  net.IPNet{IP: net.ParseIP("10.10.10.0"), Mask: net.CIDRMask(24, 32)},
+	}
 	e := Endpoint{
 		container: c,
 		scope:     s,
 		ip:        net.ParseIP("10.10.10.10"),
-		gateway:   net.ParseIP("10.10.10.1"),
-		subnet:    net.IPNet{IP: net.ParseIP("10.10.10.0"), Mask: net.CIDRMask(24, 32)},
 		static:    true,
 		ports:     make(map[Port]interface{}),
 	}
@@ -63,9 +65,9 @@ func TestEndpointCopy(t *testing.T) {
 	assert.Equal(t, other.scope, s)
 	assert.Equal(t, other.scope, e.scope)
 	assert.True(t, other.ip.Equal(e.ip), "other.ip (%s) != e.ip (%s)", other.ip, e.ip)
-	assert.True(t, other.gateway.Equal(e.gateway), "other.gateway (%s) != e.gateway (%s)", other.gateway, e.gateway)
-	assert.True(t, other.subnet.IP.Equal(e.subnet.IP), "other.subnet (%s) != e.subnet (%s)", other.subnet, e.subnet)
-	assert.Equal(t, other.subnet.Mask, e.subnet.Mask, "other.subnet (%s) != e.subnet (%s)", other.subnet, e.subnet)
+	assert.True(t, other.Gateway().Equal(e.Gateway()), "other.Gateway() (%s) != e.Gateway() (%s)", other.Gateway(), e.Gateway())
+	assert.True(t, other.Subnet().IP.Equal(e.Subnet().IP), "other.Subnet() (%s) != e.Subnet() (%s)", other.Subnet(), e.Subnet())
+	assert.Equal(t, other.Subnet().Mask, e.Subnet().Mask, "other.Subnet() (%s) != e.Subnet() (%s)", other.Subnet(), e.Subnet())
 	assert.EqualValues(t, other.ports, e.ports)
 
 	// make sure .ports is a copy

--- a/lib/portlayer/network/network.go
+++ b/lib/portlayer/network/network.go
@@ -104,8 +104,34 @@ func Init(ctx context.Context, sess *session.Session, source extraconfig.DataSou
 		// populate existing containers
 		state := exec.StateRunning
 		for _, c := range exec.Containers.Containers(&state) {
+			log.Debugf("adding container %s", c.ExecConfig.ID)
 			h := c.NewHandle()
 			defer h.Close()
+
+			// add any user created networks that show up in container's config
+			for n, ne := range h.ExecConfig.Networks {
+				var s []*Scope
+				s, err = netctx.Scopes(&n)
+				if err != nil {
+					if _, ok := err.(ResourceNotFoundError); !ok {
+						return
+					}
+				}
+
+				if len(s) > 0 {
+					continue
+				}
+
+				pools := make([]string, len(ne.Network.Pools))
+				for i, p := range ne.Network.Pools {
+					pools[i] = p.String()
+				}
+
+				log.Debugf("adding scope %s", n)
+				if _, err = netctx.NewScope(ne.Network.Type, n, nil, ne.Network.Gateway.IP, ne.Network.Nameservers, pools); err != nil {
+					return
+				}
+			}
 
 			if _, err = netctx.BindContainer(h); err != nil {
 				return

--- a/lib/portlayer/network/network.go
+++ b/lib/portlayer/network/network.go
@@ -17,7 +17,6 @@ package network
 import (
 	"context"
 	"fmt"
-	"net"
 	"sync"
 
 	log "github.com/Sirupsen/logrus"
@@ -55,7 +54,7 @@ func (e DuplicateResourceError) Error() string {
 }
 
 func Init(ctx context.Context, sess *session.Session, source extraconfig.DataSource, sink extraconfig.DataSink) error {
-	trace.End(trace.Begin("network.Init"))
+	trace.End(trace.Begin(""))
 
 	initializer.once.Do(func() {
 		var err error
@@ -86,35 +85,21 @@ func Init(ctx context.Context, sess *session.Session, source extraconfig.DataSou
 			n.PortGroup = r.(object.NetworkReference)
 		}
 
-		bridgeRange := config.BridgeIPRange
-		if bridgeRange == nil || len(bridgeRange.IP) == 0 || bridgeRange.IP.IsUnspecified() {
-			_, bridgeRange, err = net.ParseCIDR("172.16.0.0/12")
-			if err != nil {
-				return
-			}
-		}
-
 		// make sure a NIC attached to the bridge network exists
 		config.BridgeLink, err = getBridgeLink(&config)
 		if err != nil {
 			return
 		}
 
-		bridgeWidth := config.BridgeNetworkWidth
-		if bridgeWidth == nil || len(*bridgeWidth) == 0 {
-			w := net.CIDRMask(16, 32)
-			bridgeWidth = &w
-		}
-
 		var netctx *Context
-		netctx, err = NewContext(*bridgeRange, *bridgeWidth, &config)
+		netctx, err = NewContext(&config)
 		if err != nil {
 			return
 		}
 
 		if err = engageContext(netctx, exec.Config.EventManager); err == nil {
 			DefaultContext = netctx
-			log.Infof("Default network context allocated: %s", bridgeRange.String())
+			log.Infof("Default network context allocated")
 		}
 	})
 
@@ -195,7 +180,7 @@ func engageContext(netctx *Context, em event.EventManager) error {
 			}
 
 			log.Debugf("adding scope %s", n)
-			if _, err = netctx.newScope(ne.Network.Type, n, nil, ne.Network.Gateway.IP, ne.Network.Nameservers, pools); err != nil {
+			if _, err = netctx.newScope(ne.Network.Type, n, &ne.Network.Gateway, ne.Network.Gateway.IP, ne.Network.Nameservers, pools); err != nil {
 				return err
 			}
 		}

--- a/lib/portlayer/network/network.go
+++ b/lib/portlayer/network/network.go
@@ -154,8 +154,7 @@ func engageContext(netctx *Context, em event.EventManager) error {
 		}
 	}()
 
-	state := exec.StateRunning
-	for _, c := range exec.Containers.Containers(&state) {
+	for _, c := range exec.Containers.Containers(nil) {
 		log.Debugf("adding container %s", c.ExecConfig.ID)
 		h := c.NewHandle()
 		defer h.Close()
@@ -185,8 +184,10 @@ func engageContext(netctx *Context, em event.EventManager) error {
 			}
 		}
 
-		if _, err = netctx.bindContainer(h); err != nil {
-			return err
+		if *h.State == exec.StateRunning {
+			if _, err = netctx.bindContainer(h); err != nil {
+				return err
+			}
 		}
 	}
 

--- a/lib/portlayer/network/scope.go
+++ b/lib/portlayer/network/scope.go
@@ -21,12 +21,13 @@ import (
 
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/vic/lib/portlayer/constants"
+	"github.com/vmware/vic/lib/portlayer/exec"
 	"github.com/vmware/vic/pkg/ip"
 	"github.com/vmware/vic/pkg/uid"
 )
 
 type Scope struct {
-	sync.Mutex
+	sync.RWMutex
 
 	id         uid.UID
 	name       string
@@ -48,22 +49,37 @@ type IPAM struct {
 }
 
 func (s *Scope) Name() string {
+	s.RLock()
+	defer s.RUnlock()
+
 	return s.name
 }
 
 func (s *Scope) ID() uid.UID {
+	s.RLock()
+	defer s.RUnlock()
+
 	return s.id
 }
 
 func (s *Scope) Type() string {
+	s.RLock()
+	defer s.RUnlock()
+
 	return s.scopeType
 }
 
 func (s *Scope) IPAM() *IPAM {
+	s.RLock()
+	defer s.RUnlock()
+
 	return s.ipam
 }
 
 func (s *Scope) Network() object.NetworkReference {
+	s.RLock()
+	defer s.RUnlock()
+
 	return s.network
 }
 
@@ -112,7 +128,7 @@ func (s *Scope) releaseEndpointIP(e *Endpoint) error {
 	return fmt.Errorf("could not release IP for endpoint")
 }
 
-func (s *Scope) addContainer(con *Container, e *Endpoint) error {
+func (s *Scope) AddContainer(con *Container, e *Endpoint) error {
 	s.Lock()
 	defer s.Unlock()
 
@@ -135,11 +151,11 @@ func (s *Scope) addContainer(con *Container, e *Endpoint) error {
 	return nil
 }
 
-func (s *Scope) removeContainer(con *Container) error {
+func (s *Scope) RemoveContainer(con *Container) error {
 	s.Lock()
 	defer s.Unlock()
 
-	c, ok := s.containers[con.ID()]
+	c, ok := s.containers[con.id]
 	if !ok || c != con {
 		return ResourceNotFoundError{}
 	}
@@ -160,8 +176,8 @@ func (s *Scope) removeContainer(con *Container) error {
 }
 
 func (s *Scope) Containers() []*Container {
-	s.Lock()
-	defer s.Unlock()
+	s.RLock()
+	defer s.RUnlock()
 
 	containers := make([]*Container, len(s.containers))
 	i := 0
@@ -174,8 +190,8 @@ func (s *Scope) Containers() []*Container {
 }
 
 func (s *Scope) Container(id uid.UID) *Container {
-	s.Lock()
-	defer s.Unlock()
+	s.RLock()
+	defer s.RUnlock()
 
 	if c, ok := s.containers[id]; ok {
 		return c
@@ -185,12 +201,12 @@ func (s *Scope) Container(id uid.UID) *Container {
 }
 
 func (s *Scope) ContainerByAddr(addr net.IP) *Endpoint {
+	s.RLock()
+	defer s.RUnlock()
+
 	if addr == nil || addr.IsUnspecified() {
 		return nil
 	}
-
-	s.Lock()
-	defer s.Unlock()
 
 	for _, e := range s.endpoints {
 		if addr.Equal(e.IP()) {
@@ -202,21 +218,57 @@ func (s *Scope) ContainerByAddr(addr net.IP) *Endpoint {
 }
 
 func (s *Scope) Endpoints() []*Endpoint {
+	s.RLock()
+	defer s.RUnlock()
+
 	eps := make([]*Endpoint, len(s.endpoints))
 	copy(eps, s.endpoints)
 	return eps
 }
 
 func (s *Scope) Subnet() *net.IPNet {
+	s.RLock()
+	defer s.RUnlock()
+
 	return &s.subnet
 }
 
 func (s *Scope) Gateway() net.IP {
+	s.RLock()
+	defer s.RUnlock()
+
 	return s.gateway
 }
 
 func (s *Scope) DNS() []net.IP {
+	s.RLock()
+	defer s.RUnlock()
+
 	return s.dns
+}
+
+func (s *Scope) Refresh(h *exec.Handle) error {
+	s.Lock()
+	defer s.Unlock()
+
+	if !s.isDynamic() {
+		return nil
+	}
+
+	ne := h.ExecConfig.Networks[s.name]
+	if ip.IsUnspecifiedSubnet(&ne.Network.Gateway) {
+		return fmt.Errorf("updating container %s: gateway not present for scope %s", h.ExecConfig.ID, s.name)
+	}
+
+	gw, snet, err := net.ParseCIDR(ne.Network.Gateway.String())
+	if err != nil {
+		return err
+	}
+
+	s.gateway = gw
+	s.subnet = *snet
+
+	return nil
 }
 
 func (i *IPAM) Pools() []ip.Range {

--- a/lib/portlayer/network/scope_test.go
+++ b/lib/portlayer/network/scope_test.go
@@ -65,8 +65,8 @@ func TestScopeAddRemoveContainer(t *testing.T) {
 	}
 
 	for _, te := range tests1 {
-		var e *Endpoint
-		e, err = s.addContainer(te.c, te.ip)
+		e := newEndpoint(te.c, s, te.ip, s.subnet, s.gateway, nil)
+		err = s.addContainer(te.c, e)
 		if te.err != nil {
 			if err == nil {
 				t.Errorf("s.AddContainer() => (_, nil), want (_, err)")

--- a/lib/portlayer/network/scope_test.go
+++ b/lib/portlayer/network/scope_test.go
@@ -57,16 +57,16 @@ func TestScopeAddRemoveContainer(t *testing.T) {
 		// no container
 		{nil, nil, nil, fmt.Errorf("")},
 		// add a new container to scope
-		{&Container{id: idFoo}, nil, &Endpoint{ip: net.IPv4(172, 16, 0, 2), subnet: s.subnet, gateway: s.gateway}, nil},
+		{&Container{id: idFoo}, nil, &Endpoint{ip: net.IPv4(172, 16, 0, 2), scope: s}, nil},
 		// container already part of scope
 		{&Container{id: idFoo}, nil, nil, DuplicateResourceError{}},
 		// container with ip
-		{&Container{id: idBar}, makeIP(172, 16, 0, 3), &Endpoint{ip: net.IPv4(172, 16, 0, 3), subnet: s.subnet, gateway: s.gateway, static: true}, nil},
+		{&Container{id: idBar}, makeIP(172, 16, 0, 3), &Endpoint{ip: net.IPv4(172, 16, 0, 3), scope: s, static: true}, nil},
 	}
 
 	for _, te := range tests1 {
-		e := newEndpoint(te.c, s, te.ip, s.subnet, s.gateway, nil)
-		err = s.addContainer(te.c, e)
+		e := newEndpoint(te.c, s, te.ip, nil)
+		err = s.AddContainer(te.c, e)
 		if te.err != nil {
 			if err == nil {
 				t.Errorf("s.AddContainer() => (_, nil), want (_, err)")
@@ -104,8 +104,8 @@ func TestScopeAddRemoveContainer(t *testing.T) {
 			continue
 		}
 
-		if e.subnet.String() != s.subnet.String() {
-			t.Errorf("s.AddContainer() => e.subnet == %s, want e.subnet == %s", e.subnet, s.subnet)
+		if e.Subnet().String() != s.Subnet().String() {
+			t.Errorf("s.AddContainer() => e.Subnet() == %s, want e.Subnet() == %s", e.Subnet(), s.Subnet())
 			continue
 		}
 
@@ -160,7 +160,7 @@ func TestScopeAddRemoveContainer(t *testing.T) {
 	}
 
 	for _, te := range tests2 {
-		err = s.removeContainer(te.c)
+		err = s.RemoveContainer(te.c)
 		if te.err != nil {
 			if err == nil {
 				t.Errorf("s.RemoveContainer() => nil, want %v", te.err)

--- a/lib/portlayer/network/scope_test.go
+++ b/lib/portlayer/network/scope_test.go
@@ -37,7 +37,7 @@ var addEthernetCardErr = func(_ *exec.Handle, _ *Scope) (types.BaseVirtualDevice
 
 func TestScopeAddRemoveContainer(t *testing.T) {
 	var err error
-	ctx, err := NewContext(net.IPNet{IP: net.IPv4(172, 16, 0, 0), Mask: net.CIDRMask(12, 32)}, net.CIDRMask(16, 32), testConfig())
+	ctx, err := NewContext(testConfig())
 	if err != nil {
 		t.Errorf("NewContext() => (nil, %s), want (ctx, nil)", err)
 		return

--- a/lib/tether/config.go
+++ b/lib/tether/config.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/vmware/vic/lib/config/executor"
 	"github.com/vmware/vic/pkg/dio"
+	"github.com/vmware/vic/pkg/ip"
 )
 
 type ExecutorConfig struct {
@@ -103,8 +104,11 @@ type NetworkEndpoint struct {
 	// Common.ID - pci slot of the vnic allowing for interface identifcation in-guest
 	executor.Common
 
-	// IP address to assign - nil if DHCP
-	Static *net.IPNet `vic:"0.1" scope:"read-only" key:"staticip"`
+	// Whether this endpoint's IP was specified by the client (true if it was)
+	Static bool `vic:"0.1" scope:"read-only" key:"static"`
+
+	// IP address to assign
+	IP *net.IPNet `vic:"0.1" scope:"read-only" key:"eip"`
 
 	// Actual IP address assigned
 	Assigned net.IPNet `vic:"0.1" scope:"read-write" key:"ip"`
@@ -118,7 +122,7 @@ type NetworkEndpoint struct {
 }
 
 func (e *NetworkEndpoint) IsDynamic() bool {
-	return e.Static == nil || len(e.Static.IP) == 0
+	return !e.Static && (e.IP == nil || ip.IsUnspecifiedIP(e.IP.IP))
 }
 
 type DHCPInfo struct {

--- a/lib/tether/config_test.go
+++ b/lib/tether/config_test.go
@@ -55,7 +55,8 @@ func TestToExtraConfig(t *testing.T) {
 		},
 		Networks: map[string]*executor.NetworkEndpoint{
 			"eth0": {
-				Static: &net.IPNet{IP: localhost, Mask: lmask.Mask},
+				Static: true,
+				IP:     &net.IPNet{IP: localhost, Mask: lmask.Mask},
 				Network: executor.ContainerNetwork{
 					Common: executor.Common{
 						Name: "notsure",

--- a/lib/tether/net_linux_test.go
+++ b/lib/tether/net_linux_test.go
@@ -91,7 +91,8 @@ func TestSetIpAddress(t *testing.T) {
 					Default: true,
 					Gateway: *gwIP,
 				},
-				Static: &net.IPNet{
+				Static: true,
+				IP: &net.IPNet{
 					IP:   localhost,
 					Mask: lmask.Mask,
 				},
@@ -106,7 +107,8 @@ func TestSetIpAddress(t *testing.T) {
 						Name: "cnet",
 					},
 				},
-				Static: secondIP,
+				Static: true,
+				IP:     secondIP,
 			},
 			"external": {
 				Common: executor.Common{
@@ -119,7 +121,8 @@ func TestSetIpAddress(t *testing.T) {
 						Name: "external",
 					},
 				},
-				Static: &net.IPNet{
+				Static: true,
+				IP: &net.IPNet{
 					IP:   gateway,
 					Mask: gmask.Mask,
 				},

--- a/lib/tether/ops_linux.go
+++ b/lib/tether/ops_linux.go
@@ -465,8 +465,8 @@ func apply(nl Netlink, t *BaseOperations, endpoint *NetworkEndpoint) error {
 		}
 		newIP = &endpoint.DHCP.Assigned
 	} else {
-		newIP = endpoint.Static
-		if newIP.IP.IsUnspecified() {
+		newIP = endpoint.IP
+		if newIP.IP.Equal(net.IPv4zero) {
 			// managed externally
 			return nil
 		}

--- a/pkg/vsphere/extraconfig/basic_test.go
+++ b/pkg/vsphere/extraconfig/basic_test.go
@@ -202,6 +202,7 @@ func TestBasicSlice(t *testing.T) {
 	assert.Equal(t, expected, encoded, "Encoded and expected does not match")
 
 	var decoded Type
+	decoded.IntSlice = make([]int, 1)
 	Decode(MapSource(encoded), &decoded)
 
 	assert.Equal(t, IntSlice, decoded, "Encoded and decoded does not match")

--- a/pkg/vsphere/extraconfig/decode.go
+++ b/pkg/vsphere/extraconfig/decode.go
@@ -266,7 +266,7 @@ func decodeSlice(src DataSource, dest reflect.Value, prefix string, depth recurs
 	}
 
 	var this reflect.Value
-	if !dest.IsValid() || dest.IsNil() {
+	if !dest.IsValid() || dest.IsNil() || length > dest.Cap() {
 		log.Debugf("Making new slice for %s", prefix)
 		this = reflect.MakeSlice(dest.Type(), length, length)
 	} else {

--- a/tests/test-cases/Group10-VCH-Restart/10-1-VCH-Restart.robot
+++ b/tests/test-cases/Group10-VCH-Restart/10-1-VCH-Restart.robot
@@ -13,23 +13,13 @@ Get Container IP
     [Return]  ${ip}
 
 Launch Container
-    [Arguments]  ${name}  ${network}=default
-    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} run --name ${name} --net ${network} -itd busybox
+    [Arguments]  ${name}  ${network}=default  ${command}=sh
+    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} run --name ${name} --net ${network} -itd busybox ${command}
     Should Be Equal As Integers  ${rc}  0
     ${id}=  Get Line  ${output}  -1
-    ${ip}=  Get Container IP  ${id}  ${network}
-    [Return]  ${id}  ${ip}
-    
+    [Return]  ${id}
 
-*** Test Cases ***
-Created Network Persists And Containers Are Discovered With Correct IPs
-    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} network create foo
-    Should Be Equal As Integers  ${rc}  0
-    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} network create bar
-    Should Be Equal As Integers  ${rc}  0
-    Comment  Launch first container on bridge network
-    ${id1}  ${ip1}=  Launch Container  vch-restart-test1  bridge
-    ${id2}  ${ip2}=  Launch Container  vch-restart-test2  bar
+Reboot VCH
     Log To Console  Rebooting VCH ...
     ${rc}  ${output}=  Run And Return Rc And Output  govc vm.power -off=true ${vch-name}
     Should Be Equal As Integers  ${rc}  0
@@ -40,6 +30,18 @@ Created Network Persists And Containers Are Discovered With Correct IPs
     Log To Console  Waiting for VCH to power on ...
     Wait Until Vm Powers On  ${vch-name}
     Log To Console  VCH Powered On
+
+*** Test Cases ***
+Created Network Persists And Containers Are Discovered With Correct IPs
+    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} network create bar
+    Should Be Equal As Integers  ${rc}  0
+    ${bridge-exited}=  Launch Container  vch-restart-bridge-exited  bridge  ls
+    ${bridge-running}=  Launch Container  vch-restart-bridge-running  bridge
+    ${bridge-running-ip}=  Get Container IP  ${bridge-running}  bridge
+    ${bar-exited}=  Launch Container  vch-restart-bar-exited  bar  ls
+    ${bar-running}=  Launch Container  vch-restart-bar-running  bar
+    ${bar-running-ip}=  Get Container IP  ${bar-running}  bar
+    Reboot VCH
     Sleep  10
     Log To Console  Getting VCH IP ...
     ${new-vch-ip}=  Get VM IP  ${vch-name}
@@ -48,27 +50,31 @@ Created Network Persists And Containers Are Discovered With Correct IPs
     ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} network ls
     Should Be Equal As Integers  ${rc}  0
     Should Contain  ${output}  bar
+    Should Contain  ${output}  bridge
     ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} network inspect bridge
     Should Be Equal As Integers  ${rc}  0
     ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} network inspect bar
     Should Be Equal As Integers  ${rc}  0
-    ${ip}=  Get Container IP  ${id1}  bridge
-    Should Be Equal  ${ip}  ${ip1}
-    ${ip}=  Get Container IP  ${id2}  bar
-    Should Be Equal  ${ip}  ${ip2}
-    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} inspect vch-restart-test1
+    ${ip}=  Get Container IP  ${bridge-running}  bridge
+    Should Be Equal  ${ip}  ${bridge-running-ip}
+    ${ip}=  Get Container IP  ${bar-running}  bar
+    Should Be Equal  ${ip}  ${bar-running-ip}
+    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} inspect ${bridge-running} | jq '.[0].State.Status'
     Should Be Equal As Integers  ${rc}  0
-    Should Contain  ${output}  "Id"
-    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} stop vch-restart-test1
+    Should Be Equal  ${output}  \"running\"
+    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} inspect ${bar-running} | jq '.[0].State.Status'
     Should Be Equal As Integers  ${rc}  0
-    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} ps -a
+    Should Be Equal  ${output}  \"running\"
+    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} inspect ${bridge-exited} | jq '.[0].State.Status'
     Should Be Equal As Integers  ${rc}  0
-    Should Contain  ${output}  Exited (0)
-    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} start vch-restart-test1
+    Should Be Equal  ${output}  \"exited\"
+    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} inspect ${bar-exited} | jq '.[0].State.Status'
     Should Be Equal As Integers  ${rc}  0
-    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} ps -a
+    Should Be Equal  ${output}  \"exited\"
+    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} start ${bar-exited}
     Should Be Equal As Integers  ${rc}  0
-    Should Not Contain  ${output}  Exited (0)
+    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} start ${bridge-exited}
+    Should Be Equal As Integers  ${rc}  0
     ${status}=  Get State Of Github Issue  2448
     Run Keyword If  '${status}' == 'closed'  Fail  Test 10-1-VCH-Restart.robot needs to be updated now that Issue #2448 has been resolved
     Log  Issue \#2448 is blocking implementation  WARN

--- a/tests/test-cases/Group10-VCH-Restart/10-1-VCH-Restart.robot
+++ b/tests/test-cases/Group10-VCH-Restart/10-1-VCH-Restart.robot
@@ -23,15 +23,21 @@ Launch Container
 
 *** Test Cases ***
 Created Network Persists And Containers Are Discovered With Correct IPs
+    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} network create foo
+    Should Be Equal As Integers  ${rc}  0
     ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} network create bar
     Should Be Equal As Integers  ${rc}  0
     Comment  Launch first container on bridge network
     ${id1}  ${ip1}=  Launch Container  vch-restart-test1  bridge
-    ${id2}  ${ip2}=  Launch Container  vch-restart-test2  bridge
+    ${id2}  ${ip2}=  Launch Container  vch-restart-test2  bar
     Log To Console  Rebooting VCH ...
-    ${rc}  ${output}=  Run And Return Rc And Output  govc vm.power -reset=true ${vch-name}
+    ${rc}  ${output}=  Run And Return Rc And Output  govc vm.power -power=off ${vch-name}
     Should Be Equal As Integers  ${rc}  0
-    Log To Console  Waiting for VCH to boot ...
+    Log To Console  Waiting for VCH to power off ...
+    Wait Until VM Powers Off  ${vch-name}
+    ${rc}  ${output}=  Run And Return Rc And Output  govc vm.power -power=on ${vch-name}
+    Should Be Equal As Integers  ${rc}  0
+    Log To Console  Waiting for VCH to power on ...
     Wait Until Vm Powers On  ${vch-name}
     Log To Console  VCH Powered On
     Sleep  5
@@ -44,9 +50,11 @@ Created Network Persists And Containers Are Discovered With Correct IPs
     Should Contain  ${output}  bar
     ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} network inspect bridge
     Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} network inspect bar
+    Should Be Equal As Integers  ${rc}  0
     ${ip}=  Get Container IP  ${id1}  bridge
     Should Be Equal  ${ip}  ${ip1}
-    ${ip}=  Get Container IP  ${id2}  bridge
+    ${ip}=  Get Container IP  ${id2}  bar
     Should Be Equal  ${ip}  ${ip2}
     ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} inspect vch-restart-test1
     Should Be Equal As Integers  ${rc}  0
@@ -61,3 +69,8 @@ Created Network Persists And Containers Are Discovered With Correct IPs
     ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} ps -a
     Should Be Equal As Integers  ${rc}  0
     Should Not Contain  ${output}  Exited (0)
+    ${status}=  Get State Of Github Issue  2448
+    Run Keyword If  '${status}' == 'closed'  Fail  Test 10-1-VCH-Restart.robot needs to be updated now that Issue #2448 has been resolved
+    Log  Issue \#2448 is blocking implementation  WARN
+    #${rc}  ${output}=  Run And Return Rc And Output  docker ${params} network inspect foo
+    #Should Be Equal As Integers  ${rc}  0

--- a/tests/test-cases/Group10-VCH-Restart/10-1-VCH-Restart.robot
+++ b/tests/test-cases/Group10-VCH-Restart/10-1-VCH-Restart.robot
@@ -31,16 +31,16 @@ Created Network Persists And Containers Are Discovered With Correct IPs
     ${id1}  ${ip1}=  Launch Container  vch-restart-test1  bridge
     ${id2}  ${ip2}=  Launch Container  vch-restart-test2  bar
     Log To Console  Rebooting VCH ...
-    ${rc}  ${output}=  Run And Return Rc And Output  govc vm.power -power=off ${vch-name}
+    ${rc}  ${output}=  Run And Return Rc And Output  govc vm.power -off=true ${vch-name}
     Should Be Equal As Integers  ${rc}  0
     Log To Console  Waiting for VCH to power off ...
     Wait Until VM Powers Off  ${vch-name}
-    ${rc}  ${output}=  Run And Return Rc And Output  govc vm.power -power=on ${vch-name}
+    ${rc}  ${output}=  Run And Return Rc And Output  govc vm.power -on=true ${vch-name}
     Should Be Equal As Integers  ${rc}  0
     Log To Console  Waiting for VCH to power on ...
     Wait Until Vm Powers On  ${vch-name}
     Log To Console  VCH Powered On
-    Sleep  5
+    Sleep  10
     Log To Console  Getting VCH IP ...
     ${new-vch-ip}=  Get VM IP  ${vch-name}
     Log To Console  New VCH IP is ${new-vch-ip}


### PR DESCRIPTION
Includes:
* Rebuilding network layer objects from containers VM configs that are present in the VCH's resource pool. The big assumption here is that the state of the containers does not change during recreation of the various network objects, with one exception: running containers that stop during recreation. The latter case will be handled by the event callback from vSphere.
* General fixes for data races in exec and network layers
* Fix for container refresh code when listing scopes. This is only done for containers that are connected to a scope that is not managed by the network layer, i.e. containers that are connected to networks with DHCP.