### PR TITLE
Manually install govmomi to avoid gocov breakage in unit tests

### DIFF
--- a/infra/scripts/coverage.sh
+++ b/infra/scripts/coverage.sh
@@ -70,6 +70,8 @@ show_cover_report() {
     go tool cover -${1}="$profile"
 }
 
+# manually install govmomi so the huge types package doesn't break cover
+go install ./vendor/github.com/vmware/govmomi
 generate_pkg_cover_data $(dir_to_pkg "$@")
 
 show_cover_report func


### PR DESCRIPTION
Add a line to install govmomi before we call go coverage so that the govmomi types package doesn't break gocov as seen in #2329 

 Hopefully this will resolve this issue. Locally I have been able to run `docker run -v $(pwd):/go/src/github.com/vmware/vic -w /go/src/github.com/vmware/vic golang:1.7 make -j3 all test` successfully several times, and was able to run the tests successfully in Drone a number of times as well (with the old WIP name of the PR displayed on these jobs):

https://ci.vmware.run/vmware/vic/5482
https://ci.vmware.run/vmware/vic/5484
https://ci.vmware.run/vmware/vic/5486
https://ci.vmware.run/vmware/vic/5487