### PR TITLE
Renames container logs and simplifies the fetch code in vicadmin

### DIFF
--- a/cmd/vicadmin/vicadm.go
+++ b/cmd/vicadmin/vicadm.go
@@ -354,10 +354,8 @@ func findDatastoreLogs(c *session.Session) (map[string]entryReader, error) {
 		for _, file := range vmFiles {
 			// replace the VM token in file name with the VM name
 			//FIXME: this is currently a workaround until we rename the tether logs
-			vmHashName := strings.Split(logfile.VMName, "-")
-			processed := strings.Replace(file, string(vchconfig.VM), vmHashName[1], -1)
-			wpath := fmt.Sprintf("%s/%s", logfile.VMName, processed)
-			rpath := fmt.Sprintf("%s/%s", logfile.URL.Path, processed)
+			wpath := fmt.Sprintf("%s/%s", logfile.VMName, file)
+			rpath := fmt.Sprintf("%s/%s", logfile.URL.Path, file)
 			log.Infof("Processed File read Path : %s", rpath)
 			log.Infof("Processed File write Path : %s", wpath)
 			readers[wpath] = datastoreReader{

--- a/cmd/vicadmin/vicadm.go
+++ b/cmd/vicadmin/vicadm.go
@@ -352,8 +352,6 @@ func findDatastoreLogs(c *session.Session) (map[string]entryReader, error) {
 
 		// generate the full paths to collect
 		for _, file := range vmFiles {
-			// replace the VM token in file name with the VM name
-			//FIXME: this is currently a workaround until we rename the tether logs
 			wpath := fmt.Sprintf("%s/%s", logfile.VMName, file)
 			rpath := fmt.Sprintf("%s/%s", logfile.URL.Path, file)
 			log.Infof("Processed File read Path : %s", rpath)

--- a/cmd/vicadmin/vicadm.go
+++ b/cmd/vicadmin/vicadm.go
@@ -63,8 +63,8 @@ var (
 
 	// VMFiles is the set of files to collect per VM associated with the VCH
 	vmFiles = []string{
-		"vmware.log",
-		string(vchconfig.VM + ".debug"),
+		"output.log",
+		"tether.debug",
 	}
 
 	config struct {

--- a/lib/portlayer/exec/container.go
+++ b/lib/portlayer/exec/container.go
@@ -60,6 +60,7 @@ const (
 	StateRemoved
 
 	propertyCollectorTimeout = 3 * time.Minute
+	containerLogName         = "output.log"
 )
 
 // NotFoundError is returned when a types.ManagedObjectNotFound is returned from a vmomi call
@@ -519,7 +520,7 @@ func (c *Container) LogReader(ctx context.Context, tail int, follow bool) (io.Re
 		return nil, err
 	}
 
-	name := fmt.Sprintf("%s/%s.log", url.Path, c.ExecConfig.ID)
+	name := fmt.Sprintf("%s/%s", url.Path, containerLogName)
 
 	log.Infof("pulling %s", name)
 

--- a/lib/portlayer/logging/logging.go
+++ b/lib/portlayer/logging/logging.go
@@ -35,11 +35,10 @@ func Join(h interface{}) (interface{}, error) {
 	handle.SetSpec(nil)
 
 	VMPathName := handle.Spec.VMPathName()
-	VMID := handle.Spec.ID()
 	VMName := handle.Spec.Spec().Name
 
-	for _, suffix := range []string{"debug", "log"} {
-		filename := fmt.Sprintf("%s/%s/%s.%s", VMPathName, VMName, VMID, suffix)
+	for _, suffix := range []string{"tether.debug", "output.log"} {
+		filename := fmt.Sprintf("%s/%s/%s", VMPathName, VMName, suffix)
 
 		// Debug and log serial ports - backed by datastore file
 		serial := &types.VirtualSerialPort{

--- a/tests/resources/Util.robot
+++ b/tests/resources/Util.robot
@@ -403,7 +403,8 @@ Run Regression Tests
     ${rc}  ${output}=  Run And Return Rc and Output  curl -sk ${vic-admin}/container-logs.tar.gz | tar tvzf -
     Should Be Equal As Integers  ${rc}  0
     Log  ${output}
-    Should Contain  ${output}  ${container}/vmware.log
+    Should Contain  ${output}  ${container}/output.log
+    Should Contain  ${output}  ${container}/tether.debug
     ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} rm ${container}
     Should Be Equal As Integers  ${rc}  0
     ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} ps -a

--- a/tests/test-cases/Group9-VIC-Admin/9-1-VICAdmin-ShowHTML.robot
+++ b/tests/test-cases/Group9-VIC-Admin/9-1-VICAdmin-ShowHTML.robot
@@ -35,8 +35,8 @@ Get Container Logs
     ${rc}  ${output}=  Run And Return Rc and Output  curl -sk ${vic-admin}/container-logs.tar.gz | tar tvzf -
     Should Be Equal As Integers  ${rc}  0
     Log  ${output}
-    Should Contain  ${output}  ${container}/vmware.log
-    Should Match Regexp  ${output}  ${container}/*.debug
+    Should Contain  ${output}  ${container}/output.log
+    Should Contain  ${output}  ${container}/tether.debug
 
 Get VICAdmin Log
     ${rc}  ${output}=  Run And Return Rc And Output  curl -sk ${vic-admin}/logs/vicadmin.log


### PR DESCRIPTION
Renames the log files that are output by the container and the tether. This results in a much simpler approach to fetching container logs in `vicadmin`. It also should lead to much less brittle log handling when it comes to container logs. 

Fixes #2562 
Fixes #2467 

