### PR TITLE
Fix tether log file name

### DIFF
--- a/tests/test-cases/Group1-Docker-Commands/1-7-Docker-Stop.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-7-Docker-Stop.robot
@@ -35,7 +35,7 @@ Assert Kill Signal
     Run Keyword If  '%{HOST_TYPE}' == 'ESXi'  Should Be Equal  ${output}  poweredOff
     ${rc}  ${dir}=  Run And Return Rc And Output  govc datastore.ls *-${id}
     Should Be Equal As Integers  ${rc}  0
-    ${rc}  ${output}=  Run And Return Rc And Output  govc datastore.download ${dir}/${id}.debug -
+    ${rc}  ${output}=  Run And Return Rc And Output  govc datastore.download ${dir}/tether.debug -
     Should Be Equal As Integers  ${rc}  0
     Run Keyword If  ${expect}  Should Contain  ${output}  sending signal KILL
     Run Keyword Unless  ${expect}  Should Not Contain  ${output}  sending signal KILL


### PR DESCRIPTION
Fixes the name of the tether log file in [`1-7-Docker-Stop`](https://github.com/vmware/vic/blob/master/tests/test-cases/Group1-Docker-Commands/1-7-Docker-Stop.robot#L38), which was changed in #2604.

This should fix integration test failures in `1-7-Docker-Stop`. Verified locally.