### PR TITLE
Restore collection of vmware.log

### DIFF
--- a/cmd/vicadmin/vicadm.go
+++ b/cmd/vicadmin/vicadm.go
@@ -63,7 +63,7 @@ var (
 
 	// VMFiles is the set of files to collect per VM associated with the VCH
 	vmFiles = []string{
-		"output.log",
+		"vmware.log",
 		"tether.debug",
 	}
 

--- a/lib/portlayer/logging/logging.go
+++ b/lib/portlayer/logging/logging.go
@@ -37,8 +37,8 @@ func Join(h interface{}) (interface{}, error) {
 	VMPathName := handle.Spec.VMPathName()
 	VMName := handle.Spec.Spec().Name
 
-	for _, suffix := range []string{"tether.debug", "output.log"} {
-		filename := fmt.Sprintf("%s/%s/%s", VMPathName, VMName, suffix)
+	for _, logFile := range []string{"tether.debug", "output.log"} {
+		filename := fmt.Sprintf("%s/%s/%s", VMPathName, VMName, logFile)
 
 		// Debug and log serial ports - backed by datastore file
 		serial := &types.VirtualSerialPort{

--- a/tests/resources/Util.robot
+++ b/tests/resources/Util.robot
@@ -403,7 +403,7 @@ Run Regression Tests
     ${rc}  ${output}=  Run And Return Rc and Output  curl -sk ${vic-admin}/container-logs.tar.gz | tar tvzf -
     Should Be Equal As Integers  ${rc}  0
     Log  ${output}
-    Should Contain  ${output}  ${container}/output.log
+    Should Contain  ${output}  ${container}/vmware.log
     Should Contain  ${output}  ${container}/tether.debug
     ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} rm ${container}
     Should Be Equal As Integers  ${rc}  0

--- a/tests/test-cases/Group9-VIC-Admin/9-1-VICAdmin-ShowHTML.robot
+++ b/tests/test-cases/Group9-VIC-Admin/9-1-VICAdmin-ShowHTML.robot
@@ -35,7 +35,7 @@ Get Container Logs
     ${rc}  ${output}=  Run And Return Rc and Output  curl -sk ${vic-admin}/container-logs.tar.gz | tar tvzf -
     Should Be Equal As Integers  ${rc}  0
     Log  ${output}
-    Should Contain  ${output}  ${container}/output.log
+    Should Contain  ${output}  ${container}/vmware.log
     Should Contain  ${output}  ${container}/tether.debug
 
 Get VICAdmin Log


### PR DESCRIPTION
Restores the collection of vmware.log for the VMs and drops
collecting the containerVM output, which is purely customer application
data. Also renames misnamed variables.
Original changes were in #2604 

Fixes #2604 

