### PR TITLE
Implements image volumes

### DIFF
--- a/lib/apiservers/engine/backends/container.go
+++ b/lib/apiservers/engine/backends/container.go
@@ -1474,6 +1474,17 @@ func setCreateConfigOptions(config, imageConfig *containertypes.Config) {
 		config.Entrypoint = imageConfig.Entrypoint
 	}
 
+	if config.Volumes == nil {
+		config.Volumes = imageConfig.Volumes
+	} else {
+		for k, v := range imageConfig.Volumes {
+			//NOTE: the value of the map is an empty struct.
+			//      we also do not care about duplicates.
+			//      This Volumes map is really a Set.
+			config.Volumes[k] = v
+		}
+	}
+
 	// set up environment
 	setEnvFromImageConfig(config, imageConfig)
 }

--- a/lib/apiservers/engine/backends/container_proxy.go
+++ b/lib/apiservers/engine/backends/container_proxy.go
@@ -745,7 +745,7 @@ func finalizeVolumeList(specifiedVolumes, anonymousVolumes []string) ([]volumeFi
 	}
 
 	finalizedVolumes := make([]volumeFields, 0, len(processedAnonVolumes))
-	for _, v := range processedVolumes {
+	for _, v := range processedAnonVolumes {
 		finalizedVolumes = append(finalizedVolumes, v)
 	}
 	return finalizedVolumes, nil

--- a/lib/apiservers/engine/backends/container_proxy.go
+++ b/lib/apiservers/engine/backends/container_proxy.go
@@ -226,30 +226,34 @@ func (c *ContainerProxy) AddVolumesToContainer(handle string, config types.Conta
 
 	// Collect all volume mappings. In a docker create/run, they
 	// can be anonymous (-v /dir) or specific (-v vol-name:/dir).
-	volumes := config.HostConfig.Binds
-	for anonVol := range config.Config.Volumes {
-		volumes = append(volumes, anonVol)
+	// anonymous volumes can also come from Image Metadata
+
+	rawAnonVolumes := make([]string, 0, len(config.Config.Volumes))
+	for k := range config.Config.Volumes {
+		rawAnonVolumes = append(rawAnonVolumes, k)
 	}
 
-	volList, err := processVolumeFields(volumes)
+	volList, err := finalizeVolumeList(config.HostConfig.Binds, rawAnonVolumes)
 	if err != nil {
 		return handle, BadRequestError(err.Error())
 	}
+
+	log.Infof("Finalized Volume list : %#v", volList)
 
 	// Create and join volumes.
 	for _, fields := range volList {
 
 		//we only set these here for volumes made on a docker create
-		driverArgs := make(map[string]string)
-		driverArgs[DriverArgFlagKey] = fields.Flags
-		driverArgs[DriverArgContainerKey] = config.Name
-		driverArgs[DriverArgImageKey] = config.Config.Image
+		volumeData := make(map[string]string)
+		volumeData[DriverArgFlagKey] = fields.Flags
+		volumeData[DriverArgContainerKey] = config.Name
+		volumeData[DriverArgImageKey] = config.Config.Image
 
 		// NOTE: calling volumeCreate regardless of whether the volume is already
 		// present can be avoided by adding an extra optional param to VolumeJoin,
 		// which would then call volumeCreate if the volume does not exist.
 		vol := &Volume{}
-		_, err := vol.volumeCreate(fields.ID, "vsphere", driverArgs, nil)
+		_, err := vol.volumeCreate(fields.ID, "vsphere", volumeData, nil)
 		if err != nil {
 			switch err := err.(type) {
 			case *storage.CreateVolumeConflict:
@@ -257,7 +261,7 @@ func (c *ContainerProxy) AddVolumesToContainer(handle string, config types.Conta
 				// already exists. We can just join the said volume to the container.
 				log.Infof("a volume with the name %s already exists", fields.ID)
 			case *storage.CreateVolumeNotFound:
-				return handle, VolumeCreateNotFoundError(volumeStore(driverArgs))
+				return handle, VolumeCreateNotFoundError(volumeStore(volumeData))
 			default:
 				return handle, InternalServerError(err.Error())
 			}
@@ -706,8 +710,10 @@ func processVolumeParam(volString string) (volumeFields, error) {
 }
 
 // processVolumeFields parses fields for volume mappings specified in a create/run -v.
-func processVolumeFields(volumes []string) ([]volumeFields, error) {
-	var volumeFields []volumeFields
+// It returns a map of unique mountable volumes. This means that it removes dupes favoring
+// specified volumes over anonymous volumes.
+func processVolumeFields(volumes []string) (map[string]volumeFields, error) {
+	volumeFields := make(map[string]volumeFields)
 
 	for _, v := range volumes {
 		fields, err := processVolumeParam(v)
@@ -715,9 +721,36 @@ func processVolumeFields(volumes []string) ([]volumeFields, error) {
 		if err != nil {
 			return nil, err
 		}
-		volumeFields = append(volumeFields, fields)
+		volumeFields[fields.Dest] = fields
 	}
 	return volumeFields, nil
+}
+
+func finalizeVolumeList(specifiedVolumes, anonymousVolumes []string) ([]volumeFields, error) {
+	log.Infof("Specified Volumes : %#v", specifiedVolumes)
+	processedVolumes, err := processVolumeFields(specifiedVolumes)
+	if err != nil {
+		return nil, err
+	}
+
+	log.Infof("anonymous Volumes : %#v", anonymousVolumes)
+	processedAnonVolumes, err := processVolumeFields(anonymousVolumes)
+	if err != nil {
+		return nil, err
+	}
+
+	//combine all volumes, specified volumes are taken over anonymous volumes
+	for k, v := range processedAnonVolumes {
+		if _, ok := processedVolumes[k]; !ok {
+			processedVolumes[k] = v
+		}
+	}
+
+	finalizedVolumes := make([]volumeFields, 0, len(processedVolumes))
+	for _, v := range processedVolumes {
+		finalizedVolumes = append(finalizedVolumes, v)
+	}
+	return finalizedVolumes, nil
 }
 
 //-------------------------------------

--- a/lib/apiservers/engine/backends/container_proxy.go
+++ b/lib/apiservers/engine/backends/container_proxy.go
@@ -740,13 +740,11 @@ func finalizeVolumeList(specifiedVolumes, anonymousVolumes []string) ([]volumeFi
 	}
 
 	//combine all volumes, specified volumes are taken over anonymous volumes
-	for k, v := range processedAnonVolumes {
-		if _, ok := processedVolumes[k]; !ok {
-			processedVolumes[k] = v
-		}
+	for k, v := range processedVolumes {
+		processedAnonVolumes[k] = v
 	}
 
-	finalizedVolumes := make([]volumeFields, 0, len(processedVolumes))
+	finalizedVolumes := make([]volumeFields, 0, len(processedAnonVolumes))
 	for _, v := range processedVolumes {
 		finalizedVolumes = append(finalizedVolumes, v)
 	}

--- a/lib/apiservers/engine/backends/container_proxy.go
+++ b/lib/apiservers/engine/backends/container_proxy.go
@@ -109,6 +109,10 @@ const (
 	forceLogType                         = "json-file" //Use in inspect to allow docker logs to work
 	annotationKeyLabels                  = "docker.labels"
 	killWaitForExit        time.Duration = 2 * time.Second
+
+	DriverArgFlagKey      = "flags"
+	DriverArgContainerKey = "Container"
+	DriverArgImageKey     = "Image"
 )
 
 // NewContainerProxy creates a new ContainerProxy
@@ -236,7 +240,9 @@ func (c *ContainerProxy) AddVolumesToContainer(handle string, config types.Conta
 	for _, fields := range volList {
 
 		driverArgs := make(map[string]string)
-		driverArgs["flags"] = fields.Flags
+		driverArgs[DriverArgFlagKey] = fields.Flags
+		driverArgs[DriverArgContainerKey] = config.Name
+		driverArgs[DriverArgImageKey] = config.Config.Image
 
 		// NOTE: calling volumeCreate regardless of whether the volume is already
 		// present can be avoided by adding an extra optional param to VolumeJoin,

--- a/lib/apiservers/engine/backends/container_proxy.go
+++ b/lib/apiservers/engine/backends/container_proxy.go
@@ -239,6 +239,7 @@ func (c *ContainerProxy) AddVolumesToContainer(handle string, config types.Conta
 	// Create and join volumes.
 	for _, fields := range volList {
 
+		//we only set these here for volumes made on a docker create
 		driverArgs := make(map[string]string)
 		driverArgs[DriverArgFlagKey] = fields.Flags
 		driverArgs[DriverArgContainerKey] = config.Name

--- a/lib/apiservers/engine/backends/volume.go
+++ b/lib/apiservers/engine/backends/volume.go
@@ -223,12 +223,14 @@ type volumeMetadata struct {
 	Image         string
 }
 
-func createVolumeMetadata(req *models.VolumeRequest, labels map[string]string, Container, Image string) (string, error) {
+func createVolumeMetadata(req *models.VolumeRequest, driverargs, labels map[string]string) (string, error) {
 	metadata := volumeMetadata{
-		Driver:     req.Driver,
-		DriverOpts: req.DriverArgs,
-		Name:       req.Name,
-		Labels:     labels,
+		Driver:        req.Driver,
+		DriverOpts:    req.DriverArgs,
+		Name:          req.Name,
+		Labels:        labels,
+		AttachHistory: []string{driverargs[DriverArgContainerKey]},
+		Image:         driverargs[DriverArgImageKey],
 	}
 	result, err := json.Marshal(metadata)
 	return string(result), err
@@ -268,7 +270,7 @@ func newVolumeCreateReq(name, driverName string, driverArgs, labels map[string]s
 		Metadata:   make(map[string]string),
 	}
 
-	metadata, err := createVolumeMetadata(req, labels)
+	metadata, err := createVolumeMetadata(req, driverArgs, labels)
 	if err != nil {
 		return nil, err
 	}

--- a/lib/apiservers/engine/backends/volume.go
+++ b/lib/apiservers/engine/backends/volume.go
@@ -215,13 +215,15 @@ func (v *Volume) VolumeRm(name string) error {
 }
 
 type volumeMetadata struct {
-	Driver     string
-	DriverOpts map[string]string
-	Name       string
-	Labels     map[string]string
+	Driver        string
+	DriverOpts    map[string]string
+	Name          string
+	Labels        map[string]string
+	AttachHistory []string
+	Image         string
 }
 
-func createVolumeMetadata(req *models.VolumeRequest, labels map[string]string) (string, error) {
+func createVolumeMetadata(req *models.VolumeRequest, labels map[string]string, Container, Image string) (string, error) {
 	metadata := volumeMetadata{
 		Driver:     req.Driver,
 		DriverOpts: req.DriverArgs,

--- a/lib/apiservers/engine/backends/volume.go
+++ b/lib/apiservers/engine/backends/volume.go
@@ -128,7 +128,7 @@ func (v *Volume) VolumeInspect(name string) (*types.Volume, error) {
 }
 
 // volumeCreate issues a CreateVolume request to the portlayer
-func (v *Volume) volumeCreate(name, driverName string, driverArgs, labels map[string]string) (*types.Volume, error) {
+func (v *Volume) volumeCreate(name, driverName string, volumeData, labels map[string]string) (*types.Volume, error) {
 	defer trace.End(trace.Begin(""))
 	result := &types.Volume{}
 
@@ -143,7 +143,7 @@ func (v *Volume) volumeCreate(name, driverName string, driverArgs, labels map[st
 
 	// TODO: support having another driver besides vsphere.
 	// assign the values of the model to be passed to the portlayer handler
-	req, varErr := newVolumeCreateReq(name, driverName, driverArgs, labels)
+	req, varErr := newVolumeCreateReq(name, driverName, volumeData, labels)
 	if varErr != nil {
 		return result, varErr
 	}
@@ -158,17 +158,17 @@ func (v *Volume) volumeCreate(name, driverName string, driverArgs, labels map[st
 }
 
 // VolumeCreate : docker personality implementation for VIC
-func (v *Volume) VolumeCreate(name, driverName string, driverArgs, labels map[string]string) (*types.Volume, error) {
+func (v *Volume) VolumeCreate(name, driverName string, volumeData, labels map[string]string) (*types.Volume, error) {
 	defer trace.End(trace.Begin("Volume.VolumeCreate"))
 
-	result, err := v.volumeCreate(name, driverName, driverArgs, labels)
+	result, err := v.volumeCreate(name, driverName, volumeData, labels)
 	if err != nil {
 		switch err := err.(type) {
 		case *storage.CreateVolumeConflict:
 			return result, derr.NewErrorWithStatusCode(fmt.Errorf("A volume named %s already exists. Choose a different volume name.", name), http.StatusInternalServerError)
 
 		case *storage.CreateVolumeNotFound:
-			return result, derr.NewErrorWithStatusCode(fmt.Errorf("No volume store named (%s) exists", volumeStore(driverArgs)), http.StatusInternalServerError)
+			return result, derr.NewErrorWithStatusCode(fmt.Errorf("No volume store named (%s) exists", volumeStore(volumeData)), http.StatusInternalServerError)
 
 		case *storage.CreateVolumeInternalServerError:
 			// FIXME: right now this does not return an error model...
@@ -251,7 +251,7 @@ func extractDockerMetadata(metadataMap map[string]string) (*volumeMetadata, erro
 
 // Utility Functions
 
-func newVolumeCreateReq(name, driverName string, driverArgs, labels map[string]string) (*models.VolumeRequest, error) {
+func newVolumeCreateReq(name, driverName string, volumeData, labels map[string]string) (*models.VolumeRequest, error) {
 	defaultDriver := driverName == "local"
 	vsphereDriver := driverName == "vsphere"
 
@@ -265,19 +265,19 @@ func newVolumeCreateReq(name, driverName string, driverArgs, labels map[string]s
 
 	req := &models.VolumeRequest{
 		Driver:     driverName,
-		DriverArgs: driverArgs,
+		DriverArgs: volumeData,
 		Name:       name,
 		Metadata:   make(map[string]string),
 	}
 
-	metadata, err := createVolumeMetadata(req, driverArgs, labels)
+	metadata, err := createVolumeMetadata(req, volumeData, labels)
 	if err != nil {
 		return nil, err
 	}
 
 	req.Metadata[dockerMetadataModelKey] = metadata
 
-	if err := validateDriverArgs(driverArgs, req); err != nil {
+	if err := validateDriverArgs(volumeData, req); err != nil {
 		return nil, fmt.Errorf("bad driver value - %s", err)
 	}
 

--- a/lib/apiservers/engine/backends/volume_test.go
+++ b/lib/apiservers/engine/backends/volume_test.go
@@ -60,7 +60,7 @@ func TestTranslatVolumeRequestModel(t *testing.T) {
 	assert.Equal(t, "vsphere", testRequest.Driver)
 	assert.Equal(t, int64(12), testRequest.Capacity)
 
-	testMetaDatabuf, err := createVolumeMetadata(testRequest, testLabels)
+	testMetaDatabuf, err := createVolumeMetadata(testRequest, testDriverArgs, testLabels)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -80,7 +80,7 @@ func TestCreateVolumeMetada(t *testing.T) {
 	testLabels := make(map[string]string)
 	testLabels["TestMeta"] = "custom info about my volume"
 
-	testMetadataString, err := createVolumeMetadata(&testModel, testLabels)
+	testMetadataString, err := createVolumeMetadata(&testModel, testDriverOpts, testLabels)
 	if !assert.NoError(t, err) {
 		return
 	}

--- a/tests/test-cases/Group1-Docker-Commands/1-19-Docker-Volume-Create.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-19-Docker-Volume-Create.robot
@@ -8,19 +8,28 @@ Suite Teardown  Cleanup VIC Appliance On Test Server
 Simple docker volume create
     ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} volume create
     Should Be Equal As Integers  ${rc}  0
-    ${disk-size}=  Run  docker ${params} logs $(docker ${params} start $(docker ${params} create -v ${output}:/mydata busybox /bin/df -Ph) && sleep 10) | grep by-label | awk '{print $2}'
+    ${ContainerID}= Run  docker ${params} run -d -v ${output}:/mydata busybox /bin/df -Ph
+    ${ContainerRC}= Run  docker ${params} wait ${ContainerID}
+    Should Be Equal As Integers  ${ContainerRC}  0
+    ${disk-size}=  Run  docker ${params} logs ${ContainerID} | grep by-label | awk '{print $2}'
     Should Be Equal As Strings  ${disk-size}  975.9M
 
 Docker volume create named volume
     ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} volume create --name=test
     Should Be Equal As Integers  ${rc}  0
     Should Be Equal As Strings  ${output}  test
-    ${disk-size}=  Run  docker ${params} logs $(docker ${params} start $(docker ${params} create -v ${output}:/mydata busybox /bin/df -Ph) && sleep 10) | grep by-label | awk '{print $2}'
+    ${ContainerID}= Run  docker ${params} run -d -v ${output}:/mydata busybox /bin/df -Ph
+    ${ContainerRC}= Run  docker ${params} wait ${ContainerID}
+    Should Be Equal As Integers  ${ContainerRC}  0
+    ${disk-size}=  Run  docker ${params} logs ${ContainerID} | grep by-label | awk '{print $2}'
     Should Be Equal As Strings  ${disk-size}  975.9M
 
 Docker volume create image volume
-       ${disk-size}=  Run  docker ${params} logs $(docker ${params} start $(docker ${params} create mongo /bin/df -Ph ) && sleep 10) | grep by-label | awk '{print $2}'
-       Should Contain  ${disk-size}  976M
+    ${ContainerID}= Run  docker ${params} run -d -v ${output}:/mydata mongo /bin/df -Ph
+    ${ContainerRC}= Run  docker ${params} wait ${ContainerID}
+    Should Be Equal As Integers  ${ContainerRC}  0
+    ${disk-size}=  Run  docker ${params} logs ${ContainerID} | grep by-label | awk '{print $2}'
+    Should Contain  ${disk-size}  976M
 
 Docker volume create already named volume
     ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} volume create --name=test
@@ -40,8 +49,10 @@ Docker volume create with bad volumestore
 Docker volume create with specific capacity
     ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} volume create --name=test4 --opt Capacity=100000
     Should Be Equal As Integers  ${rc}  0
-    Should Be Equal As Strings  ${output}  test4
-    ${disk-size}=  Run  docker ${params} logs $(docker ${params} start $(docker ${params} create -v ${output}:/mydata busybox /bin/df -Ph) && sleep 10) | grep by-label | awk '{print $2}'
+    Should Be Equal As Strings  ${output}  test4${ContainerID}= Run  docker ${params} run -d -v ${output}:/mydata busybox /bin/df -Ph
+    ${ContainerRC}= Run  docker ${params} wait ${ContainerID}
+    Should Be Equal As Integers  ${ContainerRC}  0
+    ${disk-size}=  Run  docker ${params} logs ${ContainerID} | grep by-label | awk '{print $2}'
     Should Be Equal As Strings  ${disk-size}  96.0G
 
 Docker volume create with zero capacity

--- a/tests/test-cases/Group1-Docker-Commands/1-19-Docker-Volume-Create.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-19-Docker-Volume-Create.robot
@@ -8,8 +8,9 @@ Suite Teardown  Cleanup VIC Appliance On Test Server
 Simple docker volume create
     ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} volume create
     Should Be Equal As Integers  ${rc}  0
-    ${ContainerID}= Run  docker ${params} run -d -v ${output}:/mydata busybox /bin/df -Ph
-    ${ContainerRC}= Run  docker ${params} wait ${ContainerID}
+    Set Suite Variable  ${ContainerID}  unnamedSpecVol
+    Run  docker ${params} run --name ${ContainerID} -d -v ${output}:/mydata busybox /bin/df -Ph
+    ${ContainerRC}=  Run  docker ${params} wait ${ContainerID}
     Should Be Equal As Integers  ${ContainerRC}  0
     ${disk-size}=  Run  docker ${params} logs ${ContainerID} | grep by-label | awk '{print $2}'
     Should Be Equal As Strings  ${disk-size}  975.9M
@@ -18,25 +19,28 @@ Docker volume create named volume
     ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} volume create --name=test
     Should Be Equal As Integers  ${rc}  0
     Should Be Equal As Strings  ${output}  test
-    ${ContainerID}= Run  docker ${params} run -d -v ${output}:/mydata busybox /bin/df -Ph
-    ${ContainerRC}= Run  docker ${params} wait ${ContainerID}
+    Set Suite Variable  ${ContainerID}  specVol
+    Run  docker ${params} run --name ${ContainerID} -d -v ${output}:/mydata busybox /bin/df -Ph
+    ${ContainerRC}=  Run  docker ${params} wait ${ContainerID}
     Should Be Equal As Integers  ${ContainerRC}  0
     ${disk-size}=  Run  docker ${params} logs ${ContainerID} | grep by-label | awk '{print $2}'
     Should Be Equal As Strings  ${disk-size}  975.9M
 
 Docker volume create image volume
-    ${ContainerID}= Run  docker ${params} run -d -v ${output}:/mydata mongo /bin/df -Ph
-    ${ContainerRC}= Run  docker ${params} wait ${ContainerID}
+    Set Suite Variable  ${ContainerID}  imageVol
+    Run  docker ${params} run --name ${ContainerID} -d mongo /bin/df -Ph
+    ${ContainerRC}=  Run  docker ${params} wait ${ContainerID}
     Should Be Equal As Integers  ${ContainerRC}  0
     ${disk-size}=  Run  docker ${params} logs ${ContainerID} | grep by-label | awk '{print $2}'
     Should Contain  ${disk-size}  976M
 
 Docker volume create anonymous volume
-    ${ContainerID}= Run  docker ${params} run -d -v /mydata busybox /bin/df -Ph
-    ${ContainerRC}= Run  docker ${params} wait ${ContainerID}
+    Set Suite Variable  ${ContainerID}  anonVol
+    Run  docker ${params} run --name ${ContainerID} -d -v /mydata busybox /bin/df -Ph
+    ${ContainerRC}=  Run  docker ${params} wait ${ContainerID}
     Should Be Equal As Integers  ${ContainerRC}  0
     ${disk-size}=  Run  docker ${params} logs ${ContainerID} | grep by-label | awk '{print $2}'
-    Should Contain  ${disk-size}  976M
+    Should Contain  ${disk-size}  975.9M
 
 Docker volume create already named volume
     ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} volume create --name=test
@@ -56,8 +60,10 @@ Docker volume create with bad volumestore
 Docker volume create with specific capacity
     ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} volume create --name=test4 --opt Capacity=100000
     Should Be Equal As Integers  ${rc}  0
-    Should Be Equal As Strings  ${output}  test4${ContainerID}= Run  docker ${params} run -d -v ${output}:/mydata busybox /bin/df -Ph
-    ${ContainerRC}= Run  docker ${params} wait ${ContainerID}
+    Should Be Equal As Strings  ${output}  test4
+    Set Suite Variable  ${ContainerID}  capacityVol
+    Run  docker ${params} run --name ${ContainerID} -d -v ${output}:/mydata busybox /bin/df -Ph
+    ${ContainerRC}=  Run  docker ${params} wait ${ContainerID}
     Should Be Equal As Integers  ${ContainerRC}  0
     ${disk-size}=  Run  docker ${params} logs ${ContainerID} | grep by-label | awk '{print $2}'
     Should Be Equal As Strings  ${disk-size}  96.0G

--- a/tests/test-cases/Group1-Docker-Commands/1-19-Docker-Volume-Create.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-19-Docker-Volume-Create.robot
@@ -31,6 +31,13 @@ Docker volume create image volume
     ${disk-size}=  Run  docker ${params} logs ${ContainerID} | grep by-label | awk '{print $2}'
     Should Contain  ${disk-size}  976M
 
+Docker volume create anonymous volume
+    ${ContainerID}= Run  docker ${params} run -d -v /mydata busybox /bin/df -Ph
+    ${ContainerRC}= Run  docker ${params} wait ${ContainerID}
+    Should Be Equal As Integers  ${ContainerRC}  0
+    ${disk-size}=  Run  docker ${params} logs ${ContainerID} | grep by-label | awk '{print $2}'
+    Should Contain  ${disk-size}  976M
+
 Docker volume create already named volume
     ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} volume create --name=test
     Should Be Equal As Integers  ${rc}  1

--- a/tests/test-cases/Group1-Docker-Commands/1-19-Docker-Volume-Create.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-19-Docker-Volume-Create.robot
@@ -8,15 +8,19 @@ Suite Teardown  Cleanup VIC Appliance On Test Server
 Simple docker volume create
     ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} volume create
     Should Be Equal As Integers  ${rc}  0
-    ${disk-size}=  Run  docker ${params} logs $(docker ${params} start $(docker ${params} create -v ${output}:/mydata busybox /bin/df -Ph) && sleep 10) | grep by-label | awk '{print $2}' 
+    ${disk-size}=  Run  docker ${params} logs $(docker ${params} start $(docker ${params} create -v ${output}:/mydata busybox /bin/df -Ph) && sleep 10) | grep by-label | awk '{print $2}'
     Should Be Equal As Strings  ${disk-size}  975.9M
 
 Docker volume create named volume
     ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} volume create --name=test
     Should Be Equal As Integers  ${rc}  0
     Should Be Equal As Strings  ${output}  test
-    ${disk-size}=  Run  docker ${params} logs $(docker ${params} start $(docker ${params} create -v ${output}:/mydata busybox /bin/df -Ph) && sleep 10) | grep by-label | awk '{print $2}' 
+    ${disk-size}=  Run  docker ${params} logs $(docker ${params} start $(docker ${params} create -v ${output}:/mydata busybox /bin/df -Ph) && sleep 10) | grep by-label | awk '{print $2}'
     Should Be Equal As Strings  ${disk-size}  975.9M
+
+Docker volume create image volume
+       ${disk-size}=  Run  docker ${params} logs $(docker ${params} start $(docker ${params} create mongo /bin/df -Ph ) && sleep 10) | grep by-label | awk '{print $2}'
+       Should Contain  ${disk-size}  976M
 
 Docker volume create already named volume
     ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} volume create --name=test
@@ -37,7 +41,7 @@ Docker volume create with specific capacity
     ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} volume create --name=test4 --opt Capacity=100000
     Should Be Equal As Integers  ${rc}  0
     Should Be Equal As Strings  ${output}  test4
-    ${disk-size}=  Run  docker ${params} logs $(docker ${params} start $(docker ${params} create -v ${output}:/mydata busybox /bin/df -Ph) && sleep 10) | grep by-label | awk '{print $2}' 
+    ${disk-size}=  Run  docker ${params} logs $(docker ${params} start $(docker ${params} create -v ${output}:/mydata busybox /bin/df -Ph) && sleep 10) | grep by-label | awk '{print $2}'
     Should Be Equal As Strings  ${disk-size}  96.0G
 
 Docker volume create with zero capacity


### PR DESCRIPTION
This implements the creation of anonymous volumes from image metadata(a good example is the `mongo` image). It is important to note that a specified volume takes precedent over an anonymous volume. This includes the anonymous volumes from images. This also does not implement the copying of existing data from a mount path in the image, that will come from a later PR. 

Fixes #1819 
