### PR TITLE
Change error msg on resize failure

### DIFF
--- a/lib/apiservers/engine/backends/container.go
+++ b/lib/apiservers/engine/backends/container.go
@@ -359,7 +359,7 @@ func (c *Container) ContainerResize(name string, height, width int) error {
 	_, err := client.Interaction.ContainerResize(plResizeParam)
 	if err != nil {
 		if _, isa := err.(*interaction.ContainerResizeNotFound); isa {
-			return NotFoundError(name)
+			return ResourceNotFoundError(name, "interaction connection")
 		}
 
 		// If we get here, most likely something went wrong with the port layer API server

--- a/lib/apiservers/engine/backends/errors.go
+++ b/lib/apiservers/engine/backends/errors.go
@@ -53,6 +53,10 @@ func VolumeNotFoundError(msg string) error {
 	return derr.NewErrorWithStatusCode(fmt.Errorf("No such volume: %s", msg), http.StatusNotFound)
 }
 
+func ResourceNotFoundError(cid, res string) error {
+	return derr.NewRequestNotFoundError(fmt.Errorf("No such %s for container: %s", res, cid))
+}
+
 // NotFoundError returns a 404 docker error when a container is not found.
 func NotFoundError(msg string) error {
 	return derr.NewRequestNotFoundError(fmt.Errorf("No such container: %s", msg))


### PR DESCRIPTION
Change error message on resize 404

Fixed an issue where the personality server respond with no such
container when the portlayer respond with 404 for a resize.  The
404 actually refers to the connection and not the container.