### PR TITLE
Restore the original error handling logic

### DIFF
--- a/lib/apiservers/portlayer/restapi/handlers/interaction_handlers.go
+++ b/lib/apiservers/portlayer/restapi/handlers/interaction_handlers.go
@@ -206,10 +206,13 @@ func (i *InteractionHandlersImpl) ContainerSetStdinHandler(params interaction.Co
 	if err != nil {
 		log.Errorf("%s", err.Error())
 
-		e := &models.Error{
-			Message: fmt.Sprintf("Error copying stdin (id: %s): %s", params.ID, err.Error()),
-		}
-		return interaction.NewContainerSetStdinInternalServerError().WithPayload(e)
+		// FIXME (caglar10ur): Do not return an error here - https://github.com/vmware/vic/issues/2594
+		/*
+			e := &models.Error{
+				Message: fmt.Sprintf("Error copying stdin (id: %s): %s", params.ID, err.Error()),
+			}
+			return interaction.NewContainerSetStdinInternalServerError().WithPayload(e)
+		*/
 	}
 
 	log.Debugf("Done copying stdin")
@@ -266,10 +269,14 @@ func (i *InteractionHandlersImpl) ContainerGetStdoutHandler(params interaction.C
 	if err != nil {
 		log.Errorf("%s", err.Error())
 
-		e := &models.Error{
-			Message: fmt.Sprintf("No stdout connection found (id: %s): %s", params.ID, err.Error()),
-		}
-		return interaction.NewContainerGetStdoutNotFound().WithPayload(e)
+		// FIXME (caglar10ur): Do not return an error here - https://github.com/vmware/vic/issues/2594
+		/*
+			e := &models.Error{
+				Message: fmt.Sprintf("No stdout connection found (id: %s): %s", params.ID, err.Error()),
+			}
+			return interaction.NewContainerGetStdoutNotFound().WithPayload(e)
+		*/
+		return interaction.NewContainerGetStdoutNotFound()
 	}
 
 	return NewContainerOutputHandler("stdout").WithPayload(
@@ -305,10 +312,14 @@ func (i *InteractionHandlersImpl) ContainerGetStderrHandler(params interaction.C
 	if err != nil {
 		log.Errorf("%s", err.Error())
 
-		e := &models.Error{
-			Message: fmt.Sprintf("No stderr connection found (id: %s): %s", params.ID, err.Error()),
-		}
-		return interaction.NewContainerGetStderrNotFound().WithPayload(e)
+		// FIXME (caglar10ur): Do not return an error here - https://github.com/vmware/vic/issues/2594
+		/*
+			e := &models.Error{
+				Message: fmt.Sprintf("No stderr connection found (id: %s): %s", params.ID, err.Error()),
+			}
+			return interaction.NewContainerGetStderrNotFound().WithPayload(e)
+		*/
+		return interaction.NewContainerGetStderrNotFound()
 	}
 
 	return NewContainerOutputHandler("stderr").WithPayload(


### PR DESCRIPTION
As returning errors from GetStdin causes swagger to set context to nil
and then following Errors.WithPayload causes panics.

This is a workaround and error handling needs to corrected.

Fixes #2594