### PR TITLE
Follow up fixes from TLSVERIFY work

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -147,7 +147,7 @@ components: check apiservers $(imagec) $(vicadmin) $(rpctool)
 isos: $(appliance) $(bootstrap)
 tethers: $(tether-linux) $(tether-windows) $(tether-darwin)
 
-most: $(portlayerapi) $(docker-engine-api) $(imagec) $(vicadmin) $(rpctool) $(tether-linux) $(appliance) $(bootstrap) $(vic-machine-linux)
+most: $(portlayerapi) $(docker-engine-api) $(imagec) $(vicadmin) $(tether-linux) $(appliance) $(bootstrap) $(vic-machine-linux)
 
 # utility targets
 goversion:

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Project Bonneville was research aimed at determining best approaches to enabling
 Once built, pick up the correct binary based on your OS, and then the result can be installed with the following command.
 
 ```
-bin/vic-machine-linux create --target target-host[/datacenter] --image-store <datastore name> --name <vch-name> --user <username> --password <password> --compute-resource <cluster/a/resource/pool/path>
+bin/vic-machine-linux create --target target-host[/datacenter] --image-store <datastore name> --name <vch-name> --user <username> --password <password> --compute-resource <cluster/a/resource/pool/path> --cname <FQDN, *.wildcard.domain, or static IP>
 ```
 
 See `vic-machine-XXX create --help` for usage information.

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Project Bonneville was research aimed at determining best approaches to enabling
 Once built, pick up the correct binary based on your OS, and then the result can be installed with the following command.
 
 ```
-bin/vic-machine-linux create --target target-host[/datacenter] --image-store <datastore name> --name <vch-name> --user <username> --password <password> --compute-resource <cluster/a/resource/pool/path> --cname <FQDN, *.wildcard.domain, or static IP>
+bin/vic-machine-linux create --target target-host[/datacenter] --image-store <datastore name> --name <vch-name> --user <username> --password <password> --compute-resource <cluster/a/resource/pool/path> --tls-cname <FQDN, *.wildcard.domain, or static IP>
 ```
 
 See `vic-machine-XXX create --help` for usage information.

--- a/cmd/tether/attach_test.go
+++ b/cmd/tether/attach_test.go
@@ -230,8 +230,8 @@ func TestAttach(t *testing.T) {
 			Name: "tether_test_executor",
 		},
 
-		Sessions: map[string]executor.SessionConfig{
-			"attach": {
+		Sessions: map[string]*executor.SessionConfig{
+			"attach": &executor.SessionConfig{
 				Common: executor.Common{
 					ID:   "attach",
 					Name: "tether_test_session",
@@ -320,8 +320,8 @@ func TestAttachTTY(t *testing.T) {
 			Name: "tether_test_executor",
 		},
 
-		Sessions: map[string]executor.SessionConfig{
-			"attach": {
+		Sessions: map[string]*executor.SessionConfig{
+			"attach": &executor.SessionConfig{
 				Common: executor.Common{
 					ID:   "attach",
 					Name: "tether_test_session",
@@ -417,8 +417,8 @@ func TestAttachTwo(t *testing.T) {
 			Name: "tether_test_executor",
 		},
 
-		Sessions: map[string]executor.SessionConfig{
-			"tee1": {
+		Sessions: map[string]*executor.SessionConfig{
+			"tee1": &executor.SessionConfig{
 				Common: executor.Common{
 					ID:   "tee1",
 					Name: "tether_test_session",
@@ -433,7 +433,7 @@ func TestAttachTwo(t *testing.T) {
 					Dir:  "/",
 				},
 			},
-			"tee2": {
+			"tee2": &executor.SessionConfig{
 				Common: executor.Common{
 					ID:   "tee2",
 					Name: "tether_test_session2",
@@ -557,8 +557,8 @@ func TestAttachInvalid(t *testing.T) {
 			Name: "tether_test_executor",
 		},
 
-		Sessions: map[string]executor.SessionConfig{
-			"valid": {
+		Sessions: map[string]*executor.SessionConfig{
+			"valid": &executor.SessionConfig{
 				Common: executor.Common{
 					ID:   "valid",
 					Name: "tether_test_session",
@@ -631,7 +631,7 @@ func TestMockAttachTetherToPL(t *testing.T) {
 			Name: "tether_test_executor",
 		},
 
-		Sessions: map[string]executor.SessionConfig{
+		Sessions: map[string]*executor.SessionConfig{
 			"attach": executor.SessionConfig{
 				Common: executor.Common{
 					ID:   "attach",
@@ -694,8 +694,8 @@ func TestReattach(t *testing.T) {
 			Name: "tether_test_executor",
 		},
 
-		Sessions: map[string]executor.SessionConfig{
-			"attach": {
+		Sessions: map[string]*executor.SessionConfig{
+			"attach": &executor.SessionConfig{
 				Common: executor.Common{
 					ID:   "attach",
 					Name: "tether_test_session",

--- a/cmd/vic-init/ops.go
+++ b/cmd/vic-init/ops.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"strings"
 	"syscall"
+	"time"
 
 	log "github.com/Sirupsen/logrus"
 
@@ -68,6 +69,9 @@ func (t *operations) HandleSessionExit(config *tether.ExecutorConfig, session *t
 			log.Warnf("Debug is set to %d so squashing relaunch of exited process", config.DebugLevel)
 			return
 		}
+
+		// incredibly basic throttle
+		time.Sleep(3 * time.Second)
 
 		tthr.Reload()
 		log.Info("Triggered reload")

--- a/cmd/vic-init/restart_test.go
+++ b/cmd/vic-init/restart_test.go
@@ -45,8 +45,8 @@ func TestRestart(t *testing.T) {
 		Diagnostics: executor.Diagnostics{
 			DebugLevel: 2,
 		},
-		Sessions: map[string]executor.SessionConfig{
-			"pathlookup": {
+		Sessions: map[string]*executor.SessionConfig{
+			"pathlookup": &executor.SessionConfig{
 				Common: executor.Common{
 					ID:   "pathlookup",
 					Name: "tether_test_session",

--- a/cmd/vic-machine/common/compute.go
+++ b/cmd/vic-machine/common/compute.go
@@ -22,15 +22,16 @@ type Compute struct {
 }
 
 func (c *Compute) ComputeFlags() []cli.Flag {
-	flags := c.ComputeFlagsNoName()
-	nameFlag := cli.StringFlag{
-		Name:        "name, n",
-		Value:       "virtual-container-host",
-		Usage:       "The name of the Virtual Container Host",
-		Destination: &c.DisplayName,
+	nameFlag := []cli.Flag{
+		cli.StringFlag{
+			Name:        "name, n",
+			Value:       "virtual-container-host",
+			Usage:       "The name of the Virtual Container Host",
+			Destination: &c.DisplayName,
+		},
 	}
-	flags = append(flags, nameFlag)
-	return flags
+
+	return append(nameFlag, c.ComputeFlagsNoName()...)
 }
 
 func (c *Compute) ComputeFlagsNoName() []cli.Flag {

--- a/cmd/vic-machine/common/debug.go
+++ b/cmd/vic-machine/common/debug.go
@@ -26,6 +26,7 @@ func (d *Debug) DebugFlags() []cli.Flag {
 			Name:        "debug, v",
 			Destination: &d.Debug,
 			Usage:       "[0(default),1...n], 0 is disabled, 1 is enabled, >= 1 may alter behaviour",
+			Hidden:      true,
 		},
 	}
 }

--- a/cmd/vic-machine/common/images.go
+++ b/cmd/vic-machine/common/images.go
@@ -54,19 +54,21 @@ type Images struct {
 	OSType       string
 }
 
-func (i *Images) ImageFlags() []cli.Flag {
+func (i *Images) ImageFlags(hidden bool) []cli.Flag {
 	return []cli.Flag{
 		cli.StringFlag{
 			Name:        "appliance-iso, ai",
 			Value:       "",
 			Usage:       "The appliance iso",
 			Destination: &i.ApplianceISO,
+			Hidden:      hidden,
 		},
 		cli.StringFlag{
 			Name:        "bootstrap-iso, bi",
 			Value:       "",
 			Usage:       "The bootstrap iso",
 			Destination: &i.BootstrapISO,
+			Hidden:      hidden,
 		},
 	}
 }

--- a/cmd/vic-machine/create/create.go
+++ b/cmd/vic-machine/create/create.go
@@ -333,9 +333,9 @@ func (c *Create) Flags() []cli.Flag {
 			Destination: &c.cname,
 		},
 		cli.StringFlag{
-			Name:        "organisation",
+			Name:        "organization",
 			Value:       "default",
-			Usage:       "Organisation to use for generated CA certificate",
+			Usage:       "Organization to use for generated CA certificate",
 			Destination: &c.org,
 			Hidden:      true,
 		},
@@ -805,13 +805,14 @@ func (c *Create) generateCertificates(ca bool) ([]byte, *certificate.KeyPair, er
 	// if we've not got a specific CommonName but do have a static IP then go with that.
 	if c.cname == "" && c.clientNetworkIP != "" {
 		c.cname = c.clientNetworkIP
+		log.Infof("Using client-network-ip as cname for server certificates - use --tls-cname to override: %s", c.cname)
 	}
 
 	if c.cname == "" {
 		log.Error("Common Name must be provided when generating certificates for client authentication:")
 		log.Info("  --tls-cname=<FQDN or static IP> # for the appliance VM")
 		log.Info("  --tls-cname=<*.yourdomain.com>  # if DNS has entries in that form for DHCP addresses (less secure)")
-		log.Info("  --no-tlsverify              # disables client authentication (anyone can connect to the VCH)")
+		log.Info("  --no-tlsverify              	# disables client authentication (anyone can connect to the VCH)")
 		log.Info("")
 
 		return certs, nil, errors.New("provide Common Name for server certificate")

--- a/cmd/vic-machine/create/create.go
+++ b/cmd/vic-machine/create/create.go
@@ -868,6 +868,9 @@ func (c *Create) Run(cliContext *cli.Context) (err error) {
 		vchConfig.ExtensionKey = keybuffer.String()
 	}
 
+	// separate initial validation from dispatch of creation task
+	log.Info("")
+
 	executor := management.NewDispatcher(ctx, validator.Session, vchConfig, c.Force)
 	if err = executor.CreateVCH(vchConfig, vConfig); err != nil {
 

--- a/cmd/vic-machine/create/create.go
+++ b/cmd/vic-machine/create/create.go
@@ -152,7 +152,7 @@ func (c *Create) Flags() []cli.Flag {
 		cli.StringSliceFlag{
 			Name:  "volume-store, vs",
 			Value: &c.volumeStores,
-			Usage: "Specify location and label for volume store; path optional: \"datastore/path:label\" or \"datastore:label\"",
+			Usage: "Specify a list of location and label for volume store, e.g. \"datastore/path:label\" or \"datastore:label\".",
 		},
 
 		// bridge
@@ -248,24 +248,24 @@ func (c *Create) Flags() []cli.Flag {
 		cli.StringSliceFlag{
 			Name:  "container-network, cn",
 			Value: &c.containerNetworks,
-			Usage: "vSphere networks that containers can use directly, without port forwarding. Defaults to DCHP - see advanced help (-x)",
+			Usage: "vSphere network list that containers can use directly with labels, e.g. vsphere-net:backend. Defaults to DCHP - see advanced help (-x).",
 		},
 		cli.StringSliceFlag{
 			Name:   "container-network-gateway, cng",
 			Value:  &c.containerNetworksGateway,
-			Usage:  "Gateway for the container network's subnet in CONTAINER-NETWORK:SUBNET format, e.g. a_network:172.16.0.0/16",
+			Usage:  "Gateway for the container network's subnet in CONTAINER-NETWORK:SUBNET format, e.g. vsphere-net:172.16.0.0/16.",
 			Hidden: true,
 		},
 		cli.StringSliceFlag{
 			Name:   "container-network-ip-range, cnr",
 			Value:  &c.containerNetworksIPRanges,
-			Usage:  "IP range for the container network in CONTAINER-NETWORK:IP-RANGE format, e.g. a_network:172.16.0.0/24, a_network:172.16.0.10-20",
+			Usage:  "IP range for the container network in CONTAINER-NETWORK:IP-RANGE format, e.g. vsphere-net:172.16.0.0/24, vsphere-net:172.16.0.10-20.",
 			Hidden: true,
 		},
 		cli.StringSliceFlag{
 			Name:   "container-network-dns, cnd",
 			Value:  &c.containerNetworksDNS,
-			Usage:  "DNS servers for the container network in CONTAINER-NETWORK:DNS format, e.g. a_network:8.8.8.8. Ignored if no static IP assigned.",
+			Usage:  "DNS servers for the container network in CONTAINER-NETWORK:DNS format, e.g. vsphere-net:8.8.8.8. Ignored if no static IP assigned.",
 			Hidden: true,
 		},
 
@@ -273,7 +273,7 @@ func (c *Create) Flags() []cli.Flag {
 		cli.IntFlag{
 			Name:        "memory, mem",
 			Value:       0,
-			Usage:       "VCH resource pool memory limit in MB",
+			Usage:       "VCH resource pool memory limit in MB (unlimited=0)",
 			Destination: &c.VCHMemoryLimitsMB,
 		},
 		cli.IntFlag{
@@ -301,7 +301,7 @@ func (c *Create) Flags() []cli.Flag {
 		cli.IntFlag{
 			Name:        "cpu",
 			Value:       0,
-			Usage:       "VCH resource pool vCPUs limit in MHz",
+			Usage:       "VCH resource pool vCPUs limit in MHz (unlimited=0)",
 			Destination: &c.VCHCPULimitsMHz,
 		},
 		cli.IntFlag{
@@ -386,7 +386,7 @@ func (c *Create) Flags() []cli.Flag {
 		},
 	}
 
-	misc := []cli.Flag{
+	util := []cli.Flag{
 		// miscellaneous
 		cli.BoolFlag{
 			Name:        "use-rp",
@@ -411,7 +411,7 @@ func (c *Create) Flags() []cli.Flag {
 	help := []cli.Flag{
 		// help options
 		cli.BoolFlag{
-			Name:        "advanced-options, x",
+			Name:        "extended-help, x",
 			Usage:       "Show all options - this must be specified instead of --help",
 			Destination: &c.advancedOptions,
 		},
@@ -419,12 +419,12 @@ func (c *Create) Flags() []cli.Flag {
 
 	target := c.TargetFlags()
 	compute := c.ComputeFlags()
-	iso := c.ImageFlags()
+	iso := c.ImageFlags(true)
 	debug := c.DebugFlags()
 
 	// flag arrays are declared, now combined
 	var flags []cli.Flag
-	for _, f := range [][]cli.Flag{target, compute, create, iso, misc, debug, help} {
+	for _, f := range [][]cli.Flag{target, compute, create, iso, util, debug, help} {
 		flags = append(flags, f...)
 	}
 

--- a/cmd/vic-machine/create/create.go
+++ b/cmd/vic-machine/create/create.go
@@ -123,7 +123,8 @@ func NewCreate() *Create {
 
 // Flags return all cli flags for create
 func (c *Create) Flags() []cli.Flag {
-	flags := []cli.Flag{
+	create := []cli.Flag{
+		// images
 		cli.StringFlag{
 			Name:        "image-store, i",
 			Value:       "",
@@ -131,16 +132,30 @@ func (c *Create) Flags() []cli.Flag {
 			Destination: &c.ImageDatastorePath,
 		},
 		cli.StringFlag{
+			Name:        "base-image-size",
+			Value:       "8GB",
+			Usage:       "Specify the size of the base image from which all other images are created e.g. 8GB/8000MB",
+			Destination: &c.ScratchSize,
+			Hidden:      true,
+		},
+
+		// container disk
+		cli.StringFlag{
 			Name:        "container-store, cs",
 			Value:       "",
 			Usage:       "Container datastore path - not supported yet, defaults to image datastore",
 			Destination: &c.ContainerDatastoreName,
+			Hidden:      true,
 		},
+
+		// volume
 		cli.StringSliceFlag{
 			Name:  "volume-store, vs",
 			Value: &c.volumeStores,
 			Usage: "Specify location and label for volume store; path optional: \"datastore/path:label\" or \"datastore:label\"",
 		},
+
+		// bridge
 		cli.StringFlag{
 			Name:        "bridge-network, b",
 			Value:       "",
@@ -152,11 +167,14 @@ func (c *Create) Flags() []cli.Flag {
 			Value:       "172.16.0.0/12",
 			Usage:       "The IP range from which bridge networks are allocated",
 			Destination: &c.BridgeIPRange,
+			Hidden:      true,
 		},
+
+		// client
 		cli.StringFlag{
 			Name:        "client-network, cln",
 			Value:       "",
-			Usage:       "The client network port group name (restricts DOCKER_API access to this network)",
+			Usage:       "The client network port group name (restricts DOCKER_API access to this network). Defaults to DCHP - see advanced help (-x)",
 			Destination: &c.clientNetworkName,
 		},
 		cli.StringFlag{
@@ -164,17 +182,21 @@ func (c *Create) Flags() []cli.Flag {
 			Value:       "",
 			Usage:       "Gateway for the VCH on the client network, e.g. 10.0.0.1/24",
 			Destination: &c.clientNetworkGateway,
+			Hidden:      true,
 		},
 		cli.StringFlag{
 			Name:        "client-network-ip",
 			Value:       "",
 			Usage:       "IP address for the VCH on the client network, e.g. 10.0.0.2/24",
 			Destination: &c.clientNetworkIP,
+			Hidden:      true,
 		},
+
+		// external
 		cli.StringFlag{
 			Name:        "external-network, en",
 			Value:       "",
-			Usage:       "The external network port group name - forwarded ports are exposed on this network and this is the default route. Defaults to 'VM Network'",
+			Usage:       "The external network port group name (port forwarding and default route). Defaults to 'VM Network' and DHCP -- see advanced help (-x)",
 			Destination: &c.externalNetworkName,
 		},
 		cli.StringFlag{
@@ -182,17 +204,21 @@ func (c *Create) Flags() []cli.Flag {
 			Value:       "",
 			Usage:       "Gateway for the VCH on the external network, e.g. 10.0.1.1/24",
 			Destination: &c.externalNetworkGateway,
+			Hidden:      true,
 		},
 		cli.StringFlag{
 			Name:        "external-network-ip",
 			Value:       "",
 			Usage:       "IP address for the VCH on the external network, e.g. 10.0.1.2/24",
 			Destination: &c.externalNetworkIP,
+			Hidden:      true,
 		},
+
+		// management
 		cli.StringFlag{
 			Name:        "management-network, mn",
 			Value:       "",
-			Usage:       "The management network port group name (provides route to target hosting vSphere)",
+			Usage:       "The management network port group name (provides route to target hosting vSphere). Defaults to DCHP - see advanced help (-x)",
 			Destination: &c.managementNetworkName,
 		},
 		cli.StringFlag{
@@ -200,174 +226,208 @@ func (c *Create) Flags() []cli.Flag {
 			Value:       "",
 			Usage:       "Gateway for the VCH on the management network, e.g. 10.0.2.1/24",
 			Destination: &c.managementNetworkGateway,
+			Hidden:      true,
 		},
 		cli.StringFlag{
 			Name:        "management-network-ip",
 			Value:       "",
 			Usage:       "IP address for the VCH on the management network, e.g. 10.0.2.2/24",
 			Destination: &c.managementNetworkIP,
+			Hidden:      true,
 		},
+
+		// general DNS
+		cli.StringSliceFlag{
+			Name:   "dns-server",
+			Value:  &c.dns,
+			Usage:  "DNS server for the client, external, and management networks. Defaults to 8.8.8.8 and 8.8.4.4 when not using DHCP",
+			Hidden: true,
+		},
+
+		// container networks - mapped from vSphere
 		cli.StringSliceFlag{
 			Name:  "container-network, cn",
 			Value: &c.containerNetworks,
-			Usage: "Networks that containers can use",
+			Usage: "vSphere networks that containers can use directly, without port forwarding. Defaults to DCHP - see advanced help (-x)",
 		},
 		cli.StringSliceFlag{
-			Name:  "container-network-gateway, cng",
-			Value: &c.containerNetworksGateway,
-			Usage: "Gateway for the container network's subnet in CONTAINER-NETWORK:SUBNET format, e.g. a_network:172.16.0.0/16",
+			Name:   "container-network-gateway, cng",
+			Value:  &c.containerNetworksGateway,
+			Usage:  "Gateway for the container network's subnet in CONTAINER-NETWORK:SUBNET format, e.g. a_network:172.16.0.0/16",
+			Hidden: true,
 		},
 		cli.StringSliceFlag{
-			Name:  "container-network-ip-range, cnr",
-			Value: &c.containerNetworksIPRanges,
-			Usage: "IP range for the container network in CONTAINER-NETWORK:IP-RANGE format, e.g. a_network:172.16.0.0/24, a_network:172.16.0.10-20",
+			Name:   "container-network-ip-range, cnr",
+			Value:  &c.containerNetworksIPRanges,
+			Usage:  "IP range for the container network in CONTAINER-NETWORK:IP-RANGE format, e.g. a_network:172.16.0.0/24, a_network:172.16.0.10-20",
+			Hidden: true,
 		},
 		cli.StringSliceFlag{
-			Name:  "container-network-dns, cnd",
-			Value: &c.containerNetworksDNS,
-			Usage: "DNS servers for the container network in CONTAINER-NETWORK:DNS format, e.g. a_network:8.8.8.8. Ignored if no static IP assigned.",
+			Name:   "container-network-dns, cnd",
+			Value:  &c.containerNetworksDNS,
+			Usage:  "DNS servers for the container network in CONTAINER-NETWORK:DNS format, e.g. a_network:8.8.8.8. Ignored if no static IP assigned.",
+			Hidden: true,
 		},
-		cli.StringSliceFlag{
-			Name:  "dns-server",
-			Value: &c.dns,
-			Usage: "DNS server for the client, external, and management networks. Defaults to 8.8.8.8 and 8.8.4.4 when not using DHCP",
-		},
+
+		// memory
 		cli.IntFlag{
-			Name:        "pool-memory-reservation, pmr",
+			Name:        "memory, mem",
 			Value:       0,
-			Usage:       "VCH Memory reservation in MB",
-			Destination: &c.VCHMemoryReservationsMB,
-		},
-		cli.IntFlag{
-			Name:        "pool-memory-limit, pml",
-			Value:       0,
-			Usage:       "VCH Memory limit in MB",
+			Usage:       "VCH resource pool memory limit in MB",
 			Destination: &c.VCHMemoryLimitsMB,
 		},
+		cli.IntFlag{
+			Name:        "memory-reservation, memr",
+			Value:       0,
+			Usage:       "VCH resource pool memory reservation in MB",
+			Destination: &c.VCHMemoryReservationsMB,
+			Hidden:      true,
+		},
 		cli.GenericFlag{
-			Name:  "pool-memory-shares, pms",
-			Value: flags.NewSharesFlag(&c.VCHMemoryShares),
-			Usage: "VCH Memory shares in level or share number, e.g. high, normal, low, or 163840",
+			Name:   "memory-shares, mems",
+			Value:  flags.NewSharesFlag(&c.VCHMemoryShares),
+			Usage:  "VCH resource pool memory shares in level or share number, e.g. high, normal, low, or 163840",
+			Hidden: true,
 		},
 		cli.IntFlag{
-			Name:        "pool-cpu-reservation, pcr",
-			Value:       0,
-			Usage:       "VCH vCPUs reservation in MHz",
-			Destination: &c.VCHCPUReservationsMHz,
+			Name:        "appliance-memory",
+			Value:       2048,
+			Usage:       "Memory for the appliance VM, in MB. Does not impact resources allocated per container.",
+			Hidden:      true,
+			Destination: &c.MemoryMB,
 		},
+
+		// cpu
 		cli.IntFlag{
-			Name:        "pool-cpu-limit, pcl",
+			Name:        "cpu",
 			Value:       0,
-			Usage:       "VCH vCPUs limit in MHz",
+			Usage:       "VCH resource pool vCPUs limit in MHz",
 			Destination: &c.VCHCPULimitsMHz,
 		},
+		cli.IntFlag{
+			Name:        "cpu-reservation, cpur",
+			Value:       0,
+			Usage:       "VCH resource pool reservation in MHz",
+			Destination: &c.VCHCPUReservationsMHz,
+			Hidden:      true,
+		},
 		cli.GenericFlag{
-			Name:  "pool-cpu-shares, pcs",
-			Value: flags.NewSharesFlag(&c.VCHCPUShares),
-			Usage: "VCH vCPUs shares, in level or share number, e.g. high, normal, low, or 4000",
+			Name:   "cpu-shares, cpus",
+			Value:  flags.NewSharesFlag(&c.VCHCPUShares),
+			Usage:  "VCH VCH resource pool vCPUs shares, in level or share number, e.g. high, normal, low, or 4000",
+			Hidden: true,
+		},
+		cli.IntFlag{
+			Name:        "appliance-cpu",
+			Value:       1,
+			Usage:       "vCPUs for the appliance VM",
+			Hidden:      true,
+			Destination: &c.NumCPUs,
+		},
+
+		// TLS
+		cli.StringFlag{
+			Name:        "tls-cname",
+			Value:       "",
+			Usage:       "Common Name to use in generated CA certificate when requiring client certificate authentication",
+			Destination: &c.cname,
+		},
+		cli.StringFlag{
+			Name:        "organisation",
+			Value:       "default",
+			Usage:       "Organisation to use for generated CA certificate",
+			Destination: &c.org,
+			Hidden:      true,
+		},
+		cli.BoolFlag{
+			Name:        "no-tlsverify, kv",
+			Usage:       "Disable authentication via client certificates - for more tls options see advanced help (-x)",
+			Destination: &c.noTLSverify,
+		},
+		cli.BoolFlag{
+			Name:        "no-tls, k",
+			Usage:       "Disable TLS support completely",
+			Destination: &c.noTLS,
+			Hidden:      true,
+		},
+		cli.StringFlag{
+			Name:        "key",
+			Value:       "",
+			Usage:       "Virtual Container Host private key file",
+			Destination: &c.key,
+			Hidden:      true,
+		},
+		cli.StringFlag{
+			Name:        "cert",
+			Value:       "",
+			Usage:       "Virtual Container Host x509 certificate file",
+			Destination: &c.cert,
+			Hidden:      true,
+		},
+		cli.StringSliceFlag{
+			Name:   "tls-ca, ca",
+			Usage:  "Specify a list of certificate authorities to use for client verification",
+			Value:  &c.clientCAs,
+			Hidden: true,
+		},
+		cli.IntFlag{
+			Name:        "certificate-key-size, ksz",
+			Usage:       "Size of key to use when generating certificates",
+			Value:       2048,
+			Destination: &c.keySize,
+			Hidden:      true,
+		},
+
+		// registries
+		cli.StringSliceFlag{
+			Name:  "insecure-registry, dir",
+			Value: &c.insecureRegistries,
+			Usage: "Specify a list of permitted insecure registry server URLs",
 		},
 	}
 
-	flags = append(append(flags, c.ImageFlags()...),
-		[]cli.Flag{
-			cli.StringFlag{
-				Name:        "key",
-				Value:       "",
-				Usage:       "Virtual Container Host private key file",
-				Destination: &c.key,
-			},
-			cli.StringFlag{
-				Name:        "cert",
-				Value:       "",
-				Usage:       "Virtual Container Host x509 certificate file",
-				Destination: &c.cert,
-			},
-			cli.StringSliceFlag{
-				Name:  "client-verification-ca, ca",
-				Usage: "Specify a list of certificate authorities to use for client verification",
-				Value: &c.clientCAs,
-			},
-			cli.StringFlag{
-				Name:        "base-image-size",
-				Value:       "8GB",
-				Usage:       "Specify the size of the base image from which all other images are created e.g. 8GB/8000MB",
-				Destination: &c.ScratchSize,
-				Hidden:      true,
-			},
-			cli.BoolFlag{
-				Name:        "no-tlsverify, kv",
-				Usage:       "Disable authentication via client certificates",
-				Destination: &c.noTLSverify,
-			},
-			cli.BoolFlag{
-				Name:        "no-tls, k",
-				Usage:       "Disable TLS support completely",
-				Destination: &c.noTLS,
-			},
-			cli.BoolFlag{
-				Name:        "force, f",
-				Usage:       "Force the install, removing existing if present",
-				Destination: &c.Force,
-			},
-			cli.DurationFlag{
-				Name:        "timeout",
-				Value:       3 * time.Minute,
-				Usage:       "Time to wait for create",
-				Destination: &c.Timeout,
-			},
-			cli.BoolFlag{
-				Name:        "advanced-options, x",
-				Usage:       "Show all options",
-				Destination: &c.advancedOptions,
-			},
-			cli.IntFlag{
-				Name:        "appliance-memory",
-				Value:       2048,
-				Usage:       "Memory for the appliance VM, in MB",
-				Hidden:      true,
-				Destination: &c.MemoryMB,
-			},
-			cli.IntFlag{
-				Name:        "appliance-cpu",
-				Value:       1,
-				Usage:       "vCPUs for the appliance VM",
-				Hidden:      true,
-				Destination: &c.NumCPUs,
-			},
-			cli.BoolFlag{
-				Name:        "use-rp",
-				Usage:       "Use resource pool for vch parent in VC",
-				Destination: &c.UseRP,
-				Hidden:      true,
-			},
-			cli.IntFlag{
-				Name:        "certificate-key-size, ksz",
-				Usage:       "Size of key to use when generating certificates",
-				Value:       2048,
-				Destination: &c.keySize,
-				Hidden:      true,
-			},
-			cli.StringFlag{
-				Name:        "cname",
-				Value:       "",
-				Usage:       "Common Name to use in generated CA certificate",
-				Destination: &c.cname,
-			},
-			cli.StringFlag{
-				Name:        "organisation",
-				Value:       "default",
-				Usage:       "Organisation to use in generated CA certificate",
-				Destination: &c.org,
-				Hidden:      true,
-			},
-			cli.StringSliceFlag{
-				Name:  "docker-insecure-registry, dir",
-				Value: &c.insecureRegistries,
-				Usage: "Specify a list of insecure registry server URLs for the docker personality server",
-			},
-		}...)
+	misc := []cli.Flag{
+		// miscellaneous
+		cli.BoolFlag{
+			Name:        "use-rp",
+			Usage:       "Use resource pool for vch parent in VC instead of a vApp",
+			Destination: &c.UseRP,
+			Hidden:      true,
+		},
 
-	flags = append(append(append(c.TargetFlags(), c.ComputeFlags()...), flags...), c.DebugFlags()...)
+		cli.BoolFlag{
+			Name:        "force, f",
+			Usage:       "Force the install, removing existing if present",
+			Destination: &c.Force,
+		},
+		cli.DurationFlag{
+			Name:        "timeout",
+			Value:       3 * time.Minute,
+			Usage:       "Time to wait for create",
+			Destination: &c.Timeout,
+		},
+	}
+
+	help := []cli.Flag{
+		// help options
+		cli.BoolFlag{
+			Name:        "advanced-options, x",
+			Usage:       "Show all options - this must be specified instead of --help",
+			Destination: &c.advancedOptions,
+		},
+	}
+
+	target := c.TargetFlags()
+	compute := c.ComputeFlags()
+	iso := c.ImageFlags()
+	debug := c.DebugFlags()
+
+	// flag arrays are declared, now combined
+	var flags []cli.Flag
+	for _, f := range [][]cli.Flag{target, compute, create, iso, misc, debug, help} {
+		flags = append(flags, f...)
+	}
+
 	return flags
 }
 
@@ -749,8 +809,8 @@ func (c *Create) generateCertificates(ca bool) ([]byte, *certificate.KeyPair, er
 
 	if c.cname == "" {
 		log.Error("Common Name must be provided when generating certificates for client authentication:")
-		log.Info("  --cname=<FQDN or static IP> # for the appliance VM")
-		log.Info("  --cname=<*.yourdomain.com>  # if DNS has entries in that form for DHCP addresses (less secure)")
+		log.Info("  --tls-cname=<FQDN or static IP> # for the appliance VM")
+		log.Info("  --tls-cname=<*.yourdomain.com>  # if DNS has entries in that form for DHCP addresses (less secure)")
 		log.Info("  --no-tlsverify              # disables client authentication (anyone can connect to the VCH)")
 		log.Info("")
 

--- a/cmd/vic-machine/debug/debug.go
+++ b/cmd/vic-machine/debug/debug.go
@@ -16,6 +16,7 @@ package debug
 
 import (
 	"io/ioutil"
+	"time"
 
 	log "github.com/Sirupsen/logrus"
 
@@ -53,7 +54,7 @@ func (d *Debug) Flags() []cli.Flag {
 	preFlags := append(d.TargetFlags(), d.IDFlags()...)
 	preFlags = append(preFlags, d.ComputeFlags()...)
 
-	flags := []cli.Flag{
+	ssh := []cli.Flag{
 		cli.BoolFlag{
 			Name:        "enable-ssh, ssh",
 			Usage:       "Enable SSH server within appliance VM",
@@ -73,9 +74,27 @@ func (d *Debug) Flags() []cli.Flag {
 		},
 	}
 
-	flags = append(preFlags, flags...)
+	util := []cli.Flag{
+		cli.DurationFlag{
+			Name:        "timeout",
+			Value:       3 * time.Minute,
+			Usage:       "Time to wait for operation to complete",
+			Destination: &d.Timeout,
+		},
+	}
 
-	return append(flags, d.DebugFlags()...)
+	target := d.TargetFlags()
+	id := d.IDFlags()
+	compute := d.ComputeFlags()
+	debug := d.DebugFlags()
+
+	// flag arrays are declared, now combined
+	var flags []cli.Flag
+	for _, f := range [][]cli.Flag{target, id, compute, ssh, util, debug} {
+		flags = append(flags, f...)
+	}
+
+	return flags
 }
 
 func (d *Debug) processParams() error {

--- a/cmd/vic-machine/delete/delete.go
+++ b/cmd/vic-machine/delete/delete.go
@@ -46,10 +46,10 @@ func NewUninstall() *Uninstall {
 
 // Flags return all cli flags for delete
 func (d *Uninstall) Flags() []cli.Flag {
-	flags := []cli.Flag{
+	util := []cli.Flag{
 		cli.BoolFlag{
 			Name:        "force, f",
-			Usage:       "Force the uninstall",
+			Usage:       "Force the deletion",
 			Destination: &d.Force,
 		},
 		cli.DurationFlag{
@@ -59,10 +59,17 @@ func (d *Uninstall) Flags() []cli.Flag {
 			Destination: &d.Timeout,
 		},
 	}
-	preFlags := append(d.TargetFlags(), d.IDFlags()...)
-	preFlags = append(preFlags, d.ComputeFlags()...)
-	flags = append(preFlags, flags...)
-	flags = append(flags, d.DebugFlags()...)
+
+	target := d.TargetFlags()
+	id := d.IDFlags()
+	compute := d.ComputeFlags()
+	debug := d.DebugFlags()
+
+	// flag arrays are declared, now combined
+	var flags []cli.Flag
+	for _, f := range [][]cli.Flag{target, id, compute, util, debug} {
+		flags = append(flags, f...)
+	}
 
 	return flags
 }

--- a/cmd/vic-machine/inspect/inspect.go
+++ b/cmd/vic-machine/inspect/inspect.go
@@ -15,6 +15,8 @@
 package inspect
 
 import (
+	"time"
+
 	log "github.com/Sirupsen/logrus"
 
 	"github.com/urfave/cli"
@@ -45,9 +47,25 @@ func NewInspect() *Inspect {
 
 // Flags return all cli flags for inspect
 func (i *Inspect) Flags() []cli.Flag {
-	preFlags := append(i.TargetFlags(), i.IDFlags()...)
-	preFlags = append(preFlags, i.ComputeFlags()...)
-	flags := append(preFlags, i.DebugFlags()...)
+	util := []cli.Flag{
+		cli.DurationFlag{
+			Name:        "timeout",
+			Value:       3 * time.Minute,
+			Usage:       "Time to wait for upgrade",
+			Destination: &i.Timeout,
+		},
+	}
+
+	target := i.TargetFlags()
+	id := i.IDFlags()
+	compute := i.ComputeFlags()
+	debug := i.DebugFlags()
+
+	// flag arrays are declared, now combined
+	var flags []cli.Flag
+	for _, f := range [][]cli.Flag{target, id, compute, util, debug} {
+		flags = append(flags, f...)
+	}
 
 	return flags
 }

--- a/cmd/vic-machine/list/list.go
+++ b/cmd/vic-machine/list/list.go
@@ -64,7 +64,7 @@ func NewList() *List {
 
 // Flags return all cli flags for ls
 func (l *List) Flags() []cli.Flag {
-	flags := []cli.Flag{
+	util := []cli.Flag{
 		cli.DurationFlag{
 			Name:        "timeout",
 			Value:       3 * time.Minute,
@@ -72,9 +72,18 @@ func (l *List) Flags() []cli.Flag {
 			Destination: &l.Timeout,
 		},
 	}
-	preFlags := append(l.TargetFlags(), l.ComputeFlagsNoName()...)
-	flags = append(preFlags, flags...)
-	flags = append(flags, l.DebugFlags()...)
+
+	target := l.TargetFlags()
+	id := l.IDFlags()
+	// TODO: why not allow name as a filter, like most list operations
+	compute := l.ComputeFlagsNoName()
+	debug := l.DebugFlags()
+
+	// flag arrays are declared, now combined
+	var flags []cli.Flag
+	for _, f := range [][]cli.Flag{target, id, compute, util, debug} {
+		flags = append(flags, f...)
+	}
 
 	return flags
 }

--- a/cmd/vic-machine/upgrade/upgrade.go
+++ b/cmd/vic-machine/upgrade/upgrade.go
@@ -163,6 +163,14 @@ func (u *Upgrade) Run(cli *cli.Context) error {
 		}
 		return err
 	}
+
+	// check the docker endpoint is responsive
+	if err = executor.CheckDockerAPI(vchConfig, nil); err != nil {
+
+		executor.CollectDiagnosticLogs()
+		return err
+	}
+
 	log.Infof("Completed successfully")
 
 	return nil

--- a/cmd/vic-machine/upgrade/upgrade.go
+++ b/cmd/vic-machine/upgrade/upgrade.go
@@ -48,31 +48,32 @@ func NewUpgrade() *Upgrade {
 
 // Flags return all cli flags for upgrade
 func (u *Upgrade) Flags() []cli.Flag {
-	flags := []cli.Flag{
+	util := []cli.Flag{
+		cli.BoolFlag{
+			Name:        "force, f",
+			Usage:       "Force the upgrade (ignores version checks)",
+			Destination: &u.Force,
+		},
 		cli.DurationFlag{
 			Name:        "timeout",
 			Value:       3 * time.Minute,
 			Usage:       "Time to wait for upgrade",
 			Destination: &u.Timeout,
 		},
-		cli.BoolFlag{
-			Name:        "force, f",
-			Usage:       "Force the upgrade (ignores version checks)",
-			Destination: &u.Force,
-		},
 	}
-	flags = append(
-		append(
-			append(
-				append(
-					append(
-						u.TargetFlags(),
-						u.IDFlags()...,
-					), u.ComputeFlags()...,
-				), u.ImageFlags()...,
-			), flags...),
-		u.DebugFlags()...,
-	)
+
+	target := u.TargetFlags()
+	id := u.IDFlags()
+	compute := u.ComputeFlags()
+	iso := u.ImageFlags(false)
+	debug := u.DebugFlags()
+
+	// flag arrays are declared, now combined
+	var flags []cli.Flag
+	for _, f := range [][]cli.Flag{target, id, compute, iso, util, debug} {
+		flags = append(flags, f...)
+	}
+
 	return flags
 }
 

--- a/cmd/vicadmin/logs.go
+++ b/cmd/vicadmin/logs.go
@@ -148,15 +148,12 @@ func configureReaders() map[string]entryReader {
 		readers[path[1:]] = fileReader(path)
 	}
 
-	if config.vmPath == "" {
-		log.Info("vm-path not set, skipping datastore log collection")
-	} else {
-		err := findDatastore()
+	log.Info("vm-path not set, skipping datastore log collection")
+	// err := findDatastore()
 
-		if err != nil {
-			log.Warning(err)
-		}
-	}
+	// if err != nil {
+	// 	log.Warning(err)
+	// }
 
 	return readers
 }

--- a/cmd/vicadmin/server.go
+++ b/cmd/vicadmin/server.go
@@ -82,7 +82,7 @@ func (s *server) listen(useTLS bool) error {
 		tlsconfig.Certificates = []tls.Certificate{*certificate}
 	}
 
-	if !useTLS || err != nil {
+	if !useTLS {
 		s.l, err = net.Listen("tcp", s.addr)
 		return err
 	}

--- a/cmd/vicadmin/vicadm_test.go
+++ b/cmd/vicadmin/vicadm_test.go
@@ -63,11 +63,11 @@ func init() {
 	insecureClient = &http.Client{Transport: transport}
 	flag.Set("docker-host", u.Host)
 
-	config.hostCertFile = "fixtures/vicadmin_test_cert.pem"
-	config.hostKeyFile = "fixtures/vicadmin_test_pkey.pem"
+	hostCertFile := "fixtures/vicadmin_test_cert.pem"
+	hostKeyFile := "fixtures/vicadmin_test_pkey.pem"
 
-	cert, cerr := ioutil.ReadFile(config.hostCertFile)
-	key, kerr := ioutil.ReadFile(config.hostKeyFile)
+	cert, cerr := ioutil.ReadFile(hostCertFile)
+	key, kerr := ioutil.ReadFile(hostKeyFile)
 	if kerr != nil || cerr != nil {
 		panic("unable to load test certificate")
 	}

--- a/doc/user/usage.md
+++ b/doc/user/usage.md
@@ -19,43 +19,45 @@ Replace the `<fields>` in the example with values specific to your environment -
 - --force flag is to remove an existing datastore folder or VM with the same name.
 
 ```
-vic-machine-linux create --target target-host[/datacenter] --image-store <datastore name> --name <vch-name> --user root --password <password> --compute-resource <resource pool path>
+vic-machine-linux create --target target-host[/datacenter] --image-store <datastore name> --name <vch-name> --user root --password <password> --compute-resource <resource pool path> --no-tlsverify
 ```
 This will, if successful, produce output similar to the following when deploying VIC Engine onto an ESXi:
 ```
-INFO[2016-06-29T14:41:08-07:00] ### Installing VCH ####
-INFO[2016-06-29T14:41:08-07:00] Generating certificate/key pair - private key in ./vic-001-key.pem
-INFO[2016-06-29T14:41:09-07:00] Validating supplied configuration
-INFO[2016-06-29T14:41:09-07:00] Firewall status: DISABLED on /ha-datacenter/host/localhost.localdomain/localhost.localdomain
-INFO[2016-06-29T14:41:09-07:00] Firewall configuration OK on hosts:
-INFO[2016-06-29T14:41:09-07:00]   /ha-datacenter/host/localhost.localdomain/localhost.localdomain
-WARN[2016-06-29T14:41:09-07:00] Evaluation license detected. VIC may not function if evaluation expires or insufficient license is later assigned.
-INFO[2016-06-29T14:41:09-07:00] License check OK
-INFO[2016-06-29T14:41:09-07:00] DRS check SKIPPED - target is standalone host
-INFO[2016-06-29T14:41:09-07:00] Creating Resource Pool vic-001
-INFO[2016-06-29T14:41:09-07:00] Creating VirtualSwitch
-INFO[2016-06-29T14:41:09-07:00] Creating Portgroup
-INFO[2016-06-29T14:41:09-07:00] Creating appliance on target
-INFO[2016-06-29T14:41:09-07:00] Network role external is sharing NIC with management
-INFO[2016-06-29T14:41:09-07:00] Network role client is sharing NIC with management
-INFO[2016-06-29T14:41:09-07:00] Uploading images for container
-INFO[2016-06-29T14:41:09-07:00]   /home/user/go/src/github.com/vmware/vic/bin/appliance.iso
-INFO[2016-06-29T14:41:09-07:00]   /home/user/go/src/github.com/vmware/vic/bin/bootstrap.iso
-INFO[2016-06-29T14:41:15-07:00] Waiting for IP information
-INFO[2016-06-29T14:41:35-07:00] Waiting for major appliance components to launch
-INFO[2016-06-29T14:41:36-07:00] Initialization of appliance successful
-INFO[2016-06-29T14:41:36-07:00]
-INFO[2016-06-29T14:41:36-07:00] SSH to appliance (default=root:password)
-INFO[2016-06-29T14:41:36-07:00] ssh root@192.168.218.129
-INFO[2016-06-29T14:41:36-07:00]
-INFO[2016-06-29T14:41:36-07:00] Log server:
-INFO[2016-06-29T14:41:36-07:00] https://192.168.218.129:2378
-INFO[2016-06-29T14:41:36-07:00]
-INFO[2016-06-29T14:41:36-07:00] DOCKER_HOST=192.168.218.129:2376
-INFO[2016-06-29T14:41:36-07:00]
-INFO[2016-06-29T14:41:36-07:00] Connect to docker:
-INFO[2016-06-29T14:41:36-07:00] docker -H 192.168.218.129:2376 --tls info
-INFO[2016-06-29T14:41:36-07:00] Installer completed successfully
+INFO[2016-10-08T23:37:34Z] Generating self-signed certificate/key pair - private key in ./XXX/key.pem
+WARN[2016-10-08T23:37:34Z] Configuring without TLS verify - client authentication disabled
+INFO[2016-10-08T23:37:34Z] ### Installing VCH ####
+INFO[2016-10-08T23:37:34Z] Validating supplied configuration
+INFO[2016-10-08T23:37:34Z] Firewall status: DISABLED on "/ha-datacenter/host/esx-a.localdomain/esx-a.localdomain"
+WARN[2016-10-08T23:37:34Z] Firewall configuration will be incorrect if firewall is reenabled on hosts:
+WARN[2016-10-08T23:37:34Z]   "/ha-datacenter/host/esx-a.localdomain/esx-a.localdomain"
+WARN[2016-10-08T23:37:34Z] Firewall must permit 2377/tcp outbound if firewall is reenabled
+INFO[2016-10-08T23:37:34Z] License check OK
+INFO[2016-10-08T23:37:34Z] DRS check SKIPPED - target is standalone host
+INFO[2016-10-08T23:37:34Z] Creating Resource Pool "XXX"
+INFO[2016-10-08T23:37:35Z] Creating directory [datastore1] volumes
+INFO[2016-10-08T23:37:35Z] Datastore path is [datastore1] volumes
+INFO[2016-10-08T23:37:35Z] Creating appliance on target
+INFO[2016-10-08T23:37:35Z] Network role "management" is sharing NIC with "client"
+INFO[2016-10-08T23:37:35Z] Network role "external" is sharing NIC with "client"
+INFO[2016-10-08T23:37:35Z] Uploading images for container
+INFO[2016-10-08T23:37:35Z]      "bootstrap.iso"
+INFO[2016-10-08T23:37:35Z]      "appliance.iso"
+INFO[2016-10-08T23:37:39Z] Waiting for IP information
+INFO[2016-10-08T23:37:51Z] Waiting for major appliance components to launch
+INFO[2016-10-08T23:38:01Z] Initialization of appliance successful
+INFO[2016-10-08T23:38:01Z]
+INFO[2016-10-08T23:38:01Z] vic-admin portal:
+INFO[2016-10-08T23:38:01Z] https://x.x.x.x:2378
+INFO[2016-10-08T23:38:01Z]
+INFO[2016-10-08T23:38:01Z] Docker environment variables:
+INFO[2016-10-08T23:38:01Z]   DOCKER_HOST=x.x.x.x:2376
+INFO[2016-10-08T23:38:01Z]
+INFO[2016-10-08T23:38:01Z] Environment saved in XXX/XXX.env
+INFO[2016-10-08T23:38:01Z]
+INFO[2016-10-08T23:38:01Z] Connect to docker:
+INFO[2016-10-08T23:38:01Z] docker -H x.x.x.x:2376 --tls info
+INFO[2016-10-08T23:38:01Z] Installer completed successfully
+
 ```
 
 
@@ -83,24 +85,56 @@ Specify the same resource pool and VCH name used to create a VCH, vic-machine in
 
 ```
 vic-machine-linux inspect --target target-host[/datacenter] --user root --password <password> --compute-resource <resource pool path> --name <vch-name>
-INFO[2016-06-29T16:03:17-05:00] ### Inspecting VCH ####
-INFO[2016-06-29T16:03:20-05:00]
-INFO[2016-06-29T16:03:20-05:00] VCH: <resource pool path>/<vch-name>
-INFO[2016-06-29T16:03:21-05:00]
-INFO[2016-06-29T16:03:21-05:00] SSH to appliance (default=root:password)
-INFO[2016-06-29T16:03:21-05:00] ssh root@x.x.x.x
-INFO[2016-06-29T16:03:21-05:00]
-INFO[2016-06-29T16:03:21-05:00] Log server:
-INFO[2016-06-29T16:03:21-05:00] https://x.x.x.x:2378
-INFO[2016-06-29T16:03:21-05:00]
-INFO[2016-06-29T16:03:21-05:00] DOCKER_HOST=x.x.x.x:2376
-INFO[2016-06-29T16:03:21-05:00] DOCKER_OPTS="-H x.x.x.x:2376"
-INFO[2016-06-29T16:03:21-05:00]
-INFO[2016-06-29T16:03:21-05:00] Connect to docker:
-INFO[2016-06-29T16:03:21-05:00] docker -H x.x.x.x:2376 info
-INFO[2016-06-29T16:03:21-05:00] Completed successfully
+INFO[2016-10-08T23:40:28Z] ### Inspecting VCH ####
+INFO[2016-10-08T23:40:29Z]
+INFO[2016-10-08T23:40:29Z] VCH ID: VirtualMachine:286
+INFO[2016-10-08T23:40:29Z]
+INFO[2016-10-08T23:40:29Z] Installer version: v0.6.0-0-0fac2c0
+INFO[2016-10-08T23:40:29Z] VCH version: v0.6.0-0-0fac2c0
+INFO[2016-10-08T23:40:29Z]
+INFO[2016-10-08T23:40:29Z] VCH upgrade status:
+INFO[2016-10-08T23:40:29Z] Installer has same version as VCH
+INFO[2016-10-08T23:40:29Z] No upgrade available with this installer version
+INFO[2016-10-08T23:40:29Z]
+INFO[2016-10-08T23:40:29Z] vic-admin portal:
+INFO[2016-10-08T23:40:29Z] https://x.x.x.x:2378
+INFO[2016-10-08T23:40:29Z]
+INFO[2016-10-08T23:40:29Z] Docker environment variables:
+INFO[2016-10-08T23:40:29Z]   DOCKER_HOST=x.x.x.x:2376
+INFO[2016-10-08T23:40:29Z]
+INFO[2016-10-08T23:40:29Z]
+INFO[2016-10-08T23:40:29Z] Connect to docker:
+INFO[2016-10-08T23:40:29Z] docker -H x.x.x.x:2376 --tls info
+INFO[2016-10-08T23:40:29Z] Completed successfully
 ```
 
+
+## Enabling SSH to Virtual Container Host appliance
+Specify the same resource pool and VCH name used to create a VCH, vic-machine debug will enable SSH on the appliance VM and then display the VCH information, now with SSH entry.
+
+```
+vic-machine-linux debug --target target-host[/datacenter] --user root --password <password> --compute-resource <resource pool path> --name <vch-name> --enable-ssh --rootpw <other password> --authorized-key <keyfile>
+INFO[2016-10-08T23:41:16Z] ### Configuring VCH for debug ####
+INFO[2016-10-08T23:41:16Z]
+INFO[2016-10-08T23:41:16Z] VCH ID: VirtualMachine:286
+INFO[2016-10-08T23:41:16Z]
+INFO[2016-10-08T23:41:16Z] Installer version: v0.6.0-0-0fac2c0
+INFO[2016-10-08T23:41:16Z] VCH version: v0.6.0-0-0fac2c0
+INFO[2016-10-08T23:41:16Z]
+INFO[2016-10-08T23:41:16Z] SSH to appliance
+INFO[2016-10-08T23:41:16Z] ssh root@x.x.x.x
+INFO[2016-10-08T23:41:16Z]
+INFO[2016-10-08T23:41:16Z] vic-admin portal:
+INFO[2016-10-08T23:41:16Z] https://x.x.x.x:2378
+INFO[2016-10-08T23:41:16Z]
+INFO[2016-10-08T23:41:16Z] Docker environment variables:
+INFO[2016-10-08T23:41:16Z]   DOCKER_HOST=x.x.x.x:2376
+INFO[2016-10-08T23:41:16Z]
+INFO[2016-10-08T23:41:16Z]
+INFO[2016-10-08T23:41:16Z] Connect to docker:
+INFO[2016-10-08T23:41:16Z] docker -H x.x.x.x:2376 --tls info
+INFO[2016-10-08T23:41:16Z] Completed successfully
+```
 
 ## List Virtual Container Hosts
 

--- a/doc/user_doc/vic_installation/vch_installer_examples.md
+++ b/doc/user_doc/vic_installation/vch_installer_examples.md
@@ -253,12 +253,12 @@ This example deploys a virtual container host with the following configuration:
 --compute-resource cluster1
 --image-store datastore1
 --bridge-network vic-bridge
---pool-memory-reservation 1024
---pool-memory-limit 1024
---pool-memory-shares low
---pool-cpu-reservation 1024
---pool-cpu-limit 1024
---pool-cpu-shares low
+--memory-reservation 1024
+--memory 1024
+--memory-shares low
+--cpu-reservation 1024
+--cpu 1024
+--cpu-shares low
 --name vch1
 </pre>
 

--- a/doc/user_doc/vic_installation/vch_installer_options.md
+++ b/doc/user_doc/vic_installation/vch_installer_options.md
@@ -483,51 +483,51 @@ Wrap the folder names in the path in single quotes (Linux or Mac OS) or double q
 
 ### `pool-memory-reservation` ###
 
-Short name: `--pmr`
+Short name: `--memr`
 
 Reserve a quantity of memory for use by the virtual container host vApp   and container VMs. Specify the memory reservation value in MB. If not specified, `vic-machine create` sets the reservation to 1.
 
-<pre>--pool-memory-reservation 1024</pre>
+<pre>--memory-reservation 1024</pre>
 
 ### `pool-memory-limit` ###
 
-Short name: `--pml`
+Short name: `--mem`
 
 Limit the amount of memory that is available for use by the virtual container host vApp and container VMs. Specify the memory limit value in MB. If not specified, `vic-machine create` sets the limit to 0 (unlimited).
 
-<pre>--pool-memory-limit 1024</pre>
+<pre>--memory 1024</pre>
 
 ### `pool-memory-shares` ###
 
-Short name: `--pms`
+Short name: `--mems`
 
 Set memory shares on the virtual container host vApp. Specify the share value as a level or a number, for example `high`, `normal`, `low`, or `163840`. If not specified, `vic-machine create` sets the share to `normal`.
 
-<pre>--pool-memory-shares low</pre>
+<pre>--memory-shares low</pre>
 
 ### `pool-cpu-reservation` ###
 
-Short name: `--pcr`
+Short name: `--cpur`
 
 Reserve a quantity of CPU capacity for use by the virtual container host vApp and container VMs.  Specify the CPU reservation value in MHz. If not specified, `vic-machine create` sets the reservation to 1.
 
-<pre>--pool-cpu-reservation 1024</pre>
+<pre>--cpu-reservation 1024</pre>
 
 ### `pool-cpu-limit` ###
 
-Short name: `--pcl`
+Short name: `--cpu`
 
 Limit the amount of CPU capacity that is available for use by the virtual container host vApp and container VMs. Specify the CPU limit value in MHz. If not specified, `vic-machine create` sets the reservation to 0 (unlimited).
 
-<pre>--pool-cpu-limit 1024</pre>
+<pre>--cpu 1024</pre>
 
 ### `pool-cpu-shares` ###
 
-Short name: `--pcs`
+Short name: `--cpus`
 
 Set CPU shares on the virtual container host vApp. Specify the share value as a level or a number, for example `high`, `normal`, `low`, or `163840`. If not specified, `vic-machine create` sets the share to `normal`.
 
-<pre>--pool-cpu-shares low</pre>
+<pre>--cpu-shares low</pre>
 
 ### `debug` ###
 Short name: `-v`

--- a/lib/apiservers/portlayer/restapi/handlers/containers_handlers.go
+++ b/lib/apiservers/portlayer/restapi/handlers/containers_handlers.go
@@ -97,8 +97,8 @@ func (handler *ContainersHandlersImpl) CreateHandler(params containers.CreatePar
 		},
 		CreateTime: time.Now().UTC().Unix(),
 		Version:    version.GetBuild(),
-		Sessions: map[string]executor.SessionConfig{
-			id: {
+		Sessions: map[string]*executor.SessionConfig{
+			id: &executor.SessionConfig{
 				Common: executor.Common{
 					ID:   id,
 					Name: *params.CreateConfig.Name,

--- a/lib/config/executor/container_vm.go
+++ b/lib/config/executor/container_vm.go
@@ -118,7 +118,7 @@ type ExecutorConfig struct {
 
 	// Sessions is the set of sessions currently hosted by this executor
 	// These are keyed by session ID
-	Sessions map[string]SessionConfig `vic:"0.1" scope:"read-only" key:"sessions"`
+	Sessions map[string]*SessionConfig `vic:"0.1" scope:"read-only" key:"sessions"`
 
 	// Maps the mount name to the detail mount specification
 	Mounts map[string]MountSpec `vic:"0.1" scope:"read-only" key:"mounts"`

--- a/lib/config/virtual_container_host.go
+++ b/lib/config/virtual_container_host.go
@@ -240,7 +240,7 @@ func (t *VirtualContainerHostConfigSpec) AddContainerNetwork(net *executor.Conta
 func (t *VirtualContainerHostConfigSpec) AddComponent(name string, component *executor.SessionConfig) {
 	if component != nil {
 		if t.ExecutorConfig.Sessions == nil {
-			t.ExecutorConfig.Sessions = make(map[string]executor.SessionConfig)
+			t.ExecutorConfig.Sessions = make(map[string]*executor.SessionConfig)
 		}
 
 		if component.Name == "" {
@@ -249,7 +249,7 @@ func (t *VirtualContainerHostConfigSpec) AddComponent(name string, component *ex
 		if component.ID == "" {
 			component.ID = name
 		}
-		t.ExecutorConfig.Sessions[name] = *component
+		t.ExecutorConfig.Sessions[name] = component
 	}
 }
 

--- a/lib/install/management/appliance.go
+++ b/lib/install/management/appliance.go
@@ -466,13 +466,8 @@ func (d *Dispatcher) createAppliance(conf *config.VirtualContainerHostConfigSpec
 			Path: "/sbin/vicadmin",
 			Args: []string{
 				"/sbin/vicadmin",
-				"-docker-host=unix:///var/run/docker.sock",
-				// FIXME: hack during config migration
-				"-insecure",
-				"-ds=" + conf.ImageStores[0].Host,
-				"-cluster=" + settings.ClusterPath,
-				"-pool=" + settings.ResourcePoolPath,
-				"-vm-path=" + vm2.InventoryPath,
+				"--pool=" + settings.ResourcePoolPath,
+				"--cluster=" + settings.ClusterPath,
 			},
 			Env: []string{
 				"PATH=/sbin:/bin",
@@ -516,9 +511,16 @@ func (d *Dispatcher) createAppliance(conf *config.VirtualContainerHostConfigSpec
 			Path: "/sbin/port-layer-server",
 			Args: []string{
 				"/sbin/port-layer-server",
-				//FIXME: hack during config migration
 				"--host=localhost",
 				fmt.Sprintf("--port=%d", portLayerPort),
+			},
+			Env: []string{
+				//FIXME: hack during config migration
+				"VC_URL=" + conf.Target.String(),
+				"DC_PATH=" + settings.DatacenterName,
+				"CS_PATH=" + settings.ClusterPath,
+				"POOL_PATH=" + settings.ResourcePoolPath,
+				"DS_PATH=" + conf.ImageStores[0].Host,
 			},
 		},
 		Restart: true,

--- a/lib/install/management/appliance.go
+++ b/lib/install/management/appliance.go
@@ -21,9 +21,13 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"net"
 	"net/http"
+	"net/url"
+	"os"
 	"path"
 	"strconv"
+	"syscall"
 	"time"
 
 	log "github.com/Sirupsen/logrus"
@@ -682,7 +686,7 @@ func (d *Dispatcher) CheckDockerAPI(conf *config.VirtualContainerHostConfigSpec,
 			// find the name to use
 			addr, err = addrToUse(d.HostIP, conf)
 			if err != nil {
-				log.Warn("Unable to determine address to use with remote certificate, skipping component checks")
+				log.Warn("Unable to determine address to use with remote certificate, skipping API liveliness checks")
 				tlsErrExpected = true
 			}
 		}
@@ -706,23 +710,76 @@ func (d *Dispatcher) CheckDockerAPI(conf *config.VirtualContainerHostConfigSpec,
 	defer ticker.Stop()
 	for {
 		res, err = client.Do(req)
-		if err != nil {
-			log.Debugf("Error recieved from endpoint: %s", err)
-		}
-
 		if err == nil && res.StatusCode == http.StatusOK {
 			if isPortLayerRunning(res) {
 				break
 			}
 		}
 
-		// TODO: add check for rejection without cert - indicates a degree of initialization
-		// HTTP status 403.7. Change this to check for structured error and status codes if possible
-		if tlsErrExpected && err != nil {
-			log.Debugf("Expected TLS error from endpoint due to IP based addressing, skipping component check: %+v", err)
-			// TODO: check for 403.17 - we see that regardless until the appliance has updated
-			// it's clock in some cases
-			break
+		if err != nil {
+			// DEBU[2016-10-11T22:22:38Z] Error recieved from endpoint: Get https://192.168.78.127:2376/info: dial tcp 192.168.78.127:2376: getsockopt: connection refused &{%!t(string=Get) %!t(string=https://192.168.78.127:2376/info) %!t(*net.OpError=&{dial tcp <nil> 0xc4204505a0 0xc4203a5e00})}
+			// DEBU[2016-10-11T22:22:39Z] Components not yet initialized, retrying
+			// ERR=&url.Error{
+			//     Op:  "Get",
+			//     URL: "https://192.168.78.127:2376/info",
+			//     Err: &net.OpError{
+			//         Op:     "dial",
+			//         Net:    "tcp",
+			//         Source: nil,
+			//         Addr:   &net.TCPAddr{
+			//             IP:   {0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xff, 0xff, 0xc0, 0xa8, 0x4e, 0x7f},
+			//             Port: 2376,
+			//             Zone: "",
+			//         },
+			//         Err: &os.SyscallError{
+			//             Syscall: "getsockopt",
+			//             Err:     syscall.Errno(0x6f),
+			//         },
+			//     },
+			// }
+			// DEBU[2016-10-11T22:22:41Z] Error recieved from endpoint: Get https://192.168.78.127:2376/info: remote error: tls: bad certificate &{%!t(string=Get) %!t(string=https://192.168.78.127:2376/info) %!t(*net.OpError=&{remote error  <nil> <nil> 42})}
+			// DEBU[2016-10-11T22:22:42Z] Components not yet initialized, retrying
+			// ERR=&url.Error{
+			//     Op:  "Get",
+			//     URL: "https://192.168.78.127:2376/info",
+			//     Err: &net.OpError{
+			//         Op:     "remote error",
+			//         Net:    "",
+			//         Source: nil,
+			//         Addr:   nil,
+			//         Err:    tls.alert(0x2a),
+			//     },
+			// }
+
+			// ECONNREFUSED: 111, 0x6f
+
+			uerr, ok := err.(*url.Error)
+			if ok {
+				operr, ok2 := uerr.Err.(*net.OpError)
+				if ok2 {
+					switch root := operr.Err.(type) {
+					case *os.SyscallError:
+						if root.Err == syscall.Errno(syscall.ECONNREFUSED) {
+							// waiting for API server to start
+							log.Debug("connection refused")
+						}
+					default:
+						// the TLS package doesn't expose the raw reason codes
+						// but we're actually looking for alertBadCertificate (42)
+						errmsg := root.Error()
+						if errmsg == "tls: bad certificate" {
+							// TODO: programmatic check for clock skew on host
+							log.Errorf("Connection failed with TLS error \"bad certificate\" - check for clock skew on the host")
+						} else if tlsErrExpected {
+							log.Warnf("Expected TLS error without client certificate, received error: %s", errmsg)
+						} else {
+							log.Errorf("Connection failed with error: %s", root)
+						}
+
+						return root
+					}
+				}
+			}
 		}
 
 		select {

--- a/lib/install/management/appliance.go
+++ b/lib/install/management/appliance.go
@@ -500,7 +500,6 @@ func (d *Dispatcher) createAppliance(conf *config.VirtualContainerHostConfigSpec
 			Args: []string{
 				"/sbin/docker-engine-server",
 				//FIXME: hack during config migration
-				"-serveraddr=0.0.0.0",
 				"-port=" + d.DockerPort,
 				fmt.Sprintf("-port-layer-port=%d", portLayerPort),
 			},

--- a/lib/install/management/appliance.go
+++ b/lib/install/management/appliance.go
@@ -519,12 +519,6 @@ func (d *Dispatcher) createAppliance(conf *config.VirtualContainerHostConfigSpec
 				//FIXME: hack during config migration
 				"--host=localhost",
 				fmt.Sprintf("--port=%d", portLayerPort),
-				"--insecure",
-				"--sdk=" + conf.Target.String(),
-				"--datacenter=" + settings.DatacenterName,
-				"--cluster=" + settings.ClusterPath,
-				"--pool=" + settings.ResourcePoolPath,
-				"--datastore=" + conf.ImageStores[0].Host,
 			},
 		},
 		Restart: true,

--- a/lib/install/management/upgrade.go
+++ b/lib/install/management/upgrade.go
@@ -72,6 +72,11 @@ func (d *Dispatcher) Upgrade(vch *vm.VirtualMachine, conf *config.VirtualContain
 
 	conf.BootstrapImagePath = fmt.Sprintf("[%s] %s/%s", conf.ImageStores[0].Host, d.vmPathName, settings.BootstrapISO)
 
+	// ensure that we wait for components to come up
+	for _, s := range conf.ExecutorConfig.Sessions {
+		s.Started = ""
+	}
+
 	snapshotName := fmt.Sprintf("%s %s", UpgradePrefix, conf.Version.BuildNumber)
 	snapshotName = strings.TrimSpace(snapshotName)
 	snapshotRefID, err := d.createSnapshot(snapshotName, "upgrade snapshot")

--- a/lib/tether/cmd_test.go
+++ b/lib/tether/cmd_test.go
@@ -42,8 +42,8 @@ func TestPathLookup(t *testing.T) {
 			Name: "tether_test_executor",
 		},
 
-		Sessions: map[string]executor.SessionConfig{
-			"pathlookup": {
+		Sessions: map[string]*executor.SessionConfig{
+			"pathlookup": &executor.SessionConfig{
 				Common: executor.Common{
 					ID:   "pathlookup",
 					Name: "tether_test_session",
@@ -80,8 +80,8 @@ func TestRelativePath(t *testing.T) {
 			Name: "tether_test_executor",
 		},
 
-		Sessions: map[string]executor.SessionConfig{
-			"relpath": {
+		Sessions: map[string]*executor.SessionConfig{
+			"relpath": &executor.SessionConfig{
 				Common: executor.Common{
 					ID:   "relpath",
 					Name: "tether_test_session",
@@ -118,8 +118,8 @@ func TestAbsPath(t *testing.T) {
 			Name: "tether_test_executor",
 		},
 
-		Sessions: map[string]executor.SessionConfig{
-			"abspath": {
+		Sessions: map[string]*executor.SessionConfig{
+			"abspath": &executor.SessionConfig{
 				Common: executor.Common{
 					ID:   "abspath",
 					Name: "tether_test_session",
@@ -174,8 +174,8 @@ func TestHalt(t *testing.T) {
 			Name: "tether_test_executor",
 		},
 
-		Sessions: map[string]executor.SessionConfig{
-			"abspath": {
+		Sessions: map[string]*executor.SessionConfig{
+			"abspath": &executor.SessionConfig{
 				Common: executor.Common{
 					ID:   "abspath",
 					Name: "tether_test_session",
@@ -248,8 +248,8 @@ func TestMissingBinary(t *testing.T) {
 			Name: "tether_test_executor",
 		},
 
-		Sessions: map[string]executor.SessionConfig{
-			"missing": {
+		Sessions: map[string]*executor.SessionConfig{
+			"missing": &executor.SessionConfig{
 				Common: executor.Common{
 					ID:   "missing",
 					Name: "tether_test_session",
@@ -295,8 +295,8 @@ func TestMissingRelativeBinary(t *testing.T) {
 			Name: "tether_test_executor",
 		},
 
-		Sessions: map[string]executor.SessionConfig{
-			"missing": {
+		Sessions: map[string]*executor.SessionConfig{
+			"missing": &executor.SessionConfig{
 				Common: executor.Common{
 					ID:   "missing",
 					Name: "tether_test_session",

--- a/lib/tether/config_test.go
+++ b/lib/tether/config_test.go
@@ -36,8 +36,8 @@ func TestToExtraConfig(t *testing.T) {
 			ID:   "deadbeef",
 			Name: "configtest",
 		},
-		Sessions: map[string]executor.SessionConfig{
-			"deadbeef": {
+		Sessions: map[string]*executor.SessionConfig{
+			"deadbeef": &executor.SessionConfig{
 				Cmd: executor.Cmd{
 					Path: "/bin/bash",
 					Args: []string{"/bin/bash", "-c", "echo hello"},
@@ -45,7 +45,7 @@ func TestToExtraConfig(t *testing.T) {
 					Env:  []string{"HOME=/", "PATH=/bin"},
 				},
 			},
-			"beefed": {
+			"beefed": &executor.SessionConfig{
 				Cmd: executor.Cmd{
 					Path: "/bin/bash",
 					Args: []string{"/bin/bash", "-c", "echo goodbye"},
@@ -55,7 +55,7 @@ func TestToExtraConfig(t *testing.T) {
 			},
 		},
 		Networks: map[string]*executor.NetworkEndpoint{
-			"eth0": {
+			"eth0": &executor.SessionConfig{
 				Static: true,
 				IP:     &net.IPNet{IP: localhost, Mask: lmask.Mask},
 				Network: executor.ContainerNetwork{

--- a/tests/resources/Util.robot
+++ b/tests/resources/Util.robot
@@ -40,8 +40,9 @@ Set Test Environment Variables
     Run Keyword Unless  ${status}  Set Environment Variable  HOST_TYPE  VC
 
     # set the TLS config options suitable for vic-machine in this env
-    Run Keyword If  '%{DOMAIN}' == ''  Set Suite Variable  ${vicmachinetls}  '--no-tlsverify'
-    Run Keyword If  '%{DOMAIN}' != ''  Set Suite Variable  ${vicmachinetls}  '--cname=*.%{DOMAIN}'  
+    ${domain}=  Get Environment Variable  DOMAIN  ''
+    Run Keyword If  '${domain}' == ''  Set Suite Variable  ${vicmachinetls}  '--no-tlsverify'
+    Run Keyword If  '${domain}' != ''  Set Suite Variable  ${vicmachinetls}  '--cname=*.${domain}'
 
 Set Test VCH Name
     ${name}=  Evaluate  'VCH-%{DRONE_BUILD_NUMBER}-' + str(random.randint(1000,9999))  modules=random

--- a/tests/resources/Util.robot
+++ b/tests/resources/Util.robot
@@ -42,7 +42,7 @@ Set Test Environment Variables
     # set the TLS config options suitable for vic-machine in this env
     ${domain}=  Get Environment Variable  DOMAIN  ''
     Run Keyword If  '${domain}' == ''  Set Suite Variable  ${vicmachinetls}  '--no-tlsverify'
-    Run Keyword If  '${domain}' != ''  Set Suite Variable  ${vicmachinetls}  '--cname=*.${domain}'
+    Run Keyword If  '${domain}' != ''  Set Suite Variable  ${vicmachinetls}  '--tls-cname=*.${domain}'
 
 Set Test VCH Name
     ${name}=  Evaluate  'VCH-%{DRONE_BUILD_NUMBER}-' + str(random.randint(1000,9999))  modules=random


### PR DESCRIPTION
Block vic-machine upgrade from completing until the components
have come up cleanly. This does **not** add rollback if the VCH fails
to initialize correctly.

Only serves the docker API on the client interface as designed and
removes some of the unnecessary flags.

Updates to examples and usage doc.

Towards #2624 (handles the --no-tls case)
Fixes: #2197 
