### PR TITLE
Enable rmi integration tests

### DIFF
--- a/lib/apiservers/engine/backends/image.go
+++ b/lib/apiservers/engine/backends/image.go
@@ -79,7 +79,12 @@ func (i *Image) ImageDelete(imageRef string, force, prune bool) ([]types.ImageDe
 
 	_, err = PortLayerClient().Storage.DeleteImage(params)
 	if err != nil {
-		return nil, err
+		switch err := err.(type) {
+		case *storage.DeleteImageLocked:
+			return nil, fmt.Errorf("Failed to remove image (%s): ", imageRef, err.Payload.Message)
+		default:
+			return nil, err
+		}
 	}
 
 	cache.ImageCache().RemoveImageByConfig(img)

--- a/tests/test-cases/Group1-Docker-Commands/1-12-Docker-RMI.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-12-Docker-RMI.robot
@@ -1,60 +1,45 @@
 *** Settings ***
 Documentation  Test 1-12 - Docker RMI
 Resource  ../../resources/Util.robot
-#Suite Setup  Install VIC Appliance To Test Server
-#Suite Teardown  Cleanup VIC Appliance On Test Server
+Suite Setup  Install VIC Appliance To Test Server
+Suite Teardown  Cleanup VIC Appliance On Test Server
 
 *** Test Cases ***
 Basic docker remove image
-    ${status}=  Get State Of Github Issue  437
-    Run Keyword If  '${status}' == 'closed'  Fail  Test 1-12-Docker-RMI.robot needs to be updated now that Issue #437 has been resolved
-    Log  Issue \#437 is blocking implementation  WARN
-    #${rc}  ${output}=  Run And Return Rc And Output  docker ${params} pull busybox
-    #Should Be Equal As Integers  ${rc}  0
-    #${rc}  ${output}=  Run And Return Rc And Output  docker ${params} rmi busybox
-    #Should Be Equal As Integers  ${rc}  0
-    #${rc}  ${output}=  Run And Return Rc And Output  docker ${params} images
-    #Should Be Equal As Integers  ${rc}  0
-    #Should Not Contain  ${output}  busybox
-    
-#Remove image with a removed container
-#    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} pull busybox
-#    Should Be Equal As Integers  ${rc}  0
-#    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} create busybox /bin/top
-#    Should Be Equal As Integers  ${rc}  0
-#    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} rm ${output}
-#    Should Be Equal As Integers  ${rc}  0
-#    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} rmi busybox
-#    Should Be Equal As Integers  ${rc}  0
-#    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} images
-#    Should Be Equal As Integers  ${rc}  0
-#    Should Not Contain  ${output}  busybox
-        
-#Remove image with a container    
-#    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} pull busybox
-#    Should Be Equal As Integers  ${rc}  0
-#    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} create busybox /bin/top
-#    Should Be Equal As Integers  ${rc}  0
-#    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} rmi busybox
-#    Should Be Equal As Integers  ${rc}  1
-#    Should Contain  ${output}  Failed to remove image (busybox): Error response from daemon: conflict: unable to remove repository reference "busybox" (must force) - container
-#    Should Contain  ${output}  is using its referenced image
-#    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} images
-#    Should Be Equal As Integers  ${rc}  0
-#    Should Contain  ${output}  busybox
-    
-#Force remove image with a container
-#    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} pull busybox
-#    Should Be Equal As Integers  ${rc}  0
-#    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} create busybox /bin/top
-#    Should Be Equal As Integers  ${rc}  0
-#    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} rmi -f busybox
-#    Should Be Equal As Integers  ${rc}  0
-#    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} images
-#    Should Be Equal As Integers  ${rc}  0
-#    Should Not Contain  ${output}  busybox
-    
-#Remove a fake image
-#    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} rmi fakeImage
-#    Should Be Equal As Integers  ${rc}  1
-#    Should Contain  ${output}  Failed to remove image (fakeImage): Error response from daemon: No such image: fakeImage:latest
+    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} pull busybox
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} rmi busybox
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} images
+    Should Be Equal As Integers  ${rc}  0
+    Should Not Contain  ${output}  busybox
+
+Remove image with a removed container
+    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} pull busybox
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} create busybox /bin/top
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} rm ${output}
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} rmi busybox
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} images
+    Should Be Equal As Integers  ${rc}  0
+    Should Not Contain  ${output}  busybox
+
+Remove image with a container
+    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} pull busybox
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} create busybox /bin/top
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} rmi busybox
+    Should Be Equal As Integers  ${rc}  1
+    Should Contain  ${output}  Failed to remove image (busybox)
+    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} images
+    Should Be Equal As Integers  ${rc}  0
+    Should Contain  ${output}  busybox
+
+Remove a fake image
+    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} rmi fakeImage
+    Should Be Equal As Integers  ${rc}  1
+    Should Contain  ${output}  Error response from daemon: Error parsing reference: "fakeImage" is not a valid repository/tag

--- a/tests/test-cases/Group1-Docker-Commands/1-12-Docker-RMI.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-12-Docker-RMI.robot
@@ -8,11 +8,14 @@ Suite Teardown  Cleanup VIC Appliance On Test Server
 Basic docker remove image
     ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} pull busybox
     Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} pull alpine
+    Should Be Equal As Integers  ${rc}  0
     ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} rmi busybox
     Should Be Equal As Integers  ${rc}  0
     ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} images
     Should Be Equal As Integers  ${rc}  0
     Should Not Contain  ${output}  busybox
+    Should Contain  ${output}  alpine
 
 Remove image with a removed container
     ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} pull busybox


### PR DESCRIPTION
* Removed force test since we don't support untagging of images yet
* Fixed error message to be less horrific when an image is in use

Fixes #437