### PR TITLE
Add check for concurrent poweroff during container stop

### DIFF
--- a/lib/apiservers/engine/backends/image.go
+++ b/lib/apiservers/engine/backends/image.go
@@ -81,7 +81,7 @@ func (i *Image) ImageDelete(imageRef string, force, prune bool) ([]types.ImageDe
 	if err != nil {
 		switch err := err.(type) {
 		case *storage.DeleteImageLocked:
-			return nil, fmt.Errorf("Failed to remove image (%s): ", imageRef, err.Payload.Message)
+			return nil, fmt.Errorf("Failed to remove image (%s): %s", imageRef, err.Payload.Message)
 		default:
 			return nil, err
 		}

--- a/lib/apiservers/engine/backends/image.go
+++ b/lib/apiservers/engine/backends/image.go
@@ -81,7 +81,7 @@ func (i *Image) ImageDelete(imageRef string, force, prune bool) ([]types.ImageDe
 	if err != nil {
 		switch err := err.(type) {
 		case *storage.DeleteImageLocked:
-			return nil, fmt.Errorf("Failed to remove image (%s): %s", imageRef, err.Payload.Message)
+			return nil, fmt.Errorf("Failed to remove image %q: %s", imageRef, err.Payload.Message)
 		default:
 			return nil, err
 		}

--- a/lib/portlayer/exec/container.go
+++ b/lib/portlayer/exec/container.go
@@ -483,11 +483,9 @@ func (c *Container) stop(ctx context.Context, waitTime *int32) error {
 					log.Infof("power off %s task skipped due to guest shutdown", c.ExecConfig.ID)
 					return nil
 				}
-				log.Warnf("hard power off failed due to: %#v", terr)
-
-			default:
-				log.Warnf("hard power off failed due to: %#v", terr)
 			}
+
+			log.Warnf("hard power off failed due to: %#v", terr)
 		}
 		c.State = existingState
 	}

--- a/lib/portlayer/exec/container.go
+++ b/lib/portlayer/exec/container.go
@@ -61,6 +61,8 @@ const (
 
 	propertyCollectorTimeout = 3 * time.Minute
 	containerLogName         = "output.log"
+
+	notSuspendedMsg = "The virtual machine is not suspended."
 )
 
 // NotFoundError is returned when a types.ManagedObjectNotFound is returned from a vmomi call
@@ -458,12 +460,11 @@ func (c *Container) stop(ctx context.Context, waitTime *int32) error {
 
 	log.Warnf("stopping %s via hard power off due to: %s", c.ExecConfig.ID, err)
 
-	taskInfo, err := tasks.WaitForResult(ctx, func(ctx context.Context) (tasks.Task, error) {
+	_, err = tasks.WaitForResult(ctx, func(ctx context.Context) (tasks.Task, error) {
 		return c.vm.PowerOff(ctx)
 	})
 
 	if err != nil {
-		log.Debugf("taskInfo during failed power off: %+v", taskInfo)
 
 		// It is possible the VM has finally shutdown in between, ignore the error in that case
 		if terr, ok := err.(task.Error); ok {
@@ -475,12 +476,20 @@ func (c *Container) stop(ctx context.Context, waitTime *int32) error {
 				}
 				log.Warnf("invalid power state during power off: %s", terr.ExistingState)
 
+			case *types.GenericVmConfigFault:
+				if terr.Reason == notSuspendedMsg {
+					log.Infof("power off %s task skipped due to guest shutdown", c.ExecConfig.ID)
+					return nil
+				}
+				log.Warnf("hard power off failed due to: %#v", terr)
+
 			default:
 				log.Warnf("hard power off failed due to: %#v", terr)
 			}
 		}
 		c.State = existingState
 	}
+
 	return err
 }
 

--- a/tests/test-cases/Group1-Docker-Commands/1-12-Docker-RMI.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-12-Docker-RMI.robot
@@ -37,7 +37,7 @@ Remove image with a container
     Should Be Equal As Integers  ${rc}  0
     ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} rmi busybox
     Should Be Equal As Integers  ${rc}  1
-    Should Contain  ${output}  Failed to remove image (busybox)
+    Should Contain  ${output}  Failed to remove image "busybox"
     ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} images
     Should Be Equal As Integers  ${rc}  0
     Should Contain  ${output}  busybox


### PR DESCRIPTION
* In this [1-7-Docker-Stop](https://github.com/vmware/vic/blob/master/tests/test-cases/Group1-Docker-Commands/1-7-Docker-Stop.robot#L88) test, we sometimes get a conflicting error from vSphere due to a race between the power off and guest shutdown paths. This PR adds a check for the specific error because the container is successfully shut down.
* Also resolves govet issue on [lib/apiservers/engine/backends/image.go#L84](https://github.com/vmware/vic/blob/master/lib/apiservers/engine/backends/image.go#L84)

Fixes #2533