### PR TITLE
Enabling certs for VIC Install [skip ci]

### DIFF
--- a/tests/manual-test-cases/Group5-Functional-Tests/5-1-Distributed-Switch.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-1-Distributed-Switch.robot
@@ -57,6 +57,6 @@ Test
     Set Environment Variable  TEST_RESOURCE  /ha-datacenter/host/${esx1-ip}/Resources
     Set Environment Variable  TEST_TIMEOUT  30m
 
-    Install VIC Appliance To Test Server  ${false}  default
+    Install VIC Appliance To Test Server  certs=${true}  vol=default
 
     Run Regression Tests

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-3-Enhanced-Linked-Mode.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-3-Enhanced-Linked-Mode.robot
@@ -132,6 +132,6 @@ Test
     Set Environment Variable  TEST_RESOURCE  cls
     Set Environment Variable  TEST_TIMEOUT  30m
     
-    Install VIC Appliance To Test Server  ${false}  default
+    Install VIC Appliance To Test Server  certs=${true}  vol=default
 
     Run Regression Tests

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-4-High-Availability.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-4-High-Availability.robot
@@ -62,7 +62,7 @@ Test
     Set Environment Variable  TEST_RESOURCE  cls
     Set Environment Variable  TEST_TIMEOUT  30m
     
-    Install VIC Appliance To Test Server  ${false}  default
+    Install VIC Appliance To Test Server  certs=${true}  vol=default
 
     Run Keyword And Ignore Error  Run Regression Tests
     

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-5-Heterogenous-ESXi.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-5-Heterogenous-ESXi.robot
@@ -62,6 +62,6 @@ Test
     Set Environment Variable  TEST_RESOURCE  cls
     Set Environment Variable  TEST_TIMEOUT  30m
 
-    Install VIC Appliance To Test Server  ${false}  default
+    Install VIC Appliance To Test Server  certs=${true}  vol=default
 
     Run Regression Tests

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-6-VSAN.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-6-VSAN.robot
@@ -48,7 +48,7 @@ Simple VSAN
     Set Environment Variable  TEST_RESOURCE  cls
     Set Environment Variable  TEST_TIMEOUT  30m
     
-    Install VIC Appliance To Test Server  ${false}  default
+    Install VIC Appliance To Test Server  certs=${true}  vol=default
 
     Run Regression Tests
     
@@ -97,6 +97,6 @@ Complex VSAN
     Set Environment Variable  TEST_RESOURCE  cluster-vsan-1
     Set Environment Variable  TEST_TIMEOUT  30m
     
-    Install VIC Appliance To Test Server  ${false}  default
+    Install VIC Appliance To Test Server  certs=${true}  vol=default
 
     Run Regression Tests

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-8-DRS.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-8-DRS.robot
@@ -58,7 +58,7 @@ Test
     Set Environment Variable  TEST_RESOURCE  cls
     Set Environment Variable  TEST_TIMEOUT  30m
 
-    ${status}  ${message}=  Run Keyword And Ignore Error  Install VIC Appliance To Test Server  ${false}  default
+    ${status}  ${message}=  Run Keyword And Ignore Error  Install VIC Appliance To Test Server  certs=${true}  vol=default
     Should Contain  ${message}  DRS must be enabled to use VIC
     Should Be Equal As Strings  ${status}  FAIL
 
@@ -66,6 +66,6 @@ Test
     ${out}=  Run  govc cluster.change -drs-enabled /ha-datacenter/host/cls
     Should Be Empty  ${out}
 
-    Install VIC Appliance To Test Server  ${false}  default
+    Install VIC Appliance To Test Server  certs=${true}  vol=default
     
     Run Regression Tests

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-9-Private-Registry.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-9-Private-Registry.robot
@@ -6,7 +6,7 @@ Suite Teardown  Private Registry Cleanup
 
 *** Keywords ***
 Private Registry Setup
-    Install VIC Appliance To Test Server
+    Install VIC Appliance To Test Server  certs=${true}  vol=default
     ${rc}  ${output}=  Run And Return Rc And Output  docker run -d -p 5000:5000 --name registry registry
     Should Be Equal As Integers  ${rc}  0
     ${rc}  ${output}=  Run And Return Rc And Output  docker pull busybox


### PR DESCRIPTION
Setting certs = true for Install VIC Appliance to Test Server on all the functional tests.

