### PR TITLE
portlayer k/v store api & image tag persistence

### DIFF
--- a/lib/apiservers/engine/backends/backends.go
+++ b/lib/apiservers/engine/backends/backends.go
@@ -16,6 +16,7 @@ package backends
 
 import (
 	"context"
+	"fmt"
 	"net"
 	"net/url"
 	"strings"
@@ -115,6 +116,11 @@ func Init(portLayerAddr, product string, config *config.VirtualContainerHostConf
 		}
 		log.Info("Container cache updated successfully")
 	}()
+
+	// creates and potentially restore repository cache
+	if err := cache.NewRepositoryCache(portLayerClient); err != nil {
+		return fmt.Errorf("Failed to create repository cache: %s", err.Error())
+	}
 
 	serviceOptions := registry.ServiceOptions{}
 	for _, registry := range insecureRegs {

--- a/lib/apiservers/engine/backends/cache/repo_cache.go
+++ b/lib/apiservers/engine/backends/cache/repo_cache.go
@@ -1,0 +1,419 @@
+// Copyright 2016 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cache
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+	"sync"
+
+	"github.com/vmware/vic/lib/apiservers/engine/backends/kv"
+	"github.com/vmware/vic/lib/apiservers/portlayer/client"
+	"github.com/vmware/vic/pkg/trace"
+
+	"github.com/docker/distribution/digest"
+	"github.com/docker/docker/reference"
+
+	log "github.com/Sirupsen/logrus"
+)
+
+// repoCache is a cache of the docker repository information.
+// This info will help to provide proper tag and digest support
+//
+// The cache will be persisted to disk via the portlayer k/v
+// store and will be restored at system start
+//
+// This code is a heavy leverage of docker's reference store:
+// github.com/docker/docker/reference/store.go
+
+var (
+	rCache  *repoCache
+	repoKey = "repositories"
+)
+
+// Repo provides the set of methods which can operate on a tag store.
+type Repo interface {
+	References(imageID string) []reference.Named
+	ReferencesByName(ref reference.Named) []Association
+	Delete(ref reference.Named, save bool) (bool, error)
+	Get(ref reference.Named) (string, error)
+
+	Save() error
+	GetImageID(layerID string) string
+	Tags(imageID string) []string
+	Digests(imageID string) []string
+	AddReference(ref reference.Named, imageID string, force bool, layerID string, save bool) error
+
+	// Remove will remove from the cache and returns the
+	// stringified Named if successful -- save bool instructs
+	// func to persist to portlayer k/v or not
+	Remove(ref string, save bool) (string, error)
+}
+
+type repoCache struct {
+	// client is needed for k/v store operations
+	client *client.PortLayer
+
+	mu sync.RWMutex
+	// repositories is a map of repositories, indexed by name.
+	Repositories map[string]repository
+	// referencesByIDCache is a cache of references indexed by imageID
+	referencesByIDCache map[string]map[string]reference.Named
+	// Layers is a map of layerIDs to imageIDs
+	// TODO: we might be able to remove this later -- currently
+	// needed becasue an ImageID isn't generated for every pull
+	Layers map[string]string
+	// images is a map of imageIDs to layerIDs
+	// TODO: much like the Layers map this might be able to be
+	// removed
+	images map[string]string
+}
+
+// Repository maps tags to image IDs. The key is a a stringified Reference,
+// including the repository name.
+type repository map[string]string
+
+var (
+	// ErrDoesNotExist returned if a reference is not found in the
+	// store.
+	ErrDoesNotExist = errors.New("reference does not exist")
+)
+
+// An Association is a tuple associating a reference with an image ID.
+type Association struct {
+	Ref     reference.Named
+	ImageID string
+}
+
+type lexicalRefs []reference.Named
+
+func (a lexicalRefs) Len() int           { return len(a) }
+func (a lexicalRefs) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
+func (a lexicalRefs) Less(i, j int) bool { return a[i].String() < a[j].String() }
+
+type lexicalAssociations []Association
+
+func (a lexicalAssociations) Len() int           { return len(a) }
+func (a lexicalAssociations) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
+func (a lexicalAssociations) Less(i, j int) bool { return a[i].Ref.String() < a[j].Ref.String() }
+
+// RepositoryCache returns a ref to the repoCache interface
+func RepositoryCache() Repo {
+	return rCache
+}
+
+func init() {
+	rCache = &repoCache{
+		Repositories:        make(map[string]repository),
+		Layers:              make(map[string]string),
+		images:              make(map[string]string),
+		referencesByIDCache: make(map[string]map[string]reference.Named),
+	}
+}
+
+// NewRespositoryCache will create a new repoCache or rehydrate
+// an existing repoCache from the portlayer k/v store
+func NewRepositoryCache(client *client.PortLayer) error {
+	defer trace.End(trace.Begin(""))
+
+	rCache.client = client
+
+	val, err := kv.Get(client, repoKey)
+	if err != nil && err != kv.ErrKeyNotFound {
+		return err
+	}
+	if val != "" {
+		if err = json.Unmarshal([]byte(val), rCache); err != nil {
+			return fmt.Errorf("Failed to unmarshal repository cache: %s", err)
+		}
+		// hydrate refByIDCache
+		for _, repository := range rCache.Repositories {
+			for refStr, refID := range repository {
+				ref, _ := reference.ParseNamed(refStr)
+				if rCache.referencesByIDCache[refID] == nil {
+					rCache.referencesByIDCache[refID] = make(map[string]reference.Named)
+				}
+				rCache.referencesByIDCache[refID][refStr] = ref
+			}
+		}
+		// hydrate image -> layer cache
+		for image, layer := range rCache.Layers {
+			rCache.images[image] = layer
+		}
+
+		log.Infof("found %d repositories", len(rCache.Repositories))
+		log.Infof("found %d image layers", len(rCache.Layers))
+	}
+	return nil
+}
+
+// Save will persist the repository cache to the
+// portlayer k/v
+func (store *repoCache) Save() error {
+	defer trace.End(trace.Begin(""))
+
+	b, err := json.Marshal(store)
+	if err != nil {
+		log.Errorf("Unable to marshal repository cache: %s", err.Error())
+		return err
+	}
+
+	err = kv.Put(store.client, repoKey, string(b))
+	if err != nil {
+		log.Errorf("Unable to save repository cache: %s", err.Error())
+		return err
+	}
+
+	return nil
+}
+
+func (store *repoCache) AddReference(ref reference.Named, imageID string, force bool, layerID string, save bool) error {
+	defer trace.End(trace.Begin(""))
+	if ref.Name() == string(digest.Canonical) {
+		return errors.New("refusing to create an ambiguous tag using digest algorithm as name")
+	}
+	var err error
+	store.mu.Lock()
+	defer store.mu.Unlock()
+
+	// does this repo (i.e. busybox) exist?
+	repository, exists := store.Repositories[ref.Name()]
+	if !exists || repository == nil {
+		repository = make(map[string]string)
+		store.Repositories[ref.Name()] = repository
+	}
+
+	refStr := ref.String()
+	oldID, exists := repository[refStr]
+
+	if exists {
+		// force only works for tags
+		if digested, isDigest := ref.(reference.Canonical); isDigest {
+			return fmt.Errorf("Cannot overwrite digest %s", digested.Digest().String())
+		}
+
+		if !force {
+			return fmt.Errorf("Conflict: Tag %s is already set to image %s, if you want to replace it, please use -f option", ref.String(), oldID)
+		}
+
+		if store.referencesByIDCache[oldID] != nil {
+			delete(store.referencesByIDCache[oldID], refStr)
+			if len(store.referencesByIDCache[oldID]) == 0 {
+				delete(store.referencesByIDCache, oldID)
+			}
+		}
+	}
+
+	repository[refStr] = imageID
+	if store.referencesByIDCache[imageID] == nil {
+		store.referencesByIDCache[imageID] = make(map[string]reference.Named)
+	}
+	store.referencesByIDCache[imageID][refStr] = ref
+	store.Layers[layerID] = imageID
+	store.images[imageID] = layerID
+
+	// should we save this input?
+	if save {
+		err = store.Save()
+	}
+
+	return err
+}
+
+// Remove is a convenience function to allow the passing of a properly
+// formed string that can be parsed into a Named object.
+//
+// Examples:
+// Tags: busybox:1.25.1
+// Digest: nginx@sha256:7281cf7c854b0dfc7c68a6a4de9a785a973a14f1481bc028e2022bcd6a8d9f64
+func (store *repoCache) Remove(ref string, save bool) (string, error) {
+	defer trace.End(trace.Begin(""))
+	n, err := reference.ParseNamed(ref)
+	if err != nil {
+		return "", err
+	}
+
+	_, err = store.Delete(n, save)
+	if err != nil {
+		return "", err
+	}
+
+	return n.String(), nil
+}
+
+// Delete deletes a reference from the store. It returns true if a deletion
+// happened, or false otherwise.
+func (store *repoCache) Delete(ref reference.Named, save bool) (bool, error) {
+	defer trace.End(trace.Begin(""))
+	ref = reference.WithDefaultTag(ref)
+
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	var err error
+	// return code -- assume success
+	rtc := true
+	repoName := ref.Name()
+
+	repository, exists := store.Repositories[repoName]
+	if !exists {
+		return false, ErrDoesNotExist
+	}
+	refStr := ref.String()
+	if imageID, exists := repository[refStr]; exists {
+		delete(repository, refStr)
+		if len(repository) == 0 {
+			delete(store.Repositories, repoName)
+		}
+		if store.referencesByIDCache[imageID] != nil {
+			delete(store.referencesByIDCache[imageID], refStr)
+			if len(store.referencesByIDCache[imageID]) == 0 {
+				delete(store.referencesByIDCache, imageID)
+			}
+		}
+		if layer, exists := store.images[imageID]; exists {
+			delete(store.Layers, imageID)
+			delete(store.images, layer)
+		}
+		if save {
+			err = store.Save()
+			if err != nil {
+				rtc = false
+			}
+		}
+		return rtc, err
+	}
+
+	return false, ErrDoesNotExist
+}
+
+// GetImageID will return the imageID associated with the
+// specified layerID
+func (store *repoCache) GetImageID(layerID string) string {
+	defer trace.End(trace.Begin(layerID))
+	var imageID string
+	store.mu.RLock()
+	defer store.mu.RUnlock()
+	if image, exists := store.Layers[layerID]; exists {
+		imageID = image
+	}
+	return imageID
+}
+
+// Get returns the imageID for a parsed reference
+func (store *repoCache) Get(ref reference.Named) (string, error) {
+	defer trace.End(trace.Begin(""))
+	ref = reference.WithDefaultTag(ref)
+
+	store.mu.RLock()
+	defer store.mu.RUnlock()
+
+	repository, exists := store.Repositories[ref.Name()]
+	if !exists || repository == nil {
+		return "", ErrDoesNotExist
+	}
+	imageID, exists := repository[ref.String()]
+	if !exists {
+		return "", ErrDoesNotExist
+	}
+
+	return imageID, nil
+}
+
+// Tags returns a slice of tags for the specified imageID
+func (store *repoCache) Tags(imageID string) []string {
+	defer trace.End(trace.Begin(""))
+
+	store.mu.RLock()
+	defer store.mu.RUnlock()
+	var tags []string
+	for _, ref := range store.referencesByIDCache[imageID] {
+		if tagged, isTagged := ref.(reference.NamedTagged); isTagged {
+			tags = append(tags, tagged.String())
+		}
+	}
+	return tags
+}
+
+// Digests returns a slice of digests for the specified imageID
+func (store *repoCache) Digests(imageID string) []string {
+	defer trace.End(trace.Begin(""))
+
+	store.mu.RLock()
+	defer store.mu.RUnlock()
+	var digests []string
+	for _, ref := range store.referencesByIDCache[imageID] {
+		if d, isCanonical := ref.(reference.Canonical); isCanonical {
+			digests = append(digests, d.String())
+		}
+	}
+	return digests
+}
+
+// References returns a slice of references to the given imageID. The slice
+// will be nil if there are no references to this imageID.
+func (store *repoCache) References(imageID string) []reference.Named {
+	defer trace.End(trace.Begin(""))
+
+	store.mu.RLock()
+	defer store.mu.RUnlock()
+
+	// Convert the internal map to an array for two reasons:
+	// 1) We must not return a mutable
+	// 2) It would be ugly to expose the extraneous map keys to callers.
+
+	var references []reference.Named
+	for _, ref := range store.referencesByIDCache[imageID] {
+		references = append(references, ref)
+	}
+
+	sort.Sort(lexicalRefs(references))
+
+	return references
+}
+
+// ReferencesByName returns the references for a given repository name.
+// If there are no references known for this repository name,
+// ReferencesByName returns nil.
+func (store *repoCache) ReferencesByName(ref reference.Named) []Association {
+	defer trace.End(trace.Begin(""))
+
+	store.mu.RLock()
+	defer store.mu.RUnlock()
+
+	repository, exists := store.Repositories[ref.Name()]
+	if !exists {
+		return nil
+	}
+
+	var associations []Association
+	for refStr, refID := range repository {
+		ref, err := reference.ParseNamed(refStr)
+		if err != nil {
+			// Should never happen
+			return nil
+		}
+		associations = append(associations,
+			Association{
+				Ref:     ref,
+				ImageID: refID,
+			})
+	}
+
+	sort.Sort(lexicalAssociations(associations))
+
+	return associations
+}

--- a/lib/apiservers/engine/backends/cache/repo_cache_test.go
+++ b/lib/apiservers/engine/backends/cache/repo_cache_test.go
@@ -1,0 +1,81 @@
+// Copyright 2016 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cache
+
+import (
+	"testing"
+
+	"github.com/vmware/vic/lib/apiservers/portlayer/client"
+	"github.com/vmware/vic/pkg/uid"
+
+	"github.com/docker/docker/reference"
+	"github.com/stretchr/testify/assert"
+)
+
+func repoSetup() {
+	rCache = &repoCache{
+		client:              &client.PortLayer{},
+		Repositories:        make(map[string]repository),
+		Layers:              make(map[string]string),
+		images:              make(map[string]string),
+		referencesByIDCache: make(map[string]map[string]reference.Named),
+	}
+}
+
+func TestRepo(t *testing.T) {
+	repoSetup()
+
+	ref, _ := reference.ParseNamed("busybox:1.25.1")
+	imageID := uid.New()
+	layerID := uid.New()
+
+	// add busybox:1.25.1
+	err := RepositoryCache().AddReference(ref, imageID.String(), false, layerID.String(), false)
+	assert.NoError(t, err)
+
+	// Get will return the imageID for the named object
+	n, err := RepositoryCache().Get(ref)
+	assert.NoError(t, err)
+	assert.Equal(t, imageID.String(), n)
+
+	// get image id via layer id
+	ig := RepositoryCache().GetImageID(layerID.String())
+	assert.Equal(t, imageID.String(), ig)
+
+	// remove busybox from the cache
+	r, err := RepositoryCache().Remove(ref.String(), false)
+	assert.NoError(t, err)
+	assert.Equal(t, ref.String(), r)
+
+	// busybox is removed, so this should fail
+	x, err := RepositoryCache().Remove(ref.String(), false)
+	assert.Error(t, err)
+	assert.Equal(t, "", x)
+
+	// add reference by digest
+	ng, _ := reference.ParseNamed("nginx@sha256:7281cf7c854b0dfc7c68a6a4de9a785a973a14f1481bc028e2022bcd6a8d9f64")
+	err = RepositoryCache().AddReference(ng, imageID.String(), false, layerID.String(), false)
+	assert.NoError(t, err)
+
+	dd := RepositoryCache().Digests(imageID.String())
+	assert.Equal(t, 1, len(dd))
+	// remove the digest
+	ngx, err := RepositoryCache().Remove(ng.String(), false)
+	assert.NoError(t, err)
+	assert.Equal(t, ng.String(), ngx)
+	// nada
+	nada := RepositoryCache().Digests(imageID.String())
+	assert.Equal(t, 0, len(nada))
+}

--- a/lib/apiservers/engine/backends/container_test.go
+++ b/lib/apiservers/engine/backends/container_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/docker/docker/api/types/backend"
 	derr "github.com/docker/docker/errors"
+	"github.com/docker/docker/reference"
 	"github.com/docker/engine-api/types"
 	"github.com/docker/engine-api/types/container"
 	dnetwork "github.com/docker/engine-api/types/network"
@@ -334,6 +335,9 @@ func AddMockImageToCache() {
 	}
 
 	cache.ImageCache().AddImage(mockImage)
+
+	ref, _ := reference.ParseNamed(mockImage.Reference)
+	cache.RepositoryCache().AddReference(ref, mockImage.ImageID, false, mockImage.ImageID, false)
 }
 
 func AddMockContainerToCache() {

--- a/lib/apiservers/engine/backends/image_test.go
+++ b/lib/apiservers/engine/backends/image_test.go
@@ -41,15 +41,13 @@ func TestConvertV1ImageToDockerImage(t *testing.T) {
 			},
 		},
 		ImageID:   "test_id",
-		Digests:   []string{"12345"},
-		Tags:      []string{"test_tag"},
+		Digests:   []string{fmt.Sprintf("%s@sha:%s", "test_name", "12345")},
+		Tags:      []string{fmt.Sprintf("%s:%s", "test_name", "test_tag")},
 		Name:      "test_name",
 		DiffIDs:   map[string]string{"test_diffid": "test_layerid"},
 		History:   []v1.History{},
 		Reference: "test_name:test_tag",
 	}
-	digest := fmt.Sprintf("%s@sha:%s", image.Name, "12345")
-	tag := fmt.Sprintf("%s:%s", image.Name, "test_tag")
 
 	dockerImage := convertV1ImageToDockerImage(image)
 
@@ -59,40 +57,6 @@ func TestConvertV1ImageToDockerImage(t *testing.T) {
 	assert.Equal(t, image.Created.Unix(), dockerImage.Created, "Error: expected created %s, got %s", image.Created, dockerImage.Created)
 	assert.Equal(t, image.Parent, dockerImage.ParentID, "Error: expected parent %s, got %s", image.Parent, dockerImage.ParentID)
 	assert.Equal(t, image.Config.Labels, dockerImage.Labels, "Error: expected labels %s, got %s", image.Config.Labels, dockerImage.Labels)
-	assert.Equal(t, digest, dockerImage.RepoDigests[0], "Error: expected digest %s, got %s", digest, dockerImage.RepoDigests[0])
-	assert.Equal(t, tag, dockerImage.RepoTags[0], "Error: expected tag %s, got %s", tag, dockerImage.RepoTags[0])
-}
-
-func TestClientFriendlyTags(t *testing.T) {
-	tags := []string{"latest"}
-	defaultReference := "busybox:latest"
-	customReference := "custom.reg.com/busybox:latest"
-
-	defaultFriendlyTags := clientFriendlyTags(defaultReference, tags)
-	assert.Equal(t, len(defaultFriendlyTags), len(tags), "Error: expected %d tags, got %d", len(tags), len(defaultFriendlyTags))
-	assert.Equal(t, defaultFriendlyTags[0], "busybox:latest", "Error: expected %s, got %s", "busybox:latest", defaultFriendlyTags[0])
-
-	customFriendlyTags := clientFriendlyTags(customReference, tags)
-	assert.Equal(t, len(customFriendlyTags), len(tags), "Error: expected %d tags, got %d", len(tags), len(customFriendlyTags))
-	assert.Equal(t, customFriendlyTags[0], "custom.reg.com/busybox:latest", "Error: expected %s, got %s", "custom.reg.com/busybox:latest", customFriendlyTags[0])
-
-	emptyTags := clientFriendlyTags(defaultReference, []string{})
-	assert.Equal(t, len(emptyTags), 1, "Error: expected %d tags, got %d", 1, len(emptyTags))
-	assert.Equal(t, emptyTags[0], "<none>:<none>", "Error: expected %s tags, got %s", "<none>:<none>", emptyTags[0])
-
-}
-
-func TestClientFriendlyDigests(t *testing.T) {
-	imageName := "busybox"
-	digests := []string{"12345", "6789"}
-
-	friendlyDigests := clientFriendlyDigests(imageName, digests)
-	assert.Equal(t, len(friendlyDigests), len(digests), "Error: expected %d digests, got %d", len(digests), len(friendlyDigests))
-	assert.Equal(t, friendlyDigests[0], "busybox@sha:12345", "Error: expected %s, got %s", "busybox@sha:12345", friendlyDigests[0])
-	assert.Equal(t, friendlyDigests[1], "busybox@sha:6789", "Error: expected %s, got %s", "busybox@sha:6789", friendlyDigests[1])
-
-	emptyDigests := clientFriendlyDigests(imageName, []string{})
-	assert.Equal(t, len(emptyDigests), 1, "Error: expected %d digests, got %d", 1, len(emptyDigests))
-	assert.Equal(t, emptyDigests[0], "<none>@<none>", "Error: expected %s digests, got %s", "<none>@<none>", emptyDigests[0])
-
+	assert.Equal(t, image.Digests[0], dockerImage.RepoDigests[0], "Error: expected digest %s, got %s", image.Digests[0], dockerImage.RepoDigests[0])
+	assert.Equal(t, image.Tags[0], dockerImage.RepoTags[0], "Error: expected tag %s, got %s", image.Tags[0], dockerImage.RepoTags[0])
 }

--- a/lib/apiservers/engine/backends/kv/kv.go
+++ b/lib/apiservers/engine/backends/kv/kv.go
@@ -1,0 +1,103 @@
+// Copyright 2016 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kv
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/vmware/vic/lib/apiservers/portlayer/client"
+	ckv "github.com/vmware/vic/lib/apiservers/portlayer/client/kv"
+	"github.com/vmware/vic/lib/apiservers/portlayer/models"
+	"github.com/vmware/vic/pkg/trace"
+
+	log "github.com/Sirupsen/logrus"
+	"golang.org/x/net/context"
+)
+
+const (
+
+	// defaultNamespace is the first part of the
+	// k/v store key (i.e. docker.stuff)
+	defaultNamespace = "docker"
+	defaultSeparator = "."
+)
+
+var (
+	ErrKeyNotFound = errors.New("key not found")
+)
+
+// Get will call to the portlayer for the value of the specified key
+// The key argument is prefixed w/the defaultName space for the docker
+// persona. i.e. docker.{key}
+//
+// If the key doesn't exist an ErrKeyNotFound will be returned
+func Get(client *client.PortLayer, key string) (string, error) {
+	defer trace.End(trace.Begin(key))
+	var val string
+	resp, err := client.Kv.GetValue(ckv.NewGetValueParamsWithContext(
+		context.Background()).WithKey(createNameSpacedKey(key)))
+	if err != nil {
+		switch err.(type) {
+		case *ckv.GetValueNotFound:
+			return val, ErrKeyNotFound
+		default:
+			log.Errorf("Error Getting Key/Value: %s", err.Error())
+			return val, err
+		}
+	}
+	val = *resp.Payload.Value
+	// return the value
+	return val, nil
+
+}
+
+// Put will put the key / value in the portlayer k/v store
+func Put(client *client.PortLayer, key string, val string) error {
+	defer trace.End(trace.Begin(key))
+
+	fullKey := createNameSpacedKey(key)
+	keyval := &models.KeyValue{
+		Key:   &fullKey,
+		Value: &val,
+	}
+
+	_, err := client.Kv.PutValue(ckv.NewPutValueParamsWithContext(
+		context.Background()).WithKey(fullKey).WithKeyValue(keyval))
+	if err != nil {
+		log.Errorf("Error Putting Key/Value: %#v", err)
+		return err
+	}
+
+	return nil
+}
+
+// Delete will remove the key / value from the store
+func Delete(client *client.PortLayer, key string) error {
+	defer trace.End(trace.Begin(key))
+
+	_, err := client.Kv.DeleteValue(ckv.NewDeleteValueParamsWithContext(
+		context.Background()).WithKey(createNameSpacedKey(key)))
+	if err != nil {
+		log.Errorf("Error Deleting Key/Value: %#v", err)
+		return err
+	}
+
+	return nil
+}
+
+func createNameSpacedKey(key string) string {
+	return fmt.Sprintf("%s%s%s", defaultNamespace, defaultSeparator, key)
+}

--- a/lib/apiservers/portlayer/restapi/configure_port_layer.go
+++ b/lib/apiservers/portlayer/restapi/configure_port_layer.go
@@ -50,6 +50,7 @@ var portlayerhandlers = []handler{
 	&handlers.ContainersHandlersImpl{},
 	&handlers.InteractionHandlersImpl{},
 	&handlers.LoggingHandlersImpl{},
+	&handlers.KvHandlersImpl{},
 }
 
 func configureFlags(api *operations.PortLayerAPI) {

--- a/lib/apiservers/portlayer/restapi/handlers/kv_handlers.go
+++ b/lib/apiservers/portlayer/restapi/handlers/kv_handlers.go
@@ -1,0 +1,101 @@
+// Copyright 2016 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package handlers
+
+import (
+	"net/http"
+
+	middleware "github.com/go-swagger/go-swagger/httpkit/middleware"
+	"golang.org/x/net/context"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/go-swagger/go-swagger/swag"
+
+	"github.com/vmware/vic/lib/apiservers/portlayer/models"
+	"github.com/vmware/vic/lib/apiservers/portlayer/restapi/operations"
+	"github.com/vmware/vic/lib/apiservers/portlayer/restapi/operations/kv"
+
+	"github.com/vmware/vic/lib/portlayer/store"
+	"github.com/vmware/vic/pkg/kvstore"
+	"github.com/vmware/vic/pkg/trace"
+)
+
+type KvHandlersImpl struct {
+	defaultStore *kvstore.KeyValueStore
+}
+
+func (handler *KvHandlersImpl) Configure(api *operations.PortLayerAPI, handlerCtx *HandlerContext) {
+	api.KvGetValueHandler = kv.GetValueHandlerFunc(handler.GetValueHandler)
+	api.KvPutValueHandler = kv.PutValueHandlerFunc(handler.PutValueHandler)
+	api.KvDeleteValueHandler = kv.DeleteValueHandlerFunc(handler.DeleteValueHandler)
+
+	// Get the APIKV store -- it should always be present since it's
+	// initialized when the portlayer starts
+	s, _ := store.Store(store.APIKV)
+	handler.defaultStore = s
+}
+
+func (handler *KvHandlersImpl) GetValueHandler(params kv.GetValueParams) middleware.Responder {
+	defer trace.End(trace.Begin(params.Key))
+
+	val, err := handler.defaultStore.Get(trace.NewOperation(context.Background(), "GetValue"), params.Key)
+	if err != nil {
+		switch err {
+		case kvstore.ErrKeyNotFound:
+			return kv.NewGetValueNotFound()
+		default:
+			log.Errorf("Error Getting Key/Value: %s", err.Error())
+			return kv.NewGetValueInternalServerError().WithPayload(&models.Error{
+				Code:    swag.Int64(http.StatusInternalServerError),
+				Message: err.Error(),
+			})
+		}
+	}
+	s := string(val)
+	return kv.NewGetValueOK().WithPayload(&models.KeyValue{Key: &params.Key, Value: &s})
+}
+
+func (handler *KvHandlersImpl) PutValueHandler(params kv.PutValueParams) middleware.Responder {
+	defer trace.End(trace.Begin(*params.KeyValue.Key))
+
+	err := handler.defaultStore.Set(trace.NewOperation(context.Background(), "SetValue"), *params.KeyValue.Key, []byte(*params.KeyValue.Value))
+	if err != nil {
+		log.Errorf("Error Setting Key/Value: %s", err.Error())
+		return kv.NewGetValueInternalServerError().WithPayload(&models.Error{
+			Code:    swag.Int64(http.StatusInternalServerError),
+			Message: err.Error(),
+		})
+	}
+	return kv.NewPutValueOK()
+}
+
+func (handler *KvHandlersImpl) DeleteValueHandler(params kv.DeleteValueParams) middleware.Responder {
+	defer trace.End(trace.Begin(params.Key))
+
+	err := handler.defaultStore.Delete(trace.NewOperation(context.Background(), "DeleteValue"), params.Key)
+	if err != nil {
+		switch err {
+		case kvstore.ErrKeyNotFound:
+			return kv.NewDeleteValueNotFound()
+		default:
+			log.Errorf("Error deleting Key/Value: %s", err.Error())
+			return kv.NewGetValueInternalServerError().WithPayload(&models.Error{
+				Code:    swag.Int64(http.StatusInternalServerError),
+				Message: err.Error(),
+			})
+		}
+	}
+	return kv.NewDeleteValueOK()
+}

--- a/lib/apiservers/portlayer/swagger.json
+++ b/lib/apiservers/portlayer/swagger.json
@@ -59,6 +59,121 @@
 				}
 			}
 		},
+		"/kv/{key}": {
+			"get": {
+				"description": "Gets value from k/v store",
+				"tags": [
+					"kv"
+				],
+				"operationId": "GetValue",
+				"consumes": [
+					"application/json"
+				],
+				"produces": [
+					"application/json"
+				],
+				"parameters": [
+					{
+						"name": "key",
+						"type": "string",
+						"in": "path",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/KeyValue"
+						}
+					},
+					"404": {
+						"description": "Not found"
+					},
+					"500": {
+						"description": "error",
+						"schema": {
+							"$ref": "#/definitions/Error"
+						}
+					}
+				}
+			},
+			"delete": {
+				"description": "deletes entry in k/v store",
+				"tags": [
+					"kv"
+				],
+				"operationId": "DeleteValue",
+				"consumes": [
+					"application/json"
+				],
+				"produces": [
+					"application/json"
+				],
+				"parameters": [
+					{
+					"name": "key",
+					"type": "string",
+					"in": "path",
+					"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK"
+					},
+					"404": {
+						"description": "Not found"
+					},
+					"500": {
+						"description": "error",
+						"schema": {
+							"$ref": "#/definitions/Error"
+						}
+					}
+				}
+			},
+			"put": {
+				"description": "Adds / updates value in k/v store",
+				"tags": [
+					"kv"
+				],
+				"operationId": "PutValue",
+				"consumes": [
+					"application/json"
+				],
+				"produces": [
+					"application/json"
+				],
+				"parameters": [
+					{
+					"name": "key",
+					"type": "string",
+					"in": "path",
+					"required": true
+					},
+					{
+					"name": "key_value",
+					"required": true,
+					"in": "body",
+					"schema": {
+						"$ref": "#/definitions/KeyValue"
+					}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK"
+					},
+					"500": {
+						"description": "error",
+						"schema": {
+							"$ref": "#/definitions/Error"
+						}
+					}
+				}
+			}
+		},
 		"/storage": {
 			"post": {
 				"description": "Creates a location to store images",
@@ -2091,6 +2206,17 @@
 					"type": "string"
 				},
 				"hostOSVersion": {
+					"type": "string"
+				}
+			}
+		},
+		"KeyValue": {
+			"type": "object",
+			"properties": {
+				"Key": {
+					"type": "string"
+				},
+				"Value":{
 					"type": "string"
 				}
 			}

--- a/lib/imagec/imagec_test.go
+++ b/lib/imagec/imagec_test.go
@@ -447,35 +447,6 @@ func TestListImages(t *testing.T) {
 	}
 }
 
-func TestArrayUpdate(t *testing.T) {
-	attributes := []string{"green", "blue", "red"}
-
-	// remove an existing value
-	attributes, chg := arrayUpdate("green", attributes, Remove)
-	if !chg && len(attributes) == 2 {
-		t.Error("arrayUpdate failed to remove existing value")
-	}
-
-	// add a new value
-	attributes, chg = arrayUpdate("green", attributes, Add)
-	if !chg && len(attributes) == 3 {
-		t.Error("arrayUpdate failed to add new value")
-	}
-
-	// add existing value
-	attributes, chg = arrayUpdate("green", attributes, Add)
-	if chg && len(attributes) == 3 {
-		t.Error("arrayUpdate failed while adding existing value")
-	}
-
-	// attempt to remove non-existent value
-	attributes, chg = arrayUpdate("foobar", attributes, Remove)
-	if chg && len(attributes) == 3 {
-		t.Error("arrayUpdate failed while removing non-existent value")
-	}
-
-}
-
 func TestFetchScenarios(t *testing.T) {
 
 	ctx := context.TODO()

--- a/lib/portlayer/store/store.go
+++ b/lib/portlayer/store/store.go
@@ -1,0 +1,130 @@
+// Copyright 2016 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package store
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+	"os"
+	"regexp"
+	"sync"
+
+	"github.com/vmware/vic/pkg/kvstore"
+	"github.com/vmware/vic/pkg/trace"
+	"github.com/vmware/vic/pkg/vsphere/datastore"
+	"github.com/vmware/vic/pkg/vsphere/session"
+
+	"golang.org/x/net/context"
+)
+
+type StoreManager struct {
+	m            sync.RWMutex
+	dsStores     map[string]*kvstore.KeyValueStore
+	datastoreURL url.URL
+}
+
+var mgr *StoreManager
+
+const (
+	// default store folder name
+	dsFolder = "kvStores"
+	// available via portLayer API
+	APIKV = "apiKV"
+)
+
+var (
+	ErrDoesNotExist  = errors.New("requested store does not exist")
+	ErrDuplicateName = errors.New("duplicate store name")
+	ErrInvalidName   = errors.New("invalid store name, must be regexp(^[a-zA-Z0-9_]*$) compliant")
+)
+
+// Init will initialize the package vars and create the default portLayerKV store
+//
+// Note: The imgStoreURL is provided by the portlayer init function and is currently
+// based on the image-store specified at appliance creation via vic-machine.  That URL
+// is the starting point for the datastore persistence path and does not mean that the
+// k/v stores are presisted w/the images.
+func Init(ctx context.Context, session *session.Session, imgStoreURL url.URL) error {
+	defer trace.End(trace.Begin(imgStoreURL.String()))
+
+	mgr = &StoreManager{
+		dsStores:     make(map[string]*kvstore.KeyValueStore),
+		datastoreURL: imgStoreURL,
+	}
+	//create or restore the api accessible datastore backed k/v store
+	return NewDatastoreKeyValue(ctx, session, APIKV)
+}
+
+// Store will return the requested store
+func Store(name string) (*kvstore.KeyValueStore, error) {
+	mgr.m.RLock()
+	defer mgr.m.RUnlock()
+
+	if kv, exists := mgr.dsStores[name]; exists {
+		return kv, nil
+	}
+
+	return nil, ErrDoesNotExist
+}
+
+// NewDatastoreKeyValue will validate the supplied name and create a datastore
+// backed key / value store
+//
+// The file will be located at the init datastoreURL  -- currently that's in the
+// appliance directory under the {dsFolder} folder (i.e. [datastore]vch-appliance/{dsFolder}/{name})
+func NewDatastoreKeyValue(ctx context.Context, session *session.Session, name string) error {
+	defer trace.End(trace.Begin(name))
+
+	mgr.m.Lock()
+	defer mgr.m.Unlock()
+
+	// validate the name
+	err := validateStoreName(name)
+	if err != nil {
+		return err
+	}
+	// get a ds helper for this ds url
+	dsHelper, err := datastore.NewHelper(trace.NewOperation(ctx, "datastore helper creation"), session,
+		session.Datastore, fmt.Sprintf("%s/%s", mgr.datastoreURL.Path, dsFolder))
+	if err != nil {
+		return fmt.Errorf("unable to get datastore helper for %s store creation: %s", name, err.Error())
+	}
+
+	// create or restore the specified K/V store
+	keyVal, err := kvstore.NewKeyValueStore(trace.NewOperation(ctx, "kvStore creation"), dsHelper, name)
+	if err != nil && !os.IsExist(err) {
+		return fmt.Errorf("unable to create %s datastore backed store: %s", name, err.Error())
+	}
+	// throw it in the store map
+	mgr.dsStores[name] = keyVal
+
+	return nil
+}
+
+// validateStoreName will validate that the store name is not in use
+// and follows the regexp []
+func validateStoreName(name string) error {
+	// is the name already in use
+	if _, dupe := mgr.dsStores[name]; dupe {
+		return ErrDuplicateName
+	}
+	// compliant w/regexp
+	re := regexp.MustCompile("^[a-zA-Z0-9_]*$")
+	if !re.MatchString(name) {
+		return ErrInvalidName
+	}
+	return nil
+}

--- a/lib/portlayer/store/store_test.go
+++ b/lib/portlayer/store/store_test.go
@@ -1,0 +1,65 @@
+// Copyright 2016 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package store
+
+import (
+	"testing"
+
+	"github.com/vmware/vic/pkg/kvstore"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func setup() {
+	if mgr == nil {
+		// set up fake store manager
+		mgr = &StoreManager{
+			dsStores: make(map[string]*kvstore.KeyValueStore),
+		}
+	}
+}
+
+func TestNameValidation(t *testing.T) {
+	setup()
+
+	// valid name -- empty map
+	assert.NoError(t, validateStoreName(APIKV))
+
+	// fail regex
+	assert.Error(t, validateStoreName("jojo-1"))
+	assert.Error(t, validateStoreName("jojo%1"))
+
+	mgr.dsStores[APIKV] = &kvstore.KeyValueStore{}
+	// dupe store
+	assert.Error(t, validateStoreName(APIKV))
+	// valid name
+	assert.NoError(t, validateStoreName("AB_63cd"))
+
+}
+
+func TestStore(t *testing.T) {
+	setup()
+
+	// API store created in first test
+	s, err := Store(APIKV)
+	assert.NoError(t, err)
+	assert.NotNil(t, s)
+
+	// store not found
+	s, err = Store("jojo")
+	assert.Error(t, err)
+	assert.Nil(t, s)
+
+}


### PR DESCRIPTION
This change makes use of the kv store package to provide
image tag persistence to the docker persona that will survive
restarts. That persistence is available to the persona
via a portlayer k/v store API.


fixes #2580, #2502 