### PR TITLE
Vicadmin certificate authentication

### DIFF
--- a/cmd/vicadmin/server.go
+++ b/cmd/vicadmin/server.go
@@ -28,12 +28,12 @@ import (
 	log "github.com/Sirupsen/logrus"
 	"github.com/docker/docker/pkg/tlsconfig"
 
+	"crypto/x509"
 	"github.com/vmware/vic/lib/vicadmin"
 	"github.com/vmware/vic/pkg/trace"
 )
 
 type server struct {
-	auth Authenticator
 	l    net.Listener
 	addr string
 	mux  *http.ServeMux
@@ -53,6 +53,13 @@ func (s *server) listen(useTLS bool) error {
 
 	// FIXME: assignment copies lock value to tlsConfig: crypto/tls.Config contains sync.Once contains sync.Mutex
 	tlsconfig := func(c *tls.Config) *tls.Config {
+		if c.ClientCAs == nil {
+			c.ClientCAs = x509.NewCertPool()
+		}
+		clientCAs := c.ClientCAs
+		if !clientCAs.AppendCertsFromPEM(vchConfig.CertificateAuthorities) {
+			log.Warnf("Unable to load CAs from config; client auth via certificate will not function")
+		}
 		return &tls.Config{
 			Certificates:             c.Certificates,
 			NameToCertificate:        c.NameToCertificate,
@@ -60,8 +67,8 @@ func (s *server) listen(useTLS bool) error {
 			RootCAs:                  c.RootCAs,
 			NextProtos:               c.NextProtos,
 			ServerName:               c.ServerName,
-			ClientAuth:               c.ClientAuth,
-			ClientCAs:                c.ClientCAs,
+			ClientAuth:               tls.VerifyClientCertIfGiven,
+			ClientCAs:                clientCAs,
 			InsecureSkipVerify:       c.InsecureSkipVerify,
 			CipherSuites:             c.CipherSuites,
 			PreferServerCipherSuites: c.PreferServerCipherSuites,
@@ -101,25 +108,23 @@ func (s *server) listenPort() int {
 	return s.l.Addr().(*net.TCPAddr).Port
 }
 
+func (s *server) Handle(link string, h http.Handler) {
+	s.HandleFunc(link, h.ServeHTTP)
+}
+
 // handleFunc does preparatory work and then calls the HandleFunc method owned by the HTTP multiplexer
-func (s *server) handleFunc(link string, handler func(http.ResponseWriter, *http.Request)) {
+func (s *server) HandleFunc(link string, handler func(http.ResponseWriter, *http.Request)) {
 	defer trace.End(trace.Begin(""))
-
-	if s.auth != nil {
-		authHandler := func(w http.ResponseWriter, r *http.Request) {
-			user, password, ok := r.BasicAuth()
-			if !ok || !s.auth.Validate(user, password) {
-				w.Header().Add("WWW-Authenticate", "Basic realm=vicadmin")
-				w.WriteHeader(http.StatusUnauthorized)
-				return
-			}
-			handler(w, r)
+	authHandler := func(w http.ResponseWriter, r *http.Request) {
+		if len(r.TLS.PeerCertificates) == 0 && len(r.Cookies()) == 0 {
+			// 	// username/password authentication
+			log.Infof("redirecting to auth page")
+			http.Redirect(w, r, "/authentication", 302)
+			return
 		}
-		s.mux.HandleFunc(link, authHandler)
-		return
+		handler(w, r)
 	}
-
-	s.mux.HandleFunc(link, handler)
+	s.mux.HandleFunc(link, authHandler)
 }
 
 func (s *server) serve() error {
@@ -127,35 +132,38 @@ func (s *server) serve() error {
 
 	s.mux = http.NewServeMux()
 
+	s.mux.HandleFunc("/authentication", s.authPage)
+	// NOTE:
+	// DO NOT USE s.mux.HandleFunc directly outside of HandleFunc; you will bypass authentication!
+
 	// tar of appliance system logs
-	s.mux.HandleFunc("/logs.tar.gz", s.tarDefaultLogs)
-	s.handleFunc("/logs.zip", s.zipDefaultLogs)
+	s.HandleFunc("/logs.tar.gz", s.tarDefaultLogs)
+	s.HandleFunc("/logs.zip", s.zipDefaultLogs)
 
 	// tar of appliance system logs + container logs
-	s.mux.HandleFunc("/container-logs.tar.gz", s.tarContainerLogs)
-	s.handleFunc("/container-logs.zip", s.zipContainerLogs)
+	s.HandleFunc("/container-logs.tar.gz", s.tarContainerLogs)
+	s.HandleFunc("/container-logs.zip", s.zipContainerLogs)
 
-	s.mux.Handle("/css/", http.StripPrefix("/css/", http.FileServer(http.Dir("css/"))))
-	s.mux.Handle("/images/", http.StripPrefix("/images/", http.FileServer(http.Dir("images/"))))
-	s.mux.Handle("/fonts/", http.StripPrefix("/fonts/", http.FileServer(http.Dir("fonts/"))))
+	s.Handle("/css/", http.StripPrefix("/css/", http.FileServer(http.Dir("css/"))))
+	s.Handle("/images/", http.StripPrefix("/images/", http.FileServer(http.Dir("images/"))))
+	s.Handle("/fonts/", http.StripPrefix("/fonts/", http.FileServer(http.Dir("fonts/"))))
 
 	for _, path := range logFiles() {
 		name := filepath.Base(path)
 		p := path
 
 		// get single log file (no tail)
-		s.handleFunc("/logs/"+name, func(w http.ResponseWriter, r *http.Request) {
+		s.HandleFunc("/logs/"+name, func(w http.ResponseWriter, r *http.Request) {
 			http.ServeFile(w, r, p)
 		})
 
 		// get single log file (with tail)
-		s.handleFunc("/logs/tail/"+name, func(w http.ResponseWriter, r *http.Request) {
+		s.HandleFunc("/logs/tail/"+name, func(w http.ResponseWriter, r *http.Request) {
 			s.tailFiles(w, r, []string{p})
 		})
 	}
 
-	//s.handleFunc("/", s.index)
-	s.mux.HandleFunc("/", s.index)
+	s.HandleFunc("/", s.index)
 	server := &http.Server{
 		Handler: s.mux,
 	}
@@ -271,6 +279,19 @@ func (s *server) tailFiles(res http.ResponseWriter, req *http.Request, names []s
 	<-cc
 	for range names {
 		done <- true
+	}
+}
+
+func (s *server) authPage(res http.ResponseWriter, req *http.Request) {
+	defer trace.End(trace.Begin(""))
+	ctx := context.Background()
+	sess, err := client()
+	v := vicadmin.NewValidator(ctx, &vchConfig, sess)
+
+	tmpl, err := template.ParseFiles("auth.html")
+	err = tmpl.ExecuteTemplate(res, "auth.html", v)
+	if err != nil {
+		log.Errorf("Error parsing template: %s", err)
 	}
 }
 

--- a/cmd/vicadmin/vicadm.go
+++ b/cmd/vicadmin/vicadm.go
@@ -139,11 +139,6 @@ func init() {
 	extraconfig.Decode(src, &vchConfig)
 }
 
-type Authenticator interface {
-	// Validate will validate a user and password combo and return a bool.
-	Validate(string, string) bool
-}
-
 type entryReader interface {
 	open() (entry, error)
 }

--- a/cmd/vicadmin/vicadm_test.go
+++ b/cmd/vicadmin/vicadm_test.go
@@ -99,7 +99,6 @@ func TestLoginFailure(t *testing.T) {
 
 	s := &server{
 		addr: "127.0.0.1:0",
-		auth: &credentials{"root", "thisisinsecure"},
 	}
 
 	err := s.listen(true)
@@ -125,7 +124,6 @@ func TestNoAuth(t *testing.T) {
 
 	s := &server{
 		addr: "127.0.0.1:0",
-		auth: nil,
 	}
 
 	err := s.listen(true)
@@ -156,7 +154,6 @@ func testLogTar(t *testing.T, plainHTTP bool) {
 
 	s := &server{
 		addr: "127.0.0.1:0",
-		auth: &credentials{"root", "thisisinsecure"},
 	}
 
 	err := s.listen(!plainHTTP)

--- a/tests/test-cases/Group9-VIC-Admin/9-1-VICAdmin-ShowHTML.robot
+++ b/tests/test-cases/Group9-VIC-Admin/9-1-VICAdmin-ShowHTML.robot
@@ -1,7 +1,7 @@
 *** Settings ***
 Documentation  Test 9-1 - VICAdmin ShowHTML
 Resource  ../../resources/Util.robot
-Suite Setup  Install VIC Appliance To Test Server
+Suite Setup  Install VIC Appliance To Test Server  certs=${false}
 Suite Teardown  Cleanup VIC Appliance On Test Server
 Default Tags
 

--- a/tests/test-cases/Group9-VIC-Admin/9-2-VICAdmin-CertAuth.robot
+++ b/tests/test-cases/Group9-VIC-Admin/9-2-VICAdmin-CertAuth.robot
@@ -13,41 +13,48 @@ Curl
     [Return]  ${output}
 
 *** Test Cases ***
-# Display HTML
-#     ${output}=  Wait Until Keyword Succeeds  10x  10s  Curl  ${EMPTY}
-#     Should contain  ${output}  <title>VCH Admin</title>
+Display HTML    
+     ${output}=  Wait Until Keyword Succeeds  10x  10s  Curl  ${EMPTY}
+     Should contain  ${output}  <title>VCH Admin</title>
 
-# Get Portlayer Log
-#     ${output}=  Wait Until Keyword Succeeds  10x  10s  Curl  /logs/port-layer.log
-#     Should contain  ${output}  Launching portlayer server
+Get Portlayer Log
+    ${output}=  Wait Until Keyword Succeeds  10x  10s  Curl  /logs/port-layer.log
+    Should contain  ${output}  Launching portlayer server
 
-# Get VCH-Init Log
-#     ${output}=  Wait Until Keyword Succeeds  10x  10s  Curl  /logs/init.log
-#     Should contain  ${output}  reaping child processes
+Get VCH-Init Log
+    ${output}=  Wait Until Keyword Succeeds  10x  10s  Curl  /logs/init.log
+    Should contain  ${output}  reaping child processes
 
-# Get Docker Personality Log
-#     ${output}=  Wait Until Keyword Succeeds  10x  10s  Curl  /logs/docker-personality.log
-#     Should contain  ${output}  docker personality
-
-Get Container Logs
-    Run Keyword  Set Environment Variable  DOMAIN  ${EMPTY}
-    ${rc}  ${output}=  Run And Return Rc and Output  docker ${params} pull busybox
-    Log To Console  ${output}
-    Should Be Equal As Integers  ${rc}  0
-    Should Not Contain  ${output}  Error
-    ${rc}  ${container}=  Run And Return Rc and Output  docker ${params} create busybox /bin/top
-    Should Be Equal As Integers  ${rc}  0
-    Should Not Contain  ${container}  Error
-    ${rc}  ${output}=  Run And Return Rc and Output  docker ${params} start ${container}
-    Should Be Equal As Integers  ${rc}  0
-    Should Not Contain  ${output}  Error
-    ${output}=  Run  curl -sk --cert /drone/src/github.com/vmware/vic/${vch-name}/cert.pem --key /drone/src/github.com/vmware/vic/${vch-name}/key.pem ${vic-admin}/container-logs.tar.gz | tar tvzf -
-    Should Be Equal As Integers  ${rc}  0
-    Log  ${output}
-    Should Contain  ${output}  ${container}/vmware.log
-    Should Contain  ${output}  ${container}/tether.debug
+Get Docker Personality Log
+    ${output}=  Wait Until Keyword Succeeds  10x  10s  Curl  /logs/docker-personality.log
+    Should contain  ${output}  docker personality
 
 Get VICAdmin Log
-    ${output}=  Run  curl -sk --cert /drone/src/github.com/vmware/vic/${vch-name}/cert.pem --key /drone/src/github.com/vmware/vic/${vch-name}/key.pem ${vic-admin}/logs/vicadmin.log
+    ${output}=  Wait Until Keyword Succeeds  10x  10s  Curl  /logs/vicadmin.log
     Log  ${output}
     Should contain  ${output}  Launching vicadmin pprof server
+
+Fail to Get VICAdmin Log without cert
+    ${output}=  Run  curl -sk ${vic-admin}/logs/vicadmin.log
+    Log  ${output}
+    Should Not contain  ${output}  Launching vicadmin pprof server
+    
+Fail to Display HTML without cert
+    ${output}=  Run  curl -sk ${vic-admin}
+    Log  ${output}
+    Should Not contain  ${output}  <title>VCH Admin</title>
+
+Fail to get Portlayer Log without cert
+    ${output}=  Run  curl -sk ${vic-admin}/logs/port-layer.log
+    Log  ${output}
+    Should Not contain  ${output}  Launching portlayer server
+
+Fail to get Docker Personality Log without cert
+    ${output}=  Run  curl -sk ${vic-admin}/logs/docker-personality.log
+    Log  ${output}
+    Should Not contain  ${output}  docker personality
+
+Fail to get VCH init logs without cert
+    ${output}=  Run  curl -sk ${vic-admin}/logs/init.log
+    Log  ${output}
+    Should Not contain  ${output}  reaping child processes

--- a/tests/test-cases/Group9-VIC-Admin/9-2-VICAdmin-CertAuth.robot
+++ b/tests/test-cases/Group9-VIC-Admin/9-2-VICAdmin-CertAuth.robot
@@ -1,0 +1,52 @@
+*** Settings ***
+Documentation  Test 9-2 - VICAdmin CertAuth
+Resource  ../../resources/Util.robot
+Suite Setup  Install VIC Appliance To Test Server  certs=${true}
+Suite Teardown  Cleanup VIC Appliance On Test Server
+Default Tags
+
+*** Test Cases ***
+Wait
+    Run  sleep 30
+
+Display HTML
+    ${output}=  Run  curl -sk --cert /drone/src/github.com/vmware/vic/${vch-name}/cert.pem --key /drone/src/github.com/vmware/vic/${vch-name}/key.pem ${vic-admin}
+    Log To Console  ${output}
+    Should contain  ${output}  <title>VCH Admin</title>
+
+Get Portlayer Log
+     ${output}=  Run  curl -sk --cert /drone/src/github.com/vmware/vic/${vch-name}/cert.pem --key /drone/src/github.com/vmware/vic/${vch-name}/key.pem ${vic-admin}/logs/port-layer.log
+    Should contain  ${output}  Launching portlayer server
+
+Get VCH-Init Log
+    ${output}=  Run  curl -sk --cert /drone/src/github.com/vmware/vic/${vch-name}/cert.pem --key /drone/src/github.com/vmware/vic/${vch-name}/key.pem ${vic-admin}/logs/init.log
+    Should contain  ${output}  reaping child processes
+
+Get Docker Personality Log
+     ${output}=  Run  curl -sk --cert /drone/src/github.com/vmware/vic/${vch-name}/cert.pem --key /drone/src/github.com/vmware/vic/${vch-name}/key.pem ${vic-admin}/logs/docker-personality.log
+    Should contain  ${output}  docker personality
+
+# Get Container Logs
+#     ${rc}  ${output}=  Run And Return Rc and Output  docker ${params} pull busybox
+#     Log To Console  ${output}
+#     Should Be Equal As Integers  ${rc}  0
+#     Should Not Contain  ${output}  Error
+#     ${rc}  ${container}=  Run And Return Rc and Output  docker ${params} create busybox /bin/top
+#     Log To Console  ${output}
+#     Should Be Equal As Integers  ${rc}  0
+#     Should Not Contain  ${container}  Error
+#     ${rc}  ${output}=  Run And Return Rc and Output  docker ${params} start ${container}
+#     Log To Console  ${output}
+#     Should Be Equal As Integers  ${rc}  0
+#     Should Not Contain  ${output}  Error
+#     ${output}=  Run  curl -sk --cert /drone/src/github.com/vmware/vic/${vch-name}/cert.pem --key /drone/src/github.com/vmware/vic/${vch-name}/key.pem ${vic-admin}/container-logs.tar.gz | tar tvzf -
+#     Log To Console  ${output}
+#     Should Be Equal As Integers  ${rc}  0
+#     Log  ${output}
+#     Should Contain  ${output}  ${container}/vmware.log
+#     Should Contain  ${output}  ${container}/tether.debug
+
+Get VICAdmin Log
+    ${output}=  Run  curl -sk --cert /drone/src/github.com/vmware/vic/${vch-name}/cert.pem --key /drone/src/github.com/vmware/vic/${vch-name}/key.pem ${vic-admin}/logs/vicadmin.log
+    Log  ${output}
+    Should contain  ${output}  Launching vicadmin pprof server

--- a/tests/test-cases/Group9-VIC-Admin/9-2-VICAdmin-CertAuth.robot
+++ b/tests/test-cases/Group9-VIC-Admin/9-2-VICAdmin-CertAuth.robot
@@ -5,46 +5,47 @@ Suite Setup  Install VIC Appliance To Test Server  certs=${true}
 Suite Teardown  Cleanup VIC Appliance On Test Server
 Default Tags
 
+*** Keywords ***
+Curl
+    [Arguments]  ${path}
+    ${output}=  Run  curl -sk --cert /drone/src/github.com/vmware/vic/${vch-name}/cert.pem --key /drone/src/github.com/vmware/vic/${vch-name}/key.pem ${vic-admin}${path}
+    Should Not Be Equal As Strings  ''  ${output}
+    [Return]  ${output}
+
 *** Test Cases ***
-Wait
-    Run  sleep 30
+# Display HTML
+#     ${output}=  Wait Until Keyword Succeeds  10x  10s  Curl  ${EMPTY}
+#     Should contain  ${output}  <title>VCH Admin</title>
 
-Display HTML
-    ${output}=  Run  curl -sk --cert /drone/src/github.com/vmware/vic/${vch-name}/cert.pem --key /drone/src/github.com/vmware/vic/${vch-name}/key.pem ${vic-admin}
+# Get Portlayer Log
+#     ${output}=  Wait Until Keyword Succeeds  10x  10s  Curl  /logs/port-layer.log
+#     Should contain  ${output}  Launching portlayer server
+
+# Get VCH-Init Log
+#     ${output}=  Wait Until Keyword Succeeds  10x  10s  Curl  /logs/init.log
+#     Should contain  ${output}  reaping child processes
+
+# Get Docker Personality Log
+#     ${output}=  Wait Until Keyword Succeeds  10x  10s  Curl  /logs/docker-personality.log
+#     Should contain  ${output}  docker personality
+
+Get Container Logs
+    Run Keyword  Set Environment Variable  DOMAIN  ${EMPTY}
+    ${rc}  ${output}=  Run And Return Rc and Output  docker ${params} pull busybox
     Log To Console  ${output}
-    Should contain  ${output}  <title>VCH Admin</title>
-
-Get Portlayer Log
-     ${output}=  Run  curl -sk --cert /drone/src/github.com/vmware/vic/${vch-name}/cert.pem --key /drone/src/github.com/vmware/vic/${vch-name}/key.pem ${vic-admin}/logs/port-layer.log
-    Should contain  ${output}  Launching portlayer server
-
-Get VCH-Init Log
-    ${output}=  Run  curl -sk --cert /drone/src/github.com/vmware/vic/${vch-name}/cert.pem --key /drone/src/github.com/vmware/vic/${vch-name}/key.pem ${vic-admin}/logs/init.log
-    Should contain  ${output}  reaping child processes
-
-Get Docker Personality Log
-     ${output}=  Run  curl -sk --cert /drone/src/github.com/vmware/vic/${vch-name}/cert.pem --key /drone/src/github.com/vmware/vic/${vch-name}/key.pem ${vic-admin}/logs/docker-personality.log
-    Should contain  ${output}  docker personality
-
-# Get Container Logs
-#     ${rc}  ${output}=  Run And Return Rc and Output  docker ${params} pull busybox
-#     Log To Console  ${output}
-#     Should Be Equal As Integers  ${rc}  0
-#     Should Not Contain  ${output}  Error
-#     ${rc}  ${container}=  Run And Return Rc and Output  docker ${params} create busybox /bin/top
-#     Log To Console  ${output}
-#     Should Be Equal As Integers  ${rc}  0
-#     Should Not Contain  ${container}  Error
-#     ${rc}  ${output}=  Run And Return Rc and Output  docker ${params} start ${container}
-#     Log To Console  ${output}
-#     Should Be Equal As Integers  ${rc}  0
-#     Should Not Contain  ${output}  Error
-#     ${output}=  Run  curl -sk --cert /drone/src/github.com/vmware/vic/${vch-name}/cert.pem --key /drone/src/github.com/vmware/vic/${vch-name}/key.pem ${vic-admin}/container-logs.tar.gz | tar tvzf -
-#     Log To Console  ${output}
-#     Should Be Equal As Integers  ${rc}  0
-#     Log  ${output}
-#     Should Contain  ${output}  ${container}/vmware.log
-#     Should Contain  ${output}  ${container}/tether.debug
+    Should Be Equal As Integers  ${rc}  0
+    Should Not Contain  ${output}  Error
+    ${rc}  ${container}=  Run And Return Rc and Output  docker ${params} create busybox /bin/top
+    Should Be Equal As Integers  ${rc}  0
+    Should Not Contain  ${container}  Error
+    ${rc}  ${output}=  Run And Return Rc and Output  docker ${params} start ${container}
+    Should Be Equal As Integers  ${rc}  0
+    Should Not Contain  ${output}  Error
+    ${output}=  Run  curl -sk --cert /drone/src/github.com/vmware/vic/${vch-name}/cert.pem --key /drone/src/github.com/vmware/vic/${vch-name}/key.pem ${vic-admin}/container-logs.tar.gz | tar tvzf -
+    Should Be Equal As Integers  ${rc}  0
+    Log  ${output}
+    Should Contain  ${output}  ${container}/vmware.log
+    Should Contain  ${output}  ${container}/tether.debug
 
 Get VICAdmin Log
     ${output}=  Run  curl -sk --cert /drone/src/github.com/vmware/vic/${vch-name}/cert.pem --key /drone/src/github.com/vmware/vic/${vch-name}/key.pem ${vic-admin}/logs/vicadmin.log

--- a/tests/test-cases/Group9-VIC-Admin/9-2-VICAdmin-CertAuth.robot
+++ b/tests/test-cases/Group9-VIC-Admin/9-2-VICAdmin-CertAuth.robot
@@ -8,7 +8,7 @@ Default Tags
 *** Keywords ***
 Curl
     [Arguments]  ${path}
-    ${output}=  Run  curl -sk --cert /drone/src/github.com/vmware/vic/${vch-name}/cert.pem --key /drone/src/github.com/vmware/vic/${vch-name}/key.pem ${vic-admin}${path}
+    ${output}=  Run  curl -sk --cert %{DOCKER_CERT_PATH}/cert.pem --key %{DOCKER_CERT_PATH}/key.pem ${vic-admin}${path}
     Should Not Be Equal As Strings  ''  ${output}
     [Return]  ${output}
 


### PR DESCRIPTION
This change blocks access to vicadmin w/o a cert for authentication if tlsverify is enabled on the VCH. We decided to split #2342 into two issues, so this PR will resolve what remains of #2342

With TLS verify enabled:
<pre>~/go/src/github.com/vmware/vic vicadmin-cert-auth* 2m 0s
❯ ./bin/vic-machine-linux create --target 192.168.218.168 --user root --image-store=datastore1 --password **** --name ian-vch --image-store=datastore1/images --cname=192.168.218.212
</pre>

Firefox reports upon visiting vicadmin: "An error occurred during a connection to 192.168.218.212:2378. SSL peer cannot verify your certificate. Error code: SSL_ERROR_BAD_CERT_ALERT "

Regarding the above: @hickeng reports that it should be able to add a supported certificate to the browser once #2629 is in. I don't believe this will require changes on the vicadmin side, but I'll revisit this to be sure once those changes are in.

From `wget` with a good key:
<pre>~/go/src/github.com/vmware/vic vicadmin-cert-auth* 21s
❯ wget -v --certificate=ian-vch/cert.pem --private-key=ian-vch/key.pem --no-check-certificate https://192.168.218.212:2378/logs/vicadmin.log
--2016-10-12 14:27:48--  https://192.168.218.212:2378/logs/vicadmin.log
Connecting to 192.168.218.212:2378... connected.
WARNING: cannot verify 192.168.218.212's certificate, issued by ‘O=default’:
  Unable to locally verify the issuer's authority.
HTTP request sent, awaiting response... 200 OK
Length: 1663 (1.6K) [text/plain]
Saving to: ‘vicadmin.log’

vicadmin.log                  100%[==============================================>]   1.62K  --.-KB/s    in 0s      

2016-10-12 14:27:48 (54.6 MB/s) - ‘vicadmin.log’ saved [1663/1663]</pre>

And with a bad key (generated the last time I used vic-machine):
<pre>~/go/src/github.com/vmware/vic vicadmin-cert-auth*
❯ wget -v --certificate=old-keys/cert.pem --private-key=old-keys/key.pem --no-check-certificate https://192.168.218.212:2378/logs/vicadmin.log
--2016-10-12 14:28:16--  https://192.168.218.212:2378/logs/vicadmin.log
Connecting to 192.168.218.212:2378... connected.
OpenSSL: error:14094412:SSL routines:ssl3_read_bytes:sslv3 alert bad certificate
Unable to establish SSL connection.
</pre>

With install line including `--no-tlsverify`, `vicadmin` works as it did before this change.

I'm about to write/update some integration tests, also.