### PR TITLE
Add tests for pulling images concurrently

### DIFF
--- a/tests/manual-test-cases/Group11-Stress/11-4-Many-Volumes.robot
+++ b/tests/manual-test-cases/Group11-Stress/11-4-Many-Volumes.robot
@@ -16,7 +16,6 @@ Docker volume create 1000 volumes rapidly
     # Wait for them to finish and check their RC
     :FOR  ${pid}  IN  @{pids}
     \   ${res}=  Wait For Process  ${pid}
-    \   Log  ${res.stdout} ${res.stderr}
     \   Should Be Equal As Integers  ${res.rc}  0
 
     Run Regression Tests

--- a/tests/test-cases/Group1-Docker-Commands/1-2-Docker-Pull.md
+++ b/tests/test-cases/Group1-Docker-Commands/1-2-Docker-Pull.md
@@ -26,6 +26,8 @@ This test requires that an vSphere server is running and available.
 8. Issue a docker pull command to the new VIC appliance using a non-default repository that doesn't exist
 9. Issue a docker pull command for an image with a tag that doesn't exist
 10. Issue a docker pull command for an image that has already been pulled
+11. Issue a docker pull command multiple times for the same image
+12. Issue a docker pull command for each of two images that share layers
 
 #Expected Outcome:
 VIC appliance should respond with a properly formatted pull response to each command issued to it. No errors should be seen, except in the case of step 7, 8 and 9.

--- a/tests/test-cases/Group1-Docker-Commands/1-2-Docker-Pull.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-2-Docker-Pull.robot
@@ -74,7 +74,7 @@ Pull the same image concurrently
      \   Should Contain  ${res.stdout}  Downloaded newer image for library/redis:latest
 
 Pull two images that share layers concurrently
-     ${pid1}=  Start Process  docker ${params} pull golang  shell=True
+     ${pid1}=  Start Process  docker ${params} pull golang:1.7  shell=True
      ${pid2}=  Start Process  docker ${params} pull golang:1.6  shell=True
 
     # Wait for them to finish and check their output
@@ -82,5 +82,5 @@ Pull two images that share layers concurrently
     ${res2}=  Wait For Process  ${pid2}
     Should Be Equal As Integers  ${res1.rc}  0
     Should Be Equal As Integers  ${res2.rc}  0
-    Should Contain  ${res1.stdout}  Downloaded newer image for library/golang:latest
+    Should Contain  ${res1.stdout}  Downloaded newer image for library/golang:1.7
     Should Contain  ${res2.stdout}  Downloaded newer image for library/golang:1.6

--- a/tests/test-cases/Group1-Docker-Commands/1-2-Docker-Pull.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-2-Docker-Pull.robot
@@ -58,3 +58,29 @@ Pull image with a tag that doesn't exist
 Pull image that already has been pulled
     Wait Until Keyword Succeeds  5x  15 seconds  Pull image  alpine
     Wait Until Keyword Succeeds  5x  15 seconds  Pull image  alpine
+
+Pull the same image concurrently
+     ${pids}=  Create List
+
+     # Create 5 processes to pull the same image at once
+     :FOR  ${idx}  IN RANGE  0  5
+     \   ${pid}=  Start Process  docker ${params} pull redis  shell=True
+     \   Append To List  ${pids}  ${pid}
+
+     # Wait for them to finish and check their output
+     :FOR  ${pid}  IN  @{pids}
+     \   ${res}=  Wait For Process  ${pid}
+     \   Should Be Equal As Integers  ${res.rc}  0
+     \   Should Contain  ${res.stdout}  Downloaded newer image for library/redis:latest
+
+Pull two images that share layers concurrently
+     ${pid1}=  Start Process  docker ${params} pull golang  shell=True
+     ${pid2}=  Start Process  docker ${params} pull golang:1.6  shell=True
+
+    # Wait for them to finish and check their output
+    ${res1}=  Wait For Process  ${pid1}
+    ${res2}=  Wait For Process  ${pid2}
+    Should Be Equal As Integers  ${res1.rc}  0
+    Should Be Equal As Integers  ${res2.rc}  0
+    Should Contain  ${res1.stdout}  Downloaded newer image for library/golang:latest
+    Should Contain  ${res2.stdout}  Downloaded newer image for library/golang:1.6


### PR DESCRIPTION
This also removes some extraneous logging from the Many Volumes stress test.

Local test output:

```
Installing VCH to test server...
Installer completed successfully: VCH-0-8073...
Pull nginx
Running docker pull nginx...
Pull nginx                                                            | PASS |
------------------------------------------------------------------------------
Pull busybox
Running docker pull busybox...
Pull busybox                                                          | PASS |
------------------------------------------------------------------------------
Pull ubuntu
Running docker pull ubuntu...
Pull ubuntu                                                           | PASS |
------------------------------------------------------------------------------
Pull non-default tag
Running docker pull nginx:alpine...
Pull non-default tag                                                  | PASS |
------------------------------------------------------------------------------
Pull an image based on digest
Running docker pull nginx@sha256:7281cf7c854b0dfc7c68a6a4de9a785a973a14f1481bc028e2022bcd6a8d9f64...
Pull an image based on digest                                         | PASS |
------------------------------------------------------------------------------
Pull an image with the full docker registry URL
Running docker pull registry.hub.docker.com/library/hello-world...
Pull an image with the full docker registry URL                       | PASS |
------------------------------------------------------------------------------
Pull an image with all tags
Running docker pull --all-tags nginx...
Pull an image with all tags                                           | PASS |
------------------------------------------------------------------------------
Pull non-existent image                                               | PASS |
------------------------------------------------------------------------------
Pull image from non-existent repo                                     | PASS |
------------------------------------------------------------------------------
Pull image with a tag that doesn't exist                              | PASS |
------------------------------------------------------------------------------
Pull image that already has been pulled
Running docker pull alpine...
.
Running docker pull alpine...
Pull image that already has been pulled                               | PASS |
------------------------------------------------------------------------------
Pull the same image concurrently                                      | PASS |
------------------------------------------------------------------------------
Pull two images that share layers concurrently                        | PASS |
------------------------------------------------------------------------------
Gathering logs from the test server...
Deleting the VCH appliance...
1-2-Docker-Pull :: Test 1-2 - Docker Pull                             | PASS |
13 critical tests, 13 passed, 0 failed
13 tests total, 13 passed, 0 failed
==============================================================================
```