### PR TITLE
[full ci] Fix multiple data races reported by race detector

### DIFF
--- a/cmd/tether/attach.go
+++ b/cmd/tether/attach.go
@@ -22,12 +22,14 @@ import (
 	"sync"
 	"sync/atomic"
 	"syscall"
+	"time"
 
 	log "github.com/Sirupsen/logrus"
 	"golang.org/x/crypto/ssh"
 
 	"github.com/vmware/vic/cmd/tether/msgs"
 	"github.com/vmware/vic/lib/tether"
+	"github.com/vmware/vic/pkg/serial"
 	"github.com/vmware/vic/pkg/trace"
 )
 
@@ -218,6 +220,42 @@ func (t *attachServerSSH) stop() error {
 	log.Debugf("Released the connection lock")
 
 	return nil
+}
+
+func backchannel(ctx context.Context, conn *net.Conn) error {
+	defer trace.End(trace.Begin("establish tether backchannel"))
+
+	// HACK: currently RawConn dosn't implement timeout so throttle the spinning
+	// it does implement the Timeout methods so the intermediary code can be written
+	// to support it, but they are stub implementation in rawconn impl.
+
+	// This needs to tick *faster* than the ticker in connection.go on the
+	// portlayer side.  The PL sends the first syn and if this isn't waiting,
+	// alignment will take a few rounds (or it may never happen).
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+
+	ch := make(chan struct{}, 1)
+
+	go func() {
+		select {
+		case <-ctx.Done():
+			(*conn).Close()
+			close(ch)
+		}
+	}()
+
+	for {
+		select {
+		case <-ticker.C:
+			err := serial.HandshakeServer(ctx, *conn)
+			if err == nil {
+				return nil
+			}
+		case <-ch:
+			return ctx.Err()
+		}
+	}
 }
 
 // run should not be called directly, but via start

--- a/cmd/tether/attach_darwin.go
+++ b/cmd/tether/attach_darwin.go
@@ -20,17 +20,12 @@ import (
 	"os"
 
 	"golang.org/x/crypto/ssh"
-	"golang.org/x/net/context"
 
 	"github.com/vmware/vic/cmd/tether/msgs"
 )
 
 func rawConnectionFromSerial() (*net.Conn, error) {
 	return nil, errors.New("not supported on OSX")
-}
-
-func backchannel(ctx context.Context, conn *net.Conn) error {
-	return errors.New("not supported on OSX")
 }
 
 func (t *attachServerSSH) Start() error {

--- a/cmd/tether/attach_linux.go
+++ b/cmd/tether/attach_linux.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"context"
 	"crypto/rand"
 	"fmt"
 	"net"
@@ -25,7 +26,6 @@ import (
 
 	"golang.org/x/crypto/ssh"
 	"golang.org/x/crypto/ssh/terminal"
-	"golang.org/x/net/context"
 
 	log "github.com/Sirupsen/logrus"
 
@@ -106,13 +106,15 @@ func (t *attachServerSSH) Start() error {
 		return detail
 	}
 
-	t.conn, err = rawConnectionFromSerial()
+	t.conn.Lock()
+	defer t.conn.Unlock()
+
+	t.conn.conn, err = rawConnectionFromSerial()
 	if err != nil {
 		detail := fmt.Errorf("failed to create raw connection from ttyS0 file handle: %s", err)
 		log.Error(detail)
 		return detail
 	}
-
 	return nil
 }
 

--- a/cmd/tether/attach_linux.go
+++ b/cmd/tether/attach_linux.go
@@ -106,15 +106,6 @@ func (t *attachServerSSH) Start() error {
 		return detail
 	}
 
-	t.conn.Lock()
-	defer t.conn.Unlock()
-
-	t.conn.conn, err = rawConnectionFromSerial()
-	if err != nil {
-		detail := fmt.Errorf("failed to create raw connection from ttyS0 file handle: %s", err)
-		log.Error(detail)
-		return detail
-	}
 	return nil
 }
 

--- a/cmd/tether/attach_test.go
+++ b/cmd/tether/attach_test.go
@@ -59,14 +59,17 @@ func (t *testAttachServer) start() error {
 	return err
 }
 
-func (t *testAttachServer) stop() {
+func (t *testAttachServer) stop() error {
 	if t.enabled {
-		t.attachServerSSH.stop()
-
-		log.Info("Stopped test attach server")
-		t.updated <- true
-		t.enabled = false
+		err := t.attachServerSSH.stop()
+		if err == nil {
+			log.Info("Stopped test attach server")
+			t.updated <- true
+			t.enabled = false
+		}
+		return err
 	}
+	return nil
 }
 
 func (t *testAttachServer) Reload(config *tether.ExecutorConfig) error {

--- a/cmd/tether/attach_test.go
+++ b/cmd/tether/attach_test.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/x509"
@@ -33,7 +34,6 @@ import (
 	log "github.com/Sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/crypto/ssh"
-	"golang.org/x/net/context"
 
 	"github.com/vmware/vic/lib/config/executor"
 	"github.com/vmware/vic/lib/portlayer/attach"
@@ -99,7 +99,10 @@ func (t *testAttachServer) Start() error {
 		return errors.New(detail)
 	}
 
-	t.conn = &conn
+	t.conn.Lock()
+	defer t.conn.Unlock()
+
+	t.conn.conn = &conn
 	return nil
 }
 

--- a/cmd/tether/attach_windows.go
+++ b/cmd/tether/attach_windows.go
@@ -15,19 +15,16 @@
 package main
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"net"
 	"os"
-	"time"
 
 	"golang.org/x/crypto/ssh"
 
 	log "github.com/Sirupsen/logrus"
 
 	"github.com/vmware/vic/cmd/tether/msgs"
-	"github.com/vmware/vic/pkg/serial"
 	"github.com/vmware/vic/pkg/trace"
 )
 
@@ -54,24 +51,6 @@ func rawConnectionFromSerial() (*net.Conn, error) {
 	// regular files for testing
 	// t.conn, err := serial.NewTypedConn(f, "file")
 	return nil, nil
-}
-
-func backchannel(ctx context.Context, conn *net.Conn) error {
-	// HACK: currently RawConn dosn't implement timeout so throttle the spinning
-	ticker := time.NewTicker(10 * time.Millisecond)
-	for {
-		select {
-		case <-ticker.C:
-			err := serial.HandshakeServer(ctx, *conn)
-			if err == nil {
-				return nil
-			}
-		case <-ctx.Done():
-			(*conn).Close()
-			ticker.Stop()
-			return ctx.Err()
-		}
-	}
 }
 
 func (t *attachServerSSH) Start() error {

--- a/cmd/tether/attach_windows.go
+++ b/cmd/tether/attach_windows.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net"
@@ -22,7 +23,6 @@ import (
 	"time"
 
 	"golang.org/x/crypto/ssh"
-	"golang.org/x/net/context"
 
 	log "github.com/Sirupsen/logrus"
 
@@ -82,7 +82,10 @@ func (t *attachServerSSH) Start() error {
 
 	var err error
 
-	t.conn, err = rawConnectionFromSerial()
+	t.conn.Lock()
+	defer t.conn.Unlock()
+
+	t.conn.conn, err = rawConnectionFromSerial()
 	if err != nil {
 		detail := fmt.Errorf("failed to create raw connection from %s file handle: %s", com, err)
 		log.Error(detail)

--- a/cmd/tether/attach_windows.go
+++ b/cmd/tether/attach_windows.go
@@ -77,21 +77,6 @@ func backchannel(ctx context.Context, conn *net.Conn) error {
 func (t *attachServerSSH) Start() error {
 	defer trace.End(trace.Begin(""))
 
-	t.m.Lock()
-	defer t.m.Unlock()
-
-	var err error
-
-	t.conn.Lock()
-	defer t.conn.Unlock()
-
-	t.conn.conn, err = rawConnectionFromSerial()
-	if err != nil {
-		detail := fmt.Errorf("failed to create raw connection from %s file handle: %s", com, err)
-		log.Error(detail)
-		return detail
-	}
-
 	return nil
 }
 

--- a/cmd/tether/main_test.go
+++ b/cmd/tether/main_test.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io/ioutil"
@@ -97,9 +98,14 @@ func testSetup(t *testing.T) (string, *Mocker) {
 		t.Error(err)
 	}
 
+	ctx, cancel := context.WithCancel(context.Background())
 	// supply custom attach server so we can inspect its state
 	testServer := &testAttachServer{
 		updated: make(chan bool, 10),
+		attachServerSSH: attachServerSSH{
+			ctx:    ctx,
+			cancel: cancel,
+		},
 	}
 	server = testServer
 

--- a/cmd/tether/tether_test.go
+++ b/cmd/tether/tether_test.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -26,7 +27,6 @@ import (
 
 	log "github.com/Sirupsen/logrus"
 	"golang.org/x/crypto/ssh"
-	"golang.org/x/net/context"
 
 	"github.com/vmware/vic/lib/config/executor"
 	"github.com/vmware/vic/lib/system"

--- a/cmd/vic-init/tether_test.go
+++ b/cmd/vic-init/tether_test.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -27,7 +28,6 @@ import (
 
 	log "github.com/Sirupsen/logrus"
 	"golang.org/x/crypto/ssh"
-	"golang.org/x/net/context"
 
 	"github.com/vmware/govmomi/vim25/types"
 	"github.com/vmware/vic/lib/config/executor"

--- a/lib/tether/interfaces.go
+++ b/lib/tether/interfaces.go
@@ -15,9 +15,8 @@
 package tether
 
 import (
+	"context"
 	"io"
-
-	"golang.org/x/net/context"
 
 	"github.com/vmware/vic/pkg/dio"
 )

--- a/lib/tether/ops_darwin.go
+++ b/lib/tether/ops_darwin.go
@@ -15,6 +15,7 @@
 package tether
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -24,7 +25,6 @@ import (
 	"syscall"
 
 	log "github.com/Sirupsen/logrus"
-	"golang.org/x/net/context"
 
 	"github.com/vmware/vic/pkg/trace"
 )

--- a/lib/tether/ops_linux.go
+++ b/lib/tether/ops_linux.go
@@ -15,6 +15,7 @@
 package tether
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io/ioutil"
@@ -27,8 +28,6 @@ import (
 	"strings"
 	"syscall"
 	"time"
-
-	"golang.org/x/net/context"
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/vishvananda/netlink"

--- a/lib/tether/ops_windows.go
+++ b/lib/tether/ops_windows.go
@@ -15,12 +15,11 @@
 package tether
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
 	"syscall"
-
-	"golang.org/x/net/context"
 
 	"github.com/vmware/vic/pkg/trace"
 )

--- a/lib/tether/tether.go
+++ b/lib/tether/tether.go
@@ -15,6 +15,7 @@
 package tether
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -27,8 +28,6 @@ import (
 	"path"
 	"syscall"
 	"time"
-
-	"golang.org/x/net/context"
 
 	log "github.com/Sirupsen/logrus"
 
@@ -66,6 +65,7 @@ type tether struct {
 	sink extraconfig.DataSink
 
 	incoming chan os.Signal
+	done     chan struct{}
 }
 
 func New(src extraconfig.DataSource, sink extraconfig.DataSink, ops Operations) Tether {
@@ -79,6 +79,7 @@ func New(src extraconfig.DataSource, sink extraconfig.DataSink, ops Operations) 
 		src:        src,
 		sink:       sink,
 		incoming:   make(chan os.Signal, 32),
+		done:       make(chan struct{}),
 	}
 }
 

--- a/lib/tether/tether_linux.go
+++ b/lib/tether/tether_linux.go
@@ -71,8 +71,6 @@ func (t *tether) childReaper() error {
 		flag := syscall.WNOHANG | syscall.WUNTRACED | syscall.WCONTINUED
 
 		for range t.incoming {
-			log.Debugf("Woke up because of a received SIGCHLD")
-
 			func() {
 				// general resiliency
 				defer func() {
@@ -141,12 +139,13 @@ func (t *tether) stopReaper() {
 	log.Debugf("Removing the signal notifier")
 	signal.Reset(syscall.SIGCHLD)
 
-	log.Debugf("Closing the channel done to reaper")
-	close(t.incoming)
-
-	log.Debugf("Sending true to the done channel")
-	// just closing the channel is not going to stop the iteration over the channel so signal it as well
+	// just closing the incoming channel is not going to stop the iteration
+	// so we use done channel to signal it
+	log.Debugf("Signalling the child reaper loop")
 	close(t.done)
+
+	log.Debugf("Closing the reapers signal channel")
+	close(t.incoming)
 }
 
 func findExecutable(file string) error {

--- a/lib/tether/tether_test.go
+++ b/lib/tether/tether_test.go
@@ -16,6 +16,7 @@ package tether
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -30,7 +31,6 @@ import (
 	log "github.com/Sirupsen/logrus"
 	"github.com/vishvananda/netlink"
 	"golang.org/x/crypto/ssh"
-	"golang.org/x/net/context"
 
 	"github.com/vmware/govmomi/vim25/types"
 	"github.com/vmware/vic/lib/config/executor"

--- a/pkg/dio/reader.go
+++ b/pkg/dio/reader.go
@@ -41,10 +41,11 @@ type multiReader struct {
 func (t *multiReader) Read(p []byte) (int, error) {
 	var n int
 	var err error
+	var rTmp []io.Reader
 
 	if verbose {
 		defer func() {
-			log.Debugf("[%p] read %q from %d readers (err: %#+v)", t, string(p[:n]), len(t.readers), err)
+			log.Debugf("[%p] read %q from %d readers (err: %#+v)", t, string(p[:n]), len(rTmp), err)
 		}()
 	}
 
@@ -71,7 +72,7 @@ func (t *multiReader) Read(p []byte) (int, error) {
 		log.Debugf("[%p] Woken from sleep %d readers", t, len(t.readers))
 	}
 	// stash a copy of the readers slie to iterate later
-	rTmp := make([]io.Reader, len(t.readers))
+	rTmp = make([]io.Reader, len(t.readers))
 	copy(rTmp, t.readers)
 	// stash a copy of the t.err
 	err = t.err

--- a/pkg/dio/writer.go
+++ b/pkg/dio/writer.go
@@ -41,16 +41,17 @@ func (t *multiWriter) Write(p []byte) (int, error) {
 	var n int
 	var err error
 
+	var wTmp []io.Writer
 	if verbose {
 		defer func() {
-			log.Debugf("[%p] write %q to %d writers (err: %#+v)", t, string(p[:n]), len(t.writers), err)
+			log.Debugf("[%p] write %q to %d writers (err: %#+v)", t, string(p[:n]), len(wTmp), err)
 		}()
 	}
 
 	t.mutex.Lock()
 	// stash a local copy of the slice as we never want to write twice to a single writer
 	// if remove is called during this flow
-	wTmp := make([]io.Writer, len(t.writers))
+	wTmp = make([]io.Writer, len(t.writers))
 	copy(wTmp, t.writers)
 	t.mutex.Unlock()
 

--- a/pkg/serial/handshake.go
+++ b/pkg/serial/handshake.go
@@ -162,8 +162,7 @@ func HandshakeClient(ctx context.Context, conn net.Conn, debug bool) error {
 	return nil
 }
 
-func readMultiple(ctx context.Context, conn net.Conn, b []byte) (int, error) {
-
+func readMultiple(conn net.Conn, b []byte) (int, error) {
 	if runtime.GOOS != "windows" {
 		return conn.Read(b)
 	}
@@ -202,7 +201,7 @@ func HandshakeServer(ctx context.Context, conn net.Conn) error {
 
 	log.Debug("server: reading syn")
 	// syn is 3 bytes as that will eventually syn us again if we're offset
-	if n, err := readMultiple(ctx, conn, syn); n != 2 || err != nil || syn[0] != flagSyn {
+	if n, err := readMultiple(conn, syn); n != 2 || err != nil || syn[0] != flagSyn {
 		var msg string
 		if err != nil {
 			msg = fmt.Sprintf("server: failed to read expected SYN: n=%d, err=%s", n, err)
@@ -235,7 +234,7 @@ func HandshakeServer(ctx context.Context, conn net.Conn) error {
 	ack[0] = flagAck
 	ack[1] = synack[2] + 1
 	log.Debug("server: reading ack")
-	readMultiple(ctx, conn, buf)
+	readMultiple(conn, buf)
 	if (buf[0] != flagAck && buf[0] != flagDebugAck) || bytes.Compare(ack[1:], buf[1:]) != 0 {
 		msg := fmt.Sprintf("server: did not receive ack: %#x != %#x", ack, buf)
 		log.Debug(msg)

--- a/pkg/serial/handshake.go
+++ b/pkg/serial/handshake.go
@@ -162,9 +162,26 @@ func HandshakeClient(ctx context.Context, conn net.Conn, debug bool) error {
 	return nil
 }
 
-func readMultiple(conn net.Conn, b []byte) (int, error) {
+func readMultiple(ctx context.Context, conn net.Conn, b []byte) (int, error) {
 	if runtime.GOOS != "windows" {
-		return conn.Read(b)
+		type ioret struct {
+			n   int
+			err error
+		}
+		c := make(chan ioret, 1)
+
+		go func() {
+			n, err := conn.Read(b)
+			c <- ioret{n, err}
+			close(c)
+		}()
+
+		select {
+		case ret := <-c:
+			return ret.n, ret.err
+		case <-ctx.Done():
+			return 0, ctx.Err()
+		}
 	}
 
 	// we want a blocking read, but the behaviour described in the remarks section
@@ -201,7 +218,7 @@ func HandshakeServer(ctx context.Context, conn net.Conn) error {
 
 	log.Debug("server: reading syn")
 	// syn is 3 bytes as that will eventually syn us again if we're offset
-	if n, err := readMultiple(conn, syn); n != 2 || err != nil || syn[0] != flagSyn {
+	if n, err := readMultiple(ctx, conn, syn); n != 2 || err != nil || syn[0] != flagSyn {
 		var msg string
 		if err != nil {
 			msg = fmt.Sprintf("server: failed to read expected SYN: n=%d, err=%s", n, err)
@@ -234,7 +251,7 @@ func HandshakeServer(ctx context.Context, conn net.Conn) error {
 	ack[0] = flagAck
 	ack[1] = synack[2] + 1
 	log.Debug("server: reading ack")
-	readMultiple(conn, buf)
+	readMultiple(ctx, conn, buf)
 	if (buf[0] != flagAck && buf[0] != flagDebugAck) || bytes.Compare(ack[1:], buf[1:]) != 0 {
 		msg := fmt.Sprintf("server: did not receive ack: %#x != %#x", ack, buf)
 		log.Debug(msg)

--- a/pkg/serial/handshake.go
+++ b/pkg/serial/handshake.go
@@ -163,33 +163,9 @@ func HandshakeClient(ctx context.Context, conn net.Conn, debug bool) error {
 }
 
 func readMultiple(ctx context.Context, conn net.Conn, b []byte) (int, error) {
+
 	if runtime.GOOS != "windows" {
-		// FIXME(caglar10ur): We are passing a context with no deadlines
-		//
-		// The go func will start leaking a channel if we pass a context with timeout
-		// and timeout triggers a cancelation
-		//
-		// Right now we are only canceling the context on stop() method to solve a deadlock
-		// between run() and stop() as we block on the read and that causes run() to not to release
-		// t.conn.Lock. By calling cancel on stop path we return from this blocking call as expected.
-		type ioret struct {
-			n   int
-			err error
-		}
-		c := make(chan ioret, 1)
-
-		go func() {
-			n, err := conn.Read(b)
-			c <- ioret{n, err}
-			close(c)
-		}()
-
-		select {
-		case ret := <-c:
-			return ret.n, ret.err
-		case <-ctx.Done():
-			return 0, ctx.Err()
-		}
+		return conn.Read(b)
 	}
 
 	// we want a blocking read, but the behaviour described in the remarks section

--- a/pkg/serial/rawconn.go
+++ b/pkg/serial/rawconn.go
@@ -119,6 +119,7 @@ func (conn *RawConn) Read(b []byte) (int, error) {
 		// if we've got any bytes we need to pass them back so we cannot return
 		// the error via conn.err
 		bytes <- n
+		close(bytes)
 	}()
 
 	conn.mutex.Lock()


### PR DESCRIPTION
- attachServerSSH uses sync/atomic to get/set enabled value as there was
a race between stop and run

- underlying *net.Conn is now protected by its own mutex as there was a
race between stop and run

- *ssh.ServerConn is now protected by its own mutex as we are sending
it to channel mux (as a part of the cleanup function)

- incoming signals channel in tether is now accompanied by another
channel called done. Its whole purpose is to stop the reaper loop after we
close the incoming channel. Without this we keep reading from it.

Fixes #2647, #2646 and #2330