### PR TITLE
Clean and structure help output [full ci]

### DIFF
--- a/cmd/vic-machine/common/compute.go
+++ b/cmd/vic-machine/common/compute.go
@@ -22,15 +22,16 @@ type Compute struct {
 }
 
 func (c *Compute) ComputeFlags() []cli.Flag {
-	flags := c.ComputeFlagsNoName()
-	nameFlag := cli.StringFlag{
-		Name:        "name, n",
-		Value:       "virtual-container-host",
-		Usage:       "The name of the Virtual Container Host",
-		Destination: &c.DisplayName,
+	nameFlag := []cli.Flag{
+		cli.StringFlag{
+			Name:        "name, n",
+			Value:       "virtual-container-host",
+			Usage:       "The name of the Virtual Container Host",
+			Destination: &c.DisplayName,
+		},
 	}
-	flags = append(flags, nameFlag)
-	return flags
+
+	return append(nameFlag, c.ComputeFlagsNoName()...)
 }
 
 func (c *Compute) ComputeFlagsNoName() []cli.Flag {

--- a/cmd/vic-machine/common/debug.go
+++ b/cmd/vic-machine/common/debug.go
@@ -26,6 +26,7 @@ func (d *Debug) DebugFlags() []cli.Flag {
 			Name:        "debug, v",
 			Destination: &d.Debug,
 			Usage:       "[0(default),1...n], 0 is disabled, 1 is enabled, >= 1 may alter behaviour",
+			Hidden:      true,
 		},
 	}
 }

--- a/cmd/vic-machine/common/images.go
+++ b/cmd/vic-machine/common/images.go
@@ -54,19 +54,21 @@ type Images struct {
 	OSType       string
 }
 
-func (i *Images) ImageFlags() []cli.Flag {
+func (i *Images) ImageFlags(hidden bool) []cli.Flag {
 	return []cli.Flag{
 		cli.StringFlag{
 			Name:        "appliance-iso, ai",
 			Value:       "",
 			Usage:       "The appliance iso",
 			Destination: &i.ApplianceISO,
+			Hidden:      hidden,
 		},
 		cli.StringFlag{
 			Name:        "bootstrap-iso, bi",
 			Value:       "",
 			Usage:       "The bootstrap iso",
 			Destination: &i.BootstrapISO,
+			Hidden:      hidden,
 		},
 	}
 }

--- a/cmd/vic-machine/debug/debug.go
+++ b/cmd/vic-machine/debug/debug.go
@@ -16,6 +16,7 @@ package debug
 
 import (
 	"io/ioutil"
+	"time"
 
 	log "github.com/Sirupsen/logrus"
 
@@ -53,7 +54,7 @@ func (d *Debug) Flags() []cli.Flag {
 	preFlags := append(d.TargetFlags(), d.IDFlags()...)
 	preFlags = append(preFlags, d.ComputeFlags()...)
 
-	flags := []cli.Flag{
+	ssh := []cli.Flag{
 		cli.BoolFlag{
 			Name:        "enable-ssh, ssh",
 			Usage:       "Enable SSH server within appliance VM",
@@ -73,9 +74,27 @@ func (d *Debug) Flags() []cli.Flag {
 		},
 	}
 
-	flags = append(preFlags, flags...)
+	util := []cli.Flag{
+		cli.DurationFlag{
+			Name:        "timeout",
+			Value:       3 * time.Minute,
+			Usage:       "Time to wait for operation to complete",
+			Destination: &d.Timeout,
+		},
+	}
 
-	return append(flags, d.DebugFlags()...)
+	target := d.TargetFlags()
+	id := d.IDFlags()
+	compute := d.ComputeFlags()
+	debug := d.DebugFlags()
+
+	// flag arrays are declared, now combined
+	var flags []cli.Flag
+	for _, f := range [][]cli.Flag{target, id, compute, ssh, util, debug} {
+		flags = append(flags, f...)
+	}
+
+	return flags
 }
 
 func (d *Debug) processParams() error {

--- a/cmd/vic-machine/delete/delete.go
+++ b/cmd/vic-machine/delete/delete.go
@@ -46,10 +46,10 @@ func NewUninstall() *Uninstall {
 
 // Flags return all cli flags for delete
 func (d *Uninstall) Flags() []cli.Flag {
-	flags := []cli.Flag{
+	util := []cli.Flag{
 		cli.BoolFlag{
 			Name:        "force, f",
-			Usage:       "Force the uninstall",
+			Usage:       "Force the deletion",
 			Destination: &d.Force,
 		},
 		cli.DurationFlag{
@@ -59,10 +59,17 @@ func (d *Uninstall) Flags() []cli.Flag {
 			Destination: &d.Timeout,
 		},
 	}
-	preFlags := append(d.TargetFlags(), d.IDFlags()...)
-	preFlags = append(preFlags, d.ComputeFlags()...)
-	flags = append(preFlags, flags...)
-	flags = append(flags, d.DebugFlags()...)
+
+	target := d.TargetFlags()
+	id := d.IDFlags()
+	compute := d.ComputeFlags()
+	debug := d.DebugFlags()
+
+	// flag arrays are declared, now combined
+	var flags []cli.Flag
+	for _, f := range [][]cli.Flag{target, id, compute, util, debug} {
+		flags = append(flags, f...)
+	}
 
 	return flags
 }

--- a/cmd/vic-machine/inspect/inspect.go
+++ b/cmd/vic-machine/inspect/inspect.go
@@ -15,6 +15,8 @@
 package inspect
 
 import (
+	"time"
+
 	log "github.com/Sirupsen/logrus"
 
 	"github.com/urfave/cli"
@@ -45,9 +47,25 @@ func NewInspect() *Inspect {
 
 // Flags return all cli flags for inspect
 func (i *Inspect) Flags() []cli.Flag {
-	preFlags := append(i.TargetFlags(), i.IDFlags()...)
-	preFlags = append(preFlags, i.ComputeFlags()...)
-	flags := append(preFlags, i.DebugFlags()...)
+	util := []cli.Flag{
+		cli.DurationFlag{
+			Name:        "timeout",
+			Value:       3 * time.Minute,
+			Usage:       "Time to wait for upgrade",
+			Destination: &i.Timeout,
+		},
+	}
+
+	target := i.TargetFlags()
+	id := i.IDFlags()
+	compute := i.ComputeFlags()
+	debug := i.DebugFlags()
+
+	// flag arrays are declared, now combined
+	var flags []cli.Flag
+	for _, f := range [][]cli.Flag{target, id, compute, util, debug} {
+		flags = append(flags, f...)
+	}
 
 	return flags
 }

--- a/cmd/vic-machine/list/list.go
+++ b/cmd/vic-machine/list/list.go
@@ -64,7 +64,7 @@ func NewList() *List {
 
 // Flags return all cli flags for ls
 func (l *List) Flags() []cli.Flag {
-	flags := []cli.Flag{
+	util := []cli.Flag{
 		cli.DurationFlag{
 			Name:        "timeout",
 			Value:       3 * time.Minute,
@@ -72,9 +72,18 @@ func (l *List) Flags() []cli.Flag {
 			Destination: &l.Timeout,
 		},
 	}
-	preFlags := append(l.TargetFlags(), l.ComputeFlagsNoName()...)
-	flags = append(preFlags, flags...)
-	flags = append(flags, l.DebugFlags()...)
+
+	target := l.TargetFlags()
+	id := l.IDFlags()
+	// TODO: why not allow name as a filter, like most list operations
+	compute := l.ComputeFlagsNoName()
+	debug := l.DebugFlags()
+
+	// flag arrays are declared, now combined
+	var flags []cli.Flag
+	for _, f := range [][]cli.Flag{target, id, compute, util, debug} {
+		flags = append(flags, f...)
+	}
 
 	return flags
 }

--- a/doc/user_doc/vic_installation/vch_installer_examples.md
+++ b/doc/user_doc/vic_installation/vch_installer_examples.md
@@ -285,12 +285,12 @@ This example deploys a virtual container host with the following configuration:
 --compute-resource cluster1
 --image-store datastore1
 --bridge-network vic-bridge
---pool-memory-reservation 1024
---pool-memory-limit 1024
---pool-memory-shares low
---pool-cpu-reservation 1024
---pool-cpu-limit 1024
---pool-cpu-shares low
+--memory-reservation 1024
+--memory 1024
+--memory-shares low
+--cpu-reservation 1024
+--cpu 1024
+--cpu-shares low
 --name vch1
 </pre>
 

--- a/doc/user_doc/vic_installation/vch_installer_options.md
+++ b/doc/user_doc/vic_installation/vch_installer_options.md
@@ -561,51 +561,51 @@ Wrap the folder names in the path in single quotes (Linux or Mac OS) or double q
 
 ### `pool-memory-reservation` ###
 
-Short name: `--pmr`
+Short name: `--memr`
 
 Reserve a quantity of memory for use by the virtual container host vApp   and container VMs. Specify the memory reservation value in MB. If not specified, `vic-machine create` sets the reservation to 1.
 
-<pre>--pool-memory-reservation 1024</pre>
+<pre>--memory-reservation 1024</pre>
 
 ### `pool-memory-limit` ###
 
-Short name: `--pml`
+Short name: `--mem`
 
 Limit the amount of memory that is available for use by the virtual container host vApp and container VMs. Specify the memory limit value in MB. If not specified, `vic-machine create` sets the limit to 0 (unlimited).
 
-<pre>--pool-memory-limit 1024</pre>
+<pre>--memory 1024</pre>
 
 ### `pool-memory-shares` ###
 
-Short name: `--pms`
+Short name: `--mems`
 
 Set memory shares on the virtual container host vApp. Specify the share value as a level or a number, for example `high`, `normal`, `low`, or `163840`. If not specified, `vic-machine create` sets the share to `normal`.
 
-<pre>--pool-memory-shares low</pre>
+<pre>--memory-shares low</pre>
 
 ### `pool-cpu-reservation` ###
 
-Short name: `--pcr`
+Short name: `--cpur`
 
 Reserve a quantity of CPU capacity for use by the virtual container host vApp and container VMs.  Specify the CPU reservation value in MHz. If not specified, `vic-machine create` sets the reservation to 1.
 
-<pre>--pool-cpu-reservation 1024</pre>
+<pre>--cpu-reservation 1024</pre>
 
 ### `pool-cpu-limit` ###
 
-Short name: `--pcl`
+Short name: `--cpu`
 
 Limit the amount of CPU capacity that is available for use by the virtual container host vApp and container VMs. Specify the CPU limit value in MHz. If not specified, `vic-machine create` sets the reservation to 0 (unlimited).
 
-<pre>--pool-cpu-limit 1024</pre>
+<pre>--cpu 1024</pre>
 
 ### `pool-cpu-shares` ###
 
-Short name: `--pcs`
+Short name: `--cpus`
 
 Set CPU shares on the virtual container host vApp. Specify the share value as a level or a number, for example `high`, `normal`, `low`, or `163840`. If not specified, `vic-machine create` sets the share to `normal`.
 
-<pre>--pool-cpu-shares low</pre>
+<pre>--cpu-shares low</pre>
 
 ### `debug` ###
 Short name: `-v`

--- a/tests/resources/Util.robot
+++ b/tests/resources/Util.robot
@@ -41,7 +41,7 @@ Set Test Environment Variables
 
     # set the TLS config options suitable for vic-machine in this env
     Run Keyword If  '%{DOMAIN}' == ''  Set Suite Variable  ${vicmachinetls}  '--no-tlsverify'
-    Run Keyword If  '%{DOMAIN}' != ''  Set Suite Variable  ${vicmachinetls}  '--cname=*.%{DOMAIN}'  
+    Run Keyword If  '%{DOMAIN}' != ''  Set Suite Variable  ${vicmachinetls}  '--tls-cname=*.%{DOMAIN}'  
 
 Set Test VCH Name
     ${name}=  Evaluate  'VCH-%{DRONE_BUILD_NUMBER}-' + str(random.randint(1000,9999))  modules=random


### PR DESCRIPTION
Towards cleaner help output. Attempts the following:
 1. orders flags in logical groups
 2. hides many more flags by default
 3. rephrases descriptions
 4. renames some of the primary flags
 5. make append composition of flag groups clearer

Fixes #2633 
