### PR TITLE
Fix the broken VCH portlet

### DIFF
--- a/ui/vic-ui/swf/src/main/flex/com/vmware/vicui/constants/AppConstants.as
+++ b/ui/vic-ui/swf/src/main/flex/com/vmware/vicui/constants/AppConstants.as
@@ -1,15 +1,15 @@
 package com.vmware.vicui.constants {
-	
+
 	public class AppConstants {
-		
+
 		public static const VM_CONTAINER_NAME_PATH:String = "guestinfo.vice./common/name";
 		public static const VM_CONTAINER_IMAGE_PATH:String = "guestinfo.vice./repo";
 		public static const VM_CONTAINER_PORTMAPPING:String = "guestinfo.vice./networks|bridge/ports~";
 		public static const VCH_NAME_PATH:String = "guestinfo.vice./init/common/name";
-		public static const VCH_CLIENT_IP_PATH:String = "guestinfo.vice..init.networks|client.ip.IP";
+		public static const VCH_CLIENT_IP_PATH:String = "guestinfo.vice..init.networks|client.assigned.IP";
 		public static const VCH_ENDPOINT_PORT:String = ":2376";
-		public static const VCH_LOG_PORT:String = ":2378";	
-		
+		public static const VCH_LOG_PORT:String = ":2378";
+
 	}
-	
+
 }


### PR DESCRIPTION
Fixed a broken reference to deprecated `guestinfo.vice..init.networks|client.ip.IP` to `guestinfo.vice..init.networks|client.assigned.IP` so that VCH portlet works again.

Fixes #2717 
Reference: 8f2f04f8a212e4edd334fd8435d8724051da9360
