### PR TITLE
Stop logging docker registry auth token during pull

### DIFF
--- a/pkg/fetcher/fetcher.go
+++ b/pkg/fetcher/fetcher.go
@@ -391,7 +391,6 @@ func (u *URLFetcher) setBasicAuth(req *http.Request) {
 
 func (u *URLFetcher) setAuthToken(req *http.Request) {
 	if u.options.Token != nil {
-		log.Debugf("Setting AuthToken: %s", u.options.Token.Token)
 		req.Header.Set("Authorization", "Bearer "+u.options.Token.Token)
 	}
 }


### PR DESCRIPTION
This change will prevent logging of the docker registry auth tokens if the debug level is not explicitly set to be > 2.