### PR TITLE
Log typed task error during container stop

### DIFF
--- a/lib/portlayer/exec/container.go
+++ b/lib/portlayer/exec/container.go
@@ -483,9 +483,11 @@ func (c *Container) stop(ctx context.Context, waitTime *int32) error {
 					log.Infof("power off %s task skipped due to guest shutdown", c.ExecConfig.ID)
 					return nil
 				}
-			}
+				log.Warnf("hard power off failed due to: %#v", terr)
 
-			log.Warnf("hard power off failed due to: %#v", terr)
+			default:
+				log.Warnf("hard power off failed due to: %#v", terr)
+			}
 		}
 		c.State = existingState
 	}

--- a/lib/portlayer/exec/container.go
+++ b/lib/portlayer/exec/container.go
@@ -483,7 +483,7 @@ func (c *Container) stop(ctx context.Context, waitTime *int32) error {
 					log.Infof("power off %s task skipped due to guest shutdown", c.ExecConfig.ID)
 					return nil
 				}
-				log.Warnf("hard power off failed due to: %#v", terr)
+				log.Warnf("generic vm config fault during power off: %#v", terr)
 
 			default:
 				log.Warnf("hard power off failed due to: %#v", terr)


### PR DESCRIPTION
Follow-up of #2663

This PR logs the typed task error during a container stop to help debug related integration test failures.