### PR TITLE
Log thumbprint when target cert cannot be verified

### DIFF
--- a/lib/install/validate/validator.go
+++ b/lib/install/validate/validator.go
@@ -104,6 +104,8 @@ func CreateNoDCCheck(ctx context.Context, input *data.Data) (*Validator, error) 
 		if cert.Err != nil {
 			if !input.Force {
 				// TODO: prompt user / check ./known_hosts
+				log.Errorf("Failed to verify certificate for target=%s (thumbprint=%s)",
+					tURL.Host, cert.ThumbprintSHA1)
 				return nil, cert.Err
 			}
 		}


### PR DESCRIPTION
If the target cert is not signed by a known CA or command was run
without 'thumbprint' or 'force' flag, log the target and thumbprint.

See #2554