### PR TITLE
Adds the mount point wait workaround into the bootstrap init script

### DIFF
--- a/isos/bootstrap/bootstrap
+++ b/isos/bootstrap/bootstrap
@@ -31,6 +31,8 @@ if mount -t ext4 /dev/disk/by-label/containerfs ${MOUNTPOINT}; then
 
     cp /bin/tether ${MOUNTPOINT}/.tether/tether
 
+    until [[ $(ls -1 /dev/disk/by-label | wc -l) -eq $(ls -1 /sys/block | wc -l) ]]; do sleep 0.1;done
+
     echo "switching to the new mount"
     systemctl switch-root ${MOUNTPOINT} /.tether/tether 2>&1
 else


### PR DESCRIPTION
This is the one line fix for switch root occurring before the udev service has a chance to process all attached block devices. This leads to the inability for the "MountLabel" call in `ops_linux.go` to properly process all the volumes. That function will wait infinitely, however udev will not function since we have already called `switch-root`. This workaround will wait until the number of block devices attach at /sys/block is the same as the number of devices presented at /dev/disk/by-label.

Fixes #2485 
Fixes #2472

