### PR TITLE
Add regression test for pulling existent image

### DIFF
--- a/tests/resources/Util.robot
+++ b/tests/resources/Util.robot
@@ -431,6 +431,9 @@ Run Unit Tests
 Run Regression Tests
     ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} pull busybox
     Should Be Equal As Integers  ${rc}  0
+    # Pull an image that has been pulled already
+    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} pull busybox
+    Should Be Equal As Integers  ${rc}  0
     ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} images
     Should Be Equal As Integers  ${rc}  0
     Should Contain  ${output}  busybox


### PR DESCRIPTION
Follow-up of #2754

Adds a second `pull busybox` to the regression test to check pulling an existent image.