### PR TITLE
Clean up after debug test [skip ci]

### DIFF
--- a/tests/test-cases/Group6-VIC-Machine/6-11-Debug.robot
+++ b/tests/test-cases/Group6-VIC-Machine/6-11-Debug.robot
@@ -1,8 +1,8 @@
 *** Settings ***
 Documentation  Test 6-11 - Verify enable of ssh in the appliance
 Resource  ../../resources/Util.robot
-Test Setup  Install VIC Appliance To Test Server
-Test Teardown  Run Keyword If Test Failed  Cleanup VIC Appliance On Test Server
+Suite Setup  Install VIC Appliance To Test Server
+Suite Teardown  Cleanup VIC Appliance On Test Server
 
 *** Test Cases ***
 Enable SSH and verify


### PR DESCRIPTION
Missing VCH cleanup on success path. Could contributed to @gigawhitlocks's 
issue with CI.

Run test locally and it's passed
