### PR TITLE
Add console logging to concurrent pull test [skip ci]

### DIFF
--- a/tests/test-cases/Group1-Docker-Commands/1-2-Docker-Pull.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-2-Docker-Pull.robot
@@ -70,6 +70,7 @@ Pull the same image concurrently
      # Wait for them to finish and check their output
      :FOR  ${pid}  IN  @{pids}
      \   ${res}=  Wait For Process  ${pid}
+     \   Log  ${res.output}
      \   Should Be Equal As Integers  ${res.rc}  0
      \   Should Contain  ${res.stdout}  Downloaded newer image for library/redis:latest
 


### PR DESCRIPTION
This adds console logging to the concurrent image pull integration test. We are seeing some failures and could use some insight into what's going on. Tracking issue at #2782 (thanks @emlin).