### PR TITLE
Fix stdout, add stderr for concurrent image pull integration test [skip ci]

### DIFF
--- a/tests/test-cases/Group1-Docker-Commands/1-2-Docker-Pull.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-2-Docker-Pull.robot
@@ -70,7 +70,8 @@ Pull the same image concurrently
      # Wait for them to finish and check their output
      :FOR  ${pid}  IN  @{pids}
      \   ${res}=  Wait For Process  ${pid}
-     \   Log  ${res.output}
+     \   Log  ${res.stdout}
+     \   Log  ${res.stderr}
      \   Should Be Equal As Integers  ${res.rc}  0
      \   Should Contain  ${res.stdout}  Downloaded newer image for library/redis:latest
 


### PR DESCRIPTION
Issue tracked at #2782.