### PR TITLE
Only update repo cache in leaf layer download goroutine [full ci]

### DIFF
--- a/lib/imagec/download.go
+++ b/lib/imagec/download.go
@@ -283,8 +283,14 @@ func (ldm *LayerDownloader) makeDownloadFunc(layer *ImageWithMeta, ic *ImageC, p
 				}
 				// cache the image
 				cache.ImageCache().AddImage(&imageConfig)
+
 				// place calculated ImageID in struct
 				ic.ImageID = imageConfig.ImageID
+
+				if err = updateRepositoryCache(ic); err != nil {
+					d.err = err
+					return
+				}
 			}
 
 			ldm.m.Lock()

--- a/lib/imagec/imagec.go
+++ b/lib/imagec/imagec.go
@@ -499,9 +499,5 @@ func (ic *ImageC) PullImage() error {
 	if err != nil {
 		return err
 	}
-	if err = updateRepositoryCache(ic); err != nil {
-		return err
-	}
-
 	return nil
 }

--- a/tests/test-cases/Group1-Docker-Commands/1-2-Docker-Pull.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-2-Docker-Pull.robot
@@ -62,21 +62,20 @@ Pull image that already has been pulled
 Pull the same image concurrently
     ${status}=  Get State Of Github Issue  2782
     Run Keyword If  '${status}' == 'closed'  Fail  Test 1-2-Docker-Pull.robot needs to be updated now that Issue #2782 has been resolved
-    Log  Issue \#2782 is blocking implementation  WARN
-#     ${pids}=  Create List
+    ${pids}=  Create List
 
-     # Create 5 processes to pull the same image at once
-#     :FOR  ${idx}  IN RANGE  0  5
-#     \   ${pid}=  Start Process  docker ${params} pull redis  shell=True
-#     \   Append To List  ${pids}  ${pid}
+    # Create 5 processes to pull the same image at once
+    :FOR  ${idx}  IN RANGE  0  5
+    \   ${pid}=  Start Process  docker ${params} pull redis  shell=True
+    \   Append To List  ${pids}  ${pid}
 
-     # Wait for them to finish and check their output
-#     :FOR  ${pid}  IN  @{pids}
-#     \   ${res}=  Wait For Process  ${pid}
-#     \   Log  ${res.stdout}
-#     \   Log  ${res.stderr}
-#     \   Should Be Equal As Integers  ${res.rc}  0
-#     \   Should Contain  ${res.stdout}  Downloaded newer image for library/redis:latest
+   # Wait for them to finish and check their output
+    :FOR  ${pid}  IN  @{pids}
+    \   ${res}=  Wait For Process  ${pid}
+    \   Log  ${res.stdout}
+    \   Log  ${res.stderr}
+    \   Should Be Equal As Integers  ${res.rc}  0
+    \   Should Contain  ${res.stdout}  Downloaded newer image for library/redis:latest
 
 Pull two images that share layers concurrently
      ${pid1}=  Start Process  docker ${params} pull golang:1.7  shell=True


### PR DESCRIPTION
This change moves the call to update the repo cache into the specific goroutine that was responsible for downloading the leaf layer of the image being downloaded. This fixes a race condition between multiple clients downloading the same image.

Fixes #2782 
