### PR TITLE
Check for and return existing image blob [full ci]

### DIFF
--- a/lib/imagec/download.go
+++ b/lib/imagec/download.go
@@ -283,8 +283,10 @@ func (ldm *LayerDownloader) makeDownloadFunc(layer *ImageWithMeta, ic *ImageC, p
 				}
 				// cache the image
 				cache.ImageCache().AddImage(&imageConfig)
+
 				// place calculated ImageID in struct
 				ic.ImageID = imageConfig.ImageID
+
 			}
 
 			ldm.m.Lock()


### PR DESCRIPTION
This change will allow `CreateImageConfig` to return an image blob if one associated with the given layerID already exists. This will prevent unnecessary calculation of an imageID for the same image with a different tag. It will also allow the repoCache to update with new tags for an existing image.

Fixes #2782