### PR TITLE
Fix vicadmin failure when there are multipe DCs on vCenter

### DIFF
--- a/cmd/vicadmin/vicadm.go
+++ b/cmd/vicadmin/vicadm.go
@@ -136,6 +136,7 @@ func init() {
 	}
 
 	extraconfig.Decode(src, &vchConfig)
+
 }
 
 type entryReader interface {
@@ -388,6 +389,7 @@ func client() (*session.Session, error) {
 	ctx := context.Background()
 
 	session := session.NewSession(&config.Config)
+
 	_, err := session.Connect(ctx)
 	if err != nil {
 		log.Warnf("Unable to connect: %s", err)
@@ -407,6 +409,7 @@ func findDatastore() error {
 	defer trace.End(trace.Begin(""))
 
 	session, err := client()
+
 	if err != nil {
 		return err
 	}

--- a/cmd/vicadmin/vicadm.go
+++ b/cmd/vicadmin/vicadm.go
@@ -136,7 +136,6 @@ func init() {
 	}
 
 	extraconfig.Decode(src, &vchConfig)
-
 }
 
 type entryReader interface {
@@ -389,7 +388,6 @@ func client() (*session.Session, error) {
 	ctx := context.Background()
 
 	session := session.NewSession(&config.Config)
-
 	_, err := session.Connect(ctx)
 	if err != nil {
 		log.Warnf("Unable to connect: %s", err)
@@ -409,7 +407,6 @@ func findDatastore() error {
 	defer trace.End(trace.Begin(""))
 
 	session, err := client()
-
 	if err != nil {
 		return err
 	}

--- a/lib/install/management/appliance.go
+++ b/lib/install/management/appliance.go
@@ -477,6 +477,7 @@ func (d *Dispatcher) createAppliance(conf *config.VirtualContainerHostConfigSpec
 				"/sbin/vicadmin",
 				"-docker-host=unix:///var/run/docker.sock",
 				// FIXME: hack during config migration
+				"-dc=" + settings.DatacenterName,
 				"-ds=" + conf.ImageStores[0].Host,
 				"-cluster=" + settings.ClusterPath,
 				"-pool=" + settings.ResourcePoolPath,


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[  ] There is an associated issue that is labelled
[  ] Code is up-to-date with the `master` branch
[  ] You've successfully run `make test` locally
[  ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/vmware/vic/blob/master/.github/CONTRIBUTING.md
-->

Fixes #2725 

In "appliance.go", pass "-dc" (datacenter name) to vicadmin so that it knows the datacenterpath when finding the datastore.

Passed regression tests on my local ESXi. Haven't tried the regression test on Nimbus. 

@dougm @sgairo Could you pls review it? Thanks.
