### PR TITLE
Fix robot keyword usage in vol create tests

### DIFF
--- a/tests/test-cases/Group1-Docker-Commands/1-19-Docker-Volume-Create.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-19-Docker-Volume-Create.robot
@@ -8,38 +8,42 @@ Suite Teardown  Cleanup VIC Appliance On Test Server
 Simple docker volume create
     ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} volume create
     Should Be Equal As Integers  ${rc}  0
-    Set Suite Variable  ${ContainerID}  unnamedSpecVol
-    Run  docker ${params} run --name ${ContainerID} -d -v ${output}:/mydata busybox /bin/df -Ph
-    ${ContainerRC}=  Run  docker ${params} wait ${ContainerID}
+    Set Suite Variable  ${ContainerName}  unnamedSpecVolContainer
+    Run  docker ${params} run --name ${ContainerName} -d -v ${output}:/mydata busybox /bin/df -Ph
+    ${ContainerRC}  ${output}=  Run And Return Rc And Output  docker ${params} wait ${ContainerName}
     Should Be Equal As Integers  ${ContainerRC}  0
-    ${disk-size}=  Run  docker ${params} logs ${ContainerID} | grep by-label | awk '{print $2}'
+    Should Not Contain  ${output}  Error response from daemon
+    ${disk-size}=  Run  docker ${params} logs ${ContainerName} | grep by-label | awk '{print $2}'
     Should Be Equal As Strings  ${disk-size}  975.9M
 
 Docker volume create named volume
     ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} volume create --name=test
     Should Be Equal As Integers  ${rc}  0
     Should Be Equal As Strings  ${output}  test
-    Set Suite Variable  ${ContainerID}  specVol
-    Run  docker ${params} run --name ${ContainerID} -d -v ${output}:/mydata busybox /bin/df -Ph
-    ${ContainerRC}=  Run  docker ${params} wait ${ContainerID}
+    Set Suite Variable  ${ContainerName}  specVolContainer
+    Run  docker ${params} run --name ${ContainerName} -d -v ${output}:/mydata busybox /bin/df -Ph
+    ${ContainerRC}  ${output}=  Run And Return Rc And Output  docker ${params} wait ${ContainerName}
     Should Be Equal As Integers  ${ContainerRC}  0
-    ${disk-size}=  Run  docker ${params} logs ${ContainerID} | grep by-label | awk '{print $2}'
+    Should Not Contain  ${output}  Error response from daemon
+    ${disk-size}=  Run  docker ${params} logs ${ContainerName} | grep by-label | awk '{print $2}'
     Should Be Equal As Strings  ${disk-size}  975.9M
 
 Docker volume create image volume
-    Set Suite Variable  ${ContainerID}  imageVol
-    Run  docker ${params} run --name ${ContainerID} -d mongo /bin/df -Ph
-    ${ContainerRC}=  Run  docker ${params} wait ${ContainerID}
+    Set Suite Variable  ${ContainerName}  imageVolContainer
+    Run  docker ${params} run --name ${ContainerName} -d mongo /bin/df -Ph
+    ${ContainerRC}  ${output}=  Run And Return Rc And Output  docker ${params} wait ${ContainerName}
     Should Be Equal As Integers  ${ContainerRC}  0
-    ${disk-size}=  Run  docker ${params} logs ${ContainerID} | grep by-label | awk '{print $2}'
+    Should Not Contain  ${output}  Error response from daemon
+    ${disk-size}=  Run  docker ${params} logs ${ContainerName} | grep by-label | awk '{print $2}'
     Should Contain  ${disk-size}  976M
 
 Docker volume create anonymous volume
-    Set Suite Variable  ${ContainerID}  anonVol
-    Run  docker ${params} run --name ${ContainerID} -d -v /mydata busybox /bin/df -Ph
-    ${ContainerRC}=  Run  docker ${params} wait ${ContainerID}
+    Set Suite Variable  ${ContainerName}  anonVolContainer
+    Run  docker ${params} run --name ${ContainerName} -d -v /mydata busybox /bin/df -Ph
+    ${ContainerRC}  ${output}=  Run And Return Rc And Output  docker ${params} wait ${ContainerName}
     Should Be Equal As Integers  ${ContainerRC}  0
-    ${disk-size}=  Run  docker ${params} logs ${ContainerID} | grep by-label | awk '{print $2}'
+    Should Not Contain  ${output}  Error response from daemon
+    ${disk-size}=  Run  docker ${params} logs ${ContainerName} | grep by-label | awk '{print $2}'
     Should Contain  ${disk-size}  975.9M
 
 Docker volume create already named volume
@@ -61,11 +65,12 @@ Docker volume create with specific capacity
     ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} volume create --name=test4 --opt Capacity=100000
     Should Be Equal As Integers  ${rc}  0
     Should Be Equal As Strings  ${output}  test4
-    Set Suite Variable  ${ContainerID}  capacityVol
-    Run  docker ${params} run --name ${ContainerID} -d -v ${output}:/mydata busybox /bin/df -Ph
-    ${ContainerRC}=  Run  docker ${params} wait ${ContainerID}
+    Set Suite Variable  ${ContainerName}  capacityVolContainer
+    Run  docker ${params} run --name ${ContainerName} -d -v ${output}:/mydata busybox /bin/df -Ph
+    ${ContainerRC}  ${output}=  Run And Return Rc And Output  docker ${params} wait ${ContainerName}
     Should Be Equal As Integers  ${ContainerRC}  0
-    ${disk-size}=  Run  docker ${params} logs ${ContainerID} | grep by-label | awk '{print $2}'
+    Should Not Contain  ${output}  Error response from daemon
+    ${disk-size}=  Run  docker ${params} logs ${ContainerName} | grep by-label | awk '{print $2}'
     Should Be Equal As Strings  ${disk-size}  96.0G
 
 Docker volume create with zero capacity


### PR DESCRIPTION
https://ci.vmware.run/vmware/vic/6077

This PR uses the `Run And Return Output And Rc` robot keyword in the `1-19-Volume-Create` suite to:
* correctly grab the exit code
* check for errors