### PR TITLE
Separate handle and container cache entry states [full ci]

### DIFF
--- a/lib/apiservers/portlayer/restapi/handlers/containers_handlers.go
+++ b/lib/apiservers/portlayer/restapi/handlers/containers_handlers.go
@@ -276,7 +276,7 @@ func (handler *ContainersHandlersImpl) GetContainerInfoHandler(params containers
 		return containers.NewGetContainerInfoNotFound().WithPayload(&models.Error{Message: info})
 	}
 
-	containerInfo := convertContainerToContainerInfo(*container)
+	containerInfo := convertContainerToContainerInfo(container.Info())
 	return containers.NewGetContainerInfoOK().WithPayload(containerInfo)
 }
 
@@ -294,7 +294,7 @@ func (handler *ContainersHandlersImpl) GetContainerListHandler(params containers
 
 	for _, container := range containerVMs {
 		// convert to return model
-		info := convertContainerToContainerInfo(*container)
+		info := convertContainerToContainerInfo(container.Info())
 		containerList = append(containerList, info)
 	}
 	return containers.NewGetContainerListOK().WithPayload(containerList)
@@ -377,7 +377,7 @@ func (handler *ContainersHandlersImpl) ContainerWaitHandler(params containers.Co
 
 	select {
 	case <-c.WaitForState(exec.StateStopped):
-		containerInfo := convertContainerToContainerInfo(*c)
+		containerInfo := convertContainerToContainerInfo(c.Info())
 		return containers.NewContainerWaitOK().WithPayload(containerInfo)
 	case <-ctx.Done():
 		return containers.NewContainerWaitInternalServerError().WithPayload(&models.Error{
@@ -387,7 +387,7 @@ func (handler *ContainersHandlersImpl) ContainerWaitHandler(params containers.Co
 }
 
 // utility function to convert from a Container type to the API Model ContainerInfo (which should prob be called ContainerDetail)
-func convertContainerToContainerInfo(container exec.Container) *models.ContainerInfo {
+func convertContainerToContainerInfo(container *exec.ContainerInfo) *models.ContainerInfo {
 	defer trace.End(trace.Begin(container.ExecConfig.ID))
 	// convert the container type to the required model
 	info := &models.ContainerInfo{ContainerConfig: &models.ContainerConfig{}, ProcessConfig: &models.ProcessConfig{}}
@@ -395,7 +395,7 @@ func convertContainerToContainerInfo(container exec.Container) *models.Container
 	ccid := container.ExecConfig.ID
 	info.ContainerConfig.ContainerID = &ccid
 
-	s := container.CurrentState().String()
+	s := container.State().String()
 	info.ContainerConfig.State = &s
 	info.ContainerConfig.LayerID = &container.ExecConfig.LayerID
 	info.ContainerConfig.RepoName = &container.ExecConfig.RepoName

--- a/lib/apiservers/portlayer/restapi/handlers/containers_handlers.go
+++ b/lib/apiservers/portlayer/restapi/handlers/containers_handlers.go
@@ -90,7 +90,7 @@ func (handler *ContainersHandlersImpl) CreateHandler(params containers.CreatePar
 		Bytes:   x509.MarshalPKCS1PrivateKey(privateKey),
 	}
 
-	m := executor.ExecutorConfig{
+	m := &executor.ExecutorConfig{
 		Common: executor.Common{
 			ID:   id,
 			Name: *params.CreateConfig.Name,
@@ -118,6 +118,7 @@ func (handler *ContainersHandlersImpl) CreateHandler(params containers.CreatePar
 		LayerID:  *params.CreateConfig.Image,
 		RepoName: *params.CreateConfig.RepoName,
 	}
+
 	if params.CreateConfig.Annotations != nil && len(params.CreateConfig.Annotations) > 0 {
 		m.Annotations = make(map[string]string)
 		for k, v := range params.CreateConfig.Annotations {
@@ -127,8 +128,6 @@ func (handler *ContainersHandlersImpl) CreateHandler(params containers.CreatePar
 
 	log.Infof("CreateHandler Metadata: %#v", m)
 
-	// Create new portlayer executor and call Create on it
-	h := exec.NewContainer(uid.Parse(id))
 	// Create the executor.ExecutorCreateConfig
 	c := &exec.ContainerCreateConfig{
 		Metadata:       m,
@@ -136,7 +135,7 @@ func (handler *ContainersHandlersImpl) CreateHandler(params containers.CreatePar
 		ImageStoreName: params.CreateConfig.ImageStore.Name,
 	}
 
-	err = h.Create(ctx, session, c)
+	h, err := exec.Create(ctx, session, c)
 	if err != nil {
 		log.Errorf("ContainerCreate error: %s", err.Error())
 		return containers.NewCreateNotFound().WithPayload(&models.Error{Message: err.Error()})
@@ -167,20 +166,27 @@ func (handler *ContainersHandlersImpl) StateChangeHandler(params containers.Stat
 		return containers.NewStateChangeDefault(http.StatusServiceUnavailable).WithPayload(&models.Error{Message: "unknown state"})
 	}
 
-	h.SetState(state)
+	h.SetTargetState(state)
 	return containers.NewStateChangeOK().WithPayload(h.String())
 }
 
 func (handler *ContainersHandlersImpl) GetStateHandler(params containers.GetStateParams) middleware.Responder {
 	defer trace.End(trace.Begin(fmt.Sprintf("handle(%s)", params.Handle)))
 
+	// NOTE: I've no idea why GetStateHandler takes a handle instead of an ID - hopefully there was a reason for an inspection
+	// operation to take this path
 	h := exec.GetHandle(params.Handle)
-	if h == nil {
+	if h == nil || h.ExecConfig == nil {
+		return containers.NewGetStateNotFound()
+	}
+
+	container := exec.Containers.Container(h.ExecConfig.ID)
+	if container == nil {
 		return containers.NewGetStateNotFound()
 	}
 
 	var state string
-	switch h.CurrentState() {
+	switch container.CurrentState() {
 	case exec.StateRunning:
 		state = "RUNNING"
 
@@ -235,11 +241,17 @@ func (handler *ContainersHandlersImpl) RemoveContainerHandler(params containers.
 	// get the indicated container for removal
 	cID := uid.Parse(params.ID)
 	h := exec.GetContainer(context.Background(), cID)
-	if h == nil {
+	if h == nil || h.ExecConfig == nil {
 		return containers.NewContainerRemoveNotFound()
 	}
 
-	err := h.Container.Remove(context.Background(), handler.handlerCtx.Session)
+	container := exec.Containers.Container(h.ExecConfig.ID)
+	if container == nil {
+		return containers.NewGetStateNotFound()
+	}
+
+	// NOTE: this should allowing batching of operations, as with Create, Start, Stop, et al
+	err := container.Remove(context.Background(), handler.handlerCtx.Session)
 	if err != nil {
 		switch err := err.(type) {
 		case exec.NotFoundError:
@@ -291,12 +303,17 @@ func (handler *ContainersHandlersImpl) GetContainerListHandler(params containers
 func (handler *ContainersHandlersImpl) ContainerSignalHandler(params containers.ContainerSignalParams) middleware.Responder {
 	defer trace.End(trace.Begin(params.ID))
 
-	h := exec.GetContainer(context.Background(), uid.Parse(params.ID))
-	if h == nil {
+	// NOTE: I feel that this should be in a Commit path for consistency
+	// it would allow phrasings such as:
+	// 1. join Volume to container
+	// 2. send HUP to primary process
+	// Only really relevant when we can connect networks or join volumes live
+	container := exec.Containers.Container(params.ID)
+	if container == nil {
 		return containers.NewContainerSignalNotFound().WithPayload(&models.Error{Message: fmt.Sprintf("container %s not found", params.ID)})
 	}
 
-	err := h.Container.Signal(context.Background(), params.Signal)
+	err := container.Signal(context.Background(), params.Signal)
 	if err != nil {
 		return containers.NewContainerSignalInternalServerError().WithPayload(&models.Error{Message: err.Error()})
 	}
@@ -307,8 +324,8 @@ func (handler *ContainersHandlersImpl) ContainerSignalHandler(params containers.
 func (handler *ContainersHandlersImpl) GetContainerLogsHandler(params containers.GetContainerLogsParams) middleware.Responder {
 	defer trace.End(trace.Begin(params.ID))
 
-	h := exec.GetContainer(context.Background(), uid.Parse(params.ID))
-	if h == nil {
+	container := exec.Containers.Container(params.ID)
+	if container == nil {
 		return containers.NewGetContainerLogsNotFound().WithPayload(&models.Error{
 			Message: fmt.Sprintf("container %s not found", params.ID),
 		})
@@ -325,7 +342,7 @@ func (handler *ContainersHandlersImpl) GetContainerLogsHandler(params containers
 		tail = int(*params.Taillines)
 	}
 
-	reader, err := h.Container.LogReader(context.Background(), tail, follow)
+	reader, err := container.LogReader(context.Background(), tail, follow)
 	if err != nil {
 		return containers.NewGetContainerLogsInternalServerError().WithPayload(&models.Error{Message: err.Error()})
 	}

--- a/lib/apiservers/portlayer/restapi/handlers/containers_handlers.go
+++ b/lib/apiservers/portlayer/restapi/handlers/containers_handlers.go
@@ -276,7 +276,7 @@ func (handler *ContainersHandlersImpl) GetContainerInfoHandler(params containers
 		return containers.NewGetContainerInfoNotFound().WithPayload(&models.Error{Message: info})
 	}
 
-	containerInfo := convertContainerToContainerInfo(container)
+	containerInfo := convertContainerToContainerInfo(*container)
 	return containers.NewGetContainerInfoOK().WithPayload(containerInfo)
 }
 
@@ -294,7 +294,7 @@ func (handler *ContainersHandlersImpl) GetContainerListHandler(params containers
 
 	for _, container := range containerVMs {
 		// convert to return model
-		info := convertContainerToContainerInfo(container)
+		info := convertContainerToContainerInfo(*container)
 		containerList = append(containerList, info)
 	}
 	return containers.NewGetContainerListOK().WithPayload(containerList)
@@ -377,7 +377,7 @@ func (handler *ContainersHandlersImpl) ContainerWaitHandler(params containers.Co
 
 	select {
 	case <-c.WaitForState(exec.StateStopped):
-		containerInfo := convertContainerToContainerInfo(c)
+		containerInfo := convertContainerToContainerInfo(*c)
 		return containers.NewContainerWaitOK().WithPayload(containerInfo)
 	case <-ctx.Done():
 		return containers.NewContainerWaitInternalServerError().WithPayload(&models.Error{
@@ -387,7 +387,7 @@ func (handler *ContainersHandlersImpl) ContainerWaitHandler(params containers.Co
 }
 
 // utility function to convert from a Container type to the API Model ContainerInfo (which should prob be called ContainerDetail)
-func convertContainerToContainerInfo(container *exec.Container) *models.ContainerInfo {
+func convertContainerToContainerInfo(container exec.Container) *models.ContainerInfo {
 	defer trace.End(trace.Begin(container.ExecConfig.ID))
 	// convert the container type to the required model
 	info := &models.ContainerInfo{ContainerConfig: &models.ContainerConfig{}, ProcessConfig: &models.ProcessConfig{}}

--- a/lib/dns/dns_test.go
+++ b/lib/dns/dns_test.go
@@ -123,7 +123,7 @@ func TestVIC(t *testing.T) {
 	}
 
 	// create the container
-	con := exec.NewContainer("foo")
+	con := exec.TestHandle("foo")
 	ip := net.IPv4(172, 16, 0, 2)
 
 	ctxOptions := &network.AddContainerOptions{

--- a/lib/portlayer/attach/attach.go
+++ b/lib/portlayer/attach/attach.go
@@ -46,10 +46,8 @@ func lookupVCHIP() (net.IP, error) {
 }
 
 func toggle(handle *exec.Handle, connected bool) (*exec.Handle, error) {
-	// make sure a spec exists
-	handle.SetSpec(nil)
 	// get the virtual device list
-	devices := object.VirtualDeviceList(handle.Container.Config.Hardware.Device)
+	devices := object.VirtualDeviceList(handle.Config.Hardware.Device)
 
 	// select the virtual serial ports
 	serials := devices.SelectByBackingInfo((*types.VirtualSerialPortURIBackingInfo)(nil))
@@ -106,8 +104,6 @@ func Join(h interface{}) (interface{}, error) {
 	if !ok {
 		return nil, fmt.Errorf("Type assertion failed for %#+v", handle)
 	}
-	// make sure a spec exists
-	handle.SetSpec(nil)
 
 	// Tether serial port - backed by network
 	serial := &types.VirtualSerialPort{

--- a/lib/portlayer/exec/base.go
+++ b/lib/portlayer/exec/base.go
@@ -1,0 +1,290 @@
+// Copyright 2016 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package exec
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"golang.org/x/crypto/ssh"
+
+	"github.com/vmware/govmomi/guest"
+	"github.com/vmware/govmomi/task"
+	"github.com/vmware/govmomi/vim25/mo"
+	"github.com/vmware/govmomi/vim25/types"
+	"github.com/vmware/vic/lib/config/executor"
+	"github.com/vmware/vic/pkg/trace"
+	"github.com/vmware/vic/pkg/vsphere/extraconfig"
+	"github.com/vmware/vic/pkg/vsphere/extraconfig/vmomi"
+	"github.com/vmware/vic/pkg/vsphere/tasks"
+	"github.com/vmware/vic/pkg/vsphere/vm"
+
+	log "github.com/Sirupsen/logrus"
+)
+
+// NotYetExistError is returned when a call that requires a VM exist is made
+type NotYetExistError struct {
+	ID string
+}
+
+func (e NotYetExistError) Error() string {
+	return fmt.Sprintf("%s is not completely created", e.ID)
+}
+
+// containerBase holds fields common between Handle and Container. The fields and
+// methods in containerBase should not require locking as they're primary use is:
+// a. for read-only reference when used in Container
+// b. single use/no-concurrent modification when used in Handle
+type containerBase struct {
+	ExecConfig *executor.ExecutorConfig
+
+	// original - can be pointers so long as refreshes
+	// use different instances of the structures
+	Config  *types.VirtualMachineConfigInfo
+	Runtime *types.VirtualMachineRuntimeInfo
+
+	// doesn't change so can be copied here
+	vm *vm.VirtualMachine
+}
+
+func newBase(vm *vm.VirtualMachine, c *types.VirtualMachineConfigInfo, r *types.VirtualMachineRuntimeInfo) *containerBase {
+	base := &containerBase{
+		ExecConfig: &executor.ExecutorConfig{},
+		Config:     c,
+		Runtime:    r,
+		vm:         vm,
+	}
+
+	// construct a working copy of the exec config
+	if c != nil && c.ExtraConfig != nil {
+		src := vmomi.OptionValueSource(c.ExtraConfig)
+		extraconfig.Decode(src, base.ExecConfig)
+	}
+
+	return base
+}
+
+// unlocked refresh of container state
+func (c *containerBase) refresh(ctx context.Context) error {
+	defer trace.End(trace.Begin(c.ExecConfig.ID))
+
+	base, err := c.updates(ctx)
+	if err != nil {
+		log.Errorf("Unable to update container %s", c.ExecConfig.ID)
+		return err
+	}
+
+	// copy over the new state
+	*c = *base
+	return nil
+}
+
+// updates acquires updates from the infrastructure without holding a lock
+func (c *containerBase) updates(ctx context.Context) (*containerBase, error) {
+	defer trace.End(trace.Begin(c.ExecConfig.ID))
+
+	var o mo.VirtualMachine
+
+	// make sure we have vm
+	if c.vm == nil {
+		return nil, NotYetExistError{c.ExecConfig.ID}
+	}
+
+	if err := c.vm.Properties(ctx, c.vm.Reference(), []string{"config", "runtime"}, &o); err != nil {
+		return nil, err
+	}
+
+	base := &containerBase{
+		vm:         c.vm,
+		Config:     o.Config,
+		Runtime:    &o.Runtime,
+		ExecConfig: &executor.ExecutorConfig{},
+	}
+
+	// Get the ExtraConfig
+	extraconfig.Decode(vmomi.OptionValueSource(o.Config.ExtraConfig), base.ExecConfig)
+
+	return base, nil
+}
+
+func (c *containerBase) startGuestProgram(ctx context.Context, name string, args string) error {
+	// make sure we have vm
+	if c.vm == nil {
+		return NotYetExistError{c.ExecConfig.ID}
+	}
+
+	defer trace.End(trace.Begin(c.ExecConfig.ID))
+	o := guest.NewOperationsManager(c.vm.Client.Client, c.vm.Reference())
+	m, err := o.ProcessManager(ctx)
+	if err != nil {
+		return err
+	}
+
+	spec := types.GuestProgramSpec{
+		ProgramPath: name,
+		Arguments:   args,
+	}
+
+	auth := types.NamePasswordAuthentication{
+		Username: c.ExecConfig.ID,
+	}
+
+	_, err = m.StartProgram(ctx, &auth, &spec)
+
+	return err
+}
+
+func (c *containerBase) start(ctx context.Context) error {
+	// make sure we have vm
+	if c.vm == nil {
+		return NotYetExistError{c.ExecConfig.ID}
+	}
+
+	// Power on
+	_, err := tasks.WaitForResult(ctx, func(ctx context.Context) (tasks.Task, error) {
+		return c.vm.PowerOn(ctx)
+	})
+	if err != nil {
+		return err
+	}
+
+	// guestinfo key that we want to wait for
+	key := fmt.Sprintf("guestinfo.vice..sessions|%s.started", c.ExecConfig.ID)
+	var detail string
+
+	// Wait some before giving up...
+	ctx, cancel := context.WithTimeout(ctx, propertyCollectorTimeout)
+	defer cancel()
+
+	detail, err = c.vm.WaitForKeyInExtraConfig(ctx, key)
+	if err != nil {
+		return fmt.Errorf("unable to wait for process launch status: %s", err.Error())
+	}
+
+	if detail != "true" {
+		return errors.New(detail)
+	}
+
+	return nil
+}
+
+func (c *containerBase) stop(ctx context.Context, waitTime *int32) error {
+	// make sure we have vm
+	if c.vm == nil {
+		return NotYetExistError{c.ExecConfig.ID}
+	}
+
+	// get existing state and set to stopping
+	// if there's a failure we'll revert to existing
+
+	err := c.shutdown(ctx, waitTime)
+	if err == nil {
+		return nil
+	}
+
+	log.Warnf("stopping %s via hard power off due to: %s", c.ExecConfig.ID, err)
+
+	_, err = tasks.WaitForResult(ctx, func(ctx context.Context) (tasks.Task, error) {
+		return c.vm.PowerOff(ctx)
+	})
+
+	if err != nil {
+
+		// It is possible the VM has finally shutdown in between, ignore the error in that case
+		if terr, ok := err.(task.Error); ok {
+			switch terr := terr.Fault().(type) {
+			case *types.InvalidPowerState:
+				if terr.ExistingState == types.VirtualMachinePowerStatePoweredOff {
+					log.Warnf("power off %s task skipped (state was already %s)", c.ExecConfig.ID, terr.ExistingState)
+					return nil
+				}
+				log.Warnf("invalid power state during power off: %s", terr.ExistingState)
+
+			case *types.GenericVmConfigFault:
+
+				// Check if the poweroff task was canceled due to a concurrent guest shutdown
+				if len(terr.FaultMessage) > 0 && terr.FaultMessage[0].Key == vmNotSuspendedKey {
+					log.Infof("power off %s task skipped due to guest shutdown", c.ExecConfig.ID)
+					return nil
+				}
+				log.Warnf("generic vm config fault during power off: %#v", terr)
+
+			default:
+				log.Warnf("hard power off failed due to: %#v", terr)
+			}
+		}
+
+		return err
+	}
+
+	return nil
+}
+
+func (c *containerBase) shutdown(ctx context.Context, waitTime *int32) error {
+	// make sure we have vm
+	if c.vm == nil {
+		return NotYetExistError{c.ExecConfig.ID}
+	}
+
+	wait := 10 * time.Second // default
+	if waitTime != nil && *waitTime > 0 {
+		wait = time.Duration(*waitTime) * time.Second
+	}
+
+	cs := c.ExecConfig.Sessions[c.ExecConfig.ID]
+	stop := []string{cs.StopSignal, string(ssh.SIGKILL)}
+	if stop[0] == "" {
+		stop[0] = string(ssh.SIGTERM)
+	}
+
+	for _, sig := range stop {
+		msg := fmt.Sprintf("sending kill -%s %s", sig, c.ExecConfig.ID)
+		log.Info(msg)
+
+		err := c.startGuestProgram(ctx, "kill", sig)
+		if err != nil {
+			return fmt.Errorf("%s: %s", msg, err)
+		}
+
+		log.Infof("waiting %s for %s to power off", wait, c.ExecConfig.ID)
+		timeout, err := c.waitForPowerState(ctx, wait, types.VirtualMachinePowerStatePoweredOff)
+		if err == nil {
+			return nil // VM has powered off
+		}
+
+		if !timeout {
+			return err // error other than timeout
+		}
+
+		log.Warnf("timeout (%s) waiting for %s to power off via SIG%s", wait, c.ExecConfig.ID, sig)
+	}
+
+	return fmt.Errorf("failed to shutdown %s via kill signals %s", c.ExecConfig.ID, stop)
+}
+
+func (c *containerBase) waitForPowerState(ctx context.Context, max time.Duration, state types.VirtualMachinePowerState) (bool, error) {
+	defer trace.End(trace.Begin(c.ExecConfig.ID))
+	timeout, cancel := context.WithTimeout(ctx, max)
+	defer cancel()
+
+	err := c.vm.WaitForPowerState(timeout, state)
+	if err != nil {
+		return timeout.Err() == err, err
+	}
+
+	return false, nil
+}

--- a/lib/portlayer/exec/commit.go
+++ b/lib/portlayer/exec/commit.go
@@ -1,0 +1,205 @@
+// Copyright 2016 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package exec
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25/types"
+	"github.com/vmware/vic/lib/portlayer/event/events"
+	"github.com/vmware/vic/pkg/trace"
+	"github.com/vmware/vic/pkg/vsphere/session"
+	"github.com/vmware/vic/pkg/vsphere/tasks"
+	"github.com/vmware/vic/pkg/vsphere/vm"
+
+	log "github.com/Sirupsen/logrus"
+)
+
+// Commit executes the requires steps on the handle
+func Commit(ctx context.Context, sess *session.Session, h *Handle, waitTime *int32) error {
+	defer trace.End(trace.Begin(h.ExecConfig.ID))
+
+	c := Containers.Container(h.ExecConfig.ID)
+	creation := h.vm == nil
+	if creation {
+		if h.Spec == nil {
+			return fmt.Errorf("a spec must be provided for create operations")
+		}
+
+		if sess == nil {
+			// session must not be nil
+			return fmt.Errorf("no session provided for create operations")
+		}
+
+		// the only permissible operation is to create a VM
+		if h.Spec == nil {
+			return fmt.Errorf("only create operations can be committed without an existing VM")
+		}
+
+		if c != nil {
+			return fmt.Errorf("a container already exists in the cache with this ID")
+		}
+
+		var res *types.TaskInfo
+		var err error
+		if sess.IsVC() && Config.VirtualApp.ResourcePool != nil {
+			// Create the vm
+			res, err = tasks.WaitForResult(ctx, func(ctx context.Context) (tasks.Task, error) {
+				return Config.VirtualApp.CreateChildVM_Task(ctx, *h.Spec.Spec(), nil)
+			})
+		} else {
+			// Find the Virtual Machine folder that we use
+			var folders *object.DatacenterFolders
+			folders, err = sess.Datacenter.Folders(ctx)
+			if err != nil {
+				log.Errorf("Could not get folders")
+				return err
+			}
+			parent := folders.VmFolder
+
+			// Create the vm
+			res, err = tasks.WaitForResult(ctx, func(ctx context.Context) (tasks.Task, error) {
+				return parent.CreateVM(ctx, *h.Spec.Spec(), Config.ResourcePool, nil)
+			})
+		}
+
+		if err != nil {
+			log.Errorf("Something failed. Spec was %+v", *h.Spec.Spec())
+			return err
+		}
+
+		h.vm = vm.NewVirtualMachine(ctx, sess, res.Result.(types.ManagedObjectReference))
+		c = newContainer(&h.containerBase)
+		Containers.Put(c)
+		// inform of creation irrespective of remaining operations
+		publishContainerEvent(c.ExecConfig.ID, time.Now().UTC(), events.ContainerCreated)
+
+		// clear the spec as we've acted on it - this prevents a reconfigure from occurring in follow-on
+		// processing
+		h.Spec = nil
+	}
+
+	// if we're stopping the VM, do so before the reconfigure to preserve the extraconfig
+	refresh := true
+	if h.TargetState() == StateStopped {
+		if h.Runtime == nil {
+			log.Warnf("Commit called with incomplete runtime state for %s", h.ExecConfig.ID)
+		}
+
+		if h.Runtime != nil && h.Runtime.PowerState == types.VirtualMachinePowerStatePoweredOff {
+			log.Infof("Dropping duplicate power off operation for %s", h.ExecConfig.ID)
+		} else {
+			// stop the container
+			if err := c.stop(ctx, waitTime); err != nil {
+				return err
+			}
+
+			// inform of creation irrespective of remaining operations
+			publishContainerEvent(h.ExecConfig.ID, time.Now().UTC(), events.ContainerStopped)
+
+			// we must refresh now to get the new ChangeVersion - this is used to gate on powerstate in the reconfigure
+			// because we cannot set the ExtraConfig if the VM is powered on. There is still a race here unfortunately because
+			// tasks don't appear to contain the new ChangeVersion
+			// we don't use refresh because we want to keep the extraconfig state
+			base, err := h.updates(ctx)
+			if err != nil {
+				// TODO: can we recover here, or at least set useful state for inspection?
+				return err
+			}
+			h.Runtime = base.Runtime
+			h.Config = base.Config
+
+			refresh = false
+		}
+	}
+
+	// reconfigure operation
+	if h.Spec != nil {
+		if h.Runtime == nil {
+			log.Errorf("Refusing to perform reconfigure operation with incomplete runtime state for %s", h.ExecConfig.ID)
+		} else {
+			s := h.Spec.Spec()
+			// ensure that our logic based on Runtime state remains valid
+
+			// NOTE: this inline refresh can be removed when switching away from guestinfo where we have non-persistence issues
+			// when updating ExtraConfig via the API with a powered on VM - we therefore have to be absolutely certain about the
+			// power state to decide if we can continue without nilifying extraconfig
+			// s.ChangeVersion = h.Config.ChangeVersion
+
+			// FIXME!!! this is a temporary hack until the concurrent modification retry logic is in place
+			if refresh {
+				base, err := h.updates(ctx)
+				if err == nil {
+					h.Runtime = base.Runtime
+					h.Config = base.Config
+				}
+			}
+
+			// nilify ExtraConfig if vm is running
+			if h.Runtime.PowerState == types.VirtualMachinePowerStatePoweredOn {
+				log.Errorf("Nilifying ExtraConfig as we are running")
+				s.ExtraConfig = nil
+			}
+
+			_, err := tasks.WaitForResult(ctx, func(ctx context.Context) (tasks.Task, error) {
+				return h.vm.Reconfigure(ctx, *s)
+			})
+			if err != nil {
+				log.Errorf("Reconfigure failed with %#+v", err)
+
+				// Check whether we get ConcurrentAccess and wrap it if needed
+				if f, ok := err.(types.HasFault); ok {
+					switch f.Fault().(type) {
+					case *types.ConcurrentAccess:
+						log.Errorf("We have ConcurrentAccess for version %s", s.ChangeVersion)
+
+						return ConcurrentAccessError{err}
+					}
+				}
+				return err
+			}
+		}
+	}
+
+	// best effort update of container cache using committed state - this will not reflect the power on below, however
+	// this is primarily for updating ExtraConfig state.
+	if !creation {
+		defer c.RefreshFromHandle(ctx, h)
+	}
+
+	if h.TargetState() == StateRunning {
+		if h.Runtime != nil && h.Runtime.PowerState == types.VirtualMachinePowerStatePoweredOn {
+			log.Infof("Dropping duplicate power on operation for %s", h.ExecConfig.ID)
+			return nil
+		}
+
+		if h.Runtime == nil && !creation {
+			log.Warnf("Commit called with incomplete runtime state for %s", h.ExecConfig.ID)
+		}
+
+		// start the container
+		if err := c.start(ctx); err != nil {
+			return err
+		}
+
+		// inform of creation irrespective of remaining operations
+		publishContainerEvent(h.ExecConfig.ID, time.Now().UTC(), events.ContainerStarted)
+	}
+
+	return nil
+}

--- a/lib/portlayer/exec/container.go
+++ b/lib/portlayer/exec/container.go
@@ -21,19 +21,13 @@ import (
 	"sync"
 	"time"
 
-	"github.com/vmware/govmomi/guest"
 	"github.com/vmware/govmomi/object"
-	"github.com/vmware/govmomi/task"
 	"github.com/vmware/govmomi/vim25/mo"
 	"github.com/vmware/govmomi/vim25/soap"
 	"github.com/vmware/govmomi/vim25/types"
-	"github.com/vmware/vic/lib/config/executor"
-	"github.com/vmware/vic/lib/portlayer/event/events"
 	"github.com/vmware/vic/pkg/errors"
 	"github.com/vmware/vic/pkg/trace"
 	"github.com/vmware/vic/pkg/uid"
-	"github.com/vmware/vic/pkg/vsphere/extraconfig"
-	"github.com/vmware/vic/pkg/vsphere/extraconfig/vmomi"
 	"github.com/vmware/vic/pkg/vsphere/session"
 	"github.com/vmware/vic/pkg/vsphere/sys"
 	"github.com/vmware/vic/pkg/vsphere/tasks"
@@ -41,7 +35,6 @@ import (
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/google/uuid"
-	"golang.org/x/crypto/ssh"
 )
 
 type State int
@@ -64,6 +57,28 @@ const (
 
 	vmNotSuspendedKey = "msg.suspend.powerOff.notsuspended"
 )
+
+func (s State) String() string {
+	switch s {
+	case StateCreated:
+		return "Created"
+	case StateStarting:
+		return "Starting"
+	case StateRunning:
+		return "Running"
+	case StateRemoving:
+		return "Removing"
+	case StateRemoved:
+		return "Removed"
+	case StateStopping:
+		return "Stopping"
+	case StateStopped:
+		return "Stopped"
+	case StateUnknown:
+		return "Unknown"
+	}
+	return ""
+}
 
 // NotFoundError is returned when a types.ManagedObjectNotFound is returned from a vmomi call
 type NotFoundError struct {
@@ -95,32 +110,50 @@ func (r ConcurrentAccessError) Error() string {
 type Container struct {
 	m sync.Mutex
 
-	// Current values
-	ExecConfig *executor.ExecutorConfig
-	state      State
+	containerBase
+
+	state State
 
 	// Size of the leaf (unused)
 	VMUnsharedDisk int64
 
-	vm *vm.VirtualMachine
-
 	logFollowers []io.Closer
-
-	// Current state
-	Config  *types.VirtualMachineConfigInfo
-	Runtime *types.VirtualMachineRuntimeInfo
 
 	newStateEvents map[State]chan struct{}
 }
 
-func NewContainer(id uid.UID) *Handle {
-	con := &Container{
-		ExecConfig:     &executor.ExecutorConfig{},
-		state:          StateCreating,
+// newContainer constructs a Container suitable for adding to the cache
+// it's state is set from the Runtime.PowerState field, or StateCreated if that is not
+// viable
+// This copies (shallow) the containerBase that's provided
+func newContainer(base *containerBase) *Container {
+	c := &Container{
+		containerBase:  *base,
+		state:          StateCreated,
 		newStateEvents: make(map[State]chan struct{}),
 	}
-	con.ExecConfig.ID = id.String()
-	return newHandle(con, con.state)
+
+	// if this is a creation path, then Runtime will be nil
+	if base.Runtime != nil {
+		// set state
+		switch base.Runtime.PowerState {
+		case types.VirtualMachinePowerStatePoweredOn:
+			c.state = StateRunning
+		case types.VirtualMachinePowerStatePoweredOff:
+			// check if any of the sessions was started
+			for _, s := range base.ExecConfig.Sessions {
+				if s.Started != "" {
+					c.state = StateStopped
+					break
+				}
+			}
+		case types.VirtualMachinePowerStateSuspended:
+			c.state = StateSuspended
+			log.Warnf("container VM %s: invalid power state %s", base.vm.Reference(), base.Runtime.PowerState)
+		}
+	}
+
+	return c
 }
 
 func GetContainer(ctx context.Context, id uid.UID) *Handle {
@@ -131,28 +164,6 @@ func GetContainer(ctx context.Context, id uid.UID) *Handle {
 	}
 
 	return nil
-}
-
-func (s State) String() string {
-	switch s {
-	case StateCreated:
-		return "Created"
-	case StateStarting:
-		return "Starting"
-	case StateRunning:
-		return "Running"
-	case StateRemoving:
-		return "Removing"
-	case StateRemoved:
-		return "Removed"
-	case StateStopping:
-		return "Stopping"
-	case StateStopped:
-		return "Stopped"
-	case StateUnknown:
-		return "Unknown"
-	}
-	return ""
 }
 
 // CurrentState returns current state.
@@ -209,197 +220,55 @@ func (c *Container) WaitForState(s State) <-chan struct{} {
 }
 
 func (c *Container) NewHandle(ctx context.Context) *Handle {
-	c.m.Lock()
-	defer c.m.Unlock()
-
 	// Call property collector to fill the data
 	if c.vm != nil {
-		if err := c.refresh(ctx); err != nil {
+		// FIXME: this should be calling the cache to decide if a refresh is needed
+		if err := c.Refresh(ctx); err != nil {
 			log.Errorf("refreshing container %s failed: %s", c.ExecConfig.ID, err)
 			return nil // nil indicates error
 		}
 	}
 
-	return newHandle(c, c.state)
+	// return a handle that represents zero changes over the current configuration
+	// for this container
+	return newHandle(c)
 }
 
-// Refresh calls the property collector to get config and runtime info and Guest RPC for ExtraConfig
+// Refresh updates config and runtime info, holding a lock only while swapping
+// the new data for the old
 func (c *Container) Refresh(ctx context.Context) error {
 	defer trace.End(trace.Begin(c.ExecConfig.ID))
 
-	c.m.Lock()
-	defer c.m.Unlock()
-
-	return c.refresh(ctx)
-}
-
-func (c *Container) refresh(ctx context.Context) error {
-	defer trace.End(trace.Begin(c.ExecConfig.ID))
-
-	var o mo.VirtualMachine
-
-	// make sure we have vm
-	if c.vm == nil {
-		return fmt.Errorf("There is no backing VirtualMachine %#v", c)
-	}
-	if err := c.vm.Properties(ctx, c.vm.Reference(), []string{"config", "runtime"}, &o); err != nil {
+	base, err := c.updates(ctx)
+	if err != nil {
+		log.Errorf("Unable to update container %s", c.ExecConfig.ID)
 		return err
 	}
 
-	c.Config = o.Config
-	c.Runtime = &o.Runtime
+	c.m.Lock()
+	defer c.m.Unlock()
 
-	// Get the ExtraConfig
-	extraconfig.Decode(vmomi.OptionValueSource(o.Config.ExtraConfig), c.ExecConfig)
-
+	// copy over the new state
+	c.containerBase = *base
 	return nil
 }
 
-// Commit executes the requires steps on the handle
-func (c *Container) Commit(ctx context.Context, sess *session.Session, h *Handle, waitTime *int32) error {
-	defer trace.End(trace.Begin(h.ExecConfig.ID))
-
-	// hold the event that has occurred
-	var commitEvent string
+// Refresh updates config and runtime info, holding a lock only while swapping
+// the new data for the old
+func (c *Container) RefreshFromHandle(ctx context.Context, h *Handle) {
+	defer trace.End(trace.Begin(h.String()))
 
 	c.m.Lock()
 	defer c.m.Unlock()
 
-	// If an event has occurred then put the container in the cache
-	// and publish the container event
-	defer func() {
-		log.Debugf("Committing container %s status as: %s", c.ExecConfig.ID, commitEvent)
-		if commitEvent != "" {
-			Containers.Put(c)
-			publishContainerEvent(c.ExecConfig.ID, time.Now().UTC(), commitEvent)
-		}
-	}()
-
-	if c.vm == nil {
-		if sess == nil {
-			// session must not be nil
-			return fmt.Errorf("no session provided for commit operation")
-		}
-
-		// the only permissible operation is to create a VM
-		if h.Spec == nil {
-			return fmt.Errorf("only create operations can be committed without an existing VM")
-		}
-
-		var res *types.TaskInfo
-		var err error
-		if sess.IsVC() && Config.VirtualApp.ResourcePool != nil {
-			// Create the vm
-			res, err = tasks.WaitForResult(ctx, func(ctx context.Context) (tasks.Task, error) {
-				return Config.VirtualApp.CreateChildVM_Task(ctx, *h.Spec.Spec(), nil)
-			})
-		} else {
-			// Find the Virtual Machine folder that we use
-			var folders *object.DatacenterFolders
-			folders, err = sess.Datacenter.Folders(ctx)
-			if err != nil {
-				log.Errorf("Could not get folders")
-				return err
-			}
-			parent := folders.VmFolder
-
-			// Create the vm
-			res, err = tasks.WaitForResult(ctx, func(ctx context.Context) (tasks.Task, error) {
-				return parent.CreateVM(ctx, *h.Spec.Spec(), Config.ResourcePool, nil)
-			})
-		}
-
-		if err != nil {
-			log.Errorf("Something failed. Spec was %+v", *h.Spec.Spec())
-			return err
-		}
-
-		c.vm = vm.NewVirtualMachine(ctx, sess, res.Result.(types.ManagedObjectReference))
-		c.updateState(StateCreated)
-
-		commitEvent = events.ContainerCreated
-
-		// clear the spec as we've acted on it
-		h.Spec = nil
-
-		c.ExecConfig = &h.ExecConfig
-		// refresh the struct with what propery collector provides
-		if err = c.refresh(ctx); err != nil {
-			return err
-		}
+	if c.Config != nil && (h.Config == nil || h.Config.ChangeVersion != c.Config.ChangeVersion) {
+		log.Warnf("container and handle ChangeVersions do not match: %s != %s", c.Config.ChangeVersion, h.Config.ChangeVersion)
+		return
 	}
 
-	// if we're stopping the VM, do so before the reconfigure to preserve the extraconfig
-	if h.CurrentState() == StateStopped &&
-		c.Runtime != nil && c.Runtime.PowerState == types.VirtualMachinePowerStatePoweredOn {
-		// stop the container
-		if err := h.Container.stop(ctx, waitTime); err != nil {
-			return err
-		}
-
-		commitEvent = events.ContainerStopped
-
-		// refresh the struct with what propery collector provides
-		if err := c.refresh(ctx); err != nil {
-			return err
-		}
-	}
-
-	if h.Spec != nil {
-		s := h.Spec.Spec()
-
-		// nilify ExtraConfig if vm is running
-		if c.Runtime.PowerState == types.VirtualMachinePowerStatePoweredOn {
-			log.Errorf("Nilifying ExtraConfig as we are running")
-			s.ExtraConfig = nil
-		}
-
-		// set ChangeVersion. This property is useful because it guards against updates that have happened between when the VM’s config is read and when it is applied.
-		// Will return "Cannot complete operation due to concurrent modification by another operation.." on failure
-		s.ChangeVersion = c.Config.ChangeVersion
-
-		_, err := tasks.WaitForResult(ctx, func(ctx context.Context) (tasks.Task, error) {
-			return c.vm.Reconfigure(ctx, *s)
-		})
-		if err != nil {
-			log.Errorf("Reconfigure failed with %#+v", err)
-
-			// Check whether we get ConcurrentAccess and wrap it if needed
-			if f, ok := err.(types.HasFault); ok {
-				switch f.Fault().(type) {
-				case *types.ConcurrentAccess:
-					log.Errorf("We have ConcurrentAccess for version %s", s.ChangeVersion)
-
-					return ConcurrentAccessError{err}
-				}
-			}
-			return err
-		}
-
-		c.ExecConfig = &h.ExecConfig
-
-		// refresh the struct with what propery collector provides
-		if err = c.refresh(ctx); err != nil {
-			return err
-		}
-	}
-
-	if h.CurrentState() == StateRunning &&
-		c.Runtime != nil && c.Runtime.PowerState == types.VirtualMachinePowerStatePoweredOff {
-		// start the container
-		if err := h.Container.start(ctx); err != nil {
-			return err
-		}
-
-		commitEvent = events.ContainerStarted
-
-		// refresh the struct with what property collector provides
-		if err := c.refresh(ctx); err != nil {
-			return err
-		}
-	}
-
-	return nil
+	// copy over the new state
+	c.containerBase = h.containerBase
+	log.Debugf("container refreshed - ChangeVersion: %s", c.Config.ChangeVersion)
 }
 
 // Start starts a container vm with the given params
@@ -412,167 +281,44 @@ func (c *Container) start(ctx context.Context) error {
 	// get existing state and set to starting
 	// if there's a failure we'll revert to existing
 	finalState := c.updateState(StateStarting)
-
 	defer func() { c.updateState(finalState) }()
 
-	// Power on
-	_, err := tasks.WaitForResult(ctx, func(ctx context.Context) (tasks.Task, error) {
-		return c.vm.PowerOn(ctx)
-	})
+	err := c.containerBase.start(ctx)
 	if err != nil {
+		// leave this in state starting - if it powers off then the event
+		// will cause transition to StateStopped which is likely our original state
+		// if the container was just taking a very long time it'll eventually
+		// become responsive.
+
+		// TODO: mechanism to trigger reinspection of long term transitional states
+		finalState = StateStarting
 		return err
 	}
 
-	// guestinfo key that we want to wait for
-	key := fmt.Sprintf("guestinfo.vice..sessions|%s.started", c.ExecConfig.ID)
-	var detail string
-
-	// Wait some before giving up...
-	ctx, cancel := context.WithTimeout(ctx, propertyCollectorTimeout)
-	defer cancel()
-
-	detail, err = c.vm.WaitForKeyInExtraConfig(ctx, key)
-	if err != nil {
-		return fmt.Errorf("unable to wait for process launch status: %s", err.Error())
-	}
-
-	if detail != "true" {
-		return errors.New(detail)
-	}
-
-	// this state will be set by defer function.
 	finalState = StateRunning
-	return nil
-}
 
-func (c *Container) waitForPowerState(ctx context.Context, max time.Duration, state types.VirtualMachinePowerState) (bool, error) {
-	defer trace.End(trace.Begin(c.ExecConfig.ID))
-	timeout, cancel := context.WithTimeout(ctx, max)
-	defer cancel()
-
-	err := c.vm.WaitForPowerState(timeout, state)
-	if err != nil {
-		return timeout.Err() == err, err
-	}
-
-	return false, nil
-}
-
-func (c *Container) shutdown(ctx context.Context, waitTime *int32) error {
-	defer trace.End(trace.Begin(c.ExecConfig.ID))
-	wait := 10 * time.Second // default
-	if waitTime != nil && *waitTime > 0 {
-		wait = time.Duration(*waitTime) * time.Second
-	}
-	cs := c.ExecConfig.Sessions[c.ExecConfig.ID]
-	stop := []string{cs.StopSignal, string(ssh.SIGKILL)}
-	if stop[0] == "" {
-		stop[0] = string(ssh.SIGTERM)
-	}
-
-	for _, sig := range stop {
-		msg := fmt.Sprintf("sending kill -%s %s", sig, c.ExecConfig.ID)
-		log.Info(msg)
-
-		err := c.startGuestProgram(ctx, "kill", sig)
-		if err != nil {
-			return fmt.Errorf("%s: %s", msg, err)
-		}
-
-		log.Infof("waiting %s for %s to power off", wait, c.ExecConfig.ID)
-		timeout, err := c.waitForPowerState(ctx, wait, types.VirtualMachinePowerStatePoweredOff)
-		if err == nil {
-			return nil // VM has powered off
-		}
-
-		if !timeout {
-			return err // error other than timeout
-		}
-
-		log.Warnf("timeout (%s) waiting for %s to power off via SIG%s", wait, c.ExecConfig.ID, sig)
-	}
-
-	return fmt.Errorf("failed to shutdown %s via kill signals %s", c.ExecConfig.ID, stop)
+	return err
 }
 
 func (c *Container) stop(ctx context.Context, waitTime *int32) error {
 	defer trace.End(trace.Begin(c.ExecConfig.ID))
 
-	if c.vm == nil {
-		return fmt.Errorf("vm not set")
-	}
-
 	defer c.onStop()
 
 	// get existing state and set to stopping
 	// if there's a failure we'll revert to existing
+	finalState := c.updateState(StateStopping)
+	defer func() { c.updateState(finalState) }()
 
-	existingState := c.updateState(StateStopping)
-
-	err := c.shutdown(ctx, waitTime)
-	if err == nil {
-		c.updateState(StateStopped)
-		return nil
-	}
-
-	log.Warnf("stopping %s via hard power off due to: %s", c.ExecConfig.ID, err)
-
-	_, err = tasks.WaitForResult(ctx, func(ctx context.Context) (tasks.Task, error) {
-		return c.vm.PowerOff(ctx)
-	})
-
+	err := c.containerBase.stop(ctx, waitTime)
 	if err != nil {
-
-		// It is possible the VM has finally shutdown in between, ignore the error in that case
-		if terr, ok := err.(task.Error); ok {
-			switch terr := terr.Fault().(type) {
-			case *types.InvalidPowerState:
-				if terr.ExistingState == types.VirtualMachinePowerStatePoweredOff {
-					log.Warnf("power off %s task skipped (state was already %s)", c.ExecConfig.ID, terr.ExistingState)
-					return nil
-				}
-				log.Warnf("invalid power state during power off: %s", terr.ExistingState)
-
-			case *types.GenericVmConfigFault:
-
-				// Check if the poweroff task was canceled due to a concurrent guest shutdown
-				if len(terr.FaultMessage) > 0 && terr.FaultMessage[0].Key == vmNotSuspendedKey {
-					log.Infof("power off %s task skipped due to guest shutdown", c.ExecConfig.ID)
-					return nil
-				}
-				log.Warnf("generic vm config fault during power off: %#v", terr)
-
-			default:
-				log.Warnf("hard power off failed due to: %#v", terr)
-			}
-		}
-		c.updateState(existingState)
+		// we've got no idea what state the container is in at this point
+		// running is an _optimistic_ statement
 		return err
 	}
-	c.updateState(StateStopped)
+
+	finalState = StateStopped
 	return nil
-}
-
-func (c *Container) startGuestProgram(ctx context.Context, name string, args string) error {
-	defer trace.End(trace.Begin(c.ExecConfig.ID))
-	o := guest.NewOperationsManager(c.vm.Client.Client, c.vm.Reference())
-	m, err := o.ProcessManager(ctx)
-	if err != nil {
-		return err
-	}
-
-	spec := types.GuestProgramSpec{
-		ProgramPath: name,
-		Arguments:   args,
-	}
-
-	auth := types.NamePasswordAuthentication{
-		Username: c.ExecConfig.ID,
-	}
-
-	_, err = m.StartProgram(ctx, &auth, &spec)
-
-	return err
 }
 
 func (c *Container) Signal(ctx context.Context, num int64) error {
@@ -747,31 +493,6 @@ func instanceUUID(id string) (string, error) {
 	return uuid.NewSHA1(namespace, []byte(id)).String(), nil
 }
 
-// find the childVM for this resource pool by name
-func childVM(ctx context.Context, sess *session.Session, name string) (*vm.VirtualMachine, error) {
-	defer trace.End(trace.Begin(""))
-	// Search container back through instance UUID
-	uuid, err := instanceUUID(name)
-	if err != nil {
-		detail := fmt.Sprintf("unable to get instance UUID: %s", err)
-		log.Error(detail)
-		return nil, errors.New(detail)
-	}
-
-	searchIndex := object.NewSearchIndex(sess.Client.Client)
-	child, err := searchIndex.FindByUuid(ctx, sess.Datacenter, uuid, true, nil)
-
-	if err != nil {
-		return nil, fmt.Errorf("Unable to find container(%s): %s", name, err.Error())
-	}
-	if child == nil {
-		return nil, fmt.Errorf("Unable to find container %s", name)
-	}
-
-	// instantiate the vm object
-	return vm.NewVirtualMachine(ctx, sess, child.Reference()), nil
-}
-
 // populate the vm attributes for the specified morefs
 func populateVMAttributes(ctx context.Context, sess *session.Session, refs []types.ManagedObjectReference) ([]mo.VirtualMachine, error) {
 	defer trace.End(trace.Begin(fmt.Sprintf("populating %d refs", len(refs))))
@@ -791,32 +512,13 @@ func convertInfraContainers(ctx context.Context, sess *session.Session, vms []mo
 	var cons []*Container
 
 	for _, v := range vms {
-		source := vmomi.OptionValueSource(v.Config.ExtraConfig)
-		c := &Container{
-			state:          StateCreated,
-			newStateEvents: make(map[State]chan struct{}),
-		}
-		extraconfig.Decode(source, &c.ExecConfig)
+		vm := vm.NewVirtualMachine(ctx, sess, v.Reference())
+		base := newBase(vm, v.Config, &v.Runtime)
+		c := newContainer(base)
+
 		id := uid.Parse(c.ExecConfig.ID)
 		if id == uid.NilUID {
 			log.Warnf("skipping converting container VM %s: could not parse id", v.Reference())
-			continue
-		}
-
-		// set state
-		switch v.Runtime.PowerState {
-		case types.VirtualMachinePowerStatePoweredOn:
-			c.state = StateRunning
-		case types.VirtualMachinePowerStatePoweredOff:
-			// check if any of the sessions was started
-			for _, s := range c.ExecConfig.Sessions {
-				if s.Started != "" {
-					c.state = StateStopped
-					break
-				}
-			}
-		case types.VirtualMachinePowerStateSuspended:
-			log.Warnf("skipping converting container VM %s: invalid power state %s", v.Reference(), v.Runtime.PowerState)
 			continue
 		}
 
@@ -824,7 +526,6 @@ func convertInfraContainers(ctx context.Context, sess *session.Session, vms []mo
 			c.VMUnsharedDisk = v.Summary.Storage.Unshared
 		}
 
-		c.vm = vm.NewVirtualMachine(ctx, sess, v.Reference())
 		cons = append(cons, c)
 	}
 

--- a/lib/portlayer/exec/container_cache_test.go
+++ b/lib/portlayer/exec/container_cache_test.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/vmware/vic/lib/config/executor"
 	"github.com/vmware/vic/pkg/uid"
 	"github.com/vmware/vic/pkg/vsphere/vm"
 
@@ -75,7 +74,6 @@ func addTestVM(container *Container) {
 }
 
 func newTestContainer(id string) *Container {
-	c := &Container{ExecConfig: &executor.ExecutorConfig{}, newStateEvents: make(map[State]chan struct{})}
-	c.ExecConfig.ID = id
-	return c
+	h := TestHandle(id)
+	return newContainer(&h.containerBase)
 }

--- a/lib/portlayer/exec/container_test.go
+++ b/lib/portlayer/exec/container_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/vmware/vic/pkg/uid"
 )
 
 func TestStateStringer(t *testing.T) {
@@ -35,4 +36,16 @@ func TestStateStringer(t *testing.T) {
 	assert.Equal(t, "Starting", c.state.String())
 	c.state = StateCreated
 	assert.Equal(t, "Created", c.state.String())
+}
+
+func NewContainer(id uid.UID) *Handle {
+	con := &Container{
+		state:          StateCreating,
+		newStateEvents: make(map[State]chan struct{}),
+	}
+
+	h := newHandle(con)
+	h.ExecConfig.ID = id.String()
+
+	return h
 }

--- a/lib/portlayer/exec/container_test.go
+++ b/lib/portlayer/exec/container_test.go
@@ -23,7 +23,11 @@ import (
 
 func TestStateStringer(t *testing.T) {
 
-	c := &Container{state: StateRunning}
+	c := &Container{
+		ContainerInfo: ContainerInfo{
+			state: StateRunning,
+		},
+	}
 
 	assert.Equal(t, "Running", c.state.String())
 	c.state = StateStopped
@@ -40,7 +44,9 @@ func TestStateStringer(t *testing.T) {
 
 func NewContainer(id uid.UID) *Handle {
 	con := &Container{
-		state:          StateCreating,
+		ContainerInfo: ContainerInfo{
+			state: StateCreating,
+		},
 		newStateEvents: make(map[State]chan struct{}),
 	}
 

--- a/lib/portlayer/logging/logging.go
+++ b/lib/portlayer/logging/logging.go
@@ -31,9 +31,6 @@ func Join(h interface{}) (interface{}, error) {
 		return nil, fmt.Errorf("Type assertion failed for %#+v", handle)
 	}
 
-	// make sure a spec exists
-	handle.SetSpec(nil)
-
 	VMPathName := handle.Spec.VMPathName()
 	VMName := handle.Spec.Spec().Name
 

--- a/lib/portlayer/network/context.go
+++ b/lib/portlayer/network/context.go
@@ -894,10 +894,6 @@ func (c *Context) AddContainer(h *exec.Handle, options *AddContainerOptions) err
 		}
 	}
 
-	if err := h.SetSpec(nil); err != nil {
-		return err
-	}
-
 	// figure out if we need to add a new NIC
 	// if there is already a NIC connected to a
 	// bridge network and we are adding the container
@@ -1004,9 +1000,6 @@ func (c *Context) RemoveContainer(h *exec.Handle, scope string) error {
 	}
 
 	if removeNIC {
-		// ensure spec is not nil
-		h.SetSpec(nil)
-
 		var devices object.VirtualDeviceList
 		backing, err := s.network.EthernetCardBackingInfo(context.Background())
 		if err != nil {

--- a/lib/portlayer/network/network.go
+++ b/lib/portlayer/network/network.go
@@ -124,8 +124,6 @@ func handleEvent(netctx *Context, ie events.Event) {
 			return
 		}
 
-		// make sure we don't change the state of the container in the Commit
-		handle.SetState(exec.StateUnknown)
 		if err := handle.Commit(context.Background(), nil, nil); err != nil {
 			log.Warnf("Failed to commit handle after network unbind for container %s: %s", ie.Reference(), err)
 		}
@@ -195,7 +193,7 @@ func engageContext(ctx context.Context, netctx *Context, em event.EventManager) 
 			}
 		}
 
-		if h.CurrentState() == exec.StateRunning {
+		if c.CurrentState() == exec.StateRunning {
 			if _, err = netctx.bindContainer(h); err != nil {
 				return err
 			}

--- a/lib/portlayer/network/scope_test.go
+++ b/lib/portlayer/network/scope_test.go
@@ -144,7 +144,7 @@ func TestScopeAddRemoveContainer(t *testing.T) {
 	options := &AddContainerOptions{
 		Scope: ctx.defaultScope.Name(),
 	}
-	bound := exec.NewContainer("bound")
+	bound := exec.TestHandle("bound")
 	ctx.AddContainer(bound, options)
 	ctx.BindContainer(bound)
 

--- a/lib/portlayer/storage/vsphere/vm.go
+++ b/lib/portlayer/storage/vsphere/vm.go
@@ -29,7 +29,7 @@ func VolumeJoin(op trace.Operation, handle *exec.Handle, volume *storage.Volume,
 	defer trace.End(trace.Begin("vsphere.VolumeJoin"))
 
 	if _, ok := handle.ExecConfig.Mounts[volume.ID]; ok {
-		return nil, fmt.Errorf("Volume with ID %s is already in container %s's mountspec'", volume.ID, handle.Container.ExecConfig.ID)
+		return nil, fmt.Errorf("Volume with ID %s is already in container %s's mountspec'", volume.ID, handle.ExecConfig.ID)
 	}
 
 	newMountSpec := executor.MountSpec{

--- a/lib/spec/spec.go
+++ b/lib/spec/spec.go
@@ -74,7 +74,7 @@ type VirtualMachineConfigSpecConfig struct {
 	ImageStorePath *url.URL
 
 	// Temporary
-	Metadata executor.ExecutorConfig
+	Metadata *executor.ExecutorConfig
 }
 
 // VirtualMachineConfigSpec type


### PR DESCRIPTION
Towards #2773 

State for Handle operations should not require locking as Handles are
nominally self-contained.
State unique to Container may well require locking and is globally visible
within the portlayer, via the Containers cache.

To help with this separation I split container.go into two files:
1. base.go - should not require locking.
2. container.go - may well require locking.
Commit was moved into commit.go as it's not a method of a
Container but doesn't fit cleanly as a Handle method at this point.

Handle is still a muddle of two concepts:
1. desired changeset
2. translation of that changeset into a network transportable pointer

The naming is still misleading:
* Handle is about making changes and should be ChangeSet (or similar)
* Container is for inspecting container state, and should be read only
* Vmomi gateway should be the shared point that allows for optimisations
between those two paths. The calling code should be treating it as if it
goes the the infrastructure every time.

OMISSION: currently does not perform a refresh post power state change.
Still not clear on how best that should be integrated, without blocking in
the commit path