### PR TITLE
Improve portlayer's API session handling [full ci]

### DIFF
--- a/lib/apiservers/portlayer/restapi/configure_port_layer.go
+++ b/lib/apiservers/portlayer/restapi/configure_port_layer.go
@@ -89,11 +89,9 @@ func configureAPI(api *operations.PortLayerAPI) http.Handler {
 	api.ServerShutdown = func() {
 		log.Infof("Shutting down port-layer-server")
 
-		if sess != nil {
-			// Logout the session
-			if err := sess.Logout(ctx); err != nil {
-				log.Warnf("unable to log out of session: %s", err)
-			}
+		// Logout the session
+		if err := sess.Logout(ctx); err != nil {
+			log.Warnf("unable to log out of session: %s", err)
 		}
 	}
 

--- a/lib/apiservers/portlayer/restapi/configure_port_layer.go
+++ b/lib/apiservers/portlayer/restapi/configure_port_layer.go
@@ -85,7 +85,7 @@ func configureAPI(api *operations.PortLayerAPI) http.Handler {
 		log.Fatalf("configure_port_layer ERROR: %s", err)
 	}
 
-	// Configure the func invoked if the PL panics during init
+	// Configure the func invoked if the PL panics or is restarted by vic-init
 	api.ServerShutdown = func() {
 		log.Infof("Shutting down port-layer-server")
 

--- a/lib/apiservers/portlayer/restapi/handlers/storage_handlers_test.go
+++ b/lib/apiservers/portlayer/restapi/handlers/storage_handlers_test.go
@@ -24,7 +24,6 @@ import (
 
 	"golang.org/x/net/context"
 
-	//"github.com/go-swagger/go-swagger/httpkit/middleware"
 	"github.com/go-swagger/go-swagger/swag"
 	"github.com/stretchr/testify/assert"
 


### PR DESCRIPTION
This PR

* configures the shutdown func for the PL to account for the session created during startup. If the PL panics during initialization or is restarted by vic-init, the session will now be logged out.
* re-uses the session that is passed in to the storage handler instead of creating a new one.

Fixes #2398
