### PR TITLE
[full ci] Passing TEST_DATACENTER to vic machine delete

### DIFF
--- a/tests/resources/Util.robot
+++ b/tests/resources/Util.robot
@@ -156,7 +156,7 @@ Check Delete Success
 Run Secret VIC Machine Delete Command
     [Tags]  secret
     [Arguments]  ${vch-name}
-    ${rc}  ${output}=  Run And Return Rc And Output  bin/vic-machine-linux delete --name=${vch-name} --target=%{TEST_URL} --user=%{TEST_USERNAME} --password=%{TEST_PASSWORD} --force=true --compute-resource=%{TEST_RESOURCE} --timeout %{TEST_TIMEOUT}
+    ${rc}  ${output}=  Run And Return Rc And Output  bin/vic-machine-linux delete --name=${vch-name} --target=%{TEST_URL}%{TEST_DATACENTER} --user=%{TEST_USERNAME} --password=%{TEST_PASSWORD} --force=true --compute-resource=%{TEST_RESOURCE} --timeout %{TEST_TIMEOUT}
     [Return]  ${rc}  ${output}
 
 Run VIC Machine Delete Command


### PR DESCRIPTION
The VIC machine delete is failing for multiple datacenter test, so passing the %{TEST_DATACENTER} to vic machine delete.
