### PR TITLE
Disables snapshot functionality on containerVMs WIP

### DIFF
--- a/lib/apiservers/engine/backends/container_proxy.go
+++ b/lib/apiservers/engine/backends/container_proxy.go
@@ -120,7 +120,7 @@ const (
 	forceLogType                         = "json-file" //Use in inspect to allow docker logs to work
 	annotationKeyLabels                  = "docker.labels"
 	killWaitForExit        time.Duration = 2 * time.Second
-
+	//Keys for the volume driver argument map
 	DriverArgFlagKey      = "flags"
 	DriverArgContainerKey = "Container"
 	DriverArgImageKey     = "Image"

--- a/lib/apiservers/engine/backends/container_proxy.go
+++ b/lib/apiservers/engine/backends/container_proxy.go
@@ -110,17 +110,17 @@ type volumeFields struct {
 }
 
 const (
-	attachConnectTimeout   time.Duration = 15 * time.Second //timeout for the connection
-	attachAttemptTimeout   time.Duration = 40 * time.Second //timeout before we ditch an attach attempt
+	attachConnectTimeout   time.Duration = 15 * time.Second // timeout for the connection
+	attachAttemptTimeout   time.Duration = 40 * time.Second // timeout before we ditch an attach attempt
 	attachPLAttemptDiff    time.Duration = 10 * time.Second
-	attachPLAttemptTimeout time.Duration = attachAttemptTimeout - attachPLAttemptDiff //timeout for the portlayer before ditching an attempt
-	attachRequestTimeout   time.Duration = 2 * time.Hour                              //timeout to hold onto the attach connection
+	attachPLAttemptTimeout time.Duration = attachAttemptTimeout - attachPLAttemptDiff // timeout for the portlayer before ditching an attempt
+	attachRequestTimeout   time.Duration = 2 * time.Hour                              // timeout to hold onto the attach connection
 	attachStdinInitString                = "v1c#>"
 	swaggerSubstringEOF                  = "EOF"
-	forceLogType                         = "json-file" //Use in inspect to allow docker logs to work
+	forceLogType                         = "json-file" // Use in inspect to allow docker logs to work
 	annotationKeyLabels                  = "docker.labels"
 	killWaitForExit        time.Duration = 2 * time.Second
-	//Keys for the volume driver argument map
+	// Keys for the volume driver argument map
 	DriverArgFlagKey      = "flags"
 	DriverArgContainerKey = "Container"
 	DriverArgImageKey     = "Image"

--- a/lib/portlayer/exec/handle.go
+++ b/lib/portlayer/exec/handle.go
@@ -271,7 +271,11 @@ func Create(ctx context.Context, sess *session.Session, config *ContainerCreateC
 	}
 
 	h.Spec = linux.Spec()
-	*h.Spec.Flags.SnapshotDisabled = true // disable snapshots, we do not support snapshots on containerVMs
+
+	// create flags info object and then disable snapshots
+	h.Spec.Flags = new(types.VirtualMachineFlagInfo)
+	h.Spec.Flags.SnapshotDisabled = new(bool)
+	*h.Spec.Flags.SnapshotDisabled = true
 
 	handlesLock.Lock()
 	defer handlesLock.Unlock()

--- a/lib/portlayer/exec/handle.go
+++ b/lib/portlayer/exec/handle.go
@@ -271,6 +271,7 @@ func Create(ctx context.Context, sess *session.Session, config *ContainerCreateC
 	}
 
 	h.Spec = linux.Spec()
+	*h.Spec.Flags.SnapshotDisabled = true //disable snapshots, we do not support snapshots on containerVMs
 
 	handlesLock.Lock()
 	defer handlesLock.Unlock()

--- a/lib/portlayer/exec/handle.go
+++ b/lib/portlayer/exec/handle.go
@@ -271,7 +271,7 @@ func Create(ctx context.Context, sess *session.Session, config *ContainerCreateC
 	}
 
 	h.Spec = linux.Spec()
-	*h.Spec.Flags.SnapshotDisabled = true //disable snapshots, we do not support snapshots on containerVMs
+	*h.Spec.Flags.SnapshotDisabled = true // disable snapshots, we do not support snapshots on containerVMs
 
 	handlesLock.Lock()
 	defer handlesLock.Unlock()


### PR DESCRIPTION
We now set the "SnapshotDisable" flag to true withing the vm config spec flags
this will disable the ability to take snapshots of containerVMs which causes
poor behavior on removal of a containervm. Additionally, this commit adds a small
comment to the volume driver arguement keys in order to improve code readability.

Fixes #2856 