### PR TITLE
Add vsphere task id to disk attach detach

### DIFF
--- a/pkg/trace/operation.go
+++ b/pkg/trace/operation.go
@@ -133,8 +133,8 @@ func opID(opNum uint64) string {
 }
 
 // Add tracing info to the context.
-func NewOperation(ctx context.Context, msg string) Operation {
-	o := newOperation(ctx, opID(atomic.AddUint64(&opCount, 1)), 3, msg)
+func NewOperation(ctx context.Context, format string, args ...interface{}) Operation {
+	o := newOperation(ctx, opID(atomic.AddUint64(&opCount, 1)), 3, fmt.Sprintf(format, args...))
 
 	frame := o.t[0]
 	o.Debugf("[NewOperation] %s [%s:%d]", o.header(), frame.funcName, frame.lineNo)
@@ -142,17 +142,17 @@ func NewOperation(ctx context.Context, msg string) Operation {
 }
 
 // WithTimeout
-func WithTimeout(parent *Operation, timeout time.Duration, msg string) (Operation, context.CancelFunc) {
+func WithTimeout(parent *Operation, timeout time.Duration, format string, args ...interface{}) (Operation, context.CancelFunc) {
 	ctx, cancelFunc := context.WithTimeout(parent.Context, timeout)
-	op := parent.newChild(ctx, msg)
+	op := parent.newChild(ctx, fmt.Sprintf(format, args...))
 
 	return op, cancelFunc
 }
 
 // WithDeadline
-func WithDeadline(parent *Operation, expiration time.Time, msg string) (Operation, context.CancelFunc) {
+func WithDeadline(parent *Operation, expiration time.Time, format string, args ...interface{}) (Operation, context.CancelFunc) {
 	ctx, cancelFunc := context.WithDeadline(parent.Context, expiration)
-	op := parent.newChild(ctx, msg)
+	op := parent.newChild(ctx, fmt.Sprintf(format, args...))
 
 	return op, cancelFunc
 }

--- a/pkg/vsphere/disk/disk_manager.go
+++ b/pkg/vsphere/disk/disk_manager.go
@@ -241,7 +241,11 @@ func (m *Manager) Attach(op trace.Operation, disk *types.VirtualDisk) error {
 
 	m.reconfig.Lock()
 	_, err = tasks.WaitForResult(op, func(ctx context.Context) (tasks.Task, error) {
-		return m.vm.Reconfigure(ctx, machineSpec)
+		t, er := m.vm.Reconfigure(ctx, machineSpec)
+
+		op.Debugf("Attach reconfigure task=%s", t.Reference())
+
+		return t, er
 	})
 	m.reconfig.Unlock()
 
@@ -286,7 +290,11 @@ func (m *Manager) Detach(op trace.Operation, d *VirtualDisk) error {
 
 	m.reconfig.Lock()
 	_, err = tasks.WaitForResult(op, func(ctx context.Context) (tasks.Task, error) {
-		return m.vm.Reconfigure(ctx, spec)
+		t, er := m.vm.Reconfigure(ctx, spec)
+
+		op.Debugf("Detach reconfigure task=%s", t.Reference())
+
+		return t, er
 	})
 	m.reconfig.Unlock()
 


### PR DESCRIPTION
Aids in debugging what operation maps to what vsphere task.

Also modified `trace.Operation` to allow `format`, `arg` for `msg`.
