### PR TITLE
Remove unneeded issue checks in integration tests [skip ci]

### DIFF
--- a/tests/test-cases/Group1-Docker-Commands/1-11-Docker-RM.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-11-Docker-RM.robot
@@ -32,7 +32,6 @@ Remove a stopped container
     ${rc}  ${output}=  Run And Return Rc And Output  govc ls vm
     Should Be Equal As Integers  ${rc}  0
     Should Not Contain  ${output}  ${container}
-    ${status}=  Get State Of Github Issue  1313
     ${rc}  ${output}=  Run And Return Rc And Output  govc datastore.ls
     Should Be Equal As Integers  ${rc}  0
     Should Not Contain  ${output}  ${container}

--- a/tests/test-cases/Group1-Docker-Commands/1-16-Docker-Network-LS.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-16-Docker-Network-LS.robot
@@ -29,7 +29,6 @@ Docker network ls --no-trunc
     Should Be Equal As Integers  ${rc}  0
     @{lines}=  Split To Lines  ${output}
     @{line}=  Split String  @{lines}[1]
-    ${status}=  Get State Of Github Issue  1225
     Length Should Be  @{line}[0]  64
 
 Docker network ls -f fake network


### PR DESCRIPTION
Very minor change that cleans up a couple integration tests by removing unneeded Github issue checks.