### PR TITLE
Disable linked container ping test pending workaround [skip ci]

### DIFF
--- a/tests/test-cases/Group1-Docker-Commands/1-04-Docker-Create.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-04-Docker-Create.robot
@@ -63,18 +63,21 @@ Create and start named container
     Should Not Contain  ${output}  Error
 
 Create linked containers that can ping
-    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} pull debian
-    Should Be Equal As Integers  ${rc}  0
-
-    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} create --link busy1:busy1 --name busy2 debian ping -c2 busy1
-    Should Be Equal As Integers  ${rc}  0
-    Should Not Contain  ${output}  Error
-    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} start busy2
-    Should Be Equal As Integers  ${rc}  0
-    Should Not Contain  ${output}  Error
-    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} logs --follow busy2
-    Should Be Equal As Integers  ${rc}  0
-    Should Contain  ${output}  2 packets transmitted, 2 packets received
+    ${status}=  Get State Of Github Issue  2669
+    Run Keyword If  '${status}' == 'closed'  Fail  Test 1-06-Docker-Create.robot needs to be updated now that Issue #2669 has been resolved
+    Log  Issue \#2669 is blocking implementation  WARN
+#    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} pull debian
+#    Should Be Equal As Integers  ${rc}  0
+#
+#    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} create --link busy1:busy1 --name busy2 debian ping -c2 busy1
+#    Should Be Equal As Integers  ${rc}  0
+#    Should Not Contain  ${output}  Error
+#    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} start busy2
+#    Should Be Equal As Integers  ${rc}  0
+#    Should Not Contain  ${output}  Error
+#    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} logs --follow busy2
+#    Should Be Equal As Integers  ${rc}  0
+#    Should Contain  ${output}  2 packets transmitted, 2 packets received
 
 Create a container after the last container is removed
     ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} pull busybox


### PR DESCRIPTION
The cross-container ping test is wonky because of the way output is being processed.
