### PR TITLE
[skip ci] VSAN-Complex cluster name update

### DIFF
--- a/tests/manual-test-cases/Group5-Functional-Tests/5-6-2-VSAN-Complex.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-6-2-VSAN-Complex.robot
@@ -22,7 +22,7 @@ Complex VSAN
 
     Create Three Distributed Port Groups  vcqaDC
 
-    Add Host To Distributed Switch  /vcqaDC/host/cls
+    Add Host To Distributed Switch  /vcqaDC/host/cluster-vsan-1
 
     Log To Console  Enable DRS and VSAN on the cluster
     ${out}=  Run  govc cluster.change -drs-enabled /vcqaDC/host/cluster-vsan-1


### PR DESCRIPTION
Minor fix to update the cluster name for the vsan complex topology.

Fixes #2877 

