### PR TITLE
Fixed anonymous vol issue for postgres in voting app

### DIFF
--- a/demos/compose/voting-app/docker-compose.yml
+++ b/demos/compose/voting-app/docker-compose.yml
@@ -17,9 +17,16 @@ services:
     container_name: worker
     image: victest/vote-worker
 
+# Postgres container will create an anonymous volume.  VIC will use a
+# vmdk for the volume.  Since it is a new volume, it will have a lost+found
+# folder, and the Postgres init scripts do not like a non-empty folder (the
+# lost+found folder).  We work around this by directing the init scripts to
+# use another arbitrary folder.  We do this by setting the PGDATA env var.
   db:
     container_name: db
     image: postgres:9.4
+    environment:
+      - PGDATA=/var/lib/postgresql/data/data
 
   result:
     image: victest/vote-result

--- a/tests/test-cases/Group3-Docker-Compose/3-02-Docker-Compose-Voting-App.md
+++ b/tests/test-cases/Group3-Docker-Compose/3-02-Docker-Compose-Voting-App.md
@@ -18,7 +18,7 @@ This test requires that a vSphere server is running and available
 ```cd demos/compose/voting-app; COMPOSE_HTTP_TIMEOUT=300 DOCKER_HOST=<VCH IP> docker-compose up```
 
 #Expected Outcome:
-Docker compose should return with success and the voting and results servers are up and running.
+Docker compose should return with success and all containers in the compose yaml file are up and running.
 Docker inspect data should show networks, alias, and IP address for the container.
 
 #Possible Problems:

--- a/tests/test-cases/Group3-Docker-Compose/3-02-Docker-Compose-Voting-App.robot
+++ b/tests/test-cases/Group3-Docker-Compose/3-02-Docker-Compose-Voting-App.robot
@@ -25,6 +25,21 @@ Compose Voting App
     Should Contain  ${out}  true
     Should Be Equal As Integers  ${rc}  0
 
+    ${rc}  ${out}=  Run And Return Rc And Output  docker ${params} inspect -f {{.State.Running}} worker
+    Log  ${out}
+    Should Contain  ${out}  true
+    Should Be Equal As Integers  ${rc}  0
+
+    ${rc}  ${out}=  Run And Return Rc And Output  docker ${params} inspect -f {{.State.Running}} db
+    Log  ${out}
+    Should Contain  ${out}  true
+    Should Be Equal As Integers  ${rc}  0
+
+    ${rc}  ${out}=  Run And Return Rc And Output  docker ${params} inspect -f {{.State.Running}} redis
+    Log  ${out}
+    Should Contain  ${out}  true
+    Should Be Equal As Integers  ${rc}  0
+
     ${rc}  ${out}=  Run And Return Rc And Output  docker ${params} inspect -f '{{range $key, $value := .NetworkSettings.Networks}}{{$key}}{{end}}' vote
     Log  ${out}
     Should Not Be Empty  ${out}
@@ -39,4 +54,3 @@ Compose Voting App
     Log  ${out}
     Should Not Be Empty  ${out}
     Should Be Equal As Integers  ${rc}  0
-    


### PR DESCRIPTION
Our anonymous volume support exposed an issue with postgres and
broke our voting app.  When the modified voting app was created,
it was tested without anonymous volume support.  Our robot
scripts did not have sufficient checks to find this issue.

There is now a workaround in the compose file for postgres and
a check to make sure every container is up and running and not
just the webservers.

Related to #2929.