### PR TITLE
Added re-authentication when the connection to the VC or ESX is down …

### DIFF
--- a/pkg/vsphere/session/session.go
+++ b/pkg/vsphere/session/session.go
@@ -213,9 +213,8 @@ func (s *Session) Connect(ctx context.Context) (*Session, error) {
 					log.Warnf("session keepalive error: %s", err)
 
 					if isNotAuthenticated(err) {
-						err = login(ctx)
 
-						if err != nil {
+						if err = login(ctx); err != nil {
 							log.Errorf("session keepalive failed to re-authenticate: %s", err)
 						} else {
 							log.Info("session keepalive re-authenticated")

--- a/pkg/vsphere/session/session.go
+++ b/pkg/vsphere/session/session.go
@@ -210,7 +210,7 @@ func (s *Session) Connect(ctx context.Context) (*Session, error) {
 			func(roundTripper soap.RoundTripper) error {
 				_, err := methods.GetCurrentTime(context.Background(), roundTripper)
 				if err != nil {
-					log.Warningf("session keepalive error: %s", err)
+					log.Warnf("session keepalive error: %s", err)
 
 					if isNotAuthenticated(err) {
 						err = login(ctx)

--- a/pkg/vsphere/session/session.go
+++ b/pkg/vsphere/session/session.go
@@ -206,7 +206,6 @@ func (s *Session) Connect(ctx context.Context) (*Session, error) {
 
 	if s.Keepalive != 0 {
 		// TODO: add login() to the keep alive handler
-		// vimClient.RoundTripper = session.KeepAlive(soapClient, s.Keepalive)
 		vimClient.RoundTripper = session.KeepAliveHandler(soapClient, s.Keepalive,
 			func(roundTripper soap.RoundTripper) error {
 				_, err := methods.GetCurrentTime(context.Background(), roundTripper)

--- a/pkg/vsphere/session/session.go
+++ b/pkg/vsphere/session/session.go
@@ -208,16 +208,18 @@ func (s *Session) Connect(ctx context.Context) (*Session, error) {
 		vimClient.RoundTripper = session.KeepAliveHandler(soapClient, s.Keepalive,
 			func(roundTripper soap.RoundTripper) error {
 				_, err := methods.GetCurrentTime(context.Background(), roundTripper)
-				if err != nil {
-					log.Warnf("session keepalive error: %s", err)
+				if err == nil {
+					return nil
+				}
 
-					if isNotAuthenticated(err) {
+				log.Warnf("session keepalive error: %s", err)
 
-						if err = login(ctx); err != nil {
-							log.Errorf("session keepalive failed to re-authenticate: %s", err)
-						} else {
-							log.Info("session keepalive re-authenticated")
-						}
+				if isNotAuthenticated(err) {
+
+					if err = login(ctx); err != nil {
+						log.Errorf("session keepalive failed to re-authenticate: %s", err)
+					} else {
+						log.Info("session keepalive re-authenticated")
 					}
 				}
 

--- a/pkg/vsphere/session/session.go
+++ b/pkg/vsphere/session/session.go
@@ -205,7 +205,6 @@ func (s *Session) Connect(ctx context.Context) (*Session, error) {
 	}
 
 	if s.Keepalive != 0 {
-		// TODO: add login() to the keep alive handler
 		vimClient.RoundTripper = session.KeepAliveHandler(soapClient, s.Keepalive,
 			func(roundTripper soap.RoundTripper) error {
 				_, err := methods.GetCurrentTime(context.Background(), roundTripper)

--- a/pkg/vsphere/session/session.go
+++ b/pkg/vsphere/session/session.go
@@ -38,6 +38,7 @@ import (
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/session"
 	"github.com/vmware/govmomi/vim25"
+	"github.com/vmware/govmomi/vim25/methods"
 	"github.com/vmware/govmomi/vim25/soap"
 	"github.com/vmware/govmomi/vim25/types"
 	"github.com/vmware/vic/lib/config"
@@ -205,7 +206,26 @@ func (s *Session) Connect(ctx context.Context) (*Session, error) {
 
 	if s.Keepalive != 0 {
 		// TODO: add login() to the keep alive handler
-		vimClient.RoundTripper = session.KeepAlive(soapClient, s.Keepalive)
+		// vimClient.RoundTripper = session.KeepAlive(soapClient, s.Keepalive)
+		vimClient.RoundTripper = session.KeepAliveHandler(soapClient, s.Keepalive,
+			func(roundTripper soap.RoundTripper) error {
+				_, err := methods.GetCurrentTime(context.Background(), roundTripper)
+				if err != nil {
+					log.Warningf("session keepalive error: %s", err)
+
+					if isNotAuthenticated(err) {
+						err = login(ctx)
+
+						if err != nil {
+							log.Errorf("session keepalive failed to re-authenticate: %s", err)
+						} else {
+							log.Info("session keepalive re-authenticated")
+						}
+					}
+				}
+
+				return nil
+			})
 	}
 
 	// TODO: get rid of govmomi.Client usage, only provides a few helpers we don't need.
@@ -312,4 +332,14 @@ func (s *Session) Folders(ctx context.Context) *object.DatacenterFolders {
 	}
 
 	return s.folders
+}
+
+func isNotAuthenticated(err error) bool {
+	if soap.IsSoapFault(err) {
+		switch soap.ToSoapFault(err).VimFault().(type) {
+		case types.NotAuthenticated:
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[  ] There is an associated issue that is labelled
[  ] Code is up-to-date with the `master` branch
[  ] You've successfully run `make test` locally
[  ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/vmware/vic/blob/master/.github/CONTRIBUTING.md
-->

Fixes #2835 

```
time="2016-10-28T20:15:54Z" level=debug msg="Error configuring vSphere Event Collector: Post https://sdkTunnel:8089/sdk: EOF" 
time="2016-10-28T20:16:59Z" level=warning msg="session keepalive error: Post https://sdkTunnel:8089/sdk: Service Unavailable (Error connecting tunnel on TCP socket: (null))" 
time="2016-10-28T20:21:59Z" level=warning msg="session keepalive error: ServerFaultCode: The session is not authenticated." 
time="2016-10-28T20:21:59Z" level=info msg="session keepalive re-authenticated" 
```
