### PR TITLE
Adds Improved fault object logging on failed task retry

### DIFF
--- a/pkg/vsphere/tasks/waiter.go
+++ b/pkg/vsphere/tasks/waiter.go
@@ -112,6 +112,6 @@ func isTaskInProgress(err error) bool {
 	}
 
 	//if none are found this is an unknown fault so we are dumping the structure.
-	log.Debugf("unexpected fault om task retry : %s", spew.Sdump(err))
+	log.Debugf("unexpected fault on task retry : %s", spew.Sdump(err))
 	return false
 }

--- a/pkg/vsphere/tasks/waiter.go
+++ b/pkg/vsphere/tasks/waiter.go
@@ -22,11 +22,11 @@ import (
 	"time"
 
 	log "github.com/Sirupsen/logrus"
+	"github.com/davecgh/go-spew/spew"
 	"github.com/vmware/govmomi/task"
 	"github.com/vmware/govmomi/vim25/progress"
 	"github.com/vmware/govmomi/vim25/soap"
 	"github.com/vmware/govmomi/vim25/types"
-	"github.com/vmware/vic/vendor/github.com/davecgh/go-spew/spew"
 )
 
 const (

--- a/pkg/vsphere/tasks/waiter.go
+++ b/pkg/vsphere/tasks/waiter.go
@@ -26,6 +26,7 @@ import (
 	"github.com/vmware/govmomi/vim25/progress"
 	"github.com/vmware/govmomi/vim25/soap"
 	"github.com/vmware/govmomi/vim25/types"
+	"github.com/vmware/vic/vendor/github.com/davecgh/go-spew/spew"
 )
 
 const (
@@ -110,5 +111,7 @@ func isTaskInProgress(err error) bool {
 		}
 	}
 
+	//if none are found this is an unknown fault so we are dumping the structure.
+	log.Debugf("unexpected fault om task retry : %s", spew.Sdump(err))
 	return false
 }

--- a/pkg/vsphere/tasks/waiter.go
+++ b/pkg/vsphere/tasks/waiter.go
@@ -70,7 +70,6 @@ func WaitForResult(ctx context.Context, f func(context.Context) (Task, error)) (
 			}
 		}
 
-		log.Errorf("task failed: %s", err)
 		if !isTaskInProgress(err) {
 			return info, err
 		}

--- a/pkg/vsphere/tasks/waiter.go
+++ b/pkg/vsphere/tasks/waiter.go
@@ -94,7 +94,7 @@ func isTaskInProgress(err error) bool {
 		case types.TaskInProgress:
 			return true
 		default:
-			log.Debugf("unexpected soap fault on task retry : %#v", f)
+			logSoapFault(f)
 		}
 	}
 
@@ -103,7 +103,7 @@ func isTaskInProgress(err error) bool {
 		case *types.TaskInProgress:
 			return true
 		default:
-			log.Debugf("unexpected vim fault on task retry : %s", f)
+			logFault(f)
 		}
 	}
 
@@ -112,14 +112,26 @@ func isTaskInProgress(err error) bool {
 		if _, ok := err.Fault().(*types.TaskInProgress); ok {
 			return true
 		}
-		log.Debugf("unexpected fault on task retry : %s", err.Fault())
+		logFault(err.Fault())
 	default:
 		if f, ok := err.(types.HasFault); ok {
-			log.Debugf("unexpected fault on task retry : %s", f.Fault())
+			logFault(f.Fault())
 		} else {
-			log.Debugf("unexpected error on task retry : %s", err)
+			logError(err)
 		}
 	}
-
 	return false
+}
+
+// Helper Functions
+func logFault(fault types.BaseMethodFault) {
+	log.Debugf("unexpected fault on task retry : %#v", fault)
+}
+
+func logSoapFault(fault types.AnyType) {
+	log.Debugf("unexpected soap fault on task retry : %#v", fault)
+}
+
+func logError(err error) {
+	log.Debugf("unexpected error on task retry : %#v", err)
 }


### PR DESCRIPTION
Adding unexpected fault dumping so that we can see the entire fault with pointers being followed when a task retry operation fails. This is in response to #2767 as well as an attempt to glean more information from odd failures when making calls to vsphere. 
