### PR TITLE
Force stop if kill doesn't stop container

### DIFF
--- a/lib/apiservers/engine/backends/backends.go
+++ b/lib/apiservers/engine/backends/backends.go
@@ -303,7 +303,7 @@ func setPortMapping(info *models.ContainerInfo, backend *Container, container *c
 	}
 	for _, e := range endpointsOK.Payload {
 		if len(e.Ports) > 0 {
-			if err = backend.mapPorts(container.HostConfig, e, container.ContainerID); err != nil {
+			if err = MapPorts(container.HostConfig, e, container.ContainerID); err != nil {
 				return err
 			}
 		}

--- a/lib/apiservers/engine/backends/container_test.go
+++ b/lib/apiservers/engine/backends/container_test.go
@@ -198,6 +198,10 @@ func (m *MockContainerProxy) SetMockDataResponse(createHandleResp int, addToScop
 	m.mockRespIndices[5] = commitContainerResp
 }
 
+func (m *MockContainerProxy) Handle(id, name string) (string, error) {
+	return "", nil
+}
+
 func (m *MockContainerProxy) CreateContainerHandle(imageID string, config types.ContainerCreateConfig) (string, string, error) {
 	respIdx := m.mockRespIndices[0]
 
@@ -247,7 +251,7 @@ func (m *MockContainerProxy) AddLoggingToContainer(handle string, config types.C
 	return m.mockAddLoggingData[respIdx].retHandle, m.mockAddLoggingData[respIdx].retErr
 }
 
-func (m *MockContainerProxy) CommitContainerHandle(handle, imageID string) error {
+func (m *MockContainerProxy) CommitContainerHandle(handle, containerID string, waitTime int32) error {
 	respIdx := m.mockRespIndices[5]
 
 	if respIdx >= len(m.mockCommitData) {
@@ -277,6 +281,10 @@ func (m *MockContainerProxy) StreamContainerLogs(name string, out io.Writer, sta
 		fmt.Fprintf(out, "line %d\n", i)
 	}
 
+	return nil
+}
+
+func (m *MockContainerProxy) Stop(vc *viccontainer.VicContainer, name string, seconds int, unbound bool) error {
 	return nil
 }
 

--- a/lib/apiservers/engine/backends/errors.go
+++ b/lib/apiservers/engine/backends/errors.go
@@ -21,6 +21,11 @@ import (
 	derr "github.com/docker/docker/errors"
 )
 
+// Used to check status code of derr, which is not a public type
+type httpStatusError interface {
+	HTTPErrorStatusCode() int
+}
+
 // InvalidVolumeError is returned when the user specifies a client directory as a volume.
 type InvalidVolumeError struct {
 }
@@ -74,4 +79,17 @@ func BadRequestError(msg string) error {
 
 func ConflictError(msg string) error {
 	return derr.NewRequestConflictError(fmt.Errorf("Conflict error from portlayer: %s", msg))
+}
+
+// Error type check
+
+func IsNotFoundError(err error) bool {
+	// if error was created with the docker error function, check the status code
+	if httpErr, ok := err.(httpStatusError); ok {
+		if httpErr.HTTPErrorStatusCode() == http.StatusNotFound {
+			return true
+		}
+	}
+
+	return false
 }

--- a/lib/portlayer/exec/container.go
+++ b/lib/portlayer/exec/container.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"io"
 	"sync"
+	"syscall"
 	"time"
 
 	"github.com/vmware/govmomi/object"
@@ -358,6 +359,10 @@ func (c *Container) Signal(ctx context.Context, num int64) error {
 
 	if c.vm == nil {
 		return fmt.Errorf("vm not set")
+	}
+
+	if num == int64(syscall.SIGKILL) {
+		return c.containerBase.kill(ctx)
 	}
 
 	return c.startGuestProgram(ctx, "kill", fmt.Sprintf("%d", num))

--- a/tests/test-cases/Group1-Docker-Commands/1-14-Docker-Kill.md
+++ b/tests/test-cases/Group1-Docker-Commands/1-14-Docker-Kill.md
@@ -19,6 +19,9 @@ This test requires that a vSphere server is running and available
 6. Issue docker kill -s HUP <containerID> to the VIC appliance
 7. Issue docker kill -s TERM <containerID> to the VIC appliance
 8. Issue docker kill fakeContainer to the VIC appliance
+9. Issue docker create nginx to the VIC appliance
+10. Issue docker start <containerID to the VIC appliance
+11. Issue docker kill <containerID> to the VIC appliance
 
 #Expected Outcome:
 * Steps 2-7 should all return without error and provide the container ID in the response
@@ -29,6 +32,7 @@ This test requires that a vSphere server is running and available
 ```
 Failed to kill container (fakeContainer): Error response from daemon: Cannot kill container fakeContainer: No such container: fakeContainer
 ```
+* Step 11 should result in the container stopped
 
 #Possible Problems:
 None

--- a/tests/test-cases/Group1-Docker-Commands/1-14-Docker-Kill.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-14-Docker-Kill.robot
@@ -58,3 +58,17 @@ Signal a non-existent container
     ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} kill fakeContainer
     Should Be Equal As Integers  ${rc}  1
     Should Contain  ${output}  No such container: fakeContainer
+
+Signal a tough to kill container - nginx
+    ${rc}=  Run And Return Rc  docker ${params} pull nginx
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${id}=  Run And Return Rc And Output  docker ${params} create nginx
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} start ${id}
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} kill ${id}
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${out}=  Run And Return Rc And Output  docker ${params} inspect -f {{.State.Running}} ${id}
+    Log  ${out}
+    Should Contain  ${out}  false
+    Should Be Equal As Integers  ${rc}  0


### PR DESCRIPTION
Use Stop() to ultimately stop a container if signaling the
process in the container does not kill it.

Also refactor containerStop() to container_proxy.go.

Resolves #2617
