### PR TITLE
Disable basic docker compose test [skip ci]

### DIFF
--- a/tests/test-cases/Group3-Docker-Compose/3-03-Docker-Compose-Basic.robot
+++ b/tests/test-cases/Group3-Docker-Compose/3-03-Docker-Compose-Basic.robot
@@ -9,18 +9,21 @@ ${yml}  version: "2"\nservices:\n${SPACE}web:\n${SPACE}${SPACE}image: python:2.7
 
 *** Test Cases ***
 Compose basic
-    Run  echo '${yml}' > basic-compose.yml
-    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} network create vic_default
-    Log  ${output}
-    ${rc}  ${output}=  Run And Return Rc And Output  docker-compose ${params} --file basic-compose.yml create
-    Log  ${output}
-    Should Be Equal As Integers  ${rc}  0
-    ${rc}  ${output}=  Run And Return Rc And Output  docker-compose ${params} --file basic-compose.yml start
-    Log  ${output}
-    Should Be Equal As Integers  ${rc}  0
-    ${rc}  ${output}=  Run And Return Rc And Output  docker-compose ${params} --file basic-compose.yml logs
-    Log  ${output}
-    Should Be Equal As Integers  ${rc}  0
-    ${rc}  ${output}=  Run And Return Rc And Output  docker-compose ${params} --file basic-compose.yml stop
-    Log  ${output}
-    Should Be Equal As Integers  ${rc}  0
+    ${status}=  Get State Of Github Issue  2525
+    Run Keyword If  '${status}' == 'closed'  Fail  Test 3-03-Docker-Compose-Basic.robot needs to be updated now that Issue #2525 has been resolved
+    Log  Issue \#2525 is blocking implementation  WARN
+    # Run  echo '${yml}' > basic-compose.yml
+    # ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} network create vic_default
+    # Log  ${output}
+    # ${rc}  ${output}=  Run And Return Rc And Output  docker-compose ${params} --file basic-compose.yml create
+    # Log  ${output}
+    # Should Be Equal As Integers  ${rc}  0
+    # ${rc}  ${output}=  Run And Return Rc And Output  docker-compose ${params} --file basic-compose.yml start
+    # Log  ${output}
+    # Should Be Equal As Integers  ${rc}  0
+    # ${rc}  ${output}=  Run And Return Rc And Output  docker-compose ${params} --file basic-compose.yml logs
+    # Log  ${output}
+    # Should Be Equal As Integers  ${rc}  0
+    # ${rc}  ${output}=  Run And Return Rc And Output  docker-compose ${params} --file basic-compose.yml stop
+    # Log  ${output}
+    # Should Be Equal As Integers  ${rc}  0


### PR DESCRIPTION
Disables the `3-03-Docker-Compose-Basic` integration test and tags it with #2525.
