### PR TITLE
Increase timeout up to 10 seconds and decrease amount of data.

### DIFF
--- a/pkg/serial/handshake_test.go
+++ b/pkg/serial/handshake_test.go
@@ -129,14 +129,14 @@ func TestHandshakeServerNormalCaseScenario(t *testing.T) {
 
 func TestHandshakeServerLotsOfTrashOnTheLine(t *testing.T) {
 	log.SetLevel(log.InfoLevel)
-	clientConn, serverConn := NewFakeConnection(time.Second * 3)
+	clientConn, serverConn := NewFakeConnection(time.Second * 10)
 
 	go func() {
 		buf := make([]byte, 10)
 
 		// Do not send too many bytes, otherwise "write" will block on server side due too many flagNak.
 		x := "sdfkgn sdflkjsfdfdgis dfgs"
-		for i := 0; i < 10; i++ {
+		for i := 0; i < 5; i++ {
 			x += x
 		}
 		clientConn.Write([]byte(x))


### PR DESCRIPTION
Increase timeout up to 10 seconds and decreased amount of data many times to avoid timeouts on a loaded system.
Fixes #2963
