### PR TITLE
Change issue number for disabled docker-compose test [skip ci]

### DIFF
--- a/tests/test-cases/Group3-Docker-Compose/3-03-Docker-Compose-Basic.robot
+++ b/tests/test-cases/Group3-Docker-Compose/3-03-Docker-Compose-Basic.robot
@@ -9,9 +9,9 @@ ${yml}  version: "2"\nservices:\n${SPACE}web:\n${SPACE}${SPACE}image: python:2.7
 
 *** Test Cases ***
 Compose basic
-    ${status}=  Get State Of Github Issue  2525
-    Run Keyword If  '${status}' == 'closed'  Fail  Test 3-03-Docker-Compose-Basic.robot needs to be updated now that Issue #2525 has been resolved
-    Log  Issue \#2525 is blocking implementation  WARN
+    ${status}=  Get State Of Github Issue  2954
+    Run Keyword If  '${status}' == 'closed'  Fail  Test 3-03-Docker-Compose-Basic.robot needs to be updated now that Issue #2954 has been resolved
+    Log  Issue \#2954 is blocking implementation  WARN
     # Run  echo '${yml}' > basic-compose.yml
     # ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} network create vic_default
     # Log  ${output}


### PR DESCRIPTION
Updates the `3-03-Docker-Compose-Basic` integration test to track the related issue per @sflxn's comment on #2525.