### PR TITLE
Set http Proxy function in fetcher

### DIFF
--- a/pkg/fetcher/fetcher.go
+++ b/pkg/fetcher/fetcher.go
@@ -100,6 +100,7 @@ type URLFetcher struct {
 func NewURLFetcher(options Options) Fetcher {
 	/* #nosec */
 	tr := &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
 		TLSClientConfig: &tls.Config{
 			InsecureSkipVerify: options.InsecureSkipVerify,
 		},


### PR DESCRIPTION
With this field set, env vars can be used to configure the proxy for
imagec:  https://golang.org/pkg/net/http/#ProxyFromEnvironment

Issue #2537