### PR TITLE
Work around logs --follow truncation in test

### DIFF
--- a/tests/test-cases/Group1-Docker-Commands/1-04-Docker-Create.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-04-Docker-Create.robot
@@ -72,7 +72,10 @@ Create linked containers that can ping
     ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} start busy2
     Should Be Equal As Integers  ${rc}  0
     Should Not Contain  ${output}  Error
-    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} logs --follow busy2
+    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} wait busy2
+    Should Be Equal As Integers  ${rc}  0
+    Should Not Contain  ${output}  Error
+    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} logs busy2
     Should Be Equal As Integers  ${rc}  0
     Should Contain  ${output}  2 packets transmitted, 2 packets received
 


### PR DESCRIPTION
Use start/wait/logs instead of start/logs --follow

This adds none of the data needed for diagnosis, simply a bandaid to suppress
test failure without completely disabling it.

Bandaid #2989 

