### PR TITLE
fix NPE in vic-machine caused by vm invalid state error

### DIFF
--- a/pkg/vsphere/vm/vm.go
+++ b/pkg/vsphere/vm/vm.go
@@ -35,11 +35,6 @@ import (
 	"github.com/vmware/vic/pkg/vsphere/tasks"
 )
 
-const (
-	summary          = "summary"
-	connectionStatus = "summary.runtime.connectionState"
-)
-
 type InvalidState struct {
 	r types.ManagedObjectReference
 }
@@ -479,7 +474,7 @@ func (vm *VirtualMachine) fixVM(ctx context.Context) error {
 		return err
 	}
 
-	properties := []string{"summary.config", "summary.runtime", "resourcePool", "parentVApp"}
+	properties := []string{"summary.config", "summary.runtime.host", "resourcePool", "parentVApp"}
 	log.Debugf("Get vm properties %s", properties)
 	var mvm mo.VirtualMachine
 	if err = vm.VirtualMachine.Properties(ctx, vm.Reference(), properties, &mvm); err != nil {
@@ -536,7 +531,7 @@ func (vm *VirtualMachine) needsFix(ctx context.Context, err error) bool {
 
 func (vm *VirtualMachine) IsInvalidState(ctx context.Context) bool {
 	var o mo.VirtualMachine
-	if err := vm.VirtualMachine.Properties(ctx, vm.Reference(), []string{connectionStatus}, &o); err != nil {
+	if err := vm.VirtualMachine.Properties(ctx, vm.Reference(), []string{"summary.runtime.connectionState"}, &o); err != nil {
 		log.Debugf("Failed to get vm properties: %s", err)
 		return false
 	}
@@ -566,14 +561,14 @@ func (vm *VirtualMachine) Properties(ctx context.Context, r types.ManagedObjectR
 	log.Debugf("get vm properties %s of vm %s", ps, r)
 	contains := false
 	for i := range ps {
-		if ps[i] == summary {
+		if ps[i] == "summary" || ps[i] == "summary.runtime" {
 			contains = true
 			break
 		}
 	}
 	var newps []string
 	if !contains {
-		newps = append(ps, connectionStatus)
+		newps = append(ps, "summary.runtime.connectionState")
 	} else {
 		newps = append(newps, ps...)
 	}

--- a/pkg/vsphere/vm/vm_test.go
+++ b/pkg/vsphere/vm/vm_test.go
@@ -461,7 +461,6 @@ func TestProperties(t *testing.T) {
 
 	server := model.Service.NewServer()
 	defer server.Close()
-
 	client, err := govmomi.NewClient(ctx, server.URL, true)
 	if err != nil {
 		t.Fatal(err)
@@ -484,10 +483,11 @@ func TestProperties(t *testing.T) {
 		PoolPath:       "/ha-datacenter/host/*/Resources",
 	}
 
-	s, err := session.NewSession(config).Create(ctx)
+	s, err := session.NewSession(config).Connect(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
+	s.Populate(ctx)
 	vmm := NewVirtualMachine(ctx, s, vmo.Reference())
 	// Test the success path
 	var o mo.VirtualMachine
@@ -545,10 +545,11 @@ func TestWaitForResult(t *testing.T) {
 		PoolPath:       "/ha-datacenter/host/*/Resources",
 	}
 
-	s, err := session.NewSession(config).Create(ctx)
+	s, err := session.NewSession(config).Connect(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
+	s.Populate(ctx)
 	vmm := NewVirtualMachine(ctx, s, vmo.Reference())
 	// Test the success path
 	_, err = vmm.WaitForResult(ctx, func(ctx context.Context) (tasks.Task, error) {

--- a/pkg/vsphere/vm/vm_test.go
+++ b/pkg/vsphere/vm/vm_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25/mo"
 	"github.com/vmware/govmomi/vim25/types"
 	"github.com/vmware/vic/lib/guest"
 	"github.com/vmware/vic/pkg/vsphere/session"
@@ -181,7 +182,7 @@ func TestVM(t *testing.T) {
 	}
 	t.Logf("Got UUID: %s", ruuid)
 
-	err = vm.FixInvalidState(ctx)
+	err = vm.fixVM(ctx)
 	if err != nil {
 		t.Errorf("Failed to fix vm: %s", err)
 	}
@@ -190,6 +191,13 @@ func TestVM(t *testing.T) {
 		t.Errorf("Failed to find fixed vm: %s", err)
 	}
 	assert.Equal(t, vm.Reference(), newVM.Reference())
+
+	// VM properties
+	var ovm mo.VirtualMachine
+	if err = vm.Properties(ctx, newVM.Reference(), []string{"config"}, &ovm); err != nil {
+		t.Errorf("Failed to get vm properties: %s", err)
+	}
+
 	// Destroy the vm
 	task, err := vm.Destroy(ctx)
 	if err != nil {

--- a/pkg/vsphere/vm/vm_test.go
+++ b/pkg/vsphere/vm/vm_test.go
@@ -26,6 +26,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/vmware/govmomi"
+	"github.com/vmware/govmomi/find"
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/vim25/mo"
 	"github.com/vmware/govmomi/vim25/types"
@@ -33,7 +35,7 @@ import (
 	"github.com/vmware/vic/pkg/vsphere/session"
 	"github.com/vmware/vic/pkg/vsphere/simulator"
 	"github.com/vmware/vic/pkg/vsphere/sys"
-
+	"github.com/vmware/vic/pkg/vsphere/tasks"
 	"github.com/vmware/vic/pkg/vsphere/test"
 )
 
@@ -443,4 +445,146 @@ func TestBfsSnapshotTree(t *testing.T) {
 	if found != nil {
 		t.Errorf("Should not found snapshot")
 	}
+}
+
+// TestProperties test vm.properties happy path and fix vm path
+func TestProperties(t *testing.T) {
+	ctx := context.Background()
+
+	// Nothing VC specific in this test, so we use the simpler ESX model
+	model := simulator.ESX()
+	defer model.Remove()
+	err := model.Create()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	server := model.Service.NewServer()
+	defer server.Close()
+
+	client, err := govmomi.NewClient(ctx, server.URL, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Any VM will do
+	finder := find.NewFinder(client.Client, false)
+	vmo, err := finder.VirtualMachine(ctx, "/ha-datacenter/vm/*_VM0")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	config := &session.Config{
+		Service:        server.URL.String(),
+		Insecure:       true,
+		Keepalive:      time.Duration(5) * time.Minute,
+		DatacenterPath: "",
+		DatastorePath:  "/ha-datacenter/datastore/*",
+		HostPath:       "/ha-datacenter/host/*/*",
+		PoolPath:       "/ha-datacenter/host/*/Resources",
+	}
+
+	s, err := session.NewSession(config).Create(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	vmm := NewVirtualMachine(ctx, s, vmo.Reference())
+	// Test the success path
+	var o mo.VirtualMachine
+	err = vmm.Properties(ctx, vmo.Reference(), []string{"config", "summary", "resourcePool", "parentVApp"}, &o)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	//	// Inject invalid connection state to vm
+	ref := simulator.Map.Get(vmo.Reference()).(*simulator.VirtualMachine)
+	ref.Summary.Config.VmPathName = ref.Config.Files.VmPathName
+	ref.Summary.Runtime.ConnectionState = types.VirtualMachineConnectionStateInvalid
+
+	err = vmm.Properties(ctx, vmo.Reference(), []string{"config", "summary"}, &o)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.True(t, o.Summary.Runtime.ConnectionState != types.VirtualMachineConnectionStateInvalid, "vm state should be fixed")
+}
+
+// TestWaitForResult covers the success path and invalid vm fix path
+func TestWaitForResult(t *testing.T) {
+	ctx := context.Background()
+
+	// Nothing VC specific in this test, so we use the simpler ESX model
+	model := simulator.ESX()
+	defer model.Remove()
+	err := model.Create()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	server := model.Service.NewServer()
+	defer server.Close()
+
+	client, err := govmomi.NewClient(ctx, server.URL, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Any VM will do
+	finder := find.NewFinder(client.Client, false)
+	vmo, err := finder.VirtualMachine(ctx, "/ha-datacenter/vm/*_VM0")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	config := &session.Config{
+		Service:        server.URL.String(),
+		Insecure:       true,
+		Keepalive:      time.Duration(5) * time.Minute,
+		DatacenterPath: "",
+		DatastorePath:  "/ha-datacenter/datastore/*",
+		HostPath:       "/ha-datacenter/host/*/*",
+		PoolPath:       "/ha-datacenter/host/*/Resources",
+	}
+
+	s, err := session.NewSession(config).Create(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	vmm := NewVirtualMachine(ctx, s, vmo.Reference())
+	// Test the success path
+	_, err = vmm.WaitForResult(ctx, func(ctx context.Context) (tasks.Task, error) {
+		return vmm.PowerOn(ctx)
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = vmm.WaitForResult(ctx, func(ctx context.Context) (tasks.Task, error) {
+		return vmm.PowerOff(ctx)
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ref := simulator.Map.Get(vmm.Reference()).(*simulator.VirtualMachine)
+
+	// Test task failed, but vm is not in invalid state
+	called := 0
+	_, err = vmm.WaitForResult(ctx, func(ctx context.Context) (tasks.Task, error) {
+		called++
+		return vmm.PowerOff(ctx)
+	})
+	if err == nil {
+		t.Fatal("Should have error")
+	}
+	assert.True(t, called == 1, "task should not be retried")
+
+	// Test task failure with invalid state vm
+	ref.Summary.Config.VmPathName = ref.Config.Files.VmPathName
+	ref.Summary.Runtime.ConnectionState = types.VirtualMachineConnectionStateInvalid
+	called = 0
+	_, err = vmm.WaitForResult(ctx, func(ctx context.Context) (tasks.Task, error) {
+		called++
+		return vmm.PowerOff(ctx)
+	})
+	assert.True(t, called == 2, "task should be retried once")
+	assert.True(t, !vmm.IsInvalidState(ctx), "vm state should be fixed")
 }


### PR DESCRIPTION
Fixes #2818 
For another kind of invalid state vm, vsphere might return empty vm.Config property, so govmomi will panic for NPE. This is fixed in #2977 
This PR did following changes to fix this kind of failure:
* Override govmomi vm.Properties method in vm.go, and fix the vm if that's in invalid state, cause this function is not enclosed by waitForResult method.
* Fix waitForResult method, to handle non invalid state error, if vm is already in invalid state. This might include RPC send error.
* Update urfave/cli vendor code, cause it does not hide all error stack in latest version.
