### PR TITLE
Remove use of VC extension [full ci]

### DIFF
--- a/cmd/vic-machine/common/target.go
+++ b/cmd/vic-machine/common/target.go
@@ -66,17 +66,6 @@ func (t *Target) TargetFlags() []cli.Flag {
 	}
 }
 
-// URLWithoutPassword returns the URL stripped of password
-func (t *Target) URLWithoutPassword() *url.URL {
-	if t.URL == nil {
-		return nil
-	}
-
-	withoutCredentials := *t.URL
-	withoutCredentials.User = url.User(t.URL.User.Username())
-	return &withoutCredentials
-}
-
 // HasCredentials check that the credentials have been supplied by any of the permitted mechanisms
 func (t *Target) HasCredentials() error {
 	if t.URL == nil {
@@ -112,7 +101,7 @@ func (t *Target) HasCredentials() error {
 		t.Password = urlPassword
 	}
 
-	// Override username password if set
+	// Used by vic-machine for Session login
 	t.URL.User = url.UserPassword(t.User, *t.Password)
 
 	return nil

--- a/cmd/vic-machine/common/target_test.go
+++ b/cmd/vic-machine/common/target_test.go
@@ -32,14 +32,6 @@ func TestFlags(t *testing.T) {
 	}
 }
 
-func TestURLWithoutPassword(t *testing.T) {
-	target := NewTarget()
-	target.URL, _ = soap.ParseURL("root:pass@127.0.0.1")
-	if target.URLWithoutPassword().String() != "https://root@127.0.0.1/sdk" {
-		t.Errorf("Unexpected return of without password URL string, %s", target.URLWithoutPassword().String())
-	}
-}
-
 func TestProcess(t *testing.T) {
 	passwd := "pass"
 	url1, _ := soap.ParseURL("127.0.0.1")

--- a/cmd/vic-machine/create/create.go
+++ b/cmd/vic-machine/create/create.go
@@ -15,7 +15,6 @@
 package create
 
 import (
-	"bytes"
 	"crypto/tls"
 	"encoding"
 	"fmt"
@@ -989,15 +988,6 @@ func (c *Create) Run(cliContext *cli.Context) (err error) {
 	vConfig.HTTPSProxy = c.HTTPSProxy
 
 	vchConfig.InsecureRegistries = c.Data.InsecureRegistries
-
-	if validator.Session.IsVC() { // create certificates for VCH extension
-		var certbuffer, keybuffer bytes.Buffer
-		if certbuffer, keybuffer, err = certificate.CreateSelfSigned("", []string{"VMware Inc."}, 2048); err != nil {
-			return errors.Errorf("Failed to create certificate for VIC vSphere extension: %s", err)
-		}
-		vchConfig.ExtensionCert = certbuffer.String()
-		vchConfig.ExtensionKey = keybuffer.String()
-	}
 
 	// separate initial validation from dispatch of creation task
 	log.Info("")

--- a/lib/apiservers/portlayer/restapi/configure_port_layer.go
+++ b/lib/apiservers/portlayer/restapi/configure_port_layer.go
@@ -28,6 +28,7 @@ import (
 	"github.com/vmware/vic/lib/apiservers/portlayer/restapi/options"
 	"github.com/vmware/vic/lib/portlayer"
 	"github.com/vmware/vic/pkg/trace"
+	"github.com/vmware/vic/pkg/version"
 	"github.com/vmware/vic/pkg/vsphere/session"
 
 	"golang.org/x/net/context"
@@ -78,6 +79,7 @@ func configureAPI(api *operations.PortLayerAPI) http.Handler {
 		ClusterPath:    options.PortLayerOptions.ClusterPath,
 		PoolPath:       options.PortLayerOptions.PoolPath,
 		DatastorePath:  options.PortLayerOptions.DatastorePath,
+		UserAgent:      version.UserAgent("vic-engine"),
 	}
 
 	sess, err := session.NewSession(sessionconfig).Create(ctx)

--- a/lib/config/virtual_container_host.go
+++ b/lib/config/virtual_container_host.go
@@ -145,16 +145,11 @@ type Certificate struct {
 // Connection holds the vSphere connection configuration
 type Connection struct {
 	// The sdk URL
-	Target url.URL `vic:"0.1" scope:"read-only" key:"target"`
-	// User/Password (For ESXi only)
-	// Required because url.URL does not Marshal the UserInfo field
-	UserPassword string `vic:"0.1" scope:"secret" key:"userpw"`
-	// Certificate for authentication as vSphere Extension
-	ExtensionCert string `vic:"0.1" scope:"read-only" key:"extension_cert"`
-	ExtensionKey  string `vic:"0.1" scope:"read-only" key:"extension_key"`
-	ExtensionName string `vic:"0.1" scope:"read-only" key:"extension_name"`
-	// Whether the session connection is secure
-	Insecure bool `vic:"0.1" scope:"read-only" key:"insecure"`
+	Target string `vic:"0.1" scope:"read-only" key:"target"`
+	// Username for target login
+	Username string `vic:"0.1" scope:"read-only" key:"username"`
+	// Token is an SSO token or password
+	Token string `vic:"0.1" scope:"secret" key:"token"`
 	// TargetThumbprint is the SHA-1 digest of the Target's public certificate
 	TargetThumbprint string `vic:"0.1" scope:"read-only" key:"target_thumbprint"`
 	// The session timeout
@@ -277,12 +272,6 @@ func (t *VirtualContainerHostConfigSpec) AddVolumeLocation(name string, u *url.U
 func (t *VirtualContainerHostConfigSpec) AddComputeResource(pool *types.ManagedObjectReference) {
 	if pool != nil {
 		t.ComputeResources = append(t.ComputeResources, *pool)
-	}
-}
-
-func (t *VirtualContainerHostConfigSpec) SetvSphereTarget(url *url.URL) {
-	if url != nil {
-		t.Target = *url
 	}
 }
 

--- a/lib/install/data/data.go
+++ b/lib/install/data/data.go
@@ -117,8 +117,7 @@ type InstallerData struct {
 	PreUpgradeVersion string
 	RollbackTimeout   time.Duration
 
-	Extension types.Extension
-	UseRP     bool
+	UseRP bool
 
 	HTTPSProxy *url.URL
 	HTTPProxy  *url.URL

--- a/lib/install/management/delete.go
+++ b/lib/install/management/delete.go
@@ -68,16 +68,6 @@ func (d *Dispatcher) DeleteVCH(conf *config.VirtualContainerHostConfigSpec) erro
 		return errors.New(strings.Join(errs, "\n"))
 	}
 
-	if d.isVC {
-		log.Infoln("Removing VCH vSphere extension")
-		if err = d.GenerateExtensionName(conf, vmm); err != nil {
-			log.Warnf("Failed to get extension name during VCH deletion: %s", err)
-		}
-		if err = d.UnregisterExtension(conf.ExtensionName); err != nil {
-			log.Warnf("Failed to remove extension %q: %s", conf.ExtensionName, err)
-		}
-	}
-
 	err = d.deleteVM(vmm, true)
 	if err != nil {
 		log.Debugf("Error deleting appliance VM %s", err)
@@ -203,14 +193,4 @@ func (d *Dispatcher) networkDevices(vmm *vm.VirtualMachine) ([]types.BaseVirtual
 		}
 	}
 	return devices, nil
-}
-
-func (d *Dispatcher) UnregisterExtension(name string) error {
-	defer trace.End(trace.Begin(name))
-
-	extensionManager := object.NewExtensionManager(d.session.Vim25())
-	if err := extensionManager.Unregister(d.ctx, name); err != nil {
-		return errors.Errorf("Failed to remove extension w/ name %q due to error: %s", name, err)
-	}
-	return nil
 }

--- a/lib/install/validate/update.go
+++ b/lib/install/validate/update.go
@@ -57,14 +57,17 @@ func (v *Validator) assertDatastore(conf *config.VirtualContainerHostConfigSpec)
 
 func (v *Validator) assertTarget(conf *config.VirtualContainerHostConfigSpec) {
 	defer trace.End(trace.Begin(""))
-	if conf.Target.User != nil {
-		if _, set := conf.Target.User.Password(); set {
-			v.NoteIssue(errors.New("Password should not be set in target URL"))
-		}
+
+	if conf.Target == "" {
+		v.NoteIssue(errors.New("target is not set"))
 	}
 
-	if !v.IsVC() && conf.UserPassword == "" {
-		v.NoteIssue(errors.New("ESX credential is not set"))
+	if conf.Username == "" {
+		v.NoteIssue(errors.New("target username is not set"))
+	}
+
+	if conf.Token == "" {
+		v.NoteIssue(errors.New("target token is not set"))
 	}
 }
 

--- a/lib/install/validate/validator_test.go
+++ b/lib/install/validate/validator_test.go
@@ -240,15 +240,11 @@ func testCompute(v *Validator, input *data.Data, t *testing.T) *config.VirtualCo
 
 func testTargets(v *Validator, input *data.Data, conf *config.VirtualContainerHostConfigSpec, t *testing.T) {
 	v.target(v.Context, input, conf)
-	pass, set := conf.Target.User.Password()
-	t.Logf("target: %+v", conf.Target)
-	if v.isVC {
-		assert.Equal(t, pass, "")
-		assert.False(t, set, "Should not contain password")
-	} else {
-		assert.Equal(t, pass, "pass")
-		assert.True(t, set, "Should contain password in ESXi")
-	}
+	u, err := url.Parse(conf.Target)
+	assert.NoError(t, err)
+	assert.Nil(t, u.User)
+	assert.NotEmpty(t, conf.Token)
+	assert.NotEmpty(t, conf.Username)
 }
 
 func testStorage(v *Validator, input *data.Data, conf *config.VirtualContainerHostConfigSpec, t *testing.T) {

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"runtime"
 	"strconv"
+	"strings"
 )
 
 // These fields are set by the compiler using the linker flags upon build via Makefile.
@@ -52,6 +53,15 @@ func Show() bool {
 // String returns a string representation of the version
 func String() string {
 	return GetBuild().String()
+}
+
+// UserAgent returns component/version in HTTP User-Agent header value format
+func UserAgent(component string) string {
+	v := Version
+	if strings.HasPrefix(v, "v") {
+		v = v[1:]
+	}
+	return fmt.Sprintf("%s/%s", component, v)
 }
 
 func GetBuild() *Build {

--- a/pkg/version/version_test.go
+++ b/pkg/version/version_test.go
@@ -146,3 +146,15 @@ func TestIsNewer(t *testing.T) {
 		}
 	}
 }
+
+func TestUserAgent(t *testing.T) {
+	for _, v := range []string{"0.0.1", "v0.0.1"} {
+		Version = v
+
+		a := UserAgent("foo")
+		if a != "foo/0.0.1" {
+			t.Error(a)
+		}
+	}
+
+}

--- a/tests/resources/Util.robot
+++ b/tests/resources/Util.robot
@@ -402,7 +402,8 @@ Run Regression Tests
     # get docker_cert_path or empty string if it's unset
     ${docker_cert_path}=  Get Environment Variable  DOCKER_CERT_PATH  ${EMPTY}
     # Ensure container logs are correctly being gathered for debugging purposes
-    Run  curl -sk ${vic-admin}/authentication -XPOST -F username=%{GOVC_USERNAME} -F password=%{GOVC_PASSWORD} -D /tmp/cookies-${vch-name}
+    ${rc}  ${output}=  Run And Return Rc and Output  curl -sk ${vic-admin}/authentication -XPOST -F username=%{TEST_USERNAME} -F password=%{TEST_PASSWORD} -D /tmp/cookies-${vch-name}
+    Should Be Equal As Integers  ${rc}  0
     ${rc}  ${output}=  Run And Return Rc and Output  curl -sk ${vic-admin}/container-logs.tar.gz -b /tmp/cookies-${vch-name} | tar tvzf -
     Should Be Equal As Integers  ${rc}  0
     Log  ${output}


### PR DESCRIPTION
Follow-on to #2931 and towards #635 , #1689

The LoginExtensionByCertificate API is deprecated and has showstoppers for VIC:

- Not possible to use RBAC with an extension

- Proxy connection to sdk-tunnel vhost does not play well with Go's
  built-in certificate verification, nor is it possible to use the
  thumbprint verfication as we do with direct TLS connections.

VCH config changes:

- Connection.Target is a string, avoids encoding all url.URL fields

- Connection.Target is pruned by vic-machine to only include URL.{Scheme,Host,Path}

- Add Connection.Username and Connection.Token fields, where Token is secret

- Separate set of vSphere "operation" credentials can be provided to vic-machine for use
  by the VCH
