### PR TITLE
Fix multiple image tag support, add a test

### DIFF
--- a/lib/imagec/download.go
+++ b/lib/imagec/download.go
@@ -195,6 +195,10 @@ func (ldm *LayerDownloader) DownloadLayers(ctx context.Context, ic *ImageC) erro
 		if err != nil {
 			return err
 		}
+	} else {
+		if err := updateRepositoryCache(ic); err != nil {
+			return err
+		}
 	}
 
 	progress.Message(progressOutput, "", "Digest: "+ic.ImageManifest.Digest)

--- a/tests/test-cases/Group1-Docker-Commands/1-02-Docker-Pull.md
+++ b/tests/test-cases/Group1-Docker-Commands/1-02-Docker-Pull.md
@@ -29,6 +29,7 @@ This test requires that an vSphere server is running and available.
 11. Issue a docker pull command multiple times for the same image
 12. Issue a docker pull command for each of two images that share layers
 13. Issue docker images, rmi ubuntu, pull ubuntu, docker images commands
+14. Issue docker pull command for the same image using multiple tags
 
 #Expected Outcome:
 VIC appliance should respond with a properly formatted pull response to each command issued to it. No errors should be seen, except in the case of step 7, 8 and 9. In step 13, the image ID and size for ubuntu should match before and after removing and re-pulling the image.

--- a/tests/test-cases/Group1-Docker-Commands/1-02-Docker-Pull.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-02-Docker-Pull.robot
@@ -100,3 +100,19 @@ Re-pull a previously rmi'd image
     ${newsize}=  Get From List  ${words}  -2
     Should Be Equal  ${id}  ${newid}
     Should Be Equal  ${size}  ${newsize}
+
+Pull image by multiple tags
+    Wait Until Keyword Succeeds  5x  15 seconds  Pull image  busybox:1.25.1
+    Wait Until Keyword Succeeds  5x  15 seconds  Pull image  busybox:1.25
+    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} images |grep -E busybox.*1.25
+    Should Be Equal As Integers  ${rc}  0
+    ${lines}=  Split To Lines  ${output}
+    # one for 1.25.1 and one for 1.25
+    Length Should Be  ${lines}  2
+    ${line1}=  Get From List  ${lines}  0
+    ${line2}=  Get From List  ${lines}  -1
+    ${words1}=  Split String  ${line1}
+    ${words2}=  Split String  ${line2}
+    ${id1}=  Get From List  ${words1}  2
+    ${id2}=  Get From List  ${words2}  2
+    Should Be Equal  ${id1}  ${id2}


### PR DESCRIPTION
```
$ docker -H 192.168.218.235:2376 --tls pull busybox
Using default tag: latest
Pulling from library/busybox
56bec22e3559: Pull complete
a3ed95caeb02: Pull complete
Digest: sha256:98a0bd48d22ff96ca23bfda2fe1cf72034ea803bd79e64a5a5f274aca0f9c51c
Status: Downloaded newer image for library/busybox:latest
$ docker -H 192.168.218.235:2376 --tls pull busybox:1.25.1
Pulling from library/busybox
56bec22e3559: Already exists
a3ed95caeb02: Already exists
Digest: sha256:e27e5917b0d7525c5d75b4446e9fe16fe56d6bb88920d77373341fb4c43b4e75
Status: Image is up to date for library/busybox:1.25.1
$ docker -H 192.168.218.235:2376 --tls pull busybox:1.25
Pulling from library/busybox
56bec22e3559: Already exists
a3ed95caeb02: Already exists
Digest: sha256:972a80ad7bbb3dda30adef26486ff5c4b929f298843d2c2f2404fc90b365c65a
Status: Image is up to date for library/busybox:1.25
$ docker -H 192.168.218.235:2376 --tls pull busybox:1
Pulling from library/busybox
56bec22e3559: Already exists
a3ed95caeb02: Already exists
Digest: sha256:f4af4eef35911ced31ce3a97ab5b6e0406107518ea3f77f55943732ecfebdb3f
Status: Image is up to date for library/busybox:1
$ docker -H 192.168.218.235:2376 --tls images
REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
busybox             latest              e292aa76ad3b        4 weeks ago         1.093 MB
busybox             1.25.1              e292aa76ad3b        4 weeks ago         1.093 MB
busybox             1.25                e292aa76ad3b        4 weeks ago         1.093 MB
busybox             1                   e292aa76ad3b        4 weeks ago         1.093 MB
```

I also added a test around this.

Fixes #3025 
