### PR TITLE
Show ports in ps output when a host port is not specified

### DIFF
--- a/lib/apiservers/engine/backends/container.go
+++ b/lib/apiservers/engine/backends/container.go
@@ -623,21 +623,23 @@ func unrollPortMap(portMap nat.PortMap) ([]*portMapping, error) {
 		}
 
 		// iterate over all the ports in pb []nat.PortBinding
-		for _, p := range pb {
+		for i := range pb {
 			var hostPort int
 			var hPort string
-			if p.HostPort == "" {
+			if pb[i].HostPort == "" {
 				// use a random port since no host port is specified
 				hostPort, err = requestHostPort(proto)
 				if err != nil {
 					log.Errorf("could not find available port on host")
 					return nil, err
 				}
+				log.Infof("using port %d on the host for port mapping", hostPort)
+
 				// update the hostconfig
-				p.HostPort = strconv.Itoa(hostPort)
+				pb[i].HostPort = strconv.Itoa(hostPort)
 
 			} else {
-				hostPort, err = strconv.Atoi(p.HostPort)
+				hostPort, err = strconv.Atoi(pb[i].HostPort)
 				if err != nil {
 					return nil, err
 				}

--- a/tests/test-cases/Group1-Docker-Commands/1-10-Docker-PS.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-10-Docker-PS.robot
@@ -109,6 +109,12 @@ Docker ps ports output
     Should Contain  ${output}  :8000->80/tcp
     Should Contain  ${output}  :8443->443/tcp
 
+    ${rc}  ${container}=  Run And Return Rc And Output  docker ${params} run -d -p 6379 redis:alpine
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} ps
+    Should Be Equal As Integers  ${rc}  0
+    Should Contain  ${output}  ->6379/tcp
+
 Docker ps Remove container OOB
     ${rc}  ${container}=  Run And Return Rc And Output  docker ${params} create --name lolo busybox /bin/top
     Should Be Equal As Integers  ${rc}  0


### PR DESCRIPTION
* Fixes `docker ps` port mapping output when the host port is not specified for a container. 
* Adds integration test in `1-10-Docker-PS`

Fixes #3004
