### PR TITLE
Replace hardcoded separator with ·

### DIFF
--- a/lib/install/management/appliance.go
+++ b/lib/install/management/appliance.go
@@ -861,17 +861,17 @@ func (d *Dispatcher) ensureApplianceInitializes(conf *config.VirtualContainerHos
 	}
 
 	log.Infof("Waiting for IP information")
-	d.waitForKey("guestinfo.vice..init.networks|client.assigned.IP")
+	d.waitForKey(fmt.Sprintf("guestinfo.vice..init.networks%sclient.assigned.IP", extraconfig.Separator))
 	ctxerr := d.ctx.Err()
 
 	if ctxerr == nil {
 		log.Info("Waiting for major appliance components to launch")
 		log.Debug("waiting for vicadmin to start")
-		d.waitForKey("guestinfo.vice..init.sessions|vicadmin.started")
+		d.waitForKey(fmt.Sprintf("guestinfo.vice..init.sessions%svicadmin.started", extraconfig.Separator))
 		log.Debug("waiting for docker personality to start")
-		d.waitForKey("guestinfo.vice..init.sessions|docker-personality.started")
+		d.waitForKey(fmt.Sprintf("guestinfo.vice..init.sessions%sdocker-personality.started", extraconfig.Separator))
 		log.Debug("waiting for port layer to start")
-		d.waitForKey("guestinfo.vice..init.sessions|port-layer.started")
+		d.waitForKey(fmt.Sprintf("guestinfo.vice..init.sessions%sport-layer.started", extraconfig.Separator))
 	}
 
 	// at this point either everything has succeeded or we're going into diagnostics, ignore error

--- a/lib/portlayer/exec/base.go
+++ b/lib/portlayer/exec/base.go
@@ -163,7 +163,7 @@ func (c *containerBase) start(ctx context.Context) error {
 	}
 
 	// guestinfo key that we want to wait for
-	key := fmt.Sprintf("guestinfo.vice..sessions|%s.started", c.ExecConfig.ID)
+	key := fmt.Sprintf("guestinfo.vice..sessions%s%s.started", extraconfig.Separator, c.ExecConfig.ID)
 	var detail string
 
 	// Wait some before giving up...

--- a/lib/tether/tether.go
+++ b/lib/tether/tether.go
@@ -326,7 +326,7 @@ func (t *tether) processSessions() error {
 
 				// FIXME: we cannot have this embedded knowledge of the extraconfig encoding pattern, but not
 				// currently sure how to expose it neatly via a utility function
-				extraconfig.EncodeWithPrefix(t.sink, session, fmt.Sprintf("guestinfo.vice..sessions|%s", id))
+				extraconfig.EncodeWithPrefix(t.sink, session, fmt.Sprintf("guestinfo.vice..sessions%s%s", extraconfig.Separator, id))
 				log.Warnf("Re-launching process for session %s (count: %d)", id, session.Diagnostics.ResurrectionCount)
 				session.Cmd = *restartableCmd(&session.Cmd)
 			}
@@ -478,7 +478,7 @@ func (t *tether) handleSessionExit(session *SessionConfig) {
 
 	// FIXME: we cannot have this embedded knowledge of the extraconfig encoding pattern, but not
 	// currently sure how to expose it neatly via a utility function
-	extraconfig.EncodeWithPrefix(t.sink, session, fmt.Sprintf("guestinfo.vice..sessions|%s", session.ID))
+	extraconfig.EncodeWithPrefix(t.sink, session, fmt.Sprintf("guestinfo.vice..sessions%s%s", extraconfig.Separator, session.ID))
 
 	if f != nil {
 		f()
@@ -492,7 +492,7 @@ func (t *tether) launch(session *SessionConfig) error {
 
 	// encode the result whether success or error
 	defer func() {
-		extraconfig.EncodeWithPrefix(t.sink, session, fmt.Sprintf("guestinfo.vice..sessions|%s", session.ID))
+		extraconfig.EncodeWithPrefix(t.sink, session, fmt.Sprintf("guestinfo.vice..sessions%s%s", extraconfig.Separator, session.ID))
 	}()
 
 	session.Lock()

--- a/pkg/vsphere/extraconfig/basic_test.go
+++ b/pkg/vsphere/extraconfig/basic_test.go
@@ -148,9 +148,9 @@ func TestBasicMap(t *testing.T) {
 	Encode(MapSink(encoded), IntMap)
 
 	expected := map[string]string{
-		visibleRO("intmap|1st"): "12345",
-		visibleRO("intmap|2nd"): "67890",
-		visibleRO("intmap"):     "1st|2nd",
+		visibleRO("intmap·1st"): "12345",
+		visibleRO("intmap·2nd"): "67890",
+		visibleRO("intmap"):     "1st·2nd",
 	}
 	assert.Equal(t, expected, encoded, "Encoded and expected does not match")
 
@@ -196,7 +196,7 @@ func TestBasicSlice(t *testing.T) {
 	Encode(MapSink(encoded), IntSlice)
 
 	expected := map[string]string{
-		visibleRO("intslice~"): "1|2|3|4|5",
+		visibleRO("intslice~"): "1·2·3·4·5",
 		visibleRO("intslice"):  "4",
 	}
 	assert.Equal(t, expected, encoded, "Encoded and expected does not match")

--- a/pkg/vsphere/extraconfig/clean_test.go
+++ b/pkg/vsphere/extraconfig/clean_test.go
@@ -137,16 +137,16 @@ func TestStructMap(t *testing.T) {
 	Encode(MapSink(encoded), StructMap)
 
 	expected := map[string]string{
-		visibleRO("map|Key1/id"):    "0xDEADBEEF",
-		visibleRO("map|Key1/name"):  "beef",
-		visibleRO("map|Key1/notes"): "",
-		visibleRO("map|Key2/id"):    "0x8BADF00D",
-		visibleRO("map|Key2/name"):  "food",
-		visibleRO("map|Key2/notes"): "",
-		visibleRO("map|Key3/id"):    "0xDEADF00D",
-		visibleRO("map|Key3/name"):  "dead",
-		visibleRO("map|Key3/notes"): "",
-		visibleRO("map"):            "Key1|Key2|Key3",
+		visibleRO("map·Key1/id"):    "0xDEADBEEF",
+		visibleRO("map·Key1/name"):  "beef",
+		visibleRO("map·Key1/notes"): "",
+		visibleRO("map·Key2/id"):    "0x8BADF00D",
+		visibleRO("map·Key2/name"):  "food",
+		visibleRO("map·Key2/notes"): "",
+		visibleRO("map·Key3/id"):    "0xDEADF00D",
+		visibleRO("map·Key3/name"):  "dead",
+		visibleRO("map·Key3/notes"): "",
+		visibleRO("map"):            "Key1·Key2·Key3",
 	}
 	assert.Equal(t, expected, encoded, "Encoded and expected does not match")
 
@@ -182,16 +182,16 @@ func TestIntStructMap(t *testing.T) {
 	Encode(MapSink(encoded), StructMap)
 
 	expected := map[string]string{
-		visibleRO("map|1/id"):    "0xDEADBEEF",
-		visibleRO("map|1/name"):  "beef",
-		visibleRO("map|1/notes"): "",
-		visibleRO("map|2/id"):    "0x8BADF00D",
-		visibleRO("map|2/name"):  "food",
-		visibleRO("map|2/notes"): "",
-		visibleRO("map|3/id"):    "0xDEADF00D",
-		visibleRO("map|3/name"):  "dead",
-		visibleRO("map|3/notes"): "",
-		visibleRO("map"):         "1|2|3",
+		visibleRO("map·1/id"):    "0xDEADBEEF",
+		visibleRO("map·1/name"):  "beef",
+		visibleRO("map·1/notes"): "",
+		visibleRO("map·2/id"):    "0x8BADF00D",
+		visibleRO("map·2/name"):  "food",
+		visibleRO("map·2/notes"): "",
+		visibleRO("map·3/id"):    "0xDEADF00D",
+		visibleRO("map·3/name"):  "dead",
+		visibleRO("map·3/notes"): "",
+		visibleRO("map"):         "1·2·3",
 	}
 	assert.Equal(t, expected, encoded, "Encoded and expected does not match")
 
@@ -224,12 +224,12 @@ func TestStructSlice(t *testing.T) {
 
 	expected := map[string]string{
 		visibleRO("slice"):         "1",
-		visibleRO("slice|0/id"):    "0xDEADFEED",
-		visibleRO("slice|0/name"):  "feed",
-		visibleRO("slice|0/notes"): "",
-		visibleRO("slice|1/id"):    "0xFACEFEED",
-		visibleRO("slice|1/name"):  "face",
-		visibleRO("slice|1/notes"): "",
+		visibleRO("slice·0/id"):    "0xDEADFEED",
+		visibleRO("slice·0/name"):  "feed",
+		visibleRO("slice·0/notes"): "",
+		visibleRO("slice·1/id"):    "0xFACEFEED",
+		visibleRO("slice·1/name"):  "face",
+		visibleRO("slice·1/notes"): "",
 	}
 	assert.Equal(t, expected, encoded, "Encoded and expected does not match")
 
@@ -334,16 +334,16 @@ func TestComplex(t *testing.T) {
 		visibleRO("executorconfig/common/id"):                      "",
 		visibleRO("executorconfig/common/name"):                    "",
 		visibleRO("executorconfig/common/notes"):                   "",
-		visibleRO("executorconfig/sessions|Session1/common/id"):    "SessionID",
-		visibleRO("executorconfig/sessions|Session1/common/name"):  "SessionName",
-		visibleRO("executorconfig/sessions|Session1/common/notes"): "",
-		hidden("executorconfig/sessions|Session1/cmd/path"):        "/vmware",
-		hidden("executorconfig/sessions|Session1/cmd/args~"):       "/bin/imagec|-standalone",
-		hidden("executorconfig/sessions|Session1/cmd/args"):        "1",
-		hidden("executorconfig/sessions|Session1/cmd/env~"):        "PATH=/bin|USER=imagec",
-		hidden("executorconfig/sessions|Session1/cmd/env"):         "1",
-		hidden("executorconfig/sessions|Session1/cmd/dir"):         "/",
-		hidden("executorconfig/sessions|Session1/tty"):             "true",
+		visibleRO("executorconfig/sessions·Session1/common/id"):    "SessionID",
+		visibleRO("executorconfig/sessions·Session1/common/name"):  "SessionName",
+		visibleRO("executorconfig/sessions·Session1/common/notes"): "",
+		hidden("executorconfig/sessions·Session1/cmd/path"):        "/vmware",
+		hidden("executorconfig/sessions·Session1/cmd/args~"):       "/bin/imagec·-standalone",
+		hidden("executorconfig/sessions·Session1/cmd/args"):        "1",
+		hidden("executorconfig/sessions·Session1/cmd/env~"):        "PATH=/bin·USER=imagec",
+		hidden("executorconfig/sessions·Session1/cmd/env"):         "1",
+		hidden("executorconfig/sessions·Session1/cmd/dir"):         "/",
+		hidden("executorconfig/sessions·Session1/tty"):             "true",
 		hidden("executorconfig/sessions"):                          "Session1",
 		hidden("executorconfig/Key"):                               "",
 	}
@@ -387,16 +387,16 @@ func TestComplexPointer(t *testing.T) {
 		visibleRO("executorconfig/common/id"):                      "",
 		visibleRO("executorconfig/common/name"):                    "",
 		visibleRO("executorconfig/common/notes"):                   "",
-		visibleRO("executorconfig/sessions|Session1/common/id"):    "SessionID",
-		visibleRO("executorconfig/sessions|Session1/common/name"):  "SessionName",
-		visibleRO("executorconfig/sessions|Session1/common/notes"): "",
-		hidden("executorconfig/sessions|Session1/cmd/path"):        "/vmware",
-		hidden("executorconfig/sessions|Session1/cmd/args~"):       "/bin/imagec|-standalone",
-		hidden("executorconfig/sessions|Session1/cmd/args"):        "1",
-		hidden("executorconfig/sessions|Session1/cmd/env~"):        "PATH=/bin|USER=imagec",
-		hidden("executorconfig/sessions|Session1/cmd/env"):         "1",
-		hidden("executorconfig/sessions|Session1/cmd/dir"):         "/",
-		hidden("executorconfig/sessions|Session1/tty"):             "true",
+		visibleRO("executorconfig/sessions·Session1/common/id"):    "SessionID",
+		visibleRO("executorconfig/sessions·Session1/common/name"):  "SessionName",
+		visibleRO("executorconfig/sessions·Session1/common/notes"): "",
+		hidden("executorconfig/sessions·Session1/cmd/path"):        "/vmware",
+		hidden("executorconfig/sessions·Session1/cmd/args~"):       "/bin/imagec·-standalone",
+		hidden("executorconfig/sessions·Session1/cmd/args"):        "1",
+		hidden("executorconfig/sessions·Session1/cmd/env~"):        "PATH=/bin·USER=imagec",
+		hidden("executorconfig/sessions·Session1/cmd/env"):         "1",
+		hidden("executorconfig/sessions·Session1/cmd/dir"):         "/",
+		hidden("executorconfig/sessions·Session1/tty"):             "true",
 		hidden("executorconfig/sessions"):                          "Session1",
 		hidden("executorconfig/Key"):                               "",
 	}
@@ -436,16 +436,16 @@ func TestPointerDecode(t *testing.T) {
 		visibleRO("common/id"):                      "",
 		visibleRO("common/name"):                    "",
 		visibleRO("common/notes"):                   "",
-		visibleRO("sessions|Session1/common/id"):    "SessionID",
-		visibleRO("sessions|Session1/common/name"):  "SessionName",
-		visibleRO("sessions|Session1/common/notes"): "",
-		hidden("sessions|Session1/cmd/path"):        "/vmware",
-		hidden("sessions|Session1/cmd/args~"):       "/bin/imagec|-standalone",
-		hidden("sessions|Session1/cmd/args"):        "1",
-		hidden("sessions|Session1/cmd/env~"):        "PATH=/bin|USER=imagec",
-		hidden("sessions|Session1/cmd/env"):         "1",
-		hidden("sessions|Session1/cmd/dir"):         "/",
-		hidden("sessions|Session1/tty"):             "true",
+		visibleRO("sessions·Session1/common/id"):    "SessionID",
+		visibleRO("sessions·Session1/common/name"):  "SessionName",
+		visibleRO("sessions·Session1/common/notes"): "",
+		hidden("sessions·Session1/cmd/path"):        "/vmware",
+		hidden("sessions·Session1/cmd/args~"):       "/bin/imagec·-standalone",
+		hidden("sessions·Session1/cmd/args"):        "1",
+		hidden("sessions·Session1/cmd/env~"):        "PATH=/bin·USER=imagec",
+		hidden("sessions·Session1/cmd/env"):         "1",
+		hidden("sessions·Session1/cmd/dir"):         "/",
+		hidden("sessions·Session1/tty"):             "true",
 		hidden("sessions"):                          "Session1",
 		hidden("Key"):                               "",
 	}
@@ -527,7 +527,7 @@ func TestIPSlice(t *testing.T) {
 		visibleRO("slice"): fmt.Sprintf("%d", len(ips)-1),
 	}
 	for i := range encodedIPs {
-		expected[visibleRO(fmt.Sprintf("slice|%d", i))] = encodedIPs[i]
+		expected[visibleRO(fmt.Sprintf("slice·%d", i))] = encodedIPs[i]
 	}
 
 	assert.Equal(t, expected, encoded, "Encoded and expected do not match")

--- a/pkg/vsphere/extraconfig/common.go
+++ b/pkg/vsphere/extraconfig/common.go
@@ -1,0 +1,19 @@
+// Copyright 2016 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package extraconfig
+
+const (
+	Separator = "·"
+)

--- a/pkg/vsphere/extraconfig/decode.go
+++ b/pkg/vsphere/extraconfig/decode.go
@@ -278,8 +278,8 @@ func decodeSlice(src DataSource, dest reflect.Value, prefix string, depth recurs
 	// determine the key given the array type
 	if kind == reflect.Struct || isEncodableSliceElemType(dest.Type().Elem()) {
 		for i := 0; i < length; i++ {
-			// convert key to name|index format
-			key := fmt.Sprintf("%s|%d", prefix, i)
+			// convert key to name·index format
+			key := fmt.Sprintf("%s%s%d", prefix, Separator, i)
 
 			// if there's already a struct in the array at this index then we pass that as the current
 			// value
@@ -302,7 +302,7 @@ func decodeSlice(src DataSource, dest reflect.Value, prefix string, depth recurs
 		return this, nil
 	}
 
-	// convert key to name|index format
+	// convert key to name·index format
 	key := fmt.Sprintf("%s~", prefix)
 	kval, err := src(key)
 	if err != nil {
@@ -311,7 +311,7 @@ func decodeSlice(src DataSource, dest reflect.Value, prefix string, depth recurs
 	}
 
 	// lookup the key and split it
-	values := strings.Split(kval, "|")
+	values := strings.Split(kval, Separator)
 	for i := 0; i < length; i++ {
 		v := values[i]
 		t := this.Type().Elem()
@@ -346,14 +346,14 @@ func decodeMap(src DataSource, dest reflect.Value, prefix string, depth recursio
 	valtype := this.Type().Elem()
 
 	// split the list of map keys and iterate
-	for _, value := range strings.Split(mapkeys, "|") {
+	for _, value := range strings.Split(mapkeys, Separator) {
 		k := fromString(reflect.Zero(keytype), value)
 		target := this.MapIndex(k)
 		if !target.IsValid() {
 			target = reflect.Zero(valtype)
 		}
 
-		key := fmt.Sprintf("%s|%s", prefix, value)
+		key := fmt.Sprintf("%s%s%s", prefix, Separator, value)
 
 		// check to see if the resulting object is not nil
 		// If it is nil, then there was nothing to decode and the pointer remains nil

--- a/pkg/vsphere/extraconfig/encode.go
+++ b/pkg/vsphere/extraconfig/encode.go
@@ -169,8 +169,8 @@ func encodeSlice(sink DataSink, src reflect.Value, prefix string, depth recursio
 
 	} else if kind == reflect.Struct || isEncodableSliceElemType(src.Type().Elem()) {
 		for i := 0; i < length; i++ {
-			// convert key to name|index format
-			key := fmt.Sprintf("%s|%d", prefix, i)
+			// convert key to name·index format
+			key := fmt.Sprintf("%s%s%d", prefix, Separator, i)
 			encode(sink, src.Index(i), key, depth)
 		}
 	} else {
@@ -186,9 +186,9 @@ func encodeSlice(sink DataSink, src reflect.Value, prefix string, depth recursio
 			values[i] = toString(src.Index(i))
 		}
 
-		// convert key to name|index format
+		// convert key to name·index format
 		key := fmt.Sprintf("%s~", prefix)
-		err := sink(key, strings.Join(values, "|"))
+		err := sink(key, strings.Join(values, Separator))
 		if err != nil {
 			log.Errorf("Failed to encode slice data for key %s: %s", key, err)
 		}
@@ -216,13 +216,13 @@ func encodeMap(sink DataSink, src reflect.Value, prefix string, depth recursion)
 	keys := make([]string, length)
 	for i, v := range mkeys {
 		keys[i] = toString(v)
-		key := fmt.Sprintf("%s|%s", prefix, keys[i])
+		key := fmt.Sprintf("%s%s%s", prefix, Separator, keys[i])
 		encode(sink, src.MapIndex(v), key, depth)
 	}
 
 	// sort the keys before joining - purely to make testing viable
 	sort.Strings(keys)
-	err := sink(prefix, strings.Join(keys, "|"))
+	err := sink(prefix, strings.Join(keys, Separator))
 	if err != nil {
 		log.Errorf("Failed to encode map keys for key %s: %s", prefix, err)
 	}

--- a/ui/vic-ui/swf/src/main/flex/com/vmware/vicui/constants/AppConstants.as
+++ b/ui/vic-ui/swf/src/main/flex/com/vmware/vicui/constants/AppConstants.as
@@ -4,9 +4,9 @@ package com.vmware.vicui.constants {
 
 		public static const VM_CONTAINER_NAME_PATH:String = "guestinfo.vice./common/name";
 		public static const VM_CONTAINER_IMAGE_PATH:String = "guestinfo.vice./repo";
-		public static const VM_CONTAINER_PORTMAPPING:String = "guestinfo.vice./networks|bridge/ports~";
+		public static const VM_CONTAINER_PORTMAPPING:String = "guestinfo.vice./networks·bridge/ports~";
 		public static const VCH_NAME_PATH:String = "guestinfo.vice./init/common/name";
-		public static const VCH_CLIENT_IP_PATH:String = "guestinfo.vice..init.networks|client.assigned.IP";
+		public static const VCH_CLIENT_IP_PATH:String = "guestinfo.vice..init.networks·client.assigned.IP";
 		public static const VCH_ENDPOINT_PORT:String = ":2376";
 		public static const VCH_LOG_PORT:String = ":2378";
 


### PR DESCRIPTION
Unicode middle dot is safe to use with guestinfo and solves the
ambiguity between ```1|2|3``` and ```dmesg | grep vmxnet```