### PR TITLE
Use vmw_scsi target directly for disk attach [full ci]

### DIFF
--- a/cmd/vicadmin/logs.go
+++ b/cmd/vicadmin/logs.go
@@ -157,6 +157,7 @@ func configureReaders() map[string]entryReader {
 		"disk-by-path":  commandReader("ls -l /dev/disk/by-path"),
 		"disk-by-label": commandReader("ls -l /dev/disk/by-label"),
 		"disk-by-uuid":  commandReader("ls -l /dev/disk/by-uuid"),
+		"lsblk":         commandReader("lsblk -S"),
 		// To check we are not leaking any fds
 		"proc-self-fd": commandReader("ls -l /proc/self/fd"),
 		"ps":           commandReader("ps -ef"),

--- a/lib/portlayer/storage/vsphere/image.go
+++ b/lib/portlayer/storage/vsphere/image.go
@@ -309,7 +309,7 @@ func (v *ImageStore) writeImage(op trace.Operation, storeName, parentID, ID stri
 				}
 			}
 
-			v.ds.Rm(op, imageDir)
+			v.deleteImage(op, storeName, ID)
 		}
 	}()
 
@@ -397,6 +397,8 @@ func (v *ImageStore) scratch(op trace.Operation, storeName string) error {
 	// Create the disk
 	vmdisk, err := v.dm.CreateAndAttach(op, imageDiskDsURI, "", size, os.O_RDWR)
 	if err != nil {
+		op.Errorf("CreateAndAttach(%s) error: %s", imageDiskDsURI, err)
+		v.deleteImage(op, storeName, portlayer.Scratch.ID)
 		return err
 	}
 	defer func() {

--- a/lib/portlayer/storage/vsphere/image_test.go
+++ b/lib/portlayer/storage/vsphere/image_test.go
@@ -60,6 +60,8 @@ func setup(t *testing.T) (*portlayer.NameLookupCache, *session.Session, string, 
 	if err != nil {
 		if err.Error() == "can't find the hosting vm" {
 			t.Skip("Skipping: test must be run in a VM")
+		} else {
+			t.Log(err.Error())
 		}
 		return nil, nil, "", err
 	}

--- a/pkg/vsphere/datastore/datastore_util.go
+++ b/pkg/vsphere/datastore/datastore_util.go
@@ -40,8 +40,17 @@ func Session(ctx context.Context, t *testing.T) *session.Session {
 		Keepalive: time.Duration(5) * time.Minute,
 	}
 
-	s, err := session.NewSession(config).Create(ctx)
+	s := session.NewSession(config)
+	_, err := s.Connect(ctx)
 	if err != nil {
+		s.Client.Logout(ctx)
+		t.Log(err.Error())
+		t.SkipNow()
+	}
+
+	_, err = s.Populate(ctx)
+	if err != nil {
+		t.Log(err.Error())
 		t.SkipNow()
 	}
 

--- a/pkg/vsphere/disk/util.go
+++ b/pkg/vsphere/disk/util.go
@@ -133,8 +133,6 @@ func verifyParavirtualScsiController(op trace.Operation, vm *vm.VirtualMachine) 
 		return nil, "", errors.Trace(err)
 	}
 
-	op.Infof("controller = %#v", controller)
-
 	// build the base path
 	// first we determine which label we're looking for (requires VMW hardware version >=10)
 	controllerLabel := fmt.Sprintf("SCSI%d", controller.BusNumber)

--- a/pkg/vsphere/disk/util.go
+++ b/pkg/vsphere/disk/util.go
@@ -16,11 +16,12 @@ package disk
 
 import (
 	"fmt"
+	"io/ioutil"
 	"os"
+	"path"
+	"path/filepath"
 	"strings"
 	"time"
-
-	log "github.com/Sirupsen/logrus"
 
 	"github.com/vmware/govmomi/vim25/types"
 	"github.com/vmware/vic/pkg/errors"
@@ -36,103 +37,147 @@ const (
 	pathTimeout = 60 * time.Second
 )
 
-func waitForPath(op trace.Operation, path string) error {
-	defer trace.End(trace.Begin(path))
-	timeout := time.Duration(pathTimeout)
+// Waits for a device to appear in the given directory and returns the
+// resultant dev path (e.g /dev/sda). For instance, if sysPath is
+// /sys/bus/pci/devices/0000:03:00.0/host0/subsystem/devices/0:0:0:0/block, the
+// directory to appear in block will be mapped to /dev/<device>.  waitForDevice
+// will wait for the entry to appear in block AND the device to exist in /dev/,
+// returning the path to /dev/<device>.
+func waitForDevice(op trace.Operation, sysPath string) (string, error) {
+	defer trace.End(trace.Begin(sysPath))
 
-	op, _ = trace.WithTimeout(&op, timeout, path)
-	done := make(chan struct{})
+	var err error
+	op, _ = trace.WithTimeout(&op, time.Duration(pathTimeout), "waitForDevice(%s)", sysPath)
+	errCh := make(chan error)
 
+	var blockDev string
 	go func() {
 		t := time.NewTicker(200 * time.Microsecond)
 		defer t.Stop()
+		defer close(errCh)
+
 		for range t.C {
-			if _, err := os.Stat(path); err == nil {
-				close(done)
-				break
+			dirents, err := ioutil.ReadDir(sysPath)
+			if err != nil {
+				errCh <- err
+				return
+			}
+
+			if len(dirents) > 1 {
+				errCh <- fmt.Errorf("too many devices returned: %#v", dirents)
+				return
+			}
+
+			if len(dirents) == 1 {
+				blockDev = "/dev/" + dirents[0].Name()
+
+				// check it exists
+				if _, err := os.Stat(blockDev); err != nil {
+
+					// try again
+					if os.IsNotExist(err) {
+						continue
+					}
+
+					errCh <- err
+					return
+				}
+
+				// happy path
+				return
 			}
 
 			// We've timed out.
 			if op.Err() != nil {
-				break
+				return
 			}
 		}
 	}()
 
-	log.Debugf("Waiting for attached disk to appear in /dev/disk/by-path, or timeout")
+	op.Debugf("Waiting for attached disk to appear in %s, or timeout", sysPath)
 	select {
-	case <-done:
-		log.Infof("Attached disk present at %s", path)
+	case err = <-errCh:
+
+		if err != nil {
+			return "", err
+		}
+
+		op.Infof("Attached disk present at %s", blockDev)
 	case <-op.Done():
 		if op.Err() != nil {
-			return errors.Errorf("timeout waiting for layer to present as %s", path)
+			return "", errors.Errorf("timeout waiting for layer to present in %s", sysPath)
 		}
 	}
 
-	return nil
+	return blockDev, nil
 }
 
-// ensures that a paravirtual scsi controller is present and determines the
+// Ensures that a paravirtual scsi controller is present and determines the
 // base path of disks attached to it returns a handle to the controller and a
 // format string, with a single decimal for the disk unit number which will
-// result in the /dev/disk/by-path path
+// result in the /sys/bus/pci/devices/{pci id like
+// 0000:03:00.0}/host{N provided by kernel}/subsystem/devices/N:0:{disk id like 0}:0/block/sd{Y provided by kernel} path.
+// The directory inside block isn't a devnode, but it's name can be mapped to
+// its /dev/ path.
 func verifyParavirtualScsiController(op trace.Operation, vm *vm.VirtualMachine) (*types.ParaVirtualSCSIController, string, error) {
 	devices, err := vm.Device(op)
 	if err != nil {
-		log.Errorf("vmware driver failed to retrieve device list for VM %s: %s", vm, errors.ErrorStack(err))
+		op.Errorf("vmware driver failed to retrieve device list for VM %s: %s", vm, errors.ErrorStack(err))
 		return nil, "", errors.Trace(err)
 	}
 
 	controller, ok := devices.PickController((*types.ParaVirtualSCSIController)(nil)).(*types.ParaVirtualSCSIController)
 	if controller == nil || !ok {
 		err = errors.Errorf("vmware driver failed to find a paravirtual SCSI controller - ensure setup ran correctly")
-		log.Error(err.Error())
+		op.Errorf(err.Error())
 		return nil, "", errors.Trace(err)
 	}
 
+	op.Infof("controller = %#v", controller)
+
 	// build the base path
 	// first we determine which label we're looking for (requires VMW hardware version >=10)
-	targetLabel := fmt.Sprintf("SCSI%d", controller.BusNumber)
-	log.Debugf("Looking for scsi controller with label %s", targetLabel)
+	controllerLabel := fmt.Sprintf("SCSI%d", controller.BusNumber)
+	op.Debugf("Looking for scsi controller with label %s", controllerLabel)
 
-	pciBase := "/sys/bus/pci/devices"
-	pciBus, err := os.Open(pciBase)
+	pciDevicesDir := "/sys/bus/pci/devices"
+	pciBus, err := os.Open(pciDevicesDir)
 	if err != nil {
-		log.Errorf("Failed to open %s for reading: %s", pciBase, errors.ErrorStack(err))
+		op.Errorf("Failed to open %s for reading: %s", pciDevicesDir, errors.ErrorStack(err))
 		return controller, "", errors.Trace(err)
 	}
 	defer pciBus.Close()
 
 	pciDevices, err := pciBus.Readdirnames(0)
 	if err != nil {
-		log.Errorf("Failed to read contents of %s: %s", pciBase, errors.ErrorStack(err))
+		op.Errorf("Failed to read contents of %s: %s", pciDevicesDir, errors.ErrorStack(err))
 		return controller, "", errors.Trace(err)
 	}
 
-	var buf = make([]byte, len(targetLabel))
 	var controllerName string
 
-	for _, n := range pciDevices {
-		nlabel := fmt.Sprintf("%s/%s/label", pciBase, n)
-		flabel, err := os.Open(nlabel)
+	for _, pciDev := range pciDevices {
+		labelPath := path.Join(pciDevicesDir, pciDev, "label")
+		flabel, err := os.Open(labelPath)
 		if err != nil {
 			if !os.IsNotExist(err) {
-				log.Errorf("Unable to read label from %s: %s", nlabel, errors.ErrorStack(err))
+				op.Errorf("Unable to read label from %s: %s", labelPath, errors.ErrorStack(err))
 			}
 			continue
 		}
 		defer flabel.Close()
 
+		buf := make([]byte, len(controllerLabel))
 		_, err = flabel.Read(buf)
 		if err != nil {
-			log.Errorf("Unable to read label from %s: %s", nlabel, errors.ErrorStack(err))
+			op.Errorf("Unable to read label from %s: %s", labelPath, errors.ErrorStack(err))
 			continue
 		}
 
-		if targetLabel == string(buf) {
+		if controllerLabel == string(buf) {
 			// we've found our controller
-			controllerName = n
-			log.Debugf("Found pvscsi controller directory: %s", controllerName)
+			controllerName = pciDev
+			op.Debugf("Found pvscsi controller directory: %s", controllerName)
 
 			break
 		}
@@ -140,12 +185,31 @@ func verifyParavirtualScsiController(op trace.Operation, vm *vm.VirtualMachine) 
 
 	if controllerName == "" {
 		err := errors.Errorf("Failed to locate pvscsi controller directory")
-		log.Errorf(err.Error())
 		return controller, "", errors.Trace(err)
 	}
 
-	formatString := fmt.Sprintf("/dev/disk/by-path/pci-%s-scsi-0:0:%%d:0", controllerName)
-	log.Debugf("Disk location format: %s", formatString)
+	// Use the block subsystem directly.
+	// /sys/bus/pci/devices/0000:03:00.0/host0/subsystem/devices/0:0:0:0/block
+	// hostN (host0 in this case) is provided to us by the kernel.
+	// N:0:0:X where N is from above X is provided by vsphere
+
+	// Glob for the scsi host
+	matches, err := filepath.Glob(path.Join(pciDevicesDir, controllerName, "host*"))
+	if err != nil {
+		return controller, "", fmt.Errorf("scsi host glob failed: %s", err.Error())
+	}
+
+	if len(matches) != 1 {
+		return controller, "", fmt.Errorf("too many scsi hosts")
+	}
+
+	// Get the number on the end
+	hostStr := matches[0]
+	hostidx := string(hostStr[len(hostStr)-1])
+
+	// First param in the X:X:X:X path is the host id.  So `host2` will mean all devices will start with 2.
+	formatString := path.Join(hostStr, fmt.Sprintf("subsystem/devices/%s:0:%%d:0/block/", hostidx))
+	op.Debugf("Disk location format: %s", formatString)
 	return controller, formatString, nil
 }
 
@@ -153,7 +217,7 @@ func verifyParavirtualScsiController(op trace.Operation, vm *vm.VirtualMachine) 
 func findDisk(op trace.Operation, vm *vm.VirtualMachine, name string) (*types.VirtualDisk, error) {
 	defer trace.End(trace.Begin(vm.String()))
 
-	log.Debugf("Looking for attached disk matching filename %s", name)
+	op.Debugf("Looking for attached disk matching filename %s", name)
 
 	devices, err := vm.Device(op)
 	if err != nil {
@@ -171,17 +235,17 @@ func findDisk(op trace.Operation, vm *vm.VirtualMachine, name string) (*types.Vi
 			return false
 		}
 
-		log.Debugf("backing file name %s", backing.VirtualDeviceFileBackingInfo.FileName)
+		op.Debugf("backing file name %s", backing.VirtualDeviceFileBackingInfo.FileName)
 		match := strings.HasSuffix(backing.VirtualDeviceFileBackingInfo.FileName, name)
 		if match {
-			log.Debugf("Found candidate disk for %s at %s", name, backing.VirtualDeviceFileBackingInfo.FileName)
+			op.Debugf("Found candidate disk for %s at %s", name, backing.VirtualDeviceFileBackingInfo.FileName)
 		}
 
 		return match
 	})
 
 	if len(candidates) == 0 {
-		log.Warnf("No disks match name: %s", name)
+		op.Errorf("No disks match name: %s", name)
 		return nil, os.ErrNotExist
 	}
 


### PR DESCRIPTION
Fixes #2340 

We were relying on systemd-udevd to create the appropriate device paths
in /dev/disk/by-path to mount attached devices to the VCH.  This change
uses the vmw_scsi device directly (by looking in
/sys/devices/pci/<address>) and calculating the target directory.

* Also added lsblk to log bundle
* Added operation logging where we were previously just using logrus