### PR TITLE
Delete old VCH

### DIFF
--- a/cmd/vic-machine/delete/delete.go
+++ b/cmd/vic-machine/delete/delete.go
@@ -144,11 +144,11 @@ func (d *Uninstall) Run(cli *cli.Context) (err error) {
 	installerBuild := version.GetBuild()
 	if vchConfig.Version == nil || !installerBuild.Equal(vchConfig.Version) {
 		if !d.Data.Force {
-			log.Errorf("VCH version %q is different with installer version %s. Specify --force to force delete", vchConfig.Version.ShortVersion(), installerBuild.ShortVersion())
+			log.Errorf("VCH version %q is different than installer version %s. Specify --force to force delete", vchConfig.Version.ShortVersion(), installerBuild.ShortVersion())
 			return errors.New("delete failed")
 		}
 
-		log.Warnf("VCH version %q is different with installer version %s. Force delete will try best to delete everything found.", vchConfig.Version.ShortVersion(), installerBuild.ShortVersion())
+		log.Warnf("VCH version %q is different than installer version %s. Force delete will attempt to remove everything related to the installed VCH", vchConfig.Version.ShortVersion(), installerBuild.ShortVersion())
 	}
 	executor.InitDiagnosticLogs(vchConfig)
 

--- a/cmd/vic-machine/delete/delete.go
+++ b/cmd/vic-machine/delete/delete.go
@@ -26,6 +26,7 @@ import (
 	"github.com/vmware/vic/lib/install/validate"
 	"github.com/vmware/vic/pkg/errors"
 	"github.com/vmware/vic/pkg/trace"
+	"github.com/vmware/vic/pkg/version"
 	"github.com/vmware/vic/pkg/vsphere/vm"
 
 	"golang.org/x/net/context"
@@ -137,6 +138,17 @@ func (d *Uninstall) Run(cli *cli.Context) (err error) {
 		log.Error("Failed to get Virtual Container Host configuration")
 		log.Error(err)
 		return errors.New("delete failed")
+	}
+
+	// compare vch version and vic-machine version
+	installerBuild := version.GetBuild()
+	if vchConfig.Version == nil || !installerBuild.Equal(vchConfig.Version) {
+		if !d.Data.Force {
+			log.Errorf("VCH version %q is different with installer version %s. Specify --force to force delete", vchConfig.Version.ShortVersion(), installerBuild.ShortVersion())
+			return errors.New("delete failed")
+		}
+
+		log.Warnf("VCH version %q is different with installer version %s. Force delete will try best to delete everything found.", vchConfig.Version.ShortVersion(), installerBuild.ShortVersion())
 	}
 	executor.InitDiagnosticLogs(vchConfig)
 

--- a/lib/install/management/delete.go
+++ b/lib/install/management/delete.go
@@ -88,7 +88,7 @@ func (d *Dispatcher) getComputeResource(vmm *vm.VirtualMachine, conf *config.Vir
 			err = errors.Errorf("Cannot find compute resources from configuration")
 			return nil, err
 		}
-		log.Warnf("Cannot find compute resources from configuration, try to delete under parent resource pool")
+		log.Warnf("Cannot find compute resources from configuration, attempting to delete under parent resource pool")
 		parent, err := vmm.Parent(d.ctx)
 		if err != nil {
 			return nil, err
@@ -127,7 +127,7 @@ func (d *Dispatcher) getImageDatastore(vmm *vm.VirtualMachine, conf *config.Virt
 			err = errors.Errorf("Cannot find image stores from configuration")
 			return nil, err
 		}
-		log.Warnf("Cannot find image stores from configuration, try to delete from vm datastore")
+		log.Warnf("Cannot find image stores from configuration, attempting to delete from vm datastore")
 		dss, err := vmm.DatastoreReference(d.ctx)
 		if err != nil {
 			return nil, errors.Errorf("Failed to query vm datastore: %s", err)

--- a/lib/install/management/delete.go
+++ b/lib/install/management/delete.go
@@ -79,6 +79,76 @@ func (d *Dispatcher) DeleteVCH(conf *config.VirtualContainerHostConfigSpec) erro
 	return nil
 }
 
+func (d *Dispatcher) getComputeResource(vmm *vm.VirtualMachine, conf *config.VirtualContainerHostConfigSpec) (*compute.ResourcePool, error) {
+	var rpRef types.ManagedObjectReference
+	var err error
+
+	if len(conf.ComputeResources) == 0 {
+		if !d.force {
+			err = errors.Errorf("Cannot find compute resources from configuration")
+			return nil, err
+		}
+		log.Warnf("Cannot find compute resources from configuration, try to delete under parent resource pool")
+		parent, err := vmm.Parent(d.ctx)
+		if err != nil {
+			return nil, err
+		}
+		if parent == nil {
+			err = errors.Errorf("Cannot find VCH parent resource pool")
+			return nil, err
+		}
+		rpRef = *parent
+	} else {
+		rpRef = conf.ComputeResources[len(conf.ComputeResources)-1]
+	}
+
+	ref, err := d.session.Finder.ObjectReference(d.ctx, rpRef)
+	if err != nil {
+		err = errors.Errorf("Failed to get VCH resource pool %q: %s", rpRef, err)
+		return nil, err
+	}
+	switch ref.(type) {
+	case *object.VirtualApp:
+	case *object.ResourcePool:
+		//		ok
+	default:
+		err = errors.Errorf("Unsupported compute resource %q", rpRef)
+		return nil, err
+	}
+
+	rp := compute.NewResourcePool(d.ctx, d.session, ref.Reference())
+	return rp, nil
+}
+
+func (d *Dispatcher) getImageDatastore(vmm *vm.VirtualMachine, conf *config.VirtualContainerHostConfigSpec) (*object.Datastore, error) {
+	var err error
+	if len(conf.ImageStores) == 0 {
+		if !d.force {
+			err = errors.Errorf("Cannot find image stores from configuration")
+			return nil, err
+		}
+		log.Warnf("Cannot find image stores from configuration, try to delete from vm datastore")
+		dss, err := vmm.DatastoreReference(d.ctx)
+		if err != nil {
+			return nil, errors.Errorf("Failed to query vm datastore: %s", err)
+		}
+		if len(dss) == 0 {
+			return nil, errors.New("No VCH datastore found, cannot continue")
+		}
+		ds, err := d.session.Finder.ObjectReference(d.ctx, dss[0])
+		if err != nil {
+			return nil, errors.Errorf("Failed to search vm datastore %s: %s", dss[0], err)
+		}
+		return ds.(*object.Datastore), nil
+	}
+	ds, err := d.session.Finder.Datastore(d.ctx, conf.ImageStores[0].Host)
+	if err != nil {
+		err = errors.Errorf("Failed to find image datastore %q", conf.ImageStores[0].Host)
+		return nil, err
+	}
+	return ds, nil
+}
+
 func (d *Dispatcher) DeleteVCHInstances(vmm *vm.VirtualMachine, conf *config.VirtualContainerHostConfigSpec) error {
 	defer trace.End(trace.Begin(conf.Name))
 
@@ -87,38 +157,16 @@ func (d *Dispatcher) DeleteVCHInstances(vmm *vm.VirtualMachine, conf *config.Vir
 
 	var err error
 	var children []*vm.VirtualMachine
-
-	if len(conf.ComputeResources) == 0 {
-		err = errors.Errorf("Cannot find compute resources from configuration, please delete VCH manually")
-		return err
-	}
-
-	rpRef := conf.ComputeResources[len(conf.ComputeResources)-1]
-	ref, err := d.session.Finder.ObjectReference(d.ctx, rpRef)
+	d.parentResourcepool, err = d.getComputeResource(vmm, conf)
 	if err != nil {
-		err = errors.Errorf("Failed to get VCH resource pool %q: %s", rpRef, err)
 		return err
 	}
-	switch ref.(type) {
-	case *object.VirtualApp:
-	case *object.ResourcePool:
-		//		ok
-	default:
-		log.Errorf("Failed to find virtual app or resource pool %q: %s", rpRef, err)
+	if children, err = d.parentResourcepool.GetChildrenVMs(d.ctx, d.session); err != nil {
 		return err
 	}
-
-	rp := compute.NewResourcePool(d.ctx, d.session, ref.Reference())
-	if children, err = rp.GetChildrenVMs(d.ctx, d.session); err != nil {
+	if d.session.Datastore, err = d.getImageDatastore(vmm, conf); err != nil {
 		return err
 	}
-
-	ds, err := d.session.Finder.Datastore(d.ctx, conf.ImageStores[0].Host)
-	if err != nil {
-		err = errors.Errorf("Failed to find image datastore %q", conf.ImageStores[0].Host)
-		return err
-	}
-	d.session.Datastore = ds
 
 	for _, child := range children {
 		name, err := child.Name(d.ctx)

--- a/lib/install/management/dispatcher.go
+++ b/lib/install/management/dispatcher.go
@@ -57,7 +57,8 @@ type Dispatcher struct {
 
 	oldApplianceISO string
 
-	sshEnabled bool
+	sshEnabled         bool
+	parentResourcepool *compute.ResourcePool
 }
 
 type diagnosticLog struct {
@@ -100,6 +101,11 @@ func (d *Dispatcher) InitDiagnosticLogs(conf *config.VirtualContainerHostConfigS
 
 	var err error
 	if d.session.Datastore == nil {
+		if len(conf.ImageStores) == 0 {
+			log.Errorf("Image datastore is empty")
+			return
+
+		}
 		if d.session.Datastore, err = d.session.Finder.DatastoreOrDefault(d.ctx, conf.ImageStores[0].Host); err != nil {
 			log.Errorf("Failure finding image store from VCH config (%s): %s", conf.ImageStores[0].Host, err.Error())
 			return

--- a/lib/install/management/resource_pool.go
+++ b/lib/install/management/resource_pool.go
@@ -108,7 +108,7 @@ func (d *Dispatcher) destroyResourcePoolIfEmpty(conf *config.VirtualContainerHos
 	log.Infof("Removing Resource Pool %q", conf.Name)
 
 	if d.parentResourcepool == nil {
-		log.Warnf("Do not find parent VCH resource pool")
+		log.Warnf("Did not find parent VCH resource pool")
 		return nil
 	}
 	var vms []*vm.VirtualMachine

--- a/lib/install/management/resource_pool.go
+++ b/lib/install/management/resource_pool.go
@@ -27,7 +27,6 @@ import (
 	"github.com/vmware/vic/lib/install/data"
 	"github.com/vmware/vic/pkg/errors"
 	"github.com/vmware/vic/pkg/trace"
-	"github.com/vmware/vic/pkg/vsphere/compute"
 	"github.com/vmware/vic/pkg/vsphere/tasks"
 	"github.com/vmware/vic/pkg/vsphere/vm"
 )
@@ -108,21 +107,22 @@ func (d *Dispatcher) destroyResourcePoolIfEmpty(conf *config.VirtualContainerHos
 
 	log.Infof("Removing Resource Pool %q", conf.Name)
 
-	rpRef := conf.ComputeResources[len(conf.ComputeResources)-1]
-	rp := compute.NewResourcePool(d.ctx, d.session, rpRef)
-
+	if d.parentResourcepool == nil {
+		log.Warnf("Do not find parent VCH resource pool")
+		return nil
+	}
 	var vms []*vm.VirtualMachine
 	var err error
-	if vms, err = rp.GetChildrenVMs(d.ctx, d.session); err != nil {
-		err = errors.Errorf("Unable to get children vm of resource pool %q: %s", rp.Name(), err)
+	if vms, err = d.parentResourcepool.GetChildrenVMs(d.ctx, d.session); err != nil {
+		err = errors.Errorf("Unable to get children vm of resource pool %q: %s", d.parentResourcepool.Name(), err)
 		return err
 	}
 	if len(vms) != 0 {
-		err = errors.Errorf("Resource pool is not empty: %q", rp.Name())
+		err = errors.Errorf("Resource pool is not empty: %q", d.parentResourcepool.Name())
 		return err
 	}
 	if _, err := tasks.WaitForResult(d.ctx, func(ctx context.Context) (tasks.Task, error) {
-		return rp.Destroy(ctx)
+		return d.parentResourcepool.Destroy(ctx)
 	}); err != nil {
 		return err
 	}

--- a/pkg/vsphere/vm/vm.go
+++ b/pkg/vsphere/vm/vm.go
@@ -582,3 +582,26 @@ func (vm *VirtualMachine) Properties(ctx context.Context, r types.ManagedObjectR
 	log.Debugf("Retry properties query %s of vm %s", ps, vm.Reference())
 	return vm.VirtualMachine.Properties(ctx, vm.Reference(), ps, o)
 }
+
+func (vm *VirtualMachine) Parent(ctx context.Context) (*types.ManagedObjectReference, error) {
+	var mvm mo.VirtualMachine
+
+	if err := vm.Properties(ctx, vm.Reference(), []string{"parentVApp", "resourcePool"}, &mvm); err != nil {
+		log.Errorf("Unable to get VM parent: %s", err)
+		return nil, err
+	}
+	if mvm.ParentVApp != nil {
+		return mvm.ParentVApp, nil
+	}
+	return mvm.ResourcePool, nil
+}
+
+func (vm *VirtualMachine) DatastoreReference(ctx context.Context) ([]types.ManagedObjectReference, error) {
+	var mvm mo.VirtualMachine
+
+	if err := vm.Properties(ctx, vm.Reference(), []string{"datastore"}, &mvm); err != nil {
+		log.Errorf("Unable to get VM datastore: %s", err)
+		return nil, err
+	}
+	return mvm.Datastore, nil
+}

--- a/tests/test-cases/Group12-VCH-BC/12-01-Delete.md
+++ b/tests/test-cases/Group12-VCH-BC/12-01-Delete.md
@@ -1,0 +1,17 @@
+Test 12-01 - Delete
+=======
+
+#Purpose:
+To verify vic-machine delete can delete VCH created by vic 0.6.0
+
+#Environment:
+This test requires that a vSphere server is running and available
+
+#Test Steps:
+1. Download vic_0.6.0.tar.gz from bintray
+2. Deploy VIC 0.6.0 to vsphere server
+3. Create container
+3. Using latest version vic-machine to delete this VCH
+
+#Expected Outcome:
+* All steps should result in success

--- a/tests/test-cases/Group12-VCH-BC/12-01-Delete.robot
+++ b/tests/test-cases/Group12-VCH-BC/12-01-Delete.robot
@@ -1,0 +1,97 @@
+*** Settings ***
+Documentation  Test 12-01 - Delete
+Resource  ../../resources/Util.robot
+Suite Setup  Install VIC 0.6.0 to Test Server
+Test Teardown  Run Keyword If Test Failed  Clean up VIC Appliance And Local Binary
+
+*** Keywords ***
+Clean up VIC Appliance And Local Binary
+    Cleanup VIC Appliance On Test Server
+    Run  rm -rf vic.tar.gz vic
+
+Install VIC 0.6.0 to Test Server
+    Log To Console  \nDownloading vic 4890 from bintray...
+    ${rc}  ${output}=  Run And Return Rc And Output  wget https://bintray.com/vmware/vic-repo/download_file?file_path=vic_4890.tar.gz -O vic.tar.gz
+    ${rc}  ${output}=  Run And Return Rc And Output  tar zxvf vic.tar.gz
+    Set Test Environment Variables
+
+    Log To Console  \nInstalling VCH to test server...
+    ${output}=  Run  ./vic/vic-machine-linux create --debug 1 --name=${vch-name} --target=%{TEST_URL}%{TEST_DATACENTER} --user=%{TEST_USERNAME} --image-store=%{TEST_DATASTORE} --appliance-iso=./vic/appliance.iso --bootstrap-iso=./vic/bootstrap.iso --password=%{TEST_PASSWORD} --bridge-network=%{BRIDGE_NETWORK} --external-network=%{EXTERNAL_NETWORK} --compute-resource=%{TEST_RESOURCE} --timeout %{TEST_TIMEOUT}
+    Should Contain  ${output}  Installer completed successfully
+    Get 0.6.0 VIC Docker Params  ${output}  false
+    Log To Console  Installer completed successfully: ${vch-name}
+
+Get 0.6.0 VIC Docker Params
+    # Get VCH docker params e.g. "-H 192.168.218.181:2376 --tls"
+    [Arguments]  ${output}  ${certs}
+    @{output}=  Split To Lines  ${output}
+    :FOR  ${item}  IN  @{output}
+    \   ${status}  ${message}=  Run Keyword And Ignore Error  Should Contain  ${item}  DOCKER_HOST=
+    \   Run Keyword If  '${status}' == 'PASS'  Set Suite Variable  ${line}  ${item}
+
+    # Ensure we start from a clean slate with docker env vars
+    Remove Environment Variable  DOCKER_HOST  DOCKER_TLS_VERIFY  DOCKER_CERT_PATH
+
+    # Split the log log into pieces, discarding the initial log decoration, and assign to env vars
+    ${logdeco}  ${vars}=  Split String  ${line}  ${SPACE}  1
+    ${vars}=  Split String  ${vars}
+    :FOR  ${var}  IN  @{vars}
+    \   ${varname}  ${varval}=  Split String  ${var}  =
+    \   Set Environment Variable  ${varname}  ${varval}
+
+    ${dockerHost}=  Get Environment Variable  DOCKER_HOST
+
+    @{hostParts}=  Split String  ${dockerHost}  :
+    ${ip}=  Strip String  @{hostParts}[0]
+    ${port}=  Strip String  @{hostParts}[1]
+    Set Suite Variable  ${vch-ip}  ${ip}
+    Set Suite Variable  ${vch-port}  ${port}
+
+    ${proto}=  Set Variable If  ${port} == 2376  "https"  "http"
+    Set Suite Variable  ${proto}
+
+    Run Keyword If  ${port} == 2376  Set Suite Variable  ${params}  -H ${dockerHost} --tls
+    Run Keyword If  ${port} == 2375  Set Suite Variable  ${params}  -H ${dockerHost}
+
+
+    :FOR  ${index}  ${item}  IN ENUMERATE  @{output}
+    \   ${status}  ${message}=  Run Keyword And Ignore Error  Should Contain  ${item}  http
+    \   Run Keyword If  '${status}' == 'PASS'  Set Suite Variable  ${line}  ${item}
+    \   ${status}  ${message}=  Run Keyword And Ignore Error  Should Contain  ${item}  Published ports can be reached at
+    \   ${idx} =  Evaluate  ${index} + 1
+    \   Run Keyword If  '${status}' == 'PASS'  Set Suite Variable  ${ext-ip}  @{output}[${idx}]
+
+*** Test Cases ***
+Delete VCH with new vic-machine
+    Log To Console  \nRunning docker pull busybox...
+    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} pull busybox
+    Log  ${output}
+    Should Be Equal As Integers  ${rc}  0
+    Should Not Contain  ${output}  Error
+    ${name}=  Generate Random String  15
+    ${rc}  ${container-id}=  Run And Return Rc And Output  docker ${params} create --name ${name} busybox /bin/top
+    Should Be Equal As Integers  ${rc}  0
+    Should Not Contain  ${container-id}  Error
+    Set Suite Variable  ${containerName}  ${name}
+
+    # Get VCH uuid and container VM uuid, to check if resources are removed correctly
+    Run Keyword And Ignore Error  Gather Logs From Test Server
+    ${uuid}=  Run  govc vm.info -json\=true ${vch-name} | jq -r '.VirtualMachines[0].Config.Uuid'
+    ${ret}=  Run  bin/vic-machine-linux delete --target %{TEST_URL} --thumbprint=%{TEST_THUMBPRINT} --user %{TEST_USERNAME} --password=%{TEST_PASSWORD} --compute-resource=%{TEST_RESOURCE} --name ${vch-name}
+    Should Contain  ${ret}  is different with installer version
+
+    # Delete with force
+    ${ret}=  Run  bin/vic-machine-linux delete --target %{TEST_URL} --user %{TEST_USERNAME} --password=%{TEST_PASSWORD} --compute-resource=%{TEST_RESOURCE} --name ${vch-name} --force
+    Should Contain  ${ret}  Completed successfully
+    Should Not Contain  ${ret}  delete failed
+
+    # Check VM is removed
+    ${ret}=  Run  govc vm.info -json=true ${containerName}-*
+    Should Contain  ${ret}  {"VirtualMachines":null}
+    ${ret}=  Run  govc vm.info -json=true ${vch-name}
+    Should Contain  ${ret}  {"VirtualMachines":null}
+
+    # Check resource pool is removed
+    ${ret}=  Run  govc pool.info -json=true host/*/Resources/${vch-name}
+	Should Contain  ${ret}  {"ResourcePools":null}
+    Run  rm -rf vic.tar.gz vic

--- a/tests/test-cases/Group12-VCH-BC/TestCases.md
+++ b/tests/test-cases/Group12-VCH-BC/TestCases.md
@@ -1,0 +1,6 @@
+Group 12 - vic-machine Backward Compatibility
+=======
+
+
+[Test 12-01 - BC](12-01-Delete.md)
+-


### PR DESCRIPTION
Fixes #2719
If vic-machine identified the vm is one VCH instance, will delete the container VMs and VCH instance itself. Even the guestinfo configuration is changed, and some of configuration cannot be identified.
The problem is that if there is custom image store, or volume store configured, but vic-machine cannot read those configuration back, those resources will not be cleaned up.