### PR TITLE
Allow vicadmin to use TLS when personality does not

### DIFF
--- a/cmd/vicadmin/server.go
+++ b/cmd/vicadmin/server.go
@@ -70,8 +70,20 @@ func (s *server) listen() error {
 	defer trace.End(trace.Begin(""))
 
 	var err error
+	var certificate *tls.Certificate
 	s.uss = NewUserSessionStore()
-	certificate, err := vchConfig.HostCertificate.Certificate()
+	if vchConfig.HostCertificate != nil {
+		certificate, err = vchConfig.HostCertificate.Certificate()
+	} else {
+		var c tls.Certificate
+		if c, err = tls.X509KeyPair(
+			rootConfig.serverCert.Cert.Bytes(),
+			rootConfig.serverCert.Key.Bytes()); err != nil {
+			log.Errorf("Could not generate self-signed certificate for vicadmin running with due to error %s", err.Error())
+			return err
+		}
+		certificate = &c
+	}
 	if err != nil {
 		log.Errorf("Could not load certificate from config - running without TLS: %s", err)
 

--- a/cmd/vicadmin/vicadm.go
+++ b/cmd/vicadmin/vicadm.go
@@ -132,7 +132,7 @@ func init() {
 
 	extraconfig.Decode(src, &vchConfig)
 	if vchConfig.HostCertificate == nil {
-		log.Infoln("--no-tls is enabled")
+		log.Infoln("--no-tls is enabled on the personality")
 		rootConfig.serverCert = &ServerCertificate{}
 		rootConfig.serverCert.Cert, rootConfig.serverCert.Key, err = certificate.CreateSelfSigned(rootConfig.addr, []string{"VMware, Inc."}, 2048)
 		if err != nil {

--- a/cmd/vicadmin/vicadm.go
+++ b/cmd/vicadmin/vicadm.go
@@ -40,6 +40,7 @@ import (
 	vchconfig "github.com/vmware/vic/lib/config"
 	"github.com/vmware/vic/lib/guest"
 	"github.com/vmware/vic/lib/pprof"
+	"github.com/vmware/vic/pkg/certificate"
 	"github.com/vmware/vic/pkg/trace"
 	"github.com/vmware/vic/pkg/version"
 	"github.com/vmware/vic/pkg/vsphere/compute"
@@ -52,10 +53,16 @@ const (
 	timeout = time.Duration(2 * time.Second)
 )
 
+type ServerCertificate struct {
+	Key  bytes.Buffer
+	Cert bytes.Buffer
+}
+
 type vicAdminConfig struct {
 	session.Config
-	addr string
-	tls  bool
+	addr       string
+	tls        bool
+	serverCert *ServerCertificate
 }
 
 var (
@@ -76,6 +83,7 @@ var (
 
 	// this struct holds root credentials or vSphere extension private key instead if available
 	// if you are exposing log information to a user, create a new session for that user, do not use this one
+	// also, 'root' is a pun -- this is both the "root" config, e.g., the base config, and the one w/ root creds
 	rootConfig vicAdminConfig
 
 	resources vchconfig.Resources
@@ -123,6 +131,15 @@ func init() {
 	}
 
 	extraconfig.Decode(src, &vchConfig)
+	if vchConfig.HostCertificate == nil {
+		log.Infoln("--no-tls is enabled")
+		rootConfig.serverCert = &ServerCertificate{}
+		rootConfig.serverCert.Cert, rootConfig.serverCert.Key, err = certificate.CreateSelfSigned(rootConfig.addr, []string{"VMware, Inc."}, 2048)
+		if err != nil {
+			log.Errorf("--no-tls was specified but we couldn't generate a self-signed cert for vic admin due to error %s so vicadmin will not run", err.Error())
+			return
+		}
+	}
 
 	// FIXME: pull the rest from flags
 	flag.Parse()

--- a/lib/install/management/appliance.go
+++ b/lib/install/management/appliance.go
@@ -463,10 +463,8 @@ func (d *Dispatcher) createAppliance(conf *config.VirtualContainerHostConfigSpec
 	)
 
 	if conf.HostCertificate != nil {
-		d.VICAdminProto = "https"
 		d.DockerPort = fmt.Sprintf("%d", opts.DefaultTLSHTTPPort)
 	} else {
-		d.VICAdminProto = "http"
 		d.DockerPort = fmt.Sprintf("%d", opts.DefaultHTTPPort)
 	}
 

--- a/lib/install/management/dispatcher.go
+++ b/lib/install/management/dispatcher.go
@@ -48,9 +48,8 @@ type Dispatcher struct {
 	vmPathName    string
 	dockertlsargs string
 
-	DockerPort    string
-	HostIP        string
-	VICAdminProto string
+	DockerPort string
+	HostIP     string
 
 	vchPool   *object.ResourcePool
 	vchVapp   *object.VirtualApp

--- a/lib/install/management/inspect.go
+++ b/lib/install/management/inspect.go
@@ -65,10 +65,8 @@ func (d *Dispatcher) InspectVCH(vch *vm.VirtualMachine, conf *config.VirtualCont
 	d.HostIP = clientIP.String()
 	log.Debugf("IP address for client interface: %s", d.HostIP)
 	if !conf.HostCertificate.IsNil() {
-		d.VICAdminProto = "https"
 		d.DockerPort = fmt.Sprintf("%d", opts.DefaultTLSHTTPPort)
 	} else {
-		d.VICAdminProto = "http"
 		d.DockerPort = fmt.Sprintf("%d", opts.DefaultHTTPPort)
 	}
 
@@ -104,7 +102,7 @@ func (d *Dispatcher) ShowVCH(conf *config.VirtualContainerHostConfigSpec, key st
 
 	log.Infof("")
 	log.Infof("VCH Admin Portal:")
-	log.Infof("%s://%s:2378", d.VICAdminProto, d.HostIP)
+	log.Infof("https://%s:2378", d.HostIP)
 
 	log.Infof("")
 	externalIP := conf.ExecutorConfig.Networks["external"].Assigned.IP

--- a/lib/install/management/upgrade.go
+++ b/lib/install/management/upgrade.go
@@ -58,10 +58,8 @@ func (d *Dispatcher) Upgrade(vch *vm.VirtualMachine, conf *config.VirtualContain
 	}
 	d.session.Datastore = ds
 	if !conf.HostCertificate.IsNil() {
-		d.VICAdminProto = "https"
 		d.DockerPort = fmt.Sprintf("%d", opts.DefaultTLSHTTPPort)
 	} else {
-		d.VICAdminProto = "http"
 		d.DockerPort = fmt.Sprintf("%d", opts.DefaultHTTPPort)
 	}
 


### PR DESCRIPTION
When installing vicadmin with `--no-tls`, vicadmin was previously simply served w/o authentication or encryption on `http`. Now this is disabled and vicadmin always presents on `https`, using its own self-signed certificates if the VCH is installed with `--no-tls`.

Fixes #3063 

