### PR TITLE
Fix license check in vicadmin on vC

### DIFF
--- a/lib/install/validate/validator.go
+++ b/lib/install/validate/validator.go
@@ -63,6 +63,7 @@ func CreateFromVCHConfig(ctx context.Context, vch *config.VirtualContainerHostCo
 	v := &Validator{}
 	v.Session = sess
 	v.Context = ctx
+	v.isVC = v.Session.IsVC()
 
 	return v, nil
 }

--- a/lib/vicadmin/validate.go
+++ b/lib/vicadmin/validate.go
@@ -25,7 +25,6 @@ import (
 	"strings"
 
 	log "github.com/Sirupsen/logrus"
-	// "github.com/vmware/govmomi/vim25/types"
 
 	"github.com/docker/docker/opts"
 	"golang.org/x/net/context"


### PR DESCRIPTION
Fixes #2305 
Previously we were running the ESX check always instead of the vCenter check when appropriate. 