### PR TITLE
Improve UX for reuse of certificates [full ci]

### DIFF
--- a/cmd/vic-machine/create/create.go
+++ b/cmd/vic-machine/create/create.go
@@ -40,6 +40,8 @@ import (
 	"github.com/vmware/vic/pkg/ip"
 	"github.com/vmware/vic/pkg/trace"
 
+	"crypto/x509"
+
 	"golang.org/x/net/context"
 )
 
@@ -48,6 +50,13 @@ const (
 	MaxVirtualMachineNameLen = 80
 	// Max permitted length of Virtual Switch name
 	MaxDisplayNameLen = 31
+
+	clientCert = "cert.pem"
+	clientKey  = "key.pem"
+	serverCert = "server-cert.pem"
+	serverKey  = "server-key.pem"
+	caCert     = "ca.pem"
+	caKey      = "ca-key.pem"
 )
 
 var EntireOptionHelpTemplate = `NAME:
@@ -71,8 +80,11 @@ OPTIONS:
 type Create struct {
 	*data.Data
 
-	cert       string
-	key        string
+	certPath   string
+	scert      string
+	skey       string
+	ccert      string
+	ckey       string
 	cacert     string
 	cakey      string
 	clientCert *tls.Certificate
@@ -198,7 +210,7 @@ func (c *Create) Flags() []cli.Flag {
 		// external
 		cli.StringFlag{
 			Name:        "external-network, en",
-			Value:       "",
+			Value:       "VM Network",
 			Usage:       "The external network port group name (port forwarding and default route). Defaults to 'VM Network' and DHCP -- see advanced help (-x)",
 			Destination: &c.externalNetworkName,
 		},
@@ -355,15 +367,22 @@ func (c *Create) Flags() []cli.Flag {
 		cli.StringFlag{
 			Name:        "key",
 			Value:       "",
-			Usage:       "Virtual Container Host private key file",
-			Destination: &c.key,
+			Usage:       "Virtual Container Host private key file (server certificate)",
+			Destination: &c.skey,
 			Hidden:      true,
 		},
 		cli.StringFlag{
 			Name:        "cert",
 			Value:       "",
-			Usage:       "Virtual Container Host x509 certificate file",
-			Destination: &c.cert,
+			Usage:       "Virtual Container Host x509 certificate file (server certificate)",
+			Destination: &c.scert,
+			Hidden:      true,
+		},
+		cli.StringFlag{
+			Name:        "cert-path",
+			Value:       "",
+			Usage:       "The path to check for existing certificates and in which to save generated certificates. Defaults to './<vch name>/'",
+			Destination: &c.certPath,
 			Hidden:      true,
 		},
 		cli.StringSliceFlag{
@@ -457,17 +476,6 @@ func (c *Create) processParams() error {
 		return err
 	}
 
-	if c.cert != "" && c.key == "" {
-		return cli.NewExitError("key and cert should be specified at the same time", 1)
-	}
-	if c.cert == "" && c.key != "" {
-		return cli.NewExitError("key and cert should be specified at the same time", 1)
-	}
-
-	if c.externalNetworkName == "" {
-		c.externalNetworkName = "VM Network"
-	}
-
 	if c.BridgeNetworkName == "" {
 		c.BridgeNetworkName = c.DisplayName
 	}
@@ -524,41 +532,71 @@ func (c *Create) processParams() error {
 }
 
 func (c *Create) processCertificates() error {
+	// set up the locations for the certificates and env file
+	if c.certPath == "" {
+		c.certPath = c.DisplayName
+	}
+	c.envFile = fmt.Sprintf("%s/%s.env", c.certPath, c.DisplayName)
+
 	// check for insecure case
 	if c.noTLS {
 		log.Warn("Configuring without TLS - all communications will be insecure")
 		return nil
 	}
 
-	// if one or more CAs are provided, then so must the key and cert for host certificate
+	if c.scert != "" && c.skey == "" {
+		return cli.NewExitError("key and cert should be specified at the same time", 1)
+	}
+	if c.scert == "" && c.skey != "" {
+		return cli.NewExitError("key and cert should be specified at the same time", 1)
+	}
+
+	// if we've not got a specific CommonName but do have a static IP then go with that.
+	if c.cname == "" && c.clientNetworkIP != "" {
+		c.cname = c.clientNetworkIP
+		log.Infof("Using client-network-ip as cname where needed - use --tls-cname to override: %s", c.cname)
+	}
+
+	// load what certificates we can
 	cas, keypair, err := c.loadCertificates()
 	if err != nil {
-		log.Error("Create cannot continue: unable to load certificates")
-		return err
-	}
-
-	if len(cas) != 0 && keypair == nil {
-		log.Error("Create cannot continue: specifying a CA requires --key and --cert parameters")
-		return errors.New("If supplying a CA, certificate and key for TLS must also be supplied")
-	}
-
-	if len(cas) == 0 && keypair == nil {
-		// if we get here we didn't load a CA or keys, so we're generating
-		cas, keypair, err = c.generateCertificates(!c.noTLSverify)
-		if err != nil {
-			log.Error("Create cannot continue: unable to generate certificates")
+		log.Errorf("Unable to load certificates: %s", err)
+		if !c.Force {
 			return err
 		}
+
+		log.Warnf("Ignoring error loading certificates due to --force")
+		cas = nil
+		keypair = nil
+		err = nil
 	}
 
-	if keypair == nil {
-		// this should be caught in earlier error returns, but sanity check
-		log.Error("Create cannot continue: unable to load or generate TLS certificates and --no-tls was not specified")
+	// we need to generate some part of the certificate configuration
+	gcas, gkeypair, err := c.generateCertificates(keypair == nil, !c.noTLSverify && len(cas) == 0)
+	if err != nil {
+		log.Error("Create cannot continue: unable to generate certificates")
 		return err
 	}
 
-	c.KeyPEM = keypair.KeyPEM
-	c.CertPEM = keypair.CertPEM
+	if keypair != nil {
+		c.KeyPEM = keypair.KeyPEM
+		c.CertPEM = keypair.CertPEM
+	} else if gkeypair != nil {
+		c.KeyPEM = gkeypair.KeyPEM
+		c.CertPEM = gkeypair.CertPEM
+	}
+
+	if len(cas) == 0 {
+		cas = gcas
+	}
+
+	if len(c.KeyPEM) == 0 {
+		return errors.New("Failed to load or generate server certificates")
+	}
+
+	if len(cas) == 0 && !c.noTLSverify {
+		return errors.New("Failed to load or generate certificate authority")
+	}
 
 	// do we have key, cert, and --no-tlsverify
 	if c.noTLSverify || len(cas) == 0 {
@@ -804,16 +842,14 @@ func (c *Create) processProxies() error {
 	return nil
 }
 
+// loadCertificates returns the client CA pool and the keypair for server certificates on success
 func (c *Create) loadCertificates() ([]byte, *certificate.KeyPair, error) {
 	defer trace.End(trace.Begin(""))
-
-	c.envFile = fmt.Sprintf("%s.env", c.DisplayName)
 
 	// reads each of the files specified, assuming that they are PEM encoded certs,
 	// and constructs a byte array suitable for passing to CertPool.AppendCertsFromPEM
 	var certs []byte
 	for _, f := range c.clientCAs {
-		log.Infof("Loading CA from %s", f)
 		b, err := ioutil.ReadFile(f)
 		if err != nil {
 			err = errors.Errorf("Failed to load authority from file %s: %s", f, err)
@@ -821,64 +857,155 @@ func (c *Create) loadCertificates() ([]byte, *certificate.KeyPair, error) {
 		}
 
 		certs = append(certs, b...)
+		log.Infof("Loaded CA from %s", f)
 	}
 
 	var keypair *certificate.KeyPair
-	if c.cert != "" && c.key != "" {
-		log.Infof("Loading certificate/key pair - private key in %s", c.key)
-		keypair = certificate.NewKeyPair(c.cert, c.key, nil, nil)
+	// default names
+	skey := fmt.Sprintf("./%s/%s", c.certPath, serverKey)
+	scert := fmt.Sprintf("./%s/%s", c.certPath, serverCert)
+	ca := fmt.Sprintf("./%s/%s", c.certPath, caCert)
 
-		if err := keypair.LoadCertificate(); err != nil {
+	// if specific files are supplied, use those
+	explicit := false
+	if c.scert != "" && c.skey != "" {
+		explicit = true
+		skey = c.skey
+		scert = c.scert
+	}
+
+	// load the server certificate
+	keypair = certificate.NewKeyPair(scert, skey, nil, nil)
+	if err := keypair.LoadCertificate(); err != nil {
+		if explicit || !os.IsNotExist(err) {
+			// if these files were explicit paths, or anything other than not found, fail
 			log.Errorf("Failed to load certificate: %s", err)
 			return certs, nil, err
 		}
+
+		log.Debugf("Unable to locate existing server certificate in cert path")
+		return nil, nil, nil
+	}
+
+	// check that any supplied cname matches the server cert CN
+	cert, err := keypair.Certificate()
+	if err != nil {
+		log.Errorf("Failed to parse certificate: %s", err)
+		return certs, nil, err
+	}
+
+	// We just do a direct equality check here - trying to be clever is liable to lead to hard
+	// to diagnose errors
+	if cert.Leaf.Subject.CommonName != c.cname {
+		log.Errorf("Provided cname does not match that in existing server certificate: %s", cert.Leaf.Subject.CommonName)
+		return certs, nil, fmt.Errorf("cname option doesn't match existing server certificate in certificate path %s", c.certPath)
+	}
+
+	log.Infof("Loaded server certificate %s", scert)
+	c.skey = skey
+	c.scert = scert
+
+	// only try for CA certificate if no-tlsverify has NOT been specified and we haven't already loaded an authority cert
+	if !c.noTLSverify && len(certs) == 0 {
+		b, err := ioutil.ReadFile(ca)
+		if err != nil {
+			if os.IsNotExist(err) {
+				log.Debugf("Unable to locate existing CA in cert path")
+				return certs, keypair, nil
+			}
+
+			// if the CA exists but cannot be loaded then it's an error
+			log.Errorf("Failed to load authority from certificate path %s: %s", c.certPath, err)
+			return certs, keypair, errors.New("failed to load certificate authority")
+		}
+
+		log.Infof("Loaded CA with default name from certificate path %s", c.certPath)
+		certs = b
+
+		// load client certs - we ensure the client certs validate with the provided CA or ignore any we find
+		ckey := fmt.Sprintf("./%s/%s", c.certPath, clientKey)
+		ccert := fmt.Sprintf("./%s/%s", c.certPath, clientCert)
+
+		cpair := certificate.NewKeyPair(ccert, ckey, nil, nil)
+		if err := cpair.LoadCertificate(); err != nil {
+			log.Warnf("Unable to load client certificate - validation of API endpoint will be best effort only: %s", err)
+		}
+
+		clientCert, err := cpair.Certificate()
+		if err != nil || clientCert.Leaf == nil {
+			log.Debugf("Unable to create CA pool to check client certificate: %s", err)
+			return certs, keypair, nil
+		}
+
+		pool := x509.NewCertPool()
+		if !pool.AppendCertsFromPEM(certs) {
+			log.Debugf("Unable to create CA pool to check client certificate")
+			return certs, keypair, nil
+		}
+
+		opts := x509.VerifyOptions{
+			Roots:     pool,
+			KeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+		}
+
+		_, err = clientCert.Leaf.Verify(opts)
+		if err != nil {
+			log.Warnf("Client certificate in certificate path does not validate with provided CA - continuing without client certificate")
+			return certs, keypair, nil
+		}
+
+		c.ckey = ckey
+		c.ccert = ccert
+		c.clientCert = clientCert
+
+		log.Infof("Loaded client certificate with default name from certificate path %s", c.certPath)
 	}
 
 	return certs, keypair, nil
 }
 
-func (c *Create) generateCertificates(ca bool) ([]byte, *certificate.KeyPair, error) {
+func (c *Create) generateCertificates(server bool, client bool) ([]byte, *certificate.KeyPair, error) {
 	defer trace.End(trace.Begin(""))
+
+	if !server && !client {
+		log.Debugf("Not generating server or client certs, nothing for generateCertificates to do")
+		return nil, nil, nil
+	}
 
 	var certs []byte
 	// generate the certs and keys with names conforming the default the docker client expects
-	// to avoid overwriting for a different vch, place this in a directory named for the vch
-	err := os.MkdirAll(fmt.Sprintf("./%s", c.DisplayName), 0700)
+	err := os.MkdirAll(fmt.Sprintf("./%s", c.certPath), 0700)
 	if err != nil {
-		log.Errorf("Unable to make directory to hold certificates")
+		log.Errorf("Unable to make directory to hold certificates (set via --cert-path)")
 		return nil, nil, err
 	}
 
-	// the locations for the certificates and env file
-	c.envFile = fmt.Sprintf("%s/%[1]s.env", c.DisplayName)
+	c.skey = fmt.Sprintf("./%s/%s", c.certPath, serverKey)
+	c.scert = fmt.Sprintf("./%s/%s", c.certPath, serverCert)
 
-	c.key = fmt.Sprintf("./%s/key.pem", c.DisplayName)
-	c.cert = fmt.Sprintf("./%s/cert.pem", c.DisplayName)
+	c.ckey = fmt.Sprintf("./%s/%s", c.certPath, clientKey)
+	c.ccert = fmt.Sprintf("./%s/%s", c.certPath, clientCert)
 
-	skey := fmt.Sprintf("./%s/server-key.pem", c.DisplayName)
-	scert := fmt.Sprintf("./%s/server-cert.pem", c.DisplayName)
+	cakey := fmt.Sprintf("./%s/%s", c.certPath, caKey)
+	c.cacert = fmt.Sprintf("./%s/%s", c.certPath, caCert)
 
-	cakey := fmt.Sprintf("./%s/ca-key.pem", c.DisplayName)
-	c.cacert = fmt.Sprintf("./%s/ca.pem", c.DisplayName)
-
-	if !ca {
-		log.Infof("Generating self-signed certificate/key pair - private key in %s", c.key)
-		keypair := certificate.NewKeyPair(c.key, c.cert, nil, nil)
+	if server && !client {
+		log.Infof("Generating self-signed certificate/key pair - private key in %s", c.skey)
+		keypair := certificate.NewKeyPair(c.scert, c.skey, nil, nil)
 		err := keypair.CreateSelfSigned(c.cname, nil, c.keySize)
 		if err != nil {
 			log.Errorf("Failed to generate self-signed certificate: %s", err)
+			return nil, nil, err
+		}
+		if err = keypair.SaveCertificate(); err != nil {
+			log.Errorf("Failed to save server certificates: %s", err)
 			return nil, nil, err
 		}
 
 		return certs, keypair, nil
 	}
 
-	// if we've not got a specific CommonName but do have a static IP then go with that.
-	if c.cname == "" && c.clientNetworkIP != "" {
-		c.cname = c.clientNetworkIP
-		log.Infof("Using client-network-ip as cname for server certificates - use --tls-cname to override: %s", c.cname)
-	}
-
+	// client auth path
 	if c.cname == "" {
 		log.Error("Common Name must be provided when generating certificates for client authentication:")
 		log.Info("  --tls-cname=<FQDN or static IP> # for the appliance VM")
@@ -913,46 +1040,51 @@ func (c *Create) generateCertificates(ca bool) ([]byte, *certificate.KeyPair, er
 	}
 
 	// Server certificates
-	log.Infof("Generating server certificate/key pair - private key in %s", skey)
-	skp := certificate.NewKeyPair(scert, skey, nil, nil)
-	err = skp.CreateServerCertificate(c.cname, c.org, c.keySize, cakp)
-	if err != nil {
-		log.Errorf("Failed to generate server certificates: %s", err)
-		return nil, nil, err
-	}
-	if err = skp.SaveCertificate(); err != nil {
-		log.Errorf("Failed to save server certificates: %s", err)
-		return nil, nil, err
+	var skp *certificate.KeyPair
+	if server {
+		log.Infof("Generating server certificate/key pair - private key in %s", c.skey)
+		skp = certificate.NewKeyPair(c.scert, c.skey, nil, nil)
+		err = skp.CreateServerCertificate(c.cname, c.org, c.keySize, cakp)
+		if err != nil {
+			log.Errorf("Failed to generate server certificates: %s", err)
+			return nil, nil, err
+		}
+		if err = skp.SaveCertificate(); err != nil {
+			log.Errorf("Failed to save server certificates: %s", err)
+			return nil, nil, err
+		}
 	}
 
 	// Client certificates
-	log.Infof("Generating client certificate/key pair - private key in %s", c.key)
-	ckp := certificate.NewKeyPair(c.cert, c.key, nil, nil)
-	err = ckp.CreateClientCertificate(c.cname, c.org, c.keySize, cakp)
-	if err != nil {
-		log.Errorf("Failed to generate server certificates: %s", err)
-		return nil, nil, err
-	}
-	if err = ckp.SaveCertificate(); err != nil {
-		log.Errorf("Failed to save client certificates: %s", err)
-		return nil, nil, err
-	}
+	if client {
+		log.Infof("Generating client certificate/key pair - private key in %s", c.ckey)
+		ckp := certificate.NewKeyPair(c.ccert, c.ckey, nil, nil)
+		err = ckp.CreateClientCertificate(c.cname, c.org, c.keySize, cakp)
+		if err != nil {
+			log.Errorf("Failed to generate client certificates: %s", err)
+			return nil, nil, err
+		}
+		if err = ckp.SaveCertificate(); err != nil {
+			log.Errorf("Failed to save client certificates: %s", err)
+			return nil, nil, err
+		}
 
-	c.clientCert, err = ckp.Certificate()
-	if err != nil {
-		log.Warnf("Failed to stash client certificate for later application level validation: %s", err)
-	}
+		c.clientCert, err = ckp.Certificate()
+		if err != nil {
+			log.Warnf("Failed to stash client certificate for later application level validation: %s", err)
+		}
 
-	// If openssl is present, try to generate a browser friendly pfx file (a bundle of the public certificate AND the private key)
-	// The pfx file can be imported directly into keychains for client certificate authentication
-	args := strings.Split(fmt.Sprintf("pkcs12 -export -out ./%[1]s/cert.pfx -inkey ./%[1]s/key.pem -in ./%[1]s/cert.pem -certfile ./%[1]s/ca.pem -password pass:", c.DisplayName), " ")
-	pfx := exec.Command("openssl", args...)
-	out, err := pfx.CombinedOutput()
-	if err != nil {
-		log.Debug(out)
-		log.Warnf("Failed to generate browser friendly PFX client certificate: %s", err)
-	} else {
-		log.Infof("Generated browser friendly PFX client certificate - certificate in ./%s/cert.pfx", c.DisplayName)
+		// If openssl is present, try to generate a browser friendly pfx file (a bundle of the public certificate AND the private key)
+		// The pfx file can be imported directly into keychains for client certificate authentication
+		args := strings.Split(fmt.Sprintf("pkcs12 -export -out ./%[1]s/cert.pfx -inkey ./%[1]s/key.pem -in ./%[1]s/cert.pem -certfile ./%[1]s/ca.pem -password pass:", c.DisplayName), " ")
+		pfx := exec.Command("openssl", args...)
+		out, err := pfx.CombinedOutput()
+		if err != nil {
+			log.Debug(out)
+			log.Warnf("Failed to generate browser friendly PFX client certificate: %s", err)
+		} else {
+			log.Infof("Generated browser friendly PFX client certificate - certificate in ./%s/cert.pfx", c.DisplayName)
+		}
 	}
 
 	return cakp.CertPEM, skp, nil
@@ -964,6 +1096,8 @@ func (c *Create) Run(cliContext *cli.Context) (err error) {
 		cli.HelpPrinter(cliContext.App.Writer, EntireOptionHelpTemplate, cliContext.Command)
 		return nil
 	}
+
+	log.Infof("### Installing VCH ####")
 
 	if c.Debug.Debug > 0 {
 		log.SetLevel(log.DebugLevel)
@@ -984,8 +1118,6 @@ func (c *Create) Run(cliContext *cli.Context) (err error) {
 		log.Errorf("Unknown argument: %s", cliContext.Args()[0])
 		return errors.New("invalid CLI arguments")
 	}
-
-	log.Infof("### Installing VCH ####")
 
 	ctx, cancel := context.WithTimeout(context.Background(), c.Timeout)
 	defer cancel()
@@ -1037,7 +1169,7 @@ func (c *Create) Run(cliContext *cli.Context) (err error) {
 
 	log.Infof("Initialization of appliance successful")
 
-	executor.ShowVCH(vchConfig, c.key, c.cert, c.cacert, c.envFile)
+	executor.ShowVCH(vchConfig, c.ckey, c.ccert, c.cacert, c.envFile)
 	log.Infof("Installer completed successfully")
 	return nil
 }

--- a/cmd/vic-machine/create/install_test.go
+++ b/cmd/vic-machine/create/install_test.go
@@ -33,22 +33,18 @@ func TestGenKey(t *testing.T) {
 	os.Args = []string{"cmd", "create"}
 	flag.Parse()
 	create.noTLS = false
-	create.DisplayName = "install-test"
+	create.certPath = "install-test"
 	create.cname = "common name"
 	create.keySize = 1024
 
-	ca, kp, err := create.generateCertificates(true)
-	defer os.RemoveAll(fmt.Sprintf("./%s", create.DisplayName))
+	ca, kp, err := create.generateCertificates(true, true)
+	defer os.RemoveAll(fmt.Sprintf("./%s", create.certPath))
 
 	assert.NoError(t, err, "Expected to cleanly generate certificates")
 	assert.NotEmpty(t, ca, "Expected CA to contain data")
 	assert.NotNil(t, kp, "Expected keypair to contain data")
 	assert.NotEmpty(t, kp.CertPEM, "Expected certificate to contain data")
 	assert.NotEmpty(t, kp.CertPEM, "Expected key to contain data")
-
-	create.key = fmt.Sprintf("./%s/key.pem", create.DisplayName)
-	create.cert = fmt.Sprintf("./%s/cert.pem", create.DisplayName)
-	create.clientCAs = []string{fmt.Sprintf("./%s/ca.pem", create.DisplayName)}
 
 	ca, kp, err = create.loadCertificates()
 	assert.NoError(t, err, "Expected to cleanly load certificates")

--- a/infra/scripts/bash-helpers.sh
+++ b/infra/scripts/bash-helpers.sh
@@ -25,8 +25,6 @@ no-tls () {
 
 unset-vic () {
     unset MAPPED_NETWORKS NETWORKS IMAGE_STORE DATASTORE COMPUTE VOLUME_STORES IPADDR GOVC_INSECURE TLS THUMBPRINT
-    unset DOCKER_CERT_PATH DOCKER_TLS_VERIFY
-    unalias docker 2>/dev/null
 }
 
 vic-path () {
@@ -34,22 +32,28 @@ vic-path () {
 }
 
 vic-create () {
-    pushd $(vic-path)/bin/
+    base=$(pwd)
+    (
+        cd $(vic-path)/bin
+        $(vic-path)/bin/vic-machine-"$OS" create --target="$GOVC_URL" --image-store="$IMAGE_STORE" --compute-resource="$COMPUTE" "${TLS[@]}" ${TLS_OPTS} --name=${VIC_NAME:-${USER}test} "${MAPPED_NETWORKS[@]}" "${VOLUME_STORES[@]}" "${NETWORKS[@]}" ${IPADDR} ${TIMEOUT} --thumbprint=$THUMBPRINT $*
+    )
 
-    $(vic-path)/bin/vic-machine-"$OS" create --target="$GOVC_URL" --image-store="$IMAGE_STORE" --compute-resource="$COMPUTE" "${TLS[@]}" ${TLS_OPTS} --name=${VIC_NAME:-${USER}test} "${MAPPED_NETWORKS[@]}" "${VOLUME_STORES[@]}" "${NETWORKS[@]}" ${IPADDR} ${TIMEOUT} --thumbprint=$THUMBPRINT $*
+    unset DOCKER_CERT_PATH DOCKER_TLS_VERIFY
+    unalias docker 2>/dev/null
 
-    envfile=${VIC_NAME:-${USER}test}/${VIC_NAME:-${USER}test}.env
+    envfile=$(vic-path)/bin/${VIC_NAME:-${USER}test}/${VIC_NAME:-${USER}test}.env
     if [ -f "$envfile" ]; then
         set -a
         source $envfile
         set +a
     fi
 
-    if [ -z ${DOCKER_TLS_VERIFY+x} ]; then
+    # Something of a hack, but works for --no-tls so long as that's enabled via TLS_OPTS
+    if [ -z "${DOCKER_TLS_VERIFY+x}" -a -z "${TLS_OPTS+x}" ]; then
         alias docker='docker --tls'
     fi
 
-    popd
+    cd $base
 }
 
 vic-delete () {
@@ -72,7 +76,7 @@ vic-ssh () {
     fi
 
     out=$($(vic-path)/bin/vic-machine-"$OS" debug --target="$GOVC_URL" --compute-resource="$COMPUTE" --name=${VIC_NAME:-${USER}test} --enable-ssh $keyarg --rootpw=password --thumbprint=$THUMBPRINT $*)
-    host=$(echo $out | grep DOCKER_HOST | sed -n 's/.*DOCKER_HOST=\([^i:]*\).*/\1/p')
+    host=$(echo $out | grep DOCKER_HOST | sed -n 's/.*DOCKER_HOST=\([^:\s]*\).*/\1/p')
 
     echo "SSH to ${host}"
     sshpass -ppassword ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@${host}
@@ -80,7 +84,7 @@ vic-ssh () {
 
 vic-admin () {
     out=$($(vic-path)/bin/vic-machine-"$OS" debug --target="$GOVC_URL" --compute-resource="$COMPUTE" --name=${VIC_NAME:-${USER}test} --enable-ssh $keyarg --rootpw=password --thumbprint=$THUMBPRINT $*)
-    host=$(echo $out | grep DOCKER_HOST | sed -n 's/.*DOCKER_HOST=\([^i:]*\).*/\1/p')
+    host=$(echo $out | grep DOCKER_HOST | sed -n 's/.*DOCKER_HOST=\([^:\s*\).*/\1/p')
 
    open http://${host}:2378
 }

--- a/pkg/certificate/keypair.go
+++ b/pkg/certificate/keypair.go
@@ -42,13 +42,11 @@ func NewKeyPair(certFile, keyFile string, certPEM, keyPEM []byte) *KeyPair {
 func (kp *KeyPair) LoadCertificate() error {
 	c, err := ioutil.ReadFile(kp.CertFile)
 	if err != nil {
-		err = errors.Errorf("Failed to read certificate file %s: %s", kp.CertFile, err)
 		return err
 	}
 
 	k, err := ioutil.ReadFile(kp.KeyFile)
 	if err != nil {
-		err = errors.Errorf("Failed to read key file %s: %s", kp.KeyFile, err)
 		return err
 	}
 
@@ -111,6 +109,7 @@ func (kp *KeyPair) CreateClientCertificate(domain string, org []string, size int
 }
 
 // Certificate turns the KeyPair back into useful TLS constructs
+// This attempts to populate the certificate.Leaf field with the x509 certificate for convenience
 func (kp *KeyPair) Certificate() (*tls.Certificate, error) {
 	if kp.CertPEM == nil || kp.KeyPEM == nil {
 		return nil, errors.New("KeyPair has no data")
@@ -120,6 +119,8 @@ func (kp *KeyPair) Certificate() (*tls.Certificate, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	cert.Leaf, _, _ = ParseCertificate(kp.CertPEM, kp.KeyPEM)
 
 	return &cert, nil
 }

--- a/tests/test-cases/Group6-VIC-Machine/6-04-Create-Basic.robot
+++ b/tests/test-cases/Group6-VIC-Machine/6-04-Create-Basic.robot
@@ -237,6 +237,32 @@ Create VCH - Invalid keys
 
     Cleanup VIC Appliance On Test Server
 
+Create VCH - Reuse keys
+    ${domain}=  Get Environment Variable  DOMAIN  ''
+    Run Keyword If  '${domain}' == ''  Pass Execution  Skipping test - domain not set, won't generate keys
+
+    Set Test Environment Variables
+
+    # use one install to generate certificates
+    ${output}=  Run  bin/vic-machine-linux create --name=${vch-name} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --image-store=%{TEST_DATASTORE} --bridge-network=%{BRIDGE_NETWORK} --external-network=%{EXTERNAL_NETWORK} ${vicmachinetls}
+    Should Contain  ${output}  Installer completed successfully
+    Get Docker Params  ${output}  ${true}
+    Log To Console  Installer completed successfully: ${vch-name}
+
+    # remove the initial deployment
+    ${ret}=  Run  bin/vic-machine-linux delete --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --name=${vch-name} --force
+    Should Contain  ${ret}  Completed successfully
+
+    # deploy using the same name - should reuse certificates
+    ${output}=  Run  bin/vic-machine-linux create --name=${vch-name} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --image-store=%{TEST_DATASTORE} --bridge-network=%{BRIDGE_NETWORK} --external-network=%{EXTERNAL_NETWORK} ${vicmachinetls}
+    Should Contain  ${output}  Installer completed successfully
+
+    Should Contain  ${output}  Loaded server certificate
+    Should Contain  ${output}  Loaded CA with default name from certificate path
+    Should Contain  ${output}  Loaded client certificate with default name from certificate path
+
+    Cleanup VIC Appliance On Test Server
+
 Basic timeout
     Set Test Environment Variables
     Run Keyword And Ignore Error  Cleanup Dangling VMs On Test Server


### PR DESCRIPTION
Adds a --cert-path option, used both for sourcing existing certs and
saving generated certs.

If existing certs are found, those will be used - this avoids the scenario
of redeploying a VCH and overwriting the generated (and potentially
distributed) certificates.
Various checks are performed to ensure certificate validity and attempts
to provide better diagnostics with cert errors.

Now uses the system root pool to validate server cert as well as the
generated CA when checking API liveliness.

Fixes #2197 
