### PR TITLE
[full ci] Hetero govc nightly fix for ESX 5.5

### DIFF
--- a/tests/nightly/nightly-kickoff.sh
+++ b/tests/nightly/nightly-kickoff.sh
@@ -58,8 +58,7 @@ count=0
 
 for i in $nightly_list_var; do
     echo "Executing nightly test $i"
-    $test_var="pybot -d $i tests/manual-test-cases/Group5-Functional-Tests/$i.robot"
-    drone exec --trusted -e test=$test_var -E nightly_test_secrets.yml --yaml .drone.nightly.yml
+    drone exec --trusted -e test="pybot -d $i tests/manual-test-cases/Group5-Functional-Tests/$i.robot" -E nightly_test_secrets.yml --yaml .drone.nightly.yml
 
     if [ $? -eq 0 ]
     then

--- a/tests/resources/Nimbus-Util.robot
+++ b/tests/resources/Nimbus-Util.robot
@@ -278,7 +278,7 @@ Create a Simple VC Cluster
 Create A Distributed Switch
     [Arguments]  ${datacenter}  ${dvs}=test-ds
     Log To Console  \nCreate a distributed switch
-    ${out}=  Run  govc dvs.create -dc=${datacenter} ${dvs}
+    ${out}=  Run  govc dvs.create -product-version 5.5.0 -dc=${datacenter} ${dvs}
     Should Contain  ${out}  OK
     
 Create Three Distributed Port Groups


### PR DESCRIPTION
Adding the product version flag to govc dvs.create call for ESX 5.5 support.

Fixes #3052 
