### PR TITLE
fix #2954 and #2357 and bring Docker-Compose tests back [full ci]

### DIFF
--- a/lib/config/executor/container_vm.go
+++ b/lib/config/executor/container_vm.go
@@ -135,7 +135,7 @@ type ExecutorConfig struct {
 	LayerID string `vic:"0.1" scope:"read-only" key:"layerid"`
 
 	// Blob metadata for the caller
-	Annotations map[string]string `vic:"0.1" scope:"hidden" key:"annotation"`
+	Annotations map[string]string `vic:"0.1" scope:"hidden" key:"annotations"`
 
 	// Repository requested by user
 	// TODO: a bit docker specific

--- a/tests/test-cases/Group3-Docker-Compose/3-01-Docker-Compose-LEMP.robot
+++ b/tests/test-cases/Group3-Docker-Compose/3-01-Docker-Compose-LEMP.robot
@@ -25,10 +25,11 @@ Compose LEMP Server
 
     # Run  echo '${yml}' > lemp-compose.yml
     Run  cat %{GOPATH}/src/github.com/vmware/vic/demos/compose/webserving-app/docker-compose.yml | sed -e "s/192.168.60.130/${vch_ip}/g" > lemp-compose.yml
-    ${rc}  ${output}=  Run And Return Rc And Output  docker-compose ${params} --file lemp-compose.yml up -d
+    Run  cat lemp-compose.yml
+	${rc}  ${output}=  Run And Return Rc And Output  docker-compose ${params} --file lemp-compose.yml up -d
     Log  ${output}
     Should Be Equal As Integers  ${rc}  0
 	
-    ${rc}  ${output}=  Run And Return Rc And Output  wget ${vch_ip}:8080
-    Log  ${output}
-    Should Be Equal As Integers  ${rc}  0
+    # ${rc}  ${output}=  Run And Return Rc And Output  wget ${vch_ip}:8080
+    # Log  ${output}
+    # Should Be Equal As Integers  ${rc}  0

--- a/tests/test-cases/Group3-Docker-Compose/3-01-Docker-Compose-LEMP.robot
+++ b/tests/test-cases/Group3-Docker-Compose/3-01-Docker-Compose-LEMP.robot
@@ -4,15 +4,8 @@ Resource  ../../resources/Util.robot
 Suite Setup  Install VIC Appliance To Test Server  certs=${false}
 Suite Teardown  Cleanup VIC Appliance On Test Server
 
-*** Variables ***
-# ${yml}  vic.mysql:\n${SPACE}container_name: vic.mysql\n${SPACE}image: mysql\n${SPACE}environment:\n${SPACE}- MYSQL_ROOT_PASSWORD=root\n${SPACE}- MYSQL_DATABASE=vmware1\n\nvic.php:\n${SPACE}container_name: vic.php\n${SPACE}image: php:7.0-fpm\n${SPACE}volumes:\n${SPACE}- src:/var/www\n\nvic.nginx:\n${SPACE}container_name: vic.nginx\n${SPACE}image: nginx\n${SPACE}links:\n${SPACE}- vic.mysql\n${SPACE}- vic.php\n${SPACE}volumes:\n${SPACE}- src:/var/www\n${SPACE}ports:\n${SPACE}- "80:80"
-
 *** Test Cases ***
 Compose LEMP Server
-    # ${status}=  Get State Of Github Issue  2357
-    # Run Keyword If  '${status}' == 'closed'  Fail  Test 3-1-Docker-Compose-LEMP.robot needs to be updated now that Issue #2357 has been resolved
-    # Log  Issue \#2357 is blocking implementation  WARN
-	
     ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} login --username=victest --password=vmware!123
     Should Be Equal As Integers  ${rc}  0
 
@@ -23,13 +16,8 @@ Compose LEMP Server
     ${vch_ip}=  Get Environment Variable  VCH_IP  ${vch-ip}
     Log To Console  \nThe VCH IP is ${vch_ip}
 
-    # Run  echo '${yml}' > lemp-compose.yml
     Run  cat %{GOPATH}/src/github.com/vmware/vic/demos/compose/webserving-app/docker-compose.yml | sed -e "s/192.168.60.130/${vch_ip}/g" > lemp-compose.yml
     Run  cat lemp-compose.yml
 	${rc}  ${output}=  Run And Return Rc And Output  docker-compose ${params} --file lemp-compose.yml up -d
     Log  ${output}
     Should Be Equal As Integers  ${rc}  0
-	
-    # ${rc}  ${output}=  Run And Return Rc And Output  wget ${vch_ip}:8080
-    # Log  ${output}
-    # Should Be Equal As Integers  ${rc}  0

--- a/tests/test-cases/Group3-Docker-Compose/3-01-Docker-Compose-LEMP.robot
+++ b/tests/test-cases/Group3-Docker-Compose/3-01-Docker-Compose-LEMP.robot
@@ -13,22 +13,22 @@ Compose LEMP Server
     # Run Keyword If  '${status}' == 'closed'  Fail  Test 3-1-Docker-Compose-LEMP.robot needs to be updated now that Issue #2357 has been resolved
     # Log  Issue \#2357 is blocking implementation  WARN
 	
-	${rc}  ${output}=  Run And Return Rc And Output  docker ${params} login --username=victest --password=vmware!123
+    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} login --username=victest --password=vmware!123
     Should Be Equal As Integers  ${rc}  0
 
     Set Environment Variable  COMPOSE_HTTP_TIMEOUT  300
     # must set CURL_CA_BUNDLE to work around Compose bug https://github.com/docker/compose/issues/3365
     Set Environment Variable  CURL_CA_BUNDLE  ${EMPTY}
 	
-	${vch_ip}=  Get Environment Variable  VCH_IP  ${vch-ip}
-	Log To Console  \nThe VCH IP is ${vch_ip}
+    ${vch_ip}=  Get Environment Variable  VCH_IP  ${vch-ip}
+    Log To Console  \nThe VCH IP is ${vch_ip}
 
-	# Run  echo '${yml}' > lemp-compose.yml
+    # Run  echo '${yml}' > lemp-compose.yml
     Run  cat %{GOPATH}/src/github.com/vmware/vic/demos/compose/webserving-app/docker-compose.yml | sed -e "s/192.168.60.130/${vch_ip}/g" > lemp-compose.yml
     ${rc}  ${output}=  Run And Return Rc And Output  docker-compose ${params} --file lemp-compose.yml up -d
     Log  ${output}
     Should Be Equal As Integers  ${rc}  0
 	
     ${rc}  ${output}=  Run And Return Rc And Output  wget ${vch_ip}:8080
-	Log  ${output}
+    Log  ${output}
     Should Be Equal As Integers  ${rc}  0

--- a/tests/test-cases/Group3-Docker-Compose/3-01-Docker-Compose-LEMP.robot
+++ b/tests/test-cases/Group3-Docker-Compose/3-01-Docker-Compose-LEMP.robot
@@ -1,18 +1,23 @@
 *** Settings ***
 Documentation  Test 3-01 - Docker Compose LEMP
 Resource  ../../resources/Util.robot
-#Suite Setup  Install VIC Appliance To Test Server
-#Suite Teardown  Cleanup VIC Appliance On Test Server
+Suite Setup  Install VIC Appliance To Test Server  certs=${false}
+Suite Teardown  Cleanup VIC Appliance On Test Server
 
 *** Variables ***
 ${yml}  vic.mysql:\n${SPACE}container_name: vic.mysql\n${SPACE}image: mysql\n${SPACE}environment:\n${SPACE}- MYSQL_ROOT_PASSWORD=root\n${SPACE}- MYSQL_DATABASE=vmware1\n\nvic.php:\n${SPACE}container_name: vic.php\n${SPACE}image: php:7.0-fpm\n${SPACE}volumes:\n${SPACE}- src:/var/www\n\nvic.nginx:\n${SPACE}container_name: vic.nginx\n${SPACE}image: nginx\n${SPACE}links:\n${SPACE}- vic.mysql\n${SPACE}- vic.php\n${SPACE}volumes:\n${SPACE}- src:/var/www\n${SPACE}ports:\n${SPACE}- "80:80"
 
 *** Test Cases ***
 Compose LEMP Server
-    ${status}=  Get State Of Github Issue  2357
-    Run Keyword If  '${status}' == 'closed'  Fail  Test 3-1-Docker-Compose-LEMP.robot needs to be updated now that Issue #2357 has been resolved
-    Log  Issue \#2357 is blocking implementation  WARN
-    #Run  echo '${yml}' > lemp-compose.yml
-    #${rc}  ${output}=  Run And Return Rc And Output  docker-compose ${params} --file lemp-compose.yml up
-    #Log  ${output}
-    #Should Be Equal As Integers  ${rc}  0
+    # ${status}=  Get State Of Github Issue  2357
+    # Run Keyword If  '${status}' == 'closed'  Fail  Test 3-1-Docker-Compose-LEMP.robot needs to be updated now that Issue #2357 has been resolved
+    # Log  Issue \#2357 is blocking implementation  WARN
+
+    Set Environment Variable  COMPOSE_HTTP_TIMEOUT  300
+    # must set CURL_CA_BUNDLE to work around Compose bug https://github.com/docker/compose/issues/3365
+    Set Environment Variable  CURL_CA_BUNDLE  ${EMPTY}
+
+    Run  echo '${yml}' > lemp-compose.yml
+    ${rc}  ${output}=  Run And Return Rc And Output  docker-compose ${params} --file lemp-compose.yml up
+    Log  ${output}
+    Should Be Equal As Integers  ${rc}  0

--- a/tests/test-cases/Group3-Docker-Compose/3-01-Docker-Compose-LEMP.robot
+++ b/tests/test-cases/Group3-Docker-Compose/3-01-Docker-Compose-LEMP.robot
@@ -5,19 +5,30 @@ Suite Setup  Install VIC Appliance To Test Server  certs=${false}
 Suite Teardown  Cleanup VIC Appliance On Test Server
 
 *** Variables ***
-${yml}  vic.mysql:\n${SPACE}container_name: vic.mysql\n${SPACE}image: mysql\n${SPACE}environment:\n${SPACE}- MYSQL_ROOT_PASSWORD=root\n${SPACE}- MYSQL_DATABASE=vmware1\n\nvic.php:\n${SPACE}container_name: vic.php\n${SPACE}image: php:7.0-fpm\n${SPACE}volumes:\n${SPACE}- src:/var/www\n\nvic.nginx:\n${SPACE}container_name: vic.nginx\n${SPACE}image: nginx\n${SPACE}links:\n${SPACE}- vic.mysql\n${SPACE}- vic.php\n${SPACE}volumes:\n${SPACE}- src:/var/www\n${SPACE}ports:\n${SPACE}- "80:80"
+# ${yml}  vic.mysql:\n${SPACE}container_name: vic.mysql\n${SPACE}image: mysql\n${SPACE}environment:\n${SPACE}- MYSQL_ROOT_PASSWORD=root\n${SPACE}- MYSQL_DATABASE=vmware1\n\nvic.php:\n${SPACE}container_name: vic.php\n${SPACE}image: php:7.0-fpm\n${SPACE}volumes:\n${SPACE}- src:/var/www\n\nvic.nginx:\n${SPACE}container_name: vic.nginx\n${SPACE}image: nginx\n${SPACE}links:\n${SPACE}- vic.mysql\n${SPACE}- vic.php\n${SPACE}volumes:\n${SPACE}- src:/var/www\n${SPACE}ports:\n${SPACE}- "80:80"
 
 *** Test Cases ***
 Compose LEMP Server
     # ${status}=  Get State Of Github Issue  2357
     # Run Keyword If  '${status}' == 'closed'  Fail  Test 3-1-Docker-Compose-LEMP.robot needs to be updated now that Issue #2357 has been resolved
     # Log  Issue \#2357 is blocking implementation  WARN
+	
+	${rc}  ${output}=  Run And Return Rc And Output  docker ${params} login --username=victest --password=vmware!123
+    Should Be Equal As Integers  ${rc}  0
 
     Set Environment Variable  COMPOSE_HTTP_TIMEOUT  300
     # must set CURL_CA_BUNDLE to work around Compose bug https://github.com/docker/compose/issues/3365
     Set Environment Variable  CURL_CA_BUNDLE  ${EMPTY}
+	
+	${vch_ip}=  Get Environment Variable  VCH_IP  ${vch-ip}
+	Log To Console  \nThe VCH IP is ${vch_ip}
 
-    Run  echo '${yml}' > lemp-compose.yml
-    ${rc}  ${output}=  Run And Return Rc And Output  docker-compose ${params} --file lemp-compose.yml up
+	# Run  echo '${yml}' > lemp-compose.yml
+    Run  cat %{GOPATH}/src/github.com/vmware/vic/demos/compose/webserving-app/docker-compose.yml | sed -e "s/192.168.60.130/${vch_ip}/g" > lemp-compose.yml
+    ${rc}  ${output}=  Run And Return Rc And Output  docker-compose ${params} --file lemp-compose.yml up -d
     Log  ${output}
+    Should Be Equal As Integers  ${rc}  0
+	
+    ${rc}  ${output}=  Run And Return Rc And Output  wget ${vch_ip}:8080
+	Log  ${output}
     Should Be Equal As Integers  ${rc}  0

--- a/tests/test-cases/Group3-Docker-Compose/3-03-Docker-Compose-Basic.robot
+++ b/tests/test-cases/Group3-Docker-Compose/3-03-Docker-Compose-Basic.robot
@@ -9,21 +9,26 @@ ${yml}  version: "2"\nservices:\n${SPACE}web:\n${SPACE}${SPACE}image: python:2.7
 
 *** Test Cases ***
 Compose basic
-    ${status}=  Get State Of Github Issue  2954
-    Run Keyword If  '${status}' == 'closed'  Fail  Test 3-03-Docker-Compose-Basic.robot needs to be updated now that Issue #2954 has been resolved
-    Log  Issue \#2954 is blocking implementation  WARN
-    # Run  echo '${yml}' > basic-compose.yml
-    # ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} network create vic_default
-    # Log  ${output}
-    # ${rc}  ${output}=  Run And Return Rc And Output  docker-compose ${params} --file basic-compose.yml create
-    # Log  ${output}
-    # Should Be Equal As Integers  ${rc}  0
-    # ${rc}  ${output}=  Run And Return Rc And Output  docker-compose ${params} --file basic-compose.yml start
-    # Log  ${output}
-    # Should Be Equal As Integers  ${rc}  0
-    # ${rc}  ${output}=  Run And Return Rc And Output  docker-compose ${params} --file basic-compose.yml logs
-    # Log  ${output}
-    # Should Be Equal As Integers  ${rc}  0
-    # ${rc}  ${output}=  Run And Return Rc And Output  docker-compose ${params} --file basic-compose.yml stop
-    # Log  ${output}
-    # Should Be Equal As Integers  ${rc}  0
+    # ${status}=  Get State Of Github Issue  2954
+    # Run Keyword If  '${status}' == 'closed'  Fail  Test 3-03-Docker-Compose-Basic.robot needs to be updated now that Issue #2954 has been resolved
+    # Log  Issue \#2954 is blocking implementation  WARN
+
+    Set Environment Variable  COMPOSE_HTTP_TIMEOUT  300
+    # must set CURL_CA_BUNDLE to work around Compose bug https://github.com/docker/compose/issues/3365
+    Set Environment Variable  CURL_CA_BUNDLE  ${EMPTY}
+
+    Run  echo '${yml}' > basic-compose.yml
+    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} network create vic_default
+    Log  ${output}
+    ${rc}  ${output}=  Run And Return Rc And Output  docker-compose ${params} --file basic-compose.yml create
+    Log  ${output}
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${output}=  Run And Return Rc And Output  docker-compose ${params} --file basic-compose.yml start
+    Log  ${output}
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${output}=  Run And Return Rc And Output  docker-compose ${params} --file basic-compose.yml logs
+    Log  ${output}
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${output}=  Run And Return Rc And Output  docker-compose ${params} --file basic-compose.yml stop
+    Log  ${output}
+    Should Be Equal As Integers  ${rc}  0

--- a/tests/test-cases/Group3-Docker-Compose/3-03-Docker-Compose-Basic.robot
+++ b/tests/test-cases/Group3-Docker-Compose/3-03-Docker-Compose-Basic.robot
@@ -9,10 +9,6 @@ ${yml}  version: "2"\nservices:\n${SPACE}web:\n${SPACE}${SPACE}image: python:2.7
 
 *** Test Cases ***
 Compose basic
-    # ${status}=  Get State Of Github Issue  2954
-    # Run Keyword If  '${status}' == 'closed'  Fail  Test 3-03-Docker-Compose-Basic.robot needs to be updated now that Issue #2954 has been resolved
-    # Log  Issue \#2954 is blocking implementation  WARN
-
     Set Environment Variable  COMPOSE_HTTP_TIMEOUT  300
     # must set CURL_CA_BUNDLE to work around Compose bug https://github.com/docker/compose/issues/3365
     Set Environment Variable  CURL_CA_BUNDLE  ${EMPTY}


### PR DESCRIPTION
Fixes #2954 #2357 

-  Changing the key of "Annotations" from "annotation" to "annotations" in lib/config/executor/container_vm.go
-  Bring Docker-Compose-Basic and Docker-Compose-LEMP test cases back

From "lib/apiserver/portlayer/models/container_create_config.go", I find this
 ```
Annotations map[string]string `json:"annotations,omitempty"`
```

It is possible that #2954 was incurred because we use "annotations" when creating the container, but then we use "annotation" when decoding the extraconfig and extracting the container labels.



