### PR TITLE
Rename 'Docker log' to 'VCH Admin portal' in VCH portlet

### DIFF
--- a/ui/vic-ui/swf/src/main/flex/com/vmware/vicui/views/VchPortletView.mxml
+++ b/ui/vic-ui/swf/src/main/flex/com/vmware/vicui/views/VchPortletView.mxml
@@ -7,14 +7,14 @@
 	<fx:Metadata>
 		[DefaultMediator("com.vmware.vicui.views.VchPortletMediator")]
 	</fx:Metadata>
-	
+
 	<fx:Script>
 		<![CDATA[
 		import mx.resources.ResourceManager;
 		import flash.events.MouseEvent;
-		
-		// Utilities to load strings and images from resource file 
-		
+
+		// Utilities to load strings and images from resource file
+
 		private function getString(key:String) : String {
 		    return ResourceManager.getInstance().getString('VicuiResources', key);
 		}
@@ -22,7 +22,7 @@
 		private function jumpToURL(click:MouseEvent) : void {
 		    navigateToURL(new URLRequest(click.currentTarget.label), "_blank");
 		}
-		
+
 		[Bindable]
 		public var isVch:Boolean = false;
 		]]>
@@ -30,7 +30,7 @@
 	<ns:PropertyGridRow label="Docker API endpoint" visible="{isVch}" includeInLayout="{isVch}">
 		<mx:Label id="dockerApiEndpoint" text="{getString('placeholderText')}" selectable="true"/>
 	</ns:PropertyGridRow>
-	<ns:PropertyGridRow label="Docker log" visible="{isVch}" includeInLayout="{isVch}">
+	<ns:PropertyGridRow label="VCH Admin portal" visible="{isVch}" includeInLayout="{isVch}">
 		<mx:LinkButton id="dockerLog" label="{getString('placeholderText')}" textAlign="left" click="jumpToURL(event)"/>
 	</ns:PropertyGridRow>
 </ns:PropertyGrid>


### PR DESCRIPTION
This PR changes label `Docker log` in the Virtual Container Host portlet to `VCH Admin portal` as addressed by @stuclem 

Fixes #2806 

