### PR TITLE
correct indent for 3-01-Docker-Compose-LEMP.robot

### DIFF
--- a/tests/test-cases/Group3-Docker-Compose/3-01-Docker-Compose-LEMP.robot
+++ b/tests/test-cases/Group3-Docker-Compose/3-01-Docker-Compose-LEMP.robot
@@ -18,6 +18,6 @@ Compose LEMP Server
 
     Run  cat %{GOPATH}/src/github.com/vmware/vic/demos/compose/webserving-app/docker-compose.yml | sed -e "s/192.168.60.130/${vch_ip}/g" > lemp-compose.yml
     Run  cat lemp-compose.yml
-	${rc}  ${output}=  Run And Return Rc And Output  docker-compose ${params} --file lemp-compose.yml up -d
+    ${rc}  ${output}=  Run And Return Rc And Output  docker-compose ${params} --file lemp-compose.yml up -d
     Log  ${output}
     Should Be Equal As Integers  ${rc}  0


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[  ] There is an associated issue that is labelled
[  ] Code is up-to-date with the `master` branch
[  ] You've successfully run `make test` locally
[  ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/vmware/vic/blob/master/.github/CONTRIBUTING.md
-->

Fixes #

