### PR TITLE
Set default DNS servers when using static VCH IP

### DIFF
--- a/cmd/vic-machine/create/create.go
+++ b/cmd/vic-machine/create/create.go
@@ -243,7 +243,7 @@ func (c *Create) Flags() []cli.Flag {
 		cli.StringSliceFlag{
 			Name:   "dns-server",
 			Value:  &c.dns,
-			Usage:  "DNS server for the client, external, and management networks. Defaults to 8.8.8.8 and 8.8.4.4 when not using DHCP",
+			Usage:  "DNS server for the client, external, and management networks. Defaults to 8.8.8.8 and 8.8.4.4 when VCH uses static IP",
 			Hidden: true,
 		},
 
@@ -743,10 +743,6 @@ func (c *Create) processNetwork(network *data.NetworkConfig, netName, pgName, st
 
 // processDNSServers parses DNS servers used for client, external, mgmt networks
 func (c *Create) processDNSServers() error {
-	if len(c.dns) == 0 {
-		return nil
-	}
-
 	for _, d := range c.dns {
 		s := net.ParseIP(d)
 		if s == nil {
@@ -756,12 +752,9 @@ func (c *Create) processDNSServers() error {
 	}
 
 	if len(c.Data.DNS) > 3 {
-		log.Warn("Maximum of 3 DNS servers. Additional servers specified will be ignored.")
+		log.Warn("Maximum of 3 DNS servers allowed. Additional servers specified will be ignored.")
 	}
 
-	if c.Data.ClientNetwork.Empty() && c.Data.ExternalNetwork.Empty() && c.Data.ManagementNetwork.Empty() {
-		log.Warn("Specified DNS servers are ignored if static IP is not set on any networks. VCH will use DNS servers provided by DHCP.")
-	}
 	log.Debugf("VCH DNS servers: %s", c.Data.DNS)
 	return nil
 }

--- a/lib/install/validate/network.go
+++ b/lib/install/validate/network.go
@@ -207,6 +207,15 @@ func (v *Validator) network(ctx context.Context, input *data.Data, conf *config.
 	err = v.configureSharedPortGroups(input, c, i)
 	v.NoteIssue(err)
 
+	// check if static IP on all networks and no user provided DNS servers
+	specifiedDNS := len(input.DNS) > 0
+	usingDHCP := ip.IsUnspecifiedIP(input.ClientNetwork.IP.IP) || ip.IsUnspecifiedIP(input.ExternalNetwork.IP.IP) || ip.IsUnspecifiedIP(input.ManagementNetwork.IP.IP)
+
+	if !usingDHCP && !specifiedDNS { // Set default DNS servers
+		log.Debug("Setting default DNS servers 8.8.8.8 and 8.8.4.4")
+		input.DNS = []net.IP{net.ParseIP("8.8.8.8"), net.ParseIP("8.8.4.4")}
+	}
+
 	// External net
 	// external network is default for appliance
 	e, err = v.getEndpoint(ctx, conf, input.ExternalNetwork, "external", "external", true, input.DNS)


### PR DESCRIPTION
Fixes #3060 

```
root@chin-vic-10 [ ~ ]# cat /etc/resolv.conf 
nameserver 8.8.8.8
nameserver 8.8.4.4
options timeout:15
options attempts:5
```