### PR TITLE
Fix cache corruption bug

### DIFF
--- a/lib/apiservers/engine/backends/cache/image_cache.go
+++ b/lib/apiservers/engine/backends/cache/image_cache.go
@@ -139,7 +139,7 @@ func (ic *ICache) Get(idOrRef string) (*metadata.ImageConfig, error) {
 
 	// cover the case of creating by a full reference
 	if config, ok := ic.cacheByName[idOrRef]; ok {
-		return config, nil
+		return copyImageConfig(config), nil
 	}
 
 	// get the full image ID if supplied a prefix


### PR DESCRIPTION
We weren't returning a copy when fetching cached image metadata for custom docker registries, allowing the cache to be corrupted.

Fixes #3114 

