### PR TITLE
Switch to a whitelist logging to avoid possible security concerns

### DIFF
--- a/cmd/vic-machine/create/create.go
+++ b/cmd/vic-machine/create/create.go
@@ -980,7 +980,7 @@ func (c *Create) Run(cliContext *cli.Context) (err error) {
 		return err
 	}
 
-	log.Infof("Supplied install parameters: --compute-resource %s --image-store %s --volumes %s --bridge-network %s --client-network %s --external-network %s", c.Data.Compute, c.Data.ImageDatastorePath, c.Data.VolumeLocations, c.Data.BridgeNetworkName, c.Data.ClientNetwork, c.Data.ExternalNetwork)
+	log.Infof("Supplied install parameters: --compute-resource %s --image-store %s --volumes %s --bridge-network %s --client-network %s --external-network %s --http-proxy %s --https-proxy %s", c.Data.Compute, c.Data.ImageDatastorePath, c.Data.VolumeLocations, c.Data.BridgeNetworkName, c.Data.ClientNetwork, c.Data.ExternalNetwork, c.Data.HTTPSProxy, c.Data.HTTPProxy)
 
 	var images map[string]string
 	if images, err = c.CheckImagesFiles(c.Force); err != nil {

--- a/cmd/vic-machine/create/create.go
+++ b/cmd/vic-machine/create/create.go
@@ -980,7 +980,7 @@ func (c *Create) Run(cliContext *cli.Context) (err error) {
 		return err
 	}
 
-        log.Infof("Supplied install parameters: %s", c.Data)
+	log.Infof("Supplied install parameters: --compute-resource %s --image-store %s --volumes %s --bridge-network %s --client-network %s --external-network %s", c.Data.Compute, c.Data.ImageDatastorePath, c.Data.VolumeLocations, c.Data.BridgeNetworkName, c.Data.ClientNetwork, c.Data.ExternalNetwork)
 
 	var images map[string]string
 	if images, err = c.CheckImagesFiles(c.Force); err != nil {


### PR DESCRIPTION
This is a follow up to the previous issue:
#3037 

Output now looks like:
```
[34mINFO[0m[2016-11-14T13:07:08-06:00] Supplied install parameters: --compute-resource {/ha-datacenter/host/localhost.localdomain/Resources VCH-0-8421} --image-store datastore1 --volumes map[default:datastore1/test] --bridge-network VCH-0-8421-bridge --client-network { [] {<nil> <nil>} {<nil> <nil>}} --external-network {VM Network [] {<nil> <nil>} {<nil> <nil>}}
```