### PR TITLE
Add container op logging [full ci]

### DIFF
--- a/lib/apiservers/engine/backends/container.go
+++ b/lib/apiservers/engine/backends/container.go
@@ -218,7 +218,8 @@ func (c *Container) ContainerStatPath(name string, path string) (stat *types.Con
 
 // ContainerCreate creates a container.
 func (c *Container) ContainerCreate(config types.ContainerCreateConfig) (types.ContainerCreateResponse, error) {
-	op := trace.NewOperation(context.Background(), "Container.ContainerCreate")
+	op := trace.NewOperation(context.Background(), "")
+	defer trace.End(trace.Begin(op.SPrintf("")))
 
 	var err error
 
@@ -276,7 +277,7 @@ func (c *Container) ContainerCreate(config types.ContainerCreateConfig) (types.C
 // returns:
 //	(container id, error)
 func (c *Container) containerCreate(op trace.Operation, vc *viccontainer.VicContainer, config types.ContainerCreateConfig) (string, error) {
-	op.Debugf("Container.containerCreate")
+	defer trace.End(trace.Begin(op.SPrintf("")))
 
 	if vc == nil {
 		return "", InternalServerError("Failed to create container")
@@ -402,8 +403,8 @@ func (c *Container) ContainerRestart(name string, seconds int) error {
 // fails. If the remove succeeds, the container name is released, and
 // network links are removed.
 func (c *Container) ContainerRm(name string, config *types.ContainerRmConfig) error {
-	defer trace.End(trace.Begin(name))
-	op := trace.NewOperation(context.Background(), "container.ContainerRm(container(%s))", name)
+	op := trace.NewOperation(context.Background(), "")
+	defer trace.End(trace.Begin(op.SPrintf("container(%s)", name)))
 
 	// Look up the container name in the metadata cache to get long ID
 	vc := cache.ContainerCache().GetContainer(name)
@@ -488,12 +489,14 @@ func (c *Container) cleanupPortBindings(op trace.Operation, vc *viccontainer.Vic
 
 // ContainerStart starts a container.
 func (c *Container) ContainerStart(name string, hostConfig *containertypes.HostConfig) error {
-	op := trace.NewOperation(context.Background(), "Container.ContainerStart(container(%s))", name)
+	op := trace.NewOperation(context.Background(), "")
+	defer trace.End(trace.Begin(op.SPrintf("container(%s)", name)))
 	return c.containerStart(op, name, hostConfig, true)
 }
 
 func (c *Container) containerStart(op trace.Operation, name string, hostConfig *containertypes.HostConfig, bind bool) error {
-	op.Debugf("Container.containerStart(container(%s))", name)
+	defer trace.End(trace.Begin(op.SPrintf("container(%s)", name)))
+
 	var err error
 
 	// Get an API client to the portlayer
@@ -667,7 +670,7 @@ func unrollPortMap(portMap nat.PortMap) ([]*portMapping, error) {
 
 // MapPorts maps ports defined in hostconfig for containerID
 func MapPorts(op trace.Operation, hostconfig *containertypes.HostConfig, endpoint *models.EndpointConfig, containerID string) error {
-	op.Debugf("Container.MapPorts(container(%s))", containerID)
+	defer trace.End(trace.Begin(op.SPrintf("container(%q)", containerID)))
 	op.Debugf("mapPorts for %q: %v", containerID, hostconfig.PortBindings)
 
 	if len(hostconfig.PortBindings) == 0 {
@@ -795,7 +798,8 @@ func (c *Container) findPortBoundNetworkEndpoint(hostconfig *containertypes.Host
 // container is not found, is already stopped, or if there is a
 // problem stopping the container.
 func (c *Container) ContainerStop(name string, seconds int) error {
-	op := trace.NewOperation(context.Background(), "Container.ContainerStop(container(%s))", name)
+	op := trace.NewOperation(context.Background(), "")
+	defer trace.End(trace.Begin(op.SPrintf("container(%s)", name)))
 
 	// Look up the container name in the metadata cache to get long ID
 	vc := cache.ContainerCache().GetContainer(name)
@@ -822,7 +826,8 @@ func (c *Container) ContainerUpdate(name string, hostConfig *containertypes.Host
 // timeout, an error is returned. If you want to wait forever, supply
 // a negative duration for the timeout.
 func (c *Container) ContainerWait(name string, timeout time.Duration) (int, error) {
-	op := trace.NewOperation(context.Background(), "Container.ContainerWait(container(%s),timeout(%s))", name, timeout)
+	op := trace.NewOperation(context.Background(), "")
+	defer trace.End(trace.Begin(op.SPrintf("container(%s), timeout(%d)", name, timeout)))
 
 	// Look up the container name in the metadata cache to get long ID
 	vc := cache.ContainerCache().GetContainer(name)
@@ -898,7 +903,8 @@ func (c *Container) ContainerChanges(name string) ([]archive.Change, error) {
 // there is an error getting the data.
 func (c *Container) ContainerInspect(name string, size bool, version version.Version) (interface{}, error) {
 	// Ignore version.  We're supporting post-1.20 version.
-	op := trace.NewOperation(context.Background(), "Container.ContainerInspect(container(%s))", name)
+	op := trace.NewOperation(context.Background(), "")
+	defer trace.End(trace.Begin(op.SPrintf("container(%s)", name)))
 
 	// Look up the container name in the metadata cache to get long ID
 	vc := cache.ContainerCache().GetContainer(name)
@@ -1302,7 +1308,7 @@ func setPathFromImageConfig(config, imageConfig *containertypes.Config) {
 // validateCreateConfig() checks the parameters for ContainerCreate().
 // It may "fix up" the config param passed into ConntainerCreate() if needed.
 func validateCreateConfig(op trace.Operation, config *types.ContainerCreateConfig) error {
-	op.Debugf("Container.validateCreateConfig")
+	defer trace.End(trace.Begin(op.SPrintf("")))
 
 	// process cpucount here
 	var cpuCount int64 = DefaultCPUs

--- a/lib/apiservers/engine/backends/container_proxy.go
+++ b/lib/apiservers/engine/backends/container_proxy.go
@@ -168,7 +168,7 @@ func (c *ContainerProxy) Client() *client.PortLayer {
 // returns:
 //	(containerID, containerHandle, error)
 func (c *ContainerProxy) CreateContainerHandle(op trace.Operation, imageID string, config types.ContainerCreateConfig) (string, string, error) {
-	op.Debugf("Container_Proxy.CreateContainerHandle(image(%s))", imageID)
+	defer trace.End(trace.Begin(op.SPrintf("image(%s)", imageID)))
 
 	if c.client == nil {
 		return "", "", InternalServerError("ContainerProxy.CreateContainerHandle failed to create a portlayer client")
@@ -209,7 +209,7 @@ func (c *ContainerProxy) CreateContainerHandle(op trace.Operation, imageID strin
 // returns:
 //	modified handle
 func (c *ContainerProxy) AddContainerToScope(op trace.Operation, handle string, config types.ContainerCreateConfig) (string, error) {
-	op.Debugf("Container_proxy.AddContainerToScope(handle(%s))", handle)
+	defer trace.End(trace.Begin(op.SPrintf("handle(%s)", handle)))
 
 	if c.client == nil {
 		return "", InternalServerError("ContainerProxy.AddContainerToScope failed to create a portlayer client")
@@ -253,7 +253,7 @@ func (c *ContainerProxy) AddContainerToScope(op trace.Operation, handle string, 
 // returns:
 //	modified handle
 func (c *ContainerProxy) AddVolumesToContainer(op trace.Operation, handle string, config types.ContainerCreateConfig) (string, error) {
-	op.Debugf("Container_Proxy.AddVolumesToContainer(handle(%s))", handle)
+	defer trace.End(trace.Begin(op.SPrintf("handle(%s)", handle)))
 
 	if c.client == nil {
 		return "", InternalServerError("ContainerProxy.AddVolumesToContainer failed to create a portlayer client")
@@ -343,7 +343,7 @@ func (c *ContainerProxy) AddVolumesToContainer(op trace.Operation, handle string
 // returns:
 //	modified handle
 func (c *ContainerProxy) AddLoggingToContainer(op trace.Operation, handle string, config types.ContainerCreateConfig) (string, error) {
-	op.Debugf("Container_Proxy.AddLoggingToContainer")
+	defer trace.End(trace.Begin(op.SPrintf("")))
 
 	if c.client == nil {
 		return "", InternalServerError("ContainerProxy.AddLoggingToContainer failed to get the portlayer client")
@@ -370,7 +370,7 @@ func (c *ContainerProxy) AddLoggingToContainer(op trace.Operation, handle string
 // returns:
 //	modified handle
 func (c *ContainerProxy) AddInteractionToContainer(op trace.Operation, handle string, config types.ContainerCreateConfig) (string, error) {
-	op.Debugf("container_proxy.AddInteractionToContainer(handle(%s))", handle)
+	defer trace.End(trace.Begin(op.SPrintf("handle(%s)", handle)))
 
 	if c.client == nil {
 		return "", InternalServerError("ContainerProxy.AddInteractionToContainer failed to get the portlayer client")
@@ -396,7 +396,7 @@ func (c *ContainerProxy) AddInteractionToContainer(op trace.Operation, handle st
 // Args:
 //	waitTime <= 0 means no wait time
 func (c *ContainerProxy) CommitContainerHandle(op trace.Operation, handle, containerID string, waitTime int32) error {
-	op.Debugf("Container_Proxy.CommitContainerHandle(handle(%s))", handle)
+	defer trace.End(trace.Begin(op.SPrintf("handle(%s), container(%s), waitTime(%d)", handle, containerID, waitTime)))
 
 	if c.client == nil {
 		return InternalServerError("ContainerProxy.CommitContainerHandle failed to get a portlayer client")
@@ -467,7 +467,7 @@ func (c *ContainerProxy) StreamContainerLogs(name string, out io.Writer, started
 // returns
 //	error
 func (c *ContainerProxy) Stop(op trace.Operation, vc *viccontainer.VicContainer, name string, seconds int, unbound bool) error {
-	op.Debugf("Container_Proxy.Stop(container(%s))", name)
+	defer trace.End(trace.Begin(op.SPrintf("container(%s), waitTime(%d)", vc.Name, seconds)))
 
 	if c.client == nil {
 		return InternalServerError("ContainerProxy.Stop failed to get a portlayer client")
@@ -572,7 +572,7 @@ func (c *ContainerProxy) IsRunning(vc *viccontainer.VicContainer) (bool, error) 
 }
 
 func (c *ContainerProxy) Wait(op trace.Operation, vc *viccontainer.VicContainer, timeout time.Duration) (exitCode int32, processStatus string, containerState string, reterr error) {
-	op.Debugf("Container_Proxy.Wait(container(%s), timeout(%s))", vc.Name, timeout)
+	defer trace.End(trace.Begin(op.SPrintf("container(%s), timeout(%s)", vc.Name, timeout)))
 
 	if vc == nil {
 		reterr = InternalServerError("Wait bad arguments")

--- a/lib/apiservers/portlayer/restapi/handlers/containers_handlers.go
+++ b/lib/apiservers/portlayer/restapi/handlers/containers_handlers.go
@@ -66,7 +66,7 @@ func (handler *ContainersHandlersImpl) Configure(api *operations.PortLayerAPI, h
 
 // CreateHandler creates a new container
 func (handler *ContainersHandlersImpl) CreateHandler(params containers.CreateParams) middleware.Responder {
-	op := setupOperation(params.HTTPRequest.Context(), fmt.Sprintf("CreateContainer(%s)", id))
+	op := setupOperation(params.HTTPRequest.Context(), fmt.Sprintf("Containers_Handlers.CreateContainer(container%s)", id))
 	session := handler.handlerCtx.Session
 
 	op.Debugf("Path: %#v", params.CreateConfig.Path)
@@ -147,7 +147,7 @@ func (handler *ContainersHandlersImpl) CreateHandler(params containers.CreatePar
 
 // StateChangeHandler changes the state of a container
 func (handler *ContainersHandlersImpl) StateChangeHandler(params containers.StateChangeParams) middleware.Responder {
-	op := setupOperation(params.HTTPRequest.Context(), fmt.Sprintf("handle(%s)", params.Handle))
+	op := setupOperation(params.HTTPRequest.Context(), fmt.Sprintf("Containers_Handlers.StateChangeHandler(handle(%s))", params.Handle))
 
 	h := exec.GetHandle(params.Handle)
 	if h == nil {
@@ -171,7 +171,7 @@ func (handler *ContainersHandlersImpl) StateChangeHandler(params containers.Stat
 }
 
 func (handler *ContainersHandlersImpl) GetStateHandler(params containers.GetStateParams) middleware.Responder {
-	op := setupOperation(params.HTTPRequest.Context(), fmt.Sprintf("handle(%s)", params.Handle))
+	op := setupOperation(params.HTTPRequest.Context(), fmt.Sprintf("Containers_Handlers.GetStateHandler(handle(%s))", params.Handle))
 
 	// NOTE: I've no idea why GetStateHandler takes a handle instead of an ID - hopefully there was a reason for an inspection
 	// operation to take this path
@@ -204,7 +204,7 @@ func (handler *ContainersHandlersImpl) GetStateHandler(params containers.GetStat
 }
 
 func (handler *ContainersHandlersImpl) GetHandler(params containers.GetParams) middleware.Responder {
-	op := setupOperation(params.HTTPRequest.Context(), fmt.Sprintf("container(%s)", params.ID))
+	op := setupOperation(params.HTTPRequest.Context(), fmt.Sprintf("Containers_Handlers.GetHandler(container(%s))", params.ID))
 
 	h := exec.GetContainer(op, uid.Parse(params.ID))
 	if h == nil {
@@ -215,7 +215,7 @@ func (handler *ContainersHandlersImpl) GetHandler(params containers.GetParams) m
 }
 
 func (handler *ContainersHandlersImpl) CommitHandler(params containers.CommitParams) middleware.Responder {
-	op := setupOperation(params.HTTPRequest.Context(), fmt.Sprintf("handle(%s)", params.Handle))
+	op := setupOperation(params.HTTPRequest.Context(), fmt.Sprintf("Containers_Handlers.CommitHandler(handle(%s))", params.Handle))
 
 	h := exec.GetHandle(params.Handle)
 	if h == nil {
@@ -236,7 +236,7 @@ func (handler *ContainersHandlersImpl) CommitHandler(params containers.CommitPar
 }
 
 func (handler *ContainersHandlersImpl) RemoveContainerHandler(params containers.ContainerRemoveParams) middleware.Responder {
-	op := setupOperation(params.HTTPRequest.Context(), fmt.Sprintf("container(%s)", params.ID))
+	op := setupOperation(params.HTTPRequest.Context(), fmt.Sprintf("Containers_Handlers.RemoveContainerHandler(container(%s))", params.ID))
 
 	// get the indicated container for removal
 	cID := uid.Parse(params.ID)
@@ -267,7 +267,7 @@ func (handler *ContainersHandlersImpl) RemoveContainerHandler(params containers.
 }
 
 func (handler *ContainersHandlersImpl) GetContainerInfoHandler(params containers.GetContainerInfoParams) middleware.Responder {
-	op := setupOperation(params.HTTPRequest.Context(), fmt.Sprintf("container(%s)", params.ID))
+	op := setupOperation(params.HTTPRequest.Context(), fmt.Sprintf("Containers_Handlers.GetContainerInfoHandler(container(%s))", params.ID))
 
 	container := exec.Containers.Container(params.ID)
 	if container == nil {
@@ -283,7 +283,7 @@ func (handler *ContainersHandlersImpl) GetContainerInfoHandler(params containers
 }
 
 func (handler *ContainersHandlersImpl) GetContainerListHandler(params containers.GetContainerListParams) middleware.Responder {
-	op := setupOperation(params.HTTPRequest.Context(), fmt.Sprintf("containerList(%s)", params.ID))
+	op := setupOperation(params.HTTPRequest.Context(), fmt.Sprintf("Containers_Handlers.GetContainerListHandler(bool(%t))", *params.All))
 
 	var state *exec.State
 	if params.All != nil && !*params.All {
@@ -303,7 +303,7 @@ func (handler *ContainersHandlersImpl) GetContainerListHandler(params containers
 }
 
 func (handler *ContainersHandlersImpl) ContainerSignalHandler(params containers.ContainerSignalParams) middleware.Responder {
-	op := setupOperation(params.HTTPRequest.Context(), fmt.Sprintf("container(%s)", params.ID))
+	op := setupOperation(params.HTTPRequest.Context(), fmt.Sprintf("Containers_Handlers.ContainerSignalHandler(container(%s))", params.ID))
 
 	// NOTE: I feel that this should be in a Commit path for consistency
 	// it would allow phrasings such as:
@@ -324,7 +324,7 @@ func (handler *ContainersHandlersImpl) ContainerSignalHandler(params containers.
 }
 
 func (handler *ContainersHandlersImpl) GetContainerLogsHandler(params containers.GetContainerLogsParams) middleware.Responder {
-	op := setupOperation(params.HTTPRequest.Context(), fmt.Sprintf("container(%s)", params.ID))
+	op := setupOperation(params.HTTPRequest.Context(), fmt.Sprintf("Containers_Handlers.GetContainerLogsHandler(container(%s))", params.ID))
 
 	container := exec.Containers.Container(params.ID)
 	if container == nil {
@@ -355,7 +355,7 @@ func (handler *ContainersHandlersImpl) GetContainerLogsHandler(params containers
 }
 
 func (handler *ContainersHandlersImpl) ContainerWaitHandler(params containers.ContainerWaitParams) middleware.Responder {
-	op := setupOperation(params.HTTPRequest.Context(), fmt.Sprintf("%s:%d", params.ID, params.Timeout))
+	op := setupOperation(params.HTTPRequest.Context(), fmt.Sprintf("Containers_Handlers.ContainerWaitHandler(container(%s),timeout(%d))", params.ID, params.Timeout))
 
 	// default context timeout in seconds
 	defaultTimeout := int64(containerWaitTimeout.Seconds())

--- a/lib/apiservers/portlayer/restapi/handlers/containers_handlers.go
+++ b/lib/apiservers/portlayer/restapi/handlers/containers_handlers.go
@@ -505,6 +505,7 @@ func setupOperation(ctx context.Context, traceMsg string) trace.Operation {
 	op, err := trace.FromContext(ctx)
 	if err != nil {
 		op = trace.NewOperation(ctx, traceMsg)
+		op.Debugf("No existing opID found in context, new operation created.")
 	} else {
 		op.Debugf("%s", traceMsg)
 	}

--- a/lib/apiservers/portlayer/restapi/handlers/scopes_handlers.go
+++ b/lib/apiservers/portlayer/restapi/handlers/scopes_handlers.go
@@ -82,9 +82,9 @@ func parseScopeConfig(cfg *models.ScopeConfig) (subnet *net.IPNet, gateway net.I
 	return
 }
 
-func (handler *ScopesHandlersImpl) listScopes(idName string) ([]*models.ScopeConfig, error) {
-	defer trace.End(trace.Begin(idName))
-	scs, err := handler.netCtx.Scopes(context.Background(), &idName)
+func (handler *ScopesHandlersImpl) listScopes(op trace.Operation, idName string) ([]*models.ScopeConfig, error) {
+	defer trace.End(trace.Begin(op.SPrintf("idName(%s)", idName)))
+	scs, err := handler.netCtx.Scopes(op, &idName)
 	if err != nil {
 		return nil, err
 	}
@@ -143,9 +143,10 @@ func (handler *ScopesHandlersImpl) ScopesDelete(params scopes.DeleteScopeParams)
 }
 
 func (handler *ScopesHandlersImpl) ScopesListAll() middleware.Responder {
-	defer trace.End(trace.Begin(""))
+	op := trace.NewOperation(context.Background(), "")
+	defer trace.End(trace.Begin(op.SPrintf("")))
 
-	cfgs, err := handler.listScopes("")
+	cfgs, err := handler.listScopes(op, "")
 	if err != nil {
 		return scopes.NewListDefault(http.StatusServiceUnavailable).WithPayload(errorPayload(err))
 	}
@@ -154,9 +155,10 @@ func (handler *ScopesHandlersImpl) ScopesListAll() middleware.Responder {
 }
 
 func (handler *ScopesHandlersImpl) ScopesList(params scopes.ListParams) middleware.Responder {
-	defer trace.End(trace.Begin("ScopesList"))
+	op := trace.NewOperation(context.Background(), "")
+	defer trace.End(trace.Begin(op.SPrintf("IDName(%s)", params.IDName)))
 
-	cfgs, err := handler.listScopes(params.IDName)
+	cfgs, err := handler.listScopes(op, params.IDName)
 	if _, ok := err.(network.ResourceNotFoundError); ok {
 		return scopes.NewListNotFound().WithPayload(errorPayload(err))
 	}

--- a/lib/guest/linux.go
+++ b/lib/guest/linux.go
@@ -44,7 +44,7 @@ type LinuxGuestType struct {
 }
 
 // NewLinuxGuest returns a new Linux guest spec with predefined values
-func NewLinuxGuest(op trace.Operation, session *session.Session, config *spec.VirtualMachineConfigSpecConfig) (Guest, error) {
+func NewLinuxGuest(ctx context.Context, session *session.Session, config *spec.VirtualMachineConfigSpecConfig) (Guest, error) {
 	s, err := spec.NewVirtualMachineConfigSpec(ctx, session, config)
 	if err != nil {
 		return nil, err

--- a/lib/guest/linux.go
+++ b/lib/guest/linux.go
@@ -44,7 +44,7 @@ type LinuxGuestType struct {
 }
 
 // NewLinuxGuest returns a new Linux guest spec with predefined values
-func NewLinuxGuest(ctx context.Context, session *session.Session, config *spec.VirtualMachineConfigSpecConfig) (Guest, error) {
+func NewLinuxGuest(op trace.Operation, session *session.Session, config *spec.VirtualMachineConfigSpecConfig) (Guest, error) {
 	s, err := spec.NewVirtualMachineConfigSpec(ctx, session, config)
 	if err != nil {
 		return nil, err

--- a/lib/portlayer/exec/base.go
+++ b/lib/portlayer/exec/base.go
@@ -148,7 +148,7 @@ func (c *containerBase) startGuestProgram(op trace.Operation, name string, args 
 }
 
 func (c *containerBase) start(op trace.Operation) error {
-	op.Debugf("exec.base.start(%s)", c.ExecConfig.ID)
+	defer trace.End(trace.Begin(op.SPrintf("container(%s)", c.ExecConfig.ID)))
 
 	// make sure we have vm
 	if c.vm == nil {
@@ -184,7 +184,8 @@ func (c *containerBase) start(op trace.Operation) error {
 }
 
 func (c *containerBase) stop(op trace.Operation, waitTime *int32) error {
-	op.Debugf("exec.base.stop(%s)", c.ExecConfig.ID)
+	defer trace.End(trace.Begin(op.SPrintf("container(%s)", c.ExecConfig.ID)))
+
 	// make sure we have vm
 	if c.vm == nil {
 		return NotYetExistError{c.ExecConfig.ID}
@@ -280,7 +281,8 @@ func (c *containerBase) shutdown(op trace.Operation, waitTime *int32) error {
 }
 
 func (c *containerBase) poweroff(op trace.Operation) error {
-	op.Debugf("exec.base.poweroff(%s)", c.ExecConfig.ID)
+	defer trace.End(trace.Begin(op.SPrintf("container(%s)", c.ExecConfig.ID)))
+
 	// make sure we have vm
 	if c.vm == nil {
 		return NotYetExistError{c.ExecConfig.ID}

--- a/lib/portlayer/exec/container.go
+++ b/lib/portlayer/exec/container.go
@@ -290,7 +290,8 @@ func (c *Container) Refresh(op trace.Operation) error {
 // Refresh updates config and runtime info, holding a lock only while swapping
 // the new data for the old
 func (c *Container) RefreshFromHandle(op trace.Operation, h *Handle) {
-	op.Debugf("exec.Container.RefreshFromHandle(%s)", h.String())
+	defer trace.End(trace.Begin(op.SPrintf("handle(%s), container(%s)", h, c.ExecConfig.ID)))
+
 	c.m.Lock()
 	defer c.m.Unlock()
 
@@ -306,7 +307,7 @@ func (c *Container) RefreshFromHandle(op trace.Operation, h *Handle) {
 
 // Start starts a container vm with the given params
 func (c *Container) start(op trace.Operation) error {
-	op.Debugf("exec.Container.start(%s)", c.ExecConfig.ID)
+	defer trace.End(trace.Begin(op.SPrintf("container(%s)", c.ExecConfig.ID)))
 
 	if c.vm == nil {
 		return fmt.Errorf("vm not set")
@@ -370,7 +371,6 @@ func (c *Container) Signal(op trace.Operation, num int64) error {
 
 func (c *Container) onStop() {
 	lf := c.logFollowers
-	log.Debugf("%s", "container.infraContainers")
 	c.logFollowers = nil
 
 	log.Debugf("Container(%s) closing %d log followers", c.ExecConfig.ID, len(lf))
@@ -548,7 +548,7 @@ func populateVMAttributes(op trace.Operation, sess *session.Session, refs []type
 
 // convert the infra containers to a container object
 func convertInfraContainers(op trace.Operation, sess *session.Session, vms []mo.VirtualMachine) []*Container {
-	op.Debugf("converting %d containers", len(vms))
+	defer trace.End(trace.Begin(op.SPrintf("converting %d containers", len(vms))))
 	var cons []*Container
 
 	for _, v := range vms {

--- a/lib/portlayer/exec/container_cache.go
+++ b/lib/portlayer/exec/container_cache.go
@@ -19,6 +19,7 @@ import (
 
 	"golang.org/x/net/context"
 
+	"github.com/vmware/vic/pkg/trace"
 	"github.com/vmware/vic/pkg/uid"
 	"github.com/vmware/vic/pkg/vsphere/session"
 )
@@ -109,7 +110,8 @@ func (conCache *containerCache) sync(ctx context.Context, sess *session.Session)
 	conCache.m.Lock()
 	defer conCache.m.Unlock()
 
-	cons, err := infraContainers(ctx, sess)
+	op := trace.NewOperation(ctx, "Syncing container cache")
+	cons, err := infraContainers(op, sess)
 	if err != nil {
 		return err
 	}

--- a/lib/portlayer/exec/handle.go
+++ b/lib/portlayer/exec/handle.go
@@ -174,6 +174,7 @@ func (h *Handle) String() string {
 }
 
 func (h *Handle) Commit(op trace.Operation, sess *session.Session, waitTime *int32) error {
+	defer trace.End(trace.Begin(op.SPrintf("handle(%s), container(%s), waitTime(%d)", h.String(), h.containerBase.ExecConfig.ID, waitTime)))
 	cfg := make(map[string]string)
 
 	// Set timestamps based on target state
@@ -212,7 +213,7 @@ func (h *Handle) Close() {
 // TODO: either deep copy the configuration, or provide an alternative means of passing the data that
 // avoids the need for the caller to unpack/repack the parameters
 func Create(op trace.Operation, sess *session.Session, config *ContainerCreateConfig) (*Handle, error) {
-	op.Debugf("handle.create")
+	defer trace.End(trace.Begin(op.SPrintf("container(%s)", config.Metadata.ID)))
 
 	h := &Handle{
 		key:         newHandleKey(),

--- a/lib/portlayer/network/container.go
+++ b/lib/portlayer/network/container.go
@@ -19,8 +19,8 @@ import (
 	"sync"
 
 	"github.com/vmware/vic/lib/portlayer/exec"
+	"github.com/vmware/vic/pkg/trace"
 	"github.com/vmware/vic/pkg/uid"
-	"golang.org/x/net/context"
 )
 
 type Container struct {
@@ -93,13 +93,15 @@ func (c *Container) removeEndpoint(e *Endpoint) {
 	c.endpoints = removeEndpointHelper(e, c.endpoints)
 }
 
-func (c *Container) Refresh(ctx context.Context) error {
+func (c *Container) Refresh(op trace.Operation) error {
+	defer trace.End(trace.Begin(op.SPrintf("container(%s)", c.ID())))
+
 	c.Lock()
 	defer c.Unlock()
 
 	// this will "refresh" the container executor config that contains
 	// the current ip addresses
-	h := exec.GetContainer(ctx, c.ID())
+	h := exec.GetContainer(op, c.ID())
 	if h == nil {
 		return fmt.Errorf("could not find container %s", c.ID())
 	}

--- a/lib/portlayer/network/context.go
+++ b/lib/portlayer/network/context.go
@@ -574,8 +574,8 @@ func (c *Context) findScopes(idName *string) ([]*Scope, error) {
 	return _scopes, nil
 }
 
-func (c *Context) Scopes(ctx context.Context, idName *string) ([]*Scope, error) {
-	defer trace.End(trace.Begin(""))
+func (c *Context) Scopes(op trace.Operation, idName *string) ([]*Scope, error) {
+	defer trace.End(trace.Begin(op.SPrintf("idName(%s)", *idName)))
 
 	c.Lock()
 	defer c.Unlock()
@@ -598,7 +598,7 @@ func (c *Context) Scopes(ctx context.Context, idName *string) ([]*Scope, error) 
 	}
 
 	for _, c := range containers {
-		c.Refresh(ctx)
+		c.Refresh(op)
 	}
 
 	return scopes, nil
@@ -609,7 +609,7 @@ func (c *Context) DefaultScope() *Scope {
 }
 
 func (c *Context) BindContainer(h *exec.Handle) ([]*Endpoint, error) {
-	defer trace.End(trace.Begin(""))
+	defer trace.End(trace.Begin(fmt.Sprintf("handle(%s)", h)))
 	c.Lock()
 	defer c.Unlock()
 

--- a/pkg/trace/operation.go
+++ b/pkg/trace/operation.go
@@ -122,6 +122,10 @@ func (o *Operation) Errorf(format string, args ...interface{}) {
 	Logger.Errorf("%s: %s", o.header(), fmt.Sprintf(format, args...))
 }
 
+func (o *Operation) Warnf(format string, args ...interface{}) {
+	Logger.Warnf("%s: %s", o.header(), fmt.Sprintf(format, args...))
+}
+
 func (o *Operation) newChild(ctx context.Context, msg string) Operation {
 	child := newOperation(ctx, o.id, 4, msg)
 	child.t = append(child.t, o.t...)
@@ -169,7 +173,7 @@ func FromContext(ctx context.Context) (Operation, error) {
 	case operation:
 		o.operation = val
 	default:
-		return Operation{}, fmt.Errorf("not an Operation")
+		return Operation{Context: context.Background()}, fmt.Errorf("not an Operation")
 	}
 
 	return o, nil

--- a/pkg/trace/operation.go
+++ b/pkg/trace/operation.go
@@ -126,6 +126,10 @@ func (o *Operation) Warnf(format string, args ...interface{}) {
 	Logger.Warnf("%s: %s", o.header(), fmt.Sprintf(format, args...))
 }
 
+func (o *Operation) SPrintf(format string, args ...interface{}) string {
+	return fmt.Sprintf("%s: %s", o.header(), fmt.Sprintf(format, args...))
+}
+
 func (o *Operation) newChild(ctx context.Context, msg string) Operation {
 	child := newOperation(ctx, o.id, 4, msg)
 	child.t = append(child.t, o.t...)


### PR DESCRIPTION
This is an overhaul of our logging to allow us to reliably track concurrent calls on containers. It shifts us from using the normal logrus logger to using the `trace.Operation` object to assign operationIDs to call paths. Right now operationIDs are not reliably passed from the personality to the portlayer due to our usage of `context.Background()` which gives us a hollow context which does not actually store values across api boundaries. Both the personality server and the portlayer are affected by this change, and most function call paths have been modified to accept this operation object rather than the context object. Additionally any modifications made in the future on these functions should do their logging through the operation object rather than importing logrus for logging. 

This should also allow us to distinguish between two call paths on the same container with the same operation. 

Fixes #1865
