### PR TITLE
Fix empty session ID bug

### DIFF
--- a/cmd/vic-machine/create/create.go
+++ b/cmd/vic-machine/create/create.go
@@ -600,7 +600,7 @@ func (c *Create) processCertificates() error {
 
 	// do we have key, cert, and --no-tlsverify
 	if c.noTLSverify || len(cas) == 0 {
-		log.Warnf("Configuring without TLS verify - client authentication disabled")
+		log.Warnf("Configuring without TLS verify - certificate-based authentication disabled")
 		return nil
 	}
 

--- a/cmd/vicadmin/server.go
+++ b/cmd/vicadmin/server.go
@@ -554,9 +554,6 @@ func (s *server) index(res http.ResponseWriter, req *http.Request) {
 	defer trace.End(trace.Begin(""))
 	ctx := context.Background()
 	sess, err := s.getSessionFromRequest(ctx, req)
-	if err != nil {
-		panic(err.Error())
-	}
 	v := vicadmin.NewValidator(ctx, &vchConfig, sess)
 
 	if sess == nil {

--- a/cmd/vicadmin/server.go
+++ b/cmd/vicadmin/server.go
@@ -439,7 +439,7 @@ func (s *server) bundleContainerLogs(res http.ResponseWriter, req *http.Request,
 	}
 
 	readers := configureReaders()
-	c, err := s.getSessionFromRequest(req)
+	c, err := s.getSessionFromRequest(context.Background(), req)
 	if err != nil {
 		log.Errorf("Failed to get vSphere session while bundling container logs due to error: %s", err.Error())
 		http.Error(res, genericErrorMessage, http.StatusInternalServerError)
@@ -553,7 +553,10 @@ func deriveErrorMessage(err error) string {
 func (s *server) index(res http.ResponseWriter, req *http.Request) {
 	defer trace.End(trace.Begin(""))
 	ctx := context.Background()
-	sess, err := s.getSessionFromRequest(req)
+	sess, err := s.getSessionFromRequest(ctx, req)
+	if err != nil {
+		panic(err.Error())
+	}
 	v := vicadmin.NewValidator(ctx, &vchConfig, sess)
 
 	if sess == nil {

--- a/cmd/vicadmin/usersession.go
+++ b/cmd/vicadmin/usersession.go
@@ -83,16 +83,12 @@ func (u *UserSessionStore) VSphere(ctx context.Context, id string) (vSphereSessi
 	if us == nil {
 		return nil, fmt.Errorf("User session with unique ID %s does not exist", id)
 	}
+
 	if us.vsphere != nil {
-		_, err := methods.GetCurrentTime(ctx, us.vsphere.RoundTripper)
-		if err == nil {
-			log.Infof("Successfully found active vsphere session for websession %s", id)
-			return us.vsphere, nil
-		}
-		log.Infof("vSphere session for websession with id %s seems to not be active -- will refresh it", id)
+		log.Infof("Found cached vSphere session for vicadmin usersession %s", id)
+		return us.vsphere, nil
 	}
 
-	// us.vsphere == nil || (us.vsphere != nil and !active):
 	log.Infof("Creating vSphere session for vicadmin usersession %s", id)
 	s, err := vSphereSessionGet(us.config)
 	if err != nil {

--- a/cmd/vicadmin/usersession.go
+++ b/cmd/vicadmin/usersession.go
@@ -27,9 +27,10 @@ import (
 
 // UserSession holds a user's session metadata
 type UserSession struct {
-	username string
-	created  time.Time
-	config   *session.Config
+	id      string
+	created time.Time
+	config  *session.Config
+	vsphere *session.Session
 }
 
 // UserSessionStore holds and manages user sessions
@@ -41,10 +42,10 @@ type UserSessionStore struct {
 }
 
 type UserSessionStorer interface {
-	Add(username string, config *session.Config) *UserSession
-	Delete(username string)
-	VSphere(username string) (vSphereSession *session.Session, err error)
-	UserSession(username string) *UserSession
+	Add(id string, config *session.Config) *UserSession
+	Delete(id string)
+	VSphere(id string) (vSphereSession *session.Session, err error)
+	UserSession(id string) *UserSession
 }
 
 // Add creates a config and initializes the UserSession and adds it to the UserSessionStore & returns the created UserSession
@@ -52,6 +53,7 @@ func (u *UserSessionStore) Add(id string, config *session.Config) *UserSession {
 	u.mutex.Lock()
 	defer u.mutex.Unlock()
 	sess := &UserSession{
+		id:      id,
 		created: time.Now(),
 		config:  config,
 	}
@@ -74,7 +76,16 @@ func (u *UserSessionStore) UserSession(id string) *UserSession {
 
 // Get logs into vSphere and returns a vSphere session object. Caller responsible for error handling/logout
 func (u *UserSessionStore) VSphere(id string) (vSphereSession *session.Session, err error) {
-	return vSphereSessionGet(u.UserSession(id).config)
+	us := u.UserSession(id)
+	if us.vsphere == nil {
+		log.Infof("Creating session for %s", id)
+		s, err := vSphereSessionGet(us.config)
+		if err != nil {
+			return nil, err
+		}
+		us.vsphere = s
+	}
+	return us.vsphere, nil
 }
 
 // reaper takes abandoned sessions to a farm upstate so they don't build up forever

--- a/cmd/vicadmin/usersession.go
+++ b/cmd/vicadmin/usersession.go
@@ -64,7 +64,6 @@ func (u *UserSessionStore) Add(id string, config *session.Config) *UserSession {
 }
 
 func (u *UserSessionStore) Delete(id string) {
-	var foo string
 	u.mutex.Lock()
 	defer u.mutex.Unlock()
 	delete(u.sessions, id)

--- a/cmd/vicadmin/usersession.go
+++ b/cmd/vicadmin/usersession.go
@@ -24,7 +24,6 @@ import (
 	"github.com/gorilla/sessions"
 	"golang.org/x/net/context"
 
-	"github.com/vmware/govmomi/vim25/methods"
 	"github.com/vmware/vic/pkg/vsphere/session"
 )
 

--- a/cmd/vicadmin/usersession.go
+++ b/cmd/vicadmin/usersession.go
@@ -64,6 +64,7 @@ func (u *UserSessionStore) Add(id string, config *session.Config) *UserSession {
 }
 
 func (u *UserSessionStore) Delete(id string) {
+	var foo string
 	u.mutex.Lock()
 	defer u.mutex.Unlock()
 	delete(u.sessions, id)

--- a/cmd/vicadmin/vicadm.go
+++ b/cmd/vicadmin/vicadm.go
@@ -435,15 +435,16 @@ func (s *server) getSessionFromRequest(ctx context.Context, r *http.Request) (*s
 	if err != nil {
 		return nil, err
 	}
-	if d, ok := sessionData.Values[sessionKey]; !ok {
+	var d interface{}
+	var ok bool
+	if d, ok = sessionData.Values[sessionKey]; !ok {
 		return nil, fmt.Errorf("User-provided cookie did not contain a session ID -- it is corrupt or tampered")
-	} else {
-		c, err := s.uss.VSphere(ctx, d.(string))
-		if err != nil {
-			return nil, err
-		}
-		return c, nil
 	}
+	c, err := s.uss.VSphere(ctx, d.(string))
+	if err != nil {
+		return nil, err
+	}
+	return c, nil
 }
 
 type flushWriter struct {

--- a/cmd/vicadmin/vicadm.go
+++ b/cmd/vicadmin/vicadm.go
@@ -435,14 +435,15 @@ func (s *server) getSessionFromRequest(ctx context.Context, r *http.Request) (*s
 	if err != nil {
 		return nil, err
 	}
-	if sessionData.Values[sessionKey] == nil {
+	if d, ok := sessionData.Values[sessionKey]; !ok {
 		return nil, fmt.Errorf("User-provided cookie did not contain a session ID -- it is corrupt or tampered")
+	} else {
+		c, err := s.uss.VSphere(ctx, d.(string))
+		if err != nil {
+			return nil, err
+		}
+		return c, nil
 	}
-	c, err := s.uss.VSphere(ctx, sessionData.Values[sessionKey].(string))
-	if err != nil {
-		return nil, err
-	}
-	return c, nil
 }
 
 type flushWriter struct {

--- a/cmd/vicadmin/vicadm.go
+++ b/cmd/vicadmin/vicadm.go
@@ -435,7 +435,9 @@ func (s *server) getSessionFromRequest(ctx context.Context, r *http.Request) (*s
 	if err != nil {
 		return nil, err
 	}
-
+	if sessionData.Values[sessionKey] == nil {
+		return nil, fmt.Errorf("User-provided cookie did not contain a session ID -- it is corrupt or tampered")
+	}
 	c, err := s.uss.VSphere(ctx, sessionData.Values[sessionKey].(string))
 	if err != nil {
 		return nil, err

--- a/cmd/vicadmin/vicadm.go
+++ b/cmd/vicadmin/vicadm.go
@@ -420,16 +420,23 @@ func vSphereSessionGet(sessconfig *session.Config) (*session.Session, error) {
 		// not a critical error for vicadmin
 		log.Warnf("Unable to populate session: %s", err)
 	}
+	usersession, err := session.SessionManager.UserSession(ctx)
+	if err != nil {
+		log.Errorf("Got %s while creating user session", err)
+		return nil, err
+	}
+
+	log.Infof("Got session from vSphere with key: %s username: %s", usersession.Key, usersession.UserName)
 	return session, nil
 }
 
-func (s *server) getSessionFromRequest(r *http.Request) (*session.Session, error) {
+func (s *server) getSessionFromRequest(ctx context.Context, r *http.Request) (*session.Session, error) {
 	sessionData, err := s.uss.cookies.Get(r, sessionCookieKey)
 	if err != nil {
 		return nil, err
 	}
 
-	c, err := s.uss.VSphere(sessionData.Values[sessionKey].(string))
+	c, err := s.uss.VSphere(ctx, sessionData.Values[sessionKey].(string))
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/vicadmin/vicadm.go
+++ b/cmd/vicadmin/vicadm.go
@@ -429,7 +429,7 @@ func (s *server) getSessionFromRequest(r *http.Request) (*session.Session, error
 		return nil, err
 	}
 
-	c, err := s.uss.VSphere(sessionData.ID)
+	c, err := s.uss.VSphere(sessionData.Values[sessionKey].(string))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
While working on #3083 I noticed that the websession.ID field that was documented to be unique & provided for each cookie-based web session, turned out to be _a big stinkin' lie_ and isn't used by the type of cookie store being used. This results in the key being empty, and since we assume that the key would be unique, and in fact it's always the same, we likely cannot have more than one session at a time (in the current version on `master`) and this also may have been causing the session leakage in #3083 (still investigating/testing that, but this PR fixes a bug (or bugs) regardless, it just may be an unreported bug).

This change uses the key used to an actual UUID since @hmahmood  pointed out that we have google/uuid vendored (and I did not see this despite looking for it :facepalm:)

With a little added logging code (not included in this change) I was able to manually test two concurrent sessions from two separate browsers & did not witness the problems caused by the lies in the documentation of the `websession` object.

Egg on my face.

[Also, this bit adds some rudimentary caching to the vSphere lookup call.](https://github.com/vmware/vic/compare/master...gigawhitlocks:vicadmin-sessions?expand=1#diff-abef5e03992dd89faa301fb9709e9b78R79) This should help address some of the leaky session problem, as we won't create a new one every single time a user does a vSphere-dependent action.