### PR TITLE
Add support for self generated CAs for registries

### DIFF
--- a/cmd/vic-machine/create/create.go
+++ b/cmd/vic-machine/create/create.go
@@ -99,7 +99,8 @@ type Create struct {
 	noTLSverify     bool
 	advancedOptions bool
 
-	clientCAs cli.StringSlice
+	clientCAs   cli.StringSlice
+	registryCAs cli.StringSlice
 
 	containerNetworks         cli.StringSlice
 	containerNetworksGateway  cli.StringSlice
@@ -401,6 +402,12 @@ func (c *Create) Flags() []cli.Flag {
 
 		// registries
 		cli.StringSliceFlag{
+			Name:   "registry-ca, rc",
+			Usage:  "Specify a list of additional certificate authority files to use to verify secure registry servers",
+			Value:  &c.registryCAs,
+			Hidden: true,
+		},
+		cli.StringSliceFlag{
 			Name:  "insecure-registry, dir",
 			Value: &c.insecureRegistries,
 			Usage: "Specify a list of permitted insecure registry server URLs",
@@ -520,7 +527,7 @@ func (c *Create) processParams() error {
 		return errors.Errorf("Error occurred while processing volume stores: %s", err)
 	}
 
-	if err := c.processInsecureRegistries(); err != nil {
+	if err := c.processRegistries(); err != nil {
 		return err
 	}
 
@@ -811,7 +818,18 @@ func (c *Create) processVolumeStores() error {
 	return nil
 }
 
-func (c *Create) processInsecureRegistries() error {
+func (c *Create) processRegistries() error {
+	// load addtional certificate authorities for use with registries
+	if len(c.registryCAs) > 0 {
+		registryCAs, err := c.loadRegistryCAs()
+		if err != nil {
+			return errors.Errorf("Unable to load CA certificates for registry logins: %s", err)
+		}
+
+		c.RegistryCAs = registryCAs
+	}
+
+	// load a list of insecure registries
 	for _, registry := range c.insecureRegistries {
 		url, err := url.Parse(registry)
 		if err != nil {
@@ -962,6 +980,25 @@ func (c *Create) loadCertificates() ([]byte, *certificate.KeyPair, error) {
 	}
 
 	return certs, keypair, nil
+}
+
+// loadRegistryCAs loads additional CA certs for docker registry usage
+func (c *Create) loadRegistryCAs() ([]byte, error) {
+	defer trace.End(trace.Begin(""))
+
+	var registryCerts []byte
+	for _, f := range c.registryCAs {
+		b, err := ioutil.ReadFile(f)
+		if err != nil {
+			err = errors.Errorf("Failed to load authority from file %s: %s", f, err)
+			return nil, err
+		}
+
+		registryCerts = append(registryCerts, b...)
+		log.Infof("Loaded registry CA from %s", f)
+	}
+
+	return registryCerts, nil
 }
 
 func (c *Create) generateCertificates(server bool, client bool) ([]byte, *certificate.KeyPair, error) {
@@ -1147,8 +1184,6 @@ func (c *Create) Run(cliContext *cli.Context) (err error) {
 
 	vConfig.HTTPProxy = c.HTTPProxy
 	vConfig.HTTPSProxy = c.HTTPSProxy
-
-	vchConfig.InsecureRegistries = c.Data.InsecureRegistries
 
 	// separate initial validation from dispatch of creation task
 	log.Info("")

--- a/lib/apiservers/engine/backends/image.go
+++ b/lib/apiservers/engine/backends/image.go
@@ -209,6 +209,7 @@ func (i *Image) PullImage(ctx context.Context, ref reference.Named, metaHeaders 
 		Reference:   ref.String(),
 		Timeout:     imagec.DefaultHTTPTimeout,
 		Outstream:   outStream,
+		RegistryCAs: RegistryCertPool,
 	}
 
 	if authConfig != nil {

--- a/lib/apiservers/engine/backends/system.go
+++ b/lib/apiservers/engine/backends/system.go
@@ -250,6 +250,7 @@ func (s *System) AuthenticateToRegistry(ctx context.Context, authConfig *types.A
 		Timeout:  loginTimeout,
 		Username: authConfig.Username,
 		Password: authConfig.Password,
+		RootCAs: RegistryCertPool,
 	})
 
 	// Only look at V2 registries

--- a/lib/config/virtual_container_host.go
+++ b/lib/config/virtual_container_host.go
@@ -138,6 +138,8 @@ type Certificate struct {
 	HostCertificate *RawCertificate `vic:"0.1" scope:"read-only"`
 	// The CAs to validate client connections
 	CertificateAuthorities []byte `vic:"0.1" scope:"read-only"`
+	// The CAs to validate docker registry connections
+	RegistryCertificateAuthorities []byte `vic:"0.1" scope:"read-only"`
 	// Certificates for specific system access, keyed by FQDN
 	HostCertificates map[string]*RawCertificate
 }

--- a/lib/imagec/docker.go
+++ b/lib/imagec/docker.go
@@ -81,6 +81,7 @@ func LearnRegistryURL(options Options) (string, error) {
 			Username:           options.Username,
 			Password:           options.Password,
 			InsecureSkipVerify: options.InsecureSkipVerify,
+			RootCAs:            options.RegistryCAs,
 		})
 
 		headers, err := fetcher.Head(url)
@@ -123,6 +124,7 @@ func LearnAuthURL(options Options) (*url.URL, error) {
 		Username:           options.Username,
 		Password:           options.Password,
 		InsecureSkipVerify: options.InsecureSkipVerify,
+		RootCAs:            options.RegistryCAs,
 	})
 
 	// We expect docker registry to return a 401 to us - with a WWW-Authenticate header
@@ -159,6 +161,7 @@ func FetchToken(ctx context.Context, options Options, url *url.URL, progressOutp
 		Username:           options.Username,
 		Password:           options.Password,
 		InsecureSkipVerify: options.InsecureSkipVerify,
+		RootCAs:            options.RegistryCAs,
 	})
 
 	token, err := fetcher.FetchAuthToken(url)
@@ -194,6 +197,7 @@ func FetchImageBlob(ctx context.Context, options Options, image *ImageWithMeta, 
 		Password:           options.Password,
 		Token:              options.Token,
 		InsecureSkipVerify: options.InsecureSkipVerify,
+		RootCAs:            options.RegistryCAs,
 	})
 
 	// ctx
@@ -323,6 +327,7 @@ func FetchImageManifest(ctx context.Context, options Options, progressOutput pro
 		Password:           options.Password,
 		Token:              options.Token,
 		InsecureSkipVerify: options.InsecureSkipVerify,
+		RootCAs:            options.RegistryCAs,
 	})
 
 	manifestFileName, err := fetcher.Fetch(ctx, url, true, progressOutput)

--- a/lib/imagec/imagec.go
+++ b/lib/imagec/imagec.go
@@ -16,6 +16,7 @@ package imagec
 
 import (
 	"crypto/sha256"
+	"crypto/x509"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -94,6 +95,9 @@ type Options struct {
 	InsecureAllowHTTP  bool
 
 	ImageManifest *Manifest
+
+	// RegistryCAs will not be modified by imagec
+	RegistryCAs *x509.CertPool
 }
 
 // ImageWithMeta wraps the models.Image with some additional metadata

--- a/lib/install/data/data.go
+++ b/lib/install/data/data.go
@@ -32,9 +32,10 @@ type Data struct {
 	common.Compute
 	common.VCHID
 
-	CertPEM   []byte
-	KeyPEM    []byte
-	ClientCAs []byte
+	CertPEM   	[]byte
+	KeyPEM    	[]byte
+	ClientCAs 	[]byte
+	RegistryCAs []byte
 	common.Images
 
 	ImageDatastorePath     string

--- a/pkg/fetcher/fetcher.go
+++ b/pkg/fetcher/fetcher.go
@@ -17,6 +17,7 @@ package fetcher
 import (
 	"bytes"
 	"crypto/tls"
+	"crypto/x509"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -83,6 +84,9 @@ type Options struct {
 	InsecureSkipVerify bool
 
 	Token *Token
+
+	// RootCAs will not be modified by fetcher.
+	RootCAs *x509.CertPool
 }
 
 // URLFetcher struct
@@ -103,6 +107,7 @@ func NewURLFetcher(options Options) Fetcher {
 		Proxy: http.ProxyFromEnvironment,
 		TLSClientConfig: &tls.Config{
 			InsecureSkipVerify: options.InsecureSkipVerify,
+			RootCAs: options.RootCAs,
 		},
 	}
 	client := &http.Client{Transport: tr}


### PR DESCRIPTION
Add support for uploading certificate authority certs via vic-machine's
"--registry-ca" for docker registry login and pull usage.  The VCH's
default CA bundle will not be affected.  Any other application running
in the VCH will not be affected.

The docker personality will use these CA certs for docker login and
docker pull.

Resolves #2103