### PR TITLE
Revert "Log task MoID when vsphere task is created"

### DIFF
--- a/pkg/vsphere/tasks/waiter_test.go
+++ b/pkg/vsphere/tasks/waiter_test.go
@@ -48,18 +48,11 @@ func (t *MyTask) Wait(ctx context.Context) error {
 	_, err := t.WaitForResult(ctx, nil)
 	return err
 }
-
 func (t *MyTask) WaitForResult(ctx context.Context, s progress.Sinker) (*types.TaskInfo, error) {
 	if t.success {
 		return nil, nil
 	}
 	return nil, errors.Errorf("Wait failed")
-}
-
-func (t *MyTask) Reference() types.ManagedObjectReference {
-	return types.ManagedObjectReference{
-		Value: "MyTask",
-	}
 }
 
 func createFailedTask(context.Context) (Task, error) {
@@ -183,12 +176,6 @@ func (t *taskInProgressTask) Wait(ctx context.Context) error {
 
 func (t *taskInProgressTask) WaitForResult(ctx context.Context, s progress.Sinker) (*types.TaskInfo, error) {
 	return t.info, t.Wait(ctx)
-}
-
-func (t *taskInProgressTask) Reference() types.ManagedObjectReference {
-	return types.ManagedObjectReference{
-		Value: "MyTask",
-	}
 }
 
 func mustRunInTime(t *testing.T, d time.Duration, f func()) {
@@ -400,18 +387,18 @@ func TestSoapFaults(t *testing.T) {
 
 	// Test the task.Error path
 	res, err := task.WaitForResult(ctx, nil)
-	if !isTaskInProgress(task, err) {
+	if !isTaskInProgress(err) {
 		t.Error(err)
 	}
 
 	// Test the soap.IsVimFault() path
-	if !isTaskInProgress(task, soap.WrapVimFault(res.Error.Fault)) {
+	if !isTaskInProgress(soap.WrapVimFault(res.Error.Fault)) {
 		t.Errorf("fault=%#v", res.Error.Fault)
 	}
 
 	// Test the soap.IsSoapFault() path
 	err = vm.MarkAsTemplate(ctx)
-	if !isTaskInProgress(task, err) {
+	if !isTaskInProgress(err) {
 		t.Error(err)
 	}
 
@@ -426,7 +413,7 @@ func TestSoapFaults(t *testing.T) {
 	if err == nil {
 		t.Error("expected error")
 	}
-	if isTaskInProgress(task, err) {
+	if isTaskInProgress(err) {
 		t.Error(err)
 	}
 


### PR DESCRIPTION
Reverts vmware/vic#3222

Panic seen in builds after this points to 

Mike Hall	[10:15 AM]  
WaitForResult in #3222 never checks to see if t is nil and then passes to functions that also don’t check. I think that’s our problem… Calling @fdawg4l 

```./bin/vic-machine-linux delete -t root:Alfred\!23@192.168.31.8 -n VCH-7004-9921 --thumbprint=75:6B:87:0B:02:41:BC:73:14:F1:CC:09:03:2B:7D:DF:7D:1F:E3:D6 --force
INFO[2016-11-18T10:13:09-06:00] ### Removing VCH ####                        
INFO[2016-11-18T10:13:15-06:00]                                              
INFO[2016-11-18T10:13:15-06:00] VCH ID: VirtualMachine:13320                 
WARN[2016-11-18T10:13:16-06:00] VCH version "v0.7.0-7004-e6c9442" is different than installer version v0.7.0-0-0397b35. Force delete will attempt to remove everything related to the installed VCH 
INFO[2016-11-18T10:13:17-06:00] Removing VMs                                 
INFO[2016-11-18T10:14:33-06:00] Removing image stores                        
INFO[2016-11-18T10:16:03-06:00] Removing volume stores                       
INFO[2016-11-18T10:16:03-06:00] Deleting volume store "default" on Datastore "datastore1" at path "test" 
ERRO[2016-11-18T10:16:08-06:00] haTask--vim.FileManager.deleteFile-4705526: unexpected fault on task retry : &types.FileFault{VimFault:types.VimFault{MethodFault:types.MethodFault{FaultCause:(*types.LocalizedMethodFault)(nil), FaultMessage:[]types.LocalizableMessage(nil)}}, File:"/vmfs/volumes/57ebe8e5-b912ca38-0fd0-0050569c054c/test/volumes/70a2eb15-ad4f-11e6-9403-000c292f9fc6/70a2eb15-ad4f-11e6-9403-000c292f9fc6-flat.vmdk"} 
ERRO[2016-11-18T10:16:09-06:00] haTask--vim.FileManager.deleteFile-4705566: unexpected fault on task retry : &types.FileFault{VimFault:types.VimFault{MethodFault:types.MethodFault{FaultCause:(*types.LocalizedMethodFault)(nil), FaultMessage:[]types.LocalizableMessage(nil)}}, File:"/vmfs/volumes/57ebe8e5-b912ca38-0fd0-0050569c054c/test/volumes/70a2eb15-ad4f-11e6-9403-000c292f9fc6"} 
ERRO[2016-11-18T10:16:09-06:00] haTask--vim.FileManager.deleteFile-4705570: unexpected error on task retry : context.deadlineExceededError{} 
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
    panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x98f712]
goroutine 1 [running]:
panic(0xc464a0, 0xc420010140)
    /home/line2/Downloads/go/src/runtime/panic.go:500 +0x1a1
github.com/vmware/vic/vendor/github.com/urfave/cli.HandleAction.func1(0xc42037d6c0)
    /home/line2/gopath/src/github.com/vmware/vic/vendor/github.com/urfave/cli/app.go:473 +0x1b4
panic(0xc464a0, 0xc420010140)
    /home/line2/Downloads/go/src/runtime/panic.go:458 +0x243
github.com/vmware/vic/vendor/github.com/vmware/govmomi/object.(*Task).Reference(0x0, 0xc420255100, 0x0, 0x1662d20, 0x16992b8)
    <autogenerated>:11 +0x32
github.com/vmware/vic/pkg/vsphere/tasks.taskMoid(0x1666720, 0x0, 0x1666720, 0x0)
    /home/line2/gopath/src/github.com/vmware/vic/pkg/vsphere/tasks/waiter.go:146 +0x36
github.com/vmware/vic/pkg/vsphere/tasks.WaitForResult(0x1667220, 0xc420021020, 0xc42037c860, 0x1667220, 0xc420021020, 0x16992b8)
    /home/line2/gopath/src/github.com/vmware/vic/pkg/vsphere/tasks/waiter.go:65 +0xac
github.com/vmware/vic/lib/install/management.(*Dispatcher).deleteVMFSFiles(0xc42036a480, 0xc42037caf0, 0xc42030dc40, 0xc4204182a0, 0x11, 0x0, 0x0)
    /home/line2/gopath/src/github.com/vmware/vic/lib/install/management/store_files.go:182 +0x15f
github.com/vmware/vic/lib/install/management.(*Dispatcher).deleteFilesIteratively(0xc42036a480, 0xc42037caf0, 0xc42030dc40, 0xc4204182a0, 0x11, 0x0, 0x0)
    /home/line2/gopath/src/github.com/vmware/vic/lib/install/management/store_files.go:174 +0x1be
github.com/vmware/vic/lib/install/management.(*Dispatcher).deleteDatastoreFiles(0xc42036a480, 0xc42030dc40, 0xc4204332ad, 0x4, 0x1, 0xc420030400, 0x0, 0x0)
    /home/line2/gopath/src/github.com/vmware/vic/lib/install/management/store_files.go:142 +0x5a7
github.com/vmware/vic/lib/install/management.(*Dispatcher).deleteVolumeStoreIfForced(0xc42036a480, 0xc4201b4000, 0x0)
    /home/line2/gopath/src/github.com/vmware/vic/lib/install/management/store_files.go:341 +0x8c8
github.com/vmware/vic/lib/install/management.(*Dispatcher).DeleteVCH(0xc42036a480, 0xc4201b4000, 0x0, 0x0)
    /home/line2/gopath/src/github.com/vmware/vic/lib/install/management/delete.go:58 +0x1e5
github.com/vmware/vic/cmd/vic-machine/delete.(*Uninstall).Run(0xc42019d4b0, 0xc42008d900, 0x165dda0, 0xc4204c12f0)
    /home/line2/gopath/src/github.com/vmware/vic/cmd/vic-machine/delete/delete.go:155 +0x7d7
github.com/vmware/vic/cmd/vic-machine/delete.(*Uninstall).Run-fm(0xc42008d900, 0x0, 0x0)
    /home/line2/gopath/src/github.com/vmware/vic/cmd/vic-machine/main.go:64 +0x34
reflect.Value.call(0xc04780, 0xc42019d500, 0x13, 0xe05c30, 0x4, 0xc42037d660, 0x1, 0x1, 0x4893c8, 0xdeb1e0, ...)
    /home/line2/Downloads/go/src/reflect/value.go:434 +0x5c8
reflect.Value.Call(0xc04780, 0xc42019d500, 0x13, 0xc42037d660, 0x1, 0x1, 0xc42019d8f1, 0x140, 0x140)
    /home/line2/Downloads/go/src/reflect/value.go:302 +0xa4
github.com/vmware/vic/vendor/github.com/urfave/cli.HandleAction(0xc04780, 0xc42019d500, 0xc42008d900, 0x1663ca0, 0xc420010140)
    /home/line2/gopath/src/github.com/vmware/vic/vendor/github.com/urfave/cli/app.go:481 +0x1e0
github.com/vmware/vic/vendor/github.com/urfave/cli.Command.Run(0xe06a8d, 0x6, 0x0, 0x0, 0x0, 0x0, 0x0, 0xe3284f, 0x23, 0x0, ...)
    /home/line2/gopath/src/github.com/vmware/vic/vendor/github.com/urfave/cli/command.go:186 +0xc26
github.com/vmware/vic/vendor/github.com/urfave/cli.(*App).Run(0xc4201ae300, 0xc42000c080, 0x8, 0x8, 0x0, 0x0)
    /home/line2/gopath/src/github.com/vmware/vic/vendor/github.com/urfave/cli/app.go:236 +0x60c
main.main()
    /home/line2/gopath/src/github.com/vmware/vic/cmd/vic-machine/main.go:115 +0x1851```