### PR TITLE
[skip ci] Fixing the nightly log upload folder names

### DIFF
--- a/tests/nightly/upload-logs.sh
+++ b/tests/nightly/upload-logs.sh
@@ -25,7 +25,7 @@ outfile="functional_logs_"$1".zip"
 echo $Build
 echo $outfile
 
-/usr/bin/zip -9 -r $outfile 5-1-DistributedSwitch 5-2-Cluster 5-3-EnhancedLinkedMode 5-5-Heterogenous-ESXi 5-6-1-VSAN-Simple 5-6-2-VSAN-Complex 5-7-NSX 5-8-DRS 5-10-Multiple-Datacenter 5-11-MultipleCluster 5-12-Multiple-VLAN 5-13-Invalid-ESXi-Install 5-14-Remove-Container-OOB
+/usr/bin/zip -9 -r $outfile 5-1-Distributed-Switch 5-2-Cluster 5-3-Enhanced-Linked-Mode 5-5-Heterogenous-ESXi 5-6-1-VSAN-Simple 5-6-2-VSAN-Complex 5-7-NSX 5-8-DRS 5-10-Multiple-Datacenter 5-11-Multiple-Cluster 5-12-Multiple-VLAN 5-13-Invalid-ESXi-Install 5-14-Remove-Container-OOB
 
 # GC credentials
 keyfile="/root/vic-ci-logs.key"


### PR DESCRIPTION
Some of the folder names for log upload were incorrect. This change fixes it so we get the correct log folder uploaded for the nightly run.