### PR TITLE
Do not persist user credentials in memory in admin

### DIFF
--- a/cmd/vicadmin/server.go
+++ b/cmd/vicadmin/server.go
@@ -36,7 +36,6 @@ import (
 	"github.com/google/uuid"
 	gorillacontext "github.com/gorilla/context"
 
-	"github.com/vmware/govmomi/vim25/soap"
 	"github.com/vmware/vic/lib/vicadmin"
 	"github.com/vmware/vic/pkg/filelock"
 	"github.com/vmware/vic/pkg/trace"
@@ -172,7 +171,21 @@ func (s *server) Authenticated(link string, handler func(http.ResponseWriter, *h
 		if len(r.TLS.PeerCertificates) > 0 { // the user is authenticated by certificate at connection time
 			log.Infof("Authenticated connection via client certificate with serial %s from %s", r.TLS.PeerCertificates[0].SerialNumber, r.RemoteAddr)
 			key := uuid.New().String()
-			usersess := s.uss.Add(key, &rootConfig.Config)
+
+			vs, err := vSphereSessionGet(&rootConfig.Config)
+			if err != nil {
+				log.Errorf("Unable to get vSphere session with default config for cert-auth'd user")
+				http.Error(w, genericErrorMessage, http.StatusInternalServerError)
+				return
+			}
+			err = stripCredentials(vs)
+			if err != nil {
+				//stripCredentials logs real error messages
+				http.Error(w, genericErrorMessage, http.StatusInternalServerError)
+				return
+			}
+
+			usersess := s.uss.Add(key, &rootConfig.Config, vs)
 
 			timeNow, err := usersess.created.MarshalText()
 			if err != nil {
@@ -274,32 +287,27 @@ func (s *server) loginPage(res http.ResponseWriter, req *http.Request) {
 			DatastorePath:  rootConfig.DatastorePath,
 			HostPath:       rootConfig.Config.HostPath,
 			PoolPath:       rootConfig.PoolPath,
+			User:           url.UserPassword(req.FormValue("username"), req.FormValue("password")),
+			Service:        rootConfig.Service,
 		}
-		user := url.UserPassword(req.FormValue("username"), req.FormValue("password"))
-		serviceURL, err := soap.ParseURL(rootConfig.Service)
-		if err != nil {
-			// this could happen for a number of reasons but most likely for a plain ol' auth failure
-			log.Errorf("vSphere service URL was not a valid format; parsing returned error: %s", err)
-			http.Error(res, genericErrorMessage, http.StatusInternalServerError)
-			return
-		}
-
-		serviceURL.User = user
-		userconfig.Service = serviceURL.String()
 
 		// check login
-		usersession, err := vSphereSessionGet(&userconfig)
-		if err != nil || usersession == nil {
+		vs, err := vSphereSessionGet(&userconfig)
+		if err != nil || vs == nil {
 			// something went wrong or we could not authenticate
-			log.Warnf("User %s from %s failed to authenticate at %s", user, req.RemoteAddr, time.Now())
+			log.Warnf("User %s from %s failed to authenticate at %s", userconfig.User, req.RemoteAddr, time.Now())
 			http.Error(res, "Authentication failed due to incorrect credential(s)", http.StatusUnauthorized)
 			return
 		}
 
+		userconfig.User = nil
 		// successful login above; user is authenticated
-		// log out, disregard errors
-		usersession.Client.Logout(context.Background())
 
+		if err = stripCredentials(vs); err != nil {
+			// stripCredentials will output an actual error to the logs, so we don't really need to do it here
+			http.Error(res, genericErrorMessage, http.StatusInternalServerError)
+			return
+		}
 		// create a token to save as an encrypted & signed cookie
 		websession, err := s.uss.cookies.Get(req, sessionCookieKey)
 		if websession == nil {
@@ -309,11 +317,12 @@ func (s *server) loginPage(res http.ResponseWriter, req *http.Request) {
 		}
 
 		key := uuid.New().String()
-		usersess := s.uss.Add(key, &userconfig)
+		userconfig.Service = ""
+		us := s.uss.Add(key, &userconfig, vs)
 
-		timeNow, err := usersess.created.MarshalText()
+		timeNow, err := us.created.MarshalText()
 		if err != nil {
-			log.Errorf("Failed to unmarshal time object %+v into text due to error: %s", usersess.created, err)
+			log.Errorf("Failed to unmarshal time object %+v into text due to error: %s", us.created, err)
 			http.Error(res, genericErrorMessage, http.StatusInternalServerError)
 			return
 		}

--- a/cmd/vicadmin/server.go
+++ b/cmd/vicadmin/server.go
@@ -178,13 +178,6 @@ func (s *server) Authenticated(link string, handler func(http.ResponseWriter, *h
 				http.Error(w, genericErrorMessage, http.StatusInternalServerError)
 				return
 			}
-			err = stripCredentials(vs)
-			if err != nil {
-				//stripCredentials logs real error messages
-				http.Error(w, genericErrorMessage, http.StatusInternalServerError)
-				return
-			}
-
 			usersess := s.uss.Add(key, &rootConfig.Config, vs)
 
 			timeNow, err := usersess.created.MarshalText()
@@ -300,14 +293,8 @@ func (s *server) loginPage(res http.ResponseWriter, req *http.Request) {
 			return
 		}
 
-		userconfig.User = nil
 		// successful login above; user is authenticated
 
-		if err = stripCredentials(vs); err != nil {
-			// stripCredentials will output an actual error to the logs, so we don't really need to do it here
-			http.Error(res, genericErrorMessage, http.StatusInternalServerError)
-			return
-		}
 		// create a token to save as an encrypted & signed cookie
 		websession, err := s.uss.cookies.Get(req, sessionCookieKey)
 		if websession == nil {
@@ -317,6 +304,7 @@ func (s *server) loginPage(res http.ResponseWriter, req *http.Request) {
 		}
 
 		key := uuid.New().String()
+		userconfig.User = nil
 		userconfig.Service = ""
 		us := s.uss.Add(key, &userconfig, vs)
 

--- a/cmd/vicadmin/usersession.go
+++ b/cmd/vicadmin/usersession.go
@@ -88,14 +88,7 @@ func (u *UserSessionStore) VSphere(ctx context.Context, id string) (*session.Ses
 		return nil, fmt.Errorf("No vSphere session found. User with ID %s must authenticate again.", id)
 	}
 
-	// log.Infof("Creating vSphere session for vicadmin usersession %s", id)
-	// us.config.User = nil
-	// s, err := vSphereSessionGet(us.config)
-	// if err != nil {
-	// 	return nil, err
-	// }
-	// us.vsphere = s
-	log.Infof("Found cached vSphere session for vicadmin usersession %s", id)
+	log.Infof("Found vSphere session for vicadmin usersession %s", id)
 	return us.vsphere, nil
 }
 

--- a/cmd/vicadmin/vicadm.go
+++ b/cmd/vicadmin/vicadm.go
@@ -448,6 +448,11 @@ func vSphereSessionGet(sessconfig *session.Config) (*session.Session, error) {
 	}
 
 	log.Infof("Got session from vSphere with key: %s username: %s", usersession.Key, usersession.UserName)
+
+	err = stripCredentials(s)
+	if err != nil {
+		return nil, err
+	}
 	return s, nil
 }
 

--- a/cmd/vicadmin/vicadm.go
+++ b/cmd/vicadmin/vicadm.go
@@ -407,7 +407,7 @@ func (r datastoreReader) open() (entry, error) {
 	return httpEntry(r.path, res)
 }
 
-// removes user credentials from "in"
+// stripCredentials removes user credentials from "in"
 func stripCredentials(in *session.Session) error {
 	serviceURL, err := soap.ParseURL(rootConfig.Service)
 	if err != nil {

--- a/pkg/vsphere/session/session.go
+++ b/pkg/vsphere/session/session.go
@@ -155,13 +155,9 @@ func (s *Session) Connect(ctx context.Context) (*Session, error) {
 		}
 	}
 
+	soapURL.User = s.User
 	// Update the service URL with expanded defaults
 	s.Service = soapURL.String()
-
-	// VCH components do not include credentials within the target URL
-	if s.User != nil {
-		soapURL.User = s.User
-	}
 
 	soapClient := soap.NewClient(soapURL, s.Insecure)
 	var login func(context.Context) error

--- a/pkg/vsphere/session/session.go
+++ b/pkg/vsphere/session/session.go
@@ -155,9 +155,13 @@ func (s *Session) Connect(ctx context.Context) (*Session, error) {
 		}
 	}
 
-	soapURL.User = s.User
 	// Update the service URL with expanded defaults
 	s.Service = soapURL.String()
+
+	// VCH components do not include credentials within the target URL
+	if s.User != nil {
+		soapURL.User = s.User
+	}
 
 	soapClient := soap.NewClient(soapURL, s.Insecure)
 	var login func(context.Context) error


### PR DESCRIPTION
Fixes #3088 -- after initial login, we replace the session.Client held w/ one that does not have credentials, but instead has a SOAP cookie to talk to vSphere.

Still doing a little cleanup / ad-hoc testing but please review away.
If the vSphere session is expired for any reason, the user will be forced to log in again.