### PR TITLE
Hide upgrade command

### DIFF
--- a/cmd/vic-machine/main.go
+++ b/cmd/vic-machine/main.go
@@ -81,6 +81,7 @@ func main() {
 			Usage:  "Upgrade VCH to latest version",
 			Action: upgrade.Run,
 			Flags:  upgrade.Flags(),
+			Hidden: true,
 		},
 		{
 			Name:   "version",


### PR DESCRIPTION
We still do not support upgrade from earlier version to .8, so make this command hidden from customer.

@stuclem @npakrasi please help to update user document as well