### PR TITLE
Recursive rmi implementation [full ci]

### DIFF
--- a/lib/apiservers/portlayer/restapi/handlers/storage_handlers.go
+++ b/lib/apiservers/portlayer/restapi/handlers/storage_handlers.go
@@ -17,6 +17,7 @@ package handlers
 import (
 	"fmt"
 	"net/http"
+	"net/url"
 	"os"
 
 	log "github.com/Sirupsen/logrus"
@@ -183,8 +184,19 @@ func (h *StorageHandlersImpl) DeleteImage(params storage.DeleteImageParams) midd
 		return ferr(err, http.StatusInternalServerError)
 	}
 
-	op := trace.NewOperation(context.Background(), fmt.Sprintf("DeleteImage(%s)", image.ID))
-	if err = h.imageCache.DeleteImage(op, image); err != nil {
+	keepNodes := make([]*url.URL, len(params.KeepNodes))
+	for idx, kn := range params.KeepNodes {
+		k, err := url.Parse(kn)
+		if err != nil {
+			return ferr(err, http.StatusInternalServerError)
+		}
+
+		keepNodes[idx] = k
+	}
+
+	op := trace.NewOperation(context.Background(), fmt.Sprintf("DeleteBranch(%s)", image.ID))
+	deletedImages, err := h.imageCache.DeleteBranch(op, image, keepNodes)
+	if err != nil {
 		switch {
 		case spl.IsErrImageInUse(err):
 			return ferr(err, http.StatusLocked)
@@ -197,7 +209,12 @@ func (h *StorageHandlersImpl) DeleteImage(params storage.DeleteImageParams) midd
 		}
 	}
 
-	return storage.NewDeleteImageOK()
+	result := make([]*models.Image, len(deletedImages))
+	for idx, image := range deletedImages {
+		result[idx] = convertImage(image)
+	}
+
+	return storage.NewDeleteImageOK().WithPayload(result)
 }
 
 // GetImageTar returns an image tar file

--- a/lib/apiservers/portlayer/restapi/handlers/storage_handlers_test.go
+++ b/lib/apiservers/portlayer/restapi/handlers/storage_handlers_test.go
@@ -185,8 +185,8 @@ func (c *MockDataStore) ListImages(op trace.Operation, store *url.URL, IDs []str
 	return nil, fmt.Errorf("store (%s) doesn't exist", store.String())
 }
 
-func (c *MockDataStore) DeleteImage(op trace.Operation, image *spl.Image) error {
-	return nil
+func (c *MockDataStore) DeleteImage(op trace.Operation, image *spl.Image) (*spl.Image, error) {
+	return nil, nil
 }
 
 func TestCreateImageStore(t *testing.T) {

--- a/lib/apiservers/portlayer/swagger.json
+++ b/lib/apiservers/portlayer/swagger.json
@@ -394,13 +394,26 @@
 						"type": "string",
 						"in": "path",
 						"required": true
+					},
+					{
+						"name": "keepNodes",
+						"type": "array",
+						"required": true,
+						"in": "query",
+						"items": {
+							"type": "string",
+							"collectionFormat": "csv"
+						}
 					}
 				],
 				"responses": {
 					"200": {
 						"description": "OK",
 						"schema": {
-							"type": "string"
+							"type": "array",
+							"items": {
+								"$ref": "#/definitions/Image"
+							}
 						}
 					},
 					"404": {

--- a/lib/portlayer/storage/image.go
+++ b/lib/portlayer/storage/image.go
@@ -67,7 +67,7 @@ type ImageStorer interface {
 	// DeleteImage deletes an image from the image store.  If the image is in
 	// use either by way of inheritance or because it's attached to a
 	// container, this will return an error.
-	DeleteImage(op trace.Operation, image *Image) error
+	DeleteImage(op trace.Operation, image *Image) (*Image, error)
 }
 
 // Image is the handle to identify an image layer on the backing store.  The

--- a/lib/portlayer/storage/image_cache_test.go
+++ b/lib/portlayer/storage/image_cache_test.go
@@ -114,9 +114,9 @@ func (c *MockDataStore) ListImages(op trace.Operation, store *url.URL, IDs []str
 }
 
 // DeleteImage removes an image from the image store
-func (c *MockDataStore) DeleteImage(op trace.Operation, image *Image) error {
+func (c *MockDataStore) DeleteImage(op trace.Operation, image *Image) (*Image, error) {
 	delete(c.db[*image.Store], image.ID)
-	return nil
+	return image, nil
 }
 
 func TestListImages(t *testing.T) {
@@ -361,7 +361,7 @@ func TestDeleteImage(t *testing.T) {
 	}
 
 	// Deletion of an intermediate node should fail
-	err = imageCache.DeleteImage(op, images[1])
+	_, err = imageCache.DeleteImage(op, images[1])
 	if !assert.Error(t, err) {
 		return
 	}
@@ -381,7 +381,7 @@ func TestDeleteImage(t *testing.T) {
 		// range up the branch
 		for _, img := range []*Image{images[branch*100], images[branch*10], images[branch]} {
 
-			err = imageCache.DeleteImage(op, img)
+			_, err = imageCache.DeleteImage(op, img)
 			if !assert.NoError(t, err) {
 				return
 			}

--- a/lib/portlayer/storage/vsphere/image.go
+++ b/lib/portlayer/storage/vsphere/image.go
@@ -517,19 +517,19 @@ func (v *ImageStore) ListImages(op trace.Operation, store *url.URL, IDs []string
 // DeleteImage deletes an image from the image store.  If the image is in
 // use either by way of inheritance or because it's attached to a
 // container, this will return an error.
-func (v *ImageStore) DeleteImage(op trace.Operation, image *portlayer.Image) error {
+func (v *ImageStore) DeleteImage(op trace.Operation, image *portlayer.Image) (*portlayer.Image, error) {
 	//  check if the image is in use.
 	if err := imagesInUse(op, image.ID); err != nil {
 		op.Errorf("ImageStore: delete image error: %s", err.Error())
-		return err
+		return nil, err
 	}
 
 	storeName, err := util.ImageStoreName(image.Store)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	return v.deleteImage(op, storeName, image.ID)
+	return image, v.deleteImage(op, storeName, image.ID)
 }
 
 func (v *ImageStore) deleteImage(op trace.Operation, storeName, ID string) error {

--- a/lib/portlayer/storage/vsphere/image_test.go
+++ b/lib/portlayer/storage/vsphere/image_test.go
@@ -330,14 +330,14 @@ func TestCreateImageLayers(t *testing.T) {
 
 	// Try to delete an intermediate image (should fail)
 	exec.NewContainerCache()
-	err = cacheStore.DeleteImage(op, expectedImages["dir1"])
+	_, err = cacheStore.DeleteImage(op, expectedImages["dir1"])
 	if !assert.Error(t, err) || !assert.True(t, portlayer.IsErrImageInUse(err)) {
 		return
 	}
 
 	// Try to delete a leaf (should pass)
 	leaf := expectedImages["dir"+strconv.Itoa(numLayers-1)]
-	err = cacheStore.DeleteImage(op, leaf)
+	_, err = cacheStore.DeleteImage(op, leaf)
 	if !assert.NoError(t, err) {
 		return
 	}


### PR DESCRIPTION
Fixes #2973 

Deletes a given image all the way up to the next tag, layer with
degree > 1, or used image.