### PR TITLE
[full ci] enabling 2660 tests

### DIFF
--- a/tests/test-cases/Group1-Docker-Commands/1-06-Docker-Run.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-06-Docker-Run.robot
@@ -73,11 +73,8 @@ Docker run check exit codes
 
 Docker run ps password check
     [Tags]  secret
-    ${status}=  Get State Of Github Issue  2660
-    Run Keyword If  '${status}' == 'closed'  Fail  Test 1-6-Docker-Run.robot needs to be updated now that Issue #2660 has been resolved
-    Log  Issue \#2660 is blocking implementation  WARN
-    #${rc}  ${output}=  Run And Return Rc And Output  docker ${params} run busybox ps auxww
-    #Should Be Equal As Integers  ${rc}  0
-    #Should Contain  ${output}  ps auxww
-    #Should Not Contain  ${output}  %{TEST_USERNAME}
-    #Should Not Contain  ${output}  %{TEST_PASSWORD}
+    ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} run busybox ps auxww
+    Should Be Equal As Integers  ${rc}  0
+    Should Contain  ${output}  ps auxww
+    Should Not Contain  ${output}  %{TEST_USERNAME}
+    Should Not Contain  ${output}  %{TEST_PASSWORD}

--- a/tests/test-cases/Group1-Docker-Commands/1-06-Docker-Run.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-06-Docker-Run.robot
@@ -76,5 +76,4 @@ Docker run ps password check
     ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} run busybox ps auxww
     Should Be Equal As Integers  ${rc}  0
     Should Contain  ${output}  ps auxww
-    Should Not Contain  ${output}  %{TEST_USERNAME}
     Should Not Contain  ${output}  %{TEST_PASSWORD}


### PR DESCRIPTION
2660 was fixed in #3185 but the test was still disabled. This resolves that. 

Fixes #2660 

