### PR TITLE
Persist appliance init log

### DIFF
--- a/cmd/tether/ops_linux.go
+++ b/cmd/tether/ops_linux.go
@@ -51,7 +51,8 @@ func (t *operations) Log() (io.Writer, error) {
 	if err := setTerminalSpeed(f.Fd()); err != nil {
 		log.Errorf("Setting terminal speed failed with %s", err)
 	}
-	return f, nil
+
+	return io.MultiWriter(f, os.Stdout), nil
 }
 
 // sessionLogWriter returns a writer that will persist the session output

--- a/cmd/vicadmin/vicadm.go
+++ b/cmd/vicadmin/vicadm.go
@@ -346,6 +346,38 @@ func listVMPaths(ctx context.Context, s *session.Session) ([]logfile, error) {
 	return logfiles, nil
 }
 
+// addApplianceLogs whitelists the logs to include for the appliance.
+// TODO: once we've started encrypting all potentially senstive data and filtering out guestinfo.ovfEnv
+// we can resume collection of vmware.log and drop the appliance specific handling
+func addApplianceLogs(ctx context.Context, s *session.Session, readers map[string]entryReader) error {
+	self, err := guest.GetSelf(ctx, s)
+	if err != nil || self == nil {
+		return fmt.Errorf("Unable to collect appliance logs due to unknown self-reference: %s", err)
+	}
+
+	self2 := vm.NewVirtualMachineFromVM(ctx, s, self)
+	path, err := self2.DSPath(ctx)
+	if err != nil {
+		return err
+	}
+
+	ds, err := s.Finder.Datastore(ctx, path.Host)
+	if err != nil {
+		return err
+	}
+
+	wpath := fmt.Sprintf("appliance/tether.debug")
+	rpath := fmt.Sprintf("%s/%s", path.Path, "tether.debug")
+	log.Infof("Processed File read Path : %s", rpath)
+	log.Infof("Processed File write Path : %s", wpath)
+	readers[wpath] = datastoreReader{
+		ds:   ds,
+		path: rpath,
+	}
+
+	return nil
+}
+
 // find datastore logs for the appliance itself and all containers
 func findDatastoreLogs(c *session.Session) (map[string]entryReader, error) {
 	defer trace.End(trace.Begin(""))
@@ -359,6 +391,11 @@ func findDatastoreLogs(c *session.Session) (map[string]entryReader, error) {
 		detail := fmt.Sprintf("unable to perform datastore log collection due to failure looking up paths: %s", err)
 		log.Error(detail)
 		return nil, errors.New(detail)
+	}
+
+	err = addApplianceLogs(ctx, c, readers)
+	if err != nil {
+		log.Errorf("Issue collecting appliance logs: %s", err)
 	}
 
 	for _, logfile := range logfiles {

--- a/isos/appliance/permissions-setup
+++ b/isos/appliance/permissions-setup
@@ -2,3 +2,4 @@
 
 # Allow access to VM uuid for self-reflection
 chmod 444 /sys/devices/virtual/dmi/id/product_serial
+chmod 444 /sys/class/dmi/id/product_serial

--- a/lib/install/management/appliance.go
+++ b/lib/install/management/appliance.go
@@ -284,6 +284,32 @@ func (d *Dispatcher) addParaVirtualSCSIController(devices object.VirtualDeviceLi
 	return devices, nil
 }
 
+// addSerialPort is separate from the configLogging because I could not successfully add a serial port after initial VM creation
+// The controller slot kept colliding with the Keyboard no matter whether it was explicitly specified or left as -1 for vSphere to determine
+func (d *Dispatcher) addSerialPort(conf *config.VirtualContainerHostConfigSpec, cspec *spec.VirtualMachineConfigSpec, devices object.VirtualDeviceList) (object.VirtualDeviceList, error) {
+	defer trace.End(trace.Begin(""))
+
+	// TODO: move this construction into the spec package and update portlayer/logging to use it as well
+	serial := &types.VirtualSerialPort{
+		VirtualDevice: types.VirtualDevice{
+			Backing: &types.VirtualSerialPortFileBackingInfo{
+				VirtualDeviceFileBackingInfo: types.VirtualDeviceFileBackingInfo{
+					FileName: "[]",
+				},
+			},
+			Connectable: &types.VirtualDeviceConnectInfo{
+				Connected:         true,
+				StartConnected:    true,
+				AllowGuestControl: true,
+			},
+		},
+		YieldOnPoll: true,
+	}
+
+	devices = append(devices, serial)
+	return devices, nil
+}
+
 func (d *Dispatcher) createApplianceSpec(conf *config.VirtualContainerHostConfigSpec, vConf *data.InstallerData) (*types.VirtualMachineConfigSpec, error) {
 	defer trace.End(trace.Begin(""))
 
@@ -304,7 +330,7 @@ func (d *Dispatcher) createApplianceSpec(conf *config.VirtualContainerHostConfig
 			MemoryMB: vConf.ApplianceSize.Memory.Limit,
 			// Encode the config both here and after the VMs created so that it can be identified as a VCH appliance as soon as
 			// creation is complete.
-			ExtraConfig: vmomi.OptionValueFromMap(cfg),
+			ExtraConfig: append(vmomi.OptionValueFromMap(cfg), &types.OptionValue{Key: "answer.msg.serial.file.open", Value: "Append"}),
 		},
 	}
 
@@ -317,6 +343,10 @@ func (d *Dispatcher) createApplianceSpec(conf *config.VirtualContainerHostConfig
 	}
 
 	if devices, err = d.addNetworkDevices(conf, spec, devices); err != nil {
+		return nil, err
+	}
+
+	if devices, err = d.addSerialPort(conf, spec, devices); err != nil {
 		return nil, err
 	}
 
@@ -384,6 +414,39 @@ func (d *Dispatcher) configIso(conf *config.VirtualContainerHostConfigSpec, vm *
 	cdrom = devices.InsertIso(cdrom, fmt.Sprintf("[%s] %s/%s", conf.ImageStores[0].Host, d.vmPathName, settings.ApplianceISO))
 	devices = append(devices, cdrom)
 	return devices, nil
+}
+
+func (d *Dispatcher) configLogging(conf *config.VirtualContainerHostConfigSpec, vm *vm.VirtualMachine, settings *data.InstallerData) (object.VirtualDeviceList, error) {
+	defer trace.End(trace.Begin(""))
+
+	devices, err := vm.Device(d.ctx)
+	if err != nil {
+		log.Errorf("Failed to get vm devices for appliance: %s", err)
+		return nil, err
+	}
+
+	serial, err := devices.FindSerialPort("")
+	if err != nil {
+		log.Errorf("Failed to locate serial port for persistent log configuration: %s", err)
+		return nil, err
+	}
+
+	// TODO: we need to add an accessor for generating paths within the VM directory
+	vmx, err := vm.VMPathName(d.ctx)
+	if err != nil {
+		log.Errorf("Unable to determine path of appliance VM: %s", err)
+		return nil, err
+	}
+
+	// TODO: move this construction into the spec package and update portlayer/logging to use it as well
+	serial.Backing = &types.VirtualSerialPortFileBackingInfo{
+		VirtualDeviceFileBackingInfo: types.VirtualDeviceFileBackingInfo{
+			// name consistency with containerVM
+			FileName: fmt.Sprintf("%s/tether.debug", path.Dir(vmx)),
+		},
+	}
+
+	return []types.BaseVirtualDevice{serial}, nil
 }
 
 func (d *Dispatcher) createAppliance(conf *config.VirtualContainerHostConfigSpec, settings *data.InstallerData) error {
@@ -574,17 +637,31 @@ func (d *Dispatcher) reconfigureApplianceSpec(vm *vm.VirtualMachine, conf *confi
 		Files:   &types.VirtualMachineFileInfo{VmPathName: fmt.Sprintf("[%s]", conf.ImageStores[0].Host)},
 	}
 
+	// create new devices
 	if devices, err = d.configIso(conf, vm, settings); err != nil {
 		return nil, err
 	}
 
-	deviceChange, err := devices.ConfigSpec(types.VirtualDeviceConfigSpecOperationAdd)
+	newDevices, err := devices.ConfigSpec(types.VirtualDeviceConfigSpecOperationAdd)
 	if err != nil {
 		log.Errorf("Failed to create config spec for appliance: %s", err)
 		return nil, err
 	}
 
-	spec.DeviceChange = deviceChange
+	spec.DeviceChange = newDevices
+
+	// update existing devices
+	if devices, err = d.configLogging(conf, vm, settings); err != nil {
+		return nil, err
+	}
+
+	updateDevices, err := devices.ConfigSpec(types.VirtualDeviceConfigSpecOperationEdit)
+	if err != nil {
+		log.Errorf("Failed to create config spec for logging update: %s", err)
+		return nil, err
+	}
+
+	spec.DeviceChange = append(spec.DeviceChange, updateDevices...)
 
 	cfg, err := d.encodeConfig(conf)
 	if err != nil {

--- a/lib/tether/tether.go
+++ b/lib/tether/tether.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io"
 	"io/ioutil"
 	"net/http"
 	_ "net/http/pprof" // allow enabling pprof in contianerVM
@@ -118,7 +117,7 @@ func (t *tether) setup() error {
 		return err
 	}
 	if out != nil {
-		log.SetOutput(io.MultiWriter(out, os.Stdout))
+		log.SetOutput(out)
 	}
 
 	t.reload = make(chan bool, 1)

--- a/pkg/vsphere/toolbox/power.go
+++ b/pkg/vsphere/toolbox/power.go
@@ -16,8 +16,9 @@ package toolbox
 
 import (
 	"fmt"
-	"log"
 	"os/exec"
+
+	log "github.com/Sirupsen/logrus"
 )
 
 // GuestOsState enum as defined in open-vm-tools/lib/include/vmware/guestrpc/powerops.h
@@ -80,7 +81,7 @@ func registerPowerCommandHandler(service *Service) *PowerCommandHandler {
 func (c *PowerCommand) Dispatch([]byte) ([]byte, error) {
 	rc := rpciOK
 
-	log.Printf("dispatching power op %q", c.name)
+	log.Infof("dispatching power op %q", c.name)
 
 	if c.Handler == nil {
 		if c.state == powerStateHalt || c.state == powerStateReboot {
@@ -91,12 +92,12 @@ func (c *PowerCommand) Dispatch([]byte) ([]byte, error) {
 	msg := fmt.Sprintf("tools.os.statechange.status %s%d\x00", rc, c.state)
 
 	if _, err := c.out.Request([]byte(msg)); err != nil {
-		log.Printf("unable to send %q: %q", msg, err)
+		log.Infof("unable to send %q: %q", msg, err)
 	}
 
 	if c.Handler != nil {
 		if err := c.Handler(); err != nil {
-			log.Printf("%s: %s", c.name, err)
+			log.Infof("%s: %s", c.name, err)
 		}
 	}
 
@@ -104,11 +105,11 @@ func (c *PowerCommand) Dispatch([]byte) ([]byte, error) {
 }
 
 func Halt() error {
-	log.Printf("Halting system...")
+	log.Infof("Halting system...")
 	return exec.Command(shutdown, "-h", "now").Run()
 }
 
 func Reboot() error {
-	log.Printf("Rebooting system...")
+	log.Infof("Rebooting system...")
 	return exec.Command(shutdown, "-r", "now").Run()
 }

--- a/tests/resources/Util.robot
+++ b/tests/resources/Util.robot
@@ -402,6 +402,7 @@ Run Regression Tests
     Should Contain  ${output}  ${container}/output.log
     Should Contain  ${output}  ${container}/vmware.log
     Should Contain  ${output}  ${container}/tether.debug
+    Should Contain  ${output}  appliance/tether.debug
     ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} rm ${container}
     Should Be Equal As Integers  ${rc}  0
     ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} ps -a


### PR DESCRIPTION
Add a mechanism to persist/expose the initialization log for the
appliance. This uses the same serial mechanism as the containerVMs.
If debug > 0 then the component logs will be duplicated in here as well.

This also includes some tidying of the installer output - namely logging
of the install parameters in a less ugly and adhoc fashion.

Fixes #2079 
