### PR TITLE
Move lock file from /tmp to /var/run/lock. Do not run logrotate immediately on boot.

### DIFF
--- a/pkg/filelock/flock.go
+++ b/pkg/filelock/flock.go
@@ -36,7 +36,7 @@ type FileLock struct {
 func NewFileLock(lockName string) *FileLock {
 	return &FileLock{
 		LockName: lockName,
-		LockFile: filepath.Join(os.TempDir(), lockName),
+		LockFile: filepath.Join("/var/run/lock", lockName),
 	}
 }
 
@@ -65,6 +65,7 @@ func (fl *FileLock) Release() error {
 	if fl.fh == nil {
 		panic("Attempt to release not acquired lock!")
 	}
+	syscall.Flock(int(fl.fh.Fd()), syscall.LOCK_UN)
 	err := fl.fh.Close()
 	fl.fh = nil
 	fl.mu.Unlock()

--- a/pkg/logmgr/logmgr.go
+++ b/pkg/logmgr/logmgr.go
@@ -169,7 +169,7 @@ func (lm *LogManager) Start() error {
 			for {
 				lm.loopsCount++
 				if lm.loopsCount%10 == 0 {
-					lm.op.Debugf("logrotate has been run %s times")
+					lm.op.Debugf("logrotate has been run %d times", lm.loopsCount)
 				}
 				select {
 				case <-time.After(lm.runInterval):

--- a/pkg/logmgr/logmgr.go
+++ b/pkg/logmgr/logmgr.go
@@ -171,7 +171,6 @@ func (lm *LogManager) Start() error {
 				if lm.loopsCount%10 == 0 {
 					lm.op.Debugf("logrotate has been run %s times")
 				}
-				lm.rotateLogs()
 				select {
 				case <-time.After(lm.runInterval):
 				case <-lm.closed:
@@ -179,6 +178,7 @@ func (lm *LogManager) Start() error {
 					lm.wg.Done()
 					return
 				}
+				lm.rotateLogs()
 			}
 		}()
 	})


### PR DESCRIPTION
Fixed #3249