### PR TITLE
Add operations user

### DIFF
--- a/cmd/vic-machine/common/target.go
+++ b/cmd/vic-machine/common/target.go
@@ -89,7 +89,7 @@ func (t *Target) HasCredentials() error {
 
 	//prompt for passwd if not specified
 	if t.Password == nil && urlPassword == nil {
-		log.Print("Please enter ESX or vCenter password: ")
+		log.Printf("vSphere password for %s: ", t.User)
 		b, err := terminal.ReadPassword(int(os.Stdin.Fd()))
 		if err != nil {
 			message := fmt.Sprintf("Failed to read password from stdin: %s", err)

--- a/cmd/vic-machine/common/target.go
+++ b/cmd/vic-machine/common/target.go
@@ -60,6 +60,7 @@ func (t *Target) TargetFlags() []cli.Flag {
 		},
 		cli.StringFlag{
 			Name:        "thumbprint",
+			Value:       "",
 			Destination: &t.Thumbprint,
 			Usage:       "ESX or vCenter host certificate thumbprint",
 		},

--- a/doc/user/usage.md
+++ b/doc/user/usage.md
@@ -11,6 +11,28 @@ The intent is that vSphere Integrated Containers Engine (VIC Engine) should not 
    - vCenter - Enterprise plus license, only very simple configurations have been tested.
 - Bridge network - when installed in a vCenter environment vic-machine does not automatically create a bridge network. An existing vSwitch or Distributed Portgroup should be specified via the -bridge-network flag, should not be the same as the external network, and should not have DHCP.
 
+### Privileges and
+
+There is an operations user mechanism provided to allow a VCH to operate with less privileged credentials than are required for deploying a new VCH. These options are:
+* `--ops-user`
+* `--ops-password`
+If neither option is specified then the user supplied via `--target` or `--user` will be used and a warning will be output. If only the `--ops-user` option is provided there will be an interactive prompt for the password.
+At this time vic-machine _does not create_ the operations user, nor does it configure it with minimum set of RBAC permissions necessary for operation - this is actively being worked on (#1689)  
+
+Deploying a VCH requires credentials able to:
+* create and configure a resource pool (vApp on vCenter)
+* create a vSwitch (ESX only)
+* create and configure the endpointVM within that pool
+* upload files to datastores
+* inspect much of the vSphere inventory
+
+However operation of a VCH requires only a subset of those privileges:
+* create and configure containerVMs within the VCH resource pool/vApp
+* create/delete/attach/detach disks on the endpointVM
+* attach containerVMs to supplied networks
+* upload to/download from datastore
+
+### Example
 Replace the `<fields>` in the following example with values specific to your environment - this will install VCH to the specified resource pool of ESXi or vCenter, and the container VMs will be created under that resource pool. This example will use DHCP for the API endpoint and will not configure client authentication.  
 
 - --target is the URL of the destination vSphere environment in the form `https://user:password@ip-or-fqdn/datacenter-name`. Protocol, user, and password are OPTIONAL. Datacenter is OPTIONAL if targeting ESXi or only one datacenter is configured.
@@ -21,9 +43,10 @@ Replace the `<fields>` in the following example with values specific to your env
 vic-machine-linux create --target <target-host>[/datacenter] --user <root> --password <password> --thumbprint <certificate thumbprint> --compute-resource <resource pool path> --image-store <datastore name> --name <vch-name> --no-tlsverify
 ```
 
-This will, if successful, produce output similar to the following when deploying VIC Engine onto an ESXi (output was generated with --client-network-ip specified):
+This will, if successful, produce output similar to the following when deploying VIC Engine onto an ESXi (output was generated with --client-network-ip specified instead of `--no-tlsverify` denoted above):
 ```
 INFO[2016-11-07T22:01:22Z] Using client-network-ip as cname for server certificates - use --tls-cname to override: x.x.x.x
+WARN[2016-11-07T22:01:22Z] Using administrative user for VCH operation - use --ops-user to improve security (see -x for advanced help)
 INFO[2016-11-07T22:01:22Z] Generating CA certificate/key pair - private key in ./XXX/ca-key.pem
 INFO[2016-11-07T22:01:22Z] Generating server certificate/key pair - private key in ./XXX/server-key.pem
 INFO[2016-11-07T22:01:22Z] Generating client certificate/key pair - private key in ./XXX/key.pem
@@ -38,7 +61,7 @@ WARN[2016-11-07T22:01:23Z] Firewall must permit 2377/tcp outbound if firewall is
 INFO[2016-11-07T22:01:23Z] License check OK
 INFO[2016-11-07T22:01:23Z] DRS check SKIPPED - target is standalone host
 INFO[2016-11-07T22:01:23Z]
-INFO[2016-11-07T22:01:23Z] Creating Resource Pool "ghicken-test"
+INFO[2016-11-07T22:01:23Z] Creating Resource Pool "XXX"
 INFO[2016-11-07T22:01:23Z] Creating directory [datastore1] volumes
 INFO[2016-11-07T22:01:23Z] Datastore path is [datastore1] volumes
 INFO[2016-11-07T22:01:23Z] Creating appliance on target
@@ -58,7 +81,7 @@ INFO[2016-11-07T22:01:54Z] Published ports can be reached at:
 INFO[2016-11-07T22:01:54Z] x.x.x.x
 INFO[2016-11-07T22:01:54Z]
 INFO[2016-11-07T22:01:54Z] Docker environment variables:
-INFO[2016-11-07T22:01:54Z] DOCKER_TLS_VERIFY=1 DOCKER_CERT_PATH=/home/vagrant/vicsmb/src/github.com/vmware/vic/bin/ghicken-test DOCKER_HOST=x.x.x.x:2376
+INFO[2016-11-07T22:01:54Z] DOCKER_TLS_VERIFY=1 DOCKER_CERT_PATH=/home/vagrant/vicsmb/src/github.com/vmware/vic/bin/XXX DOCKER_HOST=x.x.x.x:2376
 INFO[2016-11-07T22:01:54Z]
 INFO[2016-11-07T22:01:54Z] Environment saved in XXX/XXX.env
 INFO[2016-11-07T22:01:54Z]

--- a/doc/user/usage.md
+++ b/doc/user/usage.md
@@ -11,7 +11,7 @@ The intent is that vSphere Integrated Containers Engine (VIC Engine) should not 
    - vCenter - Enterprise plus license, only very simple configurations have been tested.
 - Bridge network - when installed in a vCenter environment vic-machine does not automatically create a bridge network. An existing vSwitch or Distributed Portgroup should be specified via the -bridge-network flag, should not be the same as the external network, and should not have DHCP.
 
-### Privileges and
+### Privileges and credentials
 
 There is an operations user mechanism provided to allow a VCH to operate with less privileged credentials than are required for deploying a new VCH. These options are:
 * `--ops-user`

--- a/infra/scripts/bash-helpers.sh
+++ b/infra/scripts/bash-helpers.sh
@@ -24,7 +24,7 @@ no-tls () {
 }
 
 unset-vic () {
-    unset MAPPED_NETWORKS NETWORKS IMAGE_STORE DATASTORE COMPUTE VOLUME_STORES IPADDR GOVC_INSECURE TLS THUMBPRINT VIC_NAME
+    unset MAPPED_NETWORKS NETWORKS IMAGE_STORE DATASTORE COMPUTE VOLUME_STORES IPADDR GOVC_INSECURE TLS THUMBPRINT OPS_CREDS VIC_NAME
 }
 
 vic-path () {
@@ -35,7 +35,7 @@ vic-create () {
     base=$(pwd)
     (
         cd $(vic-path)/bin
-        $(vic-path)/bin/vic-machine-"$OS" create --target="$GOVC_URL" --image-store="$IMAGE_STORE" --compute-resource="$COMPUTE" "${TLS[@]}" ${TLS_OPTS} --name=${VIC_NAME:-${USER}test} "${MAPPED_NETWORKS[@]}" "${VOLUME_STORES[@]}" "${NETWORKS[@]}" ${IPADDR} ${TIMEOUT} --thumbprint=$THUMBPRINT $*
+        $(vic-path)/bin/vic-machine-"$OS" create --target="$GOVC_URL" "${OPS_CREDS[@]}" --image-store="$IMAGE_STORE" --compute-resource="$COMPUTE" "${TLS[@]}" ${TLS_OPTS} --name=${VIC_NAME:-${USER}test} "${MAPPED_NETWORKS[@]}" "${VOLUME_STORES[@]}" "${NETWORKS[@]}" ${IPADDR} ${TIMEOUT} --thumbprint=$THUMBPRINT $*
     )
 
     unset DOCKER_CERT_PATH DOCKER_TLS_VERIFY
@@ -106,15 +106,17 @@ addr-from-dockerhost () {
 #    export COMPUTE=cluster/pool
 #    export DATASTORE=datastore1
 #    export IMAGE_STORE=$DATASTORE/image/path
-#    NETWORKS=("--bridge-network=private-dpg-vlan" "--public-network=extern-dpg")
-#    MAPPED_NETWORKS=("--container-network=VM Network:external" "--container-network=SomeOtherNet:elsewhere")
-#    VOLUME_STORES=("--volume-store=$DATASTORE:default")
 #    export TLS=("--tls-cname=vch-hostname.domain.com" "--organisation=MyCompany")
 #    export TIMEOUT="--timeout=10m"
 #    export IPADDR="--client-network-ip=vch-hostname.domain.com --client-network-gateway=x.x.x.x/22 --dns-server=y.y.y.y --dns-server=z.z.z.z"
 #    export VIC_NAME="MyVCH"
 #
-#    export NETWORKS MAPPED_NETWORKS VOLUME_STORES
+#    OPS_CREDS=("--ops-user=<user>" "--ops-password=<password>")
+#    NETWORKS=("--bridge-network=private-dpg-vlan" "--public-network=extern-dpg")
+#    MAPPED_NETWORKS=("--container-network=VM Network:external" "--container-network=SomeOtherNet:elsewhere")
+#    VOLUME_STORES=("--volume-store=$DATASTORE:default")
+#
+#    export NETWORKS MAPPED_NETWORKS VOLUME_STORES OPS_CREDS
 #}
 
 . ~/.vic

--- a/lib/install/data/data.go
+++ b/lib/install/data/data.go
@@ -32,6 +32,9 @@ type Data struct {
 	common.Compute
 	common.VCHID
 
+	OpsUser     string
+	OpsPassword *string
+
 	CertPEM     []byte
 	KeyPEM      []byte
 	ClientCAs   []byte

--- a/lib/install/validate/validator.go
+++ b/lib/install/validate/validator.go
@@ -352,6 +352,7 @@ func (v *Validator) managedbyVC(ctx context.Context) {
 }
 
 func (v *Validator) credentials(ctx context.Context, input *data.Data, conf *config.VirtualContainerHostConfigSpec) {
+	// empty string for password is horrific, but a legitmate scenario especially in isolated labs
 	if input.OpsPassword == nil {
 		v.NoteIssue(errors.New("Password for operations user has not been set"))
 		return

--- a/lib/install/validate/validator_test.go
+++ b/lib/install/validate/validator_test.go
@@ -129,6 +129,9 @@ func TestMain(t *testing.T) {
 func getESXData(url *url.URL) *data.Data {
 	result := data.NewData()
 	url.Path = url.Path + "/ha-datacenter"
+	result.OpsUser = url.User.Username()
+	passwd, _ := url.User.Password()
+	result.OpsPassword = &passwd
 	result.URL = url
 	result.DisplayName = "test001"
 	result.ComputeResourcePath = "/ha-datacenter/host/localhost.localdomain/Resources"
@@ -146,6 +149,9 @@ func getESXData(url *url.URL) *data.Data {
 func getVPXData(url *url.URL) *data.Data {
 	result := data.NewData()
 	url.Path = url.Path + "/DC0"
+	result.OpsUser = url.User.Username()
+	passwd, _ := url.User.Password()
+	result.OpsPassword = &passwd
 	result.URL = url
 	result.DisplayName = "test001"
 	result.ComputeResourcePath = "/DC0/host/DC0_C0/Resources"
@@ -240,6 +246,8 @@ func testCompute(v *Validator, input *data.Data, t *testing.T) *config.VirtualCo
 
 func testTargets(v *Validator, input *data.Data, conf *config.VirtualContainerHostConfigSpec, t *testing.T) {
 	v.target(v.Context, input, conf)
+	v.credentials(v.Context, input, conf)
+
 	u, err := url.Parse(conf.Target)
 	assert.NoError(t, err)
 	assert.Nil(t, u.User)

--- a/tests/test-cases/Group6-VIC-Machine/6-04-Create-Basic.md
+++ b/tests/test-cases/Group6-VIC-Machine/6-04-Create-Basic.md
@@ -53,6 +53,13 @@ vic-machine-linux create --name=<VCH_NAME> --target="<TEST_USERNAME>:<TEST_PASSW
 ```
 2. Run regression tests
 
+## Create VCH - operations user
+1. Create with an operations user (the same as the administrative user used for deployment in this case)
+```
+vic-machine-linux create --ops-user="<TEST_USERNAME>" --ops-password="<TEST_PASSWORD>"
+```
+2. Run regression tests
+
 ### Expected Outcome
 * Deployment succeed
 * Regression test pass

--- a/tests/test-cases/Group6-VIC-Machine/6-04-Create-Basic.robot
+++ b/tests/test-cases/Group6-VIC-Machine/6-04-Create-Basic.robot
@@ -48,6 +48,19 @@ Create VCH - target URL
     Run Regression Tests
     Cleanup VIC Appliance On Test Server
 
+Create VCH - operations user
+    Set Test Environment Variables
+    Run Keyword And Ignore Error  Cleanup Dangling VMs On Test Server
+    Run Keyword And Ignore Error  Cleanup Datastore On Test Server
+
+    ${output}=  Run  bin/vic-machine-linux create --name=${vch-name} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --image-store=%{TEST_DATASTORE} --bridge-network=%{BRIDGE_NETWORK} --external-network=%{EXTERNAL_NETWORK} ${vicmachinetls} --ops-user="%{TEST_USERNAME}" --ops-password="%{TEST_PASSWORD}"
+    Should Contain  ${output}  Installer completed successfully
+    Get Docker Params  ${output}  ${true}
+    Log To Console  Installer completed successfully: ${vch-name}
+
+    Run Regression Tests
+    Cleanup VIC Appliance On Test Server
+
 Create VCH - specified datacenter
     Run Keyword If  '%{HOST_TYPE}' == 'ESXi'  Pass Execution  Requires vCenter environment
 


### PR DESCRIPTION
This adds the ability to supply an operations user that is different from
the administrative user that vic-machine requires for creation of a VCH.

This does NOT configure the required RBAC permissions for the ops user.

Towards #1689 
