### PR TITLE
Workaround a streaming panic in logs [full ci]

### DIFF
--- a/lib/apiservers/portlayer/restapi/handlers/containers_handlers.go
+++ b/lib/apiservers/portlayer/restapi/handlers/containers_handlers.go
@@ -337,9 +337,7 @@ func (handler *ContainersHandlersImpl) GetContainerLogsHandler(params containers
 
 	container := exec.Containers.Container(params.ID)
 	if container == nil {
-		return containers.NewGetContainerLogsNotFound().WithPayload(&models.Error{
-			Message: fmt.Sprintf("container %s not found", params.ID),
-		})
+		return containers.NewGetContainerLogsNotFound()
 	}
 
 	follow := false
@@ -355,7 +353,8 @@ func (handler *ContainersHandlersImpl) GetContainerLogsHandler(params containers
 
 	reader, err := container.LogReader(context.Background(), tail, follow)
 	if err != nil {
-		return containers.NewGetContainerLogsInternalServerError().WithPayload(&models.Error{Message: err.Error()})
+		// Do not return an error here.  It's a workaround for a panic similar to #2594
+		return containers.NewGetContainerLogsInternalServerError()
 	}
 
 	detachableOut := NewFlushingReader(reader)


### PR DESCRIPTION
This works around a race condition in streaming support between
us and swagger when returning errors.  Long term, we need to
change the pattern we use for logging to adopt an explicit close
from the client side, telling the server side to close.

Resolves #3261