### PR TITLE
Fix panic in QueryDatastore when session becomes nil

### DIFF
--- a/cmd/vicadmin/server.go
+++ b/cmd/vicadmin/server.go
@@ -439,6 +439,10 @@ func (s *server) bundleContainerLogs(res http.ResponseWriter, req *http.Request,
 	c, err := s.getSessionFromRequest(context.Background(), req)
 	if err != nil {
 		log.Errorf("Failed to get vSphere session while bundling container logs due to error: %s", err.Error())
+		if strings.Contains(err.Error(), "Could not validate session") {
+			http.Redirect(res, req, "/logout", http.StatusTemporaryRedirect)
+			return
+		}
 		http.Error(res, genericErrorMessage, http.StatusInternalServerError)
 		return
 	}
@@ -549,6 +553,10 @@ func (s *server) index(res http.ResponseWriter, req *http.Request) {
 	defer trace.End(trace.Begin(""))
 	ctx := context.Background()
 	sess, err := s.getSessionFromRequest(ctx, req)
+	if err != nil && strings.Contains(err.Error(), "Could not validate session") {
+		http.Redirect(res, req, "/logout", http.StatusTemporaryRedirect)
+		return
+	}
 	v := vicadmin.NewValidator(ctx, &vchConfig, sess)
 
 	if sess == nil {

--- a/cmd/vicadmin/server.go
+++ b/cmd/vicadmin/server.go
@@ -19,7 +19,6 @@ import (
 	"compress/gzip"
 	"crypto/tls"
 	"crypto/x509"
-	"fmt"
 	"html/template"
 	"net"
 	"net/http"
@@ -526,45 +525,19 @@ func (s *server) tailFiles(res http.ResponseWriter, req *http.Request, names []s
 	}
 }
 
-// deriveErrorMessage takes a vSphere session error and returns
-// an error string that is safe to display on the vicadmin page.
-func deriveErrorMessage(err error) string {
-	if err != nil {
-		switch err := err.(type) {
-		case session.SDKURLError:
-			return fmt.Sprintf("SDK URL could not be parsed: %s", err.Err)
-		case session.SoapClientError:
-			return "unable to obtain a vim client"
-		case session.UserPassLoginError:
-			return "unable to log in with username and password"
-		default:
-			return genericErrorMessage
-		}
-	}
-
-	return ""
-}
-
 func (s *server) index(res http.ResponseWriter, req *http.Request) {
 	defer trace.End(trace.Begin(""))
 	ctx := context.Background()
 	sess, err := s.getSessionFromRequest(ctx, req)
 	if err != nil {
+		log.Errorf("While loading index page got %s looking up a vSphere session", err.Error())
 		http.Redirect(res, req, "/logout", http.StatusTemporaryRedirect)
 		return
 	}
 	v := vicadmin.NewValidator(ctx, &vchConfig, sess)
-
 	if sess == nil {
 		// We're unable to connect to vSphere, so display an error message
-		errMessage := ""
-		if err != nil {
-			errMessage = fmt.Sprintf(" Error: %s", deriveErrorMessage(err))
-		}
-		vchIssues := fmt.Sprintf("<span class=\"error-message\">%s%s</span>\n",
-			v.Hostname+" is not functioning: unable to connect to vSphere. You may wish to <a href=\"/logout\">try logging in again</a>.", errMessage)
-
-		v.VCHIssues = template.HTML(vchIssues)
+		v.VCHIssues = template.HTML("<span class=\"error-message\">We're having some trouble communicating with vSphere. <a href=\"/logout\">Logging in again</a> may resolve the issue.</span>\n")
 	}
 
 	tmpl, err := template.ParseFiles("dashboard.html")

--- a/cmd/vicadmin/server.go
+++ b/cmd/vicadmin/server.go
@@ -557,9 +557,12 @@ func (s *server) index(res http.ResponseWriter, req *http.Request) {
 
 	if sess == nil {
 		// We're unable to connect to vSphere, so display an error message
-		errMessage := deriveErrorMessage(err)
-		vchIssues := fmt.Sprintf("<span class=\"error-message\">%s Error: %s</span>\n",
-			v.Hostname+" is not functioning: unable to connect to vSphere.", errMessage)
+		errMessage := ""
+		if err != nil {
+			errMessage = fmt.Sprintf(" Error: %s", deriveErrorMessage(err))
+		}
+		vchIssues := fmt.Sprintf("<span class=\"error-message\">%s%s</span>\n",
+			v.Hostname+" is not functioning: unable to connect to vSphere. You may wish to <a href=\"/logout\">try logging in again</a>.", errMessage)
 
 		v.VCHIssues = template.HTML(vchIssues)
 	}

--- a/cmd/vicadmin/server.go
+++ b/cmd/vicadmin/server.go
@@ -439,11 +439,7 @@ func (s *server) bundleContainerLogs(res http.ResponseWriter, req *http.Request,
 	c, err := s.getSessionFromRequest(context.Background(), req)
 	if err != nil {
 		log.Errorf("Failed to get vSphere session while bundling container logs due to error: %s", err.Error())
-		if strings.Contains(err.Error(), "Could not validate session") {
-			http.Redirect(res, req, "/logout", http.StatusTemporaryRedirect)
-			return
-		}
-		http.Error(res, genericErrorMessage, http.StatusInternalServerError)
+		http.Redirect(res, req, "/logout", http.StatusTemporaryRedirect)
 		return
 	}
 
@@ -553,7 +549,7 @@ func (s *server) index(res http.ResponseWriter, req *http.Request) {
 	defer trace.End(trace.Begin(""))
 	ctx := context.Background()
 	sess, err := s.getSessionFromRequest(ctx, req)
-	if err != nil && strings.Contains(err.Error(), "Could not validate session") {
+	if err != nil {
 		http.Redirect(res, req, "/logout", http.StatusTemporaryRedirect)
 		return
 	}

--- a/cmd/vicadmin/server.go
+++ b/cmd/vicadmin/server.go
@@ -538,7 +538,7 @@ func deriveErrorMessage(err error) string {
 		case session.UserPassLoginError:
 			return "unable to log in with username and password"
 		default:
-			return err.Error()
+			return genericErrorMessage
 		}
 	}
 

--- a/cmd/vicadmin/server.go
+++ b/cmd/vicadmin/server.go
@@ -443,9 +443,6 @@ func (s *server) bundleContainerLogs(res http.ResponseWriter, req *http.Request,
 		return
 	}
 
-	// Note: we don't want to Logout() until tarEntries() completes below
-	defer c.Client.Logout(context.Background())
-
 	logs, err := findDatastoreLogs(c)
 	if err != nil {
 		log.Warningf("error searching datastore: %s", err)

--- a/cmd/vicadmin/usersession.go
+++ b/cmd/vicadmin/usersession.go
@@ -86,7 +86,7 @@ func (u *UserSessionStore) VSphere(ctx context.Context, id string) (*session.Ses
 		return nil, fmt.Errorf("User session with unique ID %s does not exist", id)
 	}
 	if us.vsphere == nil {
-		return nil, fmt.Errorf("No vSphere session found for user with ID %s", id)
+		return nil, fmt.Errorf("No vSphere session found for user: %s", id)
 	}
 
 	vsphus, err := us.vsphere.SessionManager.UserSession(ctx)

--- a/cmd/vicadmin/usersession.go
+++ b/cmd/vicadmin/usersession.go
@@ -91,11 +91,12 @@ func (u *UserSessionStore) VSphere(ctx context.Context, id string) (*session.Ses
 
 	vsphus, err := us.vsphere.SessionManager.UserSession(ctx)
 	if err != nil || vsphus == nil {
-		u.Delete(id)
 		if err != nil {
-			return nil, fmt.Errorf("Failed to validate user %s session: %v", id, err)
+			log.Warnf("Failed to validate user %s session: %v", id, err)
+			return nil, nil
 		}
-		return nil, fmt.Errorf("User %s session has expired", id)
+		log.Warnf("User %s session has expired", id)
+		return nil, nil
 	}
 	log.Infof("Found vSphere session for vicadmin usersession %s", id)
 	return us.vsphere, nil

--- a/cmd/vicadmin/usersession.go
+++ b/cmd/vicadmin/usersession.go
@@ -89,6 +89,15 @@ func (u *UserSessionStore) VSphere(ctx context.Context, id string) (*session.Ses
 		return nil, fmt.Errorf("No vSphere session found. User with ID %s must authenticate again.", id)
 	}
 
+	vsphus, err := us.vsphere.SessionManager.UserSession(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("vSphere UserSession was invalid; got error: %s", err.Error())
+	}
+
+	if vsphus == nil {
+		return nil, fmt.Errorf("vSphere UserSession came back nil but no error was reported")
+	}
+
 	log.Infof("Found vSphere session for vicadmin usersession %s", id)
 	return us.vsphere, nil
 }

--- a/cmd/vicadmin/usersession.go
+++ b/cmd/vicadmin/usersession.go
@@ -92,11 +92,10 @@ func (u *UserSessionStore) VSphere(ctx context.Context, id string) (*session.Ses
 	vsphus, err := us.vsphere.SessionManager.UserSession(ctx)
 	if err != nil || vsphus == nil {
 		u.Delete(id)
-		errMsg := fmt.Sprintf("Could not validate session for user %s; must log in again", id)
 		if err != nil {
-			errMsg = fmt.Sprintf("%s. Got error %s", errMsg, err.Error())
+			return nil, fmt.Errorf("Failed to validate user %s session: %v", id, err)
 		}
-		return nil, fmt.Errorf("%s", errMsg)
+		return nil, fmt.Errorf("User %s session has expired", id)
 	}
 	log.Infof("Found vSphere session for vicadmin usersession %s", id)
 	return us.vsphere, nil

--- a/cmd/vicadmin/usersession.go
+++ b/cmd/vicadmin/usersession.go
@@ -90,10 +90,12 @@ func (u *UserSessionStore) VSphere(ctx context.Context, id string) (*session.Ses
 	}
 
 	vsphus, err := us.vsphere.SessionManager.UserSession(ctx)
+	if err != nil || vsphus == nil {
+		u.Delete(id)
+	}
 	if err != nil {
 		return nil, fmt.Errorf("vSphere UserSession was invalid; got error: %s", err.Error())
 	}
-
 	if vsphus == nil {
 		return nil, fmt.Errorf("vSphere UserSession came back nil but no error was reported")
 	}

--- a/cmd/vicadmin/usersession.go
+++ b/cmd/vicadmin/usersession.go
@@ -86,20 +86,18 @@ func (u *UserSessionStore) VSphere(ctx context.Context, id string) (*session.Ses
 		return nil, fmt.Errorf("User session with unique ID %s does not exist", id)
 	}
 	if us.vsphere == nil {
-		return nil, fmt.Errorf("No vSphere session found. User with ID %s must authenticate again.", id)
+		return nil, fmt.Errorf("No vSphere session found for user with ID %s", id)
 	}
 
 	vsphus, err := us.vsphere.SessionManager.UserSession(ctx)
 	if err != nil || vsphus == nil {
 		u.Delete(id)
+		errMsg := fmt.Sprintf("Could not validate session for user %s; must log in again", id)
+		if err != nil {
+			errMsg = fmt.Sprintf("%s. Got error %s", errMsg, err.Error())
+		}
+		return nil, fmt.Errorf("%s", errMsg)
 	}
-	if err != nil {
-		return nil, fmt.Errorf("vSphere UserSession was invalid; got error: %s", err.Error())
-	}
-	if vsphus == nil {
-		return nil, fmt.Errorf("vSphere UserSession came back nil but no error was reported")
-	}
-
 	log.Infof("Found vSphere session for vicadmin usersession %s", id)
 	return us.vsphere, nil
 }

--- a/cmd/vicadmin/vicadm.go
+++ b/cmd/vicadmin/vicadm.go
@@ -484,7 +484,7 @@ func vSphereSessionGet(sessconfig *session.Config) (*session.Session, error) {
 		return nil, err
 	}
 	if usersession == nil {
-		return nil, fmt.Errorf("UserSession from vSphere came back nil but no error was reported")
+		return nil, fmt.Errorf("vSphere session is no longer valid")
 	}
 
 	log.Infof("Got session from vSphere with key: %s username: %s", usersession.Key, usersession.UserName)

--- a/cmd/vicadmin/vicadm.go
+++ b/cmd/vicadmin/vicadm.go
@@ -507,10 +507,7 @@ func (s *server) getSessionFromRequest(ctx context.Context, r *http.Request) (*s
 		return nil, fmt.Errorf("User-provided cookie did not contain a session ID -- it is corrupt or tampered")
 	}
 	c, err := s.uss.VSphere(ctx, d.(string))
-	if err != nil {
-		return nil, err
-	}
-	return c, nil
+	return c, err
 }
 
 type flushWriter struct {

--- a/cmd/vicadmin/vicadm.go
+++ b/cmd/vicadmin/vicadm.go
@@ -483,6 +483,9 @@ func vSphereSessionGet(sessconfig *session.Config) (*session.Session, error) {
 		log.Errorf("Got %s while creating user session", err)
 		return nil, err
 	}
+	if usersession == nil {
+		return nil, fmt.Errorf("UserSession from vSphere came back nil but no error was reported")
+	}
 
 	log.Infof("Got session from vSphere with key: %s username: %s", usersession.Key, usersession.UserName)
 

--- a/lib/vicadmin/validate.go
+++ b/lib/vicadmin/validate.go
@@ -255,17 +255,13 @@ func (v *Validator) QueryDatastore(ctx context.Context, vch *config.VirtualConta
 		}
 	}
 
-	if sess.Client == nil {
-		return fmt.Errorf("Non-nil session govmomi client is nil while looking for datastore info")
-	}
-
-	if sess.Client.Client == nil {
-		return fmt.Errorf("Non-nil session vim client is nil while looking for datastore info")
-	}
-
 	pc := property.DefaultCollector(sess.Client.Client)
 	if pc == nil {
 		return fmt.Errorf("Could not get default propery collector; prop-collector came back nil")
+	}
+
+	if len(refs) == 0 {
+		return fmt.Errorf("No datastore references found")
 	}
 
 	err := pc.Retrieve(ctx, refs, nil, &dataStores)

--- a/lib/vicadmin/validate.go
+++ b/lib/vicadmin/validate.go
@@ -209,7 +209,10 @@ func NewValidator(ctx context.Context, vch *config.VirtualContainerHostConfigSpe
 		v.DockerPort = fmt.Sprintf("%d", opts.DefaultTLSHTTPPort)
 	}
 
-	v.QueryDatastore(ctx, vch, sess)
+	err = v.QueryDatastore(ctx, vch, sess)
+	if err != nil {
+		log.Errorf("Had a problem querying the datastores: %s", err.Error())
+	}
 	v.QueryVCHStatus(vch, sess)
 	return v
 }

--- a/lib/vicadmin/validate.go
+++ b/lib/vicadmin/validate.go
@@ -269,7 +269,6 @@ func (v *Validator) QueryDatastore(ctx context.Context, vch *config.VirtualConta
 	sort.Sort(dataStores)
 	if err != nil {
 		log.Errorf("Error while accessing datastore: %s", err)
-		return err
 	}
 	for _, ds := range dataStores {
 		log.Infof("Datastore %s Status: %s", ds.Name, ds.OverallStatus)

--- a/lib/vicadmin/validate.go
+++ b/lib/vicadmin/validate.go
@@ -259,16 +259,17 @@ func (v *Validator) QueryDatastore(ctx context.Context, vch *config.VirtualConta
 		return fmt.Errorf("No datastore references found")
 	}
 
-	pc := property.DefaultCollector(sess.Client.Client)
+	c := property.DefaultCollector(sess.Client.Client)
 	if pc == nil {
 		return fmt.Errorf("Could not get default propery collector; prop-collector came back nil")
 	}
 
-	sort.Sort(dataStores)
 	err := pc.Retrieve(ctx, refs, nil, &dataStores)
 	if err != nil {
 		log.Errorf("Error while accessing datastore: %s", err)
 	}
+
+	sort.Sort(dataStores)
 	for _, ds := range dataStores {
 		log.Infof("Datastore %s Status: %s", ds.Name, ds.OverallStatus)
 		log.Infof("Datastore %s Free Space: %.1fGB", ds.Name, float64(ds.Summary.FreeSpace)/(1<<30))

--- a/lib/vicadmin/validate.go
+++ b/lib/vicadmin/validate.go
@@ -247,13 +247,24 @@ func (v *Validator) QueryDatastore(ctx context.Context, vch *config.VirtualConta
 		ds, err := sess.Finder.DatastoreOrDefault(ctx, dsName)
 		if err != nil {
 			log.Errorf("Unable to collect information for datastore %s: %s", dsName, err)
-			return err
 		} else {
 			refs = append(refs, ds.Reference())
 		}
 	}
 
+	if sess.Client == nil {
+		return fmt.Errorf("Non-nil session govmomi client is nil while looking for datastore info")
+	}
+
+	if sess.Client.Client == nil {
+		return fmt.Errorf("Non-nil session vim client is nil while looking for datastore info")
+	}
+
 	pc := property.DefaultCollector(sess.Client.Client)
+	if pc == nil {
+		return fmt.Errorf("Could not get default propery collector; prop-collector came back nil")
+	}
+
 	err := pc.Retrieve(ctx, refs, nil, &dataStores)
 
 	sort.Sort(dataStores)

--- a/lib/vicadmin/validate.go
+++ b/lib/vicadmin/validate.go
@@ -130,43 +130,43 @@ func NewValidator(ctx context.Context, vch *config.VirtualContainerHostConfigSpe
 		v.FirewallIssues = template.HTML("")
 		v.LicenseStatus = BadStatus
 		v.LicenseIssues = template.HTML("")
-		return nil
-	}
-
-	v.VCHReachable = true
-	// Firewall status check
-	v2, _ := validate.CreateFromVCHConfig(ctx, vch, sess)
-	mgmtIP := GetMgmtIP()
-	log.Infof("Using management IP %s for firewall check", mgmtIP)
-	fwStatus := v2.CheckFirewallForTether(ctx, mgmtIP)
-	v2.FirewallCheckOutput(fwStatus)
-
-	firewallIssues := v2.GetIssues()
-
-	if len(firewallIssues) == 0 {
-		v.FirewallStatus = GoodStatus
-		v.FirewallIssues = template.HTML("")
 	} else {
-		v.FirewallStatus = BadStatus
-		for _, err := range firewallIssues {
-			v.FirewallIssues = template.HTML(fmt.Sprintf("%s<span class=\"error-message\">%s</span>\n", v.FirewallIssues, err))
+		v.VCHReachable = true
+		// Firewall status check
+		v2, _ := validate.CreateFromVCHConfig(ctx, vch, sess)
+		mgmtIP := GetMgmtIP()
+		log.Infof("Using management IP %s for firewall check", mgmtIP)
+		fwStatus := v2.CheckFirewallForTether(ctx, mgmtIP)
+		v2.FirewallCheckOutput(fwStatus)
+
+		firewallIssues := v2.GetIssues()
+
+		if len(firewallIssues) == 0 {
+			v.FirewallStatus = GoodStatus
+			v.FirewallIssues = template.HTML("")
+		} else {
+			v.FirewallStatus = BadStatus
+			for _, err := range firewallIssues {
+				v.FirewallIssues = template.HTML(fmt.Sprintf("%s<span class=\"error-message\">%s</span>\n", v.FirewallIssues, err))
+			}
+		}
+
+		// License status check
+		v2.ClearIssues()
+		v2.CheckLicense(ctx)
+		licenseIssues := v2.GetIssues()
+
+		if len(licenseIssues) == 0 {
+			v.LicenseStatus = GoodStatus
+			v.LicenseIssues = template.HTML("")
+		} else {
+			v.LicenseStatus = BadStatus
+			for _, err := range licenseIssues {
+				v.LicenseIssues = template.HTML(fmt.Sprintf("%s<span class=\"error-message\">%s</span>\n", v.LicenseIssues, err))
+			}
 		}
 	}
 
-	// License status check
-	v2.ClearIssues()
-	v2.CheckLicense(ctx)
-	licenseIssues := v2.GetIssues()
-
-	if len(licenseIssues) == 0 {
-		v.LicenseStatus = GoodStatus
-		v.LicenseIssues = template.HTML("")
-	} else {
-		v.LicenseStatus = BadStatus
-		for _, err := range licenseIssues {
-			v.LicenseIssues = template.HTML(fmt.Sprintf("%s<span class=\"error-message\">%s</span>\n", v.LicenseIssues, err))
-		}
-	}
 	log.Infof("FirewallStatus set to: %s", v.FirewallStatus)
 	log.Infof("FirewallIssues set to: %s", v.FirewallIssues)
 	log.Infof("LicenseStatus set to: %s", v.LicenseStatus)

--- a/lib/vicadmin/validate.go
+++ b/lib/vicadmin/validate.go
@@ -259,7 +259,7 @@ func (v *Validator) QueryDatastore(ctx context.Context, vch *config.VirtualConta
 		return fmt.Errorf("No datastore references found")
 	}
 
-	c := property.DefaultCollector(sess.Client.Client)
+	pc := property.DefaultCollector(sess.Client.Client)
 	if pc == nil {
 		return fmt.Errorf("Could not get default propery collector; prop-collector came back nil")
 	}

--- a/lib/vicadmin/validate.go
+++ b/lib/vicadmin/validate.go
@@ -255,18 +255,17 @@ func (v *Validator) QueryDatastore(ctx context.Context, vch *config.VirtualConta
 		}
 	}
 
+	if len(refs) == 0 {
+		return fmt.Errorf("No datastore references found")
+	}
+
 	pc := property.DefaultCollector(sess.Client.Client)
 	if pc == nil {
 		return fmt.Errorf("Could not get default propery collector; prop-collector came back nil")
 	}
 
-	if len(refs) == 0 {
-		return fmt.Errorf("No datastore references found")
-	}
-
-	err := pc.Retrieve(ctx, refs, nil, &dataStores)
-
 	sort.Sort(dataStores)
+	err := pc.Retrieve(ctx, refs, nil, &dataStores)
 	if err != nil {
 		log.Errorf("Error while accessing datastore: %s", err)
 	}


### PR DESCRIPTION
When sessions are expired (or nuked via govc), we were seeing an inconsistent state in vicadmin caused by a panic in QueryDatastore. This fixes that by terminating QueryDatastore if the datastore is inaccessible. The method also returns an err now, though it's not necessary that we do anything with the error at call time currently.