### PR TITLE
Connect file backed serial ports after a vMotion

### DIFF
--- a/lib/portlayer/attach/attach.go
+++ b/lib/portlayer/attach/attach.go
@@ -52,7 +52,7 @@ func toggle(handle *exec.Handle, connected bool) (*exec.Handle, error) {
 	// select the virtual serial ports
 	serials := devices.SelectByBackingInfo((*types.VirtualSerialPortURIBackingInfo)(nil))
 	if len(serials) == 0 {
-		return nil, fmt.Errorf("Unable to bind a device with desired backing")
+		return nil, fmt.Errorf("Unable to find a device with desired backing")
 	}
 	if len(serials) > 1 {
 		return nil, fmt.Errorf("Multiple matches found with desired backing")

--- a/lib/portlayer/event/collector/vsphere/collector.go
+++ b/lib/portlayer/event/collector/vsphere/collector.go
@@ -168,7 +168,9 @@ func evented(ec *EventCollector, page []types.BaseEvent) {
 			*types.VmPoweredOffEvent,
 			*types.VmRemovedEvent,
 			*types.VmSuspendedEvent,
-			*types.VmRegisteredEvent:
+			*types.VmRegisteredEvent,
+			*types.VmMigratedEvent,
+			*types.DrsVmMigratedEvent:
 			vmEvent = NewVMEvent(page[i])
 		}
 

--- a/lib/portlayer/event/collector/vsphere/vm_event.go
+++ b/lib/portlayer/event/collector/vsphere/vm_event.go
@@ -41,6 +41,10 @@ func NewVMEvent(be types.BaseEvent) *VMEvent {
 		ee = events.ContainerShutdown
 	case *types.VmRegisteredEvent:
 		ee = events.ContainerRegistered
+	case *types.VmMigratedEvent:
+		ee = events.ContainerMigrated
+	case *types.DrsVmMigratedEvent:
+		ee = events.ContainerMigratedByDrs
 	}
 	e := be.GetEvent()
 	return &VMEvent{

--- a/lib/portlayer/event/events/container_event.go
+++ b/lib/portlayer/event/events/container_event.go
@@ -15,17 +15,19 @@
 package events
 
 const (
-	ContainerCreated      = "Created"
-	ContainerShutdown     = "Shutdown"
-	ContainerPoweredOn    = "PoweredOn"
-	ContainerPoweredOff   = "PoweredOff"
-	ContainerSuspended    = "Suspended"
-	ContainerResumed      = "Resumed"
-	ContainerRemoved      = "Removed"
-	ContainerReconfigured = "Reconfigured"
-	ContainerStarted      = "Started"
-	ContainerStopped      = "Stopped"
-	ContainerRegistered   = "Registered"
+	ContainerCreated       = "Created"
+	ContainerShutdown      = "Shutdown"
+	ContainerPoweredOn     = "PoweredOn"
+	ContainerPoweredOff    = "PoweredOff"
+	ContainerSuspended     = "Suspended"
+	ContainerResumed       = "Resumed"
+	ContainerRemoved       = "Removed"
+	ContainerReconfigured  = "Reconfigured"
+	ContainerStarted       = "Started"
+	ContainerStopped       = "Stopped"
+	ContainerRegistered    = "Registered"
+	ContainerMigrated      = "Migrated"
+	ContainerMigratedByDrs = "MigratedByDrs"
 )
 
 type ContainerEvent struct {

--- a/lib/portlayer/exec/exec.go
+++ b/lib/portlayer/exec/exec.go
@@ -163,7 +163,6 @@ func eventCallback(ie events.Event) {
 				log.Debugf("Container(%s) %s via event activity", container.ExecConfig.ID, newState.String())
 				Containers.Remove(container.ExecConfig.ID)
 				publishContainerEvent(container.ExecConfig.ID, ie.Created(), ie.String())
-
 			}
 		}
 	}

--- a/lib/portlayer/logging/logging.go
+++ b/lib/portlayer/logging/logging.go
@@ -15,12 +15,115 @@
 package logging
 
 import (
+	"context"
 	"fmt"
+	"sync"
 
+	log "github.com/Sirupsen/logrus"
+
+	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/vim25/types"
+	"github.com/vmware/vic/lib/portlayer/event/collector/vsphere"
+	"github.com/vmware/vic/lib/portlayer/event/events"
 	"github.com/vmware/vic/lib/portlayer/exec"
+	"github.com/vmware/vic/pkg/retry"
 	"github.com/vmware/vic/pkg/trace"
 )
+
+var once sync.Once
+
+func Init(ctx context.Context) error {
+	once.Do(func() {
+		// Subscribe to vm events
+		exec.Config.EventManager.Subscribe(
+			events.NewEventType(vsphere.VMEvent{}).Topic(),
+			"logging",
+			func(ie events.Event) {
+				eventCallback(ctx, ie)
+			})
+	})
+	return nil
+}
+
+// listens migrated events and connects the file backed serial ports
+func eventCallback(ctx context.Context, ie events.Event) {
+	defer trace.End(trace.Begin(""))
+
+	var err error
+
+	switch ie.String() {
+	case events.ContainerMigrated,
+		events.ContainerMigratedByDrs:
+		log.Debugf("Received %s event", ie)
+
+		// grab the container from the cache
+		container := exec.Containers.Container(ie.Reference())
+		if container == nil {
+			log.Errorf("Container %s not found", ie.Reference())
+			return
+		}
+
+		operation := func() error {
+			handle := container.NewHandle(ctx)
+			if handle == nil {
+				log.Errorf("Handle for %s cannot be created", ie.Reference())
+				return err
+			}
+			defer handle.Close()
+
+			// set them to true
+			if handle, err = toggle(handle, true); err != nil {
+				log.Errorf("Failed to toggle logging after %s event for container %s: %s", ie, ie.Reference(), err)
+				return err
+			}
+
+			if err := handle.Commit(ctx, nil, nil); err != nil {
+				log.Errorf("Failed to commit handle after getting %s event for container %s: %s", ie, ie.Reference(), err)
+				return err
+			}
+			return nil
+		}
+
+		if err := retry.Do(operation, exec.IsConcurrentAccessError); err != nil {
+			log.Errorf("Multiple attempts failed to commit handle after getting %s event for container %s: %s", ie, ie.Reference(), err)
+		}
+	}
+
+}
+
+func toggle(handle *exec.Handle, connected bool) (*exec.Handle, error) {
+	defer trace.End(trace.Begin(""))
+
+	// get the virtual device list
+	devices := object.VirtualDeviceList(handle.Config.Hardware.Device)
+
+	// select the virtual serial ports
+	serials := devices.SelectByBackingInfo((*types.VirtualSerialPortFileBackingInfo)(nil))
+	if len(serials) == 0 {
+		return nil, fmt.Errorf("Unable to find a device with desired backing")
+	}
+
+	for i := range serials {
+		serial := serials[i]
+
+		log.Debugf("Found a device with desired backing: %#v", serial)
+
+		c := serial.GetVirtualDevice().Connectable
+		if c.Connected == connected {
+			log.Debugf("Already in the desired state (connected: %t)", connected)
+			continue
+		}
+		log.Debugf("Setting Connected to %t", connected)
+		c.Connected = connected
+
+		config := &types.VirtualDeviceConfigSpec{
+			Device:    serial,
+			Operation: types.VirtualDeviceConfigSpecOperationEdit,
+		}
+		handle.Spec.DeviceChange = append(handle.Spec.DeviceChange, config)
+	}
+	return handle, nil
+}
 
 // Join adds two file backed serial port and configures them
 func Join(h interface{}) (interface{}, error) {
@@ -63,18 +166,24 @@ func Join(h interface{}) (interface{}, error) {
 	return handle, nil
 }
 
-// TODO: We can't really toggle the logging ports so bind/unbind are NOOP
-
 // Bind sets the *Connected fields of the VirtualSerialPort
 func Bind(h interface{}) (interface{}, error) {
 	defer trace.End(trace.Begin(""))
 
-	return h, nil
+	handle, ok := h.(*exec.Handle)
+	if !ok {
+		return nil, fmt.Errorf("Type assertion failed for %#+v", handle)
+	}
+	return toggle(handle, true)
 }
 
 // Unbind unsets the *Connected fields of the VirtualSerialPort
 func Unbind(h interface{}) (interface{}, error) {
 	defer trace.End(trace.Begin(""))
 
-	return h, nil
+	handle, ok := h.(*exec.Handle)
+	if !ok {
+		return nil, fmt.Errorf("Type assertion failed for %#+v", handle)
+	}
+	return toggle(handle, false)
 }


### PR DESCRIPTION
This is unfortunately not the ideal solution but a workaround.

Logging subsystem now listens VmMigratedEvent and toggles the file
backed serial ports after getting triggered via event.

The underlying ESXi issue is now fixed but it is not clear whether it is
going to be backported so in the meantime this is the best we can do.

Changes since v1:

Portlayer now connects the file backed serial ports after a restart

Fixes #3243
