### PR TITLE
Make multiple passes to log browser

### DIFF
--- a/cmd/vicadmin/logs.go
+++ b/cmd/vicadmin/logs.go
@@ -90,7 +90,7 @@ func (r dlogReader) open() (entry, error) {
 
 		for _, line := range h.LineText {
 			buf.WriteString(line)
-			buf.WriteString("\n")
+			buf.WriteByte('\n')
 		}
 
 		start += lines

--- a/cmd/vicadmin/server.go
+++ b/cmd/vicadmin/server.go
@@ -472,6 +472,7 @@ func (s *server) tarDefaultLogs(res http.ResponseWriter, req *http.Request) {
 
 	s.bundleLogs(res, req, configureReaders(), formatTGZ)
 }
+
 func (s *server) zipDefaultLogs(res http.ResponseWriter, req *http.Request) {
 	defer trace.End(trace.Begin(""))
 


### PR DESCRIPTION
This ups the number of log lines gathered to 5000 (up from 1000, 500 for vpxd.log).

Fixes #3274

