### PR TITLE
Partial fix vic-machine create timeout issue

### DIFF
--- a/cmd/vic-machine/create/create.go
+++ b/cmd/vic-machine/create/create.go
@@ -1263,11 +1263,11 @@ func (c *Create) Run(cliContext *cli.Context) (err error) {
 	defer func() {
 		if timeoutctx.Err() == context.DeadlineExceeded {
 			//context deadline exceeded, replace returned error message
-			err = errors.Errorf("Creating VCH exceeded time limit of %s. Please, increase timeout using --time in case of slow network bandwidth or busy vSphere target.", c.Timeout.String())
+			err = errors.Errorf("Creating VCH exceeded time limit of %s. Please increase the timeout using --timeout to accommodate for a slow network connection or a busy vSphere target", c.Timeout.String())
 		}
 	}()
 
-	if err = executor.InsureApplicaneInit(timeoutctx, vchConfig); err != nil {
+	if err = executor.EnsureApplianceInit(timeoutctx, vchConfig); err != nil {
 		executor.CollectDiagnosticLogs()
 		log.Error(err)
 		return err

--- a/cmd/vic-machine/create/create.go
+++ b/cmd/vic-machine/create/create.go
@@ -1263,7 +1263,7 @@ func (c *Create) Run(cliContext *cli.Context) (err error) {
 	defer func() {
 		if timeoutctx.Err() == context.DeadlineExceeded {
 			//context deadline exceeded, replace returned error message
-			err = errors.Errorf("Creating VCH exceeded time limit of %s. Please increase the timeout using --timeout to accommodate for a slow network connection or a busy vSphere target", c.Timeout.String())
+			err = errors.Errorf("Creating VCH exceeded time limit of %s. Please increase the timeout using --timeout to accommodate for a busy vSphere target", c.Timeout.String())
 		}
 	}()
 

--- a/cmd/vic-machine/create/create.go
+++ b/cmd/vic-machine/create/create.go
@@ -1261,16 +1261,15 @@ func (c *Create) Run(cliContext *cli.Context) (err error) {
 	timeoutctx, cancel := context.WithTimeout(context.Background(), c.Timeout)
 	defer cancel()
 	defer func() {
-		if timeoutctx.Err() != nil && timeoutctx.Err() == context.DeadlineExceeded {
+		if timeoutctx.Err() == context.DeadlineExceeded {
 			//context deadline exceeded, replace returned error message
-			err = errors.Errorf("Create timed out: if slow connection, increase timeout with --timeout")
+			err = errors.Errorf("Creating VCH exceeded time limit of %s. Please, increase timeout using --time in case of slow network bandwidth or busy vSphere target.", c.Timeout.String())
 		}
 	}()
 
-	if err = executor.EnsureApplianceInitializes(timeoutctx, vchConfig); err != nil {
+	if err = executor.InsureApplicaneInit(timeoutctx, vchConfig); err != nil {
 		executor.CollectDiagnosticLogs()
 		log.Error(err)
-		cancel()
 		return err
 	}
 

--- a/cmd/vic-machine/upgrade/upgrade.go
+++ b/cmd/vic-machine/upgrade/upgrade.go
@@ -165,7 +165,7 @@ func (u *Upgrade) Run(cli *cli.Context) error {
 	}
 
 	// check the docker endpoint is responsive
-	if err = executor.CheckDockerAPI(vchConfig, nil); err != nil {
+	if err = executor.CheckDockerAPI(ctx, vchConfig, nil); err != nil {
 
 		executor.CollectDiagnosticLogs()
 		return err

--- a/lib/install/management/appliance.go
+++ b/lib/install/management/appliance.go
@@ -911,7 +911,7 @@ func (d *Dispatcher) CheckDockerAPI(ctx context.Context, conf *config.VirtualCon
 }
 
 // ensureApplianceInitializes checks if the appliance component processes are launched correctly
-func (d *Dispatcher) InsureApplicaneInit(ctx context.Context, conf *config.VirtualContainerHostConfigSpec) error {
+func (d *Dispatcher) EnsureApplianceInit(ctx context.Context, conf *config.VirtualContainerHostConfigSpec) error {
 	defer trace.End(trace.Begin(""))
 
 	if d.appliance == nil {

--- a/lib/install/management/appliance.go
+++ b/lib/install/management/appliance.go
@@ -673,10 +673,10 @@ func (d *Dispatcher) applianceConfiguration(conf *config.VirtualContainerHostCon
 }
 
 // waitForKey squashes the return values and simpy blocks until the key is updated or there is an error
-func (d *Dispatcher) waitForKey(key string) {
+func (d *Dispatcher) waitForKey(ctx context.Context, key string) {
 	defer trace.End(trace.Begin(key))
 
-	d.appliance.WaitForKeyInExtraConfig(d.ctx, key)
+	d.appliance.WaitForKeyInExtraConfig(ctx, key)
 	return
 }
 
@@ -919,13 +919,13 @@ func (d *Dispatcher) EnsureApplianceInitializes(ctx context.Context, conf *confi
 	}
 
 	log.Infof("Waiting for IP information")
-	d.waitForKey(extraconfig.CalculateKeys(conf, "ExecutorConfig.Networks.client.Assigned.IP", "")[0])
+	d.waitForKey(ctx, extraconfig.CalculateKeys(conf, "ExecutorConfig.Networks.client.Assigned.IP", "")[0])
 	ctxerr := ctx.Err()
 
 	if ctxerr == nil {
 		log.Info("Waiting for major appliance components to launch")
 		for _, k := range extraconfig.CalculateKeys(conf, "ExecutorConfig.Sessions.*.Started", "") {
-			d.waitForKey(k)
+			d.waitForKey(ctx, k)
 		}
 	}
 

--- a/lib/install/management/appliance.go
+++ b/lib/install/management/appliance.go
@@ -911,7 +911,7 @@ func (d *Dispatcher) CheckDockerAPI(ctx context.Context, conf *config.VirtualCon
 }
 
 // ensureApplianceInitializes checks if the appliance component processes are launched correctly
-func (d *Dispatcher) EnsureApplianceInitializes(ctx context.Context, conf *config.VirtualContainerHostConfigSpec) error {
+func (d *Dispatcher) InsureApplicaneInit(ctx context.Context, conf *config.VirtualContainerHostConfigSpec) error {
 	defer trace.End(trace.Begin(""))
 
 	if d.appliance == nil {

--- a/lib/install/management/appliance.go
+++ b/lib/install/management/appliance.go
@@ -705,7 +705,7 @@ func isPortLayerRunning(res *http.Response) bool {
 
 // CheckDockerAPI checks if the appliance components are initialized by issuing
 // `docker info` to the appliance
-func (d *Dispatcher) CheckDockerAPI(conf *config.VirtualContainerHostConfigSpec, clientCert *tls.Certificate) error {
+func (d *Dispatcher) CheckDockerAPI(ctx context.Context, conf *config.VirtualContainerHostConfigSpec, clientCert *tls.Certificate) error {
 	defer trace.End(trace.Begin(""))
 
 	var (
@@ -798,7 +798,7 @@ func (d *Dispatcher) CheckDockerAPI(conf *config.VirtualContainerHostConfigSpec,
 	if err != nil {
 		return errors.New("invalid HTTP request for docker info")
 	}
-	req = req.WithContext(d.ctx)
+	req = req.WithContext(ctx)
 
 	ticker := time.NewTicker(time.Second)
 	defer ticker.Stop()
@@ -900,8 +900,8 @@ func (d *Dispatcher) CheckDockerAPI(conf *config.VirtualContainerHostConfigSpec,
 
 		select {
 		case <-ticker.C:
-		case <-d.ctx.Done():
-			return d.ctx.Err()
+		case <-ctx.Done():
+			return ctx.Err()
 		}
 
 		log.Debug("Components not yet initialized, retrying")
@@ -911,7 +911,7 @@ func (d *Dispatcher) CheckDockerAPI(conf *config.VirtualContainerHostConfigSpec,
 }
 
 // ensureApplianceInitializes checks if the appliance component processes are launched correctly
-func (d *Dispatcher) ensureApplianceInitializes(conf *config.VirtualContainerHostConfigSpec) error {
+func (d *Dispatcher) EnsureApplianceInitializes(ctx context.Context, conf *config.VirtualContainerHostConfigSpec) error {
 	defer trace.End(trace.Begin(""))
 
 	if d.appliance == nil {
@@ -920,7 +920,7 @@ func (d *Dispatcher) ensureApplianceInitializes(conf *config.VirtualContainerHos
 
 	log.Infof("Waiting for IP information")
 	d.waitForKey(extraconfig.CalculateKeys(conf, "ExecutorConfig.Networks.client.Assigned.IP", "")[0])
-	ctxerr := d.ctx.Err()
+	ctxerr := ctx.Err()
 
 	if ctxerr == nil {
 		log.Info("Waiting for major appliance components to launch")
@@ -943,7 +943,7 @@ func (d *Dispatcher) ensureApplianceInitializes(conf *config.VirtualContainerHos
 
 	// it's possible we timed out... get updated info having adjusted context to allow it
 	// keeping it short
-	ctxerr = d.ctx.Err()
+	ctxerr = ctx.Err()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()

--- a/lib/install/management/create.go
+++ b/lib/install/management/create.go
@@ -29,10 +29,8 @@ import (
 	"github.com/vmware/vic/pkg/vsphere/tasks"
 )
 
-func (d *Dispatcher) CreateVCH(conf *config.VirtualContainerHostConfigSpec, settings *data.InstallerData) error {
+func (d *Dispatcher) CreateVCH(conf *config.VirtualContainerHostConfigSpec, settings *data.InstallerData) (err error) {
 	defer trace.End(trace.Begin(conf.Name))
-
-	var err error
 
 	if err = d.checkExistence(conf, settings); err != nil {
 		return err
@@ -94,11 +92,6 @@ func (d *Dispatcher) startAppliance(conf *config.VirtualContainerHostConfigSpec)
 	if err != nil {
 		return errors.Errorf("Failed to power on appliance %s. Exiting...", err)
 	}
-
-	if err = d.ensureApplianceInitializes(conf); err != nil {
-		return errors.Errorf("%s. Exiting...", err)
-	}
-
 	return nil
 }
 

--- a/lib/install/management/upgrade.go
+++ b/lib/install/management/upgrade.go
@@ -202,8 +202,10 @@ func (d *Dispatcher) update(conf *config.VirtualContainerHostConfigSpec, setting
 	if err = d.reconfigVCH(conf, fmt.Sprintf("[%s] %s/%s", conf.ImageStores[0].Host, d.vmPathName, settings.ApplianceISO)); err != nil {
 		return err
 	}
-
-	return d.startAppliance(conf)
+	if err = d.startAppliance(conf); err != nil {
+		return err
+	}
+	return d.EnsureApplianceInitializes(d.ctx, conf)
 }
 
 func (d *Dispatcher) rollback(conf *config.VirtualContainerHostConfigSpec, snapshot string) error {
@@ -232,7 +234,10 @@ func (d *Dispatcher) ensureRollbackReady(conf *config.VirtualContainerHostConfig
 		log.Infof("Roll back finished - Appliance is kept in powered off status")
 		return nil
 	}
-	return d.startAppliance(conf)
+	if err = d.startAppliance(conf); err != nil {
+		return err
+	}
+	return d.EnsureApplianceInitializes(d.ctx, conf)
 }
 
 func (d *Dispatcher) reconfigVCH(conf *config.VirtualContainerHostConfigSpec, isoFile string) error {

--- a/lib/install/management/upgrade.go
+++ b/lib/install/management/upgrade.go
@@ -205,7 +205,7 @@ func (d *Dispatcher) update(conf *config.VirtualContainerHostConfigSpec, setting
 	if err = d.startAppliance(conf); err != nil {
 		return err
 	}
-	return d.InsureApplicaneInit(d.ctx, conf)
+	return d.EnsureApplianceInit(d.ctx, conf)
 }
 
 func (d *Dispatcher) rollback(conf *config.VirtualContainerHostConfigSpec, snapshot string) error {
@@ -237,7 +237,7 @@ func (d *Dispatcher) ensureRollbackReady(conf *config.VirtualContainerHostConfig
 	if err = d.startAppliance(conf); err != nil {
 		return err
 	}
-	return d.InsureApplicaneInit(d.ctx, conf)
+	return d.EnsureApplianceInit(d.ctx, conf)
 }
 
 func (d *Dispatcher) reconfigVCH(conf *config.VirtualContainerHostConfigSpec, isoFile string) error {

--- a/lib/install/management/upgrade.go
+++ b/lib/install/management/upgrade.go
@@ -205,7 +205,7 @@ func (d *Dispatcher) update(conf *config.VirtualContainerHostConfigSpec, setting
 	if err = d.startAppliance(conf); err != nil {
 		return err
 	}
-	return d.EnsureApplianceInitializes(d.ctx, conf)
+	return d.InsureApplicaneInit(d.ctx, conf)
 }
 
 func (d *Dispatcher) rollback(conf *config.VirtualContainerHostConfigSpec, snapshot string) error {
@@ -237,7 +237,7 @@ func (d *Dispatcher) ensureRollbackReady(conf *config.VirtualContainerHostConfig
 	if err = d.startAppliance(conf); err != nil {
 		return err
 	}
-	return d.EnsureApplianceInitializes(d.ctx, conf)
+	return d.InsureApplicaneInit(d.ctx, conf)
 }
 
 func (d *Dispatcher) reconfigVCH(conf *config.VirtualContainerHostConfigSpec, isoFile string) error {


### PR DESCRIPTION
Partial fix for #2163 
This fix removes timeout for all vm operations and image upload. Timeout is only used to check if service is available or not. Default timeout is still 3 minutes.

There is no cancel available as well. User can ctrl+c to stop the installation at any time. And use vic-machine delete to delete partial created vch.
No progress bar to show image upload percentage.