### PR TITLE
Remove keys and command args/env from logging

### DIFF
--- a/cmd/tether/attach_linux.go
+++ b/cmd/tether/attach_linux.go
@@ -87,13 +87,13 @@ func rawConnectionFromSerial() (net.Conn, error) {
 	// set the provided FDs to raw if it's a termial
 	// 0 is the uninitialized value for Fd
 	if f.Fd() != 0 && terminal.IsTerminal(int(f.Fd())) {
-		log.Debug("setting terminal to raw mode")
+		log.Info("setting terminal to raw mode")
 		s, err := terminal.MakeRaw(int(f.Fd()))
 		if err != nil {
 			return nil, err
 		}
 
-		log.Infof("s = %#v", s)
+		log.Debugf("s = %#v", s)
 	}
 	if err := setTerminalSpeed(f.Fd()); err != nil {
 		log.Errorf("Setting terminal speed failed with %s", err)

--- a/lib/apiservers/portlayer/restapi/handlers/containers_handlers.go
+++ b/lib/apiservers/portlayer/restapi/handlers/containers_handlers.go
@@ -76,8 +76,6 @@ func (handler *ContainersHandlersImpl) CreateHandler(params containers.CreatePar
 	ctx := context.Background()
 
 	log.Debugf("Path: %#v", params.CreateConfig.Path)
-	log.Debugf("Args: %#v", params.CreateConfig.Args)
-	log.Debugf("Env: %#v", params.CreateConfig.Env)
 	log.Debugf("WorkingDir: %#v", params.CreateConfig.WorkingDir)
 	log.Debugf("OpenStdin: %#v", params.CreateConfig.OpenStdin)
 
@@ -130,8 +128,6 @@ func (handler *ContainersHandlersImpl) CreateHandler(params containers.CreatePar
 			m.Annotations[k] = v
 		}
 	}
-
-	log.Infof("CreateHandler Metadata: %#v", m)
 
 	// Create the executor.ExecutorCreateConfig
 	c := &exec.ContainerCreateConfig{

--- a/lib/portlayer/exec/handle.go
+++ b/lib/portlayer/exec/handle.go
@@ -268,7 +268,27 @@ func Create(ctx context.Context, sess *session.Session, config *ContainerCreateC
 
 		Metadata: config.Metadata,
 	}
-	log.Debugf("Config: %#v", specconfig)
+
+	// log only core portions
+	s := specconfig
+	log.Debugf("id: %s, name: %s, cpu: %d, mem: %d, parent: %s, os: %s, path: %s", s.ID, s.Name, s.NumCPUs, s.MemoryMB, s.ParentImageID, s.BootMediaPath, s.VMPathName)
+	m := s.Metadata
+	log.Debugf("annotations: %#v, reponame: %s", m.Annotations, m.RepoName)
+	for name, sess := range m.Sessions {
+		log.Debugf("session: %s, path: %s, dir: %s, runblock: %t, tty: %t, restart: %t, stdin: %t, stopsig: %s",
+			name, sess.Cmd.Path, sess.Cmd.Dir, sess.RunBlock, sess.Tty, sess.Restart, sess.OpenStdin, sess.StopSignal)
+	}
+
+	// If the debug level is high, dump everything
+	// we still do the logging above for consistency so searching the logs for common strings works.
+	// TODO: move this into a debug level aware structure renderer
+	if Config.DebugLevel > 2 {
+		log.Debugf("Config: %#v", specconfig)
+		log.Debugf("Executor spec: %#v", *specconfig.Metadata)
+		for _, sess := range m.Sessions {
+			log.Debugf("Session spec: %#v", *sess)
+		}
+	}
 
 	// Create a linux guest
 	linux, err := guest.NewLinuxGuest(ctx, sess, specconfig)

--- a/lib/spec/spec.go
+++ b/lib/spec/spec.go
@@ -20,8 +20,6 @@ import (
 
 	"context"
 
-	log "github.com/Sirupsen/logrus"
-
 	"github.com/vmware/govmomi/vim25/types"
 	"github.com/vmware/vic/lib/config/executor"
 	"github.com/vmware/vic/pkg/trace"
@@ -93,9 +91,7 @@ type VirtualMachineConfigSpec struct {
 func NewVirtualMachineConfigSpec(ctx context.Context, session *session.Session, config *VirtualMachineConfigSpecConfig) (*VirtualMachineConfigSpec, error) {
 	defer trace.End(trace.Begin(config.ID))
 
-	log.Debugf("Adding metadata to the configspec: %+v", config.Metadata)
 	// TEMPORARY
-
 	// set VM name to prettyname-ID, to make it readable a little bit
 	// if prettyname-ID is longer than max vm name length, truncate pretty name, instead of UUID, to make it unique
 	nameMaxLen := maxVMNameLength - len(config.ID)
@@ -157,7 +153,6 @@ func NewVirtualMachineConfigSpec(ctx context.Context, session *session.Session, 
 		config: config,
 	}
 
-	log.Debugf("Virtual machine config spec created: %+v", vmcs)
 	return vmcs, nil
 }
 

--- a/lib/tether/tether.go
+++ b/lib/tether/tether.go
@@ -595,13 +595,16 @@ func logConfig(config *ExecutorConfig) {
 
 	// figure out the keys to filter
 	keys := make(map[string]interface{})
-	for _, f := range []string{
-		"Sessions.*.Cmd.Args",
-		"Sessions.*.Cmd.Args.*",
-		"Sessions.*.Cmd.Env",
-		"Sessions.*.Cmd.Env.*"} {
-		for _, k := range extraconfig.CalculateKeys(config, f, "") {
-			keys[k] = nil
+	if config.DebugLevel < 2 {
+		for _, f := range []string{
+			"Sessions.*.Cmd.Args",
+			"Sessions.*.Cmd.Args.*",
+			"Sessions.*.Cmd.Env",
+			"Sessions.*.Cmd.Env.*",
+			"Key"} {
+			for _, k := range extraconfig.CalculateKeys(config, f, "") {
+				keys[k] = nil
+			}
 		}
 	}
 

--- a/lib/tether/tether_linux.go
+++ b/lib/tether/tether_linux.go
@@ -116,7 +116,7 @@ func (t *tether) childReaper() error {
 					log.Debugf("Reaped process %d, return code: %d", pid, status.ExitStatus())
 
 					session, ok := t.removeChildPid(pid)
-					log.Debugf("Remove child pid: %d session: %#+v ok: %t", pid, session, ok)
+					log.Debugf("Remove child pid: %d ok: %t", pid, ok)
 					if ok {
 						session.Lock()
 						session.ExitStatus = status.ExitStatus()


### PR DESCRIPTION
Removes potentially sensitive values from logging unless debug >= 3
This includes the generated keys and arguments and environment variables
for the commands run in containers.

The full set of data is still in vmware.log but is at least contained.

Fixes #3287 
