### PR TITLE
Remove image store if scratch creation fails on create image store [full ci]

### DIFF
--- a/lib/apiservers/portlayer/restapi/handlers/storage_handlers_test.go
+++ b/lib/apiservers/portlayer/restapi/handlers/storage_handlers_test.go
@@ -142,6 +142,10 @@ func (c *MockDataStore) CreateImageStore(op trace.Operation, storeName string) (
 	return u, nil
 }
 
+func (c *MockDataStore) DeleteImageStore(op trace.Operation, storeName string) error {
+	return nil
+}
+
 func (c *MockDataStore) ListImageStores(op trace.Operation) ([]*url.URL, error) {
 	return nil, nil
 }

--- a/lib/portlayer/storage/image.go
+++ b/lib/portlayer/storage/image.go
@@ -38,6 +38,10 @@ type ImageStorer interface {
 	// Returns the URL of the created store
 	CreateImageStore(op trace.Operation, storeName string) (*url.URL, error)
 
+	// DeleteImageStore is used to cleanup the image store.  This can only be
+	// called once there are no images left in the image store.
+	DeleteImageStore(op trace.Operation, storeName string) error
+
 	// Gets the url to an image store via name
 	GetImageStore(op trace.Operation, storeName string) (*url.URL, error)
 

--- a/lib/portlayer/storage/vsphere/image.go
+++ b/lib/portlayer/storage/vsphere/image.go
@@ -145,6 +145,12 @@ func (v *ImageStore) CreateImageStore(op trace.Operation, storeName string) (*ur
 	return u, nil
 }
 
+// DeleteImageStore deletes the image store top level directory
+func (v *ImageStore) DeleteImageStore(op trace.Operation, storeName string) error {
+	op.Infof("Cleaning up image store %s", storeName)
+	return v.ds.Rm(op, v.imageStorePath(storeName))
+}
+
 // GetImageStore checks to see if the image store exists on disk and returns an
 // error or the store's URL.
 func (v *ImageStore) GetImageStore(op trace.Operation, storeName string) (*url.URL, error) {

--- a/pkg/vsphere/disk/util.go
+++ b/pkg/vsphere/disk/util.go
@@ -90,7 +90,6 @@ func waitForDevice(op trace.Operation, sysPath string) (string, error) {
 
 					// try again
 					if os.IsNotExist(err) {
-						op.Debugf("Expected %s to appear. Trying again.", blockDev)
 						continue
 					}
 


### PR DESCRIPTION
Fixes #3273 

Creation of an image store should be itempotent.

* Also migrated log calls to op.Info/op.Debug/op.Error calls so we can
  track op IDs.