### PR TITLE
[full ci] WIP Clean up the certificates after the VCH is deleted

### DIFF
--- a/tests/resources/Util.robot
+++ b/tests/resources/Util.robot
@@ -178,10 +178,8 @@ Run VIC Machine Delete Command
     Wait Until Keyword Succeeds  6x  5s  Check Delete Success  %{VCH-NAME}
     Should Be Equal As Integers  ${rc}  0
     Should Contain  ${output}  Completed successfully
-    ${output}=  Run  rm -f %{VCH-NAME}-*.pem
+    ${output}=  Run  rm -rf %{VCH-NAME}
     [Return]  ${output}
-    Run  rm -f ${vch-name}/*
-    Run  rmdir ${vch-name}
 
 Cleanup Datastore On Test Server
     ${out}=  Run  govc datastore.ls

--- a/tests/resources/Util.robot
+++ b/tests/resources/Util.robot
@@ -180,8 +180,6 @@ Run VIC Machine Delete Command
     Should Contain  ${output}  Completed successfully
     ${output}=  Run  rm -rf %{VCH-NAME}
     [Return]  ${output}
-    Run  rm -f ${vch-name}/*
-    Run  rmdir ${vch-name}
 
 Cleanup Datastore On Test Server
     ${out}=  Run  govc datastore.ls

--- a/tests/resources/Util.robot
+++ b/tests/resources/Util.robot
@@ -180,6 +180,8 @@ Run VIC Machine Delete Command
     Should Contain  ${output}  Completed successfully
     ${output}=  Run  rm -rf %{VCH-NAME}
     [Return]  ${output}
+    Run  rm -f ${vch-name}/*
+    Run  rmdir ${vch-name}
 
 Cleanup Datastore On Test Server
     ${out}=  Run  govc datastore.ls

--- a/tests/resources/Util.robot
+++ b/tests/resources/Util.robot
@@ -180,6 +180,8 @@ Run VIC Machine Delete Command
     Should Contain  ${output}  Completed successfully
     ${output}=  Run  rm -f %{VCH-NAME}-*.pem
     [Return]  ${output}
+    Run  rm -f ${vch-name}/*
+    Run  rmdir ${vch-name}
 
 Cleanup Datastore On Test Server
     ${out}=  Run  govc datastore.ls

--- a/tests/test-cases/Group9-VIC-Admin/9-03-VICAdmin-Log-Failed-Attempts.robot
+++ b/tests/test-cases/Group9-VIC-Admin/9-03-VICAdmin-Log-Failed-Attempts.robot
@@ -17,14 +17,15 @@ Verify Temporary Redirect
 
 Verify Failed Log Attempts
     #Save the first appliance certs and cleanup the first appliance
-    ${old-certs}=  Set Variable  %{DOCKER_CERT_PATH}
+    #${old-certs}=  Set Variable  %{DOCKER_CERT_PATH}
+    Run  cp -r %{DOCKER_CERT_PATH} old-certs
     Cleanup VIC Appliance On Test Server
     
     #Install a second appliance
     Install VIC Appliance To Test Server
-    OperatingSystem.File Should Exist  ${old-certs}/cert.pem
-    OperatingSystem.File Should Exist  ${old-certs}/key.pem
-    ${out}=  Run  wget -v --tries=3 --connect-timeout=10 --certificate=${old-certs}/cert.pem --private-key=${old-certs}/key.pem --no-check-certificate %{VIC-ADMIN}/logs/vicadmin.log -O failure.log
+    OperatingSystem.File Should Exist  old-certs/cert.pem
+    OperatingSystem.File Should Exist  old-certs/key.pem
+    ${out}=  Run  wget -v --tries=3 --connect-timeout=10 --certificate=old-certs/cert.pem --private-key=old-certs/key.pem --no-check-certificate %{VIC-ADMIN}/logs/vicadmin.log -O failure.log
     Log  ${out}
     ${out}=  Run  wget -v --tries=3 --connect-timeout=10 --certificate=%{DOCKER_CERT_PATH}/cert.pem --private-key=%{DOCKER_CERT_PATH}/key.pem --no-check-certificate %{VIC-ADMIN}/logs/vicadmin.log -O success.log
     Log  ${out}
@@ -32,3 +33,4 @@ Verify Failed Log Attempts
     Log  ${out}
     ${out}=  Run  grep -i fail success.log
     Should Contain  ${out}  tls: failed to verify client's certificate: x509: certificate signed by unknown authority
+    Run  rm -r old-certs


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[  ] There is an associated issue that is labelled
[  ] Code is up-to-date with the `master` branch
[  ] You've successfully run `make test` locally
[  ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/vmware/vic/blob/master/.github/CONTRIBUTING.md
-->

This resolves the issue in build 7195 where a VCH is reusing the name of a prior VCH.

To reproduce and verify this, 

1. bin/vic-machine-linux create --target root:pwd@192.168.60.162 --name **cheng-30** --public-network-ip 192.168.60.**130** --public-network-gateway 192.168.60.2/24 --dns-server 192.168.60.2 --tls-cname 192.168.60.**130** --thumbprint=...

Or:

bin/vic-machine-linux create --target root:pwd@192.168.60.162 --name **cheng-30**  --thumbprint=...

Then the VCH cheng-30 would be created.

2. bin/vic-machine-linux delete --force --target root:1986911A@192.168.60.162 --name cheng-30  --thumbprint=...

3. bin/vic-machine-linux create --target root:pwd@192.168.60.162 --name **cheng-30** --public-network-ip 192.168.60.**140** --public-network-gateway 192.168.60.2/24 --dns-server 192.168.60.2 --tls-cname 192.168.60.**140** --thumbprint=...
```
INFO[2016-11-22T20:23:13-08:00] ### Installing VCH ####                      
ERRO[2016-11-22T20:23:13-08:00] Provided cname does not match that in existing server certificate: 192.168.60.130 
ERRO[2016-11-22T20:23:13-08:00] Unable to load certificates: cname option doesn't match existing server certificate in certificate path cheng-30 
ERRO[2016-11-22T20:23:13-08:00] --------------------                         
ERRO[2016-11-22T20:23:13-08:00] vic-machine-linux failed: cname option doesn't match existing server certificate in certificate path cheng-30
```

4. rm -rf cheng-30

5. repeat step 3.

```
Installer completed successfully
```