### PR TITLE
Log logrotate output.

### DIFF
--- a/pkg/logmgr/logmgr.go
+++ b/pkg/logmgr/logmgr.go
@@ -255,9 +255,16 @@ func (lm *LogManager) rotateLogs() {
 		lm.op.Debugf("logrotate is not defined. Skipping.")
 		return
 	}
-	if err := exec.Command(LogRotateBinary, configFile).Run(); err == nil {
+	output, err := exec.Command(LogRotateBinary, configFile).CombinedOutput()
+	if err == nil {
+		if len(output) > 0 {
+			lm.op.Debugf("Logrotate output: %s", output)
+		}
 		lm.op.Debugf("logrotate finished succesfully")
 	} else {
-		lm.op.Errorf("Failed to run logrotate: %v", err)
+		lm.op.Errorf("logrotate exited with non 0 status: %v", err)
+		if len(output) > 0 {
+			lm.op.Errorf("Logrotate output: %s", output)
+		}
 	}
 }


### PR DESCRIPTION
Log any logrotate output so user can see an additional information that can help to understand logrotate errors.

Fixes #3300

