### PR TITLE
Switch to using static IP on VIC Install Stress test

### DIFF
--- a/tests/manual-test-cases/Group11-Stress/11-1-VIC-Install-Stress.robot
+++ b/tests/manual-test-cases/Group11-Stress/11-1-VIC-Install-Stress.robot
@@ -7,8 +7,8 @@ Suite Teardown  Cleanup VIC Appliance On Test Server
 VIC Install Stress
     :FOR  ${idx}  IN RANGE  0  100
     \   Log To Console  \nLoop ${idx+1}
-    \   Install VIC Appliance To Test Server
+    \   Install VIC Appliance To Test Server  vol=default %{STATIC_VCH_OPTIONS}
     \   Cleanup VIC Appliance On Test Server
     
-    Install VIC Appliance To Test Server
+    Install VIC Appliance To Test Server  vol=default %{STATIC_VCH_OPTIONS}
     Run Regression Tests


### PR DESCRIPTION
Our Austin site DHCP server is crowded and shouldn't be stressed with this test, so switch to using a static IP address.