### PR TITLE
This test was not correct

### DIFF
--- a/tests/test-cases/Group1-Docker-Commands/1-01-Docker-Info.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-01-Docker-Info.robot
@@ -53,7 +53,7 @@ Correct container count
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} pull busybox
     Should Be Equal As Integers  ${rc}  0
     Should Not Contain  ${output}  Error
-    ${rc}  ${cid}=  Run And Return Rc And Output  docker %{VCH-PARAMS} create busybox
+    ${rc}  ${cid}=  Run And Return Rc And Output  docker %{VCH-PARAMS} create busybox /bin/top
     Should Be Equal As Integers  ${rc}  0
     Should Not Contain  ${cid}  Error
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} info


### PR DESCRIPTION
In order for the container to be running it needs to actually have a command that doesn't exit, we are thus far insulated from this due to #1687 bug, but on VC we actually work as expected so this test fails.