### PR TITLE
Pin vmodl version to 6.0

### DIFF
--- a/pkg/vsphere/session/session.go
+++ b/pkg/vsphere/session/session.go
@@ -165,6 +165,8 @@ func (s *Session) Connect(ctx context.Context) (*Session, error) {
 	}
 
 	soapClient := soap.NewClient(soapURL, s.Insecure)
+	soapClient.Version = "6.0" // Pin to 6.0 until we need 6.5+ specific API
+
 	var login func(context.Context) error
 
 	login = func(ctx context.Context) error {


### PR DESCRIPTION
govmomi 0.12 changed the default version to 6.5,
but we are seeing events in a vSAN environment for which there is no govmomi type.
This results in nil events, leading to panic by consumers.  We don't need anything
6.5 specific from vmodl, so pin to version 6.0 for now

Fixes #3431