### PR TITLE
Remove hidden option of upgrade

### DIFF
--- a/cmd/vic-machine/main.go
+++ b/cmd/vic-machine/main.go
@@ -81,7 +81,6 @@ func main() {
 			Usage:  "Upgrade VCH to latest version",
 			Action: upgrade.Run,
 			Flags:  upgrade.Flags(),
-			Hidden: true,
 		},
 		{
 			Name:   "version",

--- a/tests/test-cases/Group11-Upgrade/11-01-Upgrade.robot
+++ b/tests/test-cases/Group11-Upgrade/11-01-Upgrade.robot
@@ -32,6 +32,10 @@ Launch Container
     [Return]  ${id}  ${ip}
 
 *** Test Cases ***
+Upgrade Present in vic-machine
+    ${rc}  ${output}=  Run And Return Rc And Output  bin/vic-machine-linux
+    Should Contain  ${output}  upgrade
+
 Upgrade VCH with containers
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} network create bar
     Should Be Equal As Integers  ${rc}  0


### PR DESCRIPTION
Forgot to remove the hidden option for vic-machine upgrade in yesterday's merge.
Fixes #3451 