### PR TITLE
Support running a specific test suite in CI on PRs [specific ci=1-19-Docker-Volume-Create]

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,3 +12,11 @@ Refer to CONTRIBUTING.MD for more details.
 -->
 
 Fixes #
+
+<!--
+To trigger a custom build with this PR, include one of these in the PR's title or commit messages:
+* [skip ci]
+* [full ci]
+* [specific ci=$suitename] e.g. [specific ci=1-01-Docker-Info]
+    With this option, running only one suite is supported.
+-->

--- a/tests/integration-test.sh
+++ b/tests/integration-test.sh
@@ -21,13 +21,13 @@ set +x
 dpkg -l > package.list
 
 buildinfo=$(drone build info vmware/vic $DRONE_BUILD_NUMBER)
-buildtype=$(echo $buildinfo | grep "specific ci=")
 
 if [ $DRONE_BRANCH = "master" ] && [ $DRONE_REPO = "vmware/vic" ]; then
     pybot --removekeywords TAG:secret --exclude skip tests/test-cases
 elif grep -q "\[full ci\]" <(drone build info vmware/vic $DRONE_BUILD_NUMBER); then
     pybot --removekeywords TAG:secret --exclude skip tests/test-cases
-elif (echo $buildinfo | grep -q "specific ci="); then
+elif (echo $buildinfo | grep -q "\[specific ci="); then
+    buildtype=$(echo $buildinfo | grep "\[specific ci=")
     testsuite=$(echo $buildtype | awk -v FS="(=|])" '{print $2}')
     pybot --removekeywords TAG:secret --suite $testsuite tests/test-cases
 else


### PR DESCRIPTION
Adds basic support for running a particular integration test suite on CI. Including `[specific ci=$suitename]` in the PR's title or commit messages will trigger this behavior.

Also adds a small note to the PR template.

Fixes #3305

