### PR TITLE
[skip ci] Longevity should use the static IP for austin site as well

### DIFF
--- a/tests/manual-test-cases/Group14-Longevity/14-1-Longevity.robot
+++ b/tests/manual-test-cases/Group14-Longevity/14-1-Longevity.robot
@@ -8,10 +8,10 @@ Longevity
     :FOR  ${idx}  IN RANGE  0  48
     \   ${rand}=  Evaluate  random.randint(10, 50)  modules=random
     \   Log To Console  \nLoop: ${idx}
-    \   Install VIC Appliance To Test Server
+    \   Install VIC Appliance To Test Server  vol=default %{STATIC_VCH_OPTIONS}
     \   Repeat Keyword  ${rand} times  Run Regression Tests
     \   Cleanup VIC Appliance On Test Server
     \   ${rand}=  Evaluate  random.randint(10, 50)  modules=random
-    \   Install VIC Appliance To Test Server  certs=${true}
+    \   Install VIC Appliance To Test Server  certs=${true}  vol=default %{STATIC_VCH_OPTIONS}
     \   Repeat Keyword  ${rand} times  Run Regression Tests
     \   Cleanup VIC Appliance On Test Server


### PR DESCRIPTION
So we are not hammering the austin site dhcp pool still.