### PR TITLE
Tell browsers to use GET when redirected to login page w/o cookie

### DIFF
--- a/cmd/vicadmin/server.go
+++ b/cmd/vicadmin/server.go
@@ -213,7 +213,7 @@ func (s *server) Authenticated(link string, handler func(http.ResponseWriter, *h
 		c := websession.Values[sessionCreationTimeKey]
 		if c == nil { // no cookie, so redirect to login
 			log.Infof("No authentication token: %+v", websession.Values)
-			http.Redirect(w, r, loginPagePath, http.StatusTemporaryRedirect)
+			http.Redirect(w, r, loginPagePath, http.StatusSeeOther)
 			return
 		}
 


### PR DESCRIPTION
This addresses #3495 

When a user accesses a page on vicadmin that requires authentication, we check for the presence of a cookie in their browser. If the cookie is not there, we assume they are not authenticated, and they get redirected to the login page.

In the old version, providing a 302 would cause browsers (but not command line tools, which means I'm not 100% sure how to test this programmatically) coming from the auth page to redirect back to the auth page, but they would re-POST the data originally posted. 

If the browser is not accepting cookies, in the case of a successful login, this would cause a vSphere session to be created, and then no cookies to be found, causing a redirect back to login, a correct POST, a new session created, redirect to landing page.. no cookies found, redirect back.. about 10 times, when the browser detects the loop and bails. Whoops. 

This change tells the browser to use a GET when it is redirected back to the auth page if no cookie is found (for whatever reason). This ensures that data is not POSTed to the auth page in the case of successful login + no cookies in browser. A single session will still be created for the _successfully_ authenticated user, but the loop does not occur, and the abandoned session will get cleaned out by vSphere at the default time. I looked into adjusting this timeout also to make our sessions shorter-lived but it seems to be VI-admin controlled.