### PR TITLE
[specific ci=9-03-VICAdmin-Log-Failed-Attempts] Fix failing vicadmin test in master

### DIFF
--- a/tests/test-cases/Group9-VIC-Admin/9-03-VICAdmin-Log-Failed-Attempts.robot
+++ b/tests/test-cases/Group9-VIC-Admin/9-03-VICAdmin-Log-Failed-Attempts.robot
@@ -13,7 +13,7 @@ Verify Unable To Verify
     
 Verify Temporary Redirect
     ${out}=  Run  wget --tries=3 --connect-timeout=10 --no-check-certificate %{VIC-ADMIN}/logs/vicadmin.log -O failure.log
-    Should Contain  ${out}  HTTP request sent, awaiting response... 307 Temporary Redirect
+    Should Contain  ${out}  HTTP request sent, awaiting response... 303 See Other
 
 Verify Failed Log Attempts
     #Save the first appliance certs and cleanup the first appliance


### PR DESCRIPTION
Looks like the testing guys added a new suite and I didn't notice. Missed this test while updating the tests to match the new redirect code that's being sent by vicadmin.