### PR TITLE
handle maintanence mode

### DIFF
--- a/lib/portlayer/event/collector/vsphere/collector.go
+++ b/lib/portlayer/event/collector/vsphere/collector.go
@@ -15,6 +15,7 @@
 package vsphere
 
 import (
+	"context"
 	"fmt"
 	"sync"
 
@@ -23,8 +24,6 @@ import (
 	vmwEvents "github.com/vmware/govmomi/event"
 	"github.com/vmware/govmomi/vim25"
 	"github.com/vmware/govmomi/vim25/types"
-
-	"context"
 
 	log "github.com/Sirupsen/logrus"
 )
@@ -101,7 +100,6 @@ func (ec *EventCollector) Stop() {
 	if err != nil {
 		log.Warnf("%s failed to destroy the govmomi manager: %s", name, err.Error())
 	}
-
 }
 
 // Start the event collector
@@ -158,7 +156,7 @@ func evented(ec *EventCollector, page []types.BaseEvent) {
 	}
 
 	for i := range page {
-		var vmEvent events.Event
+		var event events.Event
 
 		// what type of event do we have
 		switch page[i].(type) {
@@ -170,12 +168,17 @@ func evented(ec *EventCollector, page []types.BaseEvent) {
 			*types.VmSuspendedEvent,
 			*types.VmRegisteredEvent,
 			*types.VmMigratedEvent,
-			*types.DrsVmMigratedEvent:
-			vmEvent = NewVMEvent(page[i])
+			*types.DrsVmMigratedEvent,
+			*types.VmRelocatedEvent:
+			event = NewVMEvent(page[i])
+		case *types.EnteringMaintenanceModeEvent,
+			*types.EnteredMaintenanceModeEvent,
+			*types.ExitMaintenanceModeEvent:
+			event = NewHostEvent(page[i])
 		}
 
-		if vmEvent != nil {
-			ec.callback(vmEvent)
+		if event != nil {
+			ec.callback(event)
 		}
 	}
 

--- a/lib/portlayer/event/collector/vsphere/host_event.go
+++ b/lib/portlayer/event/collector/vsphere/host_event.go
@@ -1,0 +1,56 @@
+// Copyright 2017 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vsphere
+
+import (
+	"github.com/vmware/vic/lib/portlayer/event/events"
+
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type HostEvent struct {
+	*events.BaseEvent
+}
+
+func NewHostEvent(be types.BaseEvent) *HostEvent {
+	var ee string
+	// host events that we care about
+	switch be.(type) {
+	case *types.EnteringMaintenanceModeEvent:
+		ee = events.HostEnteringMaintenanceMode
+	case *types.EnteredMaintenanceModeEvent:
+		ee = events.HostEnteredMaintenanceMode
+	case *types.ExitMaintenanceModeEvent:
+		ee = events.HostExitMaintenanceMode
+	}
+	e := be.GetEvent()
+	return &HostEvent{
+		&events.BaseEvent{
+			Event:       ee,
+			ID:          int(e.Key),
+			Detail:      e.FullFormattedMessage,
+			Ref:         e.Host.Host.String(),
+			CreatedTime: e.CreatedTime,
+		},
+	}
+
+}
+
+func (he *HostEvent) Topic() string {
+	if he.Type == "" {
+		he.Type = events.NewEventType(he)
+	}
+	return he.Type.Topic()
+}

--- a/lib/portlayer/event/collector/vsphere/host_event.go
+++ b/lib/portlayer/event/collector/vsphere/host_event.go
@@ -34,6 +34,8 @@ func NewHostEvent(be types.BaseEvent) *HostEvent {
 		ee = events.HostEnteredMaintenanceMode
 	case *types.ExitMaintenanceModeEvent:
 		ee = events.HostExitMaintenanceMode
+	default:
+		panic("Unknown event")
 	}
 	e := be.GetEvent()
 	return &HostEvent{

--- a/lib/portlayer/event/collector/vsphere/vm_event.go
+++ b/lib/portlayer/event/collector/vsphere/vm_event.go
@@ -45,6 +45,9 @@ func NewVMEvent(be types.BaseEvent) *VMEvent {
 		ee = events.ContainerMigrated
 	case *types.DrsVmMigratedEvent:
 		ee = events.ContainerMigratedByDrs
+	case *types.VmRelocatedEvent:
+		ee = events.ContainerRelocated
+
 	}
 	e := be.GetEvent()
 	return &VMEvent{

--- a/lib/portlayer/event/collector/vsphere/vm_event.go
+++ b/lib/portlayer/event/collector/vsphere/vm_event.go
@@ -47,7 +47,8 @@ func NewVMEvent(be types.BaseEvent) *VMEvent {
 		ee = events.ContainerMigratedByDrs
 	case *types.VmRelocatedEvent:
 		ee = events.ContainerRelocated
-
+	default:
+		panic("Unknown event")
 	}
 	e := be.GetEvent()
 	return &VMEvent{

--- a/lib/portlayer/event/events/host_event.go
+++ b/lib/portlayer/event/events/host_event.go
@@ -1,4 +1,4 @@
-// Copyright 2016 VMware, Inc. All Rights Reserved.
+// Copyright 2017 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,27 +15,16 @@
 package events
 
 const (
-	ContainerCreated       = "Created"
-	ContainerShutdown      = "Shutdown"
-	ContainerPoweredOn     = "PoweredOn"
-	ContainerPoweredOff    = "PoweredOff"
-	ContainerSuspended     = "Suspended"
-	ContainerResumed       = "Resumed"
-	ContainerRemoved       = "Removed"
-	ContainerReconfigured  = "Reconfigured"
-	ContainerStarted       = "Started"
-	ContainerStopped       = "Stopped"
-	ContainerRegistered    = "Registered"
-	ContainerMigrated      = "Migrated"
-	ContainerMigratedByDrs = "MigratedByDrs"
-	ContainerRelocated     = "Relocated"
+	HostEnteringMaintenanceMode = "EnteringMaintenance"
+	HostEnteredMaintenanceMode  = "EnteredMaintenance"
+	HostExitMaintenanceMode     = "ExitMaintenance"
 )
 
-type ContainerEvent struct {
+type HostEvent struct {
 	*BaseEvent
 }
 
-func (ce *ContainerEvent) Topic() string {
+func (ce *HostEvent) Topic() string {
 	if ce.Type == "" {
 		ce.Type = NewEventType(ce)
 	}

--- a/lib/portlayer/exec/container.go
+++ b/lib/portlayer/exec/container.go
@@ -188,6 +188,10 @@ func GetContainer(ctx context.Context, id uid.UID) *Handle {
 	return nil
 }
 
+func (c *ContainerInfo) String() string {
+	return c.ExecConfig.ID
+}
+
 // State returns the state at the time the ContainerInfo object was created
 func (c *ContainerInfo) State() State {
 	return c.state

--- a/lib/portlayer/exec/exec.go
+++ b/lib/portlayer/exec/exec.go
@@ -30,6 +30,8 @@ import (
 	"github.com/vmware/vic/lib/portlayer/event"
 	"github.com/vmware/vic/lib/portlayer/event/collector/vsphere"
 	"github.com/vmware/vic/lib/portlayer/event/events"
+	"github.com/vmware/vic/pkg/retry"
+	"github.com/vmware/vic/pkg/trace"
 	"github.com/vmware/vic/pkg/vsphere/extraconfig"
 	"github.com/vmware/vic/pkg/vsphere/session"
 )
@@ -97,6 +99,9 @@ func Init(ctx context.Context, sess *session.Session, source extraconfig.DataSou
 		// create the event manager &  register the existing collector
 		Config.EventManager = event.NewEventManager(ec)
 
+		Config.EventManager.Subscribe(events.NewEventType(vsphere.HostEvent{}).Topic(), "host", func(ie events.Event) {
+			hostEventCallback(ctx, ie)
+		})
 		// subscribe the exec layer to the event stream for Vm events
 		Config.EventManager.Subscribe(events.NewEventType(vsphere.VMEvent{}).Topic(), "exec", eventCallback)
 		// subscribe callback to handle vm registered event
@@ -130,7 +135,6 @@ func eventCallback(ie events.Event) {
 	// grab the container from the cache
 	container := Containers.Container(ie.Reference())
 	if container != nil {
-
 		newState := eventedState(ie.String(), container.CurrentState())
 		// do we have a state change
 		if newState != container.CurrentState() {
@@ -155,18 +159,123 @@ func eventCallback(ie events.Event) {
 						container.onStop()
 					}
 					log.Debugf("Container(%s) state set to %s via event activity",
-						container.ExecConfig.ID, newState.String())
+						container, newState.String())
 					// regardless of update success failure publish the container event
 					publishContainerEvent(container.ExecConfig.ID, ie.Created(), ie.String())
 				}()
 			case StateRemoved:
-				log.Debugf("Container(%s) %s via event activity", container.ExecConfig.ID, newState.String())
+				log.Debugf("Container(%s) %s via event activity", container, newState.String())
 				Containers.Remove(container.ExecConfig.ID)
 				publishContainerEvent(container.ExecConfig.ID, ie.Created(), ie.String())
 			}
+		} else {
+			switch ie.String() {
+			case events.ContainerRelocated:
+				log.Debugf("Container %s received ContainerRelocated", container)
+
+				// container state has changed so we need to update the container attributes
+				// we'll do this in a go routine to avoid blocking
+				go func() {
+					ctx, cancel := context.WithTimeout(context.Background(), propertyCollectorTimeout)
+					defer cancel()
+
+					err := container.Refresh(ctx)
+					if err != nil {
+						log.Errorf("Event driven container update failed for %s with %s", container, err.Error())
+					}
+				}()
+			}
 		}
+		return
 	}
-	return
+}
+
+// listens migrated events and connects the file backed serial ports
+func hostEventCallback(ctx context.Context, ie events.Event) {
+	defer trace.End(trace.Begin(""))
+
+	switch ie.String() {
+	// https://www.vmware.com/support/developer/vc-sdk/visdk25pubs/ReferenceGuide/vim.event.EnteringMaintenanceModeEvent.html
+	// This event records that a host has begun the process of entering maintenance mode. All virtual machine operations are blocked, except the following:
+	// MigrateVM
+	// PowerOffVM
+	// SuspendVM
+	// ShutdownGuest
+	// StandbyGuest
+	//
+	// Because of that limitation the only thing that we can do is shutting down the guest without calling reconfigure
+	case events.HostEnteringMaintenanceMode:
+		log.Debugf("Received %s event", ie)
+		ref := ie.Reference()
+
+		// we are interested with running vms
+		state := new(State)
+		*state = StateRunning
+		for _, v := range Containers.Containers(state) {
+			host := v.Runtime.Host.String()
+			if host != ref {
+				log.Debugf("Skipping %q as it is not on %q", v, ref)
+				continue
+			}
+
+			log.Debugf("%q is on %q", v, ref)
+
+			// grab the container from the cache
+			container := Containers.Container(v.String())
+			if container == nil {
+				log.Errorf("Container %s not found", v)
+				continue
+			}
+
+			operation := func() error {
+				var err error
+
+				handle := container.NewHandle(ctx)
+				if handle == nil {
+					err = fmt.Errorf("Handle for %s cannot be created", v)
+					log.Error(err)
+					return err
+				}
+				defer handle.Close()
+
+				// this check needs to be after we get a new handle otherwise we could receive stalled data
+				needsToBePoweredOff := false
+
+				// get the virtual device list
+				devices := object.VirtualDeviceList(v.Config.Hardware.Device)
+
+				// select the virtual serial ports
+				serials := devices.SelectByBackingInfo((*types.VirtualSerialPortURIBackingInfo)(nil))
+				log.Debugf("Found %d devices withe the desired backing", len(serials))
+
+				// iterate over them and set needsToBePoweredOff if neccesary
+				for _, serial := range serials {
+					log.Debugf("Connected: %t", serial.GetVirtualDevice().Connectable.Connected)
+					if serial.GetVirtualDevice().Connectable.Connected {
+						needsToBePoweredOff = true
+					}
+				}
+				if !needsToBePoweredOff {
+					log.Debugf("Skipping %q. Serial is not connected so it will be migrated", v)
+					return nil
+				}
+
+				handle.SetTargetState(StateStopped)
+
+				// call EmergencyCommit which nillify spec on behalf of caller
+				if err = handle.EmergencyCommit(ctx, nil, nil); err != nil {
+					log.Errorf("Failed to commit handle after getting %s event for container %s: %s", ie, v, err)
+					return err
+				}
+				return nil
+			}
+
+			if err := retry.Do(operation, IsConcurrentAccessError); err != nil {
+				log.Errorf("Multiple attempts failed to commit handle after getting %s event for container %s: %s", ie, v, err)
+			}
+		}
+
+	}
 }
 
 // registeredVMCallback will process registeredVMEvent

--- a/lib/portlayer/exec/exec.go
+++ b/lib/portlayer/exec/exec.go
@@ -266,8 +266,8 @@ func hostEventCallback(ctx context.Context, ie events.Event) {
 
 				handle.SetTargetState(StateStopped)
 
-				// call EmergencyCommit which nillify spec on behalf of caller
-				if err = handle.EmergencyCommit(ctx, nil, nil); err != nil {
+				// call CommitWithoutSpec which sets spec to nil
+				if err = handle.CommitWithoutSpec(ctx, nil, nil); err != nil {
 					log.Errorf("Failed to commit handle after getting %s event for container %s: %s", ie, v, err)
 					return err
 				}

--- a/lib/portlayer/exec/handle.go
+++ b/lib/portlayer/exec/handle.go
@@ -204,6 +204,17 @@ func (h *Handle) Commit(ctx context.Context, sess *session.Session, waitTime *in
 	return nil
 }
 
+// EmergencyCommit sets the handle's spec to nil so that Commit operation only does a state change and won't touch the extraconfig
+func (h *Handle) EmergencyCommit(ctx context.Context, sess *session.Session, waitTime *int32) error {
+	h.Spec = nil
+
+	if err := Commit(ctx, sess, h, waitTime); err != nil {
+		return err
+	}
+
+	removeHandle(h.key)
+	return nil
+}
 func (h *Handle) Close() {
 	removeHandle(h.key)
 }

--- a/lib/portlayer/logging/logging.go
+++ b/lib/portlayer/logging/logging.go
@@ -49,8 +49,6 @@ func Init(ctx context.Context) error {
 func eventCallback(ctx context.Context, ie events.Event) {
 	defer trace.End(trace.Begin(""))
 
-	var err error
-
 	switch ie.String() {
 	case events.ContainerMigrated,
 		events.ContainerMigratedByDrs:
@@ -64,9 +62,12 @@ func eventCallback(ctx context.Context, ie events.Event) {
 		}
 
 		operation := func() error {
+			var err error
+
 			handle := container.NewHandle(ctx)
 			if handle == nil {
-				log.Errorf("Handle for %s cannot be created", ie.Reference())
+				err = fmt.Errorf("Handle for %s cannot be created", ie.Reference())
+				log.Error(err)
 				return err
 			}
 			defer handle.Close()
@@ -77,7 +78,7 @@ func eventCallback(ctx context.Context, ie events.Event) {
 				return err
 			}
 
-			if err := handle.Commit(ctx, nil, nil); err != nil {
+			if err = handle.Commit(ctx, nil, nil); err != nil {
 				log.Errorf("Failed to commit handle after getting %s event for container %s: %s", ie, ie.Reference(), err)
 				return err
 			}


### PR DESCRIPTION
- Start listening VmRelocatedEvent and call refresh when needed

Otherwise the cache will have incorrect data due to DRS. DRS can create
the vm on one host and then power it on on another (hence relocation).

- Add new host event type and use it in exec subsystem

We receive HostEnteringMaintenanceMode when the host goes into
maintanence mode. When this happens all virtual machine operations are
blocked, except the following;

* MigrateVM
* PowerOffVM
* SuspendVM
* ShutdownGuest
* StandbyGuest

All the vms that does not have an active serial connections will end up
getting migrated by DRS. The rest needs to be powered off manually.

We can't call Commit since we are not allowerd to call reconfigure so
we now have a EmergencyCommit variant which sets the Spec to nil.

Fixes #3492