### PR TITLE
Add vicadmin to vic group to be able to share same file between diffe…

### DIFF
--- a/isos/appliance.sh
+++ b/isos/appliance.sh
@@ -98,12 +98,23 @@ rm -f $(rootfs_dir $PKGDIR)/etc/systemd/network/*
 
 chroot $(rootfs_dir $PKGDIR) groupadd -g 1000 vicadmin
 chroot $(rootfs_dir $PKGDIR) useradd -u 1000 -g 1000 -G systemd-journal -m -d /home/vicadmin -s /bin/false vicadmin
+
+# Group vic should be used to run all VIC related services.
+chroot $(rootfs_dir $PKGDIR) groupadd -g 1001 vic
+chroot $(rootfs_dir $PKGDIR) usermod -a -G vic vicadmin
+
 cp -R ${DIR}/vicadmin/* $(rootfs_dir $PKGDIR)/home/vicadmin
 chown -R 1000:1000 $(rootfs_dir $PKGDIR)/home/vicadmin
+
 # so vicadmin can read the system journal via journalctl
 install -m 755 -d $(rootfs_dir $PKGDIR)/etc/tmpfiles.d
 echo "m  /var/log/journal/%m/system.journal 2755 root systemd-journal - -" > $(rootfs_dir $PKGDIR)/etc/tmpfiles.d/systemd.conf
 
+chroot $(rootfs_dir $PKGDIR) mkdir -p /var/run/lock
+chroot $(rootfs_dir $PKGDIR) chmod 1777 /var/run/lock
+chroot $(rootfs_dir $PKGDIR) touch /var/run/lock/logrotate_run.lock
+chroot $(rootfs_dir $PKGDIR) chown root:vic /var/run/lock/logrotate_run.lock
+chroot $(rootfs_dir $PKGDIR) chmod 0660 /var/run/lock/logrotate_run.lock
 
 ## main VIC components
 # tether based init


### PR DESCRIPTION
- Added new group "vic"
- User vicadmin is added into vic group
- Set "vic" group permissions for  /var/run/lock/logrotate_run.lock to be able to share it between different processes.

Fixes: #3425