### PR TITLE
Add test to scrape logs for password leaks

### DIFF
--- a/tests/resources/Docker-Util.robot
+++ b/tests/resources/Docker-Util.robot
@@ -81,3 +81,5 @@ Run Regression Tests
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} images
     Should Be Equal As Integers  ${rc}  0
     Should Not Contain  ${output}  busybox
+
+    Scrape Logs For The Password

--- a/tests/resources/VCH-Util.robot
+++ b/tests/resources/VCH-Util.robot
@@ -159,6 +159,22 @@ Check For The Proper Log Files
     Should Contain  ${output}  ${container}/vmware.log
     Should Contain  ${output}  ${container}/tether.debug
 
+Scrape Logs For the Password
+    [Tags]  secret
+    ${rc}=  Run And Return Rc  curl -sk %{VIC-ADMIN}/authentication -XPOST -F username=%{TEST_USERNAME} -F password=%{TEST_PASSWORD} -D /tmp/cookies-%{VCH-NAME}
+    Should Be Equal As Integers  ${rc}  0
+
+    ${rc}=  Run And Return Rc  curl -sk %{VIC-ADMIN}/logs/port-layer.log -b /tmp/cookies-%{VCH-NAME} | grep -q "%{TEST_PASSWORD}"
+    Should Be Equal As Integers  ${rc}  1
+    ${rc}=  Run And Return Rc  curl -sk %{VIC-ADMIN}/logs/init.log -b /tmp/cookies-%{VCH-NAME} | grep -q "%{TEST_PASSWORD}"
+    Should Be Equal As Integers  ${rc}  1
+    ${rc}=  Run And Return Rc  curl -sk %{VIC-ADMIN}/logs/docker-personality.log -b /tmp/cookies-%{VCH-NAME} | grep -q "%{TEST_PASSWORD}"
+    Should Be Equal As Integers  ${rc}  1
+    ${rc}=  Run And Return Rc  curl -sk %{VIC-ADMIN}/logs/vicadmin.log -b /tmp/cookies-%{VCH-NAME} | grep -q "%{TEST_PASSWORD}"
+    Should Be Equal As Integers  ${rc}  1
+
+    Remove File  /tmp/cookies-%{VCH-NAME}
+
 Cleanup VIC Appliance On Test Server
     Log To Console  Gathering logs from the test server %{VCH-NAME}
     Gather Logs From Test Server

--- a/tests/test-cases/Group9-VIC-Admin/9-01-VICAdmin-ShowHTML.robot
+++ b/tests/test-cases/Group9-VIC-Admin/9-01-VICAdmin-ShowHTML.robot
@@ -101,3 +101,6 @@ Get VICAdmin Log
     ${rc}  ${output}=  Run And Return Rc And Output  curl -sk %{VIC-ADMIN}/logs/vicadmin.log -b /tmp/cookies-%{VCH-NAME}
     Log  ${output}
     Should contain  ${output}  Launching vicadmin pprof server
+
+Check that VIC logs do not contain sensitive data
+    Scrape Logs For The Password

--- a/tests/test-cases/Group9-VIC-Admin/9-02-VICAdmin-CertAuth.robot
+++ b/tests/test-cases/Group9-VIC-Admin/9-02-VICAdmin-CertAuth.robot
@@ -58,3 +58,6 @@ Fail to get VCH init logs without cert
     ${output}=  Run  curl -sk %{VIC-ADMIN}/logs/init.log
     Log  ${output}
     Should Not contain  ${output}  reaping child processes
+
+Check that VIC logs do not contain sensitive data
+    Scrape Logs For The Password


### PR DESCRIPTION
Adds a test to check log files for password leaks in the regression and vic-admin integration test suites.

Fixes #3563