### PR TITLE
vic-machine delete removes custom bridge network

### DIFF
--- a/lib/install/management/network.go
+++ b/lib/install/management/network.go
@@ -120,6 +120,7 @@ func (d *Dispatcher) removeNetwork(conf *config.VirtualContainerHostConfigSpec) 
 
 	netw, ok := net.(*object.Network)
 	if !ok {
+		log.Errorf("Expected Network Type, got %#v", net)
 		return fmt.Errorf("Failed to get network for %q", moref)
 	}
 	pgName := netw.Name()

--- a/lib/install/management/network.go
+++ b/lib/install/management/network.go
@@ -119,26 +119,18 @@ func (d *Dispatcher) removeNetwork(conf *config.VirtualContainerHostConfigSpec) 
 	log.Debugf("Delete bridge network: %s", net)
 
 	netw, ok := net.(*object.Network)
-	log.Infof("Delete bridge network: %s", net)
-	log.Infof("Delete bridge network: %s", netw)
 	if !ok {
 		log.Errorf("Failed to find network %q: %s", moref, err)
 		return err
 	}
-
-	if network, err := d.session.Finder.Network(d.ctx, netw.InventoryPath); err != nil || network == nil {
-		log.Infof("Unable to delete network - failed to find %q", netw.InventoryPath)
-		log.Debugf("Failed to find network to delete: %s", err)
-		return nil
-	}
-
 	pgName := netw.Name()
-	log.Infof("Removing Portgroup %q", pgName)
+
 	hostNetSystem, err := d.session.Host.ConfigManager().NetworkSystem(d.ctx)
 	if err != nil {
 		return err
 	}
 
+	log.Infof("Removing Portgroup %q", pgName)
 	err = hostNetSystem.RemovePortGroup(d.ctx, pgName)
 	if err != nil {
 		return err

--- a/lib/install/management/network.go
+++ b/lib/install/management/network.go
@@ -101,18 +101,18 @@ func (d *Dispatcher) removeNetwork(conf *config.VirtualContainerHostConfigSpec) 
 
 	br := conf.ExecutorConfig.Networks["bridge"]
 	if br == nil {
-		return fmt.Errorf("Bridge Network ID unknown")
+		return fmt.Errorf("Bridge Network ID is unknown")
 	}
 	name := br.Network.ID
 	log.Debugf("Remove bridge network based on %s", name)
 
-	moref := new(types.ManagedObjectReference)
+	moref := types.ManagedObjectReference{}
 	ok := moref.FromString(name)
 	if !ok {
 		return fmt.Errorf("Unable to delete port group - failed to get moref from: %q", name)
 	}
 
-	net, err := d.session.Finder.ObjectReference(d.ctx, *moref)
+	net, err := d.session.Finder.ObjectReference(d.ctx, moref)
 	if err != nil {
 		return fmt.Errorf("Unable to delete port group - failed to find network from: %q", name)
 	}

--- a/lib/install/management/network.go
+++ b/lib/install/management/network.go
@@ -120,8 +120,7 @@ func (d *Dispatcher) removeNetwork(conf *config.VirtualContainerHostConfigSpec) 
 
 	netw, ok := net.(*object.Network)
 	if !ok {
-		log.Errorf("Failed to find network %q: %s", moref, err)
-		return err
+		return fmt.Errorf("Failed to get network for %q", moref)
 	}
 	pgName := netw.Name()
 

--- a/lib/install/management/network.go
+++ b/lib/install/management/network.go
@@ -99,9 +99,13 @@ func (d *Dispatcher) removeNetwork(conf *config.VirtualContainerHostConfigSpec) 
 		return nil
 	}
 
-	log.Debugf("Remove bridge network based on %s", conf.ExecutorConfig.Networks["bridge"].Network.ID)
+	br := conf.ExecutorConfig.Networks["bridge"]
+	if br == nil {
+		return fmt.Errorf("Bridge Network ID unknown")
+	}
+	name := br.Network.ID
+	log.Debugf("Remove bridge network based on %s", name)
 
-	name := conf.ExecutorConfig.Networks["bridge"].Network.ID
 	moref := new(types.ManagedObjectReference)
 	ok := moref.FromString(name)
 	if !ok {
@@ -115,6 +119,8 @@ func (d *Dispatcher) removeNetwork(conf *config.VirtualContainerHostConfigSpec) 
 	log.Debugf("Delete bridge network: %s", net)
 
 	netw, ok := net.(*object.Network)
+	log.Infof("Delete bridge network: %s", net)
+	log.Infof("Delete bridge network: %s", netw)
 	if !ok {
 		log.Errorf("Failed to find network %q: %s", moref, err)
 		return err

--- a/lib/install/validate/network.go
+++ b/lib/install/validate/network.go
@@ -270,11 +270,6 @@ func (v *Validator) network(ctx context.Context, input *data.Data, conf *config.
 	v.checkNetworkConflict(input.BridgeNetworkName, input.ManagementNetwork.Name, "management")
 	conf.AddNetwork(e)
 
-	log.Debug("Network configuration:")
-	for net, val := range conf.ExecutorConfig.Networks {
-		log.Debugf("\tNetwork: %s NetworkEndpoint: %v", net, val)
-	}
-
 	// Bridge net -
 	//   vCenter: must exist and must be a DPG
 	//   ESX: doesn't need to exist - we will create with default value
@@ -327,6 +322,11 @@ func (v *Validator) network(ctx context.Context, input *data.Data, conf *config.
 	// port forwarding
 	conf.AddNetwork(bridgeNet)
 	conf.BridgeIPRange = input.BridgeIPRange
+
+	log.Debug("Network configuration:")
+	for net, val := range conf.ExecutorConfig.Networks {
+		log.Debugf("\tNetwork: %s NetworkEndpoint: %v", net, val)
+	}
 
 	err = v.checkVDSMembership(ctx, endpointMoref, input.BridgeNetworkName)
 	if err != nil && checkBridgeVDS {


### PR DESCRIPTION
Use the correct name to delete the bridge network now, previously used only the VCH name which failed if a custom bridge network was specified on ESX.

Fixes #3193 

```
INFO[2017-01-06T09:46:14-08:00] ### Removing VCH ####                        
INFO[2017-01-06T09:46:15-08:00] Validating target                            
INFO[2017-01-06T09:46:17-08:00]                                              
INFO[2017-01-06T09:46:17-08:00] VCH ID: VirtualMachine:5                     
INFO[2017-01-06T09:46:17-08:00] Removing VMs                                 
INFO[2017-01-06T09:46:18-08:00] Removing image stores                        
INFO[2017-01-06T09:46:26-08:00] Removing volume stores                       
INFO[2017-01-06T09:46:26-08:00] Removing appliance VM network devices        
INFO[2017-01-06T09:46:28-08:00] Removing Portgroup "asdf1"                   
INFO[2017-01-06T09:46:28-08:00] Removing VirtualSwitch "asdf1"               
INFO[2017-01-06T09:46:33-08:00] Removing Resource Pool "oceanlab"            
INFO[2017-01-06T09:46:34-08:00] Completed successfully       
```