### PR TITLE
[skip ci] Nimbus pxe folder cleanup to avoid disk quota exceeded error

### DIFF
--- a/tests/resources/Nimbus-Util.robot
+++ b/tests/resources/Nimbus-Util.robot
@@ -178,11 +178,19 @@ Kill Nimbus Server
     ${out}=  Execute Command  nimbus-ctl kill '${name}'
     Close connection
 
+Cleanup Nimbus PXE folder
+    [Arguments]  ${user}  ${password}
+    Open Connection  %{NIMBUS_GW}
+    Login  ${user}  ${password}
+    ${out}=  Execute Command  rm -rf public_html/pxe/*
+    Close connection
+
 Nimbus Cleanup
     [Arguments]  ${vm_list}
     Run Keyword And Continue On Failure  Gather Logs From Test Server
     :FOR  ${item}  IN  @{vm_list}
     \   Run Keyword And Ignore Error  Kill Nimbus Server  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}  ${item}
+    Run Keyword And Ignore Error  Cleanup Nimbus PXE folder  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}
 
 Gather Host IPs
     ${out}=  Run  govc ls host/cls


### PR DESCRIPTION
Updated Nimbus cleanup logic in nimbus-util to delete the pxe folder contents to get around the disk quota exceeded error while deploying.
