### PR TITLE
minimize vagrant port collisions with auto_correct

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -6,7 +6,7 @@ Vagrant.configure(2) do |config|
   config.ssh.forward_agent = true
   config.vm.define "vic_dev" do | vic_dev |
     vic_dev.vm.box = 'bento/ubuntu-16.04'
-    vic_dev.vm.network 'forwarded_port', guest: 2375, host: 12375
+    vic_dev.vm.network 'forwarded_port', guest: 2375, host: 12375, auto_correct: true
     vic_dev.vm.host_name = 'devbox'
     vic_dev.vm.synced_folder '.', '/vagrant', disabled: true
     vic_dev.ssh.username = 'vagrant'


### PR DESCRIPTION
Allows vagrant to attempt to auto correct a port collision.
This will only apply to guest port 2375 and host 12375.

Fixes #3612