### PR TITLE
Fix issue number in docker images tests

### DIFF
--- a/tests/test-cases/Group1-Docker-Commands/1-03-Docker-Images.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-03-Docker-Images.robot
@@ -45,8 +45,8 @@ No-trunc images
     Length Should Be  @{line}[2]  64
 
 Specific images
-    ${status}=  Get State Of Github Issue  1035
-    Run Keyword If  '${status}' == 'closed'  Fail  Test 1-3-Docker-Images.robot needs to be updated now that Issue #1035 has been resolved
+    ${status}=  Get State Of Github Issue  2248
+    Run Keyword If  '${status}' == 'closed'  Fail  Test 1-3-Docker-Images.robot needs to be updated now that Issue #2248 has been resolved
 #    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} images alpine:3.1
 #    Should Be Equal As Integers  ${rc}  0
 #    Should Not Contain  ${output}  Error


### PR DESCRIPTION
An issue was added (#2248) to capture image filtering that encompasses #1035, so #1035 was closed. There is an integration test that depends on this issue, so I changed it to reference #2248 instead of #1035.