### PR TITLE
Exclude empty layer diffIDs from rootFS

### DIFF
--- a/tests/test-cases/Group1-Docker-Commands/1-03-Docker-Images.md
+++ b/tests/test-cases/Group1-Docker-Commands/1-03-Docker-Images.md
@@ -20,6 +20,9 @@ This test requires that a vSphere server is running and available
 7. Issue docker images -q command to the new VIC appliance
 8. Issue docker images --no-trunc command to the new VIC appliance
 9. Issue docker images alpine:3.1
+10. Issue docker pull busybox:uclibc, busybox:glibc, busybox:musl
+11. Issue regular docker busybox:uclibc, busybox:glibc, busybox:musl
+12. Grep VIC docker and regular docker images command output for eacy busybox tag
 
 #Expected Outcome:
 * Each of the commands issued should return error free with a properly formatted response
@@ -27,6 +30,7 @@ This test requires that a vSphere server is running and available
 * The docker images -q command should return only the short hash of the three images
 * The docker --no-trunc command should return the full non-truncated image ID of the three images
 * The docker images alpine:3.1 command should return only the specific image specified
+* The image IDs in step 12 for all busybox versions in VIC should match those in regular docker
 
 #Possible Problems:
 None

--- a/tests/test-cases/Group1-Docker-Commands/1-03-Docker-Images.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-03-Docker-Images.robot
@@ -52,3 +52,18 @@ Specific images
 #    Should Not Contain  ${output}  Error
 #    Should Contain  ${output}  3.1
 #    Should Contain X Times  ${output}  alpine  1
+
+VIC/docker Image ID consistency
+    @{tags}=  Create List  uclibc  glibc  musl
+
+    :FOR  ${tag}  IN  @{tags}
+    \   ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} pull busybox:${tag}
+    \   Should Be Equal As Integers  ${rc}  0
+    \   Should Not Contain  ${output}  Error
+    \   ${rc}  ${output}=  Run And Return Rc And Output  docker --tls pull busybox:${tag}
+    \   Should Be Equal As Integers  ${rc}  0
+    \   Should Not Contain  ${output}  Error
+    \   ${rc}  ${vic_id}=  Run And Return Rc And Output  docker %{VCH-PARAMS} images | grep -E busybox.*.${tag} |awk '{print $3}'
+    \   Should Be Equal As Integers  ${rc}  0
+    \   ${rc}  ${docker_id}=  Run And Return Rc And Output  docker --tls images | grep -E busybox.*.${tag} |awk '{print $3}'
+    \   Should Be Equal  ${vic_id}  ${docker_id}


### PR DESCRIPTION
This changes how we construct image metadata to bring it in line with docker, resulting in image IDs that are consistent between VIC and docker. Fixes #3602 