### PR TITLE
Modify header check regexp to allow for year ranges

### DIFF
--- a/infra/scripts/header-check.sh
+++ b/infra/scripts/header-check.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2016 VMware, Inc. All Rights Reserved.
+# Copyright 2016-2017 VMware, Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -32,7 +32,7 @@ set -e -o pipefail
 # VMware-copyright file in the scripts directory.
 #
 # These will be evaluated as a regex against the target file
-HEADER[1]="^\/\/ Copyright [0-9]{4} VMware, Inc\. All Rights Reserved\.$"
+HEADER[1]="^\/\/ Copyright [0-9]{4}(-[0-9]{4})? VMware, Inc\. All Rights Reserved\.$"
 HEADER[2]="^\/\/$"
 
 # Initialize vars


### PR DESCRIPTION
This modifies the header check script to include matching for multi-year ranges, i.e. `2016-2017`.