### PR TITLE
[specific ci=1-22-Docker-Volume-RM] Move volume in use check to volume cache

### DIFF
--- a/lib/portlayer/storage/volume_cache_test.go
+++ b/lib/portlayer/storage/volume_cache_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/vmware/vic/lib/portlayer/exec"
 	"github.com/vmware/vic/lib/portlayer/util"
 	"github.com/vmware/vic/pkg/trace"
 )
@@ -105,6 +106,9 @@ func (m *MockVolumeStore) VolumesList(op trace.Operation) ([]*Volume, error) {
 
 func TestVolumeCreateGetListAndDelete(t *testing.T) {
 	op := trace.NewOperation(context.Background(), "test")
+
+	exec.NewContainerCache()
+
 	mvs := NewMockVolumeStore()
 	v, err := NewVolumeLookupCache(op, mvs)
 	if !assert.NoError(t, err) {


### PR DESCRIPTION
Move the check into the cache so it can be used by other volume store
backends.  The same check will be needed despite the backend so moving
it up a layer is the answer.

[specific ci=1-22-Docker-Volume-RM]
