### PR TITLE
Handle early container poweroff state change in docker start

### DIFF
--- a/lib/portlayer/exec/base.go
+++ b/lib/portlayer/exec/base.go
@@ -1,4 +1,4 @@
-// Copyright 2016 VMware, Inc. All Rights Reserved.
+// Copyright 2016-2017 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/portlayer/exec/base.go
+++ b/lib/portlayer/exec/base.go
@@ -149,6 +149,8 @@ func (c *containerBase) startGuestProgram(ctx context.Context, name string, args
 }
 
 func (c *containerBase) start(ctx context.Context) error {
+	defer trace.End(trace.Begin(c.ExecConfig.ID))
+
 	// make sure we have vm
 	if c.vm == nil {
 		return NotYetExistError{c.ExecConfig.ID}

--- a/lib/portlayer/exec/container.go
+++ b/lib/portlayer/exec/container.go
@@ -343,9 +343,17 @@ func (c *Container) start(ctx context.Context) error {
 		return err
 	}
 
-	finalState = StateRunning
+	// Obtain the current state and set the final state to Running only if it's Starting.
+	// The current state is already Stopped if the container's process has exited or
+	// a poweredoff event has been processed.
+	finalState = c.CurrentState()
+	if finalState == StateStarting {
+		finalState = StateRunning
+	} else {
+		log.Infof("current state of container %s is %v", c.ExecConfig.ID, finalState)
+	}
 
-	return err
+	return nil
 }
 
 func (c *Container) stop(ctx context.Context, waitTime *int32) error {


### PR DESCRIPTION
This change alters container start logic to check the container's current power state before setting it to `Running`. If the state is already set to `Stopped` by event handling due to the container's process exiting before we set the state to `Running`, we now skip the change to `Running`.

Fixes #3604
