### PR TITLE
integration test added for container start and stop time [specific-ci=1-06-Docker-Run]

### DIFF
--- a/tests/test-cases/Group1-Docker-Commands/1-06-Docker-Run.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-06-Docker-Run.robot
@@ -93,3 +93,20 @@ Docker run immediate exit
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run busybox
     Should Be Equal As Integers  ${rc}  0
     Should Be Empty  ${output}
+
+Docker run verify container start and stop time
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} pull busybox
+    Should Be Equal As Integers  ${rc}  0
+    Should Not Contain  ${output}  Error
+    ${cmdStart}=  Run  date +%s
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run --name startStop busybox
+    Should Be Equal As Integers  ${rc}  0
+    Should Be Empty  ${output}
+    ${rc}  ${containerStart}=  Run And Return Rc And Output  docker %{VCH-PARAMS} inspect -f '{{.State.StartedAt}}' startStop | xargs date +%s -d
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${containerStop}=  Run And Return Rc And Output  docker %{VCH-PARAMS} inspect -f '{{.State.FinishedAt}}' startStop | xargs date +%s -d
+    Should Be Equal As Integers  ${rc}  0
+    ${startStatus}=  Run Keyword And Return Status  Should Be True  ${cmdStart} <= ${containerStart}
+    Run Keyword Unless  ${startStatus}  Fail  container start time before command start
+    ${stopStatus}=  Run Keyword And Return Status  Should Be True  ${cmdStart} < ${containerStop}
+    Run Keyword Unless  ${stopStatus}  Fail  container stop time before command start


### PR DESCRIPTION
Integration test will check that the start and stop time of a
short lived container is not wildly inaccurate.  Specifically,
the test will ensure container FinshedAt time is after StartedAt.
Issues around these times are typically due to host NTP
configuration issues.

Fixes #2527