### PR TITLE
[specific ci=1-19-Docker-Volume-Create] Move volumestore list into volume cache

### DIFF
--- a/lib/apiservers/engine/backends/system.go
+++ b/lib/apiservers/engine/backends/system.go
@@ -26,7 +26,6 @@ package backends
 //		- It is OK to return errors returned from functions in system_portlayer.go
 
 import (
-	"bytes"
 	"fmt"
 	"net/url"
 	"runtime"
@@ -325,17 +324,11 @@ func getImageCount() int {
 }
 
 func FetchVolumeStores(client *client.PortLayer) (string, error) {
-	var volumesBuffer bytes.Buffer
 
 	res, err := client.Storage.VolumeStoresList(storage.NewVolumeStoresListParamsWithContext(ctx))
 	if err != nil {
 		return "", err
 	}
-	VolumeStoreMap := res.Payload.Stores
 
-	for label := range VolumeStoreMap {
-		volumesBuffer.WriteString(fmt.Sprintf("%s ", label))
-	}
-
-	return volumesBuffer.String(), nil
+	return strings.Join(res.Payload.Stores, " "), nil
 }

--- a/lib/apiservers/portlayer/restapi/handlers/storage_handlers.go
+++ b/lib/apiservers/portlayer/restapi/handlers/storage_handlers.go
@@ -83,7 +83,7 @@ func (h *StorageHandlersImpl) Configure(api *operations.PortLayerAPI, handlerCtx
 
 		vs, err := vsphere.NewVolumeStore(op, volStoreName, handlerCtx.Session, volDatastore)
 		if err != nil {
-			log.Panicf("Cannot instantiate the volume store: %s", err)
+			log.Errorf("Cannot instantiate the volume store: %s", err)
 		}
 
 		if _, err = h.volumeCache.AddStore(op, volStoreName, vs); err != nil {

--- a/lib/apiservers/portlayer/restapi/handlers/storage_handlers_test.go
+++ b/lib/apiservers/portlayer/restapi/handlers/storage_handlers_test.go
@@ -489,9 +489,11 @@ func TestWriteImage(t *testing.T) {
 
 func TestVolumeCreate(t *testing.T) {
 
-	testStore := NewMockVolumeStore()
 	op := trace.NewOperation(context.Background(), "test")
-	volCache, err := spl.NewVolumeLookupCache(op, testStore)
+	volCache := spl.NewVolumeLookupCache(op)
+
+	testStore := NewMockVolumeStore()
+	_, err := volCache.AddStore(op, "testStore", testStore)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -501,7 +503,7 @@ func TestVolumeCreate(t *testing.T) {
 	}
 
 	model := models.VolumeRequest{}
-	model.Store = "blah"
+	model.Store = "testStore"
 	model.Name = "testVolume"
 	model.Capacity = 1
 	model.Driver = "vsphere"
@@ -524,7 +526,7 @@ func TestVolumeCreate(t *testing.T) {
 	if !assert.NoError(t, err) {
 		return
 	}
-	if !assert.Equal(t, "blah", testVolumeStoreName) {
+	if !assert.Equal(t, "testStore", testVolumeStoreName) {
 		return
 	}
 	if !assert.Equal(t, "testVolume", testVolume.ID) {

--- a/lib/apiservers/portlayer/swagger.json
+++ b/lib/apiservers/portlayer/swagger.json
@@ -2654,8 +2654,8 @@
 			],
 			"properties": {
 				"Stores": {
-					"type": "object",
-					"additionalProperties": {
+					"type": "array",
+					"items": {
 						"type": "string"
 					}
 				}

--- a/lib/portlayer/storage/volume.go
+++ b/lib/portlayer/storage/volume.go
@@ -42,9 +42,6 @@ type VolumeStorer interface {
 
 	// Lists all volumes
 	VolumesList(op trace.Operation) ([]*Volume, error)
-
-	// List the configured volume stores
-	VolumeStoresList(op trace.Operation) (map[string]url.URL, error)
 }
 
 // Volume is the handle to identify a volume on the backing store.  The URI

--- a/lib/portlayer/storage/volume_cache.go
+++ b/lib/portlayer/storage/volume_cache.go
@@ -86,7 +86,7 @@ func (v *VolumeLookupCache) VolumeStoresList(op trace.Operation) ([]string, erro
 	defer v.vlcLock.RUnlock()
 
 	stores := make([]string, len(v.volumeStores))
-	for u, _ := range v.volumeStores {
+	for u := range v.volumeStores {
 
 		// from the storage url, get the store name
 		storeName, err := util.VolumeStoreName(&u)

--- a/lib/portlayer/storage/volume_cache_test.go
+++ b/lib/portlayer/storage/volume_cache_test.go
@@ -110,13 +110,9 @@ func TestVolumeCreateGetListAndDelete(t *testing.T) {
 	exec.NewContainerCache()
 
 	mvs := NewMockVolumeStore()
-	v, err := NewVolumeLookupCache(op, mvs)
+	v := NewVolumeLookupCache(op)
+	storeURL, err := v.AddStore(op, "testStore", mvs)
 	if !assert.NoError(t, err) {
-		return
-	}
-
-	storeURL, err := util.VolumeStoreNameToURL("testStore")
-	if !assert.NoError(t, err) || !assert.NotNil(t, storeURL) {
 		return
 	}
 
@@ -196,12 +192,9 @@ func TestVolumeCreateGetListAndDelete(t *testing.T) {
 func TestVolumeCacheRestart(t *testing.T) {
 	mvs := NewMockVolumeStore()
 	op := trace.NewOperation(context.Background(), "test")
-	firstCache, err := NewVolumeLookupCache(op, mvs)
-	if !assert.NoError(t, err) || !assert.NotNil(t, firstCache) {
-		return
-	}
 
-	storeURL, err := util.VolumeStoreNameToURL("testStore")
+	firstCache := NewVolumeLookupCache(op)
+	storeURL, err := firstCache.AddStore(op, "testStore", mvs)
 	if !assert.NoError(t, err) || !assert.NotNil(t, storeURL) {
 		return
 	}
@@ -220,8 +213,13 @@ func TestVolumeCacheRestart(t *testing.T) {
 		inVols[id] = vol
 	}
 
-	secondCache, err := NewVolumeLookupCache(op, mvs)
-	if !assert.NoError(t, err) || !assert.NotNil(t, secondCache) {
+	secondCache := NewVolumeLookupCache(op)
+	if !assert.NotNil(t, secondCache) {
+		return
+	}
+
+	_, err = secondCache.AddStore(op, "testStore", mvs)
+	if !assert.NoError(t, err) || !assert.NotNil(t, storeURL) {
 		return
 	}
 

--- a/lib/portlayer/storage/vsphere/volume.go
+++ b/lib/portlayer/storage/vsphere/volume.go
@@ -19,7 +19,6 @@ import (
 	"net/url"
 	"os"
 	"path"
-	"sync"
 
 	"github.com/vmware/govmomi/vim25/types"
 	"github.com/vmware/vic/lib/portlayer/storage"
@@ -34,98 +33,39 @@ const VolumesDir = "volumes"
 
 // VolumeStore caches Volume references to volumes in the system.
 type VolumeStore struct {
-
-	// maps datastore uri (volume store) to datastore
-	ds     map[url.URL]*datastore.Helper
-	dsLock sync.RWMutex
+	// helper to the backend
+	ds *datastore.Helper
 
 	// wraps our vmdks and filesystem primitives.
 	dm *disk.Manager
 
-	sess *session.Session
+	// Service url to this VolumeStore
+	SelfLink *url.URL
 }
 
-func NewVolumeStore(op trace.Operation, s *session.Session) (*VolumeStore, error) {
+func NewVolumeStore(op trace.Operation, storeName string, s *session.Session, ds *datastore.Helper) (*VolumeStore, error) {
+	// Create the volume dir if it doesn't already exist
+	if _, err := ds.Mkdir(op, true, VolumesDir); err != nil && !os.IsExist(err) {
+		return nil, err
+	}
+
 	dm, err := disk.NewDiskManager(op, s)
 	if err != nil {
 		return nil, err
 	}
-
-	v := &VolumeStore{
-		dm:   dm,
-		sess: s,
-		ds:   make(map[url.URL]*datastore.Helper),
-	}
-
-	return v, nil
-}
-
-// AddStore adds a volumestore by uri.
-//
-// ds is the Datastore (+ path) volumes will be created under.
-//       The resulting path will be parentDir/VIC/volumes.
-// storeName is the name used to refer to the datastore + path (ds above).
-//
-// returns the URL used to refer to the volume store
-func (v *VolumeStore) AddStore(op trace.Operation, ds *datastore.Helper, storeName string) (*url.URL, error) {
-	v.dsLock.Lock()
-	defer v.dsLock.Unlock()
 
 	u, err := util.VolumeStoreNameToURL(storeName)
 	if err != nil {
 		return nil, err
 	}
 
-	if _, ok := v.ds[*u]; ok {
-		return nil, fmt.Errorf("volumestore (%s) already added", u.String())
+	v := &VolumeStore{
+		dm:       dm,
+		ds:       ds,
+		SelfLink: u,
 	}
 
-	if _, err = ds.Mkdir(op, true, VolumesDir); err != nil && !os.IsExist(err) {
-		return nil, err
-	}
-
-	v.ds[*u] = ds
-	return u, nil
-}
-
-func (v *VolumeStore) VolumeStoresList(op trace.Operation) (map[string]url.URL, error) {
-	m := make(map[string]url.URL)
-
-	v.dsLock.RLock()
-	defer v.dsLock.RUnlock()
-
-	for u, ds := range v.ds {
-
-		// Get the ds:// URL given the datastore url ("[datastore] /path")
-		dsurl, err := datastore.ToURL(ds.RootURL)
-		if err != nil {
-			return nil, err
-		}
-
-		// from the storage url, get the store name
-		storeName, err := util.VolumeStoreName(&u)
-		if err != nil {
-			return nil, err
-		}
-
-		m[storeName] = *dsurl
-	}
-
-	return m, nil
-}
-
-func (v *VolumeStore) getDatastore(store *url.URL) (*datastore.Helper, error) {
-
-	v.dsLock.RLock()
-	defer v.dsLock.RUnlock()
-
-	// find the datastore
-	dstore, ok := v.ds[*store]
-	if !ok {
-		return nil, storage.VolumeStoreNotFoundError{Msg: fmt.Sprintf("volume store (%s) not found", store.String())}
-	}
-
-	return dstore, nil
+	return v, nil
 }
 
 // Returns the path to the vol relative to the given store.  The dir structure
@@ -141,34 +81,20 @@ func (v *VolumeStore) volMetadataDirPath(ID string) string {
 }
 
 // Returns the path to the vmdk itself (in datastore URL format)
-func (v *VolumeStore) volDiskDsURL(store *url.URL, ID string) (string, error) {
-	// find the datastore
-	dstore, err := v.getDatastore(store)
-	if err != nil {
-		return "", err
-	}
-
+func (v *VolumeStore) volDiskDsURL(ID string) (string, error) {
 	// XXX this could be hidden in a helper.  We shouldn't use rooturl outside the datastore struct
-	return path.Join(dstore.RootURL, v.volDirPath(ID), ID+".vmdk"), nil
+	return path.Join(v.ds.RootURL, v.volDirPath(ID), ID+".vmdk"), nil
 }
 
 func (v *VolumeStore) VolumeCreate(op trace.Operation, ID string, store *url.URL, capacityKB uint64, info map[string][]byte) (*storage.Volume, error) {
 
-	// find the datastore
-	dstore, err := v.getDatastore(store)
-	if err != nil {
-		return nil, err
-	}
-
 	// Create the volume directory in the store.
-	_, err = dstore.Mkdir(op, false, v.volDirPath(ID))
-	if err != nil {
+	if _, err := v.ds.Mkdir(op, false, v.volDirPath(ID)); err != nil {
 		return nil, err
 	}
 
 	// Get the path to the disk in datastore uri format
-	var volDiskDsURL string
-	volDiskDsURL, err = v.volDiskDsURL(store, ID)
+	volDiskDsURL, err := v.volDiskDsURL(ID)
 	if err != nil {
 		return nil, err
 	}
@@ -192,7 +118,7 @@ func (v *VolumeStore) VolumeCreate(op trace.Operation, ID string, store *url.URL
 
 	// Persist the metadata
 	metaDataDir := v.volMetadataDirPath(ID)
-	if err = writeMetadata(op, dstore, metaDataDir, info); err != nil {
+	if err = writeMetadata(op, v.ds, metaDataDir, info); err != nil {
 		return nil, err
 	}
 
@@ -203,13 +129,8 @@ func (v *VolumeStore) VolumeCreate(op trace.Operation, ID string, store *url.URL
 func (v *VolumeStore) VolumeDestroy(op trace.Operation, vol *storage.Volume) error {
 	volDir := v.volDirPath(vol.ID)
 
-	dstore, err := v.getDatastore(vol.Store)
-	if err != nil {
-		return err
-	}
-
 	op.Infof("VolumeStore: Deleting %s", volDir)
-	if err := dstore.Rm(op, volDir); err != nil {
+	if err := v.ds.Rm(op, volDir); err != nil {
 		op.Errorf("VolumeStore: delete error: %s", err.Error())
 		return err
 	}
@@ -225,51 +146,42 @@ func (v *VolumeStore) VolumeGet(op trace.Operation, ID string) (*storage.Volume,
 func (v *VolumeStore) VolumesList(op trace.Operation) ([]*storage.Volume, error) {
 	volumes := []*storage.Volume{}
 
-	v.dsLock.RLock()
-	defer v.dsLock.RUnlock()
+	res, err := v.ds.Ls(op, VolumesDir)
+	if err != nil {
+		return nil, fmt.Errorf("error listing vols: %s", err)
+	}
 
-	for volStore, vols := range v.ds {
+	for _, f := range res.File {
+		file, ok := f.(*types.FileInfo)
+		if !ok {
+			continue
+		}
 
-		store := volStore
+		ID := file.Path
 
-		res, err := vols.Ls(op, VolumesDir)
+		// Get the path to the disk in datastore uri format
+		volDiskDsURL, err := v.volDiskDsURL(ID)
 		if err != nil {
-			return nil, fmt.Errorf("error listing vols: %s", err)
+			return nil, err
 		}
 
-		for _, f := range res.File {
-			file, ok := f.(*types.FileInfo)
-			if !ok {
-				continue
-			}
-
-			ID := file.Path
-
-			// Get the path to the disk in datastore uri format
-			volDiskDsURL, err := v.volDiskDsURL(&store, ID)
-			if err != nil {
-				return nil, err
-			}
-
-			dev, err := disk.NewVirtualDisk(volDiskDsURL)
-			if err != nil {
-				return nil, err
-			}
-
-			metaDataDir := v.volMetadataDirPath(ID)
-			meta, err := getMetadata(op, vols, metaDataDir)
-			if err != nil {
-				return nil, err
-			}
-
-			vol, err := storage.NewVolume(&store, ID, meta, dev)
-			if err != nil {
-				return nil, err
-			}
-
-			volumes = append(volumes, vol)
+		dev, err := disk.NewVirtualDisk(volDiskDsURL)
+		if err != nil {
+			return nil, err
 		}
 
+		metaDataDir := v.volMetadataDirPath(ID)
+		meta, err := getMetadata(op, v.ds, metaDataDir)
+		if err != nil {
+			return nil, err
+		}
+
+		vol, err := storage.NewVolume(v.SelfLink, ID, meta, dev)
+		if err != nil {
+			return nil, err
+		}
+
+		volumes = append(volumes, vol)
 	}
 
 	return volumes, nil


### PR DESCRIPTION
We were keeping all of the volumestores in the implementation.  That
meant every new volumestore would go down into the vsphere
implementation and provision itself there and keep state private in the
impl.  This moves the volume store up into the volume cache so each new
volume store is an implementation itself.  This will allow us to support
volume stores beyond just vsphere (like nfs).

[specific ci=1-19-Docker-Volume-Create]