### PR TITLE
Volume opts case insensitivity & bogus option reporting

### DIFF
--- a/lib/apiservers/engine/backends/volume.go
+++ b/lib/apiservers/engine/backends/volume.go
@@ -42,6 +42,12 @@ const (
 	dockerMetadataModelKey string = "DockerMetaData"
 )
 
+// define a set (whitelist) of valid opts keys for command line argument validation
+var ValidOptsKeys = map[string]bool{
+	OptsVolumeStoreKey: true,
+	OptsCapacityKey:    true,
+}
+
 //Validation pattern for Volume Names
 var volumeNameRegex = regexp.MustCompile("^[a-zA-Z0-9][a-zA-Z0-9_.-]*$")
 
@@ -264,14 +270,6 @@ func newVolumeCreateReq(name, driverName string, volumeData, labels map[string]s
 		return nil, fmt.Errorf("volume name %q includes invalid characters, only \"[a-zA-Z0-9][a-zA-Z0-9_.-]\" are allowed", name)
 	}
 
-	for k, val := range volumeData {
-		lowercase := strings.ToLower(k)
-		if strings.Compare(val, k) != 0 {
-			delete(volumeData, k)
-			volumeData[lowercase] = val
-		}
-
-	}
 	req := &models.VolumeRequest{
 		Driver:     driverName,
 		DriverArgs: volumeData,
@@ -305,6 +303,20 @@ func volumeStore(args map[string]string) string {
 func validateDriverArgs(args map[string]string, req *models.VolumeRequest) error {
 	// volumestore name validation
 	req.Store = volumeStore(args)
+
+	// normalize keys to lowercase & validate them
+	for k, val := range args {
+		lowercase := strings.ToLower(k)
+
+		if !ValidOptsKeys[k] {
+			return fmt.Errorf("%s is not a supported option", k)
+		}
+
+		if strings.Compare(val, k) != 0 {
+			delete(args, k)
+			args[lowercase] = val
+		}
+	}
 
 	// capacity validation
 	capstr, ok := args[OptsCapacityKey]

--- a/lib/apiservers/engine/backends/volume.go
+++ b/lib/apiservers/engine/backends/volume.go
@@ -24,6 +24,7 @@ import (
 
 	"regexp"
 	"strconv"
+	"strings"
 
 	"github.com/docker/engine-api/types"
 	"github.com/docker/go-units"
@@ -36,8 +37,8 @@ import (
 
 // NOTE: FIXME: These might be moved to a utility package once there are multiple personalities
 const (
-	OptsVolumeStoreKey     string = "VolumeStore"
-	OptsCapacityKey        string = "Capacity"
+	OptsVolumeStoreKey     string = "volumestore"
+	OptsCapacityKey        string = "capacity"
 	dockerMetadataModelKey string = "DockerMetaData"
 )
 
@@ -263,6 +264,14 @@ func newVolumeCreateReq(name, driverName string, volumeData, labels map[string]s
 		return nil, fmt.Errorf("volume name %q includes invalid characters, only \"[a-zA-Z0-9][a-zA-Z0-9_.-]\" are allowed", name)
 	}
 
+	for k, val := range volumeData {
+		lowercase := strings.ToLower(k)
+		if strings.Compare(val, k) != 0 {
+			delete(volumeData, k)
+			volumeData[lowercase] = val
+		}
+
+	}
 	req := &models.VolumeRequest{
 		Driver:     driverName,
 		DriverArgs: volumeData,

--- a/lib/apiservers/engine/backends/volume_test.go
+++ b/lib/apiservers/engine/backends/volume_test.go
@@ -45,17 +45,23 @@ func TestTranslatVolumeRequestModel(t *testing.T) {
 	testLabels["TestMeta"] = "custom info about my volume"
 
 	testDriverArgs := make(map[string]string)
-	testDriverArgs["testArg"] = "important driver stuff"
+	testDriverArgs["testarg"] = "important driver stuff"
 	testDriverArgs[OptsVolumeStoreKey] = "testStore"
 	testDriverArgs[OptsCapacityKey] = "12MB"
 
 	testRequest, err := newVolumeCreateReq("testName", "vsphere", testDriverArgs, testLabels)
+	if !assert.Error(t, err) {
+		return
+	}
+
+	delete(testDriverArgs, "testarg")
+	testRequest, err = newVolumeCreateReq("testName", "vsphere", testDriverArgs, testLabels)
 	if !assert.NoError(t, err) {
 		return
 	}
 
 	assert.Equal(t, "testName", testRequest.Name)
-	assert.Equal(t, "important driver stuff", testRequest.DriverArgs["testArg"])
+	assert.Equal(t, "", testRequest.DriverArgs["testarg"]) // unsupported keys should just be empty
 	assert.Equal(t, "testStore", testRequest.Store)
 	assert.Equal(t, "vsphere", testRequest.Driver)
 	assert.Equal(t, int64(12), testRequest.Capacity)


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[ X ] There is an associated issue that is labelled
[ X ] Code is up-to-date with the `master` branch
[ X ] You've successfully run `make test` locally
[ X ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/vmware/vic/blob/master/.github/CONTRIBUTING.md
-->

Fixes #3535 

Does so by forcing all option keys to lowercase regardless of how the user provided them, so e.g. `Capacity` == `capacity` == `cApAcItY` and reports an error if the user tries to use an unsupported option, confirmed via whitelist stored in a set, `ValidOptsKeys`