### PR TITLE
[skip ci] Multiple VLAN cleanup fix for nightly

### DIFF
--- a/tests/manual-test-cases/Group5-Functional-Tests/5-12-Multiple-VLAN.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-12-Multiple-VLAN.robot
@@ -1,9 +1,14 @@
 *** Settings ***
 Documentation  Test 5-12 - Multiple VLAN
 Resource  ../../resources/Util.robot
-Suite Setup  Create a Simple VC Cluster  multi-vlan-1  cls
-Suite Teardown  Run Keyword And Ignore Error  Nimbus Cleanup
+Suite Setup  Multiple VLAN Setup
+Suite Teardown  Run Keyword And Ignore Error  Nimbus Cleanup  ${list}
 Test Teardown  Cleanup VIC Appliance On Test Server
+
+*** Keywords ***
+Multiple VLAN Setup
+    ${esx1}  ${esx2}  ${esx3}  ${vc}  ${vc-ip}=  Create a Simple VC Cluster  multi-vlan-1  cls
+    Set Global Variable  @{list}  ${esx1}  ${esx2}  ${esx3}  ${vc}
 
 *** Test Cases ***
 Test1

--- a/tests/resources/Nimbus-Util.robot
+++ b/tests/resources/Nimbus-Util.robot
@@ -306,7 +306,7 @@ Create a Simple VC Cluster
     Set Environment Variable  TEST_DATASTORE  datastore1
     Set Environment Variable  TEST_RESOURCE  ${cluster}
     Set Environment Variable  TEST_TIMEOUT  30m
-    [Return]  ${vc-ip}
+    [Return]  ${esx1}  ${esx2}  ${esx3}  ${vc}  ${vc-ip}
 
 Create A Distributed Switch
     [Arguments]  ${datacenter}  ${dvs}=test-ds


### PR DESCRIPTION
Updated Create a Simple VC Cluster to return the vm names so to pass it to the Nimbus Cleanup during Suite teardown.