### PR TITLE
[full ci] change NetworkMode to user-defined network (if any) when validating createConfig

### DIFF
--- a/lib/apiservers/engine/backends/container.go
+++ b/lib/apiservers/engine/backends/container.go
@@ -1384,10 +1384,12 @@ func validateCreateConfig(config *types.ContainerCreateConfig) error {
 	if config.NetworkingConfig == nil {
 		config.NetworkingConfig = &dnetwork.NetworkingConfig{}
 	} else {
+		if l := len(config.NetworkingConfig.EndpointsConfig); l > 1 {
+			return fmt.Errorf("Error setting NetWorkMode: Container cannot be connected to more than one network endpoints; current endpoints: %d", l)
+		}
 		// If NetworkConfig exists, set NetworkMode to the default endpoint network, assuming only one endpoint network as the default network during container create
 		for networkName := range config.NetworkingConfig.EndpointsConfig {
 			config.HostConfig.NetworkMode = containertypes.NetworkMode(networkName)
-			break
 		}
 	}
 

--- a/lib/apiservers/engine/backends/container.go
+++ b/lib/apiservers/engine/backends/container.go
@@ -1377,12 +1377,19 @@ func validateCreateConfig(config *types.ContainerCreateConfig) error {
 	config.HostConfig.Memory = memoryMB
 	log.Infof("Container memory: %d MB", config.HostConfig.Memory)
 
-	if config.NetworkingConfig == nil {
-		config.NetworkingConfig = &dnetwork.NetworkingConfig{}
-	}
-
 	if config.HostConfig == nil || config.Config == nil {
 		return BadRequestError("invalid config")
+	}
+
+	if config.NetworkingConfig == nil {
+		config.NetworkingConfig = &dnetwork.NetworkingConfig{}
+	} else {
+		// If NetworkConfig exists, set NetworkMode to the default endpoint network, assuming only one endpoint network as the default network during container create
+		for networkName := range config.NetworkingConfig.EndpointsConfig {
+			config.HostConfig.NetworkMode = containertypes.NetworkMode(networkName)
+			break
+		}
+
 	}
 
 	// validate port bindings

--- a/lib/apiservers/engine/backends/container.go
+++ b/lib/apiservers/engine/backends/container.go
@@ -1389,7 +1389,6 @@ func validateCreateConfig(config *types.ContainerCreateConfig) error {
 			config.HostConfig.NetworkMode = containertypes.NetworkMode(networkName)
 			break
 		}
-
 	}
 
 	// validate port bindings

--- a/lib/apiservers/engine/backends/container.go
+++ b/lib/apiservers/engine/backends/container.go
@@ -1385,7 +1385,7 @@ func validateCreateConfig(config *types.ContainerCreateConfig) error {
 		config.NetworkingConfig = &dnetwork.NetworkingConfig{}
 	} else {
 		if l := len(config.NetworkingConfig.EndpointsConfig); l > 1 {
-			return fmt.Errorf("Error setting NetWorkMode: Container cannot be connected to more than one network endpoints; current endpoints: %d", l)
+			return fmt.Errorf("NetworkMode error: Container can be connected to one network endpoint only")
 		}
 		// If NetworkConfig exists, set NetworkMode to the default endpoint network, assuming only one endpoint network as the default network during container create
 		for networkName := range config.NetworkingConfig.EndpointsConfig {

--- a/lib/apiservers/engine/backends/container_proxy.go
+++ b/lib/apiservers/engine/backends/container_proxy.go
@@ -890,7 +890,6 @@ func toModelsNetworkConfig(cc types.ContainerCreateConfig) *models.NetworkConfig
 	}
 
 	// Docker copies Links to NetworkConfig only if it is a UserDefined network, handle that
-	// https://github.com/docker/docker/blame/master/runconfig/opts/parse.go#L598
 	if !cc.HostConfig.NetworkMode.IsUserDefined() && len(cc.HostConfig.Links) > 0 {
 		nc.Aliases = append(nc.Aliases, cc.HostConfig.Links...)
 	}

--- a/lib/apiservers/engine/backends/container_test.go
+++ b/lib/apiservers/engine/backends/container_test.go
@@ -670,14 +670,17 @@ func TestPortInformation(t *testing.T) {
 func TestCreateConfigNetworkMode(t *testing.T) {
 
 	// mock a container create config
-	var mockConfig types.ContainerCreateConfig
-
-	mockConfig.HostConfig = &container.HostConfig{}
-	mockConfig.Config = &container.Config{}
-	mockConfig.NetworkingConfig = &dnetwork.NetworkingConfig{}
-	mockConfig.Config.Image = "busybox"
-	mockConfig.NetworkingConfig.EndpointsConfig = make(map[string]*dnetwork.EndpointSettings)
-	mockConfig.NetworkingConfig.EndpointsConfig["net1"] = &dnetwork.EndpointSettings{}
+	mockConfig := types.ContainerCreateConfig{
+		HostConfig: &container.HostConfig{},
+		Config: &container.Config{
+			Image: "busybox",
+		},
+		NetworkingConfig: &dnetwork.NetworkingConfig{
+			EndpointsConfig: map[string]*dnetwork.EndpointSettings{
+				"net1": {},
+			},
+		},
+	}
 
 	validateCreateConfig(&mockConfig)
 


### PR DESCRIPTION
Admiral sends docker rest api calls the docker daemon to create containers and networks. It does not specify the "HostConfig.NetworkMode" value in the form-data. Docker api would set "NetworkMode" to "default" if it is not set in the form-data.

On vic, if the NetworkMode is default, it will connect the container to the bridge network and ommit the user-defined network specified in the "NetworkConfig". However, if NetworkConfig is specified in the form-data, regular docker would connect the container to the user-defined network instead of the bridge network.

To address this, when validating the CreateConfig, we set the NetworkMode to the user-defined network if it is specified, which would connect the container to the user-defined network when creating the container instead of the bridge network.

<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[  ] There is an associated issue that is labelled
[  ] Code is up-to-date with the `master` branch
[  ] You've successfully run `make test` locally
[  ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/vmware/vic/blob/master/.github/CONTRIBUTING.md
-->

Fixes #3542 

<!--
To trigger a custom build with this PR, include one of these in the PR's title or commit messages:
* [skip ci]
* [full ci]
* [specific ci=$suitename] e.g. [specific ci=1-01-Docker-Info]
    With this option, running only one suite is supported.
-->
