### PR TITLE
Add new log formatter [full ci]

### DIFF
--- a/cmd/docker/main.go
+++ b/cmd/docker/main.go
@@ -1,4 +1,4 @@
-// Copyright 2016 VMware, Inc. All Rights Reserved.
+// Copyright 2016-2017 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cmd/docker/main.go
+++ b/cmd/docker/main.go
@@ -36,6 +36,7 @@ import (
 	vicbackends "github.com/vmware/vic/lib/apiservers/engine/backends"
 	"github.com/vmware/vic/lib/config"
 	"github.com/vmware/vic/lib/pprof"
+	viclog "github.com/vmware/vic/pkg/log"
 	"github.com/vmware/vic/pkg/trace"
 	"github.com/vmware/vic/pkg/vsphere/extraconfig"
 )
@@ -54,6 +55,7 @@ const (
 var vchConfig config.VirtualContainerHostConfigSpec
 
 func init() {
+	log.SetFormatter(viclog.NewTextFormatter())
 	trace.Logger.Level = log.DebugLevel
 	pprof.StartPprof("docker personality", pprof.DockerPort)
 }

--- a/cmd/port-layer-server/main.go
+++ b/cmd/port-layer-server/main.go
@@ -1,4 +1,4 @@
-// Copyright 2016 VMware, Inc. All Rights Reserved.
+// Copyright 2016-2017 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cmd/port-layer-server/main.go
+++ b/cmd/port-layer-server/main.go
@@ -15,11 +15,11 @@
 package main
 
 import (
-	"log"
 	"os"
 	"os/signal"
 	"syscall"
 
+	log "github.com/Sirupsen/logrus"
 	"github.com/go-openapi/loads"
 	"github.com/jessevdk/go-flags"
 
@@ -27,6 +27,7 @@ import (
 	"github.com/vmware/vic/lib/apiservers/portlayer/restapi/operations"
 	"github.com/vmware/vic/lib/dns"
 	"github.com/vmware/vic/lib/pprof"
+	viclog "github.com/vmware/vic/pkg/log"
 )
 
 var (
@@ -34,6 +35,8 @@ var (
 )
 
 func init() {
+	log.SetFormatter(viclog.NewTextFormatter())
+
 	pprof.StartPprof("portlayer server", pprof.PortlayerPort)
 }
 

--- a/cmd/tether/main_darwin.go
+++ b/cmd/tether/main_darwin.go
@@ -1,4 +1,4 @@
-// Copyright 2016 VMware, Inc. All Rights Reserved.
+// Copyright 2016-2017 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cmd/tether/main_darwin.go
+++ b/cmd/tether/main_darwin.go
@@ -24,6 +24,7 @@ import (
 	log "github.com/Sirupsen/logrus"
 
 	"github.com/vmware/vic/lib/tether"
+	viclog "github.com/vmware/vic/pkg/log"
 	"github.com/vmware/vic/pkg/trace"
 	"github.com/vmware/vic/pkg/vsphere/extraconfig"
 )
@@ -50,7 +51,7 @@ func main() {
 	log.SetLevel(log.DebugLevel)
 
 	// Initiliaze logger with default TextFormatter
-	log.SetFormatter(&log.TextFormatter{DisableColors: true, FullTimestamp: true})
+	log.SetFormatter(viclog.NewTextFormatter())
 
 	// TODO: hard code executor initialization status reporting via guestinfo here
 	err := createDevices()

--- a/cmd/tether/main_linux.go
+++ b/cmd/tether/main_linux.go
@@ -1,4 +1,4 @@
-// Copyright 2016 VMware, Inc. All Rights Reserved.
+// Copyright 2016-2017 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cmd/tether/main_linux.go
+++ b/cmd/tether/main_linux.go
@@ -24,13 +24,28 @@ import (
 	log "github.com/Sirupsen/logrus"
 
 	"github.com/vmware/vic/lib/tether"
+	viclog "github.com/vmware/vic/pkg/log"
 	"github.com/vmware/vic/pkg/trace"
 	"github.com/vmware/vic/pkg/vsphere/extraconfig"
 )
 
 var tthr tether.Tether
 
+func init() {
+	// Initiliaze logger with default TextFormatter
+	log.SetFormatter(viclog.NewTextFormatter())
+
+	// use the same logger for trace and other logging
+	trace.Logger = log.StandardLogger()
+	log.SetLevel(log.DebugLevel)
+}
+
 func main() {
+	if strings.HasSuffix(os.Args[0], "-debug") {
+		extraconfig.DecodeLogLevel = log.DebugLevel
+		extraconfig.EncodeLogLevel = log.DebugLevel
+	}
+
 	defer func() {
 		if r := recover(); r != nil {
 			log.Errorf("run time panic: %s : %s", r, debug.Stack())
@@ -53,17 +68,6 @@ func main() {
 
 	// where to look for the various devices and files related to tether
 	pathPrefix = "/.tether"
-
-	if strings.HasSuffix(os.Args[0], "-debug") {
-		extraconfig.DecodeLogLevel = log.DebugLevel
-		extraconfig.EncodeLogLevel = log.DebugLevel
-	}
-	// use the same logger for trace and other logging
-	trace.Logger = log.StandardLogger()
-	log.SetLevel(log.DebugLevel)
-
-	// Initiliaze logger with default TextFormatter
-	log.SetFormatter(&log.TextFormatter{DisableColors: true, FullTimestamp: true})
 
 	// TODO: hard code executor initialization status reporting via guestinfo here
 	err = createDevices()

--- a/cmd/tether/main_windows.go
+++ b/cmd/tether/main_windows.go
@@ -1,4 +1,4 @@
-// Copyright 2016 VMware, Inc. All Rights Reserved.
+// Copyright 2016-2017 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cmd/tether/main_windows.go
+++ b/cmd/tether/main_windows.go
@@ -22,6 +22,7 @@ import (
 	log "github.com/Sirupsen/logrus"
 
 	"github.com/vmware/vic/lib/tether"
+	viclog "github.com/vmware/vic/pkg/log"
 	"github.com/vmware/vic/pkg/trace"
 	"github.com/vmware/vic/pkg/vsphere/extraconfig"
 )
@@ -48,7 +49,7 @@ func main() {
 	log.SetLevel(log.DebugLevel)
 
 	// Initiliaze logger with default TextFormatter
-	log.SetFormatter(&log.TextFormatter{DisableColors: true, FullTimestamp: true})
+	log.SetFormatter(viclog.NewTextFormatter())
 
 	// get the windows service logic running so that we can play well in that mode
 	runService("VMware Tether", false)

--- a/cmd/toolbox/main.go
+++ b/cmd/toolbox/main.go
@@ -1,4 +1,4 @@
-// Copyright 2016 VMware, Inc. All Rights Reserved.
+// Copyright 2016-2017 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cmd/toolbox/main.go
+++ b/cmd/toolbox/main.go
@@ -17,16 +17,20 @@ package main
 import (
 	"flag"
 	"fmt"
-	"log"
 	"os"
 	"os/signal"
 	"syscall"
 
+	log "github.com/Sirupsen/logrus"
+
+	viclog "github.com/vmware/vic/pkg/log"
 	"github.com/vmware/vic/pkg/vsphere/toolbox"
 )
 
 // This example can be run on a VM hosted by ESX, Fusion or Workstation
 func main() {
+	log.SetFormatter(viclog.NewTextFormatter())
+
 	flag.Parse()
 
 	in := toolbox.NewBackdoorChannelIn()

--- a/cmd/vic-dns/main.go
+++ b/cmd/vic-dns/main.go
@@ -1,4 +1,4 @@
-// Copyright 2016 VMware, Inc. All Rights Reserved.
+// Copyright 2016-2017 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cmd/vic-dns/main.go
+++ b/cmd/vic-dns/main.go
@@ -25,6 +25,7 @@ import (
 	log "github.com/Sirupsen/logrus"
 
 	"github.com/vmware/vic/lib/dns"
+	vlog "github.com/vmware/vic/pkg/log"
 	"github.com/vmware/vic/pkg/version"
 )
 
@@ -62,7 +63,7 @@ func main() {
 	}
 
 	// Initiliaze logger with default TextFormatter
-	log.SetFormatter(&log.TextFormatter{DisableColors: false, FullTimestamp: true})
+	log.SetFormatter(vlog.NewTextFormatter())
 
 	// Set the log level
 	if options.Debug {

--- a/cmd/vic-init/main_linux.go
+++ b/cmd/vic-init/main_linux.go
@@ -1,4 +1,4 @@
-// Copyright 2016 VMware, Inc. All Rights Reserved.
+// Copyright 2016-2017 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cmd/vic-init/main_linux.go
+++ b/cmd/vic-init/main_linux.go
@@ -24,6 +24,7 @@ import (
 	"github.com/vishvananda/netlink"
 
 	"github.com/vmware/vic/lib/tether"
+	viclog "github.com/vmware/vic/pkg/log"
 	"github.com/vmware/vic/pkg/logmgr"
 	"github.com/vmware/vic/pkg/trace"
 	"github.com/vmware/vic/pkg/vsphere/extraconfig"
@@ -39,6 +40,7 @@ var (
 func init() {
 	// use the same logger as the log files
 	trace.Logger = log.StandardLogger()
+	log.SetFormatter(viclog.NewTextFormatter())
 }
 
 func main() {

--- a/cmd/vic-machine/main.go
+++ b/cmd/vic-machine/main.go
@@ -1,4 +1,4 @@
-// Copyright 2016 VMware, Inc. All Rights Reserved.
+// Copyright 2016-2017 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cmd/vic-machine/main.go
+++ b/cmd/vic-machine/main.go
@@ -30,6 +30,7 @@ import (
 	"github.com/vmware/vic/cmd/vic-machine/inspect"
 	"github.com/vmware/vic/cmd/vic-machine/list"
 	"github.com/vmware/vic/cmd/vic-machine/upgrade"
+	viclog "github.com/vmware/vic/pkg/log"
 	"github.com/vmware/vic/pkg/version"
 )
 
@@ -107,7 +108,7 @@ func main() {
 	}
 
 	// Initiliaze logger with default TextFormatter
-	log.SetFormatter(&log.TextFormatter{ForceColors: true, FullTimestamp: true})
+	log.SetFormatter(viclog.NewTextFormatter())
 	// SetOutput to io.MultiWriter so that we can log to stdout and a file
 	log.SetOutput(io.MultiWriter(logs...))
 	defer func() {

--- a/cmd/vic-ui/main.go
+++ b/cmd/vic-ui/main.go
@@ -1,4 +1,4 @@
-// Copyright 2016 VMware, Inc. All Rights Reserved.
+// Copyright 2016-2017 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cmd/vic-ui/main.go
+++ b/cmd/vic-ui/main.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/vmware/vic/cmd/vic-ui/ui"
 	"github.com/vmware/vic/pkg/errors"
+	viclog "github.com/vmware/vic/pkg/log"
 )
 
 var (
@@ -81,7 +82,7 @@ func main() {
 	}
 
 	// Initiliaze logger with default TextFormatter
-	log.SetFormatter(&log.TextFormatter{ForceColors: true, FullTimestamp: true})
+	log.SetFormatter(viclog.NewTextFormatter())
 	// SetOutput to io.MultiWriter so that we can log to stdout and a file
 	log.SetOutput(io.MultiWriter(logs...))
 

--- a/cmd/vicadmin/vicadm.go
+++ b/cmd/vicadmin/vicadm.go
@@ -1,4 +1,4 @@
-// Copyright 2016 VMware, Inc. All Rights Reserved.
+// Copyright 2016-2017 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cmd/vicadmin/vicadm.go
+++ b/cmd/vicadmin/vicadm.go
@@ -43,6 +43,7 @@ import (
 	"github.com/vmware/vic/lib/guest"
 	"github.com/vmware/vic/lib/pprof"
 	"github.com/vmware/vic/pkg/certificate"
+	viclog "github.com/vmware/vic/pkg/log"
 	"github.com/vmware/vic/pkg/trace"
 	"github.com/vmware/vic/pkg/version"
 	"github.com/vmware/vic/pkg/vsphere/compute"
@@ -102,6 +103,8 @@ type logfile struct {
 }
 
 func init() {
+	log.SetFormatter(viclog.NewTextFormatter())
+
 	defer trace.End(trace.Begin(""))
 	trace.Logger.Level = log.DebugLevel
 	_ = pprof.StartPprof("vicadmin", pprof.VicadminPort)

--- a/lib/apiservers/portlayer/restapi/configure_port_layer.go
+++ b/lib/apiservers/portlayer/restapi/configure_port_layer.go
@@ -1,4 +1,4 @@
-// Copyright 2016 VMware, Inc. All Rights Reserved.
+// Copyright 2016-2017 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/apiservers/portlayer/restapi/configure_port_layer.go
+++ b/lib/apiservers/portlayer/restapi/configure_port_layer.go
@@ -74,6 +74,8 @@ func configureAPI(api *operations.PortLayerAPI) http.Handler {
 		log.SetLevel(log.DebugLevel)
 	}
 
+	api.Logger = log.Printf
+
 	ctx := context.Background()
 
 	sessionconfig := &session.Config{

--- a/lib/portlayer/util/util.go
+++ b/lib/portlayer/util/util.go
@@ -1,4 +1,4 @@
-// Copyright 2016 VMware, Inc. All Rights Reserved.
+// Copyright 2016-2017 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/portlayer/util/util.go
+++ b/lib/portlayer/util/util.go
@@ -15,9 +15,10 @@
 package util
 
 import (
-	"log"
 	"net/url"
 	"os"
+
+	log "github.com/Sirupsen/logrus"
 )
 
 const (

--- a/lib/tether/scp/operation.go
+++ b/lib/tether/scp/operation.go
@@ -1,4 +1,4 @@
-// Copyright 2016 VMware, Inc. All Rights Reserved.
+// Copyright 2016-2017 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/tether/scp/operation.go
+++ b/lib/tether/scp/operation.go
@@ -18,11 +18,12 @@ import (
 	"bufio"
 	"fmt"
 	"io"
-	"log"
 	"os"
 	"path/filepath"
 	"regexp"
 	"strconv"
+
+	log "github.com/Sirupsen/logrus"
 )
 
 // the following code is a modified version of https://github.com/gnicod/goscplib

--- a/lib/tether/scp/scp.go
+++ b/lib/tether/scp/scp.go
@@ -1,4 +1,4 @@
-// Copyright 2016 VMware, Inc. All Rights Reserved.
+// Copyright 2016-2017 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/tether/scp/scp.go
+++ b/lib/tether/scp/scp.go
@@ -16,9 +16,9 @@ package scp
 
 import (
 	"io"
-	"log"
 	"os"
 
+	log "github.com/Sirupsen/logrus"
 	"golang.org/x/crypto/ssh"
 )
 

--- a/pkg/log/text_formatter.go
+++ b/pkg/log/text_formatter.go
@@ -65,8 +65,6 @@ func (f *TextFormatter) Format(entry *logrus.Entry) ([]byte, error) {
 		return []byte(t + " " + l + "\n"), nil
 	}
 
-	var b bytes.Buffer
-
 	// prefix each line of the message with timestamp
 	// level information
 	s := bufio.NewScanner(strings.NewReader(entry.Message))
@@ -84,6 +82,7 @@ func (f *TextFormatter) Format(entry *logrus.Entry) ([]byte, error) {
 	}
 	s.Split(onNewLine)
 
+	var b bytes.Buffer
 	for s.Scan() {
 		b.WriteString(t + " " + l + " " + s.Text() + "\n")
 	}

--- a/pkg/log/text_formatter.go
+++ b/pkg/log/text_formatter.go
@@ -1,4 +1,4 @@
-// Copyright 2016 VMware, Inc. All Rights Reserved.
+// Copyright 2016-2017 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,191 +15,57 @@
 package log
 
 import (
+	"bufio"
 	"bytes"
 	"fmt"
-	"runtime"
-	"sort"
 	"strings"
-	"time"
 
 	"github.com/Sirupsen/logrus"
 )
 
-const (
-	nocolor = 0
-	red     = 31
-	green   = 32
-	yellow  = 33
-	blue    = 34
-	gray    = 37
-)
-
-var (
-	baseTimestamp time.Time
-	isTerminal    bool
-)
-
-func init() {
-	baseTimestamp = time.Now()
-	isTerminal = logrus.IsTerminal()
-}
-
-func miniTS() int {
-	return int(time.Since(baseTimestamp) / time.Second)
-}
-
 type TextFormatter struct {
-
-	// Enable colors
-	Colors bool
-
-	// Enable timestamp logging. It's useful to disable timestamps when output
-	// is redirected to logging system that already adds timestamps.  When
-	// disabled, a delta is used for each log line from the start of the
-	// process.  Enabling will apply a timestamp derived from TimestampFormat.
-	Timestamp bool
-
 	// TimestampFormat is the format used to print the timestamp.  By default
 	// an RFC3339 timestamp is used.
 	TimestampFormat string
-
-	// The fields are sorted by default for a consistent output. For applications
-	// that log extremely frequently and don't use the JSON formatter this may not
-	// be desired.
-	DisableSorting bool
-
-	// Escape noncharacter ascii strings.
-	EscapeNonCharacters bool
 }
 
-// NewTextFormatter returns a text formatter with defaults appropriate for the
-// TTY or file being written to.
+// NewTextFormatter returns a text formatter
 func NewTextFormatter() *TextFormatter {
+	return &TextFormatter{
+		TimestampFormat: "Jan _2 2006 15:04:05.000Z07:00",
+	}
+}
 
-	isColorTerminal := isTerminal && (runtime.GOOS != "windows")
-
-	formatter := &TextFormatter{
-		Colors:          isColorTerminal,
-		Timestamp:       false,
-		TimestampFormat: time.RFC3339,
-		DisableSorting:  false,
+func trimOrPadToSize(s string, size int) string {
+	if len(s) > size {
+		return s[:size]
 	}
 
-	return formatter
+	return s + strings.Repeat(" ", size-len(s))
 }
 
 func (f *TextFormatter) Format(entry *logrus.Entry) ([]byte, error) {
-	var b *bytes.Buffer
-	keys := make([]string, 0, len(entry.Data))
-	for k := range entry.Data {
-		keys = append(keys, k)
-	}
+	var b bytes.Buffer
 
-	if !f.DisableSorting {
-		sort.Strings(keys)
-	}
+	t := f.timeStamp(entry)
+	l := strings.ToUpper(trimOrPadToSize(entry.Level.String(), 4))
 
-	b = &bytes.Buffer{}
-
-	// get the time string
-	ts := f.timeStamp(entry)
-
-	if f.Colors {
-		f.printColored(b, entry, keys, ts)
+	if entry.Message == "" {
+		b.WriteString(fmt.Sprintf("%s %s\n", t, l))
 	} else {
-		if f.Timestamp {
-			f.appendKeyValue(b, "time", ts)
+		s := bufio.NewScanner(strings.NewReader(entry.Message))
+		for s.Scan() {
+			b.WriteString(fmt.Sprintf("%s %s %s\n", t, l, s.Text()))
 		}
 
-		f.appendKeyValue(b, "level", entry.Level.String())
-		if entry.Message != "" {
-			f.appendKeyValue(b, "msg", entry.Message)
-		}
-
-		for _, key := range keys {
-			f.appendKeyValue(b, key, entry.Data[key])
+		if s.Err() != nil {
+			return nil, s.Err()
 		}
 	}
 
-	b.WriteByte('\n')
 	return b.Bytes(), nil
 }
 
 func (f *TextFormatter) timeStamp(entry *logrus.Entry) string {
-	if !f.Timestamp {
-		return fmt.Sprintf("%04d", miniTS())
-	}
-
-	timestampFormat := f.TimestampFormat
-
-	if timestampFormat == "" {
-		timestampFormat = logrus.DefaultTimestampFormat
-	}
-
-	return entry.Time.Format(timestampFormat)
-}
-
-func (f *TextFormatter) printColored(b *bytes.Buffer, entry *logrus.Entry, keys []string, timestamp string) {
-	var levelColor int
-	switch entry.Level {
-	case logrus.DebugLevel:
-		levelColor = gray
-	case logrus.WarnLevel:
-		levelColor = yellow
-	case logrus.ErrorLevel, logrus.FatalLevel, logrus.PanicLevel:
-		levelColor = red
-	default:
-		levelColor = blue
-	}
-
-	levelText := strings.ToUpper(entry.Level.String())[0:4]
-
-	fmt.Fprintf(b, "\x1b[%dm%s\x1b[0m[%s] %-44s ", levelColor, levelText, timestamp, entry.Message)
-
-	for _, k := range keys {
-		v := entry.Data[k]
-		fmt.Fprintf(b, " \x1b[%dm%s\x1b[0m=%+v", levelColor, k, v)
-	}
-}
-
-func (f *TextFormatter) needsQuoting(text string) bool {
-	if !f.EscapeNonCharacters {
-		return false
-	}
-
-	for _, ch := range text {
-		if !((ch >= 'a' && ch <= 'z') ||
-			(ch >= 'A' && ch <= 'Z') ||
-			(ch >= '0' && ch <= '9') ||
-			ch == '-' || ch == '.') {
-			return true
-		}
-	}
-	return false
-}
-
-func (f *TextFormatter) appendKeyValue(b *bytes.Buffer, key string, value interface{}) {
-
-	b.WriteString(key)
-	b.WriteByte('=')
-
-	switch value := value.(type) {
-	case string:
-		if !f.needsQuoting(value) {
-			b.WriteString(value)
-		} else {
-			fmt.Fprintf(b, "%q", value)
-		}
-	case error:
-		errmsg := value.Error()
-		if !f.needsQuoting(errmsg) {
-			b.WriteString(errmsg)
-		} else {
-			fmt.Fprintf(b, "%q", value)
-		}
-	default:
-		fmt.Fprint(b, value)
-	}
-
-	b.WriteByte(' ')
+	return entry.Time.Format(f.TimestampFormat)
 }

--- a/pkg/log/text_formatter_test.go
+++ b/pkg/log/text_formatter_test.go
@@ -1,0 +1,34 @@
+// Copyright 2016-2017 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package log
+
+import "testing"
+import "github.com/Sirupsen/logrus"
+
+func BenchmarkFormatNonEmpty(b *testing.B) {
+	logrus.SetFormatter(NewTextFormatter())
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		logrus.Info("the quick brown fox jumps over the lazy dog")
+	}
+}
+
+func BenchmarkFormatEmpty(b *testing.B) {
+	logrus.SetFormatter(NewTextFormatter())
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		logrus.Info("")
+	}
+}

--- a/pkg/trace/trace.go
+++ b/pkg/trace/trace.go
@@ -1,4 +1,4 @@
-// Copyright 2016 VMware, Inc. All Rights Reserved.
+// Copyright 2016-2017 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/trace/trace.go
+++ b/pkg/trace/trace.go
@@ -40,12 +40,9 @@ var Logger = &logrus.Logger{
 	Out: os.Stderr,
 	// We're using our own text formatter to skip the \n and \t escaping logrus
 	// was doing on non TTY Out (we redirect to a file) descriptors.
-	Formatter: &log.TextFormatter{
-		Timestamp:       true,
-		TimestampFormat: "2006-01-02T15:04:05.000000000Z07:00",
-	},
-	Hooks: make(logrus.LevelHooks),
-	Level: logrus.InfoLevel,
+	Formatter: log.NewTextFormatter(),
+	Hooks:     make(logrus.LevelHooks),
+	Level:     logrus.InfoLevel,
 }
 
 // trace object used to grab run-time state

--- a/pkg/vsphere/toolbox/service.go
+++ b/pkg/vsphere/toolbox/service.go
@@ -1,4 +1,4 @@
-// Copyright 2016 VMware, Inc. All Rights Reserved.
+// Copyright 2016-2017 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/vsphere/toolbox/service.go
+++ b/pkg/vsphere/toolbox/service.go
@@ -17,11 +17,12 @@ package toolbox
 import (
 	"bytes"
 	"fmt"
-	"log"
 	"net"
 	"os"
 	"sync"
 	"time"
+
+	log "github.com/Sirupsen/logrus"
 )
 
 const (

--- a/tests/resources/VCH-Util.robot
+++ b/tests/resources/VCH-Util.robot
@@ -64,7 +64,7 @@ Get Docker Params
     Remove Environment Variable  DOCKER_HOST  DOCKER_TLS_VERIFY  DOCKER_CERT_PATH
 
     # Split the log log into pieces, discarding the initial log decoration, and assign to env vars
-    ${logdeco}  ${vars}=  Split String From Right  ${line}  ${SPACE}  1
+    ${logmon}  ${logday}  ${logyear}  ${logtime}  ${loglevel}  ${vars}=  Split String From Right  ${line}  ${SPACE}  5
     ${vars}=  Split String  ${vars}
     :FOR  ${var}  IN  @{vars}
     \   ${varname}  ${varval}=  Split String  ${var}  =

--- a/tests/resources/VCH-Util.robot
+++ b/tests/resources/VCH-Util.robot
@@ -64,7 +64,7 @@ Get Docker Params
     Remove Environment Variable  DOCKER_HOST  DOCKER_TLS_VERIFY  DOCKER_CERT_PATH
 
     # Split the log log into pieces, discarding the initial log decoration, and assign to env vars
-    ${logdeco}  ${vars}=  Split String  ${line}  ${SPACE}  1
+    ${logdeco}  ${vars}=  Split String From Right  ${line}  ${SPACE}  1
     ${vars}=  Split String  ${vars}
     :FOR  ${var}  IN  @{vars}
     \   ${varname}  ${varval}=  Split String  ${var}  =
@@ -85,11 +85,11 @@ Get Docker Params
     \   ${idx} =  Evaluate  ${index} + 1
     \   Run Keyword If  '${status}' == 'PASS'  Set Suite Variable  ${ext-ip}  @{output}[${idx}]
 
-    ${rest}  ${ext-ip} =  Split String From Right  ${ext-ip}
+    ${rest}  ${ext-ip} =  Split String From Right  ${ext-ip}  ${SPACE}  1
     ${ext-ip} =  Strip String  ${ext-ip}
     Set Environment Variable  EXT-IP  ${ext-ip}
 
-    ${rest}  ${vic-admin}=  Split String From Right  ${line}
+    ${rest}  ${vic-admin}=  Split String From Right  ${line}  ${SPACE}  1
     Set Environment Variable  VIC-ADMIN  ${vic-admin}
 
     Run Keyword If  ${port} == 2376  Set Environment Variable  VCH-PARAMS  -H ${dockerHost} --tls


### PR DESCRIPTION
Fixes #3615 

Example output:
```
Jan 23 2017 21:43:18.799Z INFO Started reaping child processes
Jan 23 2017 21:43:18.802Z DEBU writing "::1 ipv6-localhost ip6-loopback ipv6-loopback ip6-localhost\n" to /etc/hosts
Jan 23 2017 21:43:18.806Z DEBU writing "127.0.0.1 localhost.localdomain localhost\n" to /etc/hosts
Jan 23 2017 21:43:18.810Z DEBU writing "ff00:: ip6-mcastprefix\n" to /etc/hosts
Jan 23 2017 21:43:18.813Z DEBU writing "ff02::1 ip6-allnodes\n" to /etc/hosts
Jan 23 2017 21:43:18.816Z DEBU writing "fe00:: ip6-localnet\n" to /etc/hosts
Jan 23 2017 21:43:18.819Z DEBU writing "ff02::2 ip6-allrouters\n" to /etc/hosts
Jan 23 2017 21:43:18.822Z WARN Unable to resolve 'client.localhost': %!(EXTRA *net.DNSError=lookup client.localhost on [2001:4860:4860::8888]:53: dial udp [2001:4860:4860::8888]:53: connect: network is unreachable)
Jan 23 2017 21:43:18.830Z INFO Launching vch-init pprof server on 127.0.0.1:6060
Jan 23 2017 21:43:18.833Z INFO Starting extension logrotate
Jan 23 2017 21:43:18.835Z DEBU op=179.1 (delta:61.792074ms): logrotate config: /var/log/vic/port-layer.log {
Jan 23 2017 21:43:18.835Z DEBU     compress
Jan 23 2017 21:43:18.835Z DEBU     daily
Jan 23 2017 21:43:18.835Z DEBU     rotate 2
Jan 23 2017 21:43:18.835Z DEBU     size 20971520
Jan 23 2017 21:43:18.835Z DEBU     minsize 20971519
Jan 23 2017 21:43:18.835Z DEBU     copytruncate
Jan 23 2017 21:43:18.835Z DEBU     dateext
Jan 23 2017 21:43:18.835Z DEBU     dateformat -%Y%m%d-%s
Jan 23 2017 21:43:18.835Z DEBU }
```