### PR TITLE
Case insensitivity and error reporting on bogus options in volume create

### DIFF
--- a/lib/apiservers/engine/backends/container_proxy.go
+++ b/lib/apiservers/engine/backends/container_proxy.go
@@ -119,8 +119,8 @@ const (
 	ShortIDLen                          = 12
 
 	DriverArgFlagKey      = "flags"
-	DriverArgContainerKey = "Container"
-	DriverArgImageKey     = "Image"
+	DriverArgContainerKey = "container"
+	DriverArgImageKey     = "image"
 )
 
 // NewContainerProxy creates a new ContainerProxy

--- a/lib/apiservers/engine/backends/volume.go
+++ b/lib/apiservers/engine/backends/volume.go
@@ -43,12 +43,12 @@ const (
 )
 
 // define a set (whitelist) of valid driver opts keys for command line argument validation
-var validDriverOptsKeys = map[string]bool{
-	OptsVolumeStoreKey:    true,
-	OptsCapacityKey:       true,
-	DriverArgFlagKey:      true,
-	DriverArgContainerKey: true,
-	DriverArgImageKey:     true,
+var validDriverOptsKeys = map[string]struct{}{
+	OptsVolumeStoreKey:    {},
+	OptsCapacityKey:       {},
+	DriverArgFlagKey:      {},
+	DriverArgContainerKey: {},
+	DriverArgImageKey:     {},
 }
 
 //Validation pattern for Volume Names
@@ -308,11 +308,11 @@ func normalizeDriverArgs(args map[string]string) error {
 	for k, val := range args {
 		lowercase := strings.ToLower(k)
 
-		if !validDriverOptsKeys[lowercase] {
+		if _, ok := validDriverOptsKeys[lowercase]; !ok {
 			return fmt.Errorf("%s is not a supported option", k)
 		}
 
-		if strings.Compare(val, k) != 0 {
+		if strings.Compare(lowercase, k) != 0 {
 			delete(args, k)
 			args[lowercase] = val
 		}

--- a/lib/apiservers/engine/backends/volume.go
+++ b/lib/apiservers/engine/backends/volume.go
@@ -42,6 +42,12 @@ const (
 	dockerMetadataModelKey string = "DockerMetaData"
 )
 
+// define a set (whitelist) of valid opts keys for command line argument validation
+var ValidOptsKeys = map[string]bool{
+	OptsVolumeStoreKey: true,
+	OptsCapacityKey:    true,
+}
+
 //Validation pattern for Volume Names
 var volumeNameRegex = regexp.MustCompile("^[a-zA-Z0-9][a-zA-Z0-9_.-]*$")
 
@@ -264,14 +270,6 @@ func newVolumeCreateReq(name, driverName string, volumeData, labels map[string]s
 		return nil, fmt.Errorf("volume name %q includes invalid characters, only \"[a-zA-Z0-9][a-zA-Z0-9_.-]\" are allowed", name)
 	}
 
-	for k, val := range volumeData {
-		lowercase := strings.ToLower(k)
-		if strings.Compare(val, k) != 0 {
-			delete(volumeData, k)
-			volumeData[lowercase] = val
-		}
-
-	}
 	req := &models.VolumeRequest{
 		Driver:     driverName,
 		DriverArgs: volumeData,
@@ -305,6 +303,20 @@ func volumeStore(args map[string]string) string {
 func validateDriverArgs(args map[string]string, req *models.VolumeRequest) error {
 	// volumestore name validation
 	req.Store = volumeStore(args)
+
+	// normalize keys to lowercase & validate them
+	for k, val := range args {
+		lowercase := strings.ToLower(k)
+
+		if !ValidOptsKeys[k] {
+			return fmt.Errorf("%s is not a supported option", k)
+		}
+
+		if strings.Compare(val, k) != 0 {
+			delete(args, k)
+			args[lowercase] = val
+		}
+	}
 
 	// capacity validation
 	capstr, ok := args[OptsCapacityKey]

--- a/lib/apiservers/engine/backends/volume.go
+++ b/lib/apiservers/engine/backends/volume.go
@@ -42,10 +42,13 @@ const (
 	dockerMetadataModelKey string = "DockerMetaData"
 )
 
-// define a set (whitelist) of valid opts keys for command line argument validation
-var ValidOptsKeys = map[string]bool{
-	OptsVolumeStoreKey: true,
-	OptsCapacityKey:    true,
+// define a set (whitelist) of valid driver opts keys for command line argument validation
+var validDriverOptsKeys = map[string]bool{
+	OptsVolumeStoreKey:    true,
+	OptsCapacityKey:       true,
+	DriverArgFlagKey:      true,
+	DriverArgContainerKey: true,
+	DriverArgImageKey:     true,
 }
 
 //Validation pattern for Volume Names
@@ -308,7 +311,7 @@ func validateDriverArgs(args map[string]string, req *models.VolumeRequest) error
 	for k, val := range args {
 		lowercase := strings.ToLower(k)
 
-		if !ValidOptsKeys[k] {
+		if !validDriverOptsKeys[lowercase] {
 			return fmt.Errorf("%s is not a supported option", k)
 		}
 

--- a/lib/apiservers/engine/backends/volume.go
+++ b/lib/apiservers/engine/backends/volume.go
@@ -303,10 +303,7 @@ func volumeStore(args map[string]string) string {
 	return storeName
 }
 
-func validateDriverArgs(args map[string]string, req *models.VolumeRequest) error {
-	// volumestore name validation
-	req.Store = volumeStore(args)
-
+func normalizeDriverArgs(args map[string]string) error {
 	// normalize keys to lowercase & validate them
 	for k, val := range args {
 		lowercase := strings.ToLower(k)
@@ -320,6 +317,16 @@ func validateDriverArgs(args map[string]string, req *models.VolumeRequest) error
 			args[lowercase] = val
 		}
 	}
+	return nil
+}
+
+func validateDriverArgs(args map[string]string, req *models.VolumeRequest) error {
+	if err := normalizeDriverArgs(args); err != nil {
+		return err
+	}
+
+	// volumestore name validation
+	req.Store = volumeStore(args)
 
 	// capacity validation
 	capstr, ok := args[OptsCapacityKey]

--- a/lib/apiservers/engine/backends/volume.go
+++ b/lib/apiservers/engine/backends/volume.go
@@ -24,6 +24,7 @@ import (
 
 	"regexp"
 	"strconv"
+	"strings"
 
 	"github.com/docker/engine-api/types"
 	"github.com/docker/go-units"
@@ -36,8 +37,8 @@ import (
 
 // NOTE: FIXME: These might be moved to a utility package once there are multiple personalities
 const (
-	OptsVolumeStoreKey     string = "VolumeStore"
-	OptsCapacityKey        string = "Capacity"
+	OptsVolumeStoreKey     string = "volumestore"
+	OptsCapacityKey        string = "capacity"
 	dockerMetadataModelKey string = "DockerMetaData"
 )
 
@@ -263,6 +264,14 @@ func newVolumeCreateReq(name, driverName string, volumeData, labels map[string]s
 		return nil, fmt.Errorf("volume name %q includes invalid characters, only \"[a-zA-Z0-9][a-zA-Z0-9_.-]\" are allowed", name)
 	}
 
+	for k, val := range volumeData {
+		lowercase := strings.ToLower(k)
+		if strings.Compare(val, k) != 0 {
+			delete(volumeData, k)
+			volumeData[lowercase] = val
+		}
+
+	}
 	req := &models.VolumeRequest{
 		Driver:     driverName,
 		DriverArgs: volumeData,

--- a/lib/apiservers/engine/backends/volume.go
+++ b/lib/apiservers/engine/backends/volume.go
@@ -310,6 +310,7 @@ func normalizeDriverArgs(args map[string]string) error {
 
 		if !validDriverOptsKeys[lowercase] {
 			return fmt.Errorf("%s is not a supported option", k)
+
 		}
 
 		if strings.Compare(val, k) != 0 {

--- a/lib/apiservers/engine/backends/volume.go
+++ b/lib/apiservers/engine/backends/volume.go
@@ -310,7 +310,6 @@ func normalizeDriverArgs(args map[string]string) error {
 
 		if !validDriverOptsKeys[lowercase] {
 			return fmt.Errorf("%s is not a supported option", k)
-
 		}
 
 		if strings.Compare(val, k) != 0 {

--- a/lib/apiservers/engine/backends/volume_test.go
+++ b/lib/apiservers/engine/backends/volume_test.go
@@ -176,3 +176,19 @@ func TestExtractDockerMetadata(t *testing.T) {
 	assert.Equal(t, metaDataBefore.Name, metadataAfter.Name)
 	assert.Equal(t, metaDataBefore.Driver, metadataAfter.Driver)
 }
+
+func TestNormalizeDriverArgs(t *testing.T) {
+	testOptMap := make(map[string]string)
+	testOptMap["VOLUMESTORE"] = "foo"
+	testOptMap["CAPACITY"] = "bar"
+
+	normalizeDriverArgs(testOptMap)
+
+	assert.Equal(t, testOptMap["volumestore"], "foo")
+	assert.Equal(t, testOptMap["capacity"], "bar")
+
+	testOptMap["bogus"] = "bogus"
+
+	err := normalizeDriverArgs(testOptMap)
+	assert.NoError(t, err)
+}

--- a/lib/apiservers/engine/backends/volume_test.go
+++ b/lib/apiservers/engine/backends/volume_test.go
@@ -190,5 +190,5 @@ func TestNormalizeDriverArgs(t *testing.T) {
 	testOptMap["bogus"] = "bogus"
 
 	err := normalizeDriverArgs(testOptMap)
-	assert.NoError(t, err)
+	assert.Error(t, err, "expected: bogus is not a supported option")
 }

--- a/lib/apiservers/engine/backends/volume_test.go
+++ b/lib/apiservers/engine/backends/volume_test.go
@@ -45,17 +45,23 @@ func TestTranslatVolumeRequestModel(t *testing.T) {
 	testLabels["TestMeta"] = "custom info about my volume"
 
 	testDriverArgs := make(map[string]string)
-	testDriverArgs["testArg"] = "important driver stuff"
+	testDriverArgs["testarg"] = "important driver stuff"
 	testDriverArgs[OptsVolumeStoreKey] = "testStore"
 	testDriverArgs[OptsCapacityKey] = "12MB"
 
 	testRequest, err := newVolumeCreateReq("testName", "vsphere", testDriverArgs, testLabels)
+	if !assert.Error(t, err) {
+		return
+	}
+
+	delete(testDriverArgs, "testarg")
+	testRequest, err = newVolumeCreateReq("testName", "vsphere", testDriverArgs, testLabels)
 	if !assert.NoError(t, err) {
 		return
 	}
 
 	assert.Equal(t, "testName", testRequest.Name)
-	assert.Equal(t, "important driver stuff", testRequest.DriverArgs["testArg"])
+	assert.Equal(t, "", testRequest.DriverArgs["testarg"]) // unsupported keys should just be empty
 	assert.Equal(t, "testStore", testRequest.Store)
 	assert.Equal(t, "vsphere", testRequest.Driver)
 	assert.Equal(t, int64(12), testRequest.Capacity)

--- a/tests/test-cases/Group1-Docker-Commands/1-19-Docker-Volume-Create.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-19-Docker-Volume-Create.robot
@@ -69,11 +69,30 @@ Docker volume create with bad volumestore
     Should Be Equal As Integers  ${rc}  1
     Should Contain  ${output}  No volume store named (fakeStore) exists
 
-Docker volume create with specific capacity no units
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} volume create --name=test4 --opt Capacity=100000
+Docker volume create with bad driver options
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} volume create --name=test3 --opt bogus=foo
+    Should Be Equal As Integers  ${rc}  1
+    Should Contain  ${output}  bogus is not a supported option
+
+Docker volume create with mis-capitalized valid driver option
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} volume create --name=test4 --opt cAPACITy=10000
     Should Be Equal As Integers  ${rc}  0
     Should Be Equal As Strings  ${output}  test4
     Set Suite Variable  ${ContainerName}  capacityVolContainer
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run --name ${ContainerName} -d -v ${output}:/mydata busybox /bin/df -Ph
+    Should Be Equal As Integers  ${rc}  0
+    ${ContainerRC}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} wait ${ContainerName}
+    Should Be Equal As Integers  ${ContainerRC}  0
+    Should Not Contain  ${output}  Error response from daemon
+    ${rc}  ${disk-size}=  Run And Return Rc And Output  docker %{VCH-PARAMS} logs ${ContainerName} | grep by-label | awk '{print $2}'
+    Should Be Equal As Integers  ${rc}  0
+    Should Be Equal As Strings  ${disk-size}  9.5G
+
+Docker volume create with specific capacity no units
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} volume create --name=test5 --opt Capacity=100000
+    Should Be Equal As Integers  ${rc}  0
+    Should Be Equal As Strings  ${output}  test5
+    Set Suite Variable  ${ContainerName}  capacityVolContainer2
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run --name ${ContainerName} -d -v ${output}:/mydata busybox /bin/df -Ph
     Should Be Equal As Integers  ${rc}  0
     ${ContainerRC}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} wait ${ContainerName}


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[  ] There is an associated issue that is labelled
[  ] Code is up-to-date with the `master` branch
[  ] You've successfully run `make test` locally
[  ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/vmware/vic/blob/master/.github/CONTRIBUTING.md
-->

Fixes #3535 by adding case insensitivity to valid options and a whitelist to allow error reporting if an unsupported option is provided during `docker volume create` or `docker create -v ..`

<!--
To trigger a custom build with this PR, include one of these in the PR's title or commit messages:
* [skip ci]
* [full ci]
* [specific ci=$suitename] e.g. [specific ci=1-01-Docker-Info]
    With this option, running only one suite is supported.
-->
