### PR TITLE
vcsim: Add Portgroup creation to VPX Model

### DIFF
--- a/pkg/vsphere/simulator/datacenter.go
+++ b/pkg/vsphere/simulator/datacenter.go
@@ -15,8 +15,11 @@
 package simulator
 
 import (
+	"strings"
+
 	"github.com/vmware/govmomi/vim25/mo"
 	"github.com/vmware/govmomi/vim25/types"
+	"github.com/vmware/vic/pkg/vsphere/simulator/esx"
 )
 
 // Create Datacenter Folders.
@@ -47,17 +50,26 @@ func createDatacenterFolders(dc *mo.Datacenter, isVC bool) {
 			ref := e.Reference()
 			f.ref.Type = ref.Type
 			f.ref.Value = ref.Value
-
-			// Add VM Network by default to each Datacenter
-			if f.ref == &dc.NetworkFolder {
-				network := &mo.Network{}
-				network.Name = "VM Network"
-				folder.putChild(network)
-			}
 		} else {
 			folder.ChildType = f.types[:1]
 			folder.Self = *f.ref
 			Map.PutEntity(dc, folder)
 		}
+	}
+
+	net := Map.Get(dc.NetworkFolder).(*Folder)
+
+	for _, ref := range esx.Datacenter.Network {
+		// Add VM Network by default to each Datacenter
+		network := &mo.Network{}
+		network.Self = ref
+		network.Name = strings.Split(ref.Value, "-")[1]
+		network.Entity().Name = network.Name
+		if isVC {
+			network.Self.Value = "" // we want a different moid per-DC
+		}
+
+		net.putChild(network)
+		dc.Network = append(dc.Network, network.Reference())
 	}
 }

--- a/pkg/vsphere/simulator/dvs.go
+++ b/pkg/vsphere/simulator/dvs.go
@@ -28,6 +28,7 @@ type VmwareDistributedVirtualSwitch struct {
 func (s *VmwareDistributedVirtualSwitch) AddDVPortgroupTask(c *types.AddDVPortgroup_Task) soap.HasFault {
 	task := CreateTask(s, "addDVPortgroupTask", func(t *Task) (types.AnyType, types.BaseMethodFault) {
 		f := Map.getEntityParent(s, "Folder").(*Folder)
+		dc := Map.getEntityDatacenter(f)
 
 		for _, spec := range c.Spec {
 			pg := &mo.DistributedVirtualPortgroup{}
@@ -42,6 +43,19 @@ func (s *VmwareDistributedVirtualSwitch) AddDVPortgroupTask(c *types.AddDVPortgr
 			}
 
 			f.putChild(pg)
+
+			pg.Key = pg.Self.Value
+			pg.Config.DistributedVirtualSwitch = &s.Self
+
+			s.Portgroup = append(s.Portgroup, pg.Self)
+			s.Summary.PortgroupName = append(s.Summary.PortgroupName, pg.Name)
+
+			for _, h := range s.Summary.HostMember {
+				host := Map.Get(h).(*HostSystem)
+				host.Network = append(host.Network, pg.Reference())
+			}
+
+			dc.Network = append(dc.Network, pg.Reference())
 		}
 
 		return nil, nil
@@ -51,6 +65,54 @@ func (s *VmwareDistributedVirtualSwitch) AddDVPortgroupTask(c *types.AddDVPortgr
 
 	return &methods.AddDVPortgroup_TaskBody{
 		Res: &types.AddDVPortgroup_TaskResponse{
+			Returnval: task.Self,
+		},
+	}
+}
+
+func (s *VmwareDistributedVirtualSwitch) ReconfigureDvsTask(req *types.ReconfigureDvs_Task) soap.HasFault {
+	task := CreateTask(s, "reconfigureDvsTask", func(t *Task) (types.AnyType, types.BaseMethodFault) {
+		spec := req.Spec.GetDVSConfigSpec()
+
+		for _, member := range spec.Host {
+			h := Map.Get(member.Host)
+			if h == nil {
+				return nil, &types.ManagedObjectNotFound{Obj: member.Host}
+			}
+
+			host := h.(*HostSystem)
+
+			switch types.ConfigSpecOperation(member.Operation) {
+			case types.ConfigSpecOperationAdd:
+				if FindReference(host.Network, s.Self) != nil {
+					return nil, &types.AlreadyExists{Name: host.Name}
+				}
+
+				host.Network = append(host.Network, s.Self)
+				host.Network = append(host.Network, s.Portgroup...)
+				s.Summary.HostMember = append(s.Summary.HostMember, member.Host)
+			case types.ConfigSpecOperationRemove:
+				if pg := FindReference(host.Network, s.Portgroup...); pg != nil {
+					return nil, &types.ResourceInUse{
+						Type: pg.Type,
+						Name: pg.Value,
+					}
+				}
+
+				host.Network = RemoveReference(s.Self, host.Network)
+				s.Summary.HostMember = RemoveReference(s.Self, s.Summary.HostMember)
+			case types.ConfigSpecOperationEdit:
+				return nil, &types.NotSupported{}
+			}
+		}
+
+		return nil, nil
+	})
+
+	task.Run()
+
+	return &methods.ReconfigureDvs_TaskBody{
+		Res: &types.ReconfigureDvs_TaskResponse{
 			Returnval: task.Self,
 		},
 	}

--- a/pkg/vsphere/simulator/dvs_test.go
+++ b/pkg/vsphere/simulator/dvs_test.go
@@ -1,0 +1,179 @@
+// Copyright 2017 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package simulator
+
+import (
+	"context"
+	"testing"
+
+	"github.com/vmware/govmomi/find"
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/task"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+func TestDVS(t *testing.T) {
+	m := VPX()
+	m.Portgroup = 0 // disabled DVS creation
+
+	defer m.Remove()
+
+	err := m.Create()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx := context.Background()
+	c := m.Service.client
+
+	finder := find.NewFinder(c, false)
+	dc, _ := finder.DatacenterList(ctx, "*")
+	finder.SetDatacenter(dc[0])
+	folders, _ := dc[0].Folders(ctx)
+	hosts, _ := finder.HostSystemList(ctx, "*/*")
+
+	var spec types.DVSCreateSpec
+	spec.ConfigSpec = &types.VMwareDVSConfigSpec{}
+	spec.ConfigSpec.GetDVSConfigSpec().Name = "DVS0"
+
+	dtask, err := folders.NetworkFolder.CreateDVS(ctx, spec)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	info, err := dtask.WaitForResult(ctx, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dvs := object.NewDistributedVirtualSwitch(c, info.Result.(types.ManagedObjectReference))
+
+	config := &types.DVSConfigSpec{}
+
+	for _, host := range hosts {
+		config.Host = append(config.Host, types.DistributedVirtualSwitchHostMemberConfigSpec{
+			Operation: string(types.ConfigSpecOperationAdd),
+			Host:      host.Reference(),
+		})
+	}
+
+	// Add == OK
+	dtask, err = dvs.Reconfigure(ctx, config)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = dtask.Wait(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Add == fail (AlreadyExists)
+	dtask, err = dvs.Reconfigure(ctx, config)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = dtask.Wait(ctx)
+	if _, ok := err.(task.Error).Fault().(*types.AlreadyExists); !ok {
+		t.Fatalf("err=%v", err)
+	}
+
+	// Edit == fail (NotSupported)
+	for i := range config.Host {
+		config.Host[i].Operation = string(types.ConfigSpecOperationEdit)
+	}
+
+	dtask, err = dvs.Reconfigure(ctx, config)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = dtask.Wait(ctx)
+	if _, ok := err.(task.Error).Fault().(*types.NotSupported); !ok {
+		t.Fatalf("err=%v", err)
+	}
+
+	// Remove == OK
+	for i := range config.Host {
+		config.Host[i].Operation = string(types.ConfigSpecOperationRemove)
+	}
+
+	dtask, err = dvs.Reconfigure(ctx, config)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = dtask.Wait(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Add == OK
+	for i := range config.Host {
+		config.Host[i].Operation = string(types.ConfigSpecOperationAdd)
+	}
+
+	dtask, err = dvs.Reconfigure(ctx, config)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = dtask.Wait(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Add (PG) == OK
+	dtask, err = dvs.AddPortgroup(ctx, []types.DVPortgroupConfigSpec{{Name: "DVPG0"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = dtask.Wait(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Remove == fail (ResourceInUse)
+	for i := range config.Host {
+		config.Host[i].Operation = string(types.ConfigSpecOperationRemove)
+	}
+
+	dtask, err = dvs.Reconfigure(ctx, config)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = dtask.Wait(ctx)
+	if _, ok := err.(task.Error).Fault().(*types.ResourceInUse); !ok {
+		t.Fatalf("err=%v", err)
+	}
+
+	// Remove == fail (ManagedObjectNotFound)
+	for i := range config.Host {
+		config.Host[i].Host.Value = "enoent"
+	}
+
+	dtask, err = dvs.Reconfigure(ctx, config)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = dtask.Wait(ctx)
+	if _, ok := err.(task.Error).Fault().(*types.ManagedObjectNotFound); !ok {
+		t.Fatalf("err=%v", err)
+	}
+}

--- a/pkg/vsphere/simulator/esx/host_system.go
+++ b/pkg/vsphere/simulator/esx/host_system.go
@@ -1799,12 +1799,10 @@ var HostSystem = mo.HostSystem{
 		VsanInternalSystem:        &types.ManagedObjectReference{Type: "HostVsanInternalSystem", Value: "ha-vsan-internal-system"},
 		CertificateManager:        &types.ManagedObjectReference{Type: "HostCertificateManager", Value: "ha-certificate-manager"},
 	},
-	Config:    (*types.HostConfigInfo)(nil),
-	Vm:        nil,
-	Datastore: nil,
-	Network: []types.ManagedObjectReference{
-		{Type: "Network", Value: "HaNetwork-VM Network"},
-	},
+	Config:           (*types.HostConfigInfo)(nil),
+	Vm:               nil,
+	Datastore:        nil,
+	Network:          nil,
 	DatastoreBrowser: types.ManagedObjectReference{Type: "HostDatastoreBrowser", Value: "ha-host-datastorebrowser"},
 	SystemResources:  (*types.HostSystemResourceInfo)(nil),
 }

--- a/pkg/vsphere/simulator/esx/virtual_device.go
+++ b/pkg/vsphere/simulator/esx/virtual_device.go
@@ -201,6 +201,41 @@ var VirtualDevice = []types.BaseVirtualDevice{
 	},
 }
 
+// EthernetCard template for types.VirtualEthernetCard
+var EthernetCard = types.VirtualE1000{
+	VirtualEthernetCard: types.VirtualEthernetCard{
+		VirtualDevice: types.VirtualDevice{
+			DynamicData: types.DynamicData{},
+			Key:         4000,
+			Backing: &types.VirtualEthernetCardNetworkBackingInfo{
+				VirtualDeviceDeviceBackingInfo: types.VirtualDeviceDeviceBackingInfo{
+					VirtualDeviceBackingInfo: types.VirtualDeviceBackingInfo{},
+					DeviceName:               "VM Network",
+					UseAutoDetect:            types.NewBool(false),
+				},
+				Network:           (*types.ManagedObjectReference)(nil),
+				InPassthroughMode: types.NewBool(false),
+			},
+			Connectable: &types.VirtualDeviceConnectInfo{
+				DynamicData:       types.DynamicData{},
+				StartConnected:    true,
+				AllowGuestControl: true,
+				Connected:         false,
+				Status:            "untried",
+			},
+			SlotInfo: &types.VirtualDevicePciBusSlotInfo{
+				VirtualDeviceBusSlotInfo: types.VirtualDeviceBusSlotInfo{},
+				PciSlotNumber:            32,
+			},
+			ControllerKey: 100,
+			UnitNumber:    newInt32(7),
+		},
+		AddressType:      "generated",
+		MacAddress:       "",
+		WakeOnLanEnabled: types.NewBool(true),
+	},
+}
+
 func newInt32(n int32) *int32 {
 	return &n
 }

--- a/pkg/vsphere/simulator/folder_test.go
+++ b/pkg/vsphere/simulator/folder_test.go
@@ -497,8 +497,23 @@ func TestFolderCreateDVS(t *testing.T) {
 		t.Error(err)
 	}
 
-	if pg, ok := net.(*object.DistributedVirtualPortgroup); !ok {
+	pg, ok := net.(*object.DistributedVirtualPortgroup)
+	if !ok {
 		t.Fatalf("%T is not of type %T", net, pg)
+	}
+
+	backing, err := net.EthernetCardBackingInfo(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	info, ok := backing.(*types.VirtualEthernetCardDistributedVirtualPortBackingInfo)
+	if ok {
+		if info.Port.SwitchUuid == "" || info.Port.PortgroupKey == "" {
+			t.Errorf("invalid port: %#v", info.Port)
+		}
+	} else {
+		t.Fatalf("%T is not of type %T", net, info)
 	}
 
 	task, err = dvs.AddPortgroup(ctx, []types.DVPortgroupConfigSpec{pspec})

--- a/pkg/vsphere/simulator/host_system.go
+++ b/pkg/vsphere/simulator/host_system.go
@@ -15,7 +15,6 @@
 package simulator
 
 import (
-	"strings"
 	"time"
 
 	"github.com/vmware/govmomi/vim25/mo"
@@ -63,14 +62,6 @@ func CreateDefaultESX(f *Folder) {
 	f.putChild(dc)
 
 	host := NewHostSystem(esx.HostSystem)
-
-	for _, ref := range host.Network {
-		network := &mo.Network{}
-		network.Self = ref
-		network.Name = strings.Split(ref.Value, "-")[1]
-		network.Entity().Name = network.Name
-		Map.Get(dc.NetworkFolder).(*Folder).putChild(network)
-	}
 
 	cr := &mo.ComputeResource{}
 	cr.Self = *host.Parent

--- a/pkg/vsphere/simulator/model_test.go
+++ b/pkg/vsphere/simulator/model_test.go
@@ -27,6 +27,8 @@ func compareModel(t *testing.T, m *Model) {
 		switch ref.Type {
 		case "Datacenter":
 			count.Datacenter++
+		case "DistributedVirtualPortgroup":
+			count.Portgroup++
 		case "ClusterComputeResource":
 			count.Cluster++
 		case "Datastore":
@@ -52,6 +54,7 @@ func compareModel(t *testing.T, m *Model) {
 	}{
 		{m.Datacenter, count.Datacenter, "Datacenter"},
 		{m.Cluster * m.Datacenter, count.Cluster, "Cluster"},
+		{m.Portgroup * m.Datacenter, count.Portgroup, "Portgroup"},
 		{m.Datastore, count.Datastore, "Datastore"},
 		{hosts, count.ClusterHost, "Host"},
 		{vms, count.Machine, "VirtualMachine"},
@@ -87,6 +90,33 @@ func TestModelESX(t *testing.T) {
 }
 
 func TestModelVPX(t *testing.T) {
+	m := VPX()
+
+	defer m.Remove()
+
+	err := m.Create()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	compareModel(t, m)
+}
+
+func TestModelNoSwitchVPX(t *testing.T) {
+	m := VPX()
+	m.Portgroup = 0 // disabled DVS creation
+
+	defer m.Remove()
+
+	err := m.Create()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	compareModel(t, m)
+}
+
+func TestModelCustomVPX(t *testing.T) {
 	m := &Model{
 		ServiceContent: vc.ServiceContent,
 		RootFolder:     vc.RootFolder,
@@ -97,6 +127,7 @@ func TestModelVPX(t *testing.T) {
 		Datastore:      1,
 		Machine:        3,
 		Pool:           2,
+		Portgroup:      2,
 	}
 
 	defer m.Remove()

--- a/pkg/vsphere/simulator/property_collector.go
+++ b/pkg/vsphere/simulator/property_collector.go
@@ -189,11 +189,11 @@ func (rr *retrieveResult) collectAll(rval reflect.Value, rtype reflect.Type, con
 	for i := 0; i < rval.NumField(); i++ {
 		val := rval.Field(i)
 
-		if isEmpty(val) {
+		f := rtype.Field(i)
+
+		if isEmpty(val) || f.Name == "Self" {
 			continue
 		}
-
-		f := rtype.Field(i)
 
 		if f.Anonymous {
 			// recurse into embedded field

--- a/pkg/vsphere/simulator/registry.go
+++ b/pkg/vsphere/simulator/registry.go
@@ -166,6 +166,19 @@ func (r *Registry) FindByName(name string, refs []types.ManagedObjectReference) 
 	return nil
 }
 
+// FindReference returns the 1st match found in refs, or nil if not found.
+func FindReference(refs []types.ManagedObjectReference, match ...types.ManagedObjectReference) *types.ManagedObjectReference {
+	for _, ref := range refs {
+		for _, m := range match {
+			if ref == m {
+				return &ref
+			}
+		}
+	}
+
+	return nil
+}
+
 // RemoveReference returns a slice with ref removed from refs
 func RemoveReference(ref types.ManagedObjectReference, refs []types.ManagedObjectReference) []types.ManagedObjectReference {
 	var result []types.ManagedObjectReference

--- a/pkg/vsphere/simulator/virtual_machine_test.go
+++ b/pkg/vsphere/simulator/virtual_machine_test.go
@@ -24,7 +24,9 @@ import (
 	"github.com/vmware/govmomi/find"
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/property"
+	"github.com/vmware/govmomi/task"
 	"github.com/vmware/govmomi/vim25/types"
+	"github.com/vmware/vic/pkg/vsphere/simulator/esx"
 )
 
 func TestCreateVm(t *testing.T) {
@@ -234,5 +236,87 @@ func TestCreateVm(t *testing.T) {
 		if err == nil {
 			t.Error("expected error")
 		}
+	}
+}
+
+func TestReconfigVm(t *testing.T) {
+	ctx := context.Background()
+
+	m := ESX()
+	defer m.Remove()
+	err := m.Create()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	s := m.Service.NewServer()
+	defer s.Close()
+
+	c, err := govmomi.NewClient(ctx, s.URL, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	finder := find.NewFinder(c.Client, false)
+	finder.SetDatacenter(object.NewDatacenter(c.Client, esx.Datacenter.Reference()))
+
+	vms, err := finder.VirtualMachineList(ctx, "*")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	vm := vms[0]
+	device, err := vm.Device(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// verify default device list
+	_, err = device.FindIDEController("")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// VM should have the default list of devices + 1 NIC created by the Model
+	if len(device) != len(esx.VirtualDevice)+1 {
+		t.Error("device list mismatch")
+	}
+
+	d := device.FindByKey(esx.EthernetCard.Key)
+
+	err = vm.AddDevice(ctx, d)
+	if _, ok := err.(task.Error).Fault().(*types.InvalidDeviceSpec); !ok {
+		t.Fatalf("err=%v", err)
+	}
+
+	err = vm.RemoveDevice(ctx, false, d)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	device, err = vm.Device(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(device) != len(esx.VirtualDevice) {
+		t.Error("device list mismatch")
+	}
+
+	// cover the path where the simulator assigns a UnitNumber
+	d.GetVirtualDevice().UnitNumber = nil
+
+	err = vm.AddDevice(ctx, d)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	device, err = vm.Device(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(device) != len(esx.VirtualDevice)+1 {
+		t.Error("device list mismatch")
 	}
 }


### PR DESCRIPTION
- Add ReconfigureDvs_Task support

- Add ReconfigVM_Task support

- Return moref in Folder.CreateDVSTask

- Add a nic to VMs by default in Model.Create

- Add default VM device description

- Filter 'Self' field in property collector

Issue #1859
