### PR TITLE
[skip ci] Resolve VIC binary paths in vicui-common.robot

### DIFF
--- a/tests/manual-test-cases/Group18-VIC-UI/vicui-common.robot
+++ b/tests/manual-test-cases/Group18-VIC-UI/vicui-common.robot
@@ -32,7 +32,7 @@ Load Nimbus Testbed Env
     Set Suite Variable  ${TEST_VC_PASSWORD}  %{TEST_PASSWORD}
 
 Install VIC Appliance For VIC UI
-    [Arguments]  ${vic-machine}=bin/vic-machine-linux  ${appliance-iso}=bin/appliance.iso  ${bootstrap-iso}=bin/bootstrap.iso  ${certs}=${true}  ${vol}=default
+    [Arguments]  ${vic-machine}=ui-nightly-run-bin/vic-machine-linux  ${appliance-iso}=ui-nightly-run-bin/appliance.iso  ${bootstrap-iso}=ui-nightly-run-bin/bootstrap.iso  ${certs}=${true}  ${vol}=default
     Set Test Environment Variables
     # disable firewall
     Run Keyword If  '%{HOST_TYPE}' == 'ESXi'  Run  govc host.esxcli network firewall set -e false
@@ -128,7 +128,7 @@ Cleanup Installer Environment
 
 Delete VIC Machine
     [Tags]  secret
-    [Arguments]  ${vch-name}  ${vic-machine}=bin/vic-machine-linux
+    [Arguments]  ${vch-name}  ${vic-machine}=ui-nightly-run-bin/vic-machine-linux
     ${rc}  ${output}=  Run And Return Rc And Output  ${vic-machine} delete --name=${vch-name} --target=%{TEST_URL}%{TEST_DATACENTER} --user=%{TEST_USERNAME} --password=%{TEST_PASSWORD} --force=true --compute-resource=%{TEST_RESOURCE} --timeout %{TEST_TIMEOUT}
     [Return]  ${rc}  ${output}
 


### PR DESCRIPTION
This PR resolves paths to some binary/ISO paths in `vicui-common.robot` which no longer are valid after deciding that the UI nightly tests will be launched in a separate cron job. @rajanashok Please note that I have updated the UI test kickoff script such that the VIC tar ball will be extracted under $VIC_ROOT/ui-nightly-run-bin.