### PR TITLE
[full ci]Do not remove container if it's fixing

### DIFF
--- a/lib/portlayer/event/collector/vsphere/collector.go
+++ b/lib/portlayer/event/collector/vsphere/collector.go
@@ -1,4 +1,4 @@
-// Copyright 2016 VMware, Inc. All Rights Reserved.
+// Copyright 2016-2017 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -166,7 +166,6 @@ func evented(ec *EventCollector, page []types.BaseEvent) {
 			*types.VmPoweredOffEvent,
 			*types.VmRemovedEvent,
 			*types.VmSuspendedEvent,
-			*types.VmRegisteredEvent,
 			*types.VmMigratedEvent,
 			*types.DrsVmMigratedEvent,
 			*types.VmRelocatedEvent:

--- a/lib/portlayer/event/collector/vsphere/vm_event.go
+++ b/lib/portlayer/event/collector/vsphere/vm_event.go
@@ -1,4 +1,4 @@
-// Copyright 2016 VMware, Inc. All Rights Reserved.
+// Copyright 2016-2017 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -39,8 +39,6 @@ func NewVMEvent(be types.BaseEvent) *VMEvent {
 		ee = events.ContainerRemoved
 	case *types.VmGuestShutdownEvent:
 		ee = events.ContainerShutdown
-	case *types.VmRegisteredEvent:
-		ee = events.ContainerRegistered
 	case *types.VmMigratedEvent:
 		ee = events.ContainerMigrated
 	case *types.DrsVmMigratedEvent:

--- a/lib/portlayer/event/events/container_event.go
+++ b/lib/portlayer/event/events/container_event.go
@@ -1,4 +1,4 @@
-// Copyright 2016 VMware, Inc. All Rights Reserved.
+// Copyright 2016-2017 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -25,7 +25,6 @@ const (
 	ContainerReconfigured  = "Reconfigured"
 	ContainerStarted       = "Started"
 	ContainerStopped       = "Stopped"
-	ContainerRegistered    = "Registered"
 	ContainerMigrated      = "Migrated"
 	ContainerMigratedByDrs = "MigratedByDrs"
 	ContainerRelocated     = "Relocated"

--- a/lib/portlayer/exec/exec.go
+++ b/lib/portlayer/exec/exec.go
@@ -162,13 +162,10 @@ func eventCallback(ie events.Event) {
 				}()
 			case StateRemoved:
 				log.Debugf("Container(%s) %s via event activity", container, newState)
-				if container.vm != nil {
-					isFixing := container.vm.Fixing.Load()
-					if isFixing != nil && isFixing.(bool) {
-						// is fixing vm, which will be registered back soon, so do not remove from containers cache
-						log.Debugf("Container(%s) %s is being fixed", container.ExecConfig.ID)
-						break
-					}
+				if container.vm != nil && container.vm.IsFixing() {
+					// is fixing vm, which will be registered back soon, so do not remove from containers cache
+					log.Debugf("Container(%s) %s is being fixed", container.ExecConfig.ID)
+					break
 				}
 				Containers.Remove(container.ExecConfig.ID)
 				publishContainerEvent(container.ExecConfig.ID, ie.Created(), ie.String())

--- a/lib/portlayer/exec/exec.go
+++ b/lib/portlayer/exec/exec.go
@@ -167,7 +167,6 @@ func eventCallback(ie events.Event) {
 					if isFixing != nil && isFixing.(bool) {
 						// is fixing vm, which will be registered back soon, so do not remove from containers cache
 						log.Debugf("Container(%s) %s is being fixed", container.ExecConfig.ID)
-						container.vm.Fixing.Store(false)
 						break
 					}
 				}

--- a/lib/portlayer/exec/exec.go
+++ b/lib/portlayer/exec/exec.go
@@ -1,4 +1,4 @@
-// Copyright 2016 VMware, Inc. All Rights Reserved.
+// Copyright 2016-2017 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -25,7 +25,6 @@ import (
 
 	"github.com/vmware/govmomi/find"
 	"github.com/vmware/govmomi/object"
-	"github.com/vmware/govmomi/vim25/mo"
 	"github.com/vmware/govmomi/vim25/types"
 	"github.com/vmware/vic/lib/portlayer/event"
 	"github.com/vmware/vic/lib/portlayer/event/collector/vsphere"
@@ -107,12 +106,6 @@ func Init(ctx context.Context, sess *session.Session, source extraconfig.DataSou
 		)
 		// subscribe the exec layer to the event stream for Vm events
 		Config.EventManager.Subscribe(events.NewEventType(vsphere.VMEvent{}).Topic(), "exec", eventCallback)
-		// subscribe callback to handle vm registered event
-		Config.EventManager.Subscribe(events.NewEventType(vsphere.VMEvent{}).Topic(), "registeredVMEvent",
-			func(ie events.Event) {
-				registeredVMCallback(sess, ie)
-			},
-		)
 
 		// instantiate the container cache now
 		NewContainerCache()
@@ -169,6 +162,15 @@ func eventCallback(ie events.Event) {
 				}()
 			case StateRemoved:
 				log.Debugf("Container(%s) %s via event activity", container, newState)
+				if container.vm != nil {
+					isFixing := container.vm.Fixing.Load()
+					if isFixing != nil && isFixing.(bool) {
+						// is fixing vm, which will be registered back soon, so do not remove from containers cache
+						log.Debugf("Container(%s) %s is being fixed", container.ExecConfig.ID)
+						container.vm.Fixing.Store(false)
+						break
+					}
+				}
 				Containers.Remove(container.ExecConfig.ID)
 				publishContainerEvent(container.ExecConfig.ID, ie.Created(), ie.String())
 			}
@@ -280,60 +282,6 @@ func hostEventCallback(ctx context.Context, ie events.Event) {
 		}
 
 	}
-}
-
-// registeredVMCallback will process registeredVMEvent
-func registeredVMCallback(sess *session.Session, ie events.Event) {
-	// check container registered event if this container is not found in container cache
-	// grab the container from the cache
-	container := Containers.Container(ie.Reference())
-	if container != nil {
-		// if container exists, ingore it
-		return
-	}
-	switch ie.String() {
-	case events.ContainerRegistered:
-		moref := new(types.ManagedObjectReference)
-		if ok := moref.FromString(ie.Reference()); !ok {
-			log.Errorf("Failed to get event VM mobref: %s", ie.Reference())
-			return
-		}
-		if !isManagedbyVCH(sess, *moref) {
-			return
-		}
-		log.Debugf("Register container VM %s", moref)
-		ctx := context.Background()
-		vms, err := populateVMAttributes(ctx, sess, []types.ManagedObjectReference{*moref})
-		if err != nil {
-			log.Error(err)
-			return
-		}
-		registeredContainers := convertInfraContainers(ctx, sess, vms)
-		for i := range registeredContainers {
-			Containers.put(registeredContainers[i])
-			log.Debugf("Registered container %q", registeredContainers[i].Config.Name)
-		}
-	}
-	return
-}
-
-func isManagedbyVCH(sess *session.Session, moref types.ManagedObjectReference) bool {
-	var vm mo.VirtualMachine
-
-	// current attributes we care about
-	attrib := []string{"resourcePool", "config.name"}
-
-	// populate the vm properties
-	ctx := context.Background()
-	if err := sess.RetrieveOne(ctx, moref, attrib, &vm); err != nil {
-		log.Errorf("Failed to query registered vm object %s: %s", moref.String(), err)
-		return false
-	}
-	if *vm.ResourcePool != Config.ResourcePool.Reference() {
-		log.Debugf("container vm %q does not belong to this VCH, ignoring", vm.Config.Name)
-		return false
-	}
-	return true
 }
 
 // eventedState will determine the target container

--- a/lib/portlayer/exec/exec_test.go
+++ b/lib/portlayer/exec/exec_test.go
@@ -105,12 +105,12 @@ func TestVMRemovedEventCallback(t *testing.T) {
 	assert.True(t, Containers.Container(id) == nil, "Container should be removed")
 
 	Containers.put(container)
-	container.vm.Fixing.Store(true)
+	container.vm.EnterFixingState()
 	publishContainerEvent(id, time.Now().UTC(), events.ContainerRemoved)
 	time.Sleep(time.Millisecond * 30)
 	assert.True(t, Containers.Container(id) != nil, "Container should not be removed in fixing status")
 
-	container.vm.Fixing.Store(false)
+	container.vm.LeaveFixingState()
 	publishContainerEvent(id, time.Now().UTC(), events.ContainerRemoved)
 	time.Sleep(time.Millisecond * 30)
 	assert.True(t, Containers.Container(id) == nil, "Container should be removed if not in fixing status")

--- a/lib/portlayer/exec/exec_test.go
+++ b/lib/portlayer/exec/exec_test.go
@@ -1,4 +1,4 @@
-// Copyright 2016 VMware, Inc. All Rights Reserved.
+// Copyright 2016-2017 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -80,4 +80,39 @@ func TestPublishContainerEvent(t *testing.T) {
 
 func containerCallback(ee events.Event) {
 	containerEvents = append(containerEvents, ee)
+}
+
+func TestVMRemovedEventCallback(t *testing.T) {
+
+	NewContainerCache()
+	containerEvents = make([]events.Event, 0)
+	Config = Configuration{}
+
+	mgr := event.NewEventManager()
+	Config.EventManager = mgr
+	// subscribe the exec layer to the event stream for Vm events
+	mgr.Subscribe(events.NewEventType(events.ContainerEvent{}).Topic(), "testing", eventCallback)
+
+	// create new running container and place in cache
+	id := "123439"
+	container := newTestContainer(id)
+	addTestVM(container)
+	container.SetState(StateRunning)
+	Containers.Put(container)
+
+	publishContainerEvent(id, time.Now().UTC(), events.ContainerRemoved)
+	time.Sleep(time.Millisecond * 30)
+	assert.True(t, Containers.Container(id) == nil, "Container should be removed")
+
+	Containers.put(container)
+	container.vm.Fixing.Store(true)
+	publishContainerEvent(id, time.Now().UTC(), events.ContainerRemoved)
+	time.Sleep(time.Millisecond * 30)
+	assert.True(t, Containers.Container(id) != nil, "Container should not be removed in fixing status")
+
+	container.vm.Fixing.Store(false)
+	publishContainerEvent(id, time.Now().UTC(), events.ContainerRemoved)
+	time.Sleep(time.Millisecond * 30)
+	assert.True(t, Containers.Container(id) == nil, "Container should be removed if not in fixing status")
+
 }

--- a/pkg/vsphere/vm/vm.go
+++ b/pkg/vsphere/vm/vm.go
@@ -55,7 +55,7 @@ type VirtualMachine struct {
 	*session.Session
 
 	// Fixing is true means the VM will be unregistered and registered back.
-	Fixing atomic.Value
+	Fixing *atomic.Value
 }
 
 // NewVirtualMachine returns a NewVirtualMachine object
@@ -67,6 +67,7 @@ func NewVirtualMachineFromVM(ctx context.Context, session *session.Session, vm *
 	return &VirtualMachine{
 		VirtualMachine: vm,
 		Session:        session,
+		Fixing:         &atomic.Value{},
 	}
 }
 

--- a/pkg/vsphere/vm/vm.go
+++ b/pkg/vsphere/vm/vm.go
@@ -1,4 +1,4 @@
-// Copyright 2016 VMware, Inc. All Rights Reserved.
+// Copyright 2016-2017 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ import (
 	"net/url"
 	"path"
 	"strings"
+	"sync/atomic"
 
 	log "github.com/Sirupsen/logrus"
 
@@ -52,6 +53,9 @@ type VirtualMachine struct {
 	*object.VirtualMachine
 
 	*session.Session
+
+	// Fixing is true means the VM will be unregistered and registered back.
+	Fixing atomic.Value
 }
 
 // NewVirtualMachine returns a NewVirtualMachine object
@@ -484,6 +488,7 @@ func (vm *VirtualMachine) fixVM(ctx context.Context) error {
 
 	name := mvm.Summary.Config.Name
 	log.Debugf("Unregister VM %s", name)
+	vm.Fixing.Store(true)
 	if err := vm.Unregister(ctx); err != nil {
 		log.Errorf("Unable to unregister vm %q: %s", name, err)
 		return err

--- a/pkg/vsphere/vm/vm.go
+++ b/pkg/vsphere/vm/vm.go
@@ -490,6 +490,8 @@ func (vm *VirtualMachine) fixVM(ctx context.Context) error {
 	name := mvm.Summary.Config.Name
 	log.Debugf("Unregister VM %s", name)
 	vm.Fixing.Store(true)
+	defer vm.Fixing.Store(false)
+
 	if err := vm.Unregister(ctx); err != nil {
 		log.Errorf("Unable to unregister vm %q: %s", name, err)
 		return err

--- a/pkg/vsphere/vm/vm_test.go
+++ b/pkg/vsphere/vm/vm_test.go
@@ -448,6 +448,20 @@ func TestBfsSnapshotTree(t *testing.T) {
 }
 
 // TestProperties test vm.properties happy path and fix vm path
+func TestIsFixing(t *testing.T) {
+	mo := types.ManagedObjectReference{Type: "vm", Value: "12"}
+	v := object.NewVirtualMachine(nil, mo)
+	vm := NewVirtualMachineFromVM(nil, nil, v)
+	assert.False(t, vm.IsFixing(), "new vm should not in fixing status")
+	vm.EnterFixingState()
+	assert.True(t, vm.IsFixing(), "vm should be in fixing status")
+	vm.EnterFixingState()
+	assert.True(t, vm.IsFixing(), "vm should be in fixing status")
+	vm.LeaveFixingState()
+	assert.False(t, vm.IsFixing(), "vm should not be in fixing status")
+}
+
+// TestProperties test vm.properties happy path and fix vm path
 func TestProperties(t *testing.T) {
 	ctx := context.Background()
 


### PR DESCRIPTION
@hickeng agree to drop the error handler solution in PR #3478 for the benefit of that solution for vmomit gateway is not clear yet, but will introduce much more error to manage handlers from everywhere.
And the issue of invalid state VM is not easy to be avoided even we didn't have non-persistent guestinfo values.

This PR is the easiest solution so far to workaround the problem.
fix #3196 