### PR TITLE
Skip logging header for Entry lines with embedded CRs

### DIFF
--- a/pkg/log/text_formatter.go
+++ b/pkg/log/text_formatter.go
@@ -55,22 +55,7 @@ func (f *TextFormatter) Format(entry *logrus.Entry) ([]byte, error) {
 	t := f.timeStamp(entry)
 	l := levelToString(entry.Level)
 
-	var buf []byte
-	switch {
-	case entry.Message == "":
-		buf = []byte(t + " " + l + "\n")
-
-	case entry.Message[0] == '\n':
-		buf = []byte(t + " " + l + " " + entry.Message[1:])
-
-	case entry.Message[len(entry.Message)-1] == '\n':
-		buf = []byte(t + " " + l + " " + entry.Message)
-
-	default:
-		buf = []byte(t + " " + l + " " + entry.Message + "\n")
-	}
-
-	return buf, nil
+	return []byte(t + " " + l + " " + entry.Message + "\n"), nil
 }
 
 func (f *TextFormatter) timeStamp(entry *logrus.Entry) string {

--- a/pkg/log/text_formatter_test.go
+++ b/pkg/log/text_formatter_test.go
@@ -99,24 +99,21 @@ func TestFormatNonEmpty(t *testing.T) {
 		{
 			"\nfoo\n",
 			[]string{
-				pre,
 				pre + "foo",
-				pre,
 			},
 		},
 		{
 			"foo\n",
 			[]string{
 				pre + "foo",
-				pre,
 			},
 		},
 		{
 			"foo \nbar\n baz ",
 			[]string{
 				pre + "foo ",
-				pre + "bar",
-				pre + " baz ",
+				"bar",
+				" baz ",
 			},
 		},
 	}

--- a/pkg/log/text_formatter_test.go
+++ b/pkg/log/text_formatter_test.go
@@ -57,7 +57,7 @@ func TestFormatEmpty(t *testing.T) {
 
 	b, err := f.Format(e)
 	assert.NoError(t, err)
-	assert.Equal(t, fmt.Sprintf("%s %s\n", ti.Format(f.TimestampFormat), levelToString(e.Level)), string(b))
+	assert.Equal(t, fmt.Sprintf("%s %s \n", ti.Format(f.TimestampFormat), levelToString(e.Level)), string(b))
 }
 
 func TestFormatNonEmpty(t *testing.T) {
@@ -86,26 +86,29 @@ func TestFormatNonEmpty(t *testing.T) {
 			"\n",
 			[]string{
 				pre,
-				pre,
+				"",
 			},
 		},
 		{
 			"foo\n",
 			[]string{
 				pre + "foo",
-				pre,
+				"",
 			},
 		},
 		{
 			"\nfoo\n",
 			[]string{
-				pre + "foo",
+				pre + "",
+				"foo",
+				"",
 			},
 		},
 		{
 			"foo\n",
 			[]string{
 				pre + "foo",
+				"",
 			},
 		},
 		{
@@ -118,15 +121,15 @@ func TestFormatNonEmpty(t *testing.T) {
 		},
 	}
 
-	for _, te := range tests {
+	for idx, te := range tests {
 		e.Message = te.in
 		b, err = f.Format(e)
 		assert.NoError(t, err)
 		s := bufio.NewScanner(strings.NewReader(string(b)))
 		i := 0
 		for s.Scan() {
-			assert.True(t, i < len(te.out))
-			assert.Equal(t, te.out[i], s.Text())
+			assert.True(t, i < len(te.out), "case %d", idx)
+			assert.Equal(t, te.out[i], s.Text(), "case %d", idx)
 			i++
 		}
 	}


### PR DESCRIPTION
We don't need a header for each line in a log entry lines with embedded carriage returns.  Print the header once for each entry.

Before
```
BenchmarkFormatNonEmpty-4   	  500000	      2056 ns/op	    4512 B/op	       7 allocs/op
BenchmarkFormatEmpty-4   	 3000000	       494 ns/op	     128 B/op	       3 allocs/op
```

After 
```
BenchmarkFormatNonEmpty-4   	 3000000	       597 ns/op	     224 B/op	       3 allocs/op
BenchmarkFormatEmpty-4      	 3000000	       515 ns/op	     128 B/op	       3 allocs/op
```