### PR TITLE
No longer return error from poweroff when VM is already powering down

### DIFF
--- a/lib/portlayer/exec/base.go
+++ b/lib/portlayer/exec/base.go
@@ -302,9 +302,12 @@ func (c *containerBase) poweroff(ctx context.Context) error {
 			case *types.GenericVmConfigFault:
 
 				// Check if the poweroff task was canceled due to a concurrent guest shutdown
-				if len(terr.FaultMessage) > 0 && terr.FaultMessage[0].Key == vmNotSuspendedKey {
-					log.Infof("power off %s task skipped due to guest shutdown", c.ExecConfig.ID)
-					return nil
+				if len(terr.FaultMessage) > 0 {
+					k := terr.FaultMessage[0].Key
+					if k == vmNotSuspendedKey || k == vmPoweringOffKey {
+						log.Infof("power off %s task skipped due to guest shutdown", c.ExecConfig.ID)
+						return nil
+					}
 				}
 				log.Warnf("generic vm config fault during power off: %#v", terr)
 

--- a/lib/portlayer/exec/container.go
+++ b/lib/portlayer/exec/container.go
@@ -57,6 +57,7 @@ const (
 	containerLogName         = "output.log"
 
 	vmNotSuspendedKey = "msg.suspend.powerOff.notsuspended"
+	vmPoweringOffKey  = "msg.rpc.error.poweringoff"
 )
 
 func (s State) String() string {

--- a/tests/test-cases/Group1-Docker-Commands/1-05-Docker-Start.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-05-Docker-Start.robot
@@ -63,7 +63,7 @@ Serially start 5 long running containers
     Should Be Equal As Integers  ${rc}  0
     Should Not Contain  ${output}  Error
     :FOR  ${idx}  IN RANGE  0  5
-    \   ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} create busybox /bin/top
+    \   ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} create -t busybox /bin/top
     \   Should Be Equal As Integers  ${rc}  0
     \   Should Not Contain  ${output}  Error:
     \   ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} start ${output}
@@ -72,7 +72,7 @@ Serially start 5 long running containers
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} ps -aq | xargs -n1 docker %{VCH-PARAMS} rm -f
     Should Be Equal As Integers  ${rc}  0
     Should Not Contain  ${output}  Error
-    
+
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} pull ubuntu
     Should Be Equal As Integers  ${rc}  0
     Should Not Contain  ${output}  Error


### PR DESCRIPTION
This change prevents `stop` from returning an error during a power off retry on an already stopping container. This fixes a small edge case where stop fails and the powered/powering off container state gets reset to `Running`, preventing `ContainerRm` from removing a container, even if `-f` is supplied. This also fixes a test that erroneously creates `/bin/top` containers without supplying `-t` (related: #3728).

Fixes #3718 

Requesting feedback on this approach from @sflxn, @hmahmood, @anchal-agrawal 