### PR TITLE
Cleanup port bindings for containers that poweroff OOB and are rm'd

### DIFF
--- a/lib/apiservers/engine/backends/container.go
+++ b/lib/apiservers/engine/backends/container.go
@@ -473,7 +473,7 @@ func (c *Container) cleanupPortBindings(vc *viccontainer.VicContainer) error {
 			if cc == nil {
 				// The container was removed from the cache and
 				// port bindings were cleaned up by another operation.
-				return nil
+				continue
 			}
 			running, err := c.containerProxy.IsRunning(cc)
 			if err != nil {

--- a/tests/test-cases/Group1-Docker-Commands/1-25-Docker-Port-Map.md
+++ b/tests/test-cases/Group1-Docker-Commands/1-25-Docker-Port-Map.md
@@ -69,8 +69,7 @@ This test requires that a vSphere server is running and available
 5. Issue `q` to the container
 
 ### Expected Outcome:
-* All steps should return without without error
-
+* All steps should return without error
 
 ## Remap mapped ports after OOB Stop
 1. Deploy VIC appliance to vSphere server
@@ -81,7 +80,19 @@ This test requires that a vSphere server is running and available
 6. Issue `docker start <containerID>` to the VIC appliance
 
 ### Expected Outcome:
-* All steps should return without without error
+* All steps should return without error
+
+
+## Remap mapped ports after OOB Stop and Remove
+1. Issue `docker run -itd -p 5001:80 --name nginx1 nginx`
+2. Hit Nginx Endpoint at VCH-IP:5001
+3. Power off the container with govc
+4. Issue `docker rm nginx1`
+5. Issue `docker run -itd -p 5001:80 --name nginx2 nginx`
+6. Hit Nginx Endpoint at VCH-IP:5001
+
+### Expected Outcome:
+* All steps should return without error
 
 
 ## Container to container traffic via VCH public interface
@@ -94,4 +105,4 @@ This test requires that a vSphere server is running and available
 8. Verify the contents of `index.html`
 
 ### Expected Outcome:
-* All steps should return without without error
+* All steps should return without error

--- a/tests/test-cases/Group1-Docker-Commands/1-25-Docker-Port-Map.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-25-Docker-Port-Map.robot
@@ -121,6 +121,24 @@ Remap mapped ports after OOB Stop
     Should Be Equal As Integers  ${rc}  0
     Should Not Contain  ${output}  Error
 
+Remap mapped ports after OOB Stop and Remove
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} rm -f $(docker %{VCH-PARAMS} ps -aq)
+
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -itd -p 5001:80 --name nginx1 nginx
+    Should Be Equal As Integers  ${rc}  0
+    Should Not Contain  ${output}  Error
+    Wait Until Keyword Succeeds  20x  5 seconds  Hit Nginx Endpoint  %{VCH-IP}  5001
+
+    Power Off VM OOB  nginx1*
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} rm nginx1
+    Should Be Equal As Integers  ${rc}  0
+    Should Not Contain  ${output}  Error
+
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -itd -p 5001:80 --name nginx2 nginx
+    Should Be Equal As Integers  ${rc}  0
+    Should Not Contain  ${output}  Error
+    Wait Until Keyword Succeeds  20x  5 seconds  Hit Nginx Endpoint  %{VCH-IP}  5001
+
 Container to container traffic via VCH public interface
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} rm -f $(docker %{VCH-PARAMS} ps -aq)
 


### PR DESCRIPTION
Unmaps ports for containers that power off out-of-band and are then removed. This resolves the failure where a new container with the same mappings would report that the port is unavailable and fail to start.

Also fixes a race between container start and remove, and adds an integration test.

Fixes #3465
