### PR TITLE
[specific ci=6-07-Create-Network] Validate bridge network range

### DIFF
--- a/lib/install/validate/network.go
+++ b/lib/install/validate/network.go
@@ -445,6 +445,9 @@ func (v *Validator) generateBridgeName(ctx, input *data.Data, conf *config.Virtu
 // checkBridgeIPRange verifies that the bridge network pool is large enough
 // port layer currently defaults to /16 for bridge network so pool must be >= /16
 func (v *Validator) checkBridgeIPRange(bridgeIPRange *net.IPNet) error {
+	if bridgeIPRange == nil {
+		return nil
+	}
 	ones, _ := bridgeIPRange.Mask.Size()
 	if ones > 16 {
 		return fmt.Errorf("Specified bridge network range is not large enough for the default bridge network size. --bridge-network-range must be /16 or larger network.")

--- a/lib/install/validate/network.go
+++ b/lib/install/validate/network.go
@@ -321,6 +321,12 @@ func (v *Validator) network(ctx context.Context, input *data.Data, conf *config.
 	// we also need to have the appliance attached to the bridge network to allow
 	// port forwarding
 	conf.AddNetwork(bridgeNet)
+
+	// make sure that the bridge IP pool is large enough for bridge networks
+	err = v.checkBridgeIPRange(input.BridgeIPRange)
+	if err != nil {
+		v.NoteIssue(err)
+	}
 	conf.BridgeIPRange = input.BridgeIPRange
 
 	log.Debug("Network configuration:")
@@ -434,6 +440,16 @@ func (v *Validator) generateBridgeName(ctx, input *data.Data, conf *config.Virtu
 	defer trace.End(trace.Begin(""))
 
 	return input.DisplayName
+}
+
+// checkBridgeIPRange verifies that the bridge network pool is large enough
+// port layer currently defaults to /16 for bridge network so pool must be >= /16
+func (v *Validator) checkBridgeIPRange(bridgeIPRange *net.IPNet) error {
+	ones, _ := bridgeIPRange.Mask.Size()
+	if ones > 16 {
+		return fmt.Errorf("Specified bridge network range is not large enough for the default bridge network size. --bridge-network-range must be /16 or larger network.")
+	}
+	return nil
 }
 
 // getNetwork gets a moref based on the network name

--- a/tests/test-cases/Group6-VIC-Machine/6-07-Create-Network.md
+++ b/tests/test-cases/Group6-VIC-Machine/6-07-Create-Network.md
@@ -100,10 +100,14 @@ This test requires that a vSphere server is running and available
 
 ## Bridge network - invalid IP settings
 1. Create with bridge network correctly set
-2. Set bridge network ip range with wrong format
+2. Set bridge network IP range with wrong format
 3. Verify create failed with user-friendly error message
 
-## Bridge network - valid
+## Bridge network - invalid bridge network range
+1. Create with bridge network IP range smaller than /16
+2. Verify create failed with user-friendly error message
+
+## Bridge network - valid with IP range
 1. Create with bridge network correctly set
 2. Set bridge network ip range correctly
 3. Verify create passed

--- a/tests/test-cases/Group6-VIC-Machine/6-07-Create-Network.robot
+++ b/tests/test-cases/Group6-VIC-Machine/6-07-Create-Network.robot
@@ -42,7 +42,7 @@ Public network - DHCP
     Pass execution  Test not implemented
 
 Public network - valid
-    Pass execution  asdf
+    Pass execution  Test not implemented
 
 Management network - none
     Set Test Environment Variables
@@ -195,7 +195,19 @@ Bridge network - invalid IP settings
     # Delete the portgroup added by env vars keyword
     Cleanup VCH Bridge Network  %{VCH-NAME}
 
-Bridge network - valid
+Bridge network - invalid bridge network range
+    Set Test Environment Variables
+    # Attempt to cleanup old/canceled tests
+    Run Keyword And Ignore Error  Cleanup Dangling VMs On Test Server
+    Run Keyword And Ignore Error  Cleanup Datastore On Test Server
+
+    ${output}=  Run  bin/vic-machine-linux create --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --image-store=%{TEST_DATASTORE} --bridge-network=%{BRIDGE_NETWORK} --bridge-network-range 1.1.1.1/17 ${vicmachinetls}
+    Should Contain  ${output}  --bridge-network-range must be /16 or larger network
+
+    # Delete the portgroup added by env vars keyword
+    Cleanup VCH Bridge Network  %{VCH-NAME}
+
+Bridge network - valid with IP range
     Pass execution  Test not implemented
 
 Container network invalid 1


### PR DESCRIPTION
Fixes #3212 

Port layer uses a default mask of 16 bits so if vic-machine sets the bridge IP range to a network smaller than /16, port layer gives the error `bridge mask is not compatible with bridge pool mask`. 
This change prevents the user from creating a VCH with a bridge pool that's too small. We will later expose a configuration option for the bridge mask so the user can specify any size bridge pool. 
Added integration test to check for this error.


Attempting to create VCH with too small bridge network pool
```
⇒  bin/vic-machine-linux create --target root:password@10.17.109.132 --name chin-vic-25 --thumbprint DC:5F:3C:3B:57:37:25:A0:84:C8:4E:31:48:00:C0:14:62:D9:95:E2 --bridge-network-range 172.16.0.0/17 --no-tlsverify             
Error opening logfile vic-machine.log: open vic-machine.log: permission denied
Jan 27 2017 09:05:43.753-08:00 INFO  ### Installing VCH ####
Jan 27 2017 09:05:43.753-08:00 WARN  Using administrative user for VCH operation - use --ops-user to improve security (see -x for advanced help)
Jan 27 2017 09:05:43.754-08:00 INFO  Loaded server certificate chin-vic-25/server-cert.pem
Jan 27 2017 09:05:43.754-08:00 WARN  Configuring without TLS verify - certificate-based authentication disabled
Jan 27 2017 09:05:45.517-08:00 INFO  Validating supplied configuration
Jan 27 2017 09:05:46.937-08:00 INFO  Using default datastore: datastore1
Jan 27 2017 09:05:48.949-08:00 INFO  Firewall status: DISABLED on "/ha-datacenter/host/ib-aus-office-132.eng.vmware.com/ib-aus-office-132.eng.vmware.com"
Jan 27 2017 09:05:49.170-08:00 WARN  Firewall configuration will be incorrect if firewall is reenabled on hosts:
Jan 27 2017 09:05:49.170-08:00 WARN  	"/ha-datacenter/host/ib-aus-office-132.eng.vmware.com/ib-aus-office-132.eng.vmware.com"
Jan 27 2017 09:05:49.170-08:00 INFO  Firewall must permit dst 2377/tcp outbound to VCH management interface if firewall is reenabled
Jan 27 2017 09:05:49.292-08:00 WARN  Evaluation license detected. VIC may not function if evaluation expires or insufficient license is later assigned.
Jan 27 2017 09:05:49.292-08:00 INFO  License check OK
Jan 27 2017 09:05:49.292-08:00 INFO  DRS check SKIPPED - target is standalone host
Jan 27 2017 09:05:50.500-08:00 ERROR --------------------
Jan 27 2017 09:05:50.500-08:00 ERROR Specified bridge network range is not large enough for the default bridge network size. --bridge-network-range must be /16 or larger network.
Jan 27 2017 09:05:50.500-08:00 ERROR Create cannot continue: configuration validation failed
Jan 27 2017 09:05:50.500-08:00 ERROR --------------------
Jan 27 2017 09:05:50.500-08:00 ERROR vic-machine-linux create failed: validation of configuration failed
```

VCH with large enough bridge network pool:
```
⇒  bin/vic-machine-linux create --target root:password@10.17.109.132 --name chin-vic-25 --thumbprint DC:5F:3C:3B:57:37:25:A0:84:C8:4E:31:48:00:C0:14:62:D9:95:E2 --bridge-network-range 172.16.0.0/16 --no-tlsverify
Error opening logfile vic-machine.log: open vic-machine.log: permission denied
Jan 27 2017 09:07:03.487-08:00 INFO  ### Installing VCH ####
Jan 27 2017 09:07:03.487-08:00 WARN  Using administrative user for VCH operation - use --ops-user to improve security (see -x for advanced help)
Jan 27 2017 09:07:03.488-08:00 INFO  Loaded server certificate chin-vic-25/server-cert.pem
Jan 27 2017 09:07:03.488-08:00 WARN  Configuring without TLS verify - certificate-based authentication disabled
Jan 27 2017 09:07:05.233-08:00 INFO  Validating supplied configuration
Jan 27 2017 09:07:06.603-08:00 INFO  Using default datastore: datastore1
Jan 27 2017 09:07:08.602-08:00 INFO  Firewall status: DISABLED on "/ha-datacenter/host/ib-aus-office-132.eng.vmware.com/ib-aus-office-132.eng.vmware.com"
Jan 27 2017 09:07:08.834-08:00 WARN  Firewall configuration will be incorrect if firewall is reenabled on hosts:
Jan 27 2017 09:07:08.834-08:00 WARN  	"/ha-datacenter/host/ib-aus-office-132.eng.vmware.com/ib-aus-office-132.eng.vmware.com"
Jan 27 2017 09:07:08.834-08:00 INFO  Firewall must permit dst 2377/tcp outbound to VCH management interface if firewall is reenabled
Jan 27 2017 09:07:08.954-08:00 WARN  Evaluation license detected. VIC may not function if evaluation expires or insufficient license is later assigned.
Jan 27 2017 09:07:08.954-08:00 INFO  License check OK
Jan 27 2017 09:07:08.954-08:00 INFO  DRS check SKIPPED - target is standalone host
Jan 27 2017 09:07:10.241-08:00 INFO  
Jan 27 2017 09:07:11.989-08:00 INFO  Creating Resource Pool "chin-vic-25"
Jan 27 2017 09:07:12.112-08:00 INFO  Creating VirtualSwitch
Jan 27 2017 09:07:12.361-08:00 INFO  Creating Portgroup
Jan 27 2017 09:07:12.738-08:00 INFO  Creating appliance on target
Jan 27 2017 09:07:12.859-08:00 INFO  Network role "client" is sharing NIC with "public"
Jan 27 2017 09:07:12.859-08:00 INFO  Network role "management" is sharing NIC with "public"
Jan 27 2017 09:07:15.299-08:00 INFO  Uploading images for container
Jan 27 2017 09:07:15.299-08:00 INFO  	"/home/chin/go/src/github.com/vmware/vic/bin/bootstrap.iso"
Jan 27 2017 09:07:15.301-08:00 INFO  	"/home/chin/go/src/github.com/vmware/vic/bin/appliance.iso"
Jan 27 2017 09:07:24.685-08:00 INFO  Waiting for IP information
Jan 27 2017 09:07:36.871-08:00 INFO  Waiting for major appliance components to launch
Jan 27 2017 09:07:38.441-08:00 INFO  Checking VCH connectivity with vSphere target
Jan 27 2017 09:07:39.832-08:00 INFO  vSphere API Test: https://10.17.109.132 vSphere API target responds as expected
Jan 27 2017 09:07:46.893-08:00 INFO  Initialization of appliance successful
...
Jan 27 2017 09:07:46.893-08:00 INFO  
Jan 27 2017 09:07:46.893-08:00 INFO  Connect to docker:
Jan 27 2017 09:07:46.893-08:00 INFO  docker -H 10.17.109.176:2376 --tls info
Jan 27 2017 09:07:46.893-08:00 INFO  Installer completed successfully

⇒  docker -H 10.17.109.176:2376 --tls run -it busybox
Unable to find image 'busybox:latest' locally
Pulling from library/busybox
4b0bc1c4050b: Pull complete 
a3ed95caeb02: Pull complete 
Digest: sha256:348432dd709c2cd6ca42e56c2a0d157f611c50c908e14c9bfc1e9cb0ed234871
Status: Downloaded newer image for library/busybox:latest
/ # 

```