### PR TITLE
Fix PullApprove author/owner catch-22

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -1,8 +1,8 @@
 version: 2
 group_defaults:
-  required: 1
+  required: 2
   author_approval:
-    ignored: true
+    auto: true
   approve_by_comment:
     enabled: true
     approve_regex: 'Approved|:shipit:|:sheep::it:|:\+1:|LGTM|lgtm'

--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -1,6 +1,6 @@
 version: 2
 group_defaults:
-  required: 2
+  required: 1
   author_approval:
     auto: true
   approve_by_comment:


### PR DESCRIPTION
Didn't notice until I merged, but I set PullApprove to ignore the author's LGTMs, which, in the case where the PR author is the component owner, means PullApprove won't allow the component owner to LGTM
