### PR TITLE
implement docker ps filtering [specific ci=1-10-Docker-PS]

### DIFF
--- a/doc/design/docker-api-filtering.md
+++ b/doc/design/docker-api-filtering.md
@@ -1,0 +1,78 @@
+### Docker API Filtering
+
+The [docker api server](components.md#docker-api-server) is the endpoint for the docker client.  In many of the docker
+client commands a user is able to specify filter criteria.  That criteria will be evaluated in
+the docker persona and will limit the results of the docker command.
+
+#### Docker Filters
+
+The docker client provides filter options across a variety of commands.  A good example of
+docker filter options is the `docker images` command.  The following options are available
+as of Docker 1.13:
+
+```
+-f, --filter value    Filter output based on conditions provided (default [])
+                        - dangling=true
+                        - label=<key> or label=<key>=<value>
+                        - before=(<image-name>[:tag]|<image-id>|<image@digest>)
+                        - since=(<image-name>[:tag]|<image-id>|<image@digest>)
+                        - reference=(<image-name>[:tag])
+```
+
+Here's an example using the images filter: `docker images -f label=prod`.  That command will
+return only the images with a label key of `prod`.
+
+#### Filter Design
+
+The vic filtering logic is provided in the filter package of the vic docker personality.  That
+package should hold all of the vic implemented logic for docker personality filtering. The
+filtering logic is a combination of new vic code and the reuse of docker validation code.
+
+The package contains the common filtering and validation logic that can be used across the
+vic docker personality.  Additionally the package contains object specific filtering logic
+isolated in object specific files.  For example all vic specific container filtering will
+be provided in the following file: `/lib/apiservers/engine/backends/filter/container.go`.
+The vic container filtering will take advantage of the common functionality as well as
+implement vic specific container filtering logic.
+
+##### Common Filtering
+
+There are a few filter options that span multiple docker client commands.  That filtering
+logic is contained in the `/lib/apiservers/engine/backends/filter/filter.go` file.  The
+following common filtering is provided:
+	- ID
+	- Name
+	- Label
+	- Before
+	- Since
+If a docker command provides any of these filtering options then the vic implementation
+should take advantage of this common filtering mechanism.
+
+##### Object Specific Filtering
+
+As mentioned above object specific filtering should be isolated in a file identifying the
+object.  For example all vic specific container filtering will be provided in the
+following file: `/lib/apiservers/engine/backends/filter/container.go`.
+
+Object specific filtering should take advantage of the aforementioned common filtering
+as well as vendored docker validation code.  Then any additional custom vic filtering
+should be provided in the file.
+
+##### Docker filter support
+
+While all docker filtering options are valid not all filtering options are supported
+by vic.  In order to segregate validity from support each command that provides filtering
+must provide maps indicating valid vs. supported.  If all docker filtering options are
+supported by vic then only one map will be needed.  The container object and specifically
+the `docker ps` command provides a good example of the [maps](https://github.com/vmware/vic/blob/master/lib/apiservers/engine/backends/container.go#L60).
+
+There are two maps for the container object since not all of the filter criteria is
+currently supported by vic.  Those two maps are provided to the common filter validation
+code to check for validity and supportability.
+
+If a command is not currently supported by vic the validation logic will provide the
+following error message:
+```
+	Error response from daemon: filter dangling is not currently supported by vic
+```
+

--- a/doc/design/volumes/nfsvolumestores.md
+++ b/doc/design/volumes/nfsvolumestores.md
@@ -34,13 +34,13 @@ The advantage to using the interface is the storage layer maintains consistency 
  37 »···// Creates a volume on the given volume store, of the given size, with the given metadata.
  38 »···VolumeCreate(op trace.Operation, ID string, store *url.URL, capacityKB uint64, info map[string][]byte) (*Volume, error)
  39
- 40 »···// Destroys a volume 
+ 40 »···// Destroys a volume
  41 »···VolumeDestroy(op trace.Operation, vol *Volume) error
  42
- 43 »···// Lists all volumes 
+ 43 »···// Lists all volumes
  44 »···VolumesList(op trace.Operation) ([]*Volume, error)
   ...
- 48 }   
+ 48 }
 ```
 
 When we create the NFS `VolumeStore`, we'll store the NFS target parameters (`host` + `path`) in the implementation's struct.  This is the only information we'll need to mount the NFS target on the container.

--- a/lib/apiservers/engine/backends/filter/container.go
+++ b/lib/apiservers/engine/backends/filter/container.go
@@ -1,0 +1,227 @@
+// Copyright 2017 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package filter
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/docker/engine-api/types"
+
+	"github.com/vmware/vic/lib/apiservers/engine/backends/cache"
+	"github.com/vmware/vic/lib/apiservers/portlayer/models"
+)
+
+// reused from docker/docker/daemon/list.go
+type ContainerListContext struct {
+	FilterContext
+
+	// Counter is the container iteration index for this context
+	Counter int
+	// ExitCode for the passed container
+	ExitCode int
+	// exitAllowed is a list of exit codes allowed to filter with
+	exitAllowed map[int]struct{}
+	// ContainerListOptions is the filters set by the user
+	*types.ContainerListOptions
+}
+
+/*
+*	IncludeContainer will evaluate the filter criteria in listContext against the provided
+* 	container and determine what action to take.  There are three options:
+*		* IncludeAction
+*		* ExcludeAction
+*		* StopAction
+*
+ */
+func IncludeContainer(listContext *ContainerListContext, container *models.ContainerInfo) FilterAction {
+
+	// if we need to filter on name add to the listContext
+	if listContext.Filter.Include("name") {
+		// containerConfig allows for multiple names, but only 1 ever
+		// assigned
+		listContext.Name = container.ContainerConfig.Names[0]
+	}
+
+	// filter common requirements
+	act := filterCommon(&listContext.FilterContext, listContext.Filter)
+	if act != IncludeAction {
+		return act
+	}
+
+	// Stop iteration when the index is over the limit
+	if listContext.Limit > 0 && listContext.Counter == listContext.Limit {
+		return StopAction
+	}
+
+	// Do we have exit codes to evaluate
+	if len(listContext.exitAllowed) > 0 {
+
+		// Is the containers exitCode in the validatedList?
+		_, ok := listContext.exitAllowed[listContext.ExitCode]
+
+		// only include conainter whose exit code is in the list and that's
+		// not currently running and has been started previously
+		// note "Running" state is congruent with PortLayer and not docker
+		if !ok || container.ContainerConfig.State == "Running" || container.ProcessConfig.StartTime == 0 {
+			return ExcludeAction
+		}
+	}
+
+	state := DockerState(container.ContainerConfig.State)
+	// Do not include container if its status doesn't match the filter
+	if !listContext.Filter.Match("status", state) {
+		return ExcludeAction
+	}
+
+	// filter on network name
+	for n := range container.Endpoints {
+		name := container.Endpoints[n].Scope
+		if listContext.Filter.Include("network") {
+			err := listContext.Filter.WalkValues("network", func(value string) error {
+				if name == value {
+					return nil
+				}
+				return fmt.Errorf("not part of container network")
+			})
+			if err != nil {
+				return ExcludeAction
+			}
+		}
+	}
+
+	return IncludeAction
+}
+
+/*
+* ValidateContainerFilters will validate the container filters are
+* valid docker filters / values and supported by vic.
+*
+* The function will reuse dockers filter validation
+*
+ */
+func ValidateContainerFilters(options *types.ContainerListOptions, acceptedFilters map[string]bool, unSupportedFilters map[string]bool) (*ContainerListContext, error) {
+	containerFilters := options.Filter
+
+	// ensure filter options are valid and supported by vic
+	if err := ValidateFilters(containerFilters, acceptedFilters, unSupportedFilters); err != nil {
+		return nil, err
+	}
+
+	// we need all containers for these options, so set the All flag
+	if options.Limit > 0 || options.Latest {
+		options.All = true
+	}
+
+	var s struct{}
+	filtExited := make(map[int]struct{})
+
+	err := containerFilters.WalkValues("exited", func(value string) error {
+		code, err := strconv.Atoi(value)
+		if err != nil {
+			return err
+		}
+		// add valid exit code to map
+		filtExited[code] = s
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	err = containerFilters.WalkValues("status", func(value string) error {
+		if !IsValidDockerState(value) {
+			return fmt.Errorf("Unrecognised filter value for status: %s", value)
+		}
+		options.All = true
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// return value
+	listContext := &ContainerListContext{
+		FilterContext:        FilterContext{},
+		exitAllowed:          filtExited,
+		ContainerListOptions: options,
+	}
+
+	err = containerFilters.WalkValues("before", func(value string) error {
+		var err error
+		before := cache.ContainerCache().GetContainer(value)
+		if before == nil {
+			err = fmt.Errorf("No such container: %s", value)
+		} else {
+			listContext.BeforeID = &before.ContainerID
+		}
+		return err
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	err = containerFilters.WalkValues("since", func(value string) error {
+		var err error
+		since := cache.ContainerCache().GetContainer(value)
+		if since == nil {
+			err = fmt.Errorf("No such container: %s", value)
+		} else {
+			listContext.SinceID = &since.ContainerID
+		}
+		return err
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return listContext, nil
+}
+
+// DockerState will attempt to transform the passed state
+// to a valid docker state
+// valid states are listed in the func IsValidContainerState
+func DockerState(containerState string) string {
+	var state string
+	switch containerState {
+	case "Stopped":
+		state = "exited"
+	case "Running":
+		state = "running"
+	case "Created":
+		state = "created"
+	default:
+		// not sure what to do, so just return
+		// what was given
+		state = containerState
+	}
+	return state
+}
+
+// IsValidDockerState will verify the provided state is
+// a valid docker container state
+func IsValidDockerState(s string) bool {
+
+	if s != "paused" &&
+		s != "restarting" &&
+		s != "removing" &&
+		s != "running" &&
+		s != "dead" &&
+		s != "created" &&
+		s != "exited" {
+		return false
+	}
+	return true
+}

--- a/lib/apiservers/engine/backends/filter/container_test.go
+++ b/lib/apiservers/engine/backends/filter/container_test.go
@@ -1,0 +1,180 @@
+// Copyright 2017 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package filter
+
+import (
+	"testing"
+
+	"github.com/docker/engine-api/types"
+	"github.com/docker/engine-api/types/filters"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/vmware/vic/lib/apiservers/engine/backends/cache"
+	viccontainer "github.com/vmware/vic/lib/apiservers/engine/backends/container"
+	"github.com/vmware/vic/lib/apiservers/portlayer/models"
+)
+
+func TestValidateContainerFilters(t *testing.T) {
+
+	options := &types.ContainerListOptions{
+		Filter: filters.NewArgs(),
+	}
+	options.Filter.Add("id", "12345")
+	options.Filter.Add("status", "running")
+	options.Filter.Add("exited", "143")
+	options.Filter.Add("exited", "127")
+	// valid status & exit
+	listContext, err := ValidateContainerFilters(options, acceptedPsFilterTags, unSupportedPsFilters)
+	assert.NoError(t, err)
+
+	// we should have two exit codes added to the list
+	// context
+	assert.Equal(t, 2, len(listContext.exitAllowed))
+	assert.Equal(t, options.Filter, listContext.Filter)
+
+	// remove valid status and replace w/invalid
+	options.Filter.Del("status", "running")
+	options.Filter.Add("status", "jackedup")
+
+	// invalid status
+	_, err = ValidateContainerFilters(options, acceptedPsFilterTags, unSupportedPsFilters)
+	assert.Error(t, err)
+
+	// remove valid exit code and replace w/invalid
+	options.Filter.Del("exited", "143")
+	options.Filter.Add("exited", "abc")
+
+	// invalid exit code
+	_, err = ValidateContainerFilters(options, acceptedPsFilterTags, unSupportedPsFilters)
+	assert.Error(t, err)
+
+	// add an invalid container option
+	options.Filter.Add("jojo", "jojo")
+
+	// invalid container filter option
+	_, err = ValidateContainerFilters(options, acceptedPsFilterTags, unSupportedPsFilters)
+	assert.Error(t, err)
+
+	options.Filter.Del("jojo", "jojo")
+
+	// add before filter
+	options.Filter = filters.NewArgs()
+	options.Filter.Add("before", "1234")
+	// fail because the before container isn't present
+	_, err = ValidateContainerFilters(options, acceptedPsFilterTags, unSupportedPsFilters)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "No such container:")
+
+	// add the container to the cache
+	containerBefore := &viccontainer.VicContainer{
+		ContainerID: "12345",
+		Name:        "fuzzy",
+	}
+	cache.ContainerCache().AddContainer(containerBefore)
+
+	// successful before validation
+	_, err = ValidateContainerFilters(options, acceptedPsFilterTags, unSupportedPsFilters)
+	assert.NoError(t, err)
+
+	options.Filter.Add("since", "8888")
+
+	// fail because the since container isn't present
+	_, err = ValidateContainerFilters(options, acceptedPsFilterTags, unSupportedPsFilters)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "No such container:")
+
+}
+
+func TestDockerState(t *testing.T) {
+	vicState := make([]string, 4, 4)
+	vicState[0] = "Running"
+	vicState[1] = "Stopped"
+	vicState[2] = "Created"
+	vicState[3] = "sammy"
+
+	docker := make(map[string]bool)
+	docker["created"] = true
+	docker["running"] = true
+	docker["exited"] = true
+
+	// This is not a docker state, but is used to validate the
+	// default switch in the tested function
+	docker["sammy"] = false
+
+	for i := range vicState {
+		if _, ok := docker[DockerState(vicState[i])]; !ok {
+			t.Errorf("vicState doesn't map to docker state: %s", vicState[i])
+		}
+	}
+
+}
+
+func TestIncludeContainer(t *testing.T) {
+
+	ep := &models.EndpointConfig{
+		Scope: "bridge",
+	}
+	eps := make([]*models.EndpointConfig, 0)
+
+	contain := &models.ContainerInfo{
+		ContainerConfig: &models.ContainerConfig{
+			Names: []string{"jojo"},
+		},
+		ProcessConfig: &models.ProcessConfig{},
+		Endpoints:     append(eps, ep),
+	}
+
+	listCtx := &ContainerListContext{
+		ContainerListOptions: &types.ContainerListOptions{
+			Filter: filters.NewArgs()},
+	}
+
+	listCtx.Filter.Add("name", "jojo")
+	assert.Equal(t, IncludeAction, IncludeContainer(listCtx, contain))
+
+	listCtx.Limit = 1
+	listCtx.Counter = listCtx.Limit
+	assert.Equal(t, StopAction, IncludeContainer(listCtx, contain))
+
+	// reset counter
+	listCtx.Counter = 0
+
+	// create exited map
+	var s struct{}
+	listCtx.exitAllowed = make(map[int]struct{})
+	listCtx.exitAllowed[137] = s
+
+	// exclude since no container exit code
+	assert.Equal(t, ExcludeAction, IncludeContainer(listCtx, contain))
+
+	startTime := int64(4444)
+	contain.ProcessConfig.StartTime = startTime
+	listCtx.ExitCode = 137
+	assert.Equal(t, IncludeAction, IncludeContainer(listCtx, contain))
+
+	// test network name
+	listCtx.Filter = filters.NewArgs()
+	listCtx.Filter.Add("network", "bridge")
+	assert.Equal(t, IncludeAction, IncludeContainer(listCtx, contain))
+
+	listCtx.Filter = filters.NewArgs()
+	listCtx.Filter.Add("network", "missed")
+	assert.Equal(t, ExcludeAction, IncludeContainer(listCtx, contain))
+
+	listCtx.Filter = filters.NewArgs()
+	listCtx.Filter.Add("status", "stopped")
+	assert.Equal(t, ExcludeAction, IncludeContainer(listCtx, contain))
+
+}

--- a/lib/apiservers/engine/backends/filter/filter.go
+++ b/lib/apiservers/engine/backends/filter/filter.go
@@ -1,0 +1,77 @@
+// Copyright 2017 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package filter
+
+import (
+	"github.com/docker/engine-api/types/filters"
+)
+
+// FilterAction represents possible results during filtering
+type FilterAction int
+
+const (
+	IncludeAction FilterAction = iota
+	ExcludeAction
+	StopAction
+)
+
+// FilterContext will hold the common filter requirements
+type FilterContext struct {
+	// ID of object to filter
+	ID string
+	// Name of object to filter
+	Name string
+	// BeforeID is the filter to ignore objects that appear before the one given
+	BeforeID *string
+	// SinceID is the filter to stop iterating
+	SinceID *string
+	// Labels of object to filter
+	Labels map[string]string
+}
+
+// filterCommon will filter the common criteria across objects
+func filterCommon(filterContext *FilterContext, cmdFilters filters.Args) FilterAction {
+
+	// have we made it to the beforeID
+	if filterContext.BeforeID != nil {
+		if filterContext.ID == *filterContext.BeforeID {
+			filterContext.BeforeID = nil
+		}
+		return ExcludeAction
+	}
+
+	// Stop iteration when the object arrives to the filter object
+	if filterContext.SinceID != nil {
+		if filterContext.ID == *filterContext.SinceID {
+			return StopAction
+		}
+	}
+
+	// Do not include object if any of the labels don't match
+	if !cmdFilters.MatchKVList("label", filterContext.Labels) {
+		return ExcludeAction
+	}
+
+	// Do not include if the id doesn't match
+	if !cmdFilters.Match("id", filterContext.ID) {
+		return ExcludeAction
+	}
+
+	if !cmdFilters.Match("name", filterContext.Name) {
+		return ExcludeAction
+	}
+
+	return IncludeAction
+}

--- a/lib/apiservers/engine/backends/filter/filter_test.go
+++ b/lib/apiservers/engine/backends/filter/filter_test.go
@@ -1,0 +1,69 @@
+// Copyright 2017 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package filter
+
+import (
+	"testing"
+
+	"github.com/docker/engine-api/types/filters"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFilterCommon(t *testing.T) {
+	cmdFilters := filters.NewArgs()
+	id := "123"
+	before := "456"
+
+	fContext := &FilterContext{
+		ID: id,
+	}
+
+	// no common filter
+	assert.Equal(t, IncludeAction, filterCommon(fContext, cmdFilters))
+
+	// exclude on Name
+	cmdFilters.Add("name", "jojo")
+	assert.Equal(t, ExcludeAction, filterCommon(fContext, cmdFilters))
+
+	// exclude on ID
+	cmdFilters.Add("id", before)
+	assert.Equal(t, ExcludeAction, filterCommon(fContext, cmdFilters))
+
+	// we've hit the before id exclude object
+	fContext.ID = before
+	fContext.BeforeID = &before
+	cmdFilters.Add("before", before)
+	assert.Equal(t, ExcludeAction, filterCommon(fContext, cmdFilters))
+
+	// stop due to since
+	since := "859"
+	fContext.SinceID = &since
+	fContext.ID = since
+	cmdFilters.Add("since", since)
+	assert.Equal(t, StopAction, filterCommon(fContext, cmdFilters))
+
+	// exclude based on label mismatch
+	fContext.Labels = createLabels()
+	fContext.ID = id
+	cmdFilters.Add("label", "joe")
+	assert.Equal(t, ExcludeAction, filterCommon(fContext, cmdFilters))
+}
+
+func createLabels() map[string]string {
+	labels := make(map[string]string)
+	labels["prod"] = "ATX"
+	labels["brown"] = "fox"
+	return labels
+}

--- a/lib/apiservers/engine/backends/filter/validation.go
+++ b/lib/apiservers/engine/backends/filter/validation.go
@@ -1,0 +1,59 @@
+// Copyright 2017 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package filter
+
+import (
+	"fmt"
+
+	"github.com/docker/engine-api/types/filters"
+)
+
+/*
+* ValidateFilters will evalute the provided filters against the docker acceptedFilters and
+* the filters vic currently doesn't support (unSupportedFilters)
+ */
+func ValidateFilters(cmdFilters filters.Args, acceptedFilters map[string]bool, unSupportedFilters map[string]bool) error {
+
+	var err error
+
+	// ensure provided filter args are accepted
+	if err = cmdFilters.Validate(acceptedFilters); err != nil {
+		return err
+	}
+
+	// verify that vic supports the provided filter args
+	// will only make it here if all the filters are valid
+	if err = validateSupport(cmdFilters, unSupportedFilters); err != nil {
+		return err
+	}
+
+	return err
+}
+
+/*
+*	validateSupport will ensure the provided filter arguments are implemented
+*  	by vic
+ */
+func validateSupport(cmdFilters filters.Args, unSupported map[string]bool) error {
+
+	for filter := range unSupported {
+		vals := cmdFilters.Get(filter)
+		if len(vals) > 0 {
+			return fmt.Errorf("filter %s is not currently supported by vic", filter)
+		}
+	}
+
+	return nil
+}

--- a/lib/apiservers/engine/backends/filter/validation_test.go
+++ b/lib/apiservers/engine/backends/filter/validation_test.go
@@ -1,0 +1,94 @@
+// Copyright 2017 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package filter
+
+import (
+	"testing"
+
+	"github.com/docker/engine-api/types/filters"
+	"github.com/stretchr/testify/assert"
+)
+
+// TODO: what can we do here...don't like this, but can't
+// reference upper package due to import constraints
+// valid filters as of docker commit 49bf474
+var acceptedImageFilterTags = map[string]bool{
+	"dangling":  true,
+	"label":     true,
+	"before":    true,
+	"since":     true,
+	"reference": true,
+}
+
+// currently not supported by vic
+var unSupportedImageFilters = map[string]bool{
+	"dangling": false,
+}
+
+// valid filters as of docker commit 49bf474
+var acceptedPsFilterTags = map[string]bool{
+	"ancestor":  true,
+	"before":    true,
+	"exited":    true,
+	"id":        true,
+	"isolation": true,
+	"label":     true,
+	"name":      true,
+	"status":    true,
+	"health":    true,
+	"since":     true,
+	"volume":    true,
+	"network":   true,
+	"is-task":   true,
+}
+
+// currently not supported by vic
+var unSupportedPsFilters = map[string]bool{
+	"ancestor":  false,
+	"health":    false,
+	"isolation": false,
+	"is-task":   false,
+}
+
+func TestValidateFilters(t *testing.T) {
+	args := filters.NewArgs()
+	args.Add("id", "12345")
+	args.Add("name", "jojo")
+
+	// valid container filter
+	assert.NoError(t, ValidateFilters(args, acceptedPsFilterTags, unSupportedPsFilters))
+
+	// unsupported container filter
+	args.Add("isolation", "windows")
+	assert.Error(t, ValidateFilters(args, acceptedPsFilterTags, unSupportedPsFilters))
+
+	// invalid container filter
+	args.Add("failure", "yoyo")
+	assert.Error(t, ValidateFilters(args, acceptedPsFilterTags, unSupportedPsFilters))
+
+	// unsupported image filter
+	args = filters.NewArgs()
+	args.Add("dangling", "true")
+	assert.Error(t, ValidateFilters(args, acceptedImageFilterTags, unSupportedImageFilters))
+
+	// invalid image filter
+	args.Add("failure", "yoyo")
+	assert.Error(t, ValidateFilters(args, acceptedImageFilterTags, unSupportedImageFilters))
+
+	// valid image filter
+	args = filters.NewArgs()
+	args.Add("label", "124")
+	assert.NoError(t, ValidateFilters(args, acceptedImageFilterTags, unSupportedImageFilters))
+}

--- a/lib/apiservers/portlayer/restapi/handlers/containers_handlers.go
+++ b/lib/apiservers/portlayer/restapi/handlers/containers_handlers.go
@@ -22,6 +22,7 @@ import (
 	"encoding/pem"
 	"fmt"
 	"net/http"
+	"sort"
 	"strings"
 	"time"
 
@@ -282,6 +283,15 @@ func (handler *ContainersHandlersImpl) GetContainerInfoHandler(params containers
 	return containers.NewGetContainerInfoOK().WithPayload(containerInfo)
 }
 
+// type and funcs to provide sorting by created date
+type containerByCreated []*models.ContainerInfo
+
+func (r containerByCreated) Len() int      { return len(r) }
+func (r containerByCreated) Swap(i, j int) { r[i], r[j] = r[j], r[i] }
+func (r containerByCreated) Less(i, j int) bool {
+	return r[i].ContainerConfig.CreateTime < r[j].ContainerConfig.CreateTime
+}
+
 func (handler *ContainersHandlersImpl) GetContainerListHandler(params containers.GetContainerListParams) middleware.Responder {
 	defer trace.End(trace.Begin(""))
 
@@ -299,6 +309,8 @@ func (handler *ContainersHandlersImpl) GetContainerListHandler(params containers
 		info := convertContainerToContainerInfo(container.Info())
 		containerList = append(containerList, info)
 	}
+
+	sort.Sort(sort.Reverse(containerByCreated(containerList)))
 	return containers.NewGetContainerListOK().WithPayload(containerList)
 }
 

--- a/tests/test-cases/Group1-Docker-Commands/1-10-Docker-PS.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-10-Docker-PS.robot
@@ -138,42 +138,33 @@ Docker ps Remove container OOB
     Should Be Equal As Integers  ${rc}  0
 
 Docker ps last container
-    ${status}=  Get State Of Github Issue  1545
-    Run Keyword If  '${status}' == 'closed'  Fail  Test 1-10-Docker-PS.robot needs to be updated now that Issue #1545 has been resolved
-    Log  Issue \#1545 is blocking implementation  WARN
-    #${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} ps -l
-    #Should Be Equal As Integers  ${rc}  0
-    #Should Contain  ${output}  ls
-    #${output}=  Split To Lines  ${output}
-    #Length Should Be  ${output}  2
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} ps -l
+    Should Be Equal As Integers  ${rc}  0
+    Should Contain  ${output}  redis
+    ${output}=  Split To Lines  ${output}
+    Length Should Be  ${output}  2
 
 Docker ps two containers
-    ${status}=  Get State Of Github Issue  1545
-    Run Keyword If  '${status}' == 'closed'  Fail  Test 1-10-Docker-PS.robot needs to be updated now that Issue #1545 has been resolved
-    Log  Issue \#1545 is blocking implementation  WARN
-    #${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} ps -n=2
-    #Should Be Equal As Integers  ${rc}  0
-    #Should Contain  ${output}  dmesg
-    #Should Contain  ${output}  ls
-    #${output}=  Split To Lines  ${output}
-    #Length Should Be  ${output}  3
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} ps -n=2
+    Should Be Equal As Integers  ${rc}  0
+    Should Contain  ${output}  redis
+    Should Contain  ${output}  nginx
+    ${output}=  Split To Lines  ${output}
+    Length Should Be  ${output}  3
 
 Docker ps last container with size
-    ${status}=  Get State Of Github Issue  1545
-    Run Keyword If  '${status}' == 'closed'  Fail  Test 1-10-Docker-PS.robot needs to be updated now that Issue #1545 has been resolved
-    Log  Issue \#1545 is blocking implementation  WARN
-    #${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} ps -ls
-    #Should Be Equal As Integers  ${rc}  0
-    #Should Contain  ${output}  SIZE
-    #Should Contain  ${output}  ls
-    #${output}=  Split To Lines  ${output}
-    #Length Should Be  ${output}  2
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} ps -ls
+    Should Be Equal As Integers  ${rc}  0
+    Should Contain  ${output}  SIZE
+    Should Contain  ${output}  redis
+    ${output}=  Split To Lines  ${output}
+    Length Should Be  ${output}  2
 
 Docker ps all containers with only IDs
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} ps -aq
     ${output}=  Split To Lines  ${output}
     ${len}=  Get Length  ${output}
-    Create several containers 
+    Create several containers
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} ps -aq
     Should Be Equal As Integers  ${rc}  0
     Should Not Contain  ${output}  CONTAINER ID
@@ -183,12 +174,23 @@ Docker ps all containers with only IDs
     ${output}=  Split To Lines  ${output}
     Length Should Be  ${output}  ${len+3}
 
-Docker ps with filter
-    ${status}=  Get State Of Github Issue  1676
-    Run Keyword If  '${status}' == 'closed'  Fail  Test 1-10-Docker-PS.robot needs to be updated now that Issue #1676 has been resolved
-    Log  Issue \#1676 is blocking implementation  WARN
-    #${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} ps -f status=created
-    #Should Be Equal As Integers  ${rc}  0
-    #Should Contain  ${output}  ls
-    #${output}=  Split To Lines  ${output}
-    #Length Should Be  ${output}  2
+Docker ps with status filter
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} ps -f status=created
+    Should Be Equal As Integers  ${rc}  0
+    Should Contain  ${output}  nginx
+    ${output}=  Split To Lines  ${output}
+    Length Should Be  ${output}  5
+
+Docker ps with label and name filter
+    ${rc}  ${container}=  Run And Return Rc And Output  docker %{VCH-PARAMS} create --name abe --label prod busybox /bin/top
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} ps -a -f label=prod
+    Should Be Equal As Integers  ${rc}  0
+    Should Contain  ${output}  busybox
+    ${output}=  Split To Lines  ${output}
+    Length Should Be  ${output}  2
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} ps -a -f name=abe
+    Should Be Equal As Integers  ${rc}  0
+    Should Contain  ${output}  busybox
+    ${output}=  Split To Lines  ${output}
+    Length Should Be  ${output}  2


### PR DESCRIPTION
The following docker ps filter options have been
implemented:
	* before, since, id, exited, label, name, status
        * network

If a filter option isn't supported by vic an error message
will be returned to the user.  Examples:
	* ancestor, isolation, health, is-task

The docker ps flags of --latest and --last have also been
implemented.

Known issue with network filtering: it only works with the
network name (bridge, etc).  network id will be added later.

Fixes #1545, #1676
