### PR TITLE
Fix string parsing logic in integration test script

### DIFF
--- a/tests/resources/VCH-Util.robot
+++ b/tests/resources/VCH-Util.robot
@@ -68,7 +68,7 @@ Parse Environment Variables
     Return From Keyword If  ${status}
     
     # Split the log log into pieces, discarding the initial log decoration, and assign to env vars
-    ${logmon}  ${logday}  ${logyear}  ${logtime}  ${loglevel}  ${vars}=  Split String  ${line}  ${SPACE}  5
+    ${logmon}  ${logday}  ${logyear}  ${logtime}  ${loglevel}  ${vars}=  Split String  ${line}  max_split=5
     Set List Of Env Variables  ${vars}
 
 Get Docker Params


### PR DESCRIPTION
Fixes the failure in https://ci.vmware.run/vmware/vic/7809 where environment variables aren't set correctly:

<img width="1217" alt="screen shot 2017-01-31 at 21 16 24" src="https://cloud.githubusercontent.com/assets/4361620/22494776/f77f928a-e7ff-11e6-9d50-361b4ee7c010.png">

Robot's `Split String` command doesn't trim consecutive delimiters when a delimiter is specified. The above issue happens because `Feb` and `1` have two spaces in-between.