### PR TITLE
claim code owner of lib/config and lib/metadata

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -86,6 +86,15 @@ groups:
           - "cmd/vic-machine/*"
           - "lib/install/*"
 
+  config:
+    users:
+      - emlin
+    conditions:
+      files:
+        include:
+          - "lib/config/*"
+          - "lib/metadata/*"
+
   vicadmin:
     users:
       - jzt


### PR DESCRIPTION
  This is to watch if there is any code change in configuration. Anything change in here might involve data migration in upgrade

