### PR TITLE
Improve Docker API check error message

### DIFF
--- a/cmd/vic-machine/create/create.go
+++ b/cmd/vic-machine/create/create.go
@@ -1373,9 +1373,16 @@ func (c *Create) Run(clic *cli.Context) (err error) {
 	}
 
 	// check the docker endpoint is responsive
+	log.Info("Checking Docker API endpoint")
 	if err = executor.CheckDockerAPI(vchConfig, c.clientCert); err != nil {
 		executor.CollectDiagnosticLogs()
-		return err
+		cmd, _ := executor.GetDockerAPICommand(vchConfig, c.ckey, c.ccert, c.cacert)
+		msg := fmt.Sprintf("Docker API endpoint check failed: %s", err)
+		log.Info(msg)
+		log.Info("\tAPI may be slow to start - try to connect to API after a few minutes:")
+		log.Infof("\t\tRun command: %s", cmd)
+		log.Info("\t\tIf command succeeds, VCH is started. If command fails, VCH failed to install - see documentation for troubleshooting.")
+		return fmt.Errorf(msg)
 	}
 
 	log.Infof("Initialization of appliance successful")

--- a/doc/user_doc/vic_installation/troubleshoot_vic_install.md
+++ b/doc/user_doc/vic_installation/troubleshoot_vic_install.md
@@ -8,3 +8,4 @@ This information provides solutions for common problems that you might encounter
 * [VCH Deployment Fails with Certificate cname Mismatch](ts_cname_mismatch.md)
 * [vSphere Integrated Containers Engine Plug-In Does Not Appear in the vSphere Web Client](ts_ui_not_appearing.md)
 * [Docker Commands Fail with a Docker API Version Error](ts_docker_version_error.md)
+* [VCH Deployment Fails with Docker API Endpoint Check Failed Error](ts_docker_api_check_error.md)

--- a/doc/user_doc/vic_installation/ts_docker_api_check_error.md
+++ b/doc/user_doc/vic_installation/ts_docker_api_check_error.md
@@ -1,0 +1,78 @@
+# VCH Deployment Fails with Docker API Endpoint Check Failed Error #
+When you use `vic-machine create` to deploy a virtual container host (VCH), deployment fails because
+vic-machine cannot contact the Docker API endpoint.
+
+## Problem ##
+
+Deployment fails with Docker API endpoint check failed:
+
+<pre>
+Docker API endpoint check failed:
+API may be slow to start - try to connect to API after a few minutes:
+   Run docker -H 192.168.218.160:2376 --tls info
+   If command succeeds, VCH is started. If command fails, VCH failed to install - see documentation for troubleshooting.
+</pre>
+
+
+## Cause ##
+
+During install, vic-machine checks that the endpoint that Docker clients connect to is reachable. If
+this check fails, vic-machine create fails with an error. The Docker API may be slow to start or it
+may have failed to start.
+
+## Solution ##
+
+### Docker API is slow to start ###
+
+After waiting a few minutes, run the `docker info` command shown in the error message to test the
+API responsiveness. If this succeeds, output similar to below will be shown:
+
+<pre>
+$ docker -H 192.168.218.160:2376 --tls info
+Containers: 0
+ Running: 0
+ Paused: 0
+ Stopped: 0
+Images: 0
+Server Version: v0.8.0-0-1652a8b
+Storage Driver: vSphere Integrated Containers v0.8.0-0-1652a8b Backend Engine
+VolumeStores:
+vSphere Integrated Containers v0.8.0-0-1652a8b Backend Engine: RUNNING
+ VCH mhz limit: 2944 Mhz
+ VCH memory limit: 1.259 GiB
+ VMware Product: VMware ESXi
+ VMware OS: vmnix-x86
+ VMware OS version: 6.5.0
+Plugins:
+ Volume:
+ Network: bridge
+Swarm:
+ NodeID:
+ Is Manager: false
+ Node Address:
+Security Options:
+Operating System: vmnix-x86
+OSType: vmnix-x86
+Architecture: x86_64
+CPUs: 2944
+Total Memory: 1.259 GiB
+Name: oceanlab
+ID: vSphere Integrated Containers
+Docker Root Dir:
+Debug Mode (client): false
+Debug Mode (server): false
+Registry: registry-1.docker.io
+</pre>
+
+This output means that the VCH is running as expected and can accept Docker commands.
+
+If the command times out, proceed to `Docker API failed to start` for troubleshooting.
+
+### Docker API failed to start ###
+
+If the Docker API is not responsive, run `vic-machine inspect`, login to the VCH Admin Portal, and
+download the Log Bundle. Follow troubleshooting steps to determine why the installation failed.
+
+If the VCH Admin Portal is not responsive, run `vic-machine debug` to enable the VCH debugging mode.
+SSH to the VCH to collect the VIC logs. Follow troubleshooting steps to determine why the installation
+failed. Collecting the vSphere log bundle may also be useful in troubleshooting.

--- a/lib/install/management/appliance.go
+++ b/lib/install/management/appliance.go
@@ -803,6 +803,7 @@ func (d *Dispatcher) CheckDockerAPI(conf *config.VirtualContainerHostConfigSpec,
 	}
 
 	dockerInfoURL := fmt.Sprintf("%s://%s:%s/info", proto, d.HostIP, d.DockerPort)
+	log.Debugf("Docker API endpoint: %s", dockerInfoURL)
 	req, err = http.NewRequest("GET", dockerInfoURL, nil)
 	if err != nil {
 		return errors.New("invalid HTTP request for docker info")
@@ -888,7 +889,7 @@ func (d *Dispatcher) CheckDockerAPI(conf *config.VirtualContainerHostConfigSpec,
 							log.Errorf("Connection failed with error: %s", root)
 						}
 
-						return root
+						return fmt.Errorf("failed to connect to %s: %s", dockerInfoURL, root)
 					}
 
 				case x509.UnknownAuthorityError:


### PR DESCRIPTION
Fixes #3440

This gives a better error message if the Docker API check in vic-machine fails. 
Updated documentation. 

```
Feb  2 2017 07:47:20.677-08:00 INFO  ### Installing VCH ####
Feb  2 2017 07:47:20.677-08:00 WARN  Using administrative user for VCH operation - use --ops-user to improve security (see -x for advanced help)
Feb  2 2017 07:47:20.678-08:00 INFO  Loaded server certificate chin-vic-25/server-cert.pem
Feb  2 2017 07:47:20.678-08:00 WARN  Configuring without TLS verify - certificate-based authentication disabled
Feb  2 2017 07:47:20.820-08:00 INFO  Validating supplied configuration
Feb  2 2017 07:47:20.916-08:00 INFO  Using default datastore: datastore1
Feb  2 2017 07:47:20.986-08:00 INFO  Firewall status: DISABLED on "/ha-datacenter/host/ib-aus-office-132.localdomain/ib-aus-office-132.localdomain"
Feb  2 2017 07:47:21.006-08:00 WARN  Firewall configuration will be incorrect if firewall is reenabled on hosts:
Feb  2 2017 07:47:21.006-08:00 WARN  	"/ha-datacenter/host/ib-aus-office-132.localdomain/ib-aus-office-132.localdomain"
Feb  2 2017 07:47:21.006-08:00 INFO  Firewall must permit dst 2377/tcp outbound to VCH management interface if firewall is reenabled
Feb  2 2017 07:47:21.023-08:00 WARN  Evaluation license detected. VIC may not function if evaluation expires or insufficient license is later assigned.
Feb  2 2017 07:47:21.023-08:00 INFO  License check OK
Feb  2 2017 07:47:21.023-08:00 INFO  DRS check SKIPPED - target is standalone host
Feb  2 2017 07:47:21.060-08:00 INFO  
Feb  2 2017 07:47:21.120-08:00 INFO  Creating Resource Pool "chin-vic-25"
Feb  2 2017 07:47:21.126-08:00 INFO  Creating VirtualSwitch
Feb  2 2017 07:47:21.166-08:00 INFO  Creating Portgroup
Feb  2 2017 07:47:21.202-08:00 INFO  Creating appliance on target
Feb  2 2017 07:47:21.206-08:00 INFO  Network role "client" is sharing NIC with "public"
Feb  2 2017 07:47:21.206-08:00 INFO  Network role "management" is sharing NIC with "public"
Feb  2 2017 07:47:21.426-08:00 INFO  Uploading images for container
Feb  2 2017 07:47:21.426-08:00 INFO  	"/home/chin/go/src/github.com/vmware/vic/bin/appliance.iso"
Feb  2 2017 07:47:21.426-08:00 INFO  	"/home/chin/go/src/github.com/vmware/vic/bin/bootstrap.iso"
Feb  2 2017 07:47:30.002-08:00 INFO  Waiting for IP information
Feb  2 2017 07:47:42.398-08:00 INFO  Waiting for major appliance components to launch
Feb  2 2017 07:47:42.478-08:00 INFO  Checking VCH connectivity with vSphere target
Feb  2 2017 07:47:42.670-08:00 INFO  vSphere API Test: https://192.168.218.129 vSphere API target responds as expected
Feb  2 2017 07:47:42.670-08:00 INFO  Checking Docker API endpoint
Feb  2 2017 07:47:46.737-08:00 INFO  Collecting ha-host hostd.log
Feb  2 2017 07:47:46.828-08:00 INFO  Docker API endpoint check failed:
Feb  2 2017 07:47:46.828-08:00 INFO  	API may be slow to start - try to connect to API after a few minutes:
Feb  2 2017 07:47:46.828-08:00 INFO  		Run command: docker -H 192.168.218.131:2376 --tls info
Feb  2 2017 07:47:46.828-08:00 INFO  		If command succeeds, VCH is started. If command fails, VCH failed to install - see documentation for troubleshooting.
Feb  2 2017 07:47:46.828-08:00 ERROR --------------------
Feb  2 2017 07:47:46.828-08:00 ERROR vic-machine-linux create failed: Docker API endpoint check failed
```