### PR TITLE
[specific ci=1-04-Docker-Create] Add default (empty) HostConfig if it is nil when validating ContainerCreateConfig

### DIFF
--- a/lib/apiservers/engine/backends/container.go
+++ b/lib/apiservers/engine/backends/container.go
@@ -1406,6 +1406,10 @@ func setPathFromImageConfig(config, imageConfig *containertypes.Config) {
 func validateCreateConfig(config *types.ContainerCreateConfig) error {
 	defer trace.End(trace.Begin("Container.validateCreateConfig"))
 
+	if config.Config == nil {
+		return BadRequestError("invalid config")
+	}
+
 	if config.HostConfig == nil {
 		config.HostConfig = &containertypes.HostConfig{}
 	}
@@ -1497,10 +1501,6 @@ func validateCreateConfig(config *types.ContainerCreateConfig) error {
 				return InternalServerError("host port ranges are not supported for port bindings")
 			}
 		}
-	}
-
-	if config.Config == nil {
-		return BadRequestError("invalid config")
 	}
 
 	// TODO(jzt): users other than root are not currently supported

--- a/tests/test-cases/Group1-Docker-Commands/1-04-Docker-Create.md
+++ b/tests/test-cases/Group1-Docker-Commands/1-04-Docker-Create.md
@@ -39,6 +39,7 @@ This test requires that a vSphere server is running and available
 26. Create a container with a custom amount of Memory in MB
 27. Create a container with a custom amount of Memory in KB
 28. Create a container with a custom amount of Memory in Bytes
+29. Create a container using a rest api call without HostConfig in the form data
 
 #Expected Outcome:
 * Steps 3-7 should all return without error and printing the container ID on return
@@ -53,6 +54,7 @@ This test requires that a vSphere server is running and available
 * Step 22 should return without error
 * Step 23 should return with the following error message - Error response from daemon: No command specified
 * Steps 24-28 should return without error.
+* Step 29 should return without error.
 
 #Possible Problems:
 None

--- a/tests/test-cases/Group1-Docker-Commands/1-04-Docker-Create.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-04-Docker-Create.robot
@@ -165,5 +165,5 @@ Create a container with custom amount of memory in Bytes
 
 Create a container using rest api call without HostConfig in the form data
     ${output}=  Run  curl -sk --cert %{DOCKER_CERT_PATH}/cert.pem --key %{DOCKER_CERT_PATH}/key.pem -H "Content-Type: application/json" -d '{"Image": "busybox", "Cmd": ["ping", "127.0.0.1"], "NetworkMode": "bridge"}' https://%{VCH-IP}:2376/containers/create
-    Log To Console  ${output}
+    Log  ${output}
     Should contain  ${output}  "Warnings":null

--- a/tests/test-cases/Group1-Docker-Commands/1-04-Docker-Create.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-04-Docker-Create.robot
@@ -162,3 +162,8 @@ Create a container with custom amount of memory in Bytes
     ${rc}  ${output}=  Run Keyword If  '%{HOST_TYPE}' == 'ESXi'  Run And Return Rc And Output  govc vm.info ${id} |awk '/Memory:/ {print $2}'
     Run Keyword If  '%{HOST_TYPE}' == 'ESXi'  Should Be Equal As Integers  ${rc}  0
     Run Keyword If  '%{HOST_TYPE}' == 'ESXi'  Should Contain  ${output}  2048MB
+
+Create a container using rest api call without HostConfig in the form data
+    ${output}=  Run  curl -sk -H "Content-Type: application/json" -d '{"Image": "busybox", "Cmd": ["ping", "127.0.0.1"], "NetworkMode": "bridge"}' https://%{VCH-IP}:2376/containers/create
+    Log To Console  ${output}
+    Should contain  ${output}  "Warnings":null

--- a/tests/test-cases/Group1-Docker-Commands/1-04-Docker-Create.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-04-Docker-Create.robot
@@ -164,6 +164,6 @@ Create a container with custom amount of memory in Bytes
     Run Keyword If  '%{HOST_TYPE}' == 'ESXi'  Should Contain  ${output}  2048MB
 
 Create a container using rest api call without HostConfig in the form data
-    ${output}=  Run  curl -sk -H "Content-Type: application/json" -d '{"Image": "busybox", "Cmd": ["ping", "127.0.0.1"], "NetworkMode": "bridge"}' https://%{VCH-IP}:2376/containers/create
+    ${output}=  Run  curl -sk --cert %{DOCKER_CERT_PATH}/cert.pem --key %{DOCKER_CERT_PATH}/key.pem -H "Content-Type: application/json" -d '{"Image": "busybox", "Cmd": ["ping", "127.0.0.1"], "NetworkMode": "bridge"}' https://%{VCH-IP}:2376/containers/create
     Log To Console  ${output}
     Should contain  ${output}  "Warnings":null


### PR DESCRIPTION
This is needed when the client request is sent via docker rest api call without specifying HostConfig in the form data. See examples in #2557. 

<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[  ] There is an associated issue that is labelled
[  ] Code is up-to-date with the `master` branch
[  ] You've successfully run `make test` locally
[  ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/vmware/vic/blob/master/.github/CONTRIBUTING.md
-->

Fixes #2557 and #3709.

<!--
To trigger a custom build with this PR, include one of these in the PR's title or commit messages:
* [skip ci]
* [full ci]
* [specific ci=$suitename] e.g. [specific ci=1-01-Docker-Info]
    With this option, running only one suite is supported.
-->
