### PR TITLE
[skip ci] don't force docs/bundle to be reviewed

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -46,6 +46,7 @@ groups:
           - "doc/*"
         exclude:
           - "doc/design/*"
+          - "doc/bundle/*"
 
   nightlies:
     users:


### PR DESCRIPTION
exclude docs/bundle/* from docs group review