### PR TITLE
[specific ci=1-21-Docker-Volume-LS] Add support for volume ls filters

### DIFF
--- a/lib/apiservers/engine/backends/errors.go
+++ b/lib/apiservers/engine/backends/errors.go
@@ -1,4 +1,4 @@
-// Copyright 2016 VMware, Inc. All Rights Reserved.
+// Copyright 2016-2017 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -56,6 +56,11 @@ func VolumeCreateNotFoundError(msg string) error {
 // VolumeNotFoundError returns a 404 docker error for a volume get request.
 func VolumeNotFoundError(msg string) error {
 	return derr.NewErrorWithStatusCode(fmt.Errorf("No such volume: %s", msg), http.StatusNotFound)
+}
+
+// VolumeInternalServerError returns a 500 docker error for a volume-related request.
+func VolumeInternalServerError(err error) error {
+	return derr.NewErrorWithStatusCode(err, http.StatusInternalServerError)
 }
 
 func ResourceNotFoundError(cid, res string) error {

--- a/lib/apiservers/engine/backends/filter/validation_test.go
+++ b/lib/apiservers/engine/backends/filter/validation_test.go
@@ -62,11 +62,12 @@ var unSupportedPsFilters = map[string]bool{
 	"is-task":   false,
 }
 
-// valid volume filters as per API v1.25
+// valid volume filters as of Docker v1.13
 var acceptedVolumeFilterTags = map[string]bool{
 	"dangling": true,
 	"name":     true,
 	"driver":   true,
+	"label":    true,
 }
 
 func TestValidateFilters(t *testing.T) {

--- a/lib/apiservers/engine/backends/filter/validation_test.go
+++ b/lib/apiservers/engine/backends/filter/validation_test.go
@@ -62,6 +62,13 @@ var unSupportedPsFilters = map[string]bool{
 	"is-task":   false,
 }
 
+// valid volume filters as per API v1.25
+var acceptedVolumeFilterTags = map[string]bool{
+	"dangling": true,
+	"name":     true,
+	"driver":   true,
+}
+
 func TestValidateFilters(t *testing.T) {
 	args := filters.NewArgs()
 	args.Add("id", "12345")
@@ -91,4 +98,13 @@ func TestValidateFilters(t *testing.T) {
 	args = filters.NewArgs()
 	args.Add("label", "124")
 	assert.NoError(t, ValidateFilters(args, acceptedImageFilterTags, unSupportedImageFilters))
+
+	// valid volume filter
+	args = filters.NewArgs()
+	args.Add("name", "vol")
+	assert.NoError(t, ValidateFilters(args, acceptedVolumeFilterTags, nil))
+
+	// invalid volume filter
+	args.Add("mountpoint", "/volumes")
+	assert.Error(t, ValidateFilters(args, acceptedVolumeFilterTags, nil))
 }

--- a/lib/apiservers/engine/backends/filter/volume.go
+++ b/lib/apiservers/engine/backends/filter/volume.go
@@ -1,0 +1,87 @@
+// Copyright 2017 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package filter
+
+import (
+	"fmt"
+
+	"github.com/docker/engine-api/types/filters"
+)
+
+// VolumeFilterContext stores volume information used while filtering
+type VolumeFilterContext struct {
+	FilterContext
+
+	// Dangling is the value of the dangling filter if supplied
+	Dangling bool
+
+	// Joined tells whether the volume is joined to a container or not
+	Joined bool
+
+	// Driver is the volume's driver
+	Driver string
+}
+
+// ValidateVolumeFilters checks that the supplied filters are valid and supported
+// and returns a context used in the IncludeVolume func.
+func ValidateVolumeFilters(volFilters filters.Args, acceptedFilters, unSupportedFilters map[string]bool) (*VolumeFilterContext, error) {
+
+	if err := ValidateFilters(volFilters, acceptedFilters, unSupportedFilters); err != nil {
+		return nil, err
+	}
+
+	volFilterContext := &VolumeFilterContext{}
+
+	// Set value of dangling filter if it's supplied
+	if volFilters.Include("dangling") {
+
+		// Validate dangling filter's usage (per Docker code)
+		// Supported formats: dangling={true, false, 1, 0}
+		if volFilters.ExactMatch("dangling", "true") || volFilters.ExactMatch("dangling", "1") {
+			volFilterContext.Dangling = true
+		} else if !volFilters.ExactMatch("dangling", "false") && !volFilters.ExactMatch("dangling", "0") {
+			return nil, fmt.Errorf("invalid filter 'dangling=%s'", volFilters.Get("dangling"))
+		}
+	}
+
+	return volFilterContext, nil
+}
+
+// IncludeVolume evaluates volume filters and the filter context and returns
+// an action to indicate whether to include the volume in the output or not.
+func IncludeVolume(volumeFilters filters.Args, volFilterContext *VolumeFilterContext) FilterAction {
+
+	// Filter by name
+	action := filterCommon(&volFilterContext.FilterContext, volumeFilters)
+	if action != IncludeAction {
+		return action
+	}
+
+	if volumeFilters.Include("dangling") {
+		// Exclude the volume if dangling=false or it is joined,
+		// and if dangling=true or it is not joined
+		if (!volFilterContext.Dangling || volFilterContext.Joined) && (volFilterContext.Dangling || !volFilterContext.Joined) {
+			return ExcludeAction
+		}
+	}
+
+	if volumeFilters.Include("driver") {
+		if !volumeFilters.ExactMatch("driver", volFilterContext.Driver) {
+			return ExcludeAction
+		}
+	}
+
+	return IncludeAction
+}

--- a/lib/apiservers/engine/backends/filter/volume.go
+++ b/lib/apiservers/engine/backends/filter/volume.go
@@ -63,7 +63,7 @@ func ValidateVolumeFilters(volFilters filters.Args, acceptedFilters, unSupported
 // an action to indicate whether to include the volume in the output or not.
 func IncludeVolume(volumeFilters filters.Args, volFilterContext *VolumeFilterContext) FilterAction {
 
-	// Filter by name
+	// Filter by name and label
 	action := filterCommon(&volFilterContext.FilterContext, volumeFilters)
 	if action != IncludeAction {
 		return action

--- a/lib/apiservers/engine/backends/filter/volume_test.go
+++ b/lib/apiservers/engine/backends/filter/volume_test.go
@@ -1,0 +1,101 @@
+// Copyright 2017 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package filter
+
+import (
+	"testing"
+
+	"github.com/docker/engine-api/types/filters"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidateVolumeFilters(t *testing.T) {
+
+	// Valid filters
+	volFilters := filters.NewArgs()
+	volFilters.Add("dangling", "true")
+	volFilters.Add("name", "mulder")
+	volFilters.Add("driver", "aliens")
+	volFilterContext, err := ValidateVolumeFilters(volFilters, acceptedVolumeFilterTags, nil)
+	assert.NoError(t, err)
+	assert.Equal(t, volFilterContext.Dangling, true)
+
+	// Change a filter's value
+	volFilters.Del("dangling", "true")
+	volFilters.Add("dangling", "false")
+	volFilterContext, err = ValidateVolumeFilters(volFilters, acceptedVolumeFilterTags, nil)
+	assert.NoError(t, err)
+	assert.Equal(t, volFilterContext.Dangling, false)
+
+	// Valid filter with invalid value
+	volFilters.Del("dangling", "false")
+	volFilters.Add("dangling", "no")
+	volFilterContext, err = ValidateVolumeFilters(volFilters, acceptedVolumeFilterTags, nil)
+	assert.Error(t, err)
+
+	// Invalid filter
+	volFilters.Add("mountpoint", "/volumes")
+	_, err = ValidateVolumeFilters(volFilters, acceptedVolumeFilterTags, nil)
+	assert.Error(t, err)
+}
+
+func TestIncludeVolume(t *testing.T) {
+
+	// Filter by dangling=true
+	volFilters := filters.NewArgs()
+	volFilters.Add("dangling", "true")
+	volFilterContext := &VolumeFilterContext{
+		FilterContext: FilterContext{
+			Name: "scully",
+		},
+		Driver:   "science",
+		Joined:   false,
+		Dangling: true,
+	}
+	action := IncludeVolume(volFilters, volFilterContext)
+	assert.Equal(t, action, IncludeAction)
+
+	// Filter by dangling=false
+	volFilters.Del("dangling", "true")
+	volFilters.Add("dangling", "false")
+	volFilterContext.Dangling = false
+	action = IncludeVolume(volFilters, volFilterContext)
+	assert.Equal(t, action, ExcludeAction)
+
+	// Filter by name and dangling=false
+	volFilters.Add("name", "scul")
+	volFilterContext.Joined = true
+	action = IncludeVolume(volFilters, volFilterContext)
+	assert.Equal(t, action, IncludeAction)
+
+	// Filter by name, dangling=false and driver=science
+	volFilters.Add("driver", "science")
+	action = IncludeVolume(volFilters, volFilterContext)
+	assert.Equal(t, action, IncludeAction)
+
+	// Filter by incorrect name, dangling=false and incorrect driver
+	volFilterContext.Name = "mulder"
+	volFilterContext.Driver = "aliens"
+	action = IncludeVolume(volFilters, volFilterContext)
+	assert.Equal(t, action, ExcludeAction)
+
+	// Filter by name, dangling=false and incorrect driver
+	volFilterContext.Name = "scully"
+	volFilterContext.Driver = "science"
+	volFilters.Del("driver", "science")
+	volFilters.Add("driver", "sci")
+	action = IncludeVolume(volFilters, volFilterContext)
+	assert.Equal(t, action, ExcludeAction)
+}

--- a/lib/apiservers/engine/backends/filter/volume_test.go
+++ b/lib/apiservers/engine/backends/filter/volume_test.go
@@ -58,7 +58,8 @@ func TestIncludeVolume(t *testing.T) {
 	volFilters.Add("dangling", "true")
 	volFilterContext := &VolumeFilterContext{
 		FilterContext: FilterContext{
-			Name: "scully",
+			Name:   "scully",
+			Labels: map[string]string{"samplelabel": ""},
 		},
 		Driver:   "science",
 		Joined:   false,
@@ -96,6 +97,18 @@ func TestIncludeVolume(t *testing.T) {
 	volFilterContext.Driver = "science"
 	volFilters.Del("driver", "science")
 	volFilters.Add("driver", "sci")
+	action = IncludeVolume(volFilters, volFilterContext)
+	assert.Equal(t, action, ExcludeAction)
+
+	// Filter by correct label
+	volFilters = filters.NewArgs()
+	volFilters.Add("label", "samplelabel")
+	action = IncludeVolume(volFilters, volFilterContext)
+	assert.Equal(t, action, IncludeAction)
+
+	// Filter by incorrect label
+	volFilters.Del("label", "samplelabel")
+	volFilters.Add("label", "wronglabel")
 	action = IncludeVolume(volFilters, volFilterContext)
 	assert.Equal(t, action, ExcludeAction)
 }

--- a/lib/apiservers/engine/backends/volume.go
+++ b/lib/apiservers/engine/backends/volume.go
@@ -1,4 +1,4 @@
-// Copyright 2016 VMware, Inc. All Rights Reserved.
+// Copyright 2016-2017 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,7 +17,6 @@ package backends
 import (
 	"encoding/json"
 	"fmt"
-	"net/http"
 
 	log "github.com/Sirupsen/logrus"
 	derr "github.com/docker/docker/errors"
@@ -27,9 +26,12 @@ import (
 	"strings"
 
 	"github.com/docker/engine-api/types"
+	"github.com/docker/engine-api/types/filters"
 	"github.com/docker/go-units"
 	"github.com/google/uuid"
 
+	vicfilter "github.com/vmware/vic/lib/apiservers/engine/backends/filter"
+	"github.com/vmware/vic/lib/apiservers/portlayer/client/containers"
 	"github.com/vmware/vic/lib/apiservers/portlayer/client/storage"
 	"github.com/vmware/vic/lib/apiservers/portlayer/models"
 	"github.com/vmware/vic/pkg/trace"
@@ -67,6 +69,15 @@ func NewVolumeModel(volume *models.VolumeResponse, labels map[string]string) *ty
 type Volume struct {
 }
 
+// acceptedVolumeFilters are filters that are supported by VIC
+var acceptedVolumeFilters = map[string]bool{
+	"dangling": true,
+	"name":     true,
+	"driver":   true,
+}
+
+var errPortlayerClient = fmt.Errorf("failed to get a portlayer client")
+
 // Volumes docker personality implementation for VIC
 func (v *Volume) Volumes(filter string) ([]*types.Volume, []string, error) {
 	defer trace.End(trace.Begin("Volume.Volumes"))
@@ -74,34 +85,94 @@ func (v *Volume) Volumes(filter string) ([]*types.Volume, []string, error) {
 
 	client := PortLayerClient()
 	if client == nil {
-		return nil, nil, derr.NewErrorWithStatusCode(fmt.Errorf("Failed to get a portlayer client"), http.StatusInternalServerError)
+		return nil, nil, VolumeInternalServerError(errPortlayerClient)
 	}
 
 	res, err := client.Storage.ListVolumes(storage.NewListVolumesParamsWithContext(ctx).WithFilterString(&filter))
 	if err != nil {
 		switch err := err.(type) {
 		case *storage.ListVolumesInternalServerError:
-			return nil, nil, derr.NewErrorWithStatusCode(fmt.Errorf("error from portlayer server: %s", err.Payload.Message), http.StatusInternalServerError)
+			return nil, nil, VolumeInternalServerError(fmt.Errorf("error from portlayer server: %s", err.Payload.Message))
 		case *storage.ListVolumesDefault:
-			return nil, nil, derr.NewErrorWithStatusCode(fmt.Errorf("error from portlayer server: %s", err.Payload.Message), http.StatusInternalServerError)
+			return nil, nil, VolumeInternalServerError(fmt.Errorf("error from portlayer server: %s", err.Payload.Message))
 		default:
-			return nil, nil, derr.NewErrorWithStatusCode(fmt.Errorf("error from portlayer server: %s", err.Error()), http.StatusInternalServerError)
+			return nil, nil, VolumeInternalServerError(fmt.Errorf("error from portlayer server: %s", err.Error()))
 		}
 	}
 
 	volumeResponses := res.Payload
 
-	log.Infoln("volumes found: ")
+	// Parse and validate filters
+	volumeFilters, err := filters.FromParam(filter)
+	if err != nil {
+		return nil, nil, VolumeInternalServerError(err)
+	}
+	volFilterContext, err := vicfilter.ValidateVolumeFilters(volumeFilters, acceptedVolumeFilters, nil)
+	if err != nil {
+		return nil, nil, VolumeInternalServerError(err)
+	}
+
+	// joinedVolumes stores names of volumes that are joined to a container
+	// and is used while filtering the output by dangling (dangling=true should
+	// return volumes that are not attached to a container)
+	joinedVolumes := make(map[string]struct{})
+
+	if volumeFilters.Include("dangling") {
+		// If the dangling filter is specified, gather required items beforehand
+
+		// Get all containers from the portlayer and use their metadata to obtain
+		// non-dangling (joined) volumes
+		conts, err := allContainers()
+		if err != nil {
+			return nil, nil, VolumeInternalServerError(err)
+		}
+
+		var s struct{}
+		for i := range conts {
+			for _, vol := range conts[i].VolumeConfig {
+				joinedVolumes[vol.Name] = s
+			}
+		}
+	}
+
+	log.Infoln("volumes found:")
 	for _, vol := range volumeResponses {
 		log.Infof("%s", vol.Name)
-		volumeMetadata, err := extractDockerMetadata(vol.Metadata)
-		if err != nil {
-			return nil, nil, fmt.Errorf("error unmarshalling docker metadata: %s", err)
+
+		// Set fields needed for filtering the output
+		volFilterContext.Name = vol.Name
+		volFilterContext.Driver = vol.Driver
+		_, volFilterContext.Joined = joinedVolumes[vol.Name]
+
+		// Include the volume in the output if it meets the filtering criteria
+		filterAction := vicfilter.IncludeVolume(volumeFilters, volFilterContext)
+		if filterAction == vicfilter.IncludeAction {
+			volumeMetadata, err := extractDockerMetadata(vol.Metadata)
+			if err != nil {
+				return nil, nil, VolumeInternalServerError(fmt.Errorf("error unmarshalling docker metadata: %s", err))
+			}
+			volume := NewVolumeModel(vol, volumeMetadata.Labels)
+			volumes = append(volumes, volume)
 		}
-		volume := NewVolumeModel(vol, volumeMetadata.Labels)
-		volumes = append(volumes, volume)
 	}
+
 	return volumes, nil, nil
+}
+
+// allContainers obtains all containers from the portlayer, akin to `docker ps -a`.
+func allContainers() ([]*models.ContainerInfo, error) {
+	client := PortLayerClient()
+	if client == nil {
+		return nil, errPortlayerClient
+	}
+
+	all := true
+	cons, err := client.Containers.GetContainerList(containers.NewGetContainerListParamsWithContext(ctx).WithAll(&all))
+	if err != nil {
+		return nil, err
+	}
+
+	return cons.Payload, nil
 }
 
 // VolumeInspect : docker personality implementation for VIC
@@ -110,7 +181,7 @@ func (v *Volume) VolumeInspect(name string) (*types.Volume, error) {
 
 	client := PortLayerClient()
 	if client == nil {
-		return nil, fmt.Errorf("failed to get a portlayer client")
+		return nil, VolumeInternalServerError(errPortlayerClient)
 	}
 
 	if name == "" {
@@ -124,13 +195,13 @@ func (v *Volume) VolumeInspect(name string) (*types.Volume, error) {
 		case *storage.GetVolumeNotFound:
 			return nil, VolumeNotFoundError(name)
 		default:
-			return nil, derr.NewErrorWithStatusCode(fmt.Errorf("error from portlayer server: %s", err.Error()), http.StatusInternalServerError)
+			return nil, VolumeInternalServerError(fmt.Errorf("error from portlayer server: %s", err.Error()))
 		}
 	}
 
 	volumeMetadata, err := extractDockerMetadata(res.Payload.Metadata)
 	if err != nil {
-		return nil, derr.NewErrorWithStatusCode(fmt.Errorf("error unmarshalling docker metadata: %s", err), http.StatusInternalServerError)
+		return nil, VolumeInternalServerError(fmt.Errorf("error unmarshalling docker metadata: %s", err))
 	}
 	volume := NewVolumeModel(res.Payload, volumeMetadata.Labels)
 
@@ -144,7 +215,7 @@ func (v *Volume) volumeCreate(name, driverName string, volumeData, labels map[st
 
 	client := PortLayerClient()
 	if client == nil {
-		return nil, fmt.Errorf("failed to get a portlayer client")
+		return nil, errPortlayerClient
 	}
 
 	if name == "" {
@@ -175,20 +246,20 @@ func (v *Volume) VolumeCreate(name, driverName string, volumeData, labels map[st
 	if err != nil {
 		switch err := err.(type) {
 		case *storage.CreateVolumeConflict:
-			return result, derr.NewErrorWithStatusCode(fmt.Errorf("A volume named %s already exists. Choose a different volume name.", name), http.StatusInternalServerError)
+			return result, VolumeInternalServerError(fmt.Errorf("A volume named %s already exists. Choose a different volume name.", name))
 
 		case *storage.CreateVolumeNotFound:
-			return result, derr.NewErrorWithStatusCode(fmt.Errorf("No volume store named (%s) exists", volumeStore(volumeData)), http.StatusInternalServerError)
+			return result, VolumeInternalServerError(fmt.Errorf("No volume store named (%s) exists", volumeStore(volumeData)))
 
 		case *storage.CreateVolumeInternalServerError:
 			// FIXME: right now this does not return an error model...
-			return result, derr.NewErrorWithStatusCode(fmt.Errorf("%s", err.Error()), http.StatusInternalServerError)
+			return result, VolumeInternalServerError(fmt.Errorf("%s", err.Error()))
 
 		case *storage.CreateVolumeDefault:
-			return result, derr.NewErrorWithStatusCode(fmt.Errorf("%s", err.Payload.Message), http.StatusInternalServerError)
+			return result, VolumeInternalServerError(fmt.Errorf("%s", err.Payload.Message))
 
 		default:
-			return result, derr.NewErrorWithStatusCode(fmt.Errorf("%s", err), http.StatusInternalServerError)
+			return result, VolumeInternalServerError(fmt.Errorf("%s", err))
 		}
 	}
 
@@ -201,7 +272,7 @@ func (v *Volume) VolumeRm(name string) error {
 
 	client := PortLayerClient()
 	if client == nil {
-		return derr.NewErrorWithStatusCode(fmt.Errorf("Failed to get a portlayer client"), http.StatusInternalServerError)
+		return VolumeInternalServerError(errPortlayerClient)
 	}
 
 	// FIXME: check whether this is a name or a UUID. UUID expected for now.
@@ -216,9 +287,9 @@ func (v *Volume) VolumeRm(name string) error {
 			return derr.NewRequestConflictError(fmt.Errorf(err.Payload.Message))
 
 		case *storage.RemoveVolumeInternalServerError:
-			return derr.NewErrorWithStatusCode(fmt.Errorf("Server error from portlayer: %s", err.Payload.Message), http.StatusInternalServerError)
+			return VolumeInternalServerError(fmt.Errorf("Server error from portlayer: %s", err.Payload.Message))
 		default:
-			return derr.NewErrorWithStatusCode(fmt.Errorf("Server error from portlayer: %s", err), http.StatusInternalServerError)
+			return VolumeInternalServerError(fmt.Errorf("Server error from portlayer: %s", err))
 		}
 	}
 	return nil

--- a/lib/apiservers/engine/backends/volume_test.go
+++ b/lib/apiservers/engine/backends/volume_test.go
@@ -1,4 +1,4 @@
-// Copyright 2016 VMware, Inc. All Rights Reserved.
+// Copyright 2016-2017 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/apiservers/engine/backends/volume_test.go
+++ b/lib/apiservers/engine/backends/volume_test.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2017 VMware, Inc. All Rights Reserved.
+// Copyright 2016 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/apiservers/portlayer/restapi/handlers/containers_handlers.go
+++ b/lib/apiservers/portlayer/restapi/handlers/containers_handlers.go
@@ -1,4 +1,4 @@
-// Copyright 2016 VMware, Inc. All Rights Reserved.
+// Copyright 2016-2017 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -407,7 +407,16 @@ func convertContainerToContainerInfo(container *exec.ContainerInfo) *models.Cont
 	info := &models.ContainerInfo{
 		ContainerConfig: &models.ContainerConfig{},
 		ProcessConfig:   &models.ProcessConfig{},
+		VolumeConfig:    make([]*models.VolumeConfig, 0),
 		Endpoints:       make([]*models.EndpointConfig, 0),
+	}
+
+	// Populate volume information
+	for volName := range container.ExecConfig.Mounts {
+		vol := &models.VolumeConfig{
+			Name: volName,
+		}
+		info.VolumeConfig = append(info.VolumeConfig, vol)
 	}
 
 	ccid := container.ExecConfig.ID

--- a/lib/apiservers/portlayer/swagger.json
+++ b/lib/apiservers/portlayer/swagger.json
@@ -2857,6 +2857,9 @@
 						"type": "string"
 					}
 				},
+				"name": {
+					"type": "string"
+				},
 				"mountPoint": {
 					"type": "string"
 				},

--- a/tests/test-cases/Group1-Docker-Commands/1-21-Docker-Volume-LS.md
+++ b/tests/test-cases/Group1-Docker-Commands/1-21-Docker-Volume-LS.md
@@ -12,24 +12,34 @@ This test requires that a vSphere server is running and available
 
 #Test Steps:
 1. Deploy VIC appliance to vSphere server
-2. Issue docker volume create --name=test to the VIC appliance
-3. Issue docker volume create --name=test2 to the VIC appliance
-4. Issue docker create -v test:/test busybox to the VIC appliance
-5. Issue docker volume ls to the VIC appliance
-6. Issue docker volume ls -q to the VIC appliance
-7. Issue docker volume ls -f dangling=true to the VIC appliance
-8. Issue docker volume ls -f name=test to the VIC appliance
-9. Issue docker volume ls -f dangling=false to the VIC appliance
+2. Issue docker volume create --name=testVol
+3. Issue docker volume ls
+4. Issue docker volume ls -q
+5. Issue docker volume ls -f bogusfilter=test
+6. Issue docker create --name=danglingVol
+7. Issue docker create -v testVol:/test busybox
+8. Issue docker volume ls -f dangling=true
+9. Issue docker volume ls -f dangling=false
+10. Issue docker volume ls -f name=dang
+11. Issue docker volume ls -f driver=vsphere
+12. Issue docker volume ls -f driver=vsph
+13. Issue docker volume ls -f dangling=true -f name=dang
+14. Issue docker volume ls -f dangling=false -f name=dang
 
 #Expected Outcome:
-* Step 5 should result in each volume being listed with both driver and volume name
-* Step 6 should result in each volume being listed with only the volume name being listed
-* Step 7 should result in the test2 volume being listed but not the test volume
-* Step 8 should result in the following error:  
+* Step 3 should result in each volume being listed with both driver and volume name
+* Step 4 should result in each volume being listed with only the volume name being listed
+* Step 5 should result in the following error:
 ```
-Error response from daemon: Invalid filter 'name'
+Error response from daemon: Invalid filter 'bogusfilter'
 ```
-* Step 9 should result in the test volume being listed but not the test2 volume
+* Step 8 should result in only danglingVol being listed
+* Step 9 should result in only testVol being listed
+* Step 10 should result in only danglingVol being listed
+* Step 11 should result in danglingVol and testVol being listed
+* Step 12 should result in no volumes being listed
+* Step 13 should result in only danglingVol being listed
+* Step 14 should result in no volumes being listed
 
 #Possible Problems:
 * VIC requires you to specify storage on creation of the VCH that volumes can be created from, so when installing the VCH make sure to specify this parameter: --volume-store=

--- a/tests/test-cases/Group1-Docker-Commands/1-21-Docker-Volume-LS.md
+++ b/tests/test-cases/Group1-Docker-Commands/1-21-Docker-Volume-LS.md
@@ -23,8 +23,10 @@ This test requires that a vSphere server is running and available
 10. Issue docker volume ls -f name=dang
 11. Issue docker volume ls -f driver=vsphere
 12. Issue docker volume ls -f driver=vsph
-13. Issue docker volume ls -f dangling=true -f name=dang
-14. Issue docker volume ls -f dangling=false -f name=dang
+13. Issue docker volume create --name=labelVol --label=labeled
+14. Issue docker volume ls -f label=labeled
+15. Issue docker volume ls -f dangling=true -f name=dang
+16. Issue docker volume ls -f dangling=false -f name=dang
 
 #Expected Outcome:
 * Step 3 should result in each volume being listed with both driver and volume name
@@ -38,8 +40,9 @@ Error response from daemon: Invalid filter 'bogusfilter'
 * Step 10 should result in only danglingVol being listed
 * Step 11 should result in danglingVol and testVol being listed
 * Step 12 should result in no volumes being listed
-* Step 13 should result in only danglingVol being listed
-* Step 14 should result in no volumes being listed
+* Step 14 should result in only labelVol being listed
+* Step 15 should result in only danglingVol being listed
+* Step 16 should result in no volumes being listed
 
 #Possible Problems:
 * VIC requires you to specify storage on creation of the VCH that volumes can be created from, so when installing the VCH make sure to specify this parameter: --volume-store=

--- a/tests/test-cases/Group1-Docker-Commands/1-21-Docker-Volume-LS.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-21-Docker-Volume-LS.robot
@@ -61,6 +61,15 @@ Volume ls filter by driver
     Should Not Contain  ${output}  danglingVol
     Should Not Contain  ${output}  testVol
 
+Volume ls filter by label
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} volume create --name=labelVol --label=labeled
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} volume ls -f label=labeled
+    Should Be Equal As Integers  ${rc}  0
+    Should Contain  ${output}  labelVol
+    Should Not Contain  ${output}  danglingVol
+    Should Not Contain  ${output}  testVol
+
 Volume ls multiple filters
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} volume ls -f dangling=true -f name=dang
     Should Be Equal As Integers  ${rc}  0

--- a/tests/test-cases/Group1-Docker-Commands/1-21-Docker-Volume-LS.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-21-Docker-Volume-LS.robot
@@ -6,13 +6,13 @@ Suite Teardown  Cleanup VIC Appliance On Test Server
 
 *** Test Cases ***
 Simple volume ls
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} volume create --name=test
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} volume create --name=testVol
     Should Be Equal As Integers  ${rc}  0
-    Should Be Equal As Strings  ${output}  test
+    Should Be Equal As Strings  ${output}  testVol
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} volume ls
     Should Be Equal As Integers  ${rc}  0
     Should Contain  ${output}  vsphere
-    Should Contain  ${output}  test
+    Should Contain  ${output}  testVol
     Should Contain  ${output}  DRIVER
     Should Contain  ${output}  VOLUME NAME
     
@@ -20,35 +20,54 @@ Volume ls quiet
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} volume ls -q
     Should Be Equal As Integers  ${rc}  0
     Should Not Contain  ${output}  vsphere
-    Should Contain  ${output}  test
+    Should Contain  ${output}  testVol
     Should Not Contain  ${output}  DRIVER
     Should Not Contain  ${output}  VOLUME NAME
-    
-Volume ls dangling volumes
-    ${status}=  Get State Of Github Issue  1718
-    Run Keyword If  '${status}' == 'closed'  Fail  Test 1-21-Docker-Volume-LS.robot needs to be updated now that Issue #1718 has been resolved
-    Log  Issue \#1718 is blocking implementation  WARN
-    #${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} volume ls -f dangling=true
-    #Should Be Equal As Integers  ${rc}  0
-    #Should Contain  ${output}  vsphere
-    #Should Contain  ${output}  test
-    #Should Contain  ${output}  DRIVER
-    #Should Contain  ${output}  VOLUME NAME
-    
+
 Volume ls invalid filter
-    ${status}=  Get State Of Github Issue  1718
-    Run Keyword If  '${status}' == 'closed'  Fail  Test 1-21-Docker-Volume-LS.robot needs to be updated now that Issue #1718 has been resolved
-    Log  Issue \#1718 is blocking implementation  WARN
-    #${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} volume ls -f name=test
-    #Should Be Equal As Integers  ${rc}  1
-    #Should Contain  ${output}  Error response from daemon: Invalid filter 'name'
-    
-Volume ls no dangling volumes
-    ${status}=  Get State Of Github Issue  1718
-    Run Keyword If  '${status}' == 'closed'  Fail  Test 1-21-Docker-Volume-LS.robot needs to be updated now that Issue #1718 has been resolved
-    Log  Issue \#1718 is blocking implementation  WARN
-    #${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} create -v test:/test busybox
-    #Should Be Equal As Integers  ${rc}  0
-    #${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} volume ls -f dangling=true
-    #Should Be Equal As Integers  ${rc}  0
-    #Log  ${output}
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} volume ls -f bogusfilter=test
+    Should Be Equal As Integers  ${rc}  1
+    Should Contain  ${output}  Error response from daemon: Invalid filter 'bogusfilter'
+
+Volume ls filter by dangling
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} volume create --name=danglingVol
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} create -v testVol:/test busybox
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} volume ls -f dangling=true
+    Should Be Equal As Integers  ${rc}  0
+    Should Contain  ${output}  danglingVol
+    Should Not Contain  ${output}  testVol
+
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} volume ls -f dangling=false
+    Should Be Equal As Integers  ${rc}  0
+    Should Contain  ${output}  testVol
+    Should Not Contain  ${output}  danglingVol
+
+Volume ls filter by name
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} volume ls -f name=dang
+    Should Be Equal As Integers  ${rc}  0
+    Should Contain  ${output}  danglingVol
+    Should Not Contain  ${output}  testVol
+
+Volume ls filter by driver
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} volume ls -f driver=vsphere
+    Should Be Equal As Integers  ${rc}  0
+    Should Contain  ${output}  danglingVol
+    Should Contain  ${output}  testVol
+
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} volume ls -f driver=vsph
+    Should Be Equal As Integers  ${rc}  0
+    Should Not Contain  ${output}  danglingVol
+    Should Not Contain  ${output}  testVol
+
+Volume ls multiple filters
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} volume ls -f dangling=true -f name=dang
+    Should Be Equal As Integers  ${rc}  0
+    Should Contain  ${output}  danglingVol
+    Should Not Contain  ${output}  testVol
+
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} volume ls -f dangling=false -f name=dang
+    Should Be Equal As Integers  ${rc}  0
+    Should Not Contain  ${output}  danglingVol
+    Should Not Contain  ${output}  testVol


### PR DESCRIPTION
Adds support for `volume ls -f` by `name`, `driver`, `dangling` and `label`.

Fixes #1718