### PR TITLE
[specific ci=Group1-Docker-Commands] Fix docker stop status code bug #3800

### DIFF
--- a/lib/apiservers/engine/backends/container.go
+++ b/lib/apiservers/engine/backends/container.go
@@ -889,16 +889,15 @@ func dockerStatus(exitCode int, status string, state string, started time.Time, 
 				exitCode = 126
 			} else if strings.Contains(status, "no such") {
 				exitCode = 127
-			} else if status == "true" && exitCode == -1 {
-				// most likely the process was killed via the cli
-				// or received a sigkill
-				exitCode = 137
-			} else if status == "" && exitCode == 0 {
-				// the process was stopped via the cli
-				// or received a sigterm
-				exitCode = 143
+			} else if status == "true" {
+				if exitCode == -1 {
+					// most likely the process was killed via the cli or received a sigkill
+					exitCode = 137
+				} else if exitCode == 0 {
+					// the process was stopped via the cli or received a sigterm
+					exitCode = 143
+				}
 			}
-
 			dockStatus = fmt.Sprintf("Exited (%d) %s ago", exitCode, units.HumanDuration(time.Now().UTC().Sub(finished)))
 		}
 	}


### PR DESCRIPTION
Fixes #3800 

This looks to be the trivial fix needed to get `docker ps` to report the correct error code for `docker stop`ped containers

New output looks like this (I'm pretty sure the time is wrong on my ESX please ignore the '17 hours ago')
```
❯ docker -H 192.168.1.168:2376 --tls stop $(docker -H 192.168.1.168:2376 --tls run -d busybox top) && docker -H 192.168.1.168:2376 --tls ps -a
37b3fe1aace9fc361986940287f78633c6345df4a0e5e021196c295de90c7b97
CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS                        PORTS               NAMES
37b3fe1aace9        busybox             "top"               17 hours ago        Exited (143) 1 seconds ago                        adoring_brown
```