### PR TITLE
implement image filtering [specific ci=1-03-Docker-Images]

### DIFF
--- a/lib/apiservers/engine/backends/cache/image_cache.go
+++ b/lib/apiservers/engine/backends/cache/image_cache.go
@@ -17,6 +17,7 @@ package cache
 import (
 	"encoding/json"
 	"fmt"
+	"sort"
 	"strings"
 	"sync"
 
@@ -55,6 +56,14 @@ var (
 	imageCache *ICache
 	ctx        = context.TODO()
 )
+
+// byCreated is a temporary type used to sort a list of images by creation
+// time.
+type byCreated []*metadata.ImageConfig
+
+func (r byCreated) Len() int           { return len(r) }
+func (r byCreated) Swap(i, j int)      { r[i], r[j] = r[j], r[i] }
+func (r byCreated) Less(i, j int) bool { return r[i].Created.Unix() < r[j].Created.Unix() }
 
 func init() {
 	imageCache = &ICache{
@@ -117,6 +126,8 @@ func (ic *ICache) GetImages() []*metadata.ImageConfig {
 	for _, image := range ic.cacheByID {
 		result = append(result, copyImageConfig(image))
 	}
+
+	sort.Sort(sort.Reverse(byCreated(result)))
 	return result
 }
 

--- a/lib/apiservers/engine/backends/filter/image.go
+++ b/lib/apiservers/engine/backends/filter/image.go
@@ -1,0 +1,109 @@
+// Copyright 2017 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package filter
+
+import (
+	"fmt"
+	"path"
+
+	"github.com/docker/engine-api/types/filters"
+
+	"github.com/vmware/vic/lib/apiservers/engine/backends/cache"
+)
+
+/*
+* ValidateImageFilters will validate the image filters are
+* valid docker filters / values and supported by vic.
+*
+* The function will reuse dockers filter validation
+*
+ */
+func ValidateImageFilters(cmdFilters filters.Args, acceptedFilters map[string]bool, unSupportedFilters map[string]bool) (*FilterContext, error) {
+
+	// ensure filter options are valid and supported by vic
+	if err := ValidateFilters(cmdFilters, acceptedFilters, unSupportedFilters); err != nil {
+		return nil, err
+	}
+
+	// return value
+	imgFilterContext := &FilterContext{}
+
+	err := cmdFilters.WalkValues("before", func(value string) error {
+		before, err := cache.ImageCache().Get(value)
+		if before == nil {
+			err = fmt.Errorf("No such image: %s", value)
+		} else {
+			imgFilterContext.BeforeID = &before.ImageID
+		}
+		return err
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	err = cmdFilters.WalkValues("since", func(value string) error {
+		since, err := cache.ImageCache().Get(value)
+		if since == nil {
+			err = fmt.Errorf("No such image: %s", value)
+		} else {
+			imgFilterContext.SinceID = &since.ImageID
+		}
+		return err
+	})
+	if err != nil {
+		return nil, err
+	}
+	return imgFilterContext, nil
+
+}
+
+/*
+*	IncludeImage will evaluate the filter criteria in filterContext against the provided
+* 	image and determine what action to take.  There are three options:
+*		* IncludeAction
+*		* ExcludeAction
+*		* StopAction
+*
+ */
+func IncludeImage(imgFilters filters.Args, listContext *FilterContext) FilterAction {
+
+	// filter common requirements
+	act := filterCommon(listContext, imgFilters)
+	if act != IncludeAction {
+		return act
+	}
+
+	// filter on image reference
+	if imgFilters.Include("reference") {
+		// references for this imageID
+		refs := cache.RepositoryCache().References(listContext.ID)
+		for _, ref := range refs {
+			err := imgFilters.WalkValues("reference", func(value string) error {
+				// match on complete ref ie. busybox:latest
+				matchRef, _ := path.Match(value, ref.String())
+				// match on repo only ie. busybox
+				matchName, _ := path.Match(value, ref.Name())
+				if !matchRef && !matchName {
+					return fmt.Errorf("reference not found")
+				}
+				return nil
+			})
+			if err != nil {
+				return ExcludeAction
+			}
+		}
+	}
+	return IncludeAction
+}

--- a/lib/apiservers/engine/backends/filter/image_test.go
+++ b/lib/apiservers/engine/backends/filter/image_test.go
@@ -1,0 +1,115 @@
+// Copyright 2017 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package filter
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/docker/docker/reference"
+	"github.com/docker/engine-api/types/container"
+	"github.com/docker/engine-api/types/filters"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/vmware/vic/lib/apiservers/engine/backends/cache"
+	"github.com/vmware/vic/lib/metadata"
+)
+
+func loadImageCache(repo string, imageCount int, t *testing.T) {
+
+	for i := 0; i < imageCount; i++ {
+		id := fmt.Sprintf("120%d", i)
+		tag := fmt.Sprintf("1.0%d", i+1)
+		ref := fmt.Sprintf("%s:%s", repo, tag)
+		img := &metadata.ImageConfig{
+			ImageID:   id,
+			Tags:      []string{tag},
+			Name:      repo,
+			Reference: ref,
+		}
+		img.Created = time.Now().UTC()
+		img.ID = id
+		img.Config = &container.Config{}
+		cache.ImageCache().Add(img)
+
+		named, err := reference.ParseNamed(ref)
+		if err != nil {
+			t.Fatalf("Error while parsing reference %s: %#v", ref, err)
+		}
+		cache.RepositoryCache().AddReference(named, id, true, id, false)
+	}
+
+	assert.Equal(t, imageCount, len(cache.ImageCache().GetImages()))
+}
+
+func TestValidateImageFilters(t *testing.T) {
+	loadImageCache("busyboxy", 5, t)
+
+	cmdFilters := filters.NewArgs()
+	cmdFilters.Add("dangling", "true")
+	_, err := ValidateImageFilters(cmdFilters, acceptedImageFilterTags, unSupportedImageFilters)
+	assert.Error(t, err)
+
+	cmdFilters.Del("dangling", "true")
+	cmdFilters.Add("before", "1200")
+	_, err = ValidateImageFilters(cmdFilters, acceptedImageFilterTags, unSupportedImageFilters)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "No such image")
+
+	cmdFilters.Del("before", "1200")
+	cmdFilters.Add("since", "1200")
+	_, err = ValidateImageFilters(cmdFilters, acceptedImageFilterTags, unSupportedImageFilters)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "No such image")
+}
+
+func TestIncludeImage(t *testing.T) {
+	cmdFilters := filters.NewArgs()
+
+	cmdFilters.Add("before", "busyboxy:1.03")
+	imageContext, err := ValidateImageFilters(cmdFilters, acceptedImageFilterTags, unSupportedImageFilters)
+	assert.NoError(t, err)
+	assert.Equal(t, "1202", *imageContext.BeforeID)
+
+	imageContext.ID = "1202"
+	action := IncludeImage(cmdFilters, imageContext)
+	assert.Equal(t, action, ExcludeAction)
+
+	imageContext.ID = "1200"
+	action = IncludeImage(cmdFilters, imageContext)
+	assert.Equal(t, action, IncludeAction)
+
+	cmdFilters.Del("before", "busyboxy:1.03")
+
+	cmdFilters.Add("since", "busyboxy:1.01")
+	imageContext, err = ValidateImageFilters(cmdFilters, acceptedImageFilterTags, unSupportedImageFilters)
+	assert.NoError(t, err)
+
+	imageContext.ID = "1200"
+	action = IncludeImage(cmdFilters, imageContext)
+	assert.Equal(t, action, StopAction)
+
+	cmdFilters.Del("since", "busyboxy:1.01")
+	cmdFilters.Add("reference", "busy*")
+	imageContext.SinceID = nil
+	action = IncludeImage(cmdFilters, imageContext)
+	assert.Equal(t, action, IncludeAction)
+
+	cmdFilters.Del("reference", "busy*")
+	cmdFilters.Add("reference", "busy")
+	action = IncludeImage(cmdFilters, imageContext)
+	assert.Equal(t, action, ExcludeAction)
+}

--- a/tests/test-cases/Group1-Docker-Commands/1-03-Docker-Images.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-03-Docker-Images.robot
@@ -45,13 +45,27 @@ No-trunc images
     Length Should Be  @{line}[2]  64
 
 Specific images
-    ${status}=  Get State Of Github Issue  2248
-    Run Keyword If  '${status}' == 'closed'  Fail  Test 1-3-Docker-Images.robot needs to be updated now that Issue #2248 has been resolved
-#    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} images alpine:3.1
-#    Should Be Equal As Integers  ${rc}  0
-#    Should Not Contain  ${output}  Error
-#    Should Contain  ${output}  3.1
-#    Should Contain X Times  ${output}  alpine  1
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} images alpine:3.1
+    Should Be Equal As Integers  ${rc}  0
+    Should Not Contain  ${output}  Error
+    Should Contain  ${output}  3.1
+
+Filter images before
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} images -f before=alpine
+    Should Be Equal As Integers  ${rc}  0
+    Should Not Contain  ${output}  Error
+    @{lines}=  Split To Lines  ${output}
+    Length Should Be  ${lines}  3
+    Should Contain  ${output}  3.1
+
+Filter images since
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} images -f since=alpine:3.1
+    Should Be Equal As Integers  ${rc}  0
+    Should Not Contain  ${output}  Error
+    @{lines}=  Split To Lines  ${output}
+    Length Should Be  ${lines}  3
+    Should Contain  ${output}  latest
+
 
 VIC/docker Image ID consistency
     @{tags}=  Create List  uclibc  glibc  musl


### PR DESCRIPTION
Provides support for filtering of images via the following criteria:
  * before, since, reference, label

Also provides support for filtering by command argument:
  * docker images busy*
This would return any images beginning with the string busy

Fixes #2248