### PR TITLE
Rename VCH endpoint resource flags

### DIFF
--- a/cmd/vic-machine/create/create.go
+++ b/cmd/vic-machine/create/create.go
@@ -322,9 +322,9 @@ func (c *Create) Flags() []cli.Flag {
 			Hidden: true,
 		},
 		cli.IntFlag{
-			Name:        "appliance-memory",
+			Name:        "endpoint-memory",
 			Value:       2048,
-			Usage:       "Memory for the appliance VM, in MB. Does not impact resources allocated per container.",
+			Usage:       "Memory for the VCH endpoint VM, in MB. Does not impact resources allocated per container.",
 			Hidden:      true,
 			Destination: &c.MemoryMB,
 		},
@@ -350,9 +350,9 @@ func (c *Create) Flags() []cli.Flag {
 			Hidden: true,
 		},
 		cli.IntFlag{
-			Name:        "appliance-cpu",
+			Name:        "endpoint-cpu",
 			Value:       1,
-			Usage:       "vCPUs for the appliance VM",
+			Usage:       "vCPUs for the VCH endpoint VM. Does not impact resources allocated per container.",
 			Hidden:      true,
 			Destination: &c.NumCPUs,
 		},

--- a/doc/user_doc/vic_installation/vch_installer_options.md
+++ b/doc/user_doc/vic_installation/vch_installer_options.md
@@ -847,25 +847,25 @@ Set CPU shares on the VCH vApp in vCenter Server, or on the VCH resource pool on
 
 <pre>--cpu-shares low</pre>
 
-### `--appliance-cpu ` ###
+### `--endpoint-cpu ` ###
 
 Short name: none
 
 The number of virtual CPUs for the VCH endpoint VM. The default is 1. Set this option to increase the number of CPUs in the VCH endpoint VM.
 
-**NOTE** Always use the `--cpu` option instead of the `--appliance-cpu` option to increase the overall CPU capacity of the VCH vApp, rather than increasing the number of CPUs on the VCH endpoint VM. The `--appliance-cpu` option is mainly intended for use by VMware Support.
+**NOTE** Always use the `--cpu` option instead of the `--endpoint-cpu` option to increase the overall CPU capacity of the VCH vApp, rather than increasing the number of CPUs on the VCH endpoint VM. The `--endpoint-cpu` option is mainly intended for use by VMware Support.
 
-<pre>--appliance-cpu <i>number_of_CPUs</i></pre>
+<pre>--endpoint-cpu <i>number_of_CPUs</i></pre>
 
-### `--appliance-memory ` ###
+### `--endpoint-memory ` ###
 
 Short name: none
 
 The amount of memory for the VCH endpoint VM. The default is 2048MB. Set this option to increase the amount of memory in the VCH endpoint VM if the VCH will pull large container images.
 
-**NOTE** With the exception of VCHs that pull large container images, always use the `--memory` option instead of the `--appliance-memory` option to increase the overall amount of memory for the VCH vApp, rather than on the VCH endpoint VM. Use `docker create -m` to set the memory on container VMs. The `--appliance-memory` option is mainly intended for use by VMware Support.
+**NOTE** With the exception of VCHs that pull large container images, always use the `--memory` option instead of the `--endpoint-memory` option to increase the overall amount of memory for the VCH vApp, rather than on the VCH endpoint VM. Use `docker create -m` to set the memory on container VMs. The `--endpoint-memory` option is mainly intended for use by VMware Support.
 
-<pre>--appliance-memory <i>amount_of_memory</i></pre>
+<pre>--endpoint-memory <i>amount_of_memory</i></pre>
 
 <a name="adv-other"></a>
 ## Other Advanced Options ##


### PR DESCRIPTION
Fixes #2760 

```
⇒  bin/vic-machine-linux create -x
NAME:
   vic-machine-linux create - Deploy VCH

USAGE:
   vic-machine-linux create [command options] [arguments...]

OPTIONS:
...
   --endpoint-memory value                          Memory for the VCH endpoint VM, in MB. Does not impact resources allocated per container. (default: 2048)
...
   --endpoint-cpu value                             vCPUs for the VCH endpoint VM. Does not impact resources allocated per container. (default: 1)
...

```