### PR TITLE
Add timestamps to container output log entries

### DIFF
--- a/cmd/tether/ops_linux.go
+++ b/cmd/tether/ops_linux.go
@@ -1,4 +1,4 @@
-// Copyright 2016 VMware, Inc. All Rights Reserved.
+// Copyright 2016-2017 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ import (
 
 	log "github.com/Sirupsen/logrus"
 
+	"github.com/vmware/vic/lib/ioutil"
 	"github.com/vmware/vic/lib/tether"
 	"github.com/vmware/vic/pkg/dio"
 	"github.com/vmware/vic/pkg/trace"
@@ -80,8 +81,11 @@ func (t *operations) SessionLog(session *tether.SessionConfig) (dio.DynamicMulti
 		log.Errorf("Setting terminal speed failed with %s", err)
 	}
 
+	// wrap entries in JSON structs containing timestamps for each
+	lw := ioutil.NewLogWriter(f)
+
 	// use multi-writer so it goes to both screen and session log
-	return dio.MultiWriter(f, os.Stdout), dio.MultiWriter(f, os.Stderr), nil
+	return dio.MultiWriter(lw, os.Stdout), dio.MultiWriter(lw, os.Stderr), nil
 }
 
 func (t *operations) Setup(sink tether.Config) error {

--- a/doc/design/container_logging.md
+++ b/doc/design/container_logging.md
@@ -1,0 +1,24 @@
+# Container VM output logging in VIC
+
+When a container VM process produces output, that output is sent down through a serial connection into the vSphere backend where it is written to a logfile. When a user wants to see this output, they use the `docker logs` command, which reads from this logfile and displays the log entries on the command line in order from oldest to newest.
+
+However, in order for users to be able to use the `--since` option with `docker logs`, we must also couple timestamps to these log entries so that the user can selectively filter log messages to be displayed based on when those entries occurred.
+
+### Requirements
+
+The container VM logging mechanism must:
+  1. Wrap each log entry in a JSON struct containing both the log message(s) in that entry, and the timestamp in which that entry occurred. 
+ 2. Allow these entries to be read and unwrapped at a later time, starting with the first entry occurring at or beyond the timestamp suppled by the user with the `--since` option to `docker logs`, or starting with the first entry in the logfile if `--since` was not used. 
+
+### Implementation
+
+A package for ioutils in VIC is added as `github.com/vmware/vic/lib/ioutil`. In this package are two files, `log_writer.go` and `log_reader.go`. These files contain an implementation of Go's `io.Writer` and `io.Reader` interface, respectively.
+
+The responsibilities of the `LogReader` are:
+ 1. To instantiate a `LogEntry` struct, and add the log message and timestamp to the `LogEntry`'s `Log` and `Time` fields. 
+ 2. To serialize and write this struct data to the serial port associated with the containerVM logfile on the backend, and follow that write with a single newline character so that the logfile can be more easily consumed by humans for debugging purposes. 
+
+The responsibilities of the `LogWriter` are:
+ 1. To scan in lines from the containerVM logfile one at a time, and unmarshal them into `LogEntry` structs. 
+ 2. To copy the `LogEntry`'s `Log` field into the underlying `Read` stream's `[]byte` slice. 
+ 3. To preserve unwritten bytes in a call to `Read` in memory so that they may be written during the next call, in the case where the supplied `[]byte` slice was smaller than the log message we are trying to write. 

--- a/lib/apiservers/portlayer/restapi/handlers/containers_handlers.go
+++ b/lib/apiservers/portlayer/restapi/handlers/containers_handlers.go
@@ -1,4 +1,4 @@
-// Copyright 2016 VMware, Inc. All Rights Reserved.
+// Copyright 2016-2017 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -33,6 +33,7 @@ import (
 	"github.com/vmware/vic/lib/apiservers/portlayer/restapi/operations"
 	"github.com/vmware/vic/lib/apiservers/portlayer/restapi/operations/containers"
 	"github.com/vmware/vic/lib/config/executor"
+	"github.com/vmware/vic/lib/ioutil"
 	"github.com/vmware/vic/lib/portlayer/exec"
 	"github.com/vmware/vic/pkg/trace"
 	"github.com/vmware/vic/pkg/uid"
@@ -360,7 +361,10 @@ func (handler *ContainersHandlersImpl) GetContainerLogsHandler(params containers
 		return containers.NewGetContainerLogsInternalServerError()
 	}
 
-	detachableOut := NewFlushingReader(reader)
+	// wrap the reader in a LogReader to pull log messages out of JSON entries
+	lr := ioutil.NewLogReader(reader)
+
+	detachableOut := NewFlushingReader(lr)
 
 	return NewContainerOutputHandler("logs").WithPayload(detachableOut, params.ID)
 }

--- a/lib/ioutil/log_reader.go
+++ b/lib/ioutil/log_reader.go
@@ -1,0 +1,79 @@
+// Copyright 2017 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ioutil
+
+import (
+	"bufio"
+	"encoding/json"
+	"io"
+
+	log "github.com/Sirupsen/logrus"
+)
+
+// LogReader unwraps entires into LogEntry structs.
+type LogReader struct {
+	io.ReadCloser
+	s *bufio.Scanner
+
+	// if the buffer we want to read into is too short for our log entry,
+	// we will need to return io.ErrShortBuffer and try again on the next call,
+	// necessitating this pointer to the previous LogEntry we attempted to use.
+	prev *LogEntry
+}
+
+// NewLogReader wraps an io.ReadCloser in a LogReader.
+func NewLogReader(r io.ReadCloser) *LogReader {
+	return &LogReader{
+		ReadCloser: r,
+		s:          bufio.NewScanner(r),
+	}
+}
+
+// Read unmarhsals a line from the underlying stream of log entries into
+// a LogEntry struct, and then writes that struct's log message to the
+// supplied []byte slice.
+func (lr *LogReader) Read(p []byte) (int, error) {
+
+	entry := &LogEntry{}
+
+	if lr.prev != nil {
+		entry = lr.prev
+	} else {
+		if lr.s.Scan() {
+			if err := json.Unmarshal(lr.s.Bytes(), entry); err != nil {
+				log.Debugf("Error unmarshaling log entry: %s", err.Error())
+				return 0, err
+			}
+		} else {
+			err := lr.s.Err()
+			if err == nil {
+				return 0, io.EOF
+			}
+			return 0, err
+		}
+	}
+
+	if len(p) < len(entry.Log) {
+		lr.prev = entry
+		return 0, io.ErrShortBuffer
+	}
+
+	w := copy(p, []byte(entry.Log))
+
+	// reset previous entry to nil
+	lr.prev = nil
+
+	return w, nil
+}

--- a/lib/ioutil/log_writer.go
+++ b/lib/ioutil/log_writer.go
@@ -1,0 +1,72 @@
+// Copyright 2017 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ioutil
+
+import (
+	"encoding/json"
+	"io"
+	"time"
+
+	log "github.com/Sirupsen/logrus"
+)
+
+// LogEntry attaches a timestamp to a log entry
+type LogEntry struct {
+	Log  string    `json:"log"`
+	Time time.Time `json:"time"`
+}
+
+// LogWriter wraps entries in a LogEntry struct with the
+// timestamp of the entry.
+type LogWriter struct {
+	w io.Writer
+}
+
+// NewLogWriter wraps an io.WriteCloser in a LogWriter
+func NewLogWriter(w io.WriteCloser) *LogWriter {
+	return &LogWriter{w: w}
+}
+
+// Write takes an incoming byte slice and wraps it in a LogEntry,
+// adding a timestamp. It then serializes the LogEntry and writes the
+// serialized bytes to the underlying stream, adding a newline at the end for
+// human readability
+func (lw *LogWriter) Write(p []byte) (n int, err error) {
+
+	bytes, err := json.Marshal(LogEntry{
+		Log:  string(p),
+		Time: time.Now(),
+	})
+
+	if err != nil {
+		return 0, err
+	}
+
+	w := 0 // running total of bytes written
+	for w != len(bytes) {
+		n, err := lw.w.Write(bytes[w:])
+		if err != nil {
+			log.Errorf("Error writing JSON entry: %s", err.Error())
+			return n, err
+		}
+		w += n
+	}
+
+	// add a newline to the end of a JSON log entry
+	lw.w.Write([]byte{'\n'})
+
+	// inform the caller that all received bytes were successfully written
+	return len(p), err
+}


### PR DESCRIPTION
This change adds a LogWriter that wraps the container VM process output in JSON along with a timestamp before sending it on its way down the serial connection to be written to `output.log`. It also adds a LogReader that does the reverse, pulling the log message out of the JSON struct before streaming it back down through the docker persona to the docker CLI after `docker logs` is called.

Fixes #1738 