### PR TITLE
VCH name input validation

### DIFF
--- a/cmd/vic-machine/common/utils.go
+++ b/cmd/vic-machine/common/utils.go
@@ -31,8 +31,8 @@ const unsuppCharsRegex = `%|&|\*|\$|#|@|!|\\|/|:|\?|"|<|>|;|'|\|`
 // Same as unsuppCharsRegex but allows / and : for datastore paths
 const unsuppCharsDatastoreRegex = `%|&|\*|\$|#|@|!|\\|\?|"|<|>|;|'|\|`
 
-var reUnsupp *regexp.Regexp = regexp.MustCompile(unsuppCharsRegex)
-var reUnsuppDatastore *regexp.Regexp = regexp.MustCompile(unsuppCharsDatastoreRegex)
+var reUnsupp = regexp.MustCompile(unsuppCharsRegex)
+var reUnsuppDatastore = regexp.MustCompile(unsuppCharsDatastoreRegex)
 
 func LogErrorIfAny(clic *cli.Context, err error) error {
 	if err == nil {

--- a/cmd/vic-machine/common/utils.go
+++ b/cmd/vic-machine/common/utils.go
@@ -15,12 +15,21 @@
 package common
 
 import (
+	"fmt"
+	"regexp"
+
 	log "github.com/Sirupsen/logrus"
 
 	"gopkg.in/urfave/cli.v1"
 
 	"github.com/vmware/vic/pkg/errors"
 )
+
+// https://kb.vmware.com/selfservice/microsites/search.do?language=en_US&cmd=displayKC&externalId=2046088
+const unsuppCharsRegex = `%|&|\*|\$|#|@|!|\\|/|:|\?|"|<|>|;|'|\|`
+
+// Same as unsuppCharsRegex but allows / and : for datastore paths
+const unsuppCharsDatastoreRegex = `%|&|\*|\$|#|@|!|\\|\?|"|<|>|;|'|\|`
 
 func LogErrorIfAny(clic *cli.Context, err error) error {
 	if err == nil {
@@ -30,4 +39,26 @@ func LogErrorIfAny(clic *cli.Context, err error) error {
 	log.Errorf("--------------------")
 	log.Errorf("%s %s failed: %s\n", clic.App.Name, clic.Command.Name, errors.ErrorStack(err))
 	return cli.NewExitError("", 1)
+}
+
+// CheckUnsupportedChars returns an error if string contains special characters
+func CheckUnsupportedChars(s string) error {
+	re := regexp.MustCompile(unsuppCharsRegex)
+	return checkUnsupportedChars(s, re)
+}
+
+// CheckUnsupportedCharsDatastore returns an error if a datastore string contains special characters
+func CheckUnsupportedCharsDatastore(s string) error {
+	re := regexp.MustCompile(unsuppCharsDatastoreRegex)
+	return checkUnsupportedChars(s, re)
+}
+
+func checkUnsupportedChars(s string, re *regexp.Regexp) error {
+	st := []byte(s)
+
+	if v := re.FindIndex(st); v == nil {
+		return nil
+	} else {
+		return fmt.Errorf("unsupported character in %q: %s", s, s[v[0]:v[1]])
+	}
 }

--- a/cmd/vic-machine/common/utils.go
+++ b/cmd/vic-machine/common/utils.go
@@ -55,10 +55,9 @@ func CheckUnsupportedCharsDatastore(s string) error {
 
 func checkUnsupportedChars(s string, re *regexp.Regexp) error {
 	st := []byte(s)
-
-	if v := re.FindIndex(st); v == nil {
+	var v []int
+	if v = re.FindIndex(st); v == nil {
 		return nil
-	} else {
-		return fmt.Errorf("unsupported character in %q: %s", s, s[v[0]:v[1]])
 	}
+	return fmt.Errorf("unsupported character in %q: %s", s, s[v[0]:v[1]])
 }

--- a/cmd/vic-machine/common/utils.go
+++ b/cmd/vic-machine/common/utils.go
@@ -31,6 +31,9 @@ const unsuppCharsRegex = `%|&|\*|\$|#|@|!|\\|/|:|\?|"|<|>|;|'|\|`
 // Same as unsuppCharsRegex but allows / and : for datastore paths
 const unsuppCharsDatastoreRegex = `%|&|\*|\$|#|@|!|\\|\?|"|<|>|;|'|\|`
 
+var reUnsupp *regexp.Regexp = regexp.MustCompile(unsuppCharsRegex)
+var reUnsuppDatastore *regexp.Regexp = regexp.MustCompile(unsuppCharsDatastoreRegex)
+
 func LogErrorIfAny(clic *cli.Context, err error) error {
 	if err == nil {
 		return nil
@@ -43,14 +46,12 @@ func LogErrorIfAny(clic *cli.Context, err error) error {
 
 // CheckUnsupportedChars returns an error if string contains special characters
 func CheckUnsupportedChars(s string) error {
-	re := regexp.MustCompile(unsuppCharsRegex)
-	return checkUnsupportedChars(s, re)
+	return checkUnsupportedChars(s, reUnsupp)
 }
 
 // CheckUnsupportedCharsDatastore returns an error if a datastore string contains special characters
 func CheckUnsupportedCharsDatastore(s string) error {
-	re := regexp.MustCompile(unsuppCharsDatastoreRegex)
-	return checkUnsupportedChars(s, re)
+	return checkUnsupportedChars(s, reUnsuppDatastore)
 }
 
 func checkUnsupportedChars(s string, re *regexp.Regexp) error {
@@ -59,5 +60,5 @@ func checkUnsupportedChars(s string, re *regexp.Regexp) error {
 	if v = re.FindIndex(st); v == nil {
 		return nil
 	}
-	return fmt.Errorf("unsupported character in %q: %s", s, s[v[0]:v[1]])
+	return fmt.Errorf("unsupported character %q in %q", s[v[0]:v[1]], s)
 }

--- a/cmd/vic-machine/common/utils_test.go
+++ b/cmd/vic-machine/common/utils_test.go
@@ -36,7 +36,12 @@ func TestCheckUnsupportedchars(t *testing.T) {
 		{"test@", false},
 		{"test!", false},
 		{`test\`, false},
-		{"test/", false},
+		{"test/", false},      // U+002F
+		{"test\u002f", false}, // U+002F
+		{`testЯ`, true},       // U+042F
+		{"test\u042f", true},  // U+042F
+		{`testį`, true},       // U+012F
+		{"test\u012f", true},  // U+012F
 		{"test:", false},
 		{"test?", false},
 		{`test"`, false},
@@ -44,6 +49,7 @@ func TestCheckUnsupportedchars(t *testing.T) {
 		{"test>", false},
 		{"test;", false},
 		{"test'", false},
+		{"test|", false},
 		{"test|", false},
 	}
 
@@ -83,7 +89,10 @@ func TestCheckUnsupportedCharsDatastore(t *testing.T) {
 		{"test$", false},
 		{"test#", false},
 		{"test@", false},
-		{"test!", false},
+		{"test!", false},      // U+0021
+		{"test\u0021", false}, // U+0021
+		{`testġ`, true},       // U+0121
+		{"test\u0121", true},  // U+0121
 		{`test\`, false},
 		{"test?", false},
 		{`test"`, false},

--- a/cmd/vic-machine/common/utils_test.go
+++ b/cmd/vic-machine/common/utils_test.go
@@ -1,0 +1,113 @@
+// Copyright 2017 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"testing"
+)
+
+func TestCheckUnsupportedchars(t *testing.T) {
+	tests := []struct {
+		S     string
+		valid bool
+	}{
+		{"anjunabeats", true},
+		{"tony-1", true},
+		{"paavo_1", true},
+		{"jono(1)", true},
+		{"oceanlab (1)", true},
+		{"test%", false},
+		{"test&", false},
+		{"test*", false},
+		{"test$", false},
+		{"test#", false},
+		{"test@", false},
+		{"test!", false},
+		{`test\`, false},
+		{"test/", false},
+		{"test:", false},
+		{"test?", false},
+		{`test"`, false},
+		{"test<", false},
+		{"test>", false},
+		{"test;", false},
+		{"test'", false},
+		{"test|", false},
+	}
+
+	for _, test := range tests {
+		err := CheckUnsupportedChars(test.S)
+
+		if err != nil {
+			if test.valid {
+				t.Errorf("got %q, expected pass for %q", err, test.S)
+			}
+			t.Logf("test case %q passed", test.S)
+			continue
+		}
+		if test.valid {
+			t.Logf("test case %q passed", test.S)
+			continue
+		}
+		t.Errorf("got %q, expected error for %q", err, test.S)
+	}
+}
+
+func TestCheckUnsupportedCharsDatastore(t *testing.T) {
+	tests := []struct {
+		S     string
+		valid bool
+	}{
+		{"anjunabeats", true},
+		{"tony-1", true},
+		{"paavo_1", true},
+		{"jono(1)", true},
+		{"oceanlab (1)", true},
+		{"waawn/", true},
+		{"tristate:", true},
+		{"test%", false},
+		{"test&", false},
+		{"test*", false},
+		{"test$", false},
+		{"test#", false},
+		{"test@", false},
+		{"test!", false},
+		{`test\`, false},
+		{"test?", false},
+		{`test"`, false},
+		{"test<", false},
+		{"test>", false},
+		{"test;", false},
+		{"test'", false},
+		{"test|", false},
+	}
+
+	for _, test := range tests {
+		err := CheckUnsupportedCharsDatastore(test.S)
+
+		if err != nil {
+			if test.valid {
+				t.Errorf("got %q, expected pass for %q", err, test.S)
+			}
+			t.Logf("test case %q passed", test.S)
+			continue
+		}
+		if test.valid {
+			t.Logf("test case %q passed", test.S)
+			continue
+		}
+		t.Errorf("got %q, expected error for %q", err, test.S)
+	}
+}

--- a/cmd/vic-machine/create/create.go
+++ b/cmd/vic-machine/create/create.go
@@ -499,12 +499,17 @@ func (c *Create) processParams() error {
 		return err
 	}
 
-	if c.BridgeNetworkName == "" {
-		c.BridgeNetworkName = c.DisplayName
+	// prevent usage of special characters for certain user provided values
+	if err := common.CheckUnsupportedChars(c.DisplayName); err != nil {
+		return cli.NewExitError(fmt.Sprintf("--name contains unsupported characters: %s", err), 1)
 	}
 
 	if len(c.DisplayName) > MaxDisplayNameLen {
 		return cli.NewExitError(fmt.Sprintf("Display name %s exceeds the permitted 31 characters limit. Please use a shorter -name parameter", c.DisplayName), 1)
+	}
+
+	if c.BridgeNetworkName == "" {
+		c.BridgeNetworkName = c.DisplayName
 	}
 
 	if err := c.processOpsCredentials(); err != nil {
@@ -541,6 +546,10 @@ func (c *Create) processParams() error {
 	// must come after client network processing as it checks for static IP on that interface
 	if err := c.processCertificates(); err != nil {
 		return err
+	}
+
+	if err := common.CheckUnsupportedCharsDatastore(c.ImageDatastorePath); err != nil {
+		return cli.NewExitError(fmt.Sprintf("--image-store contains unsupported characters: %s", err), 1)
 	}
 
 	if err := c.processVolumeStores(); err != nil {
@@ -868,6 +877,9 @@ func (c *Create) processVolumeStores() error {
 	defer trace.End(trace.Begin(""))
 	c.VolumeLocations = make(map[string]string)
 	for _, arg := range c.volumeStores {
+		if err := common.CheckUnsupportedCharsDatastore(arg); err != nil {
+			return fmt.Errorf("--volume-store contains unsupported characters: %s", err)
+		}
 		splitMeta := strings.SplitN(arg, ":", 2)
 		if len(splitMeta) != 2 {
 			return errors.New("Volume store input must be in format datastore/path:label")

--- a/cmd/vic-machine/create/create.go
+++ b/cmd/vic-machine/create/create.go
@@ -501,7 +501,7 @@ func (c *Create) processParams() error {
 
 	// prevent usage of special characters for certain user provided values
 	if err := common.CheckUnsupportedChars(c.DisplayName); err != nil {
-		return cli.NewExitError(fmt.Sprintf("--name contains unsupported characters: %s", err), 1)
+		return cli.NewExitError(fmt.Sprintf("--name contains unsupported characters: %s Allowed characters are alphanumeric, space and symbols - _ ( )", err), 1)
 	}
 
 	if len(c.DisplayName) > MaxDisplayNameLen {
@@ -549,7 +549,7 @@ func (c *Create) processParams() error {
 	}
 
 	if err := common.CheckUnsupportedCharsDatastore(c.ImageDatastorePath); err != nil {
-		return cli.NewExitError(fmt.Sprintf("--image-store contains unsupported characters: %s", err), 1)
+		return cli.NewExitError(fmt.Sprintf("--image-store contains unsupported characters: %s Allowed characters are alphanumeric, space and symbols - _ ( ) / :", err), 1)
 	}
 
 	if err := c.processVolumeStores(); err != nil {
@@ -878,7 +878,7 @@ func (c *Create) processVolumeStores() error {
 	c.VolumeLocations = make(map[string]string)
 	for _, arg := range c.volumeStores {
 		if err := common.CheckUnsupportedCharsDatastore(arg); err != nil {
-			return fmt.Errorf("--volume-store contains unsupported characters: %s", err)
+			return fmt.Errorf("--volume-store contains unsupported characters: %s Allowed characters are alphanumeric, space and symbols - _ ( ) / :", err)
 		}
 		splitMeta := strings.SplitN(arg, ":", 2)
 		if len(splitMeta) != 2 {


### PR DESCRIPTION
Fixes #3552

Prevent certain characters from being used in the VCH name
Allows `-_ ()`

```
⇒  bin/vic-machine-linux create -t 'root:password@192.168.218.129'  --thumbprint DC:5F:3C:3B:57:37:25:A0:84:C8:4E:31:48:00:C0:14:62:D9:95:E2 --public-network-ip 192.168.218.200/24 --public-network-gateway 192.168.218.2 --name "'chin'"
Feb  8 2017 12:20:51.763-08:00 INFO  ### Installing VCH ####
Feb  8 2017 12:20:51.763-08:00 ERROR --------------------
Feb  8 2017 12:20:51.763-08:00 ERROR vic-machine-linux create failed: --name contains unsupported characters: invalid characters in "'chin'"

```

Previously this would create a VCH named `'chin'`, but that caused problems.