### PR TITLE
Nfs volume Store implementation

### DIFF
--- a/lib/portlayer/storage/nfs/disk.go
+++ b/lib/portlayer/storage/nfs/disk.go
@@ -18,30 +18,30 @@ import (
 	"net/url"
 )
 
-//  Device information for interaction with the tether and portlayer
-type NFSVolume struct {
+//  Volume identifies an NFS based volume
+type Volume struct {
 
 	// This is the nfs host the the volume belongs to
 	Host *url.URL
 
 	// Path on the Host where the volume is located
-	NFSPath string
+	Path string
 }
 
-func NewNFSVolumeDevice(host *url.URL, NFSPath string) NFSVolume {
-	v := NFSVolume{
-		Host:    host,
-		NFSPath: NFSPath,
+func NewVolume(host *url.URL, NFSPath string) Volume {
+	v := Volume{
+		Host: host,
+		Path: NFSPath,
 	}
 	return v
 }
 
-func (v NFSVolume) MountPath() (string, error) {
-	return "", nil
+func (v Volume) MountPath() (string, error) {
+	return v.Path, nil
 }
 
-// Includes url to nfs directory for container to mount,
-func (v NFSVolume) DiskPath() url.URL {
+// DiskPath includes the url to the nfs directory for the container to mount,
+func (v Volume) DiskPath() url.URL {
 	if v.Host == nil {
 		return url.URL{}
 	}

--- a/lib/portlayer/storage/nfs/disk.go
+++ b/lib/portlayer/storage/nfs/disk.go
@@ -1,0 +1,44 @@
+// Copyright 2016-2017 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nfs
+
+import (
+	"github.com/vmware/vic/lib/portlayer/storage"
+)
+
+type NFSVolumeBacking struct {
+
+	//This is the path where the volume directory exists on the nfs server
+	NFSPath string
+
+	//This is the target filesystem path for mounting into a container
+	MountPath string
+}
+
+func NewNFSVolumeBacking(NFSPath string) NFSVolumeBacking {
+	v := NFSVolumeBacking{
+		NFSPath:   NFSPath,
+		MountPath: MountTargetPath,
+	}
+	return v
+}
+
+func (v *NFSVolumeBacking) MountPath() (string, error) {
+	return nil
+}
+
+func (v *NFSVolumeBacking) DiskPath() string {
+	return v.NFSPath
+}

--- a/lib/portlayer/storage/nfs/disk.go
+++ b/lib/portlayer/storage/nfs/disk.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2017 VMware, Inc. All Rights Reserved.
+// Copyright 2017 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,13 +18,13 @@ import (
 	"net/url"
 )
 
-//device information for interaction with the tether and portlayer
+//  Device information for interaction with the tether and portlayer
 type NFSVolume struct {
 
-	//This is the nfs host the the volume belongs to
+	// This is the nfs host the the volume belongs to
 	Host *url.URL
 
-	//Path on the Host where the volume is located
+	// Path on the Host where the volume is located
 	NFSPath string
 }
 
@@ -40,7 +40,7 @@ func (v NFSVolume) MountPath() (string, error) {
 	return "", nil
 }
 
-// includes url to nfs directory for container to mount,
+// Includes url to nfs directory for container to mount,
 func (v NFSVolume) DiskPath() url.URL {
 	if v.Host == nil {
 		return url.URL{}

--- a/lib/portlayer/storage/nfs/disk.go
+++ b/lib/portlayer/storage/nfs/disk.go
@@ -15,30 +15,35 @@
 package nfs
 
 import (
-	"github.com/vmware/vic/lib/portlayer/storage"
+	"net/url"
 )
 
-type NFSVolumeBacking struct {
+//device information for interaction with the tether and portlayer
+type NFSVolume struct {
 
-	//This is the path where the volume directory exists on the nfs server
+	//This is the nfs host the the volume belongs to
+	Host *url.URL
+
+	//Path on the Host where the volume is located
 	NFSPath string
-
-	//This is the target filesystem path for mounting into a container
-	MountPath string
 }
 
-func NewNFSVolumeBacking(NFSPath string) NFSVolumeBacking {
-	v := NFSVolumeBacking{
-		NFSPath:   NFSPath,
-		MountPath: MountTargetPath,
+func NewNFSVolumeDevice(host *url.URL, NFSPath string) NFSVolume {
+	v := NFSVolume{
+		Host:    host,
+		NFSPath: NFSPath,
 	}
 	return v
 }
 
-func (v *NFSVolumeBacking) MountPath() (string, error) {
-	return nil
+func (v NFSVolume) MountPath() (string, error) {
+	return "", nil
 }
 
-func (v *NFSVolumeBacking) DiskPath() string {
-	return v.NFSPath
+// includes url to nfs directory for container to mount,
+func (v NFSVolume) DiskPath() url.URL {
+	if v.Host == nil {
+		return url.URL{}
+	}
+	return *v.Host
 }

--- a/lib/portlayer/storage/nfs/target.go
+++ b/lib/portlayer/storage/nfs/target.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2017 VMware, Inc. All Rights Reserved.
+// Copyright 2017 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,34 +17,39 @@ package nfs
 import (
 	"io"
 	"net/url"
-
 	"os"
 )
 
-type MountHandler interface {
-	Mount(target *url.URL) (NFSTarget, error)
-	Unmount(target NFSTarget) error
+// The MountServer is an interface used to communicate with network attached storage.
+type MountServer interface {
+	// Mount initiates the NAS Target and returns a Target interface.
+	Mount(target *url.URL) (target, error)
+
+	// Unmount terminates the Mount on the Target.
+	Unmount(target target) error
 }
 
-type NFSTarget interface {
-	//opens a target path in a READONLY context
+// Target is the filesystem interface for performing actions against attached storage.:w
+
+type target interface {
+	// Opens a target path in a READONLY context
 	Open(path string) (io.ReadCloser, error)
 
-	//Opens targeted file with the supplied attr.
+	// Opens targeted file with the supplied attr.
 	OpenFile(path string, perm os.FileMode) (io.ReadWriteCloser, error)
 
-	//Creates a file, errors out if file already exists. assumes write permissions.
+	// Creates a file, errors out if file already exists. assumes write permissions.
 	Create(path string, perm os.FileMode) (io.ReadWriteCloser, error)
 
 	// Create directory path
-	MkDir(path string, perm os.FileMode) ([]byte, error)
+	Mkdir(path string, perm os.FileMode) ([]byte, error)
 
 	// Delete Directory Path, and children
 	RemoveAll(Path string) error
 
-	//Reads the contents of the targeted directory
+	// Reads the contents of the targeted directory
 	ReadDir(path string) ([]os.FileInfo, error)
 
-	//Looks up the file information for a target entry
+	// Looks up the file information for a target entry
 	Lookup(path string) (os.FileInfo, error)
 }

--- a/lib/portlayer/storage/nfs/target.go
+++ b/lib/portlayer/storage/nfs/target.go
@@ -1,0 +1,67 @@
+// Copyright 2016-2017 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nfs
+
+import (
+	"errors"
+	"io"
+	"net/url"
+
+	"github.com/vmware/vic/pkg/trace"
+)
+
+type NFSTarget interface {
+	// write data to target nfs filesystem
+	Write(op trace.Operation, path string, r io.Writer) error
+
+	// read data from target nfs filesystem
+	Read(path string) io.Reader
+
+	// Create directory path
+	MkDir(path string, makeParents bool) (string, error)
+
+	// Delete Directory Path, and children
+	RemoveAll(Path string) error
+
+	//Reads the contents of the targeted directory
+	ReadDir(path string)
+}
+
+type NFSv3Target struct{}
+
+func (t *NFSv3Target) Write(op trace.Operation, path string, r io.Writer) error {
+	return nil
+}
+
+func (t *NFSv3Target) Read(path string) io.Reader {
+	return nil
+}
+
+func (t *NFSv3Target) MkDir(path string, makeParents bool) (string, error) {
+	return nil, nil
+}
+
+// TODO: client implementation here
+func NewNFSv3Target(op trace.Operation, fqdn *url.URL) (NFSTarget, error) {
+	return NFSv3Target{}, errors.New("FUNCTION NOT IMPLEMENTED")
+}
+
+func OpenNFSv3Target(targetURL *url.URL) (*NFSv3Target, error) {
+	return nil
+}
+
+func CloseNFSv3Target(target *NFSv3Target) error {
+	return nil
+}

--- a/lib/portlayer/storage/nfs/target.go
+++ b/lib/portlayer/storage/nfs/target.go
@@ -20,14 +20,24 @@ import (
 	"net/url"
 
 	"github.com/vmware/vic/pkg/trace"
+	"os"
 )
 
 type NFSTarget interface {
+	//returns the NFSTarget Endpoint
+	EndPoint() *url.URL
+
+	//Binds the target NFS server to the VCH(Possible concurrency/performance issue?)
+	Open() (NFSTarget, error)
+
+	//Unbinds NFS server from the VCH(ditto to open)
+	Close() error
+
 	// write data to target nfs filesystem
-	Write(op trace.Operation, path string, r io.Writer) error
+	Write(op trace.Operation, path string, r io.Reader) error
 
 	// read data from target nfs filesystem
-	Read(path string) io.Reader
+	Read(path string) (io.Reader, error)
 
 	// Create directory path
 	MkDir(path string, makeParents bool) (string, error)
@@ -36,32 +46,53 @@ type NFSTarget interface {
 	RemoveAll(Path string) error
 
 	//Reads the contents of the targeted directory
-	ReadDir(path string)
+	ReadDir(path string) ([]os.FileInfo, error)
 }
 
-type NFSv3Target struct{}
+type NFSv3Target struct {
+	//nfs enpoint
+	host *url.URL
 
-func (t *NFSv3Target) Write(op trace.Operation, path string, r io.Writer) error {
+	//Path to the the volume store
+	directoryPath string
+}
+
+func (t NFSv3Target) EndPoint() *url.URL {
 	return nil
 }
 
-func (t *NFSv3Target) Read(path string) io.Reader {
+func (t NFSv3Target) Write(op trace.Operation, path string, r io.Reader) error {
 	return nil
 }
 
-func (t *NFSv3Target) MkDir(path string, makeParents bool) (string, error) {
+func (t NFSv3Target) Read(path string) (io.Reader, error) {
 	return nil, nil
 }
 
+func (t NFSv3Target) MkDir(path string, makeParents bool) (string, error) {
+	return "", nil
+}
+
+func (t NFSv3Target) RemoveAll(path string) error {
+	return nil
+}
+
+func (t NFSv3Target) ReadDir(path string) ([]os.FileInfo, error) {
+	return nil, nil
+}
+
+func (t NFSv3Target) Open() (NFSTarget, error) {
+	return nil, nil
+}
+
+func (t NFSv3Target) Close() error {
+	return nil
+}
+
 // TODO: client implementation here
-func NewNFSv3Target(op trace.Operation, fqdn *url.URL) (NFSTarget, error) {
+func NewNFSv3Target(op trace.Operation, fqdn *url.URL, volumeDirectory string) (NFSTarget, error) {
 	return NFSv3Target{}, errors.New("FUNCTION NOT IMPLEMENTED")
 }
 
-func OpenNFSv3Target(targetURL *url.URL) (*NFSv3Target, error) {
-	return nil
-}
-
-func CloseNFSv3Target(target *NFSv3Target) error {
-	return nil
-}
+//MAKE MOCK TARGET
+//USER TEMP DIR

--- a/lib/portlayer/storage/nfs/target.go
+++ b/lib/portlayer/storage/nfs/target.go
@@ -15,11 +15,9 @@
 package nfs
 
 import (
-	"errors"
 	"io"
 	"net/url"
 
-	"github.com/vmware/vic/pkg/trace"
 	"os"
 )
 
@@ -50,55 +48,3 @@ type NFSTarget interface {
 	//Looks up the file information for a target entry
 	Lookup(path string) (os.FileInfo, error)
 }
-
-type NFSv3Target struct {
-	//nfs endpoint
-	host *url.URL
-
-	//Path to the the volume store
-	directoryPath string
-}
-
-func (t NFSv3Target) MkDir(path string, perm os.FileMode) ([]byte, error) {
-	return nil, nil
-}
-
-func (t NFSv3Target) RemoveAll(path string) error {
-	return nil
-}
-
-func (t NFSv3Target) ReadDir(path string) ([]os.FileInfo, error) {
-	return nil, nil
-}
-
-func (t NFSv3Target) Open(path string) (io.ReadCloser, error) {
-	return nil, nil
-}
-
-func (t NFSv3Target) OpenFile(path string, perm os.FileMode) (io.ReadWriteCloser, error) {
-	return nil, nil
-}
-
-func (t NFSv3Target) Create(path string, perm os.FileMode) (io.ReadWriteCloser, error) {
-	return nil, nil
-}
-
-func (t NFSv3Target) Lookup(path string) (os.FileInfo, error) {
-	return nil, nil
-}
-
-func Mount(target *url.URL) (NFSTarget, error) {
-	return nil, nil
-}
-
-func Unmount(target NFSTarget) error {
-	return nil
-}
-
-// TODO: client implementation here
-func NewNFSv3Target(op trace.Operation, fqdn *url.URL, volumeDirectory string) (NFSTarget, error) {
-	return NFSv3Target{}, errors.New("FUNCTION NOT IMPLEMENTED")
-}
-
-//MAKE MOCK TARGET
-//USER TEMP DIR

--- a/lib/portlayer/storage/nfs/target.go
+++ b/lib/portlayer/storage/nfs/target.go
@@ -36,7 +36,7 @@ type NFSTarget interface {
 	OpenFile(path string, perm os.FileMode) (io.ReadWriteCloser, error)
 
 	//Creates a file, errors out if file already exists. assumes write permissions.
-	Create(path string) (io.ReadWriteCloser, error)
+	Create(path string, perm os.FileMode) (io.ReadWriteCloser, error)
 
 	// Create directory path
 	MkDir(path string, perm os.FileMode) ([]byte, error)
@@ -79,7 +79,7 @@ func (t NFSv3Target) OpenFile(path string, perm os.FileMode) (io.ReadWriteCloser
 	return nil, nil
 }
 
-func (t NFSv3Target) Create(path string) (io.ReadWriteCloser, error) {
+func (t NFSv3Target) Create(path string, perm os.FileMode) (io.ReadWriteCloser, error) {
 	return nil, nil
 }
 

--- a/lib/portlayer/storage/nfs/target.go
+++ b/lib/portlayer/storage/nfs/target.go
@@ -23,16 +23,16 @@ import (
 // The MountServer is an interface used to communicate with network attached storage.
 type MountServer interface {
 	// Mount initiates the NAS Target and returns a Target interface.
-	Mount(target *url.URL) (target, error)
+	Mount(target *url.URL) (Target, error)
 
 	// Unmount terminates the Mount on the Target.
-	Unmount(target target) error
+	Unmount(target Target) error
 }
 
 // Target is the filesystem interface for performing actions against attached storage.:w
 
-type target interface {
-	// Opens a target path in a READONLY context
+type Target interface {
+	// Opens a Target path in a READONLY context
 	Open(path string) (io.ReadCloser, error)
 
 	// Opens targeted file with the supplied attr.

--- a/lib/portlayer/storage/nfs/target.go
+++ b/lib/portlayer/storage/nfs/target.go
@@ -23,54 +23,44 @@ import (
 	"os"
 )
 
+type MountHandler interface {
+	Mount(target *url.URL) (NFSTarget, error)
+	Unmount(target NFSTarget) error
+}
+
 type NFSTarget interface {
-	//returns the NFSTarget Endpoint
-	EndPoint() *url.URL
+	//opens a target path in a READONLY context
+	Open(path string) (io.ReadCloser, error)
 
-	//Binds the target NFS server to the VCH(Possible concurrency/performance issue?)
-	Open() (NFSTarget, error)
+	//Opens targeted file with the supplied attr.
+	OpenFile(path string, perm os.FileMode) (io.ReadWriteCloser, error)
 
-	//Unbinds NFS server from the VCH(ditto to open)
-	Close() error
-
-	// write data to target nfs filesystem
-	Write(op trace.Operation, path string, r io.Reader) error
-
-	// read data from target nfs filesystem
-	Read(path string) (io.Reader, error)
+	//Creates a file, errors out if file already exists. assumes write permissions.
+	Create(path string) (io.ReadWriteCloser, error)
 
 	// Create directory path
-	MkDir(path string, makeParents bool) (string, error)
+	MkDir(path string, perm os.FileMode) ([]byte, error)
 
 	// Delete Directory Path, and children
 	RemoveAll(Path string) error
 
 	//Reads the contents of the targeted directory
 	ReadDir(path string) ([]os.FileInfo, error)
+
+	//Looks up the file information for a target entry
+	Lookup(path string) (os.FileInfo, error)
 }
 
 type NFSv3Target struct {
-	//nfs enpoint
+	//nfs endpoint
 	host *url.URL
 
 	//Path to the the volume store
 	directoryPath string
 }
 
-func (t NFSv3Target) EndPoint() *url.URL {
-	return nil
-}
-
-func (t NFSv3Target) Write(op trace.Operation, path string, r io.Reader) error {
-	return nil
-}
-
-func (t NFSv3Target) Read(path string) (io.Reader, error) {
+func (t NFSv3Target) MkDir(path string, perm os.FileMode) ([]byte, error) {
 	return nil, nil
-}
-
-func (t NFSv3Target) MkDir(path string, makeParents bool) (string, error) {
-	return "", nil
 }
 
 func (t NFSv3Target) RemoveAll(path string) error {
@@ -81,11 +71,27 @@ func (t NFSv3Target) ReadDir(path string) ([]os.FileInfo, error) {
 	return nil, nil
 }
 
-func (t NFSv3Target) Open() (NFSTarget, error) {
+func (t NFSv3Target) Open(path string) (io.ReadCloser, error) {
 	return nil, nil
 }
 
-func (t NFSv3Target) Close() error {
+func (t NFSv3Target) OpenFile(path string, perm os.FileMode) (io.ReadWriteCloser, error) {
+	return nil, nil
+}
+
+func (t NFSv3Target) Create(path string) (io.ReadWriteCloser, error) {
+	return nil, nil
+}
+
+func (t NFSv3Target) Lookup(path string) (os.FileInfo, error) {
+	return nil, nil
+}
+
+func Mount(target *url.URL) (NFSTarget, error) {
+	return nil, nil
+}
+
+func Unmount(target NFSTarget) error {
 	return nil
 }
 

--- a/lib/portlayer/storage/nfs/target.go
+++ b/lib/portlayer/storage/nfs/target.go
@@ -20,7 +20,7 @@ import (
 	"os"
 )
 
-// The MountServer is an interface used to communicate with network attached storage.
+// MountServer is an interface used to communicate with network attached storage.
 type MountServer interface {
 	// Mount initiates the NAS Target and returns a Target interface.
 	Mount(target *url.URL) (Target, error)
@@ -29,27 +29,26 @@ type MountServer interface {
 	Unmount(target Target) error
 }
 
-// Target is the filesystem interface for performing actions against attached storage.:w
-
+// Target is the filesystem interface for performing actions against attached storage.
 type Target interface {
-	// Opens a Target path in a READONLY context
+	// Open opens a file on the Target in RD_ONLY
 	Open(path string) (io.ReadCloser, error)
 
-	// Opens targeted file with the supplied attr.
+	// OpenFile opens a file on the Target with the given mode
 	OpenFile(path string, perm os.FileMode) (io.ReadWriteCloser, error)
 
-	// Creates a file, errors out if file already exists. assumes write permissions.
+	// Create creates a file, errors out if file already exists
 	Create(path string, perm os.FileMode) (io.ReadWriteCloser, error)
 
-	// Create directory path
+	// Mkdir creates a directory at the given path
 	Mkdir(path string, perm os.FileMode) ([]byte, error)
 
-	// Delete Directory Path, and children
+	// RemoveAll deletes Directory recursively
 	RemoveAll(Path string) error
 
-	// Reads the contents of the targeted directory
+	// ReadDir reads the dirents of the given directory
 	ReadDir(path string) ([]os.FileInfo, error)
 
-	// Looks up the file information for a target entry
+	// Lookup reads os.FileInfo for the given path
 	Lookup(path string) (os.FileInfo, error)
 }

--- a/lib/portlayer/storage/nfs/volume.go
+++ b/lib/portlayer/storage/nfs/volume.go
@@ -208,7 +208,7 @@ func writeMetadata(op trace.Operation, metadataPath string, info map[string][]by
 	op.Infof("Attempting to write metadata to (%s)", metadataPath)
 	for fileName, data := range info {
 		targetPath := path.Join(metadataPath, fileName)
-		blobFile, err := target.Create(targetPath)
+		blobFile, err := target.Create(targetPath, filePermissions)
 		// XXX: we might want to make sure the file we want to write does not exist...
 		if err != nil {
 			return err

--- a/lib/portlayer/storage/nfs/volume.go
+++ b/lib/portlayer/storage/nfs/volume.go
@@ -15,9 +15,6 @@
 package nfs
 
 import (
-	"bytes"
-	"errors"
-	"fmt"
 	"io/ioutil"
 	"net/url"
 	"os"

--- a/lib/portlayer/storage/nfs/volume.go
+++ b/lib/portlayer/storage/nfs/volume.go
@@ -1,0 +1,156 @@
+// Copyright 2016-2017 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nfs
+
+import (
+	"io"
+	"net/url"
+	"path"
+
+	"github.com/vmware/vic/lib/portlayer/storage"
+	"github.com/vmware/vic/pkg/trace"
+	"github.com/vmware/vic/pkg/vsphere/disk"
+	"os"
+)
+
+const (
+	// This is the same as our vmdk approach namespacing the data further on the filesystem
+	VolumesDir = "volumes"
+
+	// path that namespaces the metadata for a specific volume
+	metadataDir = "volumedata"
+)
+
+type NFSv3VolumeStore struct {
+	//volume store name
+	Name string
+
+	not      // Service URL to this Volumestore
+	SelfLink *url.URL
+}
+
+func NewVolumeStore(op trace.Operation, storeName string, nfsTargetUrl *url.URL) (*NFSv3VolumeStore, error) {
+	// XXX: Potential credential leak, maybe log less...
+	op.Infof("Creating datastore (%s) at target (%q)", storeName, nfsTargetUrl.String())
+
+	// Create a target which can interact with the nfs server.
+	target, err := NewNFSv3Target(op, nfsTargetUrl)
+	if err != nil {
+		return nil, err
+	}
+
+	// we need to check for os.IsExist here in case the volume store is already present.
+	// XXX: we must make sure that os.IsExist is a valid check here. implementation for the target
+	// should return this.
+	if _, err := target.MkDir(nfsTargetUrl.Path, true); !os.IsExist(err) {
+		return nil, err
+	}
+
+	v := &NFSv3VolumeStore{
+		Name:     storeName,
+		SelfLink: nfsTargetUrl,
+	}
+
+	return v, nil
+}
+
+// Returns the path to the vol relative to the given store.  The dir structure
+// for a vol in a nfs store is `<configured nfs server path>/volumes/<vol ID>/<volume contents>`.
+func (v *NFSv3VolumeStore) volDirPath(ID string) string {
+	return path.Join(v.SelfLink.Path, VolumesDir, ID)
+}
+
+// Returns the path to the metadata directory for a volume
+func (v *NFSv3VolumeStore) volMetadataDirPath(ID string) string {
+	return path.Join(v.SelfLink.Path, metadataDir, ID)
+}
+
+// Returns the path to the specified volumes directory on the nfs target
+func (v *NFSv3VolumeStore) volumeURL(ID string) string {
+	return path.Join(v.SelfLink.String(), v.volDirPath(ID))
+}
+
+// Creates a volume directory and volume object for NFS based volumes
+func (v *NFSv3VolumeStore) VolumeCreate(op trace.Operation, ID string, store *url.URL, capacityKB uint64, info map[string][]byte) (*storage.Volume, error) {
+	target, err := OpenNFSv3Target(v.SelfLink)
+	if err != nil {
+		return err
+	}
+
+	if _, err := v.nfsTarget.MkDir(v.volumeURL(ID), false); err != nil {
+		return nil, err
+	}
+
+	volBacking := NewNFSVolumeBacking(v.volDirPath(ID))
+
+	vol := storage.NewNFSVolume(v.SelfLink, ID, info, v.volDirPath(ID))
+
+	if err := writeMetadata(op, v, ID, info); err != nil {
+		return err
+	}
+
+	op.Infof("nfs volume (%s) successfully created on volume store (%s)", ID, v.Name)
+
+	CloseNFSv3Target(&target)
+	return vol, nil
+}
+
+// Removes a volume and all of it's contents from the nfs store. We already know via the cache if it is in use.
+func (v *NFSv3VolumeStore) VolumeDestroy(op trace.Operation, vol *storage.Volume) error {
+	target, err := OpenNFSv3Target(v.SelfLink)
+	if err != nil {
+		return err
+	}
+
+	volTargetPath := v.volDirPath(vol.ID)
+
+	op.Infof("Attempting to remove volume (%s) and it's metadata from volume store (%s)", vol.ID, v.Name)
+
+	//remove volume directory and children
+	if err := target.RemoveAll(v.volDirPath(vol.ID)); err != nil {
+		op.Errorf("Failed to remove volume (%s) on volume store (%s) due to error (%s)", vol.ID, v.Name, err)
+		return err
+	}
+
+	//XXX: what should we do if we lose the nfs server between volume and metadata deletion?
+
+	//remove volume metadata directory and children
+	if err := target.RemoveAll(v.volMetadataDirPath(vol.ID)); err != nil {
+		op.Errorf("Failed to remove metadata for volume (%s) at path (%q) on volume store (%s)", vol.ID, v.volDirPath(vol.ID), v.Name)
+		//FIXME: Should we bail here? the volume is gone at this point...
+	}
+
+	if err := CloseNFSv3Target(target); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (v *NFSv3VolumeStore) VolumesList(op trace.Operation) ([]*Volume, error) {
+	return nil, nil
+}
+
+func writeMetadata(op trace.Operation, store storage.VolumeStorer, ID string, info map[string][]byte) error {
+	//implement this later
+	//will use target.Write
+	return nil
+}
+
+func getMetadata() (map[string][]byte, error) {
+	//will implement this later
+	//will use target.Write
+	return nil, nil
+}

--- a/lib/portlayer/storage/nfs/volume.go
+++ b/lib/portlayer/storage/nfs/volume.go
@@ -158,6 +158,7 @@ func (v *NFSv3VolumeStore) VolumeDestroy(op trace.Operation, vol *storage.Volume
 		op.Errorf("Failed to remove metadata for volume (%s) at path (%q) on volume store (%s)", vol.ID, v.volDirPath(vol.ID), v.Name)
 		//FIXME: Should we bail here? the volume is gone at this point...
 	}
+	op.Infof("Successfully removed volume (%s) from volumestore (%s)", vol.ID, v.Name)
 
 	return nil
 }

--- a/lib/portlayer/storage/nfs/volume_test.go
+++ b/lib/portlayer/storage/nfs/volume_test.go
@@ -78,11 +78,11 @@ func (v MockTarget) Lookup(path string) (os.FileInfo, error) {
 type MockMount struct {
 }
 
-func (m MockMount) Mount(target *url.URL) (target, error) {
+func (m MockMount) Mount(target *url.URL) (Target, error) {
 	return NewMocktarget(target.Path), nil
 }
 
-func (m MockMount) Unmount(target target) error {
+func (m MockMount) Unmount(target Target) error {
 	return nil
 }
 
@@ -104,12 +104,12 @@ func TestSimpleVolumeStoreOperations(t *testing.T) {
 
 	//Create a Volume Store
 	vs, err := NewVolumeStore(op, "testStore", &targetURL, mockMount)
-	if assert.Error(t, err, "Failed during call to NewVolumeStore with err (%s)", err) {
+	if !assert.NoError(t, err, "Failed during call to NewVolumeStore with err (%s)", err) {
 		return
 	}
 
 	_, err = os.Stat(dirpath)
-	if assert.Error(t, err, "Could not find the initial volume store directory after creation of volume store. err (%s)", err) {
+	if !assert.NoError(t, err, "Could not find the initial volume store directory after creation of volume store. err (%s)", err) {
 		return
 	}
 
@@ -126,7 +126,7 @@ func TestSimpleVolumeStoreOperations(t *testing.T) {
 
 	//Create a Volume
 	vol, err := vs.VolumeCreate(op, testVolName, vs.Target, 0 /*we do not use this*/, info)
-	if assert.Error(t, err, "Failed during call to VolumeCreate with err (%s)", err) {
+	if !assert.NoError(t, err, "Failed during call to VolumeCreate with err (%s)", err) {
 		return
 	}
 
@@ -145,23 +145,23 @@ func TestSimpleVolumeStoreOperations(t *testing.T) {
 
 	metaFilesDir, err := os.Open(metadataPath)
 	defer metaFilesDir.Close()
-	if assert.Error(t, err, "opening the metadata directory failed with err (%s)", err) {
+	if !assert.NoError(t, err, "opening the metadata directory failed with err (%s)", err) {
 		return
 	}
 
 	volumeDir, err := os.Open(volumePath)
 	defer volumeDir.Close()
-	if assert.Error(t, err, "Opening the volume directory failed with err (%s)", err) {
+	if !assert.NoError(t, err, "Opening the volume directory failed with err (%s)", err) {
 		return
 	}
 
 	metaDirEntries, err := metaFilesDir.Readdir(0)
-	if assert.Error(t, err, "Failed to read the metadata directory with err (%s)", err) {
+	if !assert.NoError(t, err, "Failed to read the metadata directory with err (%s)", err) {
 		return
 	}
 
 	volumeDirEntries, err := volumeDir.Readdir(0)
-	if assert.Error(t, err, "Failed to read the volume data directory with err (%s)", err) {
+	if !assert.NoError(t, err, "Failed to read the volume data directory with err (%s)", err) {
 		return
 	}
 
@@ -176,7 +176,7 @@ func TestSimpleVolumeStoreOperations(t *testing.T) {
 
 	//Remove the Volume
 	err = vs.VolumeDestroy(op, vol)
-	if assert.Error(t, err, "Failed during a call to VolumeDestroy with err (%s)", err) {
+	if !assert.NoError(t, err, "Failed during a call to VolumeDestroy with err (%s)", err) {
 		return
 	}
 
@@ -189,23 +189,23 @@ func TestSimpleVolumeStoreOperations(t *testing.T) {
 
 	metaFilesDir, err = os.Open(metadataPath)
 	defer metaFilesDir.Close()
-	if assert.Error(t, err, "opening the metadata directory failed with err (%s)", err) {
+	if !assert.NoError(t, err, "opening the metadata directory failed with err (%s)", err) {
 		return
 	}
 
 	volumeDir, err = os.Open(volumePath)
 	defer volumeDir.Close()
-	if assert.Error(t, err, "Opening the volume directory failed with err (%s)", err) {
+	if !assert.NoError(t, err, "Opening the volume directory failed with err (%s)", err) {
 		return
 	}
 
 	metaDirEntries, err = metaFilesDir.Readdir(0)
-	if assert.Error(t, err, "Failed to read the metadata directory with err (%s)", err) {
+	if !assert.NoError(t, err, "Failed to read the metadata directory with err (%s)", err) {
 		return
 	}
 
 	volumeDirEntries, err = volumeDir.Readdir(0)
-	if assert.Error(t, err, "Failed to read the volume data directory with err (%s)", err) {
+	if !assert.NoError(t, err, "Failed to read the volume data directory with err (%s)", err) {
 		return
 	}
 
@@ -219,12 +219,12 @@ func TestSimpleVolumeStoreOperations(t *testing.T) {
 	}
 
 	volToCheck, err := vs.VolumeCreate(op, testVolName, vs.Target, 0, info)
-	if assert.Error(t, err, "Failed during call to VolumeCreate with err (%s)", err) {
+	if !assert.NoError(t, err, "Failed during call to VolumeCreate with err (%s)", err) {
 		return
 	}
 
 	volumeList, err := vs.VolumesList(op)
-	if assert.Error(t, err, "Failed during call to VolumesList with err (%s)", err) {
+	if !assert.NoError(t, err, "Failed during call to VolumesList with err (%s)", err) {
 		return
 	}
 
@@ -248,7 +248,7 @@ func TestSimpleVolumeStoreOperations(t *testing.T) {
 	}
 
 	err = vs.VolumeDestroy(op, volToCheck)
-	if assert.Error(t, err, "Failed during a call to VolumeDestroy with err (%s)", err) {
+	if !assert.NoError(t, err, "Failed during a call to VolumeDestroy with err (%s)", err) {
 		return
 	}
 
@@ -260,7 +260,7 @@ func TestSimpleVolumeStoreOperations(t *testing.T) {
 	}
 
 	volumeList, err = vs.VolumesList(op)
-	if assert.Error(t, err, "Failed during a call to VolumesListwith err (%s)", err) {
+	if !assert.NoError(t, err, "Failed during a call to VolumesListwith err (%s)", err) {
 		return
 	}
 
@@ -281,12 +281,12 @@ func TestMultipleVolumes(t *testing.T) {
 
 	//Create a Volume Store
 	vs, err := NewVolumeStore(op, "testStore", &targetURL, mockMount)
-	if assert.Error(t, err, "Failed during call to NewVolumeStore with err (%s)", err) {
+	if !assert.NoError(t, err, "Failed during call to NewVolumeStore with err (%s)", err) {
 		return
 	}
 
 	_, err = os.Stat(dirpath)
-	if assert.Error(t, err, "Could not find the initial volume store directory after creation of volume store. err (%s)", err) {
+	if !assert.NoError(t, err, "Could not find the initial volume store directory after creation of volume store. err (%s)", err) {
 		return
 	}
 
@@ -317,7 +317,7 @@ func TestMultipleVolumes(t *testing.T) {
 	//make volume one
 	volOne, err := vs.VolumeCreate(op, testVolNameOne, vs.Target, 0 /*we do not use this*/, infoOne)
 
-	if assert.Error(t, err, "Failed during call to VolumeCreate with err (%s)", err) {
+	if !assert.NoError(t, err, "Failed during call to VolumeCreate with err (%s)", err) {
 		return
 	}
 
@@ -337,7 +337,7 @@ func TestMultipleVolumes(t *testing.T) {
 	//make volume two
 	volTwo, err := vs.VolumeCreate(op, testVolNameTwo, vs.Target, 0 /*we do not use this*/, infoTwo)
 
-	if assert.Error(t, err, "Failed during call to VolumeCreate with err (%s)", err) {
+	if !assert.NoError(t, err, "Failed during call to VolumeCreate with err (%s)", err) {
 		return
 	}
 
@@ -366,7 +366,7 @@ func TestMultipleVolumes(t *testing.T) {
 	//make volume three
 	volThree, err := vs.VolumeCreate(op, testVolNameThree, vs.Target, 0 /*we do not use this*/, infoThree)
 
-	if assert.Error(t, err, "Failed during call to VolumeCreate with err (%s)", err) {
+	if !assert.NoError(t, err, "Failed during call to VolumeCreate with err (%s)", err) {
 		return
 	}
 
@@ -394,7 +394,7 @@ func TestMultipleVolumes(t *testing.T) {
 
 	//list volumes
 	volumes, err := vs.VolumesList(op)
-	if assert.Error(t, err, "Failed during a call to VolumesList with err (%s)", err) {
+	if !assert.NoError(t, err, "Failed during a call to VolumesList with err (%s)", err) {
 		return
 	}
 
@@ -409,31 +409,29 @@ func TestMultipleVolumes(t *testing.T) {
 
 	metaFilesDir, err := os.Open(metadataPath)
 	defer metaFilesDir.Close()
-	if assert.Error(t, err, "opening the metadata directory failed with err (%s)", err) {
+	if !assert.NoError(t, err, "opening the metadata directory failed with err (%s)", err) {
 		return
 	}
 
 	volumeDir, err := os.Open(volumePath)
 	defer volumeDir.Close()
-	if assert.Error(t, err, "Opening the volume directory failed with err (%s)", err) {
+	if !assert.NoError(t, err, "Opening the volume directory failed with err (%s)", err) {
 		return
 	}
 
 	metaDirEntries, err := metaFilesDir.Readdir(0)
-	if assert.Error(t, err, "Failed to read the metadata directory with err (%s)", err) {
+	if !assert.NoError(t, err, "Failed to read the metadata directory with err (%s)", err) {
 		return
 	}
 
 	volumeDirEntries, err := volumeDir.Readdir(0)
-	if assert.Error(t, err, "Failed to read the volume data directory with err (%s)", err) {
+	if !assert.NoError(t, err, "Failed to read the volume data directory with err (%s)", err) {
 		return
 	}
 
-	t.Logf("meta directory (%s)", metaDirEntries)
 	if !assert.Equal(t, len(metaDirEntries), 3, "expected metadata directory to have 1 entry and it had (%s)", len(metaDirEntries)) {
 		return
 	}
-	t.Logf("vol directory (%s)", volumeDirEntries)
 	if !assert.Equal(t, len(volumeDirEntries), 3, "expected metadata directory to have 1 entry and it had (%s)", len(volumeDirEntries)) {
 		return
 	}
@@ -442,7 +440,7 @@ func TestMultipleVolumes(t *testing.T) {
 	volThreeMetadataPath := path.Join(metadataPath, testVolNameThree)
 	volThreeMetadataDir, err := os.Open(volThreeMetadataPath)
 	defer volThreeMetadataDir.Close()
-	if assert.Error(t, err, "Expected for path (%s) to exist, but received this error instead (%s)", volThreeMetadataPath, err) {
+	if !assert.NoError(t, err, "Expected for path (%s) to exist, but received this error instead (%s)", volThreeMetadataPath, err) {
 		return
 	}
 
@@ -454,7 +452,7 @@ func TestMultipleVolumes(t *testing.T) {
 	volTwoMetadataPath := path.Join(metadataPath, testVolNameTwo)
 	volTwoMetadataDir, err := os.Open(volTwoMetadataPath)
 	defer volTwoMetadataDir.Close()
-	if assert.Error(t, err, "Expected for path (%s) to exist, but received this error instead (%s)", volTwoMetadataPath, err) {
+	if !assert.NoError(t, err, "Expected for path (%s) to exist, but received this error instead (%s)", volTwoMetadataPath, err) {
 		return
 	}
 
@@ -466,7 +464,7 @@ func TestMultipleVolumes(t *testing.T) {
 	volOneMetadataPath := path.Join(metadataPath, testVolNameOne)
 	volOneMetadataDir, err := os.Open(volOneMetadataPath)
 	defer volOneMetadataDir.Close()
-	if assert.Error(t, err, "Expected for path (%s) to exist, but received this error instead (%s)", volOneMetadataPath, err) {
+	if !assert.NoError(t, err, "Expected for path (%s) to exist, but received this error instead (%s)", volOneMetadataPath, err) {
 		return
 	}
 
@@ -477,7 +475,7 @@ func TestMultipleVolumes(t *testing.T) {
 
 	//remove volume one
 	err = vs.VolumeDestroy(op, volOne)
-	if assert.Error(t, err, "Failed during a call to VolumeDestroy with error (%s)", err) {
+	if !assert.NoError(t, err, "Failed during a call to VolumeDestroy with error (%s)", err) {
 		return
 	}
 
@@ -492,7 +490,7 @@ func TestMultipleVolumes(t *testing.T) {
 	volThreeMetadataPath = path.Join(metadataPath, testVolNameThree)
 	volThreeMetadataDir, err = os.Open(volThreeMetadataPath)
 	defer volThreeMetadataDir.Close()
-	if assert.Error(t, err, "Expected for path (%s) to exist, but received this error instead (%s)", volThreeMetadataPath, err) {
+	if !assert.NoError(t, err, "Expected for path (%s) to exist, but received this error instead (%s)", volThreeMetadataPath, err) {
 		return
 	}
 
@@ -504,7 +502,7 @@ func TestMultipleVolumes(t *testing.T) {
 	volTwoMetadataPath = path.Join(metadataPath, testVolNameTwo)
 	volTwoMetadataDir, err = os.Open(volTwoMetadataPath)
 	defer volTwoMetadataDir.Close()
-	if assert.Error(t, err, "Expected for path (%s) to exist, but received this error instead (%s)", volTwoMetadataPath, err) {
+	if !assert.NoError(t, err, "Expected for path (%s) to exist, but received this error instead (%s)", volTwoMetadataPath, err) {
 		return
 	}
 
@@ -515,7 +513,7 @@ func TestMultipleVolumes(t *testing.T) {
 
 	//remove the rest of the volumes
 	err = vs.VolumeDestroy(op, volTwo)
-	if assert.Error(t, err, "Failed during a call to VolumeDestroy with error (%s)", err) {
+	if !assert.NoError(t, err, "Failed during a call to VolumeDestroy with error (%s)", err) {
 		return
 	}
 
@@ -527,7 +525,7 @@ func TestMultipleVolumes(t *testing.T) {
 	}
 
 	err = vs.VolumeDestroy(op, volThree)
-	if assert.Error(t, err, "Failed during a call to VolumeDestroy with error (%s)", err) {
+	if !assert.NoError(t, err, "Failed during a call to VolumeDestroy with error (%s)", err) {
 		return
 	}
 

--- a/lib/portlayer/storage/nfs/volume_test.go
+++ b/lib/portlayer/storage/nfs/volume_test.go
@@ -47,7 +47,7 @@ func (v MockTarget) OpenFile(path string, mode os.FileMode) (io.ReadWriteCloser,
 	return os.OpenFile(path, os.O_RDWR, mode)
 }
 
-func (v MockTarget) Create(path string) (io.ReadWriteCloser, error) {
+func (v MockTarget) Create(path string, perm os.FileMode) (io.ReadWriteCloser, error) {
 	return os.Create(path)
 }
 

--- a/lib/portlayer/storage/nfs/volume_test.go
+++ b/lib/portlayer/storage/nfs/volume_test.go
@@ -104,12 +104,12 @@ func TestSimpleVolumeStoreOperations(t *testing.T) {
 
 	//Create a Volume Store
 	vs, err := NewVolumeStore(op, "testStore", &targetURL, mockMount)
-	if !assert.Nil(t, err, "Failed during call to NewVolumeStore with err (%s)", err) {
+	if assert.Error(t, err, "Failed during call to NewVolumeStore with err (%s)", err) {
 		return
 	}
 
 	_, err = os.Stat(dirpath)
-	if !assert.Nil(t, err, "Could not find the initial volume store directory after creation of volume store. err (%s)", err) {
+	if assert.Error(t, err, "Could not find the initial volume store directory after creation of volume store. err (%s)", err) {
 		return
 	}
 
@@ -126,7 +126,7 @@ func TestSimpleVolumeStoreOperations(t *testing.T) {
 
 	//Create a Volume
 	vol, err := vs.VolumeCreate(op, testVolName, vs.Target, 0 /*we do not use this*/, info)
-	if !assert.Nil(t, err, "Failed during call to VolumeCreate with err (%s)", err) {
+	if assert.Error(t, err, "Failed during call to VolumeCreate with err (%s)", err) {
 		return
 	}
 
@@ -145,23 +145,23 @@ func TestSimpleVolumeStoreOperations(t *testing.T) {
 
 	metaFilesDir, err := os.Open(metadataPath)
 	defer metaFilesDir.Close()
-	if !assert.Nil(t, err, "opening the metadata directory failed with err (%s)", err) {
+	if assert.Error(t, err, "opening the metadata directory failed with err (%s)", err) {
 		return
 	}
 
 	volumeDir, err := os.Open(volumePath)
 	defer volumeDir.Close()
-	if !assert.Nil(t, err, "Opening the volume directory failed with err (%s)", err) {
+	if assert.Error(t, err, "Opening the volume directory failed with err (%s)", err) {
 		return
 	}
 
 	metaDirEntries, err := metaFilesDir.Readdir(0)
-	if !assert.Nil(t, err, "Failed to read the metadata directory with err (%s)", err) {
+	if assert.Error(t, err, "Failed to read the metadata directory with err (%s)", err) {
 		return
 	}
 
 	volumeDirEntries, err := volumeDir.Readdir(0)
-	if !assert.Nil(t, err, "Failed to read the volume data directory with err (%s)", err) {
+	if assert.Error(t, err, "Failed to read the volume data directory with err (%s)", err) {
 		return
 	}
 
@@ -176,7 +176,7 @@ func TestSimpleVolumeStoreOperations(t *testing.T) {
 
 	//Remove the Volume
 	err = vs.VolumeDestroy(op, vol)
-	if !assert.Nil(t, err, "Failed during a call to VolumeDestroy with err (%s)", err) {
+	if assert.Error(t, err, "Failed during a call to VolumeDestroy with err (%s)", err) {
 		return
 	}
 
@@ -189,23 +189,23 @@ func TestSimpleVolumeStoreOperations(t *testing.T) {
 
 	metaFilesDir, err = os.Open(metadataPath)
 	defer metaFilesDir.Close()
-	if !assert.Nil(t, err, "opening the metadata directory failed with err (%s)", err) {
+	if assert.Error(t, err, "opening the metadata directory failed with err (%s)", err) {
 		return
 	}
 
 	volumeDir, err = os.Open(volumePath)
 	defer volumeDir.Close()
-	if !assert.Nil(t, err, "Opening the volume directory failed with err (%s)", err) {
+	if assert.Error(t, err, "Opening the volume directory failed with err (%s)", err) {
 		return
 	}
 
 	metaDirEntries, err = metaFilesDir.Readdir(0)
-	if !assert.Nil(t, err, "Failed to read the metadata directory with err (%s)", err) {
+	if assert.Error(t, err, "Failed to read the metadata directory with err (%s)", err) {
 		return
 	}
 
 	volumeDirEntries, err = volumeDir.Readdir(0)
-	if !assert.Nil(t, err, "Failed to read the volume data directory with err (%s)", err) {
+	if assert.Error(t, err, "Failed to read the volume data directory with err (%s)", err) {
 		return
 	}
 
@@ -219,12 +219,12 @@ func TestSimpleVolumeStoreOperations(t *testing.T) {
 	}
 
 	volToCheck, err := vs.VolumeCreate(op, testVolName, vs.Target, 0, info)
-	if !assert.Nil(t, err, "Failed during call to VolumeCreate with err (%s)", err) {
+	if assert.Error(t, err, "Failed during call to VolumeCreate with err (%s)", err) {
 		return
 	}
 
 	volumeList, err := vs.VolumesList(op)
-	if !assert.Nil(t, err, "Failed during call to VolumesList with err (%s)", err) {
+	if assert.Error(t, err, "Failed during call to VolumesList with err (%s)", err) {
 		return
 	}
 
@@ -248,7 +248,7 @@ func TestSimpleVolumeStoreOperations(t *testing.T) {
 	}
 
 	err = vs.VolumeDestroy(op, volToCheck)
-	if !assert.Nil(t, err, "Failed during a call to VolumeDestroy with err (%s)", err) {
+	if assert.Error(t, err, "Failed during a call to VolumeDestroy with err (%s)", err) {
 		return
 	}
 
@@ -260,7 +260,7 @@ func TestSimpleVolumeStoreOperations(t *testing.T) {
 	}
 
 	volumeList, err = vs.VolumesList(op)
-	if !assert.Nil(t, err, "Failed during a call to VolumesListwith err (%s)", err) {
+	if assert.Error(t, err, "Failed during a call to VolumesListwith err (%s)", err) {
 		return
 	}
 
@@ -281,12 +281,12 @@ func TestMultipleVolumes(t *testing.T) {
 
 	//Create a Volume Store
 	vs, err := NewVolumeStore(op, "testStore", &targetURL, mockMount)
-	if !assert.Nil(t, err, "Failed during call to NewVolumeStore with err (%s)", err) {
+	if assert.Error(t, err, "Failed during call to NewVolumeStore with err (%s)", err) {
 		return
 	}
 
 	_, err = os.Stat(dirpath)
-	if !assert.Nil(t, err, "Could not find the initial volume store directory after creation of volume store. err (%s)", err) {
+	if assert.Error(t, err, "Could not find the initial volume store directory after creation of volume store. err (%s)", err) {
 		return
 	}
 
@@ -317,7 +317,7 @@ func TestMultipleVolumes(t *testing.T) {
 	//make volume one
 	volOne, err := vs.VolumeCreate(op, testVolNameOne, vs.Target, 0 /*we do not use this*/, infoOne)
 
-	if !assert.Nil(t, err, "Failed during call to VolumeCreate with err (%s)", err) {
+	if assert.Error(t, err, "Failed during call to VolumeCreate with err (%s)", err) {
 		return
 	}
 
@@ -337,7 +337,7 @@ func TestMultipleVolumes(t *testing.T) {
 	//make volume two
 	volTwo, err := vs.VolumeCreate(op, testVolNameTwo, vs.Target, 0 /*we do not use this*/, infoTwo)
 
-	if !assert.Nil(t, err, "Failed during call to VolumeCreate with err (%s)", err) {
+	if assert.Error(t, err, "Failed during call to VolumeCreate with err (%s)", err) {
 		return
 	}
 
@@ -366,7 +366,7 @@ func TestMultipleVolumes(t *testing.T) {
 	//make volume three
 	volThree, err := vs.VolumeCreate(op, testVolNameThree, vs.Target, 0 /*we do not use this*/, infoThree)
 
-	if !assert.Nil(t, err, "Failed during call to VolumeCreate with err (%s)", err) {
+	if assert.Error(t, err, "Failed during call to VolumeCreate with err (%s)", err) {
 		return
 	}
 
@@ -394,7 +394,7 @@ func TestMultipleVolumes(t *testing.T) {
 
 	//list volumes
 	volumes, err := vs.VolumesList(op)
-	if !assert.Nil(t, err, "Failed during a call to VolumesList with err (%s)", err) {
+	if assert.Error(t, err, "Failed during a call to VolumesList with err (%s)", err) {
 		return
 	}
 
@@ -409,23 +409,23 @@ func TestMultipleVolumes(t *testing.T) {
 
 	metaFilesDir, err := os.Open(metadataPath)
 	defer metaFilesDir.Close()
-	if !assert.Nil(t, err, "opening the metadata directory failed with err (%s)", err) {
+	if assert.Error(t, err, "opening the metadata directory failed with err (%s)", err) {
 		return
 	}
 
 	volumeDir, err := os.Open(volumePath)
 	defer volumeDir.Close()
-	if !assert.Nil(t, err, "Opening the volume directory failed with err (%s)", err) {
+	if assert.Error(t, err, "Opening the volume directory failed with err (%s)", err) {
 		return
 	}
 
 	metaDirEntries, err := metaFilesDir.Readdir(0)
-	if !assert.Nil(t, err, "Failed to read the metadata directory with err (%s)", err) {
+	if assert.Error(t, err, "Failed to read the metadata directory with err (%s)", err) {
 		return
 	}
 
 	volumeDirEntries, err := volumeDir.Readdir(0)
-	if !assert.Nil(t, err, "Failed to read the volume data directory with err (%s)", err) {
+	if assert.Error(t, err, "Failed to read the volume data directory with err (%s)", err) {
 		return
 	}
 
@@ -442,7 +442,7 @@ func TestMultipleVolumes(t *testing.T) {
 	volThreeMetadataPath := path.Join(metadataPath, testVolNameThree)
 	volThreeMetadataDir, err := os.Open(volThreeMetadataPath)
 	defer volThreeMetadataDir.Close()
-	if !assert.Nil(t, err, "Expected for path (%s) to exist, but received this error instead (%s)", volThreeMetadataPath, err) {
+	if assert.Error(t, err, "Expected for path (%s) to exist, but received this error instead (%s)", volThreeMetadataPath, err) {
 		return
 	}
 
@@ -454,7 +454,7 @@ func TestMultipleVolumes(t *testing.T) {
 	volTwoMetadataPath := path.Join(metadataPath, testVolNameTwo)
 	volTwoMetadataDir, err := os.Open(volTwoMetadataPath)
 	defer volTwoMetadataDir.Close()
-	if !assert.Nil(t, err, "Expected for path (%s) to exist, but received this error instead (%s)", volTwoMetadataPath, err) {
+	if assert.Error(t, err, "Expected for path (%s) to exist, but received this error instead (%s)", volTwoMetadataPath, err) {
 		return
 	}
 
@@ -466,7 +466,7 @@ func TestMultipleVolumes(t *testing.T) {
 	volOneMetadataPath := path.Join(metadataPath, testVolNameOne)
 	volOneMetadataDir, err := os.Open(volOneMetadataPath)
 	defer volOneMetadataDir.Close()
-	if !assert.Nil(t, err, "Expected for path (%s) to exist, but received this error instead (%s)", volOneMetadataPath, err) {
+	if assert.Error(t, err, "Expected for path (%s) to exist, but received this error instead (%s)", volOneMetadataPath, err) {
 		return
 	}
 
@@ -477,7 +477,7 @@ func TestMultipleVolumes(t *testing.T) {
 
 	//remove volume one
 	err = vs.VolumeDestroy(op, volOne)
-	if !assert.Nil(t, err, "Failed during a call to VolumeDestroy with error (%s)", err) {
+	if assert.Error(t, err, "Failed during a call to VolumeDestroy with error (%s)", err) {
 		return
 	}
 
@@ -492,7 +492,7 @@ func TestMultipleVolumes(t *testing.T) {
 	volThreeMetadataPath = path.Join(metadataPath, testVolNameThree)
 	volThreeMetadataDir, err = os.Open(volThreeMetadataPath)
 	defer volThreeMetadataDir.Close()
-	if !assert.Nil(t, err, "Expected for path (%s) to exist, but received this error instead (%s)", volThreeMetadataPath, err) {
+	if assert.Error(t, err, "Expected for path (%s) to exist, but received this error instead (%s)", volThreeMetadataPath, err) {
 		return
 	}
 
@@ -504,7 +504,7 @@ func TestMultipleVolumes(t *testing.T) {
 	volTwoMetadataPath = path.Join(metadataPath, testVolNameTwo)
 	volTwoMetadataDir, err = os.Open(volTwoMetadataPath)
 	defer volTwoMetadataDir.Close()
-	if !assert.Nil(t, err, "Expected for path (%s) to exist, but received this error instead (%s)", volTwoMetadataPath, err) {
+	if assert.Error(t, err, "Expected for path (%s) to exist, but received this error instead (%s)", volTwoMetadataPath, err) {
 		return
 	}
 
@@ -515,7 +515,7 @@ func TestMultipleVolumes(t *testing.T) {
 
 	//remove the rest of the volumes
 	err = vs.VolumeDestroy(op, volTwo)
-	if !assert.Nil(t, err, "Failed during a call to VolumeDestroy with error (%s)", err) {
+	if assert.Error(t, err, "Failed during a call to VolumeDestroy with error (%s)", err) {
 		return
 	}
 
@@ -527,7 +527,7 @@ func TestMultipleVolumes(t *testing.T) {
 	}
 
 	err = vs.VolumeDestroy(op, volThree)
-	if !assert.Nil(t, err, "Failed during a call to VolumeDestroy with error (%s)", err) {
+	if assert.Error(t, err, "Failed during a call to VolumeDestroy with error (%s)", err) {
 		return
 	}
 

--- a/lib/portlayer/storage/nfs/volume_test.go
+++ b/lib/portlayer/storage/nfs/volume_test.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2017 VMware, Inc. All Rights Reserved.
+// Copyright 2017 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -51,7 +51,7 @@ func (v MockTarget) Create(path string, perm os.FileMode) (io.ReadWriteCloser, e
 	return os.Create(path)
 }
 
-func (v MockTarget) MkDir(path string, perm os.FileMode) ([]byte, error) {
+func (v MockTarget) Mkdir(path string, perm os.FileMode) ([]byte, error) {
 	return nil, os.Mkdir(path, perm)
 }
 
@@ -77,11 +77,11 @@ func (v MockTarget) Lookup(path string) (os.FileInfo, error) {
 type MockMount struct {
 }
 
-func (m MockMount) Mount(target *url.URL) (NFSTarget, error) {
+func (m MockMount) Mount(target *url.URL) (target, error) {
 	return NewMocktarget(target.Path), nil
 }
 
-func (m MockMount) Unmount(target NFSTarget) error {
+func (m MockMount) Unmount(target target) error {
 	return nil
 }
 
@@ -388,7 +388,7 @@ func TestMultipleVolumes(t *testing.T) {
 	}
 
 	volCount := len(volumes)
-	if !assert.Equal(t, volCount, 3, "VolumesList returned unexpected volume count. expected (%s), but received (%s) ", volCount, 3) {
+	if !assert.Equal(t, volCount, 3, "VolumesList returned unexpected volume count. expected (%s), but received (%s) ", 3, volCount) {
 		return
 	}
 

--- a/lib/portlayer/storage/nfs/volume_test.go
+++ b/lib/portlayer/storage/nfs/volume_test.go
@@ -508,6 +508,8 @@ func TestMultipleVolumes(t *testing.T) {
 		return
 	}
 
+	os.Remove(volumePath)
+	os.Remove(metadataDir)
 	return
 }
 

--- a/lib/portlayer/storage/nfs/volume_test.go
+++ b/lib/portlayer/storage/nfs/volume_test.go
@@ -1,0 +1,241 @@
+// Copyright 2016-2017 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nfs
+
+import (
+	"context"
+	"io"
+	"net/url"
+	"os"
+	"path"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/vmware/vic/pkg/trace"
+)
+
+const (
+	nfsTestDir = "NFSVolumeStoreTests"
+)
+
+// MOCK TARGET STRUCT AND IMPL
+type MockTarget struct {
+	dirPath string
+}
+
+func NewMocktarget(path string) MockTarget {
+	return MockTarget{dirPath: path}
+}
+
+func (v MockTarget) Open(path string) (io.ReadCloser, error) {
+	return os.Open(path)
+}
+
+func (v MockTarget) OpenFile(path string, mode os.FileMode) (io.ReadWriteCloser, error) {
+	return os.OpenFile(path, os.O_RDWR, mode)
+}
+
+func (v MockTarget) Create(path string) (io.ReadWriteCloser, error) {
+	return os.Create(path)
+}
+
+func (v MockTarget) MkDir(path string, perm os.FileMode) ([]byte, error) {
+	return nil, os.Mkdir(path, perm)
+}
+
+func (v MockTarget) RemoveAll(path string) error {
+	return os.RemoveAll(path)
+}
+
+func (v MockTarget) ReadDir(path string) ([]os.FileInfo, error) {
+	dir, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+
+	return dir.Readdir(0)
+}
+
+func (v MockTarget) Lookup(path string) (os.FileInfo, error) {
+	return os.Stat(path)
+}
+
+// MOCK MOUNT STRUCT AND IMPL
+
+type MockMount struct {
+}
+
+func (m MockMount) Mount(target *url.URL) (NFSTarget, error) {
+	return NewMocktarget(target.Path), nil
+}
+
+func (m MockMount) Unmount(target NFSTarget) error {
+	return nil
+}
+
+func TestMain(m *testing.M) {
+	testPath := path.Join(os.TempDir(), nfsTestDir)
+	os.Mkdir(testPath, 0755)
+	result := m.Run()
+	os.RemoveAll(testPath)
+	os.Exit(result)
+}
+
+func TestSimpleVolumeStoreOperations(t *testing.T) {
+	mockMount := MockMount{}
+	testVolName := "testVolume"
+	dirpath := path.Join(os.TempDir(), nfsTestDir)
+
+	targetURL := url.URL{Path: dirpath}
+	op := trace.NewOperation(context.TODO(), "TestOp")
+
+	//Create a Volume Store
+	vs, err := NewVolumeStore(op, "testStore", &targetURL, mockMount)
+	if !assert.Nil(t, err, "Failed during call to NewVolumeStore with err (%s)", err) {
+		return
+	}
+
+	_, err = os.Stat(dirpath)
+	if !assert.Nil(t, err, "Could not find the initial volume store directory after creation of volume store. err (%s)", err) {
+		return
+	}
+
+	if !assert.NotNil(t, vs, "Volume Store created with nil err, but return is also nil") {
+		return
+	}
+
+	info := make(map[string][]byte)
+	testInfoKey := "junk"
+	info[testInfoKey] = make([]byte, 20)
+
+	file, err := os.Open(dirpath)
+	contents, err := file.Readdir(0)
+	t.Logf("%s\n", contents)
+
+	//Create a Volume
+	vol, err := vs.VolumeCreate(op, testVolName, vs.Target, 0 /*we do not use this*/, info)
+
+	if !assert.Nil(t, err, "Failed during call to VolumeCreate with err (%s)", err) {
+		return
+	}
+
+	if !assert.Equal(t, testVolName, vol.ID, "expected volume ID (%s) got ID (%s)", testVolName, vol.ID) {
+		return
+	}
+
+	_, ok := vol.Info[testInfoKey]
+	if !assert.True(t, ok, "TestInfoKey did not exist in the return metadata map") {
+		return
+	}
+
+	metadataPath := path.Join(dirpath, metadataDir)
+	volumePath := path.Join(dirpath, VolumesDir)
+
+	metaFilesDir, err := os.Open(metadataPath)
+	if !assert.Nil(t, err, "opening the metadata directory failed with err (%s)", err) {
+		return
+	}
+
+	volumeDir, err := os.Open(volumePath)
+	if !assert.Nil(t, err, "Opening the volume directory failed with err (%s)", err) {
+		return
+	}
+
+	metaDirEntries, err := metaFilesDir.Readdir(0)
+	if !assert.Nil(t, err, "Failed to read the metadata directory with err (%s)", err) {
+		return
+	}
+
+	volumeDirEntries, err := volumeDir.Readdir(0)
+	if !assert.Nil(t, err, "Failed to read the volume data directory with err (%s)", err) {
+		return
+	}
+
+	t.Logf("meta directory (%s)", metaDirEntries)
+	if !assert.Equal(t, len(metaDirEntries), 1, "expected metadata directory to have 1 entry and it had (%s)", len(metaDirEntries)) {
+		return
+	}
+	t.Logf("vol directory (%s)", volumeDirEntries)
+	if !assert.Equal(t, len(volumeDirEntries), 1, "expected metadata directory to have 1 entry and it had (%s)", len(volumeDirEntries)) {
+		return
+	}
+
+	metaFilesDir.Close()
+	volumeDir.Close()
+
+	//Remove the same Volume
+	err = vs.VolumeDestroy(op, vol)
+	if !assert.Nil(t, err, "Failed during a call to VolumeDestroy with err (%s)", err) {
+		return
+	}
+
+	metaFilesDir, err = os.Open(metadataPath)
+	if !assert.Nil(t, err, "opening the metadata directory failed with err (%s)", err) {
+		return
+	}
+
+	volumeDir, err = os.Open(volumePath)
+	if !assert.Nil(t, err, "Opening the volume directory failed with err (%s)", err) {
+		return
+	}
+
+	metaDirEntries, err = metaFilesDir.Readdir(0)
+	if !assert.Nil(t, err, "Failed to read the metadata directory with err (%s)", err) {
+		return
+	}
+
+	volumeDirEntries, err = volumeDir.Readdir(0)
+	if !assert.Nil(t, err, "Failed to read the volume data directory with err (%s)", err) {
+		return
+	}
+
+	t.Logf("meta directory (%s)", metaDirEntries)
+	if !assert.Equal(t, len(metaDirEntries), 0, "expected metadata directory to have 1 entry and it had (%s)", len(metaDirEntries)) {
+		return
+	}
+	t.Logf("vol directory (%s)", volumeDirEntries)
+	if !assert.Equal(t, len(volumeDirEntries), 0, "expected metadata directory to have 1 entry and it had (%s)", len(volumeDirEntries)) {
+		return
+	}
+
+	volToCheck, err := vs.VolumeCreate(op, testVolName, vs.Target, 0, info)
+	if !assert.Nil(t, err, "Failed during call to VolumeCreate with err (%s)", err) {
+		return
+	}
+
+	volumeList, err := vs.VolumesList(op)
+	if !assert.Nil(t, err, "Failed during call to VolumesList with err (%s)", err) {
+		return
+	}
+
+	if !assert.Equal(t, len(volumeList), 1, "Expected 1 entry in volumeList, but it had (%s)", len(volumeList)) {
+		return
+	}
+
+	if !assert.Equal(t, volumeList[0].ID, volToCheck.ID, "Failed due to VolumeList returning an unexpected volume %#v when volume %#v was expected.", volumeList[0], volToCheck) {
+		return
+	}
+
+	RetrievedInfo := volumeList[0].Info
+	CreatedInfo := volToCheck.Info
+
+	if !assert.Equal(t, len(RetrievedInfo), len(CreatedInfo), "Length mismatch between the created volume(%s) and the volume returned from VolumeList(%s)", len(CreatedInfo), len(RetrievedInfo)) {
+		return
+	}
+
+	if !assert.Equal(t, RetrievedInfo[testInfoKey], CreatedInfo[testInfoKey], "Failed due to mismatch in metadata between the content of the Created volume(%s) and the volume return from VolumesList", CreatedInfo[testInfoKey], RetrievedInfo[testInfoKey]) {
+		return
+	}
+}

--- a/lib/portlayer/storage/volume.go
+++ b/lib/portlayer/storage/volume.go
@@ -1,4 +1,4 @@
-// Copyright 2016 VMware, Inc. All Rights Reserved.
+// Copyright 2016-2017 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -93,6 +93,23 @@ func NewVolume(store *url.URL, ID string, info map[string][]byte, device Disk) (
 		Info:     info,
 	}
 
+	return vol, nil
+}
+
+func NewNFSVolume(store *url.URL, ID string, info map[string][]byte, nfsPath string) (*Volume, error) {
+
+	selfLink := &url.URL{
+		Path: nfsPath,
+	}
+
+	vol := &Volume{
+		ID:       ID,
+		Label:    "", //no device label
+		Store:    store,
+		SelfLink: selfLink,
+		Device:   nil, //this it not backed by a virtual device
+		Info:     info,
+	}
 	return vol, nil
 }
 

--- a/lib/portlayer/storage/volume.go
+++ b/lib/portlayer/storage/volume.go
@@ -32,8 +32,6 @@ type Disk interface {
 
 	//Path to the disk on the datastore
 	DiskPath() url.URL
-	//STUFF THE STRING INTO THE PATH FIELD FOR VSPHERE IMPLEMENTATION
-	//NFS PUT THE STUFF IN THE HOST.  2 3
 }
 
 // VolumeStorer is an interface to create, remove, enumerate, and get Volumes.

--- a/lib/portlayer/storage/volume.go
+++ b/lib/portlayer/storage/volume.go
@@ -27,9 +27,13 @@ import (
 )
 
 type Disk interface {
+	//Path to this disk on the VCH
 	MountPath() (string, error)
-	DiskPath() string
-	//FIXME: Add a capacity and populate it.
+
+	//Path to the disk on the datastore
+	DiskPath() url.URL
+	//STUFF THE STRING INTO THE PATH FIELD FOR VSPHERE IMPLEMENTATION
+	//NFS PUT THE STUFF IN THE HOST.  2 3
 }
 
 // VolumeStorer is an interface to create, remove, enumerate, and get Volumes.
@@ -93,23 +97,6 @@ func NewVolume(store *url.URL, ID string, info map[string][]byte, device Disk) (
 		Info:     info,
 	}
 
-	return vol, nil
-}
-
-func NewNFSVolume(store *url.URL, ID string, info map[string][]byte, nfsPath string) (*Volume, error) {
-
-	selfLink := &url.URL{
-		Path: nfsPath,
-	}
-
-	vol := &Volume{
-		ID:       ID,
-		Label:    "", //no device label
-		Store:    store,
-		SelfLink: selfLink,
-		Device:   nil, //this it not backed by a virtual device
-		Info:     info,
-	}
 	return vol, nil
 }
 

--- a/lib/portlayer/storage/volume.go
+++ b/lib/portlayer/storage/volume.go
@@ -27,10 +27,10 @@ import (
 )
 
 type Disk interface {
-	//Path to this disk on the VCH
+	// Path to this disk on the VCH
 	MountPath() (string, error)
 
-	//Path to the disk on the datastore
+	// Path to the disk on the datastore
 	DiskPath() url.URL
 }
 

--- a/lib/portlayer/storage/vsphere/vm.go
+++ b/lib/portlayer/storage/vsphere/vm.go
@@ -51,7 +51,7 @@ func VolumeJoin(op trace.Operation, handle *exec.Handle, volume *storage.Volume,
 			Backing: &types.VirtualDiskFlatVer2BackingInfo{
 				DiskMode: string(types.VirtualDiskModeIndependent_persistent),
 				VirtualDeviceFileBackingInfo: types.VirtualDeviceFileBackingInfo{
-					FileName: volume.Device.DiskPath(),
+					FileName: volume.Device.DiskPath().Path,
 				},
 			},
 		},

--- a/lib/portlayer/storage/vsphere/volume.go
+++ b/lib/portlayer/storage/vsphere/volume.go
@@ -1,4 +1,4 @@
-// Copyright 2016 VMware, Inc. All Rights Reserved.
+// Copyright 2016-2017 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/vsphere/disk/disk.go
+++ b/pkg/vsphere/disk/disk.go
@@ -16,6 +16,7 @@ package disk
 
 import (
 	"fmt"
+	"net/url"
 	"strings"
 	"sync"
 
@@ -196,8 +197,9 @@ func (d *VirtualDisk) MountPath() (string, error) {
 	return d.mountPath, nil
 }
 
-func (d *VirtualDisk) DiskPath() string {
-	return d.DatastoreURI
+func (d *VirtualDisk) DiskPath() url.URL {
+
+	return url.URL{Path: d.DatastoreURI}
 }
 
 func (d *VirtualDisk) Mounted() bool {


### PR DESCRIPTION
fixes #3806 

This is the NFS Volume Store implementation which relies on the implementation from ticket #3803. The `Target` interface defines the api calls used by the nfs volume store implementation and the unit tests have mocked these out with go's base `os` package. The code for populating the cache with nfs volume stores has not been added yet. That will likely be part of the personality and portlayer handler work in ticket #3925.

There is no current path for creating nfs volume stores, this is just one part of the piece for moving us toward being able to write integration tests showing nfs volumestore support(#2303)

This may still need some additional alignment with @fdawg4l 's nfs client additions. 

