### PR TITLE
correct the display unit of cpu usage/limit in docker info [specific ci=1-01-Docker-Info]

### DIFF
--- a/lib/apiservers/engine/backends/system.go
+++ b/lib/apiservers/engine/backends/system.go
@@ -162,7 +162,7 @@ func (s *System) SystemInfo() (*types.Info, error) {
 		if vchInfo.CPUMhz > 0 {
 			info.NCPU = int(vchInfo.CPUMhz)
 
-			customInfo := [2]string{systemStatusMhz, fmt.Sprintf("%d Mhz", info.NCPU)}
+			customInfo := [2]string{systemStatusMhz, fmt.Sprintf("%d MHz", info.NCPU)}
 			info.SystemStatus = append(info.SystemStatus, customInfo)
 		}
 		if vchInfo.Memory > 0 {
@@ -172,7 +172,7 @@ func (s *System) SystemInfo() (*types.Info, error) {
 			info.SystemStatus = append(info.SystemStatus, customInfo)
 		}
 		if vchInfo.CPUUsage >= 0 {
-			customInfo := [2]string{systemStatusCPUUsageMhz, fmt.Sprintf("%d Mhz", int(vchInfo.CPUUsage))}
+			customInfo := [2]string{systemStatusCPUUsageMhz, fmt.Sprintf("%d MHz", int(vchInfo.CPUUsage))}
 			info.SystemStatus = append(info.SystemStatus, customInfo)
 		}
 		if vchInfo.MemUsage >= 0 {

--- a/tests/test-cases/Group1-Docker-Commands/1-01-Docker-Info.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-01-Docker-Info.robot
@@ -120,5 +120,5 @@ Check updated resource pool CPU and memory usages
     Should Be Equal As Integers  ${rc}  0
 
     ${cpuval}  ${memval}=  Get resource pool CPU and mem usages  ${output}
-    Should Be True  ${oldcpuval} < ${cpuval}
-    Should Be True  ${oldmemval} < ${memval}
+    Should Not Be Equal As Integers  ${oldcpuval}  ${cpuval}
+    Should Not Be Equal As Integers  ${oldmemval}  ${memval}


### PR DESCRIPTION
Change it from Mhz to MHz.

Fix #3950 