### PR TITLE
allow image filtering by ref for image with multiple tags

### DIFF
--- a/lib/apiservers/engine/backends/filter/image_test.go
+++ b/lib/apiservers/engine/backends/filter/image_test.go
@@ -86,11 +86,11 @@ func TestIncludeImage(t *testing.T) {
 
 	imageContext.ID = "1202"
 	action := IncludeImage(cmdFilters, imageContext)
-	assert.Equal(t, action, ExcludeAction)
+	assert.Equal(t, ExcludeAction, action)
 
 	imageContext.ID = "1200"
 	action = IncludeImage(cmdFilters, imageContext)
-	assert.Equal(t, action, IncludeAction)
+	assert.Equal(t, IncludeAction, action)
 
 	cmdFilters.Del("before", "busyboxy:1.03")
 
@@ -100,16 +100,21 @@ func TestIncludeImage(t *testing.T) {
 
 	imageContext.ID = "1200"
 	action = IncludeImage(cmdFilters, imageContext)
-	assert.Equal(t, action, StopAction)
+	assert.Equal(t, StopAction, action)
 
 	cmdFilters.Del("since", "busyboxy:1.01")
 	cmdFilters.Add("reference", "busy*")
 	imageContext.SinceID = nil
 	action = IncludeImage(cmdFilters, imageContext)
-	assert.Equal(t, action, IncludeAction)
+	assert.Equal(t, IncludeAction, action)
 
+	// remove previous filter and reset tags / digests
 	cmdFilters.Del("reference", "busy*")
-	cmdFilters.Add("reference", "busy")
+	imageContext.Tags = []string{}
+	imageContext.Digests = []string{}
+	cmdFilters.Add("reference", "busyboxy:1.01")
+
 	action = IncludeImage(cmdFilters, imageContext)
-	assert.Equal(t, action, ExcludeAction)
+	assert.Equal(t, action, IncludeAction)
+	assert.EqualValues(t, 1, len(imageContext.Tags))
 }

--- a/lib/apiservers/engine/backends/image.go
+++ b/lib/apiservers/engine/backends/image.go
@@ -232,7 +232,15 @@ imageLoop:
 			break imageLoop
 		}
 		// if we are here then add image
-		result = append(result, convertV1ImageToDockerImage(images[i]))
+		dockerImage := convertV1ImageToDockerImage(images[i])
+		// reference is a filter, so we must add the tags / digests
+		// identified by the filter
+		if imageFilters.Include("reference") {
+			dockerImage.RepoTags = filterContext.Tags
+			dockerImage.RepoDigests = filterContext.Digests
+
+		}
+		result = append(result, dockerImage)
 	}
 
 	return result, nil

--- a/tests/test-cases/Group1-Docker-Commands/1-03-Docker-Images.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-03-Docker-Images.robot
@@ -44,12 +44,6 @@ No-trunc images
     @{line}=  Split String  @{lines}[2]
     Length Should Be  @{line}[2]  64
 
-Specific images
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} images alpine:3.1
-    Should Be Equal As Integers  ${rc}  0
-    Should Not Contain  ${output}  Error
-    Should Contain  ${output}  3.1
-
 Filter images before
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} images -f before=alpine
     Should Be Equal As Integers  ${rc}  0
@@ -74,6 +68,14 @@ Tag images
     Should Be Equal As Integers  ${rc}  0
     Should Not Contain  ${output}  Error
     Should Contain  ${output}  cdg
+
+Specific images
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} images alpine:3.1
+    Should Be Equal As Integers  ${rc}  0
+    Should Not Contain  ${output}  Error
+    @{lines}=  Split To Lines  ${output}
+    Length Should Be  ${lines}  2
+    Should Contain  ${output}  3.1
 
 VIC/docker Image ID consistency
     @{tags}=  Create List  uclibc  glibc  musl


### PR DESCRIPTION
Fixes issues where filtering images by reference would return
no results for an image containing multiple tags.  Integration test updated to check for specific filtering result.

Fixes #3945
