### PR TITLE
Write the actual error not its address

### DIFF
--- a/lib/apiservers/engine/backends/kv/kv.go
+++ b/lib/apiservers/engine/backends/kv/kv.go
@@ -78,7 +78,7 @@ func Put(client *client.PortLayer, key string, val string) error {
 	_, err := client.Kv.PutValue(ckv.NewPutValueParamsWithContext(
 		context.Background()).WithKey(fullKey).WithKeyValue(keyval))
 	if err != nil {
-		log.Errorf("Error Putting Key/Value: %#v", err)
+		log.Errorf("Error Putting Key/Value: %s", err)
 		return err
 	}
 
@@ -92,7 +92,7 @@ func Delete(client *client.PortLayer, key string) error {
 	_, err := client.Kv.DeleteValue(ckv.NewDeleteValueParamsWithContext(
 		context.Background()).WithKey(createNameSpacedKey(key)))
 	if err != nil {
-		log.Errorf("Error Deleting Key/Value: %#v", err)
+		log.Errorf("Error Deleting Key/Value: %s", err)
 		return err
 	}
 


### PR DESCRIPTION
Otherwise we get log lines like following

```
level=error msg="Error Putting Key/Value: &url.Error{Op:\"Put\",
    URL:\"http://127.0.0.1:2377/kv/docker.layers\",
    Err:(*errors.errorString)(0xc42000e100)}"
```

Towards #3868