### PR TITLE
[specific ci=1-07-Docker-Stop] Fixed docker stop after upgrade to API 1.25

### DIFF
--- a/lib/apiservers/engine/backends/container.go
+++ b/lib/apiservers/engine/backends/container.go
@@ -99,6 +99,8 @@ const (
 	MinCPUs = 1
 	// DefaultCPUs - the default number of container VM CPUs
 	DefaultCPUs = 2
+	// Default timeout to stop a container if not specified in container config
+	DefaultStopTimeout = 10
 )
 
 var (
@@ -904,6 +906,14 @@ func (c *Container) ContainerStop(name string, seconds *int) error {
 	vc := cache.ContainerCache().GetContainer(name)
 	if vc == nil {
 		return NotFoundError(name)
+	}
+
+	if seconds == nil {
+		timeout := DefaultStopTimeout
+		if vc.Config.StopTimeout != nil {
+			timeout = *vc.Config.StopTimeout
+		}
+		seconds = &timeout
 	}
 
 	operation := func() error {

--- a/tests/test-cases/Group1-Docker-Commands/1-07-Docker-Stop.md
+++ b/tests/test-cases/Group1-Docker-Commands/1-07-Docker-Stop.md
@@ -21,6 +21,7 @@ This test requires that a vSphere server is running and available
 8. Issue docker stop fakeContainer to the VIC appliance
 9. Create a new container, start the container using govc/UI, attempt to stop the container using docker stop
 10. Start a new container, stop it, then attempt to restart it again
+11. Start a new container, stop it with Docker 1.13 CLI
 
 #Expected Outcome:
 * Steps 2-8 should each complete without error, and the response should be the containerID
@@ -32,6 +33,7 @@ Failed to stop container (fakeContainer): Error response from daemon: No such co
 ```
 * Step 9 should result in the container stopping successfully
 * Step 10 should result in the container starting without error the second time
+* Step 11 should result in the container stopping successfully
 
 #Possible Problems:
 None

--- a/tests/test-cases/Group1-Docker-Commands/1-07-Docker-Stop.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-07-Docker-Stop.robot
@@ -127,3 +127,15 @@ Restart a stopped container
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} start ${output}
     Should Be Equal As Integers  ${rc}  0
     Should Not Contain  ${output}  Error:
+
+Stop a container with Docker 1.13 CLI
+    ${rc}=  Run And Return Rc  docker %{VCH-PARAMS} pull busybox
+    Should Be Equal As Integers  ${rc}  0
+    ${trap}=  Trap Signal Command  HUP
+    ${rc}  ${container}=  Run And Return Rc And Output  docker %{VCH-PARAMS} create busybox /bin/top
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} start ${container}
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${output}=  Run And Return Rc And Output  docker1.13 %{VCH-PARAMS} stop ${container}
+    Should Be Equal As Integers  ${rc}  0
+   


### PR DESCRIPTION
The function signature changed but we didn't check for nil.
It's now properly handling the stop timeout the same way
that docker does.

Resolves #3976
