### PR TITLE
[specific ci=1-05-Docker-Start] Improve error msg when starting a container connected to a removed network

### DIFF
--- a/lib/portlayer/network/context.go
+++ b/lib/portlayer/network/context.go
@@ -640,7 +640,7 @@ func (c *Context) bindContainer(h *exec.Handle) ([]*Endpoint, error) {
 		var s *Scope
 		s, ok := c.scopes[ne.Network.Name]
 		if !ok {
-			return nil, &ResourceNotFoundError{}
+			return nil, &ResourceNotFoundError{error: fmt.Errorf("network %s not found", ne.Network.Name)}
 		}
 
 		defer func() {

--- a/tests/test-cases/Group1-Docker-Commands/1-05-Docker-Start.md
+++ b/tests/test-cases/Group1-Docker-Commands/1-05-Docker-Start.md
@@ -35,9 +35,9 @@ Error: failed to start containers: fakeContainer
 ```
 * Step 9 should result in an error message stating unable to wait for process launch status
 * Steps 10-12 should all result in all containers succeeding and not throwing any errors
-* Step 8 should result in the VIC appliance returning the following error:
+* Step 13 should result in the VIC appliance returning the following error:
 ```
-Error response from daemon: Server error from portlayer: Network test-network not found
+Error response from daemon: Server error from portlayer: network test-network not found
 Error: failed to start containers: containerID
 ```
 #Possible Problems:

--- a/tests/test-cases/Group1-Docker-Commands/1-05-Docker-Start.md
+++ b/tests/test-cases/Group1-Docker-Commands/1-05-Docker-Start.md
@@ -23,17 +23,22 @@ This test requires that a vSphere server is running and available
 10. Create and start 5 busybox containers running /bin/top serially
 11. Create and start 5 ubuntu containers running /bin/top serially
 12. Create and start 5 busybox containers running /bin/top all at once
+13. Run a container with a test-network, stop the container, remove the test-network, then start the container again
 
 #Expected Outcome:
 * Commands 1-7 should all return without error and respond with the container ID
 * After commands 3, 5, and 7 verify that the containers are running
-* Step 8 should result in the VIC applaiance returning the following error:
+* Step 8 should result in the VIC appliance returning the following error:
 ```
 Error response from daemon: No such container: fakeContainer
 Error: failed to start containers: fakeContainer
 ```
 * Step 9 should result in an error message stating unable to wait for process launch status
 * Steps 10-12 should all result in all containers succeeding and not throwing any errors
-
+* Step 8 should result in the VIC appliance returning the following error:
+```
+Error response from daemon: Server error from portlayer: Network test-network not found
+Error: failed to start containers: containerID
+```
 #Possible Problems:
 None

--- a/tests/test-cases/Group1-Docker-Commands/1-05-Docker-Start.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-05-Docker-Start.robot
@@ -104,3 +104,16 @@ Parallel start 5 long running containers
     :FOR  ${pid}  IN  @{pids}
     \   ${res}=  Wait For Process  ${pid}
     \   Should Be Equal As Integers  ${res.rc}  0
+
+Start a container with removed network
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} network create test-network
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${container}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -d --net test-network busybox /bin/top
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} stop ${container}
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} network rm test-network
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} start ${container}
+    Should Be Equal As Integers  ${rc}  1
+    Should Contain  ${output}  network test-network not found


### PR DESCRIPTION
After removing a user-defined network, starting a stopped container that was connected to the user-defined network would fail with the following error msg

```
Error response from daemon: Server error from portlayer: Post http://127.0.0.1:2377/scopes/containers/1d5ddc2fcffc91b7a87f852a98173e5d/binding: EOF
```
and the portlayer would panic.

This PR improves the error msg and make sure that the portlayer does not panic. A test case is also added for verification.

The new error msg becomes:
```
Error response from daemon: Server error from portlayer: network user-network not found
```
which is consistent with the error msg seen when running the test case on regular docker.

Fixes #3948.