### PR TITLE
[specific ci=6-04-Create-Basic] Add check for nil x509 leaf in vic-machine create

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -8,7 +8,7 @@ Use ./local-integration-test.sh
 
 ## Manually configure local Drone
 
-1. Create a `test_secrets.yml` file that includes:
+* Create a `test_secrets.yml` file that includes:
 
   ```
   environment:
@@ -25,24 +25,36 @@ Use ./local-integration-test.sh
     DOMAIN: <domain for TLS cert generation, may be blank>
   ```
 
-If you are using a vSAN environment or non-default ESX install, then you can also specify the two networks to use with the following command (make sure to add them to the yaml file in Step 2 below as well):
+  If you are using a vSAN environment or non-default ESX install, then you can also specify the two networks to use with the following command (make sure to add them to the yaml file in Step 2 below as well):
 
   ```
     BRIDGE_NETWORK: bridge
     PUBLIC_NETWORK: public
   ```
 
+* Execute Drone from the project root directory:
 
-2. Execute Drone from the project root directory:
+  Drone will run based on `.drone.local.yml` - defaults should be fine, edit as needed
 
-Drone will run based on `.drone.local.yml` - defaults should be fine, edit as needed
+  *  To run only the regression tests:
+     ```
+     drone exec --trusted -E "test_secrets.yml" --yaml ".drone.local.yml" --payload '{"build": {"branch":"regression", "event":"push"}, "repo": {"full_name":"regression"}}'
+     ```
 
-To run only the regression tests:
-`drone exec --trusted -E "test_secrets.yml" --yaml ".drone.local.yml" --payload '{"build": {"branch":"regression", "event":"push"}, "repo": {"full_name":"regression"}}'`
+  * To run the full suite:
+     ```
+     drone exec --trusted -E "test_secrets.yml" --yaml ".drone.local.yml" --payload '{"build": {"branch":"master", "event":"push"}, "repo": {"full_name":"vmware/vic"}}'
+     ```
 
-To run the full suite:
-`drone exec --trusted -E "test_secrets.yml" --yaml ".drone.local.yml" --payload '{"build": {"branch":"master", "event":"push"}, "repo": {"full_name":"vmware/vic"}}'`
+## Test a specific .robot file
 
+* Set environment in robot.sh
+* Run robot.sh with the desired .robot file
+
+  From the project root directory:
+  ```
+  ./tests/robot.sh tests/test-cases/Group6-VIC-Machine/6-04-Create-Basic.robot
+  ```
 
 ## Find the documentation for each of the tests here:
 

--- a/tests/robot.sh
+++ b/tests/robot.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Copyright 2017 VMware, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Run a specific robot file (from the project root directory)
+# ./tests/robot.sh tests/test-cases/Group6-VIC-Machine/6-04-Create-Basic.robot
+
+export GITHUB_TOKEN=''
+export GOVC_URL=root:password@1.1.1.1
+export GOVC_URL_HOST=1.1.1.1
+export GOVC_USERNAME=root
+export GOVC_PASSWORD=password
+export DOMAIN=''
+
+./tests/local-integration-test.sh $@

--- a/tests/test-cases/Group3-Docker-Compose/3-01-Docker-Compose-LEMP.robot
+++ b/tests/test-cases/Group3-Docker-Compose/3-01-Docker-Compose-LEMP.robot
@@ -12,7 +12,7 @@ Compose LEMP Server
     Set Environment Variable  COMPOSE_HTTP_TIMEOUT  300
     # must set CURL_CA_BUNDLE to work around Compose bug https://github.com/docker/compose/issues/3365
     Set Environment Variable  CURL_CA_BUNDLE  ${EMPTY}
-	
+
     ${vch_ip}=  Get Environment Variable  VCH_IP  %{VCH-IP}
     Log To Console  \nThe VCH IP is %{VCH-IP}
 

--- a/tests/test-cases/Group6-VIC-Machine/6-04-Create-Basic.md
+++ b/tests/test-cases/Group6-VIC-Machine/6-04-Create-Basic.md
@@ -223,12 +223,30 @@ vic-machine-linux create --name=${vch-name} --target="%{TEST_USERNAME}:%{TEST_PA
 * Regression test pass
 
 
+## Create VCH - Server certificate with multiple blocks
+1. Generate key/cert files with server-cert.pem containing a block other than CERTIFICATE as the
+   first PEM block
+2. Specify key, cert files during creation
+
+### Expected Outcome
+* vic-machine warns about failure to load x509 leaf
+* Deployment succeeds
+
+
 ## Create VCH - Invalid keys
 1. Specify key, cert files with mal-format files
 
 ### Expected Outcome
 * Command fail for wrong key/cert file
 
+
+## Create VCH - Reuse keys
+1. Create VCH
+2. Destroy VCH
+3. Create VCH using keys and certificates from previous deployment
+
+### Expected Outcome
+* Deployment succeeds
 
 
 Timeout

--- a/tests/test-cases/Group6-VIC-Machine/6-04-Create-Basic.robot
+++ b/tests/test-cases/Group6-VIC-Machine/6-04-Create-Basic.robot
@@ -243,7 +243,7 @@ Create VCH - Server certificate with multiple blocks
     Run  echo "-----BEGIN RSA PRIVATE KEY-----\nJUNK\n-----END RSA PRIVATE KEY-----" | cat - ./%{VCH-NAME}/server-cert.pem > /tmp/%{VCH-NAME}-server-cert.pem && mv /tmp/%{VCH-NAME}-server-cert.pem ./%{VCH-NAME}/server-cert.pem
 
     # Install VCH
-    ${output}=  Run  bin/vic-machine-linux create --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --image-store=%{TEST_DATASTORE} --bridge-network=%{BRIDGE_NETWORK} --public-network=%{PUBLIC_NETWORK} ${vicmachinetls}
+    ${output}=  Run  bin/vic-machine-linux create --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --image-store=%{TEST_DATASTORE} --bridge-network=%{BRIDGE_NETWORK} --public-network=%{PUBLIC_NETWORK} --no-tlsverify
     Should Contain  ${output}  Failed to load x509 leaf
     Should Contain  ${output}  Loaded server certificate
     Should Contain  ${output}  Installer completed successfully

--- a/tests/test-cases/Group6-VIC-Machine/6-04-Create-Basic.robot
+++ b/tests/test-cases/Group6-VIC-Machine/6-04-Create-Basic.robot
@@ -194,8 +194,6 @@ Create VCH - Existing vApp on vCenter
     Pass execution  Test not implemented
 
 Create VCH - defaults with --no-tls
-    ${status}=  Get State Of Github Issue  3063
-
     Set Test Environment Variables
     Run Keyword And Ignore Error  Cleanup Dangling VMs On Test Server
     Run Keyword And Ignore Error  Cleanup Datastore On Test Server
@@ -225,6 +223,32 @@ Create VCH - force accept target thumbprint
 
 Create VCH - Specified keys
     Pass execution  Test not implemented until vic-machine can poll status correctly
+
+Create VCH - Server certificate with multiple blocks
+    Set Test Environment Variables
+    Run Keyword And Ignore Error  Cleanup Dangling VMs On Test Server
+    Run Keyword And Ignore Error  Cleanup Datastore On Test Server
+
+    # Install first to generate certificates
+    ${output}=  Run  bin/vic-machine-linux create --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --image-store=%{TEST_DATASTORE} --bridge-network=%{BRIDGE_NETWORK} --public-network=%{PUBLIC_NETWORK} ${vicmachinetls}
+    Should Contain  ${output}  Installer completed successfully
+    Get Docker Params  ${output}  ${true}
+    Log To Console  Installer completed successfully: %{VCH-NAME}
+
+    # Remove the installed VCH
+    ${ret}=  Run  bin/vic-machine-linux delete --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --name=%{VCH-NAME} --force
+    Should Contain  ${ret}  Completed successfully
+
+    # Update server-cert.pem with a junk block in the beginning
+    Run  echo "-----BEGIN RSA PRIVATE KEY-----\nJUNK\n-----END RSA PRIVATE KEY-----" | cat - ./%{VCH-NAME}/server-cert.pem > /tmp/%{VCH-NAME}-server-cert.pem && mv /tmp/%{VCH-NAME}-server-cert.pem ./%{VCH-NAME}/server-cert.pem
+
+    # Install VCH
+    ${output}=  Run  bin/vic-machine-linux create --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --image-store=%{TEST_DATASTORE} --bridge-network=%{BRIDGE_NETWORK} --public-network=%{PUBLIC_NETWORK} ${vicmachinetls}
+    Should Contain  ${output}  Failed to load x509 leaf
+    Should Contain  ${output}  Loaded server certificate
+    Should Contain  ${output}  Installer completed successfully
+
+    Cleanup VIC Appliance On Test Server
 
 Create VCH - Invalid keys
     ${domain}=  Get Environment Variable  DOMAIN  ''


### PR DESCRIPTION
Fixes #3966 
Previously if the server certificate was not the first PEM block, we would have a nil pointer deref
Check for a nil cert and warn the user, but allow install to continue. If the user is not using --no-tlsverify, they will receive an error that is being addressed in another issue and the VCH will not be usable.
Added integration test

```
⇒  bin/vic-machine-linux create -t 'root:password@192.168.218.131'  --name oceanlab   --thumbprint=C1:7A:E4:A4:22:B8:8A:68:F9:A4:E4:C2:38:91:3B:0D:8E:E0:C8:FB --no-tlsverify
Feb 21 2017 14:04:33.530-08:00 INFO  ### Installing VCH ####
Feb 21 2017 14:04:33.530-08:00 WARN  Using administrative user for VCH operation - use --ops-user to improve security (see -x for advanced help)
Feb 21 2017 14:04:33.531-08:00 WARN  Failed to load x509 leaf: Unable to confirm server certificate cname matches provided cname "". Continuing...
Feb 21 2017 14:04:33.531-08:00 INFO  Loaded server certificate oceanlab/server-cert.pem
Feb 21 2017 14:04:33.531-08:00 WARN  Configuring without TLS verify - certificate-based authentication disabled
Feb 21 2017 14:04:33.654-08:00 INFO  Validating supplied configuration
Feb 21 2017 14:04:33.740-08:00 INFO  Using default datastore: datastore1
Feb 21 2017 14:04:33.801-08:00 INFO  Firewall status: ENABLED on "/ha-datacenter/host/localhost.localdomain/localhost.localdomain"
Feb 21 2017 14:04:33.808-08:00 INFO  Firewall configuration OK on hosts:
Feb 21 2017 14:04:33.808-08:00 INFO  	"/ha-datacenter/host/localhost.localdomain/localhost.localdomain"
Feb 21 2017 14:04:33.824-08:00 WARN  Evaluation license detected. VIC may not function if evaluation expires or insufficient license is later assigned.
Feb 21 2017 14:04:33.824-08:00 INFO  License check OK
Feb 21 2017 14:04:33.824-08:00 INFO  DRS check SKIPPED - target is standalone host
Feb 21 2017 14:04:33.858-08:00 INFO  
Feb 21 2017 14:04:33.916-08:00 INFO  Creating Resource Pool "oceanlab"
Feb 21 2017 14:04:33.920-08:00 INFO  Creating VirtualSwitch
Feb 21 2017 14:04:33.954-08:00 INFO  Creating Portgroup
Feb 21 2017 14:04:33.985-08:00 INFO  Creating appliance on target
Feb 21 2017 14:04:33.993-08:00 INFO  Network role "client" is sharing NIC with "public"
Feb 21 2017 14:04:33.993-08:00 INFO  Network role "management" is sharing NIC with "public"
Feb 21 2017 14:04:34.174-08:00 INFO  Uploading images for container
Feb 21 2017 14:04:34.174-08:00 INFO  	"/home/chin/go/src/github.com/vmware/vic/bin/bootstrap.iso"
Feb 21 2017 14:04:34.174-08:00 INFO  	"/home/chin/go/src/github.com/vmware/vic/bin/appliance.iso"
Feb 21 2017 14:04:41.773-08:00 INFO  Waiting for IP information
Feb 21 2017 14:04:54.164-08:00 INFO  Waiting for major appliance components to launch
Feb 21 2017 14:04:54.356-08:00 INFO  Checking VCH connectivity with vSphere target
Feb 21 2017 14:04:54.796-08:00 INFO  vSphere API Test: https://192.168.218.131 vSphere API target responds as expected
Feb 21 2017 14:04:54.796-08:00 INFO  Checking Docker API endpoint
Feb 21 2017 14:04:57.854-08:00 INFO  Initialization of appliance successful
Feb 21 2017 14:04:57.854-08:00 INFO  
Feb 21 2017 14:04:57.854-08:00 INFO  VCH Admin Portal:
Feb 21 2017 14:04:57.854-08:00 INFO  https://192.168.218.133:2378
Feb 21 2017 14:04:57.854-08:00 INFO  
Feb 21 2017 14:04:57.854-08:00 INFO  Published ports can be reached at:
Feb 21 2017 14:04:57.854-08:00 INFO  192.168.218.133
Feb 21 2017 14:04:57.854-08:00 INFO  
Feb 21 2017 14:04:57.854-08:00 INFO  Docker environment variables:
Feb 21 2017 14:04:57.854-08:00 INFO  DOCKER_HOST=192.168.218.133:2376
Feb 21 2017 14:04:57.854-08:00 INFO  
Feb 21 2017 14:04:57.854-08:00 INFO  Environment saved in oceanlab/oceanlab.env
Feb 21 2017 14:04:57.854-08:00 INFO  
Feb 21 2017 14:04:57.854-08:00 INFO  Connect to docker:
Feb 21 2017 14:04:57.854-08:00 INFO  docker -H 192.168.218.133:2376 --tls info
Feb 21 2017 14:04:57.854-08:00 INFO  Installer completed successfully
```

an example server-cert.pem that would cause this is:
```
-----BEGIN RSA PRIVATE KEY-----
JUNK
-----END RSA PRIVATE KEY-----
-----BEGIN CERTIFICATE-----
MIIDAjCCAeqgAwIBAgIQapIxSHwtGxNH0M9BaAh+kzANBgkqhkiG9w0BAQsFADAS
MRAwDgYDVQQKEwdkZWZhdWx0MB4XDTE3MDIyMDIyMDA0M1oXDTE4MDIyMTIyMDA0
M1owEjEQMA4GA1UEChMHZGVmYXVsdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCC
AQoCggEBAObOltkeRNa3UhxxDArqctWkv1DOcx6zdSKtFc92b6QjQwVosm2NA4YN
Mk+3yLjiVTDM7J49I8vxOpdAA/Yx58Qnc79cqjZVIMSg0nMreCWemPM0IW4iYO1K
ngVBX6iP6RsYMg9xiyEesKg+RtLZXjaz7O0lEwvYJjLrUj5Vo/0xiWdOJ4YC+F5d
Wr4iwbbTjfqj120opvd+GaA/UdcGgGBOIxPKdF7xSdYoY/fwgNtfOKxOa9JBCU17
WALpdKeYFv74awl1jR7ZgKwYmAEEGTr3AGAqrUeD0/MlN1/Zrxx1DmabtkAkrCol
fWKndk6waBs8t9/V3AA4GP/d9HvU9ScCAwEAAaNUMFIwDgYDVR0PAQH/BAQDAgOo
MBMGA1UdJQQMMAoGCCsGAQUFBwMBMAwGA1UdEwEB/wQCMAAwHQYDVR0OBBYEFKOs
ykvZgVngSY6xFcU4rR8jyBr4MA0GCSqGSIb3DQEBCwUAA4IBAQADnLeT4bPwuhYA
lLVDWdc2VWHRByJtQnvccWK97JoH9mdP5oUmTtK5SJSbmA4/FJbmXn3U5LGc4nPM
SAiqDWqgpfcI7Hwj/C9EsDKkmmaNmsfBw1D9sTRR99yCsR/3PD1vmyi2R35sqjO+
evmipP1/y+nReo95yauluai3LxgIKsIYPlDUc+VezNTNvSx9kNFtGI+jF0og0eI+
gRH9YnU7YahE78WJA6ymE95R/P3GD2QdQE1Ap5FMWFsi/Yb1qtM1O0SLiBCJii9W
fh3pB3RiqMCq8QHjy9smkJD1CkO6vxOsI0r+k7CiG2HUUVNS1aSA67QI69E/FkUe
GwUQ1Emg
-----END CERTIFICATE-----
```