### PR TITLE
[specific ci=Group11-Upgrade]Support data migration in vic-machine update

### DIFF
--- a/cmd/vic-machine/create/create.go
+++ b/cmd/vic-machine/create/create.go
@@ -1369,7 +1369,7 @@ func (c *Create) Run(clic *cli.Context) (err error) {
 	defer func() {
 		if ctx.Err() != nil && ctx.Err() == context.DeadlineExceeded {
 			//context deadline exceeded, replace returned error message
-			err = errors.Errorf("Create timed out: if slow connection, increase timeout with --timeout")
+			err = errors.Errorf("Creating VCH exceeded time limit of %s. Please increase the timeout using --timeout to accommodate for a busy vSphere target")
 		}
 	}()
 
@@ -1377,7 +1377,11 @@ func (c *Create) Run(clic *cli.Context) (err error) {
 		executor.CollectDiagnosticLogs()
 		cmd, _ := executor.GetDockerAPICommand(vchConfig, c.ckey, c.ccert, c.cacert)
 		log.Info("\tAPI may be slow to start - try to connect to API after a few minutes:")
-		log.Infof("\t\tRun command: %s", cmd)
+		if cmd != "" {
+			log.Infof("\t\tRun command: %s", cmd)
+		} else {
+			log.Infof("\t\tRun %s inspect to find API connection command and run the command if ip address is ready", clic.App.Name)
+		}
 		log.Info("\t\tIf command succeeds, VCH is started. If command fails, VCH failed to install - see documentation for troubleshooting.")
 		return err
 	}

--- a/cmd/vic-machine/create/create.go
+++ b/cmd/vic-machine/create/create.go
@@ -1369,7 +1369,7 @@ func (c *Create) Run(clic *cli.Context) (err error) {
 	defer func() {
 		if ctx.Err() != nil && ctx.Err() == context.DeadlineExceeded {
 			//context deadline exceeded, replace returned error message
-			err = errors.Errorf("Creating VCH exceeded time limit of %s. Please increase the timeout using --timeout to accommodate for a busy vSphere target")
+			err = errors.Errorf("Creating VCH exceeded time limit of %s. Please increase the timeout using --timeout to accommodate for a busy vSphere target", c.Timeout)
 		}
 	}()
 

--- a/cmd/vic-machine/create/create.go
+++ b/cmd/vic-machine/create/create.go
@@ -1367,7 +1367,7 @@ func (c *Create) Run(clic *cli.Context) (err error) {
 	ctx, cancel := context.WithTimeout(context.Background(), c.Timeout)
 	defer cancel()
 	defer func() {
-		if ctx.Err() != nil && ctx.Err() == context.DeadlineExceeded {
+		if ctx.Err() == context.DeadlineExceeded {
 			//context deadline exceeded, replace returned error message
 			err = errors.Errorf("Creating VCH exceeded time limit of %s. Please increase the timeout using --timeout to accommodate for a busy vSphere target", c.Timeout)
 		}

--- a/cmd/vic-machine/debug/debug.go
+++ b/cmd/vic-machine/debug/debug.go
@@ -168,7 +168,6 @@ func (d *Debug) Run(clic *cli.Context) (err error) {
 		log.Error(err)
 		return errors.New("debug failed")
 	}
-	executor.InitDiagnosticLogs(vchConfig)
 
 	installerVer := version.GetBuild()
 

--- a/cmd/vic-machine/delete/delete.go
+++ b/cmd/vic-machine/delete/delete.go
@@ -155,7 +155,7 @@ func (d *Uninstall) Run(clic *cli.Context) (err error) {
 	installerBuild := version.GetBuild()
 	if vchConfig.Version == nil || !installerBuild.Equal(vchConfig.Version) {
 		if !d.Data.Force {
-			log.Errorf("VCH version %q is different than installer version %s. Upgrade VCH before delete or specify --force to force delete", vchConfig.Version.ShortVersion(), installerBuild.ShortVersion())
+			log.Errorf("VCH version %q is different than installer version %s. Upgrade VCH before deleting or specify --force to force delete", vchConfig.Version.ShortVersion(), installerBuild.ShortVersion())
 			return errors.New("delete failed")
 		}
 

--- a/cmd/vic-machine/delete/delete.go
+++ b/cmd/vic-machine/delete/delete.go
@@ -155,7 +155,7 @@ func (d *Uninstall) Run(clic *cli.Context) (err error) {
 	installerBuild := version.GetBuild()
 	if vchConfig.Version == nil || !installerBuild.Equal(vchConfig.Version) {
 		if !d.Data.Force {
-			log.Errorf("VCH version %q is different than installer version %s. Upgrade VCH before delete or specify --force to force delete or ", vchConfig.Version.ShortVersion(), installerBuild.ShortVersion())
+			log.Errorf("VCH version %q is different than installer version %s. Upgrade VCH before delete or specify --force to force delete", vchConfig.Version.ShortVersion(), installerBuild.ShortVersion())
 			return errors.New("delete failed")
 		}
 

--- a/cmd/vic-machine/delete/delete.go
+++ b/cmd/vic-machine/delete/delete.go
@@ -1,4 +1,4 @@
-// Copyright 2016 VMware, Inc. All Rights Reserved.
+// Copyright 2016-2017 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -155,7 +155,7 @@ func (d *Uninstall) Run(clic *cli.Context) (err error) {
 	installerBuild := version.GetBuild()
 	if vchConfig.Version == nil || !installerBuild.Equal(vchConfig.Version) {
 		if !d.Data.Force {
-			log.Errorf("VCH version %q is different than installer version %s. Specify --force to force delete or upgrade VCH before delete", vchConfig.Version.ShortVersion(), installerBuild.ShortVersion())
+			log.Errorf("VCH version %q is different than installer version %s. Upgrade VCH before delete or specify --force to force delete or ", vchConfig.Version.ShortVersion(), installerBuild.ShortVersion())
 			return errors.New("delete failed")
 		}
 

--- a/cmd/vic-machine/delete/delete.go
+++ b/cmd/vic-machine/delete/delete.go
@@ -155,7 +155,7 @@ func (d *Uninstall) Run(clic *cli.Context) (err error) {
 	installerBuild := version.GetBuild()
 	if vchConfig.Version == nil || !installerBuild.Equal(vchConfig.Version) {
 		if !d.Data.Force {
-			log.Errorf("VCH version %q is different than installer version %s. Specify --force to force delete", vchConfig.Version.ShortVersion(), installerBuild.ShortVersion())
+			log.Errorf("VCH version %q is different than installer version %s. Specify --force to force delete or upgrade VCH before delete", vchConfig.Version.ShortVersion(), installerBuild.ShortVersion())
 			return errors.New("delete failed")
 		}
 

--- a/cmd/vic-machine/delete/delete.go
+++ b/cmd/vic-machine/delete/delete.go
@@ -161,7 +161,6 @@ func (d *Uninstall) Run(clic *cli.Context) (err error) {
 
 		log.Warnf("VCH version %q is different than installer version %s. Force delete will attempt to remove everything related to the installed VCH", vchConfig.Version.ShortVersion(), installerBuild.ShortVersion())
 	}
-	executor.InitDiagnosticLogs(vchConfig)
 
 	if err = executor.DeleteVCH(vchConfig); err != nil {
 		executor.CollectDiagnosticLogs()

--- a/cmd/vic-machine/inspect/inspect.go
+++ b/cmd/vic-machine/inspect/inspect.go
@@ -1,4 +1,4 @@
-// Copyright 2016 VMware, Inc. All Rights Reserved.
+// Copyright 2016-2017 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cmd/vic-machine/inspect/inspect.go
+++ b/cmd/vic-machine/inspect/inspect.go
@@ -139,7 +139,6 @@ func (i *Inspect) Run(clic *cli.Context) (err error) {
 		log.Error(err)
 		return errors.New("inspect failed")
 	}
-	executor.InitDiagnosticLogs(vchConfig)
 
 	installerVer := version.GetBuild()
 

--- a/cmd/vic-machine/upgrade/upgrade.go
+++ b/cmd/vic-machine/upgrade/upgrade.go
@@ -1,4 +1,4 @@
-// Copyright 2016 VMware, Inc. All Rights Reserved.
+// Copyright 2016-2017 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cmd/vic-machine/upgrade/upgrade.go
+++ b/cmd/vic-machine/upgrade/upgrade.go
@@ -156,6 +156,11 @@ func (u *Upgrade) Run(clic *cli.Context) (err error) {
 	vConfig.BootstrapISO = path.Base(u.BootstrapISO)
 	vConfig.Timeout = u.Timeout
 
+	if err := validator.AssertVersion(vchConfig); err != nil {
+		log.Error(err)
+		return errors.New("upgrade failed")
+	}
+
 	if vchConfig, err = validator.ValidateMigratedConfig(ctx, vchConfig); err != nil {
 		log.Errorf("Failed to migrate Virtual Container Host configuration %s", u.DisplayName)
 		log.Error(err)

--- a/lib/config/virtual_container_host.go
+++ b/lib/config/virtual_container_host.go
@@ -216,9 +216,14 @@ func (t *VirtualContainerHostConfigSpec) SetMoref(moref *types.ManagedObjectRefe
 	}
 }
 
-// SetIsCreating sets the ID of the VCH to a constant, to identify the creating VCH VM before the VM moref can be set into this property
-func (t *VirtualContainerHostConfigSpec) SetIsCreating() {
-	t.ExecutorConfig.ID = CreatingVCH
+// SetIsCreating sets the ID of the VCH to a constant if creating is true, to identify the creating VCH VM before the VM moref can be set into this property
+// Reset the property back to empty string if creating is false
+func (t *VirtualContainerHostConfigSpec) SetIsCreating(creating bool) {
+	if creating {
+		t.ExecutorConfig.ID = CreatingVCH
+	} else {
+		t.ExecutorConfig.ID = ""
+	}
 }
 
 // IsCreating is checking if this configuration is for one creating VCH VM

--- a/lib/config/virtual_container_host.go
+++ b/lib/config/virtual_container_host.go
@@ -39,6 +39,8 @@ const (
 	ID = "{id}"
 	// Name is the container name of the VM
 	Name = "{name}"
+	// ID represents the creating VCH
+	CreatingVCH = "CreatingVCH"
 )
 
 // Can we just treat the VCH appliance as a containerVM booting off a specific bootstrap image
@@ -212,6 +214,15 @@ func (t *VirtualContainerHostConfigSpec) SetMoref(moref *types.ManagedObjectRefe
 	if moref != nil {
 		t.ExecutorConfig.ID = moref.String()
 	}
+}
+
+// SetCreatingVCHID sets the ID of the VCH to a constant, to identify the creating VCH VM before the VM moref can be set into this property
+func (t *VirtualContainerHostConfigSpec) SetIsCreating() {
+	t.ExecutorConfig.ID = CreatingVCH
+}
+
+func (t *VirtualContainerHostConfigSpec) IsCreating() bool {
+	return t.ExecutorConfig.ID == CreatingVCH
 }
 
 // AddNetwork adds a network that will be configured on the appliance VM

--- a/lib/config/virtual_container_host.go
+++ b/lib/config/virtual_container_host.go
@@ -1,4 +1,4 @@
-// Copyright 2016 VMware, Inc. All Rights Reserved.
+// Copyright 2016-2017 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -39,7 +39,7 @@ const (
 	ID = "{id}"
 	// Name is the container name of the VM
 	Name = "{name}"
-	// ID represents the creating VCH
+	// ID represents the VCH in creating status, which helps to identify VCH VM which still does not have a valid VM moref set
 	CreatingVCH = "CreatingVCH"
 )
 
@@ -216,11 +216,12 @@ func (t *VirtualContainerHostConfigSpec) SetMoref(moref *types.ManagedObjectRefe
 	}
 }
 
-// SetCreatingVCHID sets the ID of the VCH to a constant, to identify the creating VCH VM before the VM moref can be set into this property
+// SetIsCreating sets the ID of the VCH to a constant, to identify the creating VCH VM before the VM moref can be set into this property
 func (t *VirtualContainerHostConfigSpec) SetIsCreating() {
 	t.ExecutorConfig.ID = CreatingVCH
 }
 
+// IsCreating is checking if this configuration is for one creating VCH VM
 func (t *VirtualContainerHostConfigSpec) IsCreating() bool {
 	return t.ExecutorConfig.ID == CreatingVCH
 }

--- a/lib/install/data/data.go
+++ b/lib/install/data/data.go
@@ -1,4 +1,4 @@
-// Copyright 2016 VMware, Inc. All Rights Reserved.
+// Copyright 2016-2017 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/install/data/data.go
+++ b/lib/install/data/data.go
@@ -120,7 +120,7 @@ type InstallerData struct {
 	BootstrapISO      string
 	ISOVersion        string
 	PreUpgradeVersion string
-	RollbackTimeout   time.Duration
+	Timeout           time.Duration
 
 	UseRP bool
 

--- a/lib/install/management/appliance.go
+++ b/lib/install/management/appliance.go
@@ -1,4 +1,4 @@
-// Copyright 2016 VMware, Inc. All Rights Reserved.
+// Copyright 2016-2017 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -291,7 +291,7 @@ func (d *Dispatcher) createApplianceSpec(conf *config.VirtualContainerHostConfig
 	var devices object.VirtualDeviceList
 	var err error
 
-	// set a creating instance ID for vch id before the vm id is set, to identify if that's one vch
+	// set to creating VCH
 	conf.SetIsCreating()
 
 	cfg, err := d.encodeConfig(conf)
@@ -1002,8 +1002,8 @@ func (d *Dispatcher) ensureApplianceInitializes(conf *config.VirtualContainerHos
 	return fmt.Errorf("Failed to get IP address information from appliance: %s", updateErr)
 }
 
-// CheckServiceReady checks service information, including appliance initialization, Docker API
-// For more checking in the future, should expand this method
+// CheckServiceReady checks if service is launched correctly, including ip address, service initialization, VC connection and Docker API
+// Should expand this method for any more VCH service checking
 func (d *Dispatcher) CheckServiceReady(ctx context.Context, conf *config.VirtualContainerHostConfigSpec, clientCert *tls.Certificate) error {
 	oldCtx := d.ctx
 	d.ctx = ctx
@@ -1012,7 +1012,7 @@ func (d *Dispatcher) CheckServiceReady(ctx context.Context, conf *config.Virtual
 	}()
 
 	if err := d.ensureApplianceInitializes(conf); err != nil {
-		return errors.Errorf("%s. Exiting...", err)
+		return err
 	}
 
 	// vic-init will try to reach out to the vSphere target.

--- a/lib/install/management/appliance.go
+++ b/lib/install/management/appliance.go
@@ -292,7 +292,7 @@ func (d *Dispatcher) createApplianceSpec(conf *config.VirtualContainerHostConfig
 	var err error
 
 	// set to creating VCH
-	conf.SetIsCreating()
+	conf.SetIsCreating(true)
 
 	cfg, err := d.encodeConfig(conf)
 	if err != nil {
@@ -301,12 +301,12 @@ func (d *Dispatcher) createApplianceSpec(conf *config.VirtualContainerHostConfig
 
 	spec := &spec.VirtualMachineConfigSpec{
 		VirtualMachineConfigSpec: &types.VirtualMachineConfigSpec{
-			Name:     conf.Name,
-			GuestId:  string(types.VirtualMachineGuestOsIdentifierOtherGuest64),
+			Name:               conf.Name,
+			GuestId:            string(types.VirtualMachineGuestOsIdentifierOtherGuest64),
 			AlternateGuestName: constants.DefaultAltVCHGuestName(),
-			Files:    &types.VirtualMachineFileInfo{VmPathName: fmt.Sprintf("[%s]", conf.ImageStores[0].Host)},
-			NumCPUs:  int32(vConf.ApplianceSize.CPU.Limit),
-			MemoryMB: vConf.ApplianceSize.Memory.Limit,
+			Files:              &types.VirtualMachineFileInfo{VmPathName: fmt.Sprintf("[%s]", conf.ImageStores[0].Host)},
+			NumCPUs:            int32(vConf.ApplianceSize.CPU.Limit),
+			MemoryMB:           vConf.ApplianceSize.Memory.Limit,
 			// Encode the config both here and after the VMs created so that it can be identified as a VCH appliance as soon as
 			// creation is complete.
 			ExtraConfig: append(vmomi.OptionValueFromMap(cfg), &types.OptionValue{Key: "answer.msg.serial.file.open", Value: "Append"}),
@@ -632,10 +632,10 @@ func (d *Dispatcher) reconfigureApplianceSpec(vm *vm.VirtualMachine, conf *confi
 	var err error
 
 	spec := &types.VirtualMachineConfigSpec{
-		Name:    conf.Name,
-		GuestId:  string(types.VirtualMachineGuestOsIdentifierOtherGuest64),
+		Name:               conf.Name,
+		GuestId:            string(types.VirtualMachineGuestOsIdentifierOtherGuest64),
 		AlternateGuestName: constants.DefaultAltVCHGuestName(),
-		Files:   &types.VirtualMachineFileInfo{VmPathName: fmt.Sprintf("[%s]", conf.ImageStores[0].Host)},
+		Files:              &types.VirtualMachineFileInfo{VmPathName: fmt.Sprintf("[%s]", conf.ImageStores[0].Host)},
 	}
 
 	// create new devices

--- a/lib/install/management/appliance.go
+++ b/lib/install/management/appliance.go
@@ -82,7 +82,7 @@ func (d *Dispatcher) isVCH(vm *vm.VirtualMachine) (bool, error) {
 	extraconfig.Decode(extraconfig.MapSource(info), &remoteConf)
 
 	// if the moref of the target matches where we expect to find it for a VCH, run with it
-	if remoteConf.ExecutorConfig.ID == vm.Reference().String() {
+	if remoteConf.ExecutorConfig.ID == vm.Reference().String() || remoteConf.IsCreating() {
 		return true, nil
 	}
 
@@ -290,6 +290,9 @@ func (d *Dispatcher) createApplianceSpec(conf *config.VirtualContainerHostConfig
 
 	var devices object.VirtualDeviceList
 	var err error
+
+	// set a creating instance ID for vch id before the vm id is set, to identify if that's one vch
+	conf.SetIsCreating()
 
 	cfg, err := d.encodeConfig(conf)
 	if err != nil {

--- a/lib/install/management/create.go
+++ b/lib/install/management/create.go
@@ -1,4 +1,4 @@
-// Copyright 2016 VMware, Inc. All Rights Reserved.
+// Copyright 2016-2017 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/install/management/create.go
+++ b/lib/install/management/create.go
@@ -95,10 +95,6 @@ func (d *Dispatcher) startAppliance(conf *config.VirtualContainerHostConfigSpec)
 		return errors.Errorf("Failed to power on appliance %s. Exiting...", err)
 	}
 
-	if err = d.ensureApplianceInitializes(conf); err != nil {
-		return errors.Errorf("%s. Exiting...", err)
-	}
-
 	return nil
 }
 

--- a/lib/install/management/delete.go
+++ b/lib/install/management/delete.go
@@ -1,4 +1,4 @@
-// Copyright 2016 VMware, Inc. All Rights Reserved.
+// Copyright 2016-2017 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -120,10 +120,10 @@ func (d *Dispatcher) getComputeResource(vmm *vm.VirtualMachine, conf *config.Vir
 	return rp, nil
 }
 
-func (d *Dispatcher) getImageDatastore(vmm *vm.VirtualMachine, conf *config.VirtualContainerHostConfigSpec) (*object.Datastore, error) {
+func (d *Dispatcher) getImageDatastore(vmm *vm.VirtualMachine, conf *config.VirtualContainerHostConfigSpec, force bool) (*object.Datastore, error) {
 	var err error
 	if conf == nil || len(conf.ImageStores) == 0 {
-		if !d.force {
+		if !force {
 			err = errors.Errorf("Cannot find image stores from configuration")
 			return nil, err
 		}
@@ -164,7 +164,7 @@ func (d *Dispatcher) DeleteVCHInstances(vmm *vm.VirtualMachine, conf *config.Vir
 	if children, err = d.parentResourcepool.GetChildrenVMs(d.ctx, d.session); err != nil {
 		return err
 	}
-	if d.session.Datastore, err = d.getImageDatastore(vmm, conf); err != nil {
+	if d.session.Datastore, err = d.getImageDatastore(vmm, conf, d.force); err != nil {
 		return err
 	}
 

--- a/lib/install/management/delete.go
+++ b/lib/install/management/delete.go
@@ -122,7 +122,7 @@ func (d *Dispatcher) getComputeResource(vmm *vm.VirtualMachine, conf *config.Vir
 
 func (d *Dispatcher) getImageDatastore(vmm *vm.VirtualMachine, conf *config.VirtualContainerHostConfigSpec) (*object.Datastore, error) {
 	var err error
-	if len(conf.ImageStores) == 0 {
+	if conf == nil || len(conf.ImageStores) == 0 {
 		if !d.force {
 			err = errors.Errorf("Cannot find image stores from configuration")
 			return nil, err

--- a/lib/install/management/delete.go
+++ b/lib/install/management/delete.go
@@ -127,7 +127,7 @@ func (d *Dispatcher) getImageDatastore(vmm *vm.VirtualMachine, conf *config.Virt
 			err = errors.Errorf("Cannot find image stores from configuration")
 			return nil, err
 		}
-		log.Debugf("Cannot find image stores from configuration, attempting to find from vm datastore")
+		log.Debugf("Cannot find image stores from configuration; attempting to find from vm datastore")
 		dss, err := vmm.DatastoreReference(d.ctx)
 		if err != nil {
 			return nil, errors.Errorf("Failed to query vm datastore: %s", err)

--- a/lib/install/management/delete.go
+++ b/lib/install/management/delete.go
@@ -127,7 +127,7 @@ func (d *Dispatcher) getImageDatastore(vmm *vm.VirtualMachine, conf *config.Virt
 			err = errors.Errorf("Cannot find image stores from configuration")
 			return nil, err
 		}
-		log.Warnf("Cannot find image stores from configuration, attempting to delete from vm datastore")
+		log.Debugf("Cannot find image stores from configuration, attempting to find from vm datastore")
 		dss, err := vmm.DatastoreReference(d.ctx)
 		if err != nil {
 			return nil, errors.Errorf("Failed to query vm datastore: %s", err)

--- a/lib/install/management/delete_test.go
+++ b/lib/install/management/delete_test.go
@@ -89,9 +89,34 @@ func TestDelete(t *testing.T) {
 		createAppliance(ctx, validator.Session, conf, installSettings, false, t)
 
 		testNewVCHFromCompute(input.ComputeResourcePath, input.DisplayName, validator, t)
+		//		testUpgrade(input.ComputeResourcePath, input.DisplayName, validator, installSettings, t) TODO: does not implement: CreateSnapshot_Task
 		testDeleteVCH(validator, conf, t)
 
 		testDeleteDatastoreFiles(validator, t)
+	}
+}
+
+func testUpgrade(computePath string, name string, v *validate.Validator, settings *data.InstallerData, t *testing.T) {
+	// TODO: add tests for rollback after snapshot func is added in vcsim
+	d := &Dispatcher{
+		session: v.Session,
+		ctx:     v.Context,
+		isVC:    v.Session.IsVC(),
+		force:   false,
+	}
+	vch, err := d.NewVCHFromComputePath(computePath, name, v)
+	if err != nil {
+		t.Errorf("Failed to get VCH: %s", err)
+		return
+	}
+	t.Logf("Got VCH %s, path %s", vch, path.Dir(vch.InventoryPath))
+	conf, err := d.GetVCHConfig(vch)
+	if err != nil {
+
+		t.Errorf("Failed to get vch configuration: %s", err)
+	}
+	if err := d.Upgrade(vch, conf, settings); err != nil {
+		t.Errorf("Failed to upgrade: %s", err)
 	}
 }
 

--- a/lib/install/management/dispatcher.go
+++ b/lib/install/management/dispatcher.go
@@ -179,6 +179,10 @@ func (d *Dispatcher) InitDiagnosticLogsFromVCH(vch *vm.VirtualMachine) {
 
 	var err error
 	// where the VM is running
+	force := d.force
+	d.force = true
+	defer d.force = force
+
 	ds, err := d.getImageDatastore(vch, nil)
 	if err != nil {
 		log.Debugf("Failure finding image store from VCH VM %s: %s", vch.Reference(), err.Error())

--- a/lib/install/management/dispatcher.go
+++ b/lib/install/management/dispatcher.go
@@ -181,7 +181,9 @@ func (d *Dispatcher) InitDiagnosticLogsFromVCH(vch *vm.VirtualMachine) {
 	// where the VM is running
 	force := d.force
 	d.force = true
-	defer d.force = force
+	defer func() {
+		d.force = force
+	}()
 
 	ds, err := d.getImageDatastore(vch, nil)
 	if err != nil {

--- a/lib/install/management/dispatcher.go
+++ b/lib/install/management/dispatcher.go
@@ -1,4 +1,4 @@
-// Copyright 2016 VMware, Inc. All Rights Reserved.
+// Copyright 2016-2017 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -179,13 +179,7 @@ func (d *Dispatcher) InitDiagnosticLogsFromVCH(vch *vm.VirtualMachine) {
 
 	var err error
 	// where the VM is running
-	force := d.force
-	d.force = true
-	defer func() {
-		d.force = force
-	}()
-
-	ds, err := d.getImageDatastore(vch, nil)
+	ds, err := d.getImageDatastore(vch, nil, true)
 	if err != nil {
 		log.Debugf("Failure finding image store from VCH VM %s: %s", vch.Reference(), err.Error())
 	}

--- a/lib/install/management/dispatcher.go
+++ b/lib/install/management/dispatcher.go
@@ -159,7 +159,6 @@ func (d *Dispatcher) InitDiagnosticLogsFromConf(conf *config.VirtualContainerHos
 		}
 		// get LineEnd without any LineText
 		h, err := m.BrowseLog(d.ctx, l.host, l.key, math.MaxInt32, 0)
-
 		if err != nil {
 			log.Warnf("Disabling %s %s collection (%s)", k, l.name, err)
 			diagnosticLogs[k] = nil

--- a/lib/install/management/dispatcher.go
+++ b/lib/install/management/dispatcher.go
@@ -154,6 +154,9 @@ func (d *Dispatcher) InitDiagnosticLogsFromConf(conf *config.VirtualContainerHos
 	m := diagnostic.NewDiagnosticManager(d.session)
 
 	for k, l := range diagnosticLogs {
+		if l == nil {
+			continue
+		}
 		// get LineEnd without any LineText
 		h, err := m.BrowseLog(d.ctx, l.host, l.key, math.MaxInt32, 0)
 
@@ -199,6 +202,9 @@ func (d *Dispatcher) InitDiagnosticLogsFromVCH(vch *vm.VirtualMachine) {
 	m := diagnostic.NewDiagnosticManager(d.session)
 
 	for k, l := range diagnosticLogs {
+		if l == nil {
+			continue
+		}
 		// get LineEnd without any LineText
 		h, err := m.BrowseLog(d.ctx, l.host, l.key, math.MaxInt32, 0)
 

--- a/lib/install/management/finder.go
+++ b/lib/install/management/finder.go
@@ -1,4 +1,4 @@
-// Copyright 2016 VMware, Inc. All Rights Reserved.
+// Copyright 2016-2017 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/install/management/finder.go
+++ b/lib/install/management/finder.go
@@ -74,6 +74,7 @@ func (d *Dispatcher) NewVCHFromID(id string) (*vm.VirtualMachine, error) {
 		log.Error(err)
 		return nil, err
 	}
+	d.InitDiagnosticLogsFromVCH(vmm)
 	return vmm, nil
 }
 
@@ -130,6 +131,7 @@ func (d *Dispatcher) NewVCHFromComputePath(computePath string, name string, v *v
 		log.Error(err)
 		return nil, err
 	}
+	d.InitDiagnosticLogsFromVCH(vmm)
 	return vmm, nil
 }
 

--- a/lib/install/management/finder.go
+++ b/lib/install/management/finder.go
@@ -162,6 +162,7 @@ func (d *Dispatcher) GetVCHConfig(vm *vm.VirtualMachine) (*config.VirtualContain
 	return vchConfig, nil
 }
 
+// FetchAndMigrateVCHConfig query VCH guestinfo, and try to migrate older version data to latest if the data is old
 func (d *Dispatcher) FetchAndMigrateVCHConfig(vm *vm.VirtualMachine) (*config.VirtualContainerHostConfigSpec, error) {
 	defer trace.End(trace.Begin(""))
 
@@ -169,7 +170,6 @@ func (d *Dispatcher) FetchAndMigrateVCHConfig(vm *vm.VirtualMachine) (*config.Vi
 	mapConfig, err := vm.FetchExtraConfigBaseOptions(d.ctx)
 	if err != nil {
 		err = errors.Errorf("Failed to get VM extra config of %q: %s", vm.Reference(), err)
-		log.Error(err)
 		return nil, err
 	}
 
@@ -177,7 +177,6 @@ func (d *Dispatcher) FetchAndMigrateVCHConfig(vm *vm.VirtualMachine) (*config.Vi
 	newMap, migrated, err := migration.MigrateApplianceConfig(d.ctx, d.session, kv)
 	if err != nil {
 		err = errors.Errorf("Failed to migrate config of %q: %s", vm.Reference(), err)
-		log.Error(err)
 		return nil, err
 	}
 	if !migrated {
@@ -189,11 +188,9 @@ func (d *Dispatcher) FetchAndMigrateVCHConfig(vm *vm.VirtualMachine) (*config.Vi
 	result := extraconfig.Decode(data, vchConfig)
 	if result == nil {
 		err = errors.Errorf("Failed to decode migrated VM configuration %q: %s", vm.Reference(), err)
-		log.Error(err)
 		return nil, err
 	}
 
-	//	vchConfig.ID
 	return vchConfig, nil
 }
 

--- a/lib/install/management/finder.go
+++ b/lib/install/management/finder.go
@@ -155,7 +155,10 @@ func (d *Dispatcher) GetVCHConfig(vm *vm.VirtualMachine) (*config.VirtualContain
 		return nil, err
 	}
 
-	//	vchConfig.ID
+	if vchConfig.IsCreating() {
+		vmRef := vm.Reference()
+		vchConfig.SetMoref(&vmRef)
+	}
 	return vchConfig, nil
 }
 

--- a/lib/install/management/inspect.go
+++ b/lib/install/management/inspect.go
@@ -1,4 +1,4 @@
-// Copyright 2016 VMware, Inc. All Rights Reserved.
+// Copyright 2016-2017 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -131,6 +131,10 @@ func (d *Dispatcher) ShowVCH(conf *config.VirtualContainerHostConfigSpec, key st
 func (d *Dispatcher) GetDockerAPICommand(conf *config.VirtualContainerHostConfigSpec, key string, cert string, cacert string) (cmd, env string) {
 	var dEnv []string
 	tls := ""
+
+	if d.HostIP == "" {
+		return "", ""
+	}
 
 	if !conf.HostCertificate.IsNil() {
 		// if we're generating then there's no CA currently

--- a/lib/install/management/upgrade.go
+++ b/lib/install/management/upgrade.go
@@ -93,7 +93,7 @@ func (d *Dispatcher) Upgrade(vch *vm.VirtualMachine, conf *config.VirtualContain
 		log.Errorf("Failed to revert appliance to snapshot: %s", rerr)
 		return err
 	}
-	log.Infof("Appliance is rollbacked to old version")
+	log.Infof("Appliance is rolled back to old version")
 
 	d.deleteUpgradeImages(ds, settings)
 	d.deleteSnapshot(snapshotName, conf.Name)
@@ -104,7 +104,7 @@ func (d *Dispatcher) Upgrade(vch *vm.VirtualMachine, conf *config.VirtualContain
 func (d *Dispatcher) deleteSnapshot(snapshotName string, applianceName string) error {
 	defer trace.End(trace.Begin(snapshotName))
 	log.Infof("Deleting upgrade snapshot %q", snapshotName)
-	// do clean up aggressively, even the previous operation failed with context deadline excceeded.
+	// do clean up aggressively, even the previous operation failed with context deadline exceeded.
 	ctx := context.Background()
 	if _, err := d.appliance.WaitForResult(ctx, func(ctx context.Context) (tasks.Task, error) {
 		consolidate := true
@@ -143,7 +143,7 @@ func (d *Dispatcher) deleteUpgradeImages(ds *object.Datastore, settings *data.In
 
 	log.Infof("Deleting upgrade images")
 
-	// do clean up aggressively, even the previous operation failed with context deadline excceeded.
+	// do clean up aggressively, even the previous operation failed with context deadline exceeded.
 	d.ctx = context.Background()
 
 	m := object.NewFileManager(ds.Client())
@@ -187,12 +187,12 @@ func (d *Dispatcher) update(conf *config.VirtualContainerHostConfigSpec, setting
 	ctx, cancel := context.WithTimeout(d.ctx, settings.Timeout)
 	defer cancel()
 	if err = d.CheckServiceReady(ctx, conf, nil); err != nil {
-		if ctx.Err() != nil && ctx.Err() == context.DeadlineExceeded {
+		if ctx.Err() == context.DeadlineExceeded {
 			//context deadline exceeded, replace returned error message
 			err = errors.Errorf("Upgrading VCH exceeded time limit of %s. Please increase the timeout using --timeout to accommodate for a busy vSphere target", settings.Timeout)
 		}
 
-		log.Info("\tAPI may be slow to start - might retry with increased timeout using --timeout: %s", err)
+		log.Info("\tAPI may be slow to start - please retry with increased timeout using --timeout: %s", err)
 		return err
 	}
 	return nil

--- a/lib/install/management/upgrade.go
+++ b/lib/install/management/upgrade.go
@@ -1,4 +1,4 @@
-// Copyright 2016 VMware, Inc. All Rights Reserved.
+// Copyright 2016-2017 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -97,12 +97,12 @@ func (d *Dispatcher) Upgrade(vch *vm.VirtualMachine, conf *config.VirtualContain
 
 	if rerr := d.rollback(conf, snapshotName, settings); rerr != nil {
 		log.Errorf("Failed to revert appliance to snapshot: %s", rerr)
-		// return the error message for upgrade, instead of rollback
 	} else {
-		log.Infof("Appliance is rollback to old version")
+		log.Infof("Appliance is rollbacked to old version")
 	}
 
 	d.deleteUpgradeImages(ds, settings)
+	// return the error message for upgrade
 	return err
 }
 
@@ -206,7 +206,7 @@ func (d *Dispatcher) update(conf *config.VirtualContainerHostConfigSpec, setting
 	ctx, cancel := context.WithTimeout(d.ctx, settings.Timeout)
 	defer cancel()
 	if err = d.CheckServiceReady(ctx, conf, nil); err != nil {
-		log.Info("\tAPI may be slow to start - might retry with increased timeout: %s", err)
+		log.Info("\tAPI may be slow to start - might retry with increased timeout using --timeout: %s", err)
 		return err
 	}
 	return nil

--- a/lib/install/management/upgrade.go
+++ b/lib/install/management/upgrade.go
@@ -264,6 +264,10 @@ func (d *Dispatcher) reconfigVCH(conf *config.VirtualContainerHostConfigSpec, is
 	spec.DeviceChange = deviceChange
 
 	if conf != nil {
+		// reset service started attribute
+		for _, sess := range conf.ExecutorConfig.Sessions {
+			sess.Started = ""
+		}
 		cfg := make(map[string]string)
 		extraconfig.Encode(extraconfig.MapSink(cfg), conf)
 		spec.ExtraConfig = append(spec.ExtraConfig, vmomi.OptionValueFromMap(cfg)...)

--- a/lib/install/management/upgrade.go
+++ b/lib/install/management/upgrade.go
@@ -119,24 +119,19 @@ func (d *Dispatcher) retryDeleteSnapshot(snapshotName string, applianceName stri
 
 func isSystemError(err error) bool {
 	if soap.IsSoapFault(err) {
-		switch soap.ToSoapFault(err).VimFault().(type) {
-		case types.SystemError:
+		if _, ok := soap.ToSoapFault(err).VimFault().(*types.SystemError); ok {
 			return true
 		}
 	}
 
 	if soap.IsVimFault(err) {
-		log.Infof("Is soap vim fault")
-		switch soap.ToVimFault(err).(type) {
-		case *types.SystemError:
+		if _, ok := soap.ToVimFault(err).(*types.SystemError); ok {
 			return true
 		}
 	}
 
 	if terr, ok := err.(task.Error); ok {
-		log.Infof("Is task fault")
-		switch terr.Fault().(type) {
-		case *types.SystemError:
+		if _, ok := terr.Fault().(*types.SystemError); ok {
 			return true
 		}
 	}

--- a/lib/install/validate/update.go
+++ b/lib/install/validate/update.go
@@ -1,4 +1,4 @@
-// Copyright 2016 VMware, Inc. All Rights Reserved.
+// Copyright 2016-2017 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -79,7 +79,7 @@ func (v *Validator) AssertVersion(conf *config.VirtualContainerHostConfigSpec) (
 		return err
 	}
 	if !older {
-		v.NoteIssue(errors.Errorf("%q has same version as installer. No upgrade is available.", conf.Name))
+		v.NoteIssue(errors.Errorf("%q has same or newer version %s than installer version. No upgrade is available.", conf.Name, conf.Version.ShortVersion(), installerBuild.ShortVersion()))
 		return err
 	}
 	return nil

--- a/lib/install/validate/update.go
+++ b/lib/install/validate/update.go
@@ -27,7 +27,6 @@ import (
 func (v *Validator) ValidateMigratedConfig(ctx context.Context, conf *config.VirtualContainerHostConfigSpec) (*config.VirtualContainerHostConfigSpec, error) {
 	defer trace.End(trace.Begin(conf.Name))
 
-	v.assertBasics(conf)
 	v.assertTarget(conf)
 	v.assertDatastore(conf)
 	v.assertNetwork(conf)
@@ -63,29 +62,25 @@ func (v *Validator) assertTarget(conf *config.VirtualContainerHostConfigSpec) {
 	}
 }
 
-func (v *Validator) assertBasics(conf *config.VirtualContainerHostConfigSpec) {
+func (v *Validator) AssertVersion(conf *config.VirtualContainerHostConfigSpec) (err error) {
 	defer trace.End(trace.Begin(""))
-	v.assertVersion(conf)
-}
+	defer func() {
+		err = v.ListIssues()
+	}()
 
-func (v *Validator) assertVersion(conf *config.VirtualContainerHostConfigSpec) {
-	defer trace.End(trace.Begin(""))
 	if conf.Version == nil {
 		v.NoteIssue(errors.Errorf("Unknown version of VCH %q", conf.Name))
-		return
+		return err
 	}
+	var older bool
 	installerBuild := version.GetBuild()
-	if installerBuild.Equal(conf.Version) {
-		v.NoteIssue(errors.Errorf("%q has same version as installer. No upgrade is available.", conf.Name))
-		return
-	}
-	older, err := installerBuild.IsOlder(conf.Version)
-	if err != nil {
+	if older, err = conf.Version.IsOlder(installerBuild); err != nil {
 		v.NoteIssue(errors.Errorf("Failed to compare VCH version %q with installer version %q: %s", conf.Version.ShortVersion(), installerBuild.ShortVersion(), err))
-		return
+		return err
 	}
-	if older {
-		v.NoteIssue(errors.Errorf("VCH version %q is newer than installer version %q", conf.Version.ShortVersion(), installerBuild.ShortVersion()))
-		return
+	if !older {
+		v.NoteIssue(errors.Errorf("%q has same version as installer. No upgrade is available.", conf.Name))
+		return err
 	}
+	return nil
 }

--- a/lib/install/validate/update.go
+++ b/lib/install/validate/update.go
@@ -79,7 +79,7 @@ func (v *Validator) AssertVersion(conf *config.VirtualContainerHostConfigSpec) (
 		return err
 	}
 	if !older {
-		v.NoteIssue(errors.Errorf("%q has same or newer version %s than installer version. No upgrade is available.", conf.Name, conf.Version.ShortVersion(), installerBuild.ShortVersion()))
+		v.NoteIssue(errors.Errorf("%q has same or newer version %s than installer version %s. No upgrade is available.", conf.Name, conf.Version.ShortVersion(), installerBuild.ShortVersion()))
 		return err
 	}
 	return nil

--- a/lib/install/validate/update.go
+++ b/lib/install/validate/update.go
@@ -24,7 +24,7 @@ import (
 )
 
 // MigrateConfig migrate old VCH configuration to new version. Currently check required fields only
-func (v *Validator) MigrateConfig(ctx context.Context, conf *config.VirtualContainerHostConfigSpec) (*config.VirtualContainerHostConfigSpec, error) {
+func (v *Validator) ValidateMigratedConfig(ctx context.Context, conf *config.VirtualContainerHostConfigSpec) (*config.VirtualContainerHostConfigSpec, error) {
 	defer trace.End(trace.Begin(conf.Name))
 
 	v.assertBasics(conf)
@@ -32,15 +32,7 @@ func (v *Validator) MigrateConfig(ctx context.Context, conf *config.VirtualConta
 	v.assertDatastore(conf)
 	v.assertNetwork(conf)
 
-	if err := v.ListIssues(); err != nil {
-		return conf, err
-	}
-	return v.migrateData(ctx, conf)
-}
-
-func (v *Validator) migrateData(ctx context.Context, conf *config.VirtualContainerHostConfigSpec) (*config.VirtualContainerHostConfigSpec, error) {
-	conf.Version = version.GetBuild()
-	return conf, nil
+	return conf, v.ListIssues()
 }
 
 func (v *Validator) assertNetwork(conf *config.VirtualContainerHostConfigSpec) {

--- a/lib/migration/manager/manager.go
+++ b/lib/migration/manager/manager.go
@@ -47,7 +47,7 @@ type Plugin interface {
 type DataMigration interface {
 	// Register plugin to data migration system
 	Register(version int, target string, plugin Plugin) error
-	// Migrate data with current version ID, return true if has any plugin executed
+	// Migrate data with current version ID, return maximum ID number of executed plugins
 	Migrate(ctx context.Context, s *session.Session, target string, currentVersion int, data interface{}) (int, error)
 	// LatestVersion return the latest plugin version for specified target
 	LatestVersion(target string) int

--- a/lib/migration/migrator.go
+++ b/lib/migration/migrator.go
@@ -47,17 +47,17 @@ func MigrateContainerConfig(conf map[string]string) (map[string]string, bool, er
 	return migrateConfig(nil, nil, conf, manager.ContainerConfigure, manager.ContainerVersionKey)
 }
 
-// IsContainerDataOlder returns true if input container config is older than latest version. If error happens, always returns false
+// ContainerDataIsOlder returns true if input container config is older than latest version. If error happens, always returns false
 func ContainerDataIsOlder(conf map[string]string) (bool, error) {
 	return dataIsOlder(conf, manager.ContainerConfigure, manager.ContainerVersionKey)
 }
 
-// IsApplianceDataOlder returns true if input appliance config is older than latest version. If error happens, always returns false
+// ApplianceDataIsOlder returns true if input appliance config is older than latest version. If error happens, always returns false
 func ApplianceDataIsOlder(conf map[string]string) (bool, error) {
 	return dataIsOlder(conf, manager.ApplianceConfigure, manager.ApplianceVersionKey)
 }
 
-// isDataOlder returns true if data is older than latest. If error happens, always returns false
+// dataIsOlder returns true if data is older than latest. If error happens, always returns false
 func dataIsOlder(data map[string]string, target string, verKey string) (bool, error) {
 	defer trace.End(trace.Begin(fmt.Sprintf("target: %s, version key: %s", target, verKey)))
 

--- a/lib/migration/migrator.go
+++ b/lib/migration/migrator.go
@@ -16,17 +16,23 @@ package migration
 
 import (
 	"context"
+	"fmt"
 	"strconv"
+
+	log "github.com/Sirupsen/logrus"
 
 	"github.com/vmware/vic/lib/migration/errors"
 	"github.com/vmware/vic/lib/migration/manager"
 	_ "github.com/vmware/vic/lib/migration/plugins"
+	"github.com/vmware/vic/pkg/trace"
+	"github.com/vmware/vic/pkg/version"
 	"github.com/vmware/vic/pkg/vsphere/session"
 )
 
 // MigrateApplianceConfigure migrate VCH appliance configuration, including guestinfo, keyvaluestore, or any other configuration related change.
 //
-// Note: Input map conf is VCH appliance guestinfo map, and returned map is the new guestinfo. Any other changes should be made in plugin.
+// Note: Input map conf is VCH appliance guestinfo map, and returned map is the new guestinfo.
+// Returns false without error means no need to migrate
 // If there is error returned, returned map might have half-migrated value
 func MigrateApplianceConfig(ctx context.Context, s *session.Session, conf map[string]string) (map[string]string, bool, error) {
 	return migrateConfig(ctx, s, conf, manager.ApplianceConfigure, manager.ApplianceVersionKey)
@@ -35,23 +41,26 @@ func MigrateApplianceConfig(ctx context.Context, s *session.Session, conf map[st
 // MigrateContainerConfigure migrate container configuration
 //
 // Note: Migrated data will be returned in map, and input object is not changed.
+// Returns false without error means no need to migrate
 // If there is error returned, returned map might have half-migrated value.
 func MigrateContainerConfig(conf map[string]string) (map[string]string, bool, error) {
 	return migrateConfig(nil, nil, conf, manager.ContainerConfigure, manager.ContainerVersionKey)
 }
 
 // IsContainerDataOlder returns true if input container config is older than latest version. If error happens, always returns false
-func IsContainerDataOlder(conf map[string]string) (bool, error) {
-	return isDataOlder(conf, manager.ContainerConfigure, manager.ContainerVersionKey)
+func ContainerDataIsOlder(conf map[string]string) (bool, error) {
+	return dataIsOlder(conf, manager.ContainerConfigure, manager.ContainerVersionKey)
 }
 
 // IsApplianceDataOlder returns true if input appliance config is older than latest version. If error happens, always returns false
-func IsApplianceDataOlder(conf map[string]string) (bool, error) {
-	return isDataOlder(conf, manager.ApplianceConfigure, manager.ApplianceVersionKey)
+func ApplianceDataIsOlder(conf map[string]string) (bool, error) {
+	return dataIsOlder(conf, manager.ApplianceConfigure, manager.ApplianceVersionKey)
 }
 
 // isDataOlder returns true if data is older than latest. If error happens, always returns false
-func isDataOlder(data map[string]string, target string, verKey string) (bool, error) {
+func dataIsOlder(data map[string]string, target string, verKey string) (bool, error) {
+	defer trace.End(trace.Begin(fmt.Sprintf("target: %s, version key: %s", target, verKey)))
+
 	var currentID int
 	var err error
 
@@ -63,7 +72,13 @@ func isDataOlder(data map[string]string, target string, verKey string) (bool, er
 }
 
 func migrateConfig(ctx context.Context, s *session.Session, data map[string]string, target string, verKey string) (map[string]string, bool, error) {
+	defer trace.End(trace.Begin(fmt.Sprintf("target: %s, version key: %s", target, verKey)))
+
 	dst := make(map[string]string)
+	for k, v := range data {
+		dst[k] = v
+	}
+
 	if len(data) == 0 {
 		return dst, false, nil
 	}
@@ -74,20 +89,19 @@ func migrateConfig(ctx context.Context, s *session.Session, data map[string]stri
 	if currentID, err = getCurrentID(data, verKey); err != nil {
 		return dst, false, err
 	}
-
-	for k, v := range data {
-		dst[k] = v
+	latestVer := manager.Migrator.LatestVersion(target)
+	if latestVer <= currentID {
+		log.Debugf("No new plugin available, no need to migrate")
+		return dst, false, nil
 	}
 
-	latestID, err := manager.Migrator.Migrate(ctx, s, target, currentID, dst)
-	if latestID == currentID {
-		return dst, false, err
-	}
-	dst[verKey] = strconv.Itoa(latestID)
+	_, err = manager.Migrator.Migrate(ctx, s, target, currentID, dst)
+	dst[verKey] = strconv.Itoa(version.MaxPluginVersion)
 	return dst, true, err
 }
 
 func getCurrentID(data map[string]string, verKey string) (int, error) {
+	defer trace.End(trace.Begin(fmt.Sprintf("version key: %s", verKey)))
 	var currentID int
 	var err error
 	strID := data[verKey]

--- a/lib/migration/migrator.go
+++ b/lib/migration/migrator.go
@@ -32,7 +32,7 @@ import (
 // MigrateApplianceConfigure migrate VCH appliance configuration, including guestinfo, keyvaluestore, or any other configuration related change.
 //
 // Note: Input map conf is VCH appliance guestinfo map, and returned map is the new guestinfo.
-// Returns false without error means no need to migrate
+// Returns false without error means no need to migrate, and returned map is the copy of input map
 // If there is error returned, returned map might have half-migrated value
 func MigrateApplianceConfig(ctx context.Context, s *session.Session, conf map[string]string) (map[string]string, bool, error) {
 	return migrateConfig(ctx, s, conf, manager.ApplianceConfigure, manager.ApplianceVersionKey)
@@ -41,7 +41,7 @@ func MigrateApplianceConfig(ctx context.Context, s *session.Session, conf map[st
 // MigrateContainerConfigure migrate container configuration
 //
 // Note: Migrated data will be returned in map, and input object is not changed.
-// Returns false without error means no need to migrate
+// Returns false without error means no need to migrate, and returned map is the copy of input map
 // If there is error returned, returned map might have half-migrated value.
 func MigrateContainerConfig(conf map[string]string) (map[string]string, bool, error) {
 	return migrateConfig(nil, nil, conf, manager.ContainerConfigure, manager.ContainerVersionKey)

--- a/lib/migration/migrator_test.go
+++ b/lib/migration/migrator_test.go
@@ -129,7 +129,7 @@ func TestIsDataOlder(t *testing.T) {
 	mapData := make(map[string]string)
 	extraconfig.Encode(extraconfig.MapSink(mapData), conf)
 	t.Logf("Old appliance data: %#v", mapData)
-	older, err := IsApplianceDataOlder(mapData)
+	older, err := ApplianceDataIsOlder(mapData)
 	assert.Equal(t, nil, err, "should not have error")
 	assert.True(t, older, "Test data should be older than latest")
 
@@ -137,7 +137,7 @@ func TestIsDataOlder(t *testing.T) {
 	extraconfig.Encode(extraconfig.MapSink(mapData), conf.ExecutorConfig)
 	t.Logf("Old container data: %#v", mapData)
 
-	older, err = IsContainerDataOlder(mapData)
+	older, err = ContainerDataIsOlder(mapData)
 	assert.Equal(t, nil, err, "should not have error")
 	assert.False(t, older, "Test data should not be older than latest, no container update plugin registered yet")
 }

--- a/pkg/vsphere/extraconfig/vmomi/optionvalue.go
+++ b/pkg/vsphere/extraconfig/vmomi/optionvalue.go
@@ -1,4 +1,4 @@
-// Copyright 2016 VMware, Inc. All Rights Reserved.
+// Copyright 2016-2017 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/vsphere/extraconfig/vmomi/optionvalue.go
+++ b/pkg/vsphere/extraconfig/vmomi/optionvalue.go
@@ -23,9 +23,8 @@ import (
 	"github.com/vmware/vic/pkg/vsphere/extraconfig"
 )
 
-// OptionValueSource is a convenience method to generate a MapSource source from
-// and array of OptionValue's
-func OptionValueSource(src []types.BaseOptionValue) extraconfig.DataSource {
+// OptionValueMap returns a map from array of OptionValues
+func OptionValueMap(src []types.BaseOptionValue) map[string]string {
 	// create the key/value store from the extraconfig slice for lookups
 	kv := make(map[string]string)
 	for i := range src {
@@ -36,7 +35,13 @@ func OptionValueSource(src []types.BaseOptionValue) extraconfig.DataSource {
 		}
 		kv[k] = v
 	}
+	return kv
+}
 
+// OptionValueSource is a convenience method to generate a MapSource source from
+// and array of OptionValue's
+func OptionValueSource(src []types.BaseOptionValue) extraconfig.DataSource {
+	kv := OptionValueMap(src)
 	return extraconfig.MapSource(kv)
 }
 

--- a/pkg/vsphere/vm/vm.go
+++ b/pkg/vsphere/vm/vm.go
@@ -334,21 +334,6 @@ func (vm *VirtualMachine) VMPathName(ctx context.Context) (string, error) {
 	return mvm.Config.Files.VmPathName, nil
 }
 
-// RemoveSnapshot delete one snapshot
-func (vm *VirtualMachine) RemoveSnapshot(ctx context.Context, id types.ManagedObjectReference, removeChildren bool, consolidate bool) (*object.Task, error) {
-	req := types.RemoveSnapshot_Task{
-		This:           id,
-		RemoveChildren: removeChildren,
-		Consolidate:    &consolidate,
-	}
-	res, err := methods.RemoveSnapshot_Task(ctx, vm.Client.RoundTripper, &req)
-	if err != nil {
-		return nil, err
-	}
-
-	return object.NewTask(vm.Vim25(), res.Returnval), nil
-}
-
 // GetCurrentSnapshotTree returns current snapshot, with tree information
 func (vm *VirtualMachine) GetCurrentSnapshotTree(ctx context.Context) (*types.VirtualMachineSnapshotTree, error) {
 	var err error

--- a/tests/test-cases/Group11-Upgrade/11-01-Upgrade.md
+++ b/tests/test-cases/Group11-Upgrade/11-01-Upgrade.md
@@ -12,11 +12,13 @@ This test requires that a vSphere server is running and available
 2. Deploy VIC 5470 to vsphere server
 3. Issue docker network create bar, creating a new network called "bar"
 4. Create container with port mapping
-5. Upgrade VCH to latest version
+5. Upgrade VCH to latest version with short timeout 1s
+6. Upgrade VCH to latest version
 6. Check the previous created container and image are still there
 
 #Expected Outcome:
-* All steps should result in success
+* Step 5 should fail with timeout
+* All other steps should result in success
 
 #Possible Problems:
 Upgrade test will upgrade VCH from build 5470, because that build has VCH restart and configuration restart features done.

--- a/tests/test-cases/Group11-Upgrade/11-01-Upgrade.robot
+++ b/tests/test-cases/Group11-Upgrade/11-01-Upgrade.robot
@@ -46,6 +46,15 @@ Upgrade VCH with containers
     Wait Until Keyword Succeeds  20x  5 seconds  Hit Nginx Endpoint  %{VCH-IP}  10000
     Wait Until Keyword Succeeds  20x  5 seconds  Hit Nginx Endpoint  %{VCH-IP}  10001
 
+    Log To Console  \nUpgrading VCH with 1s timeout ...
+    ${rc}  ${output}=  Run And Return Rc And Output  bin/vic-machine-linux upgrade --debug 1 --name=%{VCH-NAME} --target=%{TEST_URL} --user=%{TEST_USERNAME} --password=%{TEST_PASSWORD} --force=true --compute-resource=%{TEST_RESOURCE} --timeout 1s
+    Should Contain  ${output}  Upgrading VCH exceeded time limit
+    Should Not Contain  ${output}  Completed successfully
+    ${rc}  ${output}=  Run Keyword If  '%{HOST_TYPE}' == 'VC'  Run And Return Rc And Output  govc snapshot.tree -vm=%{VCH-NAME}/%{VCH-NAME}
+    Run Keyword If  '%{HOST_TYPE}' == 'VC'  Should Not Contain  ${output}  upgrade
+    ${rc}  ${output}=  Run Keyword If  '%{HOST_TYPE}' == 'ESXi'  Run And Return Rc And Output  govc snapshot.tree -vm=%{VCH-NAME}
+    Run Keyword If  '%{HOST_TYPE}' == 'ESXi'  Should Not Contain  ${output}  upgrade
+
     Log To Console  \nUpgrading VCH...
     ${rc}  ${output}=  Run And Return Rc And Output  bin/vic-machine-linux upgrade --debug 1 --name=%{VCH-NAME} --target=%{TEST_URL} --user=%{TEST_USERNAME} --password=%{TEST_PASSWORD} --force=true --compute-resource=%{TEST_RESOURCE} --timeout %{TEST_TIMEOUT}
     Should Contain  ${output}  Completed successfully

--- a/tests/test-cases/Group6-VIC-Machine/6-04-Create-Basic.md
+++ b/tests/test-cases/Group6-VIC-Machine/6-04-Create-Basic.md
@@ -259,6 +259,17 @@ Timeout
 * Command fail for timeout error #1557
 
 
+Short time creation
+===================
+
+# Stop VCH creation immediately
+=============================
+1. Interrupt creation process after 2s, 
+2. Delete the VCH
+
+### Expected Outcome
+* Delete should succeed
+
 
 Appliance size
 =======

--- a/tests/test-cases/Group6-VIC-Machine/6-04-Create-Basic.robot
+++ b/tests/test-cases/Group6-VIC-Machine/6-04-Create-Basic.robot
@@ -301,21 +301,17 @@ Create VCH - Reuse keys
     Cleanup VIC Appliance On Test Server
 
 Basic timeout
-    ${status}=  Get State Of Github Issue  3241
-    Run Keyword If  '${status}' == 'closed'  Fail  Test 6-04-Create-Basic.robot needs to be updated now that Issue #3241 has been resolved
-    Log  Issue \#3241 is blocking implementation  WARN
+    Set Test Environment Variables
+    Run Keyword And Ignore Error  Cleanup Dangling VMs On Test Server
+    Run Keyword And Ignore Error  Cleanup Datastore On Test Server
 
-#    Set Test Environment Variables
-#    Run Keyword And Ignore Error  Cleanup Dangling VMs On Test Server
-#    Run Keyword And Ignore Error  Cleanup Datastore On Test Server
-#
-#    ${output}=  Run  bin/vic-machine-linux create --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --image-store=%{TEST_DATASTORE} --bridge-network=%{BRIDGE_NETWORK} --public-network=%{PUBLIC_NETWORK} --timeout 30s ${vicmachinetls} --public-network-ip=172.16.5.5/24 --public-network-gateway=172.16.5.1/24
-#    Should Contain  ${output}  Create timed out
-#
-#    ${ret}=  Run  bin/vic-machine-linux delete --target %{TEST_URL} --thumbprint=%{TEST_THUMBPRINT} --user %{TEST_USERNAME} --password=%{TEST_PASSWORD} --compute-resource=%{TEST_RESOURCE} --name ${vch-name}
-#    Should Contain  ${ret}  Completed successfully
-#    ${out}=  Run  govc ls vm
-#    Should Not Contain  ${out}  %{VCH-NAME}
+    ${output}=  Run  bin/vic-machine-linux create --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --image-store=%{TEST_DATASTORE} --bridge-network=%{BRIDGE_NETWORK} --public-network=%{PUBLIC_NETWORK} --timeout 1s ${vicmachinetls}
+    Should Contain  ${output}  Creating VCH exceeded time limit
+
+    ${ret}=  Run  bin/vic-machine-linux delete --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --compute-resource=%{TEST_RESOURCE} --name %{VCH-NAME}
+    Should Contain  ${ret}  Completed successfully
+    ${out}=  Run  govc ls vm
+    Should Not Contain  ${out}  %{VCH-NAME}
 
 Basic VCH resource config
     Pass execution  Test not implemented


### PR DESCRIPTION
Fixes #3609

Also did a bit cleanup for timeout. In this way, timeout for vic-machine create and vic-machine upgrade will work for service waiting only. 
If iso file uploading or snapshot take long time, it would not timeout.

If upgrade timeout to wait service, it will rollback to old version cause it cannot make sure if there is anything real wrong or just a timing issue. And if that's really a timing issue, the roll back will fail to wait service ready, but it will try to finish all cleanup with a context without timeout.

@stuclem 