### PR TITLE
Ignore TERM and KILL signals for tether

### DIFF
--- a/cmd/tether/main_linux.go
+++ b/cmd/tether/main_linux.go
@@ -17,6 +17,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"os/signal"
 	"runtime/debug"
 	"strings"
 	"syscall"
@@ -32,6 +33,9 @@ import (
 var tthr tether.Tether
 
 func init() {
+	// We are pid 1 so let's ignore SIGKILL or SIGTERM signals
+	signal.Ignore(syscall.SIGTERM, syscall.SIGKILL)
+
 	// Initiliaze logger with default TextFormatter
 	log.SetFormatter(viclog.NewTextFormatter())
 


### PR DESCRIPTION
Otherwise we panic

```
[   74.127006 ] Kernel panic - not syncing: Attempted to kill init! exitcode=0x00000200
[   74.127006 ]
[   74.145909 ] CPU: 0 PID: 232 Comm: tether Tainted: G            E   4.4.41-2.ph1-esx #1-photon
[   74.163249 ] Hardware name: VMware, Inc. VMware Virtual Platform/440BX Desktop Reference Platform, BIOS 6.00 04/05/2016
[   74.185318 ]  0000000000000000 ffffffff8122091f ffffffff816f2418 ffff88007968bd08
[   74.201909 ]  ffffffff810c8ed6 0000000000000010 ffff88007968bd18 ffff88007968bcb0
[   74.218554 ]  ffff880073642948 0000000000000200 ffff88007bc9d010 0000000000000000
[   74.235204 ] Call Trace:
[   74.240879 ]  [<ffffffff8122091f>] ? dump_stack+0x5c/0x7d
[   74.252128 ]  [<ffffffff810c8ed6>] ? panic+0xbf/0x1d7
[   74.259385 ]  [<ffffffff81045735>] ? do_exit+0xa35/0xa40
[   74.264534 ]  [<ffffffff8104579e>] ? do_group_exit+0x2e/0xa0
[   74.269928 ]  [<ffffffff8104e3f6>] ? get_signal+0x1b6/0x530
[   74.275283 ]  [<ffffffff810030ce>] ? do_signal+0x1e/0x5d0
[   74.280619 ]  [<ffffffff812a88a2>] ? tty_read+0x92/0xe0
[   74.285646 ]  [<ffffffff8111f1ae>] ? __vfs_read+0x1e/0xe0
[   74.290838 ]  [<ffffffff8142dc5f>] ? __schedule+0x38f/0x800
[   74.296177 ]  [<ffffffff8100104f>] ? exit_to_usermode_loop+0x7f/0xa0
[   74.302314 ]  [<ffffffff81001405>] ? syscall_return_slowpath+0x45/0x50
[   74.309296 ]  [<ffffffff814310cc>] ? int_ret_from_sys_call+0x25/0x8f
[   74.343746 ] Kernel Offset: disabled
[   74.595373 ] ---[ end Kernel panic - not syncing: Attempted to kill init! exitcode=0x00000200
[   74.595373 ]]
```
Fixes #4011
