### PR TITLE
Add timestamps to persisted containerVM output [specific ci=1-08-Docker-Logs]

### DIFF
--- a/doc/design/container_logging.md
+++ b/doc/design/container_logging.md
@@ -1,0 +1,26 @@
+# Container VM output logging in VIC
+
+When a container VM process produces output, that output is sent down through a serial connection into the vSphere backend where it is written to a logfile. When a user wants to see this output, they use the `docker logs` command, which reads from this logfile and displays the log entries on the command line in order from oldest to newest.
+
+However, in order for users to be able to use the `--since` option with `docker logs`, we must also couple timestamps to these log entries so that the user can selectively filter log messages to be displayed based on when those entries occurred.
+
+### Requirements
+
+The container VM logging mechanism must:  
+  1. Create a header for each log entry containing both the size of that entry, the time at which that entry occurred, and the stream from which that entry originated (stdout, stderr).  
+  2. Allow these entries to be read and at a later time, starting with the first entry occurring at or beyond the timestamp supplied by the user with the `--since` option to `docker logs`, or starting with the first entry in the logfile if `--since` was not used. 
+
+### Implementation
+
+A package for containerVM logging in VIC is added as `github.com/vmware/vic/lib/iolog`. In this package are two files, `log_writer.go` and `log_reader.go`. These files contain an implementation of Go's `io.Writer` and `io.ReadCloser` interfaces, respectively.
+
+The responsibilities of the `LogWriter` are:  
+  1. To create a header for the entry, containing the timestamp at which the entry occurred, the size of the entry, and the stream that produced the entry.
+  2. To write these bytes to the serial port associated with the containerVM logfile on the backend.
+  3. To flush the remaining bytes in the supplied buffer upon `Close()`
+
+The responsibilities of the `LogReader` are:  
+  1. To read in a header and decode it into the timestamp, size and stream of the entry.
+  2. To then read the following `size` bytes that contain the actual message.
+  3. To copy the message bytes into the underlying `Read` stream's `[]byte` slice. 
+  4. To preserve unwritten bytes in a call to `Read` in memory so that they may be written during the next call, in the case where the supplied `[]byte` slice was smaller than the log message we are trying to write. 

--- a/lib/iolog/constants.go
+++ b/lib/iolog/constants.go
@@ -1,0 +1,29 @@
+// Copyright 2017 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package iolog
+
+const (
+	// TODO(jzt): re-arrange header layout so that size is on the LSB side, and TS is on MSB,
+	// with space for flags in the middle
+	futureFlag1 = 1 << iota
+	futureFlag2
+	futureFlag4
+	streamFlag
+
+	maxEntrySizeKB           = 4
+	maxEntrySizeBytes        = maxEntrySizeKB*1024 - 1
+	headerLengthBytes        = 10
+	encodedHeaderLengthBytes = 16 // base64 encoded header
+)

--- a/lib/iolog/log_reader.go
+++ b/lib/iolog/log_reader.go
@@ -1,0 +1,96 @@
+// Copyright 2017 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package iolog
+
+import (
+	"encoding/base64"
+	"encoding/binary"
+	"io"
+)
+
+// LogReader reads containerVM entries from a stream and decodes them into
+// their original form
+type LogReader struct {
+	io.ReadCloser
+	prev []byte
+}
+
+// NewLogReader wraps an io.ReadCloser in a LogReader.
+func NewLogReader(r io.ReadCloser) *LogReader {
+	return &LogReader{ReadCloser: r}
+}
+
+// Read reads a 10 byte header and decodes it into the timestamp, stream and
+// size of an entry. It uses the size to read the next set of bytes as the
+// message, and then copies the message into the supplied buffer, saving
+// what will not fit in the buffer for the next call to Read.
+func (lr *LogReader) Read(p []byte) (int, error) {
+	var (
+		err  error
+		n, w int
+	)
+
+	ehdr := make([]byte, encodedHeaderLengthBytes)
+	msg := lr.prev
+
+	if msg == nil {
+		// read a header
+		n = 0
+		for n < encodedHeaderLengthBytes {
+			w, err = lr.ReadCloser.Read(ehdr[n:])
+			n += w
+			if err != nil {
+				return 0, err
+			}
+		}
+
+		// decode base64 header
+		hdr, err := base64.StdEncoding.DecodeString(string(ehdr))
+		if err != nil {
+			return 0, err
+		}
+
+		// parse header
+		// ts := time.Unix(0, int64(binary.LittleEndian.Uint64(h[:8])))
+		s := binary.LittleEndian.Uint16(hdr[8:10])
+		// stream := int((s&streamFlag) >> 3)
+		size := int(s >> 4)
+
+		// read the associated entry
+		msg = make([]byte, size)
+		n = 0
+		for n < size {
+			w, err = lr.ReadCloser.Read(msg[n:])
+			n += w
+			if err != nil {
+				if err != io.EOF {
+					// only return if not EOF as we may actually have some bytes to copy
+					return 0, err
+				}
+				break
+			}
+		}
+	}
+
+	lr.prev = nil
+	if len(p) < len(msg) {
+		// copy what we can and save the rest for the next call
+		lr.prev = msg[len(p):]
+		msg = msg[:len(p)]
+	}
+
+	// write the log message
+	return copy(p, msg), err
+}

--- a/lib/iolog/log_writer.go
+++ b/lib/iolog/log_writer.go
@@ -1,0 +1,181 @@
+// Copyright 2017 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package iolog
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/binary"
+	"io"
+	"sync"
+	"time"
+)
+
+// Clock defines an interface that wraps time.Now()
+type Clock interface {
+	Now() time.Time
+}
+
+// LogClock is an implementation of the Clock interface that
+// returns time.Now() for use in the iolog package
+type LogClock struct{}
+
+// Now returns the local time time.Now()
+func (LogClock) Now() time.Time {
+	return time.Now()
+}
+
+// LogWriter tags log entries with a descriptive header and writes
+// them to the underlying io.Writer
+type LogWriter struct {
+	Clock
+	w    io.Writer
+	prev []byte
+
+	m      sync.Mutex
+	closed bool
+}
+
+// NewLogWriter wraps an io.WriteCloser in a LogWriter
+func NewLogWriter(w io.Writer, clock Clock) *LogWriter {
+	return &LogWriter{
+		w:     w,
+		Clock: clock,
+	}
+}
+
+// Write scans the supplied buffer, breaking off indvidual entries
+// and writing them to the underlying Writer, flushing any leftover bytes
+func (lw *LogWriter) Write(p []byte) (n int, err error) {
+	var (
+		start, end, i int
+		entry         []byte
+	)
+
+	for {
+		i = 0
+		if i = bytes.IndexByte(p[start:], '\n') + 1; i == 0 {
+			break
+		}
+		end = start + i
+		entry = p[start:end]
+
+		// do we have bytes left over from the last call?
+		if lw.prev != nil {
+			entry = append(lw.prev, entry...)
+			lw.prev = nil
+		}
+
+		// we have a complete entry, let's write it
+		n, err = lw.write(entry)
+		if err != nil {
+			return n, err
+		}
+
+		// advance starting index
+		start = end
+	}
+
+	if start < len(p) {
+		// save the rest of the buffer for the next call
+		lw.prev = append(lw.prev, p[start:]...)
+	}
+
+	return len(p), err
+}
+
+func (lw *LogWriter) write(b []byte) (int, error) {
+	var (
+		err  error
+		n, w int
+	)
+	for _, entry := range lw.split(b) {
+		w, err = lw.w.Write(entry)
+		n += w
+		if err != nil {
+			break
+		}
+	}
+	// if we have to return with error, we should let the caller know
+	// how many of the provided bytes were written, not including our header
+	return n - encodedHeaderLengthBytes, err
+}
+
+// split breaks a log entry into smaller entries if necessary, adding a header to each
+func (lw *LogWriter) split(b []byte) [][]byte {
+	// break the entry up into multiple entries if necessary
+	entries := [][]byte{}
+	for len(b) > maxEntrySizeBytes {
+		entries = append(entries, b[:maxEntrySizeBytes])
+		b = b[maxEntrySizeBytes:]
+	}
+	entries = append(entries, b)
+
+	for i := range entries {
+
+		entry := entries[i]
+
+		// Each entry has a 10-byte header that describes the entry as follows:
+		// The first 8 bytes are the timestamp in int64 unix epoch format
+		// The first 12 bits of the final two bytes represent the size of the entry
+		// 0x8 represents the stream - 0 for stdout, 1 for stderr
+		// 0x4 currently unused, reserved for a future flag
+		// 0x2 currently unused, reserved for a future flag
+		// 0x1 currently unused, reserved for a future flag
+		header := make([]byte, headerLengthBytes)
+		// prepare the header
+		size := len(entry)
+		s := uint16(size << 4) // make some room for stream and partial flags
+		stream := 0            // TODO(jzt): defaults to 0 (stdout) until we figure out how to add stream tag
+		s |= uint16(stream << 3)
+		binary.LittleEndian.PutUint64(header[:8], uint64(lw.Now().UTC().UnixNano()))
+		binary.LittleEndian.PutUint16(header[8:], s)
+
+		// base64 encode the header
+		encodedHeader := base64.StdEncoding.EncodeToString(header)
+		entries[i] = append([]byte(encodedHeader), entry...)
+	}
+	return entries
+}
+
+// Close will flush the remaining bytes that have not yet been written
+func (lw *LogWriter) Close() (err error) {
+	lw.m.Lock()
+	defer lw.m.Unlock()
+
+	if lw.closed {
+		return nil
+	}
+
+	// flush buffer if there are leftover bytes
+	if lw.prev != nil {
+		var n, w int
+		for n < len(lw.prev) {
+			w, err = lw.write(lw.prev[n:])
+			n += w
+			if err != nil {
+				break
+			}
+		}
+		// reset lw.prev
+		lw.prev = nil
+	}
+
+	if c, ok := lw.w.(io.Closer); ok {
+		c.Close()
+		lw.closed = true
+	}
+	return err
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -31,7 +31,7 @@ var (
 	State       string
 
 	// MaxPluginVersion must be increased to add new plugin and make sure the new plugin version is same to this value
-	MaxPluginVersion = 0
+	MaxPluginVersion = 1
 
 	v bool
 )

--- a/tests/test-cases/Group1-Docker-Commands/1-08-Docker-Logs.md
+++ b/tests/test-cases/Group1-Docker-Commands/1-08-Docker-Logs.md
@@ -26,13 +26,20 @@ This test requires that a vSphere server is running and available
 13. Issue docker logs <containerID> to the VIC appliance, waiting for the first 10 lines
 14. Issue docker kill -s HUP <containerID> to the VIC appliance, generating the next 10 lines
 15. Issue docker logs --tail=5 --follow <containerID> to the VIC appliance
-16. Issue docker logs --since=1s <containerID> to the VIC appliance
-17. Issue docker logs --timestamps <containerID> to the VIC appliance
-18. Issue docker logs
-19. Issue docker logs fakeContainer
+16. Issue docker pull ubuntu
+17. Issue docker run ubuntu /bin/cat /bin/hostname >/tmp/hostname
+18. Issue docker logs <containerID> >/tmp/hostname-logs
+19. Issue sha256sum on /tmp/hostname and /tmp/hostname-logs
+20. Issue docker run ubuntu /bin/ls >/tmp/ls
+21. Issue docker logs <containerID> >/tmp/ls-logs
+22. Issue sha256sum on /tmp/ls and /tmp/ls-logs
+23. Issue docker logs --since=1s <containerID> to the VIC appliance
+24. Issue docker logs --timestamps <containerID> to the VIC appliance
+25. Issue docker logs
+26. Issue docker logs fakeContainer
 
 #Expected Outcome:
-* Steps 2-15 should all complete without error
+* Steps 2-22 should all complete without error
 * Step 6 should output 200 lines
 * Step 7 should output 0 lines
 * Step 10 should have last line be
@@ -41,13 +48,14 @@ line 5
 ```
 * Step 13 should output 10 lines
 * Step 15 should output 15 lines
-* Step 16 should output 3 lines
-* Step 17 and 18 should result in an error with the following message:
+* Steps 19 and 22 should produce matching sha256 hashes for both files
+* Step 23 should output 3 lines
+* Step 24 should result in an error with the following message:
 ```
-Error: vSphere Integrated Containers does not yet support timestampped logs.
+Error: vSphere Integrated Containers does not yet support timestamped logs.
 ```
-* Step 18 should output all lines
-* Step 20 should result in an error with the following message:
+* Step 25 should output all lines
+* Step 26 should result in an error with the following message:
 ```
 Error: No such container: fakeContainer
 ```

--- a/tests/test-cases/Group1-Docker-Commands/1-08-Docker-Logs.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-08-Docker-Logs.robot
@@ -102,10 +102,42 @@ Docker logs follow shutdown
     Should Be Equal As Integers  ${rc}  0
     Should Be Equal  ${output}  ${buffer}\n${buffer}
 
+Docker binary logs
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} pull ubuntu
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run ubuntu /bin/cat /bin/hostname >/tmp/hostname
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${id}=  Run And Return Rc And Output  docker %{VCH-PARAMS} ps -a |grep ubuntu |awk '{print $1}'
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} logs ${id} >/tmp/hostname-log
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${h1}=  Run And Return Rc And Output  sha256sum /tmp/hostname |awk '{print $1}'
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${h2}=  Run And Return Rc And Output  sha256sum /tmp/hostname-log |awk '{print $1}'
+    Should Be Equal As Integers  ${rc}  0
+    Should Be Equal  ${h1}  ${h2}
+    ${rc}  ${output}=  Run And Return Rc And Output  rm /tmp/hostname*
+    Should Be Equal As Integers  ${rc}  0
+
+Docker text logs
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run ubuntu /bin/ls >/tmp/ls
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${id}=  Run And Return Rc And Output  docker %{VCH-PARAMS} ps -a |grep /bin/ls |awk '{print $1}'
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} logs ${id} >/tmp/ls-log
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${h1}=  Run And Return Rc And Output  sha256sum /tmp/ls |awk '{print $1}'
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${h2}=  Run And Return Rc And Output  sha256sum /tmp/ls-log |awk '{print $1}'
+    Should Be Equal As Integers  ${rc}  0
+    Should Be Equal  ${h1}  ${h2}
+    ${rc}  ${output}=  Run And Return Rc And Output  rm /tmp/ls*
+    Should Be Equal As Integers  ${rc}  0
+
 Docker logs with timestamps and since certain time
-    ${status}=  Get State Of Github Issue  1738
-    Run Keyword If  '${status}' == 'closed'  Fail  Test 1-8-Docker-Logs.robot needs to be updated now that Issue #366 has been resolved
-    Log  Issue \#1738 is blocking implementation  WARN
+    ${status}=  Get State Of Github Issue  2539
+    Run Keyword If  '${status}' == 'closed'  Fail  Test 1-8-Docker-Logs.robot needs to be updated now that Issue #2539 has been resolved
+    Log  Issue \#2539 is blocking implementation  WARN
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} pull busybox
     Should Be Equal As Integers  ${rc}  0
     ${rc}  ${containerID}=  Run And Return Rc And Output  docker %{VCH-PARAMS} create busybox /bin/sh -c 'a=0; while [ $a -lt 5 ]; do echo "line $a"; a=`expr $a + 1`; sleep 1; done;'


### PR DESCRIPTION
This change replaces #3882. Notable differences:

- The container output entries are persisted as bytes (no longer wrapped in JSON), each entry with a header containing a description about the entry
- `docker logs` can now faithfully reproduce binary data
- entries are broken into smaller pieces if they exceed a certain size
- renamed `jsonlog` package to `iolog` (feedback expected)
- design doc updated
- added some tests around correctly reproducing binary output
- added some tests around breaking up large entries
- brought unit tests up to date

TODO:
- figure out how to tag entries with stream (stdout/stderr) - #3954 

Follow-on issues: #3935, #2539, #3954

Fixes #1738 