### PR TITLE
[specific ci=1-13-Docker-Version] Change specific ci to run the regression suite too

### DIFF
--- a/tests/integration-test.sh
+++ b/tests/integration-test.sh
@@ -30,6 +30,7 @@ elif (echo $buildinfo | grep -q "\[specific ci="); then
     buildtype=$(echo $buildinfo | grep "\[specific ci=")
     testsuite=$(echo $buildtype | awk -v FS="(=|])" '{print $2}')
     pybot --removekeywords TAG:secret --suite $testsuite tests/test-cases
+    pybot --removekeywords TAG:secret --exclude skip --include regression tests/test-cases
 else
     pybot --removekeywords TAG:secret --exclude skip --include regression tests/test-cases
 fi


### PR DESCRIPTION
This changes the `specific ci` keyword's logic so that it always runs the regression suite along with the specific test/group.