### PR TITLE
Use DatastoreFileManager to delete files

### DIFF
--- a/lib/install/management/delete_test.go
+++ b/lib/install/management/delete_test.go
@@ -279,7 +279,8 @@ func testDeleteDatastoreFiles(v *validate.Validator, t *testing.T) {
 		return
 	}
 
-	if err = d.deleteFilesIteratively(m, ds, ds.Path("Test")); err != nil {
+	fm := ds.NewFileManager(d.session.Datacenter, true)
+	if err = d.deleteFilesIteratively(fm, ds, ds.Path("Test")); err != nil {
 		t.Errorf("Failed to delete recursively: %s", err)
 	}
 

--- a/lib/install/management/upgrade.go
+++ b/lib/install/management/upgrade.go
@@ -182,7 +182,7 @@ func (d *Dispatcher) deleteUpgradeImages(ds *object.Datastore, settings *data.In
 	// do clean up aggressively, even the previous operation failed with context deadline exceeded.
 	d.ctx = context.Background()
 
-	m := object.NewFileManager(ds.Client())
+	m := ds.NewFileManager(d.session.Datacenter, true)
 
 	file := ds.Path(path.Join(d.vmPathName, settings.ApplianceISO))
 	if err := d.deleteVMFSFiles(m, ds, file); err != nil {

--- a/pkg/vsphere/datastore/datastore.go
+++ b/pkg/vsphere/datastore/datastore.go
@@ -244,9 +244,7 @@ func (d *Helper) Mv(ctx context.Context, fromPath, toPath string) error {
 func (d *Helper) Rm(ctx context.Context, pth string) error {
 	f := path.Join(d.RootURL, pth)
 	log.Infof("Removing %s", pth)
-	return tasks.Wait(context.TODO(), func(ctx context.Context) (tasks.Task, error) {
-		return d.fm.DeleteDatastoreFile(ctx, f, d.s.Datacenter)
-	})
+	return d.ds.NewFileManager(d.s.Datacenter, true).Delete(ctx, f) // TODO: NewHelper should create the DatastoreFileManager
 }
 
 func (d *Helper) IsVSAN(ctx context.Context) bool {

--- a/pkg/vsphere/vm/vm.go
+++ b/pkg/vsphere/vm/vm.go
@@ -86,7 +86,7 @@ func (vm *VirtualMachine) FolderName(ctx context.Context) (string, error) {
 func (vm *VirtualMachine) DSPath(ctx context.Context) (url.URL, error) {
 	var mvm mo.VirtualMachine
 
-	if err := vm.Properties(ctx, vm.Reference(), []string{"runtime.host", "config"}, &mvm); err != nil {
+	if err := vm.Properties(ctx, vm.Reference(), []string{"config.files.vmPathName"}, &mvm); err != nil {
 		log.Errorf("Unable to get managed config for VM: %s", err)
 		return url.URL{}, err
 	}

--- a/vendor/github.com/vmware/govmomi/govc/datastore/cp.go
+++ b/vendor/github.com/vmware/govmomi/govc/datastore/cp.go
@@ -61,6 +61,14 @@ func (cmd *cp) Usage() string {
 	return "SRC DST"
 }
 
+func (cmd *cp) Description() string {
+	return `Copy SRC to DST on DATASTORE.
+
+Examples:
+  govc datastore.cp foo/foo.vmx foo/foo.vmx.old
+  govc datastore.cp -f my.vmx foo/foo.vmx`
+}
+
 func (cmd *cp) Run(ctx context.Context, f *flag.FlagSet) error {
 	args := f.Args()
 	if len(args) != 2 {

--- a/vendor/github.com/vmware/govmomi/govc/datastore/disk/create.go
+++ b/vendor/github.com/vmware/govmomi/govc/datastore/disk/create.go
@@ -1,0 +1,98 @@
+/*
+Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package disk
+
+import (
+	"context"
+	"flag"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/units"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type create struct {
+	*flags.DatastoreFlag
+
+	Bytes units.ByteSize
+}
+
+func init() {
+	cli.Register("datastore.disk.create", &create{})
+}
+
+func (cmd *create) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.DatastoreFlag, ctx = flags.NewDatastoreFlag(ctx)
+	cmd.DatastoreFlag.Register(ctx, f)
+
+	_ = cmd.Bytes.Set("10G")
+	f.Var(&cmd.Bytes, "size", "Size of new disk")
+}
+
+func (cmd *create) Process(ctx context.Context) error {
+	if err := cmd.DatastoreFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *create) Usage() string {
+	return "VMDK"
+}
+
+func (cmd *create) Description() string {
+	return `Create VMDK on DS.
+
+Examples:
+  govc datastore.mkdir disks
+  govc datastore.disk.create -size 24G disks/disk1.vmdk`
+}
+
+func (cmd *create) Run(ctx context.Context, f *flag.FlagSet) error {
+	if f.NArg() == 0 {
+		return flag.ErrHelp
+	}
+
+	dc, err := cmd.Datacenter()
+	if err != nil {
+		return err
+	}
+
+	ds, err := cmd.Datastore()
+	if err != nil {
+		return err
+	}
+
+	m := object.NewVirtualDiskManager(ds.Client())
+
+	spec := &types.FileBackedVirtualDiskSpec{
+		VirtualDiskSpec: types.VirtualDiskSpec{
+			AdapterType: string(types.VirtualDiskAdapterTypeLsiLogic),
+			DiskType:    string(types.VirtualDiskTypeThin),
+		},
+		CapacityKb: int64(cmd.Bytes) / 1024,
+	}
+
+	task, err := m.CreateVirtualDisk(ctx, ds.Path(f.Arg(0)), dc, spec)
+	if err != nil {
+		return err
+	}
+
+	return task.Wait(ctx)
+}

--- a/vendor/github.com/vmware/govmomi/govc/datastore/mv.go
+++ b/vendor/github.com/vmware/govmomi/govc/datastore/mv.go
@@ -54,6 +54,14 @@ func (cmd *mv) Usage() string {
 	return "SRC DST"
 }
 
+func (cmd *mv) Description() string {
+	return `Move SRC to DST on DATASTORE.
+
+Examples:
+  govc datastore.mv foo/foo.vmx foo/foo.vmx.old
+  govc datastore.mv -f my.vmx foo/foo.vmx`
+}
+
 func (cmd *mv) Run(ctx context.Context, f *flag.FlagSet) error {
 	args := f.Args()
 	if len(args) != 2 {

--- a/vendor/github.com/vmware/govmomi/govc/datastore/vsan/ls.go
+++ b/vendor/github.com/vmware/govmomi/govc/datastore/vsan/ls.go
@@ -1,0 +1,156 @@
+/*
+Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vsan
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"net/url"
+	"text/tabwriter"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25/mo"
+)
+
+type ls struct {
+	*flags.DatastoreFlag
+
+	long   bool
+	orphan bool
+}
+
+func init() {
+	cli.Register("datastore.vsan.dom.ls", &ls{})
+}
+
+func (cmd *ls) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.DatastoreFlag, ctx = flags.NewDatastoreFlag(ctx)
+	cmd.DatastoreFlag.Register(ctx, f)
+
+	f.BoolVar(&cmd.long, "l", false, "Long listing")
+	f.BoolVar(&cmd.orphan, "o", false, "List orphan objects")
+}
+
+func (cmd *ls) Process(ctx context.Context) error {
+	if err := cmd.DatastoreFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *ls) Usage() string {
+	return "[UUID]..."
+}
+
+func (cmd *ls) Description() string {
+	return `List vSAN DOM objects in DS.
+
+Examples:
+  govc datastore.vsan.dom.ls
+  govc datastore.vsan.dom.ls -ds vsanDatastore -l
+  govc datastore.vsan.dom.ls -l d85aa758-63f5-500a-3150-0200308e589c`
+}
+
+func (cmd *ls) Run(ctx context.Context, f *flag.FlagSet) error {
+	ds, err := cmd.Datastore()
+	if err != nil {
+		return err
+	}
+
+	var mds mo.Datastore
+	err = ds.Properties(ctx, ds.Reference(), []string{"summary"}, &mds)
+	if err != nil {
+		return err
+	}
+
+	if mds.Summary.Type != "vsan" {
+		return flag.ErrHelp
+	}
+
+	hosts, err := ds.AttachedHosts(ctx)
+	if err != nil {
+		return err
+	}
+
+	if len(hosts) == 0 {
+		return flag.ErrHelp
+	}
+
+	m, err := hosts[0].ConfigManager().VsanInternalSystem(ctx)
+	if err != nil {
+		return err
+	}
+
+	ids, err := m.QueryVsanObjectUuidsByFilter(ctx, f.Args(), 0, 0)
+	if err != nil {
+		return err
+	}
+
+	if len(ids) == 0 {
+		return nil
+	}
+
+	if !cmd.long && !cmd.orphan {
+		for _, id := range ids {
+			fmt.Fprintln(cmd.Out, id)
+		}
+
+		return nil
+	}
+
+	objs, err := m.GetVsanObjExtAttrs(ctx, ids)
+	if err != nil {
+		return err
+	}
+
+	u, err := url.Parse(mds.Summary.Url)
+	if err != nil {
+		return err
+	}
+
+	tw := tabwriter.NewWriter(cmd.Out, 2, 0, 2, ' ', 0)
+	cmd.Out = tw
+
+	for id, obj := range objs {
+		path := obj.DatastorePath(u.Path)
+
+		if cmd.orphan {
+			_, err = ds.Stat(ctx, path)
+			if err == nil {
+				continue
+			}
+
+			switch err.(type) {
+			case object.DatastoreNoSuchDirectoryError, object.DatastoreNoSuchFileError:
+			default:
+				return err
+			}
+
+			if !cmd.long {
+				fmt.Fprintln(cmd.Out, id)
+				continue
+			}
+		}
+
+		fmt.Fprintf(cmd.Out, "%s\t%s\t%s\n", id, obj.Class, path)
+	}
+
+	return tw.Flush()
+}

--- a/vendor/github.com/vmware/govmomi/govc/main.go
+++ b/vendor/github.com/vmware/govmomi/govc/main.go
@@ -25,6 +25,8 @@ import (
 	_ "github.com/vmware/govmomi/govc/cluster"
 	_ "github.com/vmware/govmomi/govc/datacenter"
 	_ "github.com/vmware/govmomi/govc/datastore"
+	_ "github.com/vmware/govmomi/govc/datastore/disk"
+	_ "github.com/vmware/govmomi/govc/datastore/vsan"
 	_ "github.com/vmware/govmomi/govc/device"
 	_ "github.com/vmware/govmomi/govc/device/cdrom"
 	_ "github.com/vmware/govmomi/govc/device/floppy"

--- a/vendor/github.com/vmware/govmomi/govc/vm/disk/create.go
+++ b/vendor/github.com/vmware/govmomi/govc/vm/disk/create.go
@@ -89,6 +89,13 @@ func (cmd *create) Process(ctx context.Context) error {
 	return nil
 }
 
+func (cmd *create) Description() string {
+	return `Create disk and attach to VM.
+
+Examples:
+  govc vm.disk.create -vm $name -name $name/disk1 -size 10G`
+}
+
 func (cmd *create) Run(ctx context.Context, f *flag.FlagSet) error {
 	if len(cmd.Name) == 0 {
 		return errors.New("please specify a disk name")

--- a/vendor/github.com/vmware/govmomi/object/datastore_file_manager.go
+++ b/vendor/github.com/vmware/govmomi/object/datastore_file_manager.go
@@ -1,0 +1,145 @@
+/*
+Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package object
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"log"
+	"path"
+	"strings"
+
+	"github.com/vmware/govmomi/vim25/soap"
+)
+
+// DatastoreFileManager combines FileManager and VirtualDiskManager to manage files on a Datastore
+type DatastoreFileManager struct {
+	Datacenter         *Datacenter
+	Datastore          *Datastore
+	FileManager        *FileManager
+	VirtualDiskManager *VirtualDiskManager
+
+	Force bool
+}
+
+// NewFileManager creates a new instance of DatastoreFileManager
+func (d Datastore) NewFileManager(dc *Datacenter, force bool) *DatastoreFileManager {
+	c := d.Client()
+
+	m := &DatastoreFileManager{
+		Datacenter:         dc,
+		Datastore:          &d,
+		FileManager:        NewFileManager(c),
+		VirtualDiskManager: NewVirtualDiskManager(c),
+		Force:              force,
+	}
+
+	return m
+}
+
+// Delete dispatches to the appropriate Delete method based on file name extension
+func (m *DatastoreFileManager) Delete(ctx context.Context, name string) error {
+	switch path.Ext(name) {
+	case ".vmdk":
+		return m.DeleteVirtualDisk(ctx, name)
+	default:
+		return m.DeleteFile(ctx, name)
+	}
+}
+
+// DeleteFile calls FileManager.DeleteDatastoreFile
+func (m *DatastoreFileManager) DeleteFile(ctx context.Context, name string) error {
+	p := m.Path(name)
+
+	task, err := m.FileManager.DeleteDatastoreFile(ctx, p.String(), m.Datacenter)
+	if err != nil {
+		return err
+	}
+
+	return task.Wait(ctx)
+}
+
+// DeleteVirtualDisk calls VirtualDiskManager.DeleteVirtualDisk
+// Regardless of the Datastore type, DeleteVirtualDisk will fail if 'ddb.deletable=false',
+// so if Force=true this method attempts to set 'ddb.deletable=true' before starting the delete task.
+func (m *DatastoreFileManager) DeleteVirtualDisk(ctx context.Context, name string) error {
+	p := m.Path(name)
+
+	var merr error
+
+	if m.Force {
+		merr = m.markDiskAsDeletable(ctx, p)
+	}
+
+	task, err := m.VirtualDiskManager.DeleteVirtualDisk(ctx, p.String(), m.Datacenter)
+	if err != nil {
+		log.Printf("markDiskAsDeletable(%s): %s", p, merr)
+		return err
+	}
+
+	return task.Wait(ctx)
+}
+
+// Path converts path name to a DatastorePath
+func (m *DatastoreFileManager) Path(name string) *DatastorePath {
+	var p DatastorePath
+
+	if !p.FromString(name) {
+		p.Path = name
+		p.Datastore = m.Datastore.Name()
+	}
+
+	return &p
+}
+
+func (m *DatastoreFileManager) markDiskAsDeletable(ctx context.Context, path *DatastorePath) error {
+	r, _, err := m.Datastore.Download(ctx, path.Path, &soap.DefaultDownload)
+	if err != nil {
+		return err
+	}
+
+	defer r.Close()
+
+	hasFlag := false
+	buf := new(bytes.Buffer)
+
+	s := bufio.NewScanner(&io.LimitedReader{R: r, N: 2048}) // should be only a few hundred bytes, limit to be sure
+
+	for s.Scan() {
+		line := s.Text()
+		if strings.HasPrefix(line, "ddb.deletable") {
+			hasFlag = true
+			continue
+		}
+
+		fmt.Fprintln(buf, line)
+	}
+
+	if err := s.Err(); err != nil {
+		return err // any error other than EOF
+	}
+
+	if !hasFlag {
+		return nil // already deletable, so leave as-is
+	}
+
+	// rewrite the .vmdk with ddb.deletable flag removed (the default is true)
+	return m.Datastore.Upload(ctx, buf, path.Path, &soap.DefaultUpload)
+}

--- a/vendor/github.com/vmware/govmomi/object/host_config_manager.go
+++ b/vendor/github.com/vmware/govmomi/object/host_config_manager.go
@@ -105,6 +105,22 @@ func (m HostConfigManager) VsanSystem(ctx context.Context) (*HostVsanSystem, err
 	return NewHostVsanSystem(m.c, *h.ConfigManager.VsanSystem), nil
 }
 
+func (m HostConfigManager) VsanInternalSystem(ctx context.Context) (*HostVsanInternalSystem, error) {
+	var h mo.HostSystem
+
+	err := m.Properties(ctx, m.Reference(), []string{"configManager.vsanInternalSystem"}, &h)
+	if err != nil {
+		return nil, err
+	}
+
+	// Added in 5.5
+	if h.ConfigManager.VsanInternalSystem == nil {
+		return nil, ErrNotSupported
+	}
+
+	return NewHostVsanInternalSystem(m.c, *h.ConfigManager.VsanInternalSystem), nil
+}
+
 func (m HostConfigManager) AccountManager(ctx context.Context) (*HostAccountManager, error) {
 	var h mo.HostSystem
 

--- a/vendor/github.com/vmware/govmomi/object/host_vsan_internal_system.go
+++ b/vendor/github.com/vmware/govmomi/object/host_vsan_internal_system.go
@@ -1,0 +1,117 @@
+/*
+Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package object
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/vmware/govmomi/vim25"
+	"github.com/vmware/govmomi/vim25/methods"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type HostVsanInternalSystem struct {
+	Common
+}
+
+func NewHostVsanInternalSystem(c *vim25.Client, ref types.ManagedObjectReference) *HostVsanInternalSystem {
+	m := HostVsanInternalSystem{
+		Common: NewCommon(c, ref),
+	}
+
+	return &m
+}
+
+// QueryVsanObjectUuidsByFilter returns vSAN DOM object uuids by filter.
+func (m HostVsanInternalSystem) QueryVsanObjectUuidsByFilter(ctx context.Context, uuids []string, limit int32, version int32) ([]string, error) {
+	req := types.QueryVsanObjectUuidsByFilter{
+		This:    m.Reference(),
+		Uuids:   uuids,
+		Limit:   limit,
+		Version: version,
+	}
+
+	res, err := methods.QueryVsanObjectUuidsByFilter(ctx, m.Client(), &req)
+	if err != nil {
+		return nil, err
+	}
+
+	return res.Returnval, nil
+}
+
+type VsanObjExtAttrs struct {
+	Type  string `json:"Object type"`
+	Class string `json:"Object class"`
+	Size  string `json:"Object size"`
+	Path  string `json:"Object path"`
+	Name  string `json:"User friendly name"`
+}
+
+func (a *VsanObjExtAttrs) DatastorePath(dir string) string {
+	l := len(dir)
+	path := a.Path
+
+	if len(path) >= l {
+		path = a.Path[l:]
+	}
+
+	if path != "" {
+		return path
+	}
+
+	return a.Name // vmnamespace
+}
+
+// GetVsanObjExtAttrs is internal and intended for troubleshooting/debugging situations in the field.
+// WARNING: This API can be slow because we do IOs (reads) to all the objects.
+func (m HostVsanInternalSystem) GetVsanObjExtAttrs(ctx context.Context, uuids []string) (map[string]VsanObjExtAttrs, error) {
+	req := types.GetVsanObjExtAttrs{
+		This:  m.Reference(),
+		Uuids: uuids,
+	}
+
+	res, err := methods.GetVsanObjExtAttrs(ctx, m.Client(), &req)
+	if err != nil {
+		return nil, err
+	}
+
+	var attrs map[string]VsanObjExtAttrs
+
+	err = json.Unmarshal([]byte(res.Returnval), &attrs)
+
+	return attrs, err
+}
+
+// DeleteVsanObjects is internal and intended for troubleshooting/debugging only.
+// WARNING: This API can be slow because we do IOs to all the objects.
+// DOM won't allow access to objects which have lost quorum. Such objects can be deleted with the optional "force" flag.
+// These objects may however re-appear with quorum if the absent components come back (network partition gets resolved, etc.)
+func (m HostVsanInternalSystem) DeleteVsanObjects(ctx context.Context, uuids []string, force *bool) ([]types.HostVsanInternalSystemDeleteVsanObjectsResult, error) {
+	req := types.DeleteVsanObjects{
+		This:  m.Reference(),
+		Uuids: uuids,
+		Force: force,
+	}
+
+	res, err := methods.DeleteVsanObjects(ctx, m.Client(), &req)
+	if err != nil {
+		return nil, err
+	}
+
+	return res.Returnval, nil
+}

--- a/vendor/manifest
+++ b/vendor/manifest
@@ -953,7 +953,7 @@
 			"importpath": "github.com/vmware/govmomi",
 			"repository": "https://github.com/vmware/govmomi",
 			"vcs": "git",
-			"revision": "1f82c282854c695bfe261885847cf84aeae6db46",
+			"revision": "f4a3ffe52df6113f08a3c68e473ab6ff7dad28cf",
 			"branch": "master"
 		},
 		{


### PR DESCRIPTION
Use DatastoreFileManager to delete files

DatastoreFileManager is a new govmomi helper that combines
FileManager, VirtualDiskManager and Datastore types for managing
files on a datastore.

For now the focus is on deleting files, and in particular, not leaking
DOM objects on vSAN.

Fixes #3931
