### PR TITLE
[full ci]Implement the in memory migration of container configs in the container cache

### DIFF
--- a/lib/config/executor/container_vm.go
+++ b/lib/config/executor/container_vm.go
@@ -143,6 +143,9 @@ type ExecutorConfig struct {
 
 	// version
 	Version *version.Build `vic:"0.1" scope:"read-only" key:"version"`
+
+	// migrated - this is used during in memory migration to assign whether an execConfig is viable for a commit phase
+	Migrated bool
 }
 
 // Cmd is here because the encoding packages seem to have issues with the full exec.Cmd struct

--- a/lib/portlayer/exec/commit.go
+++ b/lib/portlayer/exec/commit.go
@@ -35,6 +35,13 @@ func Commit(ctx context.Context, sess *session.Session, h *Handle, waitTime *int
 	defer trace.End(trace.Begin(h.ExecConfig.ID))
 
 	c := Containers.Container(h.ExecConfig.ID)
+
+	// check for an in memory container migration and reject the commit if it is the case.
+	if c.ExecConfig.Migrated {
+		log.Errorf("rejecting commit to container (%s) due to in memory migration of the container's ExecConfig", h.ExecConfig.ID)
+		return fmt.Errorf("container (%s) cannot complete this operation due to a previous migration.", h.ExecConfig.ID)
+	}
+
 	creation := h.vm == nil
 	if creation {
 		if h.Spec == nil {


### PR DESCRIPTION
fixes #3610

The first thing to note is that some documentation changes will be needed to inform users of the possibility that a migrated container will be restricted in viable commands.

This PR is intended to check the container cache for needed ExecConfig migrations after an upgrade. It should mark containers that are migrated and cannot have their configs committed back to the vm's config in vsphere. To do this it should check during the commit phase of operations and reject any commit that involves a config marked as migrated in the cache.
