### PR TITLE
Increase Karma's tolerance on browser fails

### DIFF
--- a/ui/vic-ui-h5c/vic/src/vic-app/config/karma.conf.js
+++ b/ui/vic-ui-h5c/vic/src/vic-app/config/karma.conf.js
@@ -56,6 +56,10 @@ module.exports = function (config) {
         logLevel: config.LOG_INFO,
         autoWatch: true,
         browsers: ['PhantomJS'],
-        singleRun: true
+        singleRun: true,
+        captureTimeout: 60000,
+        browserDisconnectTimeout: 10000,
+        browserNoActivityTimeout: 60000,
+        browserDisconnectTolerance: 3
     });
 };


### PR DESCRIPTION
This PR addresses an issue that randomly breaks the CI build process. The issue is caused by Karma failing to connect to the test server. This PR increases tolerance by making Karma try up to 3 times before giving up, and making it wait longer before timeouts.

Fixes #4046 