### PR TITLE
Add Docker container event support

### DIFF
--- a/cmd/docker/main.go
+++ b/cmd/docker/main.go
@@ -102,6 +102,8 @@ func main() {
 		log.Fatalf("failed to initialize backend: %s", err)
 	}
 
+	plEventMonitor := vicbackends.NewPortlayerEventMonitor(vicbackends.PlEventProxy{}, vicbackends.DockerEventPublisher{})
+	plEventMonitor.Start()
 	// Start API server wit options from command line args
 	api := startServer()
 
@@ -115,6 +117,7 @@ func main() {
 	})
 
 	<-serveAPIWait
+	plEventMonitor.Stop()
 }
 
 func handleFlags() bool {

--- a/lib/apiservers/engine/backends/backends.go
+++ b/lib/apiservers/engine/backends/backends.go
@@ -26,6 +26,7 @@ import (
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/docker/docker/registry"
+	"github.com/docker/docker/daemon/events"
 	rc "github.com/go-openapi/runtime/client"
 	"github.com/go-openapi/swag"
 
@@ -62,6 +63,8 @@ var (
 
 	insecureRegistries []string
 	RegistryCertPool   *x509.CertPool
+
+	eventService      *events.Events
 )
 
 func Init(portLayerAddr, product string, config *config.VirtualContainerHostConfigSpec, insecureRegs []url.URL) error {
@@ -114,6 +117,8 @@ func Init(portLayerAddr, product string, config *config.VirtualContainerHostConf
 	if len(insecureRegistries) > 0 {
 		serviceOptions.InsecureRegistries = insecureRegistries
 	}
+
+	eventService = events.New()
 
 	return nil
 }
@@ -333,4 +338,8 @@ func loadRegistryCACerts() {
 	RegistryCertPool = rootCertPool
 
 	log.Debugf("Loaded %d CAs for registries from config", len(rootCertPool.Subjects()))
+}
+
+func EventService() *events.Events {
+	return eventService
 }

--- a/lib/apiservers/engine/backends/eventmonitor.go
+++ b/lib/apiservers/engine/backends/eventmonitor.go
@@ -1,0 +1,217 @@
+// Copyright 2017 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package backends
+
+//**** eventmonitor.go
+//
+// Handles monitoring of events from the portlayer.  Events that are applicable to
+// Docker events are then translated and published to the Docker event subscribers.
+// NOTE:  This does not handle all Docker events.  In fact, most docker events are
+// passively handled by API calls in the backend routers, with no feedback from
+// the portlayer.
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+	"sync"
+
+	"golang.org/x/net/context"
+	log "github.com/Sirupsen/logrus"
+
+	"github.com/vmware/vic/lib/apiservers/engine/backends/cache"
+   	"github.com/vmware/vic/lib/apiservers/portlayer/client/events"
+	plevents "github.com/vmware/vic/lib/portlayer/event/events"
+	"github.com/vmware/vic/pkg/trace"
+
+	eventtypes "github.com/docker/docker/api/types/events"
+)
+
+// for unit testing purposes
+type eventproxy interface {
+	StreamEvents(ctx context.Context, out io.Writer) error
+}
+
+type eventpublisher interface {
+	PublishEvent(event plevents.BaseEvent)
+}
+
+type PlEventProxy struct {
+}
+
+type DockerEventPublisher struct {
+}
+
+type PortlayerEventMonitor struct {
+	stop		chan struct{}
+	proxy		eventproxy
+	publisher	eventpublisher
+}
+
+// StreamEvents() handles all swagger interaction to the Portlayer's event manager
+//
+// Input:
+//	context and a io.Writer
+func (ep PlEventProxy) StreamEvents(ctx context.Context, out io.Writer) error {
+	defer trace.End(trace.Begin(""))
+
+	plClient := PortLayerClient()
+	if plClient == nil {
+		return InternalServerError("eventproxy.StreamEvents failed to get a portlayer client")
+	}
+
+	params := events.NewGetEventsParamsWithContext(ctx)
+	if _, err := plClient.Events.GetEvents(params, out); err != nil {
+		switch err := err.(type) {
+		case *events.GetEventsInternalServerError:
+			return InternalServerError("Server error from the events port layer")
+		default:
+			//Check for EOF.  Since the connection, transport, and data handling are
+			//encapsulated inside of Swagger, we can only detect EOF by checking the
+			//error string
+			if strings.Contains(err.Error(), swaggerSubstringEOF) {
+				return nil
+			}
+			return InternalServerError(fmt.Sprintf("Unknown error from the interaction port layer: %s", err))
+		}
+	}
+
+	return nil	
+}
+
+func NewPortlayerEventMonitor(proxy eventproxy, publisher eventpublisher) *PortlayerEventMonitor {
+	return &PortlayerEventMonitor{proxy: proxy, publisher: publisher}
+}
+
+// Start() starts the portlayer event monitoring
+func (m *PortlayerEventMonitor) Start() error {
+	defer trace.End(trace.Begin(""))
+
+	if m.stop != nil {
+		return fmt.Errorf("Portlayer event monitor: Already started")
+	}
+
+	m.stop = make(chan struct{})
+	go m.monitor()
+
+	return nil
+}
+
+// Stop() stops the portlayer event monitoring
+func (m *PortlayerEventMonitor) Stop() {
+	defer trace.End(trace.Begin(""))
+
+	if m.stop != nil {
+		close(m.stop)
+	}
+}
+
+// monitor() establishes a streaming connection to the portlayer's event
+// endpoint, decodes the results, translate it to Docker events if needed,
+// and publishes the event to Docker event subscribers.
+func (m *PortlayerEventMonitor) monitor() error {
+	defer trace.End(trace.Begin(""))
+
+	var wg sync.WaitGroup
+	errors := make(chan error, 2)
+
+	reader, writer := io.Pipe()
+	ctx, cancel := context.WithCancel(context.TODO())
+	// Start streaming events
+	wg.Add(1)
+	go func() {
+		var err error
+
+		defer wg.Done()
+
+		if err = m.proxy.StreamEvents(ctx, writer); err != nil {
+			if ctx.Err() != context.Canceled {
+				log.Warnf("Event streaming from portlayer returned: %#v", err)
+			}
+		}
+		if ctx.Err() == context.Canceled {
+			log.Infof("Event streaming from portlayer was cancelled")
+			return
+		}
+		errors <- err
+
+		writer.Close()
+		reader.Close()
+	}()
+
+	// Start decoding event stream json
+	wg.Add(1)
+	go func() {
+		var err error
+		var event plevents.BaseEvent
+
+		defer wg.Done()
+
+		decoder := json.NewDecoder(reader)
+		for decoder.More() {
+			if err = decoder.Decode(&event); err == nil {
+				m.publisher.PublishEvent(event)
+			}
+		}
+		errors <- err
+
+		reader.Close()
+		writer.Close()
+	}()
+
+
+	// Create a channel signaling when the waitgroup finishes
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(errors)
+		close(done)
+	}()
+
+	select{
+		case <- done:
+			for err := range errors {
+				if err != nil {
+					log.Warnf("Exiting Events Monitor: %#v", err)
+					return err
+				}
+			}
+		case <- m.stop:
+			cancel()
+			writer.Close()
+			reader.Close()
+	}
+
+	return nil
+}
+
+// publishEvent() translate a portlayer event into a Docker event if the event is for a
+// known container and publishes them to Docker event subscribers.  Currently, it only
+// looks for stopped events.
+func (p DockerEventPublisher) PublishEvent(event plevents.BaseEvent) {
+	defer trace.End(trace.Begin(""))
+
+	vc := cache.ContainerCache().GetContainer(event.Ref)
+	if vc == nil {
+		log.Errorf("Portlayer event for container %s but not found in cache", event.Ref)
+	}
+
+	if event.Event == plevents.ContainerStopped {
+		log.Debugf("Sending event for continer %s", vc.ContainerID)
+		actor := CreateContainerEventActorWithAttributes(vc, map[string]string{})
+		EventService().Log("die", eventtypes.ContainerEventType, actor)
+	}
+}

--- a/lib/apiservers/engine/backends/eventmonitor_test.go
+++ b/lib/apiservers/engine/backends/eventmonitor_test.go
@@ -1,0 +1,136 @@
+// Copyright 2017 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package backends
+
+import (
+    "encoding/json"
+    "fmt"
+    "io"
+	"testing"
+    "time"
+
+	"golang.org/x/net/context"
+
+	plevents "github.com/vmware/vic/lib/portlayer/event/events"
+	"github.com/stretchr/testify/assert"
+)
+
+type MockEventProxy struct {
+    MockEvents  []plevents.BaseEvent
+    Delay       time.Duration
+}
+
+type MockEventPublisher struct {
+    MockEventChan   chan plevents.BaseEvent
+}
+
+func (ep *MockEventProxy) StreamEvents(ctx context.Context, out io.Writer) error {
+    encoder := json.NewEncoder(out)
+    if encoder == nil {
+        return fmt.Errorf("Failed to create a json encoder")
+    }
+
+    for _, event := range ep.MockEvents {
+        if err := encoder.Encode(event); err != nil {
+            return err
+        }
+
+        time.Sleep(ep.Delay)
+    }
+
+    return nil
+}
+
+func (p *MockEventPublisher) PublishEvent(event plevents.BaseEvent) {
+    if (p.MockEventChan != nil) {
+        p.MockEventChan <- event
+    }
+}
+
+func TestStartStopMonitor(t *testing.T) {
+    proxy := MockEventProxy{
+        MockEvents: []plevents.BaseEvent{
+            {
+                Event: plevents.ContainerCreated,
+                Ref: "abc",
+            },
+            {
+                Event: plevents.ContainerStarted,
+                Ref: "abc",
+            },
+            {
+                Event: plevents.ContainerStopped,
+                Ref: "abc",
+            },           
+        },
+        Delay: 1*time.Second,
+    }
+    publisher := MockEventPublisher{
+        MockEventChan: make(chan plevents.BaseEvent, 3),
+    }
+    monitor := NewPortlayerEventMonitor(&proxy, &publisher)
+
+    var err error
+
+    // The actual tests
+    err = monitor.Start()
+    assert.Nil(t, err, "Expected monitor start to succeed, but received: %#v", err)
+
+    err = monitor.Start()
+    assert.NotEqual(t, err, nil, "Expected error but received nil on double start")
+    if err != nil {
+        assert.Contains(t, err.Error(), "Already started", "Expected already started error but received: %s", err)
+    }
+
+    monitor.Stop()
+}
+
+func TestEventMonitor(t *testing.T) {
+   proxy := MockEventProxy{
+        MockEvents: []plevents.BaseEvent{
+            {
+                Event: plevents.ContainerCreated,
+                Ref: "abc",
+            },
+            {
+                Event: plevents.ContainerStarted,
+                Ref: "abc",
+            },
+            {
+                Event: plevents.ContainerStopped,
+                Ref: "abc",
+            },           
+        },
+        Delay: 0,
+    }
+    publisher := MockEventPublisher{
+        MockEventChan: make(chan plevents.BaseEvent, 3),
+    }
+    monitor := NewPortlayerEventMonitor(&proxy, &publisher)
+
+    var err error
+
+    // The actual tests
+    err = monitor.Start()
+    assert.Nil(t, err, "Expected monitor start to succeed, but received: %#v", err)
+
+    time.Sleep(1*time.Second)
+
+    count := len(publisher.MockEventChan)
+    for i := 0; i<count; i++ {
+        event := <- publisher.MockEventChan
+        assert.Equal(t, event.Event, proxy.MockEvents[i].Event, "Expected to find event %s but found %s", proxy.MockEvents[i].Event, event.Event)
+    }
+}


### PR DESCRIPTION
Added passive docker events for containers and images.  Volumes
and networks events not yet added.  Also added monitoring of the
portlayer's event stream for container stop event.  Added support
for Docker's pubsub for events.

Resolves #367 and #3720