### PR TITLE
[specific ci=1-13-Docker-Version] Fix log collection in specific ci logic

### DIFF
--- a/tests/integration-test.sh
+++ b/tests/integration-test.sh
@@ -29,8 +29,7 @@ elif grep -q "\[full ci\]" <(drone build info vmware/vic $DRONE_BUILD_NUMBER); t
 elif (echo $buildinfo | grep -q "\[specific ci="); then
     buildtype=$(echo $buildinfo | grep "\[specific ci=")
     testsuite=$(echo $buildtype | awk -v FS="(=|])" '{print $2}')
-    pybot --removekeywords TAG:secret --suite $testsuite tests/test-cases
-    pybot --removekeywords TAG:secret --exclude skip --include regression tests/test-cases
+    pybot --removekeywords TAG:secret --suite $testsuite --suite 7-01-Regression tests/test-cases
 else
     pybot --removekeywords TAG:secret --exclude skip --include regression tests/test-cases
 fi


### PR DESCRIPTION
This change fixes an issue with `specific ci` where the pybot log files (most importantly, `log.html`) of the chosen test suite would get overwritten by those of the regression suite.

The issue was seen in https://ci.vmware.run/vmware/vic/8229 and future `specific ci` builds.
