### PR TITLE
Fix broken portlets

### DIFF
--- a/ui/vic-ui-h5c/vic/src/main/webapp/plugin.xml
+++ b/ui/vic-ui-h5c/vic/src/main/webapp/plugin.xml
@@ -99,20 +99,6 @@
        </object>
    </extension>
 
-   <extension id="com.vmware.vic.objectView.monitorView">
-       <extendedPoint>com.vmware.vic.objectView.monitorViews</extendedPoint>
-       <object>
-           <name>MONITOR</name>
-           <componentClass className="com.vmware.vsphere.client.htmlbridge.HtmlView">
-               <object>
-                   <root>
-                       <url>/vsphere-client/chassisa/resources/chassis-summary.html</url>
-                   </root>
-               </object>
-           </componentClass>
-       </object>
-   </extension>
-
    <extension id="com.vmware.vic.homeShortcut">
        <extendedPoint>vise.home.shortcuts</extendedPoint>
        <object>

--- a/ui/vic-ui-h5c/vic/src/vic-app/src/app/app.module.ts
+++ b/ui/vic-ui-h5c/vic/src/vic-app/src/app/app.module.ts
@@ -16,7 +16,6 @@
 
 import { NgModule, ErrorHandler } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
-import { FormsModule } from '@angular/forms';
 import { HttpModule } from '@angular/http';
 
 import { ClarityModule } from 'clarity-angular';
@@ -63,7 +62,7 @@ import { AppComponent } from './app.component';
         DataPropertyService,
         { provide: ErrorHandler, useClass: AppErrorHandler }
     ],
-    bootstrap: [ AppComponent ]
+    bootstrap: [AppComponent]
 })
 export class AppModule {
 

--- a/ui/vic-ui-h5c/vic/src/vic-app/src/app/services/data-property.service.ts
+++ b/ui/vic-ui-h5c/vic/src/vic-app/src/app/services/data-property.service.ts
@@ -46,9 +46,10 @@ export class DataPropertyService {
     constructor(
         private http: Http,
         private gs: GlobalsService
-    ) {
-        // retrieve objectId from the frame's URL
-        this._objectId = this.gs.getWebPlatform().getObjectId();
+    ) {}
+
+    setObjectId(id: string) {
+        this._objectId = id;
     }
 
     /**

--- a/ui/vic-ui-h5c/vic/src/vic-app/src/app/shared/dev/webPlatformStub.ts
+++ b/ui/vic-ui-h5c/vic/src/vic-app/src/app/shared/dev/webPlatformStub.ts
@@ -32,7 +32,6 @@ export const webPlatformStub: WebPlatform = {
    },
    getClientVersion(): string { return '6.5.0'; },
    getClientType(): string { return 'html'; },
-   getObjectId(): string { return 'some-random-value'; },
 
    getRootPath(): string {
       // FIXME: change it to 3000 later

--- a/ui/vic-ui-h5c/vic/src/vic-app/src/app/shared/vSphereClientSdkTypes.ts
+++ b/ui/vic-ui-h5c/vic/src/vic-app/src/app/shared/vSphereClientSdkTypes.ts
@@ -24,7 +24,6 @@ export interface WebPlatform {
    closeDialog(): void;
    getClientType(): string;
    getClientVersion(): string;
-   getObjectId(): string;
    getString(bundleName: string, key: string, params: any): string;
    getRootPath(): string;
    getUserSession(): UserSession;

--- a/ui/vic-ui-h5c/vic/src/vic-app/src/app/summary-portlet/summary-portlet.component.ts
+++ b/ui/vic-ui-h5c/vic/src/vic-app/src/app/summary-portlet/summary-portlet.component.ts
@@ -77,7 +77,12 @@ export class VicSummaryPortletComponent implements
 
     ngAfterViewInit() {
         setTimeout(() => {
-            this.service.fetchVmInfo(VM_PROPERTIES_TO_EXTRACT, this.stubType);
+            // set up objectId in data property service
+            this.route.params.subscribe((params: any) => {
+                this.service.setObjectId(params.id);
+                this.service.fetchVmInfo(VM_PROPERTIES_TO_EXTRACT, this.stubType);
+                console.log(`objectId set to ${params.id}`);
+            });
         });
     }
 


### PR DESCRIPTION
This PR fixes #4111 by passing the Object ID from `app-routing.component.ts` to the `DataPropertyService` via `SummaryPortletComponent`. It no longer depends on platform API.