### PR TITLE
[specific ci=1-13-Docker-Version] Lower min API version to 1.19

### DIFF
--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -39,7 +39,7 @@ var (
 const (
 	DockerAPIVersion     = "1.25"
 	DockerDefaultVersion = "1.25"
-	DockerMinimumVersion = "1.23"
+	DockerMinimumVersion = "1.19"
 )
 
 type Build struct {

--- a/tests/test-cases/Group1-Docker-Commands/1-13-Docker-Version.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-13-Docker-Version.robot
@@ -51,7 +51,7 @@ Docker1.13 Version Format Server API Version
 Docker1.13 Version Format Server Minimum API Version
     ${rc}  ${output}=  Run And Return Rc And Output  docker1.13 %{VCH-PARAMS} version --format '{{.Server.MinAPIVersion}}'
     Should Be Equal As Integers  ${rc}  0
-    Should Be Equal As Strings  ${output}  1.23
+    Should Be Equal As Strings  ${output}  1.19
 
 Docker Version Format Server Go Version
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} version --format '{{.Server.GoVersion}}'


### PR DESCRIPTION
Set the minimum API version to 1.19, the lowest version
needed to support Admiral that shipped with VIC 1.0.

Resolves #4118
