### PR TITLE
[specific ci=Group11-Upgrade] vic-machine upgrade --rollback

### DIFF
--- a/cmd/vic-machine/upgrade/upgrade.go
+++ b/cmd/vic-machine/upgrade/upgrade.go
@@ -59,10 +59,9 @@ func (u *Upgrade) Flags() []cli.Flag {
 			Usage:       "Time to wait for upgrade",
 			Destination: &u.Timeout,
 		},
-		cli.IntFlag{
+		cli.BoolFlag{
 			Name:        "rollback",
-			Value:       0,
-			Usage:       "Rollback n versions, e.g. --rollback=1 to go to the version before the last upgrade",
+			Usage:       "Roll back VCH version to before the previous upgrade",
 			Destination: &u.Rollback,
 		},
 	}
@@ -163,7 +162,7 @@ func (u *Upgrade) Run(clic *cli.Context) (err error) {
 	vConfig.Timeout = u.Timeout
 
 	// only care about versions if we're not doing a manual rollback
-	if u.Data.Rollback <= 0 {
+	if !u.Data.Rollback {
 		if err := validator.AssertVersion(vchConfig); err != nil {
 			log.Error(err)
 			return errors.New("upgrade failed")
@@ -176,7 +175,7 @@ func (u *Upgrade) Run(clic *cli.Context) (err error) {
 		return errors.New("upgrade failed")
 	}
 
-	if u.Data.Rollback <= 0 {
+	if !u.Data.Rollback {
 		err = executor.Upgrade(vch, vchConfig, vConfig)
 	} else {
 		err = executor.Rollback(vch, vchConfig, vConfig)

--- a/cmd/vic-machine/upgrade/upgrade.go
+++ b/cmd/vic-machine/upgrade/upgrade.go
@@ -59,6 +59,12 @@ func (u *Upgrade) Flags() []cli.Flag {
 			Usage:       "Time to wait for upgrade",
 			Destination: &u.Timeout,
 		},
+		cli.IntFlag{
+			Name:        "rollback",
+			Value:       0,
+			Usage:       "Rollback n versions, e.g. --rollback=1 to go to the version before the last upgrade",
+			Destination: &u.Rollback,
+		},
 	}
 
 	target := u.TargetFlags()
@@ -156,9 +162,12 @@ func (u *Upgrade) Run(clic *cli.Context) (err error) {
 	vConfig.BootstrapISO = path.Base(u.BootstrapISO)
 	vConfig.Timeout = u.Timeout
 
-	if err := validator.AssertVersion(vchConfig); err != nil {
-		log.Error(err)
-		return errors.New("upgrade failed")
+	// only care about versions if we're not doing a manual rollback
+	if u.Data.Rollback <= 0 {
+		if err := validator.AssertVersion(vchConfig); err != nil {
+			log.Error(err)
+			return errors.New("upgrade failed")
+		}
 	}
 
 	if vchConfig, err = validator.ValidateMigratedConfig(ctx, vchConfig); err != nil {
@@ -167,7 +176,13 @@ func (u *Upgrade) Run(clic *cli.Context) (err error) {
 		return errors.New("upgrade failed")
 	}
 
-	if err = executor.Upgrade(vch, vchConfig, vConfig); err != nil {
+	if u.Data.Rollback <= 0 {
+		err = executor.Upgrade(vch, vchConfig, vConfig)
+	} else {
+		err = executor.Rollback(vch, vchConfig, vConfig)
+	}
+
+	if err != nil {
 		// upgrade failed
 		executor.CollectDiagnosticLogs()
 		if err == nil {

--- a/lib/install/data/data.go
+++ b/lib/install/data/data.go
@@ -80,6 +80,7 @@ type Data struct {
 	UseRP bool
 
 	ScratchSize string
+	Rollback    int
 }
 
 // NetworkConfig is used to set IP addr for each network

--- a/lib/install/data/data.go
+++ b/lib/install/data/data.go
@@ -80,7 +80,7 @@ type Data struct {
 	UseRP bool
 
 	ScratchSize string
-	Rollback    int
+	Rollback    bool
 }
 
 // NetworkConfig is used to set IP addr for each network

--- a/lib/install/management/appliance.go
+++ b/lib/install/management/appliance.go
@@ -449,6 +449,14 @@ func (d *Dispatcher) configLogging(conf *config.VirtualContainerHostConfigSpec, 
 	return []types.BaseVirtualDevice{serial}, nil
 }
 
+func (d *Dispatcher) setDockerPort(conf *config.VirtualContainerHostConfigSpec, settings *data.InstallerData) {
+	if conf.HostCertificate != nil {
+		d.DockerPort = fmt.Sprintf("%d", opts.DefaultTLSHTTPPort)
+	} else {
+		d.DockerPort = fmt.Sprintf("%d", opts.DefaultHTTPPort)
+	}
+}
+
 func (d *Dispatcher) createAppliance(conf *config.VirtualContainerHostConfigSpec, settings *data.InstallerData) error {
 	defer trace.End(trace.Begin(""))
 
@@ -534,11 +542,7 @@ func (d *Dispatcher) createAppliance(conf *config.VirtualContainerHostConfigSpec
 	},
 	)
 
-	if conf.HostCertificate != nil {
-		d.DockerPort = fmt.Sprintf("%d", opts.DefaultTLSHTTPPort)
-	} else {
-		d.DockerPort = fmt.Sprintf("%d", opts.DefaultHTTPPort)
-	}
+	d.setDockerPort(conf, settings)
 
 	personality := executor.Cmd{
 		Path: "/sbin/docker-engine-server",
@@ -1057,7 +1061,7 @@ func (d *Dispatcher) CheckServiceReady(ctx context.Context, conf *config.Virtual
 			log.Infof("vSphere API Test: %s %s", conf.Target, diag.UserReadableVCAPITestDescription(code))
 		}
 	} else {
-		log.Warningf("Could not run VCH vSphere API target check due to %v", err)
+		log.Warningf("Could not run VCH vSphere API target check: %v", err)
 	}
 
 	if err := d.CheckDockerAPI(conf, clientCert); err != nil {

--- a/lib/install/management/appliance.go
+++ b/lib/install/management/appliance.go
@@ -45,6 +45,7 @@ import (
 	"github.com/vmware/vic/lib/spec"
 	"github.com/vmware/vic/pkg/errors"
 	"github.com/vmware/vic/pkg/ip"
+	"github.com/vmware/vic/pkg/retry"
 	"github.com/vmware/vic/pkg/trace"
 	"github.com/vmware/vic/pkg/vsphere/compute"
 	"github.com/vmware/vic/pkg/vsphere/diag"
@@ -1053,14 +1054,29 @@ func (d *Dispatcher) CheckServiceReady(ctx context.Context, conf *config.Virtual
 	// vic-init will try to reach out to the vSphere target.
 	log.Info("Checking VCH connectivity with vSphere target")
 	// Checking access to vSphere API
-	if cd, err := d.CheckAccessToVCAPI(d.ctx, d.appliance, conf.Target); err == nil {
-		code := int(cd)
-		if code > 0 {
-			log.Warningf("vSphere API Test: %s %s", conf.Target, diag.UserReadableVCAPITestDescription(code))
-		} else {
-			log.Infof("vSphere API Test: %s %s", conf.Target, diag.UserReadableVCAPITestDescription(code))
-		}
-	} else {
+
+	err := retry.Do(
+
+		// check access
+		func() error {
+			cd, err := d.CheckAccessToVCAPI(d.ctx, d.appliance, conf.Target)
+			if err == nil {
+				code := int(cd)
+				if code > 0 {
+					log.Warningf("vSphere API Test: %s %s", conf.Target, diag.UserReadableVCAPITestDescription(code))
+				} else {
+					log.Infof("vSphere API Test: %s %s", conf.Target, diag.UserReadableVCAPITestDescription(code))
+				}
+			}
+			return err
+		},
+
+		// retry on error
+		func(err error) bool {
+			return true
+		})
+
+	if err != nil {
 		log.Warningf("Could not run VCH vSphere API target check: %v", err)
 	}
 

--- a/lib/install/management/upgrade.go
+++ b/lib/install/management/upgrade.go
@@ -136,7 +136,7 @@ func (d *Dispatcher) Rollback(vch *vm.VirtualMachine, conf *config.VirtualContai
 	return d.retryDeleteSnapshot(snapshot.Name, conf.Name)
 }
 
-// retryDeleteSnapshot will retry to delete snpashot if there is GenericVmConfigFault returned. This is a workaround for vSAN delete snapshot
+// retryDeleteSnapshot will retry to delete snapshot if there is GenericVmConfigFault returned. This is a workaround for vSAN delete snapshot
 func (d *Dispatcher) retryDeleteSnapshot(snapshotName string, applianceName string) error {
 	// delete snapshot immediately after snapshot rollback usually fail in vSAN, so have to retry several times
 	operation := func() error {

--- a/lib/install/management/upgrade.go
+++ b/lib/install/management/upgrade.go
@@ -94,6 +94,7 @@ func (d *Dispatcher) Upgrade(vch *vm.VirtualMachine, conf *config.VirtualContain
 		}
 		return nil
 	}
+
 	log.Errorf("Failed to upgrade: %s", err)
 	log.Infof("Rolling back upgrade")
 

--- a/lib/install/management/upgrade.go
+++ b/lib/install/management/upgrade.go
@@ -90,7 +90,7 @@ func (d *Dispatcher) Upgrade(vch *vm.VirtualMachine, conf *config.VirtualContain
 
 	if err = d.update(conf, settings); err == nil {
 		if oldSnapshot != nil && vm.IsUpgradeSnapshot(oldSnapshot, UpgradePrefix) {
-			d.retryDeleteSnapshot(oldSnapshot, conf.Name)
+			d.retryDeleteSnapshot(oldSnapshot.Name, conf.Name)
 		}
 		return nil
 	}
@@ -116,9 +116,6 @@ func (d *Dispatcher) Rollback(vch *vm.VirtualMachine, conf *config.VirtualContai
 	// some setup that is only necessary because we didn't just create a VCH in this case
 	d.appliance = vch
 	d.setDockerPort(conf, settings)
-	if !strings.HasSuffix(conf.Target, "/sdk") {
-		conf.Target = fmt.Sprintf("%s/sdk", conf.Target)
-	}
 
 	notfound := "A VCH version available from before the last upgrade could not be found."
 	snapshot, err := d.appliance.GetCurrentSnapshotTree(d.ctx)

--- a/lib/install/management/upgrade.go
+++ b/lib/install/management/upgrade.go
@@ -94,7 +94,6 @@ func (d *Dispatcher) Upgrade(vch *vm.VirtualMachine, conf *config.VirtualContain
 		}
 		return nil
 	}
-
 	log.Errorf("Failed to upgrade: %s", err)
 	log.Infof("Rolling back upgrade")
 

--- a/pkg/retry/retry.go
+++ b/pkg/retry/retry.go
@@ -32,8 +32,8 @@ const (
 	DefaultMaxElapsedTime      = 1 * time.Minute
 )
 
-// Retry retries the given function DefaultRetryCount times while sleeping some time between unsuccesfull attempts
-// if retryOnError return true, continue retry, otherwise, return error
+// Retry retries the given function DefaultRetryCount times while sleeping some time between unsuccessful attempts
+// if retryOnError returns true, continue retry, otherwise, return error
 func Do(operation func() error, retryOnError func(err error) bool) error {
 	defer trace.End(trace.Begin(""))
 

--- a/pkg/vsphere/vm/vm.go
+++ b/pkg/vsphere/vm/vm.go
@@ -364,7 +364,7 @@ func (vm *VirtualMachine) GetCurrentSnapshotTree(ctx context.Context) (*types.Vi
 	return vm.bfsSnapshotTree(q, compareID), nil
 }
 
-// GetCurrentSnapshotTree returns current snapshot, with tree information
+// GetCurrentSnapshotTreeByName returns current snapshot, with tree information
 func (vm *VirtualMachine) GetSnapshotTreeByName(ctx context.Context, name string) (*types.VirtualMachineSnapshotTree, error) {
 	var err error
 
@@ -393,6 +393,7 @@ func (vm *VirtualMachine) GetSnapshotTreeByName(ctx context.Context, name string
 	return vm.bfsSnapshotTree(q, compareName), nil
 }
 
+// Finds a snapshot tree based on comparator function 'compare' via a breadth first search of the snapshot tree attached to the VM
 func (vm *VirtualMachine) bfsSnapshotTree(q *list.List, compare func(node types.VirtualMachineSnapshotTree) bool) *types.VirtualMachineSnapshotTree {
 	if q.Len() == 0 {
 		return nil

--- a/pkg/vsphere/vm/vm.go
+++ b/pkg/vsphere/vm/vm.go
@@ -410,6 +410,11 @@ func (vm *VirtualMachine) bfsSnapshotTree(q *list.List, compare func(node types.
 	return vm.bfsSnapshotTree(q, compare)
 }
 
+// helper func that returns true if node is an upgrade snapshot image
+func IsUpgradeSnapshot(node *types.VirtualMachineSnapshotTree, upgradePrefix string) bool {
+	return node != nil && strings.HasPrefix(node.Name, upgradePrefix)
+}
+
 // UpgradeInProgress tells if an upgrade has already been started based on snapshot name beginning with upgradePrefix
 func (vm *VirtualMachine) UpgradeInProgress(ctx context.Context, upgradePrefix string) (bool, string, error) {
 	node, err := vm.GetCurrentSnapshotTree(ctx)
@@ -417,7 +422,7 @@ func (vm *VirtualMachine) UpgradeInProgress(ctx context.Context, upgradePrefix s
 		return false, "", fmt.Errorf("Failed to check upgrade snapshot status: %s", err)
 	}
 
-	if node != nil && strings.HasPrefix(node.Name, upgradePrefix) {
+	if IsUpgradeSnapshot(node, upgradePrefix) {
 		return true, node.Name, nil
 	}
 

--- a/tests/test-cases/Group11-Upgrade/11-01-Upgrade.md
+++ b/tests/test-cases/Group11-Upgrade/11-01-Upgrade.md
@@ -14,9 +14,9 @@ This test requires that a vSphere server is running and available
 4. Create container with port mapping
 5. Upgrade VCH to latest version with short timeout 1s
 6. Upgrade VCH to latest version
-6. Roll back to the previous version
-6. Upgrade again to the upgraded version
-6. Check the previous created container and image are still there
+7. Roll back to the previous version
+8. Upgrade again to the upgraded version
+9. Check the previous created container and image are still there
 
 #Expected Outcome:
 * Step 5 should fail with timeout

--- a/tests/test-cases/Group11-Upgrade/11-01-Upgrade.md
+++ b/tests/test-cases/Group11-Upgrade/11-01-Upgrade.md
@@ -14,6 +14,8 @@ This test requires that a vSphere server is running and available
 4. Create container with port mapping
 5. Upgrade VCH to latest version with short timeout 1s
 6. Upgrade VCH to latest version
+6. Roll back to the previous version
+6. Upgrade again to the upgraded version
 6. Check the previous created container and image are still there
 
 #Expected Outcome:

--- a/tests/test-cases/Group11-Upgrade/11-01-Upgrade.robot
+++ b/tests/test-cases/Group11-Upgrade/11-01-Upgrade.robot
@@ -77,6 +77,39 @@ Upgrade VCH with containers
     Should Not Contain  ${output}  Rolling back upgrade
     Should Be Equal As Integers  ${rc}  0
 
+    # check version
+    ${rc}  ${output}=  Run And Return Rc And Output  bin/vic-machine-linux version
+    @{vers}=  Split String  ${output}
+    ${rc}  ${output}=  Run And Return Rc And Output  bin/vic-machine-linux inspect --name=%{VCH-NAME} --target=%{TEST_URL} --thumbprint=%{TEST_THUMBPRINT} --user=%{TEST_USERNAME} --password=%{TEST_PASSWORD} --compute-resource=%{TEST_RESOURCE}
+    Should Contain  ${output}  Completed successfully
+    Should Contain  ${output}  @{vers}[2]
+    Should Be Equal As Integers  ${rc}  0
+    Log  ${output}
+    Get Docker Params  ${output}  ${true}
+
+    Log To Console  \nTesting rollback...
+    ${rc}  ${output}=  Run And Return Rc And Output  bin/vic-machine-linux upgrade --debug 1 --name=%{VCH-NAME} --target=%{TEST_URL} --user=%{TEST_USERNAME} --password=%{TEST_PASSWORD} --force=true --compute-resource=%{TEST_RESOURCE} --timeout %{TEST_TIMEOUT} --rollback
+    Should Contain  ${output}  Completed successfully
+    Should Be Equal As Integers  ${rc}  0
+
+    # check version again, but old version this time
+    ${rc}  ${output}=  Run And Return Rc And Output  bin/vic-machine-linux version
+    @{vers}=  Split String  ${output}
+    ${rc}  ${output}=  Run And Return Rc And Output  bin/vic-machine-linux inspect --name=%{VCH-NAME} --target=%{TEST_URL} --thumbprint=%{TEST_THUMBPRINT} --user=%{TEST_USERNAME} --password=%{TEST_PASSWORD} --compute-resource=%{TEST_RESOURCE}
+    Should Contain  ${output}  Completed successfully
+    Should Contain  ${output}  @{vers}[1]
+    Should Be Equal As Integers  ${rc}  0
+    Log  ${output}
+    Get Docker Params  ${output}  ${true}
+
+    # upgrade again to latest version
+    Log To Console  \nUpgrading VCH...
+    ${rc}  ${output}=  Run And Return Rc And Output  bin/vic-machine-linux upgrade --debug 1 --name=%{VCH-NAME} --target=%{TEST_URL} --user=%{TEST_USERNAME} --password=%{TEST_PASSWORD} --force=true --compute-resource=%{TEST_RESOURCE} --timeout %{TEST_TIMEOUT}
+    Should Contain  ${output}  Completed successfully
+    Should Not Contain  ${output}  Rolling back upgrade
+    Should Be Equal As Integers  ${rc}  0
+
+    # check version
     ${rc}  ${output}=  Run And Return Rc And Output  bin/vic-machine-linux version
     @{vers}=  Split String  ${output}
     ${rc}  ${output}=  Run And Return Rc And Output  bin/vic-machine-linux inspect --name=%{VCH-NAME} --target=%{TEST_URL} --thumbprint=%{TEST_THUMBPRINT} --user=%{TEST_USERNAME} --password=%{TEST_PASSWORD} --compute-resource=%{TEST_RESOURCE}

--- a/tests/test-cases/Group11-Upgrade/11-01-Upgrade.robot
+++ b/tests/test-cases/Group11-Upgrade/11-01-Upgrade.robot
@@ -28,6 +28,7 @@ Install VIC with version to Test Server
 	Set Environment Variable  TEST_TIMEOUT  20m0s
 	Install VIC Appliance To Test Server  vic-machine=./vic/vic-machine-linux  appliance-iso=./vic/appliance.iso  bootstrap-iso=./vic/bootstrap.iso  certs=${false}
     Set Environment Variable  VIC-ADMIN  %{VCH-IP}:2378
+    Set Environment Variable  INITIAL-VERSION  ${version}
 
 Clean up VIC Appliance And Local Binary
     Cleanup VIC Appliance On Test Server
@@ -41,75 +42,31 @@ Launch Container
     ${ip}=  Get Container IP  %{VCH-PARAMS}  ${id}  ${network}
     [Return]  ${id}  ${ip}
 
-*** Test Cases ***
-Upgrade Present in vic-machine
-    ${rc}  ${output}=  Run And Return Rc And Output  bin/vic-machine-linux
-    Should Contain  ${output}  upgrade
-
-Upgrade VCH with containers
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} network create bar
-    Should Be Equal As Integers  ${rc}  0
-    Comment  Launch container on bridge network
-    ${id1}  ${ip1}=  Launch Container  vch-restart-test1  bridge
-    ${id2}  ${ip2}=  Launch Container  vch-restart-test2  bridge
-
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} create -it -p 10000:80 -p 10001:80 --name webserver nginx
-    Should Be Equal As Integers  ${rc}  0
-    Should Not Contain  ${output}  Error
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} start webserver
-    Should Be Equal As Integers  ${rc}  0
-    Should Not Contain  ${output}  Error
-    Wait Until Keyword Succeeds  20x  5 seconds  Hit Nginx Endpoint  %{VCH-IP}  10000
-    Wait Until Keyword Succeeds  20x  5 seconds  Hit Nginx Endpoint  %{VCH-IP}  10001
-
-    Log To Console  \nUpgrading VCH with 1s timeout ...
-    ${rc}  ${output}=  Run And Return Rc And Output  bin/vic-machine-linux upgrade --debug 1 --name=%{VCH-NAME} --target=%{TEST_URL} --user=%{TEST_USERNAME} --password=%{TEST_PASSWORD} --force=true --compute-resource=%{TEST_RESOURCE} --timeout 1s
-    Should Contain  ${output}  Upgrading VCH exceeded time limit
-    Should Not Contain  ${output}  Completed successfully
-    ${rc}  ${output}=  Run Keyword If  '%{HOST_TYPE}' == 'VC'  Run And Return Rc And Output  govc snapshot.tree -vm=%{VCH-NAME}/%{VCH-NAME}
-    Run Keyword If  '%{HOST_TYPE}' == 'VC'  Should Not Contain  ${output}  upgrade
-    ${rc}  ${output}=  Run Keyword If  '%{HOST_TYPE}' == 'ESXi'  Run And Return Rc And Output  govc snapshot.tree -vm=%{VCH-NAME}
-    Run Keyword If  '%{HOST_TYPE}' == 'ESXi'  Should Not Contain  ${output}  upgrade
-
+Upgrade
     Log To Console  \nUpgrading VCH...
     ${rc}  ${output}=  Run And Return Rc And Output  bin/vic-machine-linux upgrade --debug 1 --name=%{VCH-NAME} --target=%{TEST_URL} --user=%{TEST_USERNAME} --password=%{TEST_PASSWORD} --force=true --compute-resource=%{TEST_RESOURCE} --timeout %{TEST_TIMEOUT}
     Should Contain  ${output}  Completed successfully
     Should Not Contain  ${output}  Rolling back upgrade
     Should Be Equal As Integers  ${rc}  0
 
-    # check version
-    ${rc}  ${output}=  Run And Return Rc And Output  bin/vic-machine-linux version
-    @{vers}=  Split String  ${output}
-    ${rc}  ${output}=  Run And Return Rc And Output  bin/vic-machine-linux inspect --name=%{VCH-NAME} --target=%{TEST_URL} --thumbprint=%{TEST_THUMBPRINT} --user=%{TEST_USERNAME} --password=%{TEST_PASSWORD} --compute-resource=%{TEST_RESOURCE}
-    Should Contain  ${output}  Completed successfully
-    Should Contain  ${output}  @{vers}[2]
-    Should Be Equal As Integers  ${rc}  0
-    Log  ${output}
-    Get Docker Params  ${output}  ${true}
-
-    Log To Console  \nTesting rollback...
+Rollback
+     Log To Console  \nTesting rollback...
     ${rc}  ${output}=  Run And Return Rc And Output  bin/vic-machine-linux upgrade --debug 1 --name=%{VCH-NAME} --target=%{TEST_URL} --user=%{TEST_USERNAME} --password=%{TEST_PASSWORD} --force=true --compute-resource=%{TEST_RESOURCE} --timeout %{TEST_TIMEOUT} --rollback
     Should Contain  ${output}  Completed successfully
     Should Be Equal As Integers  ${rc}  0
 
-    # check version again, but old version this time
+Check Upgraded Version
     ${rc}  ${output}=  Run And Return Rc And Output  bin/vic-machine-linux version
     @{vers}=  Split String  ${output}
     ${rc}  ${output}=  Run And Return Rc And Output  bin/vic-machine-linux inspect --name=%{VCH-NAME} --target=%{TEST_URL} --thumbprint=%{TEST_THUMBPRINT} --user=%{TEST_USERNAME} --password=%{TEST_PASSWORD} --compute-resource=%{TEST_RESOURCE}
     Should Contain  ${output}  Completed successfully
-    Should Contain  ${output}  @{vers}[1]
+    Should Contain  ${output}  @{vers}[2]
+    Should Not Contain  ${output}  %{INITIAL-VERSION}
     Should Be Equal As Integers  ${rc}  0
     Log  ${output}
     Get Docker Params  ${output}  ${true}
 
-    # upgrade again to latest version
-    Log To Console  \nUpgrading VCH...
-    ${rc}  ${output}=  Run And Return Rc And Output  bin/vic-machine-linux upgrade --debug 1 --name=%{VCH-NAME} --target=%{TEST_URL} --user=%{TEST_USERNAME} --password=%{TEST_PASSWORD} --force=true --compute-resource=%{TEST_RESOURCE} --timeout %{TEST_TIMEOUT}
-    Should Contain  ${output}  Completed successfully
-    Should Not Contain  ${output}  Rolling back upgrade
-    Should Be Equal As Integers  ${rc}  0
-
-    # check version
+Check Original Version
     ${rc}  ${output}=  Run And Return Rc And Output  bin/vic-machine-linux version
     @{vers}=  Split String  ${output}
     ${rc}  ${output}=  Run And Return Rc And Output  bin/vic-machine-linux inspect --name=%{VCH-NAME} --target=%{TEST_URL} --thumbprint=%{TEST_THUMBPRINT} --user=%{TEST_USERNAME} --password=%{TEST_PASSWORD} --compute-resource=%{TEST_RESOURCE}
@@ -119,6 +76,7 @@ Upgrade VCH with containers
     Log  ${output}
     Get Docker Params  ${output}  ${true}
 
+Run Docker Checks
     # wait for docker info to succeed
     Log To Console  Verify Containers...
     Wait Until Keyword Succeeds  20x  5 seconds  Run Docker Info  %{VCH-PARAMS}
@@ -128,10 +86,10 @@ Upgrade VCH with containers
     Should Contain  ${output}  bar
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} network inspect bridge
     Should Be Equal As Integers  ${rc}  0
-    ${ip}=  Get Container IP  %{VCH-PARAMS}  ${id1}  bridge
-    Should Be Equal  ${ip}  ${ip1}
-    ${ip}=  Get Container IP  %{VCH-PARAMS}  ${id2}  bridge
-    Should Be Equal  ${ip}  ${ip2}
+    ${ip}=  Get Container IP  %{VCH-PARAMS}  %{ID1}  bridge
+    Should Be Equal  ${ip}  %{IP1}
+    ${ip}=  Get Container IP  %{VCH-PARAMS}  %{ID2}  bridge
+    Should Be Equal  ${ip}  %{IP2}
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} inspect vch-restart-test1
     Should Be Equal As Integers  ${rc}  0
     Should Contain  ${output}  "Id"
@@ -160,6 +118,57 @@ Upgrade VCH with containers
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} ps -aq | xargs -n1 docker %{VCH-PARAMS} rm
     Should Be Equal As Integers  ${rc}  0
     Should Not Contain  ${output}  Error
+
+Create Docker Containers
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} network create bar
+    Should Be Equal As Integers  ${rc}  0
+    Comment  Launch container on bridge network
+    ${id1}  ${ip1}=  Launch Container  vch-restart-test1  bridge
+    ${id2}  ${ip2}=  Launch Container  vch-restart-test2  bridge
+    Set Environment Variable  ID1  ${id1}
+    Set Environment Variable  ID2  ${id2}
+    Set Environment Variable  IP1  ${ip1}
+    Set Environment Variable  IP2  ${ip2}
+
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} create -it -p 10000:80 -p 10001:80 --name webserver nginx
+    Should Be Equal As Integers  ${rc}  0
+    Should Not Contain  ${output}  Error
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} start webserver
+    Should Be Equal As Integers  ${rc}  0
+    Should Not Contain  ${output}  Error
+    Wait Until Keyword Succeeds  20x  5 seconds  Hit Nginx Endpoint  %{VCH-IP}  10000
+    Wait Until Keyword Succeeds  20x  5 seconds  Hit Nginx Endpoint  %{VCH-IP}  10001
+
+*** Test Cases ***
+Upgrade Present in vic-machine
+    ${rc}  ${output}=  Run And Return Rc And Output  bin/vic-machine-linux
+    Should Contain  ${output}  upgrade
+
+Upgrade VCH with unreasonably short timeout and automatic rollback after failure
+    Log To Console  \nUpgrading VCH with 1s timeout ...
+    ${rc}  ${output}=  Run And Return Rc And Output  bin/vic-machine-linux upgrade --debug 1 --name=%{VCH-NAME} --target=%{TEST_URL} --user=%{TEST_USERNAME} --password=%{TEST_PASSWORD} --force=true --compute-resource=%{TEST_RESOURCE} --timeout 1s
+    Should Contain  ${output}  Upgrading VCH exceeded time limit
+    Should Not Contain  ${output}  Completed successfully
+    ${rc}  ${output}=  Run Keyword If  '%{HOST_TYPE}' == 'VC'  Run And Return Rc And Output  govc snapshot.tree -vm=%{VCH-NAME}/%{VCH-NAME}
+    Run Keyword If  '%{HOST_TYPE}' == 'VC'  Should Not Contain  ${output}  upgrade
+    ${rc}  ${output}=  Run Keyword If  '%{HOST_TYPE}' == 'ESXi'  Run And Return Rc And Output  govc snapshot.tree -vm=%{VCH-NAME}
+    Run Keyword If  '%{HOST_TYPE}' == 'ESXi'  Should Not Contain  ${output}  upgrade
+
+Upgrade VCH
+
+    Create Docker Containers
+    Log To Console  \nUpgrading VCH...
+
+    Upgrade
+    Check Upgraded Version
+
+    Rollback
+    Check Original Version
+
+    Upgrade
+    Check Upgraded Version
+
+    Run Docker Checks
 
     Log To Console  Regression Tests...
     Run Regression Tests

--- a/tests/test-cases/Group11-Upgrade/TestCases.md
+++ b/tests/test-cases/Group11-Upgrade/TestCases.md
@@ -1,23 +1,6 @@
 Group 11 - Upgrade
 =======
 
-#Purpose:
-To test vic-machine upgrade
 
 [Test 11-01 - Upgrade](11-01-Upgrade.md)
-
-#Environment:
-Set up a VCH using an old, known version from bintray
-
-#Test Steps:
-1. Verify that Upgrade is present
-2. Perform an upgrade with a short timeout to test the automated rollback from failed upgrades
-3. Perform an upgrade and check that it is successful
-4. Manually roll back to the last version and check that it is successful 
-5. Upgrade again to make sure that rollback is also reversible.
-
-#Expected Outcome:
-  1. Upgrade is present
-  2. Upgrade times out and rolls back to the pre-upgraded, functioning VCH
-  3. Upgrade rollback upgrade again routine works as expected
-
+-

--- a/tests/test-cases/Group11-Upgrade/TestCases.md
+++ b/tests/test-cases/Group11-Upgrade/TestCases.md
@@ -16,8 +16,8 @@ Set up a VCH using an old, known version from bintray
 4. Manually roll back to the last version and check that it is successful 
 5. Upgrade again to make sure that rollback is also reversible.
 
-#Expected Outome:
-1. Upgrade is present
-2. Upgrade times out and rolls back to the pre-upgraded, functioning VCH
-3. Upgrade, rollback, upgrade again routine works as expected
--
+#Expected Outcome:
+  1. Upgrade is present
+  2. Upgrade times out and rolls back to the pre-upgraded, functioning VCH
+  3. Upgrade rollback upgrade again routine works as expected
+

--- a/tests/test-cases/Group11-Upgrade/TestCases.md
+++ b/tests/test-cases/Group11-Upgrade/TestCases.md
@@ -1,6 +1,23 @@
 Group 11 - Upgrade
 =======
 
+#Purpose:
+To test vic-machine upgrade
 
 [Test 11-01 - Upgrade](11-01-Upgrade.md)
+
+#Environment:
+Set up a VCH using an old, known version from bintray
+
+#Test Steps:
+1. Verify that Upgrade is present
+2. Perform an upgrade with a short timeout to test the automated rollback from failed upgrades
+3. Perform an upgrade and check that it is successful
+4. Manually roll back to the last version and check that it is successful 
+5. Upgrade again to make sure that rollback is also reversible.
+
+#Expected Outome:
+1. Upgrade is present
+2. Upgrade times out and rolls back to the pre-upgraded, functioning VCH
+3. Upgrade, rollback, upgrade again routine works as expected
 -


### PR DESCRIPTION
Resolves #3765 
 
Still needs tests and a little cleanup but I wanted to go ahead and post this.

This is `vic-machine upgrade --rollback` which allows you to manually go back to a saved snapshot after an upgrade if the upgrade succeeds (from the point of view of vic-machine or the product as a whole) but the user's application doesn't function properly, or for any other reason. Also this contains a couple of commits from @emlin 's open PR and a number of small typo/grammar fixes.