### PR TITLE
[specific ci=3-03-Docker-Compose-Basic] Fix docker-compose kill

### DIFF
--- a/lib/apiservers/engine/backends/container_proxy.go
+++ b/lib/apiservers/engine/backends/container_proxy.go
@@ -41,6 +41,7 @@ import (
 	"net/http"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 
 	log "github.com/Sirupsen/logrus"
@@ -629,7 +630,10 @@ func (c *ContainerProxy) Signal(vc *viccontainer.VicContainer, sig uint64) error
 		return fmt.Errorf("%s is not running", vc.ContainerID)
 	}
 
-	// If request wasn't for sigkill, we simply pass on the signal to the container
+	// If Docker CLI sends sig == 0, we use sigkill
+	if sig == 0 {
+		sig = uint64(syscall.SIGKILL)
+	}
 	params := containers.NewContainerSignalParamsWithContext(ctx).WithID(vc.ContainerID).WithSignal(int64(sig))
 	if _, err := client.Containers.ContainerSignal(params); err != nil {
 		switch err := err.(type) {

--- a/tests/test-cases/Group3-Docker-Compose/3-03-Docker-Compose-Basic.robot
+++ b/tests/test-cases/Group3-Docker-Compose/3-03-Docker-Compose-Basic.robot
@@ -28,3 +28,12 @@ Compose basic
     ${rc}  ${output}=  Run And Return Rc And Output  docker-compose %{VCH-PARAMS} --file basic-compose.yml stop
     Log  ${output}
     Should Be Equal As Integers  ${rc}  0
+
+Compose kill
+    ${rc}  ${out}=  Run And Return Rc And Output  docker-compose %{VCH-PARAMS} -f basic-compose.yml up -d
+    Log  ${out}
+    Should Be Equal As Integers  ${rc}  0
+
+    ${rc}  ${out}=  Run And Return Rc And Output  docker-compose %{VCH-PARAMS} -f basic-compose.yml kill redis
+    Log  ${out}
+    Should Be Equal As Integers  ${rc}  0


### PR DESCRIPTION
Handle docker kill with sig == 0.  This is the value that is used
when docker-compose kill is called.

Resolves #3707