### PR TITLE
Increase jasmine.DEFAULT_TIMEOUT_INTERVAL to 30sec

### DIFF
--- a/ui/vic-ui-h5c/vic/src/vic-app/src/app/app.component.spec.ts
+++ b/ui/vic-ui-h5c/vic/src/vic-app/src/app/app.component.spec.ts
@@ -37,6 +37,7 @@ import { VchPortletComponent } from './summary-portlet/vch-portlet/vch-portlet.c
 import { ContainerPortletComponent } from './summary-portlet/container-portlet/container-portlet.component';
 import { VicSummaryViewComponent } from './summary-view/summary-view.component';
 import { AppComponent } from './app.component';
+import { JASMINE_TIMEOUT } from './testing/jasmine.constants';
 
 describe('VIC UI Unit Tests', () => {
   let fixture: ComponentFixture<AppComponent>;
@@ -70,6 +71,7 @@ describe('VIC UI Unit Tests', () => {
     }));
 
     beforeEach(() => {
+      jasmine.DEFAULT_TIMEOUT_INTERVAL = JASMINE_TIMEOUT;
       fixture = TestBed.createComponent<AppComponent>(AppComponent);
       appInstance = fixture.componentInstance;
     });

--- a/ui/vic-ui-h5c/vic/src/vic-app/src/app/shared/appErrorHandler.spec.ts
+++ b/ui/vic-ui-h5c/vic/src/vic-app/src/app/shared/appErrorHandler.spec.ts
@@ -19,6 +19,7 @@ import { Response, ResponseOptions } from "@angular/http";
 
 // Internal imports
 import { AppErrorHandler, liveDataHelp, jsonServerHelp } from "../shared/appErrorHandler";
+import { JASMINE_TIMEOUT } from '../testing/jasmine.constants';
 
 // Simple service unit tests without assistance from Angular testing utilities
 
@@ -28,6 +29,7 @@ describe("AppErrorHandler tests", () => {
    let errorToDisplay = "some error message";
 
    beforeEach(() => {
+      jasmine.DEFAULT_TIMEOUT_INTERVAL = JASMINE_TIMEOUT;
       appErrorHandler = new AppErrorHandler(null);
    });
 

--- a/ui/vic-ui-h5c/vic/src/vic-app/src/app/shared/globals.service.spec.ts
+++ b/ui/vic-ui-h5c/vic/src/vic-app/src/app/shared/globals.service.spec.ts
@@ -20,6 +20,7 @@ import { TestBed } from "@angular/core/testing";
 // Internal imports
 import { Globals, GlobalsService } from "./globals.service";
 import { initGlobalService, globalStub } from "../testing/index";
+import { JASMINE_TIMEOUT } from "../testing/jasmine.constants";
 
 // ---------- Testing stubs ------------
 
@@ -35,6 +36,7 @@ describe("Globals tests", () => {
 
    describe("when WEB_PLATFORM is defined", () => {
       beforeEach(() => {
+         jasmine.DEFAULT_TIMEOUT_INTERVAL = JASMINE_TIMEOUT;
          window.parent["WEB_PLATFORM"] = globalStub.webPlatform;
          globals = new Globals();
       });

--- a/ui/vic-ui-h5c/vic/src/vic-app/src/app/shared/i18n.service.spec.ts
+++ b/ui/vic-ui-h5c/vic/src/vic-app/src/app/shared/i18n.service.spec.ts
@@ -15,6 +15,7 @@
 */
 
 import { I18nService } from "./i18n.service";
+import { JASMINE_TIMEOUT } from "../testing/jasmine.constants";
 
 let i18nService: I18nService;
 
@@ -23,6 +24,7 @@ let i18nService: I18nService;
 
 describe("I18Service tests", () => {
    beforeEach(() => {
+      jasmine.DEFAULT_TIMEOUT_INTERVAL = JASMINE_TIMEOUT;
       i18nService = new I18nService(null, null, null);
    });
    it ("interpolates messages correctly", () => {

--- a/ui/vic-ui-h5c/vic/src/vic-app/src/app/summary-portlet/summary-portlet.spec.ts
+++ b/ui/vic-ui-h5c/vic/src/vic-app/src/app/summary-portlet/summary-portlet.spec.ts
@@ -41,6 +41,7 @@ import { VchPortletComponent } from './vch-portlet/vch-portlet.component';
 import { ContainerPortletComponent } from './container-portlet/container-portlet.component';
 import { VirtualMachine } from '../vm.interface';
 import { VM_PROPERTIES_TO_EXTRACT } from '../vm.constants';
+import { JASMINE_TIMEOUT } from '../testing/jasmine.constants';
 
 describe('VIC Summary Portlet Components', () => {
     let fixture: ComponentFixture<VicSummaryPortletComponent>;
@@ -105,6 +106,7 @@ describe('VIC Summary Portlet Components', () => {
     }));
 
     beforeEach(() => {
+        jasmine.DEFAULT_TIMEOUT_INTERVAL = JASMINE_TIMEOUT;
         fixture = TestBed.createComponent<VicSummaryPortletComponent>(VicSummaryPortletComponent);
         compInstance = fixture.componentInstance;
         svc = fixture.debugElement.injector.get(DataPropertyService);

--- a/ui/vic-ui-h5c/vic/src/vic-app/src/app/summary-view/summary-view.component.spec.ts
+++ b/ui/vic-ui-h5c/vic/src/vic-app/src/app/summary-view/summary-view.component.spec.ts
@@ -31,8 +31,8 @@ import {
 import { DataPropertyService } from '../services/data-property.service';
 import { AppErrorHandler } from '../shared/appErrorHandler';
 import { VicSummaryViewComponent } from './summary-view.component';
-
 import { ClarityModule } from 'clarity-angular';
+import { JASMINE_TIMEOUT } from '../testing/jasmine.constants';
 
 describe('VIC object view: Summary tab', () => {
     let fixture: ComponentFixture<VicSummaryViewComponent>;
@@ -72,6 +72,7 @@ describe('VIC object view: Summary tab', () => {
     }));
 
     beforeEach(() => {
+        jasmine.DEFAULT_TIMEOUT_INTERVAL = JASMINE_TIMEOUT;
         fixture = TestBed.createComponent(VicSummaryViewComponent);
         compInstance = fixture.componentInstance;
         dpService = fixture.debugElement.injector.get(DataPropertyService);

--- a/ui/vic-ui-h5c/vic/src/vic-app/src/app/testing/jasmine.constants.ts
+++ b/ui/vic-ui-h5c/vic/src/vic-app/src/app/testing/jasmine.constants.ts
@@ -1,0 +1,17 @@
+/*
+ Copyright 2017 VMware, Inc. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+export const JASMINE_TIMEOUT = 30000;


### PR DESCRIPTION
If the build system gets slow enough it causes at least one of the unit tests to take more than 5 seconds. This PR addresses the issue by increasing Jasmine's default timeout interval from 5 seconds to 30 seconds. 

Fixes #4132 