### PR TITLE
[specific ci=1-23-Docker-Inspect] Fixed volume in container inspect

### DIFF
--- a/lib/apiservers/engine/backends/container.go
+++ b/lib/apiservers/engine/backends/container.go
@@ -1652,6 +1652,7 @@ func copyConfigOverrides(vc *viccontainer.VicContainer, config types.ContainerCr
 	vc.Config.OpenStdin = config.Config.OpenStdin
 	vc.Config.StdinOnce = config.Config.StdinOnce
 	vc.Config.StopSignal = config.Config.StopSignal
+	vc.Config.Volumes = config.Config.Volumes
 	vc.HostConfig = config.HostConfig
 }
 

--- a/lib/apiservers/engine/backends/container_proxy.go
+++ b/lib/apiservers/engine/backends/container_proxy.go
@@ -51,15 +51,15 @@ import (
 	"github.com/google/uuid"
 	httpclient "github.com/mreiferson/go-httpclient"
 
-	"github.com/docker/docker/api/types/backend"
 	derr "github.com/docker/docker/api/errors"
-	"github.com/docker/docker/pkg/stringid"
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/backend"
 	"github.com/docker/docker/api/types/container"
 	dnetwork "github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/api/types/strslice"
-	"github.com/docker/go-connections/nat"
+	"github.com/docker/docker/pkg/stringid"
 	"github.com/docker/docker/pkg/term"
+	"github.com/docker/go-connections/nat"
 
 	"github.com/vmware/vic/lib/apiservers/engine/backends/cache"
 	viccontainer "github.com/vmware/vic/lib/apiservers/engine/backends/container"
@@ -1271,12 +1271,6 @@ func containerConfigFromContainerInfo(vc *viccontainer.VicContainer, info *model
 		container.StopSignal = imageConfig.ContainerConfig.StopSignal // Signal to stop a container
 
 		container.OnBuild = imageConfig.ContainerConfig.OnBuild // ONBUILD metadata that were defined on the image Dockerfile
-
-		// Fill in information about the container's volumes
-		// FIXME:  Why does types.ContainerJSON have Mounts and also ContainerConfig,
-		// which also has Volumes?  Assuming this is a copy from image's container
-		// config till we figure this out.
-		container.Volumes = imageConfig.ContainerConfig.Volumes
 	}
 
 	// Pull labels from the annotation

--- a/tests/test-cases/Group1-Docker-Commands/1-23-Docker-Inspect.md
+++ b/tests/test-cases/Group1-Docker-Commands/1-23-Docker-Inspect.md
@@ -28,6 +28,8 @@ This test requires that a vSphere server is running and available
 15. Issue docker start two-net-test
 16. Issue docker inspect -f '{{range $key, $value := .NetworkSettings.Networks}}{{$key}}{{end}}' two-net-test
 17. Issue docker inspect fake to the VIC appliance
+18. Issue docker create -v /var/lib/test busybox
+19. Issue docker inspect -f {{.Config.Volumes}} <containerID>
 
 #Expected Outcome:
 * Step 3,4,7,8 should result in success and a properly formatted JSON response
@@ -45,6 +47,7 @@ Error: No such image: <containerID>
 ```
 Error: No such image or container: fake
 ```
+* Step 19 should result in the map returned containing /var/lib/test
 
 #Possible Problems:
 None

--- a/tests/test-cases/Group1-Docker-Commands/1-23-Docker-Inspect.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-23-Docker-Inspect.robot
@@ -79,3 +79,11 @@ Docker inspect invalid object
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} inspect fake
     Should Be Equal As Integers  ${rc}  1
     Should Contain  ${output}  Error: No such image or container: fake
+
+Docker inspect non-nil volume
+    ${rc}  ${container}=  Run And Return Rc And Output  docker %{VCH-PARAMS} create --name=test-with-volume -v /var/lib/test busybox
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${out}=  Run And Return Rc And Output  docker %{VCH-PARAMS} inspect -f '{{.Config.Volumes}}' test-with-volume
+    Should Be Equal As Integers  ${rc}  0
+    Should Contain  ${out}  /var/lib/test
+    


### PR DESCRIPTION
Fixed the volume map in the inspect data on container inspect.
Now, is keeps the volume data from the container create
operation.

Resolves #3740