### PR TITLE
[specific ci=Group1-Docker-Commands] Add support for network labels

### DIFF
--- a/lib/apiservers/engine/backends/network.go
+++ b/lib/apiservers/engine/backends/network.go
@@ -1,4 +1,4 @@
-// Copyright 2016 VMware, Inc. All Rights Reserved.
+// Copyright 2016-2017 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,6 +15,8 @@
 package backends
 
 import (
+	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"net"
 	"sync"
@@ -139,11 +141,21 @@ func (n *Network) CreateNetwork(nc types.NetworkCreateRequest) (*types.NetworkCr
 	}
 
 	cfg := &models.ScopeConfig{
-		Gateway:   gateway,
-		Name:      nc.Name,
-		ScopeType: nc.Driver,
-		Subnet:    subnet,
-		IPAM:      pools,
+		Gateway:     gateway,
+		Name:        nc.Name,
+		ScopeType:   nc.Driver,
+		Subnet:      subnet,
+		IPAM:        pools,
+		Annotations: make(map[string]string),
+	}
+
+	// Marshal and encode the labels for transport and storage in the portlayer
+	if labelsBytes, err := json.Marshal(nc.Labels); err == nil {
+		encodedLabels := base64.StdEncoding.EncodeToString(labelsBytes)
+		cfg.Annotations[annotationKeyLabels] = encodedLabels
+	} else {
+		log.Errorf("error marshaling labels: %s", err)
+		return nil, derr.NewErrorWithStatusCode(fmt.Errorf("unable to marshal labels: %s", err), http.StatusInternalServerError)
 	}
 
 	created, err := PortLayerClient().Scopes.CreateScope(scopes.NewCreateScopeParamsWithContext(ctx).WithConfig(cfg))
@@ -159,9 +171,9 @@ func (n *Network) CreateNetwork(nc types.NetworkCreateRequest) (*types.NetworkCr
 			return nil, derr.NewErrorWithStatusCode(err, http.StatusInternalServerError)
 		}
 	}
-	
+
 	ncResponse := &types.NetworkCreateResponse{
-		ID: created.Payload.ID,
+		ID:      created.Payload.ID,
 		Warning: "",
 	}
 
@@ -465,8 +477,29 @@ func (n *network) Internal() bool {
 	return false
 }
 
+// Labels decodes and unmarshals the stored blob of network labels.
 func (n *network) Labels() map[string]string {
-	return make(map[string]string)
+	n.Lock()
+	defer n.Unlock()
+
+	labels := make(map[string]string)
+	if n.cfg.Annotations == nil {
+		return labels
+	}
+
+	// Look for the Docker-specific annotation (label) blob and process it for the output
+	if encodedLabels, ok := n.cfg.Annotations[annotationKeyLabels]; ok {
+
+		if labelsBytes, decodeErr := base64.StdEncoding.DecodeString(encodedLabels); decodeErr == nil {
+			if unmarshalErr := json.Unmarshal(labelsBytes, &labels); unmarshalErr != nil {
+				log.Errorf("error unmarshaling labels: %s", unmarshalErr)
+			}
+		} else {
+			log.Errorf("error decoding label blob: %s", decodeErr)
+		}
+	}
+
+	return labels
 }
 
 func (n *network) Attachable() bool {

--- a/lib/apiservers/portlayer/restapi/handlers/scopes_handlers.go
+++ b/lib/apiservers/portlayer/restapi/handlers/scopes_handlers.go
@@ -1,4 +1,4 @@
-// Copyright 2016 VMware, Inc. All Rights Reserved.
+// Copyright 2016-2017 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -54,7 +54,7 @@ func (handler *ScopesHandlersImpl) Configure(api *operations.PortLayerAPI, handl
 	handler.handlerCtx = handlerCtx
 }
 
-func parseScopeConfig(cfg *models.ScopeConfig) (subnet *net.IPNet, gateway net.IP, dns []net.IP, err error) {
+func parseScopeConfig(cfg *models.ScopeConfig) (subnet *net.IPNet, gateway net.IP, dns []net.IP, annotations map[string]string, err error) {
 	if cfg.Subnet != "" {
 		if _, subnet, err = net.ParseCIDR(cfg.Subnet); err != nil {
 			return
@@ -75,6 +75,14 @@ func parseScopeConfig(cfg *models.ScopeConfig) (subnet *net.IPNet, gateway net.I
 		if dns[i] == nil {
 			err = fmt.Errorf("invalid dns entry")
 			return
+		}
+	}
+
+	// Parse annotations
+	if len(cfg.Annotations) > 0 {
+		annotations = make(map[string]string)
+		for k, v := range cfg.Annotations {
+			annotations[k] = v
 		}
 	}
 
@@ -109,13 +117,23 @@ func (handler *ScopesHandlersImpl) ScopesCreate(params scopes.CreateScopeParams)
 			&models.Error{Message: "cannot create external networks"})
 	}
 
-	subnet, gateway, dns, err := parseScopeConfig(cfg)
+	subnet, gateway, dns, annotations, err := parseScopeConfig(cfg)
 	if err != nil {
 		return scopes.NewCreateScopeDefault(http.StatusServiceUnavailable).WithPayload(
 			errorPayload(err))
 	}
 
-	s, err := handler.netCtx.NewScope(context.Background(), cfg.ScopeType, cfg.Name, subnet, gateway, dns, cfg.IPAM)
+	scopeData := &network.ScopeData{
+		ScopeType:   cfg.ScopeType,
+		Name:        cfg.Name,
+		Subnet:      subnet,
+		Gateway:     gateway,
+		DNS:         dns,
+		Pools:       cfg.IPAM,
+		Annotations: annotations,
+	}
+
+	s, err := handler.netCtx.NewScope(context.Background(), scopeData)
 	if _, ok := err.(network.DuplicateResourceError); ok {
 		return scopes.NewCreateScopeConflict()
 	}
@@ -345,6 +363,12 @@ func toScopeConfig(scope *network.Scope) *models.ScopeConfig {
 	sc.Endpoints = make([]*models.EndpointConfig, len(eps))
 	for i, e := range eps {
 		sc.Endpoints[i] = toEndpointConfig(e)
+	}
+
+	sc.Annotations = make(map[string]string)
+	annotations := scope.Annotations()
+	for k, v := range annotations {
+		sc.Annotations[k] = v
 	}
 
 	return sc

--- a/lib/apiservers/portlayer/swagger.json
+++ b/lib/apiservers/portlayer/swagger.json
@@ -2370,6 +2370,12 @@
 					"items": {
 						"$ref": "#/definitions/EndpointConfig"
 					}
+				},
+				"annotations": {
+					"type": "object",
+					"additionalProperties": {
+						"type": "string"
+					}
 				}
 			}
 		},

--- a/lib/portlayer/network/context.go
+++ b/lib/portlayer/network/context.go
@@ -1,4 +1,4 @@
-// Copyright 2016 VMware, Inc. All Rights Reserved.
+// Copyright 2016-2017 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -114,7 +114,11 @@ func NewContext(config *Configuration, kv kvstore.KeyValueStore) (*Context, erro
 		return nil, fmt.Errorf("default bridge network %s not present in config", ctx.config.BridgeNetwork)
 	}
 
-	s, err := ctx.newScope(n.Type, n.Name, nil, nil, nil, nil)
+	scopeData := &ScopeData{
+		ScopeType: n.Type,
+		Name:      n.Name,
+	}
+	s, err := ctx.newScope(scopeData)
 	if err != nil {
 		return nil, err
 	}
@@ -133,7 +137,17 @@ func NewContext(config *Configuration, kv kvstore.KeyValueStore) (*Context, erro
 		}
 
 		subnet := net.IPNet{IP: n.Gateway.IP.Mask(n.Gateway.Mask), Mask: n.Gateway.Mask}
-		s, err := ctx.newScope(n.Type, nn, &subnet, n.Gateway.IP, n.Nameservers, pools)
+
+		scopeData = &ScopeData{
+			ScopeType: n.Type,
+			Name:      nn,
+			Subnet:    &subnet,
+			Gateway:   n.Gateway.IP,
+			DNS:       n.Nameservers,
+			Pools:     pools,
+		}
+
+		s, err := ctx.newScope(scopeData)
 		if err != nil {
 			return nil, err
 		}
@@ -148,7 +162,7 @@ func NewContext(config *Configuration, kv kvstore.KeyValueStore) (*Context, erro
 			log.Warnf("error listing scopes from key value store: %s", err)
 		} else {
 			for k, v := range values {
-				s := newScope(uid.NilUID, "", "", nil, nil, nil, nil)
+				s := newScope(uid.NilUID, "", nil, &ScopeData{})
 				if err := s.UnmarshalJSON(v); err != nil {
 					log.Warnf("error loading scope data from key %s, skipping: %s", k, err)
 					continue
@@ -310,18 +324,22 @@ func (c *Context) addScope(s *Scope) error {
 	return nil
 }
 
-func (c *Context) newScopeCommon(id uid.UID, name, scopeType string, subnet *net.IPNet, gateway net.IP, dns []net.IP, pools []string, network object.NetworkReference) (*Scope, error) {
+func (c *Context) newScopeCommon(id uid.UID, scopeType string, network object.NetworkReference, scopeData *ScopeData) (*Scope, error) {
 	defer trace.End(trace.Begin(""))
 
-	newScope := newScope(id, name, scopeType, subnet, gateway, dns, network)
-	newScope.spaces = make([]*AddressSpace, len(pools))
-	for i, p := range pools {
+	newScope := newScope(id, scopeType, network, scopeData)
+	newScope.spaces = make([]*AddressSpace, len(scopeData.Pools))
+	for i, p := range scopeData.Pools {
 		r := ip.ParseRange(p)
 		if r == nil {
-			return nil, fmt.Errorf("invalid pool %s specified for scope %s", p, name)
+			return nil, fmt.Errorf("invalid pool %s specified for scope %s", p, scopeData.Name)
 		}
 
 		newScope.spaces[i] = NewAddressSpaceFromRange(r.FirstIP, r.LastIP)
+	}
+
+	for k, v := range scopeData.Annotations {
+		newScope.annotations[k] = v
 	}
 
 	if err := c.addScope(newScope); err != nil {
@@ -331,23 +349,23 @@ func (c *Context) newScopeCommon(id uid.UID, name, scopeType string, subnet *net
 	return newScope, nil
 }
 
-func (c *Context) newBridgeScope(id uid.UID, name string, subnet *net.IPNet, gateway net.IP, dns []net.IP, pools []string) (newScope *Scope, err error) {
+func (c *Context) newBridgeScope(id uid.UID, scopeData *ScopeData) (newScope *Scope, err error) {
 	defer trace.End(trace.Begin(""))
 	bnPG, ok := c.config.PortGroups[c.config.BridgeNetwork]
 	if !ok || bnPG == nil {
 		return nil, fmt.Errorf("bridge network not set")
 	}
 
-	if ip.IsUnspecifiedSubnet(subnet) {
+	if ip.IsUnspecifiedSubnet(scopeData.Subnet) {
 		// get the next available subnet from the default bridge pool
 		var err error
-		subnet, err = c.defaultBridgePool.NextIP4Net(c.defaultBridgeMask)
+		scopeData.Subnet, err = c.defaultBridgePool.NextIP4Net(c.defaultBridgeMask)
 		if err != nil {
 			return nil, err
 		}
 	}
 
-	s, err := c.newScopeCommon(id, name, constants.BridgeScopeType, subnet, gateway, dns, pools, bnPG)
+	s, err := c.newScopeCommon(id, constants.BridgeScopeType, bnPG, scopeData)
 	if err != nil {
 		return nil, err
 	}
@@ -362,29 +380,30 @@ func (c *Context) newBridgeScope(id uid.UID, name string, subnet *net.IPNet, gat
 	return s, nil
 }
 
-func (c *Context) newExternalScope(id uid.UID, name string, subnet *net.IPNet, gateway net.IP, dns []net.IP, pools []string) (*Scope, error) {
+func (c *Context) newExternalScope(id uid.UID, scopeData *ScopeData) (*Scope, error) {
 	defer trace.End(trace.Begin(""))
+
 	// ipam cannot be specified without gateway and subnet
-	if len(pools) > 0 {
-		if ip.IsUnspecifiedSubnet(subnet) || gateway.IsUnspecified() {
+	if len(scopeData.Pools) > 0 {
+		if ip.IsUnspecifiedSubnet(scopeData.Subnet) || scopeData.Gateway.IsUnspecified() {
 			return nil, fmt.Errorf("ipam cannot be specified without gateway and subnet for external network")
 		}
 	}
 
-	if !ip.IsUnspecifiedSubnet(subnet) {
+	if !ip.IsUnspecifiedSubnet(scopeData.Subnet) {
 		// cannot overlap with the default bridge pool
-		if c.defaultBridgePool.Network.Contains(subnet.IP) ||
-			c.defaultBridgePool.Network.Contains(highestIP4(subnet)) {
+		if c.defaultBridgePool.Network.Contains(scopeData.Subnet.IP) ||
+			c.defaultBridgePool.Network.Contains(highestIP4(scopeData.Subnet)) {
 			return nil, fmt.Errorf("external network cannot overlap with default bridge network")
 		}
 	}
 
-	pg := c.config.PortGroups[name]
+	pg := c.config.PortGroups[scopeData.Name]
 	if pg == nil {
-		return nil, fmt.Errorf("no network info for external scope %s", name)
+		return nil, fmt.Errorf("no network info for external scope %s", scopeData.Name)
 	}
 
-	return c.newScopeCommon(id, name, constants.ExternalScopeType, subnet, gateway, dns, pools, pg)
+	return c.newScopeCommon(id, constants.ExternalScopeType, pg, scopeData)
 }
 
 func (c *Context) reserveSubnet(subnet *net.IPNet) (*AddressSpace, bool, error) {
@@ -470,13 +489,24 @@ func scopeKey(sn string) string {
 	return fmt.Sprintf("context.scopes.%s", sn)
 }
 
-func (c *Context) NewScope(ctx context.Context, scopeType, name string, subnet *net.IPNet, gateway net.IP, dns []net.IP, pools []string) (*Scope, error) {
+// ScopeData holds fields used to create a new scope
+type ScopeData struct {
+	ScopeType   string
+	Name        string
+	Subnet      *net.IPNet
+	Gateway     net.IP
+	DNS         []net.IP
+	Pools       []string
+	Annotations map[string]string
+}
+
+func (c *Context) NewScope(ctx context.Context, scopeData *ScopeData) (*Scope, error) {
 	defer trace.End(trace.Begin(""))
 
 	c.Lock()
 	defer c.Unlock()
 
-	s, err := c.newScope(scopeType, name, subnet, gateway, dns, pools)
+	s, err := c.newScope(scopeData)
 	if err != nil {
 		return nil, err
 	}
@@ -502,28 +532,28 @@ func (c *Context) NewScope(ctx context.Context, scopeType, name string, subnet *
 	return s, nil
 }
 
-func (c *Context) newScope(scopeType, name string, subnet *net.IPNet, gateway net.IP, dns []net.IP, pools []string) (*Scope, error) {
+func (c *Context) newScope(scopeData *ScopeData) (*Scope, error) {
 	// sanity checks
-	if name == "" {
+	if scopeData.Name == "" {
 		return nil, fmt.Errorf("scope name must not be empty")
 	}
 
-	if gateway == nil {
-		gateway = net.IPv4(0, 0, 0, 0)
+	if scopeData.Gateway == nil {
+		scopeData.Gateway = net.IPv4(0, 0, 0, 0)
 	}
 
-	if _, ok := c.scopes[name]; ok {
-		return nil, DuplicateResourceError{resID: name}
+	if _, ok := c.scopes[scopeData.Name]; ok {
+		return nil, DuplicateResourceError{resID: scopeData.Name}
 	}
 
 	var s *Scope
 	var err error
-	switch scopeType {
+	switch scopeData.ScopeType {
 	case constants.BridgeScopeType:
-		s, err = c.newBridgeScope(uid.New(), name, subnet, gateway, dns, pools)
+		s, err = c.newBridgeScope(uid.New(), scopeData)
 
 	case constants.ExternalScopeType:
-		s, err = c.newExternalScope(uid.New(), name, subnet, gateway, dns, pools)
+		s, err = c.newExternalScope(uid.New(), scopeData)
 
 	default:
 		return nil, fmt.Errorf("scope type not supported")

--- a/lib/portlayer/network/network.go
+++ b/lib/portlayer/network/network.go
@@ -1,4 +1,4 @@
-// Copyright 2016 VMware, Inc. All Rights Reserved.
+// Copyright 2016-2017 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -195,7 +195,16 @@ func engageContext(ctx context.Context, netctx *Context, em event.EventManager) 
 			}
 
 			log.Debugf("adding scope %s", n)
-			if _, err = netctx.newScope(ne.Network.Type, n, &ne.Network.Gateway, ne.Network.Gateway.IP, ne.Network.Nameservers, pools); err != nil {
+
+			scopeData := &ScopeData{
+				ScopeType: ne.Network.Type,
+				Name:      n,
+				Subnet:    &ne.Network.Gateway,
+				Gateway:   ne.Network.Gateway.IP,
+				DNS:       ne.Network.Nameservers,
+				Pools:     pools,
+			}
+			if _, err = netctx.newScope(scopeData); err != nil {
 				return err
 			}
 		}

--- a/tests/test-cases/Group1-Docker-Commands/1-15-Docker-Network-Create.md
+++ b/tests/test-cases/Group1-Docker-Commands/1-15-Docker-Network-Create.md
@@ -13,16 +13,20 @@ This test requires that a vSphere server is running and available
 #Test Steps:
 1. Deploy VIC appliance to vSphere server
 2. Issue docker network create test-network to the VIC appliance
-3. Issue docker network create test-network to the VIC appliance
-4. Issue docker network create -d overlay test-network2 to the VIC appliance
+3. Issue docker network create --label=foo=bar label-network to the VIC appliance
+4. Issue docker network inspect -f '{{.Labels}}' label-network to the VIC appliance
+5. Issue docker network create test-network to the VIC appliance
+6. Issue docker network create -d overlay test-network2 to the VIC appliance
 
 #Expected Outcome:
-* Step 2 should completely successfully and a new network should be created named test-network
-* Step 3 should result in an error with the following message:  
+* Step 2 should complete successfully and a new network should be created named test-network
+* Step 3 should complete successfully and a new network should be created named label-network
+* Step 4 should complete successfully and the output should show label-network's label
+* Step 5 should result in an error with the following message:
 ```
 Error response from daemon: network with name test-network already exists
 ```
-* Step 4 should result in an error with the following message:  
+* Step 6 should result in an error with the following message:
 ```
 Error response from daemon: failed to parse pool request for address space "GlobalDefault" pool "" subpool "": cannot find address space GlobalDefault (most likely the backing datastore is not configured)
 ```

--- a/tests/test-cases/Group1-Docker-Commands/1-15-Docker-Network-Create.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-15-Docker-Network-Create.robot
@@ -26,6 +26,16 @@ Basic network create
     Should Be Equal As Integers  ${rc}  0
     Should Contain  ${output}  test-network
 
+Network create with label
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} network create --label=foo=bar label-network
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} network ls
+    Should Be Equal As Integers  ${rc}  0
+    Should Contain  ${output}  label-network
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} network inspect -f '{{.Labels}}' label-network
+    Should Be Equal As Integers  ${rc}  0
+    Should Contain  ${output}  map[foo:bar]
+
 Create already created network
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} network create test-network
     Should Be Equal As Integers  ${rc}  1

--- a/tests/test-cases/Group1-Docker-Commands/1-16-Docker-Network-LS.md
+++ b/tests/test-cases/Group1-Docker-Commands/1-16-Docker-Network-LS.md
@@ -14,17 +14,20 @@ This test requires that a vSphere server is running and available
 1. Deploy VIC appliance to vSphere server
 2. Issue docker network ls to the VIC appliance
 3. Issue docker network ls -q to the VIC appliance
-4. Issue docker network ls -f name=host to the VIC appliance
-5. Issue docker network ls --no-trunc to the VIC appliance
-6. Issue docker network ls -f name=fakeName to the VIC appliance
+4. Issue docker network ls -f name=bridge to the VIC appliance
+5. Issue docker network ls -f name=fakeName to the VIC appliance
+6. Issue docker network create --label=foo foo-network to the VIC appliance
+7. Issue docker network ls -f label=foo to the VIC appliance
+8. Issue docker network ls --no-trunc to the VIC appliance
 
 #Expected Outcome:
-* Steps 2-6 should all complete successfully
-* Step 2 should return at the least the host, null, and bridge networks that are default
+* Step 2 should return at the least the default networks
 * Step 3 should return the networks ID only
-* Step 4 should return only the host network
-* Step 5 should return all of the networks with their full IDs
-* Step 6 should return no networks listed
+* Step 4 should return only the bridge network
+* Step 5 should return no networks listed
+* Step 6 should return without errors
+* Step 7 should return only the foo-network network
+* Step 8 should return all of the networks with their full IDs
 
 #Possible Problems:
 None

--- a/tests/test-cases/Group1-Docker-Commands/1-16-Docker-Network-LS.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-16-Docker-Network-LS.robot
@@ -31,10 +31,25 @@ Docker network ls -q
     Should Not Contain  ${output}  DRIVER
     Should Not Contain  ${output}  bridge
 
-Docker network ls -f
+Docker network ls filter by name
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} network ls -f name=bridge
     Should Be Equal As Integers  ${rc}  0
     Should Contain  ${output}  bridge
+    @{lines}=  Split To Lines  ${output}
+    Length Should Be  ${lines}  2
+
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} network ls -f name=fakeName
+    Should Be Equal As Integers  ${rc}  0
+    @{lines}=  Split To Lines  ${output}
+    Length Should Be  ${lines}  1
+    Should Contain  @{lines}[0]  NAME
+
+Docker network ls filter by label
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} network create --label=foo foo-network
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} network ls -f label=foo
+    Should Be Equal As Integers  ${rc}  0
+    Should Contain  ${output}  foo-network
     @{lines}=  Split To Lines  ${output}
     Length Should Be  ${lines}  2
 
@@ -45,9 +60,3 @@ Docker network ls --no-trunc
     @{line}=  Split String  @{lines}[1]
     Length Should Be  @{line}[0]  64
 
-Docker network ls -f fake network
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} network ls -f name=fakeName
-    Should Be Equal As Integers  ${rc}  0
-    @{lines}=  Split To Lines  ${output}
-    Length Should Be  ${lines}  1
-    Should Contain  @{lines}[0]  NAME


### PR DESCRIPTION
Adds support for labels in `network create` and `network inspect`. With this change, `network ls -f label=...` also works as expected.

Fixes #3738 