### PR TITLE
Integrate nfs volume store impl with client

### DIFF
--- a/lib/portlayer/storage/nfs/target.go
+++ b/lib/portlayer/storage/nfs/target.go
@@ -18,15 +18,19 @@ import (
 	"io"
 	"net/url"
 	"os"
+
+	"github.com/vmware/vic/pkg/trace"
 )
 
 // MountServer is an interface used to communicate with network attached storage.
 type MountServer interface {
-	// Mount initiates the NAS Target and returns a Target interface.
-	Mount(target *url.URL) (Target, error)
+	// Mount executes the mount program on the Target.
+	Mount(op trace.Operation) (Target, error)
 
 	// Unmount terminates the Mount on the Target.
-	Unmount(target Target) error
+	Unmount(op trace.Operation) error
+
+	URL() (*url.URL, error)
 }
 
 // Target is the filesystem interface for performing actions against attached storage.
@@ -37,18 +41,15 @@ type Target interface {
 	// OpenFile opens a file on the Target with the given mode
 	OpenFile(path string, perm os.FileMode) (io.ReadWriteCloser, error)
 
-	// Create creates a file, errors out if file already exists
-	Create(path string, perm os.FileMode) (io.ReadWriteCloser, error)
-
 	// Mkdir creates a directory at the given path
 	Mkdir(path string, perm os.FileMode) ([]byte, error)
 
 	// RemoveAll deletes Directory recursively
 	RemoveAll(Path string) error
 
-	// ReadDir reads the dirents of the given directory
+	// ReadDir reads the dirents in the given directory
 	ReadDir(path string) ([]os.FileInfo, error)
 
 	// Lookup reads os.FileInfo for the given path
-	Lookup(path string) (os.FileInfo, error)
+	Lookup(path string) (os.FileInfo, []byte, error)
 }

--- a/lib/portlayer/storage/nfs/volume.go
+++ b/lib/portlayer/storage/nfs/volume.go
@@ -27,10 +27,10 @@ import (
 
 const (
 	// The directory created in the NFS VolumeStore which we create volumes under
-	VolumesDir = "volumes"
+	volumesDir = "volumes"
 
 	// path that namespaces the metadata for a specific volume. It lives beside the Volumes Directory.
-	metadataDir = "volumedata"
+	metadataDir = "volumes_metadata"
 
 	// Stock permissions that are set, In the future we may pass these in.
 	defaultPermissions = 0755
@@ -41,35 +41,22 @@ type VolumeStore struct {
 	// volume store name
 	Name string
 
-	// handler for establishing connection to a target.
+	// Service is the interface to the nfs target.
 	Service MountServer
-
-	// nfs target for filesystem interaction
-	Target *url.URL
 
 	// Service selflink to volume store.
 	SelfLink *url.URL
 }
 
-func NewVolumeStore(op trace.Operation, storeName string, nfsTargetURL *url.URL, mount MountServer) (*VolumeStore, error) {
-	op.Infof("Creating datastore (%s) at target (%q)", storeName, nfsTargetURL.String())
+func NewVolumeStore(op trace.Operation, storeName string, mount MountServer) (*VolumeStore, error) {
+	u, _ := mount.URL()
+	op.Infof("Creating nfs volumestore %s on %s", storeName, u.String())
 
-	target, err := mount.Mount(nfsTargetURL)
+	target, err := mount.Mount(op)
 	if err != nil {
 		return nil, err
 	}
-	defer mount.Unmount(target)
-
-	// we assume that nfsTargetURL.path already exists.
-	// make volumes directory
-	if _, err := target.Mkdir(path.Join(nfsTargetURL.Path, VolumesDir), defaultPermissions); err != nil && !os.IsExist(err) {
-		return nil, err
-	}
-
-	// make metadata directory
-	if _, err := target.Mkdir(path.Join(nfsTargetURL.Path, metadataDir), defaultPermissions); err != nil && !os.IsExist(err) {
-		return nil, err
-	}
+	defer mount.Unmount(op)
 
 	selfLink, err := util.VolumeStoreNameToURL(storeName)
 	if err != nil {
@@ -79,8 +66,18 @@ func NewVolumeStore(op trace.Operation, storeName string, nfsTargetURL *url.URL,
 	v := &VolumeStore{
 		Name:     storeName,
 		Service:  mount,
-		Target:   nfsTargetURL,
 		SelfLink: selfLink,
+	}
+
+	// we assume that nfsTargetURL.path already exists.
+	// make volumes directory
+	if _, err := target.Mkdir(volumesDir, defaultPermissions); err != nil && !os.IsExist(err) {
+		return nil, err
+	}
+
+	// make metadata directory
+	if _, err := target.Mkdir(metadataDir, defaultPermissions); err != nil && !os.IsExist(err) {
+		return nil, err
 	}
 
 	return v, nil
@@ -89,38 +86,33 @@ func NewVolumeStore(op trace.Operation, storeName string, nfsTargetURL *url.URL,
 // Returns the path to the vol relative to the given store.  The dir structure
 // for a vol in a nfs store is `<configured nfs server path>/volumes/<vol ID>/<volume contents>`.
 func (v *VolumeStore) volDirPath(ID string) string {
-	return path.Join(v.Target.Path, VolumesDir, ID)
-}
-
-func (v *VolumeStore) volumesDir() string {
-	return path.Join(v.Target.Path, VolumesDir)
+	return path.Join(volumesDir, ID)
 }
 
 // Returns the path to the metadata directory for a volume
 func (v *VolumeStore) volMetadataDirPath(ID string) string {
-	return path.Join(v.Target.Path, metadataDir, ID)
+	return path.Join(metadataDir, ID)
 }
 
 // Creates a volume directory and volume object for NFS based volumes
 func (v *VolumeStore) VolumeCreate(op trace.Operation, ID string, store *url.URL, capacityKB uint64, info map[string][]byte) (*storage.Volume, error) {
-	target, err := v.Service.Mount(v.Target)
+	target, err := v.Service.Mount(op)
 	if err != nil {
 		return nil, err
 	}
-	defer v.Service.Unmount(target)
+	defer v.Service.Unmount(op)
 
 	if _, err := target.Mkdir(v.volDirPath(ID), defaultPermissions); err != nil {
 		return nil, err
 	}
 
-	backing := NewVolume(v.Target, v.volDirPath(ID))
-
-	vol, err := storage.NewVolume(v.SelfLink, ID, info, backing)
+	u, _ := v.Service.URL()
+	vol, err := storage.NewVolume(v.SelfLink, ID, info, NewVolume(u, v.volDirPath(ID)))
 	if err != nil {
 		return nil, err
 	}
 
-	if err := writeMetadata(op, v.volMetadataDirPath(ID), info, target); err != nil {
+	if err := v.writeMetadata(op, ID, info, target); err != nil {
 		return nil, err
 	}
 
@@ -130,11 +122,11 @@ func (v *VolumeStore) VolumeCreate(op trace.Operation, ID string, store *url.URL
 
 // Removes a volume and all of its contents from the nfs store. We already know via the cache if it is in use.
 func (v *VolumeStore) VolumeDestroy(op trace.Operation, vol *storage.Volume) error {
-	target, err := v.Service.Mount(v.Target)
+	target, err := v.Service.Mount(op)
 	if err != nil {
 		return err
 	}
-	defer v.Service.Unmount(target)
+	defer v.Service.Unmount(op)
 
 	op.Infof("Attempting to remove volume (%s) and its metadata from volume store (%s)", vol.ID, v.Name)
 
@@ -155,13 +147,13 @@ func (v *VolumeStore) VolumeDestroy(op trace.Operation, vol *storage.Volume) err
 
 func (v *VolumeStore) VolumesList(op trace.Operation) ([]*storage.Volume, error) {
 
-	target, err := v.Service.Mount(v.Target)
+	target, err := v.Service.Mount(op)
 	if err != nil {
 		return nil, err
 	}
-	defer v.Service.Unmount(target)
+	defer v.Service.Unmount(op)
 
-	volFileInfo, err := target.ReadDir(v.volumesDir())
+	volFileInfo, err := target.ReadDir(volumesDir)
 	if err != nil {
 		return nil, err
 	}
@@ -180,9 +172,8 @@ func (v *VolumeStore) VolumesList(op trace.Operation) ([]*storage.Volume, error)
 			continue
 		}
 
-		volDeviceBacking := NewVolume(v.Target, v.volDirPath(fileInfo.Name()))
-
-		vol, err := storage.NewVolume(v.SelfLink, fileInfo.Name(), volMetadata, volDeviceBacking)
+		u, _ := v.Service.URL()
+		vol, err := storage.NewVolume(v.SelfLink, fileInfo.Name(), volMetadata, NewVolume(u, v.volDirPath(fileInfo.Name())))
 		if err != nil {
 			op.Errorf("Failed to create volume struct from volume directory (%s)", fileInfo.Name())
 			return nil, err
@@ -198,8 +189,13 @@ func (v *VolumeStore) VolumesList(op trace.Operation) ([]*storage.Volume, error)
 	return volumes, nil
 }
 
-func writeMetadata(op trace.Operation, metadataPath string, info map[string][]byte, target Target) error {
-	//NOTE: right now we do not support updating metadata, thus we make the ID directory here
+func (v *VolumeStore) writeMetadata(op trace.Operation, ID string, info map[string][]byte, target Target) error {
+	// write metadata into the metadata directory by key (filename) / value
+	// (data), namespaced by volume id
+	//
+	// <root>/volume_matadata/<id>/<key>
+	metadataPath := v.volMetadataDirPath(ID)
+
 	_, err := target.Mkdir(metadataPath, defaultPermissions)
 	if err != nil {
 		return err
@@ -208,8 +204,9 @@ func writeMetadata(op trace.Operation, metadataPath string, info map[string][]by
 	op.Infof("Writing metadata to (%s)", metadataPath)
 	for fileName, data := range info {
 		targetPath := path.Join(metadataPath, fileName)
-		blobFile, err := target.Create(targetPath, defaultPermissions)
+		blobFile, err := target.OpenFile(targetPath, defaultPermissions)
 		if err != nil {
+			op.Errorf("openning file %s: %s", targetPath, err.Error())
 			return err
 		}
 		defer blobFile.Close()


### PR DESCRIPTION
This is the beginning of the integration effort.  This change just unifies the interfaces and addresses some issues I found while integrating the client.

The store url wasn't being used in volume create.  Instead, the nfs
target's url was.  That's a bug.  Fixed.

The Target interface doesn't need a pointer to the target it's
implementing.

Paths in the volumesdir and metadatadir were relative to to the nfs
target's url path.  Mounts are already relative paths, since the
namespace doesn't extend to the nfs server.  That is /foo/bar/mnt is
only known to the nfs client, the server only cares about paths after
the mnt/ directory.  This was a bug and is now fixed.

Added some logging and refactored tests for the above changes.