### PR TITLE
Migrate container configuration in portlayer in memory

### DIFF
--- a/lib/apiservers/engine/backends/container.go
+++ b/lib/apiservers/engine/backends/container.go
@@ -485,12 +485,12 @@ func (c *Container) ContainerRm(name string, config *types.ContainerRmConfig) er
 	if config.ForceRemove {
 		c.containerProxy.Stop(vc, name, &secs, true)
 	} else {
-		status, err := c.containerProxy.Status(vc)
+		state, err := c.containerProxy.State(vc)
 		if err != nil {
 			return err
 		}
 		// force stop if container is broken to make sure container is deletable later
-		if status == ContainerError {
+		if state.Status == ContainerError {
 			c.containerProxy.Stop(vc, name, &secs, true)
 		}
 	}
@@ -546,12 +546,12 @@ func (c *Container) cleanupPortBindings(vc *viccontainer.VicContainer) error {
 				// port bindings were cleaned up by another operation.
 				continue
 			}
-			status, err := c.containerProxy.Status(vc)
+			state, err := c.containerProxy.State(cc)
 			if err != nil {
 				return fmt.Errorf("Failed to get container %q power state: %s",
 					mappedCtr, err)
 			}
-			if status == ContainerRunning {
+			if state.Running {
 				log.Debugf("Running container %q still holds port %s", mappedCtr, hPort)
 				continue
 			}

--- a/lib/apiservers/engine/backends/container.go
+++ b/lib/apiservers/engine/backends/container.go
@@ -489,7 +489,7 @@ func (c *Container) ContainerRm(name string, config *types.ContainerRmConfig) er
 		if err != nil {
 			return err
 		}
-		// force stop if container is broken to make sure container is deletable later
+		// force stop if container state is error to make sure container is deletable later
 		if state.Status == ContainerError {
 			c.containerProxy.Stop(vc, name, &secs, true)
 		}

--- a/lib/apiservers/engine/backends/container.go
+++ b/lib/apiservers/engine/backends/container.go
@@ -485,12 +485,12 @@ func (c *Container) ContainerRm(name string, config *types.ContainerRmConfig) er
 	if config.ForceRemove {
 		c.containerProxy.Stop(vc, name, &secs, true)
 	} else {
-		broken, err := c.containerProxy.IsBroken(vc)
+		status, err := c.containerProxy.Status(vc)
 		if err != nil {
 			return err
 		}
 		// force stop if container is broken to make sure container is deletable later
-		if broken {
+		if status == ContainerError {
 			c.containerProxy.Stop(vc, name, &secs, true)
 		}
 	}
@@ -546,12 +546,12 @@ func (c *Container) cleanupPortBindings(vc *viccontainer.VicContainer) error {
 				// port bindings were cleaned up by another operation.
 				continue
 			}
-			running, err := c.containerProxy.IsRunning(cc)
+			status, err := c.containerProxy.Status(vc)
 			if err != nil {
 				return fmt.Errorf("Failed to get container %q power state: %s",
 					mappedCtr, err)
 			}
-			if running {
+			if status == ContainerRunning {
 				log.Debugf("Running container %q still holds port %s", mappedCtr, hPort)
 				continue
 			}

--- a/lib/apiservers/engine/backends/container.go
+++ b/lib/apiservers/engine/backends/container.go
@@ -481,8 +481,18 @@ func (c *Container) ContainerRm(name string, config *types.ContainerRmConfig) er
 
 	// Use the force and stop the container first
 	secs := 0
+
 	if config.ForceRemove {
 		c.containerProxy.Stop(vc, name, &secs, true)
+	} else {
+		broken, err := c.containerProxy.IsBroken(vc)
+		if err != nil {
+			return err
+		}
+		// force stop if container is broken to make sure container is deletable later
+		if broken {
+			c.containerProxy.Stop(vc, name, &secs, true)
+		}
 	}
 
 	//call the remove directly on the name. No need for using a handle.

--- a/lib/apiservers/engine/backends/container_proxy.go
+++ b/lib/apiservers/engine/backends/container_proxy.go
@@ -555,7 +555,7 @@ func (c *ContainerProxy) Status(vc *viccontainer.VicContainer) (string, error) {
 	if err != nil {
 		switch err := err.(type) {
 		case *containers.GetContainerInfoNotFound:
-			return "", NotFoundError(fmt.Sprintf("No such container: %s", vc.ContainerID))
+			return "", NotFoundError(fmt.Sprintf("No such container: %s", vc.Name))
 		case *containers.GetContainerInfoInternalServerError:
 			return "", InternalServerError(err.Payload.Message)
 		default:

--- a/lib/apiservers/engine/backends/container_proxy.go
+++ b/lib/apiservers/engine/backends/container_proxy.go
@@ -548,7 +548,7 @@ func (c *ContainerProxy) State(vc *viccontainer.VicContainer) (*types.ContainerS
 	defer trace.End(trace.Begin(""))
 
 	if c.client == nil {
-		return nil, InternalServerError("ContainerProxy.dockerInfo failed to get a portlayer client")
+		return nil, InternalServerError("ContainerProxy.State failed to get a portlayer client")
 	}
 
 	results, err := c.client.Containers.GetContainerInfo(containers.NewGetContainerInfoParamsWithContext(ctx).WithID(vc.ContainerID))

--- a/lib/apiservers/engine/backends/container_proxy.go
+++ b/lib/apiservers/engine/backends/container_proxy.go
@@ -555,7 +555,7 @@ func (c *ContainerProxy) State(vc *viccontainer.VicContainer) (*types.ContainerS
 	if err != nil {
 		switch err := err.(type) {
 		case *containers.GetContainerInfoNotFound:
-			return nil, NotFoundError(fmt.Sprintf("No such container: %s", vc.Name))
+			return nil, NotFoundError(vc.Name)
 		case *containers.GetContainerInfoInternalServerError:
 			return nil, InternalServerError(err.Payload.Message)
 		default:

--- a/lib/apiservers/engine/backends/container_test.go
+++ b/lib/apiservers/engine/backends/container_test.go
@@ -294,16 +294,19 @@ func (m *MockContainerProxy) Stop(vc *viccontainer.VicContainer, name string, se
 	return nil
 }
 
-func (m *MockContainerProxy) Status(vc *viccontainer.VicContainer) (string, error) {
+func (m *MockContainerProxy) State(vc *viccontainer.VicContainer) (*types.ContainerState, error) {
 	// Assume container is running if container in cache.  If we need other conditions
 	// in the future, we can add it, but for now, just assume running.
 	c := cache.ContainerCache().GetContainer(vc.ContainerID)
 
 	if c == nil {
-		return "", nil
+		return nil, nil
 	}
 
-	return ContainerRunning, nil
+	state := &types.ContainerState{
+		Running: true,
+	}
+	return state, nil
 }
 
 func (m *MockContainerProxy) Wait(vc *viccontainer.VicContainer, timeout time.Duration) (exitCode int32, processStatus string, containerState string, reterr error) {

--- a/lib/apiservers/engine/backends/container_test.go
+++ b/lib/apiservers/engine/backends/container_test.go
@@ -294,28 +294,16 @@ func (m *MockContainerProxy) Stop(vc *viccontainer.VicContainer, name string, se
 	return nil
 }
 
-func (m *MockContainerProxy) IsRunning(vc *viccontainer.VicContainer) (bool, error) {
+func (m *MockContainerProxy) Status(vc *viccontainer.VicContainer) (string, error) {
 	// Assume container is running if container in cache.  If we need other conditions
 	// in the future, we can add it, but for now, just assume running.
 	c := cache.ContainerCache().GetContainer(vc.ContainerID)
 
 	if c == nil {
-		return false, nil
+		return "", nil
 	}
 
-	return true, nil
-}
-
-func (m *MockContainerProxy) IsBroken(vc *viccontainer.VicContainer) (bool, error) {
-	// Assume container is running if container in cache.  If we need other conditions
-	// in the future, we can add it, but for now, just assume running.
-	c := cache.ContainerCache().GetContainer(vc.ContainerID)
-
-	if c == nil {
-		return false, nil
-	}
-
-	return true, nil
+	return ContainerRunning, nil
 }
 
 func (m *MockContainerProxy) Wait(vc *viccontainer.VicContainer, timeout time.Duration) (exitCode int32, processStatus string, containerState string, reterr error) {

--- a/lib/apiservers/engine/backends/container_test.go
+++ b/lib/apiservers/engine/backends/container_test.go
@@ -24,12 +24,12 @@ import (
 
 	"context"
 
-	"github.com/docker/docker/api/types/backend"
 	derr "github.com/docker/docker/api/errors"
-	"github.com/docker/docker/reference"
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/backend"
 	"github.com/docker/docker/api/types/container"
 	dnetwork "github.com/docker/docker/api/types/network"
+	"github.com/docker/docker/reference"
 	"github.com/docker/go-connections/nat"
 	"github.com/stretchr/testify/assert"
 	"github.com/vishvananda/netlink"
@@ -295,6 +295,18 @@ func (m *MockContainerProxy) Stop(vc *viccontainer.VicContainer, name string, se
 }
 
 func (m *MockContainerProxy) IsRunning(vc *viccontainer.VicContainer) (bool, error) {
+	// Assume container is running if container in cache.  If we need other conditions
+	// in the future, we can add it, but for now, just assume running.
+	c := cache.ContainerCache().GetContainer(vc.ContainerID)
+
+	if c == nil {
+		return false, nil
+	}
+
+	return true, nil
+}
+
+func (m *MockContainerProxy) IsBroken(vc *viccontainer.VicContainer) (bool, error) {
 	// Assume container is running if container in cache.  If we need other conditions
 	// in the future, we can add it, but for now, just assume running.
 	c := cache.ContainerCache().GetContainer(vc.ContainerID)

--- a/lib/apiservers/portlayer/restapi/handlers/containers_handlers.go
+++ b/lib/apiservers/portlayer/restapi/handlers/containers_handlers.go
@@ -361,9 +361,8 @@ func (handler *ContainersHandlersImpl) GetContainerLogsHandler(params containers
 		return containers.NewGetContainerLogsInternalServerError()
 	}
 
-	// containers with PluginVersion > 0 will use updated output logging on the backend
-	// containers with ExecConfig.Version = nil are assumed to be PluginVersion 0
-	if container.ExecConfig.Version != nil && container.ExecConfig.Version.PluginVersion > 0 {
+	// containers with DataVersion > 0 will use updated output logging on the backend
+	if container.DataVersion > 0 {
 		// wrap the reader in a LogReader to deserialize persisted containerVM output
 		reader = iolog.NewLogReader(reader)
 	}

--- a/lib/apiservers/portlayer/restapi/handlers/containers_handlers.go
+++ b/lib/apiservers/portlayer/restapi/handlers/containers_handlers.go
@@ -432,7 +432,7 @@ func convertContainerToContainerInfo(container *exec.ContainerInfo) *models.Cont
 
 	var state string
 	if container.MigrationError != nil {
-		state = "broken"
+		state = "error"
 		info.ProcessConfig.ErrorMsg = fmt.Sprintf("Migration failed: %s", container.MigrationError.Error())
 		info.ProcessConfig.Status = state
 	} else {

--- a/lib/apiservers/portlayer/restapi/handlers/containers_handlers.go
+++ b/lib/apiservers/portlayer/restapi/handlers/containers_handlers.go
@@ -432,9 +432,9 @@ func convertContainerToContainerInfo(container *exec.ContainerInfo) *models.Cont
 
 	var state string
 	if container.MigrationError != nil {
-		state = "Migration failed"
-		info.ProcessConfig.ErrorMsg = container.MigrationError.Error()
-		info.ProcessConfi.Status = state
+		state = "broken"
+		info.ProcessConfig.ErrorMsg = fmt.Sprintf("Migration failed: %s", container.MigrationError.Error())
+		info.ProcessConfig.Status = state
 	} else {
 		state = container.State().String()
 	}

--- a/lib/apiservers/portlayer/restapi/handlers/containers_handlers.go
+++ b/lib/apiservers/portlayer/restapi/handlers/containers_handlers.go
@@ -430,8 +430,15 @@ func convertContainerToContainerInfo(container *exec.ContainerInfo) *models.Cont
 	ccid := container.ExecConfig.ID
 	info.ContainerConfig.ContainerID = ccid
 
-	s := container.State().String()
-	info.ContainerConfig.State = s
+	var state string
+	if container.MigrationError != nil {
+		state = "Migration failed"
+		info.ProcessConfig.ErrorMsg = container.MigrationError.Error()
+		info.ProcessConfi.Status = state
+	} else {
+		state = container.State().String()
+	}
+	info.ContainerConfig.State = state
 	info.ContainerConfig.LayerID = container.ExecConfig.LayerID
 	info.ContainerConfig.RepoName = &container.ExecConfig.RepoName
 	info.ContainerConfig.CreateTime = container.ExecConfig.CreateTime

--- a/lib/config/executor/container_vm.go
+++ b/lib/config/executor/container_vm.go
@@ -34,7 +34,7 @@ type Common struct {
 	// A reference to the components hosting execution environment, if any
 	ExecutionEnvironment string
 
-	// Unambiguous ID with meaning in the context of its hosting execution environment. Change this definition will cause container backward compatibility issue
+	// Unambiguous ID with meaning in the context of its hosting execution environment. Change this definition will cause container backward compatibility issue. Please don't change this.
 	ID string `vic:"0.1" scope:"read-only" key:"id"`
 
 	// Convenience field to record a human readable name

--- a/lib/config/executor/container_vm.go
+++ b/lib/config/executor/container_vm.go
@@ -34,7 +34,7 @@ type Common struct {
 	// A reference to the components hosting execution environment, if any
 	ExecutionEnvironment string
 
-	// Unambiguous ID with meaning in the context of its hosting execution environment
+	// Unambiguous ID with meaning in the context of its hosting execution environment. Change this definition will cause container backward compatibility issue
 	ID string `vic:"0.1" scope:"read-only" key:"id"`
 
 	// Convenience field to record a human readable name

--- a/lib/config/executor/container_vm.go
+++ b/lib/config/executor/container_vm.go
@@ -34,7 +34,7 @@ type Common struct {
 	// A reference to the components hosting execution environment, if any
 	ExecutionEnvironment string
 
-	// Unambiguous ID with meaning in the context of its hosting execution environment. Change this definition will cause container backward compatibility issue. Please don't change this.
+	// Unambiguous ID with meaning in the context of its hosting execution environment. Changing this definition will cause container backward compatibility issue. Please don't change this.
 	ID string `vic:"0.1" scope:"read-only" key:"id"`
 
 	// Convenience field to record a human readable name

--- a/lib/migration/migrator.go
+++ b/lib/migration/migrator.go
@@ -33,7 +33,7 @@ import (
 //
 // Note: Input map conf is VCH appliance guestinfo map, and returned map is the new guestinfo.
 // Returns false without error means no need to migrate, and returned map is the copy of input map
-// If there is error returned, return true and half-migrated value
+// If there is error returned, returns true and half-migrated value
 func MigrateApplianceConfig(ctx context.Context, s *session.Session, conf map[string]string) (map[string]string, bool, error) {
 	return migrateConfig(ctx, s, conf, manager.ApplianceConfigure, manager.ApplianceVersionKey)
 }
@@ -42,7 +42,7 @@ func MigrateApplianceConfig(ctx context.Context, s *session.Session, conf map[st
 //
 // Note: Migrated data will be returned in map, and input object is not changed.
 // Returns false without error means no need to migrate, and returned map is the copy of input map
-// If there is error returned, return true and half-migrated value
+// If there is error returned, returns true and half-migrated value
 func MigrateContainerConfig(conf map[string]string) (map[string]string, bool, error) {
 	return migrateConfig(nil, nil, conf, manager.ContainerConfigure, manager.ContainerVersionKey)
 }

--- a/lib/migration/migrator.go
+++ b/lib/migration/migrator.go
@@ -57,6 +57,11 @@ func ApplianceDataIsOlder(conf map[string]string) (bool, error) {
 	return dataIsOlder(conf, manager.ApplianceConfigure, manager.ApplianceVersionKey)
 }
 
+// ContainerDataVersion returns container data version
+func ContainerDataVersion(conf map[string]string) (int, error) {
+	return getCurrentID(conf, manager.ContainerVersionKey)
+}
+
 // dataIsOlder returns true if data is older than latest. If error happens, always returns false
 func dataIsOlder(data map[string]string, target string, verKey string) (bool, error) {
 	defer trace.End(trace.Begin(fmt.Sprintf("target: %s, version key: %s", target, verKey)))

--- a/lib/migration/migrator.go
+++ b/lib/migration/migrator.go
@@ -33,7 +33,7 @@ import (
 //
 // Note: Input map conf is VCH appliance guestinfo map, and returned map is the new guestinfo.
 // Returns false without error means no need to migrate, and returned map is the copy of input map
-// If there is error returned, returned map might have half-migrated value
+// If there is error returned, return true and half-migrated value
 func MigrateApplianceConfig(ctx context.Context, s *session.Session, conf map[string]string) (map[string]string, bool, error) {
 	return migrateConfig(ctx, s, conf, manager.ApplianceConfigure, manager.ApplianceVersionKey)
 }
@@ -42,7 +42,7 @@ func MigrateApplianceConfig(ctx context.Context, s *session.Session, conf map[st
 //
 // Note: Migrated data will be returned in map, and input object is not changed.
 // Returns false without error means no need to migrate, and returned map is the copy of input map
-// If there is error returned, returned map might have half-migrated value.
+// If there is error returned, return true and half-migrated value
 func MigrateContainerConfig(conf map[string]string) (map[string]string, bool, error) {
 	return migrateConfig(nil, nil, conf, manager.ContainerConfigure, manager.ContainerVersionKey)
 }

--- a/lib/portlayer/attach/attach.go
+++ b/lib/portlayer/attach/attach.go
@@ -147,6 +147,9 @@ func Bind(h interface{}) (interface{}, error) {
 	if !ok {
 		return nil, fmt.Errorf("Type assertion failed for %#+v", handle)
 	}
+	if handle.MigrationError != nil {
+		return nil, fmt.Errorf("Migration failed %s", handle.MigrationError)
+	}
 	return toggle(handle, true)
 }
 
@@ -157,6 +160,9 @@ func Unbind(h interface{}) (interface{}, error) {
 	handle, ok := h.(*exec.Handle)
 	if !ok {
 		return nil, fmt.Errorf("Type assertion failed for %#+v", handle)
+	}
+	if handle.MigrationError != nil {
+		return nil, fmt.Errorf("Migration failed %s", handle.MigrationError)
 	}
 	return toggle(handle, false)
 }

--- a/lib/portlayer/exec/base.go
+++ b/lib/portlayer/exec/base.go
@@ -57,6 +57,7 @@ type containerBase struct {
 	Migrated bool
 	// MigrationError means the errors happens during data migration, some operation might fail for we cannot extract the whole container configuration
 	MigrationError error
+	DataVersion    int
 
 	// original - can be pointers so long as refreshes
 	// use different instances of the structures
@@ -79,6 +80,7 @@ func newBase(vm *vm.VirtualMachine, c *types.VirtualMachineConfigInfo, r *types.
 	if c != nil && c.ExtraConfig != nil {
 		var migratedConf map[string]string
 		containerExecKeyValues := vmomi.OptionValueMap(c.ExtraConfig)
+		base.DataVersion, _ = migration.ContainerDataVersion(containerExecKeyValues)
 		migratedConf, base.Migrated, base.MigrationError = migration.MigrateContainerConfig(containerExecKeyValues)
 		extraconfig.Decode(extraconfig.MapSource(migratedConf), base.ExecConfig)
 	}
@@ -126,6 +128,7 @@ func (c *containerBase) updates(ctx context.Context) (*containerBase, error) {
 	// Get the ExtraConfig
 	var migratedConf map[string]string
 	containerExecKeyValues := vmomi.OptionValueMap(o.Config.ExtraConfig)
+	base.DataVersion, _ = migration.ContainerDataVersion(containerExecKeyValues)
 	migratedConf, base.Migrated, base.MigrationError = migration.MigrateContainerConfig(containerExecKeyValues)
 	extraconfig.Decode(extraconfig.MapSource(migratedConf), base.ExecConfig)
 

--- a/lib/portlayer/exec/base.go
+++ b/lib/portlayer/exec/base.go
@@ -27,6 +27,7 @@ import (
 	"github.com/vmware/govmomi/vim25/mo"
 	"github.com/vmware/govmomi/vim25/types"
 	"github.com/vmware/vic/lib/config/executor"
+	"github.com/vmware/vic/lib/migration"
 	"github.com/vmware/vic/pkg/trace"
 	"github.com/vmware/vic/pkg/vsphere/extraconfig"
 	"github.com/vmware/vic/pkg/vsphere/extraconfig/vmomi"
@@ -52,6 +53,11 @@ func (e NotYetExistError) Error() string {
 type containerBase struct {
 	ExecConfig *executor.ExecutorConfig
 
+	// Migrated is used during in memory migration to assign whether an execConfig is viable for a commit phase
+	Migrated bool
+	// MigrationError means the errors happens during data migration, some operation might fail for we cannot extract the whole container configuration
+	MigrationError error
+
 	// original - can be pointers so long as refreshes
 	// use different instances of the structures
 	Config  *types.VirtualMachineConfigInfo
@@ -71,8 +77,10 @@ func newBase(vm *vm.VirtualMachine, c *types.VirtualMachineConfigInfo, r *types.
 
 	// construct a working copy of the exec config
 	if c != nil && c.ExtraConfig != nil {
-		src := vmomi.OptionValueSource(c.ExtraConfig)
-		extraconfig.Decode(src, base.ExecConfig)
+		var migratedConf map[string]string
+		containerExecKeyValues := vmomi.OptionValueMap(c.ExtraConfig)
+		migratedConf, base.Migrated, base.MigrationError = migration.MigrateContainerConfig(containerExecKeyValues)
+		extraconfig.Decode(extraconfig.MapSource(migratedConf), base.ExecConfig)
 	}
 
 	return base
@@ -116,7 +124,10 @@ func (c *containerBase) updates(ctx context.Context) (*containerBase, error) {
 	}
 
 	// Get the ExtraConfig
-	extraconfig.Decode(vmomi.OptionValueSource(o.Config.ExtraConfig), base.ExecConfig)
+	var migratedConf map[string]string
+	containerExecKeyValues := vmomi.OptionValueMap(o.Config.ExtraConfig)
+	migratedConf, base.Migrated, base.MigrationError = migration.MigrateContainerConfig(containerExecKeyValues)
+	extraconfig.Decode(extraconfig.MapSource(migratedConf), base.ExecConfig)
 
 	return base, nil
 }

--- a/lib/portlayer/exec/commit.go
+++ b/lib/portlayer/exec/commit.go
@@ -146,6 +146,12 @@ func Commit(ctx context.Context, sess *session.Session, h *Handle, waitTime *int
 				log.Debugf("Nilifying ExtraConfig as we are running")
 				s.ExtraConfig = nil
 			}
+			// nilify ExtraConfig if container configuration is migrated
+			// in this case, VCH and container are in different version. Migrated configuration cannot be written back to old container, to avoid data loss in old version's container
+			if h.Migrated {
+				log.Debugf("Nilifying ExtraConfig as configuration of container %s is migrated", h.ExecConfig.ID)
+				s.ExtraConfig = nil
+			}
 
 			_, err := h.vm.WaitForResult(ctx, func(ctx context.Context) (tasks.Task, error) {
 				return h.vm.Reconfigure(ctx, *s)


### PR DESCRIPTION
Fixes #3610 

- Migrate container configuration in memory if there is migration plugin registered
- In commit method, drop extraconfig change if data is migrated
- If data migration failed, keep partial migrated value, and keep migration error in container cache
- In docker inspect and docker ps show container status as "broken" if data migration failed
- If container status is broken
  - allow container stop
  - force delete even for "docker rm"
