### PR TITLE
[specific ci=1-01-Docker-Info] Show volume drivers in the plugins section of docker info

### DIFF
--- a/lib/apiservers/engine/backends/system.go
+++ b/lib/apiservers/engine/backends/system.go
@@ -1,4 +1,4 @@
-// Copyright 2016 VMware, Inc. All Rights Reserved.
+// Copyright 2016-2017 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -145,6 +145,14 @@ func (s *System) SystemInfo() (*types.Info, error) {
 	} else {
 		customInfo := [2]string{volumeStoresID, volumeStoreString}
 		info.SystemStatus = append(info.SystemStatus, customInfo)
+
+		// Show a list of supported volume drivers if there's at least one volume
+		// store configured for the VCH
+		if len(volumeStoreString) > 0 {
+			for driver := range supportedVolDrivers {
+				info.Plugins.Volume = append(info.Plugins.Volume, driver)
+			}
+		}
 	}
 
 	if s.systemProxy.PingPortlayer() {

--- a/lib/apiservers/engine/backends/system.go
+++ b/lib/apiservers/engine/backends/system.go
@@ -147,10 +147,14 @@ func (s *System) SystemInfo() (*types.Info, error) {
 		info.SystemStatus = append(info.SystemStatus, customInfo)
 
 		// Show a list of supported volume drivers if there's at least one volume
-		// store configured for the VCH
+		// store configured for the VCH. "local" is excluded because it's the default
+		// driver supplied by the Docker client and is equivalent to "vsphere" in
+		// our implementation.
 		if len(volumeStoreString) > 0 {
 			for driver := range supportedVolDrivers {
-				info.Plugins.Volume = append(info.Plugins.Volume, driver)
+				if driver != "local" {
+					info.Plugins.Volume = append(info.Plugins.Volume, driver)
+				}
 			}
 		}
 	}

--- a/lib/apiservers/engine/backends/volume.go
+++ b/lib/apiservers/engine/backends/volume.go
@@ -53,9 +53,11 @@ var validDriverOptsKeys = map[string]struct{}{
 	DriverArgImageKey:     {},
 }
 
+// Volume drivers currently supported. "local" is the default driver supplied by the client
+// and is equivalent to "vsphere" for our implementation.
 var supportedVolDrivers = map[string]struct{}{
-	"local":   struct{}{},
 	"vsphere": struct{}{},
+	"local":   struct{}{},
 }
 
 //Validation pattern for Volume Names

--- a/lib/apiservers/engine/backends/volume.go
+++ b/lib/apiservers/engine/backends/volume.go
@@ -53,6 +53,11 @@ var validDriverOptsKeys = map[string]struct{}{
 	DriverArgImageKey:     {},
 }
 
+var supportedVolDrivers = map[string]struct{}{
+	"local":   struct{}{},
+	"vsphere": struct{}{},
+}
+
 //Validation pattern for Volume Names
 var volumeNameRegex = regexp.MustCompile("^[a-zA-Z0-9][a-zA-Z0-9_.-]*$")
 
@@ -344,11 +349,8 @@ func extractDockerMetadata(metadataMap map[string]string) (*volumeMetadata, erro
 // Utility Functions
 
 func newVolumeCreateReq(name, driverName string, volumeData, labels map[string]string) (*models.VolumeRequest, error) {
-	defaultDriver := driverName == "local"
-	vsphereDriver := driverName == "vsphere"
-
-	if !defaultDriver && !vsphereDriver {
-		return nil, fmt.Errorf("Error looking up volume plugin %s: plugin not found", driverName)
+	if _, ok := supportedVolDrivers[driverName]; !ok {
+		return nil, fmt.Errorf("error looking up volume plugin %s: plugin not found", driverName)
 	}
 
 	if !volumeNameRegex.Match([]byte(name)) && name != "" {

--- a/tests/test-cases/Group1-Docker-Commands/1-01-Docker-Info.md
+++ b/tests/test-cases/Group1-Docker-Commands/1-01-Docker-Info.md
@@ -19,7 +19,8 @@ This test requires that a vSphere server is running and available
 6. Issue docker info command, grab the resource pool CPU/mem usage, add a running container to the resource pool, docker info, check the resource pool CPU/mem usage values are updated
 
 #Expected Outcome:
-* VIC appliance should respond with a properly formatted info response, no errors should be seen. Step 3 should result in additional debug information being returned as well.
+* In Step 2, the VIC appliance should respond with a properly formatted info response without errors. Supported volume drivers should be present in the Plugins section.
+* Step 3 should result in additional debug information being returned as well.
 * Verify in step 4 that the correct number of containers is reported.
 * Verify in step 5 that docker info reports the latest resource pool CPU and memory limits.
 * Verify in step 6 that docker info reports the latest resource pool CPU and memory usages

--- a/tests/test-cases/Group1-Docker-Commands/1-01-Docker-Info.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-01-Docker-Info.robot
@@ -63,10 +63,13 @@ Set resource pool CPU and mem limits
 
 *** Test Cases ***
 Basic Info
-    Log To Console  \nRunning docker info command...
-    ${output}=  Run  docker %{VCH-PARAMS} info
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} info
+    Should Be Equal As Integers  ${rc}  0
     Log  ${output}
     Should Contain  ${output}  vSphere
+    ${volpluginline}=  Get Lines Containing String  ${output}  Volume:
+    Should Contain  ${volpluginline}  local
+    Should Contain  ${volpluginline}  vsphere
 
 Debug Info
     ${status}=  Get State Of Github Issue  780

--- a/tests/test-cases/Group1-Docker-Commands/1-01-Docker-Info.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-01-Docker-Info.robot
@@ -68,7 +68,6 @@ Basic Info
     Log  ${output}
     Should Contain  ${output}  vSphere
     ${volpluginline}=  Get Lines Containing String  ${output}  Volume:
-    Should Contain  ${volpluginline}  local
     Should Contain  ${volpluginline}  vsphere
 
 Debug Info

--- a/tests/test-cases/Group1-Docker-Commands/1-19-Docker-Volume-Create.md
+++ b/tests/test-cases/Group1-Docker-Commands/1-19-Docker-Volume-Create.md
@@ -33,7 +33,7 @@ Error response from daemon: A volume named test already exists. Choose a differe
 ```
 * Step 5 should result in error with the following error message:  
 ```
-Error looking up volume plugin fakeDriver: plugin not found
+error looking up volume plugin fakeDriver: plugin not found
 ```
 * Step 6 should result in error with the following message:  
 ```

--- a/tests/test-cases/Group1-Docker-Commands/1-19-Docker-Volume-Create.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-19-Docker-Volume-Create.robot
@@ -76,7 +76,7 @@ Docker volume create already named volume
 Docker volume create volume with bad driver
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} volume create -d fakeDriver --name=test2
     Should Be Equal As Integers  ${rc}  1
-    Should Contain  ${output}  Error looking up volume plugin fakeDriver: plugin not found
+    Should Contain  ${output}  error looking up volume plugin fakeDriver: plugin not found
 
 Docker volume create with bad volumestore
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} volume create --name=test3 --opt VolumeStore=fakeStore


### PR DESCRIPTION
This change populates a list of supported volume drivers in the `Plugins: Volume` section of `docker info`:
```
$ sudo docker -H 192.168.77.225:2376 --tls info
Containers: 0
...
Plugins: 
 Volume: vsphere
...
```

Fixes #3994