### PR TITLE
Use const param for extraconfig separator

### DIFF
--- a/pkg/vsphere/extraconfig/basic_test.go
+++ b/pkg/vsphere/extraconfig/basic_test.go
@@ -148,9 +148,9 @@ func TestBasicMap(t *testing.T) {
 	Encode(MapSink(encoded), IntMap)
 
 	expected := map[string]string{
-		visibleRO("intmap|1st"): "12345",
-		visibleRO("intmap|2nd"): "67890",
-		visibleRO("intmap"):     "1st|2nd",
+		visibleRO("intmap" + Separator + "1st"): "12345",
+		visibleRO("intmap" + Separator + "2nd"): "67890",
+		visibleRO("intmap"):                     "1st" + Separator + "2nd",
 	}
 	assert.Equal(t, expected, encoded, "Encoded and expected does not match")
 
@@ -196,7 +196,7 @@ func TestBasicSlice(t *testing.T) {
 	Encode(MapSink(encoded), IntSlice)
 
 	expected := map[string]string{
-		visibleRO("intslice~"): "1|2|3|4|5",
+		visibleRO("intslice~"): "1" + Separator + "2" + Separator + "3" + Separator + "4" + Separator + "5",
 		visibleRO("intslice"):  "4",
 	}
 	assert.Equal(t, expected, encoded, "Encoded and expected does not match")

--- a/pkg/vsphere/extraconfig/clean_test.go
+++ b/pkg/vsphere/extraconfig/clean_test.go
@@ -137,16 +137,16 @@ func TestStructMap(t *testing.T) {
 	Encode(MapSink(encoded), StructMap)
 
 	expected := map[string]string{
-		visibleRO("map|Key1/id"):    "0xDEADBEEF",
-		visibleRO("map|Key1/name"):  "beef",
-		visibleRO("map|Key1/notes"): "",
-		visibleRO("map|Key2/id"):    "0x8BADF00D",
-		visibleRO("map|Key2/name"):  "food",
-		visibleRO("map|Key2/notes"): "",
-		visibleRO("map|Key3/id"):    "0xDEADF00D",
-		visibleRO("map|Key3/name"):  "dead",
-		visibleRO("map|Key3/notes"): "",
-		visibleRO("map"):            "Key1|Key2|Key3",
+		visibleRO("map" + Separator + "Key1/id"):    "0xDEADBEEF",
+		visibleRO("map" + Separator + "Key1/name"):  "beef",
+		visibleRO("map" + Separator + "Key1/notes"): "",
+		visibleRO("map" + Separator + "Key2/id"):    "0x8BADF00D",
+		visibleRO("map" + Separator + "Key2/name"):  "food",
+		visibleRO("map" + Separator + "Key2/notes"): "",
+		visibleRO("map" + Separator + "Key3/id"):    "0xDEADF00D",
+		visibleRO("map" + Separator + "Key3/name"):  "dead",
+		visibleRO("map" + Separator + "Key3/notes"): "",
+		visibleRO("map"):                            "Key1" + Separator + "Key2" + Separator + "Key3",
 	}
 	assert.Equal(t, expected, encoded, "Encoded and expected does not match")
 
@@ -182,16 +182,16 @@ func TestIntStructMap(t *testing.T) {
 	Encode(MapSink(encoded), StructMap)
 
 	expected := map[string]string{
-		visibleRO("map|1/id"):    "0xDEADBEEF",
-		visibleRO("map|1/name"):  "beef",
-		visibleRO("map|1/notes"): "",
-		visibleRO("map|2/id"):    "0x8BADF00D",
-		visibleRO("map|2/name"):  "food",
-		visibleRO("map|2/notes"): "",
-		visibleRO("map|3/id"):    "0xDEADF00D",
-		visibleRO("map|3/name"):  "dead",
-		visibleRO("map|3/notes"): "",
-		visibleRO("map"):         "1|2|3",
+		visibleRO("map" + Separator + "1/id"):    "0xDEADBEEF",
+		visibleRO("map" + Separator + "1/name"):  "beef",
+		visibleRO("map" + Separator + "1/notes"): "",
+		visibleRO("map" + Separator + "2/id"):    "0x8BADF00D",
+		visibleRO("map" + Separator + "2/name"):  "food",
+		visibleRO("map" + Separator + "2/notes"): "",
+		visibleRO("map" + Separator + "3/id"):    "0xDEADF00D",
+		visibleRO("map" + Separator + "3/name"):  "dead",
+		visibleRO("map" + Separator + "3/notes"): "",
+		visibleRO("map"):                         "1" + Separator + "2" + Separator + "3",
 	}
 	assert.Equal(t, expected, encoded, "Encoded and expected does not match")
 
@@ -223,13 +223,13 @@ func TestStructSlice(t *testing.T) {
 	Encode(MapSink(encoded), StructSlice)
 
 	expected := map[string]string{
-		visibleRO("slice"):         "1",
-		visibleRO("slice|0/id"):    "0xDEADFEED",
-		visibleRO("slice|0/name"):  "feed",
-		visibleRO("slice|0/notes"): "",
-		visibleRO("slice|1/id"):    "0xFACEFEED",
-		visibleRO("slice|1/name"):  "face",
-		visibleRO("slice|1/notes"): "",
+		visibleRO("slice"):                         "1",
+		visibleRO("slice" + Separator + "0/id"):    "0xDEADFEED",
+		visibleRO("slice" + Separator + "0/name"):  "feed",
+		visibleRO("slice" + Separator + "0/notes"): "",
+		visibleRO("slice" + Separator + "1/id"):    "0xFACEFEED",
+		visibleRO("slice" + Separator + "1/name"):  "face",
+		visibleRO("slice" + Separator + "1/notes"): "",
 	}
 	assert.Equal(t, expected, encoded, "Encoded and expected does not match")
 
@@ -331,21 +331,21 @@ func TestComplex(t *testing.T) {
 	Encode(MapSink(encoded), ExecutorConfig)
 
 	expected := map[string]string{
-		visibleRO("executorconfig/common/id"):                      "",
-		visibleRO("executorconfig/common/name"):                    "",
-		visibleRO("executorconfig/common/notes"):                   "",
-		visibleRO("executorconfig/sessions|Session1/common/id"):    "SessionID",
-		visibleRO("executorconfig/sessions|Session1/common/name"):  "SessionName",
-		visibleRO("executorconfig/sessions|Session1/common/notes"): "",
-		hidden("executorconfig/sessions|Session1/cmd/path"):        "/vmware",
-		hidden("executorconfig/sessions|Session1/cmd/args~"):       "/bin/imagec|-standalone",
-		hidden("executorconfig/sessions|Session1/cmd/args"):        "1",
-		hidden("executorconfig/sessions|Session1/cmd/env~"):        "PATH=/bin|USER=imagec",
-		hidden("executorconfig/sessions|Session1/cmd/env"):         "1",
-		hidden("executorconfig/sessions|Session1/cmd/dir"):         "/",
-		hidden("executorconfig/sessions|Session1/tty"):             "true",
-		hidden("executorconfig/sessions"):                          "Session1",
-		hidden("executorconfig/Key"):                               "",
+		visibleRO("executorconfig/common/id"):                                      "",
+		visibleRO("executorconfig/common/name"):                                    "",
+		visibleRO("executorconfig/common/notes"):                                   "",
+		visibleRO("executorconfig/sessions" + Separator + "Session1/common/id"):    "SessionID",
+		visibleRO("executorconfig/sessions" + Separator + "Session1/common/name"):  "SessionName",
+		visibleRO("executorconfig/sessions" + Separator + "Session1/common/notes"): "",
+		hidden("executorconfig/sessions" + Separator + "Session1/cmd/path"):        "/vmware",
+		hidden("executorconfig/sessions" + Separator + "Session1/cmd/args~"):       "/bin/imagec" + Separator + "-standalone",
+		hidden("executorconfig/sessions" + Separator + "Session1/cmd/args"):        "1",
+		hidden("executorconfig/sessions" + Separator + "Session1/cmd/env~"):        "PATH=/bin" + Separator + "USER=imagec",
+		hidden("executorconfig/sessions" + Separator + "Session1/cmd/env"):         "1",
+		hidden("executorconfig/sessions" + Separator + "Session1/cmd/dir"):         "/",
+		hidden("executorconfig/sessions" + Separator + "Session1/tty"):             "true",
+		hidden("executorconfig/sessions"):                                          "Session1",
+		hidden("executorconfig/Key"):                                               "",
 	}
 	assert.Equal(t, expected, encoded, "Encoded and expected does not match")
 
@@ -384,21 +384,21 @@ func TestComplexPointer(t *testing.T) {
 	Encode(MapSink(encoded), ExecutorConfig)
 
 	expected := map[string]string{
-		visibleRO("executorconfig/common/id"):                      "",
-		visibleRO("executorconfig/common/name"):                    "",
-		visibleRO("executorconfig/common/notes"):                   "",
-		visibleRO("executorconfig/sessions|Session1/common/id"):    "SessionID",
-		visibleRO("executorconfig/sessions|Session1/common/name"):  "SessionName",
-		visibleRO("executorconfig/sessions|Session1/common/notes"): "",
-		hidden("executorconfig/sessions|Session1/cmd/path"):        "/vmware",
-		hidden("executorconfig/sessions|Session1/cmd/args~"):       "/bin/imagec|-standalone",
-		hidden("executorconfig/sessions|Session1/cmd/args"):        "1",
-		hidden("executorconfig/sessions|Session1/cmd/env~"):        "PATH=/bin|USER=imagec",
-		hidden("executorconfig/sessions|Session1/cmd/env"):         "1",
-		hidden("executorconfig/sessions|Session1/cmd/dir"):         "/",
-		hidden("executorconfig/sessions|Session1/tty"):             "true",
-		hidden("executorconfig/sessions"):                          "Session1",
-		hidden("executorconfig/Key"):                               "",
+		visibleRO("executorconfig/common/id"):                                      "",
+		visibleRO("executorconfig/common/name"):                                    "",
+		visibleRO("executorconfig/common/notes"):                                   "",
+		visibleRO("executorconfig/sessions" + Separator + "Session1/common/id"):    "SessionID",
+		visibleRO("executorconfig/sessions" + Separator + "Session1/common/name"):  "SessionName",
+		visibleRO("executorconfig/sessions" + Separator + "Session1/common/notes"): "",
+		hidden("executorconfig/sessions" + Separator + "Session1/cmd/path"):        "/vmware",
+		hidden("executorconfig/sessions" + Separator + "Session1/cmd/args~"):       "/bin/imagec" + Separator + "-standalone",
+		hidden("executorconfig/sessions" + Separator + "Session1/cmd/args"):        "1",
+		hidden("executorconfig/sessions" + Separator + "Session1/cmd/env~"):        "PATH=/bin" + Separator + "USER=imagec",
+		hidden("executorconfig/sessions" + Separator + "Session1/cmd/env"):         "1",
+		hidden("executorconfig/sessions" + Separator + "Session1/cmd/dir"):         "/",
+		hidden("executorconfig/sessions" + Separator + "Session1/tty"):             "true",
+		hidden("executorconfig/sessions"):                                          "Session1",
+		hidden("executorconfig/Key"):                                               "",
 	}
 	assert.Equal(t, expected, encoded, "Encoded and expected does not match")
 
@@ -433,21 +433,21 @@ func TestPointerDecode(t *testing.T) {
 	Encode(MapSink(encoded), reference)
 
 	expected := map[string]string{
-		visibleRO("common/id"):                      "",
-		visibleRO("common/name"):                    "",
-		visibleRO("common/notes"):                   "",
-		visibleRO("sessions|Session1/common/id"):    "SessionID",
-		visibleRO("sessions|Session1/common/name"):  "SessionName",
-		visibleRO("sessions|Session1/common/notes"): "",
-		hidden("sessions|Session1/cmd/path"):        "/vmware",
-		hidden("sessions|Session1/cmd/args~"):       "/bin/imagec|-standalone",
-		hidden("sessions|Session1/cmd/args"):        "1",
-		hidden("sessions|Session1/cmd/env~"):        "PATH=/bin|USER=imagec",
-		hidden("sessions|Session1/cmd/env"):         "1",
-		hidden("sessions|Session1/cmd/dir"):         "/",
-		hidden("sessions|Session1/tty"):             "true",
-		hidden("sessions"):                          "Session1",
-		hidden("Key"):                               "",
+		visibleRO("common/id"):                                      "",
+		visibleRO("common/name"):                                    "",
+		visibleRO("common/notes"):                                   "",
+		visibleRO("sessions" + Separator + "Session1/common/id"):    "SessionID",
+		visibleRO("sessions" + Separator + "Session1/common/name"):  "SessionName",
+		visibleRO("sessions" + Separator + "Session1/common/notes"): "",
+		hidden("sessions" + Separator + "Session1/cmd/path"):        "/vmware",
+		hidden("sessions" + Separator + "Session1/cmd/args~"):       "/bin/imagec" + Separator + "-standalone",
+		hidden("sessions" + Separator + "Session1/cmd/args"):        "1",
+		hidden("sessions" + Separator + "Session1/cmd/env~"):        "PATH=/bin" + Separator + "USER=imagec",
+		hidden("sessions" + Separator + "Session1/cmd/env"):         "1",
+		hidden("sessions" + Separator + "Session1/cmd/dir"):         "/",
+		hidden("sessions" + Separator + "Session1/tty"):             "true",
+		hidden("sessions"):                                          "Session1",
+		hidden("Key"):                                               "",
 	}
 	assert.Equal(t, expected, encoded, "Encoded and expected does not match")
 
@@ -527,7 +527,7 @@ func TestIPSlice(t *testing.T) {
 		visibleRO("slice"): fmt.Sprintf("%d", len(ips)-1),
 	}
 	for i := range encodedIPs {
-		expected[visibleRO(fmt.Sprintf("slice|%d", i))] = encodedIPs[i]
+		expected[visibleRO(fmt.Sprintf("slice"+Separator+"%d", i))] = encodedIPs[i]
 	}
 
 	assert.Equal(t, expected, encoded, "Encoded and expected do not match")

--- a/pkg/vsphere/extraconfig/decode.go
+++ b/pkg/vsphere/extraconfig/decode.go
@@ -279,7 +279,7 @@ func decodeSlice(src DataSource, dest reflect.Value, prefix string, depth recurs
 	if kind == reflect.Struct || isEncodableSliceElemType(dest.Type().Elem()) {
 		for i := 0; i < length; i++ {
 			// convert key to name|index format
-			key := fmt.Sprintf("%s|%d", prefix, i)
+			key := fmt.Sprintf("%s%s%d", prefix, Separator, i)
 
 			// if there's already a struct in the array at this index then we pass that as the current
 			// value
@@ -311,7 +311,7 @@ func decodeSlice(src DataSource, dest reflect.Value, prefix string, depth recurs
 	}
 
 	// lookup the key and split it
-	values := strings.Split(kval, "|")
+	values := strings.Split(kval, Separator)
 	for i := 0; i < length; i++ {
 		v := values[i]
 		t := this.Type().Elem()
@@ -346,14 +346,14 @@ func decodeMap(src DataSource, dest reflect.Value, prefix string, depth recursio
 	valtype := this.Type().Elem()
 
 	// split the list of map keys and iterate
-	for _, value := range strings.Split(mapkeys, "|") {
+	for _, value := range strings.Split(mapkeys, Separator) {
 		k := fromString(reflect.Zero(keytype), value)
 		target := this.MapIndex(k)
 		if !target.IsValid() {
 			target = reflect.Zero(valtype)
 		}
 
-		key := fmt.Sprintf("%s|%s", prefix, value)
+		key := fmt.Sprintf("%s%s%s", prefix, Separator, value)
 
 		// check to see if the resulting object is not nil
 		// If it is nil, then there was nothing to decode and the pointer remains nil

--- a/pkg/vsphere/extraconfig/encode.go
+++ b/pkg/vsphere/extraconfig/encode.go
@@ -170,7 +170,7 @@ func encodeSlice(sink DataSink, src reflect.Value, prefix string, depth recursio
 	} else if kind == reflect.Struct || isEncodableSliceElemType(src.Type().Elem()) {
 		for i := 0; i < length; i++ {
 			// convert key to name|index format
-			key := fmt.Sprintf("%s|%d", prefix, i)
+			key := fmt.Sprintf("%s%s%d", prefix, Separator, i)
 			encode(sink, src.Index(i), key, depth)
 		}
 	} else {
@@ -188,7 +188,7 @@ func encodeSlice(sink DataSink, src reflect.Value, prefix string, depth recursio
 
 		// convert key to name|index format
 		key := fmt.Sprintf("%s~", prefix)
-		err := sink(key, strings.Join(values, "|"))
+		err := sink(key, strings.Join(values, Separator))
 		if err != nil {
 			log.Errorf("Failed to encode slice data for key %s: %s", key, err)
 		}
@@ -216,13 +216,13 @@ func encodeMap(sink DataSink, src reflect.Value, prefix string, depth recursion)
 	keys := make([]string, length)
 	for i, v := range mkeys {
 		keys[i] = toString(v)
-		key := fmt.Sprintf("%s|%s", prefix, keys[i])
+		key := fmt.Sprintf("%s%s%s", prefix, Separator, keys[i])
 		encode(sink, src.MapIndex(v), key, depth)
 	}
 
 	// sort the keys before joining - purely to make testing viable
 	sort.Strings(keys)
-	err := sink(prefix, strings.Join(keys, "|"))
+	err := sink(prefix, strings.Join(keys, Separator))
 	if err != nil {
 		log.Errorf("Failed to encode map keys for key %s: %s", prefix, err)
 	}

--- a/pkg/vsphere/extraconfig/keys.go
+++ b/pkg/vsphere/extraconfig/keys.go
@@ -30,6 +30,8 @@ const (
 	DefaultPrefix = ""
 	// DefaultGuestInfoPrefix value
 	DefaultGuestInfoPrefix = "guestinfo.vice."
+	//Separator for slice values and map keys
+	Separator = "|"
 )
 
 const (
@@ -300,7 +302,7 @@ func calculateKeys(v reflect.Value, field string, prefix string) []string {
 			if !found {
 				panic(fmt.Sprintf("could not find map key %s", s[0]))
 			}
-			prefix = fmt.Sprintf("%s|%s", prefix, s[0])
+			prefix = fmt.Sprintf("%s%s%s", prefix, Separator, s[0])
 		case reflect.Array, reflect.Slice:
 			i, err := strconv.Atoi(s[0])
 			if err != nil {
@@ -308,7 +310,7 @@ func calculateKeys(v reflect.Value, field string, prefix string) []string {
 			}
 			switch v.Type().Elem().Kind() {
 			case reflect.Struct:
-				prefix = fmt.Sprintf("%s|%d", prefix, i)
+				prefix = fmt.Sprintf("%s%s%d", prefix, Separator, i)
 			case reflect.Uint8:
 				return []string{prefix}
 			default:
@@ -334,14 +336,14 @@ func calculateKeys(v reflect.Value, field string, prefix string) []string {
 	case reflect.Map:
 		for _, k := range v.MapKeys() {
 			sk := k.Convert(reflect.TypeOf(""))
-			prefix := fmt.Sprintf("%s|%s", prefix, sk.String())
+			prefix := fmt.Sprintf("%s%s%s", prefix, Separator, sk.String())
 			out = append(out, calculateKeys(v.MapIndex(k), field, prefix)...)
 		}
 	case reflect.Array, reflect.Slice:
 		switch v.Type().Elem().Kind() {
 		case reflect.Struct:
 			for i := 0; i < v.Len(); i++ {
-				prefix := fmt.Sprintf("%s|%d", prefix, i)
+				prefix := fmt.Sprintf("%s%s%d", prefix, Separator, i)
 				out = append(out, calculateKeys(v.Index(i), field, prefix)...)
 			}
 		case reflect.Uint8:

--- a/pkg/vsphere/extraconfig/keys_test.go
+++ b/pkg/vsphere/extraconfig/keys_test.go
@@ -179,27 +179,27 @@ func TestCalculateKeys(t *testing.T) {
 		},
 		{
 			"ExecutorConfig.Sessions.*",
-			[]string{"executorconfig/sessions|Session1"},
+			[]string{"executorconfig/sessions" + Separator + "Session1"},
 		},
 		{
 			"ExecutorConfig.Sessions.Session1.Cmd.Args",
-			[]string{"executorconfig/sessions|Session1/cmd/args"},
+			[]string{"executorconfig/sessions" + Separator + "Session1/cmd/args"},
 		},
 		{
 			"ExecutorConfig.Sessions.*.Cmd.Args.*",
-			[]string{"executorconfig/sessions|Session1/cmd/args~"},
+			[]string{"executorconfig/sessions" + Separator + "Session1/cmd/args~"},
 		},
 		{
 			"ExecutorConfig.Sessions.*.Cmd.Args.0",
-			[]string{"executorconfig/sessions|Session1/cmd/args~"},
+			[]string{"executorconfig/sessions" + Separator + "Session1/cmd/args~"},
 		},
 		{
 			"Array.0.I",
-			[]string{visibleRW("array|0/I")},
+			[]string{visibleRW("array" + Separator + "0/I")},
 		},
 		{
 			"Array.*",
-			[]string{visibleRW("array|0")},
+			[]string{visibleRW("array" + Separator + "0")},
 		},
 		{
 			"Ptr.I",


### PR DESCRIPTION
This updates the extraconfig package to use a constant instead of
hardcoded embedded value for the separator of map keys and slice values.

Towards #4110