### PR TITLE
NFS client integration with volumestore

### DIFF
--- a/lib/portlayer/storage/nfs/target.go
+++ b/lib/portlayer/storage/nfs/target.go
@@ -19,6 +19,8 @@ import (
 	"net/url"
 	"os"
 
+	nfsClient "github.com/fdawg4l/go-nfs-client/nfs"
+	"github.com/fdawg4l/go-nfs-client/nfs/rpc"
 	"github.com/vmware/vic/pkg/trace"
 )
 
@@ -52,4 +54,97 @@ type Target interface {
 
 	// Lookup reads os.FileInfo for the given path
 	Lookup(path string) (os.FileInfo, []byte, error)
+}
+
+// NfsMount is used to wrap a MountServer to do the Mount()/Unmount() and Close()
+type NfsMount struct {
+	// Hostname is the name to authenticate with to the target as
+	Hostname string
+
+	// Uid and Gid are the user id and group id to authenticate with the target
+	Uid, Gid uint32
+
+	// The URL (host + path) of the NFS server and target path
+	TargetUrl *url.URL
+
+	s *nfsClient.Mount
+}
+
+func NewMount(t *url.URL, hostname string, uid, gid uint32) *NfsMount {
+	return &NfsMount{
+		Hostname:  hostname,
+		Uid:       uid,
+		Gid:       gid,
+		TargetUrl: t,
+	}
+}
+
+func (m *NfsMount) Mount(op trace.Operation) (Target, error) {
+	op.Debugf("Mounting %s", m.TargetUrl.String())
+	s, err := nfsClient.DialMount(m.TargetUrl.Host)
+	if err != nil {
+		return nil, err
+	}
+	m.s = s
+
+	defer func() {
+		if err != nil {
+			m.s.Close()
+		}
+	}()
+
+	auth := rpc.NewAuthUnix(m.Hostname, m.Uid, m.Gid)
+	mnt, err := s.Mount(m.TargetUrl.Path, auth.Auth())
+	if err != nil {
+		op.Errorf("unable to mount volume: %v", err)
+		return nil, err
+	}
+
+	op.Infof("Mounted %s", m.TargetUrl.String())
+	return &target{mnt}, nil
+}
+
+func (m *NfsMount) Unmount(op trace.Operation) error {
+	op.Debugf("Unmounting %s", m.TargetUrl.String())
+	if err := m.s.Unmount(); err != nil {
+		return err
+	}
+
+	if err := m.s.Close(); err != nil {
+		return err
+	}
+
+	op.Debugf("Unmounted %s", m.TargetUrl.String())
+	m.s = nil
+	return nil
+}
+
+func (m *NfsMount) URL() (*url.URL, error) {
+	return m.TargetUrl, nil
+}
+
+// wrap ReadDir to return a slice of os.FileInfo
+type target struct {
+	*nfsClient.Target
+}
+
+func (t *target) ReadDir(path string) ([]os.FileInfo, error) {
+	entries, err := t.ReadDirPlus(path)
+	if err != nil {
+		return nil, err
+	}
+
+	var e []os.FileInfo
+	for i := 0; i < len(entries); i++ {
+
+		// filter out . and ..
+		name := entries[i].Name()
+		if name == "." || name == ".." {
+			continue
+		}
+
+		e = append(e, os.FileInfo(entries[i]))
+	}
+
+	return e, nil
 }

--- a/lib/portlayer/storage/nfs/target.go
+++ b/lib/portlayer/storage/nfs/target.go
@@ -61,11 +61,11 @@ type NfsMount struct {
 	// Hostname is the name to authenticate with to the target as
 	Hostname string
 
-	// Uid and Gid are the user id and group id to authenticate with the target
-	Uid, Gid uint32
+	// UID and GID are the user id and group id to authenticate with the target
+	UID, GID uint32
 
 	// The URL (host + path) of the NFS server and target path
-	TargetUrl *url.URL
+	TargetURL *url.URL
 
 	s *nfsClient.Mount
 }
@@ -73,15 +73,15 @@ type NfsMount struct {
 func NewMount(t *url.URL, hostname string, uid, gid uint32) *NfsMount {
 	return &NfsMount{
 		Hostname:  hostname,
-		Uid:       uid,
-		Gid:       gid,
-		TargetUrl: t,
+		UID:       uid,
+		GID:       gid,
+		TargetURL: t,
 	}
 }
 
 func (m *NfsMount) Mount(op trace.Operation) (Target, error) {
-	op.Debugf("Mounting %s", m.TargetUrl.String())
-	s, err := nfsClient.DialMount(m.TargetUrl.Host)
+	op.Debugf("Mounting %s", m.TargetURL.String())
+	s, err := nfsClient.DialMount(m.TargetURL.Host)
 	if err != nil {
 		return nil, err
 	}
@@ -93,19 +93,19 @@ func (m *NfsMount) Mount(op trace.Operation) (Target, error) {
 		}
 	}()
 
-	auth := rpc.NewAuthUnix(m.Hostname, m.Uid, m.Gid)
-	mnt, err := s.Mount(m.TargetUrl.Path, auth.Auth())
+	auth := rpc.NewAuthUnix(m.Hostname, m.UID, m.GID)
+	mnt, err := s.Mount(m.TargetURL.Path, auth.Auth())
 	if err != nil {
 		op.Errorf("unable to mount volume: %v", err)
 		return nil, err
 	}
 
-	op.Infof("Mounted %s", m.TargetUrl.String())
+	op.Infof("Mounted %s", m.TargetURL.String())
 	return &target{mnt}, nil
 }
 
 func (m *NfsMount) Unmount(op trace.Operation) error {
-	op.Debugf("Unmounting %s", m.TargetUrl.String())
+	op.Debugf("Unmounting %s", m.TargetURL.String())
 	if err := m.s.Unmount(); err != nil {
 		return err
 	}
@@ -114,13 +114,13 @@ func (m *NfsMount) Unmount(op trace.Operation) error {
 		return err
 	}
 
-	op.Debugf("Unmounted %s", m.TargetUrl.String())
+	op.Debugf("Unmounted %s", m.TargetURL.String())
 	m.s = nil
 	return nil
 }
 
 func (m *NfsMount) URL() (*url.URL, error) {
-	return m.TargetUrl, nil
+	return m.TargetURL, nil
 }
 
 // wrap ReadDir to return a slice of os.FileInfo

--- a/vendor/github.com/fdawg4l/go-nfs-client/nfs/file.go
+++ b/vendor/github.com/fdawg4l/go-nfs-client/nfs/file.go
@@ -153,7 +153,7 @@ func (f *File) Close() error {
 }
 
 // OpenFile writes to an existing file or creates one
-func (v *Target) OpenFile(path string, perm os.FileMode) (*File, error) {
+func (v *Target) OpenFile(path string, perm os.FileMode) (io.ReadWriteCloser, error) {
 	_, fh, err := v.Lookup(path)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -176,7 +176,7 @@ func (v *Target) OpenFile(path string, perm os.FileMode) (*File, error) {
 }
 
 // Open opens a file for reading
-func (v *Target) Open(path string) (*File, error) {
+func (v *Target) Open(path string) (io.ReadCloser, error) {
 	_, fh, err := v.Lookup(path)
 	if err != nil {
 		return nil, err

--- a/vendor/github.com/fdawg4l/go-nfs-client/nfs/target.go
+++ b/vendor/github.com/fdawg4l/go-nfs-client/nfs/target.go
@@ -103,7 +103,7 @@ func (v *Target) FSInfo() (*FSInfo, error) {
 }
 
 // Lookup returns attributes and the file handle to a given dirent
-func (v *Target) Lookup(p string) (*Fattr, []byte, error) {
+func (v *Target) Lookup(p string) (os.FileInfo, []byte, error) {
 	var (
 		err   error
 		fattr *Fattr

--- a/vendor/manifest
+++ b/vendor/manifest
@@ -360,7 +360,7 @@
 			"importpath": "github.com/fdawg4l/go-nfs-client/nfs",
 			"repository": "https://github.com/fdawg4l/go-nfs-client",
 			"vcs": "git",
-			"revision": "43c69b0d08c429520d4a8e148a472f74c892d682",
+			"revision": "ba0907caa92da3d762b621a251af64688fa1222b",
 			"branch": "master",
 			"path": "/nfs",
 			"notests": true


### PR DESCRIPTION
This change implements the wrapper to the NFS client to use it as a volume store `MountServer` and `Target`.  Most of this change is integrating the unit test.

To run against an nfs server, run the following
`$ NFS_TEST_URL="nfs://127.0.0.1/home/fahmed/f" sudo -E go test -v .`