### PR TITLE
Add non-persistent and scope filter

### DIFF
--- a/pkg/vsphere/extraconfig/encode.go
+++ b/pkg/vsphere/extraconfig/encode.go
@@ -291,3 +291,17 @@ func MapSink(sink map[string]string) DataSink {
 		return nil
 	}
 }
+
+// ScopeFilterSink will create a DataSink that only stores entries where the key scope
+// matches one or more scopes in the filter.
+// The filter is a bitwise composion of scope flags
+func ScopeFilterSink(filter uint, sink DataSink) DataSink {
+	return func(key, value string) error {
+		scope := calculateScope(calculateScopeFromKey(key))
+		if scope&filter != 0 {
+			sink(key, value)
+		}
+		log.Debugf("Skipping encode of %s with scopes that do not match filter: %v", key, calculateScopeFromKey(key))
+		return nil
+	}
+}

--- a/pkg/vsphere/extraconfig/keys_test.go
+++ b/pkg/vsphere/extraconfig/keys_test.go
@@ -17,11 +17,17 @@ package extraconfig
 import (
 	"testing"
 
+	"strings"
+
 	"github.com/stretchr/testify/assert"
 )
 
 func visibleRO(key string) string {
 	return calculateKey([]string{"read-only"}, "", key)
+}
+
+func visibleRONonpersistent(key string) string {
+	return calculateKey([]string{"read-only", "non-persistent"}, "", key)
 }
 
 func visibleRW(key string) string {
@@ -122,7 +128,23 @@ func TestSecret(t *testing.T) {
 
 	key := calculateKey(scopes, DefaultGuestInfoPrefix+".a.b", "c")
 
-	assert.Equal(t, DefaultGuestInfoPrefix+".a.b.c@secret", key, "Key should have secret suffix")
+	assert.Equal(t, DefaultGuestInfoPrefix+".a.b.c"+suffixSeparator+secretSuffix, key, "Key should have secret suffix")
+}
+
+func TestNonpersistent(t *testing.T) {
+	scopes := []string{"non-persistent", "read-write"}
+
+	key := calculateKey(scopes, DefaultGuestInfoPrefix+".a.b", "c")
+
+	assert.Equal(t, DefaultGuestInfoPrefix+".a.b.c"+suffixSeparator+nonpersistentSuffix, key, "Key should have non-persistent suffix")
+}
+
+func TestMultipleSuffixes(t *testing.T) {
+	scopes := []string{"non-persistent", "secret", "read-write"}
+
+	key := calculateKey(scopes, DefaultGuestInfoPrefix+".a.b", "c")
+
+	assert.True(t, strings.Contains(key, suffixSeparator+secretSuffix) && strings.Contains(key, suffixSeparator+nonpersistentSuffix), "Key should contain both secret and non-persistent suffix")
 }
 
 func TestCalculateKeys(t *testing.T) {

--- a/pkg/vsphere/extraconfig/secret_test.go
+++ b/pkg/vsphere/extraconfig/secret_test.go
@@ -45,7 +45,7 @@ func TestSecretFields(t *testing.T) {
 	encoded := map[string]string{}
 	Encode(out.Sink(MapSink(encoded)), config)
 
-	password := encoded["guestinfo.vice./password@secret"]
+	password := encoded["guestinfo.vice./password"+suffixSeparator+secretSuffix]
 	assert.NotEmpty(t, password, "encrypted password")
 	assert.NotEqual(t, password, config.Password, "encrypted password")
 


### PR DESCRIPTION
Adds support for non-persistent scope (although this doesn't do anything
except add a tag to the key) and ability to filter based on scope.
The non-persistent scope is added as a suffix in the same manner as @secret
given the effect is not directly enforced by vsphere based on the key, but is
instead a property that needs to be acknowledged by code.

Towards: #4110 