### PR TITLE
Add vic-machine firewall configuration command [specific ci=6-14-Update-Firewall]

### DIFF
--- a/cmd/vic-machine/delete/delete.go
+++ b/cmd/vic-machine/delete/delete.go
@@ -168,7 +168,11 @@ func (d *Uninstall) Run(clic *cli.Context) (err error) {
 		return errors.New("delete failed")
 	}
 
-	log.Infof("Completed successfully")
+	log.Info("----------")
+	log.Info("Firewall rules on the target were NOT modified")
+	log.Info("To modify firewall rules see vic-machine update firewall --help")
+	log.Info("----------")
+	log.Info("Completed successfully")
 
 	return nil
 }

--- a/cmd/vic-machine/list/list.go
+++ b/cmd/vic-machine/list/list.go
@@ -172,7 +172,7 @@ func (l *List) Run(clic *cli.Context) (err error) {
 		log.Errorf("List cannot continue - target validation failed: %s", err)
 		return errors.New("list failed")
 	}
-	_, err = validator.ValidateCompute(ctx, l.Data)
+	_, err = validator.ValidateCompute(ctx, l.Data, false)
 	if err != nil {
 		log.Errorf("List cannot continue - compute resource validation failed: %s", err)
 		return errors.New("list failed")

--- a/cmd/vic-machine/main.go
+++ b/cmd/vic-machine/main.go
@@ -29,6 +29,7 @@ import (
 	uninstall "github.com/vmware/vic/cmd/vic-machine/delete"
 	"github.com/vmware/vic/cmd/vic-machine/inspect"
 	"github.com/vmware/vic/cmd/vic-machine/list"
+	"github.com/vmware/vic/cmd/vic-machine/update"
 	"github.com/vmware/vic/cmd/vic-machine/upgrade"
 	viclog "github.com/vmware/vic/pkg/log"
 	"github.com/vmware/vic/pkg/version"
@@ -51,6 +52,7 @@ func main() {
 	list := list.NewList()
 	upgrade := upgrade.NewUpgrade()
 	debug := debug.NewDebug()
+	updateFw := update.NewUpdateFw()
 	app.Commands = []cli.Command{
 		{
 			Name:   "create",
@@ -92,6 +94,18 @@ func main() {
 			Usage:  "Debug VCH",
 			Action: debug.Run,
 			Flags:  debug.Flags(),
+		},
+		{
+			Name:  "update",
+			Usage: "Modify configuration",
+			Subcommands: []cli.Command{
+				{
+					Name:   "firewall",
+					Usage:  "Modify host firewall",
+					Action: updateFw.Run,
+					Flags:  updateFw.Flags(),
+				},
+			},
 		},
 	}
 

--- a/cmd/vic-machine/update/firewall.go
+++ b/cmd/vic-machine/update/firewall.go
@@ -1,0 +1,190 @@
+// Copyright 2017 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package update
+
+import (
+	"context"
+	"time"
+
+	log "github.com/Sirupsen/logrus"
+	"gopkg.in/urfave/cli.v1"
+
+	"github.com/vmware/vic/cmd/vic-machine/common"
+	"github.com/vmware/vic/lib/install/data"
+	"github.com/vmware/vic/lib/install/management"
+	"github.com/vmware/vic/lib/install/validate"
+	"github.com/vmware/vic/pkg/errors"
+	"github.com/vmware/vic/pkg/trace"
+)
+
+// UpdateFw has all input parameters for vic-machine update firewall command
+type UpdateFw struct {
+	*data.Data
+
+	executor *management.Dispatcher
+
+	enableFw  bool
+	disableFw bool
+}
+
+func NewUpdateFw() *UpdateFw {
+	i := &UpdateFw{}
+	i.Data = data.NewData()
+	return i
+}
+
+// Flags return all cli flags for update firewall
+func (i *UpdateFw) Flags() []cli.Flag {
+	update := []cli.Flag{
+		cli.DurationFlag{
+			Name:        "timeout",
+			Value:       3 * time.Minute,
+			Usage:       "Time to wait for update firewall",
+			Destination: &i.Timeout,
+		},
+		cli.BoolFlag{
+			Name:        "allow",
+			Usage:       "Enable a firewall rule on target host(s) to allow VIC communication",
+			Destination: &i.enableFw,
+		},
+		cli.BoolFlag{
+			Name:        "deny",
+			Usage:       "Disable the firewall rule on target host(s) that allows VIC communication",
+			Destination: &i.disableFw,
+		},
+	}
+
+	target := i.TargetFlags()
+	compute := i.ComputeFlagsNoName()
+	debug := i.DebugFlags()
+
+	// flag arrays are declared, now combined
+	var flags []cli.Flag
+	for _, f := range [][]cli.Flag{target, compute, update, debug} {
+		flags = append(flags, f...)
+	}
+
+	return flags
+}
+
+func (i *UpdateFw) processParams() error {
+	defer trace.End(trace.Begin(""))
+
+	if err := i.HasCredentials(); err != nil {
+		return err
+	}
+
+	if i.enableFw && i.disableFw {
+		return errors.New("Only one of --allow and --deny can be set")
+	}
+
+	if !i.enableFw && !i.disableFw {
+		return errors.New("No command selected")
+	}
+
+	return nil
+}
+
+func (i *UpdateFw) Run(clic *cli.Context) (err error) {
+	// urfave/cli will print out exit in error handling, so no more information in main method can be printed out.
+	defer func() {
+		err = common.LogErrorIfAny(clic, err)
+	}()
+
+	if err = i.processParams(); err != nil {
+		return err
+	}
+
+	if i.Debug.Debug > 0 {
+		log.SetLevel(log.DebugLevel)
+		trace.Logger.Level = log.DebugLevel
+	}
+
+	if len(clic.Args()) > 0 {
+		log.Errorf("Unknown argument: %s", clic.Args()[0])
+		return errors.New("invalid CLI arguments")
+	}
+
+	log.Infof("### Updating Firewall ####")
+
+	ctx, cancel := context.WithTimeout(context.Background(), i.Timeout)
+	defer cancel()
+	defer func() {
+		if ctx.Err() != nil && ctx.Err() == context.DeadlineExceeded {
+			//context deadline exceeded, replace returned error message
+			err = errors.Errorf("Update timed out: use --timeout to add more time")
+		}
+	}()
+
+	var validator *validate.Validator
+	if validator, err = validate.NewValidator(ctx, i.Data); err != nil {
+		log.Errorf("Update cannot continue - failed to create validator: %s", err)
+		return errors.New("update firewall failed")
+	}
+
+	_, err = validator.ValidateTarget(ctx, i.Data)
+	if err != nil {
+		log.Errorf("Update cannot continue - target validation failed: %s", err)
+		return errors.New("update firewall failed")
+	}
+	_, err = validator.ValidateCompute(ctx, i.Data, true)
+	if err != nil {
+		log.Errorf("Update cannot continue - compute resource validation failed: %s", err)
+		return errors.New("update firewall failed")
+	}
+
+	executor := management.NewDispatcher(validator.Context, validator.Session, nil, false)
+
+	if i.enableFw {
+		log.Info("")
+		log.Warn("### WARNING ###")
+		log.Warn("\tThis command modifies the host firewall on the target machine or cluster")
+		log.Warnf("\tThe ruleset %q will be enabled", management.RulesetID)
+		log.Warn("\tThis allows all outbound TCP traffic from the target")
+		log.Warn("\tTo undo this modification use --deny")
+		log.Info("")
+
+		err := executor.EnableFirewallRuleset()
+		if err != nil {
+			log.Errorf("Failed to enable VIC firewall rule: %s", err)
+			return errors.New("failed to enable firewall rule")
+		}
+	}
+
+	if i.disableFw {
+		log.Info("")
+		log.Warn("### WARNING ###")
+		log.Warn("\tThis command modifies the host firewall on the target machine or cluster")
+		log.Warnf("\tThe ruleset %q will be disabled", management.RulesetID)
+		log.Warn("\tThis disables the ruleset that allows all outbound TCP traffic from the target")
+		log.Warn("\tVIC Engine will not function unless 2377/tcp outbound is allowed")
+		log.Warn("\tTo undo this modification use --allow")
+		log.Info("")
+
+		err := executor.DisableFirewallRuleset()
+		if err != nil {
+			log.Errorf("Failed to disable VIC firewall rule: %s", err)
+			return errors.New("failed to disable firewall rule")
+		}
+	}
+	log.Info("")
+
+	if i.enableFw || i.disableFw {
+		log.Infof("Firewall changes complete")
+	}
+
+	log.Infof("Command completed successfully")
+	return nil
+}

--- a/lib/install/management/update.go
+++ b/lib/install/management/update.go
@@ -1,0 +1,93 @@
+// Copyright 2017 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package management
+
+import (
+	log "github.com/Sirupsen/logrus"
+
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/vic/pkg/trace"
+)
+
+type State int
+
+// ruleset ID from /etc/vmware/firewall/service.xml
+const RulesetID string = "vSPC"
+const (
+	enable State = iota
+	disable
+)
+
+func (s State) String() string {
+	switch s {
+	case enable:
+		return "enable"
+	case disable:
+		return "disable"
+	}
+	return ""
+}
+
+// EnableFirewall enables the ruleset on the target, allowing VIC backchannel traffic
+func (d *Dispatcher) EnableFirewallRuleset() error {
+	defer trace.End(trace.Begin(""))
+	return d.modifyFirewall(enable)
+}
+
+// DisableFirewall disables the ruleset on the target, denying VIC backchannel traffic
+func (d *Dispatcher) DisableFirewallRuleset() error {
+	defer trace.End(trace.Begin(""))
+	return d.modifyFirewall(disable)
+}
+
+// modifyFirewall sets the state of the firewall ruleset specified by RulesetID
+func (d *Dispatcher) modifyFirewall(state State) error {
+	defer trace.End(trace.Begin(""))
+	var err error
+	var hosts []*object.HostSystem
+
+	log.Debugf("cluster: %s", d.session.Cluster)
+
+	hosts, err = d.session.Cluster.Hosts(d.ctx)
+	if err != nil {
+		return err
+	}
+
+	if len(hosts) == 0 {
+		log.Infof("No hosts to modify")
+		return nil
+	}
+
+	for _, host := range hosts {
+		fs, err := host.ConfigManager().FirewallSystem(d.ctx)
+		if err != nil {
+			log.Errorf("Failed to get firewall system for host %q: %s", host.Name(), err)
+			return err
+		}
+
+		switch state {
+		case enable:
+			err = fs.EnableRuleset(d.ctx, RulesetID)
+		case disable:
+			err = fs.DisableRuleset(d.ctx, RulesetID)
+		}
+		if err != nil {
+			log.Errorf("Failed to %s ruleset %q on host %q: %s", state.String(), RulesetID, host.Name(), err)
+			return err
+		}
+		log.Infof("Ruleset %q %sd on host %q", RulesetID, state.String(), host)
+	}
+	return nil
+}

--- a/lib/install/management/update.go
+++ b/lib/install/management/update.go
@@ -40,13 +40,13 @@ func (s State) String() string {
 	return ""
 }
 
-// EnableFirewall enables the ruleset on the target, allowing VIC backchannel traffic
+// EnableFirewallRuleset enables the ruleset on the target, allowing VIC backchannel traffic
 func (d *Dispatcher) EnableFirewallRuleset() error {
 	defer trace.End(trace.Begin(""))
 	return d.modifyFirewall(enable)
 }
 
-// DisableFirewall disables the ruleset on the target, denying VIC backchannel traffic
+// DisableFirewallRuleset disables the ruleset on the target, denying VIC backchannel traffic
 func (d *Dispatcher) DisableFirewallRuleset() error {
 	defer trace.End(trace.Begin(""))
 	return d.modifyFirewall(disable)

--- a/lib/install/validate/compute.go
+++ b/lib/install/validate/compute.go
@@ -247,13 +247,14 @@ func (v *Validator) GetResourcePool(input *data.Data) (*object.ResourcePool, err
 	return v.ResourcePoolHelper(v.Context, input.ComputeResourcePath)
 }
 
-func (v *Validator) ValidateCompute(ctx context.Context, input *data.Data) (*config.VirtualContainerHostConfigSpec, error) {
+func (v *Validator) ValidateCompute(ctx context.Context, input *data.Data, computeRequired bool) (*config.VirtualContainerHostConfigSpec, error) {
 	defer trace.End(trace.Begin(""))
 	conf := &config.VirtualContainerHostConfigSpec{}
 
-	if input.ComputeResourcePath == "" {
+	if input.ComputeResourcePath == "" && !computeRequired {
 		return conf, nil
 	}
+
 	log.Infof("Validating compute resource")
 	v.compute(ctx, input, conf)
 	return conf, v.ListIssues()

--- a/tests/resources/Vsphere-Util.robot
+++ b/tests/resources/Vsphere-Util.robot
@@ -182,7 +182,7 @@ Change Log Level On Server
 Add Vsphere License
     [Tags]  secret
     [Arguments]  ${license}
-    ${out}=  Run  govc license.add ${license} 
+    ${out}=  Run  govc license.add ${license}
     Should Contain  ${out}  Key:
 
 Assign Vsphere License
@@ -198,3 +198,20 @@ Add Host To VCenter
     \   ${status}=  Run Keyword And Return Status  Should Contain  ${out}  OK
     \   Return From Keyword If  ${status}
     Fail  Failed to add the host to the VC in 3 attempts
+
+Get Host Firewall Enabled
+    ${output}=  Run  govc host.esxcli network firewall get
+    Should Contain  ${output}  Enabled
+    @{output}=  Split To Lines  ${output}
+    :FOR  ${line}  IN  @{output}
+    \   Run Keyword If  "Enabled" in '''${line}'''  Set Test Variable  ${out}  ${line}
+    ${enabled}=  Fetch From Right  ${out}  :
+    ${enabled}=  Strip String  ${enabled}
+    Return From Keyword If  '${enabled}' == 'false'  ${false}
+    Return From Keyword If  '${enabled}' == 'true'  ${true}
+
+Enable Host Firewall
+    Run  govc host.esxcli network firewall set --enabled true
+
+Disable Host Firewall
+    Run  govc host.esxcli network firewall set --enabled false

--- a/tests/test-cases/Group6-VIC-Machine/6-14-Update-Firewall.md
+++ b/tests/test-cases/Group6-VIC-Machine/6-14-Update-Firewall.md
@@ -1,0 +1,54 @@
+Test 6-14 - Verify vic-machine update firewall function
+=======
+
+# Purpose:
+Verify vic-machine update firewall
+
+# References:
+* vic-machine-linux update firewall -h
+
+# Environment:
+This test requires that a vSphere server is running and available
+
+
+
+Update
+=======
+
+## Enable and disable VIC firewall rule
+1. Get state of host firewall
+2. Enable host firewall
+3. Verify host firewall enabled
+4. Enable VIC firewall rule by issuing the following command:
+```
+bin/vic-machine-linux update firewall --target %{TEST_URL} \
+    --user=%{TEST_USERNAME} --password=%{TEST_PASSWORD} \
+    --compute-resource=%{TEST_RESOURCE} --timeout %{TEST_TIMEOUT} \
+    --allow
+```
+
+5. Verify state of rule by issuing the following command:
+```
+govc host.esxcli network firewall ruleset list --ruleset-id=vSPC
+```
+
+6. Create VCH
+7. Run regression tests
+8. Disable VIC firewall rule by issuing the following command:
+```
+bin/vic-machine-linux update firewall --target %{TEST_URL} \
+    --user=%{TEST_USERNAME} --password=%{TEST_PASSWORD} \
+    --compute-resource=%{TEST_RESOURCE} --timeout %{TEST_TIMEOUT} \
+    --deny
+```
+
+9. Verify state of rule by issuing the following command:
+```
+govc host.esxcli network firewall ruleset list --ruleset-id=vSPC
+```
+
+10. Revert state of host firewall
+
+### Expected Outcome
+* Firewall rule state changes as expected
+* Regression tests pass

--- a/tests/test-cases/Group6-VIC-Machine/6-14-Update-Firewall.robot
+++ b/tests/test-cases/Group6-VIC-Machine/6-14-Update-Firewall.robot
@@ -1,0 +1,58 @@
+# Copyright 2017 VMware, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#	http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License
+
+*** Settings ***
+Documentation  Test 6-14 - Verify vic-machine update firewall function
+Resource  ../../resources/Util.robot
+Test Teardown  Run Keyword  Cleanup VIC Appliance On Test Server
+
+*** Test Cases ***
+Enable and disable VIC firewall rule
+    Set Test Environment Variables
+    Run Keyword And Ignore Error  Cleanup Dangling VMs On Test Server
+    Run Keyword And Ignore Error  Cleanup Datastore On Test Server
+
+    # Save firewall state
+    ${fwSetState}=  Get Host Firewall Enabled
+
+    Enable Host Firewall
+    ${fwstatus}=  Get Host Firewall Enabled
+    Should Be True  ${fwstatus}
+
+    ${output}=  Run  bin/vic-machine-linux update firewall --target %{TEST_URL} --user=%{TEST_USERNAME} --password=%{TEST_PASSWORD} --compute-resource=%{TEST_RESOURCE} --timeout %{TEST_TIMEOUT} --thumbprint=%{TEST_THUMBPRINT} --allow
+    Should Contain  ${output}  enabled on host
+    Should Contain  ${output}  Firewall changes complete
+
+
+    ${output}=  Run  govc host.esxcli network firewall ruleset list --ruleset-id=vSPC
+    Should Contain  ${output}  true
+
+    ${output}=  Run  bin/vic-machine-linux create --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --image-store=%{TEST_DATASTORE} --bridge-network=%{BRIDGE_NETWORK} --public-network=%{PUBLIC_NETWORK} --no-tls
+    Should Contain  ${output}  Installer completed successfully
+    Get Docker Params  ${output}  ${true}
+    Log To Console  Installer completed successfully: %{VCH-NAME}
+
+    Run Regression Tests
+
+    ${output}=  Run  bin/vic-machine-linux update firewall --target %{TEST_URL} --user=%{TEST_USERNAME} --password=%{TEST_PASSWORD} --compute-resource=%{TEST_RESOURCE} --timeout %{TEST_TIMEOUT} --thumbprint=%{TEST_THUMBPRINT} --deny
+    Should Contain  ${output}  disabled on host
+    Should Contain  ${output}  Firewall changes complete
+
+
+    ${output}=  Run  govc host.esxcli network firewall ruleset list --ruleset-id=vSPC
+    Should Contain  ${output}  false
+
+    # Restore firewall state
+    Run Keyword If  ${fwSetState}  Enable Host Firewall
+    Run Keyword Unless  ${fwSetState}  Disable Host Firewall


### PR DESCRIPTION
Fixes #3979 

Tested on ESX and vCenter, integration test passes locally

Enabling the rule:
```
bin/vic-machine-linux update firewall --target root:password@10.0.0.3 --allow --thumbprint=C1:7A:E4:A4:22:B8:8A:68:F9:A4:E4:C2:38:91:3B:0D:8E:E0:C8:FB
Mar  9 2017 12:07:34.174-08:00 INFO  ### Updating ####
Mar  9 2017 12:07:35.989-08:00 INFO  Validating target
Mar  9 2017 12:07:36.459-08:00 INFO  Validating compute resource
Mar  9 2017 12:07:36.818-08:00 INFO  
Mar  9 2017 12:07:36.818-08:00 WARN  ### WARNING ###
Mar  9 2017 12:07:36.818-08:00 WARN  	This command modifies the host firewall on the target machine or cluster
Mar  9 2017 12:07:36.818-08:00 WARN  	The ruleset "vSPC" will be enabled
Mar  9 2017 12:07:36.818-08:00 WARN  	This allows all outbound TCP traffic from the target
Mar  9 2017 12:07:36.818-08:00 WARN  	To undo this modification use --deny
Mar  9 2017 12:07:36.818-08:00 INFO  
Mar  9 2017 12:07:37.281-08:00 INFO  Ruleset "vSPC" enabled on host "HostSystem:ha-host @ /ha-datacenter/host/ib-aus-office-130.eng.vmware.com/ib-aus-office-130.eng.vmware.com"
Mar  9 2017 12:07:37.281-08:00 INFO  
Mar  9 2017 12:07:37.281-08:00 INFO  Firewall changes complete
Mar  9 2017 12:07:37.281-08:00 INFO  Command completed successfully

```

Disabling the rule:
```
bin/vic-machine-linux update firewall --target root:password@10.0.0.3 --deny --thumbprint=C1:7A:E4:A4:22:B8:8A:68:F9:A4:E4:C2:38:91:3B:0D:8E:E0:C8:FB
Mar  9 2017 12:09:49.198-08:00 INFO  ### Updating ####
Mar  9 2017 12:09:50.934-08:00 INFO  Validating target
Mar  9 2017 12:09:51.383-08:00 INFO  Validating compute resource
Mar  9 2017 12:09:51.714-08:00 INFO  
Mar  9 2017 12:09:51.714-08:00 WARN  ### WARNING ###
Mar  9 2017 12:09:51.714-08:00 WARN  	This command modifies the host firewall on the target machine or cluster
Mar  9 2017 12:09:51.714-08:00 WARN  	The ruleset "vSPC" will be disabled
Mar  9 2017 12:09:51.714-08:00 WARN  	This disables the ruleset that allows all outbound TCP traffic from the target
Mar  9 2017 12:09:51.714-08:00 WARN  	VIC Engine will not function unless 2377/tcp outbound is allowed
Mar  9 2017 12:09:51.714-08:00 WARN  	To undo this modification use --allow
Mar  9 2017 12:09:51.714-08:00 INFO  
Mar  9 2017 12:09:52.161-08:00 INFO  Ruleset "vSPC" disabled on host "HostSystem:ha-host @ /ha-datacenter/host/ib-aus-office-130.eng.vmware.com/ib-aus-office-130.eng.vmware.com"
Mar  9 2017 12:09:52.161-08:00 INFO  
Mar  9 2017 12:09:52.161-08:00 INFO  Firewall changes complete
Mar  9 2017 12:09:52.161-08:00 INFO  Command completed successfully

```

Command help:
```
NAME:
   vic-machine-linux update firewall - Modify host firewall

USAGE:
   vic-machine-linux update firewall [command options] [arguments...]

OPTIONS:
   --target value, -t value            REQUIRED. ESXi or vCenter connection URL, specifying a datacenter if multiple exist e.g. root:password@VC-FQDN/datacenter (default: https://root:password@10.0.0.3)
   --user value, -u value              ESX or vCenter user
   --password value, -p value          ESX or vCenter password (default: <nil>)
   --thumbprint value                  ESX or vCenter host certificate thumbprint
   --compute-resource value, -r value  Compute resource path, e.g. myCluster/Resources/myRP. Default to <default cluster>/Resources
   --timeout value                     Time to wait for update firewall (default: 3m0s)
   --allow                             Enable a firewall rule on target host(s) to allow VIC communication
   --deny                              Disable the firewall rule on target host(s) that allows VIC communication
```