### PR TITLE
[specific ci=3-03-Docker-Compose-Basic] Robot test compose up works while another container running

### DIFF
--- a/tests/test-cases/Group3-Docker-Compose/3-03-Docker-Compose-Basic.md
+++ b/tests/test-cases/Group3-Docker-Compose/3-03-Docker-Compose-Basic.md
@@ -13,15 +13,19 @@ This test requires that a vSphere server is running and available
 #Test Steps:
 1. Create a compose file that includes a basic python server and redis server
 2. Deploy VIC appliance to the vSphere server
-3. Issue:  
-```DOCKER_HOST=<VCH IP> docker-compose up```
+3. Create a basic compose yml file
+4. Issue DOCKER_HOST=<VCH IP> docker-compose create
+5. Issue DOCKER_HOST=<VCH IP> docker-compose start
+6. Issue DOCKER_HOST=<VCH IP> docker-compose logs
+7. Issue DOCKER_HOST=<VCH IP> docker-compose stop
+8. Issue DOCKER_HOST=<VCH IP> docker-compose up -d
+9. Issue DOCKER_HOST=<VCH IP> docker-compose kill redis
+10. Issue DOCKER_HOST=<VCH IP> docker-compose down
+11. Issue DOCKER_HOST=<VCH IP> docker run -d busybox /bin/top
+12. Issue DOCKER_HOST=<VCH IP> docker-compose up -d
 
 #Expected Outcome:
-* Docker compose should return with success and the server should be running.
-* The server should report the following output:
-```
-The server is now ready to accept connections
-```
+* Step 4-12 should result in no error
 
 #Possible Problems:
 None

--- a/tests/test-cases/Group3-Docker-Compose/3-03-Docker-Compose-Basic.robot
+++ b/tests/test-cases/Group3-Docker-Compose/3-03-Docker-Compose-Basic.robot
@@ -19,7 +19,7 @@ Suite Setup  Install VIC Appliance To Test Server  certs=${false}
 Suite Teardown  Cleanup VIC Appliance On Test Server
 
 *** Variables ***
-${yml}  version: "3"\nservices:\n${SPACE}web:\n${SPACE}${SPACE}image: python:2.7\n${SPACE}${SPACE}ports:\n${SPACE}${SPACE}- "5000:5000"\n${SPACE}${SPACE}depends_on:\n${SPACE}${SPACE}- redis\n${SPACE}redis:\n${SPACE}${SPACE}image: redis\n${SPACE}${SPACE}ports:\n${SPACE}${SPACE}- "5001:5001"
+${yml}  version: "2"\nservices:\n${SPACE}web:\n${SPACE}${SPACE}image: python:2.7\n${SPACE}${SPACE}ports:\n${SPACE}${SPACE}- "5000:5000"\n${SPACE}${SPACE}depends_on:\n${SPACE}${SPACE}- redis\n${SPACE}redis:\n${SPACE}${SPACE}image: redis\n${SPACE}${SPACE}ports:\n${SPACE}${SPACE}- "5001:5001"
 
 *** Test Cases ***
 Compose basic
@@ -49,5 +49,18 @@ Compose kill
     Should Be Equal As Integers  ${rc}  0
 
     ${rc}  ${out}=  Run And Return Rc And Output  docker-compose %{VCH-PARAMS} -f basic-compose.yml kill redis
+    Log  ${out}
+    Should Be Equal As Integers  ${rc}  0
+
+    ${rc}  ${out}=  Run And Return Rc And Output  docker-compose %{VCH-PARAMS} -f basic-compose.yml down
+    Log  ${out}
+    Should Be Equal As Integers  ${rc}  0
+
+Compose Up while another container is running (ps filtering related)
+    ${rc}  ${out}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -d busybox /bin/top
+    Log  ${out}
+    Should Be Equal As Integers  ${rc}  0
+
+    ${rc}  ${out}=  Run And Return Rc And Output  docker-compose %{VCH-PARAMS} -f basic-compose.yml up -d
     Log  ${out}
     Should Be Equal As Integers  ${rc}  0


### PR DESCRIPTION
Added robot scripts to the Docker-Compose-Basic tests to test compose up
works on a VCH that has a running container not related to any of the
services in the compose yml file.

Resolves #2525