### PR TITLE
Configure volumestores by URI [specific ci=1-19-Docker-Volume-Create]

### DIFF
--- a/lib/apiservers/portlayer/restapi/handlers/storage_handlers.go
+++ b/lib/apiservers/portlayer/restapi/handlers/storage_handlers.go
@@ -1,4 +1,4 @@
-// Copyright 2016 VMware, Inc. All Rights Reserved.
+// Copyright 2017 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/apiservers/portlayer/restapi/handlers/storage_handlers.go
+++ b/lib/apiservers/portlayer/restapi/handlers/storage_handlers.go
@@ -103,9 +103,13 @@ func (h *StorageHandlersImpl) configureVolumeStores(op trace.Operation, handlerC
 	for name, dsurl := range spl.Config.VolumeLocations {
 		switch dsurl.Scheme {
 		case "nfs":
-			uid, err := strconv.Atoi(dsurl.User.Username())
-			if err != nil {
-				return err
+			uid := nfs.DefaultUID
+
+			if dsurl.User != nil && dsurl.User.Username() != "" {
+				uid, err = strconv.Atoi(dsurl.User.Username())
+				if err != nil {
+					return err
+				}
 			}
 
 			// XXX replace with the vch name
@@ -134,7 +138,6 @@ func (h *StorageHandlersImpl) configureVolumeStores(op trace.Operation, handlerC
 		if _, err = h.volumeCache.AddStore(op, name, vs); err != nil {
 			return fmt.Errorf("volume addition error %s", err)
 		}
-
 	}
 
 	return nil

--- a/lib/apiservers/portlayer/restapi/handlers/storage_handlers_test.go
+++ b/lib/apiservers/portlayer/restapi/handlers/storage_handlers_test.go
@@ -1,4 +1,4 @@
-// Copyright 2016 VMware, Inc. All Rights Reserved.
+// Copyright 2017 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/portlayer/storage/nfs/volume.go
+++ b/lib/portlayer/storage/nfs/volume.go
@@ -34,6 +34,8 @@ const (
 
 	// Stock permissions that are set, In the future we may pass these in.
 	defaultPermissions = 0755
+
+	DefaultUID = 1000
 )
 
 // VolumeStore this is nfs related volume store definition

--- a/pkg/vsphere/datastore/datastore.go
+++ b/pkg/vsphere/datastore/datastore.go
@@ -1,4 +1,4 @@
-// Copyright 2016 VMware, Inc. All Rights Reserved.
+// Copyright 2017 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/vsphere/datastore/datastore.go
+++ b/pkg/vsphere/datastore/datastore.go
@@ -81,23 +81,31 @@ func NewHelper(ctx context.Context, s *session.Session, ds *object.Datastore, ro
 	return d, nil
 }
 
+func NewHelperFromURL(ctx context.Context, s *session.Session, u *url.URL) (*Helper, error) {
+	fm := object.NewFileManager(s.Vim25())
+	vsDs, err := s.Finder.DatastoreOrDefault(ctx, u.Host)
+	if err != nil {
+		return nil, err
+	}
+
+	d := &Helper{
+		ds:      vsDs,
+		s:       s,
+		fm:      fm,
+		RootURL: u.Path,
+	}
+
+	return d, nil
+}
+
 // GetDatastores returns a map of datastores given a map of names and urls
 func GetDatastores(ctx context.Context, s *session.Session, dsURLs map[string]*url.URL) (map[string]*Helper, error) {
 	stores := make(map[string]*Helper)
 
-	fm := object.NewFileManager(s.Vim25())
 	for name, dsURL := range dsURLs {
-
-		vsDs, err := s.Finder.DatastoreOrDefault(ctx, dsURL.Host)
+		d, err := NewHelperFromURL(ctx, s, dsURL)
 		if err != nil {
 			return nil, err
-		}
-
-		d := &Helper{
-			ds:      vsDs,
-			s:       s,
-			fm:      fm,
-			RootURL: dsURL.Path,
 		}
 
 		stores[name] = d


### PR DESCRIPTION
Allows configuration of a volumestore by uri.  We check the URI and provision the volumestore accordingly.  

This will instantiate the nfs volume store if the appropriate scheme is passed.  `vic-machine` needs to be modified to pass this scheme, but that will come later.