### PR TITLE
[skip ci] NSX tests for nightlies

### DIFF
--- a/tests/manual-test-cases/Group5-Functional-Tests/5-7-NSX.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-7-NSX.robot
@@ -18,5 +18,23 @@ Resource  ../../resources/Util.robot
 
 *** Test Cases ***
 Test
-    Log To Console  TODO
-    #${out}=  Deploy Nimbus Testbed  --noSupportBundles --vcvaBuild 3634791 --esxBuild 3620759 --testbedName test-vpx-4esx-virtual-fullInstall-vcva-8gbmem-nsx1m1c --runName VIC-NSX-Test --build nsx-transformers:beta:ob-3586094:master
+    Log To Console  Set environment variables up for GOVC
+    Set Environment Variable  GOVC_URL  10.160.229.248
+    Set Environment Variable  GOVC_USERNAME  Administrator@vsphere.local
+    Set Environment Variable  GOVC_PASSWORD  Admin\!23
+
+    Log To Console  Deploy VIC to the VC cluster
+    Set Environment Variable  TEST_URL_ARRAY  10.160.229.248
+    Set Environment Variable  TEST_USERNAME  Administrator@vsphere.local
+    Set Environment Variable  TEST_PASSWORD  Admin\!23
+    Set Environment Variable  BRIDGE_NETWORK  DPortGroup
+    Set Environment Variable  PUBLIC_NETWORK  'VM Network'
+    Set Environment Variable  TEST_DATASTORE  vsanDatastore
+    Set Environment Variable  TEST_RESOURCE  cls
+    Set Environment Variable  TEST_TIMEOUT  30m
+
+    Install VIC Appliance To Test Server  certs=${false}  vol=default
+
+    Run Regression Tests
+
+    Cleanup VIC Appliance On Test Server

--- a/tests/nightly/nightly-kickoff.sh
+++ b/tests/nightly/nightly-kickoff.sh
@@ -131,7 +131,6 @@ for i in $nightly_list_var; do
 done
 
 # Setting the NSX test status to Not Implemented.
-nightlystatus[7]="TODO"
 nightlystatus[23]="TODO"
 
 for i in "${nightlystatus[@]}" 


### PR DESCRIPTION
As a phase 1 work, adding the NSX-v test using a static environment in Nimbus so we have the tests running, and later plugin the automation.
