### PR TITLE
Support --timestamps option for docker logs

### DIFF
--- a/lib/apiservers/portlayer/restapi/handlers/containers_handlers.go
+++ b/lib/apiservers/portlayer/restapi/handlers/containers_handlers.go
@@ -363,8 +363,13 @@ func (handler *ContainersHandlersImpl) GetContainerLogsHandler(params containers
 
 	// containers with DataVersion > 0 will use updated output logging on the backend
 	if container.DataVersion > 0 {
+		ts := false
+		if params.Timestamp != nil {
+			ts = *params.Timestamp
+		}
+
 		// wrap the reader in a LogReader to deserialize persisted containerVM output
-		reader = iolog.NewLogReader(reader)
+		reader = iolog.NewLogReader(reader, ts)
 	}
 
 	detachableOut := NewFlushingReader(reader)
@@ -416,6 +421,7 @@ func convertContainerToContainerInfo(container *exec.ContainerInfo) *models.Cont
 		ProcessConfig:   &models.ProcessConfig{},
 		VolumeConfig:    make([]*models.VolumeConfig, 0),
 		Endpoints:       make([]*models.EndpointConfig, 0),
+		DataVersion:     int64(container.DataVersion),
 	}
 
 	// Populate volume information

--- a/lib/apiservers/portlayer/swagger.json
+++ b/lib/apiservers/portlayer/swagger.json
@@ -2725,6 +2725,10 @@
 					"items": {
 						"$ref": "#/definitions/EndpointConfig"
 					}
+				},
+				"dataVersion": {
+					"type": "integer",
+					"format": "int64"
 				}
 			}
 		},

--- a/tests/test-cases/Group1-Docker-Commands/1-08-Docker-Logs.md
+++ b/tests/test-cases/Group1-Docker-Commands/1-08-Docker-Logs.md
@@ -11,51 +11,62 @@ To verify that docker logs command is supported by VIC appliance
 This test requires that a vSphere server is running and available
 
 #Test Steps:
-1. Deploy VIC appliance to vSphere server
-2. Issue docker create busybox /bin/sh -c 'seq 1 5000' to the VIC appliance
-3. Issue docker start <containerID> to the VIC appliance
-4. Issue docker logs <containerID> to the VIC appliance
-5. Issue docker logs --tail=all <containerID> to the VIC appliance
-6. Issue docker logs --tail=200 <containerID> to the VIC appliance
-7. Issue docker logs --tail=0 <containerID> to the VIC appliance
-8. Issue docker create -t busybox /bin/sh -c 'for i in $(seq 1 5) ; do sleep 1 && echo line $i; done'
-9. Issue docker start <containerID> to the VIC appliance
-10. Issue docker logs --follow <containerID> to the VIC appliance
-11. Issue docker create busybox /bin/sh -c 'trap "seq 11 20; exit" HUP; seq 1 10; while true; do sleep 1; done'
-12. Issue docker start <containerID> to the VIC appliance
-13. Issue docker logs <containerID> to the VIC appliance, waiting for the first 10 lines
-14. Issue docker kill -s HUP <containerID> to the VIC appliance, generating the next 10 lines
-15. Issue docker logs --tail=5 --follow <containerID> to the VIC appliance
-16. Issue docker pull ubuntu
-17. Issue docker run ubuntu /bin/cat /bin/hostname >/tmp/hostname
-18. Issue docker logs <containerID> >/tmp/hostname-logs
-19. Issue sha256sum on /tmp/hostname and /tmp/hostname-logs
-20. Issue docker run ubuntu /bin/ls >/tmp/ls
-21. Issue docker logs <containerID> >/tmp/ls-logs
-22. Issue sha256sum on /tmp/ls and /tmp/ls-logs
-23. Issue docker logs --since=1s <containerID> to the VIC appliance
-24. Issue docker logs --timestamps <containerID> to the VIC appliance
-25. Issue docker logs
-26. Issue docker logs fakeContainer
+1. Deploy VIC build 7315 to appliance to vSphere server
+2. Issue docker run -d busybox sh -c "echo These pretzels are making me thirsty"
+3. Issue docker logs <ID1>
+4. Issue docker logs --timestamps <ID1>
+5. Upgrade the VCH to current build
+6. Issue docker run -d busybox sh -c "echo Whats the deeeal with Ovaltine"
+7. Issue docker logs --timestamps <ID2>
+8. Issue docker logs --timestamps <ID1>
+9. Issue docker create busybox /bin/sh -c 'seq 1 5000' to the VIC appliance
+10. Issue docker start <containerID> to the VIC appliance
+11. Issue docker logs <containerID> to the VIC appliance
+12. Issue docker logs --tail=all <containerID> to the VIC appliance
+13. Issue docker logs --tail=200 <containerID> to the VIC appliance
+14. Issue docker logs --tail=0 <containerID> to the VIC appliance
+15. Issue docker create -t busybox /bin/sh -c 'for i in $(seq 1 5) ; do sleep 1 && echo line $i; done'
+16. Issue docker start <containerID> to the VIC appliance
+17. Issue docker logs --follow <containerID> to the VIC appliance
+18. Issue docker create busybox /bin/sh -c 'trap "seq 11 20; exit" HUP; seq 1 10; while true; do sleep 1; done'
+19. Issue docker start <containerID> to the VIC appliance
+20. Issue docker logs <containerID> to the VIC appliance, waiting for the first 10 lines
+21. Issue docker kill -s HUP <containerID> to the VIC appliance, generating the next 10 lines
+22. Issue docker logs --tail=5 --follow <containerID> to the VIC appliance
+23. Issue docker pull ubuntu
+24. Issue docker run ubuntu /bin/cat /bin/hostname >/tmp/hostname
+25. Issue docker logs <containerID> >/tmp/hostname-logs
+26. Issue sha256sum on /tmp/hostname and /tmp/hostname-logs
+27. Issue docker run ubuntu /bin/ls >/tmp/ls
+28. Issue docker logs <containerID> >/tmp/ls-logs
+29. Issue sha256sum on /tmp/ls and /tmp/ls-logs
+30. Issue docker logs --since=1s <containerID> to the VIC appliance
+31. Issue docker logs --timestamps <containerID> to the VIC appliance
+32. Issue docker logs
+33. Issue docker logs fakeContainer
 
 #Expected Outcome:
-* Steps 2-22 should all complete without error
-* Step 6 should output 200 lines
-* Step 7 should output 0 lines
-* Step 10 should have last line be
+* Steps 1-3,5-7,9-29 should all complete without error
+* Step 3 should output "These pretzels are making me thirsty"
+* Step 4 should output "vSphere Integrated Containers does not yet support '--timestamps'"
+* Step 7 should output "Whats the deeeal with Ovaltine?" with a timestamps
+* Step 8 should output "container <ID1> does not support '--timestamp'"
+* Step 13 should output 200 lines
+* Step 14 should output 0 lines
+* Step 17 should have last line be
 ```
 line 5
 ```
-* Step 13 should output 10 lines
-* Step 15 should output 15 lines
-* Steps 19 and 22 should produce matching sha256 hashes for both files
-* Step 23 should output 3 lines
-* Step 24 should result in an error with the following message:
+* Step 20 should output 10 lines
+* Step 22 should output 15 lines
+* Steps 26 and 29 should produce matching sha256 hashes for both files
+* Step 30 should output 3 lines
+* Step 31 should result in an error with the following message:
 ```
 Error: vSphere Integrated Containers does not yet support timestamped logs.
 ```
-* Step 25 should output all lines
-* Step 26 should result in an error with the following message:
+* Step 32 should output all lines
+* Step 33 should result in an error with the following message:
 ```
 Error: No such container: fakeContainer
 ```


### PR DESCRIPTION
This change adds support for the `--timestamps` options to `docker logs`.

There is a backwards-compatibility check that will return `container <container ID> does not support '--timestamps'` when `docker logs --timestamps` is attempted against a container that was created before the VCH was updated to a version on or after this commit. Unfortunately, this check requires an extra call to the portlayer to get the container version. This is required as the `docker logs` endpoint cannot return an error without the docker client misinterpreting it. That prevents us from being able to make a single portlayer call and return a specific error to the client when we realize the container version is too low. This is caused by a limitation in swagger, but will not be necessary once we are including the container version in the persona container cache that is hydrated at VCH startup (see issue #4194), as we can simply check locally in the persona.

Fixes #3935 