### PR TITLE
Fixes to support concurrent VCH and container VM state changes [full ci]

### DIFF
--- a/lib/portlayer/event/event_manager.go
+++ b/lib/portlayer/event/event_manager.go
@@ -29,13 +29,13 @@ type EventManager interface {
 	Collectors() map[string]collector.Collector
 
 	// Subscribe for event callbacks
-	Subscribe(eventTopic string, caller string, callback func(events.Event))
+	Subscribe(eventTopic string, caller string, callback func(events.Event)) Subscriber
 
 	// Unsubscribe from event callbacks
 	Unsubscribe(eventTopic string, caller string)
 
 	// Subscribers will return the subscriber map
-	Subscribers() map[string]map[string]func(events.Event)
+	Subscribers() map[string]map[string]Subscriber
 
 	// Subscribed returns subscriber count
 	Subscribed() int

--- a/lib/portlayer/event/subscriber.go
+++ b/lib/portlayer/event/subscriber.go
@@ -1,0 +1,208 @@
+// Copyright 2016-2017 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package event
+
+import (
+	"sync/atomic"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/vmware/vic/lib/portlayer/event/events"
+)
+
+const (
+	suspendDisabled int32 = iota
+	suspendDiscard
+	suspendQueue
+)
+
+type Subscriber interface {
+	// Topic returns the topic this subscriber is subscribed to
+	Topic() string
+	// Name returns the name of the subscriber
+	Name() string
+
+	// Suspend suspends processing events by the subscriber. If
+	// queueEvents is true, the events are queued until Resume()
+	// is called. If queueEvents is false, events passed into
+	// onEvent() after this call are discarded.
+	Suspend(queueEvents bool)
+	// Resume resumes processing of events by the subscriber.
+	// If Suspend() was called with queueEvents as true, any events
+	// that were passed to onEvent() after Suspend() returned are
+	// processed first.
+	Resume()
+	// IsSuspended returns true if the subscriber is suspended.
+	IsSuspended() bool
+
+	// Discarded returns the number of packets that were discarded by
+	// the subscriber as a result of Pause() being called with
+	// queueEvents as false.
+	Discarded() uint64
+	// Dropped returns the number of packets that were dropped when
+	// the event queue overflows. This only happens when Pause()
+	// is called with queueEvents as true.
+	Dropped() uint64
+
+	// onEvent is called by event.Manager to send an event to
+	// a subscriber
+	onEvent(events.Event)
+}
+
+type subscriber struct {
+	topic              string
+	name               string
+	callback           func(e events.Event)
+	eventQ             chan events.Event
+	suspendState       int32
+	discarded, dropped uint64
+	suspend            chan suspendCmd
+}
+
+type suspendCmd struct {
+	suspend bool
+	done    chan struct{}
+}
+
+const maxEventQueueSize = 1000
+
+// newSubscriber creates a new subscriber to topic
+func newSubscriber(topic, name string, callback func(e events.Event)) Subscriber {
+	s := &subscriber{
+		topic:    topic,
+		name:     name,
+		callback: callback,
+		eventQ:   make(chan events.Event, maxEventQueueSize),
+		suspend:  make(chan suspendCmd),
+	}
+
+	go func() {
+		suspended := false
+		var done chan struct{}
+		for {
+			if done != nil {
+				done <- struct{}{}
+				done = nil
+			}
+
+			if suspended {
+				select {
+				case c := <-s.suspend:
+					suspended = c.suspend
+					done = c.done
+				}
+
+				continue
+			}
+
+			// not suspended
+			select {
+			case e := <-s.eventQ:
+				s.callback(e)
+			case c := <-s.suspend:
+				suspended = c.suspend
+				done = c.done
+			}
+		}
+	}()
+
+	return s
+}
+
+// Topic returns the topic this subscriber is subscribed to
+func (s *subscriber) Topic() string {
+	return s.topic
+}
+
+// Name returns the name of the subscriber
+func (s *subscriber) Name() string {
+	return s.name
+}
+
+// onEvent is called by event.Manager to send an event to
+// a subscriber
+func (s *subscriber) onEvent(e events.Event) {
+	switch atomic.LoadInt32(&s.suspendState) {
+	case suspendDisabled:
+		s.eventQ <- e
+	case suspendDiscard:
+		log.Warnf("discarding event %q", e)
+		atomic.AddUint64(&s.discarded, 1)
+	case suspendQueue:
+		done := false
+		for !done {
+			select {
+			case s.eventQ <- e:
+				done = true
+			default:
+				// make room; discard oldest
+				log.Warnf("dropping event %q", <-s.eventQ)
+				atomic.AddUint64(&s.dropped, 1)
+			}
+		}
+	}
+}
+
+// Suspend suspends processing events by the subscriber. If
+// queueEvents is true, the events are queued until Resume()
+// is called. If queueEvents is false, events passed into
+// onEvent() after this call are discarded.
+func (s *subscriber) Suspend(queueEvents bool) {
+	defer func() {
+		done := make(chan struct{})
+		s.suspend <- suspendCmd{suspend: true, done: done}
+		<-done
+		close(done)
+	}()
+
+	if queueEvents {
+		atomic.StoreInt32(&s.suspendState, suspendQueue)
+		return
+	}
+
+	atomic.StoreInt32(&s.suspendState, suspendDiscard)
+}
+
+// Resume resumes processing of events by the subscriber.
+// If Suspend() was called with queueEvents as true, any events
+// that were passed to onEvent() after Suspend() returned are
+// processed first.
+func (s *subscriber) Resume() {
+	defer func() {
+		done := make(chan struct{})
+		s.suspend <- suspendCmd{suspend: false, done: done}
+		<-done
+		close(done)
+	}()
+	atomic.StoreInt32(&s.suspendState, suspendDisabled)
+}
+
+// IsSuspended returns true if the subscriber is suspended.
+func (s *subscriber) IsSuspended() bool {
+	return atomic.LoadInt32(&s.suspendState) != suspendDisabled
+}
+
+// Discarded returns the number of packets that were discarded by
+// the subscriber as a result of Pause() being called with
+// queueEvents as false.
+func (s *subscriber) Discarded() uint64 {
+	return atomic.LoadUint64(&s.discarded)
+}
+
+// Dropped returns the number of packets that were dropped when
+// the event queue overflows. This only happens when Pause()
+// is called with queueEvents as true.
+func (s *subscriber) Dropped() uint64 {
+	return atomic.LoadUint64(&s.dropped)
+}

--- a/lib/portlayer/event/subscriber_test.go
+++ b/lib/portlayer/event/subscriber_test.go
@@ -1,0 +1,217 @@
+// Copyright 2016-2017 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package event
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/vmware/vic/lib/portlayer/event/events"
+)
+
+func init() {
+	log.SetLevel(log.DebugLevel)
+}
+
+type mockCollector struct {
+	c func(events.Event)
+}
+
+// AddMonitoredObject will add the object for event listening
+func (m *mockCollector) AddMonitoredObject(_ string) error {
+	return nil
+}
+
+// RemoveMonitoredObject will remove the object from event listening
+func (m *mockCollector) RemoveMonitoredObject(_ string) {
+}
+
+// Start listening for events and publish to function
+func (m *mockCollector) Start() error {
+	return nil
+}
+
+// Stop listening for events
+func (m *mockCollector) Stop() {}
+
+// Register a callback function
+func (m *mockCollector) Register(c func(events.Event)) {
+	m.c = c
+}
+
+// Name returns the collector name
+func (m *mockCollector) Name() string {
+	return "mock"
+}
+
+type mockEvent struct {
+	id int
+}
+
+// id of event
+func (e *mockEvent) EventID() int {
+	return e.id
+}
+
+// event (PowerOn, PowerOff, etc)
+func (e *mockEvent) String() string {
+	return fmt.Sprintf("%d", e.id)
+}
+
+// reference evented object
+func (e *mockEvent) Reference() string {
+	return ""
+}
+
+// event message
+func (e *mockEvent) Message() string {
+	return ""
+}
+
+func (e *mockEvent) Created() time.Time {
+	return time.Now()
+}
+
+func (e *mockEvent) Topic() string {
+	return "test"
+}
+
+func TestSuspendQueue(t *testing.T) {
+	c := &mockCollector{}
+	m := NewEventManager(c)
+	var evs []events.Event
+	done := make(chan struct{})
+	s := m.Subscribe("test", "test", func(e events.Event) {
+		evs = append(evs, e)
+		if len(evs) == 100 {
+			close(done)
+		}
+	})
+
+	suspended := false
+	for i := 0; i < 100; i++ {
+		if !suspended && i >= 50 {
+			s.Suspend(true)
+			assert.True(t, s.IsSuspended())
+			suspended = true
+		}
+		c.c(&mockEvent{id: i})
+	}
+
+	select {
+	case <-done:
+		assert.Fail(t, "unexpectedly got all events despite suspend")
+	case <-time.After(2 * time.Second):
+		assert.Condition(t, func() bool { return len(evs) <= 50 })
+	}
+
+	s.Resume()
+	assert.False(t, s.IsSuspended())
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		assert.Fail(t, "timed out waiting for suspended events")
+	}
+
+	// check for dups
+	for i := range evs {
+		for j := range evs {
+			if j == i {
+				continue
+			}
+			if evs[j].EventID() == evs[i].EventID() {
+				assert.Fail(t, "dup event found for id %d", evs[j].EventID())
+			}
+		}
+	}
+}
+
+func TestSuspendDiscard(t *testing.T) {
+	c := &mockCollector{}
+	m := NewEventManager(c)
+	var evs []events.Event
+	s := m.Subscribe("test", "test", func(e events.Event) {
+		assert.Fail(t, "got an event %q when expecting none", e)
+	})
+
+	// discard events
+	s.Suspend(false)
+	assert.True(t, s.IsSuspended())
+	for i := 0; i < 50; i++ {
+		c.c(&mockEvent{id: i})
+	}
+
+	<-time.After(5 * time.Second)
+
+	assert.Empty(t, evs)
+	assert.Equal(t, uint64(50), s.Discarded())
+	assert.Equal(t, uint64(0), s.Dropped())
+}
+
+func TestSuspendOverflow(t *testing.T) {
+	c := &mockCollector{}
+	m := NewEventManager(c)
+	var evs []events.Event
+	done := make(chan struct{})
+	s := m.Subscribe("test", "test", func(e events.Event) {
+		evs = append(evs, e)
+		if len(evs) == maxEventQueueSize {
+			close(done)
+		}
+	})
+
+	s.Suspend(true)
+	assert.True(t, s.IsSuspended())
+	for i := 0; i < maxEventQueueSize+1; i++ {
+		c.c(&mockEvent{id: i})
+	}
+
+	select {
+	case <-done:
+		assert.Fail(t, "unexpectedly got all events despite suspend")
+	case <-time.After(5 * time.Second):
+	}
+
+	s.Resume()
+	assert.False(t, s.IsSuspended())
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		assert.Fail(t, "timed out waiting for sentinel event")
+	}
+
+	assert.Len(t, evs, maxEventQueueSize)
+	assert.Equal(t, uint64(1), s.Dropped())
+	assert.Equal(t, uint64(0), s.Discarded())
+
+	// check for dups
+	for i := range evs {
+		// should not have an event with id 0
+		assert.NotEqual(t, 0, evs[i].EventID(), "got event with event id 0")
+		for j := range evs {
+			if j == i {
+				continue
+			}
+			if evs[j].EventID() == evs[i].EventID() {
+				assert.Fail(t, "dup event found for id %d", evs[j].EventID())
+			}
+		}
+	}
+}

--- a/lib/portlayer/network/network.go
+++ b/lib/portlayer/network/network.go
@@ -160,7 +160,7 @@ func engageContext(ctx context.Context, netctx *Context, em event.EventManager) 
 
 	sub := fmt.Sprintf("%s(%p)", "netCtx", netctx)
 	topic := events.NewEventType(events.ContainerEvent{}).Topic()
-	em.Subscribe(topic, sub, func(ie events.Event) {
+	s := em.Subscribe(topic, sub, func(ie events.Event) {
 		handleEvent(netctx, ie)
 	})
 
@@ -170,6 +170,8 @@ func engageContext(ctx context.Context, netctx *Context, em event.EventManager) 
 		}
 	}()
 
+	s.Suspend(true)
+	defer s.Resume()
 	for _, c := range exec.Containers.Containers(nil) {
 		log.Debugf("adding container %s", c.ExecConfig.ID)
 		h := c.NewHandle(ctx)


### PR DESCRIPTION
- Added subscriber implementation that can be "paused", i.e. not
  process events until "unpaused"
- Event manager no longer launches a go routine to process each
  event that is received; instead thee event is not queued to
  preserve the order the events are recieved
- Modified high availability test to include stopped and running
  containers at time HA is triggered
 
Fixes #3137 