### PR TITLE
Nfs tether mount work

### DIFF
--- a/cmd/tether/tether_test.go
+++ b/cmd/tether/tether_test.go
@@ -152,8 +152,8 @@ func (t *Mocker) MountLabel(ctx context.Context, label, target string) error {
 	return nil
 }
 
-// MountFileSystem performs a mount with the source treated as an nfs target
-func (t *Mocker) MountFileSystem(ctx context.Context, source url.URL, target string, mountOptions string) error {
+// MountTarget performs a mount with the source treated as an nfs target
+func (t *Mocker) MountTarget(ctx context.Context, source url.URL, target string, mountOptions string) error {
 	defer trace.End(trace.Begin(fmt.Sprintf("mocking mounting %s on %s", source.String(), target)))
 
 	if t.Mounts == nil {

--- a/cmd/tether/tether_test.go
+++ b/cmd/tether/tether_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"net/url"
 	"os"
 	"runtime"
 	"testing"
@@ -148,6 +149,18 @@ func (t *Mocker) MountLabel(ctx context.Context, label, target string) error {
 	}
 
 	t.Mounts[label] = target
+	return nil
+}
+
+// MountFileSystem performs a mount with the source treated as an nfs target
+func (t *Mocker) MountFileSystem(ctx context.Context, source url.URL, target string, mountOptions string) error {
+	defer trace.End(trace.Begin(fmt.Sprintf("mocking mounting %s on %s", source.String(), target)))
+
+	if t.Mounts == nil {
+		t.Mounts = make(map[string]string)
+	}
+
+	t.Mounts[source.String()] = target
 	return nil
 }
 

--- a/cmd/vic-init/tether_test.go
+++ b/cmd/vic-init/tether_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"net/url"
 	"os"
 	"runtime"
 	"testing"
@@ -149,6 +150,18 @@ func (t *Mocker) MountLabel(ctx context.Context, label, target string) error {
 	}
 
 	t.Mounts[label] = target
+	return nil
+}
+
+// MountFileSystem performs a mount with the source treated as an nfs target
+func (t *Mocker) MountFileSystem(ctx context.Context, source url.URL, target string, mountOptions string) error {
+	defer trace.End(trace.Begin(fmt.Sprintf("mocking mounting %s on %s", source.String(), target)))
+
+	if t.Mounts == nil {
+		t.Mounts = make(map[string]string)
+	}
+
+	t.Mounts[source.String()] = target
 	return nil
 }
 

--- a/cmd/vic-init/tether_test.go
+++ b/cmd/vic-init/tether_test.go
@@ -153,8 +153,8 @@ func (t *Mocker) MountLabel(ctx context.Context, label, target string) error {
 	return nil
 }
 
-// MountFileSystem performs a mount with the source treated as an nfs target
-func (t *Mocker) MountFileSystem(ctx context.Context, source url.URL, target string, mountOptions string) error {
+// MountTarget performs a mount with the source treated as an nfs target
+func (t *Mocker) MountTarget(ctx context.Context, source url.URL, target string, mountOptions string) error {
 	defer trace.End(trace.Begin(fmt.Sprintf("mocking mounting %s on %s", source.String(), target)))
 
 	if t.Mounts == nil {

--- a/lib/apiservers/portlayer/restapi/handlers/storage_handlers.go
+++ b/lib/apiservers/portlayer/restapi/handlers/storage_handlers.go
@@ -16,6 +16,7 @@ package handlers
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -491,7 +492,7 @@ func (h *StorageHandlersImpl) VolumeJoin(params storage.VolumeJoinParams) middle
 	//Note: Name should already be populated by now.
 	volume, err := h.volumeCache.VolumeGet(op, params.Name)
 	if err != nil {
-		log.Errorf("Volumes: StorageHandler : %#v", err)
+		op.Errorf("Volumes: StorageHandler : %#v", err)
 
 		return storage.NewVolumeJoinInternalServerError().WithPayload(&models.Error{
 			Code:    http.StatusInternalServerError,
@@ -499,9 +500,18 @@ func (h *StorageHandlersImpl) VolumeJoin(params storage.VolumeJoinParams) middle
 		})
 	}
 
-	actualHandle, err = vsphere.VolumeJoin(op, actualHandle, volume, params.JoinArgs.MountPath, params.JoinArgs.Flags)
+	switch volume.Device.DiskPath().Scheme {
+	case "nfs":
+		actualHandle, err = nfs.VolumeJoin(op, actualHandle, volume, params.JoinArgs.MountPath, params.JoinArgs.Flags)
+	case "ds":
+		actualHandle, err = vsphere.VolumeJoin(op, actualHandle, volume, params.JoinArgs.MountPath, params.JoinArgs.Flags)
+	default:
+		errMsg := fmt.Sprintf("Unkown scheme (%s) for Volume (%s)", volume.Device.DiskPath().Scheme, *volume)
+		err = errors.New(errMsg)
+	}
+
 	if err != nil {
-		log.Errorf("Volumes: StorageHandler : %#v", err)
+		op.Errorf("Volumes: StorageHandler : %#v", err)
 
 		return storage.NewVolumeJoinInternalServerError().WithPayload(&models.Error{
 			Code:    http.StatusInternalServerError,
@@ -509,7 +519,7 @@ func (h *StorageHandlersImpl) VolumeJoin(params storage.VolumeJoinParams) middle
 		})
 	}
 
-	log.Infof("volume %s has been joined to a container", volume.ID)
+	op.Infof("volume %s has been joined to a container", volume.ID)
 	return storage.NewVolumeJoinOK().WithPayload(actualHandle.String())
 }
 

--- a/lib/apiservers/portlayer/restapi/handlers/storage_handlers.go
+++ b/lib/apiservers/portlayer/restapi/handlers/storage_handlers.go
@@ -16,7 +16,6 @@ package handlers
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net/http"
 	"net/url"

--- a/lib/apiservers/portlayer/restapi/handlers/storage_handlers.go
+++ b/lib/apiservers/portlayer/restapi/handlers/storage_handlers.go
@@ -506,7 +506,7 @@ func (h *StorageHandlersImpl) VolumeJoin(params storage.VolumeJoinParams) middle
 	case "ds":
 		actualHandle, err = vsphere.VolumeJoin(op, actualHandle, volume, params.JoinArgs.MountPath, params.JoinArgs.Flags)
 	default:
-		errMsg := fmt.Sprintf("Unknown scheme (%s) for Volume (%s)", volume.Device.DiskPath().Scheme, *volume)
+		errMsg := fmt.Sprintf("unknown scheme (%s) for Volume (%s)", volume.Device.DiskPath().Scheme, *volume)
 		err = errors.New(errMsg)
 	}
 

--- a/lib/apiservers/portlayer/restapi/handlers/storage_handlers.go
+++ b/lib/apiservers/portlayer/restapi/handlers/storage_handlers.go
@@ -1,4 +1,4 @@
-// Copyright 2017 VMware, Inc. All Rights Reserved.
+// Copyright 2016-2017 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/apiservers/portlayer/restapi/handlers/storage_handlers.go
+++ b/lib/apiservers/portlayer/restapi/handlers/storage_handlers.go
@@ -506,7 +506,7 @@ func (h *StorageHandlersImpl) VolumeJoin(params storage.VolumeJoinParams) middle
 	case "ds":
 		actualHandle, err = vsphere.VolumeJoin(op, actualHandle, volume, params.JoinArgs.MountPath, params.JoinArgs.Flags)
 	default:
-		errMsg := fmt.Sprintf("Unkown scheme (%s) for Volume (%s)", volume.Device.DiskPath().Scheme, *volume)
+		errMsg := fmt.Sprintf("Unknown scheme (%s) for Volume (%s)", volume.Device.DiskPath().Scheme, *volume)
 		err = errors.New(errMsg)
 	}
 

--- a/lib/apiservers/portlayer/restapi/handlers/storage_handlers.go
+++ b/lib/apiservers/portlayer/restapi/handlers/storage_handlers.go
@@ -506,8 +506,7 @@ func (h *StorageHandlersImpl) VolumeJoin(params storage.VolumeJoinParams) middle
 	case "ds":
 		actualHandle, err = vsphere.VolumeJoin(op, actualHandle, volume, params.JoinArgs.MountPath, params.JoinArgs.Flags)
 	default:
-		errMsg := fmt.Sprintf("unknown scheme (%s) for Volume (%s)", volume.Device.DiskPath().Scheme, *volume)
-		err = errors.New(errMsg)
+		err = fmt.Errorf("unknown scheme (%s) for Volume (%s)", volume.Device.DiskPath().Scheme, *volume)
 	}
 
 	if err != nil {

--- a/lib/portlayer/storage/nfs/vm.go
+++ b/lib/portlayer/storage/nfs/vm.go
@@ -1,0 +1,57 @@
+// Copyright 2017 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nfs
+
+import (
+	"fmt"
+	"net/url"
+
+	"github.com/vmware/vic/lib/config/executor"
+	"github.com/vmware/vic/lib/portlayer/exec"
+	"github.com/vmware/vic/lib/portlayer/storage"
+	"github.com/vmware/vic/pkg/trace"
+)
+
+const (
+	nfsMountOptions = "rw,noatime,vers=3,rsize=131072,wsize=131072,namlen=255,hard,proto=tcp,timeo=600,retrans=2,sec=sys,mountvers=3,mountproto=tcp,local_lock=none"
+)
+
+func VolumeJoin(op trace.Operation, handle *exec.Handle, volume *storage.Volume, mountPath string, diskOpts map[string]string) (*exec.Handle, error) {
+	defer trace.End(trace.Begin("nfs.VolumeJoin"))
+
+	if _, ok := handle.ExecConfig.Mounts[volume.ID]; ok {
+		return nil, fmt.Errorf("Volume with ID %s is already in container %s's mountspec'", volume.ID, handle.ExecConfig.ID)
+	}
+
+	//constuct MountSpec for the tether
+	mountSpec := createMountSpec(volume.Device.DiskPath(), mountPath, diskOpts)
+
+	if handle.ExecConfig.Mounts == nil {
+		handle.ExecConfig.Mounts = make(map[string]executor.MountSpec)
+	}
+	handle.ExecConfig.Mounts[volume.ID] = mountSpec
+
+	return handle, nil
+}
+
+func createMountSpec(host url.URL, mountPath string, diskOpts map[string]string) executor.MountSpec {
+	deviceMode := nfsMountOptions + ",addr=" + host.Host
+	newMountSpec := executor.MountSpec{
+		Source: host,
+		Path:   mountPath,
+		Mode:   deviceMode,
+	}
+	return newMountSpec
+}

--- a/lib/portlayer/storage/nfs/vm.go
+++ b/lib/portlayer/storage/nfs/vm.go
@@ -25,8 +25,7 @@ import (
 )
 
 const (
-	// TODO: pick potentially more sane defaults for these values
-	nfsMountOptions = "rw,noatime,vers=3,rsize=131072,wsize=131072,hard,proto=tcp,timeo=600,retrans=5,sec=sys,mountvers=3,mountproto=tcp,local_lock=none"
+	nfsMountOptions = "rw,noatime,vers=3,rsize=131072,wsize=131072,hard,proto=tcp,timeo=600,sec=sys,mountvers=3,mountproto=tcp,local_lock=none"
 )
 
 func VolumeJoin(op trace.Operation, handle *exec.Handle, volume *storage.Volume, mountPath string, diskOpts map[string]string) (*exec.Handle, error) {

--- a/lib/portlayer/storage/nfs/vm.go
+++ b/lib/portlayer/storage/nfs/vm.go
@@ -36,7 +36,7 @@ func VolumeJoin(op trace.Operation, handle *exec.Handle, volume *storage.Volume,
 		return nil, fmt.Errorf("Volume with ID %s is already in container %s's mountspec config", volume.ID, handle.ExecConfig.ID)
 	}
 
-	//constuct MountSpec for the tether
+	// construct MountSpec for the tether
 	mountSpec := createMountSpec(volume.Device.DiskPath(), mountPath, diskOpts)
 
 	if handle.ExecConfig.Mounts == nil {

--- a/lib/portlayer/storage/nfs/vm.go
+++ b/lib/portlayer/storage/nfs/vm.go
@@ -26,7 +26,7 @@ import (
 
 const (
 	// TODO: pick potentially more sane defaults for these values
-	nfsMountOptions = "rw,noatime,vers=3,rsize=131072,wsize=131072,namlen=255,hard,proto=tcp,timeo=600,retrans=2,sec=sys,mountvers=3,mountproto=tcp,local_lock=none"
+	nfsMountOptions = "rw,noatime,vers=3,rsize=131072,wsize=131072,hard,proto=tcp,timeo=600,retrans=5,sec=sys,mountvers=3,mountproto=tcp,local_lock=none"
 )
 
 func VolumeJoin(op trace.Operation, handle *exec.Handle, volume *storage.Volume, mountPath string, diskOpts map[string]string) (*exec.Handle, error) {

--- a/lib/portlayer/storage/nfs/vm.go
+++ b/lib/portlayer/storage/nfs/vm.go
@@ -25,6 +25,7 @@ import (
 )
 
 const (
+	// TODO: pick potentially more sane defaults for these values
 	nfsMountOptions = "rw,noatime,vers=3,rsize=131072,wsize=131072,namlen=255,hard,proto=tcp,timeo=600,retrans=2,sec=sys,mountvers=3,mountproto=tcp,local_lock=none"
 )
 

--- a/lib/portlayer/storage/nfs/vm.go
+++ b/lib/portlayer/storage/nfs/vm.go
@@ -32,7 +32,7 @@ func VolumeJoin(op trace.Operation, handle *exec.Handle, volume *storage.Volume,
 	defer trace.End(trace.Begin("nfs.VolumeJoin"))
 
 	if _, ok := handle.ExecConfig.Mounts[volume.ID]; ok {
-		return nil, fmt.Errorf("Volume with ID %s is already in container %s's mountspec'", volume.ID, handle.ExecConfig.ID)
+		return nil, fmt.Errorf("Volume with ID %s is already in container %s's mountspec config", volume.ID, handle.ExecConfig.ID)
 	}
 
 	//constuct MountSpec for the tether

--- a/lib/portlayer/storage/nfs/volume.go
+++ b/lib/portlayer/storage/nfs/volume.go
@@ -15,6 +15,7 @@
 package nfs
 
 import (
+	"fmt"
 	"io/ioutil"
 	"net/url"
 	"os"
@@ -109,7 +110,11 @@ func (v *VolumeStore) VolumeCreate(op trace.Operation, ID string, store *url.URL
 	}
 
 	u, _ := v.Service.URL()
-	u.Scheme = "nfs"
+	if u.Scheme != "nfs" {
+		op.Errorf("URL from nfs mount target had scheme (%s) instead of nfs for volume store (%s)", u.Scheme, v.Name)
+		return nil, fmt.Errorf("Unexpected scheme (%s) for volume store (%s)", u.Scheme, v.Name)
+	}
+
 	vol, err := storage.NewVolume(v.SelfLink, ID, info, NewVolume(u, v.volDirPath(ID)))
 	if err != nil {
 		return nil, err

--- a/lib/portlayer/storage/nfs/volume.go
+++ b/lib/portlayer/storage/nfs/volume.go
@@ -109,6 +109,7 @@ func (v *VolumeStore) VolumeCreate(op trace.Operation, ID string, store *url.URL
 	}
 
 	u, _ := v.Service.URL()
+	u.Scheme = "nfs"
 	vol, err := storage.NewVolume(v.SelfLink, ID, info, NewVolume(u, v.volDirPath(ID)))
 	if err != nil {
 		return nil, err

--- a/lib/portlayer/storage/vsphere/vm.go
+++ b/lib/portlayer/storage/vsphere/vm.go
@@ -1,4 +1,4 @@
-// Copyright 2016 VMware, Inc. All Rights Reserved.
+// Copyright 2016-2017 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/portlayer/storage/vsphere/vm.go
+++ b/lib/portlayer/storage/vsphere/vm.go
@@ -29,7 +29,7 @@ func VolumeJoin(op trace.Operation, handle *exec.Handle, volume *storage.Volume,
 	defer trace.End(trace.Begin("vsphere.VolumeJoin"))
 
 	if _, ok := handle.ExecConfig.Mounts[volume.ID]; ok {
-		return nil, fmt.Errorf("Volume with ID %s is already in container %s's mountspec'", volume.ID, handle.ExecConfig.ID)
+		return nil, fmt.Errorf("Volume with ID %s is already in container %s's mountspec config", volume.ID, handle.ExecConfig.ID)
 	}
 
 	//constuct MountSpec for the tether

--- a/lib/tether/interfaces.go
+++ b/lib/tether/interfaces.go
@@ -1,4 +1,4 @@
-// Copyright 2016 VMware, Inc. All Rights Reserved.
+// Copyright 2016-2017 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/tether/interfaces.go
+++ b/lib/tether/interfaces.go
@@ -17,6 +17,7 @@ package tether
 import (
 	"context"
 	"io"
+	"net/url"
 
 	"github.com/vmware/vic/pkg/dio"
 )
@@ -35,6 +36,7 @@ type Operations interface {
 	SetupFirewall() error
 	Apply(endpoint *NetworkEndpoint) error
 	MountLabel(ctx context.Context, label, target string) error
+	MountFileSystem(ctx context.Context, source url.URL, target string, mountOptions string) error
 	Fork() error
 	// Returns two DynamicMultiWriters for stdout and stderr
 	SessionLog(session *SessionConfig) (dio.DynamicMultiWriter, dio.DynamicMultiWriter, error)

--- a/lib/tether/interfaces.go
+++ b/lib/tether/interfaces.go
@@ -36,7 +36,7 @@ type Operations interface {
 	SetupFirewall() error
 	Apply(endpoint *NetworkEndpoint) error
 	MountLabel(ctx context.Context, label, target string) error
-	MountFileSystem(ctx context.Context, source url.URL, target string, mountOptions string) error
+	MountTarget(ctx context.Context, source url.URL, target string, mountOptions string) error
 	Fork() error
 	// Returns two DynamicMultiWriters for stdout and stderr
 	SessionLog(session *SessionConfig) (dio.DynamicMultiWriter, dio.DynamicMultiWriter, error)

--- a/lib/tether/ops_darwin.go
+++ b/lib/tether/ops_darwin.go
@@ -1,4 +1,4 @@
-// Copyright 2016 VMware, Inc. All Rights Reserved.
+// Copyright 2016-2017 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/tether/ops_darwin.go
+++ b/lib/tether/ops_darwin.go
@@ -54,9 +54,9 @@ func (t *BaseOperations) MountLabel(ctx context.Context, label, target string) e
 	return errors.New("not implemented on OSX")
 }
 
-// MountFileSystem performs a mount based on the target path from the source url
+// MountTarget performs a mount based on the target path from the source url
 // This assumes that the source url is valid and available.
-func (t *BaseOperations) MountFileSystem(ctx context.Context, source url.URL, target string, mountOptions string) error {
+func (t *BaseOperations) MountTarget(ctx context.Context, source url.URL, target string, mountOptions string) error {
 	defer trace.End(trace.Begin(fmt.Sprintf("Mounting %s on %s", source.String(), target)))
 
 	return errors.New("not implemented on OSX")

--- a/lib/tether/ops_darwin.go
+++ b/lib/tether/ops_darwin.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/url"
 	"os"
 	"os/user"
 	"strconv"
@@ -49,6 +50,14 @@ func (t *BaseOperations) Apply(endpoint *NetworkEndpoint) error {
 // This assumes that /dev/disk/by-label is being populated, probably by udev
 func (t *BaseOperations) MountLabel(ctx context.Context, label, target string) error {
 	defer trace.End(trace.Begin(fmt.Sprintf("Mounting %s on %s", label, target)))
+
+	return errors.New("not implemented on OSX")
+}
+
+// MountFileSystem performs a mount based on teh target path from the source url
+// This assumes that the source url is valid and available.
+func (t *BaseOperations) MountFileSystem(ctx context.Context, source url.URL, target string, mountOptions string) error {
+	defer trace.End(trace.Begin(fmt.Sprintf("Mounting %s on %s", source.String(), target)))
 
 	return errors.New("not implemented on OSX")
 }

--- a/lib/tether/ops_darwin.go
+++ b/lib/tether/ops_darwin.go
@@ -54,7 +54,7 @@ func (t *BaseOperations) MountLabel(ctx context.Context, label, target string) e
 	return errors.New("not implemented on OSX")
 }
 
-// MountFileSystem performs a mount based on teh target path from the source url
+// MountFileSystem performs a mount based on the target path from the source url
 // This assumes that the source url is valid and available.
 func (t *BaseOperations) MountFileSystem(ctx context.Context, source url.URL, target string, mountOptions string) error {
 	defer trace.End(trace.Begin(fmt.Sprintf("Mounting %s on %s", source.String(), target)))

--- a/lib/tether/ops_linux.go
+++ b/lib/tether/ops_linux.go
@@ -1,4 +1,4 @@
-// Copyright 2016 VMware, Inc. All Rights Reserved.
+// Copyright 2016-2017 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/tether/ops_linux.go
+++ b/lib/tether/ops_linux.go
@@ -671,7 +671,7 @@ func (t *BaseOperations) MountLabel(ctx context.Context, label, target string) e
 	return nil
 }
 
-// MountFileSystem performs a mount based on teh target path from the source url
+// MountFileSystem performs a mount based on the target path from the source url
 // This assumes that the source url is valid and available.
 func (t *BaseOperations) MountFileSystem(ctx context.Context, source url.URL, target string, mountOptions string) error {
 	defer trace.End(trace.Begin(fmt.Sprintf("Mounting %s on %s", source.String(), target)))

--- a/lib/tether/ops_linux.go
+++ b/lib/tether/ops_linux.go
@@ -671,9 +671,9 @@ func (t *BaseOperations) MountLabel(ctx context.Context, label, target string) e
 	return nil
 }
 
-// MountFileSystem performs a mount based on the target path from the source url
+// MountTarget performs a mount based on the target path from the source url
 // This assumes that the source url is valid and available.
-func (t *BaseOperations) MountFileSystem(ctx context.Context, source url.URL, target string, mountOptions string) error {
+func (t *BaseOperations) MountTarget(ctx context.Context, source url.URL, target string, mountOptions string) error {
 	defer trace.End(trace.Begin(fmt.Sprintf("Mounting %s on %s", source.String(), target)))
 
 	if err := os.MkdirAll(target, 0600); err != nil {

--- a/lib/tether/ops_windows.go
+++ b/lib/tether/ops_windows.go
@@ -1,4 +1,4 @@
-// Copyright 2016 VMware, Inc. All Rights Reserved.
+// Copyright 2016-2017 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/tether/ops_windows.go
+++ b/lib/tether/ops_windows.go
@@ -51,9 +51,9 @@ func (t *BaseOperations) MountLabel(ctx context.Context, label, target string) e
 	return errors.New("not implemented on windows")
 }
 
-// MountFileSystem performs a mount based on the target path from the source url
+// MountTarget performs a mount based on the target path from the source url
 // This assumes that the source url is valid and available.
-func (t *BaseOperations) MountFileSystem(ctx context.Context, source url.URL, target string, mountOptions string) error {
+func (t *BaseOperations) MountTarget(ctx context.Context, source url.URL, target string, mountOptions string) error {
 	defer trace.End(trace.Begin(fmt.Sprintf("Mounting %s on %s", source.String(), target)))
 
 	return errors.New("not implemented on OSX")

--- a/lib/tether/ops_windows.go
+++ b/lib/tether/ops_windows.go
@@ -51,7 +51,7 @@ func (t *BaseOperations) MountLabel(ctx context.Context, label, target string) e
 	return errors.New("not implemented on windows")
 }
 
-// MountFileSystem performs a mount based on teh target path from the source url
+// MountFileSystem performs a mount based on the target path from the source url
 // This assumes that the source url is valid and available.
 func (t *BaseOperations) MountFileSystem(ctx context.Context, source url.URL, target string, mountOptions string) error {
 	defer trace.End(trace.Begin(fmt.Sprintf("Mounting %s on %s", source.String(), target)))

--- a/lib/tether/ops_windows.go
+++ b/lib/tether/ops_windows.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/url"
 	"os"
 	"syscall"
 
@@ -48,6 +49,14 @@ func (t *BaseOperations) MountLabel(ctx context.Context, label, target string) e
 	defer trace.End(trace.Begin(fmt.Sprintf("Mounting %s on %s", label, target)))
 
 	return errors.New("not implemented on windows")
+}
+
+// MountFileSystem performs a mount based on teh target path from the source url
+// This assumes that the source url is valid and available.
+func (t *BaseOperations) MountFileSystem(ctx context.Context, source url.URL, target string, mountOptions string) error {
+	defer trace.End(trace.Begin(fmt.Sprintf("Mounting %s on %s", source.String(), target)))
+
+	return errors.New("not implemented on OSX")
 }
 
 // processEnvOS does OS specific checking and munging on the process environment prior to launch

--- a/lib/tether/tether.go
+++ b/lib/tether/tether.go
@@ -1,4 +1,4 @@
-// Copyright 2016 VMware, Inc. All Rights Reserved.
+// Copyright 2016-2017 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/tether/tether.go
+++ b/lib/tether/tether.go
@@ -242,7 +242,7 @@ func (t *tether) setMounts() error {
 			t.ops.MountLabel(context.Background(), v.Source.Path, v.Path)
 
 		case "nfs":
-			t.ops.MountFileSystem(context.Background(), v.Source, v.Path, v.Mode)
+			t.ops.MountTarget(context.Background(), v.Source, v.Path, v.Mode)
 
 		default:
 			return fmt.Errorf("unsupported volume mount type for %s: %s", k, v.Source.Scheme)

--- a/lib/tether/tether_test.go
+++ b/lib/tether/tether_test.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/url"
 	"os"
 	"runtime"
 	"testing"
@@ -150,6 +151,18 @@ func (t *Mocker) MountLabel(ctx context.Context, label, target string) error {
 	}
 
 	t.Mounts[label] = target
+	return nil
+}
+
+// MountFileSystem performs a mount with the source treated as an nfs target
+func (t *Mocker) MountFileSystem(ctx context.Context, source url.URL, target string, mountOptions string) error {
+	defer trace.End(trace.Begin(fmt.Sprintf("mocking mounting %s on %s", source.String(), target)))
+
+	if t.Mounts == nil {
+		t.Mounts = make(map[string]string)
+	}
+
+	t.Mounts[source.String()] = target
 	return nil
 }
 

--- a/lib/tether/tether_test.go
+++ b/lib/tether/tether_test.go
@@ -154,8 +154,8 @@ func (t *Mocker) MountLabel(ctx context.Context, label, target string) error {
 	return nil
 }
 
-// MountFileSystem performs a mount with the source treated as an nfs target
-func (t *Mocker) MountFileSystem(ctx context.Context, source url.URL, target string, mountOptions string) error {
+// MountTarget performs a mount with the source treated as an nfs target
+func (t *Mocker) MountTarget(ctx context.Context, source url.URL, target string, mountOptions string) error {
 	defer trace.End(trace.Begin(fmt.Sprintf("mocking mounting %s on %s", source.String(), target)))
 
 	if t.Mounts == nil {


### PR DESCRIPTION
Fixes #3812 

This PR adds a number of things. These are listed below:

- **New operation in the tether.Ops interface found in the tether `interface.go` file. This operation is `MountFileSystem`. It was chosen to signify that we are not mounting a block device, but more specifically a filesystem.**

- **Implementations of said new operation now exist for each flavor of the tether. Though naturally two of them are `NOT IMPLEMENTED`**

- **Some slight changes have been made to the nfs device backing struct to make sure that the url return from `DiskPath()` is indeed marked with a scheme of `nfs`**

- **A new version of `VolumeJoin` has been written for the nfs portion of the storage layer within the portlayer libraries. This meat of this function is that we do not need to add a new device to the device config of the vm since we are not mounting a block device. It involves the creation and addition of the mountspec to the exec config of the container.**

- **A refactor occurred for the previous `vsphere` version of VolumeJoin to make the code more readable and understandable as it is.**

- **Changes to the VolumeJoin Handler in the portlayer storage handler(the communication endpoint between docker personality and portlaer) were also needed to distinguish between which library based VolumeJoin to call. This is also done on Scheme based on the changes that @fdawg4l made for the  portlayer handler work in pr #4173**


The remaining work at this point should just be the vic-machine related work for validating proper nfs uri inputs as well as making sure the nfs endpoints are communicated effectively to the configure portion of the portlayer. I have tested this change by hand by modifying the `vmx` file of the containers and restarting them. This took significant time and was quite error prone due to the need of an available file target on an otherwise unknown filesystem(since it is a container). Further hand testing will be done against this piece during the `vic-mcahine` related work as well. 