### PR TITLE
[specific ci=3-03-Docker-Compose-Basic] Fix image repo digest calculation during pull

### DIFF
--- a/lib/apiservers/engine/backends/cache/image_cache.go
+++ b/lib/apiservers/engine/backends/cache/image_cache.go
@@ -1,4 +1,4 @@
-// Copyright 2016 VMware, Inc. All Rights Reserved.
+// Copyright 2016-2017 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -333,7 +333,9 @@ func copyImageConfig(image *metadata.ImageConfig) *metadata.ImageConfig {
 	}
 
 	newImage.Tags = tags
-	newImage.Digests = digests
+	if digests != nil {
+		newImage.Digests = digests
+	}
 
 	return &newImage
 }

--- a/lib/imagec/download.go
+++ b/lib/imagec/download.go
@@ -1,4 +1,4 @@
-// Copyright 2016 VMware, Inc. All Rights Reserved.
+// Copyright 2016-2017 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -201,7 +201,7 @@ func (ldm *LayerDownloader) DownloadLayers(ctx context.Context, ic *ImageC) erro
 		}
 	}
 
-	progress.Message(progressOutput, "", "Digest: "+ic.ImageManifest.Digest)
+	progress.Message(progressOutput, "", "Digest: "+ic.ManifestDigest)
 
 	if layerCount > 0 {
 		progress.Message(progressOutput, "", "Status: Downloaded newer image for "+ic.Image+":"+ic.Tag)

--- a/tests/test-cases/Group1-Docker-Commands/1-02-Docker-Pull.md
+++ b/tests/test-cases/Group1-Docker-Commands/1-02-Docker-Pull.md
@@ -30,6 +30,7 @@ This test requires that an vSphere server is running and available.
 12. Issue a docker pull command for each of two images that share layers
 13. Issue docker images, rmi ubuntu, pull ubuntu, docker images commands
 14. Issue docker pull command for the same image using multiple tags
+18. Issue docker pull on digest outputted by previous pull
 
 #Expected Outcome:
 VIC appliance should respond with a properly formatted pull response to each command issued to it. No errors should be seen, except in the case of step 7, 8 and 9. In step 13, the image ID and size for ubuntu should match before and after removing and re-pulling the image.

--- a/tests/test-cases/Group1-Docker-Commands/1-02-Docker-Pull.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-02-Docker-Pull.robot
@@ -119,3 +119,16 @@ Pull image by multiple tags
     ${id1}=  Get From List  ${words1}  2
     ${id2}=  Get From List  ${words2}  2
     Should Be Equal  ${id1}  ${id2}
+
+Issue docker pull on digest outputted by previous pull
+    ${rc}  Run And Return Rc  docker %{VCH-PARAMS} rmi busybox
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} pull busybox | grep Digest | awk '{print $2}'
+    Log  ${output}
+    Should Be Equal As Integers  ${rc}  0
+    Should Not Be Empty  ${output}
+    ${rc}  Run And Return Rc  docker %{VCH-PARAMS} rmi busybox
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} pull busybox@${output}
+    Log  ${output}
+    Should Be Equal As Integers  ${rc}  0
+    Should Contain  ${output}  Downloaded
+    

--- a/tests/test-cases/Group1-Docker-Commands/1-23-Docker-Inspect.md
+++ b/tests/test-cases/Group1-Docker-Commands/1-23-Docker-Inspect.md
@@ -30,6 +30,7 @@ This test requires that a vSphere server is running and available
 17. Issue docker inspect fake to the VIC appliance
 18. Issue docker create -v /var/lib/test busybox
 19. Issue docker inspect -f {{.Config.Volumes}} <containerID>
+20. Issue docker inspect busybox -f '{{.RepoDigest}}'
 
 #Expected Outcome:
 * Step 3,4,7,8 should result in success and a properly formatted JSON response
@@ -48,6 +49,7 @@ Error: No such image: <containerID>
 Error: No such image or container: fake
 ```
 * Step 19 should result in the map returned containing /var/lib/test
+* Step 20 should result in a valid digest, previously cached
 
 #Possible Problems:
 None

--- a/tests/test-cases/Group1-Docker-Commands/1-23-Docker-Inspect.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-23-Docker-Inspect.robot
@@ -100,4 +100,13 @@ Docker inspect non-nil volume
     ${rc}  ${out}=  Run And Return Rc And Output  docker %{VCH-PARAMS} inspect -f '{{.Config.Volumes}}' test-with-volume
     Should Be Equal As Integers  ${rc}  0
     Should Contain  ${out}  /var/lib/test
+
+Inspect RepoDigest is valid
+    ${rc}  Run And Return Rc  docker %{VCH-PARAMS} rmi busybox
+    ${rc}  ${busybox_digest}=  Run And Return Rc And Output  docker %{VCH-PARAMS} pull busybox | grep Digest | awk '{print $2}'
+    Should Be Equal As Integers  ${rc}  0
+    Should Not Be Empty  ${busybox_digest} 
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} inspect -f '{{.RepoDigests}}' busybox
+    Should Be Equal As Integers  ${rc}  0
+    Should Contain  ${output}  ${busybox_digest}
     

--- a/tests/test-cases/Group3-Docker-Compose/3-03-Docker-Compose-Basic.md
+++ b/tests/test-cases/Group3-Docker-Compose/3-03-Docker-Compose-Basic.md
@@ -24,10 +24,11 @@ This test requires that a vSphere server is running and available
 11. Issue DOCKER_HOST=<VCH IP> docker run -d busybox /bin/top
 12. Issue DOCKER_HOST=<VCH IP> docker-compose up -d
 13. Create compose file with link
-14. Issue  DOCKER_HOST=<VCH IP> docker-compose up -d
+14. Issue DOCKER_HOST=<VCH IP> docker-compose up -d
+15. Issue DOCKER_HOST=<VCH IP> docker-compose bundle
 
 #Expected Outcome:
-* Step 4-14 should result in no error
+* Step 4-15 should result in no error
 
 #Possible Problems:
 None

--- a/tests/test-cases/Group3-Docker-Compose/3-03-Docker-Compose-Basic.robot
+++ b/tests/test-cases/Group3-Docker-Compose/3-03-Docker-Compose-Basic.robot
@@ -75,3 +75,11 @@ Compose Up with link
     Should Be Equal As Integers  ${rc}  0
     Should Contain  ${output}  PING aaa
     Should Not Contain  ${output}  bad address 'aaa'
+
+Compose bundle creation
+    ${rc}  Run And Return Rc  docker-compose %{VCH-PARAMS} --file basic-compose.yml pull
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${output}=  Run And Return Rc And Output  docker-compose %{VCH-PARAMS} --file basic-compose.yml bundle
+    Log  ${output}
+    Should Contain  ${output}  Wrote bundle
+    Should Be Equal As Integers  ${rc}  0


### PR DESCRIPTION
VIC was calculating the repo digest from an image manifest
schema 1 while Docker was calculating it from schema 2
during pulling of an image.  This meant the digest displayed
during pull was wrong and docker compose was unable to build
a bundle file for a compose application.

Also fixed docker inspect of images.  The repo digest is stored
correctly, but we sometimes overwrite the digest information on
lookup.

Updated robot scripts for basic compose, pull, and inspect.

Resolves #3648
