### PR TITLE
Use dedicated machine for VIC UI integration tests

### DIFF
--- a/tests/manual-test-cases/Group18-VIC-UI/setup-testbed.robot
+++ b/tests/manual-test-cases/Group18-VIC-UI/setup-testbed.robot
@@ -17,8 +17,8 @@ Documentation  Set up testbed before running the UI tests
 Resource  ../../resources/Util.robot
 
 *** Variables ***
-${MACOS_SELENIUM_IP}    TBD
-${UBUNTU_SELENIUM_IP}   10.160.122.158
+${MACOS_SELENIUM_IP}    10.20.121.192
+${UBUNTU_SELENIUM_IP}   10.20.121.145
 
 *** Keywords ***
 Check If Nimbus VMs Exist


### PR DESCRIPTION
This PR makes a change to `tests/manual-test-cases/Group18-VIC-UI/setup-testbed.robot` so that tests against Ubuntu and macOS will be run against Selenium Grids running in the dedicated Mac Mini - running in Prom D. For Windows we keep using Nimbus.

Fixes #4190 