### PR TITLE
Implement tether reconfigure toolbox to tether cmd

### DIFF
--- a/cmd/tether/main_test.go
+++ b/cmd/tether/main_test.go
@@ -1,4 +1,4 @@
-// Copyright 2016 VMware, Inc. All Rights Reserved.
+// Copyright 2016-2017 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/portlayer/exec/container.go
+++ b/lib/portlayer/exec/container.go
@@ -405,6 +405,16 @@ func (c *Container) Signal(ctx context.Context, num int64) error {
 	return c.startGuestProgram(ctx, "kill", fmt.Sprintf("%d", num))
 }
 
+func (c *Container) ReloadConfig(ctx context.Context) error {
+	defer trace.End(trace.Begin(c.ExecConfig.ID))
+
+	if c.vm == nil {
+		return fmt.Errorf("vm not set")
+	}
+
+	return c.startGuestProgram(ctx, "reload", "")
+}
+
 func (c *Container) onStop() {
 	lf := c.logFollowers
 	c.logFollowers = nil

--- a/lib/tether/tether_linux.go
+++ b/lib/tether/tether_linux.go
@@ -1,4 +1,4 @@
-// Copyright 2016 VMware, Inc. All Rights Reserved.
+// Copyright 2016-2017 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/tether/tether_linux.go
+++ b/lib/tether/tether_linux.go
@@ -45,6 +45,21 @@ func Mkdev(majorNumber int, minorNumber int) int {
 	return (majorNumber << 8) | (minorNumber & 0xff) | ((minorNumber & 0xfff00) << 12)
 }
 
+// ReloadConfig signals the current process, which triggers the signal handler
+// to reload the config.
+func ReloadConfig() error {
+	p, err := os.FindProcess(os.Getpid())
+	if err != nil {
+		return err
+	}
+
+	if err = p.Signal(syscall.SIGHUP); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 // childReaper is used to handle events from child processes, including child exit.
 // If running as pid=1 then this means it handles zombie process reaping for orphaned children
 // as well as direct child processes.

--- a/lib/tether/toolbox.go
+++ b/lib/tether/toolbox.go
@@ -1,4 +1,4 @@
-// Copyright 2016 VMware, Inc. All Rights Reserved.
+// Copyright 2016-2017 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/tether/toolbox.go
+++ b/lib/tether/toolbox.go
@@ -184,6 +184,8 @@ func (t *Toolbox) containerStartCommand(r *toolbox.VixMsgStartProgramRequest) (i
 	switch r.ProgramPath {
 	case "kill":
 		return -1, t.kill(r.Arguments)
+	case "reload":
+		return -1, ReloadConfig()
 	default:
 		return -1, fmt.Errorf("unknown command %q", r.ProgramPath)
 	}


### PR DESCRIPTION
Implements the `reload` guest program handler to reload the tether config (via signal at the moment).

Fixes #4109
