### PR TITLE
[skip ci] Update the NSX testurl for nightly

### DIFF
--- a/tests/manual-test-cases/Group5-Functional-Tests/5-7-NSX.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-7-NSX.robot
@@ -19,12 +19,12 @@ Resource  ../../resources/Util.robot
 *** Test Cases ***
 Test
     Log To Console  Set environment variables up for GOVC
-    Set Environment Variable  GOVC_URL  10.160.229.248
+    Set Environment Variable  GOVC_URL  10.162.28.218
     Set Environment Variable  GOVC_USERNAME  Administrator@vsphere.local
     Set Environment Variable  GOVC_PASSWORD  Admin\!23
 
     Log To Console  Deploy VIC to the VC cluster
-    Set Environment Variable  TEST_URL_ARRAY  10.160.229.248
+    Set Environment Variable  TEST_URL_ARRAY  10.162.28.218
     Set Environment Variable  TEST_USERNAME  Administrator@vsphere.local
     Set Environment Variable  TEST_PASSWORD  Admin\!23
     Set Environment Variable  BRIDGE_NETWORK  DPortGroup


### PR DESCRIPTION
Updating the VC url, for a newly created NSX/VC testbed in Nimbus for NSX nightlies.