### PR TITLE
fixed incorrect image digest persistance

### DIFF
--- a/lib/apiservers/engine/backends/filter/image.go
+++ b/lib/apiservers/engine/backends/filter/image.go
@@ -101,6 +101,11 @@ func IncludeImage(imgFilters filters.Args, listContext *ImageListContext) Filter
 		refs := cache.RepositoryCache().References(listContext.ID)
 		// reference filters
 		refFilters := imgFilters.Get("reference")
+
+		// reset the tags / digests
+		listContext.Tags = nil
+		listContext.Digests = nil
+
 		// iterate of reporsitory references and filters
 		for _, ref := range refs {
 			for _, rf := range refFilters {
@@ -108,7 +113,6 @@ func IncludeImage(imgFilters filters.Args, listContext *ImageListContext) Filter
 				matchRef, _ := path.Match(rf, ref.String())
 				// match on repo only ie. busybox
 				matchName, _ := path.Match(rf, ref.Name())
-
 				// if either matched then add to tag / digest
 				if matchRef || matchName {
 					if _, ok := ref.(reference.Canonical); ok {
@@ -124,7 +128,7 @@ func IncludeImage(imgFilters filters.Args, listContext *ImageListContext) Filter
 		if len(listContext.Tags) == 0 && len(listContext.Digests) == 0 {
 			return ExcludeAction
 		}
-	}
 
+	}
 	return IncludeAction
 }

--- a/lib/imagec/imagec.go
+++ b/lib/imagec/imagec.go
@@ -289,11 +289,21 @@ func updateRepositoryCache(ic *ImageC) error {
 			return fmt.Errorf("ImageID not found by LayerID(%s) in RepositoryCache", imageLayerID)
 		}
 	}
-	// AddReference will add the tag / digest as appropriate and will persist
-	// to the portlayer k/v
+	// AddReference will add the repo:tag to the repositoryCache and save to the portLayer
 	err = repoCache.AddReference(ref, ic.ImageID, true, imageLayerID, true)
 	if err != nil {
 		return fmt.Errorf("Unable to Add Image Reference(%s): %s", ref.String(), err.Error())
+	}
+
+	dig, err := reference.ParseNamed(fmt.Sprintf("%s@%s", ref.Name(), ic.ManifestDigest))
+	if err != nil {
+		return fmt.Errorf("Unable to parse digest: %s", err.Error())
+	}
+
+	// AddReference will add the digest and persist to the portLayer
+	err = repoCache.AddReference(dig, ic.ImageID, true, imageLayerID, true)
+	if err != nil {
+		return fmt.Errorf("Unable to Add Image Digest(%s): %s", dig.String(), err.Error())
 	}
 
 	return nil

--- a/tests/test-cases/Group1-Docker-Commands/1-03-Docker-Images.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-03-Docker-Images.robot
@@ -32,13 +32,13 @@ Simple images
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} images
     Should Be Equal As Integers  ${rc}  0
     Should Not Contain  ${output}  Error
-    Should Contain X Times  ${output}  alpine  3
+    Should Contain X Times  ${output}  alpine  6
 
 All images
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} images -a
     Should Be Equal As Integers  ${rc}  0
     Should Not Contain  ${output}  Error
-    Should Contain X Times  ${output}  alpine  3
+    Should Contain X Times  ${output}  alpine  6
 
 Quiet images
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} images -q
@@ -46,14 +46,14 @@ Quiet images
     Should Not Contain  ${output}  Error
     Should Not Contain  ${output}  alpine
     @{lines}=  Split To Lines  ${output}
-    Length Should Be  ${lines}  3
+    Length Should Be  ${lines}  6
     Length Should Be  @{lines}[1]  12
 
 No-trunc images
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} images --no-trunc
     Should Be Equal As Integers  ${rc}  0
     Should Not Contain  ${output}  Error
-    Should Contain X Times  ${output}  alpine  3
+    Should Contain X Times  ${output}  alpine  6
     @{lines}=  Split To Lines  ${output}
     @{line}=  Split String  @{lines}[2]
     Length Should Be  @{line}[2]  64
@@ -63,7 +63,7 @@ Filter images before
     Should Be Equal As Integers  ${rc}  0
     Should Not Contain  ${output}  Error
     @{lines}=  Split To Lines  ${output}
-    Length Should Be  ${lines}  3
+    Length Should Be  ${lines}  5
     Should Contain  ${output}  3.1
 
 Filter images since
@@ -71,7 +71,7 @@ Filter images since
     Should Be Equal As Integers  ${rc}  0
     Should Not Contain  ${output}  Error
     @{lines}=  Split To Lines  ${output}
-    Length Should Be  ${lines}  3
+    Length Should Be  ${lines}  5
     Should Contain  ${output}  latest
 
 Tag images


### PR DESCRIPTION
The image digest was being persisted as part of image metadata
and not in the repository cache.  That has been corrected.

Additionally, the docker 1.11.2 client presents the docker images command
differently than 1.13, so tests were updated to satisfy our current
testing client of 1.11.2.

Fixes #4282
