### PR TITLE
[specific ci=3-03-Docker-Compose-Basic] Fixed attach for docker-compose up

### DIFF
--- a/lib/apiservers/engine/backends/container_proxy.go
+++ b/lib/apiservers/engine/backends/container_proxy.go
@@ -1022,8 +1022,9 @@ func dockerContainerCreateParamsToTask(id string, cc types.ContainerCreateConfig
 	// user
 	config.User = cc.Config.User
 
-	// attach
-	config.Attach = cc.Config.AttachStdin || cc.Config.AttachStdout || cc.Config.AttachStderr
+	// attach.  Always set to true otherwise we cannot attach later.
+	// this tells portlayer container is attachable.
+	config.Attach = true
 
 	// openstdin
 	config.OpenStdin = cc.Config.OpenStdin

--- a/tests/test-cases/Group3-Docker-Compose/3-03-Docker-Compose-Basic.md
+++ b/tests/test-cases/Group3-Docker-Compose/3-03-Docker-Compose-Basic.md
@@ -29,9 +29,12 @@ This test requires that a vSphere server is running and available
 16. Issue DOCKER_HOST=<VCH IP> docker-compose --file compose-rename.yml up -d
 17. Issue DOCKER_HOST=<VCH IP> docker-compose --file compose-rename.yml up -d --force-recreate
 18. Issue DOCKER_HOST=<VCH IP> docker-compose --file compose-rename.yml up -d
+19. Issue DOCKER_HOST=<VCH IP> docker-compose up (without -d)
+20. Issue DOCKER_HOST=<VCH IP> docker-compose stop on the above container
+21. Issue DOCKER_HOST=<VCH IP> docker-compose up (without -d) again
 
 # Expected Outcome:
-* Step 4-18 should result in no errors
+* Step 4-21 should result in no errors
 
 # Possible Problems:
 None

--- a/tests/test-cases/Group3-Docker-Compose/3-03-Docker-Compose-Basic.robot
+++ b/tests/test-cases/Group3-Docker-Compose/3-03-Docker-Compose-Basic.robot
@@ -23,6 +23,7 @@ ${yml}  version: "2"\nservices:\n${SPACE}web:\n${SPACE}${SPACE}image: python:2.7
 ${link-yml}  version: "2"\nservices:\n${SPACE}redis1:\n${SPACE}${SPACE}image: redis:alpine\n${SPACE}${SPACE}container_name: redis1\n${SPACE}${SPACE}ports: ["6379"]\n${SPACE}web1:\n${SPACE}${SPACE}image: busybox\n${SPACE}${SPACE}container_name: a.b.c\n${SPACE}${SPACE}links:\n${SPACE}${SPACE}- redis1:aaa\n${SPACE}${SPACE}command: ["ping", "aaa"]
 ${rename-yml-1}  version: "2"\nservices:\n${SPACE}web:\n${SPACE}${SPACE}image: busybox\n${SPACE}${SPACE}command: ["/bin/top"]
 ${rename-yml-2}  version: "2"\nservices:\n${SPACE}web:\n${SPACE}${SPACE}image: ubuntu\n${SPACE}${SPACE}command: ["date"]
+${hello-yml}  version: "2"\nservices:\n${SPACE}top:\n${SPACE}${SPACE}image: busybox\n${SPACE}${SPACE}container_name: top\n${SPACE}${SPACE}command: ["echo", "hello, world"]
 
 *** Keywords ***
 Check Compose Logs
@@ -72,6 +73,9 @@ Compose Up while another container is running (ps filtering related)
     ${rc}  ${out}=  Run And Return Rc And Output  docker-compose %{COMPOSE-PARAMS} -f basic-compose.yml up -d
     Log  ${out}
     Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${output}=  Run And Return Rc And Output  docker-compose %{COMPOSE-PARAMS} --file basic-compose.yml down
+    Log  ${output}
+    Should Be Equal As Integers  ${rc}  0
 
 Compose Up with link
     Run  echo '${link-yml}' > link-compose.yml
@@ -79,6 +83,9 @@ Compose Up with link
     Log  ${output}
     Should Be Equal As Integers  ${rc}  0
     Wait Until Keyword Succeeds  10x  10s  Check Compose Logs
+    ${rc}  ${output}=  Run And Return Rc And Output  docker-compose %{COMPOSE-PARAMS} --file link-compose.yml down
+    Log  ${output}
+    Should Be Equal As Integers  ${rc}  0
 
 Compose bundle creation
     ${rc}  Run And Return Rc  docker-compose %{COMPOSE-PARAMS} --file basic-compose.yml pull
@@ -86,6 +93,9 @@ Compose bundle creation
     ${rc}  ${output}=  Run And Return Rc And Output  docker-compose %{COMPOSE-PARAMS} --file basic-compose.yml bundle
     Log  ${output}
     Should Contain  ${output}  Wrote bundle
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${output}=  Run And Return Rc And Output  docker-compose %{COMPOSE-PARAMS} --file basic-compose.yml down
+    Log  ${output}
     Should Be Equal As Integers  ${rc}  0
 
 Compose up -d --force-recreate
@@ -99,6 +109,24 @@ Compose up -d --force-recreate
 
 Compose up -d with a new image
     Run  echo '${rename-yml-2}' > compose-rename.yml
-    ${rc}  ${output}=  Run And Return Rc And Output  docker-compose %{COMPOSE-PARAMS} --file compose-rename.yml up -d
+    ${rc}  ${output}=  Run And Return Rc And Output  docker-compose %{COMPOSE-PARAMS} --file compose-rename.yml up -d   
+    Log  ${output}
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${output}=  Run And Return Rc And Output  docker-compose %{COMPOSE-PARAMS} --file compose-rename.yml down
+    Log  ${output}
+    Should Be Equal As Integers  ${rc}  0
+
+Compose up in foreground (attach path)   
+    Run  echo '${hello-yml}' > hello-compose.yml
+    ${rc}  ${output}=  Run And Return Rc And Output  docker-compose %{COMPOSE-PARAMS} -f hello-compose.yml pull
+    Should Be Equal As Integers  ${rc}  0
+    Log  ${output}
+
+    # Bring up the compose app and wait till they're up and running
+    ${rc}  ${output}=  Run And Return Rc And Output  docker-compose %{COMPOSE-PARAMS} -f hello-compose.yml up
+    Log  ${output}
+    Should Contain  ${output}  hello, world
+
+    ${rc}  ${output}=  Run And Return Rc And Output  docker-compose %{COMPOSE-PARAMS} -f hello-compose.yml down
     Log  ${output}
     Should Be Equal As Integers  ${rc}  0


### PR DESCRIPTION
When running docker-compose up, without -d, the attach path
is exercised.  We did not make the container VM attachable
during ContainerCreate.

Also, discovered the interaction portlayer needed to delete
and recreate the attach server for the new bind/unbind
semantics.  If we do not do this, "docker-compose up", followed
by ctrl-c, and then do "docker-compose up" again, it should attach
and not output an error.

Resolves #4223