### PR TITLE
[skip ci] Add George to config component

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -121,7 +121,6 @@ groups:
   config:
     users:
       - emlin
-      - hickeng
     conditions:
       files:
         include:

--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -121,6 +121,7 @@ groups:
   config:
     users:
       - emlin
+      - hickeng
     conditions:
       files:
         include:


### PR DESCRIPTION
Adds George to the config component in PullApprove. Does what it says on the tin.