### PR TITLE
Fix insecure-registry URL parsing in GO1.8, #4141

### DIFF
--- a/cmd/vic-machine/create/create.go
+++ b/cmd/vic-machine/create/create.go
@@ -902,11 +902,12 @@ func (c *Create) processRegistries() error {
 
 	// load a list of insecure registries
 	for _, registry := range c.insecureRegistries {
-		url, err := url.Parse(registry)
+		regurl, err := validate.ParseURL(registry)
+
 		if err != nil {
 			return cli.NewExitError(fmt.Sprintf("%s is an invalid format for registry url", registry), 1)
 		}
-		c.InsecureRegistries = append(c.InsecureRegistries, *url)
+		c.InsecureRegistries = append(c.InsecureRegistries, *regurl)
 	}
 
 	return nil

--- a/lib/apiservers/engine/backends/backends.go
+++ b/lib/apiservers/engine/backends/backends.go
@@ -112,7 +112,11 @@ func Init(portLayerAddr, product string, config *config.VirtualContainerHostConf
 
 	serviceOptions := registry.ServiceOptions{}
 	for _, r := range insecureRegs {
-		insecureRegistries = append(insecureRegistries, r.Path)
+		// host:port was previously stored in the Path
+		// component of the URL. Go 1.8 parser puts it
+		// the Host component. VCH upgrade must move it
+		// from Path to Host.
+		insecureRegistries = append(insecureRegistries, r.Host)
 	}
 	if len(insecureRegistries) > 0 {
 		serviceOptions.InsecureRegistries = insecureRegistries
@@ -253,7 +257,7 @@ func createImageStore() error {
 }
 
 func InsecureRegistries() []string {
-	registries := make([]string, len(insecureRegistries))
+	registries := []string{}
 	for _, reg := range insecureRegistries {
 		registries = append(registries, reg)
 	}

--- a/lib/install/validate/validator.go
+++ b/lib/install/validate/validator.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 
 	"context"
+	"regexp"
 
 	log "github.com/Sirupsen/logrus"
 	units "github.com/docker/go-units"
@@ -154,6 +155,30 @@ func NewValidator(ctx context.Context, input *data.Data) (*Validator, error) {
 	}
 
 	return v, nil
+}
+
+var schemeMatch = regexp.MustCompile(`^\w+://`)
+
+// Starting from Go 1.8 the URL parser does not
+// work properly with URLs with no Scheme,
+// this function adds "https" as Scheme if necessary
+func ParseURL(s string) (*url.URL, error) {
+	var err error
+	var u *url.URL
+
+	if s != "" {
+		// Default the scheme to https
+		if !schemeMatch.MatchString(s) {
+			s = "https://" + s
+		}
+
+		u, err = url.Parse(s)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return u, nil
 }
 
 func (v *Validator) AllowEmptyDC() {

--- a/lib/install/validate/validator_test.go
+++ b/lib/install/validate/validator_test.go
@@ -32,10 +32,83 @@ import (
 	"github.com/vmware/vic/pkg/vsphere/simulator"
 
 	"context"
+	"fmt"
 )
 
 type TestValidator struct {
 	Validator
+}
+
+func TestParseURL(t *testing.T) {
+	var hosts = []string{
+		"host.domain.com",
+		"host.domain.com:123",
+		"1.2.3.4",
+		"1.2.3.4:10",
+		"[2001:4860:0:2001::68]",
+		"[2001:db8:1f70::999:de8:7648:6e8]:123",
+	}
+
+	for _, urlString := range hosts {
+		u, err := ParseURL(urlString)
+		assert.Nil(t, err)
+		assert.Equal(t, u.String(), "https://"+urlString)
+		// Null the scheme
+		u.Scheme = ""
+		assert.Equal(t, u.String(), "//"+urlString)
+		assert.Equal(t, u.Host, urlString)
+	}
+
+	// Add path to create a more significant URL
+	var urls = []string{}
+
+	for i, h := range hosts {
+		url := fmt.Sprintf("%s/path%d/test", h, i)
+		urls = append(urls, url)
+	}
+
+	for i, urlString := range urls {
+		u, err := ParseURL(urlString)
+		assert.Nil(t, err)
+		assert.Equal(t, u.String(), "https://"+urlString)
+
+		// Null the scheme
+		u.Scheme = ""
+		assert.Equal(t, u.String(), "//"+urlString)
+
+		// Check host
+		assert.Equal(t, u.Host, hosts[i])
+		// Check path
+		path := fmt.Sprintf("/path%d/test", i)
+		assert.Equal(t, u.Path, path)
+		// Check concatenation
+		assert.Equal(t, u.Host+u.Path, urlString)
+	}
+
+	// Add an HTTP scheme to verify that it is preserved
+	var urlsWithHTTPScheme = []string{}
+
+	for _, u := range urls {
+		uws := fmt.Sprintf("http://%s", u)
+		urlsWithHTTPScheme = append(urlsWithHTTPScheme, uws)
+	}
+
+	for _, urlString := range urlsWithHTTPScheme {
+		u, err := ParseURL(urlString)
+		fmt.Printf("UrlString: %s\n", u.String())
+		assert.Nil(t, err)
+		assert.Equal(t, u.String(), urlString)
+	}
+
+	var invalidUrls = []string{
+		"[2001:db8/path",
+		"1.2.3.4\\path",
+	}
+
+	for _, urlString := range invalidUrls {
+		_, err := ParseURL(urlString)
+		assert.NotNil(t, err)
+	}
 }
 
 func TestPathConversionESX(t *testing.T) {


### PR DESCRIPTION
This change includes:
- New URL parsing function (originally from GOVMOMI)
- Changed vic-machine to use new parser
- Changed backend to read host:port from the Host component of the URL

Fixes #4141
