### PR TITLE
[specific ci=Group3-Docker-Compose] Add ability to use docker-compose with TLS in robot

### DIFF
--- a/tests/resources/VCH-Util.robot
+++ b/tests/resources/VCH-Util.robot
@@ -93,6 +93,10 @@ Get Docker Params
     \   ${status}  ${message}=  Run Keyword And Ignore Error  Should Contain  ${item}  DOCKER_HOST=
     \   Run Keyword If  '${status}' == 'PASS'  Set Suite Variable  ${line}  ${item}
 
+    :FOR  ${item}  IN  @{output}
+    \   ${status}  ${message}=  Run Keyword And Ignore Error  Should Contain  ${item}  Environment saved in
+    \   Run Keyword If  '${status}' == 'PASS'  Set Suite Variable  ${cert_line}  ${item}
+
     # Ensure we start from a clean slate with docker env vars
     Remove Environment Variable  DOCKER_HOST  DOCKER_TLS_VERIFY  DOCKER_CERT_PATH
 
@@ -105,6 +109,12 @@ Get Docker Params
     ${port}=  Strip String  @{hostParts}[1]
     Set Environment Variable  VCH-IP  ${ip}
     Set Environment Variable  VCH-PORT  ${port}
+
+    # Create params for docker-compose
+    @{certparts}=  Split String  ${cert_line}  in
+    ${cert_envfile}=  Strip String  @{certparts}[1]
+    @{certpath_parts}=  Split String  ${cert_envfile}  /
+    ${cert_path}=  Strip String  @{certpath_parts}[0]
 
     :FOR  ${index}  ${item}  IN ENUMERATE  @{output}
     \   ${status}  ${message}=  Run Keyword And Ignore Error  Should Contain  ${item}  http
@@ -122,6 +132,11 @@ Get Docker Params
 
     Run Keyword If  ${port} == 2376  Set Environment Variable  VCH-PARAMS  -H ${dockerHost} --tls
     Run Keyword If  ${port} == 2375  Set Environment Variable  VCH-PARAMS  -H ${dockerHost}
+
+    # Set environment variables for docker-compose.  Also assumes DOCKER_TLS_VERIFY is set earlier!
+    Run Keyword If  ${certs} == ${True}  Set Environment Variable  COMPOSE_TLS_VERSION  TLSv1_2
+    Run Keyword If  ${certs} == ${True}  Set Environment Variable  DOCKER_CERT_PATH  ./${cert_path}
+    Set Environment Variable  COMPOSE-PARAMS  -H ${dockerHost}
 
 Install VIC Appliance To Test Server
     [Arguments]  ${vic-machine}=bin/vic-machine-linux  ${appliance-iso}=bin/appliance.iso  ${bootstrap-iso}=bin/bootstrap.iso  ${certs}=${true}  ${vol}=default

--- a/tests/test-cases/Group3-Docker-Compose/3-01-Docker-Compose-LEMP.robot
+++ b/tests/test-cases/Group3-Docker-Compose/3-01-Docker-Compose-LEMP.robot
@@ -15,7 +15,7 @@
 *** Settings ***
 Documentation  Test 3-01 - Docker Compose LEMP
 Resource  ../../resources/Util.robot
-Suite Setup  Install VIC Appliance To Test Server  certs=${false}
+Suite Setup  Install VIC Appliance To Test Server  certs=${True}
 Suite Teardown  Cleanup VIC Appliance On Test Server
 
 *** Test Cases ***
@@ -24,13 +24,11 @@ Compose LEMP Server
     Should Be Equal As Integers  ${rc}  0
 
     Set Environment Variable  COMPOSE_HTTP_TIMEOUT  300
-    # must set CURL_CA_BUNDLE to work around Compose bug https://github.com/docker/compose/issues/3365
-    Set Environment Variable  CURL_CA_BUNDLE  ${EMPTY}
 
     ${vch_ip}=  Get Environment Variable  VCH_IP  %{VCH-IP}
     Log To Console  \nThe VCH IP is %{VCH-IP}
 
     Run  cat %{GOPATH}/src/github.com/vmware/vic/demos/compose/webserving-app/docker-compose.yml | sed -e "s/192.168.60.130/${vch_ip}/g" > lemp-compose.yml
-    ${rc}  ${output}=  Run And Return Rc And Output  docker-compose %{VCH-PARAMS} --file lemp-compose.yml up -d
+    ${rc}  ${output}=  Run And Return Rc And Output  docker-compose %{COMPOSE-PARAMS} --file lemp-compose.yml up -d
     Log  ${output}
     Should Be Equal As Integers  ${rc}  0

--- a/tests/test-cases/Group3-Docker-Compose/3-02-Docker-Compose-Voting-App.robot
+++ b/tests/test-cases/Group3-Docker-Compose/3-02-Docker-Compose-Voting-App.robot
@@ -15,7 +15,7 @@
 *** Settings ***
 Documentation  Test 3-02 - Docker Compose Voting App
 Resource  ../../resources/Util.robot
-Suite Setup  Install VIC Appliance To Test Server  certs=${false}
+Suite Setup  Install VIC Appliance To Test Server  certs=${True}
 Suite Teardown  Cleanup VIC Appliance On Test Server
 
 *** Test Cases ***
@@ -24,13 +24,9 @@ Compose Voting App
     Should Be Equal As Integers  ${rc}  0
 
     Set Environment Variable  COMPOSE_HTTP_TIMEOUT  300
-    # must set CURL_CA_BUNDLE to work around Compose bug https://github.com/docker/compose/issues/3365
-    Set Environment Variable  CURL_CA_BUNDLE  ${EMPTY}
 
-    ${rc}  ${out}=  Run And Return Rc And Output  docker-compose --skip-hostname-check -f %{GOPATH}/src/github.com/vmware/vic/demos/compose/voting-app/docker-compose.yml %{VCH-PARAMS} up -d
+    ${rc}  ${out}=  Run And Return Rc And Output  docker-compose %{COMPOSE-PARAMS} --skip-hostname-check -f %{GOPATH}/src/github.com/vmware/vic/demos/compose/voting-app/docker-compose.yml up -d
     Log  ${out}
-    #Log  ${out.stdout}
-    #Log  ${out.stderr}
     Should Be Equal As Integers  ${rc}  0
 
     ${rc}  ${out}=  Run And Return Rc And Output  docker %{VCH-PARAMS} inspect -f {{.State.Running}} vote

--- a/tests/test-cases/Group3-Docker-Compose/3-03-Docker-Compose-Basic.robot
+++ b/tests/test-cases/Group3-Docker-Compose/3-03-Docker-Compose-Basic.robot
@@ -15,7 +15,7 @@
 *** Settings ***
 Documentation  Test 3-03 - Docker Compose Basic
 Resource  ../../resources/Util.robot
-Suite Setup  Install VIC Appliance To Test Server  certs=${false}
+Suite Setup  Install VIC Appliance To Test Server  certs=${True}
 Suite Teardown  Cleanup VIC Appliance On Test Server
 
 *** Variables ***
@@ -25,35 +25,33 @@ ${link-yml}  version: "2"\nservices:\n${SPACE}redis1:\n${SPACE}${SPACE}image: re
 *** Test Cases ***
 Compose basic
     Set Environment Variable  COMPOSE_HTTP_TIMEOUT  300
-    # must set CURL_CA_BUNDLE to work around Compose bug https://github.com/docker/compose/issues/3365
-    Set Environment Variable  CURL_CA_BUNDLE  ${EMPTY}
 
     Run  echo '${yml}' > basic-compose.yml
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} network create vic_default
     Log  ${output}
-    ${rc}  ${output}=  Run And Return Rc And Output  docker-compose %{VCH-PARAMS} --file basic-compose.yml create
+    ${rc}  ${output}=  Run And Return Rc And Output  docker-compose %{COMPOSE-PARAMS} --file basic-compose.yml create
     Log  ${output}
     Should Be Equal As Integers  ${rc}  0
-    ${rc}  ${output}=  Run And Return Rc And Output  docker-compose %{VCH-PARAMS} --file basic-compose.yml start
+    ${rc}  ${output}=  Run And Return Rc And Output  docker-compose %{COMPOSE-PARAMS} --file basic-compose.yml start
     Log  ${output}
     Should Be Equal As Integers  ${rc}  0
-    ${rc}  ${output}=  Run And Return Rc And Output  docker-compose %{VCH-PARAMS} --file basic-compose.yml logs
+    ${rc}  ${output}=  Run And Return Rc And Output  docker-compose %{COMPOSE-PARAMS} --file basic-compose.yml logs
     Log  ${output}
     Should Be Equal As Integers  ${rc}  0
-    ${rc}  ${output}=  Run And Return Rc And Output  docker-compose %{VCH-PARAMS} --file basic-compose.yml stop
+    ${rc}  ${output}=  Run And Return Rc And Output  docker-compose %{COMPOSE-PARAMS} --file basic-compose.yml stop
     Log  ${output}
     Should Be Equal As Integers  ${rc}  0
 
 Compose kill
-    ${rc}  ${out}=  Run And Return Rc And Output  docker-compose %{VCH-PARAMS} -f basic-compose.yml up -d
+    ${rc}  ${out}=  Run And Return Rc And Output  docker-compose %{COMPOSE-PARAMS} -f basic-compose.yml up -d
     Log  ${out}
     Should Be Equal As Integers  ${rc}  0
 
-    ${rc}  ${out}=  Run And Return Rc And Output  docker-compose %{VCH-PARAMS} -f basic-compose.yml kill redis
+    ${rc}  ${out}=  Run And Return Rc And Output  docker-compose %{COMPOSE-PARAMS} -f basic-compose.yml kill redis
     Log  ${out}
     Should Be Equal As Integers  ${rc}  0
 
-    ${rc}  ${out}=  Run And Return Rc And Output  docker-compose %{VCH-PARAMS} -f basic-compose.yml down
+    ${rc}  ${out}=  Run And Return Rc And Output  docker-compose %{COMPOSE-PARAMS} -f basic-compose.yml down
     Log  ${out}
     Should Be Equal As Integers  ${rc}  0
 
@@ -62,24 +60,24 @@ Compose Up while another container is running (ps filtering related)
     Log  ${out}
     Should Be Equal As Integers  ${rc}  0
 
-    ${rc}  ${out}=  Run And Return Rc And Output  docker-compose %{VCH-PARAMS} -f basic-compose.yml up -d
+    ${rc}  ${out}=  Run And Return Rc And Output  docker-compose %{COMPOSE-PARAMS} -f basic-compose.yml up -d
     Log  ${out}
     Should Be Equal As Integers  ${rc}  0
 
 Compose Up with link
     Run  echo '${link-yml}' > link-compose.yml
-    ${rc}  ${output}=  Run And Return Rc And Output  docker-compose %{VCH-PARAMS} --file link-compose.yml up -d
+    ${rc}  ${output}=  Run And Return Rc And Output  docker-compose %{COMPOSE-PARAMS} --file link-compose.yml up -d
     Log  ${output}
     Should Be Equal As Integers  ${rc}  0
-    ${rc}  ${output}=  Run And Return Rc And Output  docker-compose %{VCH-PARAMS} --file link-compose.yml logs
+    ${rc}  ${output}=  Run And Return Rc And Output  docker-compose %{COMPOSE-PARAMS} --file link-compose.yml logs
     Should Be Equal As Integers  ${rc}  0
     Should Contain  ${output}  PING aaa
     Should Not Contain  ${output}  bad address 'aaa'
 
 Compose bundle creation
-    ${rc}  Run And Return Rc  docker-compose %{VCH-PARAMS} --file basic-compose.yml pull
+    ${rc}  Run And Return Rc  docker-compose %{COMPOSE-PARAMS} --file basic-compose.yml pull
     Should Be Equal As Integers  ${rc}  0
-    ${rc}  ${output}=  Run And Return Rc And Output  docker-compose %{VCH-PARAMS} --file basic-compose.yml bundle
+    ${rc}  ${output}=  Run And Return Rc And Output  docker-compose %{COMPOSE-PARAMS} --file basic-compose.yml bundle
     Log  ${output}
     Should Contain  ${output}  Wrote bundle
     Should Be Equal As Integers  ${rc}  0

--- a/tests/test-cases/Group3-Docker-Compose/TestCases.md
+++ b/tests/test-cases/Group3-Docker-Compose/TestCases.md
@@ -6,3 +6,5 @@ Group 3 - Docker Compose
 -
 [Test 3-02 - Docker Compose Voting App](3-02-Docker-Compose-Voting-App.md)
 -
+[Test 3-03 - Docker Compose Basic](3-03-Docker-Compose-Basic.md)
+-


### PR DESCRIPTION
Add the appropriate environment variables for robot scripts to use
docker-compose with TLS.  Also updated all compose tests to use
certs and the new param, COMPOSE-PARAMS instead of VCH-PARAMS.

Resolves #4317