### PR TITLE
Get image ID using layer ID

### DIFF
--- a/lib/apiservers/engine/backends/cache/image_cache.go
+++ b/lib/apiservers/engine/backends/cache/image_cache.go
@@ -155,6 +155,12 @@ func (ic *ICache) Get(idOrRef string) (*metadata.ImageConfig, error) {
 		return copyImageConfig(config), nil
 	}
 
+	// let's try to get the image ID from the repocache just in case we have a layer ID
+	// see https://github.com/vmware/vic/issues/4378#issuecomment-289070799
+	if id := RepositoryCache().GetImageID(strings.Split(idOrRef, ":")[0]); id != "" {
+		idOrRef = id
+	}
+
 	// get the full image ID if supplied a prefix
 	if id, err := ic.iDIndex.Get(idOrRef); err == nil {
 		idOrRef = id


### PR DESCRIPTION
`docker compose up -d --force-recreate` causes a call to the `GetImage` endpoint using a layer ID as a parameter. This adds a safety check into the image cache to get the image ID from the repo cache just in case we have a layer ID and not an image ID/prefix/name.

This is a temporary workaround for #4378.