### PR TITLE
Fix integration test 13-01-VAC-GuestFullName

### DIFF
--- a/tests/test-cases/Group13-VAC/13-01-VAC-GuestFullName.robot
+++ b/tests/test-cases/Group13-VAC/13-01-VAC-GuestFullName.robot
@@ -20,8 +20,7 @@ Suite Teardown  Cleanup VIC Appliance On Test Server
 
 *** Test Cases ***
 Check VCH VM Guest Operating System
-    ${rc}  ${output}=  Run Keyword If  '%{HOST_TYPE}' == 'VC'  Run  govc vm.info %{VCH-NAME}/%{VCH-NAME} | grep 'Guest name'
-    ${rc}  ${output}=  Run Keyword If  '%{HOST_TYPE}' == 'ESXi'  Run And Return Rc And Output  govc vm.info %{VCH-NAME} | grep 'Guest name'
+    ${rc}  ${output}=  Run  govc vm.info %{VCH-NAME} | grep 'Guest name'
     Should Be Equal As Integers  ${rc}  0
     Should Contain  ${output}  Photon - VCH
 
@@ -31,7 +30,6 @@ Create a test container and check Guest Operating System
     ${rc}  ${id}=  Run And Return Rc And Output  docker %{VCH-PARAMS} create --name test busybox
     Should Be Equal As Integers  ${rc}  0
     ${shortID}=  Get container shortID  ${id}
-    ${rc}  ${output}=  Run Keyword If  '%{HOST_TYPE}' == 'VC'  Run  govc vm.info %{VCH-NAME}/test-${shortID}* | grep 'Guest name'
-    ${rc}  ${output}=  Run Keyword If  '%{HOST_TYPE}' == 'ESXi'  Run And Return Rc And Output  govc vm.info test-${shortID}* | grep 'Guest name'
+    ${rc}  ${output}=  Run  govc vm.info test-${shortID} | grep 'Guest name'
     Should Be Equal As Integers  ${rc}  0
     Should Contain  ${output}  Photon - Container

--- a/tests/test-cases/Group13-VAC/13-01-VAC-GuestFullName.robot
+++ b/tests/test-cases/Group13-VAC/13-01-VAC-GuestFullName.robot
@@ -20,7 +20,7 @@ Suite Teardown  Cleanup VIC Appliance On Test Server
 
 *** Test Cases ***
 Check VCH VM Guest Operating System
-    ${rc}  ${output}=  Run  govc vm.info %{VCH-NAME} | grep 'Guest name'
+    ${rc}  ${output}=  Run And return Rc and Output  govc vm.info %{VCH-NAME} | grep 'Guest name'
     Should Be Equal As Integers  ${rc}  0
     Should Contain  ${output}  Photon - VCH
 
@@ -30,6 +30,6 @@ Create a test container and check Guest Operating System
     ${rc}  ${id}=  Run And Return Rc And Output  docker %{VCH-PARAMS} create --name test busybox
     Should Be Equal As Integers  ${rc}  0
     ${shortID}=  Get container shortID  ${id}
-    ${rc}  ${output}=  Run  govc vm.info test-${shortID} | grep 'Guest name'
+    ${rc}  ${output}=  Run And Return Rc And Output  govc vm.info test-${shortID} | grep 'Guest name'
     Should Be Equal As Integers  ${rc}  0
     Should Contain  ${output}  Photon - Container


### PR DESCRIPTION
Fixes #4201 

Changes the way we look for the `govc vm.info`. Now that we have upgraded to `govc 0.13` we do not need to check for esxi vs VC. Additionally we do not need a complex path to the vm objects, So we can supply just the vm name now. 