### PR TITLE
[specific ci=3-03-Docker-Compose-Basic] Add ability to use docker-compose with TLS in robot

### DIFF
--- a/tests/test-cases/Group3-Docker-Compose/3-01-Docker-Compose-LEMP.robot
+++ b/tests/test-cases/Group3-Docker-Compose/3-01-Docker-Compose-LEMP.robot
@@ -15,7 +15,7 @@
 *** Settings ***
 Documentation  Test 3-01 - Docker Compose LEMP
 Resource  ../../resources/Util.robot
-Suite Setup  Install VIC Appliance To Test Server  certs=${false}
+Suite Setup  Install VIC Appliance To Test Server  certs=${True}
 Suite Teardown  Cleanup VIC Appliance On Test Server
 
 *** Test Cases ***
@@ -24,13 +24,11 @@ Compose LEMP Server
     Should Be Equal As Integers  ${rc}  0
 
     Set Environment Variable  COMPOSE_HTTP_TIMEOUT  300
-    # must set CURL_CA_BUNDLE to work around Compose bug https://github.com/docker/compose/issues/3365
-    Set Environment Variable  CURL_CA_BUNDLE  ${EMPTY}
 
     ${vch_ip}=  Get Environment Variable  VCH_IP  %{VCH-IP}
     Log To Console  \nThe VCH IP is %{VCH-IP}
 
     Run  cat %{GOPATH}/src/github.com/vmware/vic/demos/compose/webserving-app/docker-compose.yml | sed -e "s/192.168.60.130/${vch_ip}/g" > lemp-compose.yml
-    ${rc}  ${output}=  Run And Return Rc And Output  docker-compose %{VCH-PARAMS} --file lemp-compose.yml up -d
+    ${rc}  ${output}=  Run And Return Rc And Output  docker-compose %{COMPOSE-PARAMS} --file lemp-compose.yml up -d
     Log  ${output}
     Should Be Equal As Integers  ${rc}  0

--- a/tests/test-cases/Group3-Docker-Compose/3-02-Docker-Compose-Voting-App.robot
+++ b/tests/test-cases/Group3-Docker-Compose/3-02-Docker-Compose-Voting-App.robot
@@ -15,7 +15,7 @@
 *** Settings ***
 Documentation  Test 3-02 - Docker Compose Voting App
 Resource  ../../resources/Util.robot
-Suite Setup  Install VIC Appliance To Test Server  certs=${false}
+Suite Setup  Install VIC Appliance To Test Server  certs=${True}
 Suite Teardown  Cleanup VIC Appliance On Test Server
 
 *** Test Cases ***
@@ -24,13 +24,9 @@ Compose Voting App
     Should Be Equal As Integers  ${rc}  0
 
     Set Environment Variable  COMPOSE_HTTP_TIMEOUT  300
-    # must set CURL_CA_BUNDLE to work around Compose bug https://github.com/docker/compose/issues/3365
-    Set Environment Variable  CURL_CA_BUNDLE  ${EMPTY}
 
-    ${rc}  ${out}=  Run And Return Rc And Output  docker-compose --skip-hostname-check -f %{GOPATH}/src/github.com/vmware/vic/demos/compose/voting-app/docker-compose.yml %{VCH-PARAMS} up -d
+    ${rc}  ${out}=  Run And Return Rc And Output  docker-compose %{COMPOSE-PARAMS} --skip-hostname-check -f %{GOPATH}/src/github.com/vmware/vic/demos/compose/voting-app/docker-compose.yml up -d
     Log  ${out}
-    #Log  ${out.stdout}
-    #Log  ${out.stderr}
     Should Be Equal As Integers  ${rc}  0
 
     ${rc}  ${out}=  Run And Return Rc And Output  docker %{VCH-PARAMS} inspect -f {{.State.Running}} vote

--- a/tests/test-cases/Group3-Docker-Compose/TestCases.md
+++ b/tests/test-cases/Group3-Docker-Compose/TestCases.md
@@ -6,3 +6,5 @@ Group 3 - Docker Compose
 -
 [Test 3-02 - Docker Compose Voting App](3-02-Docker-Compose-Voting-App.md)
 -
+[Test 3-03 - Docker Compose Basic](3-03-Docker-Compose-Basic.md)
+-


### PR DESCRIPTION
Add the appropriate environment variables for robot scripts to use
docker-compose with TLS.  Also updated all compose tests to use
certs and the new param, COMPOSE-PARAMS instead of VCH-PARAMS.

Added handling for cert == true or cert == false during installing
the VCH.

Resolves #4317
