### PR TITLE
[specific ci=Group6-VIC-Machine]support user in docker command and Dockerfile

### DIFF
--- a/lib/apiservers/engine/backends/container.go
+++ b/lib/apiservers/engine/backends/container.go
@@ -1655,6 +1655,9 @@ func setCreateConfigOptions(config, imageConfig *containertypes.Config) {
 		}
 	}
 
+	if config.User == "" {
+		config.User = imageConfig.User
+	}
 	// set up environment
 	setEnvFromImageConfig(config, imageConfig)
 }
@@ -1813,12 +1816,6 @@ func validateCreateConfig(config *types.ContainerCreateConfig) error {
 				return InternalServerError("host port ranges are not supported for port bindings")
 			}
 		}
-	}
-
-	// TODO(jzt): users other than root are not currently supported
-	// We should check for USER in config.Config.Env once we support Dockerfiles.
-	if config.Config.User != "" && config.Config.User != "root" {
-		return InternalServerError("Failed to create container - users other than root are not currently supported")
 	}
 
 	// https://github.com/vmware/vic/issues/1378

--- a/lib/apiservers/engine/backends/container_proxy.go
+++ b/lib/apiservers/engine/backends/container_proxy.go
@@ -909,6 +909,9 @@ func dockerContainerCreateParamsToTask(id string, cc types.ContainerCreateConfig
 	// working dir
 	config.WorkingDir = cc.Config.WorkingDir
 
+	// user
+	config.User = cc.Config.User
+
 	// attach
 	config.Attach = cc.Config.AttachStdin || cc.Config.AttachStdout || cc.Config.AttachStderr
 
@@ -1312,6 +1315,8 @@ func containerConfigFromContainerInfo(vc *viccontainer.VicContainer, info *model
 	if info.ProcessConfig.WorkingDir != nil {
 		container.WorkingDir = *info.ProcessConfig.WorkingDir // Current directory (PWD) in the command will be launched
 	}
+
+	container.User = info.ProcessConfig.User
 
 	// Fill in information about the container network
 	if info.Endpoints == nil {

--- a/lib/apiservers/portlayer/restapi/handlers/containers_handlers.go
+++ b/lib/apiservers/portlayer/restapi/handlers/containers_handlers.go
@@ -460,7 +460,7 @@ func convertContainerToContainerInfo(container *exec.ContainerInfo) *models.Cont
 		info.ProcessConfig.StartTime = session.StartTime
 		info.ProcessConfig.StopTime = session.StopTime
 
-		if session.User != "" && session.Group != "" {
+		if session.Group != "" {
 			info.ProcessConfig.User = fmt.Sprintf("%s:%s", session.User, session.Group)
 		} else {
 			info.ProcessConfig.User = session.User

--- a/lib/apiservers/portlayer/restapi/handlers/containers_handlers.go
+++ b/lib/apiservers/portlayer/restapi/handlers/containers_handlers.go
@@ -460,10 +460,9 @@ func convertContainerToContainerInfo(container *exec.ContainerInfo) *models.Cont
 		info.ProcessConfig.StartTime = session.StartTime
 		info.ProcessConfig.StopTime = session.StopTime
 
+		info.ProcessConfig.User = session.User
 		if session.Group != "" {
 			info.ProcessConfig.User = fmt.Sprintf("%s:%s", session.User, session.Group)
-		} else {
-			info.ProcessConfig.User = session.User
 		}
 	} else {
 		// log that sessionID is missing and print the ExecConfig

--- a/lib/apiservers/portlayer/restapi/handlers/containers_handlers.go
+++ b/lib/apiservers/portlayer/restapi/handlers/containers_handlers.go
@@ -460,6 +460,11 @@ func convertContainerToContainerInfo(container *exec.ContainerInfo) *models.Cont
 		info.ProcessConfig.StartTime = session.StartTime
 		info.ProcessConfig.StopTime = session.StopTime
 
+		if session.User != "" && session.Group != "" {
+			info.ProcessConfig.User = fmt.Sprintf("%s:%s", session.User, session.Group)
+		} else {
+			info.ProcessConfig.User = session.User
+		}
 	} else {
 		// log that sessionID is missing and print the ExecConfig
 		log.Errorf("Session ID is missing from execConfig: %#v", container.ExecConfig)

--- a/lib/apiservers/portlayer/restapi/handlers/task_handlers.go
+++ b/lib/apiservers/portlayer/restapi/handlers/task_handlers.go
@@ -86,15 +86,12 @@ func (handler *TaskHandlersImpl) JoinHandler(params tasks.JoinParams) middleware
 	// parsing user
 	if params.Config.User != "" {
 		parts := strings.Split(params.Config.User, ":")
-		var user, group string
 		if len(parts) > 0 {
-			user = parts[0]
+			sessionConfig.User = parts[0]
 		}
 		if len(parts) > 1 {
-			group = parts[1]
+			sessionConfig.Group = parts[1]
 		}
-		sessionConfig.User = user
-		sessionConfig.Group = group
 	}
 
 	handleprime, err := task.Join(&op, handle, sessionConfig)

--- a/lib/apiservers/portlayer/restapi/handlers/task_handlers.go
+++ b/lib/apiservers/portlayer/restapi/handlers/task_handlers.go
@@ -16,6 +16,7 @@ package handlers
 
 import (
 	"context"
+	"strings"
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/go-openapi/runtime/middleware"
@@ -64,6 +65,7 @@ func (handler *TaskHandlersImpl) JoinHandler(params tasks.JoinParams) middleware
 	op.Debugf("Path: %#v", params.Config.Path)
 	op.Debugf("WorkingDir: %#v", params.Config.WorkingDir)
 	op.Debugf("OpenStdin: %#v", params.Config.OpenStdin)
+	op.Debugf("User: %s", params.Config.User)
 
 	sessionConfig := &executor.SessionConfig{
 		Common: executor.Common{
@@ -79,6 +81,20 @@ func (handler *TaskHandlersImpl) JoinHandler(params tasks.JoinParams) middleware
 			Args: append([]string{params.Config.Path}, params.Config.Args...),
 		},
 		StopSignal: params.Config.StopSignal,
+	}
+
+	// parsing user
+	if params.Config.User != "" {
+		parts := strings.Split(params.Config.User, ":")
+		var user, group string
+		if len(parts) > 0 {
+			user = parts[0]
+		}
+		if len(parts) > 1 {
+			group = parts[1]
+		}
+		sessionConfig.User = user
+		sessionConfig.Group = group
 	}
 
 	handleprime, err := task.Join(&op, handle, sessionConfig)

--- a/lib/apiservers/portlayer/swagger.json
+++ b/lib/apiservers/portlayer/swagger.json
@@ -3064,6 +3064,9 @@
 					"x-nullable": true,
 					"type": "string"
 				},
+				"user": {
+					"type": "string"
+				},
 				"env": {
 					"type": "array",
 					"items": {
@@ -3305,6 +3308,9 @@
 					}
 				},
 				"workingDir": {
+					"type": "string"
+				},
+				"user": {
 					"type": "string"
 				},
 				"env": {

--- a/lib/tether/ops_darwin.go
+++ b/lib/tether/ops_darwin.go
@@ -106,47 +106,5 @@ func (t *BaseOperations) Cleanup() error {
 //     * "user:gid"
 //     * "uid:group"
 func getUserSysProcAttr(uid, gid string) (*syscall.SysProcAttr, error) {
-	if len(uid) == 0 && len(gid) == 0 {
-		log.Debugf("no user id or group id specified")
-		return nil, nil
-	}
-
-	user := uid
-	if len(gid) > 0 {
-		user = fmt.Sprintf("%s:%s", uid, gid)
-	}
-	execUser, err := searchUser(user)
-	if err != nil {
-		return nil, err
-	}
-
-	sysProc := &syscall.SysProcAttr{
-		Credential: &syscall.Credential{
-			Uid: uint32(execUser.Uid),
-			Gid: uint32(execUser.Gid),
-		},
-		Setsid: true,
-	}
-	for _, sgid := range execUser.Sgids {
-		sysProc.Credential.Groups = append(sysProc.Credential.Groups, uint32(sgid))
-	}
-	return sysProc, nil
-}
-
-func searchUser(user string) (*dockerUser.ExecUser, error) {
-	defaultExecUser := dockerUser.ExecUser{
-		Uid:  syscall.Getuid(),
-		Gid:  syscall.Getgid(),
-		Home: "/",
-	}
-
-	passwdPath, err := dockerUser.GetPasswdPath()
-	if err != nil {
-		return nil, err
-	}
-	groupPath, err := dockerUser.GetGroupPath()
-	if err != nil {
-		return nil, err
-	}
-	return dockerUser.GetExecUserPath(user, &defaultExecUser, passwdPath, groupPath)
+	return nil, nil
 }

--- a/lib/tether/ops_darwin.go
+++ b/lib/tether/ops_darwin.go
@@ -23,9 +23,6 @@ import (
 	"strings"
 	"syscall"
 
-	log "github.com/Sirupsen/logrus"
-	dockerUser "github.com/opencontainers/runc/libcontainer/user"
-
 	"github.com/vmware/vic/pkg/trace"
 )
 

--- a/lib/tether/ops_darwin.go
+++ b/lib/tether/ops_darwin.go
@@ -96,8 +96,10 @@ func (t *BaseOperations) Cleanup() error {
 	return nil
 }
 
-// Need to put this here because Windows does not
-// support SysProcAttr.Credential
+// Need to put this here because Windows does not support SysProcAttr.Credential
+// getUserSysProcAttr will search uid/gid as username and groupname first, if not found and they are numeric id, set to userid and groupid without verify if these ids exist or not
+// if not numeric ids, and not found, return user or group not found error
+// this is same to docker
 func getUserSysProcAttr(uid, gid string) (*syscall.SysProcAttr, error) {
 	if len(uid) == 0 && len(gid) == 0 {
 		log.Debugf("no user id or group id specified")

--- a/lib/tether/ops_linux.go
+++ b/lib/tether/ops_linux.go
@@ -22,7 +22,6 @@ import (
 	"net"
 	"net/url"
 	"os"
-	"os/user"
 	"path"
 	"path/filepath"
 	"strconv"
@@ -32,6 +31,7 @@ import (
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/d2g/dhcp4"
+	dockerUser "github.com/opencontainers/runc/libcontainer/user"
 	"github.com/vishvananda/netlink"
 
 	"github.com/vmware/vic/lib/dhcp"
@@ -785,81 +785,57 @@ func (t *BaseOperations) Cleanup() error {
 }
 
 // Need to put this here because Windows does not support SysProcAttr.Credential
-// getUserSysProcAttr will search uid/gid as username and groupname first, if not found and they are numeric id, set to userid and groupid without verify if these ids exist or not
-// if not numeric ids, and not found, return user or group not found error
-// this is same to docker
+// getUserSysProcAttr relies on docker user package to verify user specification
+// Examples of valid user specifications are:
+//     * ""
+//     * "user"
+//     * "uid"
+//     * "user:group"
+//     * "uid:gid
+//     * "user:gid"
+//     * "uid:group"
 func getUserSysProcAttr(uid, gid string) (*syscall.SysProcAttr, error) {
 	if len(uid) == 0 && len(gid) == 0 {
 		log.Debugf("no user id or group id specified")
 		return nil, nil
 	}
 
-	var suid, sgid int
-	var suidErr, sgidErr error
-
-	var fuid, fgid int
-	var fuidErr, fgidErr error
-
-	var uinfo *user.User
-	var ginfo *user.Group
-
-	if len(uid) > 0 {
-		suid, suidErr = strconv.Atoi(uid)
-		// lookup username
-		uinfo, fuidErr = user.Lookup(uid)
-		if fuidErr == nil {
-			log.Debugf("User %s is found", uid)
-			fuid, _ = strconv.Atoi(uinfo.Uid)
-			fgid, _ = strconv.Atoi(uinfo.Gid)
-		}
-	}
+	user := uid
 	if len(gid) > 0 {
-		sgid, sgidErr = strconv.Atoi(gid)
-
-		// lookup groupname
-		ginfo, fgidErr = user.LookupGroup(gid)
-		// if found groupname, override user group
-		if fgidErr == nil {
-			log.Debugf("Group %s is found", gid)
-			fgid, _ = strconv.Atoi(ginfo.Gid)
-		}
+		user = fmt.Sprintf("%s:%s", uid, gid)
+	}
+	execUser, err := searchUser(user)
+	if err != nil {
+		return nil, err
 	}
 
-	// lookup user failed
-	if fuidErr != nil {
-		if suidErr != nil {
-			// failed to loopup username, and user is not number
-			detail := fmt.Sprintf("unable to find user %s: %s", uid, fuidErr)
-			return nil, errors.New(detail)
-		}
-		// user set user id must be inside valid uid range.
-		if suid < minID || suid > maxID {
-			detail := fmt.Sprintf("user id %s is invalid", uid)
-			return nil, errors.New(detail)
-		}
-		fuid = suid
-	}
-
-	// lookup group failed
-	if fgidErr != nil {
-		if sgidErr != nil {
-			// failed to loopup groupname, and user is not number
-			detail := fmt.Sprintf("unable to find group %s: %s", gid, fgidErr)
-			return nil, errors.New(detail)
-		}
-		// user set group id must be inside valid uid range.
-		if sgid < minID || sgid > maxID {
-			detail := fmt.Sprintf("group id %s is invalid", gid)
-			return nil, errors.New(detail)
-		}
-		fgid = sgid
-	}
-	log.Debugf("set user to %s:%s", fuid, fgid)
-	return &syscall.SysProcAttr{
+	sysProc := &syscall.SysProcAttr{
 		Credential: &syscall.Credential{
-			Uid: uint32(fuid),
-			Gid: uint32(fgid),
+			Uid: uint32(execUser.Uid),
+			Gid: uint32(execUser.Gid),
 		},
 		Setsid: true,
-	}, nil
+	}
+	for _, sgid := range execUser.Sgids {
+		sysProc.Credential.Groups = append(sysProc.Credential.Groups, uint32(sgid))
+	}
+	return sysProc, nil
+}
+
+func searchUser(user string) (*dockerUser.ExecUser, error) {
+	defaultExecUser := dockerUser.ExecUser{
+		Uid:  syscall.Getuid(),
+		Gid:  syscall.Getgid(),
+		Home: "/",
+	}
+
+	passwdPath, err := dockerUser.GetPasswdPath()
+	if err != nil {
+		return nil, err
+	}
+	groupPath, err := dockerUser.GetGroupPath()
+	if err != nil {
+		return nil, err
+	}
+	return dockerUser.GetExecUserPath(user, &defaultExecUser, passwdPath, groupPath)
 }

--- a/lib/tether/ops_linux.go
+++ b/lib/tether/ops_linux.go
@@ -784,8 +784,10 @@ func (t *BaseOperations) Cleanup() error {
 	return nil
 }
 
-// Need to put this here because Windows does not
-// support SysProcAttr.Credential
+// Need to put this here because Windows does not support SysProcAttr.Credential
+// getUserSysProcAttr will search uid/gid as username and groupname first, if not found and they are numeric id, set to userid and groupid without verify if these ids exist or not
+// if not numeric ids, and not found, return user or group not found error
+// this is same to docker
 func getUserSysProcAttr(uid, gid string) (*syscall.SysProcAttr, error) {
 	if len(uid) == 0 && len(gid) == 0 {
 		log.Debugf("no user id or group id specified")

--- a/lib/tether/ops_linux.go
+++ b/lib/tether/ops_linux.go
@@ -31,7 +31,8 @@ import (
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/d2g/dhcp4"
-	dockerUser "github.com/opencontainers/runc/libcontainer/user"
+	// need to use libcontainer for user validation, for os/user package cannot find user here if container image is busybox
+	"github.com/opencontainers/runc/libcontainer/user"
 	"github.com/vishvananda/netlink"
 
 	"github.com/vmware/vic/lib/dhcp"
@@ -45,7 +46,7 @@ var (
 	hostnameFile = "/etc/hostname"
 	byLabelDir   = "/dev/disk/by-label"
 
-	defaultExecUser = &dockerUser.ExecUser{
+	defaultExecUser = &user.ExecUser{
 		Uid:  syscall.Getuid(),
 		Gid:  syscall.Getgid(),
 		Home: "/",
@@ -806,19 +807,19 @@ func getUserSysProcAttr(uid, gid string) (*syscall.SysProcAttr, error) {
 		return nil, nil
 	}
 
-	user := uid
+	userGroup := uid
 	if gid != "" {
-		user = fmt.Sprintf("%s:%s", uid, gid)
+		userGroup = fmt.Sprintf("%s:%s", uid, gid)
 	}
-	passwdPath, err := dockerUser.GetPasswdPath()
+	passwdPath, err := user.GetPasswdPath()
 	if err != nil {
 		return nil, err
 	}
-	groupPath, err := dockerUser.GetGroupPath()
+	groupPath, err := user.GetGroupPath()
 	if err != nil {
 		return nil, err
 	}
-	execUser, err := dockerUser.GetExecUserPath(user, defaultExecUser, passwdPath, groupPath)
+	execUser, err := user.GetExecUserPath(userGroup, defaultExecUser, passwdPath, groupPath)
 	if err != nil {
 		return nil, err
 	}

--- a/lib/tether/ops_linux.go
+++ b/lib/tether/ops_linux.go
@@ -786,21 +786,78 @@ func (t *BaseOperations) Cleanup() error {
 
 // Need to put this here because Windows does not
 // support SysProcAttr.Credential
-func getUserSysProcAttr(uname string) *syscall.SysProcAttr {
-	uinfo, err := user.Lookup(uname)
-	if err != nil {
-		detail := fmt.Sprintf("Unable to find user %s: %s", uname, err)
-		log.Error(detail)
-		return nil
+func getUserSysProcAttr(uid, gid string) (*syscall.SysProcAttr, error) {
+	if len(uid) == 0 && len(gid) == 0 {
+		log.Debugf("no user id or group id specified")
+		return nil, nil
 	}
-	u, _ := strconv.Atoi(uinfo.Uid)
-	g, _ := strconv.Atoi(uinfo.Gid)
-	// Unfortunately lookup GID by name is currently unsupported in Go.
+
+	var suid, sgid int
+	var suidErr, sgidErr error
+
+	var fuid, fgid int
+	var fuidErr, fgidErr error
+
+	var uinfo *user.User
+	var ginfo *user.Group
+
+	if len(uid) > 0 {
+		suid, suidErr = strconv.Atoi(uid)
+		// lookup username
+		uinfo, fuidErr = user.Lookup(uid)
+		if fuidErr == nil {
+			log.Debugf("User %s is found", uid)
+			fuid, _ = strconv.Atoi(uinfo.Uid)
+			fgid, _ = strconv.Atoi(uinfo.Gid)
+		}
+	}
+	if len(gid) > 0 {
+		sgid, sgidErr = strconv.Atoi(gid)
+
+		// lookup groupname
+		ginfo, fgidErr = user.LookupGroup(gid)
+		// if found groupname, override user group
+		if fgidErr == nil {
+			log.Debugf("Group %s is found", gid)
+			fgid, _ = strconv.Atoi(ginfo.Gid)
+		}
+	}
+
+	// lookup user failed
+	if fuidErr != nil {
+		if suidErr != nil {
+			// failed to loopup username, and user is not number
+			detail := fmt.Sprintf("unable to find user %s: %s", uid, fuidErr)
+			return nil, errors.New(detail)
+		}
+		// user set user id must be inside valid uid range.
+		if suid < minID || suid > maxID {
+			detail := fmt.Sprintf("user id %s is invalid", uid)
+			return nil, errors.New(detail)
+		}
+		fuid = suid
+	}
+
+	// lookup group failed
+	if fgidErr != nil {
+		if sgidErr != nil {
+			// failed to loopup groupname, and user is not number
+			detail := fmt.Sprintf("unable to find group %s: %s", gid, fgidErr)
+			return nil, errors.New(detail)
+		}
+		// user set group id must be inside valid uid range.
+		if sgid < minID || sgid > maxID {
+			detail := fmt.Sprintf("group id %s is invalid", gid)
+			return nil, errors.New(detail)
+		}
+		fgid = sgid
+	}
+	log.Debugf("set user to %s:%s", fuid, fgid)
 	return &syscall.SysProcAttr{
 		Credential: &syscall.Credential{
-			Uid: uint32(u),
-			Gid: uint32(g),
+			Uid: uint32(fuid),
+			Gid: uint32(fgid),
 		},
 		Setsid: true,
-	}
+	}, nil
 }

--- a/lib/tether/ops_linux_test.go
+++ b/lib/tether/ops_linux_test.go
@@ -205,22 +205,22 @@ func TestGetUserSysProcAttr(t *testing.T) {
 		err  error
 	}{
 		{"", "", 0, 0, nil},
-		{"notexist", "notexist", 0, 0, errors.New("unable to find user notexist")},
-		{"notexist", curr.Gid, 0, 0, errors.New("unable to find user notexist")},
-		{"", "notexist", 0, 0, errors.New("unable to find group notexist")},
-		{"0", "notexist", 0, 0, errors.New("unable to find group notexist")},
-		{curr.Uid, "notexist", 0, 0, errors.New("unable to find group notexist")},
-		{"2000000", "notexist", 0, 0, errors.New("unable to find group notexist")},
-		{curr.Username, "notexist", 0, 0, errors.New("unable to find group notexist")},
+		{"notexist", "notexist", 0, 0, errors.New("Unable to find user notexist")},
+		{"notexist", curr.Gid, 0, 0, errors.New("Unable to find user notexist")},
+		{"", "notexist", 0, 0, errors.New("Unable to find group notexist")},
+		{"0", "notexist", 0, 0, errors.New("Unable to find group notexist")},
+		{curr.Uid, "notexist", 0, 0, errors.New("Unable to find group notexist")},
+		{"2000000", "notexist", 0, 0, errors.New("Unable to find group notexist")},
+		{curr.Username, "notexist", 0, 0, errors.New("Unable to find group notexist")},
 		{curr.Username, "0", currUID, 0, nil},
 		{curr.Uid, "1000", currUID, 1000, nil},
 		{curr.Uid, curr.Gid, currUID, currGID, nil},
 		{"root", curr.Gid, 0, currGID, nil},
 		{"root", "root", 0, 0, nil},
-		{moreThanMax, "root", 0, 0, fmt.Errorf("user id %s is invalid", moreThanMax)},
-		{curr.Username, moreThanMax, 0, 0, fmt.Errorf("group id %s is invalid", moreThanMax)},
-		{lessThanMin, "root", 0, 0, fmt.Errorf("user id %s is invalid", lessThanMin)},
-		{curr.Username, lessThanMin, 0, 0, fmt.Errorf("group id %s is invalid", lessThanMin)},
+		{moreThanMax, "root", 0, 0, errors.New("Uids and gids must be in range 0-2147483647")},
+		{curr.Username, moreThanMax, 0, 0, errors.New("Uids and gids must be in range 0-2147483647")},
+		{lessThanMin, "root", 0, 0, errors.New("Uids and gids must be in range 0-2147483647")},
+		{curr.Username, lessThanMin, 0, 0, errors.New("Uids and gids must be in range 0-2147483647")},
 	}
 	for _, test := range tests {
 		t.Logf("uid: %s, gid: %s", test.uid, test.gid)

--- a/lib/tether/ops_windows.go
+++ b/lib/tether/ops_windows.go
@@ -82,6 +82,6 @@ func (t *BaseOperations) Cleanup() error {
 }
 
 // Uid/Gid is not supported in Windows
-func getUserSysProcAttr(uname string) *syscall.SysProcAttr {
-	return nil
+func getUserSysProcAttr(uid, gid string) (*syscall.SysProcAttr, error) {
+	return nil, nil
 }

--- a/lib/tether/tether.go
+++ b/lib/tether/tether.go
@@ -47,10 +47,6 @@ const (
 
 	// the length of a truncated ID for use as hostname
 	shortLen = 12
-
-	// min/max user or group id, this is to keep consistent with docker
-	minID = 0
-	maxID = 1<<31 - 1
 )
 
 var Sys = system.New()


### PR DESCRIPTION
fixes #4172 

This is to respect "USER" in docker run command line and Dockerfile. The behavior will look like as following:
1. If username or username:groupname is specified, and found in image, container is started through that user.
2. If username or username:groupname is specified, will search username and groupname. Anyone does not exist, docker start will fail with following error message:
```
docker: Error response from daemon: Server error from portlayer: unable to find group notexist: group: unknown group notexist.
```
or 
```
docker: Error response from daemon: Server error from portlayer: unable to find user root: user: lookup username root: no such file or directory.
```
Depends on which image is used.

3. If userid, or userid:groupid is specified, user is set to the userid:groupid, no matter if that user exist or not.
4. Docker inspect will show user settings in Config section.
```
        "Config": {
            "Hostname": "bb946b4dbe52",
            "Domainname": "",
            "User": "2000:2000",
            "AttachStdin": true,
...
```