### PR TITLE
Store image ID in container create path

### DIFF
--- a/lib/apiservers/engine/backends/cache/image_cache.go
+++ b/lib/apiservers/engine/backends/cache/image_cache.go
@@ -155,12 +155,6 @@ func (ic *ICache) Get(idOrRef string) (*metadata.ImageConfig, error) {
 		return copyImageConfig(config), nil
 	}
 
-	// let's try to get the image ID from the repocache just in case we have a layer ID
-	// see https://github.com/vmware/vic/issues/4378#issuecomment-289070799
-	if id := RepositoryCache().GetImageID(strings.Split(idOrRef, ":")[0]); id != "" {
-		idOrRef = id
-	}
-
 	// get the full image ID if supplied a prefix
 	if id, err := ic.iDIndex.Get(idOrRef); err == nil {
 		idOrRef = id

--- a/lib/apiservers/engine/backends/container.go
+++ b/lib/apiservers/engine/backends/container.go
@@ -507,9 +507,7 @@ func (c *Container) containerCreate(vc *viccontainer.VicContainer, config types.
 		return "", InternalServerError("Failed to create container")
 	}
 
-	imageID := vc.ImageID
-
-	id, h, err := c.containerProxy.CreateContainerHandle(imageID, config)
+	id, h, err := c.containerProxy.CreateContainerHandle(vc, config)
 	if err != nil {
 		return "", err
 	}
@@ -1622,7 +1620,8 @@ func clientFriendlyContainerName(name string) string {
 func createInternalVicContainer(image *metadata.ImageConfig, config *types.ContainerCreateConfig) (*viccontainer.VicContainer, error) {
 	// provide basic container config via the image
 	container := viccontainer.NewVicContainer()
-	container.ImageID = image.ID
+	container.LayerID = image.V1Image.ID // store childmost layer ID to map to the proper vmdk
+	container.ImageID = image.ImageID
 	container.Config = image.Config //Set defaults.  Overrides will get copied below.
 
 	return container, nil

--- a/lib/apiservers/engine/backends/container/viccontainer.go
+++ b/lib/apiservers/engine/backends/container/viccontainer.go
@@ -23,7 +23,8 @@ import (
 // VicContainer is VIC's abridged version of Docker's container object.
 type VicContainer struct {
 	Name        string
-	ImageID     string
+	ImageID     string // maps to the image used by this container
+	LayerID     string // child-most layer ID used to find vmdk for this container
 	ContainerID string
 	Config      *containertypes.Config //Working copy of config (with overrides from container create)
 	HostConfig  *containertypes.HostConfig

--- a/lib/apiservers/engine/backends/container_test.go
+++ b/lib/apiservers/engine/backends/container_test.go
@@ -205,7 +205,7 @@ func (m *MockContainerProxy) Handle(id, name string) (string, error) {
 	return "", nil
 }
 
-func (m *MockContainerProxy) CreateContainerHandle(imageID string, config types.ContainerCreateConfig) (string, string, error) {
+func (m *MockContainerProxy) CreateContainerHandle(vc *viccontainer.VicContainer, config types.ContainerCreateConfig) (string, string, error) {
 	respIdx := m.mockRespIndices[0]
 
 	if respIdx >= len(m.mockCreateHandleData) {

--- a/lib/apiservers/portlayer/restapi/handlers/containers_handlers.go
+++ b/lib/apiservers/portlayer/restapi/handlers/containers_handlers.go
@@ -95,7 +95,8 @@ func (handler *ContainersHandlersImpl) CreateHandler(params containers.CreatePar
 		CreateTime: time.Now().UTC().Unix(),
 		Version:    version.GetBuild(),
 		Key:        pem.EncodeToMemory(&privateKeyBlock),
-		LayerID:    params.CreateConfig.Image,
+		LayerID:    params.CreateConfig.Layer,
+		ImageID:    params.CreateConfig.Image,
 		RepoName:   params.CreateConfig.RepoName,
 	}
 
@@ -109,7 +110,7 @@ func (handler *ContainersHandlersImpl) CreateHandler(params containers.CreatePar
 	// Create the executor.ExecutorCreateConfig
 	c := &exec.ContainerCreateConfig{
 		Metadata:       m,
-		ParentImageID:  params.CreateConfig.Image,
+		ParentImageID:  params.CreateConfig.Layer,
 		ImageStoreName: params.CreateConfig.ImageStore.Name,
 		Resources: exec.Resources{
 			NumCPUs:  params.CreateConfig.NumCpus,
@@ -423,6 +424,7 @@ func convertContainerToContainerInfo(container *exec.ContainerInfo) *models.Cont
 	}
 	info.ContainerConfig.State = state
 	info.ContainerConfig.LayerID = container.ExecConfig.LayerID
+	info.ContainerConfig.ImageID = container.ExecConfig.ImageID
 	info.ContainerConfig.RepoName = &container.ExecConfig.RepoName
 	info.ContainerConfig.CreateTime = container.ExecConfig.CreateTime
 	info.ContainerConfig.Names = []string{container.ExecConfig.Name}

--- a/lib/apiservers/portlayer/swagger.json
+++ b/lib/apiservers/portlayer/swagger.json
@@ -2680,6 +2680,9 @@
 				"image": {
 					"type": "string"
 				},
+				"layer": {
+					"type": "string"
+				},
 				"repoName": {
 					"type": "string"
 				},
@@ -2931,6 +2934,9 @@
 					"type": "string"
 				},
 				"layerId": {
+					"type": "string"
+				},
+				"imageId": {
 					"type": "string"
 				},
 				"repoName": {

--- a/lib/config/executor/container_vm.go
+++ b/lib/config/executor/container_vm.go
@@ -152,6 +152,9 @@ type ExecutorConfig struct {
 	// Layer id that is backing this container VM
 	LayerID string `vic:"0.1" scope:"read-only" key:"layerid"`
 
+	// Image id that is backing this container VM
+	ImageID string `vic:"0.1" scope:"read-only" key:"imageid"`
+
 	// Blob metadata for the caller
 	Annotations map[string]string `vic:"0.1" scope:"hidden" key:"annotations"`
 


### PR DESCRIPTION
This change is the correct fix for #4378. `ContainerCreate` will now persist the image ID on the backend so that `ContainerInspect` data can be properly constructed, allowing functionality that relies on inspect to function properly.

Fixes #4378 