### PR TITLE
WIP for --insecure-registry fix

### DIFF
--- a/cmd/vic-machine/create/create.go
+++ b/cmd/vic-machine/create/create.go
@@ -902,11 +902,12 @@ func (c *Create) processRegistries() error {
 
 	// load a list of insecure registries
 	for _, registry := range c.insecureRegistries {
-		url, err := url.Parse(registry)
+		regurl, err := validate.ParseURL(registry)
+
 		if err != nil {
 			return cli.NewExitError(fmt.Sprintf("%s is an invalid format for registry url", registry), 1)
 		}
-		c.InsecureRegistries = append(c.InsecureRegistries, *url)
+		c.InsecureRegistries = append(c.InsecureRegistries, *regurl)
 	}
 
 	return nil

--- a/lib/apiservers/engine/backends/backends.go
+++ b/lib/apiservers/engine/backends/backends.go
@@ -112,7 +112,11 @@ func Init(portLayerAddr, product string, config *config.VirtualContainerHostConf
 
 	serviceOptions := registry.ServiceOptions{}
 	for _, r := range insecureRegs {
-		insecureRegistries = append(insecureRegistries, r.Path)
+		// host:port was previously stored in the Path
+		// component of the URL. Go 1.8 parser puts it
+		// the Host component. VCH upgrade must move it
+		// from Path to Host.
+		insecureRegistries = append(insecureRegistries, r.Host)
 	}
 	if len(insecureRegistries) > 0 {
 		serviceOptions.InsecureRegistries = insecureRegistries
@@ -253,7 +257,7 @@ func createImageStore() error {
 }
 
 func InsecureRegistries() []string {
-	registries := make([]string, len(insecureRegistries))
+	registries := []string{}
 	for _, reg := range insecureRegistries {
 		registries = append(registries, reg)
 	}

--- a/lib/imagec/imagec.go
+++ b/lib/imagec/imagec.go
@@ -477,7 +477,7 @@ func (ic *ImageC) PullImage() error {
 	}
 
 	// Calculate (and overwrite) the registry URL and make sure that it responds to requests
-	ic.Registry, err = LearnRegistryURL(ic.Options)
+	ic.Registry, err = LearnRegistryURL(&ic.Options)
 	if err != nil {
 		log.Errorf("Error while pulling image: %s", err)
 		return err

--- a/lib/imagec/imagec_test.go
+++ b/lib/imagec/imagec_test.go
@@ -1,4 +1,3 @@
-// Copyright 2016-2017 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -143,14 +142,14 @@ func TestLearnRegistryURL(t *testing.T) {
 	ic.Options.Timeout = DefaultHTTPTimeout
 
 	// should fail
-	_, err := LearnRegistryURL(ic.Options)
+	_, err := LearnRegistryURL(&ic.Options)
 	if err == nil {
 		t.Errorf(err.Error())
 	}
 
 	// should pass
 	ic.Options.InsecureAllowHTTP = true
-	_, err = LearnRegistryURL(ic.Options)
+	_, err = LearnRegistryURL(&ic.Options)
 	if err != nil {
 		t.Errorf(err.Error())
 	}

--- a/lib/install/validate/validator.go
+++ b/lib/install/validate/validator.go
@@ -15,13 +15,13 @@
 package validate
 
 import (
+	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
 	"net/url"
+	"regexp"
 	"strings"
-
-	"context"
 
 	log "github.com/Sirupsen/logrus"
 	units "github.com/docker/go-units"
@@ -40,7 +40,6 @@ import (
 	"github.com/vmware/vic/pkg/trace"
 	"github.com/vmware/vic/pkg/version"
 	"github.com/vmware/vic/pkg/vsphere/session"
-	"regexp"
 )
 
 type Validator struct {

--- a/lib/install/validate/validator.go
+++ b/lib/install/validate/validator.go
@@ -40,6 +40,7 @@ import (
 	"github.com/vmware/vic/pkg/trace"
 	"github.com/vmware/vic/pkg/version"
 	"github.com/vmware/vic/pkg/vsphere/session"
+	"regexp"
 )
 
 type Validator struct {
@@ -154,6 +155,30 @@ func NewValidator(ctx context.Context, input *data.Data) (*Validator, error) {
 	}
 
 	return v, nil
+}
+
+var schemeMatch = regexp.MustCompile(`^\w+://`)
+
+// Starting from Go 1.8 the URL parser does not
+// work properly with URLs with no Scheme,
+// this function adds "https" as Scheme if necessary
+func ParseURL(s string) (*url.URL, error) {
+	var err error
+	var u *url.URL
+
+	if s != "" {
+		// Default the scheme to https
+		if !schemeMatch.MatchString(s) {
+			s = "https://" + s
+		}
+
+		u, err = url.Parse(s)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return u, nil
 }
 
 func (v *Validator) AllowEmptyDC() {

--- a/lib/install/validate/validator_test.go
+++ b/lib/install/validate/validator_test.go
@@ -32,10 +32,83 @@ import (
 	"github.com/vmware/vic/pkg/vsphere/simulator"
 
 	"context"
+	"fmt"
 )
 
 type TestValidator struct {
 	Validator
+}
+
+func TestParseURL(t *testing.T) {
+	var hosts = []string {
+		"host.domain.com",
+		"host.domain.com:123",
+		"1.2.3.4",
+		"1.2.3.4:10",
+		"[2001:4860:0:2001::68]",
+		"[2001:db8:1f70::999:de8:7648:6e8]:123",
+	}
+
+	for _, urlString := range hosts {
+		u, err := ParseURL(urlString)
+		assert.Nil(t, err)
+		assert.Equal(t, u.String(), "https://" + urlString)
+		// Null the scheme
+		u.Scheme = ""
+		assert.Equal(t, u.String(), "//" + urlString)
+		assert.Equal(t, u.Host, urlString)
+	}
+
+	// Add path to create a more significant URL
+	var urls = []string{}
+
+	for i, h := range hosts {
+		url := fmt.Sprintf("%s/path%d/test", h, i)
+		urls = append(urls, url)
+	}
+
+	for i, urlString := range urls {
+		u, err := ParseURL(urlString)
+		assert.Nil(t, err)
+		assert.Equal(t, u.String(), "https://" + urlString)
+
+		// Null the scheme
+		u.Scheme = ""
+		assert.Equal(t, u.String(), "//" + urlString)
+
+		// Check host
+		assert.Equal(t, u.Host, hosts[i])
+		// Check path
+		path := fmt.Sprintf("/path%d/test", i)
+		assert.Equal(t, u.Path, path)
+		// Check concatenation
+		assert.Equal(t, u.Host + u.Path, urlString)
+	}
+
+	// Add an HTTP scheme to verify that it is preserved
+	var urlsWithHTTPScheme = []string{}
+
+	for _, u := range urls {
+		uws := fmt.Sprintf("http://%s", u)
+		urlsWithHTTPScheme = append(urlsWithHTTPScheme, uws)
+	}
+
+	for _, urlString := range urlsWithHTTPScheme {
+		u, err := ParseURL(urlString)
+		fmt.Printf("UrlString: %s\n", u.String())
+		assert.Nil(t, err)
+		assert.Equal(t, u.String(), urlString)
+	}
+
+	var invalidUrls = []string {
+		"[2001:db8/path",
+		"1.2.3.4\\path",
+	}
+
+	for _, urlString := range invalidUrls {
+		_, err := ParseURL(urlString)
+		assert.NotNil(t, err)
+	}
 }
 
 func TestPathConversionESX(t *testing.T) {

--- a/lib/install/validate/validator_test.go
+++ b/lib/install/validate/validator_test.go
@@ -40,7 +40,7 @@ type TestValidator struct {
 }
 
 func TestParseURL(t *testing.T) {
-	var hosts = []string {
+	var hosts = []string{
 		"host.domain.com",
 		"host.domain.com:123",
 		"1.2.3.4",
@@ -52,10 +52,10 @@ func TestParseURL(t *testing.T) {
 	for _, urlString := range hosts {
 		u, err := ParseURL(urlString)
 		assert.Nil(t, err)
-		assert.Equal(t, u.String(), "https://" + urlString)
+		assert.Equal(t, u.String(), "https://"+urlString)
 		// Null the scheme
 		u.Scheme = ""
-		assert.Equal(t, u.String(), "//" + urlString)
+		assert.Equal(t, u.String(), "//"+urlString)
 		assert.Equal(t, u.Host, urlString)
 	}
 
@@ -70,11 +70,11 @@ func TestParseURL(t *testing.T) {
 	for i, urlString := range urls {
 		u, err := ParseURL(urlString)
 		assert.Nil(t, err)
-		assert.Equal(t, u.String(), "https://" + urlString)
+		assert.Equal(t, u.String(), "https://"+urlString)
 
 		// Null the scheme
 		u.Scheme = ""
-		assert.Equal(t, u.String(), "//" + urlString)
+		assert.Equal(t, u.String(), "//"+urlString)
 
 		// Check host
 		assert.Equal(t, u.Host, hosts[i])
@@ -82,7 +82,7 @@ func TestParseURL(t *testing.T) {
 		path := fmt.Sprintf("/path%d/test", i)
 		assert.Equal(t, u.Path, path)
 		// Check concatenation
-		assert.Equal(t, u.Host + u.Path, urlString)
+		assert.Equal(t, u.Host+u.Path, urlString)
 	}
 
 	// Add an HTTP scheme to verify that it is preserved
@@ -100,7 +100,7 @@ func TestParseURL(t *testing.T) {
 		assert.Equal(t, u.String(), urlString)
 	}
 
-	var invalidUrls = []string {
+	var invalidUrls = []string{
 		"[2001:db8/path",
 		"1.2.3.4\\path",
 	}


### PR DESCRIPTION
WIP because I'm handing this off to @matthewavery for the weekend (thanks dude)

What works:
Pulling from an insecure registry specified with --insecure-registry works
Pulling from an insecure registry w/o --insecure-registry fails correctly
Pulling from a secure registry works

What doesn't quite work:
Pulling an empty or nonexistent image from an insecure registry doesn't give a certificate error and instead reports that the image wasn't found (or a successful pull) -- this shouldn't happen and there should be an SSL error instead. @lcastellano and I believe that this originates from the `LearnRegistryURL` method below doing something it should not.

Also there are no tests.