### PR TITLE
[specific ci=Group6-VIC-Machine] Resource suggestion fixes for vic-machine

### DIFF
--- a/cmd/vic-machine/common/compute.go
+++ b/cmd/vic-machine/common/compute.go
@@ -39,7 +39,7 @@ func (c *Compute) ComputeFlagsNoName() []cli.Flag {
 		cli.StringFlag{
 			Name:        "compute-resource, r",
 			Value:       "",
-			Usage:       "Compute resource path, e.g. myCluster/Resources/myRP. Default to <default cluster>/Resources",
+			Usage:       "Compute resource path, e.g. myCluster",
 			Destination: &c.ComputeResourcePath,
 		},
 	}

--- a/lib/install/validate/compute.go
+++ b/lib/install/validate/compute.go
@@ -15,18 +15,13 @@
 package validate
 
 import (
-	"fmt"
-	"path"
-	"path/filepath"
-	"sort"
-	"strings"
-
 	"context"
 
 	log "github.com/Sirupsen/logrus"
 
 	"github.com/vmware/govmomi/find"
 	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25/mo"
 	"github.com/vmware/vic/lib/config"
 	"github.com/vmware/vic/lib/install/data"
 	"github.com/vmware/vic/pkg/errors"
@@ -36,40 +31,13 @@ import (
 func (v *Validator) compute(ctx context.Context, input *data.Data, conf *config.VirtualContainerHostConfigSpec) {
 	defer trace.End(trace.Begin(""))
 
-	// Compute
-
-	// compute resource looks like <toplevel>/<sub/path>
-	// this should map to /datacenter-name/host/<toplevel>/Resources/<sub/path>
-	// we need to validate that <toplevel> exists and then that the combined path exists.
+	// ComputeResourcePath should resolve to a ComputeResource, ClusterComputeResource or ResourcePool
 
 	pool, err := v.ResourcePoolHelper(ctx, input.ComputeResourcePath)
 	v.NoteIssue(err)
 	if pool == nil {
 		return
 	}
-
-	// stash the pool for later use
-	v.ResourcePoolPath = pool.InventoryPath
-
-	// some hoops for while we're still using session package
-	v.Session.Pool = pool
-	v.Session.PoolPath = pool.InventoryPath
-	v.Session.ClusterPath = v.inventoryPathToCluster(pool.InventoryPath)
-
-	clusters, err := v.Session.Finder.ComputeResourceList(v.Context, v.Session.ClusterPath)
-	if err != nil {
-		log.Errorf("Unable to acquire reference to cluster %q: %s", path.Base(v.Session.ClusterPath), err)
-		v.NoteIssue(err)
-		return
-	}
-
-	if len(clusters) != 1 {
-		err := fmt.Errorf("Unable to acquire unambiguous reference to cluster %q", path.Base(v.Session.ClusterPath))
-		log.Error(err)
-		v.NoteIssue(err)
-	}
-
-	v.Session.Cluster = clusters[0]
 
 	// TODO: for vApp creation assert that the name doesn't exist
 	// TODO: for RP creation assert whatever we decide about the pool - most likely that it's empty
@@ -81,172 +49,79 @@ func (v *Validator) ResourcePoolHelper(ctx context.Context, path string) (*objec
 	defer trace.End(trace.Begin(path))
 
 	// if compute-resource is unspecified is there a default
-	if path == "" || path == "/" {
+	if path == "" {
 		if v.Session.Pool != nil {
 			log.Debugf("Using default resource pool for compute resource: %q", v.Session.Pool.InventoryPath)
 			return v.Session.Pool, nil
 		}
 
 		// if no path specified and no default available the show all
-		v.suggestComputeResource("*")
+		v.suggestComputeResource()
 		return nil, errors.New("No unambiguous default compute resource available: --compute-resource must be specified")
 	}
 
-	ipath := v.computePathToInventoryPath(path)
-	log.Debugf("Converted original path %q to %q", path, ipath)
-
-	// first try the path directly without any processing
-	pools, err := v.Session.Finder.ResourcePoolList(ctx, path)
+	pool, err := v.Session.Finder.ResourcePool(ctx, path)
 	if err != nil {
 		log.Debugf("Failed to look up compute resource as absolute path %q: %s", path, err)
 		if _, ok := err.(*find.NotFoundError); !ok {
 			// we return err directly here so we can check the type
 			return nil, err
 		}
+	}
 
-		// if it starts with datacenter then we know it's absolute and invalid
-		if strings.HasPrefix(path, "/"+v.Session.DatacenterPath) {
-			v.suggestComputeResource(path)
+	var compute *object.ComputeResource
+
+	if pool == nil {
+		// check if its a ComputeResource or ClusterComputeResource
+
+		compute, err = v.Session.Finder.ComputeResource(ctx, path)
+		if err != nil {
+			if _, ok := err.(*find.NotFoundError); ok {
+				v.suggestComputeResource()
+			}
+
 			return nil, err
 		}
-	}
 
-	if len(pools) == 0 {
-		// assume it's a cluster specifier - that's the formal case, e.g. /cluster/resource/pool
-		// not /cluster/Resources/resource/pool
-		// everything from now on will use this assumption
-
-		pools, err = v.Session.Finder.ResourcePoolList(ctx, ipath)
+		// Use the default pool
+		pool, err = compute.ResourcePool(ctx)
 		if err != nil {
-			log.Debugf("failed to look up compute resource as cluster path %q: %s", ipath, err)
-			if _, ok := err.(*find.NotFoundError); !ok {
-				// we return err directly here so we can check the type
-				return nil, err
-			}
+			return nil, err
 		}
+	} else {
+		// TODO: add an object.ResourcePool.Owner method (see compute.ResourcePool.GetCluster)
+		var p mo.ResourcePool
+
+		if err = pool.Properties(ctx, pool.Reference(), []string{"owner"}, &p); err != nil {
+			log.Errorf("Unable to get cluster of resource pool %s: %s", pool.Name(), err)
+			return nil, err
+		}
+
+		compute = object.NewComputeResource(pool.Client(), p.Owner)
 	}
 
-	if len(pools) == 1 {
-		log.Debugf("Selected compute resource %q", pools[0].InventoryPath)
-		return pools[0], nil
-	}
+	// stash the pool for later use
+	v.ResourcePoolPath = pool.InventoryPath
 
-	// both cases we want to suggest options
-	v.suggestComputeResource(ipath)
+	// some hoops for while we're still using session package
+	v.Session.Pool = pool
+	v.Session.PoolPath = pool.InventoryPath
 
-	if len(pools) == 0 {
-		log.Debugf("no such compute resource %q", path)
-		// we return err directly here so we can check the type
-		return nil, err
-	}
+	v.Session.Cluster = compute
+	v.Session.ClusterPath = compute.InventoryPath
 
-	// TODO: error about required disabmiguation and list entries in nets
-	return nil, errors.New("ambiguous compute resource " + path)
+	return pool, nil
 }
 
-func (v *Validator) suggestComputeResource(path string) {
-	defer trace.End(trace.Begin(path))
-
-	log.Infof("Suggesting valid values for --compute-resource based on %q", path)
-
-	// allow us to work on inventory paths
-	path = v.computePathToInventoryPath(path)
-
-	var matches []string
-	for matches = nil; matches == nil; matches = v.findValidPool(path) {
-		// back up the path until we find a pool
-		newpath := filepath.Dir(path)
-		if newpath == "." {
-			// filepath.Dir returns . which has no meaning for us
-			newpath = "/"
-		}
-		if newpath == path {
-			break
-		}
-		path = newpath
-	}
-
-	if matches == nil {
-		// Backing all the way up didn't help
-		log.Info("Failed to find resource pool in the provided path, showing all top level resource pools.")
-		matches = v.findValidPool("*")
-	}
-
-	if matches != nil {
-		// we've collected recommendations - displayname
-		log.Info("Suggested values for --compute-resource:")
-		for _, p := range matches {
-			log.Infof("  %q", v.inventoryPathToComputePath(p))
-		}
-		return
-	}
-
-	log.Info("No resource pools found")
-}
-
-func (v *Validator) findValidPool(path string) []string {
-	defer trace.End(trace.Begin(path))
-
-	// list pools in path
-	matches := v.listResourcePools(path)
-	if matches != nil {
-		sort.Strings(matches)
-		return matches
-	}
-
-	// no pools in path, but if path is cluster, list pools in cluster
-	clusters, err := v.Session.Finder.ComputeResourceList(v.Context, path)
-	if len(clusters) == 0 {
-		// not a cluster
-		log.Debugf("Path %q does not identify a cluster (or clusters) or the list could not be obtained: %s", path, err)
-		return nil
-	}
-
-	if len(clusters) > 1 {
-		log.Debugf("Suggesting clusters as there are multiple matches")
-		matches = make([]string, len(clusters))
-		for i, c := range clusters {
-			matches[i] = c.InventoryPath
-		}
-		sort.Strings(matches)
-		return matches
-	}
-
-	log.Debugf("Suggesting pools for cluster %q", clusters[0].Name())
-	matches = v.listResourcePools(fmt.Sprintf("%s/Resources/*", clusters[0].InventoryPath))
-	if matches == nil {
-		// no child pools so recommend cluster directly
-		return []string{clusters[0].InventoryPath}
-	}
-
-	return matches
-}
-
-func (v *Validator) listResourcePools(path string) []string {
-	defer trace.End(trace.Begin(path))
-
-	pools, err := v.Session.Finder.ResourcePoolList(v.Context, path+"/*")
-	if err != nil {
-		log.Debugf("Unable to list pools for %q: %s", path, err)
-		return nil
-	}
-
-	if len(pools) == 0 {
-		return nil
-	}
-
-	matches := make([]string, len(pools))
-	for i, p := range pools {
-		matches[i] = p.InventoryPath
-	}
-
-	return matches
-}
-
-func (v *Validator) GetResourcePool(input *data.Data) (*object.ResourcePool, error) {
+func (v *Validator) suggestComputeResource() {
 	defer trace.End(trace.Begin(""))
 
-	return v.ResourcePoolHelper(v.Context, input.ComputeResourcePath)
+	compute, _ := v.Session.Finder.ComputeResourceList(v.Context, "*")
+
+	log.Info("Suggested values for --compute-resource:")
+	for _, c := range compute {
+		log.Infof("  %q", c.Name())
+	}
 }
 
 func (v *Validator) ValidateCompute(ctx context.Context, input *data.Data, computeRequired bool) (*config.VirtualContainerHostConfigSpec, error) {

--- a/lib/install/validate/storage.go
+++ b/lib/install/validate/storage.go
@@ -37,7 +37,7 @@ func (v *Validator) storage(ctx context.Context, input *data.Data, conf *config.
 	// Image Store
 	imageDSpath, ds, err := v.DatastoreHelper(ctx, input.ImageDatastorePath, "", "--image-store")
 
-	if imageDSpath == nil {
+	if err != nil {
 		v.NoteIssue(err)
 		return
 	}
@@ -47,7 +47,6 @@ func (v *Validator) storage(ctx context.Context, input *data.Data, conf *config.
 		imageDSpath.Path = input.DisplayName
 	}
 
-	v.NoteIssue(err)
 	if ds != nil {
 		v.SetDatastore(ds, imageDSpath)
 		conf.AddImageStore(imageDSpath)

--- a/lib/install/validate/validator.go
+++ b/lib/install/validate/validator.go
@@ -20,6 +20,7 @@ import (
 	"crypto/x509"
 	"fmt"
 	"net/url"
+	"path"
 	"regexp"
 	"strings"
 
@@ -83,7 +84,7 @@ func NewValidator(ctx context.Context, input *data.Data) (*Validator, error) {
 	tURL := input.URL
 
 	// normalize the path - strip trailing /
-	tURL.Path = strings.TrimSuffix(tURL.Path, "/")
+	input.URL.Path = strings.TrimSuffix(input.URL.Path, "/")
 
 	// default to https scheme
 	if tURL.Scheme == "" {
@@ -123,6 +124,7 @@ func NewValidator(ctx context.Context, input *data.Data) (*Validator, error) {
 	// if a datacenter was specified, set it
 	v.DatacenterPath = tURL.Path
 	if v.DatacenterPath != "" {
+		v.DatacenterPath = strings.TrimPrefix(v.DatacenterPath, "/")
 		sessionconfig.DatacenterPath = v.DatacenterPath
 		// path needs to be stripped before we can use it as a service url
 		tURL.Path = ""
@@ -142,11 +144,13 @@ func NewValidator(ctx context.Context, input *data.Data) (*Validator, error) {
 	finder := find.NewFinder(v.Session.Client.Client, false)
 	v.Session.Finder = finder
 
-	v.Session.Populate(ctx)
+	// Intentionally ignore any error returned by Populate
+	_, err = v.Session.Populate(ctx)
+	if err != nil {
+		log.Debugf("new validator Session.Populate: %s", err)
+	}
 
-	// only allow the datacenter to be specified in the target url, if any
-	pElems := strings.Split(v.DatacenterPath, "/")
-	if len(pElems) > 2 {
+	if strings.Contains(sessionconfig.DatacenterPath, "/") {
 		detail := "--target should only specify datacenter in the path (e.g. https://addr/datacenter) - specify cluster, resource pool, or folder with --compute-resource"
 		log.Error(detail)
 		v.suggestDatacenter()
@@ -194,7 +198,7 @@ func (v *Validator) datacenter() error {
 	}
 	var detail string
 	if v.DatacenterPath != "" {
-		detail = fmt.Sprintf("Datacenter %q in --target is not found", strings.TrimPrefix(v.DatacenterPath, "/"))
+		detail = fmt.Sprintf("Datacenter %q in --target is not found", path.Base(v.DatacenterPath))
 	} else {
 		// this means multiple datacenter exists, but user did not specify it in --target
 		detail = "Datacenter must be specified in --target (e.g. https://addr/datacenter)"
@@ -614,90 +618,6 @@ func intersect(one []*object.HostSystem, two []*object.HostSystem) []*object.Hos
 		}
 	}
 	return result
-}
-
-func (v *Validator) computePathToInventoryPath(path string) string {
-	defer trace.End(trace.Begin(path))
-
-	// if it opens with the datacenter prefix the assume it's an absolute
-	if strings.HasPrefix(path, v.DatacenterPath) {
-		log.Debugf("Path is treated as absolute given datacenter prefix %q", v.DatacenterPath)
-		return path
-	}
-
-	parts := []string{
-		v.DatacenterPath, // has leading /
-		"host",
-		"*", // easy for ESX
-		"Resources",
-	}
-
-	// normalize the path - strip leading /
-	path = strings.TrimPrefix(path, "/")
-
-	// if it's vCenter the first element is the cluster or host, then resource pool path
-	if v.IsVC() {
-		pElem := strings.SplitN(path, "/", 2)
-		if pElem[0] != "" {
-			parts[2] = pElem[0]
-		}
-		if len(pElem) > 1 {
-			parts = append(parts, pElem[1])
-		}
-	} else if path != "" {
-		// for ESX, first element is a pool
-		parts = append(parts, path)
-	}
-
-	return strings.Join(parts, "/")
-}
-
-func (v *Validator) inventoryPathToComputePath(path string) string {
-	defer trace.End(trace.Begin(path))
-
-	// sanity check datacenter
-	if !strings.HasPrefix(path, v.DatacenterPath) {
-		log.Debugf("Expected path to be within target datacenter %q: %q", v.DatacenterPath, path)
-		v.NoteIssue(errors.New("inventory path was not in datacenter scope"))
-		return ""
-	}
-
-	// inventory path is always /dc/host/computeResource/Resources/path/to/pool
-	// NOTE: all of the indexes are +1 because the leading / means we have an empty string for [0]
-	pElems := strings.Split(path, "/")
-	if len(pElems) < 4 {
-		log.Debugf("Expected path to be fully qualified, e.g. /dcName/host/clusterName/Resources/poolName: %s", path)
-		v.NoteIssue(errors.New("inventory path format was not recognised"))
-		return ""
-	}
-
-	if len(pElems) == 4 || len(pElems) == 5 {
-		// cluster only or cluster/Resources
-		return pElems[3]
-	}
-
-	// messy but avoid reallocation - overwrite Resources with cluster name
-	pElems[4] = pElems[3]
-
-	// /dc/host/cluster/Resources/path/to/pool
-	return strings.Join(pElems[4:], "/")
-}
-
-// inventoryPathToCluster is a convenience method that will return the cluster
-// path prefix or "" in the case of unexpected path structure
-func (v *Validator) inventoryPathToCluster(path string) string {
-	defer trace.End(trace.Begin(path))
-
-	// inventory path is always /dc/host/computeResource/Resources/path/to/pool
-	pElems := strings.Split(path, "/")
-	if len(pElems) < 3 {
-		log.Debugf("Expected path to be fully qualified, e.g. /dcName/host/clusterName/Resources/poolName: %s", path)
-		v.NoteIssue(errors.New("inventory path format was not recognised"))
-		return ""
-	}
-
-	// /dc/host/cluster/Resources/path/to/pool
-	return strings.Join(pElems[:4], "/")
 }
 
 func (v *Validator) IsVC() bool {

--- a/lib/install/validate/validator_test.go
+++ b/lib/install/validate/validator_test.go
@@ -15,14 +15,20 @@
 package validate
 
 import (
+	"context"
+	"crypto/tls"
+	"fmt"
 	"net"
 	"net/url"
+	"os"
+	"strings"
 	"testing"
 
 	log "github.com/Sirupsen/logrus"
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/vmware/govmomi/vim25/methods"
 	"github.com/vmware/govmomi/vim25/mo"
 	"github.com/vmware/govmomi/vim25/types"
 	"github.com/vmware/vic/lib/config"
@@ -30,9 +36,7 @@ import (
 	"github.com/vmware/vic/pkg/trace"
 	"github.com/vmware/vic/pkg/vsphere/session"
 	"github.com/vmware/vic/pkg/vsphere/simulator"
-
-	"context"
-	"fmt"
+	"github.com/vmware/vic/pkg/vsphere/simulator/esx"
 )
 
 type TestValidator struct {
@@ -108,39 +112,6 @@ func TestParseURL(t *testing.T) {
 	for _, urlString := range invalidUrls {
 		_, err := ParseURL(urlString)
 		assert.NotNil(t, err)
-	}
-}
-
-func TestPathConversionESX(t *testing.T) {
-	v := &TestValidator{}
-
-	v.DatacenterPath = "/ha-datacenter"
-
-	ipath := v.computePathToInventoryPath("/")
-	assert.Equal(t, "/ha-datacenter/host/*/Resources", ipath, "Expected top level resource pool")
-	cpath := v.inventoryPathToComputePath(ipath)
-	assert.Equal(t, "*", cpath, "Expected root resource specifier")
-
-	ipath = v.computePathToInventoryPath("*")
-	assert.Equal(t, "/ha-datacenter/host/*/Resources/*", ipath, "Expected top level resource pool")
-	cpath = v.inventoryPathToComputePath(ipath)
-	assert.Equal(t, "*/*", cpath, "Expected top level wildcard specifier")
-}
-
-func TestSampleConversion(t *testing.T) {
-	v := &TestValidator{}
-	v.DatacenterPath = "/ha-datacenter"
-
-	translations := map[string]string{
-		"/":              "/ha-datacenter/host/*/Resources",
-		"*":              "/ha-datacenter/host/*/Resources/*",
-		"testpool":       "/ha-datacenter/host/*/Resources/testpool",
-		"test/deep/path": "/ha-datacenter/host/*/Resources/test/deep/path",
-	}
-
-	for in, expected := range translations {
-		ipath := v.computePathToInventoryPath(in)
-		assert.Equal(t, expected, ipath, "Translation did not match")
 	}
 }
 
@@ -277,7 +248,7 @@ func testCompute(v *Validator, input *data.Data, t *testing.T) *config.VirtualCo
 		hasErr bool
 	}{
 		{"DC0_C0/Resources/validator", true, false},
-		{"DC0_C0/validator", true, false},
+		{"DC0_C0/validator", true, true},
 		{"validator", true, false},
 		{"DC0_C0/test", true, true},
 		{"/DC0_C1/test", true, true},
@@ -427,4 +398,284 @@ func testStorage(v *Validator, input *data.Data, conf *config.VirtualContainerHo
 		}
 		v.issues = nil
 	}
+}
+
+func TestValidateWithFolders(t *testing.T) {
+	log.SetLevel(log.InfoLevel)
+	ctx := context.Background()
+
+	m := simulator.VPX()
+	m.Datacenter = 3
+	m.Folder = 2
+	m.Datastore = 2
+	m.ClusterHost = 3
+	m.Pool = 1
+
+	defer m.Remove()
+
+	err := m.Create()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	m.Service.TLS = new(tls.Config)
+	s := m.Service.NewServer()
+	defer s.Close()
+
+	input := data.NewData()
+	input.URL = &url.URL{
+		Scheme: s.URL.Scheme,
+		Host:   s.URL.Host,
+	}
+
+	newShouldFail := true
+	license := simulator.EvalLicense
+	simulator.EvalLicense.Properties = nil // erase features
+
+	var validator *Validator
+	var dc string
+
+	// Cover various failure paths while we're at it
+	steps := []func(){
+		func() {},
+		func() {
+			input.Thumbprint = "nope"
+		},
+		func() {
+			input.Force = true
+			input.Thumbprint = ""
+		},
+		func() {
+			input.Force = false
+			input.Thumbprint = s.CertificateInfo().ThumbprintSHA1
+		},
+		func() {
+			input.URL.Path = "/"
+			input.URL.User = s.URL.User
+			newShouldFail = false
+			if _, err = validator.ValidateCompute(ctx, input, false); err != nil {
+				t.Error(err)
+			}
+		},
+		func() {
+			input.URL.Path = "/enoent" // Datacenter "enoent" in --target is not found
+		},
+		func() {
+			input.URL.Path = "/DC1/sorry" // --target should only specify datacenter in the path
+		},
+		func() {
+			input.URL.Path = "/DC1" // ok
+			dc = input.URL.Path
+		},
+		func() {
+			if _, err = validator.ValidateCompute(ctx, input, true); err == nil {
+				t.Error("expected error")
+			}
+			input.ComputeResourcePath = "enoent"
+		},
+		func() {
+			input.ComputeResourcePath = "DC1_C0"
+		},
+		func() {
+			input.PublicNetwork.Name = "enoent"
+		},
+		func() {
+			input.PublicNetwork.Name = "VM Network"
+			input.ManagementNetwork.Name = input.PublicNetwork.Name
+			input.ClientNetwork.Name = input.PublicNetwork.Name
+			input.BridgeNetworkName = "DC1_DVPG0"
+		},
+		func() {
+			input.ScratchSize = "10GB"
+			p, _ := s.URL.User.Password()
+			input.OpsPassword = &p
+		},
+		func() {
+			input.ImageDatastorePath = "enoent"
+		},
+		func() {
+			input.ImageDatastorePath = "LocalDS_*" // > 1
+		},
+		func() {
+			input.ImageDatastorePath = "LocalDS_0"
+		},
+		func() {
+			// TODO: volume
+		},
+		func() {
+			input.OpsUser = s.URL.User.Username()
+		},
+		func() {
+			simulator.EvalLicense.Properties = license.Properties // restore license features
+		},
+	}
+
+	for i, step := range steps {
+		if testing.Verbose() {
+			fmt.Fprintf(os.Stderr, "TestValidateVPX(%d)%s\n", i, strings.Repeat(".", 30))
+		}
+		step()
+
+		validator, err = NewValidator(ctx, input)
+		if err != nil {
+			continue
+		}
+
+		if newShouldFail {
+			t.Fatalf("%d: expected error", i)
+		}
+
+		validator.DisableFirewallCheck = true
+
+		_, err = validator.Validate(ctx, input)
+		if i == len(steps)-1 {
+			if err != nil {
+				t.Fatal(err)
+			}
+		} else {
+			if err == nil {
+				t.Fatal("expected error")
+			}
+		}
+
+		if dc != "" {
+			// NewValidator has the side-effect of setting input.URL.Path=""
+			input.URL.Path = dc
+		}
+	}
+
+	// cover some other paths now that we have a valid config
+	spec, err := validator.ValidateTarget(ctx, input)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	validator.AddDeprecatedFields(ctx, spec, input)
+
+	_, err = CreateFromVCHConfig(ctx, spec, validator.Session)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// force vim25.NewClient to fail
+	simulator.Map.Remove(methods.ServiceInstance)
+	validator.credentials(ctx, input, spec)
+
+	// cover some of the return+error paths for certs (TODO: move this elsewhere and include valid data)
+	validator.certificate(ctx, input, spec)
+	validator.certificateAuthorities(ctx, input, spec)
+
+	input.CertPEM = s.Certificate().Raw
+	validator.certificate(ctx, input, spec)
+	validator.certificateAuthorities(ctx, input, spec)
+
+	input.ClientCAs = []byte{1}
+	validator.certificateAuthorities(ctx, input, spec)
+
+	validator.registries(ctx, input, spec)
+	input.RegistryCAs = input.ClientCAs
+	validator.registries(ctx, input, spec)
+}
+
+func TestValidateWithESX(t *testing.T) {
+	log.SetLevel(log.InfoLevel)
+	ctx := context.Background()
+
+	m := simulator.ESX()
+	defer m.Remove()
+
+	err := m.Create()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	m.Service.TLS = new(tls.Config)
+	s := m.Service.NewServer()
+	defer s.Close()
+
+	input := data.NewData()
+	input.URL = &url.URL{
+		Path: s.URL.Host,
+		User: s.URL.User,
+	}
+
+	input.Thumbprint = s.CertificateInfo().ThumbprintSHA1
+
+	steps := []func(){
+		func() {
+			input.ComputeResourcePath = "enoent"
+		},
+		func() {
+			input.PublicNetwork.Name = "enoent"
+		},
+		func() {
+			input.ImageDatastorePath = "enoent"
+		},
+		func() {
+			input.ImageDatastorePath = "enoent"
+		},
+		func() {
+			input = getESXData(s.URL)
+			input.URL.Path = "/"
+			input.ScratchSize = "10GB"
+			input.Force = true
+		},
+	}
+
+	var validator *Validator
+
+	for i, step := range steps {
+		if testing.Verbose() {
+			fmt.Fprintf(os.Stderr, "TestValidateESX(%d)%s\n", i, strings.Repeat(".", 30))
+		}
+
+		step()
+
+		validator, err = NewValidator(ctx, input)
+		if err != nil {
+			t.Fatal(err)
+		}
+		validator.DisableFirewallCheck = true
+		validator.AllowEmptyDC()
+
+		_, err = validator.Validate(ctx, input)
+		if i == len(steps)-1 {
+			if err != nil {
+				t.Fatal(err)
+			}
+		} else {
+			if err == nil {
+				t.Fatal("expected error")
+			}
+		}
+	}
+
+	// cover some errors paths by destroying this ESX system
+	ref := esx.HostSystem.Reference()
+	host := simulator.Map.Get(ref).(*simulator.HostSystem)
+
+	steps = []func(){
+		func() {
+			host.Summary.ManagementServerIp = "owned"
+		},
+		func() {
+			host.Summary.ManagementServerIp = ""
+			simulator.Map.Remove(ref) // remove the host, forcing Finder.DefaultHostSystem to fail
+		},
+	}
+
+	for i, step := range steps {
+		step()
+
+		validator.managedbyVC(ctx)
+		issues := validator.GetIssues()
+
+		if len(issues) != 1 {
+			t.Errorf("%d issues: %s", i, issues)
+		}
+		validator.ClearIssues()
+	}
+
+	simulator.Map.Remove(esx.Datacenter.Reference()) // goodnight now.
+	validator.suggestDatacenter()
 }

--- a/pkg/vsphere/compute/rp.go
+++ b/pkg/vsphere/compute/rp.go
@@ -15,8 +15,6 @@
 package compute
 
 import (
-	"path"
-
 	log "github.com/Sirupsen/logrus"
 
 	"context"
@@ -47,24 +45,6 @@ func NewResourcePool(ctx context.Context, session *session.Session, moref types.
 		),
 		Session: session,
 	}
-}
-
-func FindResourcePool(ctx context.Context, s *session.Session, name string) (*ResourcePool, error) {
-	var err error
-
-	if name != "" {
-		if !path.IsAbs(name) {
-			name = path.Join(s.Cluster.InventoryPath, "Resources", name)
-		}
-	} else {
-		name = path.Join(s.Cluster.InventoryPath, "Resources")
-	}
-
-	pool, err := s.Finder.ResourcePoolOrDefault(ctx, name)
-	if err != nil {
-		return nil, err
-	}
-	return NewResourcePool(ctx, s, pool.Reference()), nil
 }
 
 func (rp *ResourcePool) GetChildrenVMs(ctx context.Context, s *session.Session) ([]*vm.VirtualMachine, error) {

--- a/pkg/vsphere/compute/rp_test.go
+++ b/pkg/vsphere/compute/rp_test.go
@@ -19,8 +19,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
-
 	"github.com/vmware/vic/pkg/vsphere/session"
 	"github.com/vmware/vic/pkg/vsphere/simulator"
 
@@ -57,7 +55,6 @@ func TestMain(t *testing.T) {
 		defer sess.Logout(ctx)
 		testGetChildrenVMs(ctx, sess, t)
 		testGetChildVM(ctx, sess, t)
-		testFindResourcePool(ctx, sess, t)
 		testGetCluster(ctx, sess, t)
 	}
 }
@@ -126,21 +123,6 @@ func testGetChildVM(ctx context.Context, sess *session.Session, t *testing.T) {
 	if err == nil && vm != nil {
 		t.Logf("vm: %s", vm.Reference())
 		t.Errorf("Should not find VM random")
-	}
-}
-
-func testFindResourcePool(ctx context.Context, sess *session.Session, t *testing.T) {
-	tests := []struct {
-		name   string
-		hasErr bool
-	}{
-		{"", false},
-		{"random123", true},
-	}
-
-	for _, test := range tests {
-		_, err := FindResourcePool(ctx, sess, test.name)
-		assert.Equal(t, test.hasErr, err != nil)
 	}
 }
 

--- a/pkg/vsphere/simulator/license_manager.go
+++ b/pkg/vsphere/simulator/license_manager.go
@@ -1,0 +1,96 @@
+// Copyright 2017 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package simulator
+
+import (
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25/methods"
+	"github.com/vmware/govmomi/vim25/mo"
+	"github.com/vmware/govmomi/vim25/soap"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+// EvalLicense is the default license
+var EvalLicense = types.LicenseManagerLicenseInfo{
+	LicenseKey: "00000-00000-00000-00000-00000",
+	EditionKey: "eval",
+	Name:       "Evaluation Mode",
+	Properties: []types.KeyAnyValue{
+		{
+			Key: "feature",
+			Value: types.KeyValue{
+				Key:   "serialuri:2",
+				Value: "Remote virtual Serial Port Concentrator",
+			},
+		},
+		{
+			Key: "feature",
+			Value: types.KeyValue{
+				Key:   "dvs",
+				Value: "vSphere Distributed Switch",
+			},
+		},
+	},
+}
+
+type LicenseManager struct {
+	mo.LicenseManager
+}
+
+func NewLicenseManager(ref types.ManagedObjectReference) object.Reference {
+	m := &LicenseManager{}
+	m.Self = ref
+	m.Licenses = []types.LicenseManagerLicenseInfo{EvalLicense}
+
+	if Map.IsVPX() {
+		am := Map.Put(&LicenseAssignmentManager{}).Reference()
+		m.LicenseAssignmentManager = &am
+	}
+
+	return m
+}
+
+type LicenseAssignmentManager struct {
+	mo.LicenseAssignmentManager
+}
+
+func (m *LicenseAssignmentManager) QueryAssignedLicenses(req *types.QueryAssignedLicenses) soap.HasFault {
+	body := &methods.QueryAssignedLicensesBody{
+		Res: &types.QueryAssignedLicensesResponse{},
+	}
+
+	// EntityId can be a HostSystem or the vCenter InstanceUuid
+	if req.EntityId != "" {
+		if req.EntityId != Map.content().About.InstanceUuid {
+			id := types.ManagedObjectReference{
+				Type:  "HostSystem",
+				Value: req.EntityId,
+			}
+
+			if Map.Get(id) == nil {
+				return body
+			}
+		}
+	}
+
+	body.Res.Returnval = []types.LicenseAssignmentManagerLicenseAssignment{
+		{
+			EntityId:        req.EntityId,
+			AssignedLicense: EvalLicense,
+		},
+	}
+
+	return body
+}

--- a/pkg/vsphere/simulator/license_manager_test.go
+++ b/pkg/vsphere/simulator/license_manager_test.go
@@ -1,0 +1,123 @@
+// Copyright 2017 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package simulator
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/vmware/govmomi"
+	"github.com/vmware/govmomi/find"
+	"github.com/vmware/govmomi/license"
+)
+
+func TestLicenseManagerVPX(t *testing.T) {
+	ctx := context.Background()
+	m := VPX()
+
+	defer m.Remove()
+
+	err := m.Create()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	s := m.Service.NewServer()
+	defer s.Close()
+
+	c, err := govmomi.NewClient(ctx, s.URL, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	lm := license.NewManager(c.Client)
+	am, err := lm.AssignmentManager(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	la, err := am.QueryAssigned(ctx, "enoent")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(la) != 0 {
+		t.Errorf("unexpected license")
+	}
+
+	finder := find.NewFinder(c.Client, false)
+	hosts, err := finder.HostSystemList(ctx, "/...")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	host := hosts[0].Reference().Value
+	vcid := c.Client.ServiceContent.About.InstanceUuid
+
+	for _, name := range []string{"", host, vcid} {
+		la, err = am.QueryAssigned(ctx, name)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if len(la) != 1 {
+			t.Fatal("no licenses")
+		}
+
+		if !reflect.DeepEqual(la[0].AssignedLicense, EvalLicense) {
+			t.Fatal("invalid license")
+		}
+	}
+}
+
+func TestLicenseManagerESX(t *testing.T) {
+	ctx := context.Background()
+	m := ESX()
+
+	defer m.Remove()
+
+	err := m.Create()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	s := m.Service.NewServer()
+	defer s.Close()
+
+	c, err := govmomi.NewClient(ctx, s.URL, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	lm := license.NewManager(c.Client)
+	_, err = lm.AssignmentManager(ctx)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+
+	la, err := lm.List(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(la) != 1 {
+		t.Fatal("no licenses")
+	}
+
+	if !reflect.DeepEqual(la[0], EvalLicense) {
+		t.Fatal("invalid license")
+	}
+}

--- a/pkg/vsphere/simulator/registry.go
+++ b/pkg/vsphere/simulator/registry.go
@@ -231,6 +231,16 @@ func (r *Registry) content() types.ServiceContent {
 	return r.Get(serviceInstance).(*ServiceInstance).Content
 }
 
+// IsESX returns true if this Registry maps an ESX model
+func (r *Registry) IsESX() bool {
+	return r.content().About.ApiType == "HostAgent"
+}
+
+// IsVPX returns true if this Registry maps a VPX model
+func (r *Registry) IsVPX() bool {
+	return !r.IsESX()
+}
+
 // SearchIndex returns the SearchIndex singleton
 func (r *Registry) SearchIndex() *SearchIndex {
 	return r.Get(r.content().SearchIndex.Reference()).(*SearchIndex)

--- a/pkg/vsphere/simulator/service_instance.go
+++ b/pkg/vsphere/simulator/service_instance.go
@@ -54,6 +54,7 @@ func NewServiceInstance(content types.ServiceContent, folder mo.Folder) *Service
 		NewSessionManager(*s.Content.SessionManager),
 		NewPropertyCollector(s.Content.PropertyCollector),
 		NewFileManager(*s.Content.FileManager),
+		NewLicenseManager(*s.Content.LicenseManager),
 		NewSearchIndex(*s.Content.SearchIndex),
 	}
 

--- a/pkg/vsphere/simulator/simulator.go
+++ b/pkg/vsphere/simulator/simulator.go
@@ -278,6 +278,7 @@ func (s *Service) NewServer() *Server {
 	// Using NewUnstartedServer() instead of NewServer(),
 	// for use in main.go, where Start() blocks, we can still set ServiceHostName
 	ts := httptest.NewUnstartedServer(mux)
+	ts.Config.ErrorLog = log.New(ioutil.Discard, "", 0) // we don't need this noise
 
 	u := &url.URL{
 		Scheme: "http",


### PR DESCRIPTION
- Support vic-machine create targeting Datacenter within an inventory folder.

- Simplify compute-resource suggestions.
  Removes quite a bit of code, which also did not work when clusters/hosts were within inventory folders.
  Some of the removed code was working around the old govmomi Finder "list mode" limitations.

- Add vcsim based tests for vic-machine validation against multiple resources of all types,
  within inventory folders.  These tests also cover most of the error paths.

- Add LicenseManager support to vcsim

Fixes #4203

