### PR TITLE
[specific ci=1-02-Docker-Pull] Fix Insecure Registry issue and Self Signed Certs Issue

### DIFF
--- a/lib/imagec/docker.go
+++ b/lib/imagec/docker.go
@@ -1,3 +1,4 @@
+// Copyright 2016-2017 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -46,7 +47,7 @@ const (
 	DigestSHA256EmptyTar = string(dlayer.DigestSHA256EmptyTar)
 )
 
-// FSLayer is a contanseciner struct for BlobSums defined in an image manifest
+// FSLayer is a container struct for BlobSums defined in an image manifest
 type FSLayer struct {
 	// BlobSum is the tarsum of the referenced filesystem image layer
 	BlobSum string `json:"blobSum"`

--- a/lib/imagec/imagec.go
+++ b/lib/imagec/imagec.go
@@ -477,7 +477,7 @@ func (ic *ImageC) PullImage() error {
 	}
 
 	// Calculate (and overwrite) the registry URL and make sure that it responds to requests
-	ic.Registry, err = LearnRegistryURL(ic.Options)
+	ic.Registry, err = LearnRegistryURL(&ic.Options)
 	if err != nil {
 		log.Errorf("Error while pulling image: %s", err)
 		return err

--- a/lib/imagec/imagec_test.go
+++ b/lib/imagec/imagec_test.go
@@ -1,4 +1,3 @@
-// Copyright 2016-2017 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -143,14 +142,14 @@ func TestLearnRegistryURL(t *testing.T) {
 	ic.Options.Timeout = DefaultHTTPTimeout
 
 	// should fail
-	_, err := LearnRegistryURL(ic.Options)
+	_, err := LearnRegistryURL(&ic.Options)
 	if err == nil {
 		t.Errorf(err.Error())
 	}
 
 	// should pass
 	ic.Options.InsecureAllowHTTP = true
-	_, err = LearnRegistryURL(ic.Options)
+	_, err = LearnRegistryURL(&ic.Options)
 	if err != nil {
 		t.Errorf(err.Error())
 	}

--- a/lib/imagec/imagec_test.go
+++ b/lib/imagec/imagec_test.go
@@ -1,3 +1,4 @@
+// Copyright 2016-2017 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/install/validate/validator.go
+++ b/lib/install/validate/validator.go
@@ -15,14 +15,13 @@
 package validate
 
 import (
+	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
 	"net/url"
-	"strings"
-
-	"context"
 	"regexp"
+	"strings"
 
 	log "github.com/Sirupsen/logrus"
 	units "github.com/docker/go-units"
@@ -41,7 +40,6 @@ import (
 	"github.com/vmware/vic/pkg/trace"
 	"github.com/vmware/vic/pkg/version"
 	"github.com/vmware/vic/pkg/vsphere/session"
-	"regexp"
 )
 
 type Validator struct {

--- a/lib/install/validate/validator.go
+++ b/lib/install/validate/validator.go
@@ -41,6 +41,7 @@ import (
 	"github.com/vmware/vic/pkg/trace"
 	"github.com/vmware/vic/pkg/version"
 	"github.com/vmware/vic/pkg/vsphere/session"
+	"regexp"
 )
 
 type Validator struct {

--- a/lib/install/validate/validator_test.go
+++ b/lib/install/validate/validator_test.go
@@ -40,7 +40,7 @@ type TestValidator struct {
 }
 
 func TestParseURL(t *testing.T) {
-	var hosts = []string {
+	var hosts = []string{
 		"host.domain.com",
 		"host.domain.com:123",
 		"1.2.3.4",
@@ -52,10 +52,10 @@ func TestParseURL(t *testing.T) {
 	for _, urlString := range hosts {
 		u, err := ParseURL(urlString)
 		assert.Nil(t, err)
-		assert.Equal(t, u.String(), "https://" + urlString)
+		assert.Equal(t, u.String(), "https://"+urlString)
 		// Null the scheme
 		u.Scheme = ""
-		assert.Equal(t, u.String(), "//" + urlString)
+		assert.Equal(t, u.String(), "//"+urlString)
 		assert.Equal(t, u.Host, urlString)
 	}
 
@@ -70,11 +70,11 @@ func TestParseURL(t *testing.T) {
 	for i, urlString := range urls {
 		u, err := ParseURL(urlString)
 		assert.Nil(t, err)
-		assert.Equal(t, u.String(), "https://" + urlString)
+		assert.Equal(t, u.String(), "https://"+urlString)
 
 		// Null the scheme
 		u.Scheme = ""
-		assert.Equal(t, u.String(), "//" + urlString)
+		assert.Equal(t, u.String(), "//"+urlString)
 
 		// Check host
 		assert.Equal(t, u.Host, hosts[i])
@@ -82,7 +82,7 @@ func TestParseURL(t *testing.T) {
 		path := fmt.Sprintf("/path%d/test", i)
 		assert.Equal(t, u.Path, path)
 		// Check concatenation
-		assert.Equal(t, u.Host + u.Path, urlString)
+		assert.Equal(t, u.Host+u.Path, urlString)
 	}
 
 	// Add an HTTP scheme to verify that it is preserved
@@ -100,7 +100,7 @@ func TestParseURL(t *testing.T) {
 		assert.Equal(t, u.String(), urlString)
 	}
 
-	var invalidUrls = []string {
+	var invalidUrls = []string{
 		"[2001:db8/path",
 		"1.2.3.4\\path",
 	}

--- a/lib/install/validate/validator_test.go
+++ b/lib/install/validate/validator_test.go
@@ -40,7 +40,7 @@ type TestValidator struct {
 }
 
 func TestParseURL(t *testing.T) {
-	var hosts = []string{
+	var hosts = []string {
 		"host.domain.com",
 		"host.domain.com:123",
 		"1.2.3.4",
@@ -52,10 +52,10 @@ func TestParseURL(t *testing.T) {
 	for _, urlString := range hosts {
 		u, err := ParseURL(urlString)
 		assert.Nil(t, err)
-		assert.Equal(t, u.String(), "https://"+urlString)
+		assert.Equal(t, u.String(), "https://" + urlString)
 		// Null the scheme
 		u.Scheme = ""
-		assert.Equal(t, u.String(), "//"+urlString)
+		assert.Equal(t, u.String(), "//" + urlString)
 		assert.Equal(t, u.Host, urlString)
 	}
 
@@ -70,11 +70,11 @@ func TestParseURL(t *testing.T) {
 	for i, urlString := range urls {
 		u, err := ParseURL(urlString)
 		assert.Nil(t, err)
-		assert.Equal(t, u.String(), "https://"+urlString)
+		assert.Equal(t, u.String(), "https://" + urlString)
 
 		// Null the scheme
 		u.Scheme = ""
-		assert.Equal(t, u.String(), "//"+urlString)
+		assert.Equal(t, u.String(), "//" + urlString)
 
 		// Check host
 		assert.Equal(t, u.Host, hosts[i])
@@ -82,7 +82,7 @@ func TestParseURL(t *testing.T) {
 		path := fmt.Sprintf("/path%d/test", i)
 		assert.Equal(t, u.Path, path)
 		// Check concatenation
-		assert.Equal(t, u.Host+u.Path, urlString)
+		assert.Equal(t, u.Host + u.Path, urlString)
 	}
 
 	// Add an HTTP scheme to verify that it is preserved
@@ -100,7 +100,7 @@ func TestParseURL(t *testing.T) {
 		assert.Equal(t, u.String(), urlString)
 	}
 
-	var invalidUrls = []string{
+	var invalidUrls = []string {
 		"[2001:db8/path",
 		"1.2.3.4\\path",
 	}


### PR DESCRIPTION
Fixes #3441 
Fixes #4363 

Original reference PR: https://github.com/vmware/vic/pull/4391

@gigawhitlocks has tested the changes from the above referenced PR and the changes appear to solve the problems seen in insecure registry and self signed certs issue. 

I have reconfirmed that this is the case. The case of an insecure registry being targeted with self-signed certs causing us to return a `image not found` is not part of this issue as far I can tell. This is also behavior that can happen with auth.docker.io as the registry target.

NOTE: these changes are not my own, I have looked through them and tested them by hand. The merit for these changes goes to @lcastellano and @gigawhitlocks as far as I am concerned. All I have done is resolve a couple of merge conflicts and do some spring cleaning on these code changes. 