### PR TITLE
Fix docker login registry url parsing

### DIFF
--- a/lib/apiservers/engine/backends/system.go
+++ b/lib/apiservers/engine/backends/system.go
@@ -288,6 +288,12 @@ func (s *System) AuthenticateToRegistry(ctx context.Context, authConfig *types.A
 		registryAddress = registryAddress + "/v2/"
 	}
 
+	// TODO(jzt) Ensuring the scheme exists in the url happens at several places in our code.
+	// We should consolidate these into a common method to deal with this.
+	if !strings.HasPrefix(registryAddress, "https://") && !strings.HasPrefix(registryAddress, "http://") {
+		registryAddress = "https://" + registryAddress
+	}
+
 	registryURL, err := url.Parse(registryAddress)
 	if err != nil {
 		msg := fmt.Sprintf("Bad login address: %s", registryAddress)


### PR DESCRIPTION
Note: `registry-1.docker.io` will return a 503 if you attempt to tack on `:443` to the end of the address, `https://registry-1.docker.io` works just fine (maybe `url.Parse()` is broken for them, too, and they haven't fixed it yet?). For this reason, we would need to use a separate registry in an integration test for this change.

PS: I know the install package's validator has this small fix too, but I didn't want to import install code into the backend. If anyone thinks this one-liner is worth having an architectural discussion over in order to prevent a 1-line DRY violation, this would be the place to have that discussion. :)

Fixes #4344 