### PR TITLE
docker cpu and memory stats implemented

### DIFF
--- a/lib/apiservers/engine/backends/container.go
+++ b/lib/apiservers/engine/backends/container.go
@@ -1336,7 +1336,38 @@ func (c *Container) ContainerLogs(ctx context.Context, name string, config *back
 // ContainerStats writes information about the container to the stream
 // given in the config object.
 func (c *Container) ContainerStats(ctx context.Context, name string, config *backend.ContainerStatsConfig) error {
-	return fmt.Errorf("%s does not yet implement ContainerStats", ProductName())
+	defer trace.End(trace.Begin(name))
+
+	// Look up the container name in the metadata cache to get long ID
+	vc := cache.ContainerCache().GetContainer(name)
+	if vc == nil {
+		return NotFoundError(name)
+	}
+
+	// get the configured CPUMhz for this VCH so that we can calculate docker CPU stats
+	cpuMhz, err := systemBackend.SystemCPUMhzLimit()
+	if err != nil {
+		// wrap error to provide a bit more detail
+		sysErr := fmt.Errorf("unable to gather system CPUMhz for container(%s): %s", vc.ContainerID, err)
+		log.Error(sysErr)
+		return InternalServerError(sysErr.Error())
+	}
+
+	out := config.OutStream
+	if config.Stream {
+		// Outstream modification (from Docker's code) so the stream is streamed with the
+		// necessary headers that the CLI expects.  This is Docker's scheme.
+		wf := ioutils.NewWriteFlusher(config.OutStream)
+		defer wf.Close()
+		wf.Flush()
+		out = io.Writer(wf)
+	}
+
+	err = c.containerProxy.StreamContainerStats(ctx, vc.ContainerID, out, config.Stream, cpuMhz, vc.HostConfig.Memory)
+	if err != nil {
+		log.Errorf("error while streaming container (%s) stats: %s", vc.ContainerID, err)
+	}
+	return nil
 }
 
 // ContainerTop lists the processes running inside of the given

--- a/lib/apiservers/engine/backends/container_test.go
+++ b/lib/apiservers/engine/backends/container_test.go
@@ -338,6 +338,9 @@ func (m *MockContainerProxy) Rename(vc *viccontainer.VicContainer, newName strin
 func (m *MockContainerProxy) AttachStreams(ctx context.Context, vc *viccontainer.VicContainer, clStdin io.ReadCloser, clStdout, clStderr io.Writer, ca *backend.ContainerAttachConfig) error {
 	return nil
 }
+func (m *MockContainerProxy) StreamContainerStats(ctx context.Context, id string, out io.Writer, stream bool, CPUMhz int64, memory int64) error {
+	return nil
+}
 
 func AddMockImageToCache() {
 	mockImage := &metadata.ImageConfig{

--- a/lib/apiservers/engine/backends/convert/stats.go
+++ b/lib/apiservers/engine/backends/convert/stats.go
@@ -1,0 +1,287 @@
+// Copyright 2017 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package convert
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"time"
+
+	log "github.com/Sirupsen/logrus"
+
+	"github.com/docker/docker/api/types"
+
+	"github.com/vmware/vic/lib/portlayer/metrics"
+)
+
+// ContainerStats encapsulates the conversion of VMMetrics to
+// docker specific metrics
+type ContainerStats struct {
+	config         ContainerStatsConfig
+	dockerStats    *types.StatsJSON
+	currentMetrics *metrics.VMMetrics
+	totalVCHMhz    uint64
+	dblVCHMhz      uint64
+	preTotalMhz    uint64
+
+	// reader/writer for stream
+	reader *io.PipeReader
+	writer *io.PipeWriter
+}
+
+type ContainerStatsConfig struct {
+	Ctx         context.Context
+	Cancel      context.CancelFunc
+	Out         io.Writer
+	ContainerID string
+	Memory      int64
+	Stream      bool
+	VchMhz      int64
+}
+
+type InvalidOrderError struct {
+	current  time.Time
+	previous time.Time
+}
+
+func (iso InvalidOrderError) Error() string {
+	return fmt.Sprintf("The current sample time (%s) is before the previous time (%s)", iso.current, iso.previous)
+}
+
+// NewContainerStats will return a new instance of ContainerStats
+func NewContainerStats(config ContainerStatsConfig) *ContainerStats {
+	return &ContainerStats{
+		config:      config,
+		dockerStats: &types.StatsJSON{},
+		totalVCHMhz: uint64(config.VchMhz),
+		dblVCHMhz:   uint64(config.VchMhz * 2),
+	}
+}
+
+// Stop will clean up remaining conversion resources
+func (cs *ContainerStats) Stop() {
+	if cs.reader != nil && cs.writer != nil {
+		cs.reader.Close()
+		cs.writer.Close()
+	}
+}
+
+// Listen will listen for new metrics from the portLayer, convert to docker format
+// and encode to the configured Writer.  The returned PipeWriter is the source of
+// the vic metrics that will be transformed to docker stats
+func (cs *ContainerStats) Listen() *io.PipeWriter {
+	// TODO: could split decode / encode into separate funcs -- would provide for easier
+	// unit testing
+
+	// we already are listening
+	if cs.reader != nil {
+		return nil
+	}
+
+	cs.reader, cs.writer = io.Pipe()
+
+	dec := json.NewDecoder(cs.reader)
+	doc := json.NewEncoder(cs.config.Out)
+
+	// channel to transfer metric from decoder to encoder
+	// closed w/in the decoder
+	metric := make(chan metrics.VMMetrics)
+
+	// signal to decoder / encoder that we are done
+	finished := make(chan struct{})
+
+	var vmm metrics.VMMetrics
+	var previousStat *types.StatsJSON
+
+	go func() {
+		for {
+			select {
+			case <-cs.config.Ctx.Done():
+				close(finished)
+			case <-finished:
+				close(metric)
+				cs.Stop()
+				return
+			default:
+				for dec.More() {
+					err := dec.Decode(&vmm)
+					if err != nil {
+						log.Errorf("container metric decoding error for container(%s): %s", cs.config.ContainerID, err)
+						cs.config.Cancel()
+					}
+					// send the decoded metric for transform and encoding
+					metric <- vmm
+				}
+			}
+		}
+
+	}()
+
+	go func() {
+		for {
+			select {
+			case <-cs.config.Ctx.Done():
+				return
+			case <-finished:
+				return
+			case nm := <-metric:
+				// convert the Stat to docker struct
+				stats, err := cs.ToContainerStats(&nm)
+				if err != nil {
+					log.Errorf("container metric conversion error for container(%s): %s", cs.config.ContainerID, err)
+					cs.config.Cancel()
+				}
+				// Do we have a complete stat that can be sent to the client?
+				if stats != nil {
+					err = doc.Encode(stats)
+					if err != nil {
+						log.Warnf("container metric encoding error for container(%s): %s", cs.config.ContainerID, err)
+						cs.config.Cancel()
+					}
+					// if we aren't streaming then cancel
+					if !cs.config.Stream {
+						cs.config.Cancel()
+					}
+					// set to previous stat so we can reuse
+					previousStat = stats
+				}
+			default:
+				// the docker client expects updates quicker than vSphere can produce them, so
+				// we need to send the previous stats to avoid intermittent empty output
+				time.Sleep(time.Second * 1)
+				if previousStat != nil && cs.reader != nil {
+					err := doc.Encode(previousStat)
+					if err != nil {
+						log.Warnf("container previous metric encoding error for container(%s): %s", cs.config.ContainerID, err)
+						cs.config.Cancel()
+					}
+				}
+			}
+		}
+	}()
+	return cs.writer
+}
+
+// ToContainerStats will convert the vic VMMetrics to a docker stats struct -- a complete docker stats
+// struct requires two samples.  Func will return nil until a complete stat is available
+func (cs *ContainerStats) ToContainerStats(current *metrics.VMMetrics) (*types.StatsJSON, error) {
+	// if we have a current metric then validate and transform
+	if cs.currentMetrics != nil {
+		// do we have the same metric as before?
+		if cs.currentMetrics.SampleTime.Equal(current.SampleTime) {
+			// we've already got this as current, so skip and wait for the
+			// next sample
+			return nil, nil
+		}
+		// we have new current stats so need to move the previous CPU
+		err := cs.previousCPU(current)
+		if err != nil {
+			return nil, err
+		}
+	}
+	cs.currentMetrics = current
+
+	// create the current CPU stats
+	cs.currentCPU()
+
+	// create memory stats
+	cs.memory()
+
+	// set sample time
+	cs.dockerStats.Read = cs.currentMetrics.SampleTime
+
+	// PreRead will be zero if we don't have two samples
+	if cs.dockerStats.PreRead.IsZero() {
+		return nil, nil
+	}
+	return cs.dockerStats, nil
+}
+
+func (cs *ContainerStats) memory() {
+	// given MB (i.e. 2048) convert to GB
+	cs.dockerStats.MemoryStats.Limit = uint64(cs.config.Memory * 1024 * 1024)
+	// given KB (i.e. 384.5) convert to Bytes
+	cs.dockerStats.MemoryStats.Usage = uint64(cs.currentMetrics.Memory.Active * 1024)
+}
+
+// previousCPU will move the current stats to the previous CPU location
+func (cs *ContainerStats) previousCPU(current *metrics.VMMetrics) error {
+	// validate that the sampling is in the correct order
+	if current.SampleTime.Before(cs.dockerStats.Read) {
+		err := InvalidOrderError{
+			current:  current.SampleTime,
+			previous: cs.dockerStats.Read,
+		}
+		return err
+	}
+
+	// move the stats
+	cs.dockerStats.PreCPUStats = cs.dockerStats.CPUStats
+
+	// set the previousTotal -- this will be added to the current CPU
+	cs.preTotalMhz = cs.dockerStats.PreCPUStats.CPUUsage.TotalUsage
+
+	cs.dockerStats.PreRead = cs.dockerStats.Read
+	// previous systemUsage will always be the VCH total
+	// see note in func currentCPU() for detail
+	cs.dockerStats.PreCPUStats.SystemUsage = cs.totalVCHMhz
+
+	return nil
+}
+
+// currentCPU will convert the VM CPU metrics to docker CPU stats
+func (cs *ContainerStats) currentCPU() {
+	cpuCount := len(cs.currentMetrics.CPU.CPUs)
+	dockerCPU := types.CPUStats{
+		CPUUsage: types.CPUUsage{
+			PercpuUsage: make([]uint64, cpuCount, cpuCount),
+		},
+	}
+
+	// collect the current CPU Metrics
+	for ci, current := range cs.currentMetrics.CPU.CPUs {
+		dockerCPU.CPUUsage.PercpuUsage[ci] = uint64(current.MhzUsage)
+		dockerCPU.CPUUsage.TotalUsage += uint64(current.MhzUsage)
+	}
+	// The first stat available for a VM will be missing detail
+	if cpuCount > 0 {
+		// TotalUsage is the sum of the individual vCPUs Mhz
+		// consumption this reading.  We must divide that by the
+		// number of vCPUs to get the average across both, since
+		// the cpuUsage calc (explained below) will multiply by
+		// the number of CPUs to get the cpuUsage percent
+		dockerCPU.CPUUsage.TotalUsage /= uint64(cpuCount)
+	}
+
+	// Set the current systemUsage to double the VCH as the
+	// previous systemUsage is the VCH total.  The docker
+	// client formula creates a SystemDelta which is the following:
+	// systemDelta = currentSystemUsage - previousSystemUsage
+	// We always need systemDelta to equal the total amount of
+	// VCH Mhz thus the doubling here.
+	dockerCPU.SystemUsage = cs.dblVCHMhz
+
+	// Much like systemUsage (above) totalCPUUsage and previous
+	// totalCPUUsage will be used to create a CPUUsage delta as such:
+	// CPUDelta = currentTotalCPUUsage - previousTotalCPUUsage
+	// This amount will then be divided by the systemDelta
+	// (explained above) as part of the CPU % Usage calculation
+	// cpuUsage = (CPUDelta / SystemDelta) * cpuCount * 100
+	// This will require the addition of the previous total usage
+	dockerCPU.CPUUsage.TotalUsage += cs.preTotalMhz
+	cs.dockerStats.CPUStats = dockerCPU
+}

--- a/lib/apiservers/engine/backends/convert/stats_test.go
+++ b/lib/apiservers/engine/backends/convert/stats_test.go
@@ -1,0 +1,202 @@
+// Copyright 2017 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package convert
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/pkg/ioutils"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/vmware/vic/lib/portlayer/metrics"
+)
+
+const (
+	vcpuMhz        = 3300
+	vcpuCount      = 1
+	vchMhzTotal    = 3300
+	memConsumed    = 1024 * 1024 * 500
+	memProvisioned = 1024 * 1024 * 1024
+)
+
+func TestContainerConverter(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	r, o := io.Pipe()
+	defer o.Close()
+	out := io.Writer(o)
+	// Outstream modification (from Docker's code) so the stream is streamed with the
+	// necessary headers that the CLI expects.  This is Docker's scheme.
+	wf := ioutils.NewWriteFlusher(out)
+	defer wf.Close()
+	wf.Flush()
+	out = io.Writer(wf)
+
+	config := ContainerStatsConfig{
+		VchMhz:      int64(vchMhzTotal),
+		Ctx:         ctx,
+		Cancel:      cancel,
+		ContainerID: "1234",
+		Out:         out,
+		Stream:      true,
+		Memory:      2048,
+	}
+
+	cStats := NewContainerStats(config)
+	assert.NotNil(t, cStats)
+
+	// this writer goes is provided to the PL
+	writer := cStats.Listen()
+	assert.NotNil(t, writer)
+
+	w2 := cStats.Listen()
+	assert.Nil(t, w2)
+
+	initCPU := 1000
+	vmBefore := vmMetrics(vcpuCount, initCPU)
+	time.Sleep(1 * time.Millisecond)
+	vmm := vmMetrics(vcpuCount, initCPU)
+
+	// first metric sent, should return nil
+	js, err := cStats.ToContainerStats(vmm)
+	assert.NoError(t, err)
+	assert.Nil(t, js)
+
+	// send the same stat should return nil
+	js, err = cStats.ToContainerStats(vmm)
+	assert.Nil(t, err)
+	assert.Nil(t, js)
+
+	// send stat before the previous
+	js, err = cStats.ToContainerStats(vmBefore)
+	assert.NotNil(t, err)
+	assert.Nil(t, js)
+
+	secondCPU := 250
+	// create a new metric
+	vmmm := vmMetrics(vcpuCount, secondCPU)
+	// sample will be 20 seconds apart..
+	vmmm.SampleTime.Add(time.Second * 20)
+	js, err = cStats.ToContainerStats(vmmm)
+	assert.NoError(t, err)
+	assert.NotZero(t, js.Read, js.PreRead)
+	assert.Equal(t, uint64(vchMhzTotal*2), js.CPUStats.SystemUsage)
+	assert.Equal(t, uint64(secondCPU+initCPU), js.CPUStats.CPUUsage.TotalUsage)
+	assert.Equal(t, uint64(initCPU), js.PreCPUStats.CPUUsage.TotalUsage)
+	assert.Equal(t, uint64(vchMhzTotal), js.PreCPUStats.SystemUsage)
+
+	// this reading should show 250mhz of 3300mhz used -- 7.58%
+	cpuPercent := fmt.Sprintf("%2.2f", calculateCPUPercentUnix(js.PreCPUStats.CPUUsage.TotalUsage, js.PreCPUStats.SystemUsage, js))
+	assert.Equal(t, "7.58", cpuPercent)
+
+	// reset listener, so reader/writer operates
+	cStats.currentMetrics = nil
+	cStats.dockerStats = &types.StatsJSON{}
+
+	// simulate portLayer
+	plEnc := json.NewEncoder(writer)
+	err = plEnc.Encode(vmm)
+	assert.NoError(t, err)
+	err = plEnc.Encode(vmmm)
+	assert.NoError(t, err)
+
+	// simulate docker client
+	docClient := json.NewDecoder(r)
+	dstat := &types.StatsJSON{}
+	err = docClient.Decode(dstat)
+	assert.NoError(t, err)
+
+	// ensure stop closes reader / writer
+	cStats.Stop()
+	_, err = cStats.reader.Read([]byte{0, 0, 0})
+	assert.Error(t, err)
+
+	config.Stream = false
+
+	cStats = NewContainerStats(config)
+	assert.NotNil(t, cStats)
+
+	writer = cStats.Listen()
+
+	// simulate portLayer
+	plEnc = json.NewEncoder(writer)
+	err = plEnc.Encode(vmm)
+	assert.NoError(t, err)
+	err = plEnc.Encode(vmmm)
+	assert.NoError(t, err)
+
+	// simulate docker client
+	dstat = &types.StatsJSON{}
+	err = docClient.Decode(dstat)
+	assert.NoError(t, err)
+
+}
+
+func vmMetrics(count int, vcpuMhz int) *metrics.VMMetrics {
+	vmm := &metrics.VMMetrics{}
+	vmm.SampleTime = time.Now()
+	vmm.CPU = cpuUsageMetrics(count, vcpuMhz)
+	vmm.Memory = metrics.MemoryMetrics{
+		Consumed:    int64(memConsumed),
+		Provisioned: int64(memProvisioned),
+	}
+	return vmm
+}
+
+// cpuUsageMetrics will return a populated CPUMetrics struct
+func cpuUsageMetrics(count int, cpuMhz int) metrics.CPUMetrics {
+	vmCPUs := make([]metrics.CPUUsage, count, count)
+	total := count * cpuMhz
+	for i := range vmCPUs {
+		vmCPUs[i] = metrics.CPUUsage{
+			ID:       i,
+			MhzUsage: int64(cpuMhz),
+		}
+	}
+
+	return metrics.CPUMetrics{
+		CPUs:  vmCPUs,
+		Usage: calcVCPUUsage(total),
+	}
+}
+
+// calcUsage is a helper function that will take the total provdied usage
+// and convert to percentage of total vCPU usage
+func calcVCPUUsage(total int) float32 {
+	return float32(total) / (vcpuMhz * vcpuCount)
+}
+
+// calculateCPUPercentUnix is a copy from docker to test the percentage calculations
+func calculateCPUPercentUnix(previousCPU, previousSystem uint64, v *types.StatsJSON) float64 {
+	var (
+		cpuPercent = 0.0
+		// calculate the change for the cpu usage of the container in between readings
+		cpuDelta = float64(v.CPUStats.CPUUsage.TotalUsage) - float64(previousCPU)
+		// calculate the change for the entire system between readings
+		systemDelta = float64(v.CPUStats.SystemUsage) - float64(previousSystem)
+	)
+
+	if systemDelta > 0.0 && cpuDelta > 0.0 {
+		cpuPercent = (cpuDelta / systemDelta) * float64(len(v.CPUStats.CPUUsage.PercpuUsage)) * 100.0
+	}
+	return cpuPercent
+}

--- a/lib/apiservers/engine/backends/system.go
+++ b/lib/apiservers/engine/backends/system.go
@@ -67,10 +67,14 @@ const (
 	loginTimeout            = 20 * time.Second
 )
 
+// var for use by other engine components
+var systemBackend *System
+
 func NewSystemBackend() *System {
-	return &System{
+	systemBackend = &System{
 		systemProxy: &SystemProxy{},
 	}
+	return systemBackend
 }
 
 func (s *System) SystemInfo() (*types.Info, error) {
@@ -254,6 +258,15 @@ func (s *System) SystemVersion() types.Version {
 	}
 
 	return version
+}
+
+// SystemCPUMhzLimit will return the VCH configured Mhz limit
+func (s *System) SystemCPUMhzLimit() (int64, error) {
+	vchInfo, err := s.systemProxy.VCHInfo()
+	if err != nil || vchInfo == nil {
+		return 0, err
+	}
+	return vchInfo.CPUMhz, nil
 }
 
 func (s *System) SystemDiskUsage() (*types.DiskUsage, error) {

--- a/lib/apiservers/portlayer/restapi/handlers/stream_handler.go
+++ b/lib/apiservers/portlayer/restapi/handlers/stream_handler.go
@@ -1,0 +1,199 @@
+// Copyright 2016-2017 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package handlers
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/go-openapi/runtime"
+)
+
+// StreamOutputHandler is a custom return handler that provides common
+// stream handling across the API.
+type StreamOutputHandler struct {
+	outputStream *FlushingReader
+	id           string
+	outputName   string
+	onHTTPClose  func() // clean up func called when transport closed
+}
+
+// NewStreamOutputHandler creates StreamOutputHandler with default headers values
+func NewStreamOutputHandler(name string) *StreamOutputHandler {
+	return &StreamOutputHandler{outputName: name}
+}
+
+// WithPayload adds the payload to the container set stdin internal server error response
+func (s *StreamOutputHandler) WithPayload(payload *FlushingReader, id string, cleanup func()) *StreamOutputHandler {
+	s.outputStream = payload
+	s.id = id
+	s.onHTTPClose = cleanup
+	return s
+}
+
+// WriteResponse to the client
+func (s *StreamOutputHandler) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
+	rw.WriteHeader(http.StatusOK)
+	if f, ok := rw.(http.Flusher); ok {
+		f.Flush()
+		s.outputStream.AddFlusher(f)
+	}
+
+	if s.onHTTPClose != nil {
+		notify := rw.(http.CloseNotifier).CloseNotify()
+		go func() {
+			<-notify
+			// execute cleanup function
+			s.onHTTPClose()
+		}()
+	}
+
+	_, err := io.Copy(rw, s.outputStream)
+	if err != nil {
+		log.Debugf("Error streaming %s for %s: %s", s.outputName, s.id, err)
+	} else {
+		log.Debugf("Finished streaming %s for %s", s.outputName, s.id)
+	}
+}
+
+// closePipe is a convenience function for closing the event stream pipe
+func closePipe(pipeReader *io.PipeReader, pipeWriter *io.PipeWriter) {
+	if pipeReader != nil {
+		pipeReader.Close()
+	}
+	if pipeWriter != nil {
+		pipeWriter.Close()
+	}
+}
+
+// GenericFlusher is a custom reader to allow us to detach cleanly during an io.Copy
+type GenericFlusher interface {
+	Flush()
+}
+
+type FlushingReader struct {
+	io.Reader
+	io.WriterTo
+
+	flusher   GenericFlusher
+	initBytes []byte
+}
+
+func NewFlushingReader(rdr io.Reader) *FlushingReader {
+	return &FlushingReader{Reader: rdr, flusher: nil, initBytes: nil}
+}
+
+func NewFlushingReaderWithInitBytes(rdr io.Reader, initBytes []byte) *FlushingReader {
+	return &FlushingReader{Reader: rdr, flusher: nil, initBytes: initBytes}
+}
+
+func (d *FlushingReader) AddFlusher(flusher GenericFlusher) {
+	d.flusher = flusher
+}
+
+// readDetectInit() is used by WriteTo() which is used by io.Copy.  It attempts
+// to detect a init byte buffer.  If it finds that init byte sequence, it is
+// ignored.  This reader does not care about the init sequeunce.  The init sequence
+// maybe used by the higher level interaction, which in this case is the Swagger
+// establishing initial connection for stdin.
+//
+// Panics if the buf is smaller than the initBytes
+func (d *FlushingReader) readDetectInit(buf []byte) (int, error) {
+	initLen := len(d.initBytes)
+
+	// fast path - len(nil) return 0
+	if initLen == 0 {
+		return d.Read(buf)
+	}
+
+	// make sure we have enough room
+	if len(buf) < initLen {
+		panic("Read buffer is smaller than the initialization byte sequence")
+	}
+
+	total := 0
+	upto := 0
+	for total < initLen {
+		nr, err := d.Read(buf[total:])
+		if nr > 0 {
+			total += nr
+			// we are only interested with the first initLen bytes
+			upto = total
+			if upto > initLen {
+				upto = initLen
+			}
+			if bytes.Compare(d.initBytes[0:upto], buf[0:upto]) != 0 {
+				// First bytes aren't part of init bytes so client must not be
+				// the docker personality so break and ignore looking for the
+				// init bytes.
+				log.Debugf("Did not find primer bytes, stopping watch")
+				return total, err
+			}
+		}
+		if err != nil && total < initLen {
+			log.Debugf("Primer bytes read %d bytes, err %s, stopping watch", nr, err)
+			return 0, err
+		}
+	}
+
+	// would have returned in the compare clause if not matching init bytes
+	copy(buf[0:], buf[initLen:])
+	log.Debugf("Found primer bytes, port layer client might be personality server")
+
+	// no risk of returning <0
+	return total - initLen, nil
+}
+
+// WriteTo is derived from go's io.Copy.  We use a smaller buffer so as to not hold up
+// writing out data.  Go's version allocates 32k, and the Read will wait till
+// buffer is filled (unless EOF is encountered).  Also, we force a flush if
+// a flusher is added.  We've seen cases where the last bit of data for a
+// screen doesn't reach the docker engine api server.  The flush solves that
+// issue.
+func (d *FlushingReader) WriteTo(w io.Writer) (written int64, err error) {
+	buf := make([]byte, ioCopyBufferSize)
+
+	nr, er := d.readDetectInit(buf)
+	for {
+		if nr > 0 {
+			nw, ew := w.Write(buf[0:nr])
+			if d.flusher != nil {
+				d.flusher.Flush()
+			}
+			if nw > 0 {
+				written += int64(nw)
+			}
+			if ew != nil {
+				err = ew
+				break
+			}
+			if nr != nw {
+				err = io.ErrShortWrite
+				break
+			}
+		}
+		if er == io.EOF {
+			break
+		}
+		if er != nil {
+			err = er
+			break
+		}
+		nr, er = d.Read(buf)
+	}
+	return written, err
+}

--- a/lib/apiservers/portlayer/swagger.json
+++ b/lib/apiservers/portlayer/swagger.json
@@ -1850,6 +1850,50 @@
 				}
 			}
 		},
+		"/containers/{id}/stats": {
+			"get": {
+				"description": "Gets the container stats by id",
+				"summary": "Gets the container stats",
+				"operationId": "GetContainerStats",
+				"tags": [
+					"containers"
+				],
+				"consumes": [
+					"application/octet-stream"
+				],
+				"produces": [
+					"application/octet-stream"
+				],
+				"parameters": [
+					{
+						"name": "id",
+						"in": "path",
+						"type": "string",
+						"required": true
+					},
+					{
+						"name": "stream",
+						"in": "query",
+						"type": "boolean",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"format": "binary"
+						}
+					},
+					"404": {
+						"description": "Stats not found"
+					},
+					"500": {
+						"description": "Failed to get stats"
+					}
+				}
+			}
+		},
 		"/containers/{id}/logs": {
 			"get": {
 				"description": "Gets the container logs by id",

--- a/lib/portlayer/exec/base.go
+++ b/lib/portlayer/exec/base.go
@@ -88,6 +88,15 @@ func newBase(vm *vm.VirtualMachine, c *types.VirtualMachineConfigInfo, r *types.
 	return base
 }
 
+// VMReference will provide the vSphere vm managed object reference
+func (c *containerBase) VMReference() types.ManagedObjectReference {
+	var moref types.ManagedObjectReference
+	if c.vm != nil {
+		moref = c.vm.Reference()
+	}
+	return moref
+}
+
 // unlocked refresh of container state
 func (c *containerBase) refresh(ctx context.Context) error {
 	defer trace.End(trace.Begin(c.ExecConfig.ID))

--- a/lib/portlayer/metrics/container.go
+++ b/lib/portlayer/metrics/container.go
@@ -1,0 +1,340 @@
+// Copyright 2017 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metrics
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"sync"
+	"time"
+
+	log "github.com/Sirupsen/logrus"
+
+	"github.com/docker/docker/pkg/pubsub"
+
+	"github.com/vmware/govmomi/performance"
+	"github.com/vmware/govmomi/vim25/types"
+
+	"github.com/vmware/vic/lib/portlayer/exec"
+	"github.com/vmware/vic/pkg/trace"
+	"github.com/vmware/vic/pkg/vsphere/session"
+)
+
+const (
+	// number of samples per collection
+	sampleSize = int32(2)
+	// number of seconds between sample collection
+	sampleInterval = int32(20)
+)
+
+// CPUUsage provides individual CPU metrics
+type CPUUsage struct {
+	// processor id (0,1,2)
+	ID int
+	// MhzUsage is the MhZ consumed by a specific processor
+	MhzUsage int64
+}
+
+// CPUMetrics encapsulates available vm CPU metrics
+type CPUMetrics struct {
+	// CPUs are the individual CPU metrics
+	CPUs []CPUUsage
+	// Usage is the percentage of total vm CPU usage
+	Usage float32
+}
+
+// MemoryMetrics encapsulates available vm memory metrics
+type MemoryMetrics struct {
+	// Consumed memory of vm in bytes
+	Consumed int64
+	// Active memory of vm in bytes
+	Active int64
+	// Provisioned memory of vm in bytes
+	Provisioned int64
+}
+
+// NetworkUsage provides metrics for specific networks
+type NetworkUsage struct {
+	//TBD
+}
+
+// NetworkMetrics encapsulates available vm Network metrics
+type NetworkMetrics struct {
+	//TBD
+}
+
+// DiskUsage provides metrics for specific disks
+type DiskUsage struct {
+	//TBD
+}
+
+// NetworkMetrics encapsulates available vm Storage metrics
+type StorageMetrics struct {
+	//TBD
+}
+
+// VMMetrics encapsulates vm metrics available
+type VMMetrics struct {
+	CPU        CPUMetrics
+	Memory     MemoryMetrics
+	Network    NetworkMetrics
+	Storage    StorageMetrics
+	SampleTime time.Time
+	// interval of collection in seconds
+	Interval int32
+}
+
+// collectorVM is the VM metrics collector
+type collectorVM struct {
+	perfMgr *performance.Manager
+
+	// subscribers to streaming
+	mu   sync.RWMutex
+	subs map[types.ManagedObjectReference]*subscriber
+}
+
+// subscriber is the receiver of the metrics
+type subscriber struct {
+	id        string
+	ref       types.ManagedObjectReference
+	publisher *pubsub.Publisher
+}
+
+func newVMCollector(session *session.Session) *collectorVM {
+	s := make(map[types.ManagedObjectReference]*subscriber)
+	cc := &collectorVM{
+		subs:    s,
+		perfMgr: performance.NewManager(session.Vim25()),
+	}
+
+	// kick off the subscription sampler
+	go cc.sampler()
+
+	return cc
+}
+
+// sampler will check for subscriptions and sample when needed
+func (cc *collectorVM) sampler() {
+	// TODO: replace this with service that only runs when there are
+	// active subscribers
+	d := time.Duration(int64(sampleInterval)) * time.Second
+	for range time.Tick(d) {
+		// if we have no subscribers skip
+		if cc.SubscriberCount() == 0 {
+			continue
+		}
+		// collect metrics for current subscribers
+		cc.collect(cc.Subscribers(), false)
+	}
+}
+
+// Sample returns a single metrics collection
+func (cc *collectorVM) Sample(contain interface{}) (chan interface{}, error) {
+	defer trace.End(trace.Begin(""))
+
+	containerSub, err := containerSubscriber(contain)
+	if err != nil {
+		return nil, err
+	}
+
+	// create a publisher and subscribe
+	containerSub.publisher = pubsub.NewPublisher(100*time.Millisecond, 0)
+	ch := containerSub.publisher.Subscribe()
+
+	// create a map with this single subscriber
+	single := make(map[types.ManagedObjectReference]*subscriber)
+	single[containerSub.ref] = containerSub
+
+	// collect the metrics
+	go cc.collect(single, true)
+
+	return ch, nil
+}
+
+// collect will query vSphere for VM metrics and return to the subscribers
+func (cc *collectorVM) collect(currentSubs map[types.ManagedObjectReference]*subscriber, single bool) {
+	defer trace.End(trace.Begin(""))
+
+	ctx := context.Background()
+	var mos []types.ManagedObjectReference
+
+	// metrics we are currently interested in monitoring
+	names := []string{"cpu.usagemhz.average", "mem.active.average"}
+
+	// create the spec
+	spec := types.PerfQuerySpec{
+		Format:     string(types.PerfFormatNormal),
+		MaxSample:  sampleSize,
+		IntervalId: sampleInterval,
+	}
+
+	// create a collection of object references
+	for mo := range currentSubs {
+		mos = append(mos, mo)
+	}
+
+	// if this is a single request close publisher when complete
+	if single {
+		defer currentSubs[mos[0]].publisher.Close()
+	}
+
+	// get the sample..
+	sample, err := cc.perfMgr.SampleByName(ctx, spec, names, mos)
+	if err != nil {
+		log.Errorf("unable to get metric sample: %s", err)
+		return
+	}
+	// convert to metrics
+	result, err := cc.perfMgr.ToMetricSeries(ctx, sample)
+	if err != nil {
+		log.Errorf("unable to convert metric sample to metric series: %s", err)
+		return
+	}
+
+	for i := range result {
+		met := result[i]
+		sub := currentSubs[met.Entity]
+		for s := range met.SampleInfo {
+
+			// assume we can publish, but if we hit an issue with a specific value
+			// we will not publish the metric
+			publish := true
+
+			metric := VMMetrics{
+				CPU: CPUMetrics{
+					CPUs: []CPUUsage{},
+				},
+				Memory:     MemoryMetrics{},
+				SampleTime: met.SampleInfo[s].Timestamp,
+				Interval:   sampleInterval,
+			}
+
+			// the series will have values for each sample
+			for _, v := range met.Value {
+				switch v.Name {
+				case "cpu.usagemhz.average":
+					// vSphere returns individual cpu metrics and
+					// the aggregate for all cpus.  We want to skip
+					// the aggregate
+					if v.Instance == "" {
+						break
+					}
+					// we aren't on the aggregate so convert to int
+					iid, err := strconv.Atoi(v.Instance)
+					if err != nil {
+						// I don't expect this to ever happen, but if it does log and don't publish
+						log.Errorf("metrics failed to convert container(%s) CPU id to an int - value(%#v): %s", sub.id, v, err)
+						publish = false
+						break
+					}
+					// specific vCPU metric
+					cpu := CPUUsage{
+						ID:       iid,
+						MhzUsage: v.Value[s],
+					}
+					metric.CPU.CPUs = append(metric.CPU.CPUs, cpu)
+				case "mem.active.average":
+					metric.Memory.Active = v.Value[s]
+				}
+
+			}
+
+			if publish {
+				sub.publisher.Publish(metric)
+			}
+		}
+	}
+}
+
+// Subscribe subscribes to a publisher that publishes metrics
+func (cc *collectorVM) Subscribe(contain interface{}) (chan interface{}, error) {
+	defer trace.End(trace.Begin(""))
+	containerSub, err := containerSubscriber(contain)
+	if err != nil {
+		return nil, err
+	}
+	cc.mu.Lock()
+	defer cc.mu.Unlock()
+
+	sub, exists := cc.subs[containerSub.ref]
+	if !exists {
+		// create a new publisher with 100ms timeout and no buffer
+		containerSub.publisher = pubsub.NewPublisher(100*time.Millisecond, 0)
+		cc.subs[containerSub.ref] = containerSub
+		sub = containerSub
+	}
+	// subscribe to this publisher -- a publisher can have multiple subscribers
+	ch := sub.publisher.Subscribe()
+	return ch, nil
+}
+
+// Unsubscribe unsubscribes from the container metrics publisher
+func (cc *collectorVM) Unsubscribe(contain interface{}, ch chan interface{}) {
+	defer trace.End(trace.Begin(""))
+	containerSub, err := containerSubscriber(contain)
+	if err != nil {
+		return
+	}
+	cc.mu.Lock()
+	defer cc.mu.Unlock()
+	sub, exists := cc.subs[containerSub.ref]
+	if exists {
+		sub.publisher.Evict(ch)
+		if sub.publisher.Len() == 0 {
+			delete(cc.subs, sub.ref)
+		}
+	}
+}
+
+// Subscribers returns the current subscribers
+func (cc *collectorVM) Subscribers() map[types.ManagedObjectReference]*subscriber {
+	current := make(map[types.ManagedObjectReference]*subscriber)
+	cc.mu.Lock()
+	defer cc.mu.Unlock()
+	for ref := range cc.subs {
+		current[ref] = cc.subs[ref]
+	}
+	return current
+}
+
+// SubscribeCount will return the current number of subscribers
+func (cc *collectorVM) SubscriberCount() int {
+	cc.mu.Lock()
+	defer cc.mu.Unlock()
+	return len(cc.subs)
+}
+
+// containerSubscriber is a helper func to convert the interface to a subscriber
+func containerSubscriber(contain interface{}) (*subscriber, error) {
+	container, ok := contain.(*exec.Container)
+	if !ok {
+		return nil, fmt.Errorf("invalid type provided for container stats request - got: %#v", contain)
+	}
+	info := container.Info()
+	moRef := info.VMReference()
+
+	// ensure we have a valid moRef..we won't worry about inspecting the details
+	if moRef.String() == "" {
+		return nil, fmt.Errorf("no vm associated with provided container(%s) stats request", container.ExecConfig.ID)
+	}
+
+	sub := &subscriber{
+		id:  info.ExecConfig.ID,
+		ref: moRef,
+	}
+
+	return sub, nil
+}

--- a/lib/portlayer/metrics/metrics.go
+++ b/lib/portlayer/metrics/metrics.go
@@ -1,0 +1,79 @@
+// Copyright 2017 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metrics
+
+import (
+	"context"
+	"sync"
+
+	"github.com/vmware/vic/pkg/trace"
+	"github.com/vmware/vic/pkg/vsphere/session"
+)
+
+var (
+	Supervisor *super
+
+	initializer struct {
+		err  error
+		once sync.Once
+	}
+)
+
+// super manages the lifecycle and access to the
+// available metrics collectors
+type super struct {
+	vms *collectorVM
+}
+
+type Collector interface {
+	// Subscribe to a stream of this collectors metrics
+	Subscribe(interface{}) (chan interface{}, error)
+	// Unsubscribe to a stream of this collectors metrics
+	Unsubscribe(interface{}, chan interface{})
+	// SubscriberCount returns the number of subscribers for the collector
+	SubscriberCount() int
+	// Sample will return metrics without a subscription
+	Sample(interface{}) (chan interface{}, error)
+}
+
+func Init(ctx context.Context, session *session.Session) error {
+	defer trace.End(trace.Begin(""))
+	initializer.once.Do(func() {
+		var err error
+		defer func() {
+			if err != nil {
+				initializer.err = err
+			}
+		}()
+		Supervisor = newSupervisor(session)
+
+	})
+	return initializer.err
+
+}
+
+func newSupervisor(session *session.Session) *super {
+	defer trace.End(trace.Begin(""))
+	// create the vm metric collector
+	v := newVMCollector(session)
+	return &super{
+		vms: v,
+	}
+}
+
+// VMCollector will return the vm metrics collector
+func (s *super) VMCollector() Collector {
+	return s.vms
+}

--- a/lib/portlayer/portlayer.go
+++ b/lib/portlayer/portlayer.go
@@ -22,6 +22,7 @@ import (
 	"github.com/vmware/vic/lib/portlayer/attach"
 	"github.com/vmware/vic/lib/portlayer/exec"
 	"github.com/vmware/vic/lib/portlayer/logging"
+	"github.com/vmware/vic/lib/portlayer/metrics"
 	"github.com/vmware/vic/lib/portlayer/network"
 	"github.com/vmware/vic/lib/portlayer/storage"
 	"github.com/vmware/vic/lib/portlayer/store"
@@ -90,6 +91,10 @@ func Init(ctx context.Context, sess *session.Session) error {
 	}
 
 	if err = logging.Init(ctx); err != nil {
+		return err
+	}
+
+	if err = metrics.Init(ctx, sess); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Initial implementation of docker stats.  This commit will
provide CPU & Memory stats -- disk / network will be addressed
in the future.

Additional refactored the custom container output handler to
be a generic streams handler.

Fixes #3965, #4171