### PR TITLE
[specific ci=1-32-Docker-Plugin] return nil error when docker plugin inspect is called

### DIFF
--- a/lib/apiservers/engine/backends/plugins.go
+++ b/lib/apiservers/engine/backends/plugins.go
@@ -44,7 +44,7 @@ func (p *Plugin) List() ([]enginetypes.Plugin, error) {
 }
 
 func (p *Plugin) Inspect(name string) (*enginetypes.Plugin, error) {
-	return nil, fmt.Errorf("%s does not yet support plugins", ProductName())
+	return nil, nil
 }
 
 func (p *Plugin) Remove(name string, config *enginetypes.PluginRmConfig) error {

--- a/tests/test-cases/Group1-Docker-Commands/1-32-Docker-Plugin.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-32-Docker-Plugin.robot
@@ -40,10 +40,10 @@ Docker plugin disable
     Should Be Equal As Integers  ${rc}  1
     Should Contain  ${output}  does not yet support plugins
 
-Docker plugin inspect
-    ${rc}  ${output}=  Run And Return Rc And Output  docker1.13 %{VCH-PARAMS} plugin inspect test-plugin
-    Should Be Equal As Integers  ${rc}  1
-    Should Contain  ${output}  does not yet support plugins
+# Docker plugin inspect
+    # ${rc}  ${output}=  Run And Return Rc And Output  docker1.13 %{VCH-PARAMS} plugin inspect test-plugin
+    # Should Be Equal As Integers  ${rc}  1
+    # Should Contain  ${output}  does not yet support plugins
 
 Docker plugin ls
     ${rc}  ${output}=  Run And Return Rc And Output  docker1.13 %{VCH-PARAMS} plugin ls

--- a/tests/test-cases/Group1-Docker-Commands/1-32-Docker-Plugin.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-32-Docker-Plugin.robot
@@ -41,7 +41,8 @@ Docker plugin disable
     Should Contain  ${output}  does not yet support plugins
 
 Docker plugin inspect
-    Pass execution  Test not implemented till plugin support is added
+    ${status}=  Get State Of Github Issue  4464
+    Run Keyword If  '${status}' == 'closed'  Fail  Test 1-32-Docker-Plugin.robot needs to be updated now that Issue #4464 has been resolved
 
 Docker plugin ls
     ${rc}  ${output}=  Run And Return Rc And Output  docker1.13 %{VCH-PARAMS} plugin ls

--- a/tests/test-cases/Group1-Docker-Commands/1-32-Docker-Plugin.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-32-Docker-Plugin.robot
@@ -40,10 +40,10 @@ Docker plugin disable
     Should Be Equal As Integers  ${rc}  1
     Should Contain  ${output}  does not yet support plugins
 
-# Docker plugin inspect
-    # ${rc}  ${output}=  Run And Return Rc And Output  docker1.13 %{VCH-PARAMS} plugin inspect test-plugin
-    # Should Be Equal As Integers  ${rc}  1
-    # Should Contain  ${output}  does not yet support plugins
+#Docker plugin inspect
+    #${rc}  ${output}=  Run And Return Rc And Output  docker1.13 %{VCH-PARAMS} plugin inspect test-plugin
+    #Should Be Equal As Integers  ${rc}  1
+    #Should Contain  ${output}  does not yet support plugins
 
 Docker plugin ls
     ${rc}  ${output}=  Run And Return Rc And Output  docker1.13 %{VCH-PARAMS} plugin ls

--- a/tests/test-cases/Group1-Docker-Commands/1-32-Docker-Plugin.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-32-Docker-Plugin.robot
@@ -40,10 +40,8 @@ Docker plugin disable
     Should Be Equal As Integers  ${rc}  1
     Should Contain  ${output}  does not yet support plugins
 
-#Docker plugin inspect
-    #${rc}  ${output}=  Run And Return Rc And Output  docker1.13 %{VCH-PARAMS} plugin inspect test-plugin
-    #Should Be Equal As Integers  ${rc}  1
-    #Should Contain  ${output}  does not yet support plugins
+Docker plugin inspect
+    Pass execution  Test not implemented till plugin support is added
 
 Docker plugin ls
     ${rc}  ${output}=  Run And Return Rc And Output  docker1.13 %{VCH-PARAMS} plugin ls


### PR DESCRIPTION
This fixes #4322 

The reason can be found here https://github.com/vmware/vic/issues/4322#issuecomment-288255042

This is a temporary workaround before we actually support `docker plugin inspect`