### PR TITLE
Make UI installer work with vic-ui-plugins in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -406,10 +406,10 @@ ENV_FLEX_SDK_HOME = "/tmp/sdk/flex_sdk_min"
 ENV_HTML_SDK_HOME = "/tmp/sdk/html-client-sdk"
 
 vic-ui-plugins:
-	@npm install -g yarn
-	sed "s/0.0.1/$(TAG_NUM)/" ./$(VICUI_SOURCE_PATH)/plugin-package.xml > ./$(VICUI_SOURCE_PATH)/new_plugin-package.xml
-	sed "s/1.0.0/$(TAG_NUM)/" ./$(VICUI_H5_UI_PATH)/plugin-package.xml > ./$(VICUI_H5_UI_PATH)/new_plugin-package.xml
-	sed "s/UI_VERSION_PLACEHOLDER/$(TAG)/" ./$(VICUI_H5_SERVICE_PATH)/src/main/resources/configs.properties > ./$(VICUI_H5_SERVICE_PATH)/src/main/resources/new_configs.properties
+	@npm install -g yarn > /dev/null
+	sed "s/0.0.1/$(shell printf %s ${TAG_NUM})/" ./$(VICUI_SOURCE_PATH)/plugin-package.xml > ./$(VICUI_SOURCE_PATH)/new_plugin-package.xml
+	sed "s/0.0.1/$(shell printf %s ${TAG_NUM})/" ./$(VICUI_H5_UI_PATH)/plugin-package.xml > ./$(VICUI_H5_UI_PATH)/new_plugin-package.xml
+	sed "s/UI_VERSION_PLACEHOLDER/$(shell printf %s ${TAG})/" ./$(VICUI_H5_SERVICE_PATH)/src/main/resources/configs.properties > ./$(VICUI_H5_SERVICE_PATH)/src/main/resources/new_configs.properties
 	rm ./$(VICUI_SOURCE_PATH)/plugin-package.xml ./$(VICUI_H5_UI_PATH)/plugin-package.xml ./$(VICUI_H5_SERVICE_PATH)/src/main/resources/configs.properties
 	mv ./$(VICUI_SOURCE_PATH)/new_plugin-package.xml ./$(VICUI_SOURCE_PATH)/plugin-package.xml
 	mv ./$(VICUI_H5_UI_PATH)/new_plugin-package.xml ./$(VICUI_H5_UI_PATH)/plugin-package.xml

--- a/installer/scripts/build-bundle.sh
+++ b/installer/scripts/build-bundle.sh
@@ -74,9 +74,8 @@ fi
 if [ -d "$bin_dir/ui/vCenterForWindows" ]; then
     cp -r $bin_dir/ui/vCenterForWindows $TEMP_DIR/ui
 fi
-if [ -d "$bin_dir/ui/plugin-packages" ]; then
-    find "$bin_dir/ui/plugin-packages" -name "vc_extension_flags" -exec cp {} $TEMP_DIR/ui \;
-    mv $TEMP_DIR/ui/vc_extension_flags $TEMP_DIR/ui/plugin-manifest
+if [ -f "$bin_dir/ui/plugin-manifest" ]; then
+    cp $bin_dir/ui/plugin-manifest $TEMP_DIR/ui/
 fi
 
 tar czvf $outfile -C $TEMP_DIR . >/dev/null 2>&1

--- a/ui/installer/HTML5Client/configs
+++ b/ui/installer/HTML5Client/configs
@@ -1,10 +1,6 @@
 # Enter the IP of VCSA
 VCENTER_IP=""
 
-WEBCLIENT_PLUGINS_FOLDER="/usr/lib/vmware-vsphere-ui/plugin-packages/"
-
-# Update the following lines if you have a local web server that is accessible from your VCSA and VIC UI zip files are uploaded to it
-
 # Change the following line to the full URL of the path where the zip files are located
 # For example, if vic-ui.zip is available at https://192.168.1.5/vic-ui-plugins/vic-ui.zip, type in: https://192.168.1.5/vic-ui-plugins/
 # Note: each uploaded zip file will be accessed only once when the user logs into vSphere Web Client for the first time after successful installation
@@ -12,3 +8,6 @@ VIC_UI_HOST_URL="NOURL"
 
 # If VIC_UI_HOST_URL starts with "https", enter SHA-1 thumbprint of the web server hosting the vic-ui.zip file
 VIC_UI_HOST_THUMBPRINT=""
+
+# WARNING: VIC UI Flex plugin can run on a vCenter 5.5 setup, but is not officially supported. Use it with your own risk. If you wish to continue change the value from 0 to 1
+IS_VCENTER_5_5=0

--- a/ui/installer/HTML5Client/uninstall.sh
+++ b/ui/installer/HTML5Client/uninstall.sh
@@ -14,26 +14,43 @@
 # limitations under the License.
 #
 
+# check for the configs file
 if [[ ! -f "configs" ]] ; then
     echo "Error! Configs file is missing. Please try downloading the VIC UI installer again"
     echo ""
     exit 1
 fi
 
-CONFIGS_FILE="configs"
+# load configs variable into env
 while IFS='' read -r line; do
     eval $line
-done < $CONFIGS_FILE
+done < ./configs
 
+# check for the VC IP
 if [[ $VCENTER_IP == "" ]] ; then
     echo "Error! vCenter IP cannot be empty. Please provide a valid IP in the configs file"
     exit 1
 fi
 
+# check for the pllugin manifest file
+if [[ ! -f ../plugin-manifest ]] ; then
+    echo "Error! Plugin manifest was not found!"
+    cleanup
+    exit 1
+fi
+
+# load plugin manifest into env
+while IFS='' read -r p_line; do
+    eval "$p_line"
+done < ../plugin-manifest
+
 read -p "Enter your vCenter Administrator Username: " VCENTER_ADMIN_USERNAME
 echo -n "Enter your vCenter Administrator Password: "
 read -s VCENTER_ADMIN_PASSWORD
 echo ""
+# TODO: we eventually want to have only one folder that handles both VCSA 6.5 and VCSA 6.0' so the ui/installer will have VCSA and vCenterForWindows folders
+# by default installer will default to h5c plugin as it's in the HTML5Client folder
+# read -p "Plugin to Install (flex/html5): " plugin_type
 
 OS=$(uname)
 PLUGIN_BUNDLES=''
@@ -48,9 +65,13 @@ else
 fi
 
 check_prerequisite () {
-    if [[ ! -d ../plugin-packages ]] ; then
-        echo "Error! VIC UI plugin bundle was not found. Please try downloading the VIC UI installer again"
-        exit 1
+    # if plugin_type is not specified default to html5 plugin
+    if [[ $plugin_type = 'flex' ]] ; then
+        plugin_type=flex
+        key=$key_flex
+    else
+        plugin_type=html5
+        key=$key_h5c
     fi
 
     if [[ $(curl -v --head https://$VCENTER_IP -k 2>&1 | grep -i "could not resolve host") ]] ; then
@@ -60,33 +81,15 @@ check_prerequisite () {
 }
 
 parse_and_unregister_plugins () {
-    for d in ../plugin-packages/* ; do
-        if [[ -d $d ]] ; then
-            echo "Reading plugin-package.xml..."
+    local plugin_flags="--key $key"
+    echo "-------------------------------------------------------------"
+    echo "Unregistering vCenter Server Extension..."
+    echo "-------------------------------------------------------------"
+    $PLUGIN_MANAGER_BIN remove $COMMONFLAGS $plugin_flags
 
-            while IFS='' read -r p_line; do
-                eval "local $p_line"
-            done < $d/vc_extension_flags
-
-            local plugin_flags="--key $key"
-            echo "-------------------------------------------------------------"
-            echo "Unregistering vCenter Server Extension..."
-            echo "-------------------------------------------------------------"
-            $PLUGIN_MANAGER_BIN remove $COMMONFLAGS $plugin_flags
-
-            if [[ $? > 0 ]] ; then
-                echo "-------------------------------------------------------------"
-                echo "Error! Could not unregister plugin from vCenter Server. Please see the message above."
-                exit 1
-            fi
-        fi
-    done
-}
-
-rename_package_folder () {
-    mv $1 $2
     if [[ $? > 0 ]] ; then
-        echo "Error! Could not rename folder"
+        echo "-------------------------------------------------------------"
+        echo "Error! Could not unregister plugin from vCenter Server. Please see the message above."
         exit 1
     fi
 }

--- a/ui/vic-ui-h5c/build-deployable.xml
+++ b/ui/vic-ui-h5c/build-deployable.xml
@@ -20,7 +20,7 @@
    <property name="SERVICE_MODULE_DIR" value="${basedir}/../${PROJECT_NAME}-service"/>
    <xmlproperty file="${H5_PROJECT_UI_HOME}/plugin-package.xml"/>
    <property name="PACKAGE_HOME" value="${basedir}/../installer/plugin-packages"/>
-   <property name="PACKAGE_NAME" value="${PACKAGE_HOME}/${pluginPackage(id)}-${pluginPackage(version)}.zip"/>
+   <property name="PACKAGE_NAME" value="${PACKAGE_HOME}/${pluginPackage(id)}-v${pluginPackage(version)}.zip"/>
 
    <!-- Check if SDKs are found -->
    <target name="check-sdks">
@@ -75,17 +75,13 @@
       <copy file="${VSPHERE_H5C_SDK_HOME}/vsphere-ui/server/repository/usr/vlsiCore.jar" tofile="${H5_PROJECT_UI_HOME}/target/vic/plugins/vlsiCore.jar"/>
       <delete dir="${basedir}/../installer/plugin-packages"/>
       <zip basedir="${H5_PROJECT_UI_HOME}/target/vic" destfile="${PACKAGE_NAME}"/>
-      <copy todir="${PACKAGE_HOME}/${pluginPackage(id)}-${pluginPackage(version)}">
+      <copy todir="${PACKAGE_HOME}/${pluginPackage(id)}-v${pluginPackage(version)}">
          <fileset dir="${H5_PROJECT_UI_HOME}/target/vic"/>
       </copy>
-      <echo file="${PACKAGE_HOME}/${pluginPackage(id)}-${pluginPackage(version)}/vc_extension_flags">key="${pluginPackage(id)}"
-name="${pluginPackage(name)}"
-version="${pluginPackage(version)}"
-summary="${pluginPackage(description)}"
-company="${pluginPackage(vendor)}"
-      </echo>
+      <echo file="${basedir}/../installer/plugin-manifest" append="true">key_h5c="${pluginPackage(id)}"
+</echo>
       <delete dir="${DEPLOY_DIR}"/>
-      <echo>${pluginPackage(id)} ${pluginPackage(version)}</echo>
+      <echo>${pluginPackage(id)} v${pluginPackage(version)}</echo>
       <echo>${PACKAGE_NAME} was created</echo>
    </target>
 

--- a/ui/vic-ui-h5c/vic/plugin-package.xml
+++ b/ui/vic-ui-h5c/vic/plugin-package.xml
@@ -9,7 +9,7 @@
    type: keep "html" for this plugin to be deployed in the vSphere HTML client.
    name: short name displayed in the Administration < Client plugins view
 -->
-<pluginPackage id="com.vmware.vic" version="1.0.0" type="html" name="VicUI"
+<pluginPackage id="com.vmware.vic" version="0.0.1" type="html" name="VicUI"
       description="VicUI" vendor="VMware">
 
    <dependencies>

--- a/ui/vic-ui/build-deployable.xml
+++ b/ui/vic-ui/build-deployable.xml
@@ -87,18 +87,18 @@
       <copy file="${basedir}/plugin-package.xml" tofile="${DEPLOY_DIR}/plugin-package.xml"/>
       <copy file="${VSPHERE_SDK_HOME}/libs/vim25.jar" tofile="${DEPLOY_DIR}/plugins/vim25.jar"/>
       <delete dir="${basedir}/../installer/vsphere-client-serenity"/>
-      <zip basedir="${DEPLOY_DIR}" destfile="${basedir}/../installer/vsphere-client-serenity/${pluginPackage(id)}-${pluginPackage(version)}.zip"/>
-      <copy todir="${basedir}/../installer/vsphere-client-serenity/${pluginPackage(id)}-${pluginPackage(version)}">
+      <zip basedir="${DEPLOY_DIR}" destfile="${basedir}/../installer/vsphere-client-serenity/${pluginPackage(id)}-v${pluginPackage(version)}.zip"/>
+      <copy todir="${basedir}/../installer/vsphere-client-serenity/${pluginPackage(id)}-v${pluginPackage(version)}">
          <fileset dir="${DEPLOY_DIR}"/>
       </copy>
-      <echo file="${basedir}/../installer/vsphere-client-serenity/${pluginPackage(id)}-${pluginPackage(version)}/vc_extension_flags">key="${pluginPackage(id)}"
+      <echo file="${basedir}/../installer/plugin-manifest">key_flex="${pluginPackage(id)}"
 name="${pluginPackage(name)}"
 version="${pluginPackage(version)}"
 summary="${pluginPackage(description)}"
 company="${pluginPackage(vendor)}"
-      </echo>
+</echo>
       <delete dir="${DEPLOY_DIR}"/>
-      <echo>${pluginPackage(id)} ${pluginPackage(version)}</echo>
+      <echo>${pluginPackage(id)} v${pluginPackage(version)}</echo>
       <echo>${PROJECT_NAME}.zip was created under ${basedir}</echo>
    </target>
    


### PR DESCRIPTION
This PR doesn't change the existing functionality, but simply refactors it for later improvement: Currently we have `VCSA`, `HTML5Client` and `vCenterForWindows` under `ui/installer` but eventually there would only be VCSA and vCenterForWindows, as HTML5Client itself is not a platform and is a bit misleading.

Fixes #4465 