### PR TITLE
[specific-ci Group1-Docker-Commands/1-37-Docker-USER] Create integration test for USER directive in Dockerfiles

### DIFF
--- a/tests/resources/dockerfiles/Dockerfile.1-37-Docker-USER-NewUser:NewGroup
+++ b/tests/resources/dockerfiles/Dockerfile.1-37-Docker-USER-NewUser:NewGroup
@@ -1,0 +1,4 @@
+FROM busybox:latest
+RUN addgroup newuser && adduser -H -S newuser -G newuser
+USER newuser
+CMD id

--- a/tests/resources/dockerfiles/Dockerfile.1-37-Docker-USER-UID-2000
+++ b/tests/resources/dockerfiles/Dockerfile.1-37-Docker-USER-UID-2000
@@ -1,0 +1,3 @@
+FROM busybox:latest
+USER 2000
+CMD id

--- a/tests/resources/dockerfiles/Dockerfile.1-37-Docker-USER-UID:GID-2000:2000
+++ b/tests/resources/dockerfiles/Dockerfile.1-37-Docker-USER-UID:GID-2000:2000
@@ -1,0 +1,3 @@
+from busybox:latest
+user 2000:2000
+cmd id

--- a/tests/test-cases/Group1-Docker-Commands/1-37-Docker-USER.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-37-Docker-USER.robot
@@ -1,0 +1,36 @@
+# Copyright 2016-2017 VMware, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#	http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License
+
+*** Settings ***
+Documentation   Test 1-37 - Docker Run As USER
+Resource        ../../resources/Util.robot
+Suite Setup     Install VIC Appliance To Test Server
+Suite Teardown  Cleanup VIC Appliance On Test Server
+
+*** Test Cases ***
+Run as NewUser in NewGroup
+     ${rc}    ${output}=    Run And Return Rc And Output    docker %{VCH-PARAMS} run gigawhitlocks/1-37-docker-user-newuser-newgroup:latest
+     Should Be Equal As Integers    ${rc}       0
+     Should Match Regexp            ${output}   uid=\\d+\\\(newuser\\\)\\s+gid=\\d+\\\(newuser\\\)\\s+groups=\\d+\\\(newuser\\\)
+
+Run as UID 2000
+     ${rc}    ${output}=    Run And Return Rc And Output    docker %{VCH-PARAMS} run gigawhitlocks/1-37-docker-user-uid-2000:latest
+     Should Be Equal As Integers    ${rc}       0
+     Should Contain                 ${output}   uid=2000 gid=0(root)
+
+Run as UID:GID 2000:2000
+     ${rc}    ${output}=    Run And Return Rc And Output    docker %{VCH-PARAMS} run gigawhitlocks/1-37-docker-user-uid-gid-2000-2000:latest
+     Should Be Equal As Integers    ${rc}       0
+     Should Contain                 ${output}   uid=2000 gid=2000
+


### PR DESCRIPTION
Addressing #4394 , this PR contains 3 dockerfiles (which I've published as images to DockerHub but the dockerfiles are checked into `resources/` for future reference) and 3 tests to make sure that `USER` works as expected

Emma laid out a few other test cases, but a few of them do not make sense or are redundant:

- nonexist
- nonexist:nonexist
- root:nonexist

None of these are possible, you cannot be a named user that doesn't exist on a Linux system as far as I am aware. Testing confirmed this hypothesis in vanilla Docker. 

- root:root

Redundant since this is the default if USER isn't specified; normal `Docker Run` tests basically test this

- 0:0

Root is uid 0, see above

- newuser:newgroup
- 2000
- 2000:2000

Tests for these are present in this change