### PR TITLE
[specific ci=1-37-Docker-USER] Create integration test for USER directive in Dockerfiles

### DIFF
--- a/tests/resources/dockerfiles/Dockerfile.1-37-Docker-USER-NewUser:NewGroup
+++ b/tests/resources/dockerfiles/Dockerfile.1-37-Docker-USER-NewUser:NewGroup
@@ -1,0 +1,4 @@
+FROM busybox:latest
+RUN addgroup newuser && adduser -H -S newuser -G newuser
+USER newuser
+CMD id

--- a/tests/resources/dockerfiles/Dockerfile.1-37-Docker-USER-UID-2000
+++ b/tests/resources/dockerfiles/Dockerfile.1-37-Docker-USER-UID-2000
@@ -1,0 +1,3 @@
+FROM busybox:latest
+USER 2000
+CMD id

--- a/tests/resources/dockerfiles/Dockerfile.1-37-Docker-USER-UID:GID-2000:2000
+++ b/tests/resources/dockerfiles/Dockerfile.1-37-Docker-USER-UID:GID-2000:2000
@@ -1,0 +1,3 @@
+from busybox:latest
+user 2000:2000
+cmd id

--- a/tests/test-cases/Group1-Docker-Commands/1-37-Docker-USER.md
+++ b/tests/test-cases/Group1-Docker-Commands/1-37-Docker-USER.md
@@ -1,0 +1,34 @@
+Test 1-37 - Docker USER
+=======
+
+#Purpose:
+To ensure that `docker run -u` and `USER` inside of a Dockerfile are respected on VIC.
+
+#References:
+[1 - Dockerfile Reference -- USER directive]( https://docs.docker.com/engine/reference/builder/#user )
+[2 - Docker command line reference (run options; look for --user)](https://docs.docker.com/engine/reference/commandline/run/#options)
+
+#Environment:
+This test requires that a vSphere server is running and available
+
+It also expects 3 Docker images exist, built from the Dockerfiles in vic/tests/resources/dockerfiles and published to a Docker image repository reachable by the machine running tests.
+
+#Test Steps:
+1. Run a container that was built with a `USER` directive using a user created with `RUN adduser`
+2. Run a container that specifies the user should have UID 2000 and doesn't specify GID
+3. Run a container that does not specify a user and set it manually with `docker run -u`
+4. Run a container that specifies UID 2000 and GID 2000
+5. Run a container that does not specify a user or group but set them manually with `docker run -u`
+6. Try to run a container with `-u` specifying a nonexistent user
+7. Try to run a container with `-u` specifying a nonexistent group
+8. Run a container specifying `-u 0:0`
+
+#Expected Outcome:
+1-5 should run successfully with the options specified taking effect inside the container and reflected via `id` or `whoami` output
+6 & 7 will fail with exit code 125 and an error message
+8 will run successfully and `whoami` will report the user `root`
+
+
+
+#Possible Problems:
+Docker image repository downtime or unreachability will cause failure on the tests that pull images from Docker Hub

--- a/tests/test-cases/Group1-Docker-Commands/1-37-Docker-USER.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-37-Docker-USER.robot
@@ -1,4 +1,4 @@
-# Copyright 2016-2017 VMware, Inc. All Rights Reserved.
+# Copyright 2017 VMware, Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,18 +19,42 @@ Suite Setup     Install VIC Appliance To Test Server
 Suite Teardown  Cleanup VIC Appliance On Test Server
 
 *** Test Cases ***
-Run as NewUser in NewGroup
-     ${rc}    ${output}=    Run And Return Rc And Output    docker %{VCH-PARAMS} run gigawhitlocks/1-37-docker-user-newuser-newgroup:latest
-     Should Be Equal As Integers    ${rc}       0
-     Should Match Regexp            ${output}   uid=\\d+\\\(newuser\\\)\\s+gid=\\d+\\\(newuser\\\)\\s+groups=\\d+\\\(newuser\\\)
+Run Image Specifying NewUser in NewGroup
+    ${rc}    ${output}=    Run And Return Rc And Output    docker %{VCH-PARAMS} run gigawhitlocks/1-37-docker-user-newuser-newgroup:latest
+    Should Be Equal As Integers    ${rc}       0
+    Should Match Regexp            ${output}   uid=\\d+\\\(newuser\\\)\\s+gid=\\d+\\\(newuser\\\)\\s+groups=\\d+\\\(newuser\\\)
 
-Run as UID 2000
-     ${rc}    ${output}=    Run And Return Rc And Output    docker %{VCH-PARAMS} run gigawhitlocks/1-37-docker-user-uid-2000:latest
-     Should Be Equal As Integers    ${rc}       0
-     Should Contain                 ${output}   uid=2000 gid=0(root)
+Run Image Specifying UID 2000
+    ${rc}    ${output}=    Run And Return Rc And Output    docker %{VCH-PARAMS} run gigawhitlocks/1-37-docker-user-uid-2000:latest
+    Should Be Equal As Integers    ${rc}       0
+    Should Contain                 ${output}   uid=2000 gid=0(root)
 
-Run as UID:GID 2000:2000
-     ${rc}    ${output}=    Run And Return Rc And Output    docker %{VCH-PARAMS} run gigawhitlocks/1-37-docker-user-uid-gid-2000-2000:latest
-     Should Be Equal As Integers    ${rc}       0
-     Should Contain                 ${output}   uid=2000 gid=2000
+Run Specifying UID 2000 With -u
+    ${rc}    ${output}=    Run And Return Rc And Output    docker %{VCH-PARAMS} run -u 2000 busybox id
+    Should Be Equal As Integers    ${rc}       0
+    Should Contain                 ${output}   uid=2000 gid=0(root)
 
+Run Image Specifying UID:GID 2000:2000
+    ${rc}    ${output}=    Run And Return Rc And Output    docker %{VCH-PARAMS} run gigawhitlocks/1-37-docker-user-uid-gid-2000-2000:latest
+    Should Be Equal As Integers    ${rc}       0
+    Should Contain                 ${output}   uid=2000 gid=2000
+
+Run Specifying UID:GID 2000:2000 With -u
+    ${rc}    ${output}=    Run And Return Rc And Output    docker %{VCH-PARAMS} run -u 2000:2000 busybox id
+    Should Be Equal As Integers    ${rc}       0
+    Should Contain                 ${output}   uid=2000 gid=2000
+
+Run as Nonexistent User With -u
+    ${rc}    ${output}=    Run And Return Rc And Output    docker %{VCH-PARAMS} run -u nonexistent busybox whoami
+    Should Be Equal As Integers    ${rc}       125
+    Should Contain                 ${output}   Unable to find user nonexistent
+
+Run as Root with Nonexistent User With -u
+    ${rc}    ${output}=    Run And Return Rc And Output    docker %{VCH-PARAMS} run -u root:nonexistent busybox whoami
+    Should Be Equal As Integers    ${rc}       125
+    Should Contain                 ${output}   Unable to find group nonexistent
+
+Run as uid 0 group 0 With -u
+    ${rc}    ${output}=    Run And Return Rc And Output    docker %{VCH-PARAMS} run -u 0:0 busybox whoami
+    Should Be Equal As Integers    ${rc}       0
+    Should Contain                 ${output}   root

--- a/tests/test-cases/Group1-Docker-Commands/1-37-Docker-USER.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-37-Docker-USER.robot
@@ -58,4 +58,3 @@ Run as uid 0 group 0 With -u
     ${rc}    ${output}=    Run And Return Rc And Output    docker %{VCH-PARAMS} run -u 0:0 busybox whoami
     Should Be Equal As Integers    ${rc}       0
     Should Contain                 ${output}   root
-

--- a/tests/test-cases/Group1-Docker-Commands/1-37-Docker-USER.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-37-Docker-USER.robot
@@ -58,3 +58,4 @@ Run as uid 0 group 0 With -u
     ${rc}    ${output}=    Run And Return Rc And Output    docker %{VCH-PARAMS} run -u 0:0 busybox whoami
     Should Be Equal As Integers    ${rc}       0
     Should Contain                 ${output}   root
+

--- a/tests/test-cases/Group1-Docker-Commands/1-37-Docker-USER.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-37-Docker-USER.robot
@@ -1,0 +1,36 @@
+# Copyright 2016-2017 VMware, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#	http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License
+
+*** Settings ***
+Documentation   Test 1-37 - Docker Run As USER
+Resource        ../../resources/Util.robot
+Suite Setup     Install VIC Appliance To Test Server
+Suite Teardown  Cleanup VIC Appliance On Test Server
+
+*** Test Cases ***
+Run as NewUser in NewGroup
+     ${rc}    ${output}=    Run And Return Rc And Output    docker %{VCH-PARAMS} run gigawhitlocks/1-37-docker-user-newuser-newgroup:latest
+     Should Be Equal As Integers    ${rc}       0
+     Should Match Regexp            ${output}   uid=\\d+\\\(newuser\\\)\\s+gid=\\d+\\\(newuser\\\)\\s+groups=\\d+\\\(newuser\\\)
+
+Run as UID 2000
+     ${rc}    ${output}=    Run And Return Rc And Output    docker %{VCH-PARAMS} run gigawhitlocks/1-37-docker-user-uid-2000:latest
+     Should Be Equal As Integers    ${rc}       0
+     Should Contain                 ${output}   uid=2000 gid=0(root)
+
+Run as UID:GID 2000:2000
+     ${rc}    ${output}=    Run And Return Rc And Output    docker %{VCH-PARAMS} run gigawhitlocks/1-37-docker-user-uid-gid-2000-2000:latest
+     Should Be Equal As Integers    ${rc}       0
+     Should Contain                 ${output}   uid=2000 gid=2000
+


### PR DESCRIPTION
Addressing #4394 this tests USER in a Dockerfile as well as `-u` on the command line
