### PR TITLE
handling vspc security/robustness against malformed data

### DIFF
--- a/lib/vspc/handlers.go
+++ b/lib/vspc/handlers.go
@@ -37,9 +37,16 @@ type handler struct {
 func (h *handler) dataHdlr(w io.Writer, b []byte, tc *telnet.Conn) {
 	cvm, exists := h.vspc.cvmFromTelnetConn(tc)
 	if !exists {
-		log.Errorf("vspc datahandler cannot find the vm with the provided data")
+		// the fsm will sense the closed connecrion and perform the necessary cleanup
+		if tc.UnderlyingConnection() != nil {
+			log.Errorln("cannot find a vm associated with this connection.")
+			log.Infoln("closing connection")
+			tc.UnderlyingConnection().Close()
+		}
+		return
 	}
 	cvm.remoteConn.Write(b)
+
 }
 
 // CmdHdlr is the telnet command handler

--- a/pkg/telnet/connection.go
+++ b/pkg/telnet/connection.go
@@ -125,6 +125,11 @@ func newConn(opts *connOpts) *Conn {
 	return tc
 }
 
+//UnderlyingConnection returns the underlying TCP connection
+func (c *Conn) UnderlyingConnection() net.Conn {
+	return c.conn
+}
+
 func (c *Conn) writeLoop() {
 	log.Debugf("entered write loop")
 	for {
@@ -149,10 +154,11 @@ func (c *Conn) startNegotiation() {
 	}
 }
 
-// Close closes the telnet connection
-func (c *Conn) Close() {
+// close closes the telnet connection
+func (c *Conn) close() {
 	c.closedMutex.Lock()
 	defer c.closedMutex.Unlock()
+
 	c.closed = true
 	log.Infof("Closing the connection")
 	c.conn.Close()

--- a/pkg/telnet/fsm.go
+++ b/pkg/telnet/fsm.go
@@ -56,7 +56,7 @@ func (fsm *fsm) start() {
 		}
 		if err != nil {
 			log.Debugf("connection read: %v", err)
-			fsm.tc.Close()
+			fsm.tc.close()
 			break
 		}
 	}


### PR DESCRIPTION
Fixes #4493 

Handling malformed data was tested by running the following command multiple times:
`cat /dev/random | nc -v endpoint-ip 2377 > /dev/null`

Proper connection clean-up in addition to continued normal operation of the vspc were examined
