### PR TITLE
Use ComputeResource as search root in vic-machine ls

### DIFF
--- a/cmd/vic-machine/list/list.go
+++ b/cmd/vic-machine/list/list.go
@@ -178,7 +178,7 @@ func (l *List) Run(clic *cli.Context) (err error) {
 		return errors.New("list failed")
 	}
 	executor := management.NewDispatcher(validator.Context, validator.Session, nil, false)
-	vchs, err := executor.SearchVCHs(validator.ResourcePoolPath)
+	vchs, err := executor.SearchVCHs(validator.ClusterPath)
 	if err != nil {
 		log.Errorf("List cannot continue - failed to search VCHs in %s: %s", validator.ResourcePoolPath, err)
 	}


### PR DESCRIPTION
Using the ResourcePool as search root here does not work on VC,
due to VirtualApp being the immediate child.

From #4483 