### PR TITLE
[skip ci] vMotion and NSX nightlies test fix

### DIFF
--- a/tests/manual-test-cases/Group13-vMotion/13-2-vMotion-Container.robot
+++ b/tests/manual-test-cases/Group13-vMotion/13-2-vMotion-Container.robot
@@ -36,10 +36,14 @@ Test
     Should Be Equal As Integers  ${rc}  0
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} start ${container3}
     Should Be Equal As Integers  ${rc}  0
-
-    vMotion A VM  %{VCH-NAME}/*-${container1}
-    vMotion A VM  %{VCH-NAME}/*-${container2}
-    vMotion A VM  %{VCH-NAME}/*-${container3}
+    
+    ${vmName1}=  Get VM display name  ${container1}
+    ${vmName2}=  Get VM display name  ${container2}
+    ${vmName3}=  Get VM display name  ${container3}
+    
+    vMotion A VM  %{VCH-NAME}/${vmName1}
+    vMotion A VM  %{VCH-NAME}/${vmName2}
+    vMotion A VM  %{VCH-NAME}/${vmName3}
     
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} start ${container1}
     Should Be Equal As Integers  ${rc}  0

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-7-NSX.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-7-NSX.robot
@@ -19,12 +19,12 @@ Resource  ../../resources/Util.robot
 *** Test Cases ***
 Test
     Log To Console  Set environment variables up for GOVC
-    Set Environment Variable  GOVC_URL  10.162.28.218
+    Set Environment Variable  GOVC_URL  10.162.48.133
     Set Environment Variable  GOVC_USERNAME  Administrator@vsphere.local
     Set Environment Variable  GOVC_PASSWORD  Admin\!23
 
     Log To Console  Deploy VIC to the VC cluster
-    Set Environment Variable  TEST_URL_ARRAY  10.162.28.218
+    Set Environment Variable  TEST_URL_ARRAY  10.162.48.133
     Set Environment Variable  TEST_USERNAME  Administrator@vsphere.local
     Set Environment Variable  TEST_PASSWORD  Admin\!23
     Set Environment Variable  BRIDGE_NETWORK  DPortGroup


### PR DESCRIPTION
Updating the vMotion tests to use the short VM display name.
And the NSX test to use a new test bed.

Fixes #4604

