### PR TITLE
Use the correct function to detect a FileNotFound issue during kvstore save operation

### DIFF
--- a/pkg/kvstore/backend.go
+++ b/pkg/kvstore/backend.go
@@ -23,7 +23,6 @@ import (
 
 	log "github.com/Sirupsen/logrus"
 
-	"github.com/vmware/govmomi/vim25/soap"
 	"github.com/vmware/govmomi/vim25/types"
 	"github.com/vmware/vic/pkg/retry"
 	"github.com/vmware/vic/pkg/vsphere/datastore"
@@ -59,10 +58,11 @@ func (d *dsBackend) Save(ctx context.Context, r io.Reader, path string) error {
 
 	// we will reattempt the move since it might take some time for the upload to replicate before presenting on VSAN.
 	// XXX: This is a workaround until the VSAN fixes the bug where they return a successful upload before replication finishes.
-	if err := retry.Do(moveOperation, isFileFault); err != nil {
+	if err := retry.Do(moveOperation, types.IsFileNotFound); err != nil {
 		log.Debugf("failed to move file (%s) to (%s) after attempting to recover from a FileNotFoundFault with error (%s) during a kv store save operation.", tmpfile, path, err.Error())
 		return err
 	}
+
 	return nil
 }
 
@@ -84,16 +84,4 @@ func (d *dsBackend) Load(ctx context.Context, path string) (io.ReadCloser, error
 	log.Debugf("kv store download of file (%s) was successful", path)
 
 	return rc, err
-}
-
-func isFileFault(err error) bool {
-	if soap.IsVimFault(err) {
-		switch soap.ToVimFault(err).(type) {
-		case *types.FileNotFound:
-			return true
-		default:
-			return false
-		}
-	}
-	return false
 }

--- a/pkg/kvstore/backend.go
+++ b/pkg/kvstore/backend.go
@@ -62,7 +62,6 @@ func (d *dsBackend) Save(ctx context.Context, r io.Reader, path string) error {
 		log.Debugf("failed to move file (%s) to (%s) after attempting to recover from a FileNotFoundFault with error (%s) during a kv store save operation.", tmpfile, path, err.Error())
 		return err
 	}
-
 	return nil
 }
 


### PR DESCRIPTION
Fixes #4601 

This is a temporary fix to the exponential backoff retry of the move operation during a kvstore save call against vsphere. The original fix did not actually catch the appropriate fault leaving us susceptible to this failure. Now we are catching the correct fault and retrying until we time out or the file presents itself. This is not ideal in the long run, but the proposed solutions in #4601 will require more time to fix. 

