### PR TITLE
[specific ci=6-07-Create-Network] Change FAILURE error msg with correct expected ERROR msg.

### DIFF
--- a/tests/test-cases/Group6-VIC-Machine/6-07-Create-Network.robot
+++ b/tests/test-cases/Group6-VIC-Machine/6-07-Create-Network.robot
@@ -224,7 +224,8 @@ Bridge network - vCenter none
     Run Keyword And Ignore Error  Cleanup Datastore On Test Server
 
     ${output}=  Run  bin/vic-machine-linux create --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --image-store=%{TEST_DATASTORE} ${vicmachinetls}
-    Should Contain  ${output}  FAILURE
+    Should Contain  ${output}  ERROR
+    Should Contain  ${output}  An existing distributed port group must be specified for bridge network on vCenter
 
     # Delete the portgroup added by env vars keyword
     Cleanup VCH Bridge Network  %{VCH-NAME}


### PR DESCRIPTION
Changed the expected check from a FAILURE message to an ERROR message.  We now look for "ERROR An existing distributed port group must be specified for bridge network on vCenter" instead of "FAILURE" in the output.

Fixes #4547 
