### PR TITLE
don't publish detach event on an attach and provide exit code with die event

### DIFF
--- a/lib/apiservers/engine/backends/container.go
+++ b/lib/apiservers/engine/backends/container.go
@@ -1589,13 +1589,13 @@ func (c *Container) containerAttach(name string, ca *backend.ContainerAttachConf
 
 	actor := CreateContainerEventActorWithAttributes(vc, map[string]string{})
 	EventService().Log(containerAttachEvent, eventtypes.ContainerEventType, actor)
-	defer func() {
-		actor := CreateContainerEventActorWithAttributes(vc, map[string]string{})
-		EventService().Log(containerDetachEvent, eventtypes.ContainerEventType, actor)
-	}()
 	err = c.containerProxy.AttachStreams(context.Background(), vc, clStdin, clStdout, clStderr, ca)
 	if err != nil {
 		if _, ok := err.(DetachError); ok {
+			// fire detach event
+			actor := CreateContainerEventActorWithAttributes(vc, map[string]string{})
+			EventService().Log(containerDetachEvent, eventtypes.ContainerEventType, actor)
+
 			log.Infof("Detach detected, tearing down connection")
 			client = c.containerProxy.Client()
 			handle, err = c.Handle(id, name)

--- a/lib/apiservers/engine/backends/container_test.go
+++ b/lib/apiservers/engine/backends/container_test.go
@@ -341,6 +341,9 @@ func (m *MockContainerProxy) AttachStreams(ctx context.Context, vc *viccontainer
 func (m *MockContainerProxy) StreamContainerStats(ctx context.Context, id string, out io.Writer, stream bool, CPUMhz int64, memory int64) error {
 	return nil
 }
+func (m *MockContainerProxy) exitCode(vc *viccontainer.VicContainer) (string, error) {
+	return "", nil
+}
 
 func AddMockImageToCache() {
 	mockImage := &metadata.ImageConfig{

--- a/tests/test-cases/Group1-Docker-Commands/1-06-Docker-Run.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-06-Docker-Run.robot
@@ -83,10 +83,8 @@ Docker run -d unspecified host port
 Docker run check exit codes
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run busybox true
     Should Be Equal As Integers  ${rc}  0
-    ${status}=  Get State Of Github Issue  4561
-	Run Keyword If  '${status}' == 'closed'  Fail  Test 1-06-Docker-Run.robot needs to be updated now that Issue #4561 has been resolved
-	# ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run busybox false
-    # Should Be Equal As Integers  ${rc}  1
+	${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run busybox false
+    Should Be Equal As Integers  ${rc}  1
 
 Docker run ps password check
     [Tags]  secret

--- a/tests/test-cases/Group1-Docker-Commands/1-17-Docker-Network-Connect.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-17-Docker-Network-Connect.robot
@@ -98,6 +98,7 @@ Connect containers to multiple networks non-overlapping
     ${ip}=  Get Container IP  %{VCH-PARAMS}  ${containerID}  cross2-network
 
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run --net cross2-network2 --name cross2-container2 debian ping -c2 ${ip}
+    Should Not Be Equal As Integers  ${rc}  0
     Should contain  ${output}  Destination Port Unreachable
 
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} logs --follow cross2-container2
@@ -110,6 +111,7 @@ Connect containers to multiple networks non-overlapping
 
     ${ip}=  Get Container IP  %{VCH-PARAMS}  ${containerID}  cross2-network
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run --net cross2-network2 --name cross2-container3 debian ping -c2 ${ip}
+    Should Not Be Equal As Integers  ${rc}  0
     Should contain  ${output}  Destination Port Unreachable
 
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} logs --follow cross2-container3
@@ -120,6 +122,7 @@ Connect containers to an internal network
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} network create --internal internal-net
     Should Be Equal As Integers  ${rc}  0
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run --net internal-net busybox ping -c1 www.google.com
+    Should Not Be Equal As Integers  ${rc}  0
     Should Contain  ${output}  Network is unreachable
 
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} network create public-net

--- a/tests/test-cases/Group1-Docker-Commands/1-24-Docker-Link.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-24-Docker-Link.robot
@@ -49,10 +49,8 @@ Link and alias
     Should Not Contain  ${output}  Error
 
     # cannot reach first from another network
-    ${status}=  Get State Of Github Issue  4561
-    Run Keyword If  '${status}' == 'closed'  Fail  Test 1-24-Docker-Link.robot needs to be updated now that Issue #4561 has been resolved
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run debian ping -c1 first
-    # Should Not Be Equal As Integers  ${rc}  0
+    Should Not Be Equal As Integers  ${rc}  0
     Should contain  ${output}  unknown host
 
     # the link
@@ -66,10 +64,8 @@ Link and alias
     Should Be Equal As Integers  ${rc}  0
     Should Not Contain  ${output}  Error
     # check if we can use alias "c1" from another container
-    ${status}=  Get State Of Github Issue  4561
-    Run Keyword If  '${status}' == 'closed'  Fail  Test 1-24-Docker-Link.robot needs to be updated now that Issue #4561 has been resolved
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run --net jedi debian ping -c1 1st
-    # Should Not Be Equal As Integers  ${rc}  0
+    Should Not Be Equal As Integers  ${rc}  0
     Should contain  ${output}  unknown host
 
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -it -d --net jedi --net-alias 2nd busybox


### PR DESCRIPTION
ContainerAttach was publishing a detach event on func exit.  This
resulted in the 1.13 client exiting docker run before container exit.
It will now only publish a detach event when a detach is detected.

Also exit code has been added to the die event, which will allow
the docker 1.13 client to return exit codes.

Fixes #4561 
