### PR TITLE
Exclude swagger response files from gas check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -231,7 +231,7 @@ govet:
 
 gas: $(GAS)
 	@echo checking security problems
-	@for i in cmd lib pkg; do pushd $$i > /dev/null; $(GAS) ./... > ../$$i.gas 2> /dev/null || exit 1; popd > /dev/null; done
+	@for i in cmd lib pkg; do pushd $$i > /dev/null; $(GAS) -skip=*_responses.go ./... > ../$$i.gas 2> /dev/null || exit 1; popd > /dev/null; done
 
 vendor: $(GVT)
 	@echo restoring vendor


### PR DESCRIPTION
This change excludes response files generated by swagger from the `gas` check. 