### PR TITLE
Docker run --rm now works with client 1.13

### DIFF
--- a/lib/apiservers/engine/backends/convert/annotation.go
+++ b/lib/apiservers/engine/backends/convert/annotation.go
@@ -1,0 +1,81 @@
+// Copyright 2017 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package convert
+
+import (
+	"encoding/base64"
+	"encoding/json"
+
+	log "github.com/Sirupsen/logrus"
+
+	"github.com/vmware/vic/lib/apiservers/portlayer/models"
+)
+
+const (
+	AnnotationKeyLabels     = "docker.labels"
+	AnnotationKeyAutoRemove = "docker.autoremove"
+)
+
+// SetContainerAnnotation encodes a docker specific attribute into a vSphere annotation.  These vSphere
+// annotations are stored in the VM vmx file
+func SetContainerAnnotation(config *models.ContainerCreateConfig, key string, value interface{}) error {
+	var err error
+
+	if config == nil || value == nil {
+		return nil
+	}
+
+	if config.Annotations == nil {
+		config.Annotations = make(map[string]string)
+	}
+
+	// Encoding the labels map into a blob that can be stored as ansi regardless
+	// of what encoding the input labels are.  We do this by first marshaling to
+	// to a json byte array to get a self describing encoding and then encoding
+	// to base64.  We could use another encoding for the self describing part,
+	// such as Golang GOB, but this data will be pushed over to a standard REST
+	// server so we use standard web standards instead.
+	if valueBytes, merr := json.Marshal(value); merr == nil {
+		blob := base64.StdEncoding.EncodeToString(valueBytes)
+		config.Annotations[key] = blob
+	} else {
+		err = merr
+		log.Errorf("Unable to marshal annotation %s to json: %s", key, err)
+	}
+
+	return err
+}
+
+// ContainerAnnotation will convert a vSphere annotation into a docker specific attribute
+func ContainerAnnotation(annotations map[string]string, key string, value interface{}) error {
+	var err error
+
+	if len(annotations) == 0 || value == nil {
+		return nil
+	}
+
+	if blob, ok := annotations[key]; ok {
+		if annotationBytes, decodeErr := base64.StdEncoding.DecodeString(blob); decodeErr == nil {
+			if err = json.Unmarshal(annotationBytes, value); err != nil {
+				log.Errorf("Unable to unmarshal %s: %s", key, err)
+			}
+		} else {
+			err = decodeErr
+			log.Errorf("Unable to decode container annotations: %s", err)
+		}
+	}
+
+	return err
+}

--- a/lib/apiservers/engine/backends/convert/annotation_test.go
+++ b/lib/apiservers/engine/backends/convert/annotation_test.go
@@ -1,0 +1,48 @@
+// Copyright 2017 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package convert
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/vmware/vic/lib/apiservers/portlayer/models"
+)
+
+func TestSetContainerAnnotation(t *testing.T) {
+
+	config := &models.ContainerCreateConfig{}
+	labels := make(map[string]string)
+	labels["environment"] = "dev"
+
+	err := SetContainerAnnotation(nil, AnnotationKeyLabels, labels)
+	assert.NoError(t, err)
+
+	err = SetContainerAnnotation(config, AnnotationKeyLabels, &labels)
+	assert.NoError(t, err)
+
+	var myLabels map[string]string
+
+	err = ContainerAnnotation(myLabels, AnnotationKeyLabels, &myLabels)
+	assert.NoError(t, err)
+
+	err = ContainerAnnotation(config.Annotations, AnnotationKeyLabels, &myLabels)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(myLabels))
+
+	err = ContainerAnnotation(config.Annotations, AnnotationKeyLabels, myLabels)
+	assert.Error(t, err)
+}

--- a/lib/apiservers/engine/backends/network.go
+++ b/lib/apiservers/engine/backends/network.go
@@ -33,6 +33,7 @@ import (
 	"github.com/docker/libnetwork/networkdb"
 
 	"github.com/vmware/vic/lib/apiservers/engine/backends/cache"
+	"github.com/vmware/vic/lib/apiservers/engine/backends/convert"
 	vicendpoint "github.com/vmware/vic/lib/apiservers/engine/backends/endpoint"
 	"github.com/vmware/vic/lib/apiservers/portlayer/client/containers"
 	"github.com/vmware/vic/lib/apiservers/portlayer/client/scopes"
@@ -153,7 +154,7 @@ func (n *Network) CreateNetwork(nc types.NetworkCreateRequest) (*types.NetworkCr
 	// Marshal and encode the labels for transport and storage in the portlayer
 	if labelsBytes, err := json.Marshal(nc.Labels); err == nil {
 		encodedLabels := base64.StdEncoding.EncodeToString(labelsBytes)
-		cfg.Annotations[annotationKeyLabels] = encodedLabels
+		cfg.Annotations[convert.AnnotationKeyLabels] = encodedLabels
 	} else {
 		log.Errorf("error marshaling labels: %s", err)
 		return nil, derr.NewErrorWithStatusCode(fmt.Errorf("unable to marshal labels: %s", err), http.StatusInternalServerError)
@@ -492,7 +493,7 @@ func (n *network) Labels() map[string]string {
 	}
 
 	// Look for the Docker-specific annotation (label) blob and process it for the output
-	if encodedLabels, ok := n.cfg.Annotations[annotationKeyLabels]; ok {
+	if encodedLabels, ok := n.cfg.Annotations[convert.AnnotationKeyLabels]; ok {
 
 		if labelsBytes, decodeErr := base64.StdEncoding.DecodeString(encodedLabels); decodeErr == nil {
 			if unmarshalErr := json.Unmarshal(labelsBytes, &labels); unmarshalErr != nil {

--- a/tests/test-cases/Group1-Docker-Commands/1-06-Docker-Run.md
+++ b/tests/test-cases/Group1-Docker-Commands/1-06-Docker-Run.md
@@ -28,18 +28,19 @@ This test requires that a vSphere server is running and available
 15. Issue docker run -it busybox /bin/fakeCommand
 16. Issue docker run busybox date
 17. Create container1 with id1 and then create container2 with name = id1
+18. Run a short lived container with autoremove specified
 
 #Expected Outcome:
 * Step 2 and 3 should result in success and print the dmesg of the container
 * Step 4 should result in the top command starting and printing it's results to the screen
 * Step 5 should result in top stopping and the container exiting
 * Step 6 should result in the top command starting and printing it's results to the screen, as it is not interactive you will need to issue ctrl-c to stop the container with a KILL signal
-* Step 7 should result in an error and the following message:  
+* Step 7 should result in an error and the following message:
 ```
 exec: "fakeCommand": executable file not found in $PATH
 docker: Error response from daemon: Container command not found or does not exist..
 ```
-* Step 8 should result in an error and the following message:  
+* Step 8 should result in an error and the following message:
 ```
 docker: Error parsing reference: "fakeImage" is not a valid repository/tag.
 ```
@@ -51,6 +52,7 @@ docker: Error parsing reference: "fakeImage" is not a valid repository/tag.
 * Step 15 should result in success with exit code 127
 * Step 16 should result in success and the output should contain the current date
 * Step 17 should result in no conflicts
+* Step 18 should result in the same container count at beginning and end
 
 #Possible Problems:
 None

--- a/tests/test-cases/Group1-Docker-Commands/1-06-Docker-Run.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-06-Docker-Run.robot
@@ -135,3 +135,15 @@ Docker run verify name and id are not conflated
     ${rc}  ${container2}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -itd --name ${shortID1} busybox
     Should Be Equal As Integers  ${rc}  0
     Should Not Contain  ${container2}  Conflict
+
+Docker run and auto remove
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} ps -a
+    Should Be Equal As Integers  ${rc}  0
+    ${output}=  Split To Lines  ${output}
+    ${count}=  Get Length  ${output}
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run --rm busybox date
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} ps -a
+    Should Be Equal As Integers  ${rc}  0
+    ${output}=  Split To Lines  ${output}
+    Length Should Be  ${output}  ${count}


### PR DESCRIPTION
The docker auto remove option (--rm) wasn't working with
the 1.13 client.  Docker moved to an event based model
with the 1.13 client and we weren't publishing the events.
The correct events are now published.

An integration test was also created.

Fixes #4504 