### PR TITLE
Fixed race and added support for all option in docker stats

### DIFF
--- a/lib/apiservers/engine/backends/container_test.go
+++ b/lib/apiservers/engine/backends/container_test.go
@@ -38,6 +38,7 @@ import (
 
 	"github.com/vmware/vic/lib/apiservers/engine/backends/cache"
 	viccontainer "github.com/vmware/vic/lib/apiservers/engine/backends/container"
+	"github.com/vmware/vic/lib/apiservers/engine/backends/convert"
 	plclient "github.com/vmware/vic/lib/apiservers/portlayer/client"
 	plscopes "github.com/vmware/vic/lib/apiservers/portlayer/client/scopes"
 	plmodels "github.com/vmware/vic/lib/apiservers/portlayer/models"
@@ -338,7 +339,7 @@ func (m *MockContainerProxy) Rename(vc *viccontainer.VicContainer, newName strin
 func (m *MockContainerProxy) AttachStreams(ctx context.Context, vc *viccontainer.VicContainer, clStdin io.ReadCloser, clStdout, clStderr io.Writer, ca *backend.ContainerAttachConfig) error {
 	return nil
 }
-func (m *MockContainerProxy) StreamContainerStats(ctx context.Context, id string, out io.Writer, stream bool, CPUMhz int64, memory int64) error {
+func (m *MockContainerProxy) StreamContainerStats(ctx context.Context, config *convert.ContainerStatsConfig) error {
 	return nil
 }
 func (m *MockContainerProxy) exitCode(vc *viccontainer.VicContainer) (string, error) {

--- a/lib/apiservers/engine/backends/convert/stats.go
+++ b/lib/apiservers/engine/backends/convert/stats.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"sync"
 	"time"
 
 	log "github.com/Sirupsen/logrus"
@@ -31,26 +32,31 @@ import (
 // ContainerStats encapsulates the conversion of VMMetrics to
 // docker specific metrics
 type ContainerStats struct {
-	config         ContainerStatsConfig
-	dockerStats    *types.StatsJSON
-	currentMetrics *metrics.VMMetrics
-	totalVCHMhz    uint64
-	dblVCHMhz      uint64
-	preTotalMhz    uint64
+	config *ContainerStatsConfig
 
-	// reader/writer for stream
-	reader *io.PipeReader
-	writer *io.PipeWriter
+	totalVCHMhz uint64
+	dblVCHMhz   uint64
+	preTotalMhz uint64
+
+	preDockerStat *types.StatsJSON
+	curDockerStat *types.StatsJSON
+	currentMetric *metrics.VMMetrics
+
+	mu        sync.Mutex
+	reader    *io.PipeReader
+	writer    *io.PipeWriter
+	listening bool
 }
 
 type ContainerStatsConfig struct {
-	Ctx         context.Context
-	Cancel      context.CancelFunc
-	Out         io.Writer
-	ContainerID string
-	Memory      int64
-	Stream      bool
-	VchMhz      int64
+	Ctx            context.Context
+	Cancel         context.CancelFunc
+	Out            io.Writer
+	ContainerID    string
+	ContainerState *types.ContainerState
+	Memory         int64
+	Stream         bool
+	VchMhz         int64
 }
 
 type InvalidOrderError struct {
@@ -63,61 +69,81 @@ func (iso InvalidOrderError) Error() string {
 }
 
 // NewContainerStats will return a new instance of ContainerStats
-func NewContainerStats(config ContainerStatsConfig) *ContainerStats {
+func NewContainerStats(config *ContainerStatsConfig) *ContainerStats {
 	return &ContainerStats{
-		config:      config,
-		dockerStats: &types.StatsJSON{},
-		totalVCHMhz: uint64(config.VchMhz),
-		dblVCHMhz:   uint64(config.VchMhz * 2),
+		config:        config,
+		curDockerStat: &types.StatsJSON{},
+		totalVCHMhz:   uint64(config.VchMhz),
+		dblVCHMhz:     uint64(config.VchMhz * 2),
 	}
 }
 
-// Stop will clean up remaining conversion resources
+// IsListening returns the listening flag
+func (cs *ContainerStats) IsListening() bool {
+	cs.mu.Lock()
+	defer cs.mu.Unlock()
+	return cs.listening
+}
+
+// Stop will clean up the pipe and flip listening flag
 func (cs *ContainerStats) Stop() {
-	if cs.reader != nil && cs.writer != nil {
+	cs.mu.Lock()
+	defer cs.mu.Unlock()
+
+	if cs.listening {
 		cs.reader.Close()
 		cs.writer.Close()
+		cs.listening = false
 	}
+}
+
+// newPipe will initialize the pipe for encoding / decoding and
+// set the listening flag
+func (cs *ContainerStats) newPipe() {
+	cs.mu.Lock()
+	defer cs.mu.Unlock()
+
+	// create a new reader / writer
+	cs.reader, cs.writer = io.Pipe()
+	cs.listening = true
 }
 
 // Listen will listen for new metrics from the portLayer, convert to docker format
 // and encode to the configured Writer.  The returned PipeWriter is the source of
 // the vic metrics that will be transformed to docker stats
 func (cs *ContainerStats) Listen() *io.PipeWriter {
-	// TODO: could split decode / encode into separate funcs -- would provide for easier
-	// unit testing
-
-	// we already are listening
-	if cs.reader != nil {
+	// Are we already listening?
+	if cs.IsListening() {
 		return nil
 	}
 
-	cs.reader, cs.writer = io.Pipe()
+	// create pipe for encode/decode
+	cs.newPipe()
 
 	dec := json.NewDecoder(cs.reader)
 	doc := json.NewEncoder(cs.config.Out)
 
 	// channel to transfer metric from decoder to encoder
-	// closed w/in the decoder
 	metric := make(chan metrics.VMMetrics)
 
-	// signal to decoder / encoder that we are done
-	finished := make(chan struct{})
+	// if we aren't streaming and the container is not running, then create an empty
+	// docker stat to return
+	if !cs.config.Stream && !cs.config.ContainerState.Running {
+		cs.preDockerStat = &types.StatsJSON{}
+	}
 
-	var vmm metrics.VMMetrics
-	var previousStat *types.StatsJSON
-
+	// go routine will decode metrics received from the portLayer and
+	// send them to the encoding routine
 	go func() {
 		for {
 			select {
 			case <-cs.config.Ctx.Done():
-				close(finished)
-			case <-finished:
 				close(metric)
 				cs.Stop()
 				return
 			default:
 				for dec.More() {
+					var vmm metrics.VMMetrics
 					err := dec.Decode(&vmm)
 					if err != nil {
 						log.Errorf("container metric decoding error for container(%s): %s", cs.config.ContainerID, err)
@@ -131,23 +157,29 @@ func (cs *ContainerStats) Listen() *io.PipeWriter {
 
 	}()
 
+	// go routine will convert incoming metrics to docker specific stats and encode for the docker client.
 	go func() {
-		for {
+		// docker needs updates quicker than vSphere can produce metrics, so we'll send a minimum of 1 metric/sec
+		ticker := time.NewTicker(time.Millisecond * 500)
+		for range ticker.C {
 			select {
 			case <-cs.config.Ctx.Done():
-				return
-			case <-finished:
+				cs.Stop()
+				ticker.Stop()
 				return
 			case nm := <-metric:
 				// convert the Stat to docker struct
-				stats, err := cs.ToContainerStats(&nm)
+				stat, err := cs.ToContainerStats(&nm)
 				if err != nil {
 					log.Errorf("container metric conversion error for container(%s): %s", cs.config.ContainerID, err)
 					cs.config.Cancel()
 				}
-				// Do we have a complete stat that can be sent to the client?
-				if stats != nil {
-					err = doc.Encode(stats)
+				if stat != nil {
+					cs.preDockerStat = stat
+				}
+			default:
+				if cs.IsListening() && cs.preDockerStat != nil {
+					err := doc.Encode(cs.preDockerStat)
 					if err != nil {
 						log.Warnf("container metric encoding error for container(%s): %s", cs.config.ContainerID, err)
 						cs.config.Cancel()
@@ -156,23 +188,11 @@ func (cs *ContainerStats) Listen() *io.PipeWriter {
 					if !cs.config.Stream {
 						cs.config.Cancel()
 					}
-					// set to previous stat so we can reuse
-					previousStat = stats
-				}
-			default:
-				// the docker client expects updates quicker than vSphere can produce them, so
-				// we need to send the previous stats to avoid intermittent empty output
-				time.Sleep(time.Second * 1)
-				if previousStat != nil && cs.reader != nil {
-					err := doc.Encode(previousStat)
-					if err != nil {
-						log.Warnf("container previous metric encoding error for container(%s): %s", cs.config.ContainerID, err)
-						cs.config.Cancel()
-					}
 				}
 			}
 		}
 	}()
+
 	return cs.writer
 }
 
@@ -180,9 +200,9 @@ func (cs *ContainerStats) Listen() *io.PipeWriter {
 // struct requires two samples.  Func will return nil until a complete stat is available
 func (cs *ContainerStats) ToContainerStats(current *metrics.VMMetrics) (*types.StatsJSON, error) {
 	// if we have a current metric then validate and transform
-	if cs.currentMetrics != nil {
+	if cs.currentMetric != nil {
 		// do we have the same metric as before?
-		if cs.currentMetrics.SampleTime.Equal(current.SampleTime) {
+		if cs.currentMetric.SampleTime.Equal(current.SampleTime) {
 			// we've already got this as current, so skip and wait for the
 			// next sample
 			return nil, nil
@@ -193,7 +213,7 @@ func (cs *ContainerStats) ToContainerStats(current *metrics.VMMetrics) (*types.S
 			return nil, err
 		}
 	}
-	cs.currentMetrics = current
+	cs.currentMetric = current
 
 	// create the current CPU stats
 	cs.currentCPU()
@@ -202,50 +222,50 @@ func (cs *ContainerStats) ToContainerStats(current *metrics.VMMetrics) (*types.S
 	cs.memory()
 
 	// set sample time
-	cs.dockerStats.Read = cs.currentMetrics.SampleTime
+	cs.curDockerStat.Read = cs.currentMetric.SampleTime
 
 	// PreRead will be zero if we don't have two samples
-	if cs.dockerStats.PreRead.IsZero() {
+	if cs.curDockerStat.PreRead.IsZero() {
 		return nil, nil
 	}
-	return cs.dockerStats, nil
+	return cs.curDockerStat, nil
 }
 
 func (cs *ContainerStats) memory() {
 	// given MB (i.e. 2048) convert to GB
-	cs.dockerStats.MemoryStats.Limit = uint64(cs.config.Memory * 1024 * 1024)
+	cs.curDockerStat.MemoryStats.Limit = uint64(cs.config.Memory * 1024 * 1024)
 	// given KB (i.e. 384.5) convert to Bytes
-	cs.dockerStats.MemoryStats.Usage = uint64(cs.currentMetrics.Memory.Active * 1024)
+	cs.curDockerStat.MemoryStats.Usage = uint64(cs.currentMetric.Memory.Active * 1024)
 }
 
 // previousCPU will move the current stats to the previous CPU location
 func (cs *ContainerStats) previousCPU(current *metrics.VMMetrics) error {
 	// validate that the sampling is in the correct order
-	if current.SampleTime.Before(cs.dockerStats.Read) {
+	if current.SampleTime.Before(cs.curDockerStat.Read) {
 		err := InvalidOrderError{
 			current:  current.SampleTime,
-			previous: cs.dockerStats.Read,
+			previous: cs.curDockerStat.Read,
 		}
 		return err
 	}
 
 	// move the stats
-	cs.dockerStats.PreCPUStats = cs.dockerStats.CPUStats
+	cs.curDockerStat.PreCPUStats = cs.curDockerStat.CPUStats
 
 	// set the previousTotal -- this will be added to the current CPU
-	cs.preTotalMhz = cs.dockerStats.PreCPUStats.CPUUsage.TotalUsage
+	cs.preTotalMhz = cs.curDockerStat.PreCPUStats.CPUUsage.TotalUsage
 
-	cs.dockerStats.PreRead = cs.dockerStats.Read
+	cs.curDockerStat.PreRead = cs.curDockerStat.Read
 	// previous systemUsage will always be the VCH total
 	// see note in func currentCPU() for detail
-	cs.dockerStats.PreCPUStats.SystemUsage = cs.totalVCHMhz
+	cs.curDockerStat.PreCPUStats.SystemUsage = cs.totalVCHMhz
 
 	return nil
 }
 
 // currentCPU will convert the VM CPU metrics to docker CPU stats
 func (cs *ContainerStats) currentCPU() {
-	cpuCount := len(cs.currentMetrics.CPU.CPUs)
+	cpuCount := len(cs.currentMetric.CPU.CPUs)
 	dockerCPU := types.CPUStats{
 		CPUUsage: types.CPUUsage{
 			PercpuUsage: make([]uint64, cpuCount, cpuCount),
@@ -253,10 +273,17 @@ func (cs *ContainerStats) currentCPU() {
 	}
 
 	// collect the current CPU Metrics
-	for ci, current := range cs.currentMetrics.CPU.CPUs {
+	for ci, current := range cs.currentMetric.CPU.CPUs {
 		dockerCPU.CPUUsage.PercpuUsage[ci] = uint64(current.MhzUsage)
 		dockerCPU.CPUUsage.TotalUsage += uint64(current.MhzUsage)
 	}
+
+	// vSphere will report negative usage for a starting VM, lets
+	// set to zero
+	if dockerCPU.CPUUsage.TotalUsage < 0 {
+		dockerCPU.CPUUsage.TotalUsage = 0
+	}
+
 	// The first stat available for a VM will be missing detail
 	if cpuCount > 0 {
 		// TotalUsage is the sum of the individual vCPUs Mhz
@@ -283,5 +310,5 @@ func (cs *ContainerStats) currentCPU() {
 	// cpuUsage = (CPUDelta / SystemDelta) * cpuCount * 100
 	// This will require the addition of the previous total usage
 	dockerCPU.CPUUsage.TotalUsage += cs.preTotalMhz
-	cs.dockerStats.CPUStats = dockerCPU
+	cs.curDockerStat.CPUStats = dockerCPU
 }

--- a/tests/test-cases/Group1-Docker-Commands/1-39-Docker-Stats.md
+++ b/tests/test-cases/Group1-Docker-Commands/1-39-Docker-Stats.md
@@ -1,0 +1,36 @@
+Test 1-39 - Docker Stats
+=======
+
+#Purpose:
+To verify that `docker stats` is supported and works as expected.
+
+#Environment:
+This test requires that a vSphere server is running and available
+
+
+#Test Steps:
+1. Run a busybox container and create a busybox container
+2. Run Stats no-stream for running container
+3. Run Stats with no-stream all which will return stats for running and stopped containers
+4. Verify the API memory output against govc
+5. Verify the API CPU output against govc
+6. Run Stats with no-stream for a non-existent container
+7. Run Stats with no-stream for a stopped container
+
+
+#Expected Outcome:
+1. Fails if two containers are not created
+2. Return stats for a running container and validate memory -- will fail if there is a variation
+   of greater than 5%
+3. Return stats for all containers -- will fail if output is missing either container
+4. Compare API results vs. govc result for memory accuracy -- will fail if variation greater than 1000 bytes
+5. Compare API results vs. govc result for CPU accuracy -- will fail if API value not present in past
+   six govc readings
+6. Failure with error message
+7. Output should include the stopped container short id
+
+
+
+#Possible Problems:
+Stats are created by the ESXi host every 20s -- if there are long pauses between calls
+in a single test the results could be incorrect and a failure could occur.

--- a/tests/test-cases/Group1-Docker-Commands/1-39-Docker-Stats.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-39-Docker-Stats.robot
@@ -1,0 +1,91 @@
+# Copyright 2017 VMware, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#	http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License
+
+*** Settings ***
+Documentation   Test 1-39 - Docker Stats
+Resource        ../../resources/Util.robot
+Suite Setup     Install VIC Appliance To Test Server
+Suite Teardown  Cleanup VIC Appliance On Test Server
+
+*** Test Cases ***
+Create test containers
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} pull busybox
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -d --name stresser busybox /bin/top
+    Should Be Equal As Integers  ${rc}  0
+    Set Environment Variable  STRESSED  ${output}
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} create --name stopper busybox /bin/top
+    Should Be Equal As Integers  ${rc}  0
+    Set Environment Variable  STOPPER  ${output}
+    ${stress}=  Get Container ShortID  %{STRESSED}
+    Run Keyword If  '%{HOST_TYPE}' == 'ESXi'  Set Environment Variable  VM-PATH  vm/*${stress}
+    Run Keyword If  '%{HOST_TYPE}' == 'VC'  Set Environment Variable  VM-PATH  */%{VCH-NAME}/*${stress}
+
+Stats No Stream
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} stats --no-stream %{STRESSED}
+    Should Be Equal As Integers  ${rc}  0
+    ${output}=  Get Line  ${output}  -1
+    ${short}=  Get Container ShortID  %{STRESSED}
+    Should Contain  ${output}  ${short}
+    ${vals}=  Split String  ${output}
+    ${vicMemory}=  Get From List  ${vals}  7
+    # only care about the integer value of memory usage
+    ${vicMemory}=  Fetch From Left  ${vicMemory}  .
+    # get the latest memory value for the "stresser" vm
+    ${rc}  ${vmomiMemory}=  Run And Return Rc And Output  govc metric.sample -n 1 -json %{VM-PATH} mem.active.average | jq -r .Sample[].Value[].Value[0]
+    Should Be Equal As Integers  ${rc}  0
+    Should Be True  ${vmomiMemory} > 0
+    # convert to percent and move decimal
+    ${percent}=  Evaluate  (${vmomiMemory}/2048000)*100
+    ${diff}=  Evaluate  ${percent}-${vicMemory}
+    # due to timing we could see some variation, but shouldn't exceed 5%
+    Should Be True  ${diff} < 5
+
+Stats No Stream All Containers
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} stats --no-stream -a
+    Should Be Equal As Integers  ${rc}  0
+    ${stress}=  Get Container ShortID  %{STRESSED}
+    ${stop}=  Get Container ShortID  %{STOPPER}
+    Should Contain  ${output}  ${stress}
+    Should Contain  ${output}  ${stop}
+
+Stats API Memory Validation
+    ${rc}  ${apiMem}=  Run And Return Rc And Output  curl -s -k -H "Accept: application/json" -H "Content-Type: application/json" -X GET https://%{VCH-IP}:%{VCH-PORT}/containers/%{STRESSED}/stats?stream=false | jq -r .memory_stats.usage
+    Should Be Equal As Integers  ${rc}  0
+    ${stress}=  Get Container ShortID  %{STRESSED}
+    ${rc}  ${vmomiMemory}=  Run And Return Rc And Output  govc metric.sample -n 1 -json %{VM-PATH} mem.active.average | jq -r .Sample[].Value[].Value[0]
+    Should Be Equal As Integers  ${rc}  0
+    ${vmomiMemory}=  Evaluate  ${vmomiMemory}*1024
+    ${diff}=  Evaluate  ${apiMem}-${vmomiMemory}
+    ${diff}=  Set Variable  abs(${diff})
+    Should Be True  ${diff} < 1000
+
+Stats API CPU Validation
+    ${rc}  ${apiCPU}=  Run And Return Rc And Output  curl -s -k -H "Accept: application/json" -H "Content-Type: application/json" -X GET https://%{VCH-IP}:%{VCH-PORT}/containers/%{STRESSED}/stats?stream=false | jq -r .cpu_stats.cpu_usage.percpu_usage[0]
+    Should Be Equal As Integers  ${rc}  0
+    ${stress}=  Get Container ShortID  %{STRESSED}
+    ${rc}  ${vmomiCPU}=  Run And Return Rc And Output  govc metric.sample -json %{VM-PATH} cpu.usagemhz.average | jq -r .Sample[].Value[0].Value[]
+    Should Be Equal As Integers  ${rc}  0
+    Should Contain  ${vmomiCPU}  ${apiCPU}
+
+Stats No Stream Non-Existent Container
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} stats --no-stream fake
+    Should Be Equal As Integers  ${rc}  1
+    Should Contain  ${output}  No such container: fake
+
+Stats No Stream Specific Stopped Container
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} stats --no-stream %{STOPPER}
+    Should Be Equal As Integers  ${rc}  0
+    ${stop}=  Get Container ShortID  %{STOPPER}
+    Should Contain  ${output}  ${stop}


### PR DESCRIPTION
In some cases a race could be encountered when executing docker
stats.  The race would result in an orphaned go routine that
would be a memory leak.

In addition if stats --no-stream -all was requested the persona
would hang on any stopped containers.  Stats now will consider
the container state when processing these requests.

Finally, the unit testing coverage was increased to just over
90% and integration tests were created.

Fixes #4549, #4585, #4421
