### PR TITLE
[skip ci] Nightly multiple cluster tests fix

### DIFF
--- a/tests/manual-test-cases/Group5-Functional-Tests/5-11-Multiple-Cluster.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-11-Multiple-Cluster.robot
@@ -27,8 +27,6 @@ Test
 
     Set Global Variable  @{list}  ${esx1}  ${esx2}  ${esx3}  ${esx4}  ${esx5}  ${vc}
 
-    Create a Simple VC Cluster  datacenter1  cls1
-
     Log To Console  Create cluster2 on the VC
     ${out}=  Run  govc cluster.create cls2
     Should Be Empty  ${out}


### PR DESCRIPTION
Fixing the bug, introduced as part of the cleanup fix that was merged recently. Removing the duplicate command to create the simple cluster.