### PR TITLE
OVA Build process pulls engine and ui from bintray instead of buildin…

### DIFF
--- a/installer/README.md
+++ b/installer/README.md
@@ -16,11 +16,15 @@ have `ovftool` installed
 
 #### Build bundle and OVA
 
-Optional step to build UI plugins to be included in the `vic-engine-bundle`, requires ant, npm,
-nodejs (it is recommend to build in a container)
+First, we have to set the revisions of the components we want to bundle in the OVA:
+
 ```
-make vic-ui-plugins
+export BUILD_HARBOR_REVISION=1.1.0-rc1     # Optional, defaults to dev
+export BUILD_ADMIRAL_REVISION=v1.1.0-rc1   # Optional, defaults to dev
+export BUILD_VICENGINE_REVISION=1.1.0-rc4  # Required
 ```
+
+Then set the required env vars for the build environment and make the release:
 
 ```
 export PACKER_ESX_HOST=1.1.1.1
@@ -28,7 +32,6 @@ export PACKER_USER=root
 export PACKER_PASSWORD=password
 export PACKER_LOG=1
 
-make vic-engine-bundle
 make ova-release
 ```
 
@@ -37,7 +40,7 @@ Deploy OVA with ovftool in a Docker container on ESX host
 docker run -it --net=host -v ~/go/src/github.com/vmware/vic/bin:/test-bin \
   gcr.io/eminent-nation-87317/vic-integration-test:1.22 ovftool --acceptAllEulas --X:injectOvfEnv \
   --X:enableHiddenProperties -st=OVA --powerOn --noSSLVerify=true -ds=datastore1 -dm=thin \
-  --net:Network="VM Network" --prop:appliance.email_from="noreply@vmware.com" \
+  --net:Network="VM Network" \
   --prop:appliance.root_pwd="VMware1\!" --prop:appliance.permit_root_login=True --prop:registry.port=443 \
   --prop:management_portal.port=8282 --prop:registry.admin_password="VMware1\!" \
   --prop:registry.db_password="VMware1\!" /test-bin/vic-1.1.0-a84985b.ova \

--- a/installer/packer/packer-vic.json
+++ b/installer/packer/packer-vic.json
@@ -6,6 +6,7 @@
     "remote_username": "",
     "remote_password": "",
     "root_password": "2RQrZ83i79N6szpvZNX6",
+    "build_vicengine_revision": "",
     "build_admiral_revision": "dev",
     "build_harbor_revision": "dev"
   },
@@ -108,16 +109,6 @@
       "type": "file",
       "source": "../../bin/ova-webserver",
       "destination": "/usr/local/bin/ova-webserver"
-    },
-    {
-      "type": "file",
-      "source": "../../bin/vic-engine-bundle/",
-      "destination": "/data/fileserver/files"
-    },
-    {
-      "type": "file",
-      "source": "../../bin/ui",
-      "destination": "/data/fileserver/files"
     },
     {
       "type": "file",
@@ -260,6 +251,7 @@
     },
     {
       "type": "shell",
+      "environment_vars": ["BUILD_VICENGINE_REVISION={{user `build_vicengine_revision`}}"],
       "script": "scripts/provision_fileserver.sh"
     },
     {

--- a/installer/packer/scripts/provision_fileserver.sh
+++ b/installer/packer/scripts/provision_fileserver.sh
@@ -16,7 +16,11 @@ set -euf -o pipefail
 
 mkdir -p /etc/vmware/fileserver
 
-# Move zip files to base directory, remove unneeded files from ui/
-cd /data/fileserver/files
-find . -name "*.zip" | xargs -t -I {} mv {} .
-rm -r ui/
+[[ x$BUILD_VICENGINE_REVISION == "x" ]] && ( echo "VIC Engine build not set, failing"; exit 1 )
+
+# Download Build
+cd /var/tmp
+echo "Downloading VIC Engine ${BUILD_VICENGINE_REVISION}"
+curl -LO "https://vmware.bintray.com/vic/vic_${BUILD_VICENGINE_REVISION}.tar.gz" 
+tar xfz vic_${BUILD_VICENGINE_REVISION}.tar.gz -C /data/fileserver/files vic/ui/vsphere-client-serenity/com.vmware.vic.ui-v${BUILD_VICENGINE_REVISION}.zip vic/ui/plugin-packages/com.vmware.vic-v${BUILD_VICENGINE_REVISION}.zip --strip-components=3
+mv vic_${BUILD_VICENGINE_REVISION}.tar.gz /data/fileserver/files

--- a/installer/packer/scripts/system_settings.sh
+++ b/installer/packer/scripts/system_settings.sh
@@ -34,7 +34,7 @@ systemctl enable admiral_startup.service admiral
 systemctl enable fileserver_startup.service fileserver.service
 
 # Clean up temporary directories
-rm -rf /var/tmp/*
+rm -rf /var/tmp/harbor
 
 # seal the template
 > /etc/machine-id


### PR DESCRIPTION
…g from source

(cherry picked from commit bf149448e10b4c7765d6d68c796ea98824badf83)

<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[  ] There is an associated issue that is labelled
[  ] Code is up-to-date with the `master` branch
[  ] You've successfully run `make test` locally
[  ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/vmware/vic/blob/master/.github/CONTRIBUTING.md
-->

Fixes #

<!--
To trigger a custom build with this PR, include one of these in the PR's title or commit messages:
* [skip ci]
* [full ci]
* [specific ci=$suitename] e.g. [specific ci=1-01-Docker-Info]
    With this option, running only one suite is supported.
-->
