### PR TITLE
Handle expired password with vic-machine debug (#4633)

### DIFF
--- a/infra/scripts/bash-helpers.sh
+++ b/infra/scripts/bash-helpers.sh
@@ -75,7 +75,7 @@ vic-ssh () {
         keyarg="--authorized-key=$HOME/.ssh/authorized_keys"
     fi
 
-    out=$($(vic-path)/bin/vic-machine-"$OS" debug --target="$GOVC_URL" --compute-resource="$COMPUTE" --name=${VIC_NAME:-${USER}test} --enable-ssh $keyarg --rootpw=password --thumbprint=$THUMBPRINT $*)
+    out=$($(vic-path)/bin/vic-machine-"$OS" debug --target="$GOVC_URL" --compute-resource="$COMPUTE" --name=${VIC_NAME:-${USER}test} --enable-ssh "$keyarg" --rootpw=password --thumbprint=$THUMBPRINT $*)
     host=$(echo $out | grep DOCKER_HOST | sed -n 's/.*DOCKER_HOST=\([^:\s]*\).*/\1/p')
 
     echo "SSH to ${host}"

--- a/isos/appliance-staging.sh
+++ b/isos/appliance-staging.sh
@@ -118,7 +118,6 @@ yum_cached -p $PKGDIR clean all
 pwhash=$(openssl passwd -1 -salt vic password)
 sed -i -e "s/^root:[^:]*:/root:${pwhash}:/" $(rootfs_dir $PKGDIR)/etc/shadow
 
-
 # Disable SSH by default - this can be enabled via guest operations
 rm $(rootfs_dir $PKGDIR)/usr/lib/systemd/system/sshd@.service
 rm $(rootfs_dir $PKGDIR)/etc/systemd/system/multi-user.target.wants/sshd.service
@@ -128,6 +127,11 @@ sed -i -e "s/\#*PermitRootLogin\s.*/PermitRootLogin yes/" $(rootfs_dir $PKGDIR)/
 
 # Disable root login
 sed -i -e 's@:/bin/bash$@:/bin/false@' $(rootfs_dir $PKGDIR)/etc/passwd
+
+# Allow chpasswd to change expired password when launched from vic-init
+cp -f ${DIR}/appliance/chpasswd.pam $(rootfs_dir $PKGDIR)/etc/pam.d/chpasswd
+# Allow chage to be used with expired password when launched from vic-init
+cp -f ${DIR}/appliance/chage.pam $(rootfs_dir $PKGDIR)/etc/pam.d/chage
 
 # package up the result
 pack $PKGDIR $OUT

--- a/isos/appliance.sh
+++ b/isos/appliance.sh
@@ -64,7 +64,7 @@ unpack $PACKAGE $PKGDIR
 #################################################################
 
 # sysctl
-cp $DIR/appliance/sysctl.conf $(rootfs_dir $PKGDIR)/etc/
+cp ${DIR}/appliance/sysctl.conf $(rootfs_dir $PKGDIR)/etc/
 
 ## systemd configuration
 # create systemd vic target

--- a/isos/appliance/chage.pam
+++ b/isos/appliance/chage.pam
@@ -1,0 +1,13 @@
+#Begin /etc/pam.d/chage
+
+# always allow root
+auth      sufficient  pam_rootok.so
+account   sufficient  pam_rootok.so
+
+# include system defaults for session
+session   include     system-session
+
+# Always permit for authentication updates
+password  required    pam_permit.so
+
+# End /etc/pam.d/chage

--- a/isos/appliance/chpasswd.pam
+++ b/isos/appliance/chpasswd.pam
@@ -1,0 +1,11 @@
+#Begin /etc/pam.d/chpasswd
+
+# always allow root
+auth      sufficient  pam_rootok.so
+account   sufficient  pam_rootok.so
+
+# include system defaults for session and password
+session   include     system-session
+password  include     system-password
+
+# End /etc/pam.d/chpasswd

--- a/tests/test-cases/Group6-VIC-Machine/6-11-Debug.md
+++ b/tests/test-cases/Group6-VIC-Machine/6-11-Debug.md
@@ -1,0 +1,39 @@
+Test 6-11 - Verify vic-machine debug
+=======
+
+#Purpose:
+Verify vic-machine debug functions
+
+#References:
+* vic-machine-linux debug -h
+
+#Environment:
+This test requires that a vSphere server is running and available
+
+
+#Test Cases
+======
+
+#Enable SSH
+1. Create VCH
+2. Generate ssh keypair with ssh-keygen
+3. Run vic-machine debug to enable SSH, supplying public key for authorized_keys file
+4. ssh to endpointVM and run `/bin/true`, asserting success via exit status
+
+#Expected Results
+* All steps should succeed
+
+#Password Change When Expired
+1. Create VCH
+2. Generate ssh keypair with ssh-keygen
+3. Run vic-machine debug to enable SSH, supplying public key for authorized_keys file
+4. ssh to endpointVM using private key and run `/bin/true`, asserting success via exit status
+5. Change date to +6 years on current time - this is past the support window
+6. ssh to endpointVM using private key and run `/bin/true`, asserting failure via exit status
+7. Run vic-machine debug to enable SSH, supplying a dictionary password that would be rejected by cracklib if change were interactive
+8. ssh to endpointVM using password and run `/bin/true`, asserting success via exit status
+
+#Expected Results
+* Step 6 should fail due to expired password
+* All other steps should succeed
+

--- a/tests/test-cases/Group6-VIC-Machine/6-11-Debug.robot
+++ b/tests/test-cases/Group6-VIC-Machine/6-11-Debug.robot
@@ -35,3 +35,34 @@ Enable SSH and verify
 
     # delete the keys
     Remove Files  %{VCH-NAME}.key  %{VCH-NAME}.key.pub
+
+
+*** Test Cases ***
+Check Password Change When Expired
+    # generate a key to use for the Test
+    ${rc}=  Run And Return Rc  ssh-keygen -t rsa -N "" -f %{VCH-NAME}.key
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}=  Run And Return Rc  chmod 600 %{VCH-NAME}.key
+    Should Be Equal As Integers  ${rc}  0
+
+    ${rc}=  Run And Return Rc  bin/vic-machine-linux debug --target %{TEST_URL} --thumbprint=%{TEST_THUMBPRINT} --user %{TEST_USERNAME} --password=%{TEST_PASSWORD} --compute-resource=%{TEST_RESOURCE} --name %{VCH-NAME} --enable-ssh --authorized-key=%{VCH-NAME}.key.pub
+    Should Be Equal As Integers  ${rc}  0
+
+    # push the date forward, past the suport duration
+    ${rc}  ${output}=  Run And Return Rc And Output  ssh -o StrictHostKeyChecking=no -i %{VCH-NAME}.key root@%{VCH-IP} 'date -s " +6 year"'
+    Should Be Equal As Integers  ${rc}  0
+
+    # command should fail with expired password
+    ${rc}=  Run And Return Rc  ssh -vv -o StrictHostKeyChecking=no -i %{VCH-NAME}.key root@%{VCH-IP} /bin/true
+    Should Not Be Equal As Integers  ${rc}  0
+
+    # Set the password to a dictionary word - this should not be rejected via this path
+    ${rc}=  Run And Return Rc  bin/vic-machine-linux debug --target %{TEST_URL} --thumbprint=%{TEST_THUMBPRINT} --user %{TEST_USERNAME} --password=%{TEST_PASSWORD} --compute-resource=%{TEST_RESOURCE} --name %{VCH-NAME} --enable-ssh --rootpw=dictionary
+    Should Be Equal As Integers  ${rc}  0
+
+    # check we can now log in cleanly - log in via password
+    ${rc}=  Run And Return Rc  sshpass -p dictionary ssh -o StrictHostKeyChecking=no root@%{VCH-IP} /bin/true
+    Should Be Equal As Integers  ${rc}  0
+
+    # delete the keys
+    Remove Files  %{VCH-NAME}.key  %{VCH-NAME}.key.pub


### PR DESCRIPTION
Updates the PAM config for chage and chpasswd to operate in the case of an
expired password.

enableShell now uses chage to set expiration to one day in the future, and
both enableSSH and passwd paths from vic-machine debug call enableShell.

Fixes #4214 
