### PR TITLE
[skip ci] Enable promiscuous mode for ESX host portgroup

### DIFF
--- a/infra/machines/vcsa/create-vcsa-vm.sh
+++ b/infra/machines/vcsa/create-vcsa-vm.sh
@@ -23,8 +23,8 @@ usage() {
 export GOVC_INSECURE=1
 
 name=vcsa
-# 6.5.0a - http://pubs.vmware.com/Release_Notes/en/vsphere/65/vsphere-vcenter-server-650a-release-notes.html
-ova=VMware-vCenter-Server-Appliance-6.5.0.5200-4944578_OVF10.ova
+# 6.5.0d - http://pubs.vmware.com/Release_Notes/en/vsphere/65/vsphere-vcenter-server-650d-release-notes.html
+ova=VMware-vCenter-Server-Appliance-6.5.0.5500-5318154_OVF10.ova
 
 while getopts a:i:n: flag
 do


### PR DESCRIPTION
This has happened to all users of these scripts at least once..
The host ESX system does not have promiscuous mode enabled by default.
The scripts run fine, but VMs on the nested ESX do not get an IP address.

Bump ESX/VCSA versions to 6.5.0b
