### PR TITLE
Fix reporting server nfs mount error

### DIFF
--- a/tests/save-test-results.sh
+++ b/tests/save-test-results.sh
@@ -16,7 +16,7 @@
 # Saves test results to reporting server
 
 echo "rpcbind : $REPORTING_SERVER_URL" >>  /etc/hosts.allow
-mkdir /run/sendsigs.omit.d
+mkdir -p /run/sendsigs.omit.d
 service rpcbind restart
 mkdir /drone-test-results
 mount $REPORTING_SERVER_URL:/export/drone-test-results /drone-test-results

--- a/tests/save-test-results.sh
+++ b/tests/save-test-results.sh
@@ -16,6 +16,7 @@
 # Saves test results to reporting server
 
 echo "rpcbind : $REPORTING_SERVER_URL" >>  /etc/hosts.allow
+mkdir /run/sendsigs.omit.d
 service rpcbind restart
 mkdir /drone-test-results
 mount $REPORTING_SERVER_URL:/export/drone-test-results /drone-test-results


### PR DESCRIPTION
Issue:
After a test run, the test results are stored on an nfs mount
To mount the nfs volume, the rpcbind service needs to be restarted
When restarting the service the following error occurs

```
Stopping rpcbind daemon....
ln: failed to create symbolic link '/run/sendsigs.omit.d/rpcbind':
No such file or directory
Starting rpcbind daemon... failed!
```
This seems to be an issue in debian
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=651826

Fix:
This fix creates the directory so that the symlink can be created


