### PR TITLE
[specific ci=Group11-Upgrade] Correct certPath output on vic-machine create

### DIFF
--- a/cmd/vic-machine/create/create.go
+++ b/cmd/vic-machine/create/create.go
@@ -1377,7 +1377,7 @@ func (c *Create) Run(clic *cli.Context) (err error) {
 
 	if err = executor.CheckServiceReady(ctx, vchConfig, c.clientCert); err != nil {
 		executor.CollectDiagnosticLogs()
-		cmd, _ := executor.GetDockerAPICommand(vchConfig, c.ckey, c.ccert, c.cacert)
+		cmd, _ := executor.GetDockerAPICommand(vchConfig, c.ckey, c.ccert, c.cacert, c.certPath)
 		log.Info("\tAPI may be slow to start - try to connect to API after a few minutes:")
 		if cmd != "" {
 			log.Infof("\t\tRun command: %s", cmd)
@@ -1390,7 +1390,7 @@ func (c *Create) Run(clic *cli.Context) (err error) {
 
 	log.Infof("Initialization of appliance successful")
 
-	executor.ShowVCH(vchConfig, c.ckey, c.ccert, c.cacert, c.envFile)
+	executor.ShowVCH(vchConfig, c.ckey, c.ccert, c.cacert, c.envFile, c.certPath)
 	log.Infof("Installer completed successfully")
 	return nil
 }

--- a/lib/install/management/inspect.go
+++ b/lib/install/management/inspect.go
@@ -89,11 +89,11 @@ func (d *Dispatcher) InspectVCH(vch *vm.VirtualMachine, conf *config.VirtualCont
 		log.Debugf("No host certificates provided")
 	}
 
-	d.ShowVCH(conf, "", "", "", "")
+	d.ShowVCH(conf, "", "", "", "", "")
 	return nil
 }
 
-func (d *Dispatcher) ShowVCH(conf *config.VirtualContainerHostConfigSpec, key string, cert string, cacert string, envfile string) {
+func (d *Dispatcher) ShowVCH(conf *config.VirtualContainerHostConfigSpec, key string, cert string, cacert string, envfile string, certpath string) {
 	if d.sshEnabled {
 		log.Infof("")
 		log.Infof("SSH to appliance:")
@@ -109,7 +109,7 @@ func (d *Dispatcher) ShowVCH(conf *config.VirtualContainerHostConfigSpec, key st
 	log.Infof("Published ports can be reached at:")
 	log.Infof("%s", publicIP.String())
 
-	cmd, env := d.GetDockerAPICommand(conf, key, cert, cacert)
+	cmd, env := d.GetDockerAPICommand(conf, key, cert, cacert, certpath)
 
 	log.Info("")
 	log.Infof("Docker environment variables:")
@@ -128,7 +128,7 @@ func (d *Dispatcher) ShowVCH(conf *config.VirtualContainerHostConfigSpec, key st
 }
 
 // GetDockerAPICommand generates values to display for usage of a deployed VCH
-func (d *Dispatcher) GetDockerAPICommand(conf *config.VirtualContainerHostConfigSpec, key string, cert string, cacert string) (cmd, env string) {
+func (d *Dispatcher) GetDockerAPICommand(conf *config.VirtualContainerHostConfigSpec, key string, cert string, cacert string, certpath string) (cmd, env string) {
 	var dEnv []string
 	tls := ""
 
@@ -147,7 +147,7 @@ func (d *Dispatcher) GetDockerAPICommand(conf *config.VirtualContainerHostConfig
 			}
 
 			dEnv = append(dEnv, "DOCKER_TLS_VERIFY=1")
-			info, err := os.Stat(conf.ExecutorConfig.Name)
+			info, err := os.Stat(certpath)
 			if err == nil && info.IsDir() {
 				if abs, err := filepath.Abs(info.Name()); err == nil {
 					dEnv = append(dEnv, fmt.Sprintf("DOCKER_CERT_PATH=%s", abs))


### PR DESCRIPTION
This fixes the displayed certificate path after a create. 

@emlin do I need to update `inspect` to show this information as well, in order to close issue #4683 ? Or is `inspect`'s output fine? Or do we have another issue for updating `inspect`?