### PR TITLE
Make Admiral start after time has been synced in the VM

### DIFF
--- a/installer/packer/scripts/systemd/admiral/admiral.service
+++ b/installer/packer/scripts/systemd/admiral/admiral.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Admiral is a highly scalable and very lightweight Container Management platform for deploying and managing container based applications.
 Documentation=https://github.com/vmware/admiral
-After=docker.service systemd-networkd.service systemd-resolved.service
+After=docker.service systemd-networkd.service systemd-resolved.service systemd-timesyncd.service vmtoolsd.service
 Requires=docker.service
 
 [Service]


### PR DESCRIPTION
(cherry picked from commit 906fa59993098c0e0752206b0e965766bc17071c)

<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[  ] There is an associated issue that is labelled
[  ] Code is up-to-date with the `master` branch
[  ] You've successfully run `make test` locally
[  ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/vmware/vic/blob/master/.github/CONTRIBUTING.md
-->

Fixes #

<!--
To trigger a custom build with this PR, include one of these in the PR's title or commit messages:
* [skip ci]
* [full ci]
* [specific ci=$suitename] e.g. [specific ci=1-01-Docker-Info]
    With this option, running only one suite is supported.
-->
