### PR TITLE
Fix incorrect port number for the attach test

### DIFF
--- a/lib/apiservers/portlayer/restapi/handlers/interaction_handlers.go
+++ b/lib/apiservers/portlayer/restapi/handlers/interaction_handlers.go
@@ -59,7 +59,7 @@ func (i *InteractionHandlersImpl) Configure(api *operations.PortLayerAPI, _ *Han
 
 	api.InteractionContainerCloseStdinHandler = interaction.ContainerCloseStdinHandlerFunc(i.ContainerCloseStdinHandler)
 
-	i.attachServer = attach.NewAttachServer(constants.ManagementHostName, 0)
+	i.attachServer = attach.NewAttachServer(constants.ManagementHostName, constants.AttachServerPort)
 
 	if err := i.attachServer.Start(false); err != nil {
 		log.Fatalf("Attach server unable to start: %s", err)

--- a/lib/portlayer/attach/server.go
+++ b/lib/portlayer/attach/server.go
@@ -22,7 +22,6 @@ import (
 
 	log "github.com/Sirupsen/logrus"
 
-	"github.com/vmware/vic/lib/portlayer/constants"
 	"github.com/vmware/vic/pkg/errors"
 	"github.com/vmware/vic/pkg/trace"
 )
@@ -41,9 +40,6 @@ type Server struct {
 func NewAttachServer(ip string, port int) *Server {
 	defer trace.End(trace.Begin(""))
 
-	if port == 0 {
-		port = constants.AttachServerPort
-	}
 	return &Server{ip: "localhost", port: port}
 }
 
@@ -54,6 +50,9 @@ func (n *Server) Start(debug bool) error {
 	log.Infof("Attach server listening on %s:%d", n.ip, n.port)
 
 	addr, err := net.ResolveTCPAddr("tcp", fmt.Sprintf("%s:%d", n.ip, n.port))
+	if err != nil {
+		return fmt.Errorf("Attach server error %s:%d: %s", n.ip, n.port, errors.ErrorStack(err))
+	}
 
 	n.l, err = net.ListenTCP("tcp", addr)
 	if err != nil {

--- a/lib/portlayer/attach/server_test.go
+++ b/lib/portlayer/attach/server_test.go
@@ -35,7 +35,7 @@ import (
 // Start the server, make 200 client connections, test they connect, then Stop.
 func TestAttachStartStop(t *testing.T) {
 	log.SetLevel(log.InfoLevel)
-	s := NewAttachServer("", -1)
+	s := NewAttachServer("", 0)
 
 	wg := &sync.WaitGroup{}
 
@@ -43,8 +43,9 @@ func TestAttachStartStop(t *testing.T) {
 		defer wg.Done()
 
 		c, err := net.Dial("tcp", s.l.Addr().String())
-		assert.NoError(t, err)
-		assert.NotNil(t, c)
+		if !assert.NoError(t, err) || !assert.NotNil(t, c) {
+			return
+		}
 		defer c.Close()
 
 		buf := make([]byte, 1)
@@ -88,7 +89,7 @@ func TestAttachStartStop(t *testing.T) {
 func TestAttachSshSession(t *testing.T) {
 	log.SetLevel(log.InfoLevel)
 
-	s := NewAttachServer("", -1)
+	s := NewAttachServer("", 0)
 	assert.NoError(t, s.Start(true))
 	defer s.Stop()
 


### PR DESCRIPTION
-1 is not a valid port and it should 0 so that operating system can assign one.