### PR TITLE
[specific ci=1-06-Docker-Run] Add time accuracy check for docker run command in docker run test

### DIFF
--- a/tests/test-cases/Group1-Docker-Commands/1-06-Docker-Run.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-06-Docker-Run.robot
@@ -125,6 +125,8 @@ Docker run verify container start and stop time
     Run Keyword Unless  ${startStatus}  Fail  container start time before command start
     ${stopStatus}=  Run Keyword And Return Status  Should Be True  ${cmdStart} < ${containerStop}
     Run Keyword Unless  ${stopStatus}  Fail  container stop time before command start
+    ${timeDiff}=  Evaluate  ${containerStop}-${cmdStart}
+    Should Be True  0 < ${timeDiff} < 60000
 
 Docker run verify name and id are not conflated
     ${rc}  ${container1}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -itd busybox


### PR DESCRIPTION
Added an extra check on the docker run command.
We first check to make sure that the start time stamp actually happened before the stop time.  After that, we make sure that the simple start/stop docker command runs within 60 seconds (60,000 milliseconds).

Fixes #3710 
