### PR TITLE
vcsim: Use soapenv namespace as required by other clients

### DIFF
--- a/cmd/vcsim/main.go
+++ b/cmd/vcsim/main.go
@@ -1,4 +1,4 @@
-// Copyright 2016 VMware, Inc. All Rights Reserved.
+// Copyright 2016-2017 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -44,9 +44,10 @@ func main() {
 	flag.IntVar(&model.Folder, "folder", model.Folder, "Number of folders")
 
 	isESX := flag.Bool("esx", false, "Simulate standalone ESX")
-	isTLS := flag.Bool("tls", false, "Enable TLS")
+	isTLS := flag.Bool("tls", true, "Enable TLS")
 	cert := flag.String("tlscert", "", "Path to TLS certificate file")
 	key := flag.String("tlskey", "", "Path to TLS key file")
+	flag.BoolVar(&simulator.Trace, "trace", simulator.Trace, "Trace SOAP to stderr")
 
 	flag.Parse()
 

--- a/pkg/vsphere/simulator/README.md
+++ b/pkg/vsphere/simulator/README.md
@@ -1,0 +1,85 @@
+# govcsim - A vCenter and ESXi API based simulator
+
+This package implements a vSphere Web Services (SOAP) SDK endpoint intended for testing consumers of the API.
+While the package is written in the Go language, it can be used by any language that can talk to the vSphere API.
+
+## Installation
+
+Note: This package is currently being incubated with the VIC repository, but at some point will be moved to the govmomi
+repository.
+
+```
+% export GOPATH=$HOME/gopath
+% go get -u github.com/vmware/vic/cmd/vcsim
+% $GOPATH/bin/vcsim -h
+```
+
+## Usage
+
+The **vcsim** program by default creates a *vCenter* model with a datacenter, hosts, cluster, resource pools, networks
+and a datastore.  The naming is similar to that of the original *vcsim* mode that was included with vCenter.  The number
+of resources can be increased or decreased using the various resource type flags.  Resources can also be created and
+removed using the API.
+
+Example using the default settings:
+
+```
+% export GOVC_URL=https://user:pass@127.0.0.1:8989
+% $GOPATH/vcsim
+% govc find
+/
+/DC0
+/DC0/vm
+/DC0/vm/DC0_H0_VM0
+/DC0/vm/DC0_H0_VM1
+/DC0/vm/DC0_C0_RP0_VM0
+/DC0/vm/DC0_C0_RP0_VM1
+/DC0/host
+/DC0/host/DC0_H0
+/DC0/host/DC0_H0/DC0_H0
+/DC0/host/DC0_H0/Resources
+/DC0/host/DC0_C0
+/DC0/host/DC0_C0/DC0_C0_H0
+/DC0/host/DC0_C0/DC0_C0_H1
+/DC0/host/DC0_C0/DC0_C0_H2
+/DC0/host/DC0_C0/Resources
+/DC0/datastore
+/DC0/datastore/LocalDS_0
+/DC0/network
+/DC0/network/VM Network
+/DC0/network/DVS0
+/DC0/network/DC0_DVPG0
+```
+
+Example using ESX mode:
+
+```
+% $GOPATH/vcsim -esx
+% govc find
+/
+/ha-datacenter
+/ha-datacenter/vm
+/ha-datacenter/vm/ha-host_VM0
+/ha-datacenter/vm/ha-host_VM1
+/ha-datacenter/host
+/ha-datacenter/host/localhost.localdomain
+/ha-datacenter/host/localhost.localdomain/localhost.localdomain
+/ha-datacenter/host/localhost.localdomain/Resources
+/ha-datacenter/datastore
+/ha-datacenter/datastore/LocalDS_0
+/ha-datacenter/network
+/ha-datacenter/network/VM Network
+
+```
+
+## Supported methods
+
+The simulator supports a subset of API methods.  However, the generated [govmomi](https://github.com/vmware/govmomi)
+code includes all types and methods defined in the vmodl, which can be used to implement any method documented in the
+[VMware vSphere API Reference](http://pubs.vmware.com/vsphere-65/index.jsp#com.vmware.wssdk.apiref.doc/right-pane.html).
+
+To see the list of supported methods:
+
+```
+curl -k https://user:pass@127.0.0.1:8989/about
+```

--- a/pkg/vsphere/simulator/property_filter.go
+++ b/pkg/vsphere/simulator/property_filter.go
@@ -1,4 +1,4 @@
-// Copyright 2016 VMware, Inc. All Rights Reserved.
+// Copyright 2016-2017 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -23,10 +23,14 @@ import (
 
 type PropertyFilter struct {
 	mo.PropertyFilter
+
+	pc *PropertyCollector
 }
 
-func (*PropertyFilter) DestroyPropertyFilter(c *types.DestroyPropertyFilter) soap.HasFault {
+func (f *PropertyFilter) DestroyPropertyFilter(c *types.DestroyPropertyFilter) soap.HasFault {
 	body := &methods.DestroyPropertyFilterBody{}
+
+	f.pc.Filter = RemoveReference(c.This, f.pc.Filter)
 
 	Map.Remove(c.This)
 

--- a/pkg/vsphere/simulator/session_manager.go
+++ b/pkg/vsphere/simulator/session_manager.go
@@ -20,6 +20,7 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/session"
 	"github.com/vmware/govmomi/vim25/methods"
 	"github.com/vmware/govmomi/vim25/mo"
 	"github.com/vmware/govmomi/vim25/soap"
@@ -41,14 +42,22 @@ func NewSessionManager(ref types.ManagedObjectReference) object.Reference {
 func (s *SessionManager) Login(login *types.Login) soap.HasFault {
 	body := &methods.LoginBody{}
 
+	if login.Locale == "" {
+		login.Locale = session.Locale
+	}
+
 	if login.UserName == "" || login.Password == "" {
 		body.Fault_ = Fault("Login failure", &types.InvalidLogin{})
 	} else {
 		body.Res = &types.LoginResponse{
 			Returnval: types.UserSession{
-				UserName:  login.UserName,
-				FullName:  login.UserName,
-				LoginTime: time.Now(),
+				Key:            uuid.New().String(),
+				UserName:       login.UserName,
+				FullName:       login.UserName,
+				LoginTime:      time.Now(),
+				LastActiveTime: time.Now(),
+				Locale:         login.Locale,
+				MessageLocale:  login.Locale,
 			},
 		}
 	}

--- a/pkg/vsphere/simulator/virtual_machine.go
+++ b/pkg/vsphere/simulator/virtual_machine.go
@@ -1,4 +1,4 @@
-// Copyright 2016 VMware, Inc. All Rights Reserved.
+// Copyright 2016-2017 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -92,7 +92,12 @@ func NewVirtualMachine(spec *types.VirtualMachineConfigSpec) (*VirtualMachine, t
 	}
 
 	vm.Runtime.PowerState = types.VirtualMachinePowerStatePoweredOff
+	vm.Runtime.ConnectionState = types.VirtualMachineConnectionStateConnected
 	vm.Summary.Runtime = vm.Runtime
+
+	vm.Summary.QuickStats.GuestHeartbeatStatus = types.ManagedEntityStatusGray
+	vm.Summary.OverallStatus = types.ManagedEntityStatusGreen
+	vm.ConfigStatus = types.ManagedEntityStatusGreen
 
 	return vm, nil
 }
@@ -122,6 +127,7 @@ func (vm *VirtualMachine) configure(spec *types.VirtualMachineConfigSpec) types.
 		{spec.Uuid, &vm.Config.Uuid},
 		{spec.Version, &vm.Config.Version},
 		{spec.Files.VmPathName, &vm.Config.Files.VmPathName},
+		{spec.Files.VmPathName, &vm.Summary.Config.VmPathName},
 		{spec.Files.SnapshotDirectory, &vm.Config.Files.SnapshotDirectory},
 		{spec.Files.LogDirectory, &vm.Config.Files.LogDirectory},
 	}

--- a/pkg/vsphere/simulator/virtual_machine_test.go
+++ b/pkg/vsphere/simulator/virtual_machine_test.go
@@ -1,4 +1,4 @@
-// Copyright 2016 VMware, Inc. All Rights Reserved.
+// Copyright 2016-2017 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
With this set of changes, the pyvmomi/sample programs and rbvmomi+rvc
basics work against vcsim.
