### PR TITLE
Copy existing volume data to mounts [full ci]

### DIFF
--- a/cmd/tether/tether_test.go
+++ b/cmd/tether/tether_test.go
@@ -164,6 +164,13 @@ func (t *Mocker) MountTarget(ctx context.Context, source url.URL, target string,
 	return nil
 }
 
+// CopyExistingContent copies the underlying files shadowed by a mount on a directory
+// to the volume mounted on the directory
+func (t *Mocker) CopyExistingContent(source string) error {
+	defer trace.End(trace.Begin(fmt.Sprintf("mocking copyExistingContent from %s", source)))
+	return nil
+}
+
 // Fork triggers vmfork and handles the necessary pre/post OS level operations
 func (t *Mocker) Fork() error {
 	defer trace.End(trace.Begin("mocking fork"))

--- a/cmd/vic-init/tether_test.go
+++ b/cmd/vic-init/tether_test.go
@@ -165,6 +165,13 @@ func (t *Mocker) MountTarget(ctx context.Context, source url.URL, target string,
 	return nil
 }
 
+// CopyExistingContent copies the underlying files shadowed by a mount on a directory
+// to the volume mounted on the directory
+func (t *Mocker) CopyExistingContent(source string) error {
+	defer trace.End(trace.Begin(fmt.Sprintf("mocking copyExistingContent from %s", source)))
+	return nil
+}
+
 // Fork triggers vmfork and handles the necessary pre/post OS level operations
 func (t *Mocker) Fork() error {
 	defer trace.End(trace.Begin("mocking fork"))

--- a/lib/config/executor/container_vm.go
+++ b/lib/config/executor/container_vm.go
@@ -29,6 +29,17 @@ const (
 	KILLED
 )
 
+// CopyMode type to define whether to copy data from the base image on mount
+type CopyMode int
+
+const (
+	// CopyNever Dont copy data on mount
+	CopyNever CopyMode = iota + 1
+
+	// CopyNew Copy data to the volume when it is first mounted
+	CopyNew
+)
+
 // Common data between managed entities, across execution environments
 type Common struct {
 	// A reference to the components hosting execution environment, if any
@@ -78,17 +89,6 @@ type ExitLog struct {
 	ExitStatus int
 	Message    string
 }
-
-// CopyMode type to define whether to copy data from the base image on mount
-type CopyMode int
-
-const (
-	// CopyNever Dont copy data on mount
-	CopyNever CopyMode = iota
-
-	// CopyNew Copy data to the volume when it is first mounted
-	CopyNew
-)
 
 // MountSpec details a mount that must be executed within the executor
 // A mount is a URI -> path mapping with a credential of some kind

--- a/lib/config/executor/container_vm.go
+++ b/lib/config/executor/container_vm.go
@@ -79,6 +79,17 @@ type ExitLog struct {
 	Message    string
 }
 
+// CopyMode type to define whether to copy data from the base image on mount
+type CopyMode int
+
+const (
+	// CopyNever Dont copy data on mount
+	CopyNever CopyMode = iota
+
+	// CopyNew Copy data to the volume when it is first mounted
+	CopyNew
+)
+
 // MountSpec details a mount that must be executed within the executor
 // A mount is a URI -> path mapping with a credential of some kind
 // In the case of a labeled disk:
@@ -94,6 +105,9 @@ type MountSpec struct {
 	// Freeform mode string, which could translate directly to mount options
 	// We may want to turn this into a more structured form eventually
 	Mode string `vic:"0.1" scope:"read-only" key:"mode"`
+
+	// CopyMode specifies if data should be copied from the base image on first mount
+	CopyMode CopyMode `vic:"0.1" scope:"read-only" key:"copymode"`
 }
 
 // ContainerVM holds that data tightly associated with a containerVM, but that should not

--- a/lib/portlayer/storage/nfs/vm.go
+++ b/lib/portlayer/storage/nfs/vm.go
@@ -16,7 +16,6 @@ package nfs
 
 import (
 	"fmt"
-	"net/url"
 
 	"github.com/vmware/vic/lib/config/executor"
 	"github.com/vmware/vic/lib/portlayer/exec"
@@ -49,8 +48,7 @@ func VolumeJoin(op trace.Operation, handle *exec.Handle, volume *storage.Volume,
 	}
 
 	// construct MountSpec for the tether
-	mountSpec := createMountSpec(volume.Device.DiskPath(), mountPath, diskOpts)
-
+	mountSpec := createMountSpec(volume, mountPath, diskOpts)
 	if handle.ExecConfig.Mounts == nil {
 		handle.ExecConfig.Mounts = make(map[string]executor.MountSpec)
 	}
@@ -59,12 +57,14 @@ func VolumeJoin(op trace.Operation, handle *exec.Handle, volume *storage.Volume,
 	return handle, nil
 }
 
-func createMountSpec(host url.URL, mountPath string, diskOpts map[string]string) *executor.MountSpec {
+func createMountSpec(volume *storage.Volume, mountPath string, diskOpts map[string]string) *executor.MountSpec {
+	host := volume.Device.DiskPath()
 	deviceMode := nfsMountOptions + ",addr=" + host.Host
 	newMountSpec := executor.MountSpec{
-		Source: host,
-		Path:   mountPath,
-		Mode:   deviceMode,
+		Source:   host,
+		Path:     mountPath,
+		Mode:     deviceMode,
+		CopyMode: volume.CopyMode,
 	}
 	return &newMountSpec
 }

--- a/lib/portlayer/storage/nfs/volume.go
+++ b/lib/portlayer/storage/nfs/volume.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"path"
 
+	"github.com/vmware/vic/lib/config/executor"
 	"github.com/vmware/vic/lib/portlayer/storage"
 	"github.com/vmware/vic/lib/portlayer/util"
 	"github.com/vmware/vic/pkg/trace"
@@ -117,7 +118,7 @@ func (v *VolumeStore) VolumeCreate(op trace.Operation, ID string, store *url.URL
 		return nil, fmt.Errorf("Unexpected scheme (%s) for volume store (%s)", u.Scheme, v.Name)
 	}
 
-	vol, err := storage.NewVolume(v.SelfLink, ID, info, NewVolume(u, v.volDirPath(ID)))
+	vol, err := storage.NewVolume(v.SelfLink, ID, info, NewVolume(u, v.volDirPath(ID)), executor.CopyNew)
 	if err != nil {
 		return nil, err
 	}
@@ -130,7 +131,7 @@ func (v *VolumeStore) VolumeCreate(op trace.Operation, ID string, store *url.URL
 	return vol, nil
 }
 
-// Removes a volume and all of its contents from the nfs store. We already know via the cache if it is in use.
+// VolumeDestroy Removes a volume and all of its contents from the nfs store. We already know via the cache if it is in use.
 func (v *VolumeStore) VolumeDestroy(op trace.Operation, vol *storage.Volume) error {
 	target, err := v.Service.Mount(op)
 	if err != nil {
@@ -184,7 +185,7 @@ func (v *VolumeStore) VolumesList(op trace.Operation) ([]*storage.Volume, error)
 		}
 
 		u, _ := v.Service.URL()
-		vol, err := storage.NewVolume(v.SelfLink, fileInfo.Name(), volMetadata, NewVolume(u, v.volDirPath(fileInfo.Name())))
+		vol, err := storage.NewVolume(v.SelfLink, fileInfo.Name(), volMetadata, NewVolume(u, v.volDirPath(fileInfo.Name())), executor.CopyNew)
 		if err != nil {
 			op.Errorf("Failed to create volume struct from volume directory (%s)", fileInfo.Name())
 			return nil, err

--- a/lib/portlayer/storage/volume.go
+++ b/lib/portlayer/storage/volume.go
@@ -22,6 +22,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/vmware/vic/lib/config/executor"
 	"github.com/vmware/vic/lib/portlayer/util"
 	"github.com/vmware/vic/pkg/trace"
 )
@@ -70,10 +71,12 @@ type Volume struct {
 
 	// Backing device
 	Device Disk
+
+	CopyMode executor.CopyMode
 }
 
 // NewVolume creates a Volume
-func NewVolume(store *url.URL, ID string, info map[string][]byte, device Disk) (*Volume, error) {
+func NewVolume(store *url.URL, ID string, info map[string][]byte, device Disk, copyMode executor.CopyMode) (*Volume, error) {
 	storeName, err := util.VolumeStoreName(store)
 	if err != nil {
 		return nil, err
@@ -93,8 +96,8 @@ func NewVolume(store *url.URL, ID string, info map[string][]byte, device Disk) (
 		SelfLink: selflink,
 		Device:   device,
 		Info:     info,
+		CopyMode: copyMode,
 	}
-
 	return vol, nil
 }
 

--- a/lib/portlayer/storage/vsphere/vm.go
+++ b/lib/portlayer/storage/vsphere/vm.go
@@ -34,7 +34,6 @@ func VolumeJoin(op trace.Operation, handle *exec.Handle, volume *storage.Volume,
 
 	//constuct MountSpec for the tether
 	mountSpec := createMountSpec(volume, mountPath, diskOpts)
-
 	//append a device addition spec change to the container config
 	diskDevice := createVolumeVirtualDisk(volume)
 	config := createDeviceConfigSpec(diskDevice)
@@ -83,8 +82,9 @@ func createMountSpec(volume *storage.Volume, mountPath string, diskOpts map[stri
 			Scheme: "label",
 			Path:   volume.Label,
 		},
-		Path: mountPath,
-		Mode: deviceMode,
+		Path:     mountPath,
+		Mode:     deviceMode,
+		CopyMode: volume.CopyMode,
 	}
 	return newMountSpec
 }

--- a/lib/portlayer/storage/vsphere/volume.go
+++ b/lib/portlayer/storage/vsphere/volume.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/vim25/types"
+	"github.com/vmware/vic/lib/config/executor"
 	"github.com/vmware/vic/lib/portlayer/storage"
 	"github.com/vmware/vic/lib/portlayer/util"
 	"github.com/vmware/vic/pkg/trace"
@@ -105,8 +106,7 @@ func (v *VolumeStore) VolumeCreate(op trace.Operation, ID string, store *url.URL
 		return nil, err
 	}
 	defer v.dm.Detach(op, vmdisk)
-
-	vol, err := storage.NewVolume(store, ID, info, vmdisk)
+	vol, err := storage.NewVolume(store, ID, info, vmdisk, executor.CopyNew)
 	if err != nil {
 		return nil, err
 	}
@@ -173,7 +173,7 @@ func (v *VolumeStore) VolumesList(op trace.Operation) ([]*storage.Volume, error)
 			return nil, err
 		}
 
-		vol, err := storage.NewVolume(v.SelfLink, ID, meta, dev)
+		vol, err := storage.NewVolume(v.SelfLink, ID, meta, dev, executor.CopyNew)
 		if err != nil {
 			return nil, err
 		}

--- a/lib/tether/interfaces.go
+++ b/lib/tether/interfaces.go
@@ -37,6 +37,7 @@ type Operations interface {
 	Apply(endpoint *NetworkEndpoint) error
 	MountLabel(ctx context.Context, label, target string) error
 	MountTarget(ctx context.Context, source url.URL, target string, mountOptions string) error
+	CopyExistingContent(source string) error
 	Fork() error
 	// Returns two DynamicMultiWriters for stdout and stderr
 	SessionLog(session *SessionConfig) (dio.DynamicMultiWriter, dio.DynamicMultiWriter, error)

--- a/lib/tether/ops_darwin.go
+++ b/lib/tether/ops_darwin.go
@@ -58,6 +58,14 @@ func (t *BaseOperations) MountTarget(ctx context.Context, source url.URL, target
 	return errors.New("not implemented on OSX")
 }
 
+// CopyExistingContent copies the underlying files shadowed by a mount on a directory
+// to the volume mounted on the directory
+func (t *BaseOperations) CopyExistingContent(source string) error {
+	defer trace.End(trace.Begin(fmt.Sprintf("copyExistingContent from %s", source)))
+
+	return errors.New("not implemented on OSX")
+}
+
 // ProcessEnv does OS specific checking and munging on the process environment prior to launch
 func (t *BaseOperations) ProcessEnv(env []string) []string {
 	// TODO: figure out how we're going to specify user and pass all the settings along

--- a/lib/tether/ops_linux.go
+++ b/lib/tether/ops_linux.go
@@ -740,7 +740,6 @@ func (t *BaseOperations) MountTarget(ctx context.Context, source url.URL, target
 
 // CopyExistingContent copies the underlying files shadowed by a mount on a directory
 // to the volume mounted on the directory
-// this is only done only once
 // see bug https://github.com/vmware/vic/issues/3482
 func (t *BaseOperations) CopyExistingContent(source string) error {
 	defer trace.End(trace.Begin(fmt.Sprintf("copyExistingContent from %s", source)))
@@ -771,14 +770,11 @@ func (t *BaseOperations) CopyExistingContent(source string) error {
 		return err
 	}
 
-	// TODO jaked copy ownership
-
 	log.Debugf("unmounting %s", bindDir)
 	if err := Sys.Syscall.Unmount(bindDir, syscall.MNT_DETACH); err != nil {
 		log.Errorf("error unmounting %+v", err)
 		return err
 	}
-
 	log.Debugf("removing %s", bindDir)
 	if err := os.Remove(bindDir); err != nil {
 		log.Errorf("error removing directory %s: %+v", bindDir, err)

--- a/lib/tether/ops_linux.go
+++ b/lib/tether/ops_linux.go
@@ -753,7 +753,7 @@ func (t *BaseOperations) CopyExistingContent(source string) error {
 		return err
 	}
 
-	parentDir := filepath.Dir(filepath.Clean(source))
+	parentDir := filepath.Dir(source)
 	// mount the parent directory of the source to bindDir
 	// e.g if source is /foo/bar, mount /foo to ./bindDir
 	log.Debugf("mounting %s on %s", parentDir, bindDir)

--- a/lib/tether/ops_linux.go
+++ b/lib/tether/ops_linux.go
@@ -31,6 +31,7 @@ import (
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/d2g/dhcp4"
+	"github.com/docker/docker/pkg/archive"
 	// need to use libcontainer for user validation, for os/user package cannot find user here if container image is busybox
 	"github.com/opencontainers/runc/libcontainer/user"
 	"github.com/vishvananda/netlink"
@@ -40,6 +41,11 @@ import (
 	"github.com/vmware/vic/pkg/ip"
 	"github.com/vmware/vic/pkg/trace"
 	"github.com/vmware/vmw-guestinfo/rpcout"
+)
+
+const (
+	bindDir      = "/.bind"
+	mountsCopied = "/.mountscopied"
 )
 
 var (
@@ -715,6 +721,11 @@ func (t *BaseOperations) MountLabel(ctx context.Context, label, target string) e
 		return errors.New(detail)
 	}
 
+	if err := copyExistingContent(target); err != nil {
+		detail := fmt.Sprintf("copying existing data to %s failed: %s", target, err)
+		return errors.New(detail)
+	}
+
 	return nil
 }
 
@@ -732,6 +743,11 @@ func (t *BaseOperations) MountTarget(ctx context.Context, source url.URL, target
 	if err := Sys.Syscall.Mount(rawSource, target, nfsFileSystemType, 0, mountOptions); err != nil {
 		log.Errorf("mounting %s on %s failed: %s", source.String(), target, err)
 		return err
+	}
+
+	if err := copyExistingContent(target); err != nil {
+		detail := fmt.Sprintf("copying existing data to %s failed: %s", target, err)
+		return errors.New(detail)
 	}
 
 	return nil
@@ -873,4 +889,59 @@ func getUserSysProcAttr(uid, gid string) (*syscall.SysProcAttr, error) {
 		sysProc.Credential.Groups = append(sysProc.Credential.Groups, uint32(sgid))
 	}
 	return sysProc, nil
+}
+
+// copyExistingContent copies the underlying files
+// shadowed by a mount on a directory to the volume mounted on the directory
+// this is only done only once
+// see bug https://github.com/vmware/vic/issues/3482
+func copyExistingContent(source string) error {
+	defer trace.End(trace.Begin(fmt.Sprintf("copyExistingContent from %s on mount", source)))
+
+	// skip if this was done before
+	if _, err := os.Stat(mountsCopied); err == nil {
+		log.Errorf("mounts already copied, skipping copy")
+		return nil
+	}
+
+	log.Debugf("creating directory %s", bindDir)
+	if err := os.MkdirAll(bindDir, 0644); err != nil {
+		log.Errorf("error creating directory %s: %+v", bindDir, err)
+		return err
+	}
+
+	log.Debugf("mounting / on %s", bindDir)
+	if err := Sys.Syscall.Mount("/", bindDir, ext4FileSystemType, syscall.MS_BIND, ""); err != nil {
+		log.Errorf("error mounting to %s: %+v", bindDir, err)
+		return err
+	}
+
+	mountedSource := filepath.Join(bindDir, source)
+	log.Debugf("copying contents from to %s to %s", mountedSource, source)
+	if err := archive.CopyWithTar(mountedSource, source); err != nil {
+		log.Errorf("err copying %s to %s: %+v", mountedSource, source, err)
+		return err
+	}
+
+	log.Debugf("unmounting / from %s", bindDir)
+	if err := Sys.Syscall.Unmount(bindDir, syscall.MNT_DETACH); err != nil {
+		log.Errorf("error unmounting %+v", err)
+		return err
+	}
+
+	log.Debugf("removing %s", bindDir)
+	if err := os.Remove(bindDir); err != nil {
+		log.Errorf("error removing directory %s: %+v", bindDir, err)
+		return err
+	}
+
+	log.Debugf("creating %s", mountsCopied)
+	f, err := os.Create(mountsCopied)
+	if err != nil {
+		log.Debugf("error creating file %s: %+v", mountsCopied, err)
+		return err
+	}
+	defer f.Close()
+
+	return nil
 }

--- a/lib/tether/ops_linux.go
+++ b/lib/tether/ops_linux.go
@@ -746,11 +746,29 @@ func (t *BaseOperations) CopyExistingContent(source string) error {
 
 	source = filepath.Clean(source)
 
+	// if mounted volume is not empty skip the copy task
+	if empty, err := isEmpty(source); err != nil || !empty {
+		if err != nil {
+			log.Errorf("error checking directory for contents %s: %+v", source, err)
+			return err
+		}
+		log.Debugf("Skipping copy as volume %s is not empty", source)
+		return nil
+	}
+
 	log.Debugf("creating directory %s", bindDir)
 	if err := os.MkdirAll(bindDir, 0644); err != nil {
 		log.Errorf("error creating directory %s: %+v", bindDir, err)
 		return err
 	}
+
+	// remove dir
+	defer func() {
+		log.Debugf("removing %s", bindDir)
+		if err := os.Remove(bindDir); err != nil {
+			log.Errorf("error removing directory %s: %+v", bindDir, err)
+		}
+	}()
 
 	parentDir := filepath.Dir(source)
 	// mount the parent directory of the source to bindDir
@@ -761,23 +779,20 @@ func (t *BaseOperations) CopyExistingContent(source string) error {
 		return err
 	}
 
+	// unmount
+	defer func() {
+		log.Debugf("unmounting %s", bindDir)
+		if err := Sys.Syscall.Unmount(bindDir, syscall.MNT_DETACH); err != nil {
+			log.Errorf("error unmounting %+v", err)
+		}
+	}()
+
 	mountedSource := filepath.Join(bindDir, filepath.Base(source))
 	// copy data from the bindDir to the source
 	// e.g if source is /foo/bar, copy ./bindDir/bar to /foo/bar
 	log.Debugf("copying contents from to %s to %s", mountedSource, source)
 	if err := archive.CopyWithTar(mountedSource, source); err != nil {
 		log.Errorf("err copying %s to %s: %+v", mountedSource, source, err)
-		return err
-	}
-
-	log.Debugf("unmounting %s", bindDir)
-	if err := Sys.Syscall.Unmount(bindDir, syscall.MNT_DETACH); err != nil {
-		log.Errorf("error unmounting %+v", err)
-		return err
-	}
-	log.Debugf("removing %s", bindDir)
-	if err := os.Remove(bindDir); err != nil {
-		log.Errorf("error removing directory %s: %+v", bindDir, err)
 		return err
 	}
 
@@ -920,4 +935,31 @@ func getUserSysProcAttr(uid, gid string) (*syscall.SysProcAttr, error) {
 		sysProc.Credential.Groups = append(sysProc.Credential.Groups, uint32(sgid))
 	}
 	return sysProc, nil
+}
+
+// isEmpty returns true if the directory is empty or contains a lost+found folder
+func isEmpty(name string) (bool, error) {
+	files, err := readDir(name)
+	if err != nil || len(files) > 0 {
+		return false, err
+	}
+	return true, nil
+}
+
+// readDir reads a directory and hides a specific dir "lost+found"
+func readDir(dir string) ([]os.FileInfo, error) {
+	lostnfound := "lost+found"
+	files, err := ioutil.ReadDir(dir)
+	if err != nil {
+		return nil, err
+	}
+
+	result := files[:0]
+	for _, f := range files {
+		if f.Name() != lostnfound {
+			result = append(result, f)
+		}
+	}
+
+	return result, nil
 }

--- a/lib/tether/ops_linux_test.go
+++ b/lib/tether/ops_linux_test.go
@@ -29,6 +29,10 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/vishvananda/netlink"
 
+	"os"
+
+	"io/ioutil"
+
 	"github.com/vmware/vic/pkg/trace"
 )
 
@@ -246,4 +250,30 @@ func TestGetUserSysProcAttr(t *testing.T) {
 		assert.Equal(t, test.ruid, int(user.Credential.Uid), "returned user id mismatch")
 		assert.Equal(t, test.rgid, int(user.Credential.Gid), "returned group id mismatch")
 	}
+}
+
+func TestIsEmpty(t *testing.T) {
+	dir, err := ioutil.TempDir("", "testisEmpty")
+	assert.NoError(t, err)
+
+	defer os.RemoveAll(dir)
+
+	err = os.MkdirAll(dir+"/lost+found", 0644)
+	assert.NoError(t, err)
+
+	ok, err := isEmpty(dir)
+	assert.True(t, ok)
+	assert.NoError(t, err)
+
+	err = os.MkdirAll(dir+"/test1", 0644)
+	assert.NoError(t, err)
+	err = os.MkdirAll(dir+"/test2", 0644)
+	assert.NoError(t, err)
+	err = ioutil.WriteFile(dir+"/test3.txt", []byte{}, 0644)
+	assert.NoError(t, err)
+
+	ok, err = isEmpty(dir)
+	assert.False(t, ok)
+	assert.NoError(t, err)
+
 }

--- a/lib/tether/ops_windows.go
+++ b/lib/tether/ops_windows.go
@@ -59,6 +59,14 @@ func (t *BaseOperations) MountTarget(ctx context.Context, source url.URL, target
 	return errors.New("not implemented on Windows")
 }
 
+// CopyExistingContent copies the underlying files shadowed by a mount on a directory
+// to the volume mounted on the directory
+func (t *BaseOperations) CopyExistingContent(source string) error {
+	defer trace.End(trace.Begin(fmt.Sprintf("copyExistingContent from %s", source)))
+
+	return errors.New("not implemented on Windows")
+}
+
 // processEnvOS does OS specific checking and munging on the process environment prior to launch
 func (t *BaseOperations) ProcessEnv(env []string) []string {
 	return env

--- a/lib/tether/tether.go
+++ b/lib/tether/tether.go
@@ -51,8 +51,6 @@ const (
 
 	// temp directory to copy existing data to mounts
 	bindDir = "/.tether/.bind"
-	// markfile to avoid re-copying existing data to mounts
-	mountsCopied = "/.tether/.mountscopied"
 )
 
 var Sys = system.New()
@@ -267,11 +265,6 @@ func (t *tether) populateVolumes() error {
 	if len(t.config.Mounts) == 0 {
 		return nil
 	}
-	// skip if this was done before
-	if _, err := os.Stat(mountsCopied); err == nil {
-		log.Debugf("mounts already copied, skipping copy")
-		return nil
-	}
 
 	for _, mnt := range t.config.Mounts {
 		if mnt.Path == "" {
@@ -285,18 +278,6 @@ func (t *tether) populateVolumes() error {
 			}
 		}
 	}
-
-	log.Debugf("creating %s", mountsCopied)
-	f, err := os.Create(mountsCopied)
-	if err != nil {
-		log.Debugf("error creating file %s: %+v", mountsCopied, err)
-		return err
-	}
-	defer func() {
-		if err := f.Close(); err != nil {
-			log.Errorf("error closing file for mount %s: %+v", f.Name(), err)
-		}
-	}()
 
 	return nil
 }

--- a/lib/tether/tether.go
+++ b/lib/tether/tether.go
@@ -263,6 +263,10 @@ func (t *tether) setMounts() error {
 
 func (t *tether) populateVolumes() error {
 	defer trace.End(trace.Begin(fmt.Sprintf("populateVolumes")))
+	// skip if no mounts present
+	if len(t.config.Mounts) == 0 {
+		return nil
+	}
 	// skip if this was done before
 	if _, err := os.Stat(mountsCopied); err == nil {
 		log.Debugf("mounts already copied, skipping copy")

--- a/lib/tether/tether_test.go
+++ b/lib/tether/tether_test.go
@@ -179,6 +179,13 @@ func (t *Mocker) MountTarget(ctx context.Context, source url.URL, target string,
 	return nil
 }
 
+// CopyExistingContent copies the underlying files shadowed by a mount on a directory
+// to the volume mounted on the directory
+func (t *Mocker) CopyExistingContent(source string) error {
+	defer trace.End(trace.Begin(fmt.Sprintf("mocking copyExistingContent from %s", source)))
+	return nil
+}
+
 // Fork triggers vmfork and handles the necessary pre/post OS level operations
 func (t *Mocker) Fork() error {
 	defer trace.End(trace.Begin("mocking fork"))

--- a/tests/resources/dockerfiles/Dockerfile.1-06-Docker-Verify-Volume-Files
+++ b/tests/resources/dockerfiles/Dockerfile.1-06-Docker-Verify-Volume-Files
@@ -1,0 +1,23 @@
+# Copyright 2017 VMware, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License
+
+# docker build --no-cache -t jakedsouza/group-1-06-docker-verify-volume-files:1.0 -f Dockerfile.1-06-Docker-Verify-Volume-Files .
+# docker push jakedsouza/group-1-06-docker-verify-volume-files:1.0
+
+FROM alpine:latest
+
+RUN mkdir -p /etc/example/thisshouldexist
+RUN echo "TestFile" >> /etc/example/testfile.txt
+
+VOLUME ["/etc/example"]

--- a/tests/resources/dockerfiles/Dockerfile.1-19-Docker-Verify-Volume-Files
+++ b/tests/resources/dockerfiles/Dockerfile.1-19-Docker-Verify-Volume-Files
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License
 
-# docker build --no-cache -t jakedsouza/group-1-06-docker-verify-volume-files:1.0 -f Dockerfile.1-06-Docker-Verify-Volume-Files .
-# docker push jakedsouza/group-1-06-docker-verify-volume-files:1.0
+# docker build --no-cache -t jakedsouza/group-1-19-docker-verify-volume-files:1.0 -f Dockerfile.1-19-Docker-Verify-Volume-Files .
+# docker push jakedsouza/group-1-19-docker-verify-volume-files:1.0
 
 FROM alpine:latest
 

--- a/tests/test-cases/Group1-Docker-Commands/1-06-Docker-Run.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-06-Docker-Run.robot
@@ -83,7 +83,7 @@ Docker run -d unspecified host port
 Docker run check exit codes
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run busybox true
     Should Be Equal As Integers  ${rc}  0
-	${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run busybox false
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run busybox false
     Should Be Equal As Integers  ${rc}  1
 
 Docker run ps password check

--- a/tests/test-cases/Group1-Docker-Commands/1-19-Docker-Volume-Create.md
+++ b/tests/test-cases/Group1-Docker-Commands/1-19-Docker-Volume-Create.md
@@ -24,18 +24,21 @@ This test requires that a vSphere server is running and available
 11. Issue docker volume create --name=test8 --opt Capacity=9999999999
 12. Issue docker volume create --name=test???
 13. Issue docker volume create --name=multipleX --opt Capacity=2MB ten times rapidly
+14. Create container with an anonymous volume in the Dockerfile, and verify that the files in the volume exist
+15. Create container with a named volume and verify that base image files are copied to the named volume
+16. Create container with a named volume. Modify the copied image file. Remount the volume in a new container.
 
 #Expected Outcome:
 * Steps 2 and 3 should complete successfully and return the name of the volume created, you should then be able to see the volume has been created
-* Step 4 should result in error with the following error message:  
+* Step 4 should result in error with the following error message:
 ```
 Error response from daemon: A volume named test already exists. Choose a different volume name.
 ```
-* Step 5 should result in error with the following error message:  
+* Step 5 should result in error with the following error message:
 ```
 error looking up volume plugin fakeDriver: plugin not found
 ```
-* Step 6 should result in error with the following message:  
+* Step 6 should result in error with the following message:
 ```
 Error looking up volume store fakeStore: datastore not found
 ```
@@ -44,11 +47,14 @@ Error looking up volume store fakeStore: datastore not found
 * Step 9 should result in error and indicate that the capacity suggested is invalid
 * Step 10 should result in error and indicate that the datastore cannot create that big of a volume
 * Step 11 should result in error and indicate that the capacity suggested in invalid
-* Step 12 should result in error with the following message:  
+* Step 12 should result in error with the following message:
 ```
 Error response from daemon: create test???: "test???" includes invalid characters for a local volume name, only "\[a-zA-Z0-9][a-zA-Z0-9_.-]" are allowed
 ```
 * Step 13 should not result in any of the volume create operations failing
+* Step 14 should result in success and print data in the volume
+* Step 15 should result in success and print data in the volume
+* Step 16 should result in success and the second container should contain the modified file contents
 
 #Possible Problems:
 * VIC requires you to specify storage on creation of the VCH that volumes can be created from, so when installing the VCH make sure to specify this parameter: --volume-store=

--- a/tests/test-cases/Group1-Docker-Commands/1-19-Docker-Volume-Create.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-19-Docker-Volume-Create.robot
@@ -164,3 +164,31 @@ Docker volume create with possibly invalid name
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} volume create --name=test???
     Should Be Equal As Integers  ${rc}  1
     Should Be Equal As Strings  ${output}  Error response from daemon: volume name "test???" includes invalid characters, only "[a-zA-Z0-9][a-zA-Z0-9_.-]" are allowed
+
+Docker volume verify anonymous volume contains base image files
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run jakedsouza/group-1-19-docker-verify-volume-files:1.0 ls /etc/example
+    Should Be Equal As Integers  ${rc}  0
+    Should Contain  ${output}  thisshouldexist
+    Should Contain  ${output}  testfile.txt
+
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run jakedsouza/group-1-19-docker-verify-volume-files:1.0 cat /etc/example/testfile.txt
+    Should Be Equal As Integers  ${rc}  0
+    Should Contain  ${output}  TestFile
+
+Docker volume verify named volume contains base image files
+	${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -v test15:/etc/example jakedsouza/group-1-19-docker-verify-volume-files:1.0 cat /etc/example/testfile.txt
+    Should Be Equal As Integers  ${rc}  0
+    Should Contain  ${output}  TestFile
+
+	# Verify file is copied to volumeA
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -v test15:/mnt/test15 jakedsouza/group-1-19-docker-verify-volume-files:1.0 cat /mnt/test15/testfile.txt
+    Should Be Equal As Integers  ${rc}  0
+    Should Contain  ${output}  TestFile
+
+Docker volume verify files are not copied again in a non empty volume
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -v test16:/etc/example jakedsouza/group-1-19-docker-verify-volume-files:1.0 sh -c "echo test16modified >> /etc/example/testfile.txt"
+    Should Be Equal As Integers  ${rc}  0
+    # Verify modified file remains
+	${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -v test16:/etc/example jakedsouza/group-1-19-docker-verify-volume-files:1.0 cat /etc/example/testfile.txt
+	Should Be Equal As Integers  ${rc}  0
+	Should Contain  ${output}  test16modified


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[  ] There is an associated issue that is labelled
[  ] Code is up-to-date with the `master` branch
[  ] You've successfully run `make test` locally
[  ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/vmware/vic/blob/master/.github/CONTRIBUTING.md
-->



**Issue:**
  A containers base image data is **not** copied when a volume is mounted, if the containers base image contains data at the mount point. 

**Fix:**
  After mounting the volumes, copy the underlying base image files to the mount point. 
 
Changes - 
1. After all volumes are mounted, call `populateVolumes` 
2. For each mountpoint, `bind mount` the underlying *parent directory* to a tmp directory `/.bind` 
3. Copy the base image data to the mounted volume 
4. Cleanup the temp directory 
5. Add a markfile `.mountscopied` in the root so that we don't perform the operation again 
6. Introduce `CopyMode` field in MountSpec. Which defines whether to copy the data or not. 
   Currently it always copies once.  

Fixes #3482 

<!--
To trigger a custom build with this PR, include one of these in the PR's title or commit messages:
* [skip ci]
* [full ci]
* [specific ci=$suitename] e.g. [specific ci=1-01-Docker-Info]
    With this option, running only one suite is supported.
-->
