### PR TITLE
Enable vsyscall emulation [specific ci=4817]

### DIFF
--- a/isos/base/isolinux/isolinux.cfg
+++ b/isos/base/isolinux/isolinux.cfg
@@ -3,6 +3,6 @@ default microcore
 label microcore
 	kernel /boot/vmlinuz64
 	initrd /boot/core.gz
-# 	append rdinit=_INIT_BINARY_ loglevel=3 console=ttyS1,115200n8 console=tty0 rcupdate.rcu_expedited=1 systemd.show_status=0 quiet noreplace-smp cpu_init_udelay=0
+# 	append rdinit=_INIT_BINARY_ loglevel=3 console=ttyS1,115200n8 console=tty0 rcupdate.rcu_expedited=1 systemd.show_status=0 quiet noreplace-smp cpu_init_udelay=0 vsyscall=emulate
 implicit 0
 F1 boot.msg

--- a/tests/test-cases/Group0-Bugs/4817.md
+++ b/tests/test-cases/Group0-Bugs/4817.md
@@ -1,0 +1,19 @@
+Test 4817 - Verify Kernel supports vsyscall
+=======
+
+#Purpose:
+Verify Kernel supports vsyscall mechanisms
+
+#References:
+* https://github.com/vmware/vic/issues/4817
+
+#Environment:
+This test requires that a vSphere server is running and available
+
+#Test Steps:
+1. Create VCH through vic-machine create
+2. Create centos:6 container
+3. Run bash -c true
+
+#Expected Outcome:
+* Step 3 should succeed (exit code of 0)

--- a/tests/test-cases/Group0-Bugs/4817.robot
+++ b/tests/test-cases/Group0-Bugs/4817.robot
@@ -1,0 +1,24 @@
+# Copyright 2016-2017 VMware, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#	http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License
+
+*** Settings ***
+Documentation  Test 4817
+Resource  ../../resources/Util.robot
+Suite Setup  Install VIC Appliance To Test Server  certs=${false}
+Suite Teardown  Cleanup VIC Appliance On Test Server
+
+*** Test Cases ***
+Check kernel vsyscall
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -t centos:6 bash -c true
+    Should Be Equal As Integers  ${rc}  0

--- a/tests/test-cases/Group0-Bugs/TestCases.md
+++ b/tests/test-cases/Group0-Bugs/TestCases.md
@@ -3,3 +3,6 @@ Group 0 - Bugs
 
 [Test 3858 - Verify Kernel modules are not compressed](3858.md)
 -
+
+[Test 4817 - Verify Kernel supports vsyscall](4817.md)
+-


### PR DESCRIPTION
Enables vsyscall emulation and adds test to confirm. The test is dependent
on centos:6 image continuing to have a glibc variant that relies on
vsyscall as a primary path, not a fallback.

Fixes #4817