### PR TITLE
[skip ci] Nightly hetro 6.0 fix when adding ESX host to VC

### DIFF
--- a/tests/manual-test-cases/Group5-Functional-Tests/5-5-Heterogenous-ESXi.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-5-Heterogenous-ESXi.robot
@@ -50,7 +50,7 @@ Test
     Log To Console  Add ESX host to the VC
     Add Host To VCenter  ${esx1-ip}  root  ha-datacenter  e2eFunctionalTest
     Add Host To VCenter  ${esx2-ip}  root  ha-datacenter  e2eFunctionalTest
-    Add Host To VCenter  ${esx3-ip}  root  ha-datacenter  e2eFunctionalTest
+    Run Keyword If  ${VC_VERSION} >= 4602587  Add Host To VCenter  ${esx3-ip}  root  ha-datacenter  e2eFunctionalTest
 
     Create A Distributed Switch  ha-datacenter
 


### PR DESCRIPTION
Check to see if the VC version is greater than or equal to 6.5 before adding a 6.5 ESX host
Fixes #4655 

