### PR TITLE
[specific ci=Group6-VIC-Machine] Fix the outputted --cert-path

### DIFF
--- a/cmd/vic-machine/create/create.go
+++ b/cmd/vic-machine/create/create.go
@@ -1204,7 +1204,8 @@ func (c *Create) generateCertificates(server bool, client bool) ([]byte, *certif
 
 		// If openssl is present, try to generate a browser friendly pfx file (a bundle of the public certificate AND the private key)
 		// The pfx file can be imported directly into keychains for client certificate authentication
-		args := strings.Split(fmt.Sprintf("pkcs12 -export -out ./%[1]s/cert.pfx -inkey ./%[1]s/key.pem -in ./%[1]s/cert.pem -certfile ./%[1]s/ca.pem -password pass:", c.DisplayName), " ")
+		certPath := filepath.Clean(c.certPath)
+		args := strings.Split(fmt.Sprintf("pkcs12 -export -out %[1]s/cert.pfx -inkey %[1]s/key.pem -in %[1]s/cert.pem -certfile %[1]s/ca.pem -password pass:", certPath), " ")
 		// #nosec: Subprocess launching with variable
 		pfx := exec.Command("openssl", args...)
 		out, err := pfx.CombinedOutput()
@@ -1212,7 +1213,7 @@ func (c *Create) generateCertificates(server bool, client bool) ([]byte, *certif
 			log.Debug(out)
 			log.Warnf("Failed to generate browser friendly PFX client certificate: %s", err)
 		} else {
-			log.Infof("Generated browser friendly PFX client certificate - certificate in ./%s/cert.pfx", c.DisplayName)
+			log.Infof("Generated browser friendly PFX client certificate - certificate in %s/cert.pfx", certPath)
 		}
 	}
 

--- a/cmd/vic-machine/create/create.go
+++ b/cmd/vic-machine/create/create.go
@@ -1099,7 +1099,7 @@ func (c *Create) generateCertificates(server bool, client bool) ([]byte, *certif
 	// generate the certs and keys with names conforming the default the docker client expects
 	files, err := ioutil.ReadDir(c.certPath)
 	if len(files) > 0 {
-		return nil, nil, fmt.Errorf("Specified directory to store certificates, \"%s\", is not empty. Please specify a new path in which to store generated certificates using --cert-path or remove the contents of \"%s\" and run vic-machine again.", c.certPath, c.certPath)
+		return nil, nil, fmt.Errorf("Specified directory to store certificates is not empty. Specify a new path in which to store generated certificates using --cert-path or remove the contents of \"%s\" and run vic-machine again.", c.certPath)
 	}
 
 	err = os.MkdirAll(c.certPath, 0700)

--- a/cmd/vic-machine/create/create.go
+++ b/cmd/vic-machine/create/create.go
@@ -1097,7 +1097,12 @@ func (c *Create) generateCertificates(server bool, client bool) ([]byte, *certif
 
 	var certs []byte
 	// generate the certs and keys with names conforming the default the docker client expects
-	err := os.MkdirAll(c.certPath, 0700)
+	files, err := ioutil.ReadDir(c.certPath)
+	if len(files) > 0 {
+		return nil, nil, fmt.Errorf("Specified directory to store certificates, \"%s\", is not empty. Please specify a new path in which to store generated certificates using --cert-path or remove the contents of \"%s\" and run vic-machine again.", c.certPath, c.certPath)
+	}
+
+	err = os.MkdirAll(c.certPath, 0700)
 	if err != nil {
 		log.Errorf("Unable to make directory to hold certificates (set via --cert-path)")
 		return nil, nil, err

--- a/cmd/vic-machine/create/create.go
+++ b/cmd/vic-machine/create/create.go
@@ -1383,7 +1383,7 @@ func (c *Create) Run(clic *cli.Context) (err error) {
 
 	if err = executor.CheckServiceReady(ctx, vchConfig, c.clientCert); err != nil {
 		executor.CollectDiagnosticLogs()
-		cmd, _ := executor.GetDockerAPICommand(vchConfig, c.ckey, c.ccert, c.cacert)
+		cmd, _ := executor.GetDockerAPICommand(vchConfig, c.ckey, c.ccert, c.cacert, c.certPath)
 		log.Info("\tAPI may be slow to start - try to connect to API after a few minutes:")
 		if cmd != "" {
 			log.Infof("\t\tRun command: %s", cmd)
@@ -1396,7 +1396,7 @@ func (c *Create) Run(clic *cli.Context) (err error) {
 
 	log.Infof("Initialization of appliance successful")
 
-	executor.ShowVCH(vchConfig, c.ckey, c.ccert, c.cacert, c.envFile)
+	executor.ShowVCH(vchConfig, c.ckey, c.ccert, c.cacert, c.envFile, c.certPath)
 	log.Infof("Installer completed successfully")
 	return nil
 }

--- a/doc/user/usage.md
+++ b/doc/user/usage.md
@@ -241,7 +241,6 @@ ERRO[2016-11-07T19:53:44Z] vic-machine-linux failed: provide Common Name for ser
 
 The [`--cert-path`](#certificate-names-and---cert-path) option applies to all of the TLS configurations other than --no-tls.
 
-Using `--force` will allow a `create` operation to move past some certificate checks performed for existing certificates, however will do so by generating __new__ certificates, __overwriting__ the old.
 
 #### Disabled, `--no-tls`
 Disabling TLS completely is strongly discouraged as it allows trivial snooping of API traffic by entities on the same network. When using this option the API will be served over HTTP, not HTTPS.

--- a/doc/user/usage.md
+++ b/doc/user/usage.md
@@ -241,8 +241,6 @@ ERRO[2016-11-07T19:53:44Z] vic-machine-linux failed: provide Common Name for ser
 
 The [`--cert-path`](#certificate-names-and---cert-path) option applies to all of the TLS configurations other than --no-tls.
 
-Using `--force` will allow a `create` operation to move past some certificate checks performed for existing certificates, however will do so by generating __new__ certificates, __overwriting__ the old.
-
 #### Disabled, `--no-tls`
 Disabling TLS completely is strongly discouraged as it allows trivial snooping of API traffic by entities on the same network. When using this option the API will be served over HTTP, not HTTPS.
 

--- a/doc/user/usage.md
+++ b/doc/user/usage.md
@@ -241,6 +241,8 @@ ERRO[2016-11-07T19:53:44Z] vic-machine-linux failed: provide Common Name for ser
 
 The [`--cert-path`](#certificate-names-and---cert-path) option applies to all of the TLS configurations other than --no-tls.
 
+Using `--force` will allow a `create` operation to move past some certificate checks performed for existing certificates, however will do so by generating __new__ certificates, __overwriting__ the old.
+
 #### Disabled, `--no-tls`
 Disabling TLS completely is strongly discouraged as it allows trivial snooping of API traffic by entities on the same network. When using this option the API will be served over HTTP, not HTTPS.
 

--- a/lib/install/management/inspect.go
+++ b/lib/install/management/inspect.go
@@ -89,11 +89,11 @@ func (d *Dispatcher) InspectVCH(vch *vm.VirtualMachine, conf *config.VirtualCont
 		log.Debugf("No host certificates provided")
 	}
 
-	d.ShowVCH(conf, "", "", "", "")
+	d.ShowVCH(conf, "", "", "", "", "")
 	return nil
 }
 
-func (d *Dispatcher) ShowVCH(conf *config.VirtualContainerHostConfigSpec, key string, cert string, cacert string, envfile string) {
+func (d *Dispatcher) ShowVCH(conf *config.VirtualContainerHostConfigSpec, key string, cert string, cacert string, envfile string, certpath string) {
 	if d.sshEnabled {
 		log.Infof("")
 		log.Infof("SSH to appliance:")
@@ -109,7 +109,7 @@ func (d *Dispatcher) ShowVCH(conf *config.VirtualContainerHostConfigSpec, key st
 	log.Infof("Published ports can be reached at:")
 	log.Infof("%s", publicIP.String())
 
-	cmd, env := d.GetDockerAPICommand(conf, key, cert, cacert)
+	cmd, env := d.GetDockerAPICommand(conf, key, cert, cacert, certpath)
 
 	log.Info("")
 	log.Infof("Docker environment variables:")
@@ -128,7 +128,7 @@ func (d *Dispatcher) ShowVCH(conf *config.VirtualContainerHostConfigSpec, key st
 }
 
 // GetDockerAPICommand generates values to display for usage of a deployed VCH
-func (d *Dispatcher) GetDockerAPICommand(conf *config.VirtualContainerHostConfigSpec, key string, cert string, cacert string) (cmd, env string) {
+func (d *Dispatcher) GetDockerAPICommand(conf *config.VirtualContainerHostConfigSpec, key string, cert string, cacert string, certpath string) (cmd, env string) {
 	var dEnv []string
 	tls := ""
 
@@ -147,7 +147,7 @@ func (d *Dispatcher) GetDockerAPICommand(conf *config.VirtualContainerHostConfig
 			}
 
 			dEnv = append(dEnv, "DOCKER_TLS_VERIFY=1")
-			info, err := os.Stat(conf.ExecutorConfig.Name)
+			info, err := os.Stat(certpath)
 			if err == nil && info.IsDir() {
 				if abs, err := filepath.Abs(info.Name()); err == nil {
 					dEnv = append(dEnv, fmt.Sprintf("DOCKER_CERT_PATH=%s", abs))

--- a/tests/test-cases/Group6-VIC-Machine/6-13-TLS.md
+++ b/tests/test-cases/Group6-VIC-Machine/6-13-TLS.md
@@ -31,6 +31,22 @@ vic-machine-linux create --name=${vch-name} --target=%{TEST_URL} \
 * Deployment succeeds
 * Regression tests pass
 
+## Create VCH - use custom --cert-path
+1. Issue the following command:
+```
+vic-machine-linux create\
+    ${vicmachinetls}\
+    --name=%{VCH-NAME}\
+    --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}"\
+    --thumbprint=%{TEST_THUMBPRINT}\
+    --image-store=%{TEST_DATASTORE}\
+    --bridge-network=%{BRIDGE_NETWORK}\
+    --public-network=%{PUBLIC_NETWORK}\
+    --cert-path=${EXECDIR}/foo-bar-certs/
+```
+### Expected Outcome
+* Certs are generated and stored in `foo-bar-cert`
+* Environment file in `foo-bar-certs/${VCH-NAME}` contains correct `DOCKER_CERT_PATH` variable definition
 
 ## Create VCH - force accept target thumbprint
 1. Issue the following command:

--- a/tests/test-cases/Group6-VIC-Machine/6-13-TLS.robot
+++ b/tests/test-cases/Group6-VIC-Machine/6-13-TLS.robot
@@ -37,18 +37,18 @@ Create VCH - defaults custom cert path
     Run Keyword And Ignore Error  Cleanup Dangling VMs On Test Server
     Run Keyword And Ignore Error  Cleanup Datastore On Test Server
 
-    ${pwd}=     Run  pwd
-    ${output}=  Run  bin/vic-machine-linux create ${vicmachinetls} --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --image-store=%{TEST_DATASTORE} --bridge-network=%{BRIDGE_NETWORK} --public-network=%{PUBLIC_NETWORK} --cert-path=${pwd}/foo-bar-certs/
-    Should Contain  ${output}  --tlscacert="${pwd}/foo-bar-certs/ca.pem" --tlscert="${pwd}/foo-bar-certs/cert.pem" --tlskey="${pwd}/foo-bar-certs/key.pem"
-    ${save_env}=  Run  cat ${pwd}/foo-bar-certs/%{VCH-NAME}.env
-    Should Contain  ${save_env}  DOCKER_CERT_PATH=${pwd}/foo-bar-certs
-    Should Contain  ${output}  Generating CA certificate/key pair - private key in ${pwd}/foo-bar-certs/ca-key.pem
-    Should Contain  ${output}  Generating server certificate/key pair - private key in ${pwd}/foo-bar-certs/server-key.pem
-    Should Contain  ${output}  Generating client certificate/key pair - private key in ${pwd}/foo-bar-certs/key.pem
-    Should Contain  ${output}  Generated browser friendly PFX client certificate - certificate in ${pwd}/foo-bar-certs/cert.pfx
+    ${output}=  Run  bin/vic-machine-linux create ${vicmachinetls} --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --image-store=%{TEST_DATASTORE} --bridge-network=%{BRIDGE_NETWORK} --public-network=%{PUBLIC_NETWORK} --cert-path=${EXECDIR}/foo-bar-certs/
+    Should Contain  ${output}  --tlscacert="${EXECDIR}/foo-bar-certs/ca.pem" --tlscert="${EXECDIR}/foo-bar-certs/cert.pem" --tlskey="${EXECDIR}/foo-bar-certs/key.pem"
+    Should Contain  ${output}  Generating CA certificate/key pair - private key in ${EXECDIR}/foo-bar-certs/ca-key.pem
+    Should Contain  ${output}  Generating server certificate/key pair - private key in ${EXECDIR}/foo-bar-certs/server-key.pem
+    Should Contain  ${output}  Generating client certificate/key pair - private key in ${EXECDIR}/foo-bar-certs/key.pem
+    Should Contain  ${output}  Generated browser friendly PFX client certificate - certificate in ${EXECDIR}/foo-bar-certs/cert.pfx
 
     Should Contain  ${output}  Installer completed successfully
     Get Docker Params  ${output}  ${true}
+
+    ${save_env}=  Run  cat ${EXECDIR}/foo-bar-certs/%{VCH-NAME}.env
+    Should Contain  ${save_env}  DOCKER_CERT_PATH=${EXECDIR}/foo-bar-certs
     Log To Console  Installer completed successfully: %{VCH-NAME}
 
     Run Regression Tests

--- a/tests/test-cases/Group6-VIC-Machine/6-13-TLS.robot
+++ b/tests/test-cases/Group6-VIC-Machine/6-13-TLS.robot
@@ -32,7 +32,27 @@ Create VCH - defaults with --no-tls
     Run Regression Tests
     Cleanup VIC Appliance On Test Server
 
+Create VCH - defaults custom cert path
+    Set Test Environment Variables
+    Run Keyword And Ignore Error  Cleanup Dangling VMs On Test Server
+    Run Keyword And Ignore Error  Cleanup Datastore On Test Server
 
+    ${pwd}=     Run  pwd
+    ${output}=  Run  bin/vic-machine-linux create ${vicmachinetls} --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --image-store=%{TEST_DATASTORE} --bridge-network=%{BRIDGE_NETWORK} --public-network=%{PUBLIC_NETWORK} --cert-path=${pwd}/foo-bar-certs/
+    Should Contain  ${output}  --tlscacert="${pwd}/foo-bar-certs/ca.pem" --tlscert="${pwd}/foo-bar-certs/cert.pem" --tlskey="${pwd}/foo-bar-certs/key.pem"
+    ${save_env}=  Run  cat ${pwd}/foo-bar-certs/%{VCH-NAME}.env
+    Should Contain  ${save_env}  DOCKER_CERT_PATH=${pwd}/foo-bar-certs
+    Should Contain  ${output}  Generating CA certificate/key pair - private key in ${pwd}/foo-bar-certs/ca-key.pem
+    Should Contain  ${output}  Generating server certificate/key pair - private key in ${pwd}/foo-bar-certs/server-key.pem
+    Should Contain  ${output}  Generating client certificate/key pair - private key in ${pwd}/foo-bar-certs/key.pem
+    Should Contain  ${output}  Generated browser friendly PFX client certificate - certificate in ${pwd}/foo-bar-certs/cert.pfx
+
+    Should Contain  ${output}  Installer completed successfully
+    Get Docker Params  ${output}  ${true}
+    Log To Console  Installer completed successfully: %{VCH-NAME}
+
+    Run Regression Tests
+    Cleanup VIC Appliance On Test Server
 
 Create VCH - force accept target thumbprint
     Set Test Environment Variables


### PR DESCRIPTION
Fixes #4683 

Also prevents destruction of provided path after --cert-path if files already exist there
Also causes the browser-friendly certificate to be generated in the right place when --cert-path is specified.
