### PR TITLE
Corrected the link to sign up to the public VIC Engine Slack channel.

### DIFF
--- a/index.html
+++ b/index.html
@@ -83,7 +83,7 @@
         <h2 id="support">Support</h2>
         <p>Full support of vSphere Integrated Containers Engine requires the vSphere Enterprise Plus license and an official VMware release of vSphere Integrated Containers Engine. To make a support request, contact <a href="http://www.vmware.com/support" target="_blank">VMware Global Support</a>.
         <p>All other releases of vSphere Integrated Containers Engine are released as open source software and come with no commercial support.</p>
-        <p>For general questions, visit the <a href="https://vmwarecode.slack.com/messages/vic-engine" target="_blank">vSphere Integrated Containers Engine channel on Slack.com</a>. If you do not have an @vmware.com or @emc.com email address, sign up at https://code.vmware.com/slack to get an invitation.</p>
+        <p>For general questions, visit the <a href="https://vmwarecode.slack.com/messages/vic-engine" target="_blank">vSphere Integrated Containers Engine channel on Slack.com</a>. If you do not have an @vmware.com or @emc.com email address, sign up at <a href="https://code.vmware.com/web/code/join" target="_blank">https://code.vmware.com</a> to get an invitation.</p>
       </div>
     </div>
   </div>


### PR DESCRIPTION
The page to sign up to code.vmware.com, and thereby to sign up to the VIC Engine Slack channel, has changed, so updated link accordingly.