### PR TITLE
Use UUID instead of symlink for endpoint VM

### DIFF
--- a/lib/install/management/appliance.go
+++ b/lib/install/management/appliance.go
@@ -600,8 +600,14 @@ func (d *Dispatcher) createAppliance(conf *config.VirtualContainerHostConfigSpec
 	},
 	)
 
+	// fix up those parts of the config that depend on the final applianceVM folder name
 	conf.BootstrapImagePath = fmt.Sprintf("[%s] %s/%s", conf.ImageStores[0].Host, d.vmPathName, settings.BootstrapISO)
 
+	if len(conf.ImageStores[0].Path) == 0 {
+		conf.ImageStores[0].Path = d.vmPathName
+	}
+
+	// apply the fixed-up configuration
 	spec, err = d.reconfigureApplianceSpec(vm2, conf, settings)
 	if err != nil {
 		log.Errorf("Error while getting appliance reconfig spec: %s", err)
@@ -650,12 +656,7 @@ func (d *Dispatcher) reconfigureApplianceSpec(vm *vm.VirtualMachine, conf *confi
 	var devices object.VirtualDeviceList
 	var err error
 
-	spec := &types.VirtualMachineConfigSpec{
-		Name:               conf.Name,
-		GuestId:            string(types.VirtualMachineGuestOsIdentifierOtherGuest64),
-		AlternateGuestName: constants.DefaultAltVCHGuestName(),
-		Files:              &types.VirtualMachineFileInfo{VmPathName: fmt.Sprintf("[%s]", conf.ImageStores[0].Host)},
-	}
+	spec := &types.VirtualMachineConfigSpec{}
 
 	// create new devices
 	if devices, err = d.configIso(conf, vm, settings); err != nil {

--- a/lib/install/validate/storage.go
+++ b/lib/install/validate/storage.go
@@ -44,7 +44,7 @@ func (v *Validator) storage(ctx context.Context, input *data.Data, conf *config.
 
 	// provide a default path if only a DS name is provided
 	if imageDSpath.Path == "" {
-		imageDSpath.Path = input.DisplayName
+		log.Debug("No path element specified for image store - will use default")
 	}
 
 	if ds != nil {

--- a/lib/install/validate/validator_test.go
+++ b/lib/install/validate/validator_test.go
@@ -310,7 +310,7 @@ func testStorage(v *Validator, input *data.Data, conf *config.VirtualContainerHo
 			map[string]string{"volume1": "LocalDS_0/volumes/volume1",
 				"volume2": "ds://LocalDS_0/volumes/volume2"},
 			false,
-			"ds://LocalDS_0/test001",
+			"ds://LocalDS_0",
 			map[string]string{"volume1": "ds://LocalDS_0/volumes/volume1",
 				"volume2": "ds://LocalDS_0/volumes/volume2"}},
 


### PR DESCRIPTION
This is a speculative change that uses the actual UUID directory name instead of the symlink to avoid the scenario where the symlink has not presented by the time a VMDK creation requires it. This issue pertains primarily to vSAN environments under load (like longevity/nightly tests).

Longevity tests with these changes are currently running on bart (VC 6.0).

Applies to #4666 