### PR TITLE
[skip ci] add more log information to debug nightly test failure in 5-4 HA test

### DIFF
--- a/tests/manual-test-cases/Group5-Functional-Tests/5-4-High-Availability.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-4-High-Availability.robot
@@ -135,4 +135,122 @@ Test
     \     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} rm -f ${c}
     \     Should Be Equal As Integers  ${rc}  0
 
-    Run Regression Tests
+    # Run Regression Tests
+Run Regression Tests
+    ${rc}  ${output}=  Run And Return Rc And Output  govc datastore.ls -R -ds=nfsDatastore %{VCH-NAME}/VIC
+    Log To Console  ${output}
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} pull busybox
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${output}=  Run And Return Rc And Output  govc datastore.ls -R -ds=nfsDatastore %{VCH-NAME}/VIC
+    Log To Console  ${output}
+    # Pull an image that has been pulled already
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} pull busybox
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${output}=  Run And Return Rc And Output  govc datastore.ls -R -ds=nfsDatastore %{VCH-NAME}/VIC
+    Log To Console  ${output}
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} images
+    Should Be Equal As Integers  ${rc}  0
+    Should Contain  ${output}  busybox
+    ${rc}  ${container}=  Run And Return Rc And Output  docker %{VCH-PARAMS} create busybox /bin/top
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} start ${container}
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} ps
+    Should Be Equal As Integers  ${rc}  0
+    Should Contain  ${output}  /bin/top
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} stop ${container}
+    Should Be Equal As Integers  ${rc}  0
+    Wait Until Container Stops  ${container}
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} ps -a
+    Should Be Equal As Integers  ${rc}  0
+    Should Contain  ${output}  Exited
+
+    ${vmName}=  Get VM Display Name  ${container}
+    Wait Until Keyword Succeeds  5x  10s  Check For The Proper Log Files  ${vmName}
+
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} rm ${container}
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} ps -a
+    Should Be Equal As Integers  ${rc}  0
+    Should Not Contain  ${output}  /bin/top
+    ${rc}  ${output}=  Run And Return Rc And Output  govc datastore.ls -R -ds=nfsDatastore %{VCH-NAME}/VIC
+    Log To Console  ${output}
+
+    # Check for regression for #1265
+    ${rc}  ${container1}=  Run And Return Rc And Output  docker %{VCH-PARAMS} create -it busybox /bin/top
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${container2}=  Run And Return Rc And Output  docker %{VCH-PARAMS} create -it busybox
+    Should Be Equal As Integers  ${rc}  0
+    ${shortname}=  Get Substring  ${container2}  1  12
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} ps -a
+    ${lines}=  Get Lines Containing String  ${output}  ${shortname}
+    Should Not Contain  ${lines}  /bin/top
+    ${rc}=  Run And Return Rc  docker %{VCH-PARAMS} rm ${container1}
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${output}=  Run And Return Rc And Output  govc datastore.ls -R -ds=nfsDatastore %{VCH-NAME}/VIC
+    Log To Console  ${output}
+    ${rc}=  Run And Return Rc  docker %{VCH-PARAMS} rm ${container2}
+    Should Be Equal As Integers  ${rc}  0
+
+    ${rc}  ${output}=  Run And Return Rc And Output  govc datastore.ls -R -ds=nfsDatastore %{VCH-NAME}/VIC
+    Log To Console  ${output}
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} rmi busybox
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${output}=  Run And Return Rc And Output  govc datastore.ls -R -ds=nfsDatastore %{VCH-NAME}/VIC
+    Log To Console  ${output}
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} images
+    Should Be Equal As Integers  ${rc}  0
+    Should Not Contain  ${output}  busybox
+
+    Scrape Logs For The Password
+
+Restart VCH
+    Reboot VM  %{VCH-NAME}
+
+    Log To Console  Getting VCH IP ...
+    ${new-vch-ip}=  Get VM IP  %{VCH-NAME}
+    Log To Console  New VCH IP is ${new-vch-ip}
+    Replace String  %{VCH-PARAMS}  %{VCH-IP}  ${new-vch-ip}
+
+    # wait for docker info to succeed
+    Wait Until Keyword Succeeds  20x  5 seconds  Run Docker Info  %{VCH-PARAMS}
+
+Run Regression Test
+    ${rc}  ${output}=  Run And Return Rc And Output  govc datastore.ls -R -ds=nfsDatastore %{VCH-NAME}/VIC
+    Log To Console  ${output}
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} pull busybox
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${output}=  Run And Return Rc And Output  govc datastore.ls -R -ds=nfsDatastore %{VCH-NAME}/VIC
+    Log To Console  ${output}
+    # Pull an image that has been pulled already
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} pull busybox
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${output}=  Run And Return Rc And Output  govc datastore.ls -R -ds=nfsDatastore %{VCH-NAME}/VIC
+    Log To Console  ${output}
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} images
+    Should Be Equal As Integers  ${rc}  0
+    Should Contain  ${output}  busybox
+    ${rc}  ${container}=  Run And Return Rc And Output  docker %{VCH-PARAMS} create busybox /bin/top
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} start ${container}
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} ps
+    Should Be Equal As Integers  ${rc}  0
+    Should Contain  ${output}  /bin/top
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} stop ${container}
+    Should Be Equal As Integers  ${rc}  0
+    Wait Until Container Stops  ${container}
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} ps -a
+    Should Be Equal As Integers  ${rc}  0
+    Should Contain  ${output}  Exited
+
+    ${vmName}=  Get VM Display Name  ${container}
+    Wait Until Keyword Succeeds  5x  10s  Check For The Proper Log Files  ${vmName}
+
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} rm ${container}
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} ps -a
+    Should Be Equal As Integers  ${rc}  0
+    Should Not Contain  ${output}  /bin/top
+    ${rc}  ${output}=  Run And Return Rc And Output  govc datastore.ls -R -ds=nfsDatastore %{VCH-NAME}/VIC
+    Log To Console  ${output}

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-4-High-Availability.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-4-High-Availability.robot
@@ -18,16 +18,6 @@ Resource  ../../resources/Util.robot
 Suite Teardown  Nimbus Cleanup  ${list}
 
 *** Keywords ***
-Check VM Info
-    ${rc}  ${output}=  Run And Return Rc And Output  govc vm.info \*
-    Should Be Equal  ${rc}  0
-    Log To Console  ${output}
-
-Check ImageStore
-    ${rc}  ${output}=  Run And Return Rc And Output  govc datastore.ls -R -ds=nfsDatastore %{VCH-NAME}/VIC
-    Should Be Equal  ${rc}  0
-    Log To Console  ${output}
-
 Run Regression Test With More Log Information
     Check ImageStore
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} pull busybox
@@ -91,6 +81,9 @@ Run Regression Test With More Log Information
 
 *** Test Cases ***
 Test
+    ${status}=  Get State Of Github Issue  4858
+    Run Keyword If  '${status}' == 'closed'  Fail  Test 5-4-High-Availability.robot needs to be updated now that Issue #4858 has been resolved
+
     Log To Console  \nStarting test...
     ${esx1}  ${esx1-ip}=  Deploy Nimbus ESXi Server  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}
     ${esx2}  ${esx2-ip}=  Deploy Nimbus ESXi Server  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}
@@ -180,7 +173,8 @@ Test
     @{output}=  Split To Lines  ${output}
     ${curHost}=  Fetch From Right  @{output}[-1]  ${SPACE}
 
-    Check VM Info
+    ${info}=  Get VM Info  \*
+    Log  ${info}
 
     # Abruptly power off the host
     Open Connection  ${curHost}  prompt=:~]
@@ -188,14 +182,16 @@ Test
     ${out}=  Execute Command  poweroff -d 0 -f
     Close connection
 
-    Check VM Info
+    ${info}=  Get VM Info  \*
+    Log  ${info}
 
     # Really not sure what better to do here?  Otherwise, vic-machine-inspect returns the old IP address... maybe some sort of power monitoring? Can I pull uptime of the system?
     Sleep  4 minutes
     Run VIC Machine Inspect Command
     Wait Until Keyword Succeeds  20x  5 seconds  Run Docker Info  %{VCH-PARAMS}
 
-    Check VM Info
+    ${info}=  Get VM Info  \*
+    Log  ${info}
 
     # check running containers are still running
     :FOR  ${c}  IN  @{running}

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-4-High-Availability.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-4-High-Availability.robot
@@ -18,6 +18,11 @@ Resource  ../../resources/Util.robot
 Suite Teardown  Nimbus Cleanup  ${list}
 
 *** Keywords ***
+Check VM Info
+    ${rc}  ${output}=  Run And Return Rc And Output  govc vm.info \*
+    Should Be Equal  ${rc}  0
+    Log To Console  ${output}
+
 Check ImageStore
     ${rc}  ${output}=  Run And Return Rc And Output  govc datastore.ls -R -ds=nfsDatastore %{VCH-NAME}/VIC
     Should Be Equal  ${rc}  0
@@ -175,16 +180,22 @@ Test
     @{output}=  Split To Lines  ${output}
     ${curHost}=  Fetch From Right  @{output}[-1]  ${SPACE}
 
+    Check VM Info
+
     # Abruptly power off the host
     Open Connection  ${curHost}  prompt=:~]
     Login  root  e2eFunctionalTest
     ${out}=  Execute Command  poweroff -d 0 -f
     Close connection
 
+    Check VM Info
+
     # Really not sure what better to do here?  Otherwise, vic-machine-inspect returns the old IP address... maybe some sort of power monitoring? Can I pull uptime of the system?
     Sleep  4 minutes
     Run VIC Machine Inspect Command
     Wait Until Keyword Succeeds  20x  5 seconds  Run Docker Info  %{VCH-PARAMS}
+
+    Check VM Info
 
     # check running containers are still running
     :FOR  ${c}  IN  @{running}

--- a/tests/resources/Vsphere-Util.robot
+++ b/tests/resources/Vsphere-Util.robot
@@ -111,6 +111,11 @@ Get VM Info
     Should Be Equal As Integers  ${rc}  0
     [Return]  ${out}
 
+Check ImageStore
+    ${rc}  ${output}=  Run And Return Rc And Output  govc datastore.ls -R -ds=%{TEST_DATASTORE} %{VCH-NAME}/VIC
+    Should Be Equal  ${rc}  0
+    Log  ${output}
+
 vMotion A VM
     [Arguments]  ${vm}
     ${host}=  Get VM Host Name  ${vm}


### PR DESCRIPTION
Whenever there is an `image`-related operation in the test, we log the output of `govc datastore.ls` and see if all necessary image files are there. 

This relates t #4858 