### PR TITLE
vcsim: support TraversalSpec references and nested SelectSet

### DIFF
--- a/pkg/vsphere/simulator/cluster_compute_resource.go
+++ b/pkg/vsphere/simulator/cluster_compute_resource.go
@@ -26,13 +26,13 @@ type ClusterComputeResource struct {
 	mo.ClusterComputeResource
 }
 
-type addHostTask struct {
+type addHost struct {
 	*ClusterComputeResource
 
 	req *types.AddHost_Task
 }
 
-func (add *addHostTask) Run(task *Task) (types.AnyType, types.BaseMethodFault) {
+func (add *addHost) Run(task *Task) (types.AnyType, types.BaseMethodFault) {
 	spec := add.req.Spec
 
 	if spec.HostName == "" {
@@ -59,7 +59,7 @@ func (add *addHostTask) Run(task *Task) (types.AnyType, types.BaseMethodFault) {
 func (c *ClusterComputeResource) AddHostTask(add *types.AddHost_Task) soap.HasFault {
 	r := &methods.AddHost_TaskBody{}
 
-	task := NewTask(&addHostTask{c, add})
+	task := NewTask(&addHost{c, add})
 
 	r.Res = &types.AddHost_TaskResponse{
 		Returnval: task.Self,

--- a/pkg/vsphere/simulator/dvs.go
+++ b/pkg/vsphere/simulator/dvs.go
@@ -26,7 +26,7 @@ type VmwareDistributedVirtualSwitch struct {
 }
 
 func (s *VmwareDistributedVirtualSwitch) AddDVPortgroupTask(c *types.AddDVPortgroup_Task) soap.HasFault {
-	task := CreateTask(s, "addDVPortgroupTask", func(t *Task) (types.AnyType, types.BaseMethodFault) {
+	task := CreateTask(s, "addDVPortgroup", func(t *Task) (types.AnyType, types.BaseMethodFault) {
 		f := Map.getEntityParent(s, "Folder").(*Folder)
 
 		for _, spec := range c.Spec {
@@ -69,7 +69,7 @@ func (s *VmwareDistributedVirtualSwitch) AddDVPortgroupTask(c *types.AddDVPortgr
 }
 
 func (s *VmwareDistributedVirtualSwitch) ReconfigureDvsTask(req *types.ReconfigureDvs_Task) soap.HasFault {
-	task := CreateTask(s, "reconfigureDvsTask", func(t *Task) (types.AnyType, types.BaseMethodFault) {
+	task := CreateTask(s, "reconfigureDvs", func(t *Task) (types.AnyType, types.BaseMethodFault) {
 		spec := req.Spec.GetDVSConfigSpec()
 
 		for _, member := range spec.Host {

--- a/pkg/vsphere/simulator/folder_test.go
+++ b/pkg/vsphere/simulator/folder_test.go
@@ -30,7 +30,7 @@ import (
 	"github.com/vmware/vic/pkg/vsphere/simulator/vc"
 )
 
-func addStandaloneHost(folder *object.Folder, spec types.HostConnectSpec) (*object.Task, error) {
+func addStandaloneHostTask(folder *object.Folder, spec types.HostConnectSpec) (*object.Task, error) {
 	// TODO: add govmomi wrapper
 	req := types.AddStandaloneHost_Task{
 		This:         folder.Reference(),
@@ -84,7 +84,7 @@ func TestFolderESX(t *testing.T) {
 	}
 
 	spec := types.HostConnectSpec{}
-	_, err = addStandaloneHost(folders.HostFolder, spec)
+	_, err = addStandaloneHostTask(folders.HostFolder, spec)
 	if err == nil {
 		t.Fatal("expected error")
 	}
@@ -165,7 +165,7 @@ func TestFolderVC(t *testing.T) {
 			HostName: test.name,
 		}
 
-		task, err := addStandaloneHost(folders.HostFolder, spec)
+		task, err := addStandaloneHostTask(folders.HostFolder, spec)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -225,7 +225,12 @@ func TestFolderFaults(t *testing.T) {
 func TestRegisterVm(t *testing.T) {
 	ctx := context.Background()
 
-	for _, model := range []*Model{ESX(), VPX()} {
+	for i, model := range []*Model{ESX(), VPX()} {
+		match := "*"
+		if i == 1 {
+			model.App = 1
+			match = "*APP*"
+		}
 		defer model.Remove()
 		err := model.Create()
 		if err != nil {
@@ -255,7 +260,7 @@ func TestRegisterVm(t *testing.T) {
 
 		vmFolder := folders.VmFolder
 
-		vms, err := finder.VirtualMachineList(ctx, "*")
+		vms, err := finder.VirtualMachineList(ctx, match)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/vsphere/simulator/host_datastore_browser.go
+++ b/pkg/vsphere/simulator/host_datastore_browser.go
@@ -30,7 +30,7 @@ type HostDatastoreBrowser struct {
 	mo.HostDatastoreBrowser
 }
 
-type searchDatastoreTask struct {
+type searchDatastore struct {
 	*HostDatastoreBrowser
 
 	DatastorePath string
@@ -41,7 +41,7 @@ type searchDatastoreTask struct {
 	recurse bool
 }
 
-func (s *searchDatastoreTask) addFile(file os.FileInfo, res *types.HostDatastoreBrowserSearchResults) {
+func (s *searchDatastore) addFile(file os.FileInfo, res *types.HostDatastoreBrowserSearchResults) {
 	details := s.SearchSpec.Details
 	if details == nil {
 		details = new(types.FileQueryFlags)
@@ -96,7 +96,7 @@ func (s *searchDatastoreTask) addFile(file os.FileInfo, res *types.HostDatastore
 	res.File = append(res.File, finfo)
 }
 
-func (s *searchDatastoreTask) search(ds *types.ManagedObjectReference, folder string, dir string) error {
+func (s *searchDatastore) search(ds *types.ManagedObjectReference, folder string, dir string) error {
 	files, err := ioutil.ReadDir(dir)
 	if err != nil {
 		log.Printf("search %s: %s", dir, err)
@@ -128,7 +128,7 @@ func (s *searchDatastoreTask) search(ds *types.ManagedObjectReference, folder st
 	return nil
 }
 
-func (s *searchDatastoreTask) Run(Task *Task) (types.AnyType, types.BaseMethodFault) {
+func (s *searchDatastore) Run(Task *Task) (types.AnyType, types.BaseMethodFault) {
 	p, fault := parseDatastorePath(s.DatastorePath)
 	if fault != nil {
 		return nil, fault
@@ -165,7 +165,7 @@ func (s *searchDatastoreTask) Run(Task *Task) (types.AnyType, types.BaseMethodFa
 }
 
 func (b *HostDatastoreBrowser) SearchDatastoreTask(s *types.SearchDatastore_Task) soap.HasFault {
-	task := NewTask(&searchDatastoreTask{
+	task := NewTask(&searchDatastore{
 		HostDatastoreBrowser: b,
 		DatastorePath:        s.DatastorePath,
 		SearchSpec:           s.SearchSpec,
@@ -181,7 +181,7 @@ func (b *HostDatastoreBrowser) SearchDatastoreTask(s *types.SearchDatastore_Task
 }
 
 func (b *HostDatastoreBrowser) SearchDatastoreSubFoldersTask(s *types.SearchDatastoreSubFolders_Task) soap.HasFault {
-	task := NewTask(&searchDatastoreTask{
+	task := NewTask(&searchDatastore{
 		HostDatastoreBrowser: b,
 		DatastorePath:        s.DatastorePath,
 		SearchSpec:           s.SearchSpec,

--- a/pkg/vsphere/simulator/service_instance.go
+++ b/pkg/vsphere/simulator/service_instance.go
@@ -1,4 +1,4 @@
-// Copyright 2016 VMware, Inc. All Rights Reserved.
+// Copyright 2016-2017 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -57,6 +57,7 @@ func NewServiceInstance(content types.ServiceContent, folder mo.Folder) *Service
 		NewLicenseManager(*s.Content.LicenseManager),
 		NewSearchIndex(*s.Content.SearchIndex),
 		NewViewManager(*s.Content.ViewManager),
+		NewTaskManager(*s.Content.TaskManager),
 	}
 
 	for _, o := range objects {

--- a/pkg/vsphere/simulator/task.go
+++ b/pkg/vsphere/simulator/task.go
@@ -1,4 +1,4 @@
-// Copyright 2016 VMware, Inc. All Rights Reserved.
+// Copyright 2016-2017 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -36,6 +36,7 @@ type Task struct {
 func NewTask(runner TaskRunner) *Task {
 	ref := runner.Reference()
 	name := reflect.TypeOf(runner).Elem().Name()
+	name = strings.Replace(name, "VM", "Vm", 1) // "VM" for the type to make go-lint happy, but "Vm" for the vmodl ID
 	return CreateTask(ref, name, runner.Run)
 }
 

--- a/pkg/vsphere/simulator/task_manager.go
+++ b/pkg/vsphere/simulator/task_manager.go
@@ -1,0 +1,50 @@
+// Copyright 2017 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package simulator
+
+import (
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25/mo"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+var recentTaskMax = 200 // the VC limit
+
+type TaskManager struct {
+	mo.TaskManager
+}
+
+func NewTaskManager(ref types.ManagedObjectReference) object.Reference {
+	s := &TaskManager{}
+	s.Self = ref
+	Map.AddHandler(s)
+	return s
+}
+
+func (m *TaskManager) PutObject(obj mo.Reference) {
+	ref := obj.Reference()
+	if ref.Type != "Task" {
+		return
+	}
+
+	m.RecentTask = append(m.RecentTask, ref)
+
+	if len(m.RecentTask) > recentTaskMax {
+		m.RecentTask = m.RecentTask[1:]
+	}
+}
+
+func (m *TaskManager) RemoveObject(_ types.ManagedObjectReference) {
+}

--- a/pkg/vsphere/simulator/task_manager_test.go
+++ b/pkg/vsphere/simulator/task_manager_test.go
@@ -1,0 +1,45 @@
+// Copyright 2017 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package simulator
+
+import (
+	"testing"
+
+	"github.com/vmware/vic/pkg/vsphere/simulator/esx"
+)
+
+func TestTaskManagerRecent(t *testing.T) {
+	m := ESX()
+	m.Datastore = 0
+	m.Machine = 0
+
+	err := m.Create()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	recentTaskMax = 5
+
+	tm := Map.Get(*esx.ServiceContent.TaskManager).(*TaskManager)
+	tm.RecentTask = nil
+
+	for i := 0; i < recentTaskMax+2; i++ {
+		CreateTask(esx.RootFolder, "noop", nil)
+
+		if len(tm.RecentTask) > recentTaskMax {
+			t.Errorf("too many tasks %d > %d", len(tm.RecentTask), recentTaskMax)
+		}
+	}
+}

--- a/pkg/vsphere/simulator/task_test.go
+++ b/pkg/vsphere/simulator/task_test.go
@@ -1,4 +1,4 @@
-// Copyright 2016 VMware, Inc. All Rights Reserved.
+// Copyright 2016-2017 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
The PropertyCollector RetrieveProperties method now properly supports
TraversalSpec references and nested SelectSet.

- Add TaskManager and keep track of recentTasks

- Fix up cross references
