### PR TITLE
[specific ci=1-01-Docker-Info] Removed %{TEST_RESOURCE} references in govc commands in docker-info test

### DIFF
--- a/tests/test-cases/Group1-Docker-Commands/1-01-Docker-Info.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-01-Docker-Info.robot
@@ -56,9 +56,9 @@ Get resource pool CPU and mem usages
 Set resource pool CPU and mem limits
     [Arguments]  ${cpuval}  ${memval}
 
-    ${rc}  ${output}=  Run And Return Rc And Output  govc pool.change -cpu.limit=${cpuval} %{TEST_RESOURCE}/%{VCH-NAME}
+    ${rc}  ${output}=  Run And Return Rc And Output  govc pool.change -cpu.limit=${cpuval} %{VCH-NAME}
     Should Be Equal As Integers  ${rc}  0
-    ${rc}  ${output}=  Run And Return Rc And Output  govc pool.change -mem.limit=${memval} %{TEST_RESOURCE}/%{VCH-NAME}
+    ${rc}  ${output}=  Run And Return Rc And Output  govc pool.change -mem.limit=${memval} %{VCH-NAME}
     Should Be Equal As Integers  ${rc}  0
 
 *** Test Cases ***


### PR DESCRIPTION
%{TEST_RESOURCE} references in 1-01-Docker-Info test are not needed anymore since there is a better path finding mechanism in place now for resources.

Fixes #4197 