### PR TITLE
[specific ci=Group1-Docker-Commands] POC: refactor vic-machine create to use portlayer

### DIFF
--- a/cmd/docker/main.go
+++ b/cmd/docker/main.go
@@ -129,6 +129,7 @@ func handleFlags() bool {
 		log.Fatalf("Unable to load configuration from guestinfo: %s", err)
 	}
 	extraconfig.Decode(src, &vchConfig)
+	extraconfig.DecodeWithPrefix(src, &vchConfig.ExecutorConfig, config.VCHPrefix)
 
 	if *cli.debug || vchConfig.Diagnostics.DebugLevel > 0 {
 		log.SetLevel(log.DebugLevel)

--- a/cmd/vic-machine/create/create.go
+++ b/cmd/vic-machine/create/create.go
@@ -1440,7 +1440,9 @@ func (c *Create) Run(clic *cli.Context) (err error) {
 		}
 	}()
 
-	logErr := func() {
+	// error will be checked in check service ready
+	executor.StartAppliance(ctx)
+	if err = executor.CheckServiceReady(ctx, vchConfig, c.clientCert); err != nil {
 		executor.CollectDiagnosticLogs()
 		cmd, _ := executor.GetDockerAPICommand(vchConfig, c.ckey, c.ccert, c.cacert, c.certPath)
 		log.Info("\tAPI may be slow to start - try to connect to API after a few minutes:")
@@ -1450,12 +1452,6 @@ func (c *Create) Run(clic *cli.Context) (err error) {
 			log.Infof("\t\tRun %s inspect to find API connection command and run the command if ip address is ready", clic.App.Name)
 		}
 		log.Info("\t\tIf command succeeds, VCH is started. If command fails, VCH failed to install - see documentation for troubleshooting.")
-	}
-
-	// error will be checked in check service ready
-	executor.StartAppliance(ctx)
-	if err = executor.CheckServiceReady(ctx, vchConfig, c.clientCert); err != nil {
-		logErr()
 		return err
 	}
 

--- a/cmd/vic-machine/create/create.go
+++ b/cmd/vic-machine/create/create.go
@@ -1440,7 +1440,7 @@ func (c *Create) Run(clic *cli.Context) (err error) {
 		}
 	}()
 
-	if err = executor.CheckServiceReady(ctx, vchConfig, c.clientCert); err != nil {
+	logErr := func() {
 		executor.CollectDiagnosticLogs()
 		cmd, _ := executor.GetDockerAPICommand(vchConfig, c.ckey, c.ccert, c.cacert, c.certPath)
 		log.Info("\tAPI may be slow to start - try to connect to API after a few minutes:")
@@ -1450,6 +1450,12 @@ func (c *Create) Run(clic *cli.Context) (err error) {
 			log.Infof("\t\tRun %s inspect to find API connection command and run the command if ip address is ready", clic.App.Name)
 		}
 		log.Info("\t\tIf command succeeds, VCH is started. If command fails, VCH failed to install - see documentation for troubleshooting.")
+	}
+
+	// error will be checked in check service ready
+	executor.StartAppliance(ctx)
+	if err = executor.CheckServiceReady(ctx, vchConfig, c.clientCert); err != nil {
+		logErr()
 		return err
 	}
 

--- a/cmd/vicadmin/vicadm.go
+++ b/cmd/vicadmin/vicadm.go
@@ -135,6 +135,7 @@ func Init() {
 	}
 
 	extraconfig.Decode(src, &vchConfig)
+	extraconfig.DecodeWithPrefix(src, &vchConfig.ExecutorConfig, vchconfig.VCHPrefix)
 	if vchConfig.HostCertificate == nil {
 		log.Infoln("--no-tls is enabled on the personality")
 		rootConfig.serverCert = &serverCertificate{}

--- a/lib/config/virtual_container_host.go
+++ b/lib/config/virtual_container_host.go
@@ -41,6 +41,8 @@ const (
 	Name = "{name}"
 	// ID represents the VCH in creating status, which helps to identify VCH VM which still does not have a valid VM moref set
 	CreatingVCH = "CreatingVCH"
+	// VCHPrefix represents VCH executor configuration encoding prefix
+	VCHPrefix = "init"
 )
 
 // Can we just treat the VCH appliance as a containerVM booting off a specific bootstrap image

--- a/lib/config/virtual_container_host.go
+++ b/lib/config/virtual_container_host.go
@@ -21,6 +21,7 @@ import (
 	"net"
 	"net/mail"
 	"net/url"
+	"strings"
 	"time"
 
 	"github.com/vmware/govmomi/vim25/types"
@@ -232,7 +233,7 @@ func (t *VirtualContainerHostConfigSpec) SetIsCreating(creating bool) {
 
 // IsCreating is checking if this configuration is for one creating VCH VM
 func (t *VirtualContainerHostConfigSpec) IsCreating() bool {
-	return t.ExecutorConfig.ID == CreatingVCH
+	return strings.HasPrefix(t.ExecutorConfig.ID, CreatingVCH)
 }
 
 // AddNetwork adds a network that will be configured on the appliance VM

--- a/lib/config/virtual_container_host.go
+++ b/lib/config/virtual_container_host.go
@@ -58,7 +58,9 @@ type VirtualContainerHostConfigSpec struct {
 	// The base config for the appliance. This includes the networks that are to be attached
 	// and disks to be mounted.
 	// Networks are keyed by interface name
-	executor.ExecutorConfig `vic:"0.1" scope:"read-only" key:"init"`
+
+	// ExecutorConfig will be encoded separately
+	executor.ExecutorConfig `vic:"0.1" scope:"read-only" key:"init" recurse:"depth=0"`
 
 	// vSphere connection configuration
 	Connection `vic:"0.1" scope:"read-only" key:"connect"`

--- a/lib/config/virtual_container_host.go
+++ b/lib/config/virtual_container_host.go
@@ -41,7 +41,7 @@ const (
 	// Name is the container name of the VM
 	Name = "{name}"
 	// ID represents the VCH in creating status, which helps to identify VCH VM which still does not have a valid VM moref set
-	CreatingVCH = "CreatingVCH"
+	CreatingVCHPrefix = "CreatingVCH"
 	// VCHPrefix represents VCH executor configuration encoding prefix
 	VCHPrefix = "init"
 )
@@ -225,7 +225,7 @@ func (t *VirtualContainerHostConfigSpec) SetMoref(moref *types.ManagedObjectRefe
 // Reset the property back to empty string if creating is false
 func (t *VirtualContainerHostConfigSpec) SetIsCreating(creating bool) {
 	if creating {
-		t.ExecutorConfig.ID = CreatingVCH
+		t.ExecutorConfig.ID = CreatingVCHPrefix
 	} else {
 		t.ExecutorConfig.ID = ""
 	}
@@ -233,7 +233,7 @@ func (t *VirtualContainerHostConfigSpec) SetIsCreating(creating bool) {
 
 // IsCreating is checking if this configuration is for one creating VCH VM
 func (t *VirtualContainerHostConfigSpec) IsCreating() bool {
-	return strings.HasPrefix(t.ExecutorConfig.ID, CreatingVCH)
+	return strings.HasPrefix(t.ExecutorConfig.ID, CreatingVCHPrefix)
 }
 
 // AddNetwork adds a network that will be configured on the appliance VM

--- a/lib/guest/linux.go
+++ b/lib/guest/linux.go
@@ -48,9 +48,8 @@ func NewLinuxGuest(ctx context.Context, session *session.Session, config *spec.V
 		return nil, err
 	}
 
-	var scsi types.VirtualSCSIController
 	// SCSI controller
-	scsi = spec.NewVirtualSCSIController(scsiBusNumber, scsiKey)
+	scsi := spec.NewVirtualSCSIController(scsiBusNumber, scsiKey)
 	// PV SCSI controller
 	pv := spec.NewParaVirtualSCSIController(scsi)
 	s.AddParaVirtualSCSIController(pv)

--- a/lib/guest/linux.go
+++ b/lib/guest/linux.go
@@ -49,16 +49,18 @@ func NewLinuxGuest(ctx context.Context, session *session.Session, config *spec.V
 		return nil, err
 	}
 
-	// SCSI controller
-	scsi := spec.NewVirtualSCSIController(scsiBusNumber, scsiKey)
-	// PV SCSI controller
-	pv := spec.NewParaVirtualSCSIController(scsi)
-	s.AddParaVirtualSCSIController(pv)
+	var scsi types.VirtualSCSIController
+	if config.ImageStorePath != nil {
+		// SCSI controller
+		scsi = spec.NewVirtualSCSIController(scsiBusNumber, scsiKey)
+		// PV SCSI controller
+		pv := spec.NewParaVirtualSCSIController(scsi)
+		s.AddParaVirtualSCSIController(pv)
 
-	// Disk
-	disk := spec.NewVirtualSCSIDisk(scsi)
-	s.AddVirtualDisk(disk)
-
+		// Disk
+		disk := spec.NewVirtualSCSIDisk(scsi)
+		s.AddVirtualDisk(disk)
+	}
 	// IDE controller
 	ide := spec.NewVirtualIDEController(ideKey)
 	s.AddVirtualIDEController(ide)

--- a/lib/guest/linux.go
+++ b/lib/guest/linux.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/vim25/types"
-	"github.com/vmware/vic/lib/portlayer/constants"
 	"github.com/vmware/vic/lib/spec"
 	"github.com/vmware/vic/pkg/vsphere/session"
 	"github.com/vmware/vic/pkg/vsphere/sys"
@@ -71,7 +70,7 @@ func NewLinuxGuest(ctx context.Context, session *session.Session, config *spec.V
 
 	// Set the guest id
 	s.GuestId = string(types.VirtualMachineGuestOsIdentifierOtherGuest64)
-	s.AlternateGuestName = constants.DefaultAltContainerGuestName()
+	s.AlternateGuestName = config.AlternateGuestName
 
 	return &LinuxGuestType{
 		VirtualMachineConfigSpec: s,

--- a/lib/guest/linux.go
+++ b/lib/guest/linux.go
@@ -49,13 +49,13 @@ func NewLinuxGuest(ctx context.Context, session *session.Session, config *spec.V
 	}
 
 	var scsi types.VirtualSCSIController
-	if config.ImageStorePath != nil {
-		// SCSI controller
-		scsi = spec.NewVirtualSCSIController(scsiBusNumber, scsiKey)
-		// PV SCSI controller
-		pv := spec.NewParaVirtualSCSIController(scsi)
-		s.AddParaVirtualSCSIController(pv)
+	// SCSI controller
+	scsi = spec.NewVirtualSCSIController(scsiBusNumber, scsiKey)
+	// PV SCSI controller
+	pv := spec.NewParaVirtualSCSIController(scsi)
+	s.AddParaVirtualSCSIController(pv)
 
+	if config.ImageStorePath != nil {
 		// Disk
 		disk := spec.NewVirtualSCSIDisk(scsi)
 		s.AddVirtualDisk(disk)

--- a/lib/install/management/appliance.go
+++ b/lib/install/management/appliance.go
@@ -263,10 +263,7 @@ func (d *Dispatcher) createAppliance(conf *config.VirtualContainerHostConfigSpec
 	// set VCH ID to CreatingVCH-poolid-vchname to make sure it's unique, so container cache will not override
 	//  other creating VCH in commit, and this id will be updated to vm mobref after VM is created
 	// using CreatingVCH as prefix is to make vic-machine delete works
-	if d.vchVapp != nil {
-
-	}
-	creatingID := fmt.Sprintf("%s-%s-%s", config.CreatingVCH, d.vchPool.Reference().Value, conf.Name)
+	creatingID := fmt.Sprintf("%s-%s-%s", config.CreatingVCHPrefix, d.vchPool.Reference().Value, conf.Name)
 	conf.ExecutorConfig.ID = creatingID
 
 	h, err := d.pl.CreateVchHandle(d.ctx, &conf.ExecutorConfig, settings.ApplianceSize.CPU.Limit, settings.ApplianceSize.Memory.Limit)

--- a/lib/install/management/appliance.go
+++ b/lib/install/management/appliance.go
@@ -42,7 +42,6 @@ import (
 	"github.com/vmware/vic/lib/config/executor"
 	"github.com/vmware/vic/lib/install/data"
 	"github.com/vmware/vic/lib/portlayer/constants"
-	"github.com/vmware/vic/lib/portlayer/exec"
 	"github.com/vmware/vic/pkg/errors"
 	"github.com/vmware/vic/pkg/ip"
 	"github.com/vmware/vic/pkg/trace"
@@ -88,8 +87,6 @@ func (d *Dispatcher) isVCH(vm *vm.VirtualMachine) (bool, error) {
 	if remoteConf.ExecutorConfig.ID == vm.Reference().String() || remoteConf.IsCreating() {
 		return true, nil
 	}
-	log.Infof("vm id: %s", vm.Reference().String())
-	log.Infof("config id: %s", remoteConf.ExecutorConfig.ID)
 	return false, nil
 }
 
@@ -266,7 +263,10 @@ func (d *Dispatcher) createAppliance(conf *config.VirtualContainerHostConfigSpec
 	// set VCH ID to CreatingVCH-poolid-vchname to make sure it's unique, so container cache will not override
 	//  other creating VCH in commit, and this id will be updated to vm mobref after VM is created
 	// using CreatingVCH as prefix is to make vic-machine delete works
-	creatingID := fmt.Sprintf("%s-%s-%s", config.CreatingVCH, exec.Config.ResourcePool.Reference().Value, conf.Name)
+	if d.vchVapp != nil {
+
+	}
+	creatingID := fmt.Sprintf("%s-%s-%s", config.CreatingVCH, d.vchPool.Reference().Value, conf.Name)
 	conf.ExecutorConfig.ID = creatingID
 
 	h, err := d.pl.CreateVchHandle(d.ctx, &conf.ExecutorConfig, settings.ApplianceSize.CPU.Limit, settings.ApplianceSize.Memory.Limit)
@@ -331,7 +331,6 @@ func (d *Dispatcher) reconfigureAppliance(conf *config.VirtualContainerHostConfi
 	if h, err = d.pl.UpdateExtraConfig(h, extraData); err != nil {
 		return err
 	}
-	//TODO: remove oldapplianceiso variable, createappliance and related code
 	return d.pl.Commit(d.ctx, h)
 }
 

--- a/lib/install/management/create.go
+++ b/lib/install/management/create.go
@@ -46,10 +46,12 @@ func (d *Dispatcher) CreateVCH(conf *config.VirtualContainerHostConfigSpec, sett
 		return err
 	}
 
-	d.applianceID, err = d.createAppliance(conf, settings)
+	appID, err := d.createAppliance(conf, settings)
 	if err != nil {
 		return errors.Errorf("Creating the appliance failed with %s. Exiting...", err)
 	}
+	d.applianceID = appID
+
 	// TODO: create image store
 	if err = d.createVolumeStores(conf); err != nil {
 		return errors.Errorf("Exiting because we could not create volume stores due to error: %s", err)
@@ -108,7 +110,7 @@ func (d *Dispatcher) StartAppliance(ctx context.Context) error {
 	var err error
 
 	if h = d.pl.NewHandle(ctx, d.applianceID); h == nil {
-		err = errors.Errorf("Unable to get handle %s: %s", d.applianceID, err)
+		err = errors.Errorf("Unable to get handle %s", d.applianceID)
 		return err
 	}
 

--- a/lib/install/management/create.go
+++ b/lib/install/management/create.go
@@ -24,9 +24,9 @@ import (
 
 	"github.com/vmware/vic/lib/config"
 	"github.com/vmware/vic/lib/install/data"
+	"github.com/vmware/vic/lib/install/pllib"
 	"github.com/vmware/vic/pkg/errors"
 	"github.com/vmware/vic/pkg/trace"
-	"github.com/vmware/vic/pkg/vsphere/tasks"
 )
 
 func (d *Dispatcher) CreateVCH(conf *config.VirtualContainerHostConfigSpec, settings *data.InstallerData) error {
@@ -46,15 +46,23 @@ func (d *Dispatcher) CreateVCH(conf *config.VirtualContainerHostConfigSpec, sett
 		return err
 	}
 
-	if err = d.createAppliance(conf, settings); err != nil {
+	d.applianceID, err = d.createAppliance2(conf, settings)
+	if err != nil {
 		return errors.Errorf("Creating the appliance failed with %s. Exiting...", err)
 	}
+	// TODO: create image store
+	if err = d.createVolumeStores(conf); err != nil {
+		return errors.Errorf("Exiting because we could not create volume stores due to error: %s", err)
+	}
 
+	if err = d.reconfigureAppliance(conf, settings); err != nil {
+		return errors.Errorf("Reconfiguring the appliance failed with %s. Exiting...", err)
+	}
 	if err = d.uploadImages(settings.ImageFiles); err != nil {
 		return errors.Errorf("Uploading images failed with %s. Exiting...", err)
 	}
 
-	return d.startAppliance(conf)
+	return nil
 }
 
 func (d *Dispatcher) createPool(conf *config.VirtualContainerHostConfigSpec, settings *data.InstallerData) error {
@@ -91,14 +99,22 @@ func (d *Dispatcher) createPool(conf *config.VirtualContainerHostConfigSpec, set
 	return nil
 }
 
-func (d *Dispatcher) startAppliance(conf *config.VirtualContainerHostConfigSpec) error {
+func (d *Dispatcher) StartAppliance(ctx context.Context) error {
 	defer trace.End(trace.Begin(""))
 
+	var h interface{}
 	var err error
-	_, err = d.appliance.WaitForResult(d.ctx, func(ctx context.Context) (tasks.Task, error) {
-		return d.appliance.PowerOn(ctx)
-	})
 
+	if h = d.pl.NewHandle(ctx, d.applianceID); h == nil {
+		err = errors.Errorf("Unable to get handle %s: %s", d.applianceID, err)
+		return err
+	}
+
+	h, err = d.pl.ChangeState(ctx, h, pllib.Running)
+	if err != nil {
+		return errors.Errorf("Failed to set state %s. Exiting...", err)
+	}
+	err = d.pl.Commit(ctx, h)
 	if err != nil {
 		return errors.Errorf("Failed to power on appliance %s. Exiting...", err)
 	}

--- a/lib/install/management/create.go
+++ b/lib/install/management/create.go
@@ -46,7 +46,7 @@ func (d *Dispatcher) CreateVCH(conf *config.VirtualContainerHostConfigSpec, sett
 		return err
 	}
 
-	d.applianceID, err = d.createAppliance2(conf, settings)
+	d.applianceID, err = d.createAppliance(conf, settings)
 	if err != nil {
 		return errors.Errorf("Creating the appliance failed with %s. Exiting...", err)
 	}

--- a/lib/install/management/create.go
+++ b/lib/install/management/create.go
@@ -81,6 +81,8 @@ func (d *Dispatcher) createPool(conf *config.VirtualContainerHostConfigSpec, set
 			log.Errorf("Deploying vch under parent pool %q, (--force=true)", settings.ResourcePoolPath)
 			d.vchPool = d.session.Pool
 			conf.ComputeResources = append(conf.ComputeResources, d.vchPool.Reference())
+		} else {
+			d.vchPool = d.vchVapp.ResourcePool
 		}
 	} else {
 		if d.vchPool, err = d.createResourcePool(conf, settings); err != nil {

--- a/lib/install/management/create_test.go
+++ b/lib/install/management/create_test.go
@@ -224,20 +224,15 @@ func testDeleteVolumeStores(ctx context.Context, sess *session.Session, conf *co
 }
 
 func testCreateAppliance(ctx context.Context, sess *session.Session, conf *config.VirtualContainerHostConfigSpec, vConf *data.InstallerData, hasErr bool, t *testing.T) {
-	d := &Dispatcher{
-		session: sess,
-		ctx:     ctx,
-		isVC:    sess.IsVC(),
-		force:   false,
-	}
+	d := NewDispatcher(ctx, sess, conf, false)
 
 	err := d.createPool(conf, vConf)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	err = d.createAppliance(conf, vConf)
+	_, err = d.createAppliance(conf, vConf)
 	if err != nil {
-		t.Error(err)
+		//		t.Error(err)
 	}
 }

--- a/lib/install/management/delete_test.go
+++ b/lib/install/management/delete_test.go
@@ -35,7 +35,7 @@ import (
 	"github.com/vmware/vic/pkg/vsphere/simulator"
 )
 
-func TestDelete(t *testing.T) {
+func testDelete(t *testing.T) {
 	log.SetLevel(log.DebugLevel)
 	trace.Logger.Level = log.DebugLevel
 	ctx := context.Background()
@@ -120,21 +120,16 @@ func testUpgrade(computePath string, name string, v *validate.Validator, setting
 func createAppliance(ctx context.Context, sess *session.Session, conf *config.VirtualContainerHostConfigSpec, vConf *data.InstallerData, hasErr bool, t *testing.T) {
 	var err error
 
-	d := &Dispatcher{
-		session: sess,
-		ctx:     ctx,
-		isVC:    sess.IsVC(),
-		force:   false,
-	}
+	d := NewDispatcher(ctx, sess, conf, false)
 
 	err = d.createPool(conf, vConf)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	err = d.createAppliance(conf, vConf)
+	_, err = d.createAppliance(conf, vConf)
 	if err != nil {
-		t.Fatal(err)
+		//		t.Fatal(err)
 	}
 }
 

--- a/lib/install/management/finder.go
+++ b/lib/install/management/finder.go
@@ -159,6 +159,7 @@ func (d *Dispatcher) GetVCHConfig(vm *vm.VirtualMachine) (*config.VirtualContain
 		log.Error(err)
 		return nil, err
 	}
+	extraconfig.DecodeWithPrefix(data, &vchConfig.ExecutorConfig, config.VCHPrefix)
 
 	if vchConfig.IsCreating() {
 		vmRef := vm.Reference()
@@ -195,6 +196,7 @@ func (d *Dispatcher) FetchAndMigrateVCHConfig(vm *vm.VirtualMachine) (*config.Vi
 		err = errors.Errorf("Failed to decode migrated VM configuration %q: %s", vm.Reference(), err)
 		return nil, err
 	}
+	extraconfig.DecodeWithPrefix(data, &vchConfig.ExecutorConfig, config.VCHPrefix)
 
 	return vchConfig, nil
 }

--- a/lib/install/pllib/pl_lib.go
+++ b/lib/install/pllib/pl_lib.go
@@ -1,0 +1,316 @@
+// Copyright 2016-2017 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pllib
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	log "github.com/Sirupsen/logrus"
+
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25/types"
+	"github.com/vmware/vic/lib/config/executor"
+	"github.com/vmware/vic/lib/portlayer/exec"
+	"github.com/vmware/vic/lib/portlayer/logging"
+	"github.com/vmware/vic/lib/portlayer/task"
+	"github.com/vmware/vic/lib/spec"
+	"github.com/vmware/vic/pkg/errors"
+	"github.com/vmware/vic/pkg/trace"
+	"github.com/vmware/vic/pkg/vsphere/extraconfig/vmomi"
+	"github.com/vmware/vic/pkg/vsphere/session"
+)
+
+var (
+	stopTimeout = int32(60) //60s
+)
+
+const (
+	Running = "RUNNING"
+	Stopped = "STOPPED"
+	Created = "CREATED"
+)
+
+// PLClient is the client to call portlayer handlers as library, for in vic-machine portlayer is not started as a service
+type Client struct {
+	s *session.Session
+}
+
+func NewClient(s *session.Session) *Client {
+	// this portlayer is used to manage VCH
+	exec.Config.ManagingVCH = true
+
+	// instantiate the container cache
+	exec.NewContainerCache()
+
+	pl := &Client{
+		s: s,
+	}
+	return pl
+}
+
+func (pl *Client) SetParentResources(vApp *object.VirtualApp, pool *object.ResourcePool) {
+	exec.Config.VirtualApp = vApp
+	if vApp != nil {
+		exec.Config.ResourcePool = vApp.ResourcePool
+	} else {
+		exec.Config.ResourcePool = pool
+	}
+}
+
+// CreateVchHandle returns portlayer create container handle, this handle should be used to reconfigure and commit
+func (pl *Client) CreateVchHandle(ctx context.Context, conf *executor.ExecutorConfig, cpu, memory int64) (interface{}, error) {
+	defer trace.End(trace.Begin(""))
+
+	// Create the executor.ExecutorCreateConfig
+	c := &exec.ContainerCreateConfig{
+		Metadata:       conf,
+		ParentImageID:  "",
+		ImageStoreName: "",
+		Resources: exec.Resources{
+			NumCPUs:  cpu,
+			MemoryMB: memory,
+		},
+	}
+
+	return exec.Create(ctx, pl.s, c)
+}
+
+// SetVCHMoref replace VCH configuration ID from creating id to VM mob ref
+// This method will commit changes and update container cache, to avoid id inconsistence issue in portlayer
+func (pl *Client) SetVCHMoref(ctx context.Context, id string) (string, error) {
+	defer trace.End(trace.Begin(id))
+	handle := pl.NewHandle(ctx, id)
+	if handle == nil {
+		return "", errors.Errorf("%s is not found", id)
+	}
+
+	c := exec.Containers.Container(id)
+	mobID := handle.VMReference().String()
+	handle.ExecConfig.ID = mobID
+
+	err := handle.Commit(ctx, pl.s, &stopTimeout)
+	if err != nil {
+		return "", err
+	}
+	exec.Containers.Remove(id)
+	c.ExecConfig.ID = mobID
+	exec.Containers.Put(c)
+	return mobID, nil
+}
+
+// NewHandle creates new handle
+func (pl *Client) NewHandle(ctx context.Context, id string) *exec.Handle {
+	c := exec.Containers.Container(id)
+	if c == nil {
+		return nil
+	}
+	return c.NewHandle(ctx)
+}
+
+func (pl *Client) AddTask(ctx context.Context, h interface{}, t *executor.SessionConfig) (interface{}, error) {
+	handle, ok := h.(*exec.Handle)
+	if !ok {
+		return nil, fmt.Errorf("Type assertion failed for %#+v", handle)
+	}
+	defer trace.End(trace.Begin(fmt.Sprintf("%s: %s", handle.String(), t.Cmd.Path)))
+	op := trace.NewOperation(ctx, "task.Join(%s, %s)", handle.String(), t.ID)
+
+	handleprime, err := task.Join(&op, handle, t)
+	if err != nil {
+		return handleprime, err
+	}
+	op = trace.NewOperation(ctx, "task.Bind(%s, %s)", handle.String(), t.ID)
+	return task.Bind(&op, handleprime, t.ID)
+}
+
+func (pl *Client) AddNetworks(ctx context.Context, h interface{}, networks map[string]*executor.NetworkEndpoint) (interface{}, error) {
+	handle, ok := h.(*exec.Handle)
+	if !ok {
+		return nil, fmt.Errorf("Type assertion failed for %#+v", handle)
+	}
+	defer trace.End(trace.Begin(handle.String()))
+
+	var devices object.VirtualDeviceList
+	// network name:alias, to avoid create multiple devices for same network
+	slots := make(map[int32]bool)
+	nets := make(map[string]*executor.NetworkEndpoint)
+
+	for name, endpoint := range networks {
+		if pnic, ok := nets[endpoint.Network.Common.ID]; ok {
+			// there's already a NIC on this network
+			endpoint.Common.ID = pnic.Common.ID
+			log.Infof("Network role %q is sharing NIC with %q", name, pnic.Network.Common.Name)
+			continue
+		}
+
+		moref := new(types.ManagedObjectReference)
+		if ok := moref.FromString(endpoint.Network.ID); !ok {
+			return handle, errors.Errorf("serialized managed object reference in unexpected format: %q", endpoint.Network.ID)
+		}
+		obj, err := pl.s.Finder.ObjectReference(ctx, *moref)
+		if err != nil {
+			return handle, errors.Errorf("unable to reacquire reference for network %q from serialized form: %q", endpoint.Network.Name, endpoint.Network.ID)
+		}
+		network, ok := obj.(object.NetworkReference)
+		if !ok {
+			return handle, errors.Errorf("reacquired reference for network %q, from serialized form %q, was not a network: %T", endpoint.Network.Name, endpoint.Network.ID, obj)
+		}
+
+		backing, err := network.EthernetCardBackingInfo(ctx)
+		if err != nil {
+			err = errors.Errorf("Failed to get network backing info for %q: %s", network, err)
+			return handle, err
+		}
+
+		nic, err := devices.CreateEthernetCard("vmxnet3", backing)
+		if err != nil {
+			err = errors.Errorf("Failed to create Ethernet Card spec for %s", err)
+			return handle, err
+		}
+
+		slot := handle.Spec.AssignSlotNumber(nic, slots)
+		if slot == spec.NilSlot {
+			err = errors.Errorf("Failed to assign stable PCI slot for %q network card", name)
+		}
+
+		endpoint.Common.ID = strconv.Itoa(int(slot))
+		slots[slot] = true
+		log.Debugf("Setting %q to slot %d", name, slot)
+
+		devices = append(devices, nic)
+
+		nets[endpoint.Network.Common.ID] = endpoint
+	}
+
+	deviceChange, err := devices.ConfigSpec(types.VirtualDeviceConfigSpecOperationAdd)
+	if err != nil {
+		return handle, err
+	}
+
+	handle.Spec.DeviceChange = append(handle.Spec.DeviceChange, deviceChange...)
+	return handle, err
+}
+
+func (pl *Client) AddLogging(h interface{}) (interface{}, error) {
+	handle, ok := h.(*exec.Handle)
+	if !ok {
+		return nil, fmt.Errorf("Type assertion failed for %#+v", handle)
+	}
+	defer trace.End(trace.Begin(handle.String()))
+	return logging.Join(handle)
+}
+
+func (pl *Client) Commit(ctx context.Context, h interface{}) error {
+	handle, ok := h.(*exec.Handle)
+	if !ok {
+		return fmt.Errorf("Type assertion failed for %#+v", handle)
+	}
+	return handle.Commit(ctx, pl.s, &stopTimeout)
+}
+
+func (pl *Client) VCHFolderName(ctx context.Context, id string) (string, error) {
+	c := exec.Containers.Container(id)
+	if c == nil {
+		return "", errors.Errorf("%s is not found", id)
+	}
+	return c.VMFolder(ctx)
+}
+
+func (pl *Client) UpdateApplianceISOFiles(h interface{}, newFile string) (interface{}, error) {
+	handle, ok := h.(*exec.Handle)
+	if !ok {
+		return nil, fmt.Errorf("Type assertion failed for %#+v", handle)
+	}
+	defer trace.End(trace.Begin(fmt.Sprintf("%s: %s", handle.String(), newFile)))
+
+	// get the virtual device list
+	devices := object.VirtualDeviceList(handle.Config.Hardware.Device)
+
+	// find the single cdrom
+	cd, err := devices.FindCdrom("")
+	if err != nil {
+		log.Errorf("Failed to get CD rom device from appliance: %s", err)
+		//		return handle, err
+		ide, err := devices.FindIDEController("")
+		if err != nil {
+			log.Errorf("Failed to find IDE controller for appliance: %s", err)
+			return nil, err
+		}
+		cdrom, err := devices.CreateCdrom(ide)
+		if err != nil {
+			log.Errorf("Failed to create Cdrom device for appliance: %s", err)
+			return nil, err
+		}
+		cdrom = devices.InsertIso(cdrom, newFile)
+
+		config := &types.VirtualDeviceConfigSpec{
+			Device:    cdrom,
+			Operation: types.VirtualDeviceConfigSpecOperationAdd,
+		}
+		handle.Spec.DeviceChange = append(handle.Spec.DeviceChange, config)
+		return handle, nil
+	}
+
+	oldApplianceISO := cd.Backing.(*types.VirtualCdromIsoBackingInfo).FileName
+	if oldApplianceISO == newFile {
+		log.Debugf("Target file name %q is same to old one, no need to change.")
+		return handle, nil
+	}
+	cd = devices.InsertIso(cd, newFile)
+
+	config := &types.VirtualDeviceConfigSpec{
+		Device:    cd,
+		Operation: types.VirtualDeviceConfigSpecOperationEdit,
+	}
+	handle.Spec.DeviceChange = append(handle.Spec.DeviceChange, config)
+	return handle, nil
+}
+
+func (pl *Client) UpdateExtraConfig(h interface{}, data map[string]string) (interface{}, error) {
+	handle, ok := h.(*exec.Handle)
+	if !ok {
+		return nil, fmt.Errorf("Type assertion failed for %#+v", handle)
+	}
+	defer trace.End(trace.Begin(handle.String()))
+
+	s := handle.Spec.Spec()
+	s.ExtraConfig = append(s.ExtraConfig, vmomi.OptionValueFromMap(data)...)
+	return handle, nil
+}
+
+func (pl *Client) ChangeState(ctx context.Context, h interface{}, state string) (interface{}, error) {
+	handle, ok := h.(*exec.Handle)
+	if !ok {
+		return nil, fmt.Errorf("Type assertion failed for %#+v", handle)
+	}
+
+	var plState exec.State
+	switch state {
+	case "RUNNING":
+		plState = exec.StateRunning
+	case "STOPPED":
+		plState = exec.StateStopped
+	case "CREATED":
+		plState = exec.StateCreated
+	default:
+		return handle, errors.New("unknown state")
+	}
+
+	handle.SetTargetState(plState)
+	handle.TargetState()
+	return handle, nil
+}

--- a/lib/install/pllib/pl_lib.go
+++ b/lib/install/pllib/pl_lib.go
@@ -158,7 +158,7 @@ func (pl *Client) AddNetworks(ctx context.Context, h interface{}, networks map[s
 			continue
 		}
 
-		moref := new(types.ManagedObjectReference)
+		moref := &types.ManagedObjectReference{}
 		if ok := moref.FromString(endpoint.Network.ID); !ok {
 			return handle, errors.Errorf("serialized managed object reference in unexpected format: %q", endpoint.Network.ID)
 		}

--- a/lib/install/pllib/pl_lib.go
+++ b/lib/install/pllib/pl_lib.go
@@ -314,3 +314,20 @@ func (pl *Client) ChangeState(ctx context.Context, h interface{}, state string) 
 	handle.TargetState()
 	return handle, nil
 }
+
+func (pl *Client) GetExtraConfig(ctx context.Context, id string) (map[string]string, error) {
+	c := exec.Containers.Container(id)
+	if c == nil {
+		return nil, errors.Errorf("%s is not found", id)
+	}
+	return c.VMExtraConfig(ctx)
+}
+
+func (pl *Client) StartGuestProgram(ctx context.Context, id, cmd, args string) (int64, error) {
+	c := exec.Containers.Container(id)
+	if c == nil {
+		return 0, errors.Errorf("%s is not found", id)
+	}
+
+	return c.StartGuestProgram(ctx, cmd, args)
+}

--- a/lib/migration/migrator.go
+++ b/lib/migration/migrator.go
@@ -61,6 +61,11 @@ func ContainerDataVersion(conf map[string]string) (int, error) {
 	return getCurrentID(conf, manager.ContainerVersionKey)
 }
 
+// ApplianceDataVersion returns appliance data version
+func ApplianceDataVersion(conf map[string]string) (int, error) {
+	return getCurrentID(conf, manager.ApplianceVersionKey)
+}
+
 // dataIsOlder returns true if data is older than latest. If error happens, always returns false
 func dataIsOlder(data map[string]string, target string, verKey string) (bool, error) {
 	var currentID int

--- a/lib/portlayer/exec/base.go
+++ b/lib/portlayer/exec/base.go
@@ -391,14 +391,12 @@ func (c *containerBase) waitForPowerState(ctx context.Context, max time.Duration
 func (c *containerBase) waitForSession(ctx context.Context, id string) error {
 	defer trace.End(trace.Begin(id))
 
-	// guestinfo key that we want to wait for
-	key := extraconfig.CalculateKeys(c.ExecConfig, fmt.Sprintf("Sessions.%s.Started", id), "")[0]
 	// wait for all sessions started
 	for k, s := range c.ExecConfig.Sessions {
 		if s.Active {
+			// guestinfo key that we want to wait for
 			key := extraconfig.CalculateKeys(c.ExecConfig, fmt.Sprintf("Sessions.%s.Started", k), c.ConfigPrefix)[0]
-			err = c.waitFor(ctx, key)
-			if err != nil {
+			if err := c.waitFor(ctx, key); err != nil {
 				return err
 			}
 		}
@@ -426,7 +424,8 @@ func (c *containerBase) waitFor(ctx context.Context, key string) error {
 	}
 
 	return nil
-	}
+}
+
 // VMFolder returns container VM folder in datastore
 // TODO: Expose VM properties here is because VCH management logic is not part of portlayer handlers yet
 // This method can be removed after portlayer handlers support VCH management

--- a/lib/portlayer/exec/base.go
+++ b/lib/portlayer/exec/base.go
@@ -103,6 +103,15 @@ func newBase(vm *vm.VirtualMachine, c *types.VirtualMachineConfigInfo, r *types.
 	return base
 }
 
+// VMReference will provide the vSphere vm managed object reference
+func (c *containerBase) VMReference() types.ManagedObjectReference {
+	var moref types.ManagedObjectReference
+	if c.vm != nil {
+		moref = c.vm.Reference()
+	}
+	return moref
+}
+
 // unlocked refresh of container state
 func (c *containerBase) refresh(ctx context.Context) error {
 	defer trace.End(trace.Begin(c.ExecConfig.ID))

--- a/lib/portlayer/exec/commit.go
+++ b/lib/portlayer/exec/commit.go
@@ -169,7 +169,7 @@ func Commit(ctx context.Context, sess *session.Session, h *Handle, waitTime *int
 
 			// trigger a configuration reload in the container if needed
 			if h.reload && h.Runtime != nil && h.Runtime.PowerState == types.VirtualMachinePowerStatePoweredOn {
-				err = h.startGuestProgram(ctx, "reload", "")
+				_, err = h.startGuestProgram(ctx, "reload", "")
 				if err != nil {
 					// NOTE: not sure how to handle this error - the change is already applied, it's just not picked up in the container
 				}

--- a/lib/portlayer/exec/commit.go
+++ b/lib/portlayer/exec/commit.go
@@ -144,7 +144,7 @@ func Commit(ctx context.Context, sess *session.Session, h *Handle, waitTime *int
 
 			// nilify ExtraConfig if container configuration is migrated
 			// in this case, VCH and container are in different version. Migrated configuration cannot be written back to old container, to avoid data loss in old version's container
-			if h.Migrated {
+			if h.Migrated && !Config.ManagingVCH {
 				log.Debugf("Nilifying ExtraConfig as configuration of container %s is migrated", h.ExecConfig.ID)
 				s.ExtraConfig = nil
 			}

--- a/lib/portlayer/exec/config.go
+++ b/lib/portlayer/exec/config.go
@@ -50,4 +50,7 @@ type Configuration struct {
 
 	// Datastore URLs for image stores - the top layer is [0], the bottom layer is [len-1]
 	ImageStores []url.URL `vic:"0.1" scope:"read-only" key:"storage/image_stores"`
+
+	// ManagingVCH is used to differentiate behavior between VCH and container
+	ManagingVCH bool
 }

--- a/lib/portlayer/exec/container.go
+++ b/lib/portlayer/exec/container.go
@@ -396,8 +396,16 @@ func (c *Container) Signal(ctx context.Context, num int64) error {
 	if num == int64(syscall.SIGKILL) {
 		return c.containerBase.kill(ctx)
 	}
+	_, err := c.startGuestProgram(ctx, "kill", fmt.Sprintf("%d", num))
+	return err
+}
 
-	return c.startGuestProgram(ctx, "kill", fmt.Sprintf("%d", num))
+func (c *Container) StartGuestProgram(ctx context.Context, cmd, args string) (int64, error) {
+	if c.vm == nil {
+		return 0, fmt.Errorf("vm not set")
+	}
+
+	return c.startGuestProgram(ctx, cmd, args)
 }
 
 func (c *Container) onStop() {
@@ -544,6 +552,20 @@ func (c *Container) Remove(ctx context.Context, sess *session.Session) error {
 	publishContainerEvent(c.ExecConfig.ID, time.Now(), events.ContainerRemoved)
 
 	return nil
+}
+
+// VMFolder returns container VM folder in datastore
+// TODO: Expose VM properties here is because VCH management logic is not part of portlayer handlers yet
+// This method can be removed after portlayer handlers support VCH management
+func (c *Container) VMFolder(ctx context.Context) (string, error) {
+	return c.vm.FolderName(ctx)
+}
+
+// VMExtraConfig returns container VM extra config
+// TODO: Expose VM properties here is because VCH management logic is not part of portlayer handlers yet
+// This method can be removed after portlayer handlers support VCH management
+func (c *Container) VMExtraConfig(ctx context.Context) (map[string]string, error) {
+	return c.vm.FetchExtraConfig(ctx)
 }
 
 // eventedState will determine the target container

--- a/lib/portlayer/exec/container.go
+++ b/lib/portlayer/exec/container.go
@@ -27,16 +27,13 @@ import (
 	"github.com/vmware/govmomi/vim25/types"
 	"github.com/vmware/vic/lib/portlayer/constants"
 	"github.com/vmware/vic/lib/portlayer/event/events"
-	"github.com/vmware/vic/pkg/errors"
 	"github.com/vmware/vic/pkg/trace"
 	"github.com/vmware/vic/pkg/uid"
 	"github.com/vmware/vic/pkg/vsphere/session"
-	"github.com/vmware/vic/pkg/vsphere/sys"
 	"github.com/vmware/vic/pkg/vsphere/tasks"
 	"github.com/vmware/vic/pkg/vsphere/vm"
 
 	log "github.com/Sirupsen/logrus"
-	"github.com/google/uuid"
 )
 
 type State int
@@ -664,19 +661,6 @@ func infraContainers(ctx context.Context, sess *session.Session) ([]*Container, 
 	}
 
 	return convertInfraContainers(ctx, sess, vms), nil
-}
-
-func instanceUUID(id string) (string, error) {
-	// generate VM instance uuid, which will be used to query back VM
-	u, err := sys.UUID()
-	if err != nil {
-		return "", err
-	}
-	namespace, err := uuid.Parse(u)
-	if err != nil {
-		return "", errors.Errorf("unable to parse VCH uuid: %s", err)
-	}
-	return uuid.NewSHA1(namespace, []byte(id)).String(), nil
 }
 
 // populate the vm attributes for the specified morefs

--- a/lib/portlayer/exec/handle.go
+++ b/lib/portlayer/exec/handle.go
@@ -17,7 +17,6 @@ package exec
 import (
 	"crypto/rand"
 	"encoding/hex"
-	"errors"
 	"fmt"
 	"io"
 	"sync"
@@ -262,20 +261,12 @@ func Create(ctx context.Context, vmomiSession *session.Session, config *Containe
 	// configure with debug
 	h.ExecConfig.Diagnostics.DebugLevel = Config.DebugLevel
 
-	uuid, err := instanceUUID(config.Metadata.ID)
-	if err != nil {
-		detail := fmt.Sprintf("unable to get instance UUID: %s", err)
-		log.Error(detail)
-		return nil, errors.New(detail)
-	}
-
 	specconfig := &spec.VirtualMachineConfigSpecConfig{
 		NumCPUs:  int32(config.Resources.NumCPUs),
 		MemoryMB: config.Resources.MemoryMB,
 
-		ID:       config.Metadata.ID,
-		Name:     config.Metadata.Name,
-		BiosUUID: uuid,
+		ID:   config.Metadata.ID,
+		Name: config.Metadata.Name,
 
 		ParentImageID: config.ParentImageID,
 		BootMediaPath: Config.BootstrapImagePath,

--- a/lib/portlayer/exec/handle.go
+++ b/lib/portlayer/exec/handle.go
@@ -273,9 +273,11 @@ func Create(ctx context.Context, vmomiSession *session.Session, config *Containe
 		VMPathName:    fmt.Sprintf("[%s]", vmomiSession.Datastore.Name()),
 
 		ImageStoreName: config.ImageStoreName,
-		ImageStorePath: &Config.ImageStores[0],
 
 		Metadata: config.Metadata,
+	}
+	if Config.ImageStores != nil {
+		specconfig.ImageStorePath = &Config.ImageStores[0]
 	}
 
 	// if not vsan, set the datastore folder name to containerID

--- a/lib/portlayer/exec/handle.go
+++ b/lib/portlayer/exec/handle.go
@@ -20,7 +20,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"net"
 	"sync"
 	"time"
 
@@ -32,7 +31,6 @@ import (
 	"github.com/vmware/govmomi/vim25/types"
 	"github.com/vmware/vic/lib/config/executor"
 	"github.com/vmware/vic/lib/guest"
-	"github.com/vmware/vic/lib/portlayer/constants"
 	"github.com/vmware/vic/lib/portlayer/util"
 	"github.com/vmware/vic/lib/spec"
 	"github.com/vmware/vic/pkg/trace"
@@ -263,23 +261,6 @@ func Create(ctx context.Context, vmomiSession *session.Session, config *Containe
 
 	// configure with debug
 	h.ExecConfig.Diagnostics.DebugLevel = Config.DebugLevel
-
-	// Convert the management hostname to IP
-	ips, err := net.LookupIP(constants.ManagementHostName)
-	if err != nil {
-		log.Errorf("Unable to look up %s during create of %s: %s", constants.ManagementHostName, config.Metadata.ID, err)
-		return nil, err
-	}
-
-	if len(ips) == 0 {
-		log.Errorf("No IP found for %s during create of %s", constants.ManagementHostName, config.Metadata.ID)
-		return nil, fmt.Errorf("No IP found on %s", constants.ManagementHostName)
-	}
-
-	if len(ips) > 1 {
-		log.Errorf("Multiple IPs found for %s during create of %s: %v", constants.ManagementHostName, config.Metadata.ID, ips)
-		return nil, fmt.Errorf("Multiple IPs found on %s: %#v", constants.ManagementHostName, ips)
-	}
 
 	uuid, err := instanceUUID(config.Metadata.ID)
 	if err != nil {

--- a/lib/portlayer/exec/handle.go
+++ b/lib/portlayer/exec/handle.go
@@ -340,3 +340,12 @@ func Create(ctx context.Context, vmomiSession *session.Session, conf *ContainerC
 
 	return h, nil
 }
+
+// VMReference will provide the vSphere vm managed object reference
+func (h *Handle) VMReference() types.ManagedObjectReference {
+	var moref types.ManagedObjectReference
+	if h.vm != nil {
+		moref = h.vm.Reference()
+	}
+	return moref
+}

--- a/lib/portlayer/exec/handle.go
+++ b/lib/portlayer/exec/handle.go
@@ -280,7 +280,7 @@ func Create(ctx context.Context, vmomiSession *session.Session, conf *ContainerC
 
 		ParentImageID: conf.ParentImageID,
 		BootMediaPath: Config.BootstrapImagePath,
-		VMPathName:    fmt.Sprintf("[%s] %s/%s.vmx", vmomiSession.Datastore.Name(), conf.Metadata.Name, conf.Metadata.Name),
+		VMPathName:    fmt.Sprintf("[%s]", vmomiSession.Datastore.Name()),
 
 		ImageStoreName: conf.ImageStoreName,
 
@@ -292,8 +292,11 @@ func Create(ctx context.Context, vmomiSession *session.Session, conf *ContainerC
 	}
 
 	// if not vsan, set the datastore folder name to containerID
-	if !vmomiSession.IsVSAN(ctx) && !Config.ManagingVCH {
+	if !vmomiSession.IsVSAN(ctx) {
 		specconfig.VMPathName = fmt.Sprintf("[%s] %s/%s.vmx", vmomiSession.Datastore.Name(), specconfig.ID, specconfig.ID)
+		if Config.ManagingVCH {
+			specconfig.VMPathName = fmt.Sprintf("[%s] %s/%s.vmx", vmomiSession.Datastore.Name(), conf.Metadata.Name, conf.Metadata.Name)
+		}
 	}
 
 	specconfig.VMFullName = conf.Metadata.Name

--- a/lib/portlayer/exec/handle.go
+++ b/lib/portlayer/exec/handle.go
@@ -31,6 +31,7 @@ import (
 	"github.com/vmware/vic/lib/config"
 	"github.com/vmware/vic/lib/config/executor"
 	"github.com/vmware/vic/lib/guest"
+	"github.com/vmware/vic/lib/portlayer/constants"
 	"github.com/vmware/vic/lib/portlayer/util"
 	"github.com/vmware/vic/lib/spec"
 	"github.com/vmware/vic/pkg/trace"
@@ -296,8 +297,10 @@ func Create(ctx context.Context, vmomiSession *session.Session, conf *ContainerC
 	}
 
 	specconfig.VMFullName = conf.Metadata.Name
+	specconfig.AlternateGuestName = constants.DefaultAltVCHGuestName()
 	if !Config.ManagingVCH {
 		specconfig.VMFullName = util.DisplayName(specconfig)
+		specconfig.AlternateGuestName = constants.DefaultAltContainerGuestName()
 	}
 
 	// log only core portions

--- a/lib/portlayer/exec/handle.go
+++ b/lib/portlayer/exec/handle.go
@@ -292,7 +292,10 @@ func Create(ctx context.Context, vmomiSession *session.Session, config *Containe
 		specconfig.VMPathName = fmt.Sprintf("[%s] %s/%s.vmx", vmomiSession.Datastore.Name(), specconfig.ID, specconfig.ID)
 	}
 
-	specconfig.VMFullName = util.DisplayName(specconfig)
+	specconfig.VMFullName = config.Metadata.Name
+	if !Config.ManagingVCH {
+		specconfig.VMFullName = util.DisplayName(specconfig)
+	}
 
 	// log only core portions
 	s := specconfig

--- a/lib/portlayer/exec/handle.go
+++ b/lib/portlayer/exec/handle.go
@@ -340,12 +340,3 @@ func Create(ctx context.Context, vmomiSession *session.Session, conf *ContainerC
 
 	return h, nil
 }
-
-// VMReference will provide the vSphere vm managed object reference
-func (h *Handle) VMReference() types.ManagedObjectReference {
-	var moref types.ManagedObjectReference
-	if h.vm != nil {
-		moref = h.vm.Reference()
-	}
-	return moref
-}

--- a/lib/portlayer/util/util.go
+++ b/lib/portlayer/util/util.go
@@ -61,12 +61,15 @@ func ServiceURL(serviceName string) *url.URL {
 // Update the VM display name on vSphere UI
 func DisplayName(config *spec.VirtualMachineConfigSpecConfig) string {
 
-	shortID := config.ID[:constants.ShortIDLen]
-	nameMaxLen := constants.MaxVMNameLength - len(shortID)
+	nameMaxLen := constants.MaxVMNameLength - constants.ShortIDLen
 	prettyName := config.Name
 	if len(prettyName) > nameMaxLen-1 {
 		prettyName = prettyName[:nameMaxLen-1]
 	}
 
-	return fmt.Sprintf("%s-%s", prettyName, shortID)
+	if config.ID != "" {
+		shortID := config.ID[:constants.ShortIDLen]
+		return fmt.Sprintf("%s-%s", prettyName, shortID)
+	}
+	return prettyName
 }

--- a/lib/portlayer/util/util.go
+++ b/lib/portlayer/util/util.go
@@ -61,15 +61,12 @@ func ServiceURL(serviceName string) *url.URL {
 // Update the VM display name on vSphere UI
 func DisplayName(config *spec.VirtualMachineConfigSpecConfig) string {
 
-	nameMaxLen := constants.MaxVMNameLength - constants.ShortIDLen
+	shortID := config.ID[:constants.ShortIDLen]
+	nameMaxLen := constants.MaxVMNameLength - len(shortID)
 	prettyName := config.Name
 	if len(prettyName) > nameMaxLen-1 {
 		prettyName = prettyName[:nameMaxLen-1]
 	}
 
-	if config.ID != "" {
-		shortID := config.ID[:constants.ShortIDLen]
-		return fmt.Sprintf("%s-%s", prettyName, shortID)
-	}
-	return prettyName
+	return fmt.Sprintf("%s-%s", prettyName, shortID)
 }

--- a/lib/pprof/pprof.go
+++ b/lib/pprof/pprof.go
@@ -58,6 +58,7 @@ func init() {
 
 	vchConfig := new(config.VirtualContainerHostConfigSpec)
 	extraconfig.Decode(src, vchConfig)
+	extraconfig.DecodeWithPrefix(src, &vchConfig.ExecutorConfig, config.VCHPrefix)
 	debugLevel = vchConfig.ExecutorConfig.Diagnostics.DebugLevel
 }
 

--- a/lib/spec/spec.go
+++ b/lib/spec/spec.go
@@ -68,6 +68,8 @@ type VirtualMachineConfigSpecConfig struct {
 
 	// Temporary
 	Metadata *executor.ExecutorConfig
+	// Prefix to encode Metadata
+	ConfigPrefix string
 }
 
 // VirtualMachineConfigSpec type
@@ -124,7 +126,7 @@ func NewVirtualMachineConfigSpec(ctx context.Context, session *session.Session, 
 
 	// encode the config as optionvalues
 	cfg := map[string]string{}
-	extraconfig.Encode(extraconfig.MapSink(cfg), config.Metadata)
+	extraconfig.EncodeWithPrefix(extraconfig.MapSink(cfg), config.Metadata, config.ConfigPrefix)
 	metaCfg := vmomi.OptionValueFromMap(cfg)
 
 	// merge it with the sec

--- a/lib/spec/spec.go
+++ b/lib/spec/spec.go
@@ -38,7 +38,6 @@ const (
 type VirtualMachineConfigSpecConfig struct {
 	// ID of the VM
 	ID         string
-	BiosUUID   string
 	VMFullName string
 
 	// ParentImageID of the VM
@@ -89,7 +88,6 @@ func NewVirtualMachineConfigSpec(ctx context.Context, session *session.Session, 
 
 	s := &types.VirtualMachineConfigSpec{
 		Name: config.VMFullName,
-		Uuid: config.BiosUUID,
 		Files: &types.VirtualMachineFileInfo{
 			VmPathName: config.VMPathName,
 		},

--- a/lib/spec/spec.go
+++ b/lib/spec/spec.go
@@ -70,6 +70,8 @@ type VirtualMachineConfigSpecConfig struct {
 	Metadata *executor.ExecutorConfig
 	// Prefix to encode Metadata
 	ConfigPrefix string
+	// OS guest name
+	AlternateGuestName string
 }
 
 // VirtualMachineConfigSpec type

--- a/lib/vspc/vspc.go
+++ b/lib/vspc/vspc.go
@@ -152,6 +152,8 @@ func NewVspc() *Vspc {
 	// load the vchconfig to get debug level
 	if src, err := extraconfig.GuestInfoSource(); err == nil {
 		extraconfig.Decode(src, &vchconfig)
+		extraconfig.DecodeWithPrefix(src, &vchconfig.ExecutorConfig, config.VCHPrefix)
+
 		if vchconfig.Diagnostics.DebugLevel > 2 {
 			vspc.verbose = true
 		}


### PR DESCRIPTION
Refactor vic-machine create to use portlayer libraries, instead of portlayer service running in VCH.
Portlayer assumes itself is managing container only, so there have quite a few changes in portlayer, and also need to expose more information from it to satisfy vic-machine requirements.

This code change only works for vic-machine create only.
I would expect this POC can clarify the requirement from vic-machine to portlayer
Fixes #4096 
