### PR TITLE
[specific ci=1-06-Docker-Run] Allow for up to 3 seconds worth of NTP drift

### DIFF
--- a/tests/test-cases/Group1-Docker-Commands/1-06-Docker-Run.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-06-Docker-Run.robot
@@ -113,7 +113,7 @@ Docker run verify container start and stop time
     Should Be Equal As Integers  ${rc}  0
     Should Not Contain  ${output}  Error
     ${cmdStart}=  Run  date +%s
-    Sleep  1
+    Sleep  3
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run --name startStop busybox
     Should Be Equal As Integers  ${rc}  0
     Should Be Empty  ${output}


### PR DESCRIPTION
fixes #4984 