### PR TITLE
Restore containerVM starting state during vch restart

### DIFF
--- a/lib/apiservers/engine/backends/container_test.go
+++ b/lib/apiservers/engine/backends/container_test.go
@@ -332,8 +332,9 @@ func (m *MockContainerProxy) State(vc *viccontainer.VicContainer) (*types.Contai
 	return state, nil
 }
 
-func (m *MockContainerProxy) Wait(vc *viccontainer.VicContainer, timeout time.Duration) (exitCode int32, processStatus string, containerState string, reterr error) {
-	return 0, "", "", nil
+func (m *MockContainerProxy) Wait(vc *viccontainer.VicContainer, timeout time.Duration) (*types.ContainerState, error) {
+	dockerState := &types.ContainerState{ExitCode: 0}
+	return dockerState, nil
 }
 
 func (m *MockContainerProxy) Signal(vc *viccontainer.VicContainer, sig uint64) error {

--- a/lib/apiservers/engine/backends/convert/state.go
+++ b/lib/apiservers/engine/backends/convert/state.go
@@ -1,0 +1,96 @@
+// Copyright 2017 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package convert
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/go-units"
+
+	"github.com/vmware/vic/lib/apiservers/portlayer/models"
+	"github.com/vmware/vic/pkg/trace"
+)
+
+// State will create and return a docker ContainerState object
+// from the passed vic ContainerInfo object
+func State(info *models.ContainerInfo) *types.ContainerState {
+	defer trace.End(trace.Begin(""))
+
+	// ensure we have the data we need
+	if info == nil || info.ProcessConfig == nil || info.ContainerConfig == nil {
+		return nil
+	}
+
+	dockerState := &types.ContainerState{}
+
+	// convert start / stop times
+	var started time.Time
+	var finished time.Time
+
+	if info.ProcessConfig.StartTime > 0 {
+		started = time.Unix(info.ProcessConfig.StartTime, 0)
+		dockerState.StartedAt = time.Unix(info.ProcessConfig.StartTime, 0).Format(time.RFC3339Nano)
+	}
+
+	if info.ProcessConfig.StopTime > 0 {
+		finished = time.Unix(info.ProcessConfig.StopTime, 0)
+		dockerState.FinishedAt = time.Unix(info.ProcessConfig.StopTime, 0).Format(time.RFC3339Nano)
+	}
+
+	// set docker status to state and we'll change if needed
+	dockStatus := info.ContainerConfig.State
+	// set exitCode and change if needed
+	exitCode := int(info.ProcessConfig.ExitCode)
+
+	switch info.ContainerConfig.State {
+	case "Running":
+		// if we don't have a start date leave the status as the state
+		if !started.IsZero() {
+			dockStatus = fmt.Sprintf("Up %s", units.HumanDuration(time.Now().UTC().Sub(started)))
+			dockerState.Running = true
+		}
+	case "Stopped":
+		// if we don't have a finished date then don't process exitCode and return "Stopped" for the status
+		if !finished.IsZero() {
+			// interrogate the process status returned from the portlayer
+			// and based on status text and exit codes set the appropriate
+			// docker exit code
+			if strings.Contains(info.ProcessConfig.Status, "permission denied") {
+				exitCode = 126
+			} else if strings.Contains(info.ProcessConfig.Status, "no such") {
+				exitCode = 127
+			} else if info.ProcessConfig.Status == "true" && exitCode == -1 {
+				// most likely the process was killed via the cli
+				// or received a sigkill
+				exitCode = 137
+			} else if info.ProcessConfig.Status == "" && exitCode == 0 {
+				// the process was stopped via the cli
+				// or received a sigterm
+				exitCode = 143
+			}
+
+			dockStatus = fmt.Sprintf("Exited (%d) %s ago", exitCode, units.HumanDuration(time.Now().UTC().Sub(finished)))
+		}
+	}
+	dockerState.Status = dockStatus
+	dockerState.ExitCode = exitCode
+	dockerState.Pid = int(info.ProcessConfig.Pid)
+	dockerState.Error = info.ProcessConfig.ErrorMsg
+
+	return dockerState
+}

--- a/lib/portlayer/exec/container.go
+++ b/lib/portlayer/exec/container.go
@@ -161,7 +161,16 @@ func newContainer(base *containerBase) *Container {
 		// set state
 		switch base.Runtime.PowerState {
 		case types.VirtualMachinePowerStatePoweredOn:
-			c.state = StateRunning
+			// the containerVM is poweredOn, so set state to starting
+			// then check to see if a start was successful
+			c.state = StateStarting
+			// If any sessions successfully started then set to running
+			for _, s := range base.ExecConfig.Sessions {
+				if s.Started != "" {
+					c.state = StateRunning
+					break
+				}
+			}
 		case types.VirtualMachinePowerStatePoweredOff:
 			// check if any of the sessions was started
 			for _, s := range base.ExecConfig.Sessions {

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-20-Restore-Starting-State.md
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-20-Restore-Starting-State.md
@@ -1,0 +1,21 @@
+Test 5-20 - Restore Starting State
+=======
+
+#Purpose:
+To verify that a container that is starting will have it's starting state restored
+during appliance reboot
+
+#Test Steps:
+1. Deploy VCH
+2. Enable ESXi Firewall
+3. Pull busybox
+4. docker run -i busybox
+5. verify run timeout
+6. restart VCH
+7. verify state starting
+
+#Expected Outcome:
+All test steps should complete without error
+
+#Possible Problems:
+Only will work with stand alone esxi

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-20-Restore-Starting-State.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-20-Restore-Starting-State.robot
@@ -1,0 +1,41 @@
+# Copyright 2016-2017 VMware, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#	http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License
+
+*** Settings ***
+Documentation  Test 5-20 - Restore Starting State
+Resource  ../../resources/Util.robot
+Suite Setup  Install VIC Appliance To Test Server
+Suite Teardown  Cleanup VIC Appliance On Test Server
+
+*** Test Cases ***
+Restore Container Starting State on Restart
+	# enable firewall
+	Run  govc host.esxcli network firewall set -e true
+	${out}=  Run  docker %{VCH-PARAMS} pull busybox
+	# with enabled firewall this will timeout
+	${rc}  ${container}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -i busybox
+	#Should Be Equal As Integers  ${rc}  0
+	#${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} start ${container}
+	Should Contain  ${container}  deadline
+	${rc}  ${out}=  Run And Return Rc And Output  docker %{VCH-PARAMS} ps -a
+	Should Contain  ${out}  Starting
+	# disable firewall
+	Run  govc host.esxcli network firewall set -e false
+	# restart appliance
+	Reboot VM  %{VCH-NAME}
+	# wait for docker info to succeed
+	Wait Until Keyword Succeeds  20x  5 seconds  Run Docker Info  %{VCH-PARAMS}
+	# ensure we have a starting container
+	${rc}  ${out}=  Run And Return Rc And Output  docker %{VCH-PARAMS} ps -a
+	Should Contain  ${out}  Starting


### PR DESCRIPTION
In some cases a containerVM may powerOn, but no sessions will start.  The containerVM
is in a starting state and that state will be restored if the vch restarts before any
sessions are started.

Additionally, if a user attempts to remove a starting container an error will be returned
informing the user to use the -f (force) flag to remove it.  Previously, the following error
was returned: [DELETE /containers/{id}][500] containerRemoveInternalServerError

Fixes #4494
