### PR TITLE
[specific ci=Group6-VIC-Machine] Show cert path in vic-machine inspect output

### DIFF
--- a/cmd/vic-machine/create/create.go
+++ b/cmd/vic-machine/create/create.go
@@ -52,13 +52,6 @@ const (
 	// Max permitted length of Virtual Switch name
 	MaxDisplayNameLen = 31
 
-	clientCert = "cert.pem"
-	clientKey  = "key.pem"
-	serverCert = "server-cert.pem"
-	serverKey  = "server-key.pem"
-	caCert     = "ca.pem"
-	caKey      = "ca-key.pem"
-
 	dsInputFormat  = "<datastore url w/ path>:label"
 	nfsInputFormat = "nfs://<host>/<url-path>?<mount option as query parameters>:<label>"
 )
@@ -1034,11 +1027,11 @@ func (c *Create) loadCertificates() ([]byte, *certificate.KeyPair, error) {
 
 	var keypair *certificate.KeyPair
 	// default names
-	skey := filepath.Join(c.certPath, serverKey)
-	scert := filepath.Join(c.certPath, serverCert)
-	ca := filepath.Join(c.certPath, caCert)
-	ckey := filepath.Join(c.certPath, clientKey)
-	ccert := filepath.Join(c.certPath, clientCert)
+	skey := filepath.Join(c.certPath, management.ServerKey)
+	scert := filepath.Join(c.certPath, management.ServerCert)
+	ca := filepath.Join(c.certPath, management.CACert)
+	ckey := filepath.Join(c.certPath, management.ClientKey)
+	ccert := filepath.Join(c.certPath, management.ClientCert)
 
 	// if specific files are supplied, use those
 	explicit := false
@@ -1184,14 +1177,14 @@ func (c *Create) generateCertificates(server bool, client bool) ([]byte, *certif
 		return nil, nil, err
 	}
 
-	c.skey = filepath.Join(c.certPath, serverKey)
-	c.scert = filepath.Join(c.certPath, serverCert)
+	c.skey = filepath.Join(c.certPath, management.ServerKey)
+	c.scert = filepath.Join(c.certPath, management.ServerCert)
 
-	c.ckey = filepath.Join(c.certPath, clientKey)
-	c.ccert = filepath.Join(c.certPath, clientCert)
+	c.ckey = filepath.Join(c.certPath, management.ClientKey)
+	c.ccert = filepath.Join(c.certPath, management.ClientCert)
 
-	cakey := filepath.Join(c.certPath, caKey)
-	c.cacert = filepath.Join(c.certPath, caCert)
+	cakey := filepath.Join(c.certPath, management.CAKey)
+	c.cacert = filepath.Join(c.certPath, management.CACert)
 
 	if server && !client {
 		log.Infof("Generating self-signed certificate/key pair - private key in %s", c.skey)

--- a/cmd/vic-machine/create/create.go
+++ b/cmd/vic-machine/create/create.go
@@ -1026,11 +1026,11 @@ func (c *Create) loadCertificates() ([]byte, *certificate.KeyPair, error) {
 
 	var keypair *certificate.KeyPair
 	// default names
-	skey := filepath.Join(c.certPath, management.ServerKey)
-	scert := filepath.Join(c.certPath, management.ServerCert)
-	ca := filepath.Join(c.certPath, management.CACert)
-	ckey := filepath.Join(c.certPath, management.ClientKey)
-	ccert := filepath.Join(c.certPath, management.ClientCert)
+	skey := filepath.Join(c.certPath, certificate.ServerKey)
+	scert := filepath.Join(c.certPath, certificate.ServerCert)
+	ca := filepath.Join(c.certPath, certificate.CACert)
+	ckey := filepath.Join(c.certPath, certificate.ClientKey)
+	ccert := filepath.Join(c.certPath, certificate.ClientCert)
 
 	// if specific files are supplied, use those
 	explicit := false
@@ -1103,15 +1103,13 @@ func (c *Create) loadCertificates() ([]byte, *certificate.KeyPair, error) {
 			log.Warnf("Unable to load client certificate - validation of API endpoint will be best effort only: %s", err)
 		}
 
-		clientCert, err := management.VerifyClientCert(certs, cpair)
+		clientCert, err := certificate.VerifyClientCert(certs, cpair)
 		if err != nil {
 			switch err.(type) {
-			case management.CertParseError:
-				log.Debugf("Unable to parse client certificate: %s", err)
-			case management.CreateCAPoolError:
-				log.Debugf("Unable to create CA pool to check client certificate")
-			case management.CertVerifyError:
-				log.Warnf("Client certificate in certificate path does not validate with provided CA - continuing without client certificate")
+			case certificate.CertParseError, certificate.CreateCAPoolError:
+				log.Debugf(err.Error())
+			case certificate.CertVerifyError:
+				log.Warnf("%s - continuing without client certificate", err.Error())
 			}
 
 			return certs, keypair, nil
@@ -1167,14 +1165,14 @@ func (c *Create) generateCertificates(server bool, client bool) ([]byte, *certif
 		return nil, nil, err
 	}
 
-	c.skey = filepath.Join(c.certPath, management.ServerKey)
-	c.scert = filepath.Join(c.certPath, management.ServerCert)
+	c.skey = filepath.Join(c.certPath, certificate.ServerKey)
+	c.scert = filepath.Join(c.certPath, certificate.ServerCert)
 
-	c.ckey = filepath.Join(c.certPath, management.ClientKey)
-	c.ccert = filepath.Join(c.certPath, management.ClientCert)
+	c.ckey = filepath.Join(c.certPath, certificate.ClientKey)
+	c.ccert = filepath.Join(c.certPath, certificate.ClientCert)
 
-	cakey := filepath.Join(c.certPath, management.CAKey)
-	c.cacert = filepath.Join(c.certPath, management.CACert)
+	cakey := filepath.Join(c.certPath, certificate.CAKey)
+	c.cacert = filepath.Join(c.certPath, certificate.CACert)
 
 	if server && !client {
 		log.Infof("Generating self-signed certificate/key pair - private key in %s", c.skey)

--- a/cmd/vic-machine/debug/debug.go
+++ b/cmd/vic-machine/debug/debug.go
@@ -1,4 +1,4 @@
-// Copyright 2016 VMware, Inc. All Rights Reserved.
+// Copyright 2016-2017 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -192,7 +192,7 @@ func (d *Debug) Run(clic *cli.Context) (err error) {
 	}
 
 	// display the VCH endpoints again for convenience
-	if err = executor.InspectVCH(vch, vchConfig); err != nil {
+	if err = executor.InspectVCH(vch, vchConfig, ""); err != nil {
 		executor.CollectDiagnosticLogs()
 		log.Errorf("%s", err)
 		return errors.New("debug failed")

--- a/cmd/vic-machine/inspect/inspect.go
+++ b/cmd/vic-machine/inspect/inspect.go
@@ -35,8 +35,11 @@ import (
 // Inspect has all input parameters for vic-machine inspect command
 type Inspect struct {
 	*data.Data
+
 	showConfig bool
-	executor   *management.Dispatcher
+	CertPath   string
+
+	executor *management.Dispatcher
 }
 
 func NewInspect() *Inspect {
@@ -45,7 +48,7 @@ func NewInspect() *Inspect {
 	return d
 }
 
-// Flags return all cli flags for inspect
+// Flags returns all cli flags for inspect
 func (i *Inspect) Flags() []cli.Flag {
 	util := []cli.Flag{
 		cli.BoolFlag{
@@ -58,6 +61,12 @@ func (i *Inspect) Flags() []cli.Flag {
 			Value:       3 * time.Minute,
 			Usage:       "Time to wait for inspect",
 			Destination: &i.Timeout,
+		},
+		cli.StringFlag{
+			Name:        "cert-path",
+			Value:       "",
+			Usage:       "The path to check for existing certificates. Defaults to './<vch name>/'",
+			Destination: &i.CertPath,
 		},
 	}
 
@@ -161,7 +170,7 @@ func (i *Inspect) Run(clic *cli.Context) (err error) {
 	log.Info("VCH upgrade status:")
 	i.upgradeStatusMessage(ctx, vch, installerVer, vchConfig.Version)
 
-	if err = executor.InspectVCH(vch, vchConfig); err != nil {
+	if err = executor.InspectVCH(vch, vchConfig, i.CertPath); err != nil {
 		executor.CollectDiagnosticLogs()
 		log.Errorf("%s", err)
 		return errors.New("inspect failed")

--- a/lib/install/management/errors.go
+++ b/lib/install/management/errors.go
@@ -1,0 +1,38 @@
+// Copyright 2017 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package management
+
+// CertParseError is returned when there's an error parsing a cert.
+type CertParseError struct {
+	msg string
+}
+
+func (e CertParseError) Error() string {
+	return e.msg
+}
+
+// CreateCAPoolError is returned when there's an error creating a CA cert pool.
+type CreateCAPoolError struct{}
+
+func (e CreateCAPoolError) Error() string {
+	return "error creating CA pool"
+}
+
+// CertVerifyError is returned when the client cert cannot be validated against the CA.
+type CertVerifyError struct{}
+
+func (e CertVerifyError) Error() string {
+	return "error verifying certificate"
+}

--- a/lib/install/management/inspect.go
+++ b/lib/install/management/inspect.go
@@ -15,10 +15,12 @@
 package management
 
 import (
+	"crypto/x509"
 	"fmt"
 	"io/ioutil"
 	"net"
 	"os"
+	"os/user"
 	"path/filepath"
 	"strings"
 
@@ -28,13 +30,24 @@ import (
 
 	"github.com/vmware/govmomi/vim25/types"
 	"github.com/vmware/vic/lib/config"
+	"github.com/vmware/vic/pkg/certificate"
 	"github.com/vmware/vic/pkg/errors"
 	"github.com/vmware/vic/pkg/ip"
 	"github.com/vmware/vic/pkg/trace"
 	"github.com/vmware/vic/pkg/vsphere/vm"
 )
 
-func (d *Dispatcher) InspectVCH(vch *vm.VirtualMachine, conf *config.VirtualContainerHostConfigSpec) error {
+// Default certificate file names
+const (
+	ClientCert = "cert.pem"
+	ClientKey  = "key.pem"
+	ServerCert = "server-cert.pem"
+	ServerKey  = "server-key.pem"
+	CACert     = "ca.pem"
+	CAKey      = "ca-key.pem"
+)
+
+func (d *Dispatcher) InspectVCH(vch *vm.VirtualMachine, conf *config.VirtualContainerHostConfigSpec, certPath string) error {
 	defer trace.End(trace.Begin(conf.Name))
 
 	state, err := vch.PowerState(d.ctx)
@@ -89,8 +102,79 @@ func (d *Dispatcher) InspectVCH(vch *vm.VirtualMachine, conf *config.VirtualCont
 		log.Debugf("No host certificates provided")
 	}
 
-	d.ShowVCH(conf, "", "", "", "", "")
+	// Check for valid client cert for a tls-verify configuration
+	if len(conf.CertificateAuthorities) > 0 {
+
+		var possibleCertPaths []string
+		if certPath != "" {
+			log.Infof("cert-path supplied - only checking in %s/ for certs", certPath)
+			possibleCertPaths = append(possibleCertPaths, certPath)
+		} else {
+			possibleCertPaths = append(possibleCertPaths, conf.Name, ".")
+			logMsg := fmt.Sprintf("cert-path not supplied - checking in current directory, %s/", conf.Name)
+
+			dockerConfPath := ""
+			user, err := user.Current()
+			if err == nil {
+				dockerConfPath = filepath.Join(user.HomeDir, ".docker")
+				possibleCertPaths = append(possibleCertPaths, dockerConfPath)
+				logMsg = fmt.Sprintf("%s and %s/", logMsg, dockerConfPath)
+			}
+
+			log.Infof(logMsg)
+		}
+
+		// Check if a valid client cert exists in one of possibleCertPaths
+		certPath = ""
+		for i := range possibleCertPaths {
+			if err = verifyClientCert(conf.CertificateAuthorities, possibleCertPaths[i]); err == nil {
+				certPath = possibleCertPaths[i]
+				break
+			} else {
+				log.Debugf("Unable to verify client cert in %s: %s", possibleCertPaths[i], err)
+			}
+		}
+	}
+
+	d.ShowVCH(conf, "", "", "", "", certPath)
 	return nil
+}
+
+// verifyClientCert checks whether the input path has a client cert that's valid for the VCH.
+func verifyClientCert(ca []byte, path string) error {
+	var err error
+
+	certFile := filepath.Join(path, ClientCert)
+	keyFile := filepath.Join(path, ClientKey)
+	ckp := certificate.NewKeyPair(certFile, keyFile, nil, nil)
+	if err = ckp.LoadCertificate(); err != nil {
+		return err
+	}
+
+	rawCert := &config.RawCertificate{
+		Key:  ckp.KeyPEM,
+		Cert: ckp.CertPEM,
+	}
+	cert, err := rawCert.X509Certificate()
+	if err != nil {
+		return err
+	}
+
+	// Add persisted CA to cert pool
+	pool, err := x509.SystemCertPool()
+	if err != nil {
+		log.Debugf("Failed to load system cert pool: %s. Using empty pool.", err)
+		pool = x509.NewCertPool()
+	}
+	pool.AppendCertsFromPEM(ca)
+
+	opts := x509.VerifyOptions{
+		Roots:     pool,
+		KeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	}
+	_, err = cert.Verify(opts)
+
+	return err
 }
 
 func (d *Dispatcher) ShowVCH(conf *config.VirtualContainerHostConfigSpec, key string, cert string, cacert string, envfile string, certpath string) {
@@ -143,7 +227,7 @@ func (d *Dispatcher) GetDockerAPICommand(conf *config.VirtualContainerHostConfig
 			if key != "" {
 				tls = fmt.Sprintf(" --tlsverify --tlscacert=%q --tlscert=%q --tlskey=%q", cacert, cert, key)
 			} else {
-				tls = fmt.Sprintf(" --tlsverify ")
+				tls = fmt.Sprintf(" --tlsverify")
 			}
 
 			dEnv = append(dEnv, "DOCKER_TLS_VERIFY=1")
@@ -152,6 +236,9 @@ func (d *Dispatcher) GetDockerAPICommand(conf *config.VirtualContainerHostConfig
 				if abs, err := filepath.Abs(info.Name()); err == nil {
 					dEnv = append(dEnv, fmt.Sprintf("DOCKER_CERT_PATH=%s", abs))
 				}
+			} else {
+				log.Warnf("Unable to find valid client certs")
+				log.Warnf("DOCKER_CERT_PATH must be provided in environment or certificates specified individually via CLI arguments")
 			}
 		} else {
 			tls = " --tls"

--- a/lib/install/management/inspect_test.go
+++ b/lib/install/management/inspect_test.go
@@ -1,0 +1,51 @@
+// Copyright 2017 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package management
+
+import (
+	"os"
+	"testing"
+
+	"github.com/vmware/vic/pkg/certificate"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestVerifyClientCert(t *testing.T) {
+	cacert, cakey, err := certificate.CreateRootCA("foo.com", []string{"FooOrg"}, 2048)
+	assert.NoError(t, err)
+
+	cert, key, err := certificate.CreateClientCertificate("foo.com", []string{"FooOrg"}, 2048, cacert.Bytes(), cakey.Bytes())
+	assert.NoError(t, err)
+
+	kp := certificate.NewKeyPair(ClientCert, ClientKey, cert.Bytes(), key.Bytes())
+	err = kp.SaveCertificate()
+	assert.NoError(t, err)
+	defer func() {
+		os.Remove(ClientCert)
+		os.Remove(ClientKey)
+	}()
+
+	// Validate client certificate created with the right CA
+	err = verifyClientCert(cacert.Bytes(), ".")
+	assert.NoError(t, err)
+
+	cacert, cakey, err = certificate.CreateRootCA("bar.com", []string{"BarOrg"}, 2048)
+	assert.NoError(t, err)
+
+	// Attempt to validate client certificate created with a different CA
+	err = verifyClientCert(cacert.Bytes(), ".")
+	assert.NotNil(t, err)
+}

--- a/lib/install/management/inspect_test.go
+++ b/lib/install/management/inspect_test.go
@@ -38,14 +38,14 @@ func TestVerifyClientCert(t *testing.T) {
 		os.Remove(ClientKey)
 	}()
 
-	// Validate client certificate created with the right CA
-	err = verifyClientCert(cacert.Bytes(), ".")
+	// Validate client certificate keypair created with the right CA
+	_, err = VerifyClientCert(cacert.Bytes(), kp)
 	assert.NoError(t, err)
 
 	cacert, cakey, err = certificate.CreateRootCA("bar.com", []string{"BarOrg"}, 2048)
 	assert.NoError(t, err)
 
-	// Attempt to validate client certificate created with a different CA
-	err = verifyClientCert(cacert.Bytes(), ".")
+	// Attempt to validate client certificate keypair created with a different CA
+	_, err = VerifyClientCert(cacert.Bytes(), kp)
 	assert.NotNil(t, err)
 }

--- a/pkg/certificate/errors.go
+++ b/pkg/certificate/errors.go
@@ -12,7 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package management
+package certificate
+
+import "fmt"
 
 // CertParseError is returned when there's an error parsing a cert.
 type CertParseError struct {
@@ -20,19 +22,19 @@ type CertParseError struct {
 }
 
 func (e CertParseError) Error() string {
-	return e.msg
+	return fmt.Sprintf("Unable to parse client certificate: %s", e.msg)
 }
 
 // CreateCAPoolError is returned when there's an error creating a CA cert pool.
 type CreateCAPoolError struct{}
 
 func (e CreateCAPoolError) Error() string {
-	return "error creating CA pool"
+	return "Unable to create CA pool to check client certificate"
 }
 
 // CertVerifyError is returned when the client cert cannot be validated against the CA.
 type CertVerifyError struct{}
 
 func (e CertVerifyError) Error() string {
-	return "error verifying certificate"
+	return "Client certificate in certificate path does not validate with provided CA"
 }

--- a/tests/test-cases/Group6-VIC-Machine/6-09-Inspect.md
+++ b/tests/test-cases/Group6-VIC-Machine/6-09-Inspect.md
@@ -23,8 +23,8 @@ This test requires that a vSphere server is running and available
 10. Inspect the VCH without specifying --cert-path
 
 # Expected Outcome:
-* Steps 1 and 2 should succeed, and output from step 7 should contain expected flags & values
-* Steps 3-10 should complete successfully, however, step 6 should show a warning in the output (see below).
+* Steps 1 should succeed, and output from step 2 should contain expected flags & values
+* Steps 3-10 should complete successfully, however, step 6 should show a warning in the output (see below)
 * The output of steps 4 and 5 should contain the correct `DOCKER_CERT_PATH`.
 * The output of step 6 should not contain a `DOCKER_CERT_PATH` and should contain:
 ```

--- a/tests/test-cases/Group6-VIC-Machine/6-09-Inspect.md
+++ b/tests/test-cases/Group6-VIC-Machine/6-09-Inspect.md
@@ -1,23 +1,39 @@
 Test 6-09 - Verify vic-machine inspect
 =======
 
-#Purpose:
-Verify vic-machine inspect functions
+# Purpose:
+Verify vic-machine inspect functionality
 
-#References:
+# References:
 * vic-machine-linux inspect -h
 
-#Environment:
+# Environment:
 This test requires that a vSphere server is running and available
 
-#Test Steps
-1. Create VCH1
-2. Create VCH2
-3. Run inspect for VCH1
-4. Using inspect result to run docker command
-5. Verify docker VM is created under correct VCH resource pool or Virtual App through govc
-6. Install VCH
-7. Issue vic-machine inspect --conf command
+# Test Steps:
+1. Install VCH
+2. Issue vic-machine inspect --conf command
+3. Create a VCH with tlsverify
+4. Inspect the VCH without specifying --cert-path
+5. Inspect the VCH with a valid --cert-path
+6. Inspect the VCH with an invalid --cert-path
+7. Create a VCH with --no-tls
+8. Inspect the VCH without specifying --cert-path
+9. Create a VCH with --no-tlsverify
+10. Inspect the VCH without specifying --cert-path
 
-#Expected Results
-Steps 6 and 7 should succeed, and output from step 7 should contain expected flags & values
+# Expected Outcome:
+* Steps 1 and 2 should succeed, and output from step 7 should contain expected flags & values
+* Steps 3-10 should complete successfully, however, step 6 should show a warning in the output (see below).
+* The output of steps 4 and 5 should contain the correct `DOCKER_CERT_PATH`.
+* The output of step 6 should not contain a `DOCKER_CERT_PATH` and should contain:
+```
+Unable to find valid client certs
+DOCKER_CERT_PATH must be provided in environment or certificates specified individually via CLI arguments
+```
+* The outputs of steps 8 and 10 should not contain a `DOCKER_CERT_PATH` and should not contain:
+```
+Unable to find valid client certs
+DOCKER_CERT_PATH must be provided in environment or certificates specified individually via CLI arguments
+```
+

--- a/tests/test-cases/Group6-VIC-Machine/6-09-Inspect.robot
+++ b/tests/test-cases/Group6-VIC-Machine/6-09-Inspect.robot
@@ -1,4 +1,4 @@
-# Copyright 2016-2017 VMware, Inc. All Rights Reserved.
+# Copyright 2017 VMware, Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -10,16 +10,17 @@
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
-# limitations under the License
+# limitations under the License.
 
 *** Settings ***
 Documentation  Test 6-09 - Verify vic-machine inspect functions
 Resource  ../../resources/Util.robot
-Suite Setup  Install VIC Appliance To Test Server
-Suite Teardown  Cleanup VIC Appliance On Test Server
+Test Teardown  Run Keyword If Test Failed  Cleanup VIC Appliance On Test Server
 
 *** Test Cases ***
 Inspect VCH configuration
+    Install VIC Appliance To Test Server
+
     ${rc}  ${output}=  Run And Return Rc And Output  bin/vic-machine-linux inspect --configuration --target=%{TEST_URL} --thumbprint=%{TEST_THUMBPRINT} --user %{TEST_USERNAME} --password=%{TEST_PASSWORD} --name=%{VCH-NAME}
     Should Contain  ${output}  --debug=1
     Should Contain  ${output}  --name=%{VCH-NAME}
@@ -37,4 +38,48 @@ Inspect VCH configuration
     Should Not Contain  ${output}  --insecure-registry
     Should Not Contain  ${output}  --cpu
     Should Be Equal As Integers  0  ${rc}
+
+    Cleanup VIC Appliance On Test Server
+
+Verify inspect output for a full tls VCH
+    Install VIC Appliance To Test Server
+
+    ${output}=  Run  bin/vic-machine-linux inspect --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT}
+    Should Contain  ${output}  DOCKER_CERT_PATH=${EXECDIR}/%{VCH-NAME}
+
+    ${output}=  Run  bin/vic-machine-linux inspect --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --cert-path=%{VCH-NAME}
+    Should Contain  ${output}  DOCKER_CERT_PATH=${EXECDIR}/%{VCH-NAME}
+
+    ${output}=  Run  bin/vic-machine-linux inspect --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --cert-path=fakeDir
+    Should Not Contain  ${output}  DOCKER_CERT_PATH=${EXECDIR}/%{VCH-NAME}
+    Should Contain  ${output}  Unable to find valid client certs
+    Should Contain  ${output}  DOCKER_CERT_PATH must be provided in environment or certificates specified individually via CLI arguments
+
+    Cleanup VIC Appliance On Test Server
+
+Verify inspect output for a --no-tls VCH
+    Set Test Environment Variables
+    ${output}=  Run  bin/vic-machine-linux create --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --image-store=%{TEST_DATASTORE} --bridge-network=%{BRIDGE_NETWORK} --public-network=%{PUBLIC_NETWORK} --no-tls
+    Should Contain  ${output}  Installer completed successfully
+    Get Docker Params  ${output}  ${true}
+
+    ${output}=  Run  bin/vic-machine-linux inspect --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT}
+    Should Not Contain  ${output}  DOCKER_CERT_PATH=${EXECDIR}/%{VCH-NAME}
+    Should Not Contain  ${output}  Unable to find valid client certs
+    Should Not Contain  ${output}  DOCKER_CERT_PATH must be provided in environment or certificates specified individually via CLI arguments
+
+    Cleanup VIC Appliance On Test Server
+
+Verify inspect output for a --no-tlsverify VCH
+    Set Test Environment Variables
+    ${output}=  Run  bin/vic-machine-linux create --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --image-store=%{TEST_DATASTORE} --bridge-network=%{BRIDGE_NETWORK} --public-network=%{PUBLIC_NETWORK} --no-tlsverify
+    Should Contain  ${output}  Installer completed successfully
+    Get Docker Params  ${output}  ${true}
+
+    ${output}=  Run  bin/vic-machine-linux inspect --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT}
+    Should Not Contain  ${output}  DOCKER_CERT_PATH=${EXECDIR}/%{VCH-NAME}
+    Should Not Contain  ${output}  Unable to find valid client certs
+    Should Not Contain  ${output}  DOCKER_CERT_PATH must be provided in environment or certificates specified individually via CLI arguments
+
+    Cleanup VIC Appliance On Test Server
 


### PR DESCRIPTION
Fixes #4490
User doc impact: https://github.com/vmware/vic-product/issues/211

This change furnishes a valid `DOCKER_CERT_PATH` (if found) for a VCH with tls-verify.

`vic-machine inspect`:

```
...
May  4 2017 19:38:57.873Z INFO  cert-path not supplied - checking in current directory, VCH-0-6641/ and /root/.docker/
...
May  4 2017 19:38:57.887Z INFO  Docker environment variables:
May  4 2017 19:38:57.887Z INFO  DOCKER_TLS_VERIFY=1 DOCKER_CERT_PATH=/drone/src/github.com/vmware/vic/VCH-0-6641 DOCKER_HOST=<vch>:2376
May  4 2017 19:38:57.887Z INFO  
May  4 2017 19:38:57.887Z INFO  Connect to docker:
May  4 2017 19:38:57.887Z INFO  docker -H <vch>:2376 --tlsverify info
```

`vic-machine inspect --cert-path=foo`, with no valid certs in `$PWD/foo`:

```
...
May  4 2017 19:38:57.873Z INFO  cert-path supplied - only checking in foo/ for certs
...
May  4 2017 19:39:12.887Z WARN  Unable to find valid client certs
May  4 2017 19:39:12.887Z WARN  DOCKER_CERT_PATH must be provided in environment or certificates specified individually via CLI arguments
May  4 2017 19:38:57.887Z INFO 
May  4 2017 19:38:57.887Z INFO  Docker environment variables:
May  4 2017 19:38:57.887Z INFO  DOCKER_TLS_VERIFY=1 DOCKER_HOST=<vch>:2376
May  4 2017 19:38:57.887Z INFO  
May  4 2017 19:38:57.887Z INFO  Connect to docker:
May  4 2017 19:38:57.887Z INFO  docker -H <vch>:2376 --tlsverify info
```