### PR TITLE
Fix wrong port number for Docker API endpoint

### DIFF
--- a/ui/vic-ui-h5c/vic/src/vic-app/src/app/vm.constants.ts
+++ b/ui/vic-ui-h5c/vic/src/vic-app/src/app/vm.constants.ts
@@ -25,5 +25,5 @@ export const CONTAINER_VM_IMAGE_NAME_KEY = 'guestinfo.vice./repo';
 export const CONTAINER_VM_PORTMAPPING_KEY = 'guestinfo.vice./networks|bridge/ports~';
 export const CONTAINER_PRETTY_NAME_KEY = 'common/name';
 export const VCH_VM_CLIENT_IP_KEY = 'guestinfo.vice..init.networks|client.assigned.IP';
-export const VCH_VM_ENDPOINT_PORT = ':2376';
+export const DOCKER_PERSONALITY_ARGS_KEY = 'guestinfo.vice./init/sessions|docker-personality/cmd/Args~';
 export const VCH_VM_LOG_PORT = ':2378';

--- a/ui/vic-ui/swf/src/main/flex/com/vmware/vicui/constants/AppConstants.as
+++ b/ui/vic-ui/swf/src/main/flex/com/vmware/vicui/constants/AppConstants.as
@@ -7,6 +7,7 @@ package com.vmware.vicui.constants {
 		public static const VM_CONTAINER_PORTMAPPING:String = "guestinfo.vice./networks|bridge/ports~";
 		public static const VCH_NAME_PATH:String = "init/common/name";
 		public static const VCH_CLIENT_IP_PATH:String = "guestinfo.vice..init.networks|client.assigned.IP";
+		public static const DOCKER_PERSONALITY_ARGS_PATH:String = "guestinfo.vice./init/sessions|docker-personality/cmd/Args~";
 		public static const VCH_ENDPOINT_PORT:String = ":2376";
 		public static const VCH_LOG_PORT:String = ":2378";
 

--- a/ui/vic-ui/swf/src/main/flex/com/vmware/vicui/views/VchPortletMediator.as
+++ b/ui/vic-ui/swf/src/main/flex/com/vmware/vicui/views/VchPortletMediator.as
@@ -92,6 +92,7 @@ package com.vmware.vicui.views {
 					   var keyName:String = new String();
 					   var keyVal:String = new String();
 					   var key:String = new String();
+					   var isUsingTls:Boolean = true;
 
 					   for (key in config ) {
 
@@ -115,11 +116,24 @@ package com.vmware.vicui.views {
 							   bytes = base64Decoder.toByteArray();
 							   ip_ipv4 = bytes.readUnsignedByte() + "." + bytes.readUnsignedByte() + "." + bytes.readUnsignedByte() + "." + bytes.readUnsignedByte();
 
-							   _view.dockerApiEndpoint.text = "DOCKER_HOST=tcp://" + ip_ipv4 + AppConstants.VCH_ENDPOINT_PORT;
+							   _view.dockerApiEndpoint.text = "DOCKER_HOST=tcp://" + ip_ipv4;
 							   _view.dockerLog.label = "https://" + ip_ipv4 + AppConstants.VCH_LOG_PORT;
 							   continue;
-
 						   }
+
+						   if (keyName == AppConstants.DOCKER_PERSONALITY_ARGS_PATH) {
+							   // port 2376 is used for tls, and 2375 for no-tls
+							   isUsingTls = keyVal.indexOf("2376") > -1;
+							   continue;
+						   }
+					   }
+
+					   // since the order in which list items are processed is not much guaranteed,
+					   // we set the port for Docker API endpoint at the end of the loop
+					   if (isUsingTls) {
+						   _view.dockerApiEndpoint.text = _view.dockerApiEndpoint.text + ":2376";
+					   } else {
+						   _view.dockerApiEndpoint.text = _view.dockerApiEndpoint.text + ":2375";
 					   }
 				   }
 			   } else {


### PR DESCRIPTION
This PR fixes a bug where, when VCH was deployed using the `--no-tls` mode, the Docker API endpoint information shown in the VCH portlet displays a wrong port. (2375 instead of 2376) This issue impacts BOTH the HTML5 Client and the Flex Client.

Fixes #5036 

<img width="1009" alt="screen shot 2017-05-05 at 1 04 35 pm" src="https://cloud.githubusercontent.com/assets/3834071/25758431/2ef15702-3194-11e7-8514-d40f090127dd.png">
<img width="1003" alt="screen shot 2017-05-05 at 1 04 46 pm" src="https://cloud.githubusercontent.com/assets/3834071/25758436/317eec6e-3194-11e7-931e-06da0d2192e1.png">
<img width="1778" alt="screen shot 2017-05-05 at 12 41 48 pm" src="https://cloud.githubusercontent.com/assets/3834071/25758439/34179aca-3194-11e7-92e1-cb202fe876a7.png">
<img width="1785" alt="screen shot 2017-05-05 at 12 43 39 pm" src="https://cloud.githubusercontent.com/assets/3834071/25758441/362993cc-3194-11e7-8227-0cba14b49c0e.png">
