### PR TITLE
[specific ci=1-01-Docker-Info] Check for build event before running tests 

### DIFF
--- a/tests/integration-test.sh
+++ b/tests/integration-test.sh
@@ -23,7 +23,7 @@ dpkg -l > package.list
 
 buildinfo=$(drone build info vmware/vic $DRONE_BUILD_NUMBER)
 
-if [[ $DRONE_BRANCH == "master" || $DRONE_BRANCH == *"refs/tags"* || $DRONE_BRANCH == "releases/"* ]] && [[ $DRONE_REPO == "vmware/vic" ]] && [[ $DRONE_BUILD_EVENT == "push" || $DRONE_BUILD_EVENT == "tag"]]; then
+if [[ $DRONE_BRANCH == "master" || $DRONE_BRANCH == *"refs/tags"* || $DRONE_BRANCH == "releases/"* ]] && [[ $DRONE_REPO == "vmware/vic" ]] && [[ $DRONE_BUILD_EVENT == "push" || $DRONE_BUILD_EVENT == "tag" ]]; then
     echo "Running full CI for $DRONE_BUILD_EVENT on $DRONE_BRANCH"
 	pybot --removekeywords TAG:secret --exclude skip tests/test-cases
 elif grep -q "\[full ci\]" <(drone build info vmware/vic $DRONE_BUILD_NUMBER); then


### PR DESCRIPTION
Issue:
Drone changed the DRONE_BRANCH env var to be the target branch.

Fix:
- Add condition to check if DRONE_BUILD_EVENT is of type push or tag, run
then a full ci