### PR TITLE
Adding version number in more visible places

### DIFF
--- a/doc/user_doc/vic_admin/SUMMARY.md
+++ b/doc/user_doc/vic_admin/SUMMARY.md
@@ -1,6 +1,6 @@
 # Summary
 
-* [Introduction](README.md)
+* [Version 0.8](README.md)
 * [Interoperability with Other VMware Software](interop.md)
 * [VCH Administration](vch_admin.md)
   * [Obtain vic-machine Version Information](vic_machine_version.md)

--- a/doc/user_doc/vic_admin/book.json
+++ b/doc/user_doc/vic_admin/book.json
@@ -1,6 +1,6 @@
 {
 
-	"title": "VMware vSphere Integrated Containers Engine 0.8 for vSphere Administrators",
+	"title": "Version 0.8",
         "gitbook": "2.x.x",
 
 	"pdf": {

--- a/doc/user_doc/vic_app_dev/SUMMARY.md
+++ b/doc/user_doc/vic_app_dev/SUMMARY.md
@@ -1,6 +1,6 @@
 # Summary
 
-* [Introduction](README.md)
+* [Version 0.8](README.md)
 * [Overview of vSphere Integrated Containers Engine For Container Application Developers](overview_of_vic_engine.md)
 * [Supported Docker Commands](container_operations.md)
 * [Use and Limitations of Containers in vSphere Integrated Containers Engine](container_limitations.md)

--- a/doc/user_doc/vic_app_dev/book.json
+++ b/doc/user_doc/vic_app_dev/book.json
@@ -1,5 +1,5 @@
 {
-	"title": "Developing Container Applications with VMware vSphere Integrated Containers 0.8",
+	"title": "Version 0.8",
         "gitbook": "2.x.x",
 
 	"pdf": {

--- a/doc/user_doc/vic_installation/SUMMARY.md
+++ b/doc/user_doc/vic_installation/SUMMARY.md
@@ -1,6 +1,6 @@
 # Summary
 
-* [Introduction](README.md)
+* [Version 0.8](README.md)
 * [Overview of vSphere Integrated Containers Engine for vSphere Administrators](introduction.md)
   * [Networks Used by vSphere Integrated Containers Engine](networks.md)
 * [Download vSphere Integrated Containers](download_vic.md)

--- a/doc/user_doc/vic_installation/book.json
+++ b/doc/user_doc/vic_installation/book.json
@@ -1,6 +1,6 @@
 {
 
-	"title": "VMware vSphere Integrated Containers Engine 0.8 Installation",
+	"title": "Version 0.8",
         "gitbook": "2.x.x",
 
 	"pdf": {

--- a/doc/user_doc/vic_installation/set_up_ops_user.md
+++ b/doc/user_doc/vic_installation/set_up_ops_user.md
@@ -61,7 +61,7 @@ When you deploy a VCH, a user account that you specify in `--ops-user` must have
 
 2. (Optional) Go to **Hosts and Clusters** and create a resource pool in which to deploy VCHs.
 
-   By creating a resource pool for VCHs, you can set the correct permissons on just that resource pool rather than on an entire host or cluster. You specify this resource pool in the `vic-machine create --compute-resource` option when you deploy the VCH. For a more granular application of privileges, you can also apply the permissions directly to VCH vApps after deployment, rather than to a resource pool.
+   By creating a resource pool for VCHs, you can set the correct permissions on just that resource pool rather than on an entire host or cluster. You specify this resource pool in the `vic-machine create --compute-resource` option when you deploy the VCH. For a more granular application of privileges, you can also apply the permissions directly to VCH vApps after deployment, rather than to a resource pool.
 
 5. In each of the **Hosts and Clusters**, **Storage**, and **Networking** views, select inventory objects and assign the user group and the appropriate role to each one.
 

--- a/doc/user_doc/vic_security/SUMMARY.md
+++ b/doc/user_doc/vic_security/SUMMARY.md
@@ -1,6 +1,6 @@
 # Summary
 
-* [Introduction](README.md)
+* [Version 0.8](README.md)
 * [Security Reference](security_reference.md)
 * [Send Documentation Feedback](feedback.md)
 

--- a/doc/user_doc/vic_security/book.json
+++ b/doc/user_doc/vic_security/book.json
@@ -1,6 +1,6 @@
 {
 
-	"title": "VMware vSphere Integrated Containers Engine 0.8 Security",
+	"title": "Version 0.8",
         "gitbook": "2.x.x",
 
 	"pdf": {


### PR DESCRIPTION
Following an internal customer using the 0.8 version of the docs with version 1.1 of the product, attempting to make the version number more apparent. In the HTML output, this puts "Version 0.8" at the top of the left-hand TOC and in the title text that appears  if you move your mouse to the top of the page. This is as much as the older version of Gitbook that we use for the older docs will allow us to do. Things are better in version 1.1, which uses a later version of Gitbook to generate output.