### PR TITLE
[skip ci] Fail more clearly when testbed fails to deploy

### DIFF
--- a/tests/resources/Nimbus-Util.robot
+++ b/tests/resources/Nimbus-Util.robot
@@ -183,10 +183,10 @@ Deploy Nimbus Testbed
     \   ${out}=  Execute Command  nimbus-testbeddeploy ${testbed}
     \   # Make sure the deploy actually worked
     \   ${status}=  Run Keyword And Return Status  Should Contain  ${out}  is up. IP:
-    \   Exit For Loop If  ${status}
+    \   Return From Keyword If  ${status}  ${out}
     \   Log To Console  Nimbus deployment ${IDX} failed, trying again in 5 minutes
     \   Sleep  5 minutes
-    [Return]  ${out}
+    Fail  Deploy Nimbus Testbed Failed 5 times over the course of more than 25 minutes
 
 Kill Nimbus Server
     [Arguments]  ${user}  ${password}  ${name}


### PR DESCRIPTION
fixes #4941 
fixes #4942
fixes #4943 

This PR doesn't fix the underlying issue, as it is being covered elsewhere, but this PR improves the failure messaging at least.

The root of this problem is here:
https://github.com/vmware/vic/issues/4939