### PR TITLE
Stop clobbering user-supplied nameservers with dhcp's

### DIFF
--- a/lib/tether/ops_linux.go
+++ b/lib/tether/ops_linux.go
@@ -475,8 +475,13 @@ func (t *BaseOperations) updateHosts(endpoint *NetworkEndpoint) error {
 }
 
 func (t *BaseOperations) updateNameservers(endpoint *NetworkEndpoint) error {
-	ns := endpoint.Network.Assigned.Nameservers
 	gw := endpoint.Network.Assigned.Gateway
+	ns := endpoint.Network.Assigned.Nameservers
+	// if `--dns-server` option is supplied at VCH creation, do not overwrite with
+	// dhcp-provided name servers, and make sure they appear at the top of the list
+	if len(endpoint.Network.Nameservers) > 0 {
+		ns = append(endpoint.Network.Nameservers, ns...)
+	}
 	// Add nameservers
 	// This is incredibly trivial for now - should be updated to a less messy approach
 	if len(ns) > 0 {

--- a/tests/test-cases/Group6-VIC-Machine/6-04-Create-Basic.md
+++ b/tests/test-cases/Group6-VIC-Machine/6-04-Create-Basic.md
@@ -12,6 +12,18 @@ This test requires that a vSphere server is running and available
 
 
 
+DNS Servers
+=======
+
+### Create VCH - supply DNS server
+1. Create VCH while supplying the `--dns-server` option twice with values `1.1.1.1` and `2.2.2.2`
+2. Enable SSH on the VCH using the `vic-machine debug` command
+3. SSH into the VCH run `cat /etc/resolv.conf`
+
+
+### Expected Outcome
+* The top two lines of the output from `cat /etc/resolv.conf` should contain `1.1.1.1` and `2.2.2.2` in that order.
+
 Image size
 =======
 

--- a/tests/test-cases/Group6-VIC-Machine/6-04-Create-Basic.robot
+++ b/tests/test-cases/Group6-VIC-Machine/6-04-Create-Basic.robot
@@ -18,6 +18,29 @@ Resource  ../../resources/Util.robot
 Test Teardown  Run Keyword If Test Failed  Cleanup VIC Appliance On Test Server
 
 *** Test Cases ***
+Create VCH - supply DNS server
+    Set Test Environment Variables
+    # Attempt to cleanup old/canceled tests
+    Run Keyword And Ignore Error  Cleanup Dangling VMs On Test Server
+    Run Keyword And Ignore Error  Cleanup Datastore On Test Server
+
+    ${output}=  Run  bin/vic-machine-linux create --name=%{VCH-NAME} --target=%{TEST_URL} --thumbprint=%{TEST_THUMBPRINT} --user=%{TEST_USERNAME} --bridge-network=%{BRIDGE_NETWORK} --public-network=%{PUBLIC_NETWORK} --image-store=%{TEST_DATASTORE} --password=%{TEST_PASSWORD} --no-tls --dns-server=1.1.1.1 --dns-server=2.2.2.2
+    Should Contain  ${output}  Installer completed successfully
+    ${output}=  Run  bin/vic-machine-linux debug --target=%{TEST_URL} --name=%{VCH-NAME} --user=%{TEST_USERNAME} --password=%{TEST_PASSWORD} --enable-ssh --pw password --thumbprint=%{TEST_THUMBPRINT}
+    Should Contain  ${output}  Completed successfully
+    Get Docker Params  ${output}  ${true}
+    Log To Console  Installer completed successfully: %{VCH-NAME}
+    Open Connection  %{VCH-IP}
+    Login  root  password
+    ${out}=  Execute Command  cat /etc/resolv.conf
+    Log  ${out}
+    ${first}=  Get Line  ${out}  0
+    Should Be Equal  ${first}  nameserver 1.1.1.1
+    ${second}=  Get Line  ${out}  1
+    Should Be Equal  ${second}  nameserver 2.2.2.2
+
+    Cleanup VIC Appliance On Test Server
+
 Create VCH - custom base disk
     Set Test Environment Variables
     # Attempt to cleanup old/canceled tests


### PR DESCRIPTION
This change prioritizes user-supplied DNS servers at create time over those offered by the DHCP server. This is a follow-on to #5092.

Fixes #4961 