### PR TITLE
[specific ci=1-04-Docker-Create] Fix test for docker create with no CMD

### DIFF
--- a/tests/test-cases/Group1-Docker-Commands/1-04-Docker-Create.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-04-Docker-Create.robot
@@ -113,7 +113,10 @@ Create a container from an image that has not been pulled yet
     Should Not Contain  ${output}  Error
 
 Create a container with no command specified
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} create alpine
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} pull centos:6.6
+    Should Be Equal As Integers  ${rc}  0
+    Should Not Contain  ${output}  Error
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} create centos:6.6
     Should Be Equal As Integers  ${rc}  1
     Should Contain  ${output}  Error response from daemon: No command specified
 


### PR DESCRIPTION
The public alpine image was recently updated to include a default CMD, so this change replaces it with centos:6.6 in the test.