### PR TITLE
Add support for whitelisting registries

### DIFF
--- a/cmd/docker/main.go
+++ b/cmd/docker/main.go
@@ -101,7 +101,7 @@ func main() {
 		log.Fatalf("failed to initialize logging: %s", err)
 	}
 
-	if err := vicbackends.Init(*cli.portLayerAddr, productName, &vchConfig, vchConfig.InsecureRegistries); err != nil {
+	if err := vicbackends.Init(*cli.portLayerAddr, productName, &vchConfig); err != nil {
 		log.Fatalf("failed to initialize backend: %s", err)
 	}
 

--- a/cmd/vic-machine/create/create.go
+++ b/cmd/vic-machine/create/create.go
@@ -104,6 +104,7 @@ type Create struct {
 	containerNetworksDNS      cli.StringSlice `arg:"container-network-dns"`
 	volumeStores              cli.StringSlice `arg:"volume-store"`
 	insecureRegistries        cli.StringSlice `arg:"insecure-registry"`
+	whitelistRegistries       cli.StringSlice `arg:"whitelist-registry"`
 	dns                       cli.StringSlice `arg:"dns-server"`
 	clientNetworkName         string
 	clientNetworkGateway      string
@@ -445,7 +446,12 @@ func (c *Create) Flags() []cli.Flag {
 		cli.StringSliceFlag{
 			Name:  "insecure-registry, dir",
 			Value: &c.insecureRegistries,
-			Usage: "Specify a list of permitted insecure registry server URLs",
+			Usage: "Specify a list of permitted insecure registry server addresses",
+		},
+		cli.StringSliceFlag{
+			Name:  "whitelist-registry, wr",
+			Value: &c.whitelistRegistries,
+			Usage: "Specify a list of permitted whitelist registry server addresses (insecure addresses still require the --insecure-registry option in addition)",
 		},
 
 		// proxies
@@ -996,6 +1002,16 @@ func (c *Create) processRegistries() error {
 			return cli.NewExitError(fmt.Sprintf("%s is an invalid format for registry url", registry), 1)
 		}
 		c.InsecureRegistries = append(c.InsecureRegistries, *regurl)
+	}
+
+	// load a list of whitelisted registries
+	for _, registry := range c.whitelistRegistries {
+		regurl, err := validate.ParseURL(registry)
+
+		if err != nil {
+			return cli.NewExitError(fmt.Sprintf("%s is an invalid format for registry url", registry), 1)
+		}
+		c.WhitelistRegistries = append(c.WhitelistRegistries, *regurl)
 	}
 
 	return nil

--- a/doc/design/registries/whitelist-registry.md
+++ b/doc/design/registries/whitelist-registry.md
@@ -1,0 +1,159 @@
+# Whitelist Registries
+
+vSphere Integrated Containers 1.2 (VIC) added the ability to whitelist registry access in an installed VCH.  When one or more registries are whitelisted for the VCH at install time the VCH goes into 'whitelist mode'.  From this point on, the VCH will only allow access to registries in its list of whitelisted registries.  In this mode, users will not be able to access any non-whitelisted registries, public or private.
+
+## Specifying Whitelist Registries at Installation
+
+Whitelisted registries can be declared during a VCH installation with *vic-machine* parameter, `--whitelist-registry`.  Two other vic-machine parameters affect whitelist registries, `--registry-ca` and `--insecure-registry`.  When whitelisted registries are declared during installation, the latter two parameters acts as modifiers to the whitelisted registries.
+
+Registry-ca declares additional certificates to verify access to registry servers secured with TLS.  If a registry is declared as a whitelist registry and not an insecure registry (discussed below), the VCH must have access to the server certificate to verify access.  The Photon-based VM that VIC uses has a base set of well-known certificates from public CAs.  If a whitelist registry uses a certificate that is not in that set of well-known certificates, the certificate must be uploaded to the VCH via vic-machine's `--registry-ca` parameter.
+
+Insecure-registry declares a registry server that can be used without requiring TLS certificate verification.  This modifies the whitelist label and takes precedence.  For instance, if a registry is declared with `--whitelist-registry` and with `--insecure-registry`, the VCH will assume the registry is an insecure whitelisted registry.  If the registry is listed with only `--whitelist-registry`, then the VCH will attempt to verify access using certificates.
+
+If a registry is declared with `--insecure-registry` but not with `--whitelist-registry`, vic-machine will add the insecure registries to the list of whitelist registries *IF* at least one whitelist registry was declared.
+
+A note about certificates.  During installation, vic-machine will attempt to verify the registry server is actually a valid registry server.  It will also attempt to validate that the certificates declared in `--registry-ca` are valid for the secure whitelisted registries.  Vic-machine only performs best effort validation of registry servers.  It will not remove the server's access from the VCH if it cannot validate the server.
+
+Acceptable values for whitelist registry values are numbered IP, FQDN, CIDR formatted range, and wildcard domains.  If a CIDR format is used, e.g. 192.168.1.1/24, then the VCH will whitelist any IP address within that subnet.  Vic-machine will not try to validate CIDR defined ranges.  If a wildcard domain is provided, e.g. *.company.com, the VCH will whitelist any IP address or FQDN address that it can validate against the domain provided during installation.  A numeric IP address will cause the VCH to perform a reverse DNS lookup to validate against that wild card domain.  As with CIDR values, vic-machine will not attempt to validate wildcard domains during installation.  Examples are provided below.
+
+The parameter `--whitelist-registry` creates a list of registries.  If multiple whitelist registries need to be declared, repeat `--whitelist-registry` multiple times during installation for each registry.
+
+### Example: vch installation with vic-machine
+
+This example installs 2 whitelist registries and 1 insecure registry.
+
+```
+./vic-machine-linux create --target=10.2.2.5 --image-store=datastore1 --name=vic-docker --user=root --password=xxxxx --compute-resource="/ha-datacenter/host/office2-sfo2-dhcp121.mycompany.com/Resources" --bridge-network=vic-network --debug=0 --volume-store=datastore1/test:default --tls-cname=*.mycompany.com --whitelist-registry="10.2.40.40:443" --whitelist-registry=10.2.2.1/24 --whitelist-registry=*.mycompany.com --insecure-registry=192.168.100.207  --registry-ca=/home/admin/mycerts/ca.crt
+```
+
+### Example: vic-machine's output during installation
+
+Below is a snippet from the vic-machine output for the above command.
+
+```
+May 15 2017 16:36:12.453-07:00 WARN  Unable to confirm insecure registry 192.168.100.207 is a valid registry at this time.
+May 15 2017 16:36:12.505-07:00 INFO  Insecure registries = 192.168.100.207
+May 15 2017 16:36:12.505-07:00 INFO  Whitelist registries = 10.2.40.40:443, 10.2.2.1/24, *.mycompany.com, 192.168.100.207
+```
+
+Had the above command also included --debug=1 (or higher), the following would be the output
+
+```
+May 15 2017 16:36:12.453-07:00 WARN  Unable to confirm insecure registry 192.168.100.207 is a valid registry at this time.
+May 15 2017 16:36:12.505-07:00 DEBUG  Secure registry 10.2.40.40:443 confirmed.
+May 15 2017 16:36:12.505-07:00 DEBUG  Skipping registry validation for 10.2.2.1/24
+May 15 2017 16:36:12.505-07:00 DEBUG Skipping registry validation for *.eng.vmware.com
+May 15 2017 16:36:12.505-07:00 INFO  Insecure registries = 192.168.100.207
+May 15 2017 16:36:12.505-07:00 INFO  Whitelist registries = 10.2.40.40:443, 10.2.2.1/24, *.mycompany.com, 192.168.100.207
+```
+
+There are a few things to note from this snippet.
+
+1. The confirmation of the insecure registry was not attempted.
+2. The whitelist registry that is secured was confirmed.
+3. Both CIDR and wildcard domain declared as whitelist were skipped during validation.
+4. The final whitelist registry list contains all registries declared with both --whitelist-registry and --insecure-registry.
+5. While not stated yet, the IP address above that contained :443 will not prevent users to use just the server address during docker commands.  This will be discussed below.
+
+## Using Docker Commands Against a VCH in 'Whitelist mode'
+
+VIC currently supports Docker commands that are most applicable for production deployment of containers.  The commands that are affected by whitelist mode are docker info, docker login, and docker pull.  Below are examples of docker commands issued for the VCH installed with the command above.  Let's assume vic-machine properly installs a VCH with the above command and it reports the VCH has an FQDN of myvch.mycompany.com.
+
+### Example: docker -H myvch.mycompany.com info
+
+```
+devbox:~/$ docker -H myvch.mycompany.com:2376 --tlsverify --tlscacert="vic-docker/ca.pem" --tlscert="vic-docker/cert.pem" --tlskey="vic-docker/key.pem" info
+
+Containers: 0
+ Running: 0
+ Paused: 0
+ Stopped: 0
+Images: 0
+Server Version: v1.1.0-rc3-0-c913391
+Storage Driver: vSphere Integrated Containers v1.1.0-rc3-0-c913391 Backend Engine
+VolumeStores: default
+vSphere Integrated Containers v1.1.0-rc3-0-c913391 Backend Engine: RUNNING
+ VCH CPU limit: 10414 MHz
+ VCH memory limit: 58.61 GiB
+ VCH CPU usage: 3103 MHz
+ VCH memory usage: 56.03 GiB
+ VMware Product: VMware ESXi
+ VMware OS: vmnix-x86
+ VMware OS version: 6.0.0
+ Insecure Registries: 192.168.100.207
+ Registry Whitelist Mode: enabled
+ Whitelisted Registries: 10.2.40.40:443, 10.2.2.1/24, *.mycompany.com, 192.168.100.207
+Plugins: 
+ Volume: vsphere
+ Network: bridge
+Swarm: inactive
+Operating System: vmnix-x86
+OSType: vmnix-x86
+Architecture: x86_64
+CPUs: 10414
+Total Memory: 58.61 GiB
+ID: vSphere Integrated Containers
+Docker Root Dir: 
+Debug Mode (client): false
+Debug Mode (server): false
+Registry: registry-1.docker.io
+Experimental: false
+Live Restore Enabled: false
+```
+
+There are a few things to note in the output of this docker info call.
+
+1. Insecure Registry and whitelist registry lists are shown.
+2. There is a message, 'Registry Whitelist Mode: enabled'.  If no whitelist registries are declared during installation, this message will not be shown.
+3. 'Registry: registry-1.docker.io' is displayed even though that address was not whitelisted.  This is the address for docker hub.  It does not mean docker hub is accessible (shown in example below).  It is simply the default registry that is attempted when attempting to login or pull without a registry address.
+
+### Example: docker -H myvch.mycompany.com login 10.2.40.40
+
+```
+devbox:~/$ docker -H myvch.mycompany.com:2376 --tlsverify --tlscacert="vic-docker/ca.pem" --tlscert="vic-docker/cert.pem" --tlskey="vic-docker/key.pem" login 10.2.40.40
+
+Username: 
+Password: 
+Login Succeeded
+```
+
+In this example, a command was issued to log onto a registry that was declared during installation.  Note, :443 was included during installation but left off during docker login.  The VCH will accept either form of the address.
+
+### Example: docker -H myvch.mycompany.com login
+
+```
+devbox:~/$ docker -H myvch.mycompany.com:2376 --tlsverify --tlscacert="vic-docker/ca.pem" --tlscert="vic-docker/cert.pem" --tlskey="vic-docker/key.pem" login
+
+Login with your Docker ID to push and pull images from Docker Hub. If you don't have a Docker ID, head over to https://hub.docker.com to create one.
+Username: user
+Password: 
+Error response from daemon: Access denied to unauthorized registry (registry-1.docker.io) while VCH is in whitelist mode
+```
+
+Notice when the registry address is left off, it attempts to access docker hub (which was indicated in the docker info output above), but the VCH denies access.
+
+### Example: docker -H myvch.mycompany.com pull 10.2.40.40/test/busybox
+
+```
+devbox:~/$ docker -H myvch.mycompany.com:2376 --tlsverify --tlscacert="vic-docker/ca.pem" --tlscert="vic-docker/cert.pem" --tlskey="vic-docker/key.pem" pull 10.2.40.40/test/busybox
+
+Using default tag: latest
+Pulling from test/busybox
+c05511d7505a: Pull complete 
+a3ed95caeb02: Pull complete 
+Digest: sha256:85f3a6aadbb0f25e148d9cfbcf23fbb206f7e6159ea168c33ac51e76fdff4b8e
+Status: Downloaded newer image for test/busybox:latest
+```
+
+This succeeds as it should.
+
+### Example: docker pull busybox
+
+```
+devbox:~/$ docker -H myvch.mycompany.com:2376 --tlsverify --tlscacert="vic-docker/ca.pem" --tlscert="vic-docker/cert.pem" --tlskey="vic-docker/key.pem" pull busybox
+
+Using default tag: latest
+Access denied to unauthorized registry (docker.io) while VCH is in whitelist mode
+```
+
+An attempt to pull from docker hub fails with a message that access was denied while the VCH is in whitelist mode.

--- a/lib/config/virtual_container_host.go
+++ b/lib/config/virtual_container_host.go
@@ -103,7 +103,7 @@ type Container struct {
 // RegistryConfig defines the registries virtual container host can talk to
 type Registry struct {
 	// Whitelist of registries
-	RegistryWhitelist []url.URL `vic:"0.1" scope:"read-only" recurse:"depth=0"`
+	RegistryWhitelist []url.URL `vic:"0.1" scope:"read-only" key:"whitelist_registries"`
 	// Blacklist of registries
 	RegistryBlacklist []url.URL `vic:"0.1" scope:"read-only" recurse:"depth=0"`
 	// Insecure registries

--- a/lib/install/data/data.go
+++ b/lib/install/data/data.go
@@ -63,7 +63,8 @@ type Data struct {
 
 	BridgeIPRange *net.IPNet
 
-	InsecureRegistries []url.URL
+	InsecureRegistries  []url.URL
+	WhitelistRegistries []url.URL
 
 	HTTPSProxy *url.URL
 	HTTPProxy  *url.URL

--- a/lib/install/validate/validator.go
+++ b/lib/install/validate/validator.go
@@ -23,9 +23,12 @@ import (
 	"path"
 	"regexp"
 	"strings"
+	"time"
 
 	log "github.com/Sirupsen/logrus"
 	units "github.com/docker/go-units"
+
+	"net"
 
 	"github.com/vmware/govmomi"
 	"github.com/vmware/govmomi/find"
@@ -40,12 +43,14 @@ import (
 	"github.com/vmware/vic/lib/config/executor"
 	"github.com/vmware/vic/lib/install/data"
 	"github.com/vmware/vic/pkg/errors"
+	registryutils "github.com/vmware/vic/pkg/registry"
 	"github.com/vmware/vic/pkg/trace"
 	"github.com/vmware/vic/pkg/version"
 	"github.com/vmware/vic/pkg/vsphere/session"
 )
 
 const defaultSyslogPort = 514
+const registryValidationTime = 10 * time.Second
 
 type Validator struct {
 	TargetPath        string
@@ -501,21 +506,147 @@ func (v *Validator) certificateAuthorities(ctx context.Context, input *data.Data
 func (v *Validator) registries(ctx context.Context, input *data.Data, conf *config.VirtualContainerHostConfigSpec) {
 	defer trace.End(trace.Begin(""))
 
+	// Check if CAs can be loaded
+	pool := x509.NewCertPool()
+	if len(input.RegistryCAs) > 0 {
+		if !pool.AppendCertsFromPEM(input.RegistryCAs) {
+			v.NoteIssue(errors.New("Unable to load certificate authority data for registry"))
+			return
+		}
+	}
+
+	conf.RegistryCertificateAuthorities = input.RegistryCAs
+
+	// test reachability
+	insecureRegistries, whitelistRegistries, err := v.reachableRegistries(ctx, input, pool)
+	if err != nil {
+		v.NoteIssue(err)
+		return
+	}
+
 	// copy the list of insecure registries
-	conf.InsecureRegistries = input.InsecureRegistries
+	conf.InsecureRegistries = insecureRegistries
+
+	// copy the list of whitelist registries
+	conf.RegistryWhitelist = whitelistRegistries
+
+	// create vic-machine info message
+	msg := v.friendlyRegistryList("Insecure registries", conf.InsecureRegistries)
+	if msg != "" {
+		log.Infof(msg)
+	}
+	msg = v.friendlyRegistryList("Whitelist registries", conf.RegistryWhitelist)
+	if msg != "" {
+		log.Infof(msg)
+	}
 
 	if len(input.RegistryCAs) == 0 {
 		return
 	}
+}
 
-	// Check if CAs can be loaded
-	pool := x509.NewCertPool()
-	if !pool.AppendCertsFromPEM(input.RegistryCAs) {
-		v.NoteIssue(errors.New("Unable to load certificate authority data for registry"))
-		return
+func (v *Validator) friendlyRegistryList(registryType string, registryList []url.URL) string {
+	var msg string
+
+	if len(registryList) > 0 {
+		var host string
+		msg = registryType + " = "
+		for i, r := range registryList {
+			host = r.Host
+			if strings.Contains(r.Path, "/") {
+				host = host + r.Path
+			}
+
+			if i == 0 {
+				msg = msg + host
+			} else {
+				msg = msg + ", " + host
+			}
+		}
 	}
 
-	conf.RegistryCertificateAuthorities = input.RegistryCAs
+	return msg
+}
+
+// Validate registries are reachable.  Secure registries that are not specified as insecure are validated with the
+// CA certs passed into vic-machine.
+func (v *Validator) reachableRegistries(ctx context.Context, input *data.Data, pool *x509.CertPool) (insecureRegistries []url.URL, whitelistRegistries []url.URL, err error) {
+	secureRegistries := input.WhitelistRegistries
+
+	// Remove intersection between insecure registries and whitelist registries from whitelist set so
+	// we can ensure we test the exclusion set with certs
+	var exist bool
+	var idx int
+	var s url.URL
+	for _, r := range input.InsecureRegistries {
+		exist = false
+		for idx, s = range secureRegistries {
+			if r.Host == s.Host {
+				exist = true
+				break
+			}
+		}
+
+		// remove the insecure registry from list of registries to get validated against certs
+		if exist {
+			secureRegistries = append(secureRegistries[:idx], secureRegistries[idx+1:]...)
+		}
+	}
+
+	// Test insecure registries' reachability
+	for _, r := range input.InsecureRegistries {
+		// Make sure address is not a wildcard domain or CIDR.  If it is, do not validate.
+		if strings.HasPrefix(r.Host, "*") {
+			log.Debugf("Skipping registry validation for %s", r.Host)
+			continue
+		}
+		if _, _, err = net.ParseCIDR(r.Host + r.Path); err == nil {
+			log.Debugf("Skipping registry validation for %s%s", r.Host, r.Path)
+			continue
+		}
+
+		_, err = registryutils.Reachable(r.Host, "https", "", "", nil, registryValidationTime, true)
+		if err != nil {
+			_, err = registryutils.Reachable(r.Host, "http", "", "", nil, registryValidationTime, true)
+		}
+
+		if err != nil {
+			log.Warnf("Unable to confirm insecure registry %s is a valid registry at this time.", r.Host)
+		} else {
+			log.Debugf("Insecure registry %s confirmed.", r.Host)
+		}
+	}
+
+	// Test secure registries' reachability
+	for _, w := range secureRegistries {
+		// Make sure address is not a wildcard domain or CIDR.  If it is, do not validate.
+		if strings.HasPrefix(w.Hostname(), "*") {
+			log.Debugf("Skipping registry validation for %s", w.Host)
+			continue
+		}
+		if _, _, err = net.ParseCIDR(w.Host + w.Path); err == nil {
+			log.Debugf("Skipping registry validation for %s%s", w.Host, w.Path)
+			continue
+		}
+
+		_, err = registryutils.Reachable(w.Host, "https", "", "", pool, registryValidationTime, false)
+
+		if err != nil {
+			log.Warnf("Unable to confirm secure registry %s is a valid registry at this time.", w.Host)
+		} else {
+			log.Debugf("Secure registry %s confirmed.", w.Host)
+		}
+	}
+
+	// Return output
+	insecureRegistries = input.InsecureRegistries
+	// If vic-machine had whitelist registry specified
+	if len(input.WhitelistRegistries) > 0 {
+		whitelistRegistries = append(secureRegistries, insecureRegistries...)
+	}
+	err = nil
+
+	return
 }
 
 func (v *Validator) compatibility(ctx context.Context, conf *config.VirtualContainerHostConfigSpec) {

--- a/pkg/registry/utils.go
+++ b/pkg/registry/utils.go
@@ -1,0 +1,55 @@
+// Copyright 2017 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package registry
+
+import (
+	"crypto/x509"
+	"fmt"
+	"net/url"
+	"time"
+
+	log "github.com/Sirupsen/logrus"
+
+	urlfetcher "github.com/vmware/vic/pkg/fetcher"
+)
+
+// Reachable test if a registry is a valid registry for VIC use and returns a url with scheme prepended
+func Reachable(registry, schema, username, password string, registryCAs *x509.CertPool, timeout time.Duration, skipVerify bool) (string, error) {
+	registryPath := fmt.Sprintf("%s://%s/v2/", schema, registry)
+
+	url, err := url.Parse(registryPath)
+	if err != nil {
+		return "", err
+	}
+	log.Debugf("URL: %s", url)
+
+	fetcher := urlfetcher.NewURLFetcher(urlfetcher.Options{
+		Timeout:            timeout,
+		Username:           username,
+		Password:           password,
+		InsecureSkipVerify: skipVerify,
+		RootCAs:            registryCAs,
+	})
+
+	headers, err := fetcher.Head(url)
+	if err != nil {
+		return "", err
+	}
+	// v2 API requires this check
+	if headers.Get("Docker-Distribution-API-Version") != "registry/2.0" {
+		return "", fmt.Errorf("Missing Docker-Distribution-API-Version header")
+	}
+	return registryPath, nil
+}

--- a/tests/manual-test-cases/Group21-Registries/21-1-Whitelist.md
+++ b/tests/manual-test-cases/Group21-Registries/21-1-Whitelist.md
@@ -1,0 +1,139 @@
+Test 21-01 - Whitelist Registries
+=======
+
+#Purpose:
+To verify that VIC appliance can whitelist registries
+
+#Environment:
+This test requires that a vSphere server is running and available
+
+Test Case -- Basic whitelisting
+=========
+
+##Test Steps:
+1. Use ovftool to deploy two harbor server, one using HTTP, the other HTTPS
+2. Deploy VIC appliance to vSphere server with vic-machine and --whitelist-registry and --registry-ca options
+3. Issue docker info
+4. Issue docker login against the whitelist registry
+5. Issue docker pull against the whitelist registry
+6. Issue docker login against the whitelist registry:443
+7. Issue docker pull against the whitelist registry:443
+8. Issue docker login against docker.io
+9. Issue docker pull against docker.io
+10. Tear down VCH
+
+##Expected Outcome:
+* Step 2 has no Warning for registry and whitelist registries are listed and were confirmed
+* Step 3 have docker hub for registry and whitelist registries listed
+* Step 4-5 succeeds
+* Step 6-7 succeeds.  VCH should not care if port is added at the end of docker operation or vic-machine creation
+* Step 8-9 fails and return a message containing 'Access denied to unauthorized registry'
+
+
+Test Case -- Basic whitelisting with NO certs
+=========
+1. Deploy VIC appliance to vSphere server with vic-machine and --whitelist-registry and NO --registry-ca options
+2. Issue docker login against the whitelist registry
+3. Issue docker pull against the whitelist registry
+4. Tear down VCH
+
+##Test Steps:
+* Step 1 has a warning the registry cannot be confirmed
+* Step 2-3 fails
+
+##Possible Problems:
+None
+
+
+Test Case -- Whitelist + HTTP Insecure-registry
+=========
+
+##Test Steps:
+1. Deploy VIC appliance to vSphere server with vic-machine and --registry-ca, --whitelist-registry and --insecure-registry options with NON-overlapping whitelist and insecure servers and one fake registry
+2. Issue docker info
+3. Issue docker login against the whitelist registry
+4. Issue docker pull against the whitelist registry
+5. Issue docker login against the insecure registry
+6. Issue docker pull against the insecure registry
+7. Issue docker login against docker.io
+8. Issue docker pull against docker.io
+9. Tear down VCH
+
+##Expected Outcome:
+* Step 1 has no warnings for registry, whitelist registries are listed and includes all whitelist and insecure servers
+* Step 2 have docker hub, whitelist registries and have insecure registries listed
+* Step 3-6 succeeds
+* Step 7-8 fails and return a message containing 'Access denied to unauthorized registry'
+
+##Possible Problems:
+None
+
+
+Test Case -- Whitelist + overlapping HTTP Insecure-registry with certs
+=========
+
+1. Deploy VIC appliance to vSphere server with vic-machine and --registry-ca, --whitelist-registry and --insecure-registry options with the same servers for both
+2. Issue docker info
+3. Issue docker login against the registry
+4. Issue docker pull against a public library on the registry
+5. Tear down VCH
+
+##Expected Outcome:
+* Step 1 has no warnings for registry, whitelist registries are listed, and the registry was confirmed as insecure
+* Step 2 have docker hub, whitelist registries and have insecure registries listed
+* Step 3-4 succeeds
+
+##Possible Problems:
+None
+
+
+Test Case -- Whitelist + overlapping HTTP Insecure-registry with NO certs
+=========
+
+1. Deploy VIC appliance to vSphere server with vic-machine and --whitelist-registry and --insecure-registry options with the same servers for both
+2. Issue docker login against the overlapping registry
+3. Issue docker pull against a public library on the registry
+4. Tear down VCH
+
+##Expected Outcome:
+* Step 1 has no warnings for registry, whitelist registries are listed, and the registry was confirmed as insecure
+* Step 2-3 succeeds as insecure-registry modifies the whitelist-registry server
+
+##Possible Problems:
+None
+
+
+Test Case -- Whitelist registry in CIDR format
+=========
+
+1. Deploy VIC appliance to vSphere server with vic-machine and --registry-ca, --whitelist-registry
+2. Issue docker info
+3. Issue docker login against the registry with IP address
+4. Issue docker pull against a public library on the registry with IP address
+5. Tear down VCH
+
+##Expected Outcome:
+* Step 1 have no warnings for registry, whitelist registries are listed, and a message that the registry confirmation was skipped
+* Step 2 have docker hub and whitelist registries listed
+* Step 3-4 succeeds
+
+##Possible Problems:
+None
+
+
+Test Case -- Whitelist registry in wildcard domain format
+=========
+
+1. Deploy VIC appliance to vSphere server with vic-machine and --registry-ca, --whitelist-registry
+2. Issue docker info
+3. Issue docker login against the registry with IP address
+4. Issue docker pull against a public library on the registry with IP address
+5. Tear down VCH
+
+##Expected Outcome:
+* Step 1 have no warnings for registry, whitelist registries are listed, and a message that the registry confirmation was skipped
+* Step 2 have docker hub and whitelist registries listed
+* Step 3-4 succeeds
+
+##Possible Problems:
+None

--- a/tests/manual-test-cases/Group21-Registries/21-1-Whitelist.robot
+++ b/tests/manual-test-cases/Group21-Registries/21-1-Whitelist.robot
@@ -1,0 +1,93 @@
+# Copyright 2017 VMware, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#	http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License
+
+*** Settings ***
+Documentation  Test 21-01 - Whitelist
+Resource  ../../resources/Util.robot
+Resource  ../../resources/Harbor-Util.robot
+Suite Setup  Setup Harbor
+Suite Teardown  Harbor Test Cleanup
+Test Teardown  Run Keyword If Test Failed  Cleanup VIC Appliance On Test Server
+
+*** Keywords ***
+Setup Harbor
+    Set Test Environment Variables
+
+    Run Keyword If  '%{HOST_TYPE}' == 'ESXi'  Pass Execution  Test skipped on ESXi as Harbor is only supported on VC
+    
+    # Install a Harbor server with HTTPS a Harbor server with HTTP
+    Install Harbor To Test Server  protocol=https  name=harbor-https
+    Set Environment Variable  HTTPS_HARBOR_IP  %{HARBOR-IP}
+
+    Install Harbor To Test Server  protocol=http  name=harbor-http
+    Set Environment Variable  HTTP_HARBOR_IP  %{HARBOR-IP}
+
+    Get HTTPS Harbor Certificate
+
+Harbor Test Cleanup
+    ${out}=  Run  govc vm.destroy harbor-http
+    ${out}=  Run  govc vm.destroy harbor-https
+    Log To Console  Cleaning up Harbor servers
+
+Get HTTPS Harbor Certificate
+    [Arguments]  ${HARBOR_IP}=%{HTTPS_HARBOR_IP}
+    # Get the certificates from the HTTPS server
+    ${out}=  Run  wget --tries=10 --connect-timeout=10 --auth-no-challenge --no-check-certificate --user admin --password %{TEST_PASSWORD} https://${HARBOR_IP}/api/systeminfo/getcert
+    Log  ${out}
+    Move File  getcert  ./ca.crt
+
+
+*** Test Cases ***
+Basic Whitelisting
+    Run Keyword If  '%{HOST_TYPE}' == 'ESXi'  Pass Execution  Test skipped on ESXi as Harbor is only supported on VC
+    
+    # Attempt to cleanup old/canceled tests
+    Run Keyword And Ignore Error  Cleanup Dangling VMs On Test Server
+    Run Keyword And Ignore Error  Cleanup Datastore On Test Server
+
+    # Install VCH with registry CA for whitelisted registry
+    ${output}=  Install VIC Appliance To Test Server  vol=default --whitelist-registry=%{HTTPS_HARBOR_IP} --registry-ca=./ca.crt
+    Should Contain  ${output}  Secure registry %{HTTPS_HARBOR_IP} confirmed
+    Should Contain  ${output}  Whitelist registries =
+
+    # Check docker info for whitelist info
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} info
+    Should Be Equal As Integers  ${rc}  0
+    Should Contain  ${output}  Registry Whitelist Mode: enabled
+    Should Contain  ${output}  Whitelisted Registries:
+    Should Contain  ${output}  Registry: registry-1.docker.io
+
+    # Try to login and pull from the HTTPS whitelisted registry (should succeed)
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} login -u admin -p %{TEST_PASSWORD} %{HTTPS_HARBOR_IP}
+    Should Contain  ${output}  Succeeded
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} pull %{HTTPS_HARBOR_IP}/library/photon:1.0
+    Should Be Equal As Integers  ${rc}  0
+
+    # Try to login and pull from the HTTPS whitelisted registry with :443 tacked on at the end (should succeed)
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} login -u admin -p %{TEST_PASSWORD} %{HTTPS_HARBOR_IP}:443
+    Should Contain  ${output}  Succeeded
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} pull %{HTTPS_HARBOR_IP}:443/library/photon:1.0
+    Should Be Equal As Integers  ${rc}  0
+
+    # Try to login and pull from docker hub (should fail)
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} login --username=victest --password=vmware!123
+    Should Be Equal As Integers  ${rc}  1
+    Should Contain  ${output}  Access denied to unauthorized registry
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} pull victest/busybox
+    Should Be Equal As Integers  ${rc}  1
+    Should Contain  ${output}  Access denied to unauthorized registry
+
+    Cleanup VIC Appliance On Test Server

--- a/tests/manual-test-cases/Group21-Registries/TestCases.md
+++ b/tests/manual-test-cases/Group21-Registries/TestCases.md
@@ -1,0 +1,5 @@
+Group 21 - Registries
+=======
+
+[Test 21-1 - Whitelist](21-1-Whitelist.md)
+-

--- a/tests/manual-test-cases/TestGroups.md
+++ b/tests/manual-test-cases/TestGroups.md
@@ -24,3 +24,4 @@ VIC Manual Test Suite
 -
 [Group 20 - Security](Group20-Security/TestCases.md)
 -
+[Group 21 - Whitelist](Group21-Registries/TestCases.md)

--- a/tests/nightly/nightly-kickoff.sh
+++ b/tests/nightly/nightly-kickoff.sh
@@ -29,7 +29,8 @@ nightly_list_var="5-1-Distributed-Switch \
 5-13-Invalid-ESXi-Install \
 5-14-Remove-Container-OOB \
 13-1-vMotion-VCH-Appliance \
-13-2-vMotion-Container"
+13-2-vMotion-Container \
+21-1-Whitelist"
 
 echo "Removing VIC directory if present"
 echo "Cleanup logs from previous run"

--- a/tests/resources/Harbor-Util.robot
+++ b/tests/resources/Harbor-Util.robot
@@ -38,7 +38,8 @@ Install Harbor To Test Server
     ${len}=  Get Length  ${URLs}
     ${IDX}=  Evaluate  %{DRONE_BUILD_NUMBER} \% ${len}
 
-    Set Test Variable  ${host}  @{URLs}[${IDX}]
+    ${rc}  ${output}=  Run Keyword If  '%{HOST_TYPE}' == 'ESXi'  Set Suite Variable  ${host}  @{URLs}[${IDX}]
+    ${rc}  ${output}=  Run Keyword If  '%{HOST_TYPE}' == 'VC'  Set Suite Variable  ${host}  @{URLs}[${IDX}]%{TEST_DATACENTER}/host/%{TEST_RESOURCE}
 
     Log To Console  \nDeploying ova...
     ${out}=  Run  ovftool --noSSLVerify --acceptAllEulas --datastore=${datastore} --name=${name} --net:"Network 1"='${network}' --diskMode=thin --powerOn --X:waitForIp --X:injectOvfEnv --X:enableHiddenProperties --prop:root_pwd=${password} --prop:harbor_admin_password=${password} --prop:db_password=${db_password} --prop:auth_mode=db_auth --prop:verify_remote_cert=${verify} --prop:protocol=${protocol} ${HARBOR_VERSION}.ova 'vi://${user}:${password}@${host}'
@@ -56,8 +57,7 @@ Install Harbor To Test Server
     :FOR  ${i}  IN RANGE  20
     \  ${out}=  Run  curl -k ${protocol}://%{HARBOR-IP}
     \  Log  ${out}
-    \  ${status}=  Run Keyword And Return Status  Should Not Contain  ${out}  502 Bad Gateway
-    \  ${status}=  Run Keyword If  ${status}  Run Keyword And Return Status  Should Not Contain  ${out}  Connection refused
+    \  ${status}=  Run Keyword And Return Status  Should Not Contain Any  ${out}  502 Bad Gateway  Connection refused  Connection timed out
     \  ${status}=  Run Keyword If  ${status}  Run Keyword And Return Status  Should Contain  ${out}  <title>Harbor</title>
     \  Return From Keyword If  ${status}  %{HARBOR-IP}
     \  Sleep  30s

--- a/tests/resources/VCH-Util.robot
+++ b/tests/resources/VCH-Util.robot
@@ -170,6 +170,7 @@ Install VIC Appliance To Test Server
     Should Contain  ${output}  Installer completed successfully
     Get Docker Params  ${output}  ${certs}
     Log To Console  Installer completed successfully: %{VCH-NAME}...
+    [Return]  ${output}
 
 Run VIC Machine Command
     [Tags]  secret


### PR DESCRIPTION
Add ability to put VCH into whitelist mode.  In whitelist
mode, only registries specified in --whitelist-registry and
--insecure-registry may be access.  In public mode, any
public registry or --insecure-registry may be access.

Removed caching of vch config from personality server.
Registry certs and registry lists are now created dynamically.
This was done to support dynamic config in the future.

Fixed docker login for insecure registries to support testing
whitelist + insecure registries installation.

Fixed docker info to display whitelist and insecure registries.

Add support for wildcard domains and CIDR registry format for
docker login and docker pull.

Added integration tests that also deploys Harbor to verify
a matrix of whitelist support in both vic-machine and docker
info, docker login, docker pull.

resolves #3586 and #4681
