### PR TITLE
[specific ci=Group1-Docker-Commands]reset runblock in tether after process is launched

### DIFF
--- a/lib/config/executor/container_vm.go
+++ b/lib/config/executor/container_vm.go
@@ -227,7 +227,7 @@ type SessionConfig struct {
 	OpenStdin bool `vic:"0.1" scope:"read-only" key:"openstdin"`
 
 	// Delay launching the Cmd until an attach request comes
-	RunBlock bool `vic:"0.1" scope:"read-only" key:"runblock"`
+	RunBlock bool `vic:"0.1" scope:"read-write" key:"runblock"`
 
 	// Should this config be activated or not
 	Active bool `vic:"0.1" scope:"read-only" key:"active"`

--- a/lib/tether/config.go
+++ b/lib/tether/config.go
@@ -96,7 +96,7 @@ type SessionConfig struct {
 	OpenStdin bool `vic:"0.1" scope:"read-only" key:"openstdin"`
 
 	// Delay launching the Cmd until an attach request comes
-	RunBlock bool `vic:"0.1" scope:"read-only" key:"runblock"`
+	RunBlock bool `vic:"0.1" scope:"read-write" key:"runblock"`
 
 	// Should this config be activated or not
 	Active bool `vic:"0.1" scope:"read-only" key:"active"`

--- a/lib/tether/tether.go
+++ b/lib/tether/tether.go
@@ -582,6 +582,8 @@ func (t *tether) cleanupSession(session *SessionConfig) {
 		log.Debugf("Calling close chan: %s", session.ID)
 		close(session.ClearToLaunch)
 		session.ClearToLaunch = nil
+		// rest Runblock to unblock process start next time
+		session.RunBlock = false
 	}
 }
 
@@ -679,6 +681,10 @@ func (t *tether) launch(session *SessionConfig) error {
 		case <-session.ClearToLaunch:
 			log.Infof("Received the clear signal to launch %s", session.ID)
 		}
+		// reset RunBlock to unblock process start next time
+		session.RunBlock = false
+		prefix := extraconfig.CalculateKeys(t.config, fmt.Sprintf("%s.%s", session.extraconfigKey, session.ID), "")[0]
+		extraconfig.EncodeWithPrefix(t.sink, session, prefix)
 	}
 
 	pid := 0

--- a/lib/tether/tether.go
+++ b/lib/tether/tether.go
@@ -683,8 +683,6 @@ func (t *tether) launch(session *SessionConfig) error {
 		}
 		// reset RunBlock to unblock process start next time
 		session.RunBlock = false
-		prefix := extraconfig.CalculateKeys(t.config, fmt.Sprintf("%s.%s", session.extraconfigKey, session.ID), "")[0]
-		extraconfig.EncodeWithPrefix(t.sink, session, prefix)
 	}
 
 	pid := 0

--- a/lib/tether/tether.go
+++ b/lib/tether/tether.go
@@ -582,7 +582,7 @@ func (t *tether) cleanupSession(session *SessionConfig) {
 		log.Debugf("Calling close chan: %s", session.ID)
 		close(session.ClearToLaunch)
 		session.ClearToLaunch = nil
-		// rest Runblock to unblock process start next time
+		// reset Runblock to unblock process start next time
 		session.RunBlock = false
 	}
 }

--- a/tests/manual-test-cases/Group17-ManualTTY/17-1-TTY-Tests.md
+++ b/tests/manual-test-cases/Group17-ManualTTY/17-1-TTY-Tests.md
@@ -18,7 +18,7 @@ This test requires that a vSphere server is running and available
 5. Issue docker create -it busybox /bin/top to VIC appliance
 6. Issue docker start -ai <containerID> from previous step
 7. Issue commands to make container stuck in starting status, and then test docker stop can stop the container
-
+8. Issue commands to test the second start works after docker run with -it
 
 ### Expected Outcome:
-* Steps 1-7 should all succeed and return the expected output from those commands
+* Steps 1-8 should all succeed and return the expected output from those commands

--- a/tests/manual-test-cases/Group17-ManualTTY/17-1-TTY-Tests.robot
+++ b/tests/manual-test-cases/Group17-ManualTTY/17-1-TTY-Tests.robot
@@ -99,6 +99,16 @@ Stop a container stuck in starting state
     Should Be Equal As Integers  ${rc}  0
     Should Be Equal  ${output}  poweredOff
 
+Start a container after docker run
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} pull busybox
+    Should Be Equal As Integers  ${rc}  0
+    ${name}=  Generate Random String  15
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -it --name ${name} busybox /bin/date
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} start ${name}
+    Should Be Equal As Integers  ${rc}  0
+    Should Not Contain  ${output}  Error:
+
 Attach with custom detach keys
     ${rc}  ${output}=  Run And Return Rc And Output  mkfifo /tmp/fifo
     ${out}=  Run  docker %{VCH-PARAMS} pull busybox


### PR DESCRIPTION
fixes #4296 

after this change, the container in older version will not block process running even user meant to attach the container because the guestinfo key is changed to writable. 
this issue cannot be fixed by upgrade plugin because we cannot write back container configuration if tether is in older version.

but if container is new, the issue #4296 can be fixed, here is the test result:
```
vagrant@vagrant:~/gopath/src/github.com/vmware/vic$ docker -H 10.192.162.98:2376 --tls run -it busybox sh
Unable to find image 'busybox:latest' locally
Pulling from library/busybox
7520415ce762: Pull complete 
a3ed95caeb02: Pull complete 
Digest: sha256:32f093055929dbc23dec4d03e09dfe971f5973a9ca5cf059cbfb644c206aa83f
Status: Downloaded newer image for library/busybox:latest
/ # exit
vagrant@vagrant:~/gopath/src/github.com/vmware/vic$ docker -H 10.192.162.98:2376 --tls ps -a
CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS                      PORTS               NAMES
6c13e905e3ef        busybox             "sh"                4 minutes ago       Exited (0) 10 seconds ago                       modest_engelbart
vagrant@vagrant:~/gopath/src/github.com/vmware/vic$ docker -H 10.192.162.98:2376 --tls start 6c
6c
vagrant@vagrant:~/gopath/src/github.com/vmware/vic$ docker -H 10.192.162.98:2376 --tls ps -a
CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS              PORTS               NAMES
6c13e905e3ef        busybox             "sh"                5 minutes ago       Up 34 seconds                           modest_engelbart
```

