### PR TITLE
[skip ci] Fix pullapprove for the contributors group

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -12,7 +12,8 @@ group_defaults:
 groups:
   contributors:
     required: 2
-    users: all
+    teams:
+      - vic-maintainers
 
   tether:
     users:


### PR DESCRIPTION
Putting `all users` in the contributors group includes everyone in the VMware GitHub org. We should use the `vic-maintainers` team instead.
