### PR TITLE
Filter out scratch in vsphere impl of ListImages [specific ci=Group1-Docker-Commands]

### DIFF
--- a/lib/portlayer/storage/image_cache.go
+++ b/lib/portlayer/storage/image_cache.go
@@ -99,7 +99,6 @@ func (c *NameLookupCache) GetImageStore(op trace.Operation, storeName string) (*
 
 		// XXX after creating the indx and populating the map, we can put the rest in a go routine
 
-		// Fall out here if there are no images.  We should at least have a scratch.
 		images, err := c.DataStore.ListImages(op, store, nil)
 		if err != nil {
 			return nil, err

--- a/lib/portlayer/storage/vsphere/image.go
+++ b/lib/portlayer/storage/vsphere/image.go
@@ -421,7 +421,7 @@ func (v *ImageStore) scratch(op trace.Operation, storeName string) error {
 }
 
 func (v *ImageStore) GetImage(op trace.Operation, store *url.URL, ID string) (*portlayer.Image, error) {
-	defer trace.End(trace.Begin(store.String()))
+	defer trace.End(trace.Begin(store.String() + "/" + ID))
 	storeName, err := util.ImageStoreName(store)
 	if err != nil {
 		return nil, err
@@ -494,6 +494,11 @@ func (v *ImageStore) ListImages(op trace.Operation, store *url.URL, IDs []string
 		}
 
 		ID := file.Path
+
+		// filter out scratch
+		if ID == portlayer.Scratch.ID {
+			continue
+		}
 
 		// GetImage verifies the image is good by calling verifyImage.
 		img, err := v.GetImage(op, store, ID)


### PR DESCRIPTION
Remove a redundant lookup on scratch when restarting the VCH.