### PR TITLE
Implement the Containers section

### DIFF
--- a/ui/vic-ui-h5c/vic-service/src/main/java/com/vmware/vic/ObjectStore.java
+++ b/ui/vic-ui-h5c/vic-service/src/main/java/com/vmware/vic/ObjectStore.java
@@ -172,4 +172,5 @@ public class ObjectStore {
 	public URI createUri(String type, String id) {
 		return _modelObjectUriResolver.createUri(type, id);
 	}
+
 }

--- a/ui/vic-ui-h5c/vic-service/src/main/java/com/vmware/vic/model/ContainerVm.java
+++ b/ui/vic-ui-h5c/vic-service/src/main/java/com/vmware/vic/model/ContainerVm.java
@@ -19,6 +19,7 @@ package com.vmware.vic.model;
 
 import java.util.List;
 
+import com.vmware.vic.model.constants.Container;
 import com.vmware.vim25.ArrayOfOptionValue;
 import com.vmware.vim25.DynamicProperty;
 import com.vmware.vim25.ManagedEntityStatus;
@@ -30,14 +31,17 @@ import com.vmware.vim25.VirtualMachineSummary;
 
 public class ContainerVm extends VicBaseVm {
 	private static final String EXTRACONFIG_CONTAINER_NAME_KEY =
-			"common/name";
+			Container.VM_EXTRACONFIG_CONTAINER_KEY;
 	private static final String EXTRACONFIG_IMAGE_NAME_KEY =
-			"guestinfo.vice./repo";
+			Container.VM_EXTRACONFIG_IMAGE_NAME_KEY;
 	private static final String EXTRACONFIG_PORTMAPPING_KEY =
-			"guestinfo.vice./networks|bridge/ports~";
-	private static final String VM_KEY_CONTAINERNAME = "containerName";
-	private static final String VM_KEY_IMAGENAME = "imageName";
-	private static final String VM_KEY_PORTMAPPING = "portMapping";
+			Container.VM_EXTRACONFIG_PORTMAPPING_KEY;
+	private static final String VM_CONTAINERNAME_KEY =
+	        Container.VM_CONTAINERNAME_KEY;
+	private static final String VM_IMAGENAME_KEY =
+	        Container.VM_IMAGENAME_KEY;
+	private static final String VM_PORTMAPPING_KEY =
+	        Container.VM_PORTMAPPING_KEY;
 	private String _containerName = null;
 	private String _imageName = null;
 	private String _portMapping = null;
@@ -47,18 +51,31 @@ public class ContainerVm extends VicBaseVm {
 		processDynamicProperties(objContent.getPropSet());
 	}
 
+	/**
+	 * Getter for Docker Container's name
+	 */
 	public String getContainerName() {
 		return _containerName;
 	}
 
+	/**
+     * Getter for Docker Container's imageName
+     */
 	public String getImageName() {
 		return _imageName;
 	}
 
+	/**
+     * Getter for Docker Container's portMapping
+     */
 	public String getPortMapping() {
 		return _portMapping;
 	}
 
+	/**
+     * Property getter
+     * @param property : property to retrieve
+     */
 	@Override
 	public Object getProperty(String property) {
 		if ("objectRef".equals(property)) {
@@ -77,11 +94,11 @@ public class ContainerVm extends VicBaseVm {
 			return _guestMemoryUsage;
 		} else if (VM_KEY_COMMITTEDSTORAGE.equals(property)) {
 			return _committedStorage;
-		} else if (VM_KEY_CONTAINERNAME.equals(property)) {
+		} else if (VM_CONTAINERNAME_KEY.equals(property)) {
 			return _containerName;
-		} else if (VM_KEY_IMAGENAME.equals(property)) {
+		} else if (VM_IMAGENAME_KEY.equals(property)) {
 			return _imageName;
-		} else if (VM_KEY_PORTMAPPING.equals(property)) {
+		} else if (VM_PORTMAPPING_KEY.equals(property)) {
 			return _portMapping;
 		} else if (VM_KEY_RESOURCECONFIG.equals(property)) {
             return _resourceConfig;
@@ -91,6 +108,11 @@ public class ContainerVm extends VicBaseVm {
 		return UNSUPPORTED_PROPERTY;
 	}
 
+	/**
+     * Process DynamicProperty[] and extract information
+     * needed for the ContainerVm model
+     * @param dpsList : DynamicProperty list from ObjectContent.getPropSet()
+     */
 	@Override
 	protected void processDynamicProperties(List<DynamicProperty> dpsList) {
 		for (DynamicProperty dp : dpsList) {

--- a/ui/vic-ui-h5c/vic-service/src/main/java/com/vmware/vic/model/VicBaseVm.java
+++ b/ui/vic-ui-h5c/vic-service/src/main/java/com/vmware/vic/model/VicBaseVm.java
@@ -19,6 +19,8 @@ package com.vmware.vic.model;
 
 import java.util.List;
 
+import com.vmware.vic.model.constants.BaseVm;
+import com.vmware.vic.model.constants.Vch;
 import com.vmware.vim25.DynamicProperty;
 import com.vmware.vim25.ManagedEntityStatus;
 import com.vmware.vim25.ManagedObjectReference;
@@ -30,18 +32,27 @@ import com.vmware.vim25.VirtualMachineStorageSummary;
 import com.vmware.vim25.VirtualMachineSummary;
 
 public abstract class VicBaseVm extends ModelObject {
-	protected static final String VM_KEY_NAME = "name";
-	protected static final String VM_KEY_OVERALL_STATUS = "overallStatus";
-	protected static final String VM_KEY_POWERSTATE = "runtime.powerState";
-	protected static final String VM_KEY_SUMMARY = "summary";
-	protected static final String VM_KEY_GUESTFULLNAME = "config.guestFullName";
-	protected static final String VM_KEY_CONFIG_EXTRACONFIG = "config.extraConfig";
-	protected static final String VM_KEY_RESOURCECONFIG = "resourceConfig";
-	protected static final String VM_KEY_RESOURCEPOOL = "resourcePool";
-	protected static final String VM_KEY_CLIENT_IP = "clientIp";
-	protected static final String VM_KEY_OVERALLCPUUSAGE = "overallCpuUsage";
-	protected static final String VM_KEY_GUESTMEMORYUSAGE = "guestMemoryUsage";
-	protected static final String VM_KEY_COMMITTEDSTORAGE = "committedStorage";
+	protected static final String VM_KEY_NAME = BaseVm.VM_NAME;
+	protected static final String VM_KEY_OVERALL_STATUS =
+	        BaseVm.VM_OVERALL_STATUS;
+	protected static final String VM_KEY_POWERSTATE =
+	        BaseVm.Runtime.VM_POWERSTATE_FULLPATH;
+	protected static final String VM_KEY_SUMMARY = BaseVm.VM_SUMMARY;
+	protected static final String VM_KEY_GUESTFULLNAME =
+	        BaseVm.Config.VM_GUESTFULLNAME;
+	protected static final String VM_KEY_CONFIG_EXTRACONFIG =
+	        BaseVm.Config.VM_EXTRACONFIG;
+	protected static final String VM_KEY_RESOURCECONFIG =
+	        BaseVm.VM_RESOURCECONFIG;
+	protected static final String VM_KEY_RESOURCEPOOL =
+	        BaseVm.VM_RESOURCEPOOL;
+	protected static final String VM_KEY_CLIENT_IP = Vch.VM_CLIENT_IP;
+	protected static final String VM_KEY_OVERALLCPUUSAGE =
+	        BaseVm.VM_OVERALLCPUUSAGE;
+	protected static final String VM_KEY_GUESTMEMORYUSAGE =
+	        BaseVm.VM_GUESTMEMORYUSAGE;
+	protected static final String VM_KEY_COMMITTEDSTORAGE =
+	        BaseVm.VM_COMMITTEDSTORAGE;
 	protected final ManagedObjectReference _objectRef;
 	protected String _vmName = null;
 	protected String _guestFullName = null;

--- a/ui/vic-ui-h5c/vic-service/src/main/java/com/vmware/vic/model/VirtualContainerHostVm.java
+++ b/ui/vic-ui-h5c/vic-service/src/main/java/com/vmware/vic/model/VirtualContainerHostVm.java
@@ -21,6 +21,7 @@ import java.util.List;
 
 import javax.xml.bind.DatatypeConverter;
 
+import com.vmware.vic.model.constants.Vch;
 import com.vmware.vim25.ArrayOfOptionValue;
 import com.vmware.vim25.DynamicProperty;
 import com.vmware.vim25.ManagedEntityStatus;
@@ -32,11 +33,11 @@ import com.vmware.vim25.VirtualMachineSummary;
 
 public class VirtualContainerHostVm extends VicBaseVm {
 	private static final String EXTRACONFIG_CLIENT_IP_KEY =
-			"guestinfo.vice..init.networks|client.assigned.IP";
+			Vch.VM_EXTRACONFIG_CLIENT_IP_KEY;
 	private static final String EXTRACONFIG_DOCKER_PERSONALITY_ARGS_KEY =
-            "guestinfo.vice./init/sessions|docker-personality/cmd/Args~";
-	private static final String VM_KEY_IS_USING_TLS = "isUsingTls";
+            Vch.VM_EXTRACONFIG_DOCKER_PERSONALITY_ARGS_KEY;
 	private static final String DOCKER_ENGINE_SERVER_TLS_PORT = "2376";
+	private static final String VM_KEY_IS_USING_TLS = Vch.VM_IS_USING_TLS;
 	private String _clientIp = null;
 	private boolean _isUsingTls = true;
 

--- a/ui/vic-ui-h5c/vic-service/src/main/java/com/vmware/vic/model/constants/BaseVm.java
+++ b/ui/vic-ui-h5c/vic-service/src/main/java/com/vmware/vic/model/constants/BaseVm.java
@@ -1,0 +1,38 @@
+/*
+
+Copyright 2017 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+package com.vmware.vic.model.constants;
+
+public class BaseVm {
+    public static final String ID = "id";
+    public static final String VM_NAME = "name";
+    public static final String VM_OVERALL_STATUS = "overallStatus";
+    public static class Runtime {
+        public static final String VM_POWERSTATE_FULLPATH = "runtime.powerState";
+        public static final String VM_POWERSTATE_BASENAME = "powerState";
+    }
+    public static final String VM_SUMMARY = "summary";
+    public static class Config {
+        public static final String VM_GUESTFULLNAME = "config.guestFullName";
+        public static final String VM_EXTRACONFIG = "config.extraConfig";
+    }
+    public static final String VM_RESOURCECONFIG = "resourceConfig";
+    public static final String VM_RESOURCEPOOL = "resourcePool";
+    public static final String VM_OVERALLCPUUSAGE = "overallCpuUsage";
+    public static final String VM_GUESTMEMORYUSAGE = "guestMemoryUsage";
+    public static final String VM_COMMITTEDSTORAGE = "committedStorage";
+}

--- a/ui/vic-ui-h5c/vic-service/src/main/java/com/vmware/vic/model/constants/Container.java
+++ b/ui/vic-ui-h5c/vic-service/src/main/java/com/vmware/vic/model/constants/Container.java
@@ -1,0 +1,29 @@
+/*
+
+Copyright 2017 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+package com.vmware.vic.model.constants;
+
+public class Container {
+    public static final String VM_EXTRACONFIG_CONTAINER_KEY = "common/name";
+    public static final String VM_EXTRACONFIG_IMAGE_NAME_KEY =
+            "guestinfo.vice./repo";
+    public static final String VM_EXTRACONFIG_PORTMAPPING_KEY =
+            "guestinfo.vice./networks|bridge/ports~";
+    public static final String VM_CONTAINERNAME_KEY = "containerName";
+    public static final String VM_IMAGENAME_KEY = "imageName";
+    public static final String VM_PORTMAPPING_KEY = "portMapping";
+}

--- a/ui/vic-ui-h5c/vic-service/src/main/java/com/vmware/vic/model/constants/Vch.java
+++ b/ui/vic-ui-h5c/vic-service/src/main/java/com/vmware/vic/model/constants/Vch.java
@@ -1,0 +1,29 @@
+/*
+
+Copyright 2017 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+package com.vmware.vic.model.constants;
+
+public class Vch {
+    public static final String VM_IS_USING_TLS = "isUsingTls";
+    public static final String VM_CLIENT_IP = "clientIp";
+    public static final String VM_VCH_IP = "vchIp";
+    public static final String VM_EXTRACONFIG_VCH_KEY = "init/common/name";
+    public static final String VM_EXTRACONFIG_CLIENT_IP_KEY =
+            "guestinfo.vice..init.networks|client.assigned.IP";
+    public static final String VM_EXTRACONFIG_DOCKER_PERSONALITY_ARGS_KEY =
+            "guestinfo.vice./init/sessions|docker-personality/cmd/Args~";
+}

--- a/ui/vic-ui-h5c/vic-service/src/main/java/com/vmware/vic/model/constants/VsphereObjects.java
+++ b/ui/vic-ui-h5c/vic-service/src/main/java/com/vmware/vic/model/constants/VsphereObjects.java
@@ -1,0 +1,24 @@
+/*
+
+Copyright 2017 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+package com.vmware.vic.model.constants;
+
+public class VsphereObjects {
+    public static final String VirtualMachine = "VirtualMachine";
+    public static final String VmPropertyValueKey = "vm";
+    public static final String VirtualApp = "VirtualApp";
+}

--- a/ui/vic-ui-h5c/vic-service/src/main/java/com/vmware/vic/mvc/QueryUtil.java
+++ b/ui/vic-ui-h5c/vic-service/src/main/java/com/vmware/vic/mvc/QueryUtil.java
@@ -38,6 +38,9 @@ import org.apache.commons.logging.LogFactory;
 import com.vmware.vic.model.ContainerVm;
 import com.vmware.vic.model.ModelObject;
 import com.vmware.vic.model.VirtualContainerHostVm;
+import com.vmware.vic.model.constants.BaseVm;
+import com.vmware.vic.model.constants.Container;
+import com.vmware.vic.model.constants.Vch;
 import com.vmware.vic.utils.VicVmComparator;
 import com.vmware.vise.data.Constraint;
 import com.vmware.vise.data.PropertySpec;
@@ -713,32 +716,32 @@ static ResultSet getListData(
 
    private static String getVmPropValue(ModelObject mo, String property) {
 	   if (mo instanceof VirtualContainerHostVm) {
-		   if ("name".equals(property)) {
+		   if (BaseVm.VM_NAME.equals(property)) {
 			   return ((VirtualContainerHostVm) mo).getName().toLowerCase();
-		   } else if ("vchIp".equals(property)) {
+		   } else if (Vch.VM_VCH_IP.equals(property)) {
 			   return ((VirtualContainerHostVm) mo).getClientIp().toLowerCase();
-		   } else if ("overallStatus".equals(property)) {
+		   } else if (BaseVm.VM_OVERALL_STATUS.equals(property)) {
 			   return ((VirtualContainerHostVm) mo).getOverallStatus()
 					   .toLowerCase();
 		   }
 		   return null;
 	   } else if (mo instanceof ContainerVm) {
-		   if ("containerName".equals(property)) {
+		   if (Container.VM_CONTAINERNAME_KEY.equals(property)) {
 		       return ((ContainerVm) mo).getContainerName().toLowerCase();
-		   } else if ("powerState".equals(property)) {
+		   } else if (BaseVm.Runtime.VM_POWERSTATE_BASENAME.equals(property)) {
 		       return ((ContainerVm) mo).getPowerState().toLowerCase();
-		   } else if ("guestMemoryUsage".equals(property)) {
+		   } else if (BaseVm.VM_GUESTMEMORYUSAGE.equals(property)) {
 		       return Integer.toString(((ContainerVm) mo).getGuestMemoryUsage());
-		   } else if ("overallCpuUsage".equals(property)) {
+		   } else if (BaseVm.VM_OVERALLCPUUSAGE.equals(property)) {
 		       return Integer.toString(((ContainerVm) mo).getOverallCpuUsage());
-		   } else if ("committedStorage".equals(property)) {
+		   } else if (BaseVm.VM_COMMITTEDSTORAGE.equals(property)) {
 		       return Long.toString(((ContainerVm) mo).getCommittedStorage());
-		   } else if ("portMapping".equals(property)) {
+		   } else if (Container.VM_PORTMAPPING_KEY.equals(property)) {
 		       String pm = ((ContainerVm) mo).getPortMapping();
 		       return pm != null ? pm.toLowerCase() : "";
-		   } else if ("name".equals(property)) {
+		   } else if (BaseVm.VM_NAME.equals(property)) {
 		       return ((ContainerVm) mo).getName().toLowerCase();
-		   } else if ("imageName".equals(property)) {
+		   } else if (Container.VM_IMAGENAME_KEY.equals(property)) {
 		       return ((ContainerVm) mo).getImageName().toLowerCase();
 		   }
 	   }

--- a/ui/vic-ui-h5c/vic-service/src/main/java/com/vmware/vic/utils/VicVmComparator.java
+++ b/ui/vic-ui-h5c/vic-service/src/main/java/com/vmware/vic/utils/VicVmComparator.java
@@ -22,6 +22,9 @@ import java.util.Map;
 import com.vmware.vic.model.ContainerVm;
 import com.vmware.vic.model.ModelObject;
 import com.vmware.vic.model.VirtualContainerHostVm;
+import com.vmware.vic.model.constants.BaseVm;
+import com.vmware.vic.model.constants.Container;
+import com.vmware.vic.model.constants.Vch;
 
 /**
  * Comparator for VIC VMs
@@ -71,34 +74,34 @@ public class VicVmComparator implements Comparator<String> {
 	 */
 	private String getStringPropertyFromVm(ModelObject mo) {
 		if (mo instanceof VirtualContainerHostVm) {
-			if ("id".equals(compareBy)) {
+			if (BaseVm.ID.equals(compareBy)) {
 				return ((VirtualContainerHostVm) mo).getId();
-			} else if ("name".equals(compareBy)) {
+			} else if (BaseVm.VM_NAME.equals(compareBy)) {
 				return ((VirtualContainerHostVm) mo).getName();
-			} else if ("vchIp".equals(compareBy)) {
+			} else if (Vch.VM_VCH_IP.equals(compareBy)) {
 				return ((VirtualContainerHostVm) mo).getClientIp();
-			} else if ("overallStatus".equals(compareBy)) {
+			} else if (BaseVm.VM_OVERALL_STATUS.equals(compareBy)) {
 				return ((VirtualContainerHostVm) mo).getOverallStatus();
 			}
 		} else if (mo instanceof ContainerVm) {
-			if ("id".equals(compareBy)) {
+			if (BaseVm.ID.equals(compareBy)) {
 			    return ((ContainerVm) mo).getId();
-			} else if ("containerName".equals(compareBy)) {
+			} else if (Container.VM_CONTAINERNAME_KEY.equals(compareBy)) {
 			    return ((ContainerVm) mo).getContainerName();
-			} else if ("powerState".equals(compareBy)) {
+			} else if (BaseVm.Runtime.VM_POWERSTATE_BASENAME.equals(compareBy)) {
 			    return ((ContainerVm) mo).getPowerState();
-			} else if ("guestMemoryUsage".equals(compareBy)) {
+			} else if (BaseVm.VM_GUESTMEMORYUSAGE.equals(compareBy)) {
 			    return Integer.toString(((ContainerVm) mo).getGuestMemoryUsage());
-			} else if ("overallCpuUsage".equals(compareBy)) {
+			} else if (BaseVm.VM_OVERALLCPUUSAGE.equals(compareBy)) {
                 return Integer.toString(((ContainerVm) mo).getOverallCpuUsage());
-			} else if ("committedStorage".equals(compareBy)) {
+			} else if (BaseVm.VM_COMMITTEDSTORAGE.equals(compareBy)) {
                 return Long.toString(((ContainerVm) mo).getCommittedStorage());
-			} else if ("portMapping".equals(compareBy)) {
+			} else if (Container.VM_PORTMAPPING_KEY.equals(compareBy)) {
 			    String pm = ((ContainerVm) mo).getPortMapping();
                 return pm != null ? pm : "";
-			} else if ("name".equals(compareBy)) {
+			} else if (BaseVm.VM_NAME.equals(compareBy)) {
 			    return ((ContainerVm) mo).getName();
-			} else if ("imageName".equals(compareBy)) {
+			} else if (Container.VM_IMAGENAME_KEY.equals(compareBy)) {
 			    return ((ContainerVm) mo).getImageName();
 			}
 		}

--- a/ui/vic-ui-h5c/vic-service/src/test/java/com/vmware/vic/test/ContainerVmTest.java
+++ b/ui/vic-ui-h5c/vic-service/src/test/java/com/vmware/vic/test/ContainerVmTest.java
@@ -26,10 +26,13 @@ import org.junit.Test;
 import com.vmware.vic.ModelObjectUriResolver;
 import com.vmware.vic.model.ContainerVm;
 import com.vmware.vic.model.ModelObject;
+import com.vmware.vic.model.constants.BaseVm;
+import com.vmware.vic.model.constants.Container;
 import com.vmware.vim25.ManagedEntityStatus;
 import com.vmware.vim25.VirtualMachinePowerState;
 
 public class ContainerVmTest extends Common {
+    private static final String VM_TYPE_CONTAINERVM = "vic:ContainerVm";
 	private ContainerVm _vm;
 
 	private ContainerVm createMockContainerVmWithoutPortMapping() {
@@ -62,7 +65,7 @@ public class ContainerVmTest extends Common {
 	public void testGetTypeForContainerVmWithoutPortMapping() {
 		_vm = createMockContainerVmWithoutPortMapping();
 		assertNotNull(_vm);
-		assertEquals("vic:ContainerVm", _vm.getType());
+		assertEquals(VM_TYPE_CONTAINERVM, _vm.getType());
 	}
 
 	@Test
@@ -76,21 +79,29 @@ public class ContainerVmTest extends Common {
 		_vm = createMockContainerVmWithoutPortMapping();
 		ModelObjectUriResolver uriResolver = new ModelObjectUriResolver();
 		URI uri = _vm.getUri(uriResolver);
-		assertEquals("urn:vic:vic:ContainerVm:server1/id1", uri.toString());
+		assertEquals(String.format(
+		        "urn:vic:%s:%s", VM_TYPE_CONTAINERVM, "server1/id1"),
+		        uri.toString());
 	}
 
 	@Test
 	public void testGetPropertyForContainerVmWithoutPortMapping() {
 		_vm = createMockContainerVmWithoutPortMapping();
-		assertTrue(_vm.getProperty("name").equals("container vm 1"));
-		assertTrue(_vm.getProperty("overallStatus").equals(ManagedEntityStatus.GREEN));
-		assertTrue(_vm.getProperty("runtime.powerState").equals(VirtualMachinePowerState.POWERED_ON));
-		assertTrue(_vm.getProperty("containerName").equals("container without portmapping info"));
-		assertTrue(_vm.getProperty("imageName").equals("busybox"));
-		assertTrue(_vm.getProperty("overallCpuUsage").equals(1000));
-		assertTrue(_vm.getProperty("guestMemoryUsage").equals(500));
-		assertTrue(_vm.getProperty("committedStorage").equals((long)123456789));
-		assertTrue(_vm.getProperty("iDontExist").equals(ModelObject.UNSUPPORTED_PROPERTY));
+		assertTrue(_vm.getProperty(BaseVm.VM_NAME).equals("container vm 1"));
+		assertTrue(_vm.getProperty(BaseVm.VM_OVERALL_STATUS)
+		        .equals(ManagedEntityStatus.GREEN));
+		assertTrue(_vm.getProperty(BaseVm.Runtime.VM_POWERSTATE_FULLPATH)
+	            .equals(VirtualMachinePowerState.POWERED_ON));
+		assertTrue(_vm.getProperty(Container.VM_CONTAINERNAME_KEY)
+		        .equals("container without portmapping info"));
+		assertTrue(_vm.getProperty(Container.VM_IMAGENAME_KEY)
+		        .equals("busybox"));
+		assertTrue(_vm.getProperty(BaseVm.VM_OVERALLCPUUSAGE).equals(1000));
+		assertTrue(_vm.getProperty(BaseVm.VM_GUESTMEMORYUSAGE).equals(500));
+		assertTrue(_vm.getProperty(BaseVm.VM_COMMITTEDSTORAGE)
+		        .equals((long)123456789));
+		assertTrue(_vm.getProperty("iDontExist")
+		        .equals(ModelObject.UNSUPPORTED_PROPERTY));
 	}
 
 	@Test
@@ -131,16 +142,22 @@ public class ContainerVmTest extends Common {
 	@Test
 	public void testGetPropertyForContainerVmWithPortMapping() {
 		_vm = createMockContainerVmWithPortMapping();
-		assertTrue(_vm.getProperty("name").equals("container vm 2"));
-		assertTrue(_vm.getProperty("overallStatus").equals(ManagedEntityStatus.GRAY));
-		assertTrue(_vm.getProperty("runtime.powerState").equals(VirtualMachinePowerState.SUSPENDED));
-		assertTrue(_vm.getProperty("containerName").equals("container with portmapping info"));
-		assertTrue(_vm.getProperty("imageName").equals("nginx"));
-		assertTrue(_vm.getProperty("portMapping").equals("8080:80/tcp"));
-		assertTrue(_vm.getProperty("overallCpuUsage").equals(1000));
-		assertTrue(_vm.getProperty("guestMemoryUsage").equals(500));
-		assertTrue(_vm.getProperty("committedStorage").equals((long)123456789));
-		assertTrue(_vm.getProperty("iDontExist").equals(ModelObject.UNSUPPORTED_PROPERTY));
+		assertTrue(_vm.getProperty(BaseVm.VM_NAME).equals("container vm 2"));
+		assertTrue(_vm.getProperty(BaseVm.VM_OVERALL_STATUS)
+		        .equals(ManagedEntityStatus.GRAY));
+		assertTrue(_vm.getProperty(BaseVm.Runtime.VM_POWERSTATE_FULLPATH)
+		        .equals(VirtualMachinePowerState.SUSPENDED));
+		assertTrue(_vm.getProperty(Container.VM_CONTAINERNAME_KEY)
+		        .equals("container with portmapping info"));
+		assertTrue(_vm.getProperty(Container.VM_IMAGENAME_KEY).equals("nginx"));
+		assertTrue(_vm.getProperty(Container.VM_PORTMAPPING_KEY)
+		        .equals("8080:80/tcp"));
+		assertTrue(_vm.getProperty(BaseVm.VM_OVERALLCPUUSAGE).equals(1000));
+		assertTrue(_vm.getProperty(BaseVm.VM_GUESTMEMORYUSAGE).equals(500));
+		assertTrue(_vm.getProperty(BaseVm.VM_COMMITTEDSTORAGE)
+		        .equals((long)123456789));
+		assertTrue(_vm.getProperty("iDontExist")
+		        .equals(ModelObject.UNSUPPORTED_PROPERTY));
 	}
 
 	@Test

--- a/ui/vic-ui-h5c/vic-service/src/test/java/com/vmware/vic/test/VirtualContainerHostVmTest.java
+++ b/ui/vic-ui-h5c/vic-service/src/test/java/com/vmware/vic/test/VirtualContainerHostVmTest.java
@@ -27,10 +27,13 @@ import java.net.URI;
 import com.vmware.vic.ModelObjectUriResolver;
 import com.vmware.vic.model.ModelObject;
 import com.vmware.vic.model.VirtualContainerHostVm;
+import com.vmware.vic.model.constants.BaseVm;
+import com.vmware.vic.model.constants.Vch;
 import com.vmware.vim25.ManagedEntityStatus;
 import com.vmware.vim25.VirtualMachinePowerState;
 
 public class VirtualContainerHostVmTest extends Common {
+    private static final String VM_TYPE_VCHVM = "vic:VirtualContainerHostVm";
 	private VirtualContainerHostVm _vm;
 
 	@Before
@@ -46,7 +49,7 @@ public class VirtualContainerHostVmTest extends Common {
 
 	@Test
 	public void testGetType() {
-		assertEquals("vic:VirtualContainerHostVm", _vm.getType());
+		assertEquals(VM_TYPE_VCHVM, _vm.getType());
 	}
 
 	@Test
@@ -58,18 +61,27 @@ public class VirtualContainerHostVmTest extends Common {
 	public void testGetUri() {
 		ModelObjectUriResolver uriResolver = new ModelObjectUriResolver();
 		URI uri = _vm.getUri(uriResolver);
-		assertEquals("urn:vic:vic:VirtualContainerHostVm:server1/id1", uri.toString());
+		assertEquals(String.format(
+                "urn:vic:%s:%s", VM_TYPE_VCHVM, "server1/id1"),
+                uri.toString());
 	}
 
 	@Test
 	public void testGetProperty() {
-		assertFalse(_vm.getProperty("name").equals(ModelObject.UNSUPPORTED_PROPERTY));
-		assertFalse(_vm.getProperty("overallStatus").equals(ModelObject.UNSUPPORTED_PROPERTY));
-		assertFalse(_vm.getProperty("runtime.powerState").equals(ModelObject.UNSUPPORTED_PROPERTY));
-		assertFalse(_vm.getProperty("clientIp").equals(ModelObject.UNSUPPORTED_PROPERTY));
-		assertFalse(_vm.getProperty("overallCpuUsage").equals(ModelObject.UNSUPPORTED_PROPERTY));
-		assertFalse(_vm.getProperty("guestMemoryUsage").equals(ModelObject.UNSUPPORTED_PROPERTY));
-		assertFalse(_vm.getProperty("committedStorage").equals(ModelObject.UNSUPPORTED_PROPERTY));
+		assertFalse(_vm.getProperty(BaseVm.VM_NAME)
+		        .equals(ModelObject.UNSUPPORTED_PROPERTY));
+		assertFalse(_vm.getProperty(BaseVm.VM_OVERALL_STATUS)
+		        .equals(ModelObject.UNSUPPORTED_PROPERTY));
+		assertFalse(_vm.getProperty(BaseVm.Runtime.VM_POWERSTATE_FULLPATH)
+		        .equals(ModelObject.UNSUPPORTED_PROPERTY));
+		assertFalse(_vm.getProperty(Vch.VM_CLIENT_IP)
+		        .equals(ModelObject.UNSUPPORTED_PROPERTY));
+		assertFalse(_vm.getProperty(BaseVm.VM_OVERALLCPUUSAGE)
+		        .equals(ModelObject.UNSUPPORTED_PROPERTY));
+		assertFalse(_vm.getProperty(BaseVm.VM_GUESTMEMORYUSAGE)
+		        .equals(ModelObject.UNSUPPORTED_PROPERTY));
+		assertFalse(_vm.getProperty(BaseVm.VM_COMMITTEDSTORAGE)
+		        .equals(ModelObject.UNSUPPORTED_PROPERTY));
 		assertTrue(_vm.getProperty("iDontExist").equals(ModelObject.UNSUPPORTED_PROPERTY));
 	}
 

--- a/ui/vic-ui-h5c/vic/src/main/locale/de_DE/com_vmware_vic.properties
+++ b/ui/vic-ui-h5c/vic/src/main/locale/de_DE/com_vmware_vic.properties
@@ -1,3 +1,4 @@
+# portlets
 container.label=Container
 container.name.label=Name
 container.image.label=Image
@@ -6,6 +7,36 @@ vch.label=Virtual Container Host
 vch.dockerApiEndpoint.label=Docker API endpoint
 vch.vchAdminPortal.label=VCH Admin portal
 
+# vic object workspace: vic obj datagrid
+vic_workspace.datagrid.columns.name=Name
+vic_workspace.datagrid.columns.vchVmsLen=# of VCH VMs
+vic_workspace.datagrid.columns.containerVmsLen=# of Container VMs
+
+# vic object workspace: summary
+vic_workspace.summary.tab.label=Summary
+vic_workspace.summary.vendor.label=Vendor
+vic_workspace.summary.version.label=Version
+vic_workspace.summary.vch.label=Virtual Container Hosts
+
+# vic object workspace: vch view
+vic_workspace.vch.tab.label=Virtual Container Hosts
+vic_workspace.vch.datagrid.columns.name=Name
+vic_workspace.vch.datagrid.columns.overallStatus=Status
+vic_workspace.vch.datagrid.columns.dockerApiEndpoint=Docker API Endpoint
+vic_workspace.vch.datagrid.columns.vchAdminPortal=VCH Admin Portal
+
+# vic object workspace: container view
+vic_workspace.container.tab.label=Containers
+vic_workspace.container.datagrid.columns.containerName=Name
+vic_workspace.container.datagrid.columns.powerState=State
+vic_workspace.container.datagrid.columns.guestMemoryUsage=Memory Usage
+vic_workspace.container.datagrid.columns.overallCpuUsage=CPU Usage
+vic_workspace.container.datagrid.columns.committedStorage=Storage Usage
+vic_workspace.container.datagrid.columns.portMapping=Port Mapping
+vic_workspace.container.datagrid.columns.name=VM
+vic_workspace.container.datagrid.columns.imageName=Image
+
+# resources
 home.shortcut.icon = Embed("../../webapp/assets/vic-icons/32x32.png")
 viinventory.vic.icon = Embed("../../webapp/assets/vic-icons/16x16.png")
 addIcon = Embed("../../webapp/assets/images/addIcon.png")

--- a/ui/vic-ui-h5c/vic/src/main/locale/en_US/com_vmware_vic.properties
+++ b/ui/vic-ui-h5c/vic/src/main/locale/en_US/com_vmware_vic.properties
@@ -1,3 +1,4 @@
+# portlets
 container.label=Container
 container.name.label=Name
 container.image.label=Image
@@ -6,6 +7,36 @@ vch.label=Virtual Container Host
 vch.dockerApiEndpoint.label=Docker API endpoint
 vch.vchAdminPortal.label=VCH Admin portal
 
+# vic object workspace: vic obj datagrid
+vic_workspace.datagrid.columns.name=Name
+vic_workspace.datagrid.columns.vchVmsLen=# of VCH VMs
+vic_workspace.datagrid.columns.containerVmsLen=# of Container VMs
+
+# vic object workspace: summary
+vic_workspace.summary.tab.label=Summary
+vic_workspace.summary.vendor.label=Vendor
+vic_workspace.summary.version.label=Version
+vic_workspace.summary.vch.label=Virtual Container Hosts
+
+# vic object workspace: vch view
+vic_workspace.vch.tab.label=Virtual Container Hosts
+vic_workspace.vch.datagrid.columns.name=Name
+vic_workspace.vch.datagrid.columns.overallStatus=Status
+vic_workspace.vch.datagrid.columns.dockerApiEndpoint=Docker API Endpoint
+vic_workspace.vch.datagrid.columns.vchAdminPortal=VCH Admin Portal
+
+# vic object workspace: container view
+vic_workspace.container.tab.label=Containers
+vic_workspace.container.datagrid.columns.containerName=Name
+vic_workspace.container.datagrid.columns.powerState=State
+vic_workspace.container.datagrid.columns.guestMemoryUsage=Memory Usage
+vic_workspace.container.datagrid.columns.overallCpuUsage=CPU Usage
+vic_workspace.container.datagrid.columns.committedStorage=Storage Usage
+vic_workspace.container.datagrid.columns.portMapping=Port Mapping
+vic_workspace.container.datagrid.columns.name=VM
+vic_workspace.container.datagrid.columns.imageName=Image
+
+# resources
 home.shortcut.icon = Embed("../../webapp/assets/vic-icons/32x32.png")
 viinventory.vic.icon = Embed("../../webapp/assets/vic-icons/16x16.png")
 addIcon = Embed("../../webapp/assets/images/addIcon.png")

--- a/ui/vic-ui-h5c/vic/src/main/locale/fr_FR/com_vmware_vic.properties
+++ b/ui/vic-ui-h5c/vic/src/main/locale/fr_FR/com_vmware_vic.properties
@@ -1,3 +1,4 @@
+# portlets
 container.label=Container
 container.name.label=Name
 container.image.label=Image
@@ -6,6 +7,36 @@ vch.label=Virtual Container Host
 vch.dockerApiEndpoint.label=Docker API endpoint
 vch.vchAdminPortal.label=VCH Admin portal
 
+# vic object workspace: vic obj datagrid
+vic_workspace.datagrid.columns.name=Name
+vic_workspace.datagrid.columns.vchVmsLen=# of VCH VMs
+vic_workspace.datagrid.columns.containerVmsLen=# of Container VMs
+
+# vic object workspace: summary
+vic_workspace.summary.tab.label=Summary
+vic_workspace.summary.vendor.label=Vendor
+vic_workspace.summary.version.label=Version
+vic_workspace.summary.vch.label=Virtual Container Hosts
+
+# vic object workspace: vch view
+vic_workspace.vch.tab.label=Virtual Container Hosts
+vic_workspace.vch.datagrid.columns.name=Name
+vic_workspace.vch.datagrid.columns.overallStatus=Status
+vic_workspace.vch.datagrid.columns.dockerApiEndpoint=Docker API Endpoint
+vic_workspace.vch.datagrid.columns.vchAdminPortal=VCH Admin Portal
+
+# vic object workspace: container view
+vic_workspace.container.tab.label=Containers
+vic_workspace.container.datagrid.columns.containerName=Name
+vic_workspace.container.datagrid.columns.powerState=State
+vic_workspace.container.datagrid.columns.guestMemoryUsage=Memory Usage
+vic_workspace.container.datagrid.columns.overallCpuUsage=CPU Usage
+vic_workspace.container.datagrid.columns.committedStorage=Storage Usage
+vic_workspace.container.datagrid.columns.portMapping=Port Mapping
+vic_workspace.container.datagrid.columns.name=VM
+vic_workspace.container.datagrid.columns.imageName=Image
+
+# resources
 home.shortcut.icon = Embed("../../webapp/assets/vic-icons/32x32.png")
 viinventory.vic.icon = Embed("../../webapp/assets/vic-icons/16x16.png")
 addIcon = Embed("../../webapp/assets/images/addIcon.png")

--- a/ui/vic-ui-h5c/vic/src/main/locale/ja_JP/com_vmware_vic.properties
+++ b/ui/vic-ui-h5c/vic/src/main/locale/ja_JP/com_vmware_vic.properties
@@ -1,3 +1,4 @@
+# portlets
 container.label=Container
 container.name.label=Name
 container.image.label=Image
@@ -6,6 +7,36 @@ vch.label=Virtual Container Host
 vch.dockerApiEndpoint.label=Docker API endpoint
 vch.vchAdminPortal.label=VCH Admin portal
 
+# vic object workspace: vic obj datagrid
+vic_workspace.datagrid.columns.name=Name
+vic_workspace.datagrid.columns.vchVmsLen=# of VCH VMs
+vic_workspace.datagrid.columns.containerVmsLen=# of Container VMs
+
+# vic object workspace: summary
+vic_workspace.summary.tab.label=Summary
+vic_workspace.summary.vendor.label=Vendor
+vic_workspace.summary.version.label=Version
+vic_workspace.summary.vch.label=Virtual Container Hosts
+
+# vic object workspace: vch view
+vic_workspace.vch.tab.label=Virtual Container Hosts
+vic_workspace.vch.datagrid.columns.name=Name
+vic_workspace.vch.datagrid.columns.overallStatus=Status
+vic_workspace.vch.datagrid.columns.dockerApiEndpoint=Docker API Endpoint
+vic_workspace.vch.datagrid.columns.vchAdminPortal=VCH Admin Portal
+
+# vic object workspace: container view
+vic_workspace.container.tab.label=Containers
+vic_workspace.container.datagrid.columns.containerName=Name
+vic_workspace.container.datagrid.columns.powerState=State
+vic_workspace.container.datagrid.columns.guestMemoryUsage=Memory Usage
+vic_workspace.container.datagrid.columns.overallCpuUsage=CPU Usage
+vic_workspace.container.datagrid.columns.committedStorage=Storage Usage
+vic_workspace.container.datagrid.columns.portMapping=Port Mapping
+vic_workspace.container.datagrid.columns.name=VM
+vic_workspace.container.datagrid.columns.imageName=Image
+
+# resources
 home.shortcut.icon = Embed("../../webapp/assets/vic-icons/32x32.png")
 viinventory.vic.icon = Embed("../../webapp/assets/vic-icons/16x16.png")
 addIcon = Embed("../../webapp/assets/images/addIcon.png")

--- a/ui/vic-ui-h5c/vic/src/main/locale/ko_KR/com_vmware_vic.properties
+++ b/ui/vic-ui-h5c/vic/src/main/locale/ko_KR/com_vmware_vic.properties
@@ -1,3 +1,4 @@
+# portlets
 container.label=Container
 container.name.label=Name
 container.image.label=Image
@@ -6,6 +7,36 @@ vch.label=Virtual Container Host
 vch.dockerApiEndpoint.label=Docker API endpoint
 vch.vchAdminPortal.label=VCH Admin portal
 
+# vic object workspace: vic obj datagrid
+vic_workspace.datagrid.columns.name=Name
+vic_workspace.datagrid.columns.vchVmsLen=# of VCH VMs
+vic_workspace.datagrid.columns.containerVmsLen=# of Container VMs
+
+# vic object workspace: summary
+vic_workspace.summary.tab.label=Summary
+vic_workspace.summary.vendor.label=Vendor
+vic_workspace.summary.version.label=Version
+vic_workspace.summary.vch.label=Virtual Container Hosts
+
+# vic object workspace: vch view
+vic_workspace.vch.tab.label=Virtual Container Hosts
+vic_workspace.vch.datagrid.columns.name=Name
+vic_workspace.vch.datagrid.columns.overallStatus=Status
+vic_workspace.vch.datagrid.columns.dockerApiEndpoint=Docker API Endpoint
+vic_workspace.vch.datagrid.columns.vchAdminPortal=VCH Admin Portal
+
+# vic object workspace: container view
+vic_workspace.container.tab.label=Containers
+vic_workspace.container.datagrid.columns.containerName=Name
+vic_workspace.container.datagrid.columns.powerState=State
+vic_workspace.container.datagrid.columns.guestMemoryUsage=Memory Usage
+vic_workspace.container.datagrid.columns.overallCpuUsage=CPU Usage
+vic_workspace.container.datagrid.columns.committedStorage=Storage Usage
+vic_workspace.container.datagrid.columns.portMapping=Port Mapping
+vic_workspace.container.datagrid.columns.name=VM
+vic_workspace.container.datagrid.columns.imageName=Image
+
+# resources
 home.shortcut.icon = Embed("../../webapp/assets/vic-icons/32x32.png")
 viinventory.vic.icon = Embed("../../webapp/assets/vic-icons/16x16.png")
 addIcon = Embed("../../webapp/assets/images/addIcon.png")

--- a/ui/vic-ui-h5c/vic/src/main/locale/zh_CN/com_vmware_vic.properties
+++ b/ui/vic-ui-h5c/vic/src/main/locale/zh_CN/com_vmware_vic.properties
@@ -1,3 +1,4 @@
+# portlets
 container.label=Container
 container.name.label=Name
 container.image.label=Image
@@ -6,6 +7,36 @@ vch.label=Virtual Container Host
 vch.dockerApiEndpoint.label=Docker API endpoint
 vch.vchAdminPortal.label=VCH Admin portal
 
+# vic object workspace: vic obj datagrid
+vic_workspace.datagrid.columns.name=Name
+vic_workspace.datagrid.columns.vchVmsLen=# of VCH VMs
+vic_workspace.datagrid.columns.containerVmsLen=# of Container VMs
+
+# vic object workspace: summary
+vic_workspace.summary.tab.label=Summary
+vic_workspace.summary.vendor.label=Vendor
+vic_workspace.summary.version.label=Version
+vic_workspace.summary.vch.label=Virtual Container Hosts
+
+# vic object workspace: vch view
+vic_workspace.vch.tab.label=Virtual Container Hosts
+vic_workspace.vch.datagrid.columns.name=Name
+vic_workspace.vch.datagrid.columns.overallStatus=Status
+vic_workspace.vch.datagrid.columns.dockerApiEndpoint=Docker API Endpoint
+vic_workspace.vch.datagrid.columns.vchAdminPortal=VCH Admin Portal
+
+# vic object workspace: container view
+vic_workspace.container.tab.label=Containers
+vic_workspace.container.datagrid.columns.containerName=Name
+vic_workspace.container.datagrid.columns.powerState=State
+vic_workspace.container.datagrid.columns.guestMemoryUsage=Memory Usage
+vic_workspace.container.datagrid.columns.overallCpuUsage=CPU Usage
+vic_workspace.container.datagrid.columns.committedStorage=Storage Usage
+vic_workspace.container.datagrid.columns.portMapping=Port Mapping
+vic_workspace.container.datagrid.columns.name=VM
+vic_workspace.container.datagrid.columns.imageName=Image
+
+# resources
 home.shortcut.icon = Embed("../../webapp/assets/vic-icons/32x32.png")
 viinventory.vic.icon = Embed("../../webapp/assets/vic-icons/16x16.png")
 addIcon = Embed("../../webapp/assets/images/addIcon.png")

--- a/ui/vic-ui-h5c/vic/src/main/locale/zh_TW/com_vmware_vic.properties
+++ b/ui/vic-ui-h5c/vic/src/main/locale/zh_TW/com_vmware_vic.properties
@@ -1,3 +1,4 @@
+# portlets
 container.label=Container
 container.name.label=Name
 container.image.label=Image
@@ -6,6 +7,36 @@ vch.label=Virtual Container Host
 vch.dockerApiEndpoint.label=Docker API endpoint
 vch.vchAdminPortal.label=VCH Admin portal
 
+# vic object workspace: vic obj datagrid
+vic_workspace.datagrid.columns.name=Name
+vic_workspace.datagrid.columns.vchVmsLen=# of VCH VMs
+vic_workspace.datagrid.columns.containerVmsLen=# of Container VMs
+
+# vic object workspace: summary
+vic_workspace.summary.tab.label=Summary
+vic_workspace.summary.vendor.label=Vendor
+vic_workspace.summary.version.label=Version
+vic_workspace.summary.vch.label=Virtual Container Hosts
+
+# vic object workspace: vch view
+vic_workspace.vch.tab.label=Virtual Container Hosts
+vic_workspace.vch.datagrid.columns.name=Name
+vic_workspace.vch.datagrid.columns.overallStatus=Status
+vic_workspace.vch.datagrid.columns.dockerApiEndpoint=Docker API Endpoint
+vic_workspace.vch.datagrid.columns.vchAdminPortal=VCH Admin Portal
+
+# vic object workspace: container view
+vic_workspace.container.tab.label=Containers
+vic_workspace.container.datagrid.columns.containerName=Name
+vic_workspace.container.datagrid.columns.powerState=State
+vic_workspace.container.datagrid.columns.guestMemoryUsage=Memory Usage
+vic_workspace.container.datagrid.columns.overallCpuUsage=CPU Usage
+vic_workspace.container.datagrid.columns.committedStorage=Storage Usage
+vic_workspace.container.datagrid.columns.portMapping=Port Mapping
+vic_workspace.container.datagrid.columns.name=VM
+vic_workspace.container.datagrid.columns.imageName=Image
+
+# resources
 home.shortcut.icon = Embed("../../webapp/assets/vic-icons/32x32.png")
 viinventory.vic.icon = Embed("../../webapp/assets/vic-icons/16x16.png")
 addIcon = Embed("../../webapp/assets/images/addIcon.png")

--- a/ui/vic-ui-h5c/vic/src/main/webapp/plugin.xml
+++ b/ui/vic-ui-h5c/vic/src/main/webapp/plugin.xml
@@ -36,7 +36,7 @@
                     <uid>com.vmware.vic.objectView.column.name</uid>
                     <dataInfo>
                         <com.vmware.ui.lists.ColumnDataSourceInfo>
-                            <headerText>Name</headerText>
+                            <headerText>#{vic_workspace.datagrid.columns.name}</headerText>
                             <requestedProperties>
                                 <String>name</String>
                             </requestedProperties>
@@ -44,7 +44,7 @@
                             <exportProperty>name</exportProperty>
                         </com.vmware.ui.lists.ColumnDataSourceInfo>
                         <com.vmware.ui.lists.ColumnDataSourceInfo>
-                            <headerText># of VCH VMs</headerText>
+                            <headerText>#{vic_workspace.datagrid.columns.vchVmsLen}</headerText>
                             <requestedProperties>
                                 <String>vchVmsLen</String>
                             </requestedProperties>
@@ -52,7 +52,7 @@
                             <exportProperty>vchVmsLen</exportProperty>
                         </com.vmware.ui.lists.ColumnDataSourceInfo>
                         <com.vmware.ui.lists.ColumnDataSourceInfo>
-                            <headerText># of Container VMs</headerText>
+                            <headerText>#{vic_workspace.datagrid.columns.containerVmsLen}</headerText>
                             <requestedProperties>
                                 <String>containerVmsLen</String>
                             </requestedProperties>
@@ -78,7 +78,7 @@
     <extension id="com.vmware.vic.objectView.summaryView">
         <extendedPoint>com.vmware.vic.objectView.summaryViews</extendedPoint>
         <object>
-            <name>Summary</name>
+            <name>#{vic_workspace.summary.tab.label}</name>
             <componentClass className="com.vmware.vsphere.client.htmlbridge.HtmlView">
                 <object>
                     <root>
@@ -157,28 +157,61 @@
             </propertyConditions>
         </metadata>
     </extension>
-    <extensionPoint id="com.vmware.vic.customTab">
+    <!-- Extension Point for VCH view -->
+    <extensionPoint id="com.vmware.vic.extpoint-vch">
         <objectType class="com.vmware.vise.mvc.model.ViewSpec"/>
     </extensionPoint>
-    <extension id="com.vmware.vic.custom">
+    <!-- Extension Point for Container view -->
+    <extensionPoint id="com.vmware.vic.extpoint-container">
+        <objectType class="com.vmware.vise.mvc.model.ViewSpec"/>
+    </extensionPoint>
+    <!-- Tab specs definition for VCH view -->
+    <extension id="com.vmware.vic.customtab-vch">
         <extendedPoint>com.vmware.vic.objectView.views</extendedPoint>
-        <hostedPoint>com.vmware.vic.customTab</hostedPoint>
+        <hostedPoint>com.vmware.vic.extpoint-vch</hostedPoint>
         <precedingExtension>com.vmware.vic.vchSummaryView</precedingExtension>
         <object>
-            <name>Virtual Container Hosts</name>
+            <name>#{vic_workspace.vch.tab.label}</name>
             <contentSpec>
                 <url>resources/ui/views/tabs/TabContent.html</url>
             </contentSpec>
         </object>
     </extension>
-    <extension id="com.vmware.vic.customView">
-        <extendedPoint>com.vmware.vic.customTab</extendedPoint>
+    <!-- Tab specs definition for Container view -->
+    <extension id="com.vmware.vic.customtab-container">
+        <extendedPoint>com.vmware.vic.objectView.views</extendedPoint>
+        <hostedPoint>com.vmware.vic.extpoint-container</hostedPoint>
+        <precedingExtension>com.vmware.vic.customVchView</precedingExtension>
         <object>
-            <name>Virtual Container Hosts</name>
+            <name>#{vic_workspace.container.tab.label}</name>
+            <contentSpec>
+                <url>resources/ui/views/tabs/TabContent.html</url>
+            </contentSpec>
+        </object>
+    </extension>
+    <!-- Tab instance for VCH view -->
+    <extension id="com.vmware.vic.customVchView">
+        <extendedPoint>com.vmware.vic.extpoint-vch</extendedPoint>
+        <object>
+            <name>#{vic_workspace.vch.tab.label}</name>
             <componentClass className="com.vmware.vsphere.client.htmlbridge.HtmlView">
                 <object>
                     <root>
                         <url>/vsphere-client/vic/resources/build-dev/index.html?view=vch-view</url>
+                    </root>
+                </object>
+            </componentClass>
+        </object>
+    </extension>
+    <!-- Tab instance for Container view -->
+    <extension id="com.vmware.vic.customContainerView">
+        <extendedPoint>com.vmware.vic.extpoint-container</extendedPoint>
+        <object>
+            <name>#{vic_workspace.container.tab.label}</name>
+            <componentClass className="com.vmware.vsphere.client.htmlbridge.HtmlView">
+                <object>
+                    <root>
+                        <url>/vsphere-client/vic/resources/build-dev/index.html?view=container-view</url>
                     </root>
                 </object>
             </componentClass>

--- a/ui/vic-ui-h5c/vic/src/vic-app/src/app/app-routing.module.ts
+++ b/ui/vic-ui-h5c/vic/src/vic-app/src/app/app-routing.module.ts
@@ -22,6 +22,7 @@ import { AppRoutingComponent } from './app-routing.component';
 import { VicSummaryPortletComponent } from './summary-portlet/summary-portlet.component';
 import { VicSummaryViewComponent } from './summary-view/summary-view.component';
 import { VicVchViewComponent } from './vch-view/vch-view.component';
+import { VicContainerViewComponent } from './container-view/container-view.component';
 
 const appRoutes: Routes = [
     { path: 'index.html', component: AppRoutingComponent },
@@ -30,7 +31,9 @@ const appRoutes: Routes = [
     { path: 'summary-view', component: VicSummaryViewComponent },
     { path: 'summary-view/:id', component: VicSummaryViewComponent },
     { path: 'vch-view', component: VicVchViewComponent },
-    { path: 'vch-view/:id', component: VicVchViewComponent }
+    { path: 'vch-view/:id', component: VicVchViewComponent },
+    { path: 'container-view', component: VicContainerViewComponent },
+    { path: 'container-view/:id', component: VicContainerViewComponent }
 ];
 
 export const extensionToRoutes = {};
@@ -43,7 +46,8 @@ export const routedComponents = [
     AppRoutingComponent,
     VicSummaryPortletComponent,
     VicSummaryViewComponent,
-    VicVchViewComponent
+    VicVchViewComponent,
+    VicContainerViewComponent
 ];
 
 @NgModule({

--- a/ui/vic-ui-h5c/vic/src/vic-app/src/app/app.module.ts
+++ b/ui/vic-ui-h5c/vic/src/vic-app/src/app/app.module.ts
@@ -24,6 +24,7 @@ import {
     Globals,
     GlobalsService,
     I18nService,
+    Vic18nService,
     RefreshService,
     AppAlertComponent,
     AppAlertService
@@ -59,6 +60,7 @@ import { AppComponent } from './app.component';
         Globals,
         GlobalsService,
         I18nService,
+        Vic18nService,
         RefreshService,
         DataPropertyService,
         VicVmViewService,

--- a/ui/vic-ui-h5c/vic/src/vic-app/src/app/container-view/container-view.component.spec.ts
+++ b/ui/vic-ui-h5c/vic/src/vic-app/src/app/container-view/container-view.component.spec.ts
@@ -1,0 +1,125 @@
+/*
+ Copyright 2017 VMware, Inc. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+import { async, TestBed, ComponentFixture } from '@angular/core/testing';
+import { HttpModule } from '@angular/http';
+import { Observable } from 'rxjs/Observable';
+import { Subject } from 'rxjs/Subject';
+import { By } from '@angular/platform-browser';
+
+import { JASMINE_TIMEOUT } from '../testing/jasmine.constants';
+import {
+    RefreshService,
+    GlobalsService,
+    Globals,
+    AppAlertService,
+    Vic18nService,
+    I18nService
+} from '../shared';
+import { VicVmViewService } from '../services/vm-view.service';
+import { VicContainerViewComponent } from './container-view.component';
+import { ContainerVm } from './container.model';
+import { ClarityModule } from 'clarity-angular';
+import {
+    getContainerResponseStub,
+    getMalformedContainerResponseStub
+} from '../services/mocks/container.response';
+
+let responseProperlyFormatted: boolean = true;
+
+class VicVmViewServiceStub {
+    private containersSubj: Subject<ContainerVm[]>;
+    public containers$: Observable<ContainerVm[]>;
+    private data: ContainerVm[] = [];
+
+    constructor() {
+        this.containersSubj = new Subject<ContainerVm[]>();
+        this.containers$ = this.containersSubj.asObservable();
+    }
+
+    reloadContainers() {
+        // populates data with either correctly or incorrectly formatted data
+        // based on the responseProperlyFormatted flag
+        this.data = [];
+        let cResponse = responseProperlyFormatted ?
+            getContainerResponseStub().results :
+            getMalformedContainerResponseStub().results;
+
+        for (let objId in cResponse) {
+            if (cResponse.hasOwnProperty(objId)) {
+                this.data.push(new ContainerVm(cResponse[objId]));
+            }
+        }
+
+        this.containersSubj.next(this.data);
+    }
+}
+
+describe('VicContainerViewComponent', () => {
+    let fixture: ComponentFixture<VicContainerViewComponent>;
+    let vmViewService: VicVmViewServiceStub;
+    jasmine.DEFAULT_TIMEOUT_INTERVAL = JASMINE_TIMEOUT;
+
+    beforeEach(async(() => {
+        TestBed.configureTestingModule({
+            providers: [
+                { provide: VicVmViewService, useClass: VicVmViewServiceStub },
+                GlobalsService,
+                Globals,
+                RefreshService,
+                AppAlertService,
+                I18nService,
+                Vic18nService
+            ],
+            declarations: [
+                VicContainerViewComponent
+            ],
+            imports: [
+                ClarityModule.forRoot(),
+                HttpModule
+            ]
+        }).compileComponents();
+        fixture = TestBed.createComponent<VicContainerViewComponent>
+            (VicContainerViewComponent);
+    }));
+
+    it('should have fixture', () => {
+        expect(fixture).toBeTruthy();
+    });
+
+    it('should render the data grid with properly formatted data', async(() => {
+        let compInstance = fixture.componentInstance;
+        compInstance.ngOnInit();
+        compInstance.reloadContainers();
+        fixture.detectChanges();
+        let rowElements = fixture.debugElement.queryAll(By.css('clr-dg-row'));
+        let rowElementsLength = rowElements.length;
+        expect(rowElementsLength).toBe(30);
+    }));
+
+    it('should render zero row for malformed data', async(() => {
+        responseProperlyFormatted = false;
+        let compInstance = fixture.componentInstance;
+        compInstance.ngOnInit();
+        compInstance.reloadContainers();
+        fixture.detectChanges();
+        let rowElements = fixture.debugElement.queryAll(By.css('clr-dg-row'));
+        let rowElementsLength = rowElements.length;
+        expect(rowElementsLength).toBe(0);
+    }));
+
+    //TODO: i18n tests
+});

--- a/ui/vic-ui-h5c/vic/src/vic-app/src/app/container-view/container-view.component.ts
+++ b/ui/vic-ui-h5c/vic/src/vic-app/src/app/container-view/container-view.component.ts
@@ -1,0 +1,176 @@
+/*
+ Copyright 2017 VMware, Inc. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+import {
+    Component,
+    OnInit,
+    OnDestroy
+} from '@angular/core';
+import { Subscription } from 'rxjs/Subscription';
+import { State, Comparator } from 'clarity-angular';
+import { ContainerVm } from './container.model';
+import {
+    GlobalsService,
+    RefreshService,
+    Vic18nService
+} from '../shared';
+import { VicVmViewService } from '../services/vm-view.service';
+import {
+    VM_COMMITTEDSTORAGE,
+    VM_GUESTMEMORYUSAGE,
+    VM_OVERALLCPUUSAGE,
+    VSPHERE_VM_SUMMARY_KEY,
+    WS_CONTAINER
+} from '../shared/constants';
+
+class GuestMemoryUsageComparator implements Comparator<any> {
+    compare(a: any, b: any) {
+        return a[VM_GUESTMEMORYUSAGE] - b[VM_GUESTMEMORYUSAGE];
+    }
+
+    toString(): string {
+        return VM_GUESTMEMORYUSAGE;
+    }
+}
+
+class OverallCpuUsageComparator implements Comparator<any> {
+    compare(a: any, b: any) {
+        return a[VM_OVERALLCPUUSAGE] - b[VM_OVERALLCPUUSAGE];
+    }
+
+    toString(): string {
+        return VM_OVERALLCPUUSAGE;
+    }
+}
+
+class CommittedStorageComparator implements Comparator<any> {
+    compare(a: any, b: any) {
+        return a[VM_COMMITTEDSTORAGE] - b[VM_COMMITTEDSTORAGE];
+    }
+
+    toString(): string {
+        return VM_COMMITTEDSTORAGE;
+    }
+}
+
+@Component({
+    selector: 'vic-container-view',
+    styleUrls: [],
+    templateUrl: './container-view.template.html'
+})
+export class VicContainerViewComponent implements OnInit, OnDestroy {
+    public readonly WS_CONTAINER_CONSTANTS = WS_CONTAINER;
+    private refreshSubscription: Subscription;
+    public guestMemoryUsageComparator = new GuestMemoryUsageComparator();
+    public overallCpuUsageComparator = new OverallCpuUsageComparator();
+    public committedStorageComparator = new CommittedStorageComparator();
+    public isDgLoading: boolean = true;
+    public containers: ContainerVm[] = [];
+    public totalContainersCount: number = 0;
+    public currentOffset: number = 0;
+    public currentSort: string = 'id,asc';
+    public currentFilter: string = '';
+    public readonly maxResultCount: number = 10;
+    public readonly MEGABYTE: number = Math.pow(1024, 2);
+    public readonly GIGABYTE: number = Math.pow(1024, 3);
+
+    constructor(
+        private vmViewService: VicVmViewService,
+        private refreshService: RefreshService,
+        private gs: GlobalsService,
+        public vicI18n: Vic18nService
+    ) {
+        // subscribes to the global refresh event
+        this.refreshSubscription = this.refreshService
+            .refreshObservable$.subscribe(() => {
+                this.reloadContainers();
+            });
+    }
+
+    ngOnInit() {
+        // sets up a listener for updating this.containers
+        this.vmViewService.containers$.subscribe(vms => {
+            this.containers = vms;
+            this.isDgLoading = false;
+        }, err => {
+            this.containers = [];
+            console.error(err);
+        });
+    }
+
+    ngOnDestroy() {
+        this.refreshSubscription.unsubscribe();
+    }
+
+    /**
+     * Queries vic-service with the current Datagrid state
+     * @param state current Datagrid state
+     */
+    refreshGrid(state: State) {
+        this.currentFilter = state.filters ? state.filters
+            .map(item => item['property'] + '=' + item['value'])
+            .join(',') : '';
+
+        if (state.sort) {
+            let sortBy = typeof state.sort.by === 'object' ?
+                state.sort.by.toString() : state.sort.by;
+
+            this.currentSort = `${sortBy},${state.sort.reverse ? 'desc' : 'asc'}`;
+        }
+
+        this.currentOffset = state.page.from;
+        this.reloadContainers();
+    }
+
+    /**
+     * Calls vm-view service to reload Containers
+     */
+    reloadContainers() {
+        this.isDgLoading = true;
+        this.vmViewService.reloadContainers({
+            offset: this.currentOffset,
+            maxResultCount: this.maxResultCount,
+            sorting: this.currentSort,
+            filter: this.currentFilter
+        });
+    }
+
+    /**
+     * Navigates to an object specified by objectId
+     * @param objectId Full vSphere objectId which starts with urn:
+     */
+    navigateToObject(objectId: string) {
+        this.gs.getWebPlatform()
+            .sendNavigationRequest(VSPHERE_VM_SUMMARY_KEY, objectId);
+    }
+
+    /**
+     * Turns size in byte into a more legible unit
+     * @param size 
+     * @return pretty-formatted size
+     */
+    formatStorage(size: number): string {
+        let results: string;
+        if (size < this.MEGABYTE) {
+            results = Math.round(size / 1024) + ' KB';
+        } else if (size < this.GIGABYTE) {
+            results = Math.round(size / this.MEGABYTE) + ' MB';
+        } else {
+            results = Math.round(size / this.GIGABYTE) + ' GB';
+        }
+        return results;
+    }
+}

--- a/ui/vic-ui-h5c/vic/src/vic-app/src/app/container-view/container-view.template.html
+++ b/ui/vic-ui-h5c/vic/src/vic-app/src/app/container-view/container-view.template.html
@@ -1,0 +1,61 @@
+<clr-datagrid (clrDgRefresh)="refreshGrid($event)" [clrDgLoading]="isDgLoading">
+    <clr-dg-column [clrDgField]="'containerName'">
+        {{vicI18n.translate(this.WS_CONTAINER_CONSTANTS.DG.COLUMNS, 'CONTAINER_NAME')}}
+    </clr-dg-column>
+    <clr-dg-column [clrDgField]="'powerState'">
+        {{vicI18n.translate(this.WS_CONTAINER_CONSTANTS.DG.COLUMNS, 'POWER_STATE')}}
+    </clr-dg-column>
+    <clr-dg-column [clrDgSortBy]="guestMemoryUsageComparator">
+        {{vicI18n.translate(this.WS_CONTAINER_CONSTANTS.DG.COLUMNS, 'MEMORY_USAGE')}}
+    </clr-dg-column>
+    <clr-dg-column [clrDgSortBy]="overallCpuUsageComparator">
+        {{vicI18n.translate(this.WS_CONTAINER_CONSTANTS.DG.COLUMNS, 'CPU_USAGE')}}
+    </clr-dg-column>
+    <clr-dg-column [clrDgSortBy]="committedStorageComparator">
+        {{vicI18n.translate(this.WS_CONTAINER_CONSTANTS.DG.COLUMNS, 'STORAGE_USAGE')}}
+    </clr-dg-column>
+    <clr-dg-column [clrDgField]="'portMapping'">
+        {{vicI18n.translate(this.WS_CONTAINER_CONSTANTS.DG.COLUMNS, 'PORT_MAPPING')}}
+    </clr-dg-column>
+    <clr-dg-column [clrDgField]="'name'">
+        {{vicI18n.translate(this.WS_CONTAINER_CONSTANTS.DG.COLUMNS, 'VM_NAME')}}
+    </clr-dg-column>
+    <clr-dg-column [clrDgField]="'imageName'">
+        {{vicI18n.translate(this.WS_CONTAINER_CONSTANTS.DG.COLUMNS, 'IMAGE_NAME')}}
+    </clr-dg-column>
+
+    <clr-dg-row *ngFor="let item of containers">
+        <clr-dg-cell>
+            <span>{{item.containerName}}</span>
+        </clr-dg-cell>
+        <clr-dg-cell>
+            <span>{{item.powerState}}</span>
+        </clr-dg-cell>
+        <clr-dg-cell>
+            <span>{{item.guestMemoryUsage}} MB</span>
+        </clr-dg-cell>
+        <clr-dg-cell>
+            <span>{{item.overallCpuUsage}} MHz</span>
+        </clr-dg-cell>
+        <clr-dg-cell>
+            <span>{{formatStorage(item.committedStorage)}}</span>
+        </clr-dg-cell>
+        <clr-dg-cell>
+            <span>{{item.portMapping || '-'}}</span>
+        </clr-dg-cell>
+        <clr-dg-cell>
+            <a href="#" (click)="navigateToObject(item.id)">
+                    {{item.name}}
+                </a>
+        </clr-dg-cell>
+        <clr-dg-cell>
+            <span>{{item.imageName}}</span>
+        </clr-dg-cell>
+    </clr-dg-row>
+
+    <clr-dg-footer>
+        {{pagination.firstItem + 1}} - {{pagination.lastItem + 1}} of {{containers.length}} Container VMs
+        <clr-dg-pagination [clrDgPageSize]="maxResultCount" #pagination [clrDgTotalItems]="containers.length">
+        </clr-dg-pagination>
+    </clr-dg-footer>
+</clr-datagrid>

--- a/ui/vic-ui-h5c/vic/src/vic-app/src/app/container-view/container.model.ts
+++ b/ui/vic-ui-h5c/vic/src/vic-app/src/app/container-view/container.model.ts
@@ -1,0 +1,73 @@
+/*
+ Copyright 2017 VMware, Inc. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+import {
+    VirtualMachine,
+    ContainerVmResponse
+} from '../vm.interface';
+
+const FORWARD_SLASH = '/';
+const COLON = ':';
+
+export class ContainerVm implements VirtualMachine {
+    private _parentObj: {
+        value: string;
+        type: string;
+    };
+    public vmId: string;
+    public readonly isVCH: boolean = false;
+    public readonly isContainer: boolean = true;
+    public name: string;
+    public overallStatus: string;
+    public powerState: string;
+    public containerName: string;
+    public imageName: string;
+    public portMapping: string;
+    public overallCpuUsage: number;
+    public guestMemoryUsage: number;
+    public committedStorage: number;
+    public resourceConfig: any;
+
+    constructor(data: ContainerVmResponse) {
+        try {
+            // populate vm information
+            let splitVmId = data.id.split(FORWARD_SLASH);
+            this._parentObj = data.resourcePool;
+            this.vmId = `urn:vmomi:VirtualMachine:${splitVmId[1]}${COLON}${splitVmId[0]}`;
+            this.name = data.name;
+            this.overallStatus = data.overallStatus;
+            this.powerState = data.powerState;
+            this.containerName = data.containerName;
+            this.imageName = data.imageName;
+            this.portMapping = data.portMapping;
+            this.overallCpuUsage = data.overallCpuUsage;
+            this.guestMemoryUsage = data.guestMemoryUsage;
+            this.committedStorage = data.committedStorage;
+            this.resourceConfig = data.resourceConfig;
+        } catch (e) {
+            throw new Error('response does not fit into the required type! ' +
+                e.toString());
+        }
+    }
+
+    get parentType() {
+        return this._parentObj.type;
+    }
+
+    get id(): string {
+        return this.vmId;
+    }
+}

--- a/ui/vic-ui-h5c/vic/src/vic-app/src/app/services/mocks/container.response.ts
+++ b/ui/vic-ui-h5c/vic/src/vic-app/src/app/services/mocks/container.response.ts
@@ -1,0 +1,82 @@
+/*
+ Copyright 2017 VMware, Inc. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+function generateRandomContainers(length: number) {
+    if (length < 1) {
+        length = 1;
+    }
+    let results = {};
+    for (let i = 0; i < length; i++) {
+        results[`vm-${100 + i}`] = {
+            name: `Container-VM-${i}-blablablabla`,
+            containerName: `Container-VM-${i}`,
+            portMapping: 'tcp/8081:80',
+            imageName: 'busybox',
+            powerState: 'POWERED_ON',
+            overallStatus: 'GREEN',
+            overallCpuUsage: Math.round(Math.random() * 100),
+            guestMemoryUsage: Math.round(Math.random() * 2048),
+            commitedStorage: 123456789,
+            id: `85421094-c58e-40f9-a42c-b624160d05f5/vm-${200 + i}`,
+            type: 'vic:ContainerVm',
+            resourcePool: {
+                value: `resgroup-v${100 + i}`,
+                type: Math.random() > 0.5 ? 'VirtualApp' : 'ResourcePool'
+            },
+            resourceConfig: {
+                entity: {
+                    value: `vm-${100 + i}`,
+                    type: 'VirtualMachine'
+                },
+                changeVersion: null,
+                lastModified: null,
+                cpuAllocation: {
+                    reservation: 0,
+                    expandableReservation: false,
+                    limit: -1,
+                    shares: { shares: 1000, level: 'NORMAL' },
+                    overheadLimit: null
+                },
+                memoryAllocation: {
+                    reservation: 0,
+                    expandableReservation: false,
+                    limit: -1,
+                    shares: { shares: 20480, level: 'NORMAL' },
+                    overheadLimit: 57
+                }
+            }
+        };
+    }
+    return results;
+}
+
+export const getContainerResponseStub = () => {
+    let randomContainersObj = generateRandomContainers(30);
+
+    return {
+        id: 'something',
+        match: 30,
+        results: randomContainersObj
+    };
+};
+
+export const getMalformedContainerResponseStub = () => {
+    return {
+        id: 'something-wrong',
+        match: 0,
+        results: {}
+    };
+};

--- a/ui/vic-ui-h5c/vic/src/vic-app/src/app/shared/constants/index.ts
+++ b/ui/vic-ui-h5c/vic/src/vic-app/src/app/shared/constants/index.ts
@@ -16,3 +16,4 @@
 
 export * from './resources.path';
 export * from './portlets.text';
+export * from './vicvms';

--- a/ui/vic-ui-h5c/vic/src/vic-app/src/app/shared/constants/resources.path.ts
+++ b/ui/vic-ui-h5c/vic/src/vic-app/src/app/shared/constants/resources.path.ts
@@ -15,3 +15,70 @@
 */
 
 export const VIC_LOGO_100X100 = '/assets/vic-icons/100x100.png';
+export const VSPHERE_VM_SUMMARY_KEY = 'vsphere.core.vm.summary';
+export const VSPHERE_SERVEROBJ_VIEWEXT_KEY =
+    'vsphere.core.inventory.serverObjectViewsExtension';
+export const VSPHERE_VITREE_HOSTCLUSTERVIEW_KEY =
+    'vsphere.core.viTree.hostsAndClustersView';
+export const WS_SUMMARY = {
+    keys: {
+        VENDOR: 'vic_workspace.summary.vendor.label',
+        VERSION: 'vic_workspace.summary.version.label',
+        VCH: 'vic_workspace.summary.vch.label'
+    },
+    defaults: {
+        'vic_workspace.summary.vendor.label': 'Vendor',
+        'vic_workspace.summary.version.label': 'Version',
+        'vic_workspace.summary.vch.label': null
+    }
+};
+export const WS_VCH = {
+    DG: {
+        COLUMNS: {
+            keys: {
+                NAME: 'vic_workspace.vch.datagrid.columns.name',
+                OVERALL_STATUS:
+                'vic_workspace.vch.datagrid.columns.overallStatus',
+                DOCKER_API_ENDPOINT:
+                'vic_workspace.vch.datagrid.columns.dockerApiEndpoint',
+                VCH_ADMIN_PORTAL:
+                'vic_workspace.vch.datagrid.columns.vchAdminPortal'
+            },
+            defaults: {
+                'vic_workspace.vch.datagrid.columns.name': 'Name',
+                'vic_workspace.vch.datagrid.columns.overallStatus': 'Status',
+                'vic_workspace.vch.datagrid.columns.dockerApiEndpoint':
+                'Docker API Endpoint',
+                'vic_workspace.vch.datagrid.columns.vchAdminPortal':
+                'VCH Admin Portal'
+            }
+        }
+    }
+};
+
+export const WS_CONTAINER = {
+    DG: {
+        COLUMNS: {
+            keys: {
+                CONTAINER_NAME: 'vic_workspace.container.datagrid.columns.containerName',
+                POWER_STATE: 'vic_workspace.container.datagrid.columns.powerState',
+                MEMORY_USAGE: 'vic_workspace.container.datagrid.columns.guestMemoryUsage',
+                CPU_USAGE: 'vic_workspace.container.datagrid.columns.overallCpuUsage',
+                STORAGE_USAGE: 'vic_workspace.container.datagrid.columns.committedStorage',
+                PORT_MAPPING: 'vic_workspace.container.datagrid.columns.portMapping',
+                VM_NAME: 'vic_workspace.container.datagrid.columns.name',
+                IMAGE_NAME: 'vic_workspace.container.datagrid.columns.imageName'
+            },
+            defaults: {
+                'vic_workspace.container.datagrid.columns.containerName': 'Name',
+                'vic_workspace.container.datagrid.columns.powerState': 'State',
+                'vic_workspace.container.datagrid.columns.guestMemoryUsage': 'Memory Usage',
+                'vic_workspace.container.datagrid.columns.overallCpuUsage': 'CPU Usage',
+                'vic_workspace.container.datagrid.columns.committedStorage': 'Storage Usage',
+                'vic_workspace.container.datagrid.columns.portMapping': 'Port Mapping',
+                'vic_workspace.container.datagrid.columns.name': 'VM',
+                'vic_workspace.container.datagrid.columns.imageName': 'Image'
+            }
+        }
+    }
+};

--- a/ui/vic-ui-h5c/vic/src/vic-app/src/app/shared/constants/vicvms.ts
+++ b/ui/vic-ui-h5c/vic/src/vic-app/src/app/shared/constants/vicvms.ts
@@ -14,10 +14,8 @@
  limitations under the License.
 */
 
-export * from './app-config';
-export * from './app-alert.component';
-export * from './app-alert.service';
-export * from './globals.service';
-export * from './refresh.service';
-export * from './i18n.service';
-export * from './vic-i18n.service';
+export const VM_GUESTMEMORYUSAGE = 'guestMemoryUsage';
+export const VM_OVERALLCPUUSAGE = 'overallCpuUsage';
+export const VM_COMMITTEDSTORAGE = 'committedStorage';
+export const DOCKER_ENGINE_PORT_TLS = '2376';
+export const DOCKER_ENGINE_PORT_NOTLS = '2375';

--- a/ui/vic-ui-h5c/vic/src/vic-app/src/app/shared/i18n.service.ts
+++ b/ui/vic-ui-h5c/vic/src/vic-app/src/app/shared/i18n.service.ts
@@ -72,7 +72,8 @@ export class I18nService {
     * @returns {any}
     */
    public translate(key: string, params: string|string[] = null): string {
-      if (this.gs.isPluginMode()) {
+      if (this.gs.isPluginMode() &&
+          this.gs.getWebPlatform().getString) {
          // SDK's getString allows compatibility with vSphere Flex Client
          return this.gs.getWebPlatform().getString(this.bundleName, key, params);
       }

--- a/ui/vic-ui-h5c/vic/src/vic-app/src/app/shared/vic-i18n.service.spec.ts
+++ b/ui/vic-ui-h5c/vic/src/vic-app/src/app/shared/vic-i18n.service.spec.ts
@@ -1,0 +1,71 @@
+/*
+ Copyright 2017 VMware, Inc. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+import { async, TestBed } from '@angular/core/testing';
+import {
+    Globals,
+    GlobalsService,
+    I18nService,
+    Vic18nService
+} from './index';
+import { JASMINE_TIMEOUT } from '../testing/jasmine.constants';
+
+class I18nServiceStub {
+    public translate(key: string, params: string | string[] = null): string {
+        // this.i18n.translate() is already tested by h5c team
+        // so just assume the key is returned as-is in this case
+        return key;
+    }
+}
+
+describe('VicI18nService', () => {
+    jasmine.DEFAULT_TIMEOUT_INTERVAL = JASMINE_TIMEOUT;
+    let vicI18n: Vic18nService;
+    let stub = {
+        WS_SUMMARY: {
+            keys: {
+                NAME: 'a.b.c.d.e'
+            },
+            defaults: {
+                'a.b.c.d.e': 'Default Value'
+            }
+        }
+    };
+
+    beforeEach(async(() => {
+        TestBed.configureTestingModule({
+            providers: [
+                { provide: I18nService, useClass: I18nServiceStub },
+                Vic18nService
+            ]
+        });
+        vicI18n = TestBed.get(Vic18nService);
+    }));
+
+    it('should be initialized', () => {
+        expect(vicI18n).toBeTruthy();
+    });
+
+    it('should get a translated value for an existing key', () => {
+        let v = vicI18n.translate(stub.WS_SUMMARY, 'NAME');
+        expect(v).toBe('Default Value');
+    });
+
+    it('should display no value for a nonexistent key', () => {
+        let v = vicI18n.translate(stub.WS_SUMMARY, 'A');
+        expect(v).toBe('');
+    });
+});

--- a/ui/vic-ui-h5c/vic/src/vic-app/src/app/shared/vic-i18n.service.ts
+++ b/ui/vic-ui-h5c/vic/src/vic-app/src/app/shared/vic-i18n.service.ts
@@ -1,0 +1,41 @@
+/*
+ Copyright 2017 VMware, Inc. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+import { Injectable } from '@angular/core';
+import { I18nService } from '../shared/i18n.service';
+@Injectable()
+export class Vic18nService {
+    constructor(
+        private i18n: I18nService
+    ) { }
+
+    /**
+     * Returns localized text for a given key
+     * @param key : key defined in com_vmware_vic.properties
+     * @returns localized text
+     */
+    translate(ns: any, alias: string) {
+        let key = ns['keys'][alias];
+        let results = this.i18n.translate(key);
+        if (results === key) {
+            // when unit testing or run in a standalone mode,
+            // key is returned as-is. for this case, look for its default
+            // value defined in constants/resources.path.ts
+            return ns['defaults'][key] || '';
+        }
+        return results;
+    }
+}

--- a/ui/vic-ui-h5c/vic/src/vic-app/src/app/summary-portlet/summary-portlet.component.ts
+++ b/ui/vic-ui-h5c/vic/src/vic-app/src/app/summary-portlet/summary-portlet.component.ts
@@ -16,7 +16,6 @@
 
 import {
     Component,
-    AfterViewInit,
     OnDestroy,
     ChangeDetectorRef
 } from '@angular/core';
@@ -40,8 +39,7 @@ import { VM_PROPERTIES_TO_EXTRACT } from '../vm.constants';
     `
 })
 
-export class VicSummaryPortletComponent implements
-    AfterViewInit, OnDestroy {
+export class VicSummaryPortletComponent implements OnDestroy {
     public activeVm: VirtualMachine;
     private refreshSubscription: Subscription;
     private vmInfoSubscription: Subscription;
@@ -73,17 +71,18 @@ export class VicSummaryPortletComponent implements
                 console.error('data fetch failed!', err);
             }
         );
-    }
 
-    ngAfterViewInit() {
-        setTimeout(() => {
-            // set up objectId in data property service
-            this.route.params.subscribe((params: any) => {
-                this.service.setObjectId(params.id);
-                this.service.fetchVmInfo(VM_PROPERTIES_TO_EXTRACT, this.stubType);
-                console.log(`objectId set to ${params.id}`);
-            });
-        });
+        // set up objectId in data property service
+        let paramsIntervalTimer = setInterval(() => {
+            if (this.route && this.route.params) {
+                this.route.params.subscribe((params: any) => {
+                    this.service.setObjectId(params.id);
+                    this.service.fetchVmInfo(VM_PROPERTIES_TO_EXTRACT, this.stubType);
+                    console.log(`objectId set to ${params.id}`);
+                });
+                clearInterval(paramsIntervalTimer);
+            }
+        }, 5);
     }
 
     ngOnDestroy() {

--- a/ui/vic-ui-h5c/vic/src/vic-app/src/app/summary-portlet/summary-portlet.spec.ts
+++ b/ui/vic-ui-h5c/vic/src/vic-app/src/app/summary-portlet/summary-portlet.spec.ts
@@ -103,7 +103,7 @@ describe('VIC Summary Portlet Components', () => {
                 ClarityModule
             ]
         })
-        .compileComponents();
+            .compileComponents();
     }));
 
     beforeEach(() => {

--- a/ui/vic-ui-h5c/vic/src/vic-app/src/app/summary-view/summary-view.component.spec.ts
+++ b/ui/vic-ui-h5c/vic/src/vic-app/src/app/summary-view/summary-view.component.spec.ts
@@ -26,7 +26,8 @@ import {
     Globals,
     GlobalsService,
     I18nService,
-    RefreshService
+    Vic18nService,
+    RefreshService,
 } from '../shared/index';
 import { DataPropertyService } from '../services/data-property.service';
 import { AppErrorHandler } from '../shared/appErrorHandler';
@@ -61,6 +62,8 @@ describe('VIC object view: Summary tab', () => {
                 AppAlertService,
                 Globals,
                 GlobalsService,
+                I18nService,
+                Vic18nService,
                 RefreshService
             ],
             imports: [
@@ -93,4 +96,6 @@ describe('VIC object view: Summary tab', () => {
         expect(span_uiVersion.nativeElement.textContent.trim()).toBe('1.1', 'should be 1.1');
         expect(span_vchVmsLen.nativeElement.textContent.trim()).toBe('1', 'should be 1');
     });
+
+    // TODO: i18n test
 });

--- a/ui/vic-ui-h5c/vic/src/vic-app/src/app/summary-view/summary-view.component.ts
+++ b/ui/vic-ui-h5c/vic/src/vic-app/src/app/summary-view/summary-view.component.ts
@@ -16,10 +16,14 @@
 
 import { Component, OnInit, OnDestroy } from '@angular/core';
 import { GlobalsService, RefreshService } from '../shared/index';
+import { Vic18nService } from '../shared/vic-i18n.service';
 import { DataPropertyService } from '../services/data-property.service';
 import { Subscription } from 'rxjs/Rx';
 
-import { VIC_LOGO_100X100 } from '../shared/constants/index';
+import {
+    VIC_LOGO_100X100,
+    WS_SUMMARY
+} from '../shared/constants/index';
 
 @Component({
     selector: 'vic-summary-view',
@@ -31,7 +35,9 @@ import { VIC_LOGO_100X100 } from '../shared/constants/index';
             <ul class="summary-items-list">
                 <li id="vendor">
                     <span class="summary-label">
-                        Vendor
+                        {{vicI18n.translate(
+                            this.WS_SUMMARY_CONSTANTS,
+                            'VENDOR')}}
                     </span>
                     <span class="summary-value">
                         VMware
@@ -39,7 +45,9 @@ import { VIC_LOGO_100X100 } from '../shared/constants/index';
                 </li>
                 <li id="version">
                     <span class="summary-label">
-                        Version
+                        {{vicI18n.translate(
+                            this.WS_SUMMARY_CONSTANTS,
+                            'VERSION')}}
                     </span>
                     <span class="summary-value">
                         {{ pluginVersion }}
@@ -47,7 +55,9 @@ import { VIC_LOGO_100X100 } from '../shared/constants/index';
                 </li>
                 <li id="vch_len">
                     <span class="summary-label">
-                        Virtual Container Hosts
+                        {{vicI18n.translate(
+                            this.WS_SUMMARY_CONSTANTS,
+                            'VCH')}}
                     </span>
                     <span class="summary-value">
                         {{ vchVmsLen }}
@@ -63,11 +73,13 @@ export class VicSummaryViewComponent implements OnInit, OnDestroy {
     public vicLogoPath: string;
     public pluginVersion: string;
     public vchVmsLen: number;
+    public readonly WS_SUMMARY_CONSTANTS = WS_SUMMARY;
     private rootInfoSubscription: Subscription;
     private refreshSubscription: Subscription;
 
     constructor(
         private gs: GlobalsService,
+        public vicI18n: Vic18nService,
         private refreshService: RefreshService,
         private dataPropertyService: DataPropertyService
     ) {

--- a/ui/vic-ui-h5c/vic/src/vic-app/src/app/vch-view/vch-view.component.spec.ts
+++ b/ui/vic-ui-h5c/vic/src/vic-app/src/app/vch-view/vch-view.component.spec.ts
@@ -15,14 +15,20 @@
 */
 
 import { TestBed, async, ComponentFixture } from '@angular/core/testing';
+import { HttpModule } from '@angular/http';
 import { Observable } from 'rxjs/Observable';
 import { Subject } from 'rxjs/Subject';
 import { By } from '@angular/platform-browser';
 
 import { JASMINE_TIMEOUT } from '../testing/jasmine.constants';
-import { GlobalsService, Globals } from '../shared/globals.service';
-import { RefreshService } from '../shared/refresh.service';
-import { AppAlertService } from '../shared/app-alert.service';
+import {
+    RefreshService,
+    AppAlertService,
+    I18nService,
+    Vic18nService,
+    Globals,
+    GlobalsService,
+} from '../shared';
 import { VicVmViewService } from '../services/vm-view.service';
 import { VicVchViewComponent } from './vch-view.component';
 import { VirtualContainerHost } from './vch.model';
@@ -87,13 +93,16 @@ describe('VicVchViewComponent', () => {
                 GlobalsService,
                 Globals,
                 RefreshService,
-                AppAlertService
+                AppAlertService,
+                Vic18nService,
+                I18nService
             ],
             declarations: [
                 VicVchViewComponent
             ],
             imports: [
-                ClarityModule.forRoot()
+                ClarityModule.forRoot(),
+                HttpModule
             ]
         }).compileComponents();
         fixture = TestBed.createComponent<VicVchViewComponent>(VicVchViewComponent);

--- a/ui/vic-ui-h5c/vic/src/vic-app/src/app/vch-view/vch-view.component.ts
+++ b/ui/vic-ui-h5c/vic/src/vic-app/src/app/vch-view/vch-view.component.ts
@@ -22,9 +22,20 @@ import {
 import { Subscription } from 'rxjs/Subscription';
 import { State } from 'clarity-angular';
 import { VirtualContainerHost } from './vch.model';
-import { GlobalsService } from '../shared/globals.service';
+import {
+    GlobalsService,
+    RefreshService,
+    Vic18nService
+} from '../shared';
 import { VicVmViewService } from '../services/vm-view.service';
-import { RefreshService } from '../shared/refresh.service';
+import {
+    VSPHERE_VM_SUMMARY_KEY,
+    DOCKER_ENGINE_PORT_NOTLS,
+    DOCKER_ENGINE_PORT_TLS,
+    VSPHERE_SERVEROBJ_VIEWEXT_KEY,
+    VSPHERE_VITREE_HOSTCLUSTERVIEW_KEY,
+    WS_VCH
+} from '../shared/constants';
 
 @Component({
     selector: 'vic-vch-view',
@@ -32,6 +43,7 @@ import { RefreshService } from '../shared/refresh.service';
     templateUrl: './vch-view.template.html'
 })
 export class VicVchViewComponent implements OnInit, OnDestroy {
+    public readonly WS_VCH_CONSTANTS = WS_VCH;
     private refreshSubscription: Subscription;
     public isDgLoading: boolean = true;
     public vchs: VirtualContainerHost[] = [];
@@ -44,7 +56,8 @@ export class VicVchViewComponent implements OnInit, OnDestroy {
     constructor(
         private vmViewService: VicVmViewService,
         private refreshService: RefreshService,
-        private gs: GlobalsService
+        private gs: GlobalsService,
+        public vicI18n: Vic18nService
     ) {
         // subscribes to the global refresh event
         this.refreshSubscription = this.refreshService
@@ -74,7 +87,8 @@ export class VicVchViewComponent implements OnInit, OnDestroy {
      * @return DOCKER_HOST environment variable
      */
     getDockerEndpointString(item: VirtualContainerHost): string {
-        return `DOCKER_HOST=${item.vchIp}:${item.isUsingTls ? '2376' : '2375'}`;
+        return `DOCKER_HOST=${item.vchIp}:${item.isUsingTls ?
+            DOCKER_ENGINE_PORT_TLS : DOCKER_ENGINE_PORT_NOTLS}`;
     }
 
     /**
@@ -113,12 +127,13 @@ export class VicVchViewComponent implements OnInit, OnDestroy {
      */
     navigateToObject(objectId: string) {
         if (objectId.indexOf('VirtualMachine') > -1) {
-            this.gs.getWebPlatform().sendNavigationRequest('vsphere.core.vm.summary', objectId);
+            this.gs.getWebPlatform().sendNavigationRequest(
+                VSPHERE_VM_SUMMARY_KEY, objectId);
         } else {
             window.parent.location.href = '/ui/#?extensionId=' +
-                'vsphere.core.inventory.serverObjectViewsExtension&' +
+                VSPHERE_SERVEROBJ_VIEWEXT_KEY + '&' +
                 'objectId=' + objectId + '&' +
-                'navigator=vsphere.core.viTree.hostsAndClustersView';
+                'navigator=' + VSPHERE_VITREE_HOSTCLUSTERVIEW_KEY;
         }
     }
 }

--- a/ui/vic-ui-h5c/vic/src/vic-app/src/app/vch-view/vch-view.template.html
+++ b/ui/vic-ui-h5c/vic/src/vic-app/src/app/vch-view/vch-view.template.html
@@ -1,8 +1,16 @@
 <clr-datagrid (clrDgRefresh)="refreshGrid($event)" [clrDgLoading]="isDgLoading">
-    <clr-dg-column [clrDgField]="'name'">Name</clr-dg-column>
-    <clr-dg-column [clrDgField]="'overallStatus'">Status</clr-dg-column>
-    <clr-dg-column [clrDgField]="'vchIp'">Docker API Endpoint</clr-dg-column>
-    <clr-dg-column [clrDgField]="'vchIp'">VCH Admin Portal</clr-dg-column>
+    <clr-dg-column [clrDgField]="'name'">
+        {{vicI18n.translate(this.WS_VCH_CONSTANTS.DG.COLUMNS, 'NAME')}}
+    </clr-dg-column>
+    <clr-dg-column [clrDgField]="'overallStatus'">
+        {{vicI18n.translate(this.WS_VCH_CONSTANTS.DG.COLUMNS, 'OVERALL_STATUS')}}
+    </clr-dg-column>
+    <clr-dg-column [clrDgField]="'vchIp'">
+        {{vicI18n.translate(this.WS_VCH_CONSTANTS.DG.COLUMNS, 'DOCKER_API_ENDPOINT')}}
+    </clr-dg-column>
+    <clr-dg-column [clrDgField]="'vchIp'">
+        {{vicI18n.translate(this.WS_VCH_CONSTANTS.DG.COLUMNS, 'VCH_ADMIN_PORTAL')}}
+    </clr-dg-column>
 
     <clr-dg-row *ngFor="let item of vchs">
         <clr-dg-cell>


### PR DESCRIPTION
This PR adds a section to the VIC object workspace in H5 Client which shows the information on all Containers deployed in the current VC.

Note that this PR has a bunch of new lines added here but most are redundant with #4952 . Once the PR on the VCH section gets merged this PR will be rebased on the new master branch.

![image](https://cloud.githubusercontent.com/assets/3834071/26120767/782b615a-3a37-11e7-9757-8b169c8e019b.png)

Fixes #3752 