### PR TITLE
Move to three approvers, since it was counting the author

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -11,7 +11,7 @@ group_defaults:
 
 groups:
   contributors:
-    required: 2
+    required: 3
     teams:
       - vic-maintainers
 


### PR DESCRIPTION
This is a follow on from #5019 , because pull approve counts author as 1 it still was not enforcing 2 LGTMs as we have agreed to as a team.