### PR TITLE
[skip ci] add retry logic when creating a distributed switch during the creation of a VSAN cluster 

### DIFF
--- a/tests/resources/Nimbus-Util.robot
+++ b/tests/resources/Nimbus-Util.robot
@@ -236,7 +236,7 @@ Create a VSAN Cluster
     Set Environment Variable  GOVC_PASSWORD  Admin\!23
 
     Log To Console  Create a distributed switch
-    ${out}=  Run  govc dvs.create -dc=vcqaDC test-ds
+    ${out}=  Wait Until Keyword Succeeds  10x  3 minutes  Run  govc dvs.create -dc=vcqaDC test-ds
     Should Contain  ${out}  OK
 
     Log To Console  Create three new distributed switch port groups for management and vm network traffic


### PR DESCRIPTION
This fixes #4986 for the nightly test 13-2-vMotion-Container.

The fix is the same with this https://github.com/vmware/vic/pull/4944/files#diff-f235a2c398c04bc4f296449856c1e13fR39
