### PR TITLE
[skip ci] correct test 13-1-vMotion-VCH-Appliance

### DIFF
--- a/tests/manual-test-cases/Group13-vMotion/13-1-vMotion-VCH-Appliance.robot
+++ b/tests/manual-test-cases/Group13-vMotion/13-1-vMotion-VCH-Appliance.robot
@@ -60,9 +60,8 @@ Step 6-9
     Run Regression Tests
     ${host}=  Get VM Host Name  %{VCH-NAME}/%{VCH-NAME}
     ${status}=  Run Keyword And Return Status  Should Contain  ${host}  ${esx1-ip}
-    Run Keyword If  ${status}  Run  govc vm.migrate -host cls/${esx2-ip} -pool cls/Resources %{VCH-NAME}/%{VCH-NAME}
-    Run Keyword Unless  ${status}  Run  govc vm.migrate -host cls/${esx1-ip} -pool cls/Resources %{VCH-NAME}/%{VCH-NAME}
-    Set Environment Variable  VCH-NAME  "%{VCH-NAME} (1)"
+    Run Keyword If  ${status}  Run  govc vm.migrate -host cls/${esx2-ip} %{VCH-NAME}/%{VCH-NAME}
+    Run Keyword Unless  ${status}  Run  govc vm.migrate -host cls/${esx1-ip} %{VCH-NAME}/%{VCH-NAME}
     Run Regression Tests
 
 Step 10-13
@@ -84,10 +83,9 @@ Step 10-13
 
     ${host}=  Get VM Host Name  %{VCH-NAME}/%{VCH-NAME}
     ${status}=  Run Keyword And Return Status  Should Contain  ${host}  ${esx1-ip}
-    Run Keyword If  ${status}  Run  govc vm.migrate -host cls/${esx2-ip} -pool cls/Resources %{VCH-NAME}/%{VCH-NAME}
-    Run Keyword Unless  ${status}  Run  govc vm.migrate -host cls/${esx1-ip} -pool cls/Resources %{VCH-NAME}/%{VCH-NAME}
-    Set Environment Variable  VCH-NAME  "%{VCH-NAME} (1)"
-
+    Run Keyword If  ${status}  Run  govc vm.migrate -host cls/${esx2-ip} %{VCH-NAME}/%{VCH-NAME}
+    Run Keyword Unless  ${status}  Run  govc vm.migrate -host cls/${esx1-ip} %{VCH-NAME}/%{VCH-NAME}
+    
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} start ${container1}
     Should Be Equal As Integers  ${rc}  0
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} stop ${container1}


### PR DESCRIPTION
fixes #4963 

In the original test, we use `govc vm.migrate ... -pool cls/Resources vch_name` to migrate the VCH to a different host. However, since the original resource pool of the VCH is the vApp of the VCH, we move the VCH outside of its original resource pool by specifying `-pool ...`. Therefore, `vic-machine delete` is not able to find the VCH from within the original resource pool and throws the error msg reported in the bug.

Another thing to note is: in the original test, since the vApp has the same name as the VCH and they are in the same resource pool after migration, vc will rename the VCH to `vch_name (1)` . Now with this PR, the VCH name will remain the same as before. 