### PR TITLE
Fix version clash between FlexC and H5C

### DIFF
--- a/ui/vic-ui-h5c/vic/plugin-package.xml
+++ b/ui/vic-ui-h5c/vic/plugin-package.xml
@@ -20,6 +20,7 @@
          Otherwise put version="6.5.0" to have your plugin loaded only by vSphere Client 6.5.0 and up.
        -->
       <pluginPackage id="com.vmware.vsphere.client" version="6.0.0" />
+      <pluginPackage id="com.vmware.vsphere.client.html" version="6.5.0" />
 
       <!-- you may add dependencies on other plugin packages if necessary -->
    </dependencies>


### PR DESCRIPTION
Fixes #5151 by specifying a strict dependency for vSphere Client in the `plugin-package.xml` of the H5 Client plugin project. This PR fixes a bug where the H5C plugin is activated in the Flex client when it's not supposed to. This also partially resolves issue #4981 and might potentially be a permanent solution, as it is very likely that when the both plugins are registered with vCenter Server,  the Flex client plugin might conflict with the H5 client plugin which is not supposed to be enabled on the Flex client.