### PR TITLE
Check last Nak in handshake

### DIFF
--- a/cmd/tether/attach_test.go
+++ b/cmd/tether/attach_test.go
@@ -147,10 +147,7 @@ func mockBackChannel(ctx context.Context) (net.Conn, error) {
 	for {
 		select {
 		case <-ticker.C:
-			// FIXME: need to implement timeout of purging hangs with no content
-			// on the pipe
-			// serial.PurgeIncoming(ctx, conn)
-			err := serial.HandshakeClient(conn, true)
+			err := serial.HandshakeClient(conn)
 			if err != nil {
 				if err == io.EOF {
 					// with unix pipes the open will block until both ends are open, therefore

--- a/lib/apiservers/portlayer/restapi/handlers/interaction_handlers.go
+++ b/lib/apiservers/portlayer/restapi/handlers/interaction_handlers.go
@@ -61,7 +61,7 @@ func (i *InteractionHandlersImpl) Configure(api *operations.PortLayerAPI, _ *Han
 	api.InteractionContainerCloseStdinHandler = interaction.ContainerCloseStdinHandlerFunc(i.ContainerCloseStdinHandler)
 
 	i.server = communication.NewServer("localhost", constants.AttachServerPort)
-	if err := i.server.Start(false); err != nil {
+	if err := i.server.Start(); err != nil {
 		log.Fatalf("Attach server unable to start: %s", err)
 	}
 }

--- a/lib/portlayer/attach/communication/server.go
+++ b/lib/portlayer/attach/communication/server.go
@@ -49,7 +49,7 @@ func NewServer(ip string, port int) *Server {
 }
 
 // Start starts the connector with given listener
-func (n *Server) Start(debug bool) error {
+func (n *Server) Start() error {
 	defer trace.End(trace.Begin(""))
 
 	n.m.Lock()
@@ -68,7 +68,7 @@ func (n *Server) Start(debug bool) error {
 	log.Infof("Attach server listening on %s:%d", n.ip, n.port)
 
 	// starts serving requests immediately
-	n.c = NewConnector(n.l, debug)
+	n.c = NewConnector(n.l)
 	n.c.Start()
 
 	return nil

--- a/lib/portlayer/attach/communication/server_test.go
+++ b/lib/portlayer/attach/communication/server_test.go
@@ -36,6 +36,9 @@ import (
 // Start the server, make 200 client connections, test they connect, then Stop.
 func TestAttachStartStop(t *testing.T) {
 	log.SetLevel(log.InfoLevel)
+	if testing.Verbose() {
+		log.SetLevel(log.DebugLevel)
+	}
 	s := NewServer("localhost", 0)
 
 	var wg sync.WaitGroup
@@ -63,7 +66,7 @@ func TestAttachStartStop(t *testing.T) {
 		}
 	}
 
-	assert.NoError(t, s.Start(true))
+	assert.NoError(t, s.Start())
 
 	for i := 0; i < 100; i++ {
 		wg.Add(1)
@@ -89,9 +92,11 @@ func TestAttachStartStop(t *testing.T) {
 
 func TestAttachSshSession(t *testing.T) {
 	log.SetLevel(log.InfoLevel)
-
+	if testing.Verbose() {
+		log.SetLevel(log.DebugLevel)
+	}
 	s := NewServer("localhost", 0)
-	assert.NoError(t, s.Start(true))
+	assert.NoError(t, s.Start())
 	defer s.Stop()
 
 	expectedID := "foo"

--- a/pkg/serial/handshake.go
+++ b/pkg/serial/handshake.go
@@ -11,15 +11,34 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+//
+//	Client:
+//		generate a random uint8 (#)
+//		send 2 bytes Syn|#
+//
+//	Server:
+//		generate a random uint8 (&)
+//		read at least 2 bytes and make sure Syn|# is received
+//		send 3 bytes Ack|#+1|& (or Nak)
+//
+//  Client:
+//	    read at least 3 bytes and make sure Ack|#+1|& is received
+//		send 2 bytes Ack|&+1
+//
+//	Server:
+//		read at least 2 bytes and make sure Ack|&+1 is received
+//		send 1 byte Ack (or Nak)
+//	Client:
+//		read at leat 1 byte and make sure Ack is received
 
 package serial
 
 import (
-	"bytes"
-	"crypto/rand"
 	"fmt"
 	"io"
-	"net"
+	"math"
+	"math/rand"
 	"time"
 
 	log "github.com/Sirupsen/logrus"
@@ -28,10 +47,9 @@ import (
 )
 
 const (
-	flagSyn      byte = 0x16
-	flagAck      byte = 0x06
-	flagDebugAck byte = 0x07
-	flagNak      byte = 0x15
+	flagSyn byte = 0x16
+	flagAck      = 0x06
+	flagNak      = 0x15
 )
 
 // HandshakeError should only occure if the protocol between HandshakeServer and HandshakeClient was violated.
@@ -39,123 +57,90 @@ type HandshakeError struct {
 	msg string
 }
 
-func (he *HandshakeError) Error() string { return "HandshakeServer: " + he.msg }
-
-// PurgeIncoming is used to clear a channel of bytes prior to handshaking
-func PurgeIncoming(conn net.Conn) {
-	if tracing {
-		defer trace.End(trace.Begin(""))
-	}
-	buf := make([]byte, 255)
-
-	// read until the incoming channel is empty
-	conn.SetReadDeadline(time.Now().Add(time.Duration(10 * time.Millisecond)))
-	for n, err := conn.Read(buf); n != 0 || err == nil; n, err = conn.Read(buf) {
-		log.Debugf("discarding following %d bytes from input channel\n", n)
-		log.Debugf("%+v\n", buf[0:n])
-	}
-
-	// disable the read timeout
-	conn.SetReadDeadline(time.Time{})
+func (he *HandshakeError) Error() string {
+	return he.msg
+}
+func init() {
+	rand.Seed(time.Now().UTC().UnixNano())
 }
 
-func incrementByte(syncPos byte) byte { return (syncPos + 1) | 0x80 }
+// ReadAtLeastN reads at least l bytes and returns those l bytes or errors
+// We get lots of garbage data when we get the initial connection which handshake supposed to clear them and leave the connection in a known state so that the real ssh handshake can start.
+// Client and server is looping with different frequencies so client could send multiple requests before server even had a chance to read.
+// By getting the last l bytes we are saying that we are not interested with garbage data and also eliminating duplicated flags by only using the last one
+func ReadAtLeastN(conn io.ReadWriter, buffer []byte, l int) ([]byte, error) {
+	n, err := io.ReadAtLeast(conn, buffer, l)
+	if err != nil {
+		return nil, err
+	}
+
+	// however if we read more than l, it means buffer is not empty
+	if n != l {
+		buffer = buffer[n-l:]
+	}
+
+	return buffer, nil
+}
 
 // HandshakeClient establishes connection with the server making sure
 // they both are in sync.
-func HandshakeClient(conn io.ReadWriter, debug bool) error {
+func HandshakeClient(conn io.ReadWriter) error {
 	if tracing {
 		defer trace.End(trace.Begin(""))
 	}
 
-	buf1byte := make([]byte, 1)
+	// generate a random pos between [0, math.MaxUint8)
+	pos := uint8(rand.Intn(math.MaxUint8))
+	buffer := make([]byte, 32*1024)
 
-	if _, err := rand.Read(buf1byte); err != nil {
-		log.Errorf("HandshakeClient: Could not read a random byte due to: %v", err)
-	}
-
-	pos := incrementByte(buf1byte[0])
-
-	// set the read deadline for timeout
-	// this has no effect on windows as the deadline is set at port open time
-
-	log.Debug("HandshakeClient: Sending syn.")
-	conn.Write([]byte{flagSyn, pos})
-	pos = incrementByte(pos)
-
-	if _, err := conn.Read(buf1byte); err != nil {
+	// send syn with pos
+	log.Debugf("HandshakeClient: Sending syn with pos %d", pos)
+	if _, err := conn.Write([]byte{flagSyn, pos}); err != nil {
+		log.Errorf("syn: write failed")
 		return err
 	}
 
-	if buf1byte[0] != flagAck {
-		if buf1byte[0] == flagNak {
-			log.Debugf("HandshakeClient: Server didn't accept sync. Trying one more time.")
-			return &HandshakeError{
-				msg: "Server declined handshake request",
-			}
-		}
+	// read ack with pos+1 and token
+	buffer, err := ReadAtLeastN(conn, buffer, 3)
+	if err != nil {
+		return err
+	}
+
+	// extract pos and the token from it
+	flag, posack, token := uint8(buffer[0]), uint8(buffer[1]), uint8(buffer[2])
+	if flag == flagNak {
 		return &HandshakeError{
-			msg: fmt.Sprintf("Unexpected server response: %d", buf1byte[0]),
+			msg: "HandshakeClient: Server declined handshake request",
 		}
 	}
-
-	// read response sync position.
-	if _, err := conn.Read(buf1byte); err != nil {
-		return err
-	}
-
-	if buf1byte[0] != pos {
-		log.Debugf("HandshakeClient: Unexpected byte pos for SynAck: %x, expected: %x", buf1byte[0], pos)
+	if flag != flagAck {
 		return &HandshakeError{
-			msg: fmt.Sprintf("Unexpected sync position response: %d", buf1byte[0]),
+			msg: fmt.Sprintf("HandshakeClient: Unexpected server response: %#v", flag),
 		}
 	}
 
-	if _, err := conn.Read(buf1byte); err != nil {
+	if posack != pos+1 {
+		return &HandshakeError{
+			msg: fmt.Sprintf("HandshakeClient: Unexpected ack position: %d, expected %d", posack, pos+1),
+		}
+	}
+
+	log.Debugf("HandshakeClient: Sending ack with %d", token+1)
+
+	if _, err := conn.Write([]byte{flagAck, token + 1}); err != nil {
 		return err
 	}
 
-	log.Debug("HandshakeClient: Sending ack.")
+	// last ack packet is 1 byte and could be followed by SSH handshake so read only 1 byteand leave the rest in the net.Conn buffer
+	buffer = buffer[:1]
+	if _, err := conn.Read(buffer); err != nil {
+		return err
+	}
 
-	if !debug {
-		conn.Write([]byte{flagAck, incrementByte(buf1byte[0])})
-	} else {
-		conn.Write([]byte{flagDebugAck, incrementByte(buf1byte[0])})
-		// Verify packet length handling works.  We're going to send a known stream
-		// of data to the container and it will echo it back.  Verify the sent and
-		// received bufs are the same and we know the channel is lossless.
-
-		log.Debugf("HandshakeClient: Checking for lossiness")
-		txbuf := []byte("\x1b[32mhello world\x1b[39m!\n")
-		rxbuf := make([]byte, len(txbuf))
-
-		_, err := conn.Write(txbuf)
-		if err != nil {
-			return err
+	if buffer[0] != flagAck {
+		return &HandshakeError{
+			msg: fmt.Sprintf("HandshakeClient: Unexpected server response: %#v", flag),
 		}
-
-		var n int
-		log.Debugf("HandshakeClient: Reading response")
-		n, err = io.ReadFull(conn, rxbuf)
-		if err != nil {
-			log.Error(err)
-			return err
-		}
-
-		if n != len(rxbuf) {
-			return fmt.Errorf("packet size mismatch (expected %d, received %d)", len(rxbuf), n)
-		}
-
-		if bytes.Compare(rxbuf, txbuf) != 0 {
-			return fmt.Errorf("HandshakeClient: lossiness check FAILED")
-		}
-
-		// Tell the server we're good.
-		if _, err = conn.Write([]byte{flagAck}); err != nil {
-			return err
-		}
-
-		log.Infof("HandshakeClient: lossiness check PASSED")
 	}
 
 	log.Debug("HandshakeClient: Connection established.")
@@ -169,96 +154,66 @@ func HandshakeServer(conn io.ReadWriter) error {
 		defer trace.End(trace.Begin(""))
 	}
 
-	buf1byte := make([]byte, 1)
-	syncBuf := make([]byte, 4096)
-
-	if _, err := rand.Read(buf1byte); err != nil {
-		log.Errorf("HandshakeClient: Could not read a random byte due to: %v", err)
-	}
-	pos := incrementByte(buf1byte[0])
+	// generate a random pos between [0, math.MaxUint8)
+	pos := uint8(rand.Intn(math.MaxUint8))
+	buffer := make([]byte, 32*1024)
 
 	log.Debug("HandshakeServer: Waiting for incoming syn request...")
 
-	// Sync packet is 2 bytes, however if we read more than 2
-	// it means buffer is not empty and data is not trusted for this sync.
-
-	n, err := io.ReadAtLeast(conn, syncBuf, 2)
+	// Sync packet is 2 bytes, however if we read more than 2 it means buffer is not empty and data is not trusted for this sync.
+	buffer, err := ReadAtLeastN(conn, buffer, 2)
 	if err != nil {
 		return err
 	}
-	if n != 2 {
-		log.Debugf("HandshakeServer: Received %d bytes while awaiting for syn.", n)
-	}
-	syncBuf = syncBuf[n-2:]
 
-	if syncBuf[0] != flagSyn {
-		conn.Write([]byte{flagNak})
+	// Read 2 bytes, extract flag and the token from it
+	flag, token := uint8(buffer[0]), uint8(buffer[1])
+	if flag != flagSyn {
+		if _, err := conn.Write([]byte{flagNak}); err != nil {
+			return err
+		}
 		return &HandshakeError{
-			msg: fmt.Sprintf("Unexpected syn packet: %x", syncBuf[0]),
+			msg: fmt.Sprintf("Unexpected syn packet: %x", flag),
 		}
 	}
+	log.Debugf("HandshakeServer: Received syn with pos %d. Writing syn-ack with %d and %d", token, token+1, pos)
 
-	log.Debugf("HandshakeServer: Received Syn. Writing SynAck.")
-
-	// syncBuf[1] contains position token that needs to be incremented
-	// by one to send it back.
-	conn.Write([]byte{flagAck, incrementByte(syncBuf[1]), pos})
-	pos = incrementByte(pos)
-
-	if _, err := conn.Read(buf1byte); err != nil {
+	// token contains position token that needs to be incremented by one to send it back.
+	if _, err := conn.Write([]byte{flagAck, token + 1, pos}); err != nil {
 		return err
 	}
 
-	ackType := buf1byte[0]
-	if ackType != flagAck && ackType != flagDebugAck {
-		conn.Write([]byte{flagNak})
-		return &HandshakeError{
-			msg: fmt.Sprintf("Not an ack packet received: %x", ackType),
-		}
-	}
-
-	if _, err := conn.Read(buf1byte); err != nil {
+	// ACK packet is 2 bytes, however if we read more than 2 it means buffer is not empty and data is not trusted for this sync.
+	buffer, err = ReadAtLeastN(conn, buffer, 2)
+	if err != nil {
 		return err
 	}
 
-	if buf1byte[0] != pos {
-		conn.Write([]byte{flagNak})
+	// Read 2 bytes, extract flag and the token from it
+	flag, token = uint8(buffer[0]), uint8(buffer[1])
+	if flag != flagAck {
+		if _, err := conn.Write([]byte{flagNak}); err != nil {
+			return err
+		}
 		return &HandshakeError{
-			msg: fmt.Sprintf(
-				"HandshakeServer: Unexpected position %x, expected: %x",
-				buf1byte[0], pos),
+			msg: fmt.Sprintf("Unexpected syn packet: %x", flag),
 		}
 	}
 
-	if ackType == flagDebugAck {
-		log.Debugf("HandshakeServer: Debug ACK received")
-		rxbuf := make([]byte, 23)
-		log.Debugf("HandshakeServer: Checking for lossiness")
-
-		n, err := io.ReadFull(conn, rxbuf)
-		if err != nil {
+	// token should contain incremented pos
+	if token != pos+1 {
+		if _, err := conn.Write([]byte{flagNak}); err != nil {
 			return err
 		}
-
-		if n != len(rxbuf) {
-			return fmt.Errorf("packet size mismatch (expected %d, received %d)", len(rxbuf), n)
+		return &HandshakeError{
+			msg: fmt.Sprintf("HandshakeServer: Unexpected position %x, expected: %x", token, pos+1),
 		}
+	}
+	log.Debugf("HandshakeServer: Received ACK with %d.", token)
 
-		// echo the data back
-		_, err = conn.Write(rxbuf)
-		if err != nil {
-			return err
-		}
-
-		// wait for the ack
-		if _, err = conn.Read(buf1byte); err != nil {
-			return err
-		}
-
-		if buf1byte[0] != flagAck {
-			return fmt.Errorf("lossiness check FAILED")
-		}
-		log.Infof("HandshakeServer: lossiness check PASSED")
+	// send the last ACK
+	if _, err := conn.Write([]byte{flagAck}); err != nil {
+		return err
 	}
 
 	log.Debug("HandshakeServer: Connection established.")


### PR DESCRIPTION
Client now checks the last Nak before declaring success. Otherwise server might
reject that connection attempt but client never gets it.

Also removes debugFlag, PurgeIncoming and related code.

Fixes #5015

<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[  ] There is an associated issue that is labelled
[  ] Code is up-to-date with the `master` branch
[  ] You've successfully run `make test` locally
[  ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/vmware/vic/blob/master/.github/CONTRIBUTING.md
-->

Fixes #

<!--
To trigger a custom build with this PR, include one of these in the PR's title or commit messages:
- To skip running tests (e.g. for a work-in-progress PR), add `[ci skip]` or `[skip ci]`
to the commit message or the PR title.
- To run the full test suite, use `[full ci]`.
- To run _one_ integration test or group, use `[specific ci=$test]`. Examples:
  - To run the `1-01-Docker-Info` suite: `[specific ci=1-01-Docker-Info]`
  - To run all suites under the `Group1-Docker-Commands` group: `[specific ci=Group1-Docker-Commands]`
-->
