### PR TITLE
Fix for issue: 5216, remove tight loop from bootstrap script

### DIFF
--- a/isos/bootstrap/bootstrap
+++ b/isos/bootstrap/bootstrap
@@ -26,7 +26,7 @@ MOUNTPOINT="/mnt/containerfs"
 mkdir -p /mnt/containerfs
 
 echo "Waiting for rootfs"
-while [ ! -e /dev/disk/by-label/containerfs ]; do :;done
+while [ ! -e /dev/disk/by-label/containerfs ]; do sleep 0.1;done
 if mount -t ext4 /dev/disk/by-label/containerfs ${MOUNTPOINT}; then
     # ensure mountpoint exists
     mkdir -p ${MOUNTPOINT}/.tether


### PR DESCRIPTION

Fixes # 5216
This fix has tested positively when creating and starting several containers concurrently.