### PR TITLE
[specific ci=1-11-Docker-RM] Enable Destroy_Task before calling vsphere API to remove the containerVM

### DIFF
--- a/lib/portlayer/exec/container.go
+++ b/lib/portlayer/exec/container.go
@@ -519,6 +519,9 @@ func (c *Container) Remove(ctx context.Context, sess *session.Session) error {
 		return err
 	}
 
+	// enable Destroy
+	c.vm.EnableDestroy(ctx)
+
 	//removes the vm from vsphere, but detaches the disks first
 	_, err = c.vm.WaitForResult(ctx, func(ctx context.Context) (tasks.Task, error) {
 		return c.vm.DeleteExceptDisks(ctx)

--- a/pkg/vsphere/vm/vm.go
+++ b/pkg/vsphere/vm/vm.go
@@ -618,7 +618,7 @@ func (vm *VirtualMachine) DisableDestroy(ctx context.Context) {
 	}
 }
 
-// EnableDestroy attempts to enable the VitualMachine.Destroy_Task method
+// EnableDestroy attempts to enable the VirtualMachine.Destroy_Task method
 // so that the VC UI can enable the VM "delete" action.
 func (vm *VirtualMachine) EnableDestroy(ctx context.Context) {
 	if !vm.IsVC() {

--- a/pkg/vsphere/vm/vm.go
+++ b/pkg/vsphere/vm/vm.go
@@ -38,7 +38,10 @@ import (
 	"github.com/vmware/vic/pkg/vsphere/tasks"
 )
 
-const UpdateStatus = "UpdateInProgress"
+const (
+	Destroy_Task = "Destroy_Task"
+	UpdateStatus = "UpdateInProgress"
+)
 
 type InvalidState struct {
 	r types.ManagedObjectReference
@@ -602,7 +605,7 @@ func (vm *VirtualMachine) DisableDestroy(ctx context.Context) {
 
 	method := []object.DisabledMethodRequest{
 		{
-			Method: "Destroy_Task",
+			Method: Destroy_Task,
 			Reason: "Managed by VIC Engine",
 		},
 	}
@@ -611,6 +614,23 @@ func (vm *VirtualMachine) DisableDestroy(ctx context.Context) {
 
 	err := m.DisableMethods(ctx, obj, method, "VIC")
 	if err != nil {
-		log.Warnf("failed to disable method %s for %s: %s", method[0].Method, obj[0], err)
+		log.Warnf("Failed to disable method %s for %s: %s", method[0].Method, obj[0], err)
+	}
+}
+
+// EnableDestroy attempts to enable the VitualMachine.Destroy_Task method
+// so that the VC UI can enable the VM "delete" action.
+func (vm *VirtualMachine) EnableDestroy(ctx context.Context) {
+	if !vm.IsVC() {
+		return
+	}
+
+	m := object.NewAuthorizationManager(vm.Vim25())
+
+	obj := []types.ManagedObjectReference{vm.Reference()}
+
+	err := m.EnableMethods(ctx, obj, []string{Destroy_Task}, "VIC")
+	if err != nil {
+		log.Warnf("Failed to enable Destroy_Task for %s: %s", obj[0], err)
 	}
 }

--- a/pkg/vsphere/vm/vm.go
+++ b/pkg/vsphere/vm/vm.go
@@ -39,7 +39,7 @@ import (
 )
 
 const (
-	Destroy_Task = "Destroy_Task"
+	DestroyTask  = "Destroy_Task"
 	UpdateStatus = "UpdateInProgress"
 )
 
@@ -605,7 +605,7 @@ func (vm *VirtualMachine) DisableDestroy(ctx context.Context) {
 
 	method := []object.DisabledMethodRequest{
 		{
-			Method: Destroy_Task,
+			Method: DestroyTask,
 			Reason: "Managed by VIC Engine",
 		},
 	}
@@ -629,7 +629,7 @@ func (vm *VirtualMachine) EnableDestroy(ctx context.Context) {
 
 	obj := []types.ManagedObjectReference{vm.Reference()}
 
-	err := m.EnableMethods(ctx, obj, []string{Destroy_Task}, "VIC")
+	err := m.EnableMethods(ctx, obj, []string{DestroyTask}, "VIC")
 	if err != nil {
 		log.Warnf("Failed to enable Destroy_Task for %s: %s", obj[0], err)
 	}


### PR DESCRIPTION
Fixes #5198 

In nightly test 5-4-High-Availability, the VCH throws an error of `containerRemoveInteranlServerError` when performing `docker rm -f container` after HA event.

We find that the error is reproducible ever since build 10290 which relates to PR #4965 (disable VM delete action from VC UI).

In this PR, I enable `Destroy_Task` right before calling vpshere API for container removal and it seems that the issue can be fixed by doing so.

However, we still do not understand why disabling `Destroy_Task` would affect `docker rm -f container` after HA, since disabling `Destroy_Task` is suppose to only disable/grey the VM deletion action from VC UI but not to block calling vsphere API.
