### PR TITLE
Fix tail n0 case [specific ci=1-08-Docker-Logs]

### DIFF
--- a/vendor/github.com/vmware/govmomi/object/datastore_file.go
+++ b/vendor/github.com/vmware/govmomi/object/datastore_file.go
@@ -256,18 +256,22 @@ func lastIndexLines(s []byte, line *int, include func(l int, m string) bool) (in
 
 // Tail seeks to the position of the last N lines of the file.
 func (f *DatastoreFile) Tail(n int) error {
-	return f.TailFunc(func(line int, _ string) bool { return n > line })
+	return f.TailFunc(n, func(line int, _ string) bool { return n > line })
 }
 
 // TailFunc will seek backwards in the datastore file until it hits a line that does
 // not satisfy the supplied `include` function.
-func (f *DatastoreFile) TailFunc(include func(line int, message string) bool) error {
+func (f *DatastoreFile) TailFunc(lines int, include func(line int, message string) bool) error {
 	// Read the file in reverse using bsize chunks
 	const bsize = int64(1024 * 16)
 
 	fsize, err := f.Seek(0, io.SeekEnd)
 	if err != nil {
 		return err
+	}
+
+	if lines == 0 {
+		return nil
 	}
 
 	chunk := int64(-1)

--- a/vendor/manifest
+++ b/vendor/manifest
@@ -1021,7 +1021,7 @@
 			"importpath": "github.com/vmware/govmomi",
 			"repository": "https://github.com/vmware/govmomi",
 			"vcs": "git",
-			"revision": "10e6ced96b1ee198cd65cc419bb8072677f3b750",
+			"revision": "8bff8355d10c46dcac74d3d64b2d38740f9e3dcd",
 			"branch": "master"
 		},
 		{


### PR DESCRIPTION
This fixes a bug that causes the `docker logs` test for `tail` to fail.