### PR TITLE
Add hgfs server support to toolbox

### DIFF
--- a/pkg/vsphere/toolbox/guest_info.go
+++ b/pkg/vsphere/toolbox/guest_info.go
@@ -155,8 +155,10 @@ func DefaultGuestNicInfo() *GuestNicInfo {
 			continue
 		}
 
-		nic := GuestNicV3{
-			MacAddress: i.HardwareAddr.String(),
+		nic := GuestNicV3{}
+
+		if len(i.HardwareAddr) != 0 {
+			nic.MacAddress = i.HardwareAddr.String()
 		}
 
 		addrs, _ := i.Addrs()

--- a/pkg/vsphere/toolbox/hgfs/encoding.go
+++ b/pkg/vsphere/toolbox/hgfs/encoding.go
@@ -1,0 +1,67 @@
+// Copyright 2017 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hgfs
+
+import (
+	"bytes"
+	"encoding"
+	"encoding/binary"
+)
+
+// MarshalBinary is a wrapper around binary.Write
+func MarshalBinary(fields ...interface{}) ([]byte, error) {
+	buf := new(bytes.Buffer)
+
+	for _, p := range fields {
+		switch m := p.(type) {
+		case encoding.BinaryMarshaler:
+			data, err := m.MarshalBinary()
+			if err != nil {
+				return nil, ProtocolError(err)
+			}
+
+			_, _ = buf.Write(data)
+		case []byte:
+			_, _ = buf.Write(m)
+		case string:
+			_, _ = buf.WriteString(m)
+		default:
+			err := binary.Write(buf, binary.LittleEndian, p)
+			if err != nil {
+				return nil, ProtocolError(err)
+			}
+		}
+	}
+
+	return buf.Bytes(), nil
+}
+
+// UnmarshalBinary is a wrapper around binary.Read
+func UnmarshalBinary(data []byte, fields ...interface{}) error {
+	buf := bytes.NewBuffer(data)
+
+	for _, p := range fields {
+		if m, ok := p.(encoding.BinaryUnmarshaler); ok {
+			return m.UnmarshalBinary(buf.Bytes())
+		}
+
+		err := binary.Read(buf, binary.LittleEndian, p)
+		if err != nil {
+			return ProtocolError(err)
+		}
+	}
+
+	return nil
+}

--- a/pkg/vsphere/toolbox/hgfs/hgfs_darwin.go
+++ b/pkg/vsphere/toolbox/hgfs/hgfs_darwin.go
@@ -12,41 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package toolbox
+package hgfs
 
 import (
-	"net"
-	"reflect"
-	"testing"
+	"os"
 )
 
-func TestDefaultGuestNicProto(t *testing.T) {
-	p := DefaultGuestNicInfo()
-
-	info := p.V3
-
-	for _, nic := range info.Nics {
-		if len(nic.MacAddress) == 0 {
-			continue
-		}
-		_, err := net.ParseMAC(nic.MacAddress)
-		if err != nil {
-			t.Errorf("invalid MAC %s: %s", nic.MacAddress, err)
-		}
-	}
-
-	b, err := EncodeXDR(p)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	var dp GuestNicInfo
-	err = DecodeXDR(b, &dp)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if !reflect.DeepEqual(p, &dp) {
-		t.Error("decode mismatch")
-	}
+func (a *AttrV2) sysStat(info os.FileInfo) {
 }

--- a/pkg/vsphere/toolbox/hgfs/hgfs_linux.go
+++ b/pkg/vsphere/toolbox/hgfs/hgfs_linux.go
@@ -1,0 +1,52 @@
+// Copyright 2017 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hgfs
+
+import (
+	"os"
+	"syscall"
+)
+
+const attrMask = AttrValidAllocationSize |
+	AttrValidAccessTime | AttrValidWriteTime | AttrValidCreateTime | AttrValidChangeTime |
+	AttrValidSpecialPerms | AttrValidOwnerPerms | AttrValidGroupPerms | AttrValidOtherPerms | AttrValidEffectivePerms |
+	AttrValidUserID | AttrValidGroupID | AttrValidFileID | AttrValidVolID
+
+func (a *AttrV2) sysStat(info os.FileInfo) {
+	sys := info.Sys().(*syscall.Stat_t)
+
+	a.AllocationSize = uint64(sys.Blocks * 512)
+
+	nt := func(t syscall.Timespec) uint64 {
+		return uint64(t.Nano()) // TODO: this is supposed to be Windows NT system time, not needed atm
+	}
+
+	a.AccessTime = nt(sys.Atim)
+	a.WriteTime = nt(sys.Mtim)
+	a.CreationTime = a.WriteTime // see HgfsGetCreationTime
+	a.AttrChangeTime = nt(sys.Ctim)
+
+	a.SpecialPerms = uint8((sys.Mode & (syscall.S_ISUID | syscall.S_ISGID | syscall.S_ISVTX)) >> 9)
+	a.OwnerPerms = uint8((sys.Mode & syscall.S_IRWXU) >> 6)
+	a.GroupPerms = uint8((sys.Mode & syscall.S_IRWXG) >> 3)
+	a.OtherPerms = uint8(sys.Mode & syscall.S_IRWXO)
+
+	a.UserID = sys.Uid
+	a.GroupID = sys.Gid
+	a.HostFileID = sys.Ino
+	a.VolumeID = uint32(sys.Dev)
+
+	a.Mask |= attrMask
+}

--- a/pkg/vsphere/toolbox/hgfs/hgfs_windows.go
+++ b/pkg/vsphere/toolbox/hgfs/hgfs_windows.go
@@ -12,41 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package toolbox
+package hgfs
 
 import (
-	"net"
-	"reflect"
-	"testing"
+	"os"
 )
 
-func TestDefaultGuestNicProto(t *testing.T) {
-	p := DefaultGuestNicInfo()
-
-	info := p.V3
-
-	for _, nic := range info.Nics {
-		if len(nic.MacAddress) == 0 {
-			continue
-		}
-		_, err := net.ParseMAC(nic.MacAddress)
-		if err != nil {
-			t.Errorf("invalid MAC %s: %s", nic.MacAddress, err)
-		}
-	}
-
-	b, err := EncodeXDR(p)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	var dp GuestNicInfo
-	err = DecodeXDR(b, &dp)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if !reflect.DeepEqual(p, &dp) {
-		t.Error("decode mismatch")
-	}
+func (a *AttrV2) sysStat(info os.FileInfo) {
 }

--- a/pkg/vsphere/toolbox/hgfs/protocol.go
+++ b/pkg/vsphere/toolbox/hgfs/protocol.go
@@ -1,0 +1,681 @@
+// Copyright 2017 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hgfs
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"os"
+	"strings"
+)
+
+// See: https://github.com/vmware/open-vm-tools/blob/master/open-vm-tools/lib/include/hgfsProto.h
+
+// Opcodes for server operations as defined in hgfsProto.h
+const (
+	OpOpen               = iota /* Open file */
+	OpRead                      /* Read from file */
+	OpWrite                     /* Write to file */
+	OpClose                     /* Close file */
+	OpSearchOpen                /* Start new search */
+	OpSearchRead                /* Get next search response */
+	OpSearchClose               /* End a search */
+	OpGetattr                   /* Get file attributes */
+	OpSetattr                   /* Set file attributes */
+	OpCreateDir                 /* Create new directory */
+	OpDeleteFile                /* Delete a file */
+	OpDeleteDir                 /* Delete a directory */
+	OpRename                    /* Rename a file or directory */
+	OpQueryVolumeInfo           /* Query volume information */
+	OpOpenV2                    /* Open file */
+	OpGetattrV2                 /* Get file attributes */
+	OpSetattrV2                 /* Set file attributes */
+	OpSearchReadV2              /* Get next search response */
+	OpCreateSymlink             /* Create a symlink */
+	OpServerLockChange          /* Change the oplock on a file */
+	OpCreateDirV2               /* Create a directory */
+	OpDeleteFileV2              /* Delete a file */
+	OpDeleteDirV2               /* Delete a directory */
+	OpRenameV2                  /* Rename a file or directory */
+	OpOpenV3                    /* Open file */
+	OpReadV3                    /* Read from file */
+	OpWriteV3                   /* Write to file */
+	OpCloseV3                   /* Close file */
+	OpSearchOpenV3              /* Start new search */
+	OpSearchReadV3              /* Read V3 directory entries */
+	OpSearchCloseV3             /* End a search */
+	OpGetattrV3                 /* Get file attributes */
+	OpSetattrV3                 /* Set file attributes */
+	OpCreateDirV3               /* Create new directory */
+	OpDeleteFileV3              /* Delete a file */
+	OpDeleteDirV3               /* Delete a directory */
+	OpRenameV3                  /* Rename a file or directory */
+	OpQueryVolumeInfoV3         /* Query volume information */
+	OpCreateSymlinkV3           /* Create a symlink */
+	OpServerLockChangeV3        /* Change the oplock on a file */
+	OpWriteWin32StreamV3        /* Write WIN32_STREAM_ID format data to file */
+	OpCreateSessionV4           /* Create a session and return host capabilities. */
+	OpDestroySessionV4          /* Destroy/close session. */
+	OpReadFastV4                /* Read */
+	OpWriteFastV4               /* Write */
+	OpSetWatchV4                /* Start monitoring directory changes. */
+	OpRemoveWatchV4             /* Stop monitoring directory changes. */
+	OpNotifyV4                  /* Notification for a directory change event. */
+	OpSearchReadV4              /* Read V4 directory entries. */
+	OpOpenV4                    /* Open file */
+	OpEnumerateStreamsV4        /* Enumerate alternative named streams for a file. */
+	OpGetattrV4                 /* Get file attributes */
+	OpSetattrV4                 /* Set file attributes */
+	OpDeleteV4                  /* Delete a file or a directory */
+	OpLinkmoveV4                /* Rename/move/create hard link. */
+	OpFsctlV4                   /* Sending FS control requests. */
+	OpAccessCheckV4             /* Access check. */
+	OpFsyncV4                   /* Flush all cached data to the disk. */
+	OpQueryVolumeInfoV4         /* Query volume information. */
+	OpOplockAcquireV4           /* Acquire OPLOCK. */
+	OpOplockBreakV4             /* Break or downgrade OPLOCK. */
+	OpLockByteRangeV4           /* Acquire byte range lock. */
+	OpUnlockByteRangeV4         /* Release byte range lock. */
+	OpQueryEasV4                /* Query extended attributes. */
+	OpSetEasV4                  /* Add or modify extended attributes. */
+	OpNewHeader          = 0xff /* Header op, must be unique, distinguishes packet headers. */
+)
+
+// Status codes
+const (
+	StatusSuccess = iota
+	StatusNoSuchFileOrDir
+	StatusInvalidHandle
+	StatusOperationNotPermitted
+	StatusFileExists
+	StatusNotDirectory
+	StatusDirNotEmpty
+	StatusProtocolError
+	StatusAccessDenied
+	StatusInvalidName
+	StatusGenericError
+	StatusSharingViolation
+	StatusNoSpace
+	StatusOperationNotSupported
+	StatusNameTooLong
+	StatusInvalidParameter
+	StatusNotSameDevice
+	StatusStaleSession
+	StatusTooManySessions
+	StatusTransportError
+)
+
+// Flags for attr mask
+const (
+	AttrValidType = 1 << iota
+	AttrValidSize
+	AttrValidCreateTime
+	AttrValidAccessTime
+	AttrValidWriteTime
+	AttrValidChangeTime
+	AttrValidSpecialPerms
+	AttrValidOwnerPerms
+	AttrValidGroupPerms
+	AttrValidOtherPerms
+	AttrValidFlags
+	AttrValidAllocationSize
+	AttrValidUserID
+	AttrValidGroupID
+	AttrValidFileID
+	AttrValidVolID
+	AttrValidNonStaticFileID
+	AttrValidEffectivePerms
+	AttrValidExtendAttrSize
+	AttrValidReparsePoint
+	AttrValidShortName
+)
+
+// HeaderVersion for HGFS protocol version 4
+const HeaderVersion = 0x1
+
+// Packet flags
+const (
+	PacketFlagRequest = 1 << iota
+	PacketFlagReply
+	PacketFlagInfoExterror
+	PacketFlagValidFlags = 0x7
+)
+
+// Status is an error type that encapsulates an error status code and the cause
+type Status struct {
+	Err  error
+	Code uint32
+}
+
+func (s *Status) Error() string {
+	if s.Err != nil {
+		return s.Err.Error()
+	}
+
+	return fmt.Sprintf("status=%d", s.Code)
+}
+
+// errorStatus maps the given error type to a status code
+func errorStatus(err error) uint32 {
+	if x, ok := err.(*Status); ok {
+		return x.Code
+	}
+
+	switch {
+	case os.IsNotExist(err):
+		return StatusNoSuchFileOrDir
+	case os.IsExist(err):
+		return StatusFileExists
+	case os.IsPermission(err):
+		return StatusOperationNotPermitted
+	}
+
+	return StatusGenericError
+}
+
+// ProtocolError wraps the given error as a Status type
+func ProtocolError(err error) error {
+	return &Status{
+		Err:  err,
+		Code: StatusProtocolError,
+	}
+}
+
+// Request as defined in hgfsProto.h:HgfsRequest
+type Request struct {
+	Handle uint32
+	Op     int32
+}
+
+// Reply as defined in hgfsProto.h:HgfsReply
+type Reply struct {
+	Handle uint32
+	Status uint32
+}
+
+// Header as defined in hgfsProto.h:HgfsHeader
+type Header struct {
+	Version     uint8
+	Reserved1   [3]uint8
+	Dummy       int32
+	PacketSize  uint32
+	HeaderSize  uint32
+	RequestID   uint32
+	Op          int32
+	Status      uint32
+	Flags       uint32
+	Information uint32
+	SessionID   uint64
+	Reserved    uint64
+}
+
+var (
+	headerSize = uint32(binary.Size(new(Header)))
+
+	packetSize = func(r *Packet) uint32 {
+		return headerSize + uint32(len(r.Payload))
+	}
+)
+
+// UnmarshalBinary implements the encoding.BinaryUnmarshaler interface
+func (h *Header) UnmarshalBinary(data []byte) error {
+	buf := bytes.NewBuffer(data)
+
+	err := binary.Read(buf, binary.LittleEndian, h)
+	if err != nil {
+		return fmt.Errorf("reading hgfs header: %s", err)
+	}
+
+	if h.Dummy != OpNewHeader {
+		return fmt.Errorf("expected hgfs header with OpNewHeader (%#x), got: %#x", OpNewHeader, h.Dummy)
+	}
+
+	return nil
+}
+
+// Packet encapsulates an hgfs Header and Payload
+type Packet struct {
+	Header
+
+	Payload []byte
+}
+
+// Reply composes a new Packet with the given payload or error
+func (r *Packet) Reply(payload interface{}, err error) ([]byte, error) {
+	p := new(Packet)
+
+	status := uint32(StatusSuccess)
+
+	if err != nil {
+		status = errorStatus(err)
+	} else {
+		p.Payload, err = MarshalBinary(payload)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	p.Header = Header{
+		Version:     HeaderVersion,
+		Dummy:       OpNewHeader,
+		PacketSize:  headerSize + uint32(len(p.Payload)),
+		HeaderSize:  headerSize,
+		RequestID:   r.RequestID,
+		Op:          r.Op,
+		Status:      status,
+		Flags:       PacketFlagReply,
+		Information: 0,
+		SessionID:   r.SessionID,
+	}
+
+	if Trace {
+		fmt.Fprintf(os.Stderr, "[hgfs] response %#v\n", p.Header)
+	}
+
+	return p.MarshalBinary()
+}
+
+// MarshalBinary implements the encoding.BinaryMarshaler interface
+func (r *Packet) MarshalBinary() ([]byte, error) {
+	r.Header.PacketSize = packetSize(r)
+
+	buf, _ := MarshalBinary(r.Header)
+
+	return append(buf, r.Payload...), nil
+}
+
+// UnmarshalBinary implements the encoding.BinaryUnmarshaler interface
+func (r *Packet) UnmarshalBinary(data []byte) error {
+	err := r.Header.UnmarshalBinary(data)
+	if err != nil {
+		return err
+	}
+
+	r.Payload = data[r.HeaderSize:r.PacketSize]
+
+	return nil
+}
+
+// Capability as defined in hgfsProto.h:HgfsCapability
+type Capability struct {
+	Op    int32
+	Flags uint32
+}
+
+// RequestCreateSessionV4 as defined in hgfsProto.h:HgfsRequestCreateSessionV4
+type RequestCreateSessionV4 struct {
+	NumCapabilities uint32
+	MaxPacketSize   uint32
+	Flags           uint32
+	Reserved        uint32
+	Capabilities    []Capability
+}
+
+// MarshalBinary implements the encoding.BinaryMarshaler interface
+func (r *RequestCreateSessionV4) MarshalBinary() ([]byte, error) {
+	buf := new(bytes.Buffer)
+
+	r.NumCapabilities = uint32(len(r.Capabilities))
+
+	fields := []*uint32{
+		&r.NumCapabilities,
+		&r.MaxPacketSize,
+		&r.Flags,
+		&r.Reserved,
+	}
+
+	for _, p := range fields {
+		err := binary.Write(buf, binary.LittleEndian, p)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	for i := uint32(0); i < r.NumCapabilities; i++ {
+		err := binary.Write(buf, binary.LittleEndian, &r.Capabilities[i])
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return buf.Bytes(), nil
+}
+
+// UnmarshalBinary implements the encoding.BinaryUnmarshaler interface
+func (r *RequestCreateSessionV4) UnmarshalBinary(data []byte) error {
+	buf := bytes.NewBuffer(data)
+
+	fields := []*uint32{
+		&r.NumCapabilities,
+		&r.MaxPacketSize,
+		&r.Flags,
+		&r.Reserved,
+	}
+
+	for _, p := range fields {
+		err := binary.Read(buf, binary.LittleEndian, p)
+		if err != nil {
+			return err
+		}
+	}
+
+	for i := uint32(0); i < r.NumCapabilities; i++ {
+		var cap Capability
+		err := binary.Read(buf, binary.LittleEndian, &cap)
+		if err != nil {
+			return err
+		}
+
+		r.Capabilities = append(r.Capabilities, cap)
+	}
+
+	return nil
+}
+
+// ReplyCreateSessionV4 as defined in hgfsProto.h:HgfsReplyCreateSessionV4
+type ReplyCreateSessionV4 struct {
+	SessionID       uint64
+	NumCapabilities uint32
+	MaxPacketSize   uint32
+	IdentityOffset  uint32
+	Flags           uint32
+	Reserved        uint32
+	Capabilities    []Capability
+}
+
+// MarshalBinary implements the encoding.BinaryMarshaler interface
+func (r *ReplyCreateSessionV4) MarshalBinary() ([]byte, error) {
+	buf := new(bytes.Buffer)
+
+	fields := []interface{}{
+		&r.SessionID,
+		&r.NumCapabilities,
+		&r.MaxPacketSize,
+		&r.IdentityOffset,
+		&r.Flags,
+		&r.Reserved,
+	}
+
+	for _, p := range fields {
+		err := binary.Write(buf, binary.LittleEndian, p)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	for i := uint32(0); i < r.NumCapabilities; i++ {
+		err := binary.Write(buf, binary.LittleEndian, &r.Capabilities[i])
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return buf.Bytes(), nil
+}
+
+// UnmarshalBinary implements the encoding.BinaryUnmarshaler interface
+func (r *ReplyCreateSessionV4) UnmarshalBinary(data []byte) error {
+	buf := bytes.NewBuffer(data)
+
+	fields := []interface{}{
+		&r.SessionID,
+		&r.NumCapabilities,
+		&r.MaxPacketSize,
+		&r.IdentityOffset,
+		&r.Flags,
+		&r.Reserved,
+	}
+
+	for _, p := range fields {
+		err := binary.Read(buf, binary.LittleEndian, p)
+		if err != nil {
+			return err
+		}
+	}
+
+	for i := uint32(0); i < r.NumCapabilities; i++ {
+		var cap Capability
+		err := binary.Read(buf, binary.LittleEndian, &cap)
+		if err != nil {
+			return err
+		}
+
+		r.Capabilities = append(r.Capabilities, cap)
+	}
+
+	return nil
+}
+
+// RequestDestroySessionV4 as defined in hgfsProto.h:HgfsRequestDestroySessionV4
+type RequestDestroySessionV4 struct {
+	Reserved uint64
+}
+
+// ReplyDestroySessionV4 as defined in hgfsProto.h:HgfsReplyDestroySessionV4
+type ReplyDestroySessionV4 struct {
+	Reserved uint64
+}
+
+// FileName as defined in hgfsProto.h:HgfsFileName
+type FileName struct {
+	Length uint32
+	Name   string
+}
+
+// MarshalBinary implements the encoding.BinaryMarshaler interface
+func (f *FileName) MarshalBinary() ([]byte, error) {
+	name := f.Name
+	f.Length = uint32(len(f.Name))
+	if f.Length == 0 {
+		// field is defined as 'char name[1];', this byte is required for min sizeof() validation
+		name = "\x00"
+	}
+	return MarshalBinary(&f.Length, name)
+}
+
+// UnmarshalBinary implements the encoding.BinaryUnmarshaler interface
+func (f *FileName) UnmarshalBinary(data []byte) error {
+	buf := bytes.NewBuffer(data)
+
+	_ = binary.Read(buf, binary.LittleEndian, &f.Length)
+
+	f.Name = string(buf.Next(int(f.Length)))
+
+	return nil
+}
+
+const serverPolicyRootShareName = "root"
+
+// FromString converts name to a FileName
+func (f *FileName) FromString(name string) {
+	name = strings.TrimPrefix(name, "/")
+
+	cp := strings.Split(name, "/")
+
+	cp = append([]string{serverPolicyRootShareName}, cp...)
+
+	f.Name = strings.Join(cp, "\x00")
+	f.Length = uint32(len(f.Name))
+}
+
+// Path converts FileName to a string
+func (f *FileName) Path() string {
+	cp := strings.Split(f.Name, "\x00")
+
+	if len(cp) == 0 || cp[0] != serverPolicyRootShareName {
+		return "" // TODO: not happening until if/when we handle Windows shares
+	}
+
+	cp[0] = ""
+
+	return strings.Join(cp, "/")
+}
+
+// FileType
+const (
+	FileTypeRegular = iota
+	FileTypeDirectory
+	FileTypeSymlink
+)
+
+// AttrV2 as defined in hgfsProto.h:HgfsAttrV2
+type AttrV2 struct {
+	Mask           uint64
+	Type           int32
+	Size           uint64
+	CreationTime   uint64
+	AccessTime     uint64
+	WriteTime      uint64
+	AttrChangeTime uint64
+	SpecialPerms   uint8
+	OwnerPerms     uint8
+	GroupPerms     uint8
+	OtherPerms     uint8
+	AttrFlags      uint64
+	AllocationSize uint64
+	UserID         uint32
+	GroupID        uint32
+	HostFileID     uint64
+	VolumeID       uint32
+	EffectivePerms uint32
+	Reserved2      uint64
+}
+
+// RequestGetattrV2 as defined in hgfsProto.h:HgfsRequestGetattrV2
+type RequestGetattrV2 struct {
+	Request
+	AttrHint uint64
+	Handle   uint32
+	FileName FileName
+}
+
+// MarshalBinary implements the encoding.BinaryMarshaler interface
+func (r *RequestGetattrV2) MarshalBinary() ([]byte, error) {
+	return MarshalBinary(&r.Request, &r.AttrHint, &r.Handle, &r.FileName)
+}
+
+// UnmarshalBinary implements the encoding.BinaryUnmarshaler interface
+func (r *RequestGetattrV2) UnmarshalBinary(data []byte) error {
+	return UnmarshalBinary(data, &r.Request, &r.AttrHint, &r.Handle, &r.FileName)
+}
+
+// ReplyGetattrV2 as defined in hgfsProto.h:HgfsReplyGetattrV2
+type ReplyGetattrV2 struct {
+	Reply
+	Attr          AttrV2
+	SymlinkTarget FileName
+}
+
+// MarshalBinary implements the encoding.BinaryMarshaler interface
+func (r *ReplyGetattrV2) MarshalBinary() ([]byte, error) {
+	return MarshalBinary(&r.Reply, &r.Attr, &r.SymlinkTarget)
+}
+
+// UnmarshalBinary implements the encoding.BinaryUnmarshaler interface
+func (r *ReplyGetattrV2) UnmarshalBinary(data []byte) error {
+	return UnmarshalBinary(data, &r.Reply, &r.Attr, &r.SymlinkTarget)
+}
+
+// OpenMode
+const (
+	OpenModeReadOnly = iota
+	OpenModeWriteOnly
+	OpenModeReadWrite
+	OpenModeAccmodes
+)
+
+// OpenFlags
+const (
+	Open = iota
+	OpenEmpty
+	OpenCreate
+	OpenCreateSafe
+	OpenCreateEmpty
+)
+
+// Permissions
+const (
+	PermRead  = 4
+	PermWrite = 2
+	PermExec  = 1
+)
+
+// RequestOpen as defined in hgfsProto.h:HgfsRequestOpen
+type RequestOpen struct {
+	Request
+	OpenMode    int32
+	OpenFlags   int32
+	Permissions uint8
+	FileName    FileName
+}
+
+// MarshalBinary implements the encoding.BinaryMarshaler interface
+func (r *RequestOpen) MarshalBinary() ([]byte, error) {
+	return MarshalBinary(&r.Request, &r.OpenMode, &r.OpenFlags, r.Permissions, &r.FileName)
+}
+
+// UnmarshalBinary implements the encoding.BinaryUnmarshaler interface
+func (r *RequestOpen) UnmarshalBinary(data []byte) error {
+	return UnmarshalBinary(data, &r.Request, &r.OpenMode, &r.OpenFlags, &r.Permissions, &r.FileName)
+}
+
+// ReplyOpen as defined in hgfsProto.h:HgfsReplyOpen
+type ReplyOpen struct {
+	Reply
+	Handle uint32
+}
+
+// RequestClose as defined in hgfsProto.h:HgfsRequestClose
+type RequestClose struct {
+	Request
+	Handle uint32
+}
+
+// ReplyClose as defined in hgfsProto.h:HgfsReplyClose
+type ReplyClose struct {
+	Reply
+}
+
+// RequestReadV3 as defined in hgfsProto.h:HgfsRequestReadV3
+type RequestReadV3 struct {
+	Handle       uint32
+	Offset       uint64
+	RequiredSize uint32
+	Reserved     uint64
+}
+
+// ReplyReadV3 as defined in hgfsProto.h:HgfsReplyReadV3
+type ReplyReadV3 struct {
+	ActualSize uint32
+	Reserved   uint64
+	Payload    []byte
+}
+
+// MarshalBinary implements the encoding.BinaryMarshaler interface
+func (r *ReplyReadV3) MarshalBinary() ([]byte, error) {
+	return MarshalBinary(&r.ActualSize, &r.Reserved, r.Payload)
+}
+
+// UnmarshalBinary implements the encoding.BinaryUnmarshaler interface
+func (r *ReplyReadV3) UnmarshalBinary(data []byte) error {
+	buf := bytes.NewBuffer(data)
+
+	_ = binary.Read(buf, binary.LittleEndian, &r.ActualSize)
+	_ = binary.Read(buf, binary.LittleEndian, &r.Reserved)
+	r.Payload = buf.Bytes()
+
+	return nil
+}

--- a/pkg/vsphere/toolbox/hgfs/protocol_test.go
+++ b/pkg/vsphere/toolbox/hgfs/protocol_test.go
@@ -1,0 +1,151 @@
+// Copyright 2017 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hgfs
+
+import (
+	"bytes"
+	"encoding/base64"
+	"testing"
+)
+
+func TestProtocolEncoding(t *testing.T) {
+	ps := packetSize
+	defer func() {
+		packetSize = ps
+	}()
+
+	// a few structs have pading of some sort, leave PacketSize as-is for now with these tests
+	packetSize = func(r *Packet) uint32 {
+		return r.PacketSize
+	}
+
+	decode := func(s string) []byte {
+		b, _ := base64.StdEncoding.DecodeString(s)
+		return b
+	}
+
+	// base64 encoded packets below were captured from vmtoolsd during:
+	// govc guest.download /etc/hosts -
+	tests := []struct {
+		pkt string
+		dec interface{}
+	}{
+		{
+			"AQAAAP8AAABMAAAANAAAAAAAAIApAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA+AAAAAAAAAAAAAAAAAAAAAAAAA==",
+			new(RequestCreateSessionV4),
+		},
+		{
+			"AQAAAP8AAABYAgAANAAAAAAAAIApAAAAAAAAAAIAAAAAAAAA//////////8AAAAAAAAAAF/NcjwZ1DYAQQAAAAD4AAAAAAAAAQAAAAAAAAAAAAAAAQAAAAEAAAABAAAAAgAAAAEAAAADAAAAAQAAAAQAAAABAAAABQAAAAEAAAAGAAAAAQAAAAcAAAABAAAACAAAAAEAAAAJAAAAAQAAAAoAAAABAAAACwAAAAEAAAAMAAAAAQAAAA0AAAABAAAADgAAAAEAAAAPAAAAAQAAABAAAAABAAAAEQAAAAEAAAASAAAAAQAAABMAAAAAAAAAFAAAAAEAAAAVAAAAAQAAABYAAAABAAAAFwAAAAEAAAAYAAAAAQAAABkAAAABAAAAGgAAAAEAAAAbAAAAAQAAABwAAAABAAAAHQAAAAEAAAAeAAAAAQAAAB8AAAABAAAAIAAAAAEAAAAhAAAAAQAAACIAAAABAAAAIwAAAAEAAAAkAAAAAQAAACUAAAABAAAAJgAAAAEAAAAnAAAAAAAAACgAAAAAAAAAKQAAAAEAAAAqAAAAAQAAACsAAAAAAAAALAAAAAAAAAAtAAAAAAAAAC4AAAAAAAAALwAAAAAAAAAwAAAAAAAAADEAAAAAAAAAMgAAAAAAAAAzAAAAAAAAADQAAAAAAAAANQAAAAAAAAA2AAAAAAAAADcAAAAAAAAAOAAAAAAAAAA5AAAAAAAAADoAAAAAAAAAOwAAAAAAAAA8AAAAAAAAAD0AAAAAAAAAPgAAAAAAAAA/AAAAAAAAAEAAAAAAAAAA",
+			new(ReplyCreateSessionV4),
+		},
+		{
+			"AQAAAP8AAABbAAAANAAAAAAAAIAPAAAAAAAAAAEAAAAAAAAAX81yPBnUNgAAAAAAAAAAAAAAAIAPAAAAAAAAAAAAAAAAAACADgAAAHJvb3QAZXRjAGhvc3RzAA==",
+			new(RequestGetattrV2),
+		},
+		{
+			"AQAAAP8AAACpAAAANAAAAAAAAIAPAAAAAAAAAAIAAAAAAAAAX81yPBnUNgAAAAAAAAAAAAAAAAAAAAAA//sCAAAAAAAAAAAAxgAAAAAAAABkP/0QmUzSAaAHo3qfz9IBZD/9EJlM0gFkP/0QmUzSAQAGBAQAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAABY9xMAAAAAAAD8AAAEAAAAAAAAAAAAAAAAAAAAAA==",
+			new(ReplyGetattrV2),
+		},
+		{
+			"AQAAAP8AAABYAAAANAAAAAAAAIAAAAAAAAAAAAEAAAAAAAAAX81yPBnUNgAAAAAAAAAAAAAAAIAAAAAAAAAAAAAAAAAGDgAAAHJvb3QAZXRjAGhvc3Rzcw==",
+			new(RequestOpen),
+		},
+		{
+			"AQAAAP8AAABAAAAANAAAAAAAAIAAAAAAAAAAAAIAAAAAAAAAX81yPBnUNgAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+			new(ReplyOpen),
+		},
+		{
+			"AQAAAP8AAABMAAAANAAAAAAAAIAZAAAAAAAAAAEAAAAAAAAAX81yPBnUNgAAAAAAAAAAAAAAAAAAAAAAAAAAAADwAAAAAAAAAAAAAA==",
+			new(RequestReadV3),
+		},
+		{
+			"AQAAAP8AAAAHAQAANAAAAAAAAIAZAAAAAAAAAAIAAAAAAAAAX81yPBnUNgAAAAAAAAAAAMYAAAAAAAAAAAAAADEyNy4wLjAuMQlsb2NhbGhvc3QKMTI3LjAuMS4xCXZhZ3JhbnQudm0JdmFncmFudAoKIyBUaGUgZm9sbG93aW5nIGxpbmVzIGFyZSBkZXNpcmFibGUgZm9yIElQdjYgY2FwYWJsZSBob3N0cwo6OjEgICAgIGxvY2FsaG9zdCBpcDYtbG9jYWxob3N0IGlwNi1sb29wYmFjawpmZjAyOjoxIGlwNi1hbGxub2RlcwpmZjAyOjoyIGlwNi1hbGxyb3V0ZXJzCgA=",
+			new(ReplyReadV3),
+		},
+		{
+			"AQAAAP8AAABAAAAANAAAAAAAAIADAAAAAAAAAAEAAAAAAAAAX81yPBnUNgAAAAAAAAAAAAAAAIADAAAAAAAAAA==",
+			new(RequestClose),
+		},
+		{
+			"AQAAAP8AAAA8AAAANAAAAAAAAIADAAAAAAAAAAIAAAAAAAAAX81yPBnUNgAAAAAAAAAAAAAAAAAAAAAA",
+			new(ReplyClose),
+		},
+		{
+			"AQAAAP8AAAA8AAAANAAAAAAAAIAqAAAAAAAAAAEAAAAAAAAAX81yPBnUNgAAAAAAAAAAAAAAAAAAAAAA",
+			new(RequestDestroySessionV4),
+		},
+		{
+			"AQAAAP8AAAA8AAAANAAAAAAAAIAqAAAAAAAAAAIAAAAAAAAAX81yPBnUNgAAAAAAAAAAAAAAAAAAAAAA",
+			new(ReplyDestroySessionV4),
+		},
+	}
+
+	for i, test := range tests {
+		dec := decode(test.pkt)
+		pkt := new(Packet)
+		err := pkt.UnmarshalBinary(dec)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		err = UnmarshalBinary(pkt.Payload, test.dec)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		pkt.Payload, err = MarshalBinary(test.dec)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		enc, err := pkt.MarshalBinary()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if !bytes.HasPrefix(dec, enc) {
+			t.Errorf("%d: %T != %s\n", i, test.dec, test.pkt)
+		}
+	}
+}
+
+func TestFileName(t *testing.T) {
+	tests := []struct {
+		raw  string
+		name string
+	}{
+		{
+			"root\x00etc\x00hosts",
+			"/etc/hosts",
+		},
+	}
+
+	for i, test := range tests {
+		fn := FileName{
+			Name:   test.raw,
+			Length: uint32(len(test.raw)),
+		}
+
+		if fn.Path() != test.name {
+			t.Errorf("%d: %q != %q", i, fn.Path(), test.name)
+		}
+
+		var fs FileName
+		fs.FromString(test.name)
+		if fs != fn {
+			t.Errorf("%d: %v != %v", i, fn, fs)
+		}
+	}
+}

--- a/pkg/vsphere/toolbox/hgfs/server.go
+++ b/pkg/vsphere/toolbox/hgfs/server.go
@@ -1,0 +1,342 @@
+// Copyright 2017 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hgfs
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"log"
+	"math/rand"
+	"os"
+	"strconv"
+	"sync"
+	"sync/atomic"
+)
+
+// See: https://github.com/vmware/open-vm-tools/blob/master/open-vm-tools/lib/hgfsServer/hgfsServer.c
+
+var (
+	// Trace enables hgfs packet tracing
+	Trace = false
+)
+
+// Server provides an HGFS protocol implementation to support guest tools VmxiHgfsSendPacketCommand
+type Server struct {
+	Capabilities []Capability
+
+	handlers map[int32]func(*Packet) (interface{}, error)
+	sessions map[uint64]*session
+	mu       sync.Mutex
+	handle   uint32
+}
+
+// NewServer creates a new Server instance with the default handlers
+func NewServer() *Server {
+	if f := flag.Lookup("toolbox.trace"); f != nil {
+		Trace, _ = strconv.ParseBool(f.Value.String())
+	}
+
+	s := &Server{
+		sessions: make(map[uint64]*session),
+	}
+
+	s.handlers = map[int32]func(*Packet) (interface{}, error){
+		OpCreateSessionV4:  s.CreateSessionV4,
+		OpDestroySessionV4: s.DestroySessionV4,
+		OpGetattrV2:        s.GetattrV2,
+		OpOpen:             s.Open,
+		OpClose:            s.Close,
+		OpReadV3:           s.ReadV3,
+	}
+
+	for op := range s.handlers {
+		s.Capabilities = append(s.Capabilities, Capability{Op: op, Flags: 0x1})
+	}
+
+	return s
+}
+
+// Dispatch unpacks the given request packet and dispatches to the appropriate handler
+func (s *Server) Dispatch(packet []byte) ([]byte, error) {
+	req := &Packet{}
+
+	err := req.UnmarshalBinary(packet)
+	if err != nil {
+		return nil, err
+	}
+
+	if Trace {
+		fmt.Fprintf(os.Stderr, "[hgfs] request  %#v\n", req.Header)
+	}
+
+	var res interface{}
+
+	handler, ok := s.handlers[req.Op]
+	if ok {
+		res, err = handler(req)
+	} else {
+		err = &Status{
+			Code: StatusOperationNotSupported,
+			Err:  fmt.Errorf("unsupported Op(%d)", req.Op),
+		}
+	}
+
+	return req.Reply(res, err)
+}
+
+type session struct {
+	files map[uint32]*os.File
+	mu    sync.Mutex
+}
+
+// TODO: we currently depend on the VMX to close files and remove sessions,
+// which it does provided it can communicate with the toolbox.  Let's look at
+// adding session expiration when implementing OpenModeWriteOnly support.
+func newSession() *session {
+	return &session{
+		files: make(map[uint32]*os.File),
+	}
+}
+
+func (s *Server) getSession(p *Packet) (*session, error) {
+	s.mu.Lock()
+	session, ok := s.sessions[p.SessionID]
+	s.mu.Unlock()
+
+	if !ok {
+		return nil, &Status{
+			Code: StatusStaleSession,
+			Err:  errors.New("session not found"),
+		}
+	}
+
+	return session, nil
+}
+
+func (s *Server) removeSession(id uint64) bool {
+	s.mu.Lock()
+	session, ok := s.sessions[id]
+	delete(s.sessions, id)
+	s.mu.Unlock()
+
+	if !ok {
+		return false
+	}
+
+	session.mu.Lock()
+	defer session.mu.Unlock()
+
+	for _, f := range session.files {
+		log.Printf("[hgfs] session %X removed with open file: %s", id, f.Name())
+		_ = f.Close()
+	}
+
+	return true
+}
+
+// open-vm-tools' session max is 1024, there shouldn't be more than a handful at a given time in our use cases
+const maxSessions = 24
+
+// CreateSessionV4 handls OpCreateSessionV4 requests
+func (s *Server) CreateSessionV4(p *Packet) (interface{}, error) {
+	const SessionMaxPacketSizeValid = 0x1
+
+	req := new(RequestCreateSessionV4)
+	err := UnmarshalBinary(p.Payload, req)
+	if err != nil {
+		return nil, err
+	}
+
+	res := &ReplyCreateSessionV4{
+		SessionID:       uint64(rand.Int63()),
+		NumCapabilities: uint32(len(s.Capabilities)),
+		MaxPacketSize:   0xf800, // HGFS_LARGE_PACKET_MAX
+		Flags:           SessionMaxPacketSizeValid,
+		Capabilities:    s.Capabilities,
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if len(s.sessions) > maxSessions {
+		return nil, &Status{Code: StatusTooManySessions}
+	}
+
+	s.sessions[res.SessionID] = newSession()
+
+	return res, nil
+}
+
+// DestroySessionV4 handls OpDestroySessionV4 requests
+func (s *Server) DestroySessionV4(p *Packet) (interface{}, error) {
+	if s.removeSession(p.SessionID) {
+		return &ReplyDestroySessionV4{}, nil
+	}
+
+	return nil, &Status{Code: StatusStaleSession}
+}
+
+// Stat maps os.FileInfo to AttrV2
+func (a *AttrV2) Stat(info os.FileInfo) {
+	switch {
+	case info.IsDir():
+		a.Type = FileTypeDirectory
+	case info.Mode()&os.ModeSymlink == os.ModeSymlink:
+		a.Type = FileTypeSymlink
+	default:
+		a.Type = FileTypeRegular
+	}
+
+	a.Size = uint64(info.Size())
+
+	a.Mask = AttrValidType | AttrValidSize
+
+	a.sysStat(info)
+}
+
+// GetattrV2 handles OpGetattrV2 requests
+func (s *Server) GetattrV2(p *Packet) (interface{}, error) {
+	res := &ReplyGetattrV2{}
+
+	req := new(RequestGetattrV2)
+	err := UnmarshalBinary(p.Payload, req)
+	if err != nil {
+		return nil, err
+	}
+
+	name := req.FileName.Path()
+	info, err := os.Stat(name)
+	if err != nil {
+		return nil, err
+	}
+
+	res.Attr.Stat(info)
+
+	return res, nil
+}
+
+func (s *Server) newHandle() uint32 {
+	return atomic.AddUint32(&s.handle, 1)
+}
+
+// Open handles OpOpen requests
+func (s *Server) Open(p *Packet) (interface{}, error) {
+	req := new(RequestOpen)
+	err := UnmarshalBinary(p.Payload, req)
+	if err != nil {
+		return nil, err
+	}
+
+	session, err := s.getSession(p)
+	if err != nil {
+		return nil, err
+	}
+
+	name := req.FileName.Path()
+
+	var file *os.File
+
+	switch req.OpenMode {
+	case OpenModeReadOnly:
+		file, err = os.Open(name)
+	default:
+		err = &Status{
+			Err:  fmt.Errorf("open mode(%d) not supported for file %q", req.OpenMode, name),
+			Code: StatusAccessDenied,
+		}
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	res := &ReplyOpen{
+		Handle: s.newHandle(),
+	}
+
+	session.mu.Lock()
+	session.files[res.Handle] = file
+	session.mu.Unlock()
+
+	return res, nil
+}
+
+// Close handles OpClose requests
+func (s *Server) Close(p *Packet) (interface{}, error) {
+	req := new(RequestClose)
+	err := UnmarshalBinary(p.Payload, req)
+	if err != nil {
+		return nil, err
+	}
+
+	session, err := s.getSession(p)
+	if err != nil {
+		return nil, err
+	}
+
+	session.mu.Lock()
+	file, ok := session.files[req.Handle]
+	if ok {
+		delete(session.files, req.Handle)
+	}
+	session.mu.Unlock()
+
+	if ok {
+		err = file.Close()
+	} else {
+		return nil, &Status{Code: StatusInvalidHandle}
+	}
+
+	return &ReplyClose{}, err
+}
+
+// ReadV3 handles OpReadV3 requests
+func (s *Server) ReadV3(p *Packet) (interface{}, error) {
+	req := new(RequestReadV3)
+	err := UnmarshalBinary(p.Payload, req)
+	if err != nil {
+		return nil, err
+	}
+
+	session, err := s.getSession(p)
+	if err != nil {
+		return nil, err
+	}
+
+	session.mu.Lock()
+	file, ok := session.files[req.Handle]
+	session.mu.Unlock()
+
+	if !ok {
+		return nil, &Status{Code: StatusInvalidHandle}
+	}
+
+	buf := make([]byte, req.RequiredSize)
+
+	n, err := file.ReadAt(buf, int64(req.Offset))
+	if err != nil {
+		if err != io.EOF || n <= 0 {
+			return nil, err
+		}
+	}
+
+	res := &ReplyReadV3{
+		ActualSize: uint32(n),
+		Payload:    buf[:n],
+	}
+
+	return res, nil
+}

--- a/pkg/vsphere/toolbox/hgfs/server_test.go
+++ b/pkg/vsphere/toolbox/hgfs/server_test.go
@@ -1,0 +1,299 @@
+// Copyright 2017 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hgfs
+
+import (
+	"fmt"
+	"os"
+	"path"
+	"testing"
+)
+
+type Client struct {
+	s         *Server
+	SessionID uint64
+}
+
+func NewClient() *Client {
+	return &Client{
+		s: NewServer(),
+	}
+}
+
+func (c *Client) Dispatch(op int32, req interface{}, res interface{}) *Packet {
+	var err error
+	p := new(Packet)
+	p.Payload, err = MarshalBinary(req)
+	if err != nil {
+		panic(err)
+	}
+
+	p.Header.Version = 0x1
+	p.Header.Dummy = OpNewHeader
+	p.Header.HeaderSize = headerSize
+	p.Header.PacketSize = headerSize + uint32(len(p.Payload))
+	p.Header.SessionID = c.SessionID
+	p.Header.Op = op
+
+	data, err := p.MarshalBinary()
+	if err != nil {
+		panic(err)
+	}
+
+	data, err = c.s.Dispatch(data)
+	if err != nil {
+		panic(err)
+	}
+
+	p = new(Packet)
+	err = p.UnmarshalBinary(data)
+	if err != nil {
+		panic(err)
+	}
+
+	if p.Status == StatusSuccess {
+		err = UnmarshalBinary(p.Payload, res)
+		if err != nil {
+			panic(err)
+		}
+	}
+
+	return p
+}
+
+func (c *Client) CreateSession() uint32 {
+	req := new(RequestCreateSessionV4)
+	res := new(ReplyCreateSessionV4)
+
+	p := c.Dispatch(OpCreateSessionV4, req, res)
+
+	if p.Status == StatusSuccess {
+		c.SessionID = res.SessionID
+	}
+
+	return p.Status
+}
+
+func (c *Client) DestroySession() uint32 {
+	req := new(RequestDestroySessionV4)
+	res := new(ReplyDestroySessionV4)
+
+	return c.Dispatch(OpDestroySessionV4, req, res).Status
+}
+
+func (c *Client) GetAttr(name string) (*AttrV2, uint32) {
+	req := new(RequestGetattrV2)
+	res := new(ReplyGetattrV2)
+
+	req.FileName.FromString(name)
+
+	p := c.Dispatch(OpGetattrV2, req, res)
+
+	if p.Status != StatusSuccess {
+		return nil, p.Status
+	}
+
+	return &res.Attr, p.Status
+}
+
+func (c *Client) Open(name string, write ...bool) (uint32, uint32) {
+	req := new(RequestOpen)
+	res := new(ReplyOpen)
+
+	if len(write) == 1 && write[0] {
+		req.OpenMode = OpenModeWriteOnly
+	}
+
+	req.FileName.FromString(name)
+
+	p := c.Dispatch(OpOpen, req, res)
+	if p.Status != StatusSuccess {
+		return 0, p.Status
+	}
+
+	return res.Handle, p.Status
+}
+
+func (c *Client) Close(handle uint32) uint32 {
+	req := new(RequestClose)
+	res := new(ReplyClose)
+
+	req.Handle = handle
+
+	return c.Dispatch(OpClose, req, res).Status
+}
+
+func TestStaleSession(t *testing.T) {
+	c := NewClient()
+
+	// list of methods that can return StatusStaleSession
+	invalid := []func() uint32{
+		func() uint32 { _, status := c.Open("enoent"); return status },
+		func() uint32 { return c.Dispatch(OpReadV3, new(RequestReadV3), new(ReplyReadV3)).Status },
+		func() uint32 { return c.Close(0) },
+		c.DestroySession,
+	}
+
+	for i, f := range invalid {
+		status := f()
+		if status != StatusStaleSession {
+			t.Errorf("%d: status=%d", i, status)
+		}
+	}
+}
+
+func TestSessionMax(t *testing.T) {
+	c := NewClient()
+	var status uint32
+
+	for i := 0; i <= maxSessions+1; i++ {
+		status = c.CreateSession()
+	}
+
+	if status != StatusTooManySessions {
+		t.Errorf("status=%d", status)
+	}
+}
+
+func TestSessionDestroy(t *testing.T) {
+	Trace = true
+	c := NewClient()
+	c.CreateSession()
+	_, status := c.Open("/etc/resolv.conf")
+	if status != StatusSuccess {
+		t.Errorf("status=%d", status)
+	}
+	c.DestroySession()
+
+	if c.s.removeSession(c.SessionID) {
+		t.Error("session was not removed")
+	}
+}
+
+func TestInvalidOp(t *testing.T) {
+	c := NewClient()
+	status := c.Dispatch(1024, new(RequestClose), new(ReplyClose)).Status
+	if status != StatusOperationNotSupported {
+		t.Errorf("status=%d", status)
+	}
+}
+
+func TestReadV3(t *testing.T) {
+	Trace = testing.Verbose()
+
+	c := NewClient()
+	c.CreateSession()
+
+	_, status := c.GetAttr("enoent")
+
+	if status != StatusNoSuchFileOrDir {
+		t.Errorf("status=%d", status)
+	}
+
+	_, status = c.Open("enoent")
+	if status != StatusNoSuchFileOrDir {
+		t.Errorf("status=%d", status)
+	}
+
+	fname := "/etc/resolv.conf"
+
+	attr, _ := c.GetAttr(path.Dir(fname))
+	if attr.Type != FileTypeDirectory {
+		t.Errorf("type=%d", attr.Type)
+	}
+
+	attr, _ = c.GetAttr(fname)
+	if attr.Type != FileTypeRegular {
+		t.Errorf("type=%d", attr.Type)
+	}
+
+	if attr.Size <= 0 {
+		t.Errorf("size=%d", attr.Size)
+	}
+
+	handle, status := c.Open(fname)
+	if status != StatusSuccess {
+		t.Fatalf("status=%d", status)
+	}
+
+	var req *RequestReadV3
+	var offset uint64
+	size := uint32(attr.Size / 2)
+
+	for offset = 0; offset < attr.Size; {
+		req = &RequestReadV3{
+			Offset:       offset,
+			Handle:       handle,
+			RequiredSize: size,
+		}
+
+		res := new(ReplyReadV3)
+
+		status = c.Dispatch(OpReadV3, req, res).Status
+
+		if status != StatusSuccess {
+			t.Fatalf("status=%d", status)
+		}
+
+		if Trace {
+			fmt.Fprintf(os.Stderr, "read %d: %q\n", res.ActualSize, string(res.Payload))
+		}
+
+		offset += uint64(res.ActualSize)
+	}
+
+	if uint64(offset) != attr.Size {
+		t.Errorf("size %d vs %d", offset, attr.Size)
+	}
+
+	req.Offset *= 2 // read with offset past file length
+	status = c.Dispatch(OpReadV3, req, new(ReplyReadV3)).Status
+	if status != StatusGenericError {
+		t.Fatalf("status=%d", status)
+	}
+
+	status = c.Dispatch(OpReadV3, new(RequestReadV3), new(ReplyReadV3)).Status
+	if status != StatusInvalidHandle {
+		t.Fatalf("status=%d", status)
+	}
+
+	status = c.Close(0)
+	if status != StatusInvalidHandle {
+		t.Fatalf("status=%d", status)
+	}
+
+	status = c.Close(handle)
+	if status != StatusSuccess {
+		t.Fatalf("status=%d", status)
+	}
+
+	status = c.DestroySession()
+	if status != StatusSuccess {
+		t.Fatalf("status=%d", status)
+	}
+}
+
+func TestWriteV3(t *testing.T) {
+	Trace = testing.Verbose()
+
+	c := NewClient()
+	c.CreateSession()
+
+	_, status := c.Open("enoent", true)
+	// write not supported yet
+	if status != StatusAccessDenied {
+		t.Errorf("status=%d", status)
+	}
+}

--- a/pkg/vsphere/toolbox/service.go
+++ b/pkg/vsphere/toolbox/service.go
@@ -23,6 +23,8 @@ import (
 	"time"
 
 	log "github.com/Sirupsen/logrus"
+
+	"github.com/vmware/vic/pkg/vsphere/toolbox/hgfs"
 )
 
 const (
@@ -40,6 +42,8 @@ var (
 
 		// Required to invoke guest power operations (shutdown, reboot)
 		"tools.capability.statechange",
+
+		"tools.capability.hgfs_server toolbox 1",
 	}
 
 	netInterfaceAddrs = net.InterfaceAddrs
@@ -80,6 +84,7 @@ func NewService(rpcIn Channel, rpcOut Channel) *Service {
 	s.RegisterHandler("Capabilities_Register", s.CapabilitiesRegister)
 
 	s.VixCommand = registerVixRelayedCommandHandler(s)
+	s.VixCommand.FileServer = hgfs.NewServer()
 	s.PowerCommand = registerPowerCommandHandler(s)
 
 	return s

--- a/pkg/vsphere/toolbox/toolbox-test.sh
+++ b/pkg/vsphere/toolbox/toolbox-test.sh
@@ -124,6 +124,8 @@ opts=(-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o LogLevel=er
 scp "${opts[@]}" "$GOPATH"/bin/toolbox{,.test} "core@${ip}:"
 
 if [ -n "$test" ] ; then
+    export GOVC_GUEST_LOGIN=user:pass
+
     echo "Running toolbox tests..."
     ssh "${opts[@]}" "core@${ip}" ./toolbox.test -test.v -test.run TestServiceRunESX -toolbox.testesx \
         -toolbox.testpid="$$" -toolbox.powerState="$state" &
@@ -133,11 +135,14 @@ if [ -n "$test" ] ; then
     echo "toolbox vm.ip=$ip"
 
     echo "Testing guest operations via govc..."
-    out=$(govc guest.start -vm "$vm" -l user:pass /bin/date)
+    out=$(govc guest.start -vm "$vm" /bin/date)
 
     if [ "$out" != "$$" ] ; then
         echo "'$out' != '$$'" 1>&2
     fi
+
+    echo "Testing copy file from guest via govc..."
+    govc guest.download -vm "$vm" /etc/lsb-release -
 
     echo "Waiting for tests to complete..."
     wait

--- a/pkg/vsphere/toolbox/toolbox_darwin.go
+++ b/pkg/vsphere/toolbox/toolbox_darwin.go
@@ -15,38 +15,9 @@
 package toolbox
 
 import (
-	"net"
-	"reflect"
-	"testing"
+	"os"
 )
 
-func TestDefaultGuestNicProto(t *testing.T) {
-	p := DefaultGuestNicInfo()
-
-	info := p.V3
-
-	for _, nic := range info.Nics {
-		if len(nic.MacAddress) == 0 {
-			continue
-		}
-		_, err := net.ParseMAC(nic.MacAddress)
-		if err != nil {
-			t.Errorf("invalid MAC %s: %s", nic.MacAddress, err)
-		}
-	}
-
-	b, err := EncodeXDR(p)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	var dp GuestNicInfo
-	err = DecodeXDR(b, &dp)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if !reflect.DeepEqual(p, &dp) {
-		t.Error("decode mismatch")
-	}
+func fileExtendedInfoFormat(info os.FileInfo) string {
+	return ""
 }

--- a/pkg/vsphere/toolbox/toolbox_linux.go
+++ b/pkg/vsphere/toolbox/toolbox_linux.go
@@ -1,0 +1,60 @@
+// Copyright 2017 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package toolbox
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+	"time"
+)
+
+func fileExtendedInfoFormat(info os.FileInfo) string {
+	const format = "<fxi>" +
+		"<Name>%s</Name>" +
+		"<ft>%d</ft>" +
+		"<fs>%d</fs>" +
+		"<mt>%d</mt>" +
+		"<at>%d</at>" +
+		"<uid>%d</uid>" +
+		"<gid>%d</gid>" +
+		"<perm>%d</perm>" +
+		"<slt>%s</slt>" +
+		"</fxi>"
+
+	props := 0
+
+	if info.IsDir() {
+		props |= vixFileAttributesDirectory
+	}
+
+	if info.Mode()&os.ModeSymlink == os.ModeSymlink {
+		props |= vixFileAttributesSymlink
+	}
+
+	size := info.Size()
+	mtime := info.ModTime().Unix()
+	perm := info.Mode().Perm()
+
+	sys := info.Sys().(*syscall.Stat_t)
+
+	atime := time.Unix(sys.Atim.Unix()).Unix()
+	uid := sys.Uid
+	gid := sys.Gid
+
+	targ := ""
+
+	return fmt.Sprintf(format, info.Name(), props, size, mtime, atime, uid, gid, perm, targ)
+}

--- a/pkg/vsphere/toolbox/toolbox_windows.go
+++ b/pkg/vsphere/toolbox/toolbox_windows.go
@@ -15,38 +15,25 @@
 package toolbox
 
 import (
-	"net"
-	"reflect"
-	"testing"
+	"fmt"
+	"os"
 )
 
-func TestDefaultGuestNicProto(t *testing.T) {
-	p := DefaultGuestNicInfo()
+func fileExtendedInfoFormat(info os.FileInfo) string {
+	const format = "<fxi>" +
+		"<Name>%s</Name>" +
+		"<ft>%d</ft>" +
+		"<fs>%d</fs>" +
+		"<mt>%d</mt>" +
+		"<ct>%d</ct>" +
+		"<at>%d</at>" +
+		"</fxi>"
 
-	info := p.V3
+	props := 0
+	size := info.Size()
+	mtime := info.ModTime().Unix()
+	ctime := 0
+	atime := 0
 
-	for _, nic := range info.Nics {
-		if len(nic.MacAddress) == 0 {
-			continue
-		}
-		_, err := net.ParseMAC(nic.MacAddress)
-		if err != nil {
-			t.Errorf("invalid MAC %s: %s", nic.MacAddress, err)
-		}
-	}
-
-	b, err := EncodeXDR(p)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	var dp GuestNicInfo
-	err = DecodeXDR(b, &dp)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if !reflect.DeepEqual(p, &dp) {
-		t.Error("decode mismatch")
-	}
+	return fmt.Sprintf(format, info.Name(), props, size, mtime, ctime, atime)
 }

--- a/pkg/vsphere/toolbox/vix_command.go
+++ b/pkg/vsphere/toolbox/vix_command.go
@@ -23,13 +23,22 @@ import (
 	"fmt"
 	"os"
 	"runtime"
+
+	"github.com/vmware/vic/pkg/vsphere/toolbox/hgfs"
 )
 
 const (
 	vixCommandMagicWord = 0xd00d0001
 
 	vixCommandGetToolsState = 62
-	vixCommandStartProgram  = 185
+
+	vixCommandKillProcess     = 85
+	vixCommandStartProgram    = 185
+	vixCommandListProcessesEx = 186
+
+	vmxiHgfsSendPacketCommand               = 84
+	vixCommandInitiateFileTransferFromGuest = 188
+	vixCommandInitiateFileTransferToGuest   = 189
 
 	// VIX_USER_CREDENTIAL_NAME_PASSWORD
 	vixUserCredentialNamePassword = 1
@@ -41,6 +50,13 @@ const (
 	vixUnrecognizedCommandInGuest = 3025
 	vixInvalidMessageHeader       = 10000
 	vixInvalidMessageBody         = 10001
+
+	// VIX_COMMAND_* constants from vixCommands.h
+	vixCommandGuestReturnsBinary = 0x80
+
+	// VIX_FILE_ATTRIBUTES_ constants from vix.h
+	vixFileAttributesDirectory = 0x0001
+	vixFileAttributesSymlink   = 0x0002
 )
 
 type VixMsgHeader struct {
@@ -87,6 +103,33 @@ type VixMsgStartProgramRequest struct {
 	EnvVars     []string
 }
 
+type VixMsgListFilesRequest struct {
+	VixCommandRequestHeader
+
+	header struct {
+		FileOptions         int32
+		GuestPathNameLength uint32
+		PatternLength       uint32
+		Index               int32
+		MaxResults          int32
+		Offset              uint64
+	}
+
+	GuestPathName string
+	Pattern       string
+}
+
+type VixCommandHgfsSendPacket struct {
+	VixCommandRequestHeader
+
+	header struct {
+		PacketSize uint32
+		Timeout    int32
+	}
+
+	Packet []byte
+}
+
 type VixCommandHandler func(string, VixCommandRequestHeader, []byte) ([]byte, error)
 
 type VixRelayedCommandHandler struct {
@@ -97,6 +140,8 @@ type VixRelayedCommandHandler struct {
 	ProcessStartCommand func(*VixMsgStartProgramRequest) (int, error)
 
 	handlers map[uint32]VixCommandHandler
+
+	FileServer *hgfs.Server
 }
 
 type VixUserCredentialNamePassword struct {
@@ -121,12 +166,16 @@ func registerVixRelayedCommandHandler(service *Service) *VixRelayedCommandHandle
 
 	handler.RegisterHandler(vixCommandStartProgram, handler.StartCommand)
 
+	handler.RegisterHandler(vixCommandInitiateFileTransferFromGuest, handler.InitiateFileTransferFromGuest)
+
+	handler.RegisterHandler(vmxiHgfsSendPacketCommand, handler.ProcessHgfsPacket)
+
 	handler.ProcessStartCommand = handler.ExecCommandStart
 
 	return handler
 }
 
-func vixCommandResult(rc int, err error, response []byte) []byte {
+func vixCommandResult(header VixCommandRequestHeader, rc int, err error, response []byte) []byte {
 	// All Foundry tools commands return results that start with a foundry error
 	// and a guest-OS-specific error (e.g. errno)
 	errno := 0
@@ -137,7 +186,21 @@ func vixCommandResult(rc int, err error, response []byte) []byte {
 		response = []byte(err.Error())
 	}
 
-	return append([]byte(fmt.Sprintf("%d %d ", rc, errno)), response...)
+	buf := bytes.NewBufferString(fmt.Sprintf("%d %d ", rc, errno))
+
+	if header.CommonFlags&vixCommandGuestReturnsBinary != 0 {
+		// '#' delimits end of ascii and the start of the binary data (see ToolsDaemonTcloReceiveVixCommand)
+		_ = buf.WriteByte('#')
+	}
+
+	_, _ = buf.Write(response)
+
+	if header.CommonFlags&vixCommandGuestReturnsBinary == 0 {
+		// this is not binary data, so it should be a NULL terminated string (see ToolsDaemonTcloReceiveVixCommand)
+		_ = buf.WriteByte(0)
+	}
+
+	return buf.Bytes()
 }
 
 func (c *VixRelayedCommandHandler) Dispatch(data []byte) ([]byte, error) {
@@ -170,12 +233,12 @@ func (c *VixRelayedCommandHandler) Dispatch(data []byte) ([]byte, error) {
 	}
 
 	if header.Magic != vixCommandMagicWord {
-		return vixCommandResult(vixInvalidMessageHeader, nil, nil), nil
+		return vixCommandResult(header, vixInvalidMessageHeader, nil, nil), nil
 	}
 
 	handler, ok := c.handlers[header.OpCode]
 	if !ok {
-		return vixCommandResult(vixUnrecognizedCommandInGuest, nil, nil), nil
+		return vixCommandResult(header, vixUnrecognizedCommandInGuest, nil, nil), nil
 	}
 
 	if header.OpCode != vixCommandGetToolsState {
@@ -184,7 +247,7 @@ func (c *VixRelayedCommandHandler) Dispatch(data []byte) ([]byte, error) {
 
 		err = c.authenticate(header, creds[:header.CredentialLength])
 		if err != nil {
-			return vixCommandResult(vixAuthenticationFail, err, nil), nil
+			return vixCommandResult(header, vixAuthenticationFail, err, nil), nil
 		}
 	}
 
@@ -195,7 +258,7 @@ func (c *VixRelayedCommandHandler) Dispatch(data []byte) ([]byte, error) {
 		rc = vixFail
 	}
 
-	return vixCommandResult(rc, err, response), nil
+	return vixCommandResult(header, rc, err, response), nil
 }
 
 func (c *VixRelayedCommandHandler) RegisterHandler(op uint32, handler VixCommandHandler) {
@@ -216,6 +279,7 @@ func (c *VixRelayedCommandHandler) GetToolsState(_ string, _ VixCommandRequestHe
 		NewInt32Property(VixPropertyGuestToolsAPIOptions, 0x0001), // TODO: const VIX_TOOLSFEATURE_SUPPORT_GET_HANDLE_STATE
 		NewInt32Property(VixPropertyGuestOsFamily, 1),             // TODO: const GUEST_OS_FAMILY_*
 		NewBoolProperty(VixPropertyGuestStartProgramEnabled, true),
+		NewBoolProperty(VixPropertyGuestInitiateFileTransferFromGuestEnabled, true),
 	}
 
 	src, _ := props.MarshalBinary()
@@ -329,6 +393,125 @@ func (c *VixRelayedCommandHandler) StartCommand(_ string, header VixCommandReque
 func (c *VixRelayedCommandHandler) ExecCommandStart(r *VixMsgStartProgramRequest) (int, error) {
 	// TODO: we could map to exec.Command(...).Start here
 	return -1, errors.New("not implemented")
+}
+
+// MarshalBinary implements the encoding.BinaryMarshaler interface
+func (r *VixMsgListFilesRequest) MarshalBinary() ([]byte, error) {
+	var fields []string
+
+	add := func(s string, l *uint32) {
+		if n := len(s); n != 0 {
+			*l = uint32(n) + 1
+			fields = append(fields, s)
+		}
+	}
+
+	add(r.GuestPathName, &r.header.GuestPathNameLength)
+	add(r.Pattern, &r.header.PatternLength)
+
+	buf := new(bytes.Buffer)
+
+	_ = binary.Write(buf, binary.LittleEndian, &r.header)
+
+	for _, val := range fields {
+		_, _ = buf.Write([]byte(val))
+		_ = buf.WriteByte(0)
+	}
+
+	return buf.Bytes(), nil
+}
+
+// UnmarshalBinary implements the encoding.BinaryUnmarshaler interface
+func (r *VixMsgListFilesRequest) UnmarshalBinary(data []byte) error {
+	buf := bytes.NewBuffer(data)
+
+	err := binary.Read(buf, binary.LittleEndian, &r.header)
+	if err != nil {
+		return err
+	}
+
+	fields := []struct {
+		len uint32
+		val *string
+	}{
+		{r.header.GuestPathNameLength, &r.GuestPathName},
+		{r.header.PatternLength, &r.Pattern},
+	}
+
+	for _, field := range fields {
+		if field.len == 0 {
+			continue
+		}
+
+		x := buf.Next(int(field.len))
+		*field.val = string(bytes.TrimRight(x, "\x00"))
+	}
+
+	return nil
+}
+
+// MarshalBinary implements the encoding.BinaryMarshaler interface
+func (r *VixCommandHgfsSendPacket) MarshalBinary() ([]byte, error) {
+	buf := new(bytes.Buffer)
+
+	_ = binary.Write(buf, binary.LittleEndian, &r.header)
+
+	_, _ = buf.Write(r.Packet)
+
+	return buf.Bytes(), nil
+}
+
+// UnmarshalBinary implements the encoding.BinaryUnmarshaler interface
+func (r *VixCommandHgfsSendPacket) UnmarshalBinary(data []byte) error {
+	buf := bytes.NewBuffer(data)
+
+	err := binary.Read(buf, binary.LittleEndian, &r.header)
+	if err != nil {
+		return err
+	}
+
+	r.Packet = buf.Next(int(r.header.PacketSize))
+
+	return nil
+}
+
+func (c *VixRelayedCommandHandler) InitiateFileTransferFromGuest(_ string, header VixCommandRequestHeader, data []byte) ([]byte, error) {
+	r := &VixMsgListFilesRequest{
+		VixCommandRequestHeader: header,
+	}
+
+	err := r.UnmarshalBinary(data)
+	if err != nil {
+		return nil, err
+	}
+
+	info, err := os.Stat(r.GuestPathName)
+	if err != nil {
+		return nil, err
+	}
+
+	if info.Mode()&os.ModeSymlink == os.ModeSymlink {
+		return nil, errors.New("VIX_E_INVALID_ARG")
+	}
+
+	if info.IsDir() {
+		return nil, errors.New("VIX_E_NOT_A_FILE")
+	}
+
+	return []byte(fileExtendedInfoFormat(info)), nil
+}
+
+func (c *VixRelayedCommandHandler) ProcessHgfsPacket(_ string, header VixCommandRequestHeader, data []byte) ([]byte, error) {
+	r := &VixCommandHgfsSendPacket{
+		VixCommandRequestHeader: header,
+	}
+
+	err := r.UnmarshalBinary(data)
+	if err != nil {
+		return nil, err
+	}
+
+	return c.FileServer.Dispatch(r.Packet)
 }
 
 func (c *VixRelayedCommandHandler) authenticate(r VixCommandRequestHeader, data []byte) error {

--- a/pkg/vsphere/toolbox/vix_property.go
+++ b/pkg/vsphere/toolbox/vix_property.go
@@ -33,14 +33,20 @@ const (
 
 // Property ID enum as defined in open-vm-tools/lib/include/vixOpenSource.h
 const (
-	VixPropertyGuestToolsAPIOptions     = 4501
-	VixPropertyGuestOsFamily            = 4502
-	VixPropertyGuestOsVersion           = 4503
-	VixPropertyGuestToolsProductNam     = 4511
-	VixPropertyGuestToolsVersion        = 4500
-	VixPropertyGuestName                = 4505
-	VixPropertyGuestOsVersionShort      = 4520
-	VixPropertyGuestStartProgramEnabled = 4540
+	VixPropertyGuestToolsAPIOptions = 4501
+	VixPropertyGuestOsFamily        = 4502
+	VixPropertyGuestOsVersion       = 4503
+	VixPropertyGuestToolsProductNam = 4511
+	VixPropertyGuestToolsVersion    = 4500
+	VixPropertyGuestName            = 4505
+	VixPropertyGuestOsVersionShort  = 4520
+
+	VixPropertyGuestStartProgramEnabled     = 4540
+	VixPropertyGuestListProcessesEnabled    = 4541
+	VixPropertyGuestTerminateProcessEnabled = 4542
+
+	VixPropertyGuestInitiateFileTransferFromGuestEnabled = 4556
+	VixPropertyGuestInitiateFileTransferToGuestEnabled   = 4557
 )
 
 type VixProperty struct {


### PR DESCRIPTION
Add hgfs server support to toolbox

This makes it possible to copy files from inside the guest to the outside,
using the GuestFileManager.InitiateFileTransferFromGuest API.

Exercising the API, for example with:
  govc guest.download -vm $vm /etc/lsb-release -

Results in the VMX calling the following RPCs:

- vixCommandInitiateFileTransferFromGuest

- vmxiHgfsSendPacketCommand(s):
  * OpCreateSessionV4
  * OpGetattrV4
  * OpOpen
  * OpReadV3 [N times depending on file size]
  * OpClose
  * OpDestroySessionV4

For VMX reference, see: lib/hgFileCopy/hgFileCopy.c

Writing files to the guest is not included in this change, but will be a similar flow,
with Write/Setattr rather than Getattr/Read.

Fixes #4103
