### PR TITLE
Update go-nfs-client vendor to vmware github

### DIFF
--- a/lib/portlayer/storage/nfs/target.go
+++ b/lib/portlayer/storage/nfs/target.go
@@ -19,8 +19,8 @@ import (
 	"net/url"
 	"os"
 
-	nfsClient "github.com/fdawg4l/go-nfs-client/nfs"
-	"github.com/fdawg4l/go-nfs-client/nfs/rpc"
+	nfsClient "github.com/vmware/go-nfs-client/nfs"
+	"github.com/vmware/go-nfs-client/nfs/rpc"
 
 	"github.com/vmware/vic/pkg/trace"
 )

--- a/vendor/github.com/vmware/go-nfs-client/nfs/error.go
+++ b/vendor/github.com/vmware/go-nfs-client/nfs/error.go
@@ -1,36 +1,39 @@
+// Copyright © 2017 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: BSD-2-Clause
+//
 package nfs
 
 import "os"
 
 const (
-	NFS3_OK             = 0
-	NFS3ERR_PERM        = 1
-	NFS3ERR_NOENT       = 2
-	NFS3ERR_IO          = 5
-	NFS3ERR_NXIO        = 6
-	NFS3ERR_ACCES       = 13
-	NFS3ERR_EXIST       = 17
-	NFS3ERR_XDEV        = 18
-	NFS3ERR_NODEV       = 19
-	NFS3ERR_NOTDIR      = 20
-	NFS3ERR_ISDIR       = 21
-	NFS3ERR_INVAL       = 22
-	NFS3ERR_FBIG        = 27
-	NFS3ERR_NOSPC       = 28
-	NFS3ERR_ROFS        = 30
-	NFS3ERR_MLINK       = 31
-	NFS3ERR_NAMETOOLONG = 63
-	NFS3ERR_NOTEMPTY    = 66
-	NFS3ERR_DQUOT       = 69
-	NFS3ERR_STALE       = 70
-	NFS3ERR_REMOTE      = 71
-	NFS3ERR_BADHANDLE   = 10001
-	NFS3ERR_NOT_SYNC    = 10002
-	NFS3ERR_BAD_COOKIE  = 10003
-	NFS3ERR_NOTSUPP     = 10004
-	NFS3ERR_TOOSMALL    = 10005
-	NFS3ERR_SERVERFAULT = 10006
-	NFS3ERR_BADTYPE     = 10007
+	NFS3Ok             = 0
+	NFS3ErrPerm        = 1
+	NFS3ErrNoEnt       = 2
+	NFS3ErrIO          = 5
+	NFS3ErrNXIO        = 6
+	NFS3ErrAcces       = 13
+	NFS3ErrExist       = 17
+	NFS3ErrXDev        = 18
+	NFS3ErrNoDev       = 19
+	NFS3ErrNotDir      = 20
+	NFS3ErrIsDir       = 21
+	NFS3ErrInval       = 22
+	NFS3ErrFBig        = 27
+	NFS3ErrNoSpc       = 28
+	NFS3ErrROFS        = 30
+	NFS3ErrMLink       = 31
+	NFS3ErrNameTooLong = 63
+	NFS3ErrNotEmpty    = 66
+	NFS3ErrDQuot       = 69
+	NFS3ErrStale       = 70
+	NFS3ErrRemote      = 71
+	NFS3ErrBadHandle   = 10001
+	NFS3ErrNotSync     = 10002
+	NFS3ErrBadCookie   = 10003
+	NFS3ErrNotSupp     = 10004
+	NFS3ErrTooSmall    = 10005
+	NFS3ErrServerFault = 10006
+	NFS3ErrBadType     = 10007
 )
 
 var errToName = map[uint32]string{
@@ -66,13 +69,13 @@ var errToName = map[uint32]string{
 
 func NFS3Error(errnum uint32) error {
 	switch errnum {
-	case NFS3_OK:
+	case NFS3Ok:
 		return nil
-	case NFS3ERR_PERM:
+	case NFS3ErrPerm:
 		return os.ErrPermission
-	case NFS3ERR_EXIST:
+	case NFS3ErrExist:
 		return os.ErrExist
-	case NFS3ERR_NOENT:
+	case NFS3ErrNoEnt:
 		return os.ErrNotExist
 	default:
 		if errStr, ok := errToName[errnum]; ok {
@@ -84,8 +87,6 @@ func NFS3Error(errnum uint32) error {
 
 		return os.ErrInvalid
 	}
-
-	return nil
 }
 
 // Error represents an unexpected I/O behavior.
@@ -102,7 +103,7 @@ func IsNotEmptyError(err error) bool {
 		return false
 	}
 
-	if nfsErr.ErrorNum == NFS3ERR_NOTEMPTY {
+	if nfsErr.ErrorNum == NFS3ErrNotEmpty {
 		return true
 	}
 
@@ -115,7 +116,7 @@ func IsNotDirError(err error) bool {
 		return false
 	}
 
-	if nfsErr.ErrorNum == NFS3ERR_NOTDIR {
+	if nfsErr.ErrorNum == NFS3ErrNotDir {
 		return true
 	}
 

--- a/vendor/github.com/vmware/go-nfs-client/nfs/example/test/main.go
+++ b/vendor/github.com/vmware/go-nfs-client/nfs/example/test/main.go
@@ -1,3 +1,6 @@
+// Copyright © 2017 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: BSD-2-Clause
+//
 package main
 
 import (
@@ -10,9 +13,9 @@ import (
 	"os"
 	"strings"
 
-	"github.com/fdawg4l/go-nfs-client/nfs"
-	"github.com/fdawg4l/go-nfs-client/nfs/rpc"
-	"github.com/fdawg4l/go-nfs-client/nfs/util"
+	"github.com/vmware/go-nfs-client/nfs"
+	"github.com/vmware/go-nfs-client/nfs/rpc"
+	"github.com/vmware/go-nfs-client/nfs/util"
 )
 
 func main() {
@@ -87,7 +90,7 @@ func main() {
 		log.Fatalf("expected a NOTADIR error")
 	} else {
 		nfserr := err.(*nfs.Error)
-		if nfserr.ErrorNum != nfs.NFS3ERR_NOTDIR {
+		if nfserr.ErrorNum != nfs.NFS3ErrNotDir {
 			log.Fatalf("Wrong error")
 		}
 	}

--- a/vendor/github.com/vmware/go-nfs-client/nfs/file.go
+++ b/vendor/github.com/vmware/go-nfs-client/nfs/file.go
@@ -1,14 +1,19 @@
+// Copyright © 2017 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: BSD-2-Clause
+//
 package nfs
 
 import (
 	"io"
 	"os"
 
-	"github.com/fdawg4l/go-nfs-client/nfs/rpc"
-	"github.com/fdawg4l/go-nfs-client/nfs/util"
-	"github.com/fdawg4l/go-nfs-client/nfs/xdr"
+	"github.com/vmware/go-nfs-client/nfs/rpc"
+	"github.com/vmware/go-nfs-client/nfs/util"
+	"github.com/vmware/go-nfs-client/nfs/xdr"
 )
 
+// File wraps the NfsProc3Read and NfsProc3Write methods to implement a
+// io.ReadWriteCloser.
 type File struct {
 	*Target
 
@@ -34,7 +39,7 @@ func (f *File) Read(p []byte) (int, error) {
 			Attrs Fattr
 		}
 		Count uint32
-		Eof   uint32
+		EOF   uint32
 		Data  struct {
 			Length uint32
 		}
@@ -73,7 +78,7 @@ func (f *File) Read(p []byte) (int, error) {
 		return n, err
 	}
 
-	if readres.Eof != 0 {
+	if readres.EOF != 0 {
 		err = io.EOF
 	}
 
@@ -124,6 +129,7 @@ func (f *File) Write(p []byte) (int, error) {
 	return int(writeSize), nil
 }
 
+// Close commits the file
 func (f *File) Close() error {
 	type CommitArg struct {
 		rpc.Header

--- a/vendor/github.com/vmware/go-nfs-client/nfs/mount.go
+++ b/vendor/github.com/vmware/go-nfs-client/nfs/mount.go
@@ -1,11 +1,14 @@
+// Copyright © 2017 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: BSD-2-Clause
+//
 package nfs
 
 import (
 	"errors"
 	"fmt"
 
-	"github.com/fdawg4l/go-nfs-client/nfs/rpc"
-	"github.com/fdawg4l/go-nfs-client/nfs/xdr"
+	"github.com/vmware/go-nfs-client/nfs/rpc"
+	"github.com/vmware/go-nfs-client/nfs/xdr"
 )
 
 const (

--- a/vendor/github.com/vmware/go-nfs-client/nfs/nfs.go
+++ b/vendor/github.com/vmware/go-nfs-client/nfs/nfs.go
@@ -1,3 +1,6 @@
+// Copyright © 2017 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: BSD-2-Clause
+//
 package nfs
 
 import (
@@ -9,8 +12,8 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/fdawg4l/go-nfs-client/nfs/rpc"
-	"github.com/fdawg4l/go-nfs-client/nfs/util"
+	"github.com/vmware/go-nfs-client/nfs/rpc"
+	"github.com/vmware/go-nfs-client/nfs/util"
 )
 
 const (

--- a/vendor/github.com/vmware/go-nfs-client/nfs/rpc/client.go
+++ b/vendor/github.com/vmware/go-nfs-client/nfs/rpc/client.go
@@ -1,3 +1,6 @@
+// Copyright © 2017 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: BSD-2-Clause
+//
 package rpc
 
 import (
@@ -10,7 +13,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/fdawg4l/go-nfs-client/nfs/xdr"
+	"github.com/vmware/go-nfs-client/nfs/xdr"
 )
 
 const (

--- a/vendor/github.com/vmware/go-nfs-client/nfs/rpc/portmap.go
+++ b/vendor/github.com/vmware/go-nfs-client/nfs/rpc/portmap.go
@@ -1,9 +1,12 @@
+// Copyright © 2017 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: BSD-2-Clause
+//
 package rpc
 
 import (
 	"fmt"
 
-	"github.com/fdawg4l/go-nfs-client/nfs/xdr"
+	"github.com/vmware/go-nfs-client/nfs/xdr"
 )
 
 // PORTMAP

--- a/vendor/github.com/vmware/go-nfs-client/nfs/rpc/rpc.go
+++ b/vendor/github.com/vmware/go-nfs-client/nfs/rpc/rpc.go
@@ -1,3 +1,6 @@
+// Copyright © 2017 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: BSD-2-Clause
+//
 package rpc
 
 import (
@@ -5,7 +8,7 @@ import (
 	"math/rand"
 	"time"
 
-	"github.com/fdawg4l/go-nfs-client/nfs/xdr"
+	"github.com/vmware/go-nfs-client/nfs/xdr"
 )
 
 type Auth struct {

--- a/vendor/github.com/vmware/go-nfs-client/nfs/rpc/tcp.go
+++ b/vendor/github.com/vmware/go-nfs-client/nfs/rpc/tcp.go
@@ -1,3 +1,6 @@
+// Copyright © 2017 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: BSD-2-Clause
+//
 package rpc
 
 import (

--- a/vendor/github.com/vmware/go-nfs-client/nfs/target.go
+++ b/vendor/github.com/vmware/go-nfs-client/nfs/target.go
@@ -1,3 +1,6 @@
+// Copyright © 2017 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: BSD-2-Clause
+//
 package nfs
 
 import (
@@ -7,9 +10,9 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/fdawg4l/go-nfs-client/nfs/rpc"
-	"github.com/fdawg4l/go-nfs-client/nfs/util"
-	"github.com/fdawg4l/go-nfs-client/nfs/xdr"
+	"github.com/vmware/go-nfs-client/nfs/rpc"
+	"github.com/vmware/go-nfs-client/nfs/util"
+	"github.com/vmware/go-nfs-client/nfs/xdr"
 )
 
 type Target struct {

--- a/vendor/github.com/vmware/go-nfs-client/nfs/util/log.go
+++ b/vendor/github.com/vmware/go-nfs-client/nfs/util/log.go
@@ -1,3 +1,6 @@
+// Copyright © 2017 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: BSD-2-Clause
+//
 // Copyright 2016 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/vendor/github.com/vmware/go-nfs-client/nfs/xdr/decode.go
+++ b/vendor/github.com/vmware/go-nfs-client/nfs/xdr/decode.go
@@ -1,3 +1,6 @@
+// Copyright © 2017 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: BSD-2-Clause
+//
 package xdr
 
 import (

--- a/vendor/github.com/vmware/go-nfs-client/nfs/xdr/encode.go
+++ b/vendor/github.com/vmware/go-nfs-client/nfs/xdr/encode.go
@@ -1,3 +1,6 @@
+// Copyright © 2017 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: BSD-2-Clause
+//
 package xdr
 
 import (

--- a/vendor/manifest
+++ b/vendor/manifest
@@ -375,15 +375,6 @@
 			"notests": true
 		},
 		{
-			"importpath": "github.com/fdawg4l/go-nfs-client/nfs",
-			"repository": "https://github.com/fdawg4l/go-nfs-client",
-			"vcs": "git",
-			"revision": "ba0907caa92da3d762b621a251af64688fa1222b",
-			"branch": "master",
-			"path": "/nfs",
-			"notests": true
-		},
-		{
 			"importpath": "github.com/gizak/termui",
 			"repository": "https://github.com/gizak/termui",
 			"vcs": "git",
@@ -1015,6 +1006,14 @@
 			"vcs": "git",
 			"revision": "604eaf189ee867d8c147fafc28def2394e878d25",
 			"branch": "HEAD",
+			"notests": true
+		},
+		{
+			"importpath": "github.com/vmware/go-nfs-client",
+			"repository": "https://github.com/vmware/go-nfs-client",
+			"vcs": "git",
+			"revision": "492894f630f2f2e2c38de9d6e076c6c801dc3362",
+			"branch": "master",
 			"notests": true
 		},
 		{


### PR DESCRIPTION
Getting off of the fdawg4l repo now that the `go-nfs-client` is a vmw project.