### PR TITLE
Partial fix for issues: #5235, #5245

### DIFF
--- a/lib/portlayer/event/collector/vsphere/collector.go
+++ b/lib/portlayer/event/collector/vsphere/collector.go
@@ -128,7 +128,7 @@ func (ec *EventCollector) Start() error {
 	force := false
 
 	//TODO: need a proper way to handle failures / status
-	go func(page int32, follow bool, ff bool, refs []types.ManagedObjectReference, ec *EventCollector) error {
+	go func(pageSize int32, follow bool, ff bool, refs []types.ManagedObjectReference, ec *EventCollector) error {
 		// the govmomi event listener can only be configured once per session -- so if it's already listening it
 		// will be replaced
 		//
@@ -176,7 +176,7 @@ func evented(ec *EventCollector, page []types.BaseEvent) {
 			ec.callback(NewVMEvent(page[i]))
 		case *types.VmReconfiguredEvent:
 			// reconfigures happen often, so completely ignore for now
-			return
+			continue
 		default:
 			// log the skipped event
 			e := page[i].GetEvent()

--- a/lib/portlayer/event/collector/vsphere/collector_test.go
+++ b/lib/portlayer/event/collector/vsphere/collector_test.go
@@ -25,6 +25,12 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+const (
+	LifeCycle = iota
+	Reconfigure
+	Mixed
+)
+
 // used to test callbacks
 var callcount int
 
@@ -61,12 +67,19 @@ func TestEvented(t *testing.T) {
 	mgr.Register(callMe)
 
 	// test lifecycle events
-	page := eventPage(3, true)
+	page := eventPage(3, LifeCycle)
 	evented(mgr, page)
 	assert.Equal(t, 3, callcount)
 
-	// non-lifecycle events
-	page = eventPage(2, false)
+	// non-lifecycle events, should be ignored
+	callcount = 0
+	page = eventPage(2, Reconfigure)
+	evented(mgr, page)
+	assert.Equal(t, 0, callcount)
+
+	// mixed events, ignore half
+	callcount = 0
+	page = eventPage(6, Mixed)
 	evented(mgr, page)
 	assert.Equal(t, 3, callcount)
 
@@ -98,14 +111,24 @@ func callMe(vm events.Event) {
 // size is the number of events to create
 // lifeCycle is true when we want to generate state events
 // lifeCycle events == poweredOn, poweredOff, etc..
-func eventPage(size int, lifeCycle bool) []types.BaseEvent {
+
+func eventPage(size int, eventType int) []types.BaseEvent {
 	page := make([]types.BaseEvent, 0, size)
 	moid := 100
 	for i := 0; i < size; i++ {
 		var eve types.BaseEvent
+		var eType int
 		moid++
 		vm := types.ManagedObjectReference{Value: strconv.Itoa(moid), Type: "vm"}
-		if lifeCycle {
+		eType = eventType
+		if eType == Mixed {
+			if i%2 == 0 {
+				eType = LifeCycle
+			} else {
+				eType = Reconfigure
+			}
+		}
+		if eType == LifeCycle {
 			eve = types.BaseEvent(&types.VmPoweredOnEvent{VmEvent: types.VmEvent{Event: types.Event{Vm: &types.VmEventArgument{Vm: vm}}}})
 		} else {
 			eve = types.BaseEvent(&types.VmReconfiguredEvent{VmEvent: types.VmEvent{Event: types.Event{Vm: &types.VmEventArgument{Vm: vm}}}})


### PR DESCRIPTION
This fixes a real problem where events go missing. It was seen in multiple/concurrent container create/start. However, there could be other problems. In particular if an event is not received from VSphere, VIC engine could still be in an inconsistent state. Where the VM is powered off but the container is still listed as running.

Fixes #5235