### PR TITLE
Add VCH column to Containers section Datagrid

### DIFF
--- a/ui/vic-ui-h5c/vic-service/src/main/java/com/vmware/vic/model/ContainerVm.java
+++ b/ui/vic-ui-h5c/vic-service/src/main/java/com/vmware/vic/model/ContainerVm.java
@@ -42,7 +42,10 @@ public class ContainerVm extends VicBaseVm {
 	        Container.VM_IMAGENAME_KEY;
 	private static final String VM_PORTMAPPING_KEY =
 	        Container.VM_PORTMAPPING_KEY;
+	private static final String PARENT_OBJ_NAME_KEY =
+            Container.PARENT_NAME_KEY;
 	private String _containerName = null;
+	private String _parentObjectName = null;
 	private String _imageName = null;
 	private String _portMapping = null;
 
@@ -59,23 +62,30 @@ public class ContainerVm extends VicBaseVm {
 	}
 
 	/**
-     * Getter for Docker Container's imageName
-     */
+	 * Getter for Parent Object's name
+	 */
+	public String getParentObjectName() {
+	    return _parentObjectName;
+	}
+
+	/**
+	 * Getter for Docker Container's imageName
+	 */
 	public String getImageName() {
 		return _imageName;
 	}
 
 	/**
-     * Getter for Docker Container's portMapping
-     */
+	 * Getter for Docker Container's portMapping
+	 */
 	public String getPortMapping() {
 		return _portMapping;
 	}
 
 	/**
-     * Property getter
-     * @param property : property to retrieve
-     */
+	 * Property getter
+	 * @param property : property to retrieve
+	 */
 	@Override
 	public Object getProperty(String property) {
 		if ("objectRef".equals(property)) {
@@ -96,7 +106,9 @@ public class ContainerVm extends VicBaseVm {
 			return _committedStorage;
 		} else if (VM_CONTAINERNAME_KEY.equals(property)) {
 			return _containerName;
-		} else if (VM_IMAGENAME_KEY.equals(property)) {
+		} else if (PARENT_OBJ_NAME_KEY.equals(property)) {
+            return _parentObjectName;
+        } else if (VM_IMAGENAME_KEY.equals(property)) {
 			return _imageName;
 		} else if (VM_PORTMAPPING_KEY.equals(property)) {
 			return _portMapping;
@@ -109,10 +121,10 @@ public class ContainerVm extends VicBaseVm {
 	}
 
 	/**
-     * Process DynamicProperty[] and extract information
-     * needed for the ContainerVm model
-     * @param dpsList : DynamicProperty list from ObjectContent.getPropSet()
-     */
+	 * Process DynamicProperty[] and extract information
+	 * needed for the ContainerVm model
+	 * @param dpsList : DynamicProperty list from ObjectContent.getPropSet()
+	 */
 	@Override
 	protected void processDynamicProperties(List<DynamicProperty> dpsList) {
 		for (DynamicProperty dp : dpsList) {
@@ -151,5 +163,23 @@ public class ContainerVm extends VicBaseVm {
 				}
 			}
 		}
+	}
+
+	/**
+	 * Return ManagedObjectReference's value portion
+	 * @return the 'value' of the ManagedObjectReference object
+	 */
+	public String getMorValue() {
+	    String[] splitIdString = this.getId().split("/");
+	    return splitIdString[1];
+	}
+
+	/**
+	 * Set _parentObjectName which is the name of this VM's
+	 * parent object (VirtualApp or ResourcePool)
+	 * @param name
+	 */
+	public void setParentName(String name) {
+	    _parentObjectName = name;
 	}
 }

--- a/ui/vic-ui-h5c/vic-service/src/main/java/com/vmware/vic/model/constants/Container.java
+++ b/ui/vic-ui-h5c/vic-service/src/main/java/com/vmware/vic/model/constants/Container.java
@@ -26,4 +26,5 @@ public class Container {
     public static final String VM_CONTAINERNAME_KEY = "containerName";
     public static final String VM_IMAGENAME_KEY = "imageName";
     public static final String VM_PORTMAPPING_KEY = "portMapping";
+    public static final String PARENT_NAME_KEY = "parentObjectName";
 }

--- a/ui/vic-ui-h5c/vic-service/src/main/java/com/vmware/vic/model/constants/VsphereObjects.java
+++ b/ui/vic-ui-h5c/vic-service/src/main/java/com/vmware/vic/model/constants/VsphereObjects.java
@@ -20,5 +20,7 @@ package com.vmware.vic.model.constants;
 public class VsphereObjects {
     public static final String VirtualMachine = "VirtualMachine";
     public static final String VmPropertyValueKey = "vm";
+    public static final String NamePropertyKey = "name";
     public static final String VirtualApp = "VirtualApp";
+    public static final String ResourcePool = "ResourcePool";
 }

--- a/ui/vic-ui-h5c/vic-service/src/main/java/com/vmware/vic/mvc/QueryUtil.java
+++ b/ui/vic-ui-h5c/vic-service/src/main/java/com/vmware/vic/mvc/QueryUtil.java
@@ -739,7 +739,9 @@ static ResultSet getListData(
 		   } else if (Container.VM_PORTMAPPING_KEY.equals(property)) {
 		       String pm = ((ContainerVm) mo).getPortMapping();
 		       return pm != null ? pm.toLowerCase() : "";
-		   } else if (BaseVm.VM_NAME.equals(property)) {
+		   } else if (Container.PARENT_NAME_KEY.equals(property)) {
+               return ((ContainerVm) mo).getParentObjectName();
+           } else if (BaseVm.VM_NAME.equals(property)) {
 		       return ((ContainerVm) mo).getName().toLowerCase();
 		   } else if (Container.VM_IMAGENAME_KEY.equals(property)) {
 		       return ((ContainerVm) mo).getImageName().toLowerCase();

--- a/ui/vic-ui-h5c/vic-service/src/main/java/com/vmware/vic/utils/VicVmComparator.java
+++ b/ui/vic-ui-h5c/vic-service/src/main/java/com/vmware/vic/utils/VicVmComparator.java
@@ -152,6 +152,8 @@ public class VicVmComparator implements Comparator<String> {
                 return pm != null ? pm : "";
 			} else if (BaseVm.VM_NAME.equals(compareBy)) {
 			    return ((ContainerVm) mo).getName();
+			} else if (Container.PARENT_NAME_KEY.equals(compareBy)) {
+			    return ((ContainerVm) mo).getParentObjectName();
 			} else if (Container.VM_IMAGENAME_KEY.equals(compareBy)) {
 			    return ((ContainerVm) mo).getImageName();
 			}

--- a/ui/vic-ui-h5c/vic/src/vic-app/src/app/app.component.ts
+++ b/ui/vic-ui-h5c/vic/src/vic-app/src/app/app.component.ts
@@ -21,12 +21,12 @@ import { ActionDevService } from './services/action-dev.service';
 @Component({
     selector: 'vic-app',
     template: `
-    <div *ngIf="!gs.isPluginMode()" class="floating-left">
-        <a (click)="gs.toggleDevUI()" class="tooltip tooltip-sm tooltip-bottom-right"
+    <div *ngIf="!globalsService.isPluginMode()" class="floating-left">
+        <a (click)="globalsService.toggleDevUI()" class="tooltip tooltip-sm tooltip-bottom-right"
            role="tooltip" aria-haspopup="true" href="javascript://">
-           <clr-icon [attr.shape]="gs.showDevUI() ? 'remove' : 'plus-circle'" size="16"
-                     [attr.class]="gs.showDevUI() ? 'is-inverse' : ''"></clr-icon>
-           <span class="tooltip-content">{{gs.showDevUI() ? "Remove dev UI" : "Show dev UI"}}</span>
+           <clr-icon [attr.shape]="globalsService.showDevUI() ? 'remove' : 'plus-circle'" size="16"
+                     [attr.class]="globalsService.showDevUI() ? 'is-inverse' : ''"></clr-icon>
+           <span class="tooltip-content">{{globalsService.showDevUI() ? "Remove dev UI" : "Show dev UI"}}</span>
         </a>
     </div>
     <router-outlet></router-outlet>
@@ -36,18 +36,18 @@ import { ActionDevService } from './services/action-dev.service';
 export class AppComponent {
 
     constructor(
-        public gs: GlobalsService,
+        public globalsService: GlobalsService,
         private injector: Injector,
         private refreshService: RefreshService,
         private i18nService: I18nService
     ) {
         // Refresh handler to be used in plugin mode
-        this.gs.getWebPlatform().setGlobalRefreshHandler(
+        this.globalsService.getWebPlatform().setGlobalRefreshHandler(
             this.refresh.bind(this), document
         );
 
         // Manual injection of ActionDevService, used in webPlatformStub
-        if (!this.gs.isPluginMode()) {
+        if (!this.globalsService.isPluginMode()) {
             this.injector.get(ActionDevService);
         }
 

--- a/ui/vic-ui-h5c/vic/src/vic-app/src/app/container-view/container-view.component.ts
+++ b/ui/vic-ui-h5c/vic/src/vic-app/src/app/container-view/container-view.component.ts
@@ -34,6 +34,8 @@ import {
     VM_GUESTMEMORYUSAGE,
     VM_OVERALLCPUUSAGE,
     VSPHERE_VM_SUMMARY_KEY,
+    VSPHERE_SERVEROBJ_VIEWEXT_KEY,
+    VSPHERE_VITREE_HOSTCLUSTERVIEW_KEY,
     WS_CONTAINER
 } from '../shared/constants';
 
@@ -164,8 +166,15 @@ export class VicContainerViewComponent implements OnInit, OnDestroy {
      * @param objectId Full vSphere objectId which starts with urn:
      */
     navigateToObject(objectId: string) {
-        this.globalsService.getWebPlatform()
-            .sendNavigationRequest(VSPHERE_VM_SUMMARY_KEY, objectId);
+        if (objectId.indexOf('VirtualMachine') > -1) {
+            this.globalsService.getWebPlatform().sendNavigationRequest(
+                VSPHERE_VM_SUMMARY_KEY, objectId);
+        } else {
+            window.parent.location.href = '/ui/#?extensionId=' +
+                VSPHERE_SERVEROBJ_VIEWEXT_KEY + '&' +
+                'objectId=' + objectId + '&' +
+                'navigator=' + VSPHERE_VITREE_HOSTCLUSTERVIEW_KEY;
+        }
     }
 
     /**

--- a/ui/vic-ui-h5c/vic/src/vic-app/src/app/container-view/container-view.template.html
+++ b/ui/vic-ui-h5c/vic/src/vic-app/src/app/container-view/container-view.template.html
@@ -17,6 +17,9 @@
     <clr-dg-column [clrDgField]="'portMapping'">
         {{vicI18n.translate(this.WS_CONTAINER_CONSTANTS.DG.COLUMNS, 'PORT_MAPPING')}}
     </clr-dg-column>
+    <clr-dg-column [clrDgField]="'parentObjectName'">
+        {{vicI18n.translate(this.WS_CONTAINER_CONSTANTS.DG.COLUMNS, 'VCH_NAME')}}
+    </clr-dg-column>
     <clr-dg-column [clrDgField]="'name'">
         {{vicI18n.translate(this.WS_CONTAINER_CONSTANTS.DG.COLUMNS, 'VM_NAME')}}
     </clr-dg-column>
@@ -42,6 +45,11 @@
         </clr-dg-cell>
         <clr-dg-cell>
             <span>{{item.portMapping || '-'}}</span>
+        </clr-dg-cell>
+        <clr-dg-cell>
+            <a href="#" (click)="navigateToObject(item.parentObj.id)">
+                    {{item.parentObjectName}}
+                </a>
         </clr-dg-cell>
         <clr-dg-cell>
             <a href="#" (click)="navigateToObject(item.id)">

--- a/ui/vic-ui-h5c/vic/src/vic-app/src/app/container-view/container.model.ts
+++ b/ui/vic-ui-h5c/vic/src/vic-app/src/app/container-view/container.model.ts
@@ -23,7 +23,8 @@ const FORWARD_SLASH = '/';
 const COLON = ':';
 
 export class ContainerVm implements VirtualMachine {
-    private _parentObj: {
+    public parentObj: {
+        id: string;
         value: string;
         type: string;
     };
@@ -34,6 +35,7 @@ export class ContainerVm implements VirtualMachine {
     public overallStatus: string;
     public powerState: string;
     public containerName: string;
+    public parentObjectName: string;
     public imageName: string;
     public portMapping: string;
     public overallCpuUsage: number;
@@ -45,7 +47,12 @@ export class ContainerVm implements VirtualMachine {
         try {
             // populate vm information
             let splitVmId = data.id.split(FORWARD_SLASH);
-            this._parentObj = data.resourcePool;
+            this.parentObj = {
+                id: `urn:vmomi:${data.resourcePool.type}:${data.resourcePool.value}${COLON}${splitVmId[0]}`,
+                type: data.resourcePool.type,
+                value: data.resourcePool.value
+            };
+            this.parentObjectName = data.parentObjectName;
             this.vmId = `urn:vmomi:VirtualMachine:${splitVmId[1]}${COLON}${splitVmId[0]}`;
             this.name = data.name;
             this.overallStatus = data.overallStatus;
@@ -64,7 +71,7 @@ export class ContainerVm implements VirtualMachine {
     }
 
     get parentType() {
-        return this._parentObj.type;
+        return this.parentObj.type;
     }
 
     get id(): string {

--- a/ui/vic-ui-h5c/vic/src/vic-app/src/app/shared/constants/resources.path.ts
+++ b/ui/vic-ui-h5c/vic/src/vic-app/src/app/shared/constants/resources.path.ts
@@ -66,6 +66,7 @@ export const WS_CONTAINER = {
                 CPU_USAGE: 'vic_workspace.container.datagrid.columns.overallCpuUsage',
                 STORAGE_USAGE: 'vic_workspace.container.datagrid.columns.committedStorage',
                 PORT_MAPPING: 'vic_workspace.container.datagrid.columns.portMapping',
+                VCH_NAME: 'vic_workspace.container.datagrid.columns.vch',
                 VM_NAME: 'vic_workspace.container.datagrid.columns.name',
                 IMAGE_NAME: 'vic_workspace.container.datagrid.columns.imageName'
             },
@@ -76,6 +77,7 @@ export const WS_CONTAINER = {
                 'vic_workspace.container.datagrid.columns.overallCpuUsage': 'CPU Usage',
                 'vic_workspace.container.datagrid.columns.committedStorage': 'Storage Usage',
                 'vic_workspace.container.datagrid.columns.portMapping': 'Port Mapping',
+                'vic_workspace.container.datagrid.columns.vch': 'VCH',
                 'vic_workspace.container.datagrid.columns.name': 'VM',
                 'vic_workspace.container.datagrid.columns.imageName': 'Image'
             }

--- a/ui/vic-ui-h5c/vic/src/vic-app/src/app/vm.interface.ts
+++ b/ui/vic-ui-h5c/vic/src/vic-app/src/app/vm.interface.ts
@@ -71,6 +71,7 @@ export interface ContainerVmResponse {
     id: string;
     type: string;
     containerName: string;
+    parentObjectName: string;
     imageName: string;
     portMapping?: string | null;
     name: string;


### PR DESCRIPTION
This PR adds the VCH column to the Datagrid showing all Container VMs in the H5C's VIC section.

![image](https://cloud.githubusercontent.com/assets/3834071/26595234/5e2da85e-4530-11e7-9fc6-34aec5d11a4b.png)

Fixes #5249 