### PR TITLE
Add service to OVA for default VCH install wizard

### DIFF
--- a/installer/README.md
+++ b/installer/README.md
@@ -21,8 +21,8 @@ First, we have to set the revisions of the components we want to bundle in the O
 ```
 export BUILD_VICENGINE_REVISION=1.1.1      # Required (https://console.cloud.google.com/storage/browser/vic-engine-releases) if using dev build, this is used for UI plugin version
 export BUILD_VICENGINE_DEV_REVISION=10000  # Optional, (https://console.cloud.google.com/storage/browser/vic-engine-builds)
-export BUILD_HARBOR_REVISION=v1.1.1        # Optional, defaults to dev (https://console.cloud.google.com/storage/browser/harbor-dev-builds)
-export BUILD_ADMIRAL_REVISION=v1.1.1       # Optional, defaults to dev (https://hub.docker.com/r/vmware/admiral/tags/)
+export BUILD_HARBOR_REVISION=v1.1.1        # Optional, defaults to dev (https://console.cloud.google.com/storage/browser/harbor-builds)
+export BUILD_ADMIRAL_REVISION=v1.1.1       # Optional, defaults to vic_dev tag (https://hub.docker.com/r/vmware/admiral/tags/)
 ```
 
 Then set the required env vars for the build environment and make the release:

--- a/installer/README.md
+++ b/installer/README.md
@@ -21,7 +21,7 @@ First, we have to set the revisions of the components we want to bundle in the O
 ```
 export BUILD_VICENGINE_REVISION=1.1.1      # Required (https://console.cloud.google.com/storage/browser/vic-engine-releases) if using dev build, this is used for UI plugin version
 export BUILD_VICENGINE_DEV_REVISION=10000  # Optional, (https://console.cloud.google.com/storage/browser/vic-engine-builds)
-export BUILD_HARBOR_REVISION=v1.1.1        # Optional, defaults to dev (https://console.cloud.google.com/storage/browser/harbor-builds)
+export BUILD_HARBOR_REVISION=v1.1.1        # Optional, defaults to dev (https://console.cloud.google.com/storage/browser/harbor-dev-builds)
 export BUILD_ADMIRAL_REVISION=v1.1.1       # Optional, defaults to vic_dev tag (https://hub.docker.com/r/vmware/admiral/tags/)
 ```
 

--- a/installer/engine_installer/engine_installer.go
+++ b/installer/engine_installer/engine_installer.go
@@ -1,0 +1,7 @@
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("hello world")
+}

--- a/installer/engine_installer/engine_installer.go
+++ b/installer/engine_installer/engine_installer.go
@@ -1,3 +1,17 @@
+// Copyright 2017 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 import "fmt"

--- a/installer/packer/packer-vic.json
+++ b/installer/packer/packer-vic.json
@@ -112,6 +112,11 @@
     },
     {
       "type": "file",
+      "source": "../../bin/engine-installer",
+      "destination": "/usr/local/bin/engine-installer"
+    },
+    {
+      "type": "file",
       "source": "scripts/systemd/docker.service",
       "destination": "/usr/lib/systemd/system/docker.service"
     },
@@ -274,6 +279,30 @@
       "type": "file",
       "source": "scripts/fileserver/start_fileserver.sh",
       "destination": "/etc/vmware/fileserver/start_fileserver.sh"
+    },
+    {
+      "type": "shell",
+      "script": "scripts/provision_engine_installer.sh"
+    },
+    {
+      "type": "file",
+      "source": "scripts/systemd/engine_installer/engine_installer_startup.service",
+      "destination": "/usr/lib/systemd/system/engine_installer_startup.service"
+    },
+    {
+      "type": "file",
+      "source": "scripts/systemd/engine_installer/engine_installer.service",
+      "destination": "/usr/lib/systemd/system/engine_installer.service"
+    },
+    {
+      "type": "file",
+      "source": "scripts/fileserver/configure_engine_installer.sh",
+      "destination": "/etc/vmware/engine_installer/configure_engine_installer.sh"
+    },
+    {
+      "type": "file",
+      "source": "scripts/fileserver/start_engine_installer.sh",
+      "destination": "/etc/vmware/engine_installer/start_engine_installer.sh"
     },
     {
       "type": "shell",

--- a/installer/packer/packer-vic.json
+++ b/installer/packer/packer-vic.json
@@ -112,8 +112,8 @@
     },
     {
       "type": "file",
-      "source": "../../bin/engine-installer",
-      "destination": "/usr/local/bin/engine-installer"
+      "source": "../../bin/ova-engine-installer",
+      "destination": "/usr/local/bin/ova-engine-installer"
     },
     {
       "type": "file",
@@ -296,12 +296,12 @@
     },
     {
       "type": "file",
-      "source": "scripts/fileserver/configure_engine_installer.sh",
+      "source": "scripts/engine_installer/configure_engine_installer.sh",
       "destination": "/etc/vmware/engine_installer/configure_engine_installer.sh"
     },
     {
       "type": "file",
-      "source": "scripts/fileserver/start_engine_installer.sh",
+      "source": "scripts/engine_installer/start_engine_installer.sh",
       "destination": "/etc/vmware/engine_installer/start_engine_installer.sh"
     },
     {

--- a/installer/packer/scripts/engine_installer/configure_engine_installer.sh
+++ b/installer/packer/scripts/engine_installer/configure_engine_installer.sh
@@ -49,7 +49,8 @@ if [[ x${engine_installer_cert} != "x" && x${engine_installer_key} != "x" ]]; th
 fi
 
 FILESERVER_DIR="/opt/vmware/fileserver/files"
-if [ ! -d "${FILESERVER_DIR}" ]; then
+FILE_COUNT=$(find ${FILESERVER_DIR} -name "vic*.tar.gz" | wc -l)
+if [ ! -d "${FILESERVER_DIR}" ] || [ ${FILE_COUNT} -ne 1] ; then
 	echo "Fileserver files not present. Unable to get VIC Engine tarball"
 	systemctl stop engine_installer
 	exit 1

--- a/installer/packer/scripts/engine_installer/configure_engine_installer.sh
+++ b/installer/packer/scripts/engine_installer/configure_engine_installer.sh
@@ -50,7 +50,7 @@ fi
 
 FILESERVER_DIR="/opt/vmware/fileserver/files"
 FILE_COUNT=$(find ${FILESERVER_DIR} -name "vic*.tar.gz" | wc -l)
-if [ ! -d "${FILESERVER_DIR}" ] || [ ${FILE_COUNT} -ne 1] ; then
+if [ ! -d "${FILESERVER_DIR}" ] || [ ${FILE_COUNT} -ne 1 ] ; then
 	echo "Fileserver files not present. Unable to get VIC Engine tarball"
 	systemctl stop engine_installer
 	exit 1

--- a/installer/packer/scripts/engine_installer/configure_engine_installer.sh
+++ b/installer/packer/scripts/engine_installer/configure_engine_installer.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/bash
+# Copyright 2017 VMware, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+set -euf -o pipefail
+
+umask 077
+
+run_engine_installer=$(ovfenv -k engine_installer.wizard_enabled)
+
+if [ ${deploy,,} != "true" ]; then
+  echo "Not configuring Engine Installer and disabling service startup"
+  systemctl stop engine_installer
+  exit 0
+fi
+
+data_dir=/opt/vmware/engine_installer
+cert_dir=${data_dir}/cert
+cert=${cert_dir}/server.crt
+key=${cert_dir}/server.key
+
+engine_installer_cert=$(ovfenv -k engine_installer.ssl_cert)
+engine_installer_key=$(ovfenv -k engine_installer.ssl_cert_key)
+port=$(ovfenv -k engine_installer.port)
+
+iptables -w -A INPUT -j ACCEPT -p tcp --dport $port
+
+# Format cert file
+function formatCert {
+  content=$1
+  file=$2
+  echo ${content} | sed -r 's/(-{5}BEGIN [A-Z ]+-{5})/&\n/g; s/(-{5}END [A-Z ]+-{5})/\n&\n/g' | sed -r 's/.{64}/&\n/g; /^\s*$/d' > ${file}
+}
+
+if [[ x${engine_installer_cert} != "x" && x${engine_installer_key} != "x" ]]; then
+  mkdir -p "${cert_dir}"
+  formatCert "${engine_installer_cert}" ${cert}
+  formatCert "${engine_installer_key}" ${key}
+fi
+
+FILESERVER_DIR="/opt/vmware/fileserver/files"
+if [ ! -d "${FILESERVER_DIR}" ]; then
+	echo "Fileserver files not present. Unable to get VIC Engine tarball"
+	systemctl stop engine_installer
+	exit 1
+fi
+
+# Extract vic-machine
+find ${FILESERVER_DIR} -name "vic*.tar.gz" | xargs -I {} tar xvf {} --directory ${data_dir}

--- a/installer/packer/scripts/engine_installer/configure_engine_installer.sh
+++ b/installer/packer/scripts/engine_installer/configure_engine_installer.sh
@@ -16,37 +16,11 @@ set -euf -o pipefail
 
 umask 077
 
-run_engine_installer=$(ovfenv -k engine_installer.wizard_enabled)
+data_dir="/opt/vmware/engine_installer"
+mkdir -p ${data_dir}
 
-if [ ${deploy,,} != "true" ]; then
-  echo "Not configuring Engine Installer and disabling service startup"
-  systemctl stop engine_installer
-  exit 0
-fi
-
-data_dir=/opt/vmware/engine_installer
-cert_dir=${data_dir}/cert
-cert=${cert_dir}/server.crt
-key=${cert_dir}/server.key
-
-engine_installer_cert=$(ovfenv -k engine_installer.ssl_cert)
-engine_installer_key=$(ovfenv -k engine_installer.ssl_cert_key)
 port=$(ovfenv -k engine_installer.port)
-
 iptables -w -A INPUT -j ACCEPT -p tcp --dport $port
-
-# Format cert file
-function formatCert {
-  content=$1
-  file=$2
-  echo ${content} | sed -r 's/(-{5}BEGIN [A-Z ]+-{5})/&\n/g; s/(-{5}END [A-Z ]+-{5})/\n&\n/g' | sed -r 's/.{64}/&\n/g; /^\s*$/d' > ${file}
-}
-
-if [[ x${engine_installer_cert} != "x" && x${engine_installer_key} != "x" ]]; then
-  mkdir -p "${cert_dir}"
-  formatCert "${engine_installer_cert}" ${cert}
-  formatCert "${engine_installer_key}" ${key}
-fi
 
 FILESERVER_DIR="/opt/vmware/fileserver/files"
 FILE_COUNT=$(find ${FILESERVER_DIR} -name "vic*.tar.gz" | wc -l)

--- a/installer/packer/scripts/engine_installer/configure_engine_installer.sh
+++ b/installer/packer/scripts/engine_installer/configure_engine_installer.sh
@@ -31,4 +31,9 @@ if [ ! -d "${FILESERVER_DIR}" ] || [ ${FILE_COUNT} -ne 1 ] ; then
 fi
 
 # Extract vic-machine
+VIC_DIR="${FILESERVER_DIR}/vic"
+if [ -d "${VIC_DIR}" ]; then
+  rm -rf ${VIC_DIR}
+fi
+
 find ${FILESERVER_DIR} -name "vic*.tar.gz" | xargs -I {} tar xvf {} --directory ${data_dir}

--- a/installer/packer/scripts/engine_installer/start_engine_installer.sh
+++ b/installer/packer/scripts/engine_installer/start_engine_installer.sh
@@ -14,22 +14,8 @@
 # limitations under the License.
 set -euf -o pipefail
 
-data_dir=/opt/vmware/engine_installer
-cert_dir=${data_dir}/cert
-cert=${cert_dir}/server.crt
-key=${cert_dir}/server.key
+data_dir="/opt/vmware/engine_installer"
 
-engine_installer_cert=$(ovfenv -k engine_installer.ssl_cert)
-engine_installer_key=$(ovfenv -k engine_installer.ssl_cert_key)
 port=$(ovfenv -k engine_installer.port)
-target=$(ovfenv -k engine_installer.vcenter_addr)
-username=$(ovfenv -k engine_installer.admin_user)
-password=$(ovfenv -k engine_installer.admin_password)
 
-if [[ x$engine_installer_cert != "x" && x$engine_installer_key != "x" ]]; then
-  /usr/local/bin/ova-engine-installer --addr ":${port}" --cert "${cert}" --key "${key}" --target "${target}" --username "${username}" --password "${password}"
-else
-  /usr/local/bin/ova-engine-installer --addr ":${port}" --target "${target}" --username "${username}" --password "${password}"
-
-fi
-
+/usr/local/bin/ova-engine-installer --addr ":${port}" --data "${data_dir}"

--- a/installer/packer/scripts/engine_installer/start_engine_installer.sh
+++ b/installer/packer/scripts/engine_installer/start_engine_installer.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/bash
+# Copyright 2017 VMware, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+set -euf -o pipefail
+
+data_dir=/opt/vmware/engine_installer
+cert_dir=${data_dir}/cert
+cert=${cert_dir}/server.crt
+key=${cert_dir}/server.key
+
+engine_installer_cert=$(ovfenv -k engine_installer.ssl_cert)
+engine_installer_key=$(ovfenv -k engine_installer.ssl_cert_key)
+port=$(ovfenv -k engine_installer.port)
+target=$(ovfenv -k engine_installer.vcenter_addr)
+username=$(ovfenv -k engine_installer.admin_user)
+password=$(ovfenv -k engine_installer.admin_password)
+
+if [[ x$engine_installer_cert != "x" && x$engine_installer_key != "x" ]]; then
+  /usr/local/bin/engine-installer --addr ":${port}" --cert "${cert}" --key "${key}" --target "${target}" --username "${username}" --password "${password}"
+else
+  /usr/local/bin/engine-installer --addr ":${port}" --target "${target}" --username "${username}" --password "${password}"
+
+fi
+

--- a/installer/packer/scripts/engine_installer/start_engine_installer.sh
+++ b/installer/packer/scripts/engine_installer/start_engine_installer.sh
@@ -27,9 +27,9 @@ username=$(ovfenv -k engine_installer.admin_user)
 password=$(ovfenv -k engine_installer.admin_password)
 
 if [[ x$engine_installer_cert != "x" && x$engine_installer_key != "x" ]]; then
-  /usr/local/bin/engine-installer --addr ":${port}" --cert "${cert}" --key "${key}" --target "${target}" --username "${username}" --password "${password}"
+  /usr/local/bin/ova-engine-installer --addr ":${port}" --cert "${cert}" --key "${key}" --target "${target}" --username "${username}" --password "${password}"
 else
-  /usr/local/bin/engine-installer --addr ":${port}" --target "${target}" --username "${username}" --password "${password}"
+  /usr/local/bin/ova-engine-installer --addr ":${port}" --target "${target}" --username "${username}" --password "${password}"
 
 fi
 

--- a/installer/packer/scripts/fileserver/configure_fileserver.sh
+++ b/installer/packer/scripts/fileserver/configure_fileserver.sh
@@ -16,10 +16,10 @@ set -euf -o pipefail
 
 umask 077
 
-data_dir=/opt/vmware/fileserver
-cert_dir=${data_dir}/cert
-cert=${cert_dir}/server.crt
-key=${cert_dir}/server.key
+data_dir="/opt/vmware/fileserver"
+cert_dir="${data_dir}/cert"
+cert="${cert_dir}/server.crt"
+key="${cert_dir}/server.key"
 
 port=$(ovfenv -k fileserver.port)
 fileserver_cert=$(ovfenv -k fileserver.ssl_cert)

--- a/installer/packer/scripts/provision_engine_installer.sh
+++ b/installer/packer/scripts/provision_engine_installer.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/bash
+# Copyright 2017 VMware, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+set -euf -o pipefail
+
+mkdir -p /etc/vmware/engine_installer # Engine installer config scripts

--- a/installer/packer/scripts/provision_harbor.sh
+++ b/installer/packer/scripts/provision_harbor.sh
@@ -17,7 +17,7 @@ set -euf -o pipefail
 BUILD_HARBOR_REVISION="${BUILD_HARBOR_REVISION:-dev}"
 
 # Download Build
-HARBOR_URL="https://storage.googleapis.com/harbor-dev-builds/harbor-offline-installer-${BUILD_HARBOR_REVISION}.tgz"
+HARBOR_URL="https://storage.googleapis.com/harbor-builds/harbor-offline-installer-${BUILD_HARBOR_REVISION}.tgz"
 echo "Downloading Harbor ${BUILD_HARBOR_REVISION}: ${HARBOR_URL}"
 curl -L ${HARBOR_URL}  | tar xz -C /var/tmp
 

--- a/installer/packer/scripts/provision_harbor.sh
+++ b/installer/packer/scripts/provision_harbor.sh
@@ -17,7 +17,7 @@ set -euf -o pipefail
 BUILD_HARBOR_REVISION="${BUILD_HARBOR_REVISION:-dev}"
 
 # Download Build
-HARBOR_URL="https://storage.googleapis.com/harbor-builds/harbor-offline-installer-${BUILD_HARBOR_REVISION}.tgz"
+HARBOR_URL="https://storage.googleapis.com/harbor-dev-builds/harbor-offline-installer-${BUILD_HARBOR_REVISION}.tgz"
 echo "Downloading Harbor ${BUILD_HARBOR_REVISION}: ${HARBOR_URL}"
 curl -L ${HARBOR_URL}  | tar xz -C /var/tmp
 

--- a/installer/packer/scripts/system_settings.sh
+++ b/installer/packer/scripts/system_settings.sh
@@ -32,6 +32,7 @@ systemctl enable ova-firewall.service
 systemctl enable harbor_startup.service harbor.service
 systemctl enable admiral_startup.service admiral
 systemctl enable fileserver_startup.service fileserver.service
+systemctl enable engine_installer_startup.service engine_installer.service
 
 # Clean up temporary directories
 rm -rf /var/tmp/harbor

--- a/installer/packer/scripts/systemd/engine_installer/engine_installer.service
+++ b/installer/packer/scripts/systemd/engine_installer/engine_installer.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=VIC Engine Install Wizard Service
+Documentation=https://github.com/vmware/vic
+After=engine_installer_startup.service
+
+[Service]
+Type=simple
+Restart=on-failure
+RestartSec=5
+ExecStart=/etc/vmware/engine_installer/start_engine_installer.sh
+
+[Install]
+WantedBy=multi-user.target

--- a/installer/packer/scripts/systemd/engine_installer/engine_installer_startup.service
+++ b/installer/packer/scripts/systemd/engine_installer/engine_installer_startup.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=VIC Engine Install Wizard Startup Configuration
+Documentation=https://github.com/vmware/vic
+After=systemd-networkd.service systemd-resolved.service
+Before=engine_installer.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/bash /etc/vmware/engine_installer/configure_engine_installer.sh
+
+[Install]
+WantedBy=multi-user.target

--- a/installer/packer/vic-unified.ovf
+++ b/installer/packer/vic-unified.ovf
@@ -297,33 +297,9 @@ EVALUATION LICENSE. If You are licensing the Software for evaluation purposes, Y
     <ProductSection ovf:class="engine_installer" ovf:required="false">
       <Info>VIC Engine Install Wizard Properties</Info>
       <Category>6. VIC Engine Install Wizard Configuration</Category>
-      <Property ovf:key="deploy" ovf:type="boolean" ovf:userConfigurable="true" ovf:value="false">
-        <Label>6.1. Enable VIC Engine Install Wizard</Label>
-        <Description>When setting this to true, starts the VIC Engine Install Wizard web application.</Description>
-      </Property>
-      <Property ovf:key="vcenter_addr" ovf:qualifiers="MinLen(0),MaxLen(65535)" ovf:type="string" ovf:userConfigurable="true" ovf:value="">
-        <Label>6.2. vCenter Address</Label>
-        <Description>IP address or FQDN of the vCenter. Leave blank if not using VIC Engine Install Wizard.</Description>
-      </Property>
-      <Property ovf:key="admin_user" ovf:qualifiers="MinLen(0),MaxLen(65535)" ovf:type="string" ovf:userConfigurable="true" ovf:value="">
-        <Label>6.3. vCenter Admin Username</Label>
-        <Description>Username of the vCenter admin user. Leave blank if not using VIC Engine Install Wizard.</Description>
-      </Property>
-      <Property ovf:key="admin_password" ovf:password="true" ovf:qualifiers="MinLen(0),MaxLen(65535)" ovf:type="string" ovf:userConfigurable="true" ovf:value="">
-        <Label>6.4. vCenter Admin Password</Label>
-        <Description>Password of the vCenter admin user. Leave blank if not using VIC Engine Install Wizard.</Description>
-      </Property>
       <Property ovf:key="port" ovf:qualifiers="MinValue(1),MaxValue(65535)" ovf:type="int" ovf:userConfigurable="true" ovf:value="1337">
-        <Label>6.5. Engine Install Wizard Port</Label>
+        <Label>6.1. Engine Install Wizard Port</Label>
         <Description>Specifies the port on which fileserver will be published.</Description>
-      </Property>
-      <Property ovf:key="ssl_cert" ovf:qualifiers="MinLen(0),MaxLen(65535)" ovf:type="string" ovf:userConfigurable="true" ovf:value="">
-        <Label>6.6. SSL Cert</Label>
-        <Description>Paste in the content of a certificate file. Leave blank for a generated self-signed certificate.</Description>
-      </Property>
-      <Property ovf:key="ssl_cert_key" ovf:qualifiers="MinLen(0),MaxLen(65535)" ovf:type="string" ovf:userConfigurable="true" ovf:value="">
-        <Label>6.7. SSL Cert Key</Label>
-        <Description>Paste in the content of certificate key file. Leave blank for a generated key.</Description>
       </Property>
     </ProductSection>
     <ProductSection ovf:class="vm" ovf:required="false">

--- a/installer/packer/vic-unified.ovf
+++ b/installer/packer/vic-unified.ovf
@@ -309,7 +309,7 @@ EVALUATION LICENSE. If You are licensing the Software for evaluation purposes, Y
         <Label>6.3. vCenter Admin Username</Label>
         <Description>Username of the vCenter admin user. Leave blank if not using VIC Engine Install Wizard.</Description>
       </Property>
-      <Property ovf:key="admin_password" ovf:password="true" ovf:qualifiers="MinLen(0),MaxLen(i65535)" ovf:type="string" ovf:userConfigurable="true" ovf:value="">
+      <Property ovf:key="admin_password" ovf:password="true" ovf:qualifiers="MinLen(0),MaxLen(65535)" ovf:type="string" ovf:userConfigurable="true" ovf:value="">
         <Label>6.4. vCenter Admin Password</Label>
         <Description>Password of the vCenter admin user. Leave blank if not using VIC Engine Install Wizard.</Description>
       </Property>

--- a/installer/packer/vic-unified.ovf
+++ b/installer/packer/vic-unified.ovf
@@ -301,24 +301,28 @@ EVALUATION LICENSE. If You are licensing the Software for evaluation purposes, Y
         <Label>6.1. Enable VIC Engine Install Wizard</Label>
         <Description>When setting this to true, starts the VIC Engine Install Wizard web application.</Description>
       </Property>
+      <Property ovf:key="vcenter_addr" ovf:qualifiers="MinLen(0),MaxLen(65535)" ovf:type="string" ovf:userConfigurable="true" ovf:value="">
+        <Label>6.2. vCenter Address</Label>
+        <Description>IP address or FQDN of the vCenter. Leave blank if not using VIC Engine Install Wizard.</Description>
+      </Property>
       <Property ovf:key="admin_user" ovf:qualifiers="MinLen(0),MaxLen(65535)" ovf:type="string" ovf:userConfigurable="true" ovf:value="">
-        <Label>6.2. vCenter Admin Username</Label>
-        <Description>Username of the vCenter admin user. Leave blank if not using VIC Engine Install Wizard..</Description>
+        <Label>6.3. vCenter Admin Username</Label>
+        <Description>Username of the vCenter admin user. Leave blank if not using VIC Engine Install Wizard.</Description>
       </Property>
       <Property ovf:key="admin_password" ovf:password="true" ovf:qualifiers="MinLen(0),MaxLen(i65535)" ovf:type="string" ovf:userConfigurable="true" ovf:value="">
-        <Label>6.3. vCenter Admin Password</Label>
+        <Label>6.4. vCenter Admin Password</Label>
         <Description>Password of the vCenter admin user. Leave blank if not using VIC Engine Install Wizard.</Description>
       </Property>
       <Property ovf:key="port" ovf:qualifiers="MinValue(1),MaxValue(65535)" ovf:type="int" ovf:userConfigurable="true" ovf:value="1337">
-        <Label>6.4. Engine Install Wizard Port</Label>
+        <Label>6.5. Engine Install Wizard Port</Label>
         <Description>Specifies the port on which fileserver will be published.</Description>
       </Property>
       <Property ovf:key="ssl_cert" ovf:qualifiers="MinLen(0),MaxLen(65535)" ovf:type="string" ovf:userConfigurable="true" ovf:value="">
-        <Label>6.5. SSL Cert</Label>
+        <Label>6.6. SSL Cert</Label>
         <Description>Paste in the content of a certificate file. Leave blank for a generated self-signed certificate.</Description>
       </Property>
       <Property ovf:key="ssl_cert_key" ovf:qualifiers="MinLen(0),MaxLen(65535)" ovf:type="string" ovf:userConfigurable="true" ovf:value="">
-        <Label>6.6. SSL Cert Key</Label>
+        <Label>6.7. SSL Cert Key</Label>
         <Description>Paste in the content of certificate key file. Leave blank for a generated key.</Description>
       </Property>
     </ProductSection>

--- a/installer/packer/vic-unified.ovf
+++ b/installer/packer/vic-unified.ovf
@@ -294,6 +294,34 @@ EVALUATION LICENSE. If You are licensing the Software for evaluation purposes, Y
         <Description>Paste in the content of certificate key file. Leave blank for a generated key.</Description>
       </Property>
     </ProductSection>
+    <ProductSection ovf:class="engine_installer" ovf:required="false">
+      <Info>VIC Engine Install Wizard Properties</Info>
+      <Category>6. VIC Engine Install Wizard Configuration</Category>
+      <Property ovf:key="wizard_enabled" ovf:type="boolean" ovf:userConfigurable="true" ovf:value="false">
+        <Label>6.1. Enable VIC Engine Install Wizard</Label>
+        <Description>When setting this to true, starts the VIC Engine Install Wizard web application.</Description>
+      </Property>
+      <Property ovf:key="admin_user" ovf:qualifiers="MinLen(0),MaxLen(65535)" ovf:type="string" ovf:userConfigurable="true" ovf:value="">
+        <Label>6.2. vCenter Admin Username</Label>
+        <Description>Username of the vCenter admin user. Leave blank if not using VIC Engine Install Wizard..</Description>
+      </Property>
+      <Property ovf:key="admin_password" ovf:password="true" ovf:qualifiers="MinLen(0),MaxLen(i65535)" ovf:type="string" ovf:userConfigurable="true" ovf:value="">
+        <Label>6.3. vCenter Admin Password</Label>
+        <Description>Password of the vCenter admin user. Leave blank if not using VIC Engine Install Wizard.</Description>
+      </Property>
+      <Property ovf:key="port" ovf:qualifiers="MinValue(1),MaxValue(65535)" ovf:type="int" ovf:userConfigurable="true" ovf:value="1337">
+        <Label>6.4. Engine Install Wizard Port</Label>
+        <Description>Specifies the port on which fileserver will be published.</Description>
+      </Property>
+      <Property ovf:key="ssl_cert" ovf:qualifiers="MinLen(0),MaxLen(65535)" ovf:type="string" ovf:userConfigurable="true" ovf:value="">
+        <Label>6.5. SSL Cert</Label>
+        <Description>Paste in the content of a certificate file. Leave blank for a generated self-signed certificate.</Description>
+      </Property>
+      <Property ovf:key="ssl_cert_key" ovf:qualifiers="MinLen(0),MaxLen(65535)" ovf:type="string" ovf:userConfigurable="true" ovf:value="">
+        <Label>6.6. SSL Cert Key</Label>
+        <Description>Paste in the content of certificate key file. Leave blank for a generated key.</Description>
+      </Property>
+    </ProductSection>
     <ProductSection ovf:class="vm" ovf:required="false">
       <Info>VM specific properties</Info>
       <Property ovf:key="vmname" ovf:type="string" ovf:value="vic"/>

--- a/installer/packer/vic-unified.ovf
+++ b/installer/packer/vic-unified.ovf
@@ -297,7 +297,7 @@ EVALUATION LICENSE. If You are licensing the Software for evaluation purposes, Y
     <ProductSection ovf:class="engine_installer" ovf:required="false">
       <Info>VIC Engine Install Wizard Properties</Info>
       <Category>6. VIC Engine Install Wizard Configuration</Category>
-      <Property ovf:key="wizard_enabled" ovf:type="boolean" ovf:userConfigurable="true" ovf:value="false">
+      <Property ovf:key="deploy" ovf:type="boolean" ovf:userConfigurable="true" ovf:value="false">
         <Label>6.1. Enable VIC Engine Install Wizard</Label>
         <Description>When setting this to true, starts the VIC Engine Install Wizard web application.</Description>
       </Property>

--- a/installer/vic-unified-installer.mk
+++ b/installer/vic-unified-installer.mk
@@ -29,9 +29,11 @@ PHOTON_ISO_SHA1SUM := c4c6cb94c261b162e7dac60fdffa96ddb5836d66
 ovfenv := $(BIN)/ovfenv
 vic-ova-ui := $(BIN)/vic-ova-ui
 ova-webserver := $(BIN)/ova-webserver
+ova-engine-installer := $(BIN)/ova-engine-installer
 ovfenv: $(ovfenv)
 vic-ova-ui: $(vic-ova-ui)
 ova-webserver: $(ova-webserver)
+ova-engine-installer: $(ova-engine-installer)
 
 $(ovfenv): $$(call godeps,installer/ovatools/ovfenv/*.go)
 	@echo building ovfenv linux...
@@ -45,7 +47,11 @@ $(ova-webserver): $$(call godeps,installer/fileserver/*.go)
 	@echo building ova-webserver
 	@GOARCH=amd64 GOOS=linux $(TIME) $(GO) build $(RACE) -ldflags "$(LDFLAGS)" -o ./$@ ./$(dir $<)
 
-ova-release: $(ovfenv) $(vic-ova-ui) $(ova-webserver)
+$(ova-engine-installer): $$(call godeps,installer/engine_installer/*.go)
+	@echo building ova-engine-installer
+	@GOARCH=amd64 GOOS=linux $(TIME) $(GO) build $(RACE) -ldflags "$(LDFLAGS)" -o ./$@ ./$(dir $<)
+
+ova-release: $(ovfenv) $(vic-ova-ui) $(ova-webserver) $(ova-engine-installer)
 	@echo building vic-unified-installer OVA using packer...
 	@cd $(BASE_DIR)installer/packer && $(PACKER) build \
 			-only=ova-release \
@@ -68,7 +74,7 @@ ova-release: $(ovfenv) $(vic-ova-ui) $(ova-webserver)
 	@echo cleaning packer directory...
 	@cd $(BASE_DIR)installer/packer && $(RM) -rf vic
 
-ova-debug: $(ovfenv) $(vic-ova-ui) $(ova-webserver)
+ova-debug: $(ovfenv) $(vic-ova-ui) $(ova-webserver) $(ova-engine-installer)
 	@echo building vic-unified-installer OVA using packer...
 	cd $(BASE_DIR)installer/packer && PACKER_LOG=1 $(PACKER) build \
 			-only=ova-release \
@@ -91,7 +97,7 @@ ova-debug: $(ovfenv) $(vic-ova-ui) $(ova-webserver)
 	@echo cleaning packer directory...
 	cd $(BASE_DIR)installer/packer && $(RM) -rf vic
 
-vagrant-local: $(ovfenv) $(vic-ova-ui) $(ova-webserver)
+vagrant-local: $(ovfenv) $(vic-ova-ui) $(ova-webserver) $(ova-engine-installer)
 	@echo building vic-unified-installer Vagrant box using packer...
 	@cd $(BASE_DIR)installer/packer && $(PACKER) build \
 			-only=vagrant-local \


### PR DESCRIPTION
Partial for 4731

Install systemd unit for OVA engine installer, update makefiles, add VIC engine install wizard section to OVA deploy

Following work will add a web app for users to input values that will be used to run `vic-machine create` to make a default VCH