### PR TITLE
Various speed improvements in the nightly tests

### DIFF
--- a/tests/manual-test-cases/Group5-Functional-Tests/5-1-Distributed-Switch.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-1-Distributed-Switch.robot
@@ -20,17 +20,21 @@ Suite Teardown  Run Keyword And Ignore Error  Nimbus Cleanup  ${list}
 *** Test Cases ***
 Test
     Log To Console  \nStarting test...
-    ${esx1}  ${esx1-ip}=  Deploy Nimbus ESXi Server  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}
-    Set Suite Variable  ${ESX1}  ${esx1}
-    ${esx2}  ${esx2-ip}=  Deploy Nimbus ESXi Server  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}
-    Set Suite Variable  ${ESX2}  ${esx2}
-    ${esx3}  ${esx3-ip}=  Deploy Nimbus ESXi Server  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}
-    Set Suite Variable  ${ESX3}  ${esx3}
+    # Let's make 5 because it is free and in parallel, but only use 3 of them
+    &{esxes}=  Deploy Multiple Nimbus ESXi Servers in Parallel  5  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}
+    @{esx-names}=  Get Dictionary Keys  ${esxes}
+    @{esx-ips}=  Get Dictionary Values  ${esxes}
+    ${esx1}=  Get From List  ${esx-names}  0
+    ${esx2}=  Get From List  ${esx-names}  1
+    ${esx3}=  Get From List  ${esx-names}  2
+    ${esx1-ip}=  Get From List  ${esx-ips}  0
+    ${esx2-ip}=  Get From List  ${esx-ips}  1
+    ${esx3-ip}=  Get From List  ${esx-ips}  2
 
     ${vc}  ${vc-ip}=  Deploy Nimbus vCenter Server  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}
     Set Suite Variable  ${VC}  ${vc}
 
-    Set Global Variable  @{list}  ${esx1}  ${esx2}  ${esx3}  ${vc}
+    Set Global Variable  @{list}  ${esx-names}  ${vc}
 
     Log To Console  Create a datacenter on the VC
     ${out}=  Run  govc datacenter.create ha-datacenter

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-3-Enhanced-Linked-Mode.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-3-Enhanced-Linked-Mode.robot
@@ -31,25 +31,8 @@ Combine Dictionaries
 Test
     ${name}=  Evaluate  'els-' + str(random.randint(1000,9999))  modules=random
     Set Test Variable  ${user}  %{NIMBUS_USER}
-    ${output}=  Deploy Nimbus Testbed  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}  --plugin test-vpx --testbedName test-vpx-m2n2-vcva-3esx-pxeBoot-8gbmem --vcvaBuild ${VC_VERSION} --esxPxeDir ${ESX_VERSION} --runName ${name}
-
-    ${output}=  Split To Lines  ${output}
-    :FOR  ${line}  IN  @{output}
-    \   ${status}=  Run Keyword And Return Status  Should Contain  ${line}  ${name}.vc.0' is up. IP:
-    \   ${ip}=  Run Keyword If  ${status}  Fetch From Right  ${line}  ${SPACE}
-    \   Run Keyword If  ${status}  Set Test Variable  ${vc1-ip}  ${ip}
-    \   ${status}=  Run Keyword And Return Status  Should Contain  ${line}  ${name}.vc.1' is up. IP:
-    \   ${ip}=  Run Keyword If  ${status}  Fetch From Right  ${line}  ${SPACE}
-    \   Run Keyword If  ${status}  Set Test Variable  ${vc2-ip}  ${ip}
-    \   ${status}=  Run Keyword And Return Status  Should Contain  ${line}  ${name}.esx.0' is up. IP:
-    \   ${ip}=  Run Keyword If  ${status}  Fetch From Right  ${line}  ${SPACE}
-    \   Run Keyword If  ${status}  Set Test Variable  ${esx1-ip}  ${ip}
-    \   ${status}=  Run Keyword And Return Status  Should Contain  ${line}  ${name}.esx.1' is up. IP:
-    \   ${ip}=  Run Keyword If  ${status}  Fetch From Right  ${line}  ${SPACE}
-    \   Run Keyword If  ${status}  Set Test Variable  ${esx2-ip}  ${ip}
-    \   ${status}=  Run Keyword And Return Status  Should Contain  ${line}  ${name}.esx.2' is up. IP:
-    \   ${ip}=  Run Keyword If  ${status}  Fetch From Right  ${line}  ${SPACE}
-    \   Run Keyword If  ${status}  Set Test Variable  ${esx3-ip}  ${ip}
+    Log To Console  \nDeploying Nimbus Testbed: ${name}
+    ${pid}=  Run Secret SSHPASS command  %{NIMBUS_USER}  '%{NIMBUS_PASSWORD}'  'nimbus-testbeddeploy --plugin test-vpx --testbedName test-vpx-m2n2-vcva-3esx-pxeBoot-8gbmem --vcvaBuild ${VC_VERSION} --esxPxeDir ${ESX_VERSION} --runName ${name}'
 
     &{esxes}=  Create Dictionary
     ${num_of_esxes}=  Evaluate  3
@@ -74,6 +57,27 @@ Test
     ${esx4-ip}=  Get From List  ${esx-ips}  0
     ${esx5-ip}=  Get From List  ${esx-ips}  1
     ${esx6-ip}=  Get From List  ${esx-ips}  2
+
+    # Finish test bed deploy
+    ${output}=  Wait For Process  ${pid}
+    Should Be Equal As Integers  ${output.rc}  0
+    ${output}=  Split To Lines  ${output.stdout}
+    :FOR  ${line}  IN  @{output}
+    \   ${status}=  Run Keyword And Return Status  Should Contain  ${line}  ${name}.vc.0' is up. IP:
+    \   ${ip}=  Run Keyword If  ${status}  Fetch From Right  ${line}  ${SPACE}
+    \   Run Keyword If  ${status}  Set Test Variable  ${vc1-ip}  ${ip}
+    \   ${status}=  Run Keyword And Return Status  Should Contain  ${line}  ${name}.vc.1' is up. IP:
+    \   ${ip}=  Run Keyword If  ${status}  Fetch From Right  ${line}  ${SPACE}
+    \   Run Keyword If  ${status}  Set Test Variable  ${vc2-ip}  ${ip}
+    \   ${status}=  Run Keyword And Return Status  Should Contain  ${line}  ${name}.esx.0' is up. IP:
+    \   ${ip}=  Run Keyword If  ${status}  Fetch From Right  ${line}  ${SPACE}
+    \   Run Keyword If  ${status}  Set Test Variable  ${esx1-ip}  ${ip}
+    \   ${status}=  Run Keyword And Return Status  Should Contain  ${line}  ${name}.esx.1' is up. IP:
+    \   ${ip}=  Run Keyword If  ${status}  Fetch From Right  ${line}  ${SPACE}
+    \   Run Keyword If  ${status}  Set Test Variable  ${esx2-ip}  ${ip}
+    \   ${status}=  Run Keyword And Return Status  Should Contain  ${line}  ${name}.esx.2' is up. IP:
+    \   ${ip}=  Run Keyword If  ${status}  Fetch From Right  ${line}  ${SPACE}
+    \   Run Keyword If  ${status}  Set Test Variable  ${esx3-ip}  ${ip}
 
     Set Global Variable  @{list}  ${esx1}  ${esx2}  ${esx3}  ${user}-${name}.vc.0  ${user}-${name}.vc.1  ${user}-${name}.vc.2  ${user}-${name}.vc.3  ${user}-${name}.nfs.0  ${user}-${name}.esx.0  ${user}-${name}.esx.1  ${user}-${name}.esx.2
 

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-4-High-Availability.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-4-High-Availability.robot
@@ -85,14 +85,21 @@ Test
     Run Keyword If  '${status}' == 'closed'  Fail  Test 5-4-High-Availability.robot needs to be updated now that Issue #4858 has been resolved
 
     Log To Console  \nStarting test...
-    ${esx1}  ${esx1-ip}=  Deploy Nimbus ESXi Server  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}
-    ${esx2}  ${esx2-ip}=  Deploy Nimbus ESXi Server  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}
-    ${esx3}  ${esx3-ip}=  Deploy Nimbus ESXi Server  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}
+    # Let's make 5 because it is free and in parallel, but only use 3 of them
+    &{esxes}=  Deploy Multiple Nimbus ESXi Servers in Parallel  5  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}
+    @{esx-names}=  Get Dictionary Keys  ${esxes}
+    @{esx-ips}=  Get Dictionary Values  ${esxes}
+    ${esx1}=  Get From List  ${esx-names}  0
+    ${esx2}=  Get From List  ${esx-names}  1
+    ${esx3}=  Get From List  ${esx-names}  2
+    ${esx1-ip}=  Get From List  ${esx-ips}  0
+    ${esx2-ip}=  Get From List  ${esx-ips}  1
+    ${esx3-ip}=  Get From List  ${esx-ips}  2
 
     ${vc}  ${vc-ip}=  Deploy Nimbus vCenter Server  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}
     Set Suite Variable  ${VC}  ${vc}
 
-    Set Global Variable  @{list}  ${esx1}  ${esx2}  ${esx3}  ${vc}
+    Set Global Variable  @{list}  ${esx-names}  ${vc}
 
     Log To Console  Create a datacenter on the VC
     ${out}=  Run  govc datacenter.create ha-datacenter

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-6-2-VSAN-Complex.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-6-2-VSAN-Complex.robot
@@ -15,7 +15,16 @@
 *** Settings ***
 Documentation  Test 5-6-2 - VSAN-Complex
 Resource  ../../resources/Util.robot
-Test Teardown  Run Keyword And Ignore Error  Nimbus Cleanup  ${list}
+Test Teardown  VSAN Cleanup
+
+*** Keywords ***
+VSAN Cleanup
+    Cleanup VIC Appliance On Test Server
+
+    ${out}=  Run  govc datastore.vsan.dom.ls -ds %{TEST_DATASTORE} -l -o
+    Should Be Empty  ${out}
+
+    Nimbus Cleanup  ${list}  ${false}
 
 *** Test Cases ***
 Complex VSAN
@@ -63,8 +72,3 @@ Complex VSAN
     Install VIC Appliance To Test Server
 
     Run Regression Tests
-
-    Cleanup VIC Appliance On Test Server
-
-    ${out}=  Run  govc datastore.vsan.dom.ls -ds %{TEST_DATASTORE} -l -o
-    Should Be Empty  ${out}

--- a/tests/resources/Nimbus-Util.robot
+++ b/tests/resources/Nimbus-Util.robot
@@ -222,7 +222,7 @@ Gather Host IPs
 
 Create a VSAN Cluster
     Log To Console  \nStarting basic VSAN cluster deploy...
-    ${out}=  Deploy Nimbus Testbed  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}  --noSupportBundles --vcvaBuild ${VC_VERSION} --esxPxeDir ${ESX_VERSION} --esxBuild ${ESX_VERSION} --testbedName vcqa-vsan-simple-pxeBoot-vcva --runName vic-vmotion
+    ${out}=  Deploy Nimbus Testbed  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}  --plugin testng --noSupportBundles --vcvaBuild ${VC_VERSION} --esxPxeDir ${ESX_VERSION} --esxBuild ${ESX_VERSION} --testbedName vcqa-vsan-simple-pxeBoot-vcva --runName vic-vmotion
     Should Contain  ${out}  .vcva-${VC_VERSION}' is up. IP:
     ${out}=  Split To Lines  ${out}
     :FOR  ${line}  IN  @{out}


### PR DESCRIPTION
fixes #5190 

Parallelize several deployments, re-arrange cleanup on vsan complex so that we don't pay any time penalties for cleanup and use the testng plugin during simple vsan cluster deploy to speed it up.