### PR TITLE
Fix the panic'ing tether test

### DIFF
--- a/cmd/tether/attach.go
+++ b/cmd/tether/attach.go
@@ -362,6 +362,13 @@ func (t *attachServerSSH) run() error {
 						log.Error(detail)
 						return detail
 					}
+				} else {
+					// A series of unfortunate events can lead calling backchannel with nil when we run unit tests.
+					// https://github.com/vmware/vic/pull/5327#issuecomment-305619860
+					// This check is here to handle that
+					if t.conn.conn == nil {
+						return fmt.Errorf("nil connection")
+					}
 				}
 
 				// wait for backchannel to establish

--- a/cmd/tether/attach_test.go
+++ b/cmd/tether/attach_test.go
@@ -96,7 +96,7 @@ func (t *testAttachServer) Start() error {
 		return errors.New(detail)
 	}
 
-	log.Infof("creating raw connection from ttyS0 pipe pair (c=%d, s=%d)\n", c.Fd(), s.Fd())
+	log.Infof("creating raw connection from ttyS0 pipe pair for server (c=%d, s=%d) %s\n", c.Fd(), s.Fd(), pathPrefix)
 	var conn net.Conn
 	conn, err = serial.NewHalfDuplexFileConn(s, c, pathPrefix+"/ttyS0", "file")
 	if err != nil {
@@ -133,7 +133,7 @@ func mockBackChannel(ctx context.Context) (net.Conn, error) {
 		return nil, errors.New(detail)
 	}
 
-	log.Infof("creating raw connection from ttyS0 pipe pair (c=%d, s=%d)\n", c.Fd(), s.Fd())
+	log.Infof("creating raw connection from ttyS0 pipe pair for backchannel (c=%d, s=%d) %s\n", c.Fd(), s.Fd(), pathPrefix)
 	conn, err := serial.NewHalfDuplexFileConn(c, s, pathPrefix+"/ttyS0", "file")
 
 	if err != nil {
@@ -226,14 +226,14 @@ func genKey() []byte {
 }
 
 func attachCase(t *testing.T, runblock bool) {
-	_, mocker := testSetup(t)
+	mocker := testSetup(t)
 	defer testTeardown(t, mocker)
 
 	testServer, _ := server.(*testAttachServer)
 
 	cfg := executor.ExecutorConfig{
 		Diagnostics: executor.Diagnostics{
-			DebugLevel: 2,
+			DebugLevel: 1,
 		},
 		ExecutorConfigCommon: executor.ExecutorConfigCommon{
 			ID:   "attach",
@@ -335,7 +335,7 @@ func TestAttachBlock(t *testing.T) {
 func TestAttachTTY(t *testing.T) {
 	t.Skip("TTY test skipped - not sure how to test this correctly")
 
-	_, mocker := testSetup(t)
+	mocker := testSetup(t)
 	defer testTeardown(t, mocker)
 
 	testServer, _ := server.(*testAttachServer)
@@ -433,7 +433,7 @@ func TestAttachTTY(t *testing.T) {
 // TestAttachTTYStdinClose sets up the config for attach testing
 //
 func TestAttachTTYStdinClose(t *testing.T) {
-	_, mocker := testSetup(t)
+	mocker := testSetup(t)
 	defer testTeardown(t, mocker)
 
 	testServer, _ := server.(*testAttachServer)
@@ -445,7 +445,7 @@ func TestAttachTTYStdinClose(t *testing.T) {
 		},
 
 		Diagnostics: executor.Diagnostics{
-			DebugLevel: 2,
+			DebugLevel: 1,
 		},
 
 		Sessions: map[string]*executor.SessionConfig{
@@ -542,7 +542,7 @@ func TestAttachTTYStdinClose(t *testing.T) {
 // TestEcho ensures we get back data without a tty and without any stdin interaction
 //
 func TestEcho(t *testing.T) {
-	_, mocker := testSetup(t)
+	mocker := testSetup(t)
 	defer testTeardown(t, mocker)
 
 	testServer, _ := server.(*testAttachServer)
@@ -554,7 +554,7 @@ func TestEcho(t *testing.T) {
 		},
 
 		Diagnostics: executor.Diagnostics{
-			DebugLevel: 2,
+			DebugLevel: 1,
 		},
 
 		Sessions: map[string]*executor.SessionConfig{
@@ -657,8 +657,6 @@ func TestEcho(t *testing.T) {
 
 	<-doneStderr
 	assert.Equal(t, "", string(buferr.Bytes()))
-
-	// TODO: remove this when we've verified stdin behaviour
 }
 
 func TestEchoRepeat(t *testing.T) {
@@ -679,7 +677,7 @@ func TestEchoRepeat(t *testing.T) {
 // attaching to multiple processes simultaneously
 //
 func TestAttachMultiple(t *testing.T) {
-	_, mocker := testSetup(t)
+	mocker := testSetup(t)
 	defer testTeardown(t, mocker)
 
 	testServer, _ := server.(*testAttachServer)
@@ -748,7 +746,7 @@ func TestAttachMultiple(t *testing.T) {
 		},
 		Key: genKey(),
 		Diagnostics: executor.Diagnostics{
-			DebugLevel: 2,
+			DebugLevel: 1,
 		},
 	}
 
@@ -849,7 +847,7 @@ func TestAttachMultiple(t *testing.T) {
 // tries to attach to an invalid session id
 //
 func TestAttachInvalid(t *testing.T) {
-	_, mocker := testSetup(t)
+	mocker := testSetup(t)
 	defer testTeardown(t, mocker)
 
 	testServer, _ := server.(*testAttachServer)
@@ -989,7 +987,7 @@ func TestMockAttachTetherToPL(t *testing.T) {
 */
 
 func TestReattach(t *testing.T) {
-	_, mocker := testSetup(t)
+	mocker := testSetup(t)
 	defer testTeardown(t, mocker)
 
 	testServer, _ := server.(*testAttachServer)
@@ -1000,7 +998,7 @@ func TestReattach(t *testing.T) {
 			Name: "tether_test_executor",
 		},
 		Diagnostics: executor.Diagnostics{
-			DebugLevel: 2,
+			DebugLevel: 1,
 		},
 
 		Sessions: map[string]*executor.SessionConfig{

--- a/cmd/tether/main_test.go
+++ b/cmd/tether/main_test.go
@@ -39,6 +39,7 @@ func init() {
 // in a full VM
 func createFakeDevices() error {
 	var err error
+
 	// create control channel
 	path := fmt.Sprintf("%s/ttyS0", pathPrefix)
 	err = syscall.Mkfifo(path+"s", uint32(backchannelMode))
@@ -75,12 +76,12 @@ func createFakeDevices() error {
 	return nil
 }
 
-func testSetup(t *testing.T) (string, *Mocker) {
+func testSetup(t *testing.T) *Mocker {
 	var err error
 
-	name, mocker := tetherTestSetup(t)
+	mocker := tetherTestSetup(t)
 
-	pathPrefix, err = ioutil.TempDir("", path.Base(name))
+	pathPrefix, err = ioutil.TempDir("", path.Base(t.Name()))
 	if err != nil {
 		fmt.Println(err)
 		t.Error(err)
@@ -111,7 +112,7 @@ func testSetup(t *testing.T) (string, *Mocker) {
 	}
 	server = testServer
 
-	return name, mocker
+	return mocker
 }
 
 func testTeardown(t *testing.T, mocker *Mocker) {


### PR DESCRIPTION
Also remove the unneccesarry calls to runtime and fix printing test
names.

For more;

https://github.com/vmware/vic/pull/5327#issuecomment-305619860