### PR TITLE
Fix the redirect issue #5020 [specific ci=Group9-VIC-Admin]

### DIFF
--- a/cmd/vicadmin/server.go
+++ b/cmd/vicadmin/server.go
@@ -353,7 +353,7 @@ func (s *server) loginPage(res http.ResponseWriter, req *http.Request) {
 		}
 
 		// redirect to dashboard
-		http.Redirect(res, req, "/", http.StatusTemporaryRedirect)
+		http.Redirect(res, req, "/", http.StatusSeeOther)
 		return
 	}
 


### PR DESCRIPTION
Fixes #5020 

A 303 "see other" redirect is needed instead of 307 "temporary redirect" HTTP response. 303 will redirect only to GET, but 307 will continually try to POST the previous data, leading to the form resubmission page. See https://en.wikipedia.org/wiki/HTTP_303