### PR TITLE
Fix VCH portlet displaying wrong information in Flex Client

### DIFF
--- a/ui/vic-ui/swf/src/main/flex/com/vmware/vicui/constants/AppConstants.as
+++ b/ui/vic-ui/swf/src/main/flex/com/vmware/vicui/constants/AppConstants.as
@@ -8,8 +8,10 @@ package com.vmware.vicui.constants {
 		public static const VCH_NAME_PATH:String = "init/common/name";
 		public static const VCH_CLIENT_IP_PATH:String = "guestinfo.vice..init.networks|client.assigned.IP";
 		public static const DOCKER_PERSONALITY_ARGS_PATH:String = "guestinfo.vice./init/sessions|docker-personality/cmd/Args~";
-		public static const VCH_ENDPOINT_PORT:String = ":2376";
-		public static const VCH_LOG_PORT:String = ":2378";
+		public static const VCH_ENDPOINT_PORT_TLS:String = "2376";
+		public static const VCH_ENDPOINT_PORT_NO_TLS:String = "2375";
+		public static const VCH_LOG_PORT:String = "2378";
+		public static const PLACEHOLDER_VAL:String = "-";
 
 	}
 

--- a/ui/vic-ui/swf/src/main/flex/com/vmware/vicui/views/ContainerPortletMediator.as
+++ b/ui/vic-ui/swf/src/main/flex/com/vmware/vicui/views/ContainerPortletMediator.as
@@ -77,9 +77,9 @@ package com.vmware.vicui.views {
 			   //set default placeholder data
 			   _view.isContainer = new Boolean(false);
 			   _view.hasPortmappingInfo = new Boolean(false);
-			   _view.containerName.text = new String("-");
-			   _view.imageName.text = new String("-");
-			   _view.portmappingInfo.text = new String("-");
+			   _view.containerName.text = new String(AppConstants.PLACEHOLDER_VAL);
+			   _view.imageName.text = new String(AppConstants.PLACEHOLDER_VAL);
+			   _view.portmappingInfo.text = new String(AppConstants.PLACEHOLDER_VAL);
 
 			   if (result != null) {
 				   
@@ -129,9 +129,9 @@ package com.vmware.vicui.views {
 		      // clear the UI data
 			   _view.isContainer = false;
 			   _view.hasPortmappingInfo = false;
-			   _view.containerName.text = new String("-");
-			   _view.imageName.text = new String("-");
-			   _view.portmappingInfo.text = new String("-");
+			   _view.containerName.text = new String(AppConstants.PLACEHOLDER_VAL);
+			   _view.imageName.text = new String(AppConstants.PLACEHOLDER_VAL);
+			   _view.portmappingInfo.text = new String(AppConstants.PLACEHOLDER_VAL);
 		   }
 	   }
 	}

--- a/ui/vic-ui/swf/src/main/flex/com/vmware/vicui/views/VchPortletMediator.as
+++ b/ui/vic-ui/swf/src/main/flex/com/vmware/vicui/views/VchPortletMediator.as
@@ -77,8 +77,8 @@ package com.vmware.vicui.views {
 
 			   //set default placeholder data
 			   _view.isVch = new Boolean(false);
-			   _view.dockerApiEndpoint.text = new String("-");
-			   _view.dockerLog.label = new String("-");
+			   _view.dockerApiEndpoint.text = new String(AppConstants.PLACEHOLDER_VAL);
+			   _view.dockerLog.label = new String(AppConstants.PLACEHOLDER_VAL);
 
 			   if (result != null) {
 
@@ -117,23 +117,27 @@ package com.vmware.vicui.views {
 							   ip_ipv4 = bytes.readUnsignedByte() + "." + bytes.readUnsignedByte() + "." + bytes.readUnsignedByte() + "." + bytes.readUnsignedByte();
 
 							   _view.dockerApiEndpoint.text = "DOCKER_HOST=tcp://" + ip_ipv4;
-							   _view.dockerLog.label = "https://" + ip_ipv4 + AppConstants.VCH_LOG_PORT;
+							   _view.dockerLog.label = "https://" + ip_ipv4 + ":" + AppConstants.VCH_LOG_PORT;
 							   continue;
 						   }
 
 						   if (keyName == AppConstants.DOCKER_PERSONALITY_ARGS_PATH) {
 							   // port 2376 is used for tls, and 2375 for no-tls
-							   isUsingTls = keyVal.indexOf("2376") > -1;
+							   isUsingTls = keyVal.indexOf(AppConstants.VCH_ENDPOINT_PORT_TLS) > -1;
 							   continue;
 						   }
 					   }
 
 					   // since the order in which list items are processed is not much guaranteed,
 					   // we set the port for Docker API endpoint at the end of the loop
-					   if (isUsingTls) {
-						   _view.dockerApiEndpoint.text = _view.dockerApiEndpoint.text + ":2376";
-					   } else {
-						   _view.dockerApiEndpoint.text = _view.dockerApiEndpoint.text + ":2375";
+					   if (_view.dockerApiEndpoint.text != AppConstants.PLACEHOLDER_VAL) {
+					       if (isUsingTls) {
+							   _view.dockerApiEndpoint.text = _view.dockerApiEndpoint.text + ":" +
+								   AppConstants.VCH_ENDPOINT_PORT_TLS;
+					       } else {
+							   _view.dockerApiEndpoint.text = _view.dockerApiEndpoint.text + ":" +
+								   AppConstants.VCH_ENDPOINT_PORT_NO_TLS;
+					       }
 					   }
 				   }
 			   } else {
@@ -146,8 +150,8 @@ package com.vmware.vicui.views {
 		   if(_view != null) {
 			   // clear the UI data
 			   _view.isVch = false;
-			   _view.dockerApiEndpoint.text = new String("-");
-			   _view.dockerLog.label = new String("-");
+			   _view.dockerApiEndpoint.text = new String(AppConstants.PLACEHOLDER_VAL);
+			   _view.dockerLog.label = new String(AppConstants.PLACEHOLDER_VAL);
 		   }
 	   }
 	}


### PR DESCRIPTION
This PR fixes the issue where VCH portlet shows "-:2376" (TLS on)
or "-:2375" (TLS off) when the VCH appliance VM is off. The correct
value to appear is "-"

Fixes #5346 
