### PR TITLE
Re-establish vsphere event stream [full ci]

### DIFF
--- a/lib/apiservers/portlayer/restapi/configure_port_layer.go
+++ b/lib/apiservers/portlayer/restapi/configure_port_layer.go
@@ -30,6 +30,7 @@ import (
 	"github.com/vmware/vic/lib/apiservers/portlayer/restapi/operations"
 	"github.com/vmware/vic/lib/apiservers/portlayer/restapi/options"
 	"github.com/vmware/vic/lib/portlayer"
+	"github.com/vmware/vic/lib/portlayer/exec"
 	"github.com/vmware/vic/pkg/version"
 	"github.com/vmware/vic/pkg/vsphere/session"
 )
@@ -90,6 +91,12 @@ func configureAPI(api *operations.PortLayerAPI) http.Handler {
 	// Configure the func invoked if the PL panics or is restarted by vic-init
 	api.ServerShutdown = func() {
 		log.Infof("Shutting down port-layer-server")
+
+		// stop the event collectors
+		collectors := exec.Config.EventManager.Collectors()
+		for _, c := range collectors {
+			c.Stop()
+		}
 
 		// Logout the session
 		if err := sess.Logout(ctx); err != nil {

--- a/lib/apiservers/portlayer/restapi/options/options.go
+++ b/lib/apiservers/portlayer/restapi/options/options.go
@@ -21,7 +21,7 @@ type PortLayerOptionsType struct {
 	Cert      string        `long:"cert" description:"Client certificate" env:"VC_CERTIFICATE"`
 	Key       string        `long:"key" description:"Private key file" env:"VC_PRIVATE_KEY"`
 	Insecure  bool          `long:"insecure" default:"false" description:"Skip verification of server certificate" env:"VC_INSECURE"`
-	Keepalive time.Duration `long:"keepalive" default:"5m" description:"Session timeout" env:"VC_KEEPALIVE"`
+	Keepalive time.Duration `long:"keepalive" default:"20s" description:"Session timeout" env:"VC_KEEPALIVE"`
 
 	DatacenterPath string `long:"datacenter" default:"/ha-datacenter" description:"Datacenter path" env:"DC_PATH" required:"true"`
 	ClusterPath    string `long:"cluster" default:"" description:"Cluster path" env:"CS_PATH" required:"true"`

--- a/lib/portlayer/event/collector/vsphere/collector_test.go
+++ b/lib/portlayer/event/collector/vsphere/collector_test.go
@@ -98,7 +98,7 @@ func TestStart(t *testing.T) {
 }
 
 func newCollector() *EventCollector {
-	return &EventCollector{mos: monitoredCache{mos: make(map[string]types.ManagedObjectReference)}}
+	return &EventCollector{mos: monitoredCache{mos: make(map[string]types.ManagedObjectReference)}, lastProcessedID: -1}
 }
 
 // simple callback counter

--- a/tests/resources/Docker-Util.robot
+++ b/tests/resources/Docker-Util.robot
@@ -36,9 +36,8 @@ Pull image
 Wait Until Container Stops
     [Arguments]  ${container}
     :FOR  ${idx}  IN RANGE  0  60
-    \   ${out}=  Run  docker %{VCH-PARAMS} inspect ${container} | grep Status
-    \   ${status}=  Run Keyword And Return Status  Should Contain  ${out}  exited
-    \   Return From Keyword If  ${status}
+    \   ${out}=  Run  docker %{VCH-PARAMS} inspect -f '{{.State.Running}}' ${container}
+    \   Return From Keyword If  '${out}' == 'false'
     \   Sleep  1
     Fail  Container did not stop within 60 seconds
 

--- a/tests/resources/VCH-Util.robot
+++ b/tests/resources/VCH-Util.robot
@@ -219,6 +219,14 @@ Check UpdateInProgress
     Should Be Equal As Integers  ${rc}  0
     Should Contain  ${output}  ${expected}
 
+Portlayer Log Should Match Regexp
+    [Tags]  secret
+    [Arguments]  ${pattern}
+    ${out}=  Run  curl -k -D /tmp/cookies-%{VCH-NAME} -Fusername=%{TEST_USERNAME} -Fpassword=%{TEST_PASSWORD} %{VIC-ADMIN}/authentication
+    Log  ${out}
+    ${rc}=  Run And Return Rc  curl -sk %{VIC-ADMIN}/logs/port-layer.log -b /tmp/cookies-%{VCH-NAME} | grep -q -e \'${pattern}\'
+    Should Be Equal As Integers  ${rc}  0
+
 Gather Logs From Test Server
     [Tags]  secret
     Run Keyword And Continue On Failure  Run  zip %{VCH-NAME}-certs -r %{VCH-NAME}

--- a/tests/test-cases/Group0-Bugs/5343.md
+++ b/tests/test-cases/Group0-Bugs/5343.md
@@ -1,0 +1,25 @@
+Test 5343 - Confirm event collection after SDK connection re-establishment
+=======
+
+# Purpose:
+Confirm that vSphere event collection occurs correctly after re-establishment of a dropped SDK connection
+
+# References:
+* https://github.com/vmware/vic/issues/5343
+
+# Environment:
+This test requires that a vSphere server is running and available
+
+# Test Steps:
+1. Create VCH through vic-machine create
+2. Create container
+3. Power on container
+4. Confirm creation and power on events in logs
+5. Delete vSphere SDK session via govc session.rm
+6. Trigger SDK connection re-establishment (via VCH operation)
+7. Power off container VM via govc
+8. Confirm power off event in logs
+9. Confirm container is reported as stopped
+
+# Expected Outcome:
+All steps should succeed

--- a/tests/test-cases/Group0-Bugs/5343.robot
+++ b/tests/test-cases/Group0-Bugs/5343.robot
@@ -1,0 +1,69 @@
+# Copyright 2016-2017 VMware, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#	http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License
+
+*** Settings ***
+Documentation  Test 5343
+Resource  ../../resources/Util.robot
+Suite Setup  Install VIC Appliance To Test Server
+Suite Teardown  Cleanup VIC Appliance On Test Server
+
+
+
+*** Test Cases ***
+Check vsphere event stream
+    ${status}=  Get State Of Github Issue  5343
+    Run Keyword If  '${status}' == 'closed'  Fail  Test 5343.robot needs to be updated now that Issue #5343 has been resolved
+    Log  Issue \#5343 is blocking implementation  WARN
+
+    # basic confirmation of function
+    ${rc}  ${id}=  Run And Return Rc And Output  docker %{VCH-PARAMS} pull busybox
+    Should Be Equal As Integers  ${rc}  0
+
+    ${name}=  Generate Random String  15
+    ${rc}  ${id}=  Run And Return Rc And Output  docker %{VCH-PARAMS} create --name ${name} busybox sleep 600
+    Should Be Equal As Integers  ${rc}  0
+    ${shortid}=  Get container shortID  ${id}
+
+    ${rc}=  Run And Return Rc  docker %{VCH-PARAMS} start ${name}
+    Should Be Equal As Integers  ${rc}  0
+
+    # ensure that portlayer log contains the powered on event - this string comes in the e.Message portion of the vSphere event
+    # and may be prone to Localization which would cause this test to fail.
+    # for efficiency We assume that if we saw powered on then "${id} Created" would also have matched
+    Portlayer Log Should Match Regexp  ${name}-${shortid} on \\s\\S* in \\S* is powered on
+
+    # delete the session to suppress reception of events
+    ${rc}  ${out}=  Run And Return Rc And Output  govc session.ls
+    ${out}=  Get Lines Matching Pattern  ${out}  %{VCH-IP}\\s* vic-engine
+    @{sessions}=  Split to lines  ${out}
+    :FOR  ${session}  IN  @{sessions}
+    \  @{key}=  Fetch From Left  ${session}   
+    \  ${rc}=  Run And Return Rc  govc session.rm ${key}
+    \  Should Be Equal As Integers  ${rc}  0
+
+    # power off the VM directly
+    ${rc}  ${output}=  Run And Return Rc And Output  govc vm.power --off ${name}-${shortid}
+    Log  ${output}
+    Should Be Equal As Integers  ${rc}  0
+
+    # perform operation to force re-auth
+    # NOTE: this is a concession to current implementation - we should not need an op to get a timely reconnect
+    ${rc}=  Run And Return Rc  docker %{VCH-PARAMS} ps
+
+    # Assert that the power off event is present
+    # Would prefer to do this as a tail on the live log but no idea how to do stream processing in robot
+    Wait Until Keyword Succeeds  1m  10s  Portlayer Log Should Match Regexp  ${name}-${shortid} on \\s*\\S* in \\S* is powered off
+    
+    # Confirm container reported as stopped by VCH
+    Wait Until Container Stops  ${id}

--- a/tests/test-cases/Group0-Bugs/5343.robot
+++ b/tests/test-cases/Group0-Bugs/5343.robot
@@ -22,10 +22,6 @@ Suite Teardown  Cleanup VIC Appliance On Test Server
 
 *** Test Cases ***
 Check vsphere event stream
-    ${status}=  Get State Of Github Issue  5343
-    Run Keyword If  '${status}' == 'closed'  Fail  Test 5343.robot needs to be updated now that Issue #5343 has been resolved
-    Log  Issue \#5343 is blocking implementation  WARN
-
     # basic confirmation of function
     ${rc}  ${id}=  Run And Return Rc And Output  docker %{VCH-PARAMS} pull busybox
     Should Be Equal As Integers  ${rc}  0

--- a/tests/test-cases/Group0-Bugs/TestCases.md
+++ b/tests/test-cases/Group0-Bugs/TestCases.md
@@ -6,3 +6,4 @@ Group 0 - Bugs
 -
 [Test 4817 - Verify Kernel supports vsyscall](4817.md)
 -
+[Test 5343 - Confirm event collection after SDK connection re-establishment](5343.md)


### PR DESCRIPTION
The vSphere event collector should be re-established after SDK connection
drops for any reason. This adds a test to check that we see an event for
an out-of-band power operation and that the VCH status for the container
in question is correctly updated.

Using full ci as I've made some neatness changes to a robot resource file. 

Fixes #5343
