### PR TITLE
Bump govmomi to latest

### DIFF
--- a/vendor/github.com/vmware/govmomi/govc/host/maintenance/exit.go
+++ b/vendor/github.com/vmware/govmomi/govc/host/maintenance/exit.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package maintenancec
+package maintenance
 
 import (
 	"context"

--- a/vendor/github.com/vmware/govmomi/govc/metric/sample.go
+++ b/vendor/github.com/vmware/govmomi/govc/metric/sample.go
@@ -69,6 +69,10 @@ func (cmd *sample) Description() string {
 
 Interval ID defaults to 20 (realtime) if supported, otherwise 300 (5m interval).
 
+By default, INSTANCE '*' samples all instances and the aggregate counter.
+An INSTANCE value of '-' will only sample the aggregate counter.
+An INSTANCE value other than '*' or '-' will only sample the given instance counter.
+
 If PLOT value is set to '-', output a gnuplot script.  If non-empty with another
 value, PLOT will pipe the script to gnuplot for you.  The value is also used to set
 the gnuplot 'terminal' variable, unless the value is that of the DISPLAY env var.
@@ -77,7 +81,9 @@ Only 1 metric NAME can be specified when the PLOT flag is set.
 Examples:
   govc metric.sample host/cluster1/* cpu.usage.average
   govc metric.sample -plot .png host/cluster1/* cpu.usage.average | xargs open
-  govc metric.sample vm/* net.bytesTx.average net.bytesTx.average`
+  govc metric.sample vm/* net.bytesTx.average net.bytesTx.average
+  govc metric.sample -instance vmnic0 vm/* net.bytesTx.average
+  govc metric.sample -instance - vm/* net.bytesTx.average`
 }
 
 func (cmd *sample) Process(ctx context.Context) error {
@@ -292,6 +298,10 @@ func (cmd *sample) Run(ctx context.Context, f *flag.FlagSet) error {
 	s, err := m.ProviderSummary(ctx, objs[0])
 	if err != nil {
 		return err
+	}
+
+	if cmd.instance == "-" {
+		cmd.instance = ""
 	}
 
 	spec := types.PerfQuerySpec{

--- a/vendor/github.com/vmware/govmomi/object/datastore_file.go
+++ b/vendor/github.com/vmware/govmomi/object/datastore_file.go
@@ -242,12 +242,13 @@ func lastIndexLines(s []byte, line *int, include func(l int, m string) bool) (in
 			break
 		}
 
-		msg := string(s[o:i])
-		i = o
-		*line++
+		msg := string(s[o+1 : i+1])
 		if !include(*line, msg) {
 			done = true
 			break
+		} else {
+			i = o
+			*line++
 		}
 	}
 

--- a/vendor/manifest
+++ b/vendor/manifest
@@ -1020,7 +1020,7 @@
 			"importpath": "github.com/vmware/govmomi",
 			"repository": "https://github.com/vmware/govmomi",
 			"vcs": "git",
-			"revision": "8bff8355d10c46dcac74d3d64b2d38740f9e3dcd",
+			"revision": "f4b81866f481347eab3a10b4f2a3e215f50bfa16",
 			"branch": "master"
 		},
 		{


### PR DESCRIPTION
Bumps vendor'd govmomi to latest to include support for `docker logs --since`.