### PR TITLE
Support xfs as a filesystem

### DIFF
--- a/lib/portlayer/storage/vsphere/image.go
+++ b/lib/portlayer/storage/vsphere/image.go
@@ -1,4 +1,4 @@
-// Copyright 2016 VMware, Inc. All Rights Reserved.
+// Copyright 2016-2017 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/portlayer/storage/vsphere/image.go
+++ b/lib/portlayer/storage/vsphere/image.go
@@ -305,7 +305,7 @@ func (v *ImageStore) writeImage(op trace.Operation, storeName, parentID, ID stri
 	}()
 
 	// Create the disk
-	vmdisk, err = v.dm.CreateAndAttach(op, diskDsURI, parentDiskDsURI, 0, os.O_RDWR)
+	vmdisk, err = v.dm.CreateAndAttach(op, diskDsURI, parentDiskDsURI, 0, os.O_RDWR, disk.Ext4)
 	if err != nil {
 		return nil, err
 	}
@@ -397,7 +397,7 @@ func (v *ImageStore) scratch(op trace.Operation, storeName string) error {
 	}()
 
 	// Create the disk
-	vmdisk, err = v.dm.CreateAndAttach(op, imageDiskDsURI, nil, size, os.O_RDWR)
+	vmdisk, err = v.dm.CreateAndAttach(op, imageDiskDsURI, nil, size, os.O_RDWR, disk.Ext4)
 	if err != nil {
 		op.Errorf("CreateAndAttach(%s) error: %s", imageDiskDsURI, err)
 		return err
@@ -447,7 +447,7 @@ func (v *ImageStore) GetImage(op trace.Operation, store *url.URL, ID string) (*p
 
 	var s = *store
 
-	dsk, err := v.dm.Get(op, diskDsURI)
+	dsk, err := v.dm.Get(op, diskDsURI, disk.Ext4)
 	if err != nil {
 		return nil, err
 	}

--- a/lib/portlayer/storage/vsphere/image_test.go
+++ b/lib/portlayer/storage/vsphere/image_test.go
@@ -1,4 +1,4 @@
-// Copyright 2016 VMware, Inc. All Rights Reserved.
+// Copyright 2016-2017 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/portlayer/storage/vsphere/image_test.go
+++ b/lib/portlayer/storage/vsphere/image_test.go
@@ -580,7 +580,7 @@ func mountLayerRO(v *ImageStore, parent *portlayer.Image) (*disk.VirtualDisk, er
 
 	op := trace.NewOperation(context.TODO(), "ro")
 
-	roDisk, err := v.dm.CreateAndAttach(op, roName, parentDsURI, 0, os.O_RDONLY)
+	roDisk, err := v.dm.CreateAndAttach(op, roName, parentDsURI, 0, os.O_RDONLY, disk.Ext4)
 	if err != nil {
 		return nil, err
 	}

--- a/lib/portlayer/storage/vsphere/volume.go
+++ b/lib/portlayer/storage/vsphere/volume.go
@@ -101,7 +101,7 @@ func (v *VolumeStore) VolumeCreate(op trace.Operation, ID string, store *url.URL
 	volDiskDsURL := v.volDiskDsURL(ID)
 
 	// Create the disk
-	vmdisk, err := v.dm.CreateAndAttach(op, volDiskDsURL, nil, int64(capacityKB), os.O_RDWR)
+	vmdisk, err := v.dm.CreateAndAttach(op, volDiskDsURL, nil, int64(capacityKB), os.O_RDWR, disk.Ext4)
 	if err != nil {
 		return nil, err
 	}
@@ -162,7 +162,7 @@ func (v *VolumeStore) VolumesList(op trace.Operation) ([]*storage.Volume, error)
 		// Get the path to the disk in datastore uri format
 		volDiskDsURL := v.volDiskDsURL(ID)
 
-		dev, err := disk.NewVirtualDisk(volDiskDsURL)
+		dev, err := disk.NewVirtualDisk(volDiskDsURL, disk.Ext4)
 		if err != nil {
 			return nil, err
 		}

--- a/lib/portlayer/storage/vsphere/volume_test.go
+++ b/lib/portlayer/storage/vsphere/volume_test.go
@@ -1,4 +1,4 @@
-// Copyright 2016 VMware, Inc. All Rights Reserved.
+// Copyright 2016-2017 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/fs/xfs.go
+++ b/pkg/fs/xfs.go
@@ -1,0 +1,84 @@
+// Copyright 2016-2017 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fs
+
+import (
+	"os/exec"
+	"strings"
+
+	"github.com/docker/docker/pkg/mount"
+
+	"github.com/vmware/vic/pkg/trace"
+
+	log "github.com/Sirupsen/logrus"
+)
+
+// XFS satisfies the Filesystem interface
+type XFS struct{}
+
+// Create an XFS filesystem manager
+func NewXFS() *XFS {
+	return &XFS{}
+}
+
+// Mkfs creates an xfs fs on the given device and applices the given label
+func (e *XFS) Mkfs(devPath, label string) error {
+	defer trace.End(trace.Begin(devPath))
+
+	log.Infof("Creating xfs filesystem on device %s", devPath)
+
+	// #nosec: Subprocess launching with variable
+	cmd := exec.Command("/sbin/mkfs.xfs", "-n", "ftype=1", "-L", label, devPath)
+
+	if output, err := cmd.CombinedOutput(); err != nil {
+		log.Errorf("vmdk storage driver failed to format disk %s: %s", devPath, err)
+		log.Errorf("mkfs output: %s", string(output))
+		return err
+	}
+	log.Debugf("Filesystem created on device %s", devPath)
+
+	return nil
+}
+
+// Mount mounts an xfs formatted device at the given path.  From the Docker
+// mount pkg, args must in the form arg=val.
+func (e *XFS) Mount(devPath, targetPath string, options []string) error {
+	defer trace.End(trace.Begin(devPath))
+	log.Infof("Mounting %s to %s", devPath, targetPath)
+	return mount.Mount(devPath, targetPath, "xfs", strings.Join(options, ","))
+}
+
+// Unmount unmounts the disk.
+// path can be a device path or a mount point
+func (e *XFS) Unmount(path string) error {
+	defer trace.End(trace.Begin(path))
+	log.Infof("Unmounting %s", path)
+	return mount.Unmount(path)
+}
+
+// SetLabel sets the label of an xfs formated device
+func (e *XFS) SetLabel(devPath, labelName string) error {
+	defer trace.End(trace.Begin(devPath))
+
+	// #nosec: Subprocess launching with variable
+	cmd := exec.Command("/sbin/e2label", devPath, labelName)
+	if output, err := cmd.CombinedOutput(); err != nil {
+		log.Errorf("failed to set label %s: %s", devPath, err)
+		log.Error(string(output))
+		return err
+	}
+
+	return nil
+}

--- a/pkg/trace/operation_test.go
+++ b/pkg/trace/operation_test.go
@@ -1,4 +1,4 @@
-// Copyright 2016 VMware, Inc. All Rights Reserved.
+// Copyright 2016-2017 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/trace/operation_test.go
+++ b/pkg/trace/operation_test.go
@@ -34,7 +34,7 @@ func TestContextUnpack(t *testing.T) {
 	wg := &sync.WaitGroup{}
 	wg.Add(cnt)
 	for i := 0; i < cnt; i++ {
-		go func() {
+		go func(i int) {
 			defer wg.Done()
 			ctx := NewOperation(context.TODO(), "testmsg")
 
@@ -45,7 +45,7 @@ func TestContextUnpack(t *testing.T) {
 				return
 			}
 			c.Infof("test info message %d", i)
-		}()
+		}(i) // fix race in test
 	}
 	wg.Wait()
 }

--- a/pkg/vsphere/disk/disk.go
+++ b/pkg/vsphere/disk/disk.go
@@ -1,4 +1,4 @@
-// Copyright 2016 VMware, Inc. All Rights Reserved.
+// Copyright 2016-2017 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/vsphere/disk/disk.go
+++ b/pkg/vsphere/disk/disk.go
@@ -28,6 +28,7 @@ type FilesystemType uint8
 
 const (
 	Ext4 FilesystemType = iota + 1
+	Xfs
 	Ntfs
 )
 
@@ -40,6 +41,8 @@ type Filesystem interface {
 
 func FilesystemTypeToFilesystem(fstype FilesystemType) Filesystem {
 	switch fstype {
+	case Xfs:
+		return fs.NewXFS()
 	default:
 		return fs.NewExt4()
 	}
@@ -67,7 +70,7 @@ type VirtualDisk struct {
 	fs Filesystem
 }
 
-func NewVirtualDisk(DatastoreURI *object.DatastorePath) (*VirtualDisk, error) {
+func NewVirtualDisk(DatastoreURI *object.DatastorePath, fst FilesystemType) (*VirtualDisk, error) {
 	if err := VerifyDatastoreDiskURI(DatastoreURI.String()); err != nil {
 		return nil, err
 	}
@@ -75,7 +78,7 @@ func NewVirtualDisk(DatastoreURI *object.DatastorePath) (*VirtualDisk, error) {
 	d := &VirtualDisk{
 		DatastoreURI: DatastoreURI,
 		// We only support ext4 for now
-		fs: FilesystemTypeToFilesystem(Ext4),
+		fs: FilesystemTypeToFilesystem(fst),
 	}
 
 	return d, nil

--- a/pkg/vsphere/disk/disk_ext4_test.go
+++ b/pkg/vsphere/disk/disk_ext4_test.go
@@ -1,4 +1,4 @@
-// Copyright 2016 VMware, Inc. All Rights Reserved.
+// Copyright 2016-2017 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/vsphere/disk/disk_ext4_test.go
+++ b/pkg/vsphere/disk/disk_ext4_test.go
@@ -82,7 +82,7 @@ func TestCreateFS(t *testing.T) {
 		Datastore: client.Datastore.Name(),
 		Path:      path.Join(imagestore.Path, "scratch.vmdk"),
 	}
-	d, err := vdm.CreateAndAttach(op, scratch, nil, diskSize, os.O_RDWR)
+	d, err := vdm.CreateAndAttach(op, scratch, nil, diskSize, os.O_RDWR, Ext4)
 	if !assert.NoError(t, err) {
 		return
 	}

--- a/pkg/vsphere/disk/disk_manager.go
+++ b/pkg/vsphere/disk/disk_manager.go
@@ -1,4 +1,4 @@
-// Copyright 2016 VMware, Inc. All Rights Reserved.
+// Copyright 2016-2017 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/vsphere/disk/disk_manager.go
+++ b/pkg/vsphere/disk/disk_manager.go
@@ -88,7 +88,7 @@ func NewDiskManager(op trace.Operation, session *session.Session, detachAll bool
 // Returns a VirtualDisk corresponding to the created and attached disk.
 func (m *Manager) CreateAndAttach(op trace.Operation, newDiskURI,
 	parentURI *object.DatastorePath,
-	capacity int64, flags int) (*VirtualDisk, error) {
+	capacity int64, flags int, fst FilesystemType) (*VirtualDisk, error) {
 	defer trace.End(trace.Begin(newDiskURI.String()))
 
 	// ensure we abide by max attached disks limits
@@ -108,7 +108,7 @@ func (m *Manager) CreateAndAttach(op trace.Operation, newDiskURI,
 		return nil, errors.Trace(err)
 	}
 
-	d, err := NewVirtualDisk(newDiskURI)
+	d, err := NewVirtualDisk(newDiskURI, fst)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -172,13 +172,13 @@ func (m *Manager) createDiskSpec(childURI, parentURI *object.DatastorePath, capa
 
 // Create creates a disk without a parent (and doesn't attach it).
 func (m *Manager) Create(op trace.Operation, newDiskURI *object.DatastorePath,
-	capacityKB int64) (*VirtualDisk, error) {
+	capacityKB int64, fst FilesystemType) (*VirtualDisk, error) {
 
 	defer trace.End(trace.Begin(newDiskURI.String()))
 
 	vdm := object.NewVirtualDiskManager(m.vm.Vim25())
 
-	d, err := NewVirtualDisk(newDiskURI)
+	d, err := NewVirtualDisk(newDiskURI, fst)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -205,10 +205,10 @@ func (m *Manager) Create(op trace.Operation, newDiskURI *object.DatastorePath,
 }
 
 // Gets a disk given a datastore path URI to the vmdk
-func (m *Manager) Get(op trace.Operation, diskURI *object.DatastorePath) (*VirtualDisk, error) {
+func (m *Manager) Get(op trace.Operation, diskURI *object.DatastorePath, fst FilesystemType) (*VirtualDisk, error) {
 	defer trace.End(trace.Begin(diskURI.String()))
 
-	dsk, err := NewVirtualDisk(diskURI)
+	dsk, err := NewVirtualDisk(diskURI, fst)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/vsphere/disk/disk_manager_test.go
+++ b/pkg/vsphere/disk/disk_manager_test.go
@@ -1,4 +1,4 @@
-// Copyright 2016 VMware, Inc. All Rights Reserved.
+// Copyright 2016-2017 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/vsphere/disk/disk_manager_test.go
+++ b/pkg/vsphere/disk/disk_manager_test.go
@@ -113,7 +113,7 @@ func TestCreateAndDetach(t *testing.T) {
 		Datastore: client.Datastore.Name(),
 		Path:      path.Join(imagestore.Path, "scratch.vmdk"),
 	}
-	parent, err := vdm.Create(op, scratch, diskSize)
+	parent, err := vdm.Create(op, scratch, diskSize, Ext4)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -131,7 +131,7 @@ func TestCreateAndDetach(t *testing.T) {
 			Path:      path.Join(imagestore.Path, fmt.Sprintf("child%d.vmdk", i)),
 		}
 
-		child, cerr := vdm.CreateAndAttach(op, p, parent.DatastoreURI, 0, os.O_RDWR)
+		child, cerr := vdm.CreateAndAttach(op, p, parent.DatastoreURI, 0, os.O_RDWR, Ext4)
 		if !assert.NoError(t, cerr) {
 			return
 		}

--- a/pkg/vsphere/disk/util.go
+++ b/pkg/vsphere/disk/util.go
@@ -1,4 +1,4 @@
-// Copyright 2016 VMware, Inc. All Rights Reserved.
+// Copyright 2016-2017 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
fix a race condition in trace pkg test

These are changes I made in the kubernetes version of the vsphere package, want to keep these 2 in sync so that we can keep updating as changes are made in VIC