### PR TITLE
enable docker ps only running containers test [specific ci=1-10-Docker-PS]

### DIFF
--- a/tests/test-cases/Group1-Docker-Commands/1-10-Docker-PS.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-10-Docker-PS.robot
@@ -79,9 +79,7 @@ Docker ps only running containers
     ${output}=  Split To Lines  ${output}
     ${len}=  Get Length  ${output}
     Create several containers
-    ${status}=  Get State Of Github Issue  5235
-    Run Keyword If  '${status}' == 'closed'  Fail  Test 1-10-Docker-PS.robot needs to be updated now that Issue #5235 has been resolved
-    #Wait Until Keyword Succeeds  5x  5 seconds  Check Length of PS  ${len+1}
+    Wait Until Keyword Succeeds  5x  5 seconds  Check Length of PS  ${len+1}
 
 Docker ps all containers
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} ps -a


### PR DESCRIPTION

Previously a change was made to increase the event collector page
size, but that change wasn't complete. (#5047)  #5350 was most recently
merged that completes the previous attempt at updating the event
collector page size.

Fixes #5235, #4997

