### PR TITLE
[specific ci=Group11-Upgrade]workaround the upgrade issue reported in 5343

### DIFF
--- a/lib/install/validate/validator.go
+++ b/lib/install/validate/validator.go
@@ -769,18 +769,26 @@ func (v *Validator) IsVC() bool {
 }
 
 func (v *Validator) AddDeprecatedFields(ctx context.Context, conf *config.VirtualContainerHostConfigSpec, input *data.Data) *data.InstallerData {
-	defer trace.End(trace.Begin(""))
+	defer trace.End(trace.Begin(fmt.Sprintf("session: %#v, input: %#v", v.Session, input)))
 
 	dconfig := data.InstallerData{}
 
 	dconfig.ApplianceSize.CPU.Limit = int64(input.NumCPUs)
 	dconfig.ApplianceSize.Memory.Limit = int64(input.MemoryMB)
 
-	dconfig.Datacenter = v.Session.Datacenter.Reference()
-	dconfig.DatacenterName = v.Session.Datacenter.Name()
+	if v.Session.Datacenter != nil {
+		dconfig.Datacenter = v.Session.Datacenter.Reference()
+		dconfig.DatacenterName = v.Session.Datacenter.Name()
+	} else {
+		log.Debugf("session datacenter is nil")
+	}
 
-	dconfig.Cluster = v.Session.Cluster.Reference()
-	dconfig.ClusterPath = v.Session.Cluster.InventoryPath
+	if v.Session.Cluster != nil {
+		dconfig.Cluster = v.Session.Cluster.Reference()
+		dconfig.ClusterPath = v.Session.Cluster.InventoryPath
+	} else {
+		log.Debugf("session cluster is nil")
+	}
 
 	dconfig.ResourcePoolPath = v.ResourcePoolPath
 	dconfig.UseRP = input.UseRP


### PR DESCRIPTION
the only thing possible is session datacenter or cluster is nil, but without any vic-machine log, cannot know what caused that.
this is to workaround the possible nil reference, and add some more logging to see what happens