### PR TITLE
[skip ci]Add nightly reporting to our reporting server

### DIFF
--- a/tests/nightly/nightly-autorun.sh
+++ b/tests/nightly/nightly-autorun.sh
@@ -29,4 +29,4 @@ git pull
 # Kick off the nightly
 now=$(date +"%m_%d_%Y")
 mkdir -p /home/vicadmin/nightly-log/
-sudo ./tests/nightly/nightly-kickoff.sh > /home/vicadmin/nightly-log/nightly_$now.txt 2>&1
+sudo -E ./tests/nightly/nightly-kickoff.sh > /home/vicadmin/nightly-log/nightly_$now.txt 2>&1

--- a/tests/nightly/nightly-kickoff.sh
+++ b/tests/nightly/nightly-kickoff.sh
@@ -260,3 +260,23 @@ EOT
 # Emails an HTML report of the test run results using SendMail.
 sendmail -t < nightly_mail.html
 fi
+
+# Saves test results to reporting server
+testresultsdb="vic-nightly.db"
+rm $testresultsdb
+scp $REPORTING_USER@$REPORTING_SERVER_URL:/export/drone-test-results/testruns-db/$testresultsdb .
+
+for i in $nightly_list_var; do
+python -m dbbot.run -k  -b $testresultsdb 65/$i/output.xml
+ssh $REPORTING_USER@$REPORTING_SERVER_URL mkdir -p /export/drone-test-results/testruns/$buildNumber-nightly/65/$i
+scp 65/$i/log.html $REPORTING_USER@$REPORTING_SERVER_URL:/export/drone-test-results/testruns/$buildNumber-nightly/65/$i
+scp 65/$i/report.html $REPORTING_USER@$REPORTING_SERVER_URL:/export/drone-test-results/testruns/$buildNumber-nightly/65/$i
+
+python -m dbbot.run -k  -b $testresultsdb 60/$i/output.xml
+ssh $REPORTING_USER@$REPORTING_SERVER_URL mkdir -p /export/drone-test-results/testruns/$buildNumber-nightly/60/$i
+scp 60/$i/log.html $REPORTING_USER@$REPORTING_SERVER_URL:/export/drone-test-results/testruns/$buildNumber-nightly/60/$i
+scp 60/$i/report.html $REPORTING_USER@$REPORTING_SERVER_URL:/export/drone-test-results/testruns/$buildNumber-nightly/60/$i
+done
+
+scp $testresultsdb $REPORTING_USER@$REPORTING_SERVER_URL:/export/drone-test-results/testruns-db/$testresultsdb
+


### PR DESCRIPTION
fixes #4302 

I changed the kickoff to sudo -E, and added the reporting variables to the vicadmin profile.  I also had to change the perms on the some of the folders on the reporting server @jakedsouza 

Also, had to pip install dbbot into the nightly executor.