### PR TITLE
[full ci]Fail correctly on docker login with incorrect credentials

### DIFF
--- a/lib/apiservers/engine/backends/system.go
+++ b/lib/apiservers/engine/backends/system.go
@@ -375,6 +375,12 @@ func (s *System) AuthenticateToRegistry(ctx context.Context, authConfig *types.A
 		token, err := fetcher.FetchAuthToken(authURL)
 		if err != nil || token.Token == "" {
 			log.Errorf("Fetch auth token failed: %s", err)
+			// At this point, if a request cannot be solved by a retry, it is an authentication error.
+			switch err.(type) {
+			case urlfetcher.DoNotRetry:
+				err = fmt.Errorf("Get %s: unauthorized: incorrect username or password", loginURL)
+				return "", err
+			}
 			return "", err
 		}
 

--- a/pkg/fetcher/fetcher.go
+++ b/pkg/fetcher/fetcher.go
@@ -423,9 +423,9 @@ func (u *URLFetcher) setAuthToken(req *http.Request) {
 func (u *URLFetcher) ExtractOAuthURL(hdr string, repository *url.URL) (*url.URL, error) {
 	tokens := strings.Split(hdr, " ")
 	if len(tokens) != 2 || strings.ToLower(tokens[0]) != "bearer" {
-		return nil, fmt.Errorf("www-authenticate header is corrupted")
+		err := fmt.Errorf("www-authenticate header is corrupted")
+		return nil, DoNotRetry{Err: err}
 	}
-
 	tokens = strings.Split(tokens[1], ",")
 
 	var realm, service, scope string
@@ -442,14 +442,17 @@ func (u *URLFetcher) ExtractOAuthURL(hdr string, repository *url.URL) (*url.URL,
 	}
 
 	if realm == "" {
-		return nil, fmt.Errorf("missing realm in bearer auth challenge")
+		err := fmt.Errorf("missing realm in bearer auth challenge")
+		return nil, DoNotRetry{Err: err}
 	}
 	if service == "" {
-		return nil, fmt.Errorf("missing service in bearer auth challenge")
+		err := fmt.Errorf("missing service in bearer auth challenge")
+		return nil, DoNotRetry{Err: err}
 	}
 	// The scope can be empty if we're not getting a token for a specific repo
 	if scope == "" && repository != nil {
-		return nil, fmt.Errorf("missing scope in bearer auth challenge")
+		err := fmt.Errorf("missing scope in bearer auth challenge")
+		return nil, DoNotRetry{Err: err}
 	}
 
 	auth, err := url.Parse(realm)

--- a/tests/test-cases/Group1-Docker-Commands/1-27-Docker-Login.md
+++ b/tests/test-cases/Group1-Docker-Commands/1-27-Docker-Login.md
@@ -14,13 +14,16 @@ This test requires that a vSphere server is running and available
 1. Deploy VIC appliance to vSphere server
 2. Issue docker pull private image on docker.io
 3. Issue docker pull public image on docker.io
-4. Issue docker login on docker.io
-5. Issue docker pull private image on docker.io
-6. Issue docker logout on docker.io
+4. Issue docker login on docker.io with invalid credentials 
+5. Issue docker login on docker.io with valid credentials
+6. Issue docker pull private image on docker.io
+7. Issue docker logout on docker.io
 
 # Expected Outcome:
 * Step 2 should result in an error without login
-* Step 3-6 should each succeed
+* Step 4 should result in an error of invalid credentials
+* Step 3, 5-7 should each succeed
 
 # Possible Problems:
-None
+Test will fail if docker account victest is disabled, or if connection to docker.io cannot be 
+established.

--- a/tests/test-cases/Group1-Docker-Commands/1-27-Docker-Login.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-27-Docker-Login.robot
@@ -24,7 +24,11 @@ Docker login and pull from docker.io
     Should Be Equal As Integers  ${rc}  1
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} pull victest/public-hello-world
     Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} login --username=victest --password=incorrectPassword
+	Should Contain  ${output}  incorrect username or password
+	Should Be Equal As Integers  ${rc}  1
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} login --username=victest --password=vmware!123
+	Should Contain  ${output}  Login Succeeded
     Should Be Equal As Integers  ${rc}  0
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} pull victest/busybox
     Should Be Equal As Integers  ${rc}  0


### PR DESCRIPTION
fixes #5195
Full ci is required since docker login is used in tests 3-01, 3-02, 11-03, and 1-27.