### PR TITLE
Set default docker start timeout [specific ci=1-40-Docker-Restart]

### DIFF
--- a/lib/apiservers/engine/backends/container.go
+++ b/lib/apiservers/engine/backends/container.go
@@ -741,7 +741,7 @@ func (c *Container) ContainerRestart(name string, seconds *int) error {
 	}
 
 	operation = func() error {
-		return c.containerStart(name, nil, false)
+		return c.containerStart(name, nil, true)
 	}
 	if err := retry.Do(operation, IsConflictError); err != nil {
 		return InternalServerError(fmt.Sprintf("Start failed with: %s", err))

--- a/tests/test-cases/Group1-Docker-Commands/1-40-Docker-Restart.md
+++ b/tests/test-cases/Group1-Docker-Commands/1-40-Docker-Restart.md
@@ -1,0 +1,25 @@
+Test 1-40 - Docker Restart
+=======
+
+# Purpose:
+To verify that `docker restart` is supported and works as expected.
+
+# Environment:
+This test requires that a vSphere server is running and available
+
+
+# Test Steps:
+1. Run a busybox container and create a busybox container
+2. Run restart for running container
+3. Run restart for created container
+4. Run restart for stopped container
+
+
+# Expected Outcome:
+1. Fails if two containers are not created
+2. Successfully stop and restart container - failure on op failure or ip address change
+3. Successfully start created container - failure if container doesn't start
+4. Successfully stop running container and then restart stopped container - failure on op failure or ip address change
+
+# Possible Problems:
+

--- a/tests/test-cases/Group1-Docker-Commands/1-40-Docker-Restart.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-40-Docker-Restart.robot
@@ -1,0 +1,86 @@
+# Copyright 2017 VMware, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#	http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License
+
+*** Settings ***
+Documentation   Test 1-40 - Docker Restart
+Resource        ../../resources/Util.robot
+Suite Setup     Install VIC Appliance To Test Server
+Suite Teardown  Cleanup VIC Appliance On Test Server
+
+*** Keywords ***
+
+Create test containers
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} pull busybox
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -d busybox /bin/top
+    Should Be Equal As Integers  ${rc}  0
+    Set Environment Variable  RUNNER  ${output}
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} create busybox /bin/top
+    Should Be Equal As Integers  ${rc}  0
+    Set Environment Variable  CREATOR  ${output}
+
+*** Test Cases ***
+Restart Running Container
+    Create test containers
+    # grab the containerVM ip address - will compare after restart to ensure it remains the same
+    ${rc}  ${originalIP}=  Run And Return Rc And Output  docker %{VCH-PARAMS} inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' %{RUNNER}
+    Should Be Equal As Integers  ${rc}  0
+    Should Contain  ${originalIP}  172
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} restart %{RUNNER}
+    Should Be Equal As Integers  ${rc}  0
+    Should Contain  ${output}  %{RUNNER}
+    # verify that IP address didn't chnage during restart
+    ${rc}  ${restartIP}=  Run And Return Rc And Output  docker %{VCH-PARAMS} inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' %{RUNNER}
+    Should Be Equal As Integers  ${rc}  0
+    Should Be Equal  ${originalIP}  ${restartIP}
+    # verify that the containerVM started
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} ps -f id=%{RUNNER} -f status=running
+    Should Be Equal As Integers  ${rc}  0
+    ${output}=  Split To Lines  ${output}
+    Length Should Be  ${output}  2
+
+Restart Created Container
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} restart %{CREATOR}
+    Should Be Equal As Integers  ${rc}  0
+    Should Contain  ${output}  %{CREATOR}
+    # verify that the containerVM started
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} ps -f id=%{CREATOR} -f status=running
+    Should Be Equal As Integers  ${rc}  0
+    ${output}=  Split To Lines  ${output}
+    Length Should Be  ${output}  2
+
+Restart Stopped Container
+    # grab the containerVM ip address - will compare after restart to ensure it remains the same
+    ${rc}  ${originalIP}=  Run And Return Rc And Output  docker %{VCH-PARAMS} inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' %{RUNNER}
+    Should Be Equal As Integers  ${rc}  0
+    Should Contain  ${originalIP}  172
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} stop %{RUNNER}
+    Should Be Equal As Integers  ${rc}  0
+    # verify that the containerVM exited
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} ps -f id=%{RUNNER} -f status=exited
+    Should Be Equal As Integers  ${rc}  0
+    ${output}=  Split To Lines  ${output}
+    Length Should Be  ${output}  2
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} restart %{RUNNER}
+    Should Be Equal As Integers  ${rc}  0
+    Should Contain  ${output}  %{RUNNER}
+    # verify that the containerVM started
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} ps -f id=%{RUNNER} -f status=running
+    Should Be Equal As Integers  ${rc}  0
+    ${output}=  Split To Lines  ${output}
+    Length Should Be  ${output}  2
+    # verify that IP address didn't chnage during restart
+    ${rc}  ${restartIP}=  Run And Return Rc And Output  docker %{VCH-PARAMS} inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' %{RUNNER}
+    Should Be Equal As Integers  ${rc}  0
+    Should Be Equal  ${originalIP}  ${restartIP}


### PR DESCRIPTION
In the docker 1.13.x client a default of 10s for start timeout
is not provided.  We now check the value and will set default
if it's missing. Also created ci tests for restart.

Fixes #5399 