### PR TITLE
[specific ci=6-16-Config] Add support for vic-machine configure dns 

### DIFF
--- a/cmd/vic-machine/common/dns.go
+++ b/cmd/vic-machine/common/dns.go
@@ -1,0 +1,66 @@
+// Copyright 2017 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"net"
+
+	log "github.com/Sirupsen/logrus"
+	"gopkg.in/urfave/cli.v1"
+
+	"github.com/vmware/vic/pkg/errors"
+)
+
+// general dns
+type DNS struct {
+	dns   cli.StringSlice `arg:"dns-server"`
+	IsSet bool
+}
+
+func (d *DNS) DNSFlags(hidden bool) []cli.Flag {
+	return []cli.Flag{
+		cli.StringSliceFlag{
+			Name:   "dns-server",
+			Value:  &d.dns,
+			Usage:  "DNS server for the client, public, and management networks. Defaults to 8.8.8.8 and 8.8.4.4 when VCH uses static IP",
+			Hidden: hidden,
+		},
+	}
+}
+
+// processDNSServers parses DNS servers used for client, public, mgmt networks
+func (d *DNS) ProcessDNSServers() ([]net.IP, error) {
+	var parsedDNS []net.IP
+	if len(d.dns) > 0 {
+		d.IsSet = true
+	}
+
+	for _, n := range d.dns {
+		if n != "" {
+			s := net.ParseIP(n)
+			if s == nil {
+				return nil, errors.Errorf("Invalid DNS server specified: %s", n)
+			}
+			parsedDNS = append(parsedDNS, s)
+		}
+	}
+
+	if len(parsedDNS) > 3 {
+		log.Warn("Maximum of 3 DNS servers allowed. Additional servers specified will be ignored.")
+	}
+
+	log.Debugf("VCH DNS servers: %s", parsedDNS)
+	return parsedDNS, nil
+}

--- a/cmd/vic-machine/configure/configure.go
+++ b/cmd/vic-machine/configure/configure.go
@@ -88,6 +88,7 @@ func (c *Configure) Flags() []cli.Flag {
 	}
 
 	proxies := c.proxies.ProxyFlags(false)
+	// TODO (Jialin): after issue #5472 is fixed, change hidden back to false
 	dns := c.dns.DNSFlags(true)
 	target := c.TargetFlags()
 	ops := c.OpsCredentials.Flags(false)
@@ -314,6 +315,7 @@ func (c *Configure) Run(clic *cli.Context) (err error) {
 	// evaluate merged configuration
 	newConfig, err := validator.Validate(ctx, c.Data)
 	if err != nil {
+		log.Error("Configuring cannot continue: configuration validation failed")
 		return err
 	}
 

--- a/lib/install/data/data.go
+++ b/lib/install/data/data.go
@@ -263,5 +263,7 @@ func (d *Data) CopyNonEmpty(src *Data) error {
 
 	d.Timeout = src.Timeout
 
+	d.DNS = src.DNS
+
 	return nil
 }

--- a/tests/test-cases/Group6-VIC-Machine/6-16-Config.md
+++ b/tests/test-cases/Group6-VIC-Machine/6-16-Config.md
@@ -34,10 +34,10 @@ This test requires that a vSphere server is running and available
 21. Configure VCH http proxy
 22. Verify http proxy is set correctly through govc
 23. Configure the VCH's operations user credentials
-24. Run vic-machine inspect --conf
-25. Run vic-machine inspect --conf
+24. Run vic-machine inspect config
+25. Run vic-machine inspect config
 26. Configure VCH dns server to 10.118.81.1 and 10.118.81.2
-27. Run vic-machine inspect --conf
+27. Run vic-machine inspect config
 
 # Expected Outcome
 * Steps 1 to 11 should succeed

--- a/tests/test-cases/Group6-VIC-Machine/6-16-Config.md
+++ b/tests/test-cases/Group6-VIC-Machine/6-16-Config.md
@@ -35,6 +35,9 @@ This test requires that a vSphere server is running and available
 22. Verify http proxy is set correctly through govc
 23. Configure the VCH's operations user credentials
 24. Run vic-machine inspect --conf
+25. Run vic-machine inspect --conf
+26. Configure VCH dns server to 10.118.81.1 and 10.118.81.2
+27. Run vic-machine inspect --conf
 
 # Expected Outcome
 * Steps 1 to 11 should succeed
@@ -48,3 +51,4 @@ This test requires that a vSphere server is running and available
 * Steps 21 and 22 should succeed
 * Steps 23 and 24 should succeed
 * Step 24's output should contain the operations user's name and the host thumbprint
+* Steps 25 to 27 should succeed

--- a/tests/test-cases/Group6-VIC-Machine/6-16-Config.robot
+++ b/tests/test-cases/Group6-VIC-Machine/6-16-Config.robot
@@ -150,10 +150,10 @@ Configure VCH https-proxy through vch id
     Should Not Contain  ${output}  proxy.vmware.com:3128
 
 Configure VCH DNS server
-    ${output}=  Run  bin/vic-machine-linux inspect --name=%{VCH-NAME} --target=%{TEST_URL} --thumbprint=%{TEST_THUMBPRINT} --user=%{TEST_USERNAME} --password=%{TEST_PASSWORD} --timeout %{TEST_TIMEOUT} --conf
+    ${output}=  Run  bin/vic-machine-linux inspect --name=%{VCH-NAME} --target=%{TEST_URL} --thumbprint=%{TEST_THUMBPRINT} --user=%{TEST_USERNAME} --password=%{TEST_PASSWORD} --timeout %{TEST_TIMEOUT} config
     Should Not Contain  ${output}  --dns-server  
     ${output}=  Run  bin/vic-machine-linux configure --name=%{VCH-NAME} --target=%{TEST_URL} --thumbprint=%{TEST_THUMBPRINT} --user=%{TEST_USERNAME} --password=%{TEST_PASSWORD} --timeout %{TEST_TIMEOUT} --dns-server 10.118.81.1 --dns-server 10.118.81.2
     Should Contain  ${output}  Completed successfully
-    ${output}=  Run  bin/vic-machine-linux inspect --name=%{VCH-NAME} --target=%{TEST_URL} --thumbprint=%{TEST_THUMBPRINT} --user=%{TEST_USERNAME} --password=%{TEST_PASSWORD} --timeout %{TEST_TIMEOUT} --conf
+    ${output}=  Run  bin/vic-machine-linux inspect --name=%{VCH-NAME} --target=%{TEST_URL} --thumbprint=%{TEST_THUMBPRINT} --user=%{TEST_USERNAME} --password=%{TEST_PASSWORD} --timeout %{TEST_TIMEOUT} config
     Should Contain  ${output}  --dns-server=10.118.81.1
     Should Contain  ${output}  --dns-server=10.118.81.2

--- a/tests/test-cases/Group6-VIC-Machine/6-16-Config.robot
+++ b/tests/test-cases/Group6-VIC-Machine/6-16-Config.robot
@@ -148,3 +148,12 @@ Configure VCH https-proxy through vch id
     ${rc}  ${output}=  Run And Return Rc And Output  govc vm.info -e %{VCH-NAME} | grep HTTPS_PROXY
     Should Be Equal As Integers  ${rc}  1
     Should Not Contain  ${output}  proxy.vmware.com:3128
+
+Configure VCH DNS server
+    ${output}=  Run  bin/vic-machine-linux inspect --name=%{VCH-NAME} --target=%{TEST_URL} --thumbprint=%{TEST_THUMBPRINT} --user=%{TEST_USERNAME} --password=%{TEST_PASSWORD} --timeout %{TEST_TIMEOUT} --conf
+    Should Not Contain  ${output}  --dns-server  
+    ${output}=  Run  bin/vic-machine-linux configure --name=%{VCH-NAME} --target=%{TEST_URL} --thumbprint=%{TEST_THUMBPRINT} --user=%{TEST_USERNAME} --password=%{TEST_PASSWORD} --timeout %{TEST_TIMEOUT} --dns-server 10.118.81.1 --dns-server 10.118.81.2
+    Should Contain  ${output}  Completed successfully
+    ${output}=  Run  bin/vic-machine-linux inspect --name=%{VCH-NAME} --target=%{TEST_URL} --thumbprint=%{TEST_THUMBPRINT} --user=%{TEST_USERNAME} --password=%{TEST_PASSWORD} --timeout %{TEST_TIMEOUT} --conf
+    Should Contain  ${output}  --dns-server=10.118.81.1
+    Should Contain  ${output}  --dns-server=10.118.81.2


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[  ] There is an associated issue that is labelled
[  ] Code is up-to-date with the `master` branch
[  ] You've successfully run `make test` locally
[  ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/vmware/vic/blob/master/.github/CONTRIBUTING.md
-->

Fixes #4517 

<!--
To trigger a custom build with this PR, include one of these in the PR's title or commit messages:
- To skip running tests (e.g. for a work-in-progress PR), add `[ci skip]` or `[skip ci]`
to the commit message or the PR title.
- To run the full test suite, use `[full ci]`.
- To run _one_ integration test or group, use `[specific ci=$test]`. Examples:
  - To run the `1-01-Docker-Info` suite: `[specific ci=1-01-Docker-Info]`
  - To run all suites under the `Group1-Docker-Commands` group: `[specific ci=Group1-Docker-Commands]`
-->
