### PR TITLE
Fix incorrect IP handling in VCH portlet

### DIFF
--- a/ui/vic-ui-h5c/vic-service/src/main/java/com/vmware/vic/model/VirtualContainerHostVm.java
+++ b/ui/vic-ui-h5c/vic-service/src/main/java/com/vmware/vic/model/VirtualContainerHostVm.java
@@ -100,8 +100,9 @@ public class VirtualContainerHostVm extends VicBaseVm {
 				String key = ov.getKey();
 				if (EXTRACONFIG_CLIENT_IP_KEY.equals(key)) {
 					byte[] decoded = DatatypeConverter.parseBase64Binary((String)ov.getValue());
+					int idx = decoded.length == 16 ? 12 : 0;
 					StringBuilder sb = new StringBuilder();
-					for (int i = 0; i < decoded.length; i++) {
+					for (int i = idx; i < decoded.length; i++) {
 						sb.append((decoded[i] << 24) >>> 24);
 						if (i < decoded.length - 1) {
 							sb.append(".");

--- a/ui/vic-ui-h5c/vic/src/vic-app/src/app/services/data-property.service.spec.ts
+++ b/ui/vic-ui-h5c/vic/src/vic-app/src/app/services/data-property.service.spec.ts
@@ -1,0 +1,123 @@
+/*
+ Copyright 2017 VMware, Inc. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+import { TestBed, async } from '@angular/core/testing';
+import {
+    BaseRequestOptions,
+    ConnectionBackend,
+    RequestOptions,
+    HttpModule,
+    Http,
+    Response,
+    ResponseOptions,
+    ResponseType,
+    XHRBackend,
+    Headers
+} from '@angular/http';
+import { MockBackend, MockConnection } from '@angular/http/testing';
+import { GlobalsService, Globals } from '../shared/globals.service';
+import { DataPropertyService } from './data-property.service';
+import { VirtualMachine } from '../vm.interface';
+import { VM_PROPERTIES_TO_EXTRACT } from '../vm.constants';
+import { JASMINE_TIMEOUT } from '../testing/jasmine.constants';
+
+describe('VicDataPropertyService', () => {
+    let service: DataPropertyService;
+    let backend: MockBackend;
+    let connection: MockConnection;
+    let http: Http;
+    jasmine.DEFAULT_TIMEOUT_INTERVAL = JASMINE_TIMEOUT;
+
+    beforeEach(async(() => {
+        TestBed.configureCompiler({
+            providers: [
+                Http,
+                { provide: ConnectionBackend, useClass: MockBackend },
+                { provide: RequestOptions, useClass: BaseRequestOptions },
+                DataPropertyService,
+                GlobalsService,
+                Globals
+            ]
+        });
+        service = TestBed.get(DataPropertyService);
+        backend = TestBed.get(ConnectionBackend);
+        backend.connections.subscribe((c: MockConnection) => connection = c);
+    }));
+
+    it('should process a VCH with TLS on and a client network configured to use DHCP', async(() => {
+        const mockResponse = { "id": "urn:vmomi:VirtualMachine:vm-76:85421094-c58e-40f9-a42c-b624160d05f5", "summary.runtime.powerState": "poweredOn", "name": "virtual-container-host", "isVCH": true, "config.extraConfig": [{ "dynamicType": null, "dynamicProperty": null, "key": "guestinfo.vice./init/sessions|docker-personality/cmd/Args~", "value": "/sbin/docker-engine-server|-port=2376|-port-layer-port=2377" }, { "dynamicType": null, "dynamicProperty": null, "key": "guestinfo.vice..init.networks|client.assigned.IP", "value": "ChFtcg==" }], "isContainer": false };
+        service.fetchVmInfo(VM_PROPERTIES_TO_EXTRACT);
+        service.vmInfo$.subscribe((data: VirtualMachine) => {
+            expect(data).toBeTruthy();
+            expect(data.isVCH).toEqual(true);
+            expect(data.isContainer).toEqual(false);
+            expect(data['dockerLog']).toEqual('https://10.17.109.114:2378');
+            expect(data['dockerEndpoint']).toEqual('DOCKER_HOST=tcp://10.17.109.114:2376');
+        });
+
+        connection.mockRespond(new Response(new ResponseOptions({
+            body: mockResponse
+        })));
+    }));
+
+    it('should process a VCH without TLS on and a client network configured to use DHCP', async(() => {
+        const mockResponse = { "id": "urn:vmomi:VirtualMachine:vm-76:85421094-c58e-40f9-a42c-b624160d05f5", "summary.runtime.powerState": "poweredOn", "name": "virtual-container-host", "isVCH": true, "config.extraConfig": [{ "dynamicType": null, "dynamicProperty": null, "key": "guestinfo.vice./init/sessions|docker-personality/cmd/Args~", "value": "/sbin/docker-engine-server|-port=2375|-port-layer-port=2377" }, { "dynamicType": null, "dynamicProperty": null, "key": "guestinfo.vice..init.networks|client.assigned.IP", "value": "ChFtcg==" }], "isContainer": false };
+        service.fetchVmInfo(VM_PROPERTIES_TO_EXTRACT);
+        service.vmInfo$.subscribe((data: VirtualMachine) => {
+            expect(data).toBeTruthy();
+            expect(data.isVCH).toEqual(true);
+            expect(data.isContainer).toEqual(false);
+            expect(data['dockerLog']).toEqual('https://10.17.109.114:2378');
+            expect(data['dockerEndpoint']).toEqual('DOCKER_HOST=tcp://10.17.109.114:2375');
+        });
+
+        connection.mockRespond(new Response(new ResponseOptions({
+            body: mockResponse
+        })));
+    }));
+
+    it('should process a VCH with TLS on and a client network configured to use a static IP', async(() => {
+        const mockResponse = { "id": "urn:vmomi:VirtualMachine:vm-76:85421094-c58e-40f9-a42c-b624160d05f5", "summary.runtime.powerState": "poweredOn", "name": "virtual-container-host", "isVCH": true, "config.extraConfig": [{ "dynamicType": null, "dynamicProperty": null, "key": "guestinfo.vice./init/sessions|docker-personality/cmd/Args~", "value": "/sbin/docker-engine-server|-port=2376|-port-layer-port=2377" }, { "dynamicType": null, "dynamicProperty": null, "key": "guestinfo.vice..init.networks|client.assigned.IP", "value": "AAAAAAAAAAAAAP//wKhkFg==" }], "isContainer": false };
+        service.fetchVmInfo(VM_PROPERTIES_TO_EXTRACT);
+        service.vmInfo$.subscribe((data: VirtualMachine) => {
+            expect(data).toBeTruthy();
+            expect(data.isVCH).toEqual(true);
+            expect(data.isContainer).toEqual(false);
+            expect(data['dockerLog']).toEqual('https://192.168.100.22:2378');
+            expect(data['dockerEndpoint']).toEqual('DOCKER_HOST=tcp://192.168.100.22:2376');
+        });
+
+        connection.mockRespond(new Response(new ResponseOptions({
+            body: mockResponse
+        })));
+    }));
+
+    it('should process a VCH without TLS on and a client network configured to use a static IP', async(() => {
+        const mockResponse = { "id": "urn:vmomi:VirtualMachine:vm-76:85421094-c58e-40f9-a42c-b624160d05f5", "summary.runtime.powerState": "poweredOn", "name": "virtual-container-host", "isVCH": true, "config.extraConfig": [{ "dynamicType": null, "dynamicProperty": null, "key": "guestinfo.vice./init/sessions|docker-personality/cmd/Args~", "value": "/sbin/docker-engine-server|-port=2375|-port-layer-port=2377" }, { "dynamicType": null, "dynamicProperty": null, "key": "guestinfo.vice..init.networks|client.assigned.IP", "value": "AAAAAAAAAAAAAP//wKhkFg==" }], "isContainer": false };
+        service.fetchVmInfo(VM_PROPERTIES_TO_EXTRACT);
+        service.vmInfo$.subscribe((data: VirtualMachine) => {
+            expect(data).toBeTruthy();
+            expect(data.isVCH).toEqual(true);
+            expect(data.isContainer).toEqual(false);
+            expect(data['dockerLog']).toEqual('https://192.168.100.22:2378');
+            expect(data['dockerEndpoint']).toEqual('DOCKER_HOST=tcp://192.168.100.22:2375');
+        });
+
+        connection.mockRespond(new Response(new ResponseOptions({
+            body: mockResponse
+        })));
+    }));
+});

--- a/ui/vic-ui-h5c/vic/src/vic-app/src/app/services/data-property.service.ts
+++ b/ui/vic-ui-h5c/vic/src/vic-app/src/app/services/data-property.service.ts
@@ -59,9 +59,11 @@ export class DataPropertyService {
      * @return  data URL
      */
     buildDataUrl(id: string = this._objectId, props: string[]): string {
-        let url: string = window[APP_CONFIG.bundleName]
-            .buildDataUrl(id, props);
-        return url;
+        let namespace = window[APP_CONFIG.bundleName];
+        if (namespace) {
+            return namespace.buildDataUrl(id, props);
+        }
+        return null;
     }
 
     /**
@@ -151,11 +153,15 @@ function processVmType(obj: any): any {
 
         for (let { key, value } of extConfig) {
             if (key === VCH_VM_CLIENT_IP_KEY) {
-                const base64_decoded: string = atob(value);
-                const ipv4: string = base64_decoded.charCodeAt(0) + '.'
-                    + base64_decoded.charCodeAt(1) + '.'
-                    + base64_decoded.charCodeAt(2) + '.'
-                    + base64_decoded.charCodeAt(3);
+                const base64Decoded: string = atob(value);
+                const decIpLength = base64Decoded.length;
+                // if the ip is in ipv6 format, the decoded string is
+                // 16 bytes long
+                const decIpIdx = decIpLength === 16 ? decIpLength - 4 : 0;
+                const ipv4: string = base64Decoded.charCodeAt(decIpIdx) + '.'
+                    + base64Decoded.charCodeAt(decIpIdx + 1) + '.'
+                    + base64Decoded.charCodeAt(decIpIdx + 2) + '.'
+                    + base64Decoded.charCodeAt(decIpIdx + 3);
                 obj.dockerEndpoint = `DOCKER_HOST=tcp://${ipv4}`;
                 obj.dockerLog = `https://${ipv4}${VCH_VM_LOG_PORT}`;
                 continue;

--- a/ui/vic-ui/swf/src/main/flex/com/vmware/vicui/views/VchPortletMediator.as
+++ b/ui/vic-ui/swf/src/main/flex/com/vmware/vicui/views/VchPortletMediator.as
@@ -114,6 +114,13 @@ package com.vmware.vicui.views {
 							   var ip_ipv4:String = new String();
 
 							   bytes = base64Decoder.toByteArray();
+							   // if the ip is in ipv6 format, the decoded string is
+							   // 16 bytes long. fast-forward 12 bytes
+							   if (bytes.length == 16) {
+								   for (var i:int = 0; i < 12; i++) {
+									   bytes.readUnsignedByte();
+								   }
+							   }
 							   ip_ipv4 = bytes.readUnsignedByte() + "." + bytes.readUnsignedByte() + "." + bytes.readUnsignedByte() + "." + bytes.readUnsignedByte();
 
 							   _view.dockerApiEndpoint.text = "DOCKER_HOST=tcp://" + ip_ipv4;


### PR DESCRIPTION
This PR fixes the handling of config.extraConfig["guestinfo.vice./init/networks|public/ip/IP"] where its value is 4 bytes (IPv4) long when VCH is deployed with client network using DHCP, and 16 bytes long (IPv6) when client network is static.