### PR TITLE
Introduce VirtualDiskConfig to DiskManager

### DIFF
--- a/lib/portlayer/storage/vsphere/image.go
+++ b/lib/portlayer/storage/vsphere/image.go
@@ -62,11 +62,11 @@ var (
 )
 
 const (
-	StorageImageDir  = "images"
-	defaultDiskLabel = "containerfs"
-	defaultDiskSize  = 8 * 1024 * 1024
-	metaDataDir      = "imageMetadata"
-	manifest         = "manifest"
+	StorageImageDir     = "images"
+	defaultDiskLabel    = "containerfs"
+	defaultDiskSizeInKB = 8 * 1024 * 1024
+	metaDataDir         = "imageMetadata"
+	manifest            = "manifest"
 )
 
 type ImageStore struct {
@@ -409,7 +409,7 @@ func (v *ImageStore) scratch(op trace.Operation, storeName string) error {
 	imageDiskDsURI := v.imageDiskDSPath(storeName, portlayer.Scratch.ID)
 	op.Infof("Creating image %s (%s)", portlayer.Scratch.ID, imageDiskDsURI)
 
-	size = defaultDiskSize
+	size = defaultDiskSizeInKB
 	if portlayer.Config.ScratchSize != 0 {
 		size = portlayer.Config.ScratchSize
 	}

--- a/lib/portlayer/storage/vsphere/image_test.go
+++ b/lib/portlayer/storage/vsphere/image_test.go
@@ -301,7 +301,7 @@ func TestCreateImageLayers(t *testing.T) {
 				roDisk.Unmount()
 			}
 			if roDisk.Attached() {
-				vsStore.dm.Detach(op, roDisk)
+				vsStore.dm.Detach(op, roDisk.VirtualDiskConfig)
 			}
 		}
 		os.RemoveAll(p)
@@ -580,7 +580,8 @@ func mountLayerRO(v *ImageStore, parent *portlayer.Image) (*disk.VirtualDisk, er
 
 	op := trace.NewOperation(context.TODO(), "ro")
 
-	roDisk, err := v.dm.CreateAndAttach(op, roName, parentDsURI, 0, os.O_RDONLY, disk.Ext4)
+	config := disk.NewNonPersistentDisk(roName).WithParent(parentDsURI)
+	roDisk, err := v.dm.CreateAndAttach(op, config)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/vsphere/disk/config.go
+++ b/pkg/vsphere/disk/config.go
@@ -1,0 +1,87 @@
+// Copyright 2017 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package disk
+
+import (
+	"fmt"
+	"hash/fnv"
+
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25/types"
+	"github.com/vmware/vic/pkg/fs"
+)
+
+type VirtualDiskConfig struct {
+	// The URI in the datastore this disk can be found with
+	DatastoreURI *object.DatastorePath
+
+	// The URI in the datastore to the parent of this disk
+	ParentDatastoreURI *object.DatastorePath
+
+	// The size of the disk
+	CapacityInKB int64
+
+	// Underlying filesystem
+	Filesystem Filesystem
+
+	DiskMode types.VirtualDiskMode
+}
+
+func NewPersistentDisk(URI *object.DatastorePath) *VirtualDiskConfig {
+	return &VirtualDiskConfig{
+		DatastoreURI: URI,
+		DiskMode:     types.VirtualDiskModeIndependent_persistent,
+		Filesystem:   fs.NewExt4(),
+	}
+}
+
+func NewNonPersistentDisk(URI *object.DatastorePath) *VirtualDiskConfig {
+	return &VirtualDiskConfig{
+		DatastoreURI: URI,
+		DiskMode:     types.VirtualDiskModeIndependent_nonpersistent,
+		Filesystem:   fs.NewExt4(),
+	}
+}
+
+func (d *VirtualDiskConfig) WithParent(parent *object.DatastorePath) *VirtualDiskConfig {
+	d.ParentDatastoreURI = parent
+
+	return d
+}
+
+func (d *VirtualDiskConfig) WithFilesystem(ftype FilesystemType) *VirtualDiskConfig {
+	switch ftype {
+	case Xfs:
+		d.Filesystem = fs.NewXFS()
+	default:
+		d.Filesystem = fs.NewExt4()
+	}
+	return d
+}
+
+func (d *VirtualDiskConfig) WithCapacity(capacity int64) *VirtualDiskConfig {
+	d.CapacityInKB = capacity
+
+	return d
+}
+
+func (d *VirtualDiskConfig) Hash() uint64 {
+	key := fmt.Sprintf("%s-%s-%d-%s", d.DatastoreURI, d.ParentDatastoreURI, d.CapacityInKB, d.DiskMode)
+
+	hash := fnv.New64a()
+	hash.Write([]byte(key))
+
+	return hash.Sum64()
+}

--- a/pkg/vsphere/disk/config.go
+++ b/pkg/vsphere/disk/config.go
@@ -78,7 +78,7 @@ func (d *VirtualDiskConfig) WithCapacity(capacity int64) *VirtualDiskConfig {
 }
 
 func (d *VirtualDiskConfig) Hash() uint64 {
-	key := fmt.Sprintf("%s-%s-%d-%s", d.DatastoreURI, d.ParentDatastoreURI, d.CapacityInKB, d.DiskMode)
+	key := fmt.Sprintf("%s-%s-%s", d.DatastoreURI, d.ParentDatastoreURI, d.DiskMode)
 
 	hash := fnv.New64a()
 	hash.Write([]byte(key))

--- a/pkg/vsphere/disk/disk.go
+++ b/pkg/vsphere/disk/disk.go
@@ -126,7 +126,15 @@ func (d *VirtualDisk) canBeDetached() error {
 	return nil
 }
 
-func (d *VirtualDisk) setDetached() error {
+func (d *VirtualDisk) setDetached(disks map[uint64]*VirtualDisk) error {
+	defer func() {
+		if d.attachedRefs == 0 {
+			log.Debugf("Dropping %s from the DiskManager cache", d.DatastoreURI)
+
+			delete(disks, d.Hash())
+		}
+	}()
+
 	if !d.Attached() {
 		return fmt.Errorf("%s is already detached", d.DatastoreURI)
 	}

--- a/pkg/vsphere/disk/disk_manager.go
+++ b/pkg/vsphere/disk/disk_manager.go
@@ -359,7 +359,7 @@ func (m *Manager) Detach(op trace.Operation, config *VirtualDiskConfig) error {
 	}
 
 	// don't decrement reference count here as setDetached() does it already
-	return d.setDetached()
+	return d.setDetached(m.Disks)
 }
 
 func (m *Manager) DetachAll(op trace.Operation) error {

--- a/pkg/vsphere/disk/disk_manager.go
+++ b/pkg/vsphere/disk/disk_manager.go
@@ -147,7 +147,7 @@ func (m *Manager) CreateAndAttach(op trace.Operation, config *VirtualDiskConfig)
 
 	op.Infof("Create/attach vmdk %s from parent %s", config.DatastoreURI, config.ParentDatastoreURI)
 
-	if err := m.Attach(op, config); err != nil {
+	if err := m.attach(op, config); err != nil {
 		return nil, errors.Trace(err)
 	}
 
@@ -272,7 +272,7 @@ func (m *Manager) Get(op trace.Operation, config *VirtualDiskConfig) (*VirtualDi
 // }
 
 // Attach attempts to attach a virtual disk
-func (m *Manager) Attach(op trace.Operation, config *VirtualDiskConfig) error {
+func (m *Manager) attach(op trace.Operation, config *VirtualDiskConfig) error {
 	defer trace.End(trace.Begin(""))
 
 	disk := m.toSpec(config)

--- a/pkg/vsphere/disk/disk_manager.go
+++ b/pkg/vsphere/disk/disk_manager.go
@@ -331,7 +331,7 @@ func (m *Manager) Detach(op trace.Operation, config *VirtualDiskConfig) error {
 
 	op.Infof("Detaching disk %s", d.DevicePath)
 
-	if !d.Attached() {
+	if !d.attached() {
 		op.Infof("Disk %s is already detached", d.DevicePath)
 		return nil
 	}

--- a/pkg/vsphere/disk/disk_manager_test.go
+++ b/pkg/vsphere/disk/disk_manager_test.go
@@ -291,7 +291,7 @@ func TestRefCounting(t *testing.T) {
 	assert.Equal(t, 2, d.attachedRefs, "%s has %d attach references but should have 2", d.DatastoreURI, d.attachedRefs)
 
 	// reduce reference count by calling detach
-	assert.NoError(t, d.setDetached(), "Error attempting to mark %s as detached", d.DatastoreURI)
+	assert.NoError(t, d.setDetached(vdm.Disks), "Error attempting to mark %s as detached", d.DatastoreURI)
 
 	assert.True(t, d.Attached(), "%s is not attached but should be", d.DatastoreURI)
 	assert.NoError(t, d.canBeDetached(), "%s should be detachable but is not", d.DatastoreURI)

--- a/pkg/vsphere/disk/disk_manager_test.go
+++ b/pkg/vsphere/disk/disk_manager_test.go
@@ -253,7 +253,7 @@ func TestRefCounting(t *testing.T) {
 	config = NewPersistentDisk(child).WithParent(scratch)
 
 	// attempt attach
-	assert.NoError(t, vdm.Attach(op, config), "Error attempting to attach %s", config)
+	assert.NoError(t, vdm.attach(op, config), "Error attempting to attach %s", config)
 
 	devicePath, err := vdm.devicePathByURI(op, child)
 	if !assert.NoError(t, err) {

--- a/pkg/vsphere/disk/disk_manager_test.go
+++ b/pkg/vsphere/disk/disk_manager_test.go
@@ -100,7 +100,7 @@ func TestCreateAndDetach(t *testing.T) {
 	_ = fm.MakeDirectory(context.TODO(), imagestore.String(), nil, true)
 
 	op := trace.NewOperation(context.Background(), "test")
-	vdm, err := NewDiskManager(op, client, false)
+	vdm, err := NewDiskManager(op, client)
 	if err != nil && err.Error() == "can't find the hosting vm" {
 		t.Skip("Skipping: test must be run in a VM")
 	}
@@ -114,7 +114,8 @@ func TestCreateAndDetach(t *testing.T) {
 		Datastore: client.Datastore.Name(),
 		Path:      path.Join(imagestore.Path, "scratch.vmdk"),
 	}
-	parent, err := vdm.Create(op, scratch, diskSize, Ext4)
+	config := NewPersistentDisk(scratch).WithCapacity(diskSize)
+	parent, err := vdm.Create(op, config)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -132,7 +133,8 @@ func TestCreateAndDetach(t *testing.T) {
 			Path:      path.Join(imagestore.Path, fmt.Sprintf("child%d.vmdk", i)),
 		}
 
-		child, cerr := vdm.CreateAndAttach(op, p, parent.DatastoreURI, 0, os.O_RDWR, Ext4)
+		config := NewPersistentDisk(p).WithParent(parent.DatastoreURI)
+		child, cerr := vdm.CreateAndAttach(op, config)
 		if !assert.NoError(t, cerr) {
 			return
 		}
@@ -177,7 +179,7 @@ func TestCreateAndDetach(t *testing.T) {
 
 		f.Close()
 
-		cerr = vdm.Detach(op, child)
+		cerr = vdm.Detach(op, config)
 		if !assert.NoError(t, cerr) {
 			return
 		}
@@ -222,7 +224,7 @@ func TestRefCounting(t *testing.T) {
 	_ = fm.MakeDirectory(context.TODO(), imagestore.String(), nil, true)
 
 	op := trace.NewOperation(context.Background(), "test")
-	vdm, err := NewDiskManager(op, client, false)
+	vdm, err := NewDiskManager(op, client)
 	if err != nil && err.Error() == "can't find the hosting vm" {
 		t.Skip("Skipping: test must be run in a VM")
 	}
@@ -236,7 +238,8 @@ func TestRefCounting(t *testing.T) {
 		Datastore: client.Datastore.Name(),
 		Path:      path.Join(imagestore.Path, "scratch.vmdk"),
 	}
-	p, err := vdm.Create(op, scratch, diskSize, Ext4)
+	config := NewPersistentDisk(scratch).WithCapacity(diskSize)
+	p, err := vdm.Create(op, config)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -247,18 +250,17 @@ func TestRefCounting(t *testing.T) {
 		Datastore: imagestore.Datastore,
 		Path:      path.Join(imagestore.Path, "testDisk.vmdk"),
 	}
-
-	spec := vdm.createDiskSpec(child, scratch, diskSize, os.O_RDWR)
+	config = NewPersistentDisk(child).WithParent(scratch)
 
 	// attempt attach
-	assert.NoError(t, vdm.Attach(op, spec), "Error attempting to attach %s", spec)
+	assert.NoError(t, vdm.Attach(op, config), "Error attempting to attach %s", config)
 
 	devicePath, err := vdm.devicePathByURI(op, child)
 	if !assert.NoError(t, err) {
 		return
 	}
 
-	d, err := NewVirtualDisk(child, Ext4)
+	d, err := NewVirtualDisk(config, vdm.Disks)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -349,7 +351,7 @@ func TestRefCounting(t *testing.T) {
 	assert.Equal(t, 0, d.mountedRefs, "%s has %d mount references but should have 0", d.DatastoreURI, d.mountedRefs)
 
 	// detach
-	assert.NoError(t, vdm.Detach(op, d), "Error attempting to detach %s", d.DatastoreURI)
+	assert.NoError(t, vdm.Detach(op, config), "Error attempting to detach %s", d.DatastoreURI)
 
 	assert.False(t, d.Attached(), "%s is attached but should not be", d.DatastoreURI)
 	assert.False(t, d.Mounted(), "%s is mounted but should not be", d.DatastoreURI)


### PR DESCRIPTION
This is a non-functional change to make DiskManager methods consistent.
 NewVirtualDisk now checks the diskmanager's cache before creating a new
 struct. Before that each call was creating a new instance and making
 locking and ref counting problematic.

 I still want to split CreateAndAttach into multiple pieces to make each
 function do a one thing instead of current behaviour. That will be a follow-up
 PR after this.
