### PR TITLE
Add reference counting for mount and attach

### DIFF
--- a/pkg/vsphere/disk/disk.go
+++ b/pkg/vsphere/disk/disk.go
@@ -20,18 +20,27 @@ import (
 	"strings"
 	"sync"
 
+	log "github.com/Sirupsen/logrus"
+
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/vic/pkg/fs"
 )
 
+// FilesystemType represents the filesystem in use by a virtual disk
 type FilesystemType uint8
 
 const (
+	// Ext4 represents the ext4 file system
 	Ext4 FilesystemType = iota + 1
+
+	// Xfs represents the XFS file system
 	Xfs
+
+	// Ntfs represents the NTFS file system
 	Ntfs
 )
 
+// Filesystem defines the interface for handling an attached virtual disk
 type Filesystem interface {
 	Mkfs(devPath, label string) error
 	SetLabel(devPath, labelName string) error
@@ -39,6 +48,8 @@ type Filesystem interface {
 	Unmount(path string) error
 }
 
+// FilesystemTypeToFilesystem returns a new Filesystem implementation
+// associated with the supplied FilesystemType
 func FilesystemTypeToFilesystem(fstype FilesystemType) Filesystem {
 	switch fstype {
 	case Xfs:
@@ -67,9 +78,15 @@ type VirtualDisk struct {
 	// To avoid attach/detach races, this lock serializes operations to the disk.
 	l sync.Mutex
 
+	mountedRefs int
+
+	attachedRefs int
+
 	fs Filesystem
 }
 
+// NewVirtualDisk creates and returns a new VirtualDisk object associated with the
+// given datastore formatted with the specified FilesystemType
 func NewVirtualDisk(DatastoreURI *object.DatastorePath, fst FilesystemType) (*VirtualDisk, error) {
 	if err := VerifyDatastoreDiskURI(DatastoreURI.String()); err != nil {
 		return nil, err
@@ -92,15 +109,26 @@ func (d *VirtualDisk) unlock() {
 	d.l.Unlock()
 }
 
-func (d *VirtualDisk) setAttached(devicePath string) error {
+func (d *VirtualDisk) setAttached(devicePath string) (err error) {
+	defer func() {
+		if err == nil {
+			// bump the attached reference count
+			d.attachedRefs++
+			log.Debugf("Increased attach references for %s to %d", d.DatastoreURI, d.attachedRefs)
+		}
+	}()
+
 	if d.Attached() {
-		return fmt.Errorf("%s is already attached (%s)", d.DatastoreURI, devicePath)
+		log.Warnf("%s is already attached (%s)", d.DatastoreURI, devicePath)
+		return nil
 	}
 
 	if devicePath == "" {
-		return fmt.Errorf("no device path specified")
+		err = fmt.Errorf("no device path specified")
+		return err
 	}
 
+	// set the device path where attached
 	d.DevicePath = devicePath
 	return nil
 }
@@ -114,22 +142,34 @@ func (d *VirtualDisk) canBeDetached() error {
 		return fmt.Errorf("%s is mounted (%s)", d.DatastoreURI, d.mountPath)
 	}
 
+	if d.InUseByOther() {
+		return fmt.Errorf("%s is still in use", d.DatastoreURI)
+	}
+
 	return nil
 }
 
 func (d *VirtualDisk) setDetached() error {
 	if !d.Attached() {
-		return fmt.Errorf("%s is already dettached", d.DatastoreURI)
+		return fmt.Errorf("%s is already detached", d.DatastoreURI)
 	}
 
 	if d.Mounted() {
 		return fmt.Errorf("%s is still mounted (%s)", d.DatastoreURI, d.mountPath)
 	}
 
-	d.DevicePath = ""
+	if !d.AttachedByOther() {
+		d.DevicePath = ""
+	} else {
+		log.Warnf("%s is still in use", d.DatastoreURI)
+	}
+	d.attachedRefs--
+	log.Debugf("Decreased attach references for %s to %d", d.DatastoreURI, d.attachedRefs)
+
 	return nil
 }
 
+// Mkfs formats the disk with Filesystem and sets the disk label
 func (d *VirtualDisk) Mkfs(labelName string) error {
 	d.lock()
 	defer d.unlock()
@@ -145,6 +185,7 @@ func (d *VirtualDisk) Mkfs(labelName string) error {
 	return d.fs.Mkfs(d.DevicePath, labelName)
 }
 
+// SetLabel sets this disk's label
 func (d *VirtualDisk) SetLabel(labelName string) error {
 	d.lock()
 	defer d.unlock()
@@ -156,23 +197,50 @@ func (d *VirtualDisk) SetLabel(labelName string) error {
 	return d.fs.SetLabel(d.DevicePath, labelName)
 }
 
+// Attached returns true if this disk is attached, false otherwise
 func (d *VirtualDisk) Attached() bool {
 	return d.DevicePath != ""
 }
 
-func (d *VirtualDisk) Mount(mountPath string, options []string) error {
+// AttachedByOther returns true if the attached references are > 1
+func (d *VirtualDisk) AttachedByOther() bool {
+	return d.attachedRefs > 1
+}
+
+// MountedByOther returns true if the mounted references are > 1
+func (d *VirtualDisk) MountedByOther() bool {
+	return d.mountedRefs > 1
+}
+
+// InUseByOther returns true if the disk is currently attached or
+// mounted by someone else
+func (d *VirtualDisk) InUseByOther() bool {
+	return d.MountedByOther() || d.AttachedByOther()
+}
+
+// Mount attempts to mount this disk. A NOP occurs if the disk is already mounted
+func (d *VirtualDisk) Mount(mountPath string, options []string) (err error) {
 	d.lock()
 	defer d.unlock()
 
-	if !d.Attached() {
-		return fmt.Errorf("%s isn't attached", d.DatastoreURI)
-	}
+	defer func() {
+		// bump mounted reference count
+		d.mountedRefs++
+		log.Debugf("Increased mount references for %s to %d", d.DatastoreURI, d.mountedRefs)
+	}()
 
 	if d.Mounted() {
-		return fmt.Errorf("%s already mounted", d.DatastoreURI)
+		p, _ := d.MountPath()
+		log.Warnf("%s already mounted at %s", d.DatastoreURI, p)
+		return nil
 	}
 
-	if err := d.fs.Mount(d.DevicePath, mountPath, options); err != nil {
+	if !d.Attached() {
+		err = fmt.Errorf("%s isn't attached", d.DatastoreURI)
+		return err
+	}
+
+	if err = d.fs.Mount(d.DevicePath, mountPath, options); err != nil {
 		return err
 	}
 
@@ -180,6 +248,7 @@ func (d *VirtualDisk) Mount(mountPath string, options []string) error {
 	return nil
 }
 
+// Unmount attempts to unmount a virtual disk
 func (d *VirtualDisk) Unmount() error {
 	d.lock()
 	defer d.unlock()
@@ -188,14 +257,22 @@ func (d *VirtualDisk) Unmount() error {
 		return fmt.Errorf("%s already unmounted", d.DatastoreURI)
 	}
 
-	if err := d.fs.Unmount(d.mountPath); err != nil {
-		return err
+	d.mountedRefs--
+	log.Debugf("Decreased mount references for %s to %d", d.DatastoreURI, d.mountedRefs)
+
+	// no more mount references to this disk, so actually unmount
+	if d.mountedRefs == 0 {
+		if err := d.fs.Unmount(d.mountPath); err != nil {
+			return err
+		}
+		d.mountPath = ""
 	}
 
-	d.mountPath = ""
 	return nil
 }
 
+// MountPath returns the path on which the virtual disk is mounted,
+// or an error if the disk is not mounted
 func (d *VirtualDisk) MountPath() (string, error) {
 	if !d.Mounted() {
 		return "", fmt.Errorf("%s isn't mounted", d.DatastoreURI)
@@ -204,6 +281,8 @@ func (d *VirtualDisk) MountPath() (string, error) {
 	return d.mountPath, nil
 }
 
+// DiskPath returns a URL referencing the path of the virtual disk
+// on the datastore
 func (d *VirtualDisk) DiskPath() url.URL {
 
 	return url.URL{
@@ -212,6 +291,7 @@ func (d *VirtualDisk) DiskPath() url.URL {
 	}
 }
 
+// Mounted returns true if the virtual disk is mounted, false otherwise
 func (d *VirtualDisk) Mounted() bool {
 	return d.mountPath != ""
 }
@@ -237,6 +317,7 @@ func (d *VirtualDisk) setUmounted() error {
 	return nil
 }
 
+// VerifyDatastoreDiskURI ensures the disk name ends in ".vmdk"
 func VerifyDatastoreDiskURI(name string) error {
 	if !strings.HasSuffix(name, ".vmdk") {
 		return fmt.Errorf("%s isn't a vmdk", name)

--- a/pkg/vsphere/disk/disk_manager_test.go
+++ b/pkg/vsphere/disk/disk_manager_test.go
@@ -17,6 +17,7 @@ package disk
 import (
 	"context"
 	"fmt"
+	"io/ioutil"
 	"os"
 	"path"
 	"testing"
@@ -96,7 +97,7 @@ func TestCreateAndDetach(t *testing.T) {
 
 	// create a directory in the datastore
 	// eat the error because we dont care if it exists
-	fm.MakeDirectory(context.TODO(), imagestore.String(), nil, true)
+	_ = fm.MakeDirectory(context.TODO(), imagestore.String(), nil, true)
 
 	op := trace.NewOperation(context.Background(), "test")
 	vdm, err := NewDiskManager(op, client, false)
@@ -123,7 +124,7 @@ func TestCreateAndDetach(t *testing.T) {
 
 	testString := "Ground control to Major Tom"
 	writeSize := len(testString) / numChildren
-	// Create children which inherit from eachother
+	// Create children which inherit from each other
 	for i := 0; i < numChildren; i++ {
 
 		p := &object.DatastorePath{
@@ -192,6 +193,170 @@ func TestCreateAndDetach(t *testing.T) {
 	//			return
 	//		}
 	//	}
+
+	// Nuke the image store
+	_, err = tasks.WaitForResult(op, func(ctx context.Context) (tasks.Task, error) {
+		return fm.DeleteDatastoreFile(ctx, imagestore.String(), nil)
+	})
+
+	if !assert.NoError(t, err) {
+		return
+	}
+}
+
+func TestRefCounting(t *testing.T) {
+	client := Session(context.Background(), t)
+	if client == nil {
+		return
+	}
+
+	imagestore := &object.DatastorePath{
+		Datastore: client.Datastore.Name(),
+		Path:      datastore.TestName("diskManagerTest"),
+	}
+
+	fm := object.NewFileManager(client.Vim25())
+
+	// create a directory in the datastore
+	// eat the error because we dont care if it exists
+	_ = fm.MakeDirectory(context.TODO(), imagestore.String(), nil, true)
+
+	op := trace.NewOperation(context.Background(), "test")
+	vdm, err := NewDiskManager(op, client, false)
+	if err != nil && err.Error() == "can't find the hosting vm" {
+		t.Skip("Skipping: test must be run in a VM")
+	}
+
+	if !assert.NoError(t, err) || !assert.NotNil(t, vdm) {
+		return
+	}
+
+	diskSize := int64(1 << 10)
+	scratch := &object.DatastorePath{
+		Datastore: client.Datastore.Name(),
+		Path:      path.Join(imagestore.Path, "scratch.vmdk"),
+	}
+	p, err := vdm.Create(op, scratch, diskSize, Ext4)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	assert.False(t, p.Attached(), "%s is attached but should not be", p.DatastoreURI)
+
+	child := &object.DatastorePath{
+		Datastore: imagestore.Datastore,
+		Path:      path.Join(imagestore.Path, "testDisk.vmdk"),
+	}
+
+	spec := vdm.createDiskSpec(child, scratch, diskSize, os.O_RDWR)
+
+	// attempt attach
+	assert.NoError(t, vdm.Attach(op, spec), "Error attempting to attach %s", spec)
+
+	devicePath, err := vdm.devicePathByURI(op, child)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	d, err := NewVirtualDisk(child, Ext4)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	blockDev, err := waitForDevice(op, devicePath)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	assert.False(t, d.Attached(), "%s is attached but should not be", d.DatastoreURI)
+
+	// Attach the disk
+	assert.NoError(t, d.setAttached(blockDev), "Error attempting to mark %s as attached", d.DatastoreURI)
+
+	assert.True(t, d.Attached(), "%s is not attached but should be", d.DatastoreURI)
+	assert.NoError(t, d.canBeDetached(), "%s should be detachable but is not", d.DatastoreURI)
+	assert.False(t, d.InUseByOther(), "%s is in use but should not be", d.DatastoreURI)
+	assert.Equal(t, 1, d.attachedRefs, "%s has %d attach references but should have 1", d.DatastoreURI, d.attachedRefs)
+
+	// attempt another attach at disk level to increase reference count
+	// TODO(jzt): This should probably eventually use the attach code coming in
+	// https://github.com/vmware/vic/issues/5422
+	assert.NoError(t, d.setAttached(blockDev), "Error attempting to mark %s as attached", d.DatastoreURI)
+
+	assert.True(t, d.Attached(), "%s is not attached but should be", d.DatastoreURI)
+	assert.Error(t, d.canBeDetached(), "%s should not be detachable but is", d.DatastoreURI)
+	assert.True(t, d.InUseByOther(), "%s is not in use but should be", d.DatastoreURI)
+	assert.Equal(t, 2, d.attachedRefs, "%s has %d attach references but should have 2", d.DatastoreURI, d.attachedRefs)
+
+	// reduce reference count by calling detach
+	assert.NoError(t, d.setDetached(), "Error attempting to mark %s as detached", d.DatastoreURI)
+
+	assert.True(t, d.Attached(), "%s is not attached but should be", d.DatastoreURI)
+	assert.NoError(t, d.canBeDetached(), "%s should be detachable but is not", d.DatastoreURI)
+	assert.False(t, d.InUseByOther(), "%s is in use but should not be", d.DatastoreURI)
+	assert.Equal(t, 1, d.attachedRefs, "%s has %d attach references but should have 1", d.DatastoreURI, d.attachedRefs)
+
+	// test mount reference counting
+	assert.NoError(t, d.Mkfs("testDisk"), "Error attempting to format %s", d.DatastoreURI)
+
+	// create temp mount path
+	dir, err := ioutil.TempDir("", "mnt")
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	// cleanup
+	defer func() {
+		assert.NoError(t, os.RemoveAll(dir), "Error cleaning up mount path %s", dir)
+	}()
+
+	// initial mount
+	assert.NoError(t, d.Mount(dir, nil), "Error attempting to mount %s at %s", d.DatastoreURI, dir)
+
+	mountPath, err := d.MountPath()
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	assert.True(t, d.Mounted(), "%s is not mounted but should be", d.DatastoreURI)
+	assert.Error(t, d.canBeDetached(), "%s should not be detachable but is", d.DatastoreURI)
+	assert.False(t, d.InUseByOther(), "%s is in use but should not be", d.DatastoreURI)
+	assert.Equal(t, 1, d.mountedRefs, "%s has %d mount references but should have 1", d.DatastoreURI, d.mountedRefs)
+	assert.Equal(t, dir, mountPath, "%s is mounted at %s but should be mounted at %s", d.DatastoreURI, mountPath, dir)
+
+	// attempt another mount
+	assert.NoError(t, d.Mount(dir, nil), "Error attempting to mount %s at %s", d.DatastoreURI, dir)
+
+	assert.True(t, d.Mounted(), "%s is not mounted but should be", d.DatastoreURI)
+	assert.Error(t, d.canBeDetached(), "%s should not be detachable but is", d.DatastoreURI)
+	assert.True(t, d.InUseByOther(), "%s is not in use but should be", d.DatastoreURI)
+	assert.Equal(t, 2, d.mountedRefs, "%s has %d mount references but should have 2", d.DatastoreURI, d.mountedRefs)
+
+	// attempt unmount
+	assert.NoError(t, d.Unmount(), "Error attempting to unmount %s", d.DatastoreURI)
+
+	assert.True(t, d.Mounted(), "%s is not mounted but should be", d.DatastoreURI)
+	assert.Error(t, d.canBeDetached(), "%s should not be detachable but is", d.DatastoreURI)
+	assert.False(t, d.InUseByOther(), "%s is in use but should not be", d.DatastoreURI)
+	assert.Equal(t, 1, d.mountedRefs, "%s has %d mount references but should have 1", d.DatastoreURI, d.mountedRefs)
+
+	// actually unmount
+	assert.NoError(t, d.Unmount(), "Error attempting to unmount %s", d.DatastoreURI)
+
+	assert.False(t, d.Mounted(), "%s is mounted but should not be", d.DatastoreURI)
+	assert.NoError(t, d.canBeDetached(), "%s should be detachable but is not", d.DatastoreURI)
+	assert.False(t, d.InUseByOther(), "%s is in use but should not be", d.DatastoreURI)
+	assert.Equal(t, 0, d.mountedRefs, "%s has %d mount references but should have 0", d.DatastoreURI, d.mountedRefs)
+
+	// detach
+	assert.NoError(t, vdm.Detach(op, d), "Error attempting to detach %s", d.DatastoreURI)
+
+	assert.False(t, d.Attached(), "%s is attached but should not be", d.DatastoreURI)
+	assert.False(t, d.Mounted(), "%s is mounted but should not be", d.DatastoreURI)
+	assert.Error(t, d.canBeDetached(), "%s should not be detachable but is", d.DatastoreURI)
+	assert.False(t, d.InUseByOther(), "%s is in use but should not be", d.DatastoreURI)
+	assert.Equal(t, 0, d.attachedRefs, "%s has %d attach references but should have 0", d.DatastoreURI, d.attachedRefs)
+	assert.Equal(t, 0, d.mountedRefs, "%s has %d mount references but should have 0", d.DatastoreURI, d.mountedRefs)
 
 	// Nuke the image store
 	_, err = tasks.WaitForResult(op, func(ctx context.Context) (tasks.Task, error) {


### PR DESCRIPTION
This change implements reference counting for keeping track of attached and mounted disks. Fixes #5396.