### PR TITLE
[specific ci=1-38-Docker-Exec] Don't panic if stdout is nil

### DIFF
--- a/lib/apiservers/engine/backends/container.go
+++ b/lib/apiservers/engine/backends/container.go
@@ -438,8 +438,9 @@ func (c *Container) ContainerExecStart(ctx context.Context, eid string, stdin io
 
 				// we can't return a proper error as we close the streams as soon as AttachStreams returns so we mimic Docker and write to stdout directly
 				// https://github.com/docker/docker/blob/a039ca9affe5fa40c4e029d7aae399b26d433fe9/api/server/router/container/exec.go#L114
-				stdout.Write([]byte(err.Error() + "\r\n"))
-
+				if stdout != nil {
+					stdout.Write([]byte(err.Error() + "\r\n"))
+				}
 				cancel()
 			}
 		}()


### PR DESCRIPTION
Fixes following panic observed in tests;

panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0x18f3178]

goroutine 167 [running]:
github.com/vmware/vic/lib/apiservers/engine/backends.(*Container).ContainerExecStart.func1.1(0xc420ceed31, 0x40, 0xc4201e7c20, 0xc4207cbc00, 0x40, 0xc42062a6c0, 0x11, 0x0, 0x0, 0xc420605a40)
	/go/src/github.com/vmware/vic/lib/apiservers/engine/backends/container.go:441 +0x1c8
created by github.com/vmware/vic/lib/apiservers/engine/backends.(*Container).ContainerExecStart.func1
	/go/src/github.com/vmware/vic/lib/apiservers/engine/backends/container.go:445 +0x28a

Seen in build 11441 test 1-38-Exec