### PR TITLE
Add fileserver and demo installer links to ova ui

### DIFF
--- a/installer/engine_installer/engine_installer.go
+++ b/installer/engine_installer/engine_installer.go
@@ -168,13 +168,14 @@ func (ei *EngineInstaller) verifyLogin() error {
 
 	input := data.NewData()
 
-	input.OpsUser = u.User.Username()
+	username := u.User.Username()
+	input.OpsCredentials.OpsUser = &username
 	passwd, _ := u.User.Password()
-	input.OpsPassword = &passwd
+	input.OpsCredentials.OpsPassword = &passwd
 	input.URL = &u
 	input.Force = true
 
-	input.User = u.User.Username()
+	input.User = username
 	input.Password = &passwd
 
 	v, err := validate.NewValidator(ctx, input)

--- a/installer/ovatools/vic-ova-ui/main.go
+++ b/installer/ovatools/vic-ova-ui/main.go
@@ -101,6 +101,12 @@ func main() {
 		if strings.ToLower(ovf.Properties["management_portal.deploy"]) == "true" {
 			ips = fmt.Sprintf("%sAccess the Container Management Portal at:\nhttps://%s:%s\n", ips, ip.String(), ovf.Properties["management_portal.port"])
 		}
+		if port, ok := ovf.Properties["fileserver.port"]; ok {
+			ips = fmt.Sprintf("%sAccess the fileserver at:\nhttps://%s:%s\n", ips, ip.String(), port)
+		}
+		if port, ok := ovf.Properties["engine_installer.port"]; ok {
+			ips = fmt.Sprintf("%sAccess the Demo VCH Installer at:\nhttps://%s:%s\n", ips, ip.String(), port)
+		}
 	}
 
 	bottompanel := ui.NewPar(ips)


### PR DESCRIPTION
Fixes #4684 
Adds urls for the fileserver and demo vch installer to the ova ui.