### PR TITLE
[specific-ci=Group6-VIC-Machine] vic-machine configure certs

### DIFF
--- a/cmd/vic-machine/common/certificate.go
+++ b/cmd/vic-machine/common/certificate.go
@@ -60,13 +60,13 @@ type CertFactory struct {
 func (c *CertFactory) CertFlags() []cli.Flag {
 	return []cli.Flag{
 		cli.StringFlag{
-			Name:        "tls-key",
+			Name:        "key",
 			Value:       "",
 			Usage:       "Virtual Container Host private key file (server certificate)",
 			Destination: &c.Skey,
 		},
 		cli.StringFlag{
-			Name:        "tls-cert",
+			Name:        "cert",
 			Value:       "",
 			Usage:       "Virtual Container Host x509 certificate file (server certificate)",
 			Destination: &c.Scert,

--- a/cmd/vic-machine/common/certificate.go
+++ b/cmd/vic-machine/common/certificate.go
@@ -34,45 +34,33 @@ import (
 
 // CertSeed has all input parameters for vic-machine certificate commands
 type CertSeed struct {
-	RegistryCAs               cli.StringSlice `arg:"registry-ca"`
-	CertPath                  string
-	DisplayName               string
-	Scert                     string
-	Skey                      string
-	Ccert                     string
-	Ckey                      string
-	Cacert                    string
-	Cakey                     string
-	ClientCert                *tls.Certificate
-	ClientCAsArg              cli.StringSlice `arg:"tls-ca"`
-	clientCAs                 []byte
-	EnvFile                   string
-	Cname                     string
-	Org                       cli.StringSlice
-	KeySize                   int
-	NoTLS                     bool
-	NoTLSverify               bool
-	ContainerNetworks         cli.StringSlice `arg:"container-network"`
-	ContainerNetworksGateway  cli.StringSlice `arg:"container-network-gateway"`
-	ContainerNetworksIPRanges cli.StringSlice `arg:"container-network-ip-range"`
-	ContainerNetworksDNS      cli.StringSlice `arg:"container-network-dns"`
-	VolumeStores              cli.StringSlice `arg:"volume-store"`
-	InsecureRegistries        cli.StringSlice `arg:"insecure-registry"`
-	DNS                       cli.StringSlice `arg:"dns-server"`
-	ClientNetworkName         string
-	ClientNetworkGateway      string
-	ClientNetworkIP           string
-	PublicNetworkName         string
-	PublicNetworkGateway      string
-	PublicNetworkIP           string
-	ManagementNetworkName     string
-	ManagementNetworkGateway  string
-	ManagementNetworkIP       string
-	KeyPEM                    []byte
-	CertPEM                   []byte
-	Debug                     int
-	ClientCAs                 []byte
-	Force                     bool
+	CertPath              string
+	DisplayName           string
+	Scert                 string
+	Skey                  string
+	Ccert                 string
+	Ckey                  string
+	Cacert                string
+	Cakey                 string
+	ClientCert            *tls.Certificate
+	ClientCAsArg          cli.StringSlice `arg:"tls-ca"`
+	ClientCAs             []byte
+	EnvFile               string
+	Cname                 string
+	Org                   cli.StringSlice
+	KeySize               int
+	NoTLS                 bool
+	NoTLSverify           bool
+	ClientNetworkName     string
+	ClientNetworkIP       string
+	PublicNetworkName     string
+	PublicNetworkIP       string
+	ManagementNetworkName string
+	ManagementNetworkIP   string
+	KeyPEM                []byte
+	CertPEM               []byte
+	Debug                 int
+	Force                 bool
 }
 
 func (c *CertSeed) ProcessCertificates() error {
@@ -133,7 +121,7 @@ func (c *CertSeed) ProcessCertificates() error {
 	// we need to generate some part of the certificate configuration
 	gcas, gkeypair, err := c.generateCertificates(keypair == nil, !c.NoTLSverify && len(cas) == 0)
 	if err != nil {
-		log.Error("CertSeed cannot continue: unable to generate certificates")
+		log.Error("cannot continue: unable to generate certificates")
 		return err
 	}
 

--- a/cmd/vic-machine/common/certificate.go
+++ b/cmd/vic-machine/common/certificate.go
@@ -1,0 +1,420 @@
+// Copyright 2017 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"crypto/tls"
+	"fmt"
+	"io/ioutil"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	log "github.com/Sirupsen/logrus"
+	"gopkg.in/urfave/cli.v1"
+
+	"github.com/vmware/vic/pkg/certificate"
+	"github.com/vmware/vic/pkg/errors"
+	"github.com/vmware/vic/pkg/trace"
+)
+
+// CertSeed has all input parameters for vic-machine certificate commands
+type CertSeed struct {
+	RegistryCAs               cli.StringSlice `arg:"registry-ca"`
+	CertPath                  string
+	DisplayName               string
+	Scert                     string
+	Skey                      string
+	Ccert                     string
+	Ckey                      string
+	Cacert                    string
+	Cakey                     string
+	ClientCert                *tls.Certificate
+	ClientCAsArg              cli.StringSlice `arg:"tls-ca"`
+	clientCAs                 []byte
+	EnvFile                   string
+	Cname                     string
+	Org                       cli.StringSlice
+	KeySize                   int
+	NoTLS                     bool
+	NoTLSverify               bool
+	ContainerNetworks         cli.StringSlice `arg:"container-network"`
+	ContainerNetworksGateway  cli.StringSlice `arg:"container-network-gateway"`
+	ContainerNetworksIPRanges cli.StringSlice `arg:"container-network-ip-range"`
+	ContainerNetworksDNS      cli.StringSlice `arg:"container-network-dns"`
+	VolumeStores              cli.StringSlice `arg:"volume-store"`
+	InsecureRegistries        cli.StringSlice `arg:"insecure-registry"`
+	DNS                       cli.StringSlice `arg:"dns-server"`
+	ClientNetworkName         string
+	ClientNetworkGateway      string
+	ClientNetworkIP           string
+	PublicNetworkName         string
+	PublicNetworkGateway      string
+	PublicNetworkIP           string
+	ManagementNetworkName     string
+	ManagementNetworkGateway  string
+	ManagementNetworkIP       string
+	KeyPEM                    []byte
+	CertPEM                   []byte
+	Debug                     int
+	ClientCAs                 []byte
+	Force                     bool
+}
+
+func (c *CertSeed) ProcessCertificates() error {
+	// set up the locations for the certificates and env file
+	if c.CertPath == "" {
+		c.CertPath = c.DisplayName
+	}
+	c.EnvFile = fmt.Sprintf("%s/%s.env", c.CertPath, c.DisplayName)
+
+	// check for insecure case
+	if c.NoTLS {
+		log.Warn("Configuring without TLS - all communications will be insecure")
+		return nil
+	}
+
+	if c.Scert != "" && c.Skey == "" {
+		return cli.NewExitError("key and cert should be specified at the same time", 1)
+	}
+	if c.Scert == "" && c.Skey != "" {
+		return cli.NewExitError("key and cert should be specified at the same time", 1)
+	}
+
+	// if we've not got a specific CommonName but do have a static IP then go with that.
+	if c.Cname == "" {
+		if c.ClientNetworkIP != "" {
+			c.Cname = c.ClientNetworkIP
+			log.Infof("Using client-network-ip as cname where needed - use --tls-cname to override: %s", c.Cname)
+		} else if c.PublicNetworkIP != "" && (c.PublicNetworkName == c.ClientNetworkName || c.ClientNetworkName == "") {
+			c.Cname = c.PublicNetworkIP
+			log.Infof("Using public-network-ip as cname where needed - use --tls-cname to override: %s", c.Cname)
+		} else if c.ManagementNetworkIP != "" && (c.ManagementNetworkName == c.ClientNetworkName || (c.ClientNetworkName == "" && c.ManagementNetworkName == c.PublicNetworkName)) {
+			c.Cname = c.ManagementNetworkIP
+			log.Infof("Using management-network-ip as cname where needed - use --tls-cname to override: %s", c.Cname)
+		}
+
+		if c.Cname != "" {
+			// Strip network mask from IP address if set
+			if cnameIP, _, _ := net.ParseCIDR(c.Cname); cnameIP != nil {
+				c.Cname = cnameIP.String()
+			}
+		}
+	}
+
+	// load what certificates we can
+	cas, keypair, err := c.loadCertificates()
+	if err != nil {
+		log.Errorf("Unable to load certificates: %s", err)
+		if !c.Force {
+			return err
+		}
+
+		log.Warnf("Ignoring error loading certificates due to --force")
+		cas = nil
+		keypair = nil
+		err = nil
+	}
+
+	// we need to generate some part of the certificate configuration
+	gcas, gkeypair, err := c.generateCertificates(keypair == nil, !c.NoTLSverify && len(cas) == 0)
+	if err != nil {
+		log.Error("CertSeed cannot continue: unable to generate certificates")
+		return err
+	}
+
+	if keypair != nil {
+		c.KeyPEM = keypair.KeyPEM
+		c.CertPEM = keypair.CertPEM
+	} else if gkeypair != nil {
+		c.KeyPEM = gkeypair.KeyPEM
+		c.CertPEM = gkeypair.CertPEM
+	}
+
+	if len(cas) == 0 {
+		cas = gcas
+	}
+
+	if len(c.KeyPEM) == 0 {
+		return errors.New("Failed to load or generate server certificates")
+	}
+
+	if len(cas) == 0 && !c.NoTLSverify {
+		return errors.New("Failed to load or generate certificate authority")
+	}
+
+	// do we have key, cert, and --no-tlsverify
+	if c.NoTLSverify || len(cas) == 0 {
+		log.Warnf("Configuring without TLS verify - certificate-based authentication disabled")
+		return nil
+	}
+
+	c.ClientCAs = cas
+	return nil
+}
+
+// loadCertificates returns the client CA pool and the keypair for server certificates on success
+func (c *CertSeed) loadCertificates() ([]byte, *certificate.KeyPair, error) {
+	defer trace.End(trace.Begin(""))
+
+	// reads each of the files specified, assuming that they are PEM encoded certs,
+	// and constructs a byte array suitable for passing to CertPool.AppendCertsFromPEM
+	var certs []byte
+	for _, f := range c.ClientCAsArg {
+		b, err := ioutil.ReadFile(f)
+		if err != nil {
+			err = errors.Errorf("Failed to load authority from file %s: %s", f, err)
+			return nil, nil, err
+		}
+
+		certs = append(certs, b...)
+		log.Infof("Loaded CA from %s", f)
+	}
+
+	var keypair *certificate.KeyPair
+	// default names
+	skey := filepath.Join(c.CertPath, certificate.ServerKey)
+	scert := filepath.Join(c.CertPath, certificate.ServerCert)
+	ca := filepath.Join(c.CertPath, certificate.CACert)
+	ckey := filepath.Join(c.CertPath, certificate.ClientKey)
+	ccert := filepath.Join(c.CertPath, certificate.ClientCert)
+
+	// if specific files are supplied, use those
+	explicit := false
+	if c.Scert != "" && c.Skey != "" {
+		explicit = true
+		skey = c.Skey
+		scert = c.Scert
+	}
+
+	// load the server certificate
+	keypair = certificate.NewKeyPair(scert, skey, nil, nil)
+	if err := keypair.LoadCertificate(); err != nil {
+		if explicit || !os.IsNotExist(err) {
+			// if these files were explicit paths, or anything other than not found, fail
+			log.Errorf("Failed to load certificate: %s", err)
+			return certs, nil, err
+		}
+
+		log.Debugf("Unable to locate existing server certificate in cert path")
+		return nil, nil, nil
+	}
+
+	// check that any supplied cname matches the server cert CN
+	cert, err := keypair.Certificate()
+	if err != nil {
+		log.Errorf("Failed to parse certificate: %s", err)
+		return certs, nil, err
+	}
+
+	if cert.Leaf == nil {
+		log.Warnf("Failed to load x509 leaf: Unable to confirm server certificate cname matches provided cname %q. Continuing...", c.Cname)
+	} else {
+		// We just do a direct equality check here - trying to be clever is liable to lead to hard
+		// to diagnose errors
+		if cert.Leaf.Subject.CommonName != c.Cname {
+			log.Errorf("Provided cname does not match that in existing server certificate: %s", cert.Leaf.Subject.CommonName)
+			if c.Debug > 2 {
+				log.Debugf("Certificate does not match provided cname: %#+v", cert.Leaf)
+			}
+			return certs, nil, fmt.Errorf("cname option doesn't match existing server certificate in certificate path %s", c.CertPath)
+		}
+	}
+
+	log.Infof("Loaded server certificate %s", scert)
+	c.Skey = skey
+	c.Scert = scert
+
+	// only try for CA certificate if no-tlsverify has NOT been specified and we haven't already loaded an authority cert
+	if !c.NoTLSverify && len(certs) == 0 {
+		b, err := ioutil.ReadFile(ca)
+		if err != nil {
+			if os.IsNotExist(err) {
+				log.Debugf("Unable to locate existing CA in cert path")
+				return certs, keypair, nil
+			}
+
+			// if the CA exists but cannot be loaded then it's an error
+			log.Errorf("Failed to load authority from certificate path %s: %s", c.CertPath, err)
+			return certs, keypair, errors.New("failed to load certificate authority")
+		}
+
+		c.Cacert = ca
+
+		log.Infof("Loaded CA with default name from certificate path %s", c.CertPath)
+		certs = b
+
+		// load client certs - we ensure the client certs validate with the provided CA or ignore any we find
+		cpair := certificate.NewKeyPair(ccert, ckey, nil, nil)
+		if err := cpair.LoadCertificate(); err != nil {
+			log.Warnf("Unable to load client certificate - validation of API endpoint will be best effort only: %s", err)
+		}
+
+		clientCert, err := certificate.VerifyClientCert(certs, cpair)
+		if err != nil {
+			switch err.(type) {
+			case certificate.CertParseError, certificate.CreateCAPoolError:
+				log.Debugf(err.Error())
+			case certificate.CertVerifyError:
+				log.Warnf("%s - continuing without client certificate", err.Error())
+			}
+
+			return certs, keypair, nil
+		}
+
+		c.Ckey = ckey
+		c.Ccert = ccert
+		c.ClientCert = clientCert
+
+		log.Infof("Loaded client certificate with default name from certificate path %s", c.CertPath)
+	}
+
+	return certs, keypair, nil
+}
+
+func (c *CertSeed) generateCertificates(server bool, client bool) ([]byte, *certificate.KeyPair, error) {
+	defer trace.End(trace.Begin(""))
+
+	if !server && !client {
+		log.Debugf("Not generating server or client certs, nothing for generateCertificates to do")
+		return nil, nil, nil
+	}
+
+	var certs []byte
+	// generate the certs and keys with names conforming the default the docker client expects
+	files, err := ioutil.ReadDir(c.CertPath)
+	if len(files) > 0 {
+		return nil, nil, fmt.Errorf("Specified directory to store certificates is not empty. Specify a new path in which to store generated certificates using --cert-path or remove the contents of \"%s\" and run vic-machine again.", c.CertPath)
+	}
+
+	err = os.MkdirAll(c.CertPath, 0700)
+	if err != nil {
+		log.Errorf("Unable to make directory to hold certificates (set via --cert-path)")
+		return nil, nil, err
+	}
+
+	c.Skey = filepath.Join(c.CertPath, certificate.ServerKey)
+	c.Scert = filepath.Join(c.CertPath, certificate.ServerCert)
+
+	c.Ckey = filepath.Join(c.CertPath, certificate.ClientKey)
+	c.Ccert = filepath.Join(c.CertPath, certificate.ClientCert)
+
+	cakey := filepath.Join(c.CertPath, certificate.CAKey)
+	c.Cacert = filepath.Join(c.CertPath, certificate.CACert)
+
+	if server && !client {
+		log.Infof("Generating self-signed certificate/key pair - private key in %s", c.Skey)
+		keypair := certificate.NewKeyPair(c.Scert, c.Skey, nil, nil)
+		err := keypair.CreateSelfSigned(c.Cname, nil, c.KeySize)
+		if err != nil {
+			log.Errorf("Failed to generate self-signed certificate: %s", err)
+			return nil, nil, err
+		}
+		if err = keypair.SaveCertificate(); err != nil {
+			log.Errorf("Failed to save server certificates: %s", err)
+			return nil, nil, err
+		}
+
+		return certs, keypair, nil
+	}
+
+	// client auth path
+	if c.Cname == "" {
+		log.Error("Common Name must be provided when generating certificates for client authentication:")
+		log.Info("  --tls-cname=<FQDN or static IP> # for the appliance VM")
+		log.Info("  --tls-cname=<*.yourdomain.com>  # if DNS has entries in that form for DHCP addresses (less secure)")
+		log.Info("  --no-tlsverify                  # disables client authentication (anyone can connect to the VCH)")
+		log.Info("  --no-tls                        # disables TLS entirely")
+		log.Info("")
+
+		return certs, nil, errors.New("provide Common Name for server certificate")
+	}
+
+	// for now re-use the display name as the organisation if unspecified
+	if len(c.Org) == 0 {
+		c.Org = []string{c.DisplayName}
+	}
+	if len(c.Org) == 1 && !strings.HasPrefix(c.Cname, "*") {
+		// Add in the cname if it's not a wildcard
+		c.Org = append(c.Org, c.Cname)
+	}
+
+	// Certificate authority
+	log.Infof("Generating CA certificate/key pair - private key in %s", cakey)
+	cakp := certificate.NewKeyPair(c.Cacert, cakey, nil, nil)
+	err = cakp.CreateRootCA(c.Cname, c.Org, c.KeySize)
+	if err != nil {
+		log.Errorf("Failed to generate CA: %s", err)
+		return nil, nil, err
+	}
+	if err = cakp.SaveCertificate(); err != nil {
+		log.Errorf("Failed to save CA certificates: %s", err)
+		return nil, nil, err
+	}
+
+	// Server certificates
+	var skp *certificate.KeyPair
+	if server {
+		log.Infof("Generating server certificate/key pair - private key in %s", c.Skey)
+		skp = certificate.NewKeyPair(c.Scert, c.Skey, nil, nil)
+		err = skp.CreateServerCertificate(c.Cname, c.Org, c.KeySize, cakp)
+		if err != nil {
+			log.Errorf("Failed to generate server certificates: %s", err)
+			return nil, nil, err
+		}
+		if err = skp.SaveCertificate(); err != nil {
+			log.Errorf("Failed to save server certificates: %s", err)
+			return nil, nil, err
+		}
+	}
+
+	// Client certificates
+	if client {
+		log.Infof("Generating client certificate/key pair - private key in %s", c.Ckey)
+		ckp := certificate.NewKeyPair(c.Ccert, c.Ckey, nil, nil)
+		err = ckp.CreateClientCertificate(c.Cname, c.Org, c.KeySize, cakp)
+		if err != nil {
+			log.Errorf("Failed to generate client certificates: %s", err)
+			return nil, nil, err
+		}
+		if err = ckp.SaveCertificate(); err != nil {
+			log.Errorf("Failed to save client certificates: %s", err)
+			return nil, nil, err
+		}
+
+		c.ClientCert, err = ckp.Certificate()
+		if err != nil {
+			log.Warnf("Failed to stash client certificate for later application level validation: %s", err)
+		}
+
+		// If openssl is present, try to generate a browser friendly pfx file (a bundle of the public certificate AND the private key)
+		// The pfx file can be imported directly into keychains for client certificate authentication
+		certPath := filepath.Clean(c.CertPath)
+		args := strings.Split(fmt.Sprintf("pkcs12 -export -out %[1]s/cert.pfx -inkey %[1]s/key.pem -in %[1]s/cert.pem -certfile %[1]s/ca.pem -password pass:", certPath), " ")
+		// #nosec: Subprocess launching with variable
+		pfx := exec.Command("openssl", args...)
+		out, err := pfx.CombinedOutput()
+		if err != nil {
+			log.Debug(out)
+			log.Warnf("Failed to generate browser friendly PFX client certificate: %s", err)
+		} else {
+			log.Infof("Generated browser friendly PFX client certificate - certificate in %s/cert.pfx", certPath)
+		}
+	}
+
+	return cakp.CertPEM, skp, nil
+}

--- a/cmd/vic-machine/common/certificate_test.go
+++ b/cmd/vic-machine/common/certificate_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 var (
-	cs = &CertSeed{}
+	cs = &CertFactory{}
 )
 
 func TestGenKey(t *testing.T) {

--- a/cmd/vic-machine/common/certificate_test.go
+++ b/cmd/vic-machine/common/certificate_test.go
@@ -46,7 +46,7 @@ func TestGenKey(t *testing.T) {
 	assert.NotEmpty(t, kp.CertPEM, "Expected certificate to contain data")
 	assert.NotEmpty(t, kp.CertPEM, "Expected key to contain data")
 
-	ca, kp, err = cs.loadCertificates()
+	ca, kp, err = cs.loadCertificates(2)
 	assert.NoError(t, err, "Expected to cleanly load certificates")
 	assert.NotEmpty(t, ca, "Expected CA to contain data")
 	assert.NotNil(t, kp, "Expected keypair to contain data")

--- a/cmd/vic-machine/common/certificate_test.go
+++ b/cmd/vic-machine/common/certificate_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package create
+package common
 
 import (
 	"flag"
@@ -25,20 +25,20 @@ import (
 )
 
 var (
-	create = NewCreate()
+	cs = &CertSeed{}
 )
 
 func TestGenKey(t *testing.T) {
 	log.SetLevel(log.DebugLevel)
 	os.Args = []string{"cmd", "create"}
 	flag.Parse()
-	create.noTLS = false
-	create.certPath = "install-test"
-	create.cname = "common name"
-	create.keySize = 1024
+	cs.NoTLS = false
+	cs.CertPath = "install-test"
+	cs.Cname = "common name"
+	cs.KeySize = 1024
 
-	ca, kp, err := create.generateCertificates(true, true)
-	defer os.RemoveAll(fmt.Sprintf("./%s", create.certPath))
+	ca, kp, err := cs.generateCertificates(true, true)
+	defer os.RemoveAll(fmt.Sprintf("./%s", cs.CertPath))
 
 	assert.NoError(t, err, "Expected to cleanly generate certificates")
 	assert.NotEmpty(t, ca, "Expected CA to contain data")
@@ -46,7 +46,7 @@ func TestGenKey(t *testing.T) {
 	assert.NotEmpty(t, kp.CertPEM, "Expected certificate to contain data")
 	assert.NotEmpty(t, kp.CertPEM, "Expected key to contain data")
 
-	ca, kp, err = create.loadCertificates()
+	ca, kp, err = cs.loadCertificates()
 	assert.NoError(t, err, "Expected to cleanly load certificates")
 	assert.NotEmpty(t, ca, "Expected CA to contain data")
 	assert.NotNil(t, kp, "Expected keypair to contain data")

--- a/cmd/vic-machine/common/networks.go
+++ b/cmd/vic-machine/common/networks.go
@@ -1,0 +1,29 @@
+// Copyright 2017 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+type Networks struct {
+	ClientNetworkName    string
+	ClientNetworkIP      string
+	ClientNetworkGateway string
+
+	PublicNetworkName    string
+	PublicNetworkIP      string
+	PublicNetworkGateway string
+
+	ManagementNetworkName    string
+	ManagementNetworkIP      string
+	ManagementNetworkGateway string
+}

--- a/cmd/vic-machine/configure/configure.go
+++ b/cmd/vic-machine/configure/configure.go
@@ -238,7 +238,7 @@ func updateSessionEnv(sess *executor.SessionConfig, envName, envValue string) {
 	sess.Cmd.Env = newEnvs
 }
 
-func (c *Configure) processCertificates(conf *config.VirtualContainerHostConfigSpec) error {
+func (c *Configure) processCertificates(networks map[string]*executor.NetworkEndpoint) error {
 
 	if !c.certificates.NoTLSverify && (c.certificates.Skey == "" || c.certificates.Scert == "") {
 		log.Infof("No certificate regeneration requested. No new certificates provided. Certificates left unchanged.")
@@ -262,12 +262,12 @@ func (c *Configure) processCertificates(conf *config.VirtualContainerHostConfigS
 	}
 
 	c.certificates.Networks = common.Networks{
-		ClientNetworkName:     conf.ExecutorConfig.Networks["client"].Name,
-		ClientNetworkIP:       conf.ExecutorConfig.Networks["client"].Assigned.String(),
-		PublicNetworkName:     conf.ExecutorConfig.Networks["public"].Name,
-		PublicNetworkIP:       conf.ExecutorConfig.Networks["public"].Assigned.String(),
-		ManagementNetworkName: conf.ExecutorConfig.Networks["management"].Name,
-		ManagementNetworkIP:   conf.ExecutorConfig.Networks["management"].Assigned.String(),
+		ClientNetworkName:     networks["client"].Name,
+		ClientNetworkIP:       networks["client"].Assigned.String(),
+		PublicNetworkName:     networks["public"].Name,
+		PublicNetworkIP:       networks["public"].Assigned.String(),
+		ManagementNetworkName: networks["management"].Name,
+		ManagementNetworkIP:   networks["management"].Assigned.String(),
 	}
 
 	if err := c.certificates.ProcessCertificates(c.DisplayName, c.Force, debug); err != nil {
@@ -394,7 +394,7 @@ func (c *Configure) Run(clic *cli.Context) (err error) {
 
 	// in Create we process certificates as part of processParams but we need the old conf
 	// to do this in the context of Configure so we need to call this method here instead
-	if err = c.processCertificates(vchConfig); err != nil {
+	if err = c.processCertificates(vchConfig.ExecutorConfig.Networks); err != nil {
 		return err
 	}
 

--- a/cmd/vic-machine/configure/configure.go
+++ b/cmd/vic-machine/configure/configure.go
@@ -17,6 +17,7 @@ package configure
 import (
 	"context"
 	"fmt"
+	"net"
 	"os"
 	"strings"
 	"time"

--- a/cmd/vic-machine/configure/configure.go
+++ b/cmd/vic-machine/configure/configure.go
@@ -110,21 +110,18 @@ func (c *Configure) Flags() []cli.Flag {
 			Name:        "regenerate-certs",
 			Usage:       "Generate self-signed certs and enable them on this VCH automatically",
 			Destination: &c.regenerateCerts,
-			Hidden:      true,
 		},
 		cli.StringFlag{
 			Name:        "tls-key",
 			Value:       "",
 			Usage:       "Virtual Container Host private key file (server certificate)",
 			Destination: &c.skey,
-			Hidden:      true,
 		},
 		cli.StringFlag{
 			Name:        "tls-cert",
 			Value:       "",
 			Usage:       "Virtual Container Host x509 certificate file (server certificate)",
 			Destination: &c.scert,
-			Hidden:      true,
 		},
 		cli.StringFlag{
 			Name:        "tls-cname",
@@ -137,18 +134,11 @@ func (c *Configure) Flags() []cli.Flag {
 			Value:       "",
 			Usage:       "The path to check for existing certificates and in which to save generated certificates. Defaults to './<vch name>/'",
 			Destination: &c.certPath,
-			Hidden:      true,
 		},
 		cli.BoolFlag{
 			Name:        "no-tlsverify, kv",
 			Usage:       "Disable authentication via client certificates - for more tls options see advanced help (-x)",
 			Destination: &c.noTLSverify,
-		},
-		cli.BoolFlag{
-			Name:        "no-tls, k",
-			Usage:       "Disable TLS support completely",
-			Destination: &c.noTLS,
-			Hidden:      true,
 		},
 		cli.StringSliceFlag{
 			Name:   "organization",
@@ -284,7 +274,8 @@ func (c *Configure) copyChangedConf(o *config.VirtualContainerHostConfigSpec, n 
 	}
 	o.HostCertificate = n.HostCertificate
 	o.CertificateAuthorities = n.CertificateAuthorities
-
+	o.UserCertificates = n.UserCertificates
+	o.RegistryCertificateAuthorities = n.RegistryCertificateAuthorities
 }
 
 func updateSessionEnv(sess *executor.SessionConfig, envName, envValue string) {

--- a/cmd/vic-machine/configure/configure.go
+++ b/cmd/vic-machine/configure/configure.go
@@ -238,7 +238,7 @@ func updateSessionEnv(sess *executor.SessionConfig, envName, envValue string) {
 	sess.Cmd.Env = newEnvs
 }
 
-func (c *Configure) processCertificates(networks map[string]*executor.NetworkEndpoint) error {
+func (c *Configure) processCertificates(client, public, management *data.NetworkConfig) error {
 
 	if !c.certificates.NoTLSverify && (c.certificates.Skey == "" || c.certificates.Scert == "") {
 		log.Infof("No certificate regeneration requested. No new certificates provided. Certificates left unchanged.")
@@ -262,12 +262,12 @@ func (c *Configure) processCertificates(networks map[string]*executor.NetworkEnd
 	}
 
 	c.certificates.Networks = common.Networks{
-		ClientNetworkName:     networks["client"].Name,
-		ClientNetworkIP:       networks["client"].Assigned.String(),
-		PublicNetworkName:     networks["public"].Name,
-		PublicNetworkIP:       networks["public"].Assigned.String(),
-		ManagementNetworkName: networks["management"].Name,
-		ManagementNetworkIP:   networks["management"].Assigned.String(),
+		ClientNetworkName:     client.Name,
+		ClientNetworkIP:       client.IP.String(),
+		PublicNetworkName:     public.Name,
+		PublicNetworkIP:       public.IP.String(),
+		ManagementNetworkName: management.Name,
+		ManagementNetworkIP:   management.IP.String(),
 	}
 
 	if err := c.certificates.ProcessCertificates(c.DisplayName, c.Force, debug); err != nil {
@@ -394,7 +394,7 @@ func (c *Configure) Run(clic *cli.Context) (err error) {
 
 	// in Create we process certificates as part of processParams but we need the old conf
 	// to do this in the context of Configure so we need to call this method here instead
-	if err = c.processCertificates(vchConfig.ExecutorConfig.Networks); err != nil {
+	if err = c.processCertificates(c.Data.ClientNetwork, c.Data.PublicNetwork, c.Data.ManagementNetwork); err != nil {
 		return err
 	}
 

--- a/cmd/vic-machine/configure/configure.go
+++ b/cmd/vic-machine/configure/configure.go
@@ -261,6 +261,15 @@ func (c *Configure) processCertificates(conf *config.VirtualContainerHostConfigS
 		debug = *c.Debug.Debug
 	}
 
+	c.certificates.Networks = common.Networks{
+		ClientNetworkName:     conf.ExecutorConfig.Networks["client"].Name,
+		ClientNetworkIP:       conf.ExecutorConfig.Networks["client"].Assigned.String(),
+		PublicNetworkName:     conf.ExecutorConfig.Networks["public"].Name,
+		PublicNetworkIP:       conf.ExecutorConfig.Networks["public"].Assigned.String(),
+		ManagementNetworkName: conf.ExecutorConfig.Networks["management"].Name,
+		ManagementNetworkIP:   conf.ExecutorConfig.Networks["management"].Assigned.String(),
+	}
+
 	if err := c.certificates.ProcessCertificates(c.DisplayName, c.Force, debug); err != nil {
 		return err
 	}

--- a/cmd/vic-machine/configure/configure.go
+++ b/cmd/vic-machine/configure/configure.go
@@ -238,7 +238,7 @@ func updateSessionEnv(sess *executor.SessionConfig, envName, envValue string) {
 	sess.Cmd.Env = newEnvs
 }
 
-func (c *Configure) processCertificates(client, public, management *data.NetworkConfig) error {
+func (c *Configure) processCertificates(client, public, management data.NetworkConfig) error {
 
 	if !c.certificates.NoTLSverify && (c.certificates.Skey == "" || c.certificates.Scert == "") {
 		log.Infof("No certificate regeneration requested. No new certificates provided. Certificates left unchanged.")

--- a/cmd/vic-machine/configure/configure.go
+++ b/cmd/vic-machine/configure/configure.go
@@ -206,10 +206,21 @@ func (c *Configure) copyChangedConf(o *config.VirtualContainerHostConfigSpec, n 
 			v.Network.Assigned.Nameservers = nil
 		}
 	}
-	o.HostCertificate = n.HostCertificate
-	o.CertificateAuthorities = n.CertificateAuthorities
-	o.UserCertificates = n.UserCertificates
-	o.RegistryCertificateAuthorities = n.RegistryCertificateAuthorities
+
+	if n.HostCertificate != nil {
+		o.HostCertificate = n.HostCertificate
+	}
+
+	if n.CertificateAuthorities != nil {
+		o.CertificateAuthorities = n.CertificateAuthorities
+	}
+	if n.UserCertificates != nil {
+		o.UserCertificates = n.UserCertificates
+	}
+
+	if n.RegistryCertificateAuthorities != nil {
+		o.RegistryCertificateAuthorities = n.RegistryCertificateAuthorities
+	}
 }
 
 func updateSessionEnv(sess *executor.SessionConfig, envName, envValue string) {
@@ -372,14 +383,11 @@ func (c *Configure) Run(clic *cli.Context) (err error) {
 	}
 	c.Data = oldData
 
-	log.Errorf("After copying oldData, c.KeyPEM: %p", c.KeyPEM)
 	// in Create we process certificates as part of processParams but we need the old conf
 	// to do this in the context of Configure so we need to call this method here instead
 	if err = c.processCertificates(vchConfig); err != nil {
 		return err
 	}
-
-	log.Errorf("After processCertificates, c.KeyPEM: %p", c.KeyPEM)
 
 	// evaluate merged configuration
 	newConfig, err := validator.Validate(ctx, c.Data)

--- a/cmd/vic-machine/configure/configure.go
+++ b/cmd/vic-machine/configure/configure.go
@@ -45,7 +45,7 @@ type Configure struct {
 	dns       common.DNS
 	volStores common.VolumeStores
 
-	certificates common.CertSeed
+	certificates common.CertFactory
 
 	upgrade  bool
 	executor *management.Dispatcher
@@ -91,54 +91,6 @@ func (c *Configure) Flags() []cli.Flag {
 			Destination: &c.upgrade,
 			Hidden:      true,
 		},
-		cli.StringFlag{
-			Name:        "tls-key",
-			Value:       "",
-			Usage:       "Virtual Container Host private key file (server certificate)",
-			Destination: &c.certificates.Skey,
-		},
-		cli.StringFlag{
-			Name:        "tls-cert",
-			Value:       "",
-			Usage:       "Virtual Container Host x509 certificate file (server certificate)",
-			Destination: &c.certificates.Scert,
-		},
-		cli.StringFlag{
-			Name:        "tls-cname",
-			Value:       "",
-			Usage:       "Common Name to use in generated CA certificate when requiring client certificate authentication",
-			Destination: &c.certificates.Cname,
-		},
-		cli.StringFlag{
-			Name:        "cert-path",
-			Value:       "",
-			Usage:       "The path to check for existing certificates and in which to save generated certificates. Defaults to './<vch name>/'",
-			Destination: &c.certificates.CertPath,
-		},
-		cli.BoolFlag{
-			Name:        "no-tlsverify, kv",
-			Usage:       "Disable authentication via client certificates - for more tls options see advanced help (-x)",
-			Destination: &c.certificates.NoTLSverify,
-		},
-		cli.StringSliceFlag{
-			Name:   "organization",
-			Usage:  "A list of identifiers to record in the generated certificates. Defaults to VCH name and IP/FQDN if not provided.",
-			Value:  &c.certificates.Org,
-			Hidden: true,
-		},
-		cli.IntFlag{
-			Name:        "certificate-key-size, ksz",
-			Usage:       "Size of key to use when generating certificates",
-			Value:       2048,
-			Destination: &c.certificates.KeySize,
-			Hidden:      true,
-		},
-		cli.StringSliceFlag{
-			Name:   "tls-ca, ca",
-			Usage:  "Specify a list of certificate authority files to use for client verification",
-			Value:  &c.certificates.ClientCAsArg,
-			Hidden: true,
-		},
 	}
 
 	dns := c.dns.DNSFlags(false)
@@ -152,10 +104,11 @@ func (c *Configure) Flags() []cli.Flag {
 	proxies := c.proxies.ProxyFlags(false)
 	memory := c.VCHMemoryLimitFlags(false)
 	cpu := c.VCHCPULimitFlags(false)
+	certificates := c.certificates.CertFlags()
 
 	// flag arrays are declared, now combined
 	var flags []cli.Flag
-	for _, f := range [][]cli.Flag{target, ops, id, compute, volume, dns, cNetwork, memory, cpu, proxies, util, debug} {
+	for _, f := range [][]cli.Flag{target, ops, id, compute, volume, dns, cNetwork, memory, cpu, certificates, proxies, util, debug} {
 		flags = append(flags, f...)
 	}
 

--- a/cmd/vic-machine/create/create.go
+++ b/cmd/vic-machine/create/create.go
@@ -21,7 +21,6 @@ import (
 	"io/ioutil"
 	"net"
 	"net/url"
-	"os"
 	"path"
 	"reflect"
 	"strings"

--- a/cmd/vic-machine/create/create.go
+++ b/cmd/vic-machine/create/create.go
@@ -527,45 +527,42 @@ func (c *Create) loadRegistryCAs() ([]byte, error) {
 }
 
 func (c *Create) processCertificates() error {
+
+	// debuglevel is a pointer now so we have to do this song and dance
+	var debug int
+	if c.Debug.Debug == nil {
+		debug = 0
+	} else {
+		debug = *c.Debug.Debug
+	}
+
 	seed := &common.CertSeed{
-		RegistryCAs:               c.registryCAs,
-		CertPath:                  c.certPath,
-		DisplayName:               c.DisplayName,
-		Scert:                     c.scert,
-		Skey:                      c.skey,
-		Ccert:                     c.ccert,
-		Ckey:                      c.ckey,
-		Cacert:                    c.cacert,
-		Cakey:                     c.cakey, // mm, cake
-		ClientCert:                c.clientCert,
-		ClientCAsArg:              c.clientCAs,
-		ClientCAs:                 c.ClientCAs, // good grief
-		EnvFile:                   c.envFile,
-		Cname:                     c.cname,
-		Org:                       c.org,
-		KeySize:                   c.keySize,
-		NoTLS:                     c.noTLS,
-		NoTLSverify:               c.noTLSverify,
-		ContainerNetworks:         c.containerNetworks,
-		ContainerNetworksGateway:  c.containerNetworksGateway,
-		ContainerNetworksIPRanges: c.containerNetworksIPRanges,
-		ContainerNetworksDNS:      c.containerNetworksDNS,
-		VolumeStores:              c.volumeStores,
-		InsecureRegistries:        c.insecureRegistries,
-		DNS:                       c.dns,
-		ClientNetworkName:         c.clientNetworkName,
-		ClientNetworkGateway:      c.clientNetworkGateway,
-		ClientNetworkIP:           c.clientNetworkIP,
-		PublicNetworkName:         c.publicNetworkName,
-		PublicNetworkGateway:      c.publicNetworkGateway,
-		PublicNetworkIP:           c.publicNetworkIP,
-		ManagementNetworkName:     c.managementNetworkName,
-		ManagementNetworkGateway:  c.managementNetworkGateway,
-		ManagementNetworkIP:       c.managementNetworkIP,
-		KeyPEM:                    c.KeyPEM,
-		CertPEM:                   c.CertPEM,
-		Debug:                     c.Debug.Debug,
-		Force:                     c.Force,
+		CertPath:              c.certPath,
+		DisplayName:           c.DisplayName,
+		Scert:                 c.scert,
+		Skey:                  c.skey,
+		Ccert:                 c.ccert,
+		Ckey:                  c.ckey,
+		Cacert:                c.cacert,
+		Cakey:                 c.cakey, // mm, cake
+		ClientCert:            c.clientCert,
+		ClientCAsArg:          c.clientCAs,
+		ClientCAs:             c.ClientCAs, // good grief
+		Cname:                 c.cname,
+		Org:                   c.org,
+		KeySize:               c.keySize,
+		NoTLS:                 c.noTLS,
+		NoTLSverify:           c.noTLSverify,
+		ClientNetworkName:     c.clientNetworkName,
+		ClientNetworkIP:       c.clientNetworkIP,
+		PublicNetworkName:     c.publicNetworkName,
+		PublicNetworkIP:       c.publicNetworkIP,
+		ManagementNetworkName: c.managementNetworkName,
+		ManagementNetworkIP:   c.managementNetworkIP,
+		KeyPEM:                c.KeyPEM,
+		CertPEM:               c.CertPEM,
+		Debug:                 debug,
+		Force:                 c.Force,
 	}
 
 	if err := seed.ProcessCertificates(); err != nil {

--- a/cmd/vic-machine/create/create.go
+++ b/cmd/vic-machine/create/create.go
@@ -67,6 +67,12 @@ type Create struct {
 	certs             common.CertFactory
 	containerNetworks common.CNetworks
 
+	volumeStores common.VolumeStores
+
+	insecureRegistries  cli.StringSlice `arg:"insecure-registry"`
+	whitelistRegistries cli.StringSlice `arg:"whitelist-registry"`
+	dns                 common.DNS
+
 	memoryReservLimits string
 	cpuReservLimits    string
 
@@ -241,12 +247,6 @@ func (c *Create) Flags() []cli.Flag {
 		})
 
 	tls := c.certs.CertFlags()
-	tls = append(tls, cli.BoolFlag{ // TODO: add --no-tls to configure and move this to common afterwards
-		Name:        "no-tls, k",
-		Usage:       "Disable TLS support completely",
-		Destination: &c.certs.NoTLS,
-		Hidden:      true,
-	})
 
 	registries := []cli.Flag{
 		cli.StringSliceFlag{

--- a/cmd/vic-machine/create/create.go
+++ b/cmd/vic-machine/create/create.go
@@ -448,6 +448,8 @@ func (c *Create) processCertificates() error {
 		debug = *c.Debug.Debug
 	}
 
+	c.certs.Networks = c.Networks
+
 	if err := c.certs.ProcessCertificates(c.DisplayName, c.Force, debug); err != nil {
 		return err
 	}

--- a/cmd/vic-machine/create/create.go
+++ b/cmd/vic-machine/create/create.go
@@ -22,9 +22,7 @@ import (
 	"net"
 	"net/url"
 	"os"
-	"os/exec"
 	"path"
-	"path/filepath"
 	"reflect"
 	"strings"
 	"time"
@@ -36,7 +34,6 @@ import (
 	"github.com/vmware/vic/lib/install/data"
 	"github.com/vmware/vic/lib/install/management"
 	"github.com/vmware/vic/lib/install/validate"
-	"github.com/vmware/vic/pkg/certificate"
 	"github.com/vmware/vic/pkg/errors"
 	"github.com/vmware/vic/pkg/trace"
 )
@@ -510,95 +507,86 @@ func (c *Create) processParams() error {
 	return nil
 }
 
+// loadRegistryCAs loads additional CA certs for docker registry usage
+func (c *Create) loadRegistryCAs() ([]byte, error) {
+	defer trace.End(trace.Begin(""))
+
+	var registryCerts []byte
+	for _, f := range c.registryCAs {
+		b, err := ioutil.ReadFile(f)
+		if err != nil {
+			err = errors.Errorf("Failed to load authority from file %s: %s", f, err)
+			return nil, err
+		}
+
+		registryCerts = append(registryCerts, b...)
+		log.Infof("Loaded registry CA from %s", f)
+	}
+
+	return registryCerts, nil
+}
+
 func (c *Create) processCertificates() error {
-	// set up the locations for the certificates and env file
-	if c.certPath == "" {
-		c.certPath = c.DisplayName
-	}
-	c.envFile = fmt.Sprintf("%s/%s.env", c.certPath, c.DisplayName)
-
-	// check for insecure case
-	if c.noTLS {
-		log.Warn("Configuring without TLS - all communications will be insecure")
-		return nil
-	}
-
-	if c.scert != "" && c.skey == "" {
-		return cli.NewExitError("key and cert should be specified at the same time", 1)
-	}
-	if c.scert == "" && c.skey != "" {
-		return cli.NewExitError("key and cert should be specified at the same time", 1)
-	}
-
-	// if we've not got a specific CommonName but do have a static IP then go with that.
-	if c.cname == "" {
-		if c.clientNetworkIP != "" {
-			c.cname = c.clientNetworkIP
-			log.Infof("Using client-network-ip as cname where needed - use --tls-cname to override: %s", c.cname)
-		} else if c.publicNetworkIP != "" && (c.publicNetworkName == c.clientNetworkName || c.clientNetworkName == "") {
-			c.cname = c.publicNetworkIP
-			log.Infof("Using public-network-ip as cname where needed - use --tls-cname to override: %s", c.cname)
-		} else if c.managementNetworkIP != "" && (c.managementNetworkName == c.clientNetworkName || (c.clientNetworkName == "" && c.managementNetworkName == c.publicNetworkName)) {
-			c.cname = c.managementNetworkIP
-			log.Infof("Using management-network-ip as cname where needed - use --tls-cname to override: %s", c.cname)
-		}
-
-		if c.cname != "" {
-			// Strip network mask from IP address if set
-			if cnameIP, _, _ := net.ParseCIDR(c.cname); cnameIP != nil {
-				c.cname = cnameIP.String()
-			}
-		}
-	}
-
-	// load what certificates we can
-	cas, keypair, err := c.loadCertificates()
-	if err != nil {
-		log.Errorf("Unable to load certificates: %s", err)
-		if !c.Force {
-			return err
-		}
-
-		log.Warnf("Ignoring error loading certificates due to --force")
-		cas = nil
-		keypair = nil
-		err = nil
+	seed := &common.CertSeed{
+		RegistryCAs:               c.registryCAs,
+		CertPath:                  c.certPath,
+		DisplayName:               c.DisplayName,
+		Scert:                     c.scert,
+		Skey:                      c.skey,
+		Ccert:                     c.ccert,
+		Ckey:                      c.ckey,
+		Cacert:                    c.cacert,
+		Cakey:                     c.cakey, // mm, cake
+		ClientCert:                c.clientCert,
+		ClientCAsArg:              c.clientCAs,
+		ClientCAs:                 c.ClientCAs, // good grief
+		EnvFile:                   c.envFile,
+		Cname:                     c.cname,
+		Org:                       c.org,
+		KeySize:                   c.keySize,
+		NoTLS:                     c.noTLS,
+		NoTLSverify:               c.noTLSverify,
+		ContainerNetworks:         c.containerNetworks,
+		ContainerNetworksGateway:  c.containerNetworksGateway,
+		ContainerNetworksIPRanges: c.containerNetworksIPRanges,
+		ContainerNetworksDNS:      c.containerNetworksDNS,
+		VolumeStores:              c.volumeStores,
+		InsecureRegistries:        c.insecureRegistries,
+		DNS:                       c.dns,
+		ClientNetworkName:         c.clientNetworkName,
+		ClientNetworkGateway:      c.clientNetworkGateway,
+		ClientNetworkIP:           c.clientNetworkIP,
+		PublicNetworkName:         c.publicNetworkName,
+		PublicNetworkGateway:      c.publicNetworkGateway,
+		PublicNetworkIP:           c.publicNetworkIP,
+		ManagementNetworkName:     c.managementNetworkName,
+		ManagementNetworkGateway:  c.managementNetworkGateway,
+		ManagementNetworkIP:       c.managementNetworkIP,
+		KeyPEM:                    c.KeyPEM,
+		CertPEM:                   c.CertPEM,
+		Debug:                     c.Debug.Debug,
+		Force:                     c.Force,
 	}
 
-	// we need to generate some part of the certificate configuration
-	gcas, gkeypair, err := c.generateCertificates(keypair == nil, !c.noTLSverify && len(cas) == 0)
-	if err != nil {
-		log.Error("Create cannot continue: unable to generate certificates")
+	if err := seed.ProcessCertificates(); err != nil {
 		return err
 	}
 
-	if keypair != nil {
-		c.KeyPEM = keypair.KeyPEM
-		c.CertPEM = keypair.CertPEM
-	} else if gkeypair != nil {
-		c.KeyPEM = gkeypair.KeyPEM
-		c.CertPEM = gkeypair.CertPEM
-	}
+	// copy a few things out of seed because ProcessCertificates has side effects
+	c.certPath = seed.CertPath
+	c.envFile = seed.EnvFile
+	c.cname = seed.Cname
+	c.KeyPEM = seed.KeyPEM
+	c.CertPEM = seed.CertPEM
+	c.ClientCAs = seed.ClientCAs
+	c.skey = seed.Skey
+	c.scert = seed.Scert
+	c.ckey = seed.Ckey
+	c.ccert = seed.Ccert
+	c.clientCert = seed.ClientCert
+	c.cacert = seed.Cacert
+	c.org = seed.Org
 
-	if len(cas) == 0 {
-		cas = gcas
-	}
-
-	if len(c.KeyPEM) == 0 {
-		return errors.New("Failed to load or generate server certificates")
-	}
-
-	if len(cas) == 0 && !c.noTLSverify {
-		return errors.New("Failed to load or generate certificate authority")
-	}
-
-	// do we have key, cert, and --no-tlsverify
-	if c.noTLSverify || len(cas) == 0 {
-		log.Warnf("Configuring without TLS verify - certificate-based authentication disabled")
-		return nil
-	}
-
-	c.ClientCAs = cas
 	return nil
 }
 
@@ -712,277 +700,6 @@ func (c *Create) processRegistries() error {
 	c.InsecureRegistries = c.insecureRegistries.Value()
 	c.WhitelistRegistries = c.whitelistRegistries.Value()
 	return nil
-}
-
-// loadCertificates returns the client CA pool and the keypair for server certificates on success
-func (c *Create) loadCertificates() ([]byte, *certificate.KeyPair, error) {
-	defer trace.End(trace.Begin(""))
-
-	// reads each of the files specified, assuming that they are PEM encoded certs,
-	// and constructs a byte array suitable for passing to CertPool.AppendCertsFromPEM
-	var certs []byte
-	for _, f := range c.clientCAs {
-		b, err := ioutil.ReadFile(f)
-		if err != nil {
-			err = errors.Errorf("Failed to load authority from file %s: %s", f, err)
-			return nil, nil, err
-		}
-
-		certs = append(certs, b...)
-		log.Infof("Loaded CA from %s", f)
-	}
-
-	var keypair *certificate.KeyPair
-	// default names
-	skey := filepath.Join(c.certPath, certificate.ServerKey)
-	scert := filepath.Join(c.certPath, certificate.ServerCert)
-	ca := filepath.Join(c.certPath, certificate.CACert)
-	ckey := filepath.Join(c.certPath, certificate.ClientKey)
-	ccert := filepath.Join(c.certPath, certificate.ClientCert)
-
-	// if specific files are supplied, use those
-	explicit := false
-	if c.scert != "" && c.skey != "" {
-		explicit = true
-		skey = c.skey
-		scert = c.scert
-	}
-
-	// load the server certificate
-	keypair = certificate.NewKeyPair(scert, skey, nil, nil)
-	if err := keypair.LoadCertificate(); err != nil {
-		if explicit || !os.IsNotExist(err) {
-			// if these files were explicit paths, or anything other than not found, fail
-			log.Errorf("Failed to load certificate: %s", err)
-			return certs, nil, err
-		}
-
-		log.Debugf("Unable to locate existing server certificate in cert path")
-		return nil, nil, nil
-	}
-
-	// check that any supplied cname matches the server cert CN
-	cert, err := keypair.Certificate()
-	if err != nil {
-		log.Errorf("Failed to parse certificate: %s", err)
-		return certs, nil, err
-	}
-
-	if cert.Leaf == nil {
-		log.Warnf("Failed to load x509 leaf: Unable to confirm server certificate cname matches provided cname %q. Continuing...", c.cname)
-	} else {
-		// We just do a direct equality check here - trying to be clever is liable to lead to hard
-		// to diagnose errors
-		if cert.Leaf.Subject.CommonName != c.cname {
-			log.Errorf("Provided cname does not match that in existing server certificate: %s", cert.Leaf.Subject.CommonName)
-			if c.Debug.Debug != nil && *c.Debug.Debug > 2 {
-				log.Debugf("Certificate does not match provided cname: %#+v", cert.Leaf)
-			}
-			return certs, nil, fmt.Errorf("cname option doesn't match existing server certificate in certificate path %s", c.certPath)
-		}
-	}
-
-	log.Infof("Loaded server certificate %s", scert)
-	c.skey = skey
-	c.scert = scert
-
-	// only try for CA certificate if no-tlsverify has NOT been specified and we haven't already loaded an authority cert
-	if !c.noTLSverify && len(certs) == 0 {
-		b, err := ioutil.ReadFile(ca)
-		if err != nil {
-			if os.IsNotExist(err) {
-				log.Debugf("Unable to locate existing CA in cert path")
-				return certs, keypair, nil
-			}
-
-			// if the CA exists but cannot be loaded then it's an error
-			log.Errorf("Failed to load authority from certificate path %s: %s", c.certPath, err)
-			return certs, keypair, errors.New("failed to load certificate authority")
-		}
-
-		c.cacert = ca
-
-		log.Infof("Loaded CA with default name from certificate path %s", c.certPath)
-		certs = b
-
-		// load client certs - we ensure the client certs validate with the provided CA or ignore any we find
-		cpair := certificate.NewKeyPair(ccert, ckey, nil, nil)
-		if err := cpair.LoadCertificate(); err != nil {
-			log.Warnf("Unable to load client certificate - validation of API endpoint will be best effort only: %s", err)
-		}
-
-		clientCert, err := certificate.VerifyClientCert(certs, cpair)
-		if err != nil {
-			switch err.(type) {
-			case certificate.CertParseError, certificate.CreateCAPoolError:
-				log.Debugf(err.Error())
-			case certificate.CertVerifyError:
-				log.Warnf("%s - continuing without client certificate", err.Error())
-			}
-
-			return certs, keypair, nil
-		}
-
-		c.ckey = ckey
-		c.ccert = ccert
-		c.clientCert = clientCert
-
-		log.Infof("Loaded client certificate with default name from certificate path %s", c.certPath)
-	}
-
-	return certs, keypair, nil
-}
-
-// loadRegistryCAs loads additional CA certs for docker registry usage
-func (c *Create) loadRegistryCAs() ([]byte, error) {
-	defer trace.End(trace.Begin(""))
-
-	var registryCerts []byte
-	for _, f := range c.registryCAs {
-		b, err := ioutil.ReadFile(f)
-		if err != nil {
-			err = errors.Errorf("Failed to load authority from file %s: %s", f, err)
-			return nil, err
-		}
-
-		registryCerts = append(registryCerts, b...)
-		log.Infof("Loaded registry CA from %s", f)
-	}
-
-	return registryCerts, nil
-}
-
-func (c *Create) generateCertificates(server bool, client bool) ([]byte, *certificate.KeyPair, error) {
-	defer trace.End(trace.Begin(""))
-
-	if !server && !client {
-		log.Debugf("Not generating server or client certs, nothing for generateCertificates to do")
-		return nil, nil, nil
-	}
-
-	var certs []byte
-	// generate the certs and keys with names conforming the default the docker client expects
-	files, err := ioutil.ReadDir(c.certPath)
-	if len(files) > 0 {
-		return nil, nil, fmt.Errorf("Specified directory to store certificates is not empty. Specify a new path in which to store generated certificates using --cert-path or remove the contents of \"%s\" and run vic-machine again.", c.certPath)
-	}
-
-	err = os.MkdirAll(c.certPath, 0700)
-	if err != nil {
-		log.Errorf("Unable to make directory to hold certificates (set via --cert-path)")
-		return nil, nil, err
-	}
-
-	c.skey = filepath.Join(c.certPath, certificate.ServerKey)
-	c.scert = filepath.Join(c.certPath, certificate.ServerCert)
-
-	c.ckey = filepath.Join(c.certPath, certificate.ClientKey)
-	c.ccert = filepath.Join(c.certPath, certificate.ClientCert)
-
-	cakey := filepath.Join(c.certPath, certificate.CAKey)
-	c.cacert = filepath.Join(c.certPath, certificate.CACert)
-
-	if server && !client {
-		log.Infof("Generating self-signed certificate/key pair - private key in %s", c.skey)
-		keypair := certificate.NewKeyPair(c.scert, c.skey, nil, nil)
-		err := keypair.CreateSelfSigned(c.cname, nil, c.keySize)
-		if err != nil {
-			log.Errorf("Failed to generate self-signed certificate: %s", err)
-			return nil, nil, err
-		}
-		if err = keypair.SaveCertificate(); err != nil {
-			log.Errorf("Failed to save server certificates: %s", err)
-			return nil, nil, err
-		}
-
-		return certs, keypair, nil
-	}
-
-	// client auth path
-	if c.cname == "" {
-		log.Error("Common Name must be provided when generating certificates for client authentication:")
-		log.Info("  --tls-cname=<FQDN or static IP> # for the appliance VM")
-		log.Info("  --tls-cname=<*.yourdomain.com>  # if DNS has entries in that form for DHCP addresses (less secure)")
-		log.Info("  --no-tlsverify                  # disables client authentication (anyone can connect to the VCH)")
-		log.Info("  --no-tls                        # disables TLS entirely")
-		log.Info("")
-
-		return certs, nil, errors.New("provide Common Name for server certificate")
-	}
-
-	// for now re-use the display name as the organisation if unspecified
-	if len(c.org) == 0 {
-		c.org = []string{c.DisplayName}
-	}
-	if len(c.org) == 1 && !strings.HasPrefix(c.cname, "*") {
-		// Add in the cname if it's not a wildcard
-		c.org = append(c.org, c.cname)
-	}
-
-	// Certificate authority
-	log.Infof("Generating CA certificate/key pair - private key in %s", cakey)
-	cakp := certificate.NewKeyPair(c.cacert, cakey, nil, nil)
-	err = cakp.CreateRootCA(c.cname, c.org, c.keySize)
-	if err != nil {
-		log.Errorf("Failed to generate CA: %s", err)
-		return nil, nil, err
-	}
-	if err = cakp.SaveCertificate(); err != nil {
-		log.Errorf("Failed to save CA certificates: %s", err)
-		return nil, nil, err
-	}
-
-	// Server certificates
-	var skp *certificate.KeyPair
-	if server {
-		log.Infof("Generating server certificate/key pair - private key in %s", c.skey)
-		skp = certificate.NewKeyPair(c.scert, c.skey, nil, nil)
-		err = skp.CreateServerCertificate(c.cname, c.org, c.keySize, cakp)
-		if err != nil {
-			log.Errorf("Failed to generate server certificates: %s", err)
-			return nil, nil, err
-		}
-		if err = skp.SaveCertificate(); err != nil {
-			log.Errorf("Failed to save server certificates: %s", err)
-			return nil, nil, err
-		}
-	}
-
-	// Client certificates
-	if client {
-		log.Infof("Generating client certificate/key pair - private key in %s", c.ckey)
-		ckp := certificate.NewKeyPair(c.ccert, c.ckey, nil, nil)
-		err = ckp.CreateClientCertificate(c.cname, c.org, c.keySize, cakp)
-		if err != nil {
-			log.Errorf("Failed to generate client certificates: %s", err)
-			return nil, nil, err
-		}
-		if err = ckp.SaveCertificate(); err != nil {
-			log.Errorf("Failed to save client certificates: %s", err)
-			return nil, nil, err
-		}
-
-		c.clientCert, err = ckp.Certificate()
-		if err != nil {
-			log.Warnf("Failed to stash client certificate for later application level validation: %s", err)
-		}
-
-		// If openssl is present, try to generate a browser friendly pfx file (a bundle of the public certificate AND the private key)
-		// The pfx file can be imported directly into keychains for client certificate authentication
-		certPath := filepath.Clean(c.certPath)
-		args := strings.Split(fmt.Sprintf("pkcs12 -export -out %[1]s/cert.pfx -inkey %[1]s/key.pem -in %[1]s/cert.pem -certfile %[1]s/ca.pem -password pass:", certPath), " ")
-		// #nosec: Subprocess launching with variable
-		pfx := exec.Command("openssl", args...)
-		out, err := pfx.CombinedOutput()
-		if err != nil {
-			log.Debug(out)
-			log.Warnf("Failed to generate browser friendly PFX client certificate: %s", err)
-		} else {
-			log.Infof("Generated browser friendly PFX client certificate - certificate in %s/cert.pfx", certPath)
-		}
-	}
-
-	return cakp.CertPEM, skp, nil
 }
 
 func (c *Create) processSyslog() error {

--- a/cmd/vic-machine/create/create.go
+++ b/cmd/vic-machine/create/create.go
@@ -241,6 +241,12 @@ func (c *Create) Flags() []cli.Flag {
 		})
 
 	tls := c.certs.CertFlags()
+	tls = append(tls, cli.BoolFlag{ // TODO: add --no-tls to configure and move this to common afterwards
+		Name:        "no-tls, k",
+		Usage:       "Disable TLS support completely",
+		Destination: &c.certs.NoTLS,
+		Hidden:      true,
+	})
 
 	registries := []cli.Flag{
 		cli.StringSliceFlag{

--- a/tests/test-cases/Group6-VIC-Machine/6-17-Configure-TLS.md
+++ b/tests/test-cases/Group6-VIC-Machine/6-17-Configure-TLS.md
@@ -1,0 +1,38 @@
+Test 6-17 - Verify vic-machine configure TLS function
+=======
+
+# Purpose:
+Verify vic-machine configure certificates
+
+# References:
+* vic-machine-linux configure -h
+
+# Environment:
+This test requires that a vSphere server is running and available. One VCH is created for the suite and used throughout by each test so that we don't have to call create & configure in each test (which would duplicate the work of 6-13-TLS).
+
+Configure VCH w/ own CA
+===
+Performs a similar test to the one in create.
+1) Generates a CA, self-signed
+2) Runs vic-machine configure against the VCH set up in pre-test
+3) Makes sure the installed certificate is the correct one
+
+Configure VCH w/ trusted CA
+===
+1) Generates a CA, adds it to trust pool, just like the test in Create
+2) Runs vic-machine to replace the previous cert with this one
+3) Uses openssl tool to verify correct trusted certificate is in place
+
+
+Configure VCH - Run Configure Without Cert Options & Ensure Certs are Unchanged
+===
+1) Generates a CA, installs it, verifies it's installed, as in the last test
+2) Calls configure again with *no* TLS options
+3) Check to make sure the installed cert from 1) is still presented
+
+
+Configure VCH - Replace certificates with self-signed certificate using --no-tlsverify
+===
+1) Calls configure against the existing VCH with --no-tlsverify and an empty --cert-path 
+2) Checks that a self-signed certificate is generated
+3) Checks that the installed certificate is the self-signed one that we just generated

--- a/tests/test-cases/Group6-VIC-Machine/6-17-Configure-TLS.robot
+++ b/tests/test-cases/Group6-VIC-Machine/6-17-Configure-TLS.robot
@@ -43,50 +43,50 @@ Cleanup
     Run Keyword  Cleanup VIC Appliance On Test Server
 
 *** Test Cases ***
-# Configure VCH - Server cert with untrusted CA
-#     ${domain}=  Get Environment Variable  DOMAIN  ''
-#     Run Keyword If  '${domain}' == ''  Pass Execution  Skipping test - domain not set, won't generate keys
-#     # Generate CA and wildcard cert for *.<DOMAIN>
-#     Generate Certificate Authority
-#     Generate Wildcard Server Certificate
+Configure VCH - Server cert with untrusted CA
+    ${domain}=  Get Environment Variable  DOMAIN  ''
+    Run Keyword If  '${domain}' == ''  Pass Execution  Skipping test - domain not set, won't generate keys
+    # Generate CA and wildcard cert for *.<DOMAIN>
+    Generate Certificate Authority
+    Generate Wildcard Server Certificate
 
-#     ${out}=  Run  cp /root/ca/cert-bundle.tgz .; tar xvf cert-bundle.tgz
-#     Log  ${out}
+    ${out}=  Run  cp /root/ca/cert-bundle.tgz .; tar xvf cert-bundle.tgz
+    Log  ${out}
 
-#     # Run vic-machine configure, supply server cert and key
-#     ${output}=  Run  bin/vic-machine-linux configure --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --tls-key "bundle/*.${domain}.key.pem" --tls-cert "bundle/*.${domain}.cert.pem" ${vicmachinetls} --cert-path "out-bundle" --debug 1
-#     Log  ${output}
-#     Should Contain  ${output}  Completed successfully
+    # Run vic-machine configure, supply server cert and key
+    ${output}=  Run  bin/vic-machine-linux configure --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --tls-key "bundle/*.${domain}.key.pem" --tls-cert "bundle/*.${domain}.cert.pem" ${vicmachinetls} --cert-path "out-bundle" --debug 1
+    Log  ${output}
+    Should Contain  ${output}  Completed successfully
 
-#     # Verify that the supplied certificate is presented on web interface
-#     ${output}=  Run  openssl s_client -showcerts -connect %{VCH-IP}:2378
-#     Log  ${output}
-#     Should Contain  ${output}  issuer=/C=US/ST=California/L=Los Angeles/O=Stark Enterprises/OU=Stark Enterprises Certificate Authority/CN=Stark Enterprises Global CA
+    # Verify that the supplied certificate is presented on web interface
+    ${output}=  Run  openssl s_client -showcerts -connect %{VCH-IP}:2378
+    Log  ${output}
+    Should Contain  ${output}  issuer=/C=US/ST=California/L=Los Angeles/O=Stark Enterprises/OU=Stark Enterprises Certificate Authority/CN=Stark Enterprises Global CA
 
-#     Run  rm -rf bundle
-#     Run  rm -f cert-bundle.tgz
-#     Run  rm -f out-bundle
-#     Run  rm -rf /root/ca
+    Run  rm -rf bundle
+    Run  rm -f cert-bundle.tgz
+    Run  rm -f out-bundle
+    Run  rm -rf /root/ca
 
 
-# Configure VCH - Server cert with trusted CA
-#     ${domain}=  Get Environment Variable  DOMAIN  ''
-#     Run Keyword If  '${domain}' == ''  Pass Execution  Skipping test - domain not set, won't generate keys
+Configure VCH - Server cert with trusted CA
+    ${domain}=  Get Environment Variable  DOMAIN  ''
+    Run Keyword If  '${domain}' == ''  Pass Execution  Skipping test - domain not set, won't generate keys
 
-#     # Generate CA and wildcard cert for *.<DOMAIN>, install CA into root store
-#     Generate Certificate Authority
-#     Generate Wildcard Server Certificate
-#     Trust Certificate Authority
+    # Generate CA and wildcard cert for *.<DOMAIN>, install CA into root store
+    Generate Certificate Authority
+    Generate Wildcard Server Certificate
+    Trust Certificate Authority
 
-#     ${out}=  Run  cp /root/ca/cert-bundle.tgz .; tar xvf cert-bundle.tgz
-#     Log  ${out}
+    ${out}=  Run  cp /root/ca/cert-bundle.tgz .; tar xvf cert-bundle.tgz
+    Log  ${out}
 
-#     # Run vic-machine install, supply server cert and key
-#     ${output}=  Run  bin/vic-machine-linux configure --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --tls-key "bundle/*.%{DOMAIN}.key.pem" --tls-cert "bundle/*.%{DOMAIN}.cert.pem" ${vicmachinetls} --debug 1
-#     Log  ${output}
-#     Should Contain  ${output}  Loaded server certificate bundle
-#     Should Contain  ${output}  Unable to locate existing CA in cert path
-#     Should Contain  ${output}  Completed successfully
+    # Run vic-machine install, supply server cert and key
+    ${output}=  Run  bin/vic-machine-linux configure --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --tls-key "bundle/*.%{DOMAIN}.key.pem" --tls-cert "bundle/*.%{DOMAIN}.cert.pem" ${vicmachinetls} --debug 1
+    Log  ${output}
+    Should Contain  ${output}  Loaded server certificate bundle
+    Should Contain  ${output}  Unable to locate existing CA in cert path
+    Should Contain  ${output}  Completed successfully
 
 
     # ${output}=  Run  openssl s_client -showcerts -connect %{VCH-IP}:2378

--- a/tests/test-cases/Group6-VIC-Machine/6-17-Configure-TLS.robot
+++ b/tests/test-cases/Group6-VIC-Machine/6-17-Configure-TLS.robot
@@ -1,0 +1,118 @@
+# Copyright 2016-2017 VMware, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#	http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License
+
+*** Settings ***
+Documentation  Test 6-13 - Verify vic-machine configure TLS options
+Resource  ../../resources/Util.robot
+Suite Teardown  Run Keyword  Cleanup
+Suite Setup  Run Keyword  Setup Test Environment
+
+*** Keywords ***
+Setup Test Environment
+    Set Test Environment Variables
+    Run Keyword And Ignore Error  Cleanup Dangling VMs On Test Server
+    Run Keyword And Ignore Error  Cleanup Datastore On Test Server
+
+    ${output}=  Run  bin/vic-machine-linux create ${vicmachinetls} --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --image-store=%{TEST_DATASTORE} --bridge-network=%{BRIDGE_NETWORK} --public-network=%{PUBLIC_NETWORK} --cert-path=${EXECDIR}/foo-bar-certs/
+    Should Contain  ${output}  --tlscacert="${EXECDIR}/foo-bar-certs/ca.pem" --tlscert="${EXECDIR}/foo-bar-certs/cert.pem" --tlskey="${EXECDIR}/foo-bar-certs/key.pem"
+    Should Contain  ${output}  Generating CA certificate/key pair - private key in ${EXECDIR}/foo-bar-certs/ca-key.pem
+    Should Contain  ${output}  Generating server certificate/key pair - private key in ${EXECDIR}/foo-bar-certs/server-key.pem
+    Should Contain  ${output}  Generating client certificate/key pair - private key in ${EXECDIR}/foo-bar-certs/key.pem
+    Should Contain  ${output}  Generated browser friendly PFX client certificate - certificate in ${EXECDIR}/foo-bar-certs/cert.pfx
+
+    Should Contain  ${output}  Installer completed successfully
+    Get Docker Params  ${output}  ${true}
+
+    ${save_env}=  Run  cat ${EXECDIR}/foo-bar-certs/%{VCH-NAME}.env
+    Should Contain  ${save_env}  DOCKER_CERT_PATH=${EXECDIR}/foo-bar-certs
+    Log To Console  Installer completed successfully: %{VCH-NAME}
+
+Cleanup
+    Run  rm -rf bundle; rm -rf foo-bar-certs
+    Run Keyword  Cleanup VIC Appliance On Test Server
+
+*** Test Cases ***
+Configure VCH - Server cert with untrusted CA
+    ${domain}=  Get Environment Variable  DOMAIN  ''
+    Run Keyword If  '${domain}' == ''  Pass Execution  Skipping test - domain not set, won't generate keys
+    # Generate CA and wildcard cert for *.<DOMAIN>
+    Generate Certificate Authority
+    Generate Wildcard Server Certificate
+
+    ${out}=  Run  cp /root/ca/cert-bundle.tgz .; tar xvf cert-bundle.tgz
+    Log  ${out}
+
+    # Run vic-machine configure, supply server cert and key
+    ${output}=  Run  bin/vic-machine-linux configure --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --tls-key "bundle/*.${domain}.key.pem" --tls-cert "bundle/*.${domain}.cert.pem" ${vicmachinetls} --cert-path "out-bundle" --debug 1
+    Log  ${output}
+    Should Contain  ${output}  Completed successfully
+
+    # Verify that the supplied certificate is presented on web interface
+    ${output}=  Run  openssl s_client -showcerts -connect %{VCH-IP}:2378
+    Log  ${output}
+    Should Contain  ${output}  issuer=/C=US/ST=California/L=Los Angeles/O=Stark Enterprises/OU=Stark Enterprises Certificate Authority/CN=Stark Enterprises Global CA
+
+    Run  rm -rf bundle
+    Run  rm -f cert-bundle.tgz
+    Run  rm -f out-bundle
+    Run  rm -rf /root/ca
+
+
+Configure VCH - Server cert with trusted CA
+    ${domain}=  Get Environment Variable  DOMAIN  ''
+    Run Keyword If  '${domain}' == ''  Pass Execution  Skipping test - domain not set, won't generate keys
+
+    # Generate CA and wildcard cert for *.<DOMAIN>, install CA into root store
+    Generate Certificate Authority
+    Generate Wildcard Server Certificate
+    Trust Certificate Authority
+
+    ${out}=  Run  cp /root/ca/cert-bundle.tgz .; tar xvf cert-bundle.tgz
+    Log  ${out}
+
+    # Run vic-machine install, supply server cert and key
+    ${output}=  Run  bin/vic-machine-linux configure --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --tls-key "bundle/*.%{DOMAIN}.key.pem" --tls-cert "bundle/*.%{DOMAIN}.cert.pem" ${vicmachinetls} --debug 1
+    Log  ${output}
+    Should Contain  ${output}  Loaded server certificate bundle
+    Should Contain  ${output}  Unable to locate existing CA in cert path
+    Should Contain  ${output}  Completed successfully
+
+
+    ${output}=  Run  openssl s_client -showcerts -connect %{VCH-IP}:2378
+    Log  ${output}
+    Should Contain  ${output}  issuer=/C=US/ST=California/L=Los Angeles/O=Stark Enterprises/OU=Stark Enterprises Certificate Authority/CN=Stark Enterprises Global CA
+
+    Run  rm -rf bundle
+    Run  rm -f cert-bundle.tgz
+    Run  rm -rf /root/ca
+
+    Reload Default Certificate Authorities
+
+Configure VCH - Replace certificates with self-signed certificate using --cert-path
+
+    ${domain}=  Get Environment Variable  DOMAIN  ''
+    Run Keyword If  '${domain}' == ''  Pass Execution  Skipping test - domain not set, won't generate keys
+    Run  rm -rf foo-bar-certs
+    ${output}=  Run  bin/vic-machine-linux configure --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} ${vicmachinetls} --cert-path "foo-bar-certs" --debug 1 --regenerate-certs
+
+    Should Contain  ${output}  Generating CA certificate/key pair - private key in foo-bar-certs/ca-key.pem
+    Should Contain  ${output}  Generating server certificate/key pair - private key in foo-bar-certs/server-key.pem
+    Should Contain  ${output}  Generating client certificate/key pair - private key in foo-bar-certs/key.pem
+    Should Contain  ${output}  Generated browser friendly PFX client certificate - certificate in foo-bar-certs/cert.pfx
+
+    Should Contain  ${output}  Completed successfully
+
+    ${output}=  Run  openssl s_client -showcerts -connect %{VCH-IP}:2378
+    Log  ${output}
+    Should Contain  ${output}  issuer=/O=%{VCH-NAME}

--- a/tests/test-cases/Group6-VIC-Machine/6-17-Configure-TLS.robot
+++ b/tests/test-cases/Group6-VIC-Machine/6-17-Configure-TLS.robot
@@ -54,7 +54,7 @@ Configure VCH - Server cert with untrusted CA
     Log  ${out}
 
     # Run vic-machine configure, supply server cert and key
-    ${output}=  Run  bin/vic-machine-linux configure --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --tls-key "bundle/*.${domain}.key.pem" --tls-cert "bundle/*.${domain}.cert.pem" ${vicmachinetls} --cert-path "out-bundle" --debug 1
+    ${output}=  Run  bin/vic-machine-linux configure --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --key "bundle/*.${domain}.key.pem" --cert "bundle/*.${domain}.cert.pem" ${vicmachinetls} --cert-path "out-bundle" --debug 1
     Log  ${output}
     Should Contain  ${output}  Completed successfully
 
@@ -82,7 +82,7 @@ Configure VCH - Server cert with trusted CA
     Log  ${out}
 
     # Run vic-machine install, supply server cert and key
-    ${output}=  Run  bin/vic-machine-linux configure --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --tls-key "bundle/*.%{DOMAIN}.key.pem" --tls-cert "bundle/*.%{DOMAIN}.cert.pem" ${vicmachinetls} --debug 1
+    ${output}=  Run  bin/vic-machine-linux configure --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --key "bundle/*.%{DOMAIN}.key.pem" --cert "bundle/*.%{DOMAIN}.cert.pem" ${vicmachinetls} --debug 1
     Log  ${output}
     Should Contain  ${output}  Loaded server certificate bundle
     Should Contain  ${output}  Unable to locate existing CA in cert path
@@ -113,7 +113,7 @@ Configure VCH - Run Configure Without Cert Options & Ensure Certs Are Unchanged
 
     Run  rm -rf foo-bar-certs
     # Run vic-machine configure, supply server cert and key
-    ${output}=  Run  bin/vic-machine-linux configure --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --tls-key "bundle/*.%{DOMAIN}.key.pem" --tls-cert "bundle/*.%{DOMAIN}.cert.pem" ${vicmachinetls} --cert-path=foo-bar-certs --debug 1
+    ${output}=  Run  bin/vic-machine-linux configure --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --key "bundle/*.%{DOMAIN}.key.pem" --cert "bundle/*.%{DOMAIN}.cert.pem" ${vicmachinetls} --cert-path=foo-bar-certs --debug 1
     Log  ${output}
     Should Contain  ${output}  Loaded server certificate bundle
     Should Contain  ${output}  Unable to locate existing CA in cert path

--- a/tests/test-cases/Group6-VIC-Machine/6-17-Configure-TLS.robot
+++ b/tests/test-cases/Group6-VIC-Machine/6-17-Configure-TLS.robot
@@ -43,33 +43,63 @@ Cleanup
     Run Keyword  Cleanup VIC Appliance On Test Server
 
 *** Test Cases ***
-Configure VCH - Server cert with untrusted CA
-    ${domain}=  Get Environment Variable  DOMAIN  ''
-    Run Keyword If  '${domain}' == ''  Pass Execution  Skipping test - domain not set, won't generate keys
-    # Generate CA and wildcard cert for *.<DOMAIN>
-    Generate Certificate Authority
-    Generate Wildcard Server Certificate
+# Configure VCH - Server cert with untrusted CA
+#     ${domain}=  Get Environment Variable  DOMAIN  ''
+#     Run Keyword If  '${domain}' == ''  Pass Execution  Skipping test - domain not set, won't generate keys
+#     # Generate CA and wildcard cert for *.<DOMAIN>
+#     Generate Certificate Authority
+#     Generate Wildcard Server Certificate
 
-    ${out}=  Run  cp /root/ca/cert-bundle.tgz .; tar xvf cert-bundle.tgz
-    Log  ${out}
+#     ${out}=  Run  cp /root/ca/cert-bundle.tgz .; tar xvf cert-bundle.tgz
+#     Log  ${out}
 
-    # Run vic-machine configure, supply server cert and key
-    ${output}=  Run  bin/vic-machine-linux configure --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --tls-key "bundle/*.${domain}.key.pem" --tls-cert "bundle/*.${domain}.cert.pem" ${vicmachinetls} --cert-path "out-bundle" --debug 1
-    Log  ${output}
-    Should Contain  ${output}  Completed successfully
+#     # Run vic-machine configure, supply server cert and key
+#     ${output}=  Run  bin/vic-machine-linux configure --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --tls-key "bundle/*.${domain}.key.pem" --tls-cert "bundle/*.${domain}.cert.pem" ${vicmachinetls} --cert-path "out-bundle" --debug 1
+#     Log  ${output}
+#     Should Contain  ${output}  Completed successfully
 
-    # Verify that the supplied certificate is presented on web interface
-    ${output}=  Run  openssl s_client -showcerts -connect %{VCH-IP}:2378
-    Log  ${output}
-    Should Contain  ${output}  issuer=/C=US/ST=California/L=Los Angeles/O=Stark Enterprises/OU=Stark Enterprises Certificate Authority/CN=Stark Enterprises Global CA
+#     # Verify that the supplied certificate is presented on web interface
+#     ${output}=  Run  openssl s_client -showcerts -connect %{VCH-IP}:2378
+#     Log  ${output}
+#     Should Contain  ${output}  issuer=/C=US/ST=California/L=Los Angeles/O=Stark Enterprises/OU=Stark Enterprises Certificate Authority/CN=Stark Enterprises Global CA
 
-    Run  rm -rf bundle
-    Run  rm -f cert-bundle.tgz
-    Run  rm -f out-bundle
-    Run  rm -rf /root/ca
+#     Run  rm -rf bundle
+#     Run  rm -f cert-bundle.tgz
+#     Run  rm -f out-bundle
+#     Run  rm -rf /root/ca
 
 
-Configure VCH - Server cert with trusted CA
+# Configure VCH - Server cert with trusted CA
+#     ${domain}=  Get Environment Variable  DOMAIN  ''
+#     Run Keyword If  '${domain}' == ''  Pass Execution  Skipping test - domain not set, won't generate keys
+
+#     # Generate CA and wildcard cert for *.<DOMAIN>, install CA into root store
+#     Generate Certificate Authority
+#     Generate Wildcard Server Certificate
+#     Trust Certificate Authority
+
+#     ${out}=  Run  cp /root/ca/cert-bundle.tgz .; tar xvf cert-bundle.tgz
+#     Log  ${out}
+
+#     # Run vic-machine install, supply server cert and key
+#     ${output}=  Run  bin/vic-machine-linux configure --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --tls-key "bundle/*.%{DOMAIN}.key.pem" --tls-cert "bundle/*.%{DOMAIN}.cert.pem" ${vicmachinetls} --debug 1
+#     Log  ${output}
+#     Should Contain  ${output}  Loaded server certificate bundle
+#     Should Contain  ${output}  Unable to locate existing CA in cert path
+#     Should Contain  ${output}  Completed successfully
+
+
+    # ${output}=  Run  openssl s_client -showcerts -connect %{VCH-IP}:2378
+    # Log  ${output}
+    # Should Contain  ${output}  issuer=/C=US/ST=California/L=Los Angeles/O=Stark Enterprises/OU=Stark Enterprises Certificate Authority/CN=Stark Enterprises Global CA
+
+    # Run  rm -rf bundle
+    # Run  rm -f cert-bundle.tgz
+    # Run  rm -rf /root/ca
+
+    # Reload Default Certificate Authorities
+
+Configure VCH - Run Configure Without Cert Options & Ensure Certs Are Unchanged
     ${domain}=  Get Environment Variable  DOMAIN  ''
     Run Keyword If  '${domain}' == ''  Pass Execution  Skipping test - domain not set, won't generate keys
 
@@ -81,8 +111,9 @@ Configure VCH - Server cert with trusted CA
     ${out}=  Run  cp /root/ca/cert-bundle.tgz .; tar xvf cert-bundle.tgz
     Log  ${out}
 
-    # Run vic-machine install, supply server cert and key
-    ${output}=  Run  bin/vic-machine-linux configure --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --tls-key "bundle/*.%{DOMAIN}.key.pem" --tls-cert "bundle/*.%{DOMAIN}.cert.pem" ${vicmachinetls} --debug 1
+    Run  rm -rf foo-bar-certs
+    # Run vic-machine configure, supply server cert and key
+    ${output}=  Run  bin/vic-machine-linux configure --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --tls-key "bundle/*.%{DOMAIN}.key.pem" --tls-cert "bundle/*.%{DOMAIN}.cert.pem" ${vicmachinetls} --cert-path=foo-bar-certs --debug 1
     Log  ${output}
     Should Contain  ${output}  Loaded server certificate bundle
     Should Contain  ${output}  Unable to locate existing CA in cert path
@@ -99,20 +130,39 @@ Configure VCH - Server cert with trusted CA
 
     Reload Default Certificate Authorities
 
-Configure VCH - Replace certificates with self-signed certificate using --cert-path
+    # Run vic-machine configure, supply server cert and key
+    ${output}=  Run  bin/vic-machine-linux configure --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} ${vicmachinetls} --debug 1
+
+    Log  ${output}
+    Should Contain  ${output}  No certificate regeneration requested. No new certificates provided. Certificates left unchanged
+
+    ${output}=  Run  openssl s_client -showcerts -connect %{VCH-IP}:2378
+    Log  ${output}
+    Should Contain  ${output}  issuer=/C=US/ST=California/L=Los Angeles/O=Stark Enterprises/OU=Stark Enterprises Certificate Authority/CN=Stark Enterprises Global CA
+
+    Run  rm -rf bundle
+    Run  rm -f cert-bundle.tgz
+    Run  rm -rf /root/ca
+
+    Reload Default Certificate Authorities
+
+Configure VCH - Replace certificates with self-signed certificate using --no-tlsverify
 
     ${domain}=  Get Environment Variable  DOMAIN  ''
     Run Keyword If  '${domain}' == ''  Pass Execution  Skipping test - domain not set, won't generate keys
-    Run  rm -rf foo-bar-certs
-    ${output}=  Run  bin/vic-machine-linux configure --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} ${vicmachinetls} --cert-path "foo-bar-certs" --debug 1 --regenerate-certs
 
-    Should Contain  ${output}  Generating CA certificate/key pair - private key in foo-bar-certs/ca-key.pem
-    Should Contain  ${output}  Generating server certificate/key pair - private key in foo-bar-certs/server-key.pem
-    Should Contain  ${output}  Generating client certificate/key pair - private key in foo-bar-certs/key.pem
-    Should Contain  ${output}  Generated browser friendly PFX client certificate - certificate in foo-bar-certs/cert.pfx
+    Run  rm -rf foo-bar-certs
+    ${output}=  Run  bin/vic-machine-linux configure --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} ${vicmachinetls} --cert-path "foo-bar-certs" --debug 1 --no-tlsverify
+
+    Should Contain  ${output}  Generating self-signed certificate/key pair - private key in foo-bar-certs/server-key.pem
 
     Should Contain  ${output}  Completed successfully
 
     ${output}=  Run  openssl s_client -showcerts -connect %{VCH-IP}:2378
     Log  ${output}
-    Should Contain  ${output}  issuer=/O=%{VCH-NAME}
+
+    Should Contain  ${output}  Verify return code: 21 (unable to verify the first certificate)
+    Should Contain  ${output}  verify error:num=20:unable to get local issuer certificate
+    Should Not Contain  ${output}  issuer=/C=US/ST=California/L=Los Angeles/O=Stark Enterprises/OU=Stark Enterprises Certificate Authority/CN=Stark Enterprises Global CA
+
+    Run  rm -rf foo-bar-certs

--- a/tests/test-cases/Group6-VIC-Machine/6-17-Configure-TLS.robot
+++ b/tests/test-cases/Group6-VIC-Machine/6-17-Configure-TLS.robot
@@ -89,15 +89,15 @@ Configure VCH - Server cert with trusted CA
     Should Contain  ${output}  Completed successfully
 
 
-    # ${output}=  Run  openssl s_client -showcerts -connect %{VCH-IP}:2378
-    # Log  ${output}
-    # Should Contain  ${output}  issuer=/C=US/ST=California/L=Los Angeles/O=Stark Enterprises/OU=Stark Enterprises Certificate Authority/CN=Stark Enterprises Global CA
+    ${output}=  Run  openssl s_client -showcerts -connect %{VCH-IP}:2378
+    Log  ${output}
+    Should Contain  ${output}  issuer=/C=US/ST=California/L=Los Angeles/O=Stark Enterprises/OU=Stark Enterprises Certificate Authority/CN=Stark Enterprises Global CA
 
-    # Run  rm -rf bundle
-    # Run  rm -f cert-bundle.tgz
-    # Run  rm -rf /root/ca
+    Run  rm -rf bundle
+    Run  rm -f cert-bundle.tgz
+    Run  rm -rf /root/ca
 
-    # Reload Default Certificate Authorities
+    Reload Default Certificate Authorities
 
 Configure VCH - Run Configure Without Cert Options & Ensure Certs Are Unchanged
     ${domain}=  Get Environment Variable  DOMAIN  ''

--- a/tests/test-cases/Group6-VIC-Machine/6-17-Configure-TLS.robot
+++ b/tests/test-cases/Group6-VIC-Machine/6-17-Configure-TLS.robot
@@ -17,6 +17,8 @@ Documentation  Test 6-13 - Verify vic-machine configure TLS options
 Resource  ../../resources/Util.robot
 Suite Teardown  Run Keyword  Cleanup
 Suite Setup  Run Keyword  Setup Test Environment
+Test Teardown  Test Cleanup
+Suite Teardown  Suite Cleanup
 
 *** Keywords ***
 Setup Test Environment
@@ -38,9 +40,11 @@ Setup Test Environment
     Should Contain  ${save_env}  DOCKER_CERT_PATH=${EXECDIR}/foo-bar-certs
     Log To Console  Installer completed successfully: %{VCH-NAME}
 
-Cleanup
-    Run  rm -rf bundle; rm -rf foo-bar-certs
+Suite Cleanup
     Run Keyword  Cleanup VIC Appliance On Test Server
+
+Test Cleanup
+    Run  rm -rf bundle cert-bundle.tgz out-bundle /root/ca
 
 *** Test Cases ***
 Configure VCH - Server cert with untrusted CA
@@ -62,12 +66,6 @@ Configure VCH - Server cert with untrusted CA
     ${output}=  Run  openssl s_client -showcerts -connect %{VCH-IP}:2378
     Log  ${output}
     Should Contain  ${output}  issuer=/C=US/ST=California/L=Los Angeles/O=Stark Enterprises/OU=Stark Enterprises Certificate Authority/CN=Stark Enterprises Global CA
-
-    Run  rm -rf bundle
-    Run  rm -f cert-bundle.tgz
-    Run  rm -f out-bundle
-    Run  rm -rf /root/ca
-
 
 Configure VCH - Server cert with trusted CA
     ${domain}=  Get Environment Variable  DOMAIN  ''
@@ -92,10 +90,6 @@ Configure VCH - Server cert with trusted CA
     ${output}=  Run  openssl s_client -showcerts -connect %{VCH-IP}:2378
     Log  ${output}
     Should Contain  ${output}  issuer=/C=US/ST=California/L=Los Angeles/O=Stark Enterprises/OU=Stark Enterprises Certificate Authority/CN=Stark Enterprises Global CA
-
-    Run  rm -rf bundle
-    Run  rm -f cert-bundle.tgz
-    Run  rm -rf /root/ca
 
     Reload Default Certificate Authorities
 
@@ -140,10 +134,6 @@ Configure VCH - Run Configure Without Cert Options & Ensure Certs Are Unchanged
     Log  ${output}
     Should Contain  ${output}  issuer=/C=US/ST=California/L=Los Angeles/O=Stark Enterprises/OU=Stark Enterprises Certificate Authority/CN=Stark Enterprises Global CA
 
-    Run  rm -rf bundle
-    Run  rm -f cert-bundle.tgz
-    Run  rm -rf /root/ca
-
     Reload Default Certificate Authorities
 
 Configure VCH - Replace certificates with self-signed certificate using --no-tlsverify
@@ -164,5 +154,3 @@ Configure VCH - Replace certificates with self-signed certificate using --no-tls
     Should Contain  ${output}  Verify return code: 21 (unable to verify the first certificate)
     Should Contain  ${output}  verify error:num=20:unable to get local issuer certificate
     Should Not Contain  ${output}  issuer=/C=US/ST=California/L=Los Angeles/O=Stark Enterprises/OU=Stark Enterprises Certificate Authority/CN=Stark Enterprises Global CA
-
-    Run  rm -rf foo-bar-certs


### PR DESCRIPTION
Adds the ability to insert new certificates & regenerate self-signed certificates in the VCH using `vic-machine configure`. Has a couple small things I still want to tweak before I merge this but the basic functionality is complete, basic tests are provided, and it's definitely past due getting some feedback.

I'm pretty much expecting a lot of feedback, especially over the refactoring of the `processCertificates` methods into the `common` package, so please don't hold back 😆 