### PR TITLE
Give the system a break if it isn't ready for adding hosts

### DIFF
--- a/tests/resources/Vsphere-Util.robot
+++ b/tests/resources/Vsphere-Util.robot
@@ -203,6 +203,7 @@ Add Host To VCenter
     \   ${out}=  Run  govc cluster.add -hostname=${host} -username=${user} -dc=${dc} -password=${pw} -noverify=true
     \   ${status}=  Run Keyword And Return Status  Should Contain  ${out}  OK
     \   Return From Keyword If  ${status}
+    \   Sleep  3 minutes
     Fail  Failed to add the host to the VC in 3 attempts
 
 Get Host Firewall Enabled


### PR DESCRIPTION
fixes #5199 

If the system is not succeeding to add a host, it doesn't help to keep hammering it, so let's sleep for a few minutes and try again after the sleep.