### PR TITLE
Log what happens during parallel ESXi deploy

### DIFF
--- a/tests/resources/Nimbus-Util.robot
+++ b/tests/resources/Nimbus-Util.robot
@@ -98,7 +98,9 @@ Deploy Multiple Nimbus ESXi Servers in Parallel
 
     :FOR  ${process}  IN  @{processes}
     \    ${pid}=  Convert To Integer  ${process}
-    \    Wait For Process  ${pid}
+    \    ${result}=  Wait For Process  ${pid}
+    \    Log  ${result.stdout}
+    \    Log  ${result.stderr}
 
     &{ips}=  Create Dictionary
     :FOR  ${name}  IN  @{names}


### PR DESCRIPTION
fixes #5212 
fixes #5210 

In this case, all ESXi failed to deploy which caused the add host to VC to fail. We don't have any logging here to see exactly why the ESXi deploy failed.  So this adds that logging and closes the bug until we see that issue again.