### PR TITLE
Bring imagec binary back for dev tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -148,11 +148,11 @@ all: components tethers isos vic-machine vic-ui
 tools: $(GOIMPORTS) $(GVT) $(GOLINT) $(SWAGGER) $(GAS) $(MISSPELL) goversion
 check: goversion goimports gofmt misspell govet golint copyright whitespace gas
 apiservers: $(portlayerapi) $(docker-engine-api)
-components: check apiservers $(imagec) $(vicadmin) $(rpctool)
+components: check apiservers $(vicadmin) $(rpctool)
 isos: $(appliance) $(bootstrap)
 tethers: $(tether-linux)
 
-most: $(portlayerapi) $(docker-engine-api) $(imagec) $(vicadmin) $(tether-linux) $(appliance) $(bootstrap) $(vic-machine-linux)
+most: $(portlayerapi) $(docker-engine-api) $(vicadmin) $(tether-linux) $(appliance) $(bootstrap) $(vic-machine-linux)
 
 # utility targets
 goversion:
@@ -344,7 +344,7 @@ $(appliance-staging): isos/appliance-staging.sh $(iso-base)
 	@$(TIME) $< -c $(BIN)/.yum-cache.tgz -p $(iso-base) -o $@
 
 # main appliance target - depends on all top level component targets
-$(appliance): isos/appliance.sh isos/appliance/* isos/vicadmin/** $(vicadmin) $(imagec) $(vic-init) $(portlayerapi) $(docker-engine-api) $(appliance-staging)
+$(appliance): isos/appliance.sh isos/appliance/* isos/vicadmin/** $(vicadmin) $(vic-init) $(portlayerapi) $(docker-engine-api) $(appliance-staging)
 	@echo building VCH appliance ISO
 	@$(TIME) $< -p $(appliance-staging) -b $(BIN)
 

--- a/cmd/imagec/hook.go
+++ b/cmd/imagec/hook.go
@@ -1,0 +1,47 @@
+// Copyright 2017 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/Sirupsen/logrus"
+)
+
+// ErrorHook is a simple logrus hook to duplicate Fatalf leveled error messages to stderr
+type ErrorHook struct {
+	w io.Writer
+}
+
+// NewErrorHook returns an empty ErrorHook struct
+func NewErrorHook(w io.Writer) *ErrorHook {
+	return &ErrorHook{w: w}
+}
+
+// Fire dumps the entry.Message to Stderr
+func (hook *ErrorHook) Fire(entry *logrus.Entry) error {
+	err := fmt.Errorf("%s", entry.Message)
+	fmt.Fprintf(hook.w, string(sf.FormatError(err)))
+
+	return nil
+}
+
+// Levels returns the logging level that we want to subscribe
+func (hook *ErrorHook) Levels() []logrus.Level {
+	return []logrus.Level{
+		logrus.FatalLevel,
+	}
+}

--- a/cmd/imagec/main.go
+++ b/cmd/imagec/main.go
@@ -1,0 +1,177 @@
+// Copyright 2016-2017 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"runtime/debug"
+	"runtime/trace"
+	"time"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/docker/docker/pkg/streamformatter"
+	"github.com/docker/docker/reference"
+	"github.com/pkg/profile"
+
+	"github.com/vmware/vic/lib/imagec"
+	"github.com/vmware/vic/pkg/version"
+)
+
+var (
+	imageCOptions = ImageCOptions{}
+
+	// https://raw.githubusercontent.com/docker/docker/master/distribution/pull_v2.go
+	sf = streamformatter.NewJSONStreamFormatter()
+)
+
+const (
+	PullImage = "pull"
+	PushImage = "push"
+)
+
+// ImageCOptions wraps the cli arguments
+type ImageCOptions struct {
+	imageName string
+
+	options imagec.Options
+
+	logfile string
+
+	stdout bool
+	debug  bool
+
+	profiling string
+	tracing   bool
+
+	operation string
+}
+
+func init() {
+
+	flag.StringVar(&imageCOptions.imageName, "reference", "", "Name of the reference")
+
+	flag.StringVar(&imageCOptions.options.Destination, "destination", imagec.DefaultDestination, "Destination directory")
+
+	flag.StringVar(&imageCOptions.options.Host, "host", imagec.DefaultPortLayerHost, "Host that runs portlayer API (FQDN:port format)")
+
+	flag.StringVar(&imageCOptions.logfile, "logfile", imagec.DefaultLogfile, "Path of the imagec log file")
+
+	flag.StringVar(&imageCOptions.options.Username, "username", "", "Username")
+	flag.StringVar(&imageCOptions.options.Password, "password", "", "Password")
+
+	flag.DurationVar(&imageCOptions.options.Timeout, "timeout", imagec.DefaultHTTPTimeout, "HTTP timeout")
+
+	flag.BoolVar(&imageCOptions.stdout, "stdout", false, "Enable writing to stdout")
+	flag.BoolVar(&imageCOptions.debug, "debug", false, "Show debug logging")
+	flag.BoolVar(&imageCOptions.options.InsecureSkipVerify, "insecure-skip-verify", false, "Don't verify certificates when fetching images")
+	flag.BoolVar(&imageCOptions.options.InsecureAllowHTTP, "insecure-allow-http", false, "Uses unencrypted connections when fetching images")
+	flag.BoolVar(&imageCOptions.options.Standalone, "standalone", false, "Disable port-layer integration")
+
+	flag.StringVar(&imageCOptions.profiling, "profile.mode", "", "Enable profiling mode, one of [cpu, mem, block]")
+	flag.BoolVar(&imageCOptions.tracing, "tracing", false, "Enable runtime tracing")
+
+	flag.StringVar(&imageCOptions.operation, "operation", "pull", "Pull/push an image")
+
+	flag.StringVar(&imageCOptions.options.Registry, "registry", imagec.DefaultDockerURL, "Registry to pull/push images (default: registry-1.docker.io)")
+
+	flag.Parse()
+
+	var err error
+	if imageCOptions.options.Reference, err = reference.ParseNamed(imageCOptions.imageName); err != nil {
+		panic(err)
+	}
+}
+
+func main() {
+	defer func() {
+		if r := recover(); r != nil {
+			fmt.Fprintf(os.Stderr, string(sf.FormatError(fmt.Errorf("%s : %s", r, debug.Stack()))))
+		}
+	}()
+
+	if version.Show() {
+		fmt.Fprintf(os.Stdout, "%s\n", version.String())
+		return
+	}
+
+	// Enable profiling if mode is set
+	switch imageCOptions.profiling {
+	case "cpu":
+		defer profile.Start(profile.CPUProfile, profile.ProfilePath("."), profile.Quiet).Stop()
+	case "mem":
+		defer profile.Start(profile.MemProfile, profile.ProfilePath("."), profile.Quiet).Stop()
+	case "block":
+		defer profile.Start(profile.BlockProfile, profile.ProfilePath("."), profile.Quiet).Stop()
+	default:
+		// do nothing
+	}
+
+	// Register our custom Error hook
+	log.AddHook(NewErrorHook(os.Stderr))
+
+	// Enable runtime tracing if tracing is true
+	if imageCOptions.tracing {
+		tracing, err := os.Create(time.Now().Format("2006-01-02T150405.pprof"))
+		if err != nil {
+			log.Fatalf("Failed to create tracing logfile: %s", err)
+		}
+		defer tracing.Close()
+
+		if err := trace.Start(tracing); err != nil {
+			log.Fatalf("Failed to start tracing: %s", err)
+		}
+		defer trace.Stop()
+	}
+
+	// Open the log file
+	// #nosec: Expect file permissions to be 0600 or less
+	f, err := os.OpenFile(imageCOptions.logfile, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0644)
+	if err != nil {
+		log.Fatalf("Failed to open the logfile %s: %s", imageCOptions.logfile, err)
+	}
+	defer f.Close()
+
+	// Initiliaze logger with default TextFormatter
+	log.SetFormatter(&log.TextFormatter{DisableColors: true, FullTimestamp: true})
+
+	// Set the log level
+	if imageCOptions.debug {
+		log.SetLevel(log.DebugLevel)
+	}
+
+	// SetOutput to log file and/or stdout
+	log.SetOutput(f)
+	if imageCOptions.stdout {
+		log.SetOutput(io.MultiWriter(os.Stdout, f))
+	}
+
+	if imageCOptions.operation == PullImage {
+		options := imageCOptions.options
+
+		options.Outstream = os.Stdout
+
+		ic := imagec.NewImageC(options, streamformatter.NewJSONStreamFormatter())
+		if err := ic.PullImage(); err != nil {
+			log.Fatalf("Pulling image failed due to %s\n", err)
+		}
+	} else if imageCOptions.operation == PushImage {
+		log.Errorf("The operation '%s' is not implemented\n", PushImage)
+	} else {
+		log.Errorf("The operation '%s' is not valid\n", imageCOptions.operation)
+	}
+}

--- a/lib/imagec/imagec.go
+++ b/lib/imagec/imagec.go
@@ -15,6 +15,7 @@
 package imagec
 
 import (
+	"context"
 	"crypto/sha256"
 	"crypto/x509"
 	"encoding/json"
@@ -25,8 +26,6 @@ import (
 	"path"
 	"strings"
 	"time"
-
-	"context"
 
 	log "github.com/Sirupsen/logrus"
 
@@ -107,6 +106,9 @@ type Options struct {
 
 	// RegistryCAs will not be modified by imagec
 	RegistryCAs *x509.CertPool
+
+	// If being set to true, do not bother portlayer or persona
+	Standalone bool
 }
 
 // ImageWithMeta wraps the models.Image with some additional metadata
@@ -259,6 +261,10 @@ func (ic *ImageC) LayersToDownload() ([]*ImageWithMeta, error) {
 // that resides in the docker persona.  This will add image tag,
 // digest and layer information.
 func updateRepositoryCache(ic *ImageC) error {
+	// if standalone then no persona, so exit
+	if ic.Standalone {
+		return nil
+	}
 
 	// LayerID for the image layer
 	imageLayerID := ic.ImageLayers[0].ID
@@ -325,10 +331,15 @@ func (ic *ImageC) WriteImageBlob(image *ImageWithMeta, progressOutput progress.O
 	)
 	defer in.Close()
 
-	// Write the image
-	err = WriteImage(ic.Host, image, in)
-	if err != nil {
-		return fmt.Errorf("Failed to write to image store: %s", err)
+	if !ic.Standalone {
+		// Write the image
+		err = WriteImage(ic.Host, image, in)
+		if err != nil {
+			return fmt.Errorf("Failed to write to image store: %s", err)
+		}
+	} else {
+		// If standalone, write to a local directory
+		cleanup = false
 	}
 
 	progress.Update(progressOutput, image.String(), "Pull complete")
@@ -452,15 +463,24 @@ func (ic *ImageC) PullImage() error {
 
 	if host != "" {
 		log.Infof("Using UUID (%s) for imagestore name", host)
+	} else if ic.Standalone {
+		host, err = os.Hostname()
+		log.Infof("Using host (%s) for imagestore name", host)
 	}
 
 	ic.Storename = host
 
-	// Ping the server to ensure it's at least running
-	ok, err := PingPortLayer(ic.Host)
-	if err != nil || !ok {
-		log.Errorf("Failed to ping portlayer: %s", err)
-		return err
+	if !ic.Standalone {
+		log.Debugf("Running with portlayer")
+
+		// Ping the server to ensure it's at least running
+		ok, err := PingPortLayer(ic.Host)
+		if err != nil || !ok {
+			log.Errorf("Failed to ping portlayer: %s", err)
+			return err
+		}
+	} else {
+		log.Debugf("Running standalone")
 	}
 
 	// Calculate (and overwrite) the registry URL and make sure that it responds to requests

--- a/lib/imagec/imagec.go
+++ b/lib/imagec/imagec.go
@@ -107,7 +107,7 @@ type Options struct {
 	// RegistryCAs will not be modified by imagec
 	RegistryCAs *x509.CertPool
 
-	// If being set to true, do not bother portlayer or persona
+	// If true, do not bother portlayer or persona
 	Standalone bool
 }
 

--- a/vendor/github.com/vmware/vmw-guestinfo/examples/main.go
+++ b/vendor/github.com/vmware/vmw-guestinfo/examples/main.go
@@ -1,4 +1,4 @@
-// Copyright 2016 VMware, Inc. All Rights Reserved.
+// Copyright 2017 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/vmware/vmw-guestinfo/examples/main.go
+++ b/vendor/github.com/vmware/vmw-guestinfo/examples/main.go
@@ -1,4 +1,4 @@
-// Copyright 2017 VMware, Inc. All Rights Reserved.
+// Copyright 2016 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
fixes #5330 

This is only used for dev test purposes so there is no need to add integration test.
 
To run it in standalone mode without starting persona/portlayer, run `sudo bin/imagec --reference=busybox:latest --operation=push --standalone`; this cmd will pull `busybox` from dockerhub by default. 

In standalone mode, the image tar will be written to a local folder `images`
