### PR TITLE
populate scratch with min os structure

### DIFF
--- a/isos/bootstrap/bootstrap
+++ b/isos/bootstrap/bootstrap
@@ -28,8 +28,6 @@ mkdir -p /mnt/containerfs
 echo "Waiting for rootfs"
 while [ ! -e /dev/disk/by-label/containerfs ]; do sleep 0.1;done
 if mount -t ext4 /dev/disk/by-label/containerfs ${MOUNTPOINT}; then
-    # ensure mountpoint exists
-    mkdir -p ${MOUNTPOINT}/.tether
 
     # ensure that no matter what we have access to required devices
     # WARNING WARNING WARNING WARNING WARNING

--- a/lib/portlayer/storage/vsphere/image.go
+++ b/lib/portlayer/storage/vsphere/image.go
@@ -55,6 +55,8 @@ var (
 		"/proc":             0555,
 		"/sys":              0555,
 		"/usr/lib/iptables": 0755,
+		// The permission of .tether should be drwxrwxrwt.
+		// The sticky bit 't' is added when mounting the tmpfs in bootstrap
 		"/.tether":          0777,
 	}
 )

--- a/lib/portlayer/storage/vsphere/image.go
+++ b/lib/portlayer/storage/vsphere/image.go
@@ -49,14 +49,14 @@ var (
 		"/etc/hosts":       0644,
 		"/etc/resolv.conf": 0644,
 	}
+	// Here the permission of .tether should be drwxrwxrwt.
+	// The sticky bit 't' is added when mounting the tmpfs in bootstrap
 	DirForMinOS = map[string]os.FileMode{
 		"/etc":              0755,
 		"/lib/modules":      0755,
 		"/proc":             0555,
 		"/sys":              0555,
 		"/usr/lib/iptables": 0755,
-		// The permission of .tether should be drwxrwxrwt.
-		// The sticky bit 't' is added when mounting the tmpfs in bootstrap
 		"/.tether":          0777,
 	}
 )

--- a/lib/portlayer/storage/vsphere/image.go
+++ b/lib/portlayer/storage/vsphere/image.go
@@ -662,7 +662,7 @@ func imagesInUse(op trace.Operation, ID string) error {
 	return nil
 }
 
-// populate the scratch with minimum OS structure refined in fileMinOS and dirMinOS
+// populate the scratch with minimum OS structure defined in FileForMinOS and DirForMinOS
 func populateMinOS(op trace.Operation, vmdisk *disk.VirtualDisk) error {
 	// tmp dir to mount the disk
 	dir, err := ioutil.TempDir("", "mnt-"+portlayer.Scratch.ID)
@@ -679,7 +679,7 @@ func populateMinOS(op trace.Operation, vmdisk *disk.VirtualDisk) error {
 		dirPath := fmt.Sprintf("%s%s", dir, dname)
 		m, err := strconv.ParseUint(dmode, 0, 0)
 		if err != nil {
-			op.Errorf("Failed to ParseUInt for %s: %e", dmode, err)
+			op.Errorf("Failed to ParseUint for %s: %e", dmode, err)
 		}
 		if err = os.MkdirAll(dirPath, os.FileMode(m)); err != nil {
 			op.Errorf("Failed to create directory %s: %s", dirPath, err)
@@ -697,7 +697,7 @@ func populateMinOS(op trace.Operation, vmdisk *disk.VirtualDisk) error {
 		}
 		n, err := strconv.ParseUint(fmode, 0, 0)
 		if err != nil {
-			op.Errorf("Failed to ParseUInt for %s: %e", fmode, err)
+			op.Errorf("Failed to ParseUint for %s: %e", fmode, err)
 		}
 		err = f.Chmod(os.FileMode(n))
 		if err != nil {

--- a/lib/portlayer/storage/vsphere/image.go
+++ b/lib/portlayer/storage/vsphere/image.go
@@ -427,7 +427,7 @@ func (v *ImageStore) scratch(op trace.Operation, storeName string) error {
 		return err
 	}
 
-	if err = populateMinOS(op, vmdisk); err != nil {
+	if err = createBaseStructure(op, vmdisk); err != nil {
 		return err
 	}
 
@@ -665,7 +665,7 @@ func imagesInUse(op trace.Operation, ID string) error {
 }
 
 // populate the scratch with minimum OS structure defined in FileForMinOS and DirForMinOS
-func populateMinOS(op trace.Operation, vmdisk *disk.VirtualDisk) error {
+func createBaseStructure(op trace.Operation, vmdisk *disk.VirtualDisk) (err error) {
 	// tmp dir to mount the disk
 	dir, err := ioutil.TempDir("", "mnt-"+portlayer.Scratch.ID)
 	if err != nil {
@@ -673,8 +673,12 @@ func populateMinOS(op trace.Operation, vmdisk *disk.VirtualDisk) error {
 	}
 
 	defer func() {
-		if err = os.RemoveAll(dir); err != nil {
-			op.Errorf("Failed to remove tempDir: %s", err)
+		e1 := os.RemoveAll(dir)
+		if e1 != nil {
+			op.Errorf("Failed to remove tempDir: %s", e1)
+			if err == nil {
+				err = e1
+			}
 		}
 	}()
 
@@ -684,8 +688,12 @@ func populateMinOS(op trace.Operation, vmdisk *disk.VirtualDisk) error {
 	}
 
 	defer func() {
-		if err = vmdisk.Unmount(); err != nil {
-			op.Errorf("Failed to unmount device: %s", err)
+		e2 := vmdisk.Unmount()
+		if e2 != nil {
+			op.Errorf("Failed to unmount device: %s", e2)
+			if err == nil {
+				err = e2
+			}
 		}
 	}()
 

--- a/lib/portlayer/storage/vsphere/image.go
+++ b/lib/portlayer/storage/vsphere/image.go
@@ -22,6 +22,7 @@ import (
 	"net/url"
 	"os"
 	"path"
+	"strconv"
 	"strings"
 
 	"github.com/docker/docker/pkg/archive"
@@ -41,7 +42,22 @@ import (
 var StorageParentDir = "VIC"
 
 // Set to false for unit tests
-var DetachAll = true
+var (
+	DetachAll = true
+
+	FileForMinOS = map[string]string{
+		"/etc/hostname":    "0644",
+		"/etc/hosts":       "0644",
+		"/etc/resolv.conf": "0644",
+	}
+	DirForMinOS = map[string]string{
+		"/etc":              "0755",
+		"/lib/modules":      "0755",
+		"/proc":             "0555",
+		"/sys":              "0555",
+		"/usr/lib/iptables": "0755",
+	}
+)
 
 const (
 	StorageImageDir  = "images"
@@ -409,6 +425,10 @@ func (v *ImageStore) scratch(op trace.Operation, storeName string) error {
 		return err
 	}
 
+	if err = populateMinOS(op, vmdisk); err != nil {
+		return err
+	}
+
 	if err = v.dm.Detach(op, vmdisk); err != nil {
 		return err
 	}
@@ -637,6 +657,64 @@ func imagesInUse(op trace.Operation, ID string) error {
 				Msg: fmt.Sprintf("image %s in use by %s", ID, cont.ExecConfig.ID),
 			}
 		}
+	}
+
+	return nil
+}
+
+// populate the scratch with minimum OS structure refined in fileMinOS and dirMinOS
+func populateMinOS(op trace.Operation, vmdisk *disk.VirtualDisk) error {
+	// tmp dir to mount the disk
+	dir, err := ioutil.TempDir("", "mnt-"+portlayer.Scratch.ID)
+	if err != nil {
+		op.Errorf("Failed to create tempDir: %s", err)
+	}
+	defer os.RemoveAll(dir)
+
+	if err = vmdisk.Mount(dir, nil); err != nil {
+		op.Errorf("Failed to mount device %s to dir %s", vmdisk.DevicePath, dir)
+	}
+
+	for dname, dmode := range DirForMinOS {
+		dirPath := fmt.Sprintf("%s%s", dir, dname)
+		m, err := strconv.ParseUint(dmode, 0, 0)
+		if err != nil {
+			op.Errorf("Failed to ParseUInt for %s: %e", dmode, err)
+		}
+		if err = os.MkdirAll(dirPath, os.FileMode(m)); err != nil {
+			op.Errorf("Failed to create directory %s: %s", dirPath, err)
+			return err
+		}
+	}
+
+	// The directory has to exist before creating the new file
+	for fname, fmode := range FileForMinOS {
+		filePath := fmt.Sprintf("%s%s", dir, fname)
+		f, err := os.Create(filePath)
+		if err != nil {
+			op.Errorf("Failed to create file %s: %s", filePath, err)
+			return err
+		}
+		n, err := strconv.ParseUint(fmode, 0, 0)
+		if err != nil {
+			op.Errorf("Failed to ParseUInt for %s: %e", fmode, err)
+		}
+		err = f.Chmod(os.FileMode(n))
+		if err != nil {
+			op.Errorf("Failed to chmod for file %s: %s", filePath, err)
+			return err
+		}
+		err = f.Close()
+		if err != nil {
+			op.Errorf("Failed to close file %s: %s", filePath, err)
+			return err
+		}
+	}
+
+	err = vmdisk.Unmount()
+	if err != nil {
+		op.Errorf("Failed to unmount device: %s", err)
+		return err
 	}
 
 	return nil


### PR DESCRIPTION
This is about the first part of #489 . When creating the `scratch` during `image-store` creation, I also create certain files/folders required as the minimum OS structure so that these files/folders do not show up in `docker diff`.

Next step (in a separate PR): bind-mount these files/folders as discussed [here](https://github.com/vmware/vic/issues/489#issuecomment-308573659). 
