### PR TITLE
Create .tether folder in bootstrap

### DIFF
--- a/isos/bootstrap/bootstrap
+++ b/isos/bootstrap/bootstrap
@@ -28,6 +28,8 @@ mkdir -p /mnt/containerfs
 echo "Waiting for rootfs"
 while [ ! -e /dev/disk/by-label/containerfs ]; do sleep 0.1;done
 if mount -t ext4 /dev/disk/by-label/containerfs ${MOUNTPOINT}; then
+    # ensure mountpoint exists
+    mkdir -p ${MOUNTPOINT}/.tether
 
     # ensure that no matter what we have access to required devices
     # WARNING WARNING WARNING WARNING WARNING


### PR DESCRIPTION
This should fix all the test failures seen in ci build 11638.

The reason is:
In PR #5493 , the `.tether` folder is already created in `scratch` when creating the image-store, therefore there is no need to `mkdir /.tether` in `bootstrap`. However, in the VCH upgrade related tests, the image-store was created by an older-version VCH which didn't create the `.tether` folder in the scratch vmdk. So VM creation from an upgraded VCH would fail when running the bootstrap.