### PR TITLE
add scratch version number to the metadata of scratch disk

### DIFF
--- a/lib/metadata/ScratchMetaData.go
+++ b/lib/metadata/ScratchMetaData.go
@@ -1,0 +1,19 @@
+// Copyright 2017 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metadata
+
+type ScratchMetaData struct {
+	ScratchVersion   int            `json:"scratch_version"`
+}

--- a/lib/metadata/ScratchMetaData.go
+++ b/lib/metadata/ScratchMetaData.go
@@ -15,5 +15,5 @@
 package metadata
 
 type ScratchMetaData struct {
-	ScratchVersion   int            `json:"scratch_version"`
+	ScratchVersion int `json:"scratch_version"`
 }

--- a/lib/metadata/scratch_disk.go
+++ b/lib/metadata/scratch_disk.go
@@ -15,5 +15,5 @@
 package metadata
 
 type ScratchMetaData struct {
-	ScratchVersion int `json:"scratch_version"`
+	ScratchVersion int `json:"portlayer.storage.scratchVersion"`
 }

--- a/lib/migration/feature/feature.go
+++ b/lib/migration/feature/feature.go
@@ -23,7 +23,7 @@ const (
 	ExecSupportedVersion
 	VicadminProxyVarRenameVersion
 	InsecureRegistriesTypeChangeVersion
-
+	ScratchBaseStructureVersion
 	// Add new feature flag here
 
 	// MaxPluginVersion must be the last

--- a/lib/portlayer/storage/vsphere/image.go
+++ b/lib/portlayer/storage/vsphere/image.go
@@ -64,11 +64,12 @@ var (
 )
 
 const (
-	StorageImageDir  = "images"
-	defaultDiskLabel = "containerfs"
-	defaultDiskSize  = 8388608
-	metaDataDir      = "imageMetadata"
-	manifest         = "manifest"
+	StorageImageDir     = "images"
+	defaultDiskLabel    = "containerfs"
+	defaultDiskSize     = 8388608
+	metaDataDir         = "imageMetadata"
+	manifest            = "manifest"
+	scratchMetaDataFile = "metaData"
 )
 
 type ImageStore struct {
@@ -401,7 +402,7 @@ func (v *ImageStore) scratch(op trace.Operation, storeName string) error {
 		ScratchVersion: feature.ScratchBaseStructureVersion,
 	}
 	meta := make(map[string][]byte)
-	meta["metaData"] = []byte(fmt.Sprintf("%+v", scratchMetaData))
+	meta[scratchMetaDataFile] = []byte(fmt.Sprintf("%+v", scratchMetaData))
 	if err := writeMetadata(op, v.ds, metaDataDir, meta); err != nil {
 		return err
 	}

--- a/lib/portlayer/storage/vsphere/image.go
+++ b/lib/portlayer/storage/vsphere/image.go
@@ -22,7 +22,6 @@ import (
 	"net/url"
 	"os"
 	"path"
-	"strconv"
 	"strings"
 
 	"github.com/docker/docker/pkg/archive"
@@ -37,6 +36,7 @@ import (
 	"github.com/vmware/vic/pkg/vsphere/datastore"
 	"github.com/vmware/vic/pkg/vsphere/disk"
 	"github.com/vmware/vic/pkg/vsphere/session"
+	"github.com/vmware/vic/lib/metadata"
 )
 
 // All paths on the datastore for images are relative to <datastore>/VIC/
@@ -69,7 +69,6 @@ const (
 	defaultDiskSize  = 8388608
 	metaDataDir      = "imageMetadata"
 	manifest         = "manifest"
-	scratchVersion = "scratchVersion"
 )
 
 type ImageStore struct {
@@ -398,8 +397,11 @@ func (v *ImageStore) scratch(op trace.Operation, storeName string) error {
 
 	// Write the metadata to the datastore
 	metaDataDir := v.imageMetadataDirPath(storeName, portlayer.Scratch.ID)
+	scratchMetaData := &metadata.ScratchMetaData{
+		ScratchVersion: feature.ScratchBaseStructureVersion,
+	}
 	meta := make(map[string][]byte)
-	meta[scratchVersion] = []byte(strconv.Itoa(feature.ScratchBaseStructureVersion))
+	meta["metaData"] = []byte(fmt.Sprintf("%+v",scratchMetaData))
 	if err := writeMetadata(op, v.ds, metaDataDir, meta); err != nil {
 		return err
 	}

--- a/lib/portlayer/storage/vsphere/image.go
+++ b/lib/portlayer/storage/vsphere/image.go
@@ -22,12 +22,14 @@ import (
 	"net/url"
 	"os"
 	"path"
+	"strconv"
 	"strings"
 
 	"github.com/docker/docker/pkg/archive"
 
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/vim25/types"
+	"github.com/vmware/vic/lib/migration/feature"
 	"github.com/vmware/vic/lib/portlayer/exec"
 	portlayer "github.com/vmware/vic/lib/portlayer/storage"
 	"github.com/vmware/vic/lib/portlayer/util"
@@ -67,6 +69,7 @@ const (
 	defaultDiskSize  = 8388608
 	metaDataDir      = "imageMetadata"
 	manifest         = "manifest"
+	scratchVersion = "scratchVersion"
 )
 
 type ImageStore struct {
@@ -395,7 +398,9 @@ func (v *ImageStore) scratch(op trace.Operation, storeName string) error {
 
 	// Write the metadata to the datastore
 	metaDataDir := v.imageMetadataDirPath(storeName, portlayer.Scratch.ID)
-	if err := writeMetadata(op, v.ds, metaDataDir, nil); err != nil {
+	meta := make(map[string][]byte)
+	meta[scratchVersion] = []byte(strconv.Itoa(feature.ScratchBaseStructureVersion))
+	if err := writeMetadata(op, v.ds, metaDataDir, meta); err != nil {
 		return err
 	}
 

--- a/lib/portlayer/storage/vsphere/image.go
+++ b/lib/portlayer/storage/vsphere/image.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/vim25/types"
+	"github.com/vmware/vic/lib/metadata"
 	"github.com/vmware/vic/lib/migration/feature"
 	"github.com/vmware/vic/lib/portlayer/exec"
 	portlayer "github.com/vmware/vic/lib/portlayer/storage"
@@ -36,7 +37,6 @@ import (
 	"github.com/vmware/vic/pkg/vsphere/datastore"
 	"github.com/vmware/vic/pkg/vsphere/disk"
 	"github.com/vmware/vic/pkg/vsphere/session"
-	"github.com/vmware/vic/lib/metadata"
 )
 
 // All paths on the datastore for images are relative to <datastore>/VIC/
@@ -401,7 +401,7 @@ func (v *ImageStore) scratch(op trace.Operation, storeName string) error {
 		ScratchVersion: feature.ScratchBaseStructureVersion,
 	}
 	meta := make(map[string][]byte)
-	meta["metaData"] = []byte(fmt.Sprintf("%+v",scratchMetaData))
+	meta["metaData"] = []byte(fmt.Sprintf("%+v", scratchMetaData))
 	if err := writeMetadata(op, v.ds, metaDataDir, meta); err != nil {
 		return err
 	}


### PR DESCRIPTION
This is part of #489 

- If the scratch version number is less than a certain number, the scratch disk wouldn't have the minimum os structure, and then PL needs to use a file mask for `diff`;
- Otherwise, the scratch is already populated with min os structure, so there is no need for the file mask.