### PR TITLE
Fix mount information in docker inspect

### DIFF
--- a/lib/apiservers/engine/backends/volume.go
+++ b/lib/apiservers/engine/backends/volume.go
@@ -42,6 +42,7 @@ const (
 	OptsVolumeStoreKey     string = "volumestore"
 	OptsCapacityKey        string = "capacity"
 	dockerMetadataModelKey string = "DockerMetaData"
+	DefaultVolumeDriver    string = "vsphere"
 )
 
 // define a set (whitelist) of valid driver opts keys for command line argument validation

--- a/tests/test-cases/Group1-Docker-Commands/1-23-Docker-Inspect.md
+++ b/tests/test-cases/Group1-Docker-Commands/1-23-Docker-Inspect.md
@@ -31,6 +31,7 @@ This test requires that a vSphere server is running and available
 18. Issue docker create -v /var/lib/test busybox
 19. Issue docker inspect -f {{.Config.Volumes}} <containerID>
 20. Issue docker inspect busybox -f '{{.RepoDigest}}'
+21. Issue docker inspect on container with both an anonymous and named volume bound to mount points
 
 # Expected Outcome:
 * Step 3,4,7,8 should result in success and a properly formatted JSON response
@@ -50,6 +51,7 @@ Error: No such image or container: fake
 ```
 * Step 19 should result in the map returned containing /var/lib/test
 * Step 20 should result in a valid digest, previously cached
+* Step 21 should result in valid Mounts data
 
 # Possible Problems:
 None

--- a/tests/test-cases/Group1-Docker-Commands/1-23-Docker-Inspect.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-23-Docker-Inspect.robot
@@ -109,3 +109,13 @@ Inspect RepoDigest is valid
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} inspect -f '{{.RepoDigests}}' ${busybox}
     Should Be Equal As Integers  ${rc}  0
     Should Contain  ${output}  ${busybox_digest}
+
+Docker inspect mount data
+    ${rc}  ${container}=  Run And Return Rc And Output  docker %{VCH-PARAMS} volume create --name=named-volume
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${container}=  Run And Return Rc And Output  docker %{VCH-PARAMS} create --name=test-with-volume -v /mnt/test -v named-volume:/mnt/named busybox
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${out}=  Run And Return Rc And Output  docker %{VCH-PARAMS} inspect -f '{{.Mounts}}' test-with-volume
+    Should Be Equal As Integers  ${rc}  0
+    Should Contain  ${out}  /mnt/test
+    Should Contain  ${out}  /mnt/named


### PR DESCRIPTION
Fixed mount information in docker inspect after container create.
There is still a problem with VCH restart that will be addressed
in 5558.

Resolves #5557