### PR TITLE
[specific ci=13-01-VAC-GuestFullName] Switch default registry to local harbor for Group13

### DIFF
--- a/tests/test-cases/Group13-VAC/13-01-VAC-GuestFullName.robot
+++ b/tests/test-cases/Group13-VAC/13-01-VAC-GuestFullName.robot
@@ -25,9 +25,9 @@ Check VCH VM Guest Operating System
     Should Contain  ${output}  Photon - VCH
 
 Create a test container and check Guest Operating System
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} pull busybox
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} pull ${busybox}
     Should Be Equal As Integers  ${rc}  0
-    ${rc}  ${id}=  Run And Return Rc And Output  docker %{VCH-PARAMS} create --name test busybox
+    ${rc}  ${id}=  Run And Return Rc And Output  docker %{VCH-PARAMS} create --name test ${busybox}
     Should Be Equal As Integers  ${rc}  0
     ${shortID}=  Get container shortID  ${id}
     ${rc}  ${output}=  Run And Return Rc And Output  govc vm.info test-${shortID} | grep 'Guest name'


### PR DESCRIPTION

Fixes #4181 

Switch the CI default registry to a local harbor instance.
This PR is specifically to test changes made to fix issue 4181- Group13-01-VAC-GuestFullName

