### PR TITLE
Implement archive Export in the storage portlayer

### DIFF
--- a/lib/apiservers/portlayer/restapi/handlers/storage_handlers_test.go
+++ b/lib/apiservers/portlayer/restapi/handlers/storage_handlers_test.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/vmware/vic/lib/apiservers/portlayer/models"
 	"github.com/vmware/vic/lib/apiservers/portlayer/restapi/operations/storage"
+	"github.com/vmware/vic/lib/archive"
 	spl "github.com/vmware/vic/lib/portlayer/storage"
 	"github.com/vmware/vic/lib/portlayer/util"
 	"github.com/vmware/vic/pkg/trace"
@@ -121,6 +122,10 @@ func (m *MockVolumeStore) VolumesList(op trace.Operation) ([]*spl.Volume, error)
 	return list, nil
 }
 
+func (m *MockVolumeStore) Export(op trace.Operation, store *url.URL, child, ancestor string, spec *archive.FilterSpec, data bool) (io.ReadCloser, error) {
+	return nil, nil
+}
+
 // GetImageStore checks to see if a named image store exists and returls the
 // URL to it if so or error.
 func (c *MockDataStore) GetImageStore(op trace.Operation, storeName string) (*url.URL, error) {
@@ -145,6 +150,10 @@ func (c *MockDataStore) DeleteImageStore(op trace.Operation, storeName string) e
 }
 
 func (c *MockDataStore) ListImageStores(op trace.Operation) ([]*url.URL, error) {
+	return nil, nil
+}
+
+func (c *MockDataStore) Export(op trace.Operation, store *url.URL, child, ancestor string, spec *archive.FilterSpec, data bool) (io.ReadCloser, error) {
 	return nil, nil
 }
 

--- a/lib/archive/archiver.go
+++ b/lib/archive/archiver.go
@@ -1,0 +1,106 @@
+// Copyright 2017 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package archive
+
+import (
+	"fmt"
+	"io"
+	"net/url"
+
+	"github.com/vmware/vic/pkg/trace"
+)
+
+// FilterType specifies what type of filter to apply in a FilterSpec
+type FilterType int
+
+const (
+	// Include specifies a path inclusion.
+	// Note: An included path that sits under an excluded path should be included.
+	// Example: if / is excluded, and /files is included, /files should  be added to the archive.
+	Include = iota
+	// Exclude specifies a path exclusion.
+	Exclude
+	// Rebase specifies a path rebase.
+	// The rebase path is prepended to the path in the archive header.
+	Rebase
+	// Strip specifies a path strip.
+	// The inverse of a rebase, the path is stripped from the header path
+	// before writing to disk.
+	Strip
+)
+
+// FilterSpec describes rules for handling specified paths during archival
+type FilterSpec struct {
+	Inclusions map[string]struct{}
+	Exclusions map[string]struct{}
+	RebasePath string
+	StripPath  string
+}
+
+// Archiver defines an API for creating archives consisting of data that
+// exist between a child and parent layer, as well as unpacking archives
+// to container filesystems
+type Archiver interface {
+
+	// Export reads the delta between child and ancestor layers, returning
+	// the difference as a tar archive.
+	//
+	// store - the store containing the two layers
+	// id - must inherit from ancestor if ancestor is specified
+	// ancestor - the old layer against which to diff. If omitted, the entire filesystem will be included
+	// spec - describes filters on paths found in the data (include, exclude, rebase, strip)
+	// data - include file data in the tar archive if true, headers only otherwise
+	Export(op trace.Operation, store *url.URL, id, ancestor string, spec *FilterSpec, data bool) (io.ReadCloser, error)
+}
+
+// CreateFilterSpec creates a FilterSpec from a supplied map
+func CreateFilterSpec(op trace.Operation, spec map[string]FilterType) (*FilterSpec, error) {
+	var rebase, strip string
+
+	fs := &FilterSpec{
+		Inclusions: make(map[string]struct{}),
+		Exclusions: make(map[string]struct{}),
+	}
+
+	if spec == nil {
+		return fs, nil
+	}
+
+	for k, v := range spec {
+		switch v {
+		case Include:
+			fs.Inclusions[k] = struct{}{}
+		case Exclude:
+			fs.Exclusions[k] = struct{}{}
+		case Rebase:
+			if rebase != "" {
+				return nil, fmt.Errorf("Error creating filter spec: only one rebase path allowed")
+			}
+			rebase = k
+		case Strip:
+			if strip != "" {
+				return nil, fmt.Errorf("Error creating filter spec: only one strip path allowed")
+			}
+			strip = k
+		default:
+			return nil, fmt.Errorf("Invalid filter specification: %d", v)
+		}
+	}
+
+	fs.RebasePath = rebase
+	fs.StripPath = strip
+
+	return fs, nil
+}

--- a/lib/archive/diff.go
+++ b/lib/archive/diff.go
@@ -1,0 +1,179 @@
+// Copyright 2017 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package archive
+
+import (
+	"archive/tar"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"time"
+
+	docker "github.com/docker/docker/pkg/archive"
+
+	"github.com/vmware/vic/pkg/trace"
+)
+
+const (
+	// ChangeTypeKey defines the key for the type of diff change stored in the tar Xattrs header
+	ChangeTypeKey = "change_type"
+)
+
+// for sort.Sort
+type changesByPath []docker.Change
+
+func (c changesByPath) Less(i, j int) bool { return c[i].Path < c[j].Path }
+func (c changesByPath) Len() int           { return len(c) }
+func (c changesByPath) Swap(i, j int)      { c[j], c[i] = c[i], c[j] }
+
+// Diff produces a tar archive containing the differences between two filesystems
+func Diff(op trace.Operation, newDir, oldDir string, spec *FilterSpec, data bool) (io.ReadCloser, error) {
+
+	var err error
+	if spec == nil {
+		spec, err = CreateFilterSpec(op, nil)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	changes, err := docker.ChangesDirs(newDir, oldDir)
+	if err != nil {
+		return nil, err
+	}
+
+	sort.Sort(changesByPath(changes))
+
+	return Tar(op, newDir, changes, spec, data)
+}
+
+func Tar(op trace.Operation, dir string, changes []docker.Change, spec *FilterSpec, data bool) (io.ReadCloser, error) {
+	var (
+		err error
+		hdr *tar.Header
+	)
+
+	// Note: it is up to the caller to handle errors and the closing of the read side of the pipe
+	r, w := io.Pipe()
+	go func() {
+		tw := tar.NewWriter(w)
+		defer func() {
+			var cerr error
+			if cerr = tw.Close(); cerr != nil {
+				op.Errorf("Error closing tar writer: %s", cerr.Error())
+			}
+			if err == nil {
+				_ = w.CloseWithError(cerr)
+			} else {
+				_ = w.CloseWithError(err)
+			}
+			return
+		}()
+
+		for _, change := range changes {
+			if excluded(change.Path, spec) {
+				continue
+			}
+
+			hdr, err = createHeader(op, dir, change, spec)
+			if err != nil {
+				op.Errorf("Error creating header from change: %s", err.Error())
+				return
+			}
+
+			var f *os.File
+
+			if !data {
+				hdr.Size = 0
+			}
+
+			_ = tw.WriteHeader(hdr)
+
+			p := filepath.Join(dir, change.Path)
+			if hdr.Typeflag == tar.TypeReg && hdr.Size != 0 {
+				f, err = os.Open(p)
+				if err != nil {
+					if os.IsPermission(err) {
+						err = nil
+					}
+					return
+				}
+				if f != nil {
+					_, err = io.Copy(tw, f)
+					if err != nil {
+						op.Errorf("Error writing archive data: %s", err.Error())
+					}
+					_ = f.Close()
+				}
+			}
+		}
+	}()
+	return r, err
+}
+
+// handle exclusion/inclusion of paths
+func excluded(filePath string, spec *FilterSpec) bool {
+	for p := filePath; p != string(filepath.Separator); p = filepath.Dir(p) {
+		if _, ok := spec.Inclusions[p]; ok {
+			return false
+		}
+		if _, ok := spec.Exclusions[p]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+func createHeader(op trace.Operation, dir string, change docker.Change, spec *FilterSpec) (*tar.Header, error) {
+	var hdr *tar.Header
+	timestamp := time.Now()
+
+	switch change.Kind {
+	case docker.ChangeDelete:
+		whiteOutDir := filepath.Dir(change.Path)
+		whiteOutBase := filepath.Base(change.Path)
+		whiteOut := filepath.Join(whiteOutDir, docker.WhiteoutPrefix+whiteOutBase)
+		hdr = &tar.Header{
+			Name:       filepath.Join(spec.RebasePath, whiteOut),
+			ModTime:    timestamp,
+			AccessTime: timestamp,
+			ChangeTime: timestamp,
+		}
+	default:
+		fi, err := os.Stat(filepath.Join(dir, change.Path))
+		if err != nil {
+			op.Errorf("Error getting file info: %s", err.Error())
+			return nil, err
+		}
+
+		hdr, err = tar.FileInfoHeader(fi, change.Path)
+		if err != nil {
+			op.Errorf("Error getting file info header: %s", err.Error())
+			return nil, err
+		}
+
+		hdr.Name = filepath.Join(spec.RebasePath, change.Path)
+
+		if hdr.Typeflag == tar.TypeDir {
+			hdr.Name += "/"
+		}
+	}
+
+	hdr.Xattrs = make(map[string]string)
+	hdr.Xattrs[ChangeTypeKey] = change.Kind.String()
+
+	return hdr, nil
+}

--- a/lib/archive/diff_test.go
+++ b/lib/archive/diff_test.go
@@ -1,0 +1,625 @@
+// Copyright 2017 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package archive
+
+import (
+	"archive/tar"
+	"bytes"
+	"context"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/vmware/vic/pkg/trace"
+)
+
+var (
+	newDir, oldDir string
+	a, b           []byte
+	files          map[string][]string
+	directories    map[string]struct{}
+	err            error
+)
+
+func TestMain(m *testing.M) {
+
+	var err error
+
+	directories = make(map[string]struct{}, 4)
+	files = make(map[string][]string, 6)
+	files["original"] = []string{"/file1", "/file2", "/file3", "/file4",
+		"/original/file1", "/original/file2", "/original/remove",
+		"/exclude/excludeme", "/exclude/includeme", "/excludeme", "/include/excludeme", "/include/includeme"}
+	files["added"] = []string{"/added1", "/added2", "/add/file1", "/add/file2"}
+	files["changed"] = []string{"/file1", "/original/file2",
+		"/exclude/excludeme", "/exclude/includeme",
+		"/include/excludeme", "/include/includeme",
+		"/excludeme"}
+	files["removed"] = []string{"/file2", "/original/file1", "/original/remove"}
+	files["excluded"] = []string{"/exclude", "/excludeme", "/include/excludeme"}
+	files["included"] = []string{"/exclude/includeme", "/include/"}
+
+	newDir, err = ioutil.TempDir("", "mnt")
+	if err != nil {
+		return
+	}
+	defer os.RemoveAll(newDir)
+
+	oldDir, err = ioutil.TempDir("", "mnt")
+	if err != nil {
+		return
+	}
+	defer os.RemoveAll(oldDir)
+
+	a = []byte("The mollusk lingers with its wandering eye\n")
+	b = []byte("The waking of all creatures that live on the land\n")
+
+	for _, dir := range []string{"original", "add", "exclude", "include"} {
+		directories["/"+dir+"/"] = struct{}{}
+		if err = os.Mkdir(filepath.Join(oldDir, dir), 0777); err != nil {
+			log.Errorf("Failed to add directory: %s", err.Error())
+			return
+		}
+		if err = os.Mkdir(filepath.Join(newDir, dir), 0777); err != nil {
+			log.Errorf("Failed to add directory: %s", err.Error())
+			return
+		}
+	}
+
+	for _, file := range files["original"] {
+		if err = ioutil.WriteFile(filepath.Join(oldDir, file), a, 0777); err != nil {
+			log.Errorf("Failed to add file: %s", err.Error())
+			return
+		}
+		if err = ioutil.WriteFile(filepath.Join(newDir, file), a, 0777); err != nil {
+			log.Errorf("Failed to add file: %s", err.Error())
+			return
+		}
+	}
+	for _, file := range append(files["added"], files["changed"]...) {
+		if err = ioutil.WriteFile(filepath.Join(newDir, file), b, 0777); err != nil {
+			log.Errorf("Failed to add file: %s", err.Error())
+			return
+		}
+	}
+	for _, file := range files["removed"] {
+		if err = os.Remove(filepath.Join(newDir, file)); err != nil {
+			log.Errorf("Failed to remove file: %s", err.Error())
+			return
+		}
+	}
+
+	os.Exit(m.Run())
+}
+
+func TestDiff(t *testing.T) {
+	op := trace.NewOperation(context.Background(), "TestDiff")
+
+	tarFile, err := Diff(op, newDir, oldDir, nil, true)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	tarredFiles := make(map[string][]byte)
+	tr := tar.NewReader(tarFile)
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			op.Errorf("Error reading tar archive: %s", err.Error())
+		}
+
+		buf := bytes.NewBuffer([]byte{})
+		if _, err := io.Copy(buf, tr); !assert.NoError(t, err) {
+			return
+		}
+		tarredFiles[hdr.Name] = buf.Bytes()
+	}
+
+	all := append(files["added"], append(files["changed"], files["included"]...)...)
+	for _, file := range all {
+		f, ok := tarredFiles[file]
+		assert.True(t, ok, "Expected to find %s in tar archive", file)
+
+		// don't try to check the contents if its a directory
+		if _, ok := directories[file]; !ok {
+			assert.Equal(t, b, f, "Expected file contents \"%s\", but found \"%s\"", b, f)
+		}
+	}
+	for _, file := range files["removed"] {
+		wh := filepath.Join(filepath.Dir(file), ".wh."+filepath.Base(file))
+		_, ok := tarredFiles[wh]
+		assert.True(t, ok, "Expected to find whiteout file in archive: %s", wh)
+	}
+
+}
+
+func TestDiffNoAncestor(t *testing.T) {
+	op := trace.NewOperation(context.Background(), "TestDiffNoParent")
+
+	// test without ancestor
+	tarFile, err := Diff(op, newDir, "", nil, true)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	tarredFiles := make(map[string][]byte)
+	tr := tar.NewReader(tarFile)
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			op.Errorf("Error reading tar header: %s", err.Error())
+		}
+
+		buf := bytes.NewBuffer([]byte{})
+		if _, err := io.Copy(buf, tr); !assert.NoError(t, err) {
+			return
+		}
+		tarredFiles[hdr.Name] = buf.Bytes()
+		if hdr.Typeflag == tar.TypeDir {
+			directories[hdr.Name] = struct{}{}
+		}
+	}
+
+	all := append(files["added"], append(files["changed"], files["included"]...)...)
+	for _, file := range all {
+		f, ok := tarredFiles[file]
+		assert.True(t, ok, "Expected to find %s in tar archive", file)
+
+		// don't try to check the contents if its a directory
+		if _, ok := directories[file]; !ok {
+			assert.Equal(t, b, f, "Expected file contents \"%s\", but found \"%s\"", b, f)
+		}
+	}
+
+	for _, file := range files["removed"] {
+		wh := filepath.Join(filepath.Dir(file), ".wh."+filepath.Base(file))
+		_, ok := tarredFiles[wh]
+		assert.False(t, ok, "Expected not to find whiteout file in archive: %s", wh)
+	}
+}
+
+func TestDiffNoData(t *testing.T) {
+	op := trace.NewOperation(context.Background(), "TestDiffNoData")
+
+	tarFile, err := Diff(op, newDir, oldDir, nil, false)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	tarredFiles := make(map[string]string)
+	changeTypes := make(map[string]string)
+	tr := tar.NewReader(tarFile)
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if !assert.NoError(t, err) {
+			op.Errorf("Error reading tar header: %s", err.Error())
+		}
+
+		buf := bytes.NewBuffer([]byte{})
+		n, err := io.Copy(buf, tr)
+		if !assert.NoError(t, err) {
+			return
+		}
+		assert.EqualValues(t, 0, n, "Expected 0 bytes copied, got %d instead", n)
+		tarredFiles[hdr.Name] = string(buf.Bytes())
+		changeTypes[hdr.Name] = hdr.Xattrs[ChangeTypeKey]
+	}
+
+	for _, file := range files["added"] {
+		f, ok := tarredFiles[file]
+		ctype := changeTypes[file]
+		assert.True(t, ok, "Expected to find %s in tar archive", file)
+
+		// don't try to check the contents if its a directory
+		if _, ok := directories[file]; !ok {
+			assert.Equal(t, "", f, "Expected file contents \"%s\", but found \"%s\"", "", f)
+			assert.Equal(t, "A", ctype, "Expected change type \"%s\", but found \"%s\"", "A", ctype)
+		}
+	}
+	for _, file := range append(files["changed"], files["included"]...) {
+		f, ok := tarredFiles[file]
+		ctype := changeTypes[file]
+		assert.True(t, ok, "expected to find %s in tar archive", file)
+		// don't try to check the contents if its a directory
+		if _, ok := directories[file]; !ok {
+			assert.Equal(t, "", f, "expected file contents \"%s\", but found \"%s\"", "", f)
+			assert.Equal(t, "C", ctype, "expected change type \"%s\", but found \"%s\"", "C", ctype)
+		}
+	}
+	for _, file := range files["removed"] {
+		wh := filepath.Join(filepath.Dir(file), ".wh."+filepath.Base(file))
+		_, ok := tarredFiles[wh]
+		ctype, cok := changeTypes[wh]
+		assert.True(t, ok, "Expected to find whiteout file in archive: %s", wh)
+		assert.True(t, cok, "Expected to find change type for %s", wh)
+		assert.Equal(t, "D", ctype, "Expected change type \"%s\" but found \"%s\"", "D", ctype)
+	}
+}
+
+func TestDiffFilterSpec(t *testing.T) {
+	op := trace.NewOperation(context.Background(), "TestDiffFilterSpec")
+
+	filter := make(map[string]FilterType)
+	for _, path := range files["excluded"] {
+		filter[path] = Exclude
+	}
+	for _, path := range files["included"] {
+		filter[path] = Include
+	}
+
+	spec, err := CreateFilterSpec(op, filter)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	tarFile, err := Diff(op, newDir, oldDir, spec, true)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	tarredFiles := make(map[string][]byte)
+	tr := tar.NewReader(tarFile)
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			op.Errorf("Error reading tar archive: %s", err.Error())
+		}
+
+		buf := bytes.NewBuffer([]byte{})
+		if _, err := io.Copy(buf, tr); !assert.NoError(t, err) {
+			return
+		}
+		tarredFiles[hdr.Name] = buf.Bytes()
+	}
+
+	all := append(files["added"], files["included"]...)
+	for _, file := range all {
+		if file == string(filepath.Separator) {
+			continue
+		}
+		f, ok := tarredFiles[file]
+		assert.True(t, ok, "Expected to find %s in tar archive", file)
+
+		// don't try to check the contents if its a directory
+		if _, ok := directories[file]; !ok {
+			assert.Equal(t, b, f, "Expected file contents \"%s\", but found \"%s\"", b, f)
+		}
+	}
+	for _, file := range files["removed"] {
+		wh := filepath.Join(filepath.Dir(file), ".wh."+filepath.Base(file))
+		_, ok := tarredFiles[wh]
+		assert.True(t, ok, "Expected to find whiteout file in archive: %s", wh)
+	}
+	for _, file := range files["excluded"] {
+		_, ok := tarredFiles[file]
+		assert.False(t, ok, "Expected excluded file to be missing from archive: %s", file)
+	}
+}
+
+func TestDiffFilterSpecNoAncestor(t *testing.T) {
+	op := trace.NewOperation(context.Background(), "TestDiffFilterSpecNoParent")
+
+	filter := make(map[string]FilterType)
+	for _, path := range files["excluded"] {
+		filter[path] = Exclude
+	}
+	for _, path := range files["included"] {
+		filter[path] = Include
+	}
+
+	spec, err := CreateFilterSpec(op, filter)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	// test without ancestor
+	tarFile, err := Diff(op, newDir, "", spec, true)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	tarredFiles := make(map[string][]byte)
+	tr := tar.NewReader(tarFile)
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			op.Errorf("Error reading tar archive: %s", err.Error())
+		}
+
+		buf := bytes.NewBuffer([]byte{})
+		if _, err := io.Copy(buf, tr); !assert.NoError(t, err) {
+			return
+		}
+		tarredFiles[hdr.Name] = buf.Bytes()
+	}
+
+	all := append(files["added"], files["included"]...)
+	for _, file := range all {
+		f, ok := tarredFiles[file]
+		if file == string(filepath.Separator) {
+			continue
+		}
+		assert.True(t, ok, "Expected to find %s in tar archive", file)
+
+		// don't try to check the contents if its a directory
+		if _, ok := directories[file]; !ok {
+			assert.Equal(t, b, f, "Expected file contents \"%s\", but found \"%s\"", b, f)
+		}
+	}
+	for _, file := range files["removed"] {
+		wh := filepath.Join(filepath.Dir(file), ".wh."+filepath.Base(file))
+		_, ok := tarredFiles[wh]
+		assert.False(t, ok, "Expected not to find whiteout file in archive: %s", wh)
+	}
+	for _, file := range files["excluded"] {
+		_, ok := tarredFiles[file]
+		assert.False(t, ok, "Expected excluded file to be missing from archive: %s", file)
+	}
+}
+
+func TestDiffFilterSpecRebase(t *testing.T) {
+	op := trace.NewOperation(context.Background(), "TestDiffFilterSpecRebase")
+
+	filter := make(map[string]FilterType)
+	for _, path := range files["excluded"] {
+		filter[path] = Exclude
+	}
+	for _, path := range files["included"] {
+		filter[path] = Include
+	}
+	rebasePath := "/path/to/prefix"
+	filter[rebasePath] = Rebase
+
+	spec, err := CreateFilterSpec(op, filter)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	// test without ancestor
+	tarFile, err := Diff(op, newDir, oldDir, spec, true)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	tarredFiles := make(map[string][]byte)
+	tr := tar.NewReader(tarFile)
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			op.Errorf("Error reading tar archive: %s", err.Error())
+		}
+
+		buf := bytes.NewBuffer([]byte{})
+		if _, err := io.Copy(buf, tr); !assert.NoError(t, err) {
+			return
+		}
+		tarredFiles[hdr.Name] = buf.Bytes()
+	}
+
+	all := append(files["added"], files["included"]...)
+	for _, file := range all {
+		if file == string(filepath.Separator) {
+			continue
+		}
+
+		rebasedPath := filepath.Join(rebasePath, file)
+		var isDir bool
+		if _, isDir = directories[file]; isDir {
+			rebasedPath += "/"
+		}
+
+		f, ok := tarredFiles[rebasedPath]
+		assert.True(t, ok, "Expected to find %s in tar archive", rebasedPath)
+		if !isDir {
+			assert.Equal(t, b, f, "Expected file contents \"%s\", but found \"%s\"", b, f)
+		}
+	}
+	for _, file := range files["removed"] {
+		wh := filepath.Join(filepath.Dir(file), ".wh."+filepath.Base(file))
+		wh = filepath.Join(rebasePath, wh)
+		_, ok := tarredFiles[wh]
+		assert.True(t, ok, "Expected not to find whiteout file in archive: %s", wh)
+	}
+	for _, file := range files["excluded"] {
+		_, ok := tarredFiles[file]
+		assert.False(t, ok, "Expected excluded file to be missing from archive: %s", file)
+	}
+}
+
+func TestDiffFilterSpecRebaseNoData(t *testing.T) {
+	op := trace.NewOperation(context.Background(), "TestDiffFilterSpecRebase")
+
+	filter := make(map[string]FilterType)
+	for _, path := range files["excluded"] {
+		filter[path] = Exclude
+	}
+	for _, path := range files["included"] {
+		filter[path] = Include
+	}
+	rebasePath := "/path/to/prefix"
+	filter[rebasePath] = Rebase
+
+	spec, err := CreateFilterSpec(op, filter)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	tarFile, err := Diff(op, newDir, oldDir, spec, false)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	tarredFiles := make(map[string]struct{})
+	changeTypes := make(map[string]string)
+	tr := tar.NewReader(tarFile)
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if !assert.NoError(t, err) {
+			op.Errorf("Error reading tar header: %s", err.Error())
+		}
+
+		buf := bytes.NewBuffer([]byte{})
+		n, err := io.Copy(buf, tr)
+		if !assert.NoError(t, err) {
+			return
+		}
+		assert.EqualValues(t, 0, n, "Expected 0 bytes copied, got %d instead", n)
+		tarredFiles[hdr.Name] = struct{}{}
+		changeTypes[hdr.Name] = hdr.Xattrs[ChangeTypeKey]
+	}
+
+	for _, file := range files["added"] {
+
+		rebasedPath := filepath.Join(rebasePath, file)
+		var isDir bool
+		if _, isDir = directories[file]; isDir {
+			rebasedPath += "/"
+		}
+
+		_, ok := tarredFiles[rebasedPath]
+		ctype := changeTypes[rebasedPath]
+		assert.True(t, ok, "Expected to find %s in tar archive", file)
+
+		// don't try to check the contents if its a directory
+		if !isDir {
+			assert.Equal(t, "A", ctype, "Expected change type \"%s\", but found \"%s\"", "A", ctype)
+		}
+	}
+	for _, file := range append(files["changed"], files["included"]...) {
+
+		// don't check for excludes or whiteouts yet
+		base := filepath.Base(file)
+		if strings.HasSuffix(file, "excludeme") || strings.HasPrefix(base, ".wh.") {
+			continue
+		}
+
+		rebasedPath := filepath.Join(rebasePath, file)
+		var isDir bool
+		if _, isDir = directories[file]; isDir {
+			rebasedPath += "/"
+		}
+		_, ok := tarredFiles[rebasedPath]
+		ctype := changeTypes[rebasedPath]
+		assert.True(t, ok, "expected to find %s in tar archive", file)
+		// don't try to check the contents if its a directory
+		if !isDir {
+			assert.Equal(t, "C", ctype, "expected change type \"%s\", but found \"%s\"", "C", ctype)
+		}
+	}
+	for _, file := range files["removed"] {
+		wh := filepath.Join(filepath.Dir(file), ".wh."+filepath.Base(file))
+		wh = filepath.Join(rebasePath, wh)
+		_, ok := tarredFiles[wh]
+		ctype, cok := changeTypes[wh]
+		assert.True(t, ok, "Expected to find whiteout file in archive: %s", wh)
+		assert.True(t, cok, "Expected to find change type for %s", wh)
+		assert.Equal(t, "D", ctype, "Expected change type \"%s\" but found \"%s\"", "D", ctype)
+	}
+
+	for _, file := range files["excluded"] {
+		_, ok := tarredFiles[file]
+		assert.False(t, ok, "Expected excluded file to be missing from archive: %s", file)
+	}
+}
+
+func TestDiffCreateFilterSpec(t *testing.T) {
+	op := trace.NewOperation(context.Background(), "TestDiffCreateFilterSpec")
+
+	filter := make(map[string]FilterType)
+	for _, path := range files["excluded"] {
+		filter[path] = Exclude
+	}
+	for _, path := range files["included"] {
+		filter[path] = Include
+	}
+	rebasePath := "/path/to/prefix"
+	filter[rebasePath] = Rebase
+
+	stripPath := "/path/to/strip"
+	filter[stripPath] = Strip
+
+	spec, err := CreateFilterSpec(op, filter)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	for _, path := range files["included"] {
+		_, ok := spec.Inclusions[path]
+		assert.True(t, ok, "Expected to find %s in inclusions set", path)
+		_, ok = spec.Exclusions[path]
+		assert.False(t, ok, "Expected not to find %s in exclusions set", path)
+	}
+
+	for _, path := range files["excluded"] {
+		_, ok := spec.Exclusions[path]
+		assert.True(t, ok, "Expected to find %s in exclusions set", path)
+		_, ok = spec.Inclusions[path]
+		assert.False(t, ok, "Expected not to find %s in inclusions set", path)
+	}
+
+	assert.Equal(t, rebasePath, spec.RebasePath)
+	assert.Equal(t, stripPath, spec.StripPath)
+	e := "/path/to/extra/rebase"
+	filter[e] = Rebase
+
+	spec, err = CreateFilterSpec(op, filter)
+	assert.Nil(t, spec, "Expected nil spec")
+	assert.Error(t, err)
+	assert.EqualError(t, err, "Error creating filter spec: only one rebase path allowed")
+
+	delete(filter, e)
+
+	s := "/path/to/extra/strippath"
+	filter[s] = Strip
+	spec, err = CreateFilterSpec(op, filter)
+	assert.Nil(t, spec, "Expected nil spec")
+	assert.Error(t, err)
+	assert.EqualError(t, err, "Error creating filter spec: only one strip path allowed")
+
+	delete(filter, s)
+
+	filter[s] = 20
+	spec, err = CreateFilterSpec(op, filter)
+	assert.Nil(t, spec, "Expected nil spec")
+	assert.Error(t, err)
+	assert.EqualError(t, err, "Invalid filter specification: 20")
+}

--- a/lib/portlayer/portlayer.go
+++ b/lib/portlayer/portlayer.go
@@ -1,4 +1,4 @@
-// Copyright 2016 VMware, Inc. All Rights Reserved.
+// Copyright 2016-2017 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -37,13 +37,7 @@ import (
 	"github.com/vmware/vic/pkg/vsphere/vm"
 )
 
-// API defines the interface the REST server used by the portlayer expects the
-// implementation side to export
-type API interface {
-	storage.ImageStorer
-	storage.VolumeStorer
-}
-
+// Init initializes portlayer components at startup
 func Init(ctx context.Context, sess *session.Session) error {
 	source, err := extraconfig.GuestInfoSource()
 	if err != nil {

--- a/lib/portlayer/storage/image.go
+++ b/lib/portlayer/storage/image.go
@@ -1,4 +1,4 @@
-// Copyright 2016 VMware, Inc. All Rights Reserved.
+// Copyright 2016-2017 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/vmware/vic/lib/archive"
 	"github.com/vmware/vic/lib/portlayer/util"
 	"github.com/vmware/vic/pkg/index"
 	"github.com/vmware/vic/pkg/trace"
@@ -73,6 +74,9 @@ type ImageStorer interface {
 	// use either by way of inheritance or because it's attached to a
 	// container, this will return an error.
 	DeleteImage(op trace.Operation, image *Image) (*Image, error)
+
+	// Archiver defines the Export and WriteArchive interface methods
+	archive.Archiver
 }
 
 // Image is the handle to identify an image layer on the backing store.  The

--- a/lib/portlayer/storage/image_cache.go
+++ b/lib/portlayer/storage/image_cache.go
@@ -1,4 +1,4 @@
-// Copyright 2016 VMware, Inc. All Rights Reserved.
+// Copyright 2016-2017 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ import (
 	"os"
 	"sync"
 
+	"github.com/vmware/vic/lib/archive"
 	"github.com/vmware/vic/lib/portlayer/util"
 	"github.com/vmware/vic/pkg/index"
 	"github.com/vmware/vic/pkg/trace"
@@ -230,6 +231,10 @@ func (c *NameLookupCache) WriteImage(op trace.Operation, parent *Image, ID strin
 	}
 
 	return i, nil
+}
+
+func (c *NameLookupCache) Export(op trace.Operation, store *url.URL, id, ancestor string, spec *archive.FilterSpec, data bool) (io.ReadCloser, error) {
+	return c.DataStore.Export(op, store, id, ancestor, spec, data)
 }
 
 // GetImage gets the specified image from the given store by retreiving it from the cache.

--- a/lib/portlayer/storage/image_cache_test.go
+++ b/lib/portlayer/storage/image_cache_test.go
@@ -1,4 +1,4 @@
-// Copyright 2016 VMware, Inc. All Rights Reserved.
+// Copyright 2016-2017 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -27,6 +27,7 @@ import (
 	"github.com/Sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 
+	"github.com/vmware/vic/lib/archive"
 	"github.com/vmware/vic/lib/portlayer/util"
 	"github.com/vmware/vic/pkg/trace"
 )
@@ -149,6 +150,10 @@ func (c *MockDataStore) ListImages(op trace.Operation, store *url.URL, IDs []str
 func (c *MockDataStore) DeleteImage(op trace.Operation, image *Image) (*Image, error) {
 	delete(c.db[*image.Store], image.ID)
 	return image, nil
+}
+
+func (c *MockDataStore) Export(op trace.Operation, store *url.URL, child, ancestor string, spec *archive.FilterSpec, data bool) (io.ReadCloser, error) {
+	return nil, nil
 }
 
 func TestListImages(t *testing.T) {

--- a/lib/portlayer/storage/nfs/volume.go
+++ b/lib/portlayer/storage/nfs/volume.go
@@ -16,11 +16,13 @@ package nfs
 
 import (
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/url"
 	"os"
 	"path"
 
+	"github.com/vmware/vic/lib/archive"
 	"github.com/vmware/vic/lib/config/executor"
 	"github.com/vmware/vic/lib/portlayer/storage"
 	"github.com/vmware/vic/lib/portlayer/util"
@@ -52,6 +54,9 @@ type VolumeStore struct {
 
 	// Service selflink to volume store.
 	SelfLink *url.URL
+
+	// Archiver defines WriteArchive and Export interface methods
+	archive.Archiver
 }
 
 func NewVolumeStore(op trace.Operation, storeName string, mount MountServer) (*VolumeStore, error) {
@@ -200,6 +205,11 @@ func (v *VolumeStore) VolumesList(op trace.Operation) ([]*storage.Volume, error)
 	}
 
 	return volumes, nil
+}
+
+// Export creates and returns a tar archive containing data found between an nfs layer one or all of its ancestors
+func (v *VolumeStore) Export(op trace.Operation, store *url.URL, id, ancestor string, spec *archive.FilterSpec, data bool) (io.ReadCloser, error) {
+	return nil, fmt.Errorf("vSphere Integrated Containers does not yet implement Export for nfs volumes")
 }
 
 func (v *VolumeStore) writeMetadata(op trace.Operation, ID string, info map[string][]byte, target Target) error {

--- a/lib/portlayer/storage/volume.go
+++ b/lib/portlayer/storage/volume.go
@@ -22,6 +22,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/vmware/vic/lib/archive"
 	"github.com/vmware/vic/lib/config/executor"
 	"github.com/vmware/vic/lib/portlayer/util"
 	"github.com/vmware/vic/pkg/trace"
@@ -45,6 +46,9 @@ type VolumeStorer interface {
 
 	// Lists all volumes
 	VolumesList(op trace.Operation) ([]*Volume, error)
+
+	// Archiver defines the Import and Export interface methods
+	archive.Archiver
 }
 
 // Volume is the handle to identify a volume on the backing store.  The URI

--- a/lib/portlayer/storage/volume_cache_test.go
+++ b/lib/portlayer/storage/volume_cache_test.go
@@ -1,4 +1,4 @@
-// Copyright 2016 VMware, Inc. All Rights Reserved.
+// Copyright 2016-2017 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@ package storage
 
 import (
 	"fmt"
+	"io"
 	"net/url"
 	"os"
 	"sync"
@@ -25,6 +26,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/vmware/vic/lib/archive"
 	"github.com/vmware/vic/lib/portlayer/exec"
 	"github.com/vmware/vic/lib/portlayer/util"
 	"github.com/vmware/vic/pkg/trace"
@@ -102,6 +104,10 @@ func (m *MockVolumeStore) VolumesList(op trace.Operation) ([]*Volume, error) {
 	}
 
 	return list, nil
+}
+
+func (m *MockVolumeStore) Export(op trace.Operation, store *url.URL, child, ancestor string, spec *archive.FilterSpec, data bool) (io.ReadCloser, error) {
+	return nil, nil
 }
 
 func TestVolumeCreateGetListAndDelete(t *testing.T) {

--- a/lib/portlayer/storage/vsphere/vsphere.go
+++ b/lib/portlayer/storage/vsphere/vsphere.go
@@ -1,0 +1,34 @@
+// Copyright 2017 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vsphere
+
+import (
+	"io"
+)
+
+// cleanReader wraps an io.ReadCloser, calling the supplied cleanup function on Close()
+type cleanReader struct {
+	io.ReadCloser
+	clean func()
+}
+
+func (c *cleanReader) Read(p []byte) (int, error) {
+	return c.ReadCloser.Read(p)
+}
+
+func (c *cleanReader) Close() error {
+	defer c.clean()
+	return c.ReadCloser.Close()
+}


### PR DESCRIPTION
This change is the first pass for the `Read` function used to create tar archives from image layer data.

Fixes #5320