### PR TITLE
[specific ci=Group6-VIC-Machine] Add no-tls back in

### DIFF
--- a/cmd/vic-machine/create/create.go
+++ b/cmd/vic-machine/create/create.go
@@ -247,12 +247,12 @@ func (c *Create) Flags() []cli.Flag {
 		})
 
 	tls := c.certs.CertFlags()
+
 	tls = append(tls, cli.BoolFlag{
-		Name:        "no-tls",
-		Value:       false,
-		Usage:       "Disable TLS entirely",
+		Name:        "no-tls, k",
+		Usage:       "Disable TLS support completely",
+		Destination: &c.noTLS,
 		Hidden:      true,
-		Destination: c.certs.NoTLS,
 	})
 
 	registries := []cli.Flag{

--- a/cmd/vic-machine/create/create.go
+++ b/cmd/vic-machine/create/create.go
@@ -247,6 +247,13 @@ func (c *Create) Flags() []cli.Flag {
 		})
 
 	tls := c.certs.CertFlags()
+	tls = append(tls, cli.BoolFlag{
+		Name:        "no-tls",
+		Value:       false,
+		Usage:       "Disable TLs entirely",
+		Hidden:      true,
+		Destination: c.certs.NoTLS,
+	})
 
 	registries := []cli.Flag{
 		cli.StringSliceFlag{

--- a/cmd/vic-machine/create/create.go
+++ b/cmd/vic-machine/create/create.go
@@ -251,7 +251,7 @@ func (c *Create) Flags() []cli.Flag {
 	tls = append(tls, cli.BoolFlag{
 		Name:        "no-tls, k",
 		Usage:       "Disable TLS support completely",
-		Destination: &c.noTLS,
+		Destination: &c.certs.NoTLS,
 		Hidden:      true,
 	})
 

--- a/cmd/vic-machine/create/create.go
+++ b/cmd/vic-machine/create/create.go
@@ -250,7 +250,7 @@ func (c *Create) Flags() []cli.Flag {
 	tls = append(tls, cli.BoolFlag{
 		Name:        "no-tls",
 		Value:       false,
-		Usage:       "Disable TLs entirely",
+		Usage:       "Disable TLS entirely",
 		Hidden:      true,
 		Destination: c.certs.NoTLS,
 	})


### PR DESCRIPTION
Specific CI didn't run on my last PR for some reason (let's see if it actually runs the tests I requested this time) and I missed this, which I stripped out, and added back in, and stripped again, and apparently forgot to add back, as we waffled around on whether or not `--no-tls` should be an option in `configure`