### PR TITLE
[specific ci=9-01-VICAdmin-ShowHTML]Switch default registry to local harbor Group9

### DIFF
--- a/tests/test-cases/Group9-VIC-Admin/9-01-VICAdmin-ShowHTML.robot
+++ b/tests/test-cases/Group9-VIC-Admin/9-01-VICAdmin-ShowHTML.robot
@@ -51,10 +51,10 @@ While Logged Out Fail To Get Docker Personality Log
     Should Contain  ${output}  <a href="/authentication">See Other</a>.
 
 While Logged Out Fail To Get Container Logs
-    ${rc}  ${output}=  Run And Return Rc and Output  docker %{VCH-PARAMS} pull busybox
+    ${rc}  ${output}=  Run And Return Rc and Output  docker %{VCH-PARAMS} pull ${busybox}
     Should Be Equal As Integers  ${rc}  0
     Should Not Contain  ${output}  Error
-    ${rc}  ${container}=  Run And Return Rc and Output  docker %{VCH-PARAMS} create busybox /bin/top
+    ${rc}  ${container}=  Run And Return Rc and Output  docker %{VCH-PARAMS} create ${busybox} /bin/top
     Should Be Equal As Integers  ${rc}  0
     Should Not Contain  ${container}  Error
     ${rc}  ${output}=  Run And Return Rc and Output  docker %{VCH-PARAMS} start ${container}
@@ -95,10 +95,10 @@ Get Docker Personality Log
 
 Get Container Logs
     Login And Save Cookies
-    ${rc}  ${output}=  Run And Return Rc and Output  docker %{VCH-PARAMS} pull busybox
+    ${rc}  ${output}=  Run And Return Rc and Output  docker %{VCH-PARAMS} pull ${busybox}
     Should Be Equal As Integers  ${rc}  0
     Should Not Contain  ${output}  Error
-    ${rc}  ${container}=  Run And Return Rc and Output  docker %{VCH-PARAMS} create busybox /bin/top
+    ${rc}  ${container}=  Run And Return Rc and Output  docker %{VCH-PARAMS} create ${busybox} /bin/top
     Should Be Equal As Integers  ${rc}  0
     Should Not Contain  ${container}  Error
     ${rc}  ${output}=  Run And Return Rc and Output  docker %{VCH-PARAMS} start ${container}


### PR DESCRIPTION

Fixes #4181 
Switch the CI default registry to a local harbor instance.

This PR is specifically to test changes made to fix issue 4181-Group9