### PR TITLE
Improve UI installer scripts

### DIFF
--- a/tests/manual-test-cases/Group18-VIC-UI/18-1-VIC-UI-Installer.robot
+++ b/tests/manual-test-cases/Group18-VIC-UI/18-1-VIC-UI-Installer.robot
@@ -17,14 +17,10 @@ Documentation  Test 18-1 - VIC UI Installation
 Resource  ../../resources/Util.robot
 Resource  ./vicui-common.robot
 Test Teardown  Cleanup Installer Environment
-Suite Setup  Check Config And Install VCH
-Suite Teardown  Uninstall VCH
+Suite Setup  Check Config And Install VCH  remove
+Suite Teardown  Uninstall VCH  ${TRUE}
 
 *** Test Cases ***
-Ensure Vicui Plugin Is Not Registered Before Testing
-    Set Vcenter Ip
-    Force Remove Vicui Plugin
-
 Attempt To Install With Configs File Missing
     # Rename the configs file and run the installer script to see if it fails in an expected way
     Move File  ${UI_INSTALLER_PATH}/configs  ${UI_INSTALLER_PATH}/configs_renamed
@@ -32,119 +28,49 @@ Attempt To Install With Configs File Missing
     Run Keyword And Continue On Failure  Should Contain  ${output}  Configs file is missing
     Move File  ${UI_INSTALLER_PATH}/configs_renamed  ${UI_INSTALLER_PATH}/configs
 
-Attempt To Install With Plugin Missing
-    # Rename the folder containing the VIC UI binaries and run the installer script to see if it fails in an expected way
-    Set Vcenter Ip
-    Move Directory  ${UI_INSTALLER_PATH}/../${plugin_folder}  ${UI_INSTALLER_PATH}/../${plugin_folder}-a
-    Install Fails At Extension Reg  ${TEST_VC_USERNAME}  ${TEST_VC_PASSWORD}  ${TEST_VC_ROOT_PASSWORD}  ${TRUE}
-    ${output}=  OperatingSystem.GetFile  install.log
-    ${passed}=  Run Keyword And Return Status  Should Contain  ${output}  VIC UI plugin bundle was not found
-    Run Keyword Unless  ${passed}  Copy File  install.log  install-fail-install-with-plugin-missing.log
-    Move Directory  ${UI_INSTALLER_PATH}/../${plugin_folder}-a  ${UI_INSTALLER_PATH}/../${plugin_folder}
-    Remove File  install.log
-    Should Be True  ${passed}
-
-Attempt To Install With vCenter IP Missing
-    # Leave VCENTER_IP empty and run the installer script to see if it fails in an expected way
-    Remove File  ${UI_INSTALLER_PATH}/configs
-    ${results}=  Replace String Using Regexp  ${configs}  VCENTER_IP=.*  VCENTER_IP=\"\"
-    Create File  ${UI_INSTALLER_PATH}/configs  ${results}
+Attempt To Install With Manifest Missing
+    Move File  ${UI_INSTALLER_PATH}/../plugin-manifest  ${UI_INSTALLER_PATH}/../plugin-manifest-a
     ${rc}  ${output}=  Run And Return Rc And Output  cd ${UI_INSTALLER_PATH} && ${INSTALLER_SCRIPT_PATH}
-    Run Keyword And Continue On Failure  Should Contain  ${output}  Please provide a valid IP
+    Run Keyword And Continue On Failure  Should Contain  ${output}  manifest was not found
+    Move File  ${UI_INSTALLER_PATH}/../plugin-manifest-a  ${UI_INSTALLER_PATH}/../plugin-manifest
 
-Attempt To Install With Invalid vCenter IP
-    # Populate VCENTER_IP with an invalid hostname and run the installer script to see if it fails in an expected way
-    Remove File  ${UI_INSTALLER_PATH}/configs
-    ${results}=  Replace String Using Regexp  ${configs}  VCENTER_IP=.*  VCENTER_IP=\"i-am-not-a-valid-ip\"
-    Create File  ${UI_INSTALLER_PATH}/configs  ${results}
-    Install Fails For Wrong Vcenter Ip  ${TEST_VC_USERNAME}  ${TEST_VC_PASSWORD}  ${TEST_VC_ROOT_PASSWORD}
+Attempt To Install To A Non vCenter Server
+    Install Fails  not-a-vcenter-server  admin  password  ${TRUE}
     ${output}=  OperatingSystem.GetFile  install.log
-    ${passed}=  Run Keyword And Return Status  Should Contain  ${output}  Could not resolve the hostname
-    Run Keyword Unless  ${passed}  Copy File  install.log  install-fail-attempt-to-install-with-invalid-vcenterip.log
-    Remove File  install.log
+    ${passed}=  Run Keyword And Return Status  Should Contain  ${output}  vCenter Server was not found
+    Run Keyword Unless  ${passed}  Move File  install.log  install-fail-attempt-to-a-non-vcenter-server.log
     Should Be True  ${passed}
 
 Attempt To Install With Wrong Vcenter Credentials
-    # Try installing the plugin with wrong vCenter credentials and see if it fails in an expected way
-    Remove File  ${UI_INSTALLER_PATH}/configs
-    ${results}=  Replace String Using Regexp  ${configs}  VCENTER_IP=.*  VCENTER_IP=\"${TEST_VC_IP}\"
-    Create File  ${UI_INSTALLER_PATH}/configs  ${results}
-    Set Vcenter Ip
-    Install Fails At Extension Reg  ${TEST_VC_USERNAME}_nope  ${TEST_VC_PASSWORD}_nope  ${TEST_VC_ROOT_PASSWORD}  ${TRUE}
+    Set Fileserver And Thumbprint In Configs
+    Append To File  ${UI_INSTALLER_PATH}/configs  BYPASS_PLUGIN_VERIFICATION=1\n
+    Install Fails  ${TEST_VC_IP}  ${TEST_VC_USERNAME}_nope  ${TEST_VC_PASSWORD}_nope  ${FALSE}  %{VC_FINGERPRINT}
     ${output}=  OperatingSystem.GetFile  install.log
     ${passed}=  Run Keyword And Return Status  Should Contain  ${output}  Cannot complete login due to an incorrect user name or password
-    Run Keyword Unless  ${passed}  Copy File  install.log  install-fail-attempt-to-install-with-wrong-vcenter-credentials.log
-    Remove File  install.log
+    Run Keyword Unless  ${passed}  Move File  install.log  install-fail-attempt-to-install-with-wrong-vcenter-credentials.log
     Should Be True  ${passed}
 
-Attempt To Install With Wrong Root Password
-    # Try installing the plugin with wrong vCenter root password and see if it fails in an expected way
-    Log To Console  Skipping this test, as making three incorrect attempts will lock the root account for a certain amount of time
-    #Set Vcenter Ip
-    #Install Vicui Without Webserver  ${TEST_VC_USERNAME}  ${TEST_VC_PASSWORD}  ${TEST_VC_ROOT_PASSWORD}_abc
-    #${output}=  OperatingSystem.GetFile  install.log
-    #Should Contain  ${output}  Root password is incorrect
-    #Remove File  install.log
-
-Attempt To Install Without Webserver Nor Bash Support
-    # Try installing the plugin against a VCSA that has Bash disabled and see if it fails gracefully with instructions
-    [Timeout]  ${TIMEOUT}
-    Set Vcenter Ip
-    Append To File  ${UI_INSTALLER_PATH}/configs  SIMULATE_NO_BASH_SUPPORT=1\n
-    Install Vicui Without Webserver Nor Bash  ${TEST_VC_USERNAME}  ${TEST_VC_PASSWORD}  ${TEST_VC_ROOT_PASSWORD}
+Attempt to Install With Unmatching Fingerprint
+    Append To File  ${UI_INSTALLER_PATH}/configs  BYPASS_PLUGIN_VERIFICATION=1\n
+    Install Fails  ${TEST_VC_IP}  ${TEST_VC_USERNAME}  ${TEST_VC_PASSWORD}  ${FALSE}  ff:ff:ff
     ${output}=  OperatingSystem.GetFile  install.log
-    ${passed}=  Run Keyword And Return Status  Should Contain  ${output}  Bash shell is required
-    Run Keyword Unless  ${passed}  Copy File  install.log  install-fail-attempt-to-install-without-webserver-nor-bash-support.log
-    Force Remove Vicui Plugin
-    Remove File  install.log
+    ${passed}=  Run Keyword And Return Status  Should Contain  ${output}  does not match
+    Run Keyword Unless  ${passed}  Move File  install.log  install-fail-attempt-to-install-with-unmatching-fingerprint.log
     Should Be True  ${passed}
 
-Install Successfully Without Webserver
-    [Timeout]  ${TIMEOUT}
-    Set Vcenter Ip
-    Install Vicui Without Webserver  ${TEST_VC_USERNAME}  ${TEST_VC_PASSWORD}  ${TEST_VC_ROOT_PASSWORD}
+Attempt To Install With Wrong OVA Fileserver URL
+    Set Fileserver And Thumbprint In Configs  ${TRUE}
+    Install Fails  ${TEST_VC_IP}  ${TEST_VC_USERNAME}  ${TEST_VC_PASSWORD}  ${TRUE}
     ${output}=  OperatingSystem.GetFile  install.log
-    ${passed}=  Run Keyword And Return Status  Should Contain  ${output}  was successful
-    Run Keyword Unless  ${passed}  Copy File  install.log  install-fail-install-successfully-without-webserver.log
-    Remove File  install.log
+    ${passed}=  Run Keyword And Return Status  Should Contain  ${output}  Error
+    Run Keyword Unless  ${passed}  Move File  install.log  install-fail-attempt-to-install-with-wrong-ova-fileserver-url.log
     Should Be True  ${passed}
 
-Attempt To Install When Plugin Is Already Registered
-    # Plugin is already installed at this moment on he target VCSA
-    # Try installing the plugin and see if it fails in an expected way
-    [Timeout]  ${TIMEOUT}
-    Set Vcenter Ip
-    Install Fails At Extension Reg  ${TEST_VC_USERNAME}  ${TEST_VC_PASSWORD}  ${TEST_VC_ROOT_PASSWORD}  ${TRUE}
+Install Plugin Successfully
+    Set Fileserver And Thumbprint In Configs
+    Append To File  ${UI_INSTALLER_PATH}/configs  BYPASS_PLUGIN_VERIFICATION=1\n
+    Install Plugin Successfully  ${TEST_VC_IP}  ${TEST_VC_USERNAME}  ${TEST_VC_PASSWORD}  ${TRUE}
     ${output}=  OperatingSystem.GetFile  install.log
-    ${passed}=  Run Keyword And Return Status  Should Contain  ${output}  is already registered
-    Run Keyword Unless  ${passed}  Copy File  install.log  install-fail-attempt-to-install-when-plugin-is-already-registered.log
-    Remove File  install.log
-    Should Be True  ${passed}
-
-Install Successfully Without Webserver Using Force Flag
-    # Plugin is already installed at this moment on he target VCSA
-    # Install the plugin using the --force flag and see if it succeeds
-    [Timeout]  ${TIMEOUT}
-    Set Vcenter Ip
-    Install Vicui Without Webserver  ${TEST_VC_USERNAME}  ${TEST_VC_PASSWORD}  ${TEST_VC_ROOT_PASSWORD}  ${TRUE}
-    ${output}=  OperatingSystem.GetFile  install.log
-    ${passed}=  Run Keyword And Return Status  Should Contain  ${output}  was successful
-    Run Keyword Unless  ${passed}  Copy File  install.log  install-fail-install-successfully-without-webserver-using-force-flag.log
-    Remove File  install.log
-    Log To Console  Force removing Vicui for next tests...
-    Force Remove Vicui Plugin
-    Should Be True  ${passed}
-
-Attempt To Install With Webserver And Wrong Path To Plugin
-    # Try installing the plugin using a web server while providing VIC_UI_HOST_URL that does not exist and see if it fails in an expected way
-    Set Vcenter Ip
-    ${results}=  Replace String Using Regexp  ${configs}  VCENTER_IP=.*  VCENTER_IP=\"${TEST_VC_IP}\"
-    ${results}=  Replace String Using Regexp  ${results}  VIC_UI_HOST_URL=.*  VIC_UI_HOST_URL=\"http:\/\/this-fake-host\.does-not-exist\"
-    Create File  ${UI_INSTALLER_PATH}/configs  ${results}
-    Wait Until Created  ${UI_INSTALLER_PATH}/configs
-    Install Fails At Extension Reg  ${TEST_VC_USERNAME}  ${TEST_VC_PASSWORD}  ${TEST_VC_ROOT_PASSWORD}  ${FALSE}
-    ${output}=  OperatingSystem.GetFile  install.log
-    ${passed}=  Run Keyword And Return Status  Should Contain  ${output}  Could not resolve the host
-    Run Keyword Unless  ${passed}  Copy File  install.log  install-fail-attempt-to-install-with-sebserver-and-wrong-path-to-plugin.log
-    Remove File  install.log
+    ${passed}=  Run Keyword And Return Status  Should Contain  ${output}  exited successfully
+    Run Keyword Unless  ${passed}  Move File  install.log  install-fail-ensure-vicui-is-installed-before-testing.log
     Should Be True  ${passed}

--- a/tests/manual-test-cases/Group18-VIC-UI/18-2-VIC-UI-Uninstaller.robot
+++ b/tests/manual-test-cases/Group18-VIC-UI/18-2-VIC-UI-Uninstaller.robot
@@ -17,19 +17,10 @@ Documentation  Test 18-2 - VIC UI Uninstallation
 Resource  ../../resources/Util.robot
 Resource  ./vicui-common.robot
 Test Teardown  Cleanup Installer Environment
-Suite Setup  Check Config And Install VCH
-Suite Teardown  Uninstall VCH
+Suite Setup  Check Config And Install VCH  install
+Suite Teardown  Uninstall VCH  ${TRUE}
 
 *** Test Cases ***
-Ensure Vicui Is Installed Before Testing
-    Set Vcenter Ip
-    Install Vicui Without Webserver  ${TEST_VC_USERNAME}  ${TEST_VC_PASSWORD}  ${TEST_VC_ROOT_PASSWORD}  ${TRUE}
-    ${output}=  OperatingSystem.GetFile  install.log
-    ${passed}=  Run Keyword And Return Status  Should Contain  ${output}  was successful
-    Run Keyword Unless  ${passed}  Copy File  install.log  install-fail-ensure-vicui-is-installed-before-testing.log
-    Remove File  install.log
-    Should Be True  ${passed}
-
 Attempt To Uninstall With Configs File Missing
     # Rename the configs file and run the uninstaller script to see if it fails in an expected way
     Move File  ${UI_INSTALLER_PATH}/configs  ${UI_INSTALLER_PATH}/configs_renamed
@@ -37,50 +28,40 @@ Attempt To Uninstall With Configs File Missing
     Run Keyword And Continue On Failure  Should Contain  ${output}  Configs file is missing
     Move File  ${UI_INSTALLER_PATH}/configs_renamed  ${UI_INSTALLER_PATH}/configs
 
-Attempt To Uninstall With Plugin Missing
-    # Rename the folder containing the VIC UI binaries and run the uninstaller script to see if it fails in an expected way
-    Set Vcenter Ip
-    Move Directory  ${UI_INSTALLER_PATH}/../${plugin_folder}  ${UI_INSTALLER_PATH}/../${plugin_folder}-a
-    Uninstall Fails  ${TEST_VC_USERNAME}  ${TEST_VC_PASSWORD}
+Attempt To Uninstall With Plugin Manifest Missing
+    Move File  ${UI_INSTALLER_PATH}/../plugin-manifest  ${UI_INSTALLER_PATH}/../plugin-manifest-a
+    ${rc}  ${output}=  Run And Return Rc And Output  cd ${UI_INSTALLER_PATH} && ${UNINSTALLER_SCRIPT_PATH}
+    Run Keyword And Continue On Failure  Should Contain  ${output}  manifest was not found
+    Move File  ${UI_INSTALLER_PATH}/../plugin-manifest-a  ${UI_INSTALLER_PATH}/../plugin-manifest
+
+Attempt To Uninstall From A Non vCenter Server
+    Uninstall Fails  not-a-vcenter-server  admin  password
     ${output}=  OperatingSystem.GetFile  uninstall.log
-    ${passed}=  Run Keyword And Return Status  Should Contain  ${output}  VIC UI plugin bundle was not found
-    Run Keyword Unless  ${passed}  Copy File  uninstall.log  uninstall-fail-attempt-to-uninstall-with-plugin-missing.log
-    Move Directory  ${UI_INSTALLER_PATH}/../${plugin_folder}-a  ${UI_INSTALLER_PATH}/../${plugin_folder}
-    Remove File  uninstall.log
+    ${passed}=  Run Keyword And Return Status  Should Contain  ${output}  vCenter Server was not found
+    Run Keyword Unless  ${passed}  Move File  uninstall.log  uninstall-fail-attempt-to-uninstall-from-a-non-vcenter-server.log
     Should Be True  ${passed}
 
-Attempt To Uninstall With vCenter IP Missing
-    # Leave VCENTER_IP empty and run the uninstaller script to see if it fails in an expected way
-    Remove File  ${UI_INSTALLER_PATH}/configs
-    ${results}=  Replace String Using Regexp  ${configs}  VCENTER_IP=.*  VCENTER_IP=\"\"
-    Create File  ${UI_INSTALLER_PATH}/configs  ${results}
-    ${rc}  ${output}=  Run And Return Rc And Output  cd ${UI_INSTALLER_PATH} && ${UNINSTALLER_SCRIPT_PATH}
-    Run Keyword And Continue On Failure  Should Contain  ${output}  Please provide a valid IP
-
 Attempt To Uninstall With Wrong Vcenter Credentials
-    # Try uninstalling the plugin with wrong vCenter credentials and see if it fails in an expected way
-    Set Vcenter Ip
-    Uninstall Fails  ${TEST_VC_USERNAME}_nope  ${TEST_VC_PASSWORD}_nope
+    Set Fileserver And Thumbprint In Configs
+    Uninstall Fails  ${TEST_VC_IP}  ${TEST_VC_USERNAME}_nope  ${TEST_VC_PASSWORD}_nope
     ${output}=  OperatingSystem.GetFile  uninstall.log
     ${passed}=  Run Keyword And Return Status  Should Contain  ${output}  Cannot complete login due to an incorrect user name or password
-    Run Keyword Unless  ${passed}  Copy File  uninstall.log  uninstall-fail-attempt-to-uninstall-with-wrong-vcenter-credentials.log
-    Remove File  uninstall.log
+    Run Keyword Unless  ${passed}  Move File  uninstall.log  uninstall-fail-attempt-to-uninstall-with-wrong-vcenter-credentials.log
     Should Be True  ${passed}
 
 Uninstall Successfully
-    Set Vcenter Ip
-    Uninstall Vicui  ${TEST_VC_USERNAME}  ${TEST_VC_PASSWORD}
+    Set Fileserver And Thumbprint In Configs
+    Uninstall Vicui  ${TEST_VC_IP}  ${TEST_VC_USERNAME}  ${TEST_VC_PASSWORD}
     ${output}=  OperatingSystem.GetFile  uninstall.log
-    ${passed}=  Run Keyword And Return Status  Should Match Regexp  ${output}  unregistration was successful
-    Run Keyword Unless  ${passed}  Copy File  uninstall.log  uninstall-fail-uninstall-successfully.log
-    Remove File  uninstall.log
+    ${passed}=  Run Keyword And Return Status  Should Match Regexp  ${output}  exited successfully
+    Run Keyword Unless  ${passed}  Move File  uninstall.log  uninstall-fail-uninstall-successfully.log
     Should Be True  ${passed}
 
 Attempt To Uninstall Plugin That Is Already Gone
-    Set Vcenter Ip
-    Uninstall Fails  ${TEST_VC_USERNAME}  ${TEST_VC_PASSWORD}
+    Set Fileserver And Thumbprint In Configs
+    Uninstall Vicui  ${TEST_VC_IP}  ${TEST_VC_USERNAME}  ${TEST_VC_PASSWORD}
     ${output}=  OperatingSystem.GetFile  uninstall.log
-    ${passed}=  Run Keyword And Return Status  Should Contain  ${output}  failed to find target
-    Run Keyword Unless  ${passed}  Copy File  uninstall.log  uninstall-fail-attempt-to-uninstall-plugin-that-is-already-gone.log
-    Remove File  uninstall.log
+    ${passed}=  Run Keyword And Return Status  Should Contain  ${output}  'com.vmware.vic.ui' is not registered
+    ${passed2}=  Run Keyword And Return Status  Should Contain  ${output}  'com.vmware.vic' is not registered
+    Run Keyword Unless  (${passed} and ${passed2})  Move File  uninstall.log  uninstall-fail-attempt-to-uninstall-plugin-that-is-already-gone.log
     Should Be True  ${passed}

--- a/tests/manual-test-cases/Group18-VIC-UI/setup-testbed.robot
+++ b/tests/manual-test-cases/Group18-VIC-UI/setup-testbed.robot
@@ -118,14 +118,47 @@ Deploy BrowserVm
 
 Deploy Esx
     # deploy an esxi server
-    ${esx1}  ${esx1-ip}=  Run Keyword If  %{TEST_VSPHERE_VER} == 60  Deploy Nimbus ESXi Server For NGC Testing  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}  ELSE  Deploy Nimbus ESXi Server For NGC Testing  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}  4564106
-    Set Environment Variable  TEST_ESX_NAME  ${esx1}
+    ${name}=  Evaluate  'UITEST-ESX%{TEST_VSPHERE_VER}-' + str(random.randint(1000,9999))  modules=random
+    ${buildnum}=  Run Keyword If  %{TEST_VSPHERE_VER} == 60  Set Variable  3620759  ELSE  Set Variable  5310538
+    ${out}=  Deploy Nimbus ESXi Server Async  ${name}  ${buildnum}
+    ${result}=  Wait For Process  ${out}
+    Log  ${result.stdout}
+    Log  ${result.stderr}
+
+    Open Connection  %{NIMBUS_GW}
+    Wait Until Keyword Succeeds  2 min  30 sec  Login  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}
+    ${esx1-ip}=  Get IP  ${name}
+    Remove Environment Variable  GOVC_PASSWORD
+    Remove Environment Variable  GOVC_USERNAME
+    Set Environment Variable  GOVC_INSECURE  1
+    Set Environment Variable  GOVC_URL  root:@${esx1-ip}
+    ${out}=  Run  govc host.account.update -id root -password e2eFunctionalTest
+    Should Be Empty  ${out}
+    Log To Console  Successfully deployed %{NIMBUS_USER}-${name}. IP: ${esx1-ip}
+    Close Connection
+
+    Set Environment Variable  TEST_ESX_NAME  %{NIMBUS_USER}-${name}
     Set Environment Variable  ESX_HOST_IP  ${esx1-ip}
     Set Environment Variable  ESX_HOST_PASSWORD  e2eFunctionalTest
 
 Deploy Vcsa
     # deploy a vcsa
-    ${vc}  ${vc-ip}=  Run Keyword If  %{TEST_VSPHERE_VER} == 60  Deploy Nimbus vCenter Server For NGC Testing  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}  ELSE  Deploy Nimbus vCenter Server For NGC Testing  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}  4602587
+    ${name}=  Evaluate  'UITEST-VC%{TEST_VSPHERE_VER}-' + str(random.randint(1000,9999))  modules=random
+    ${buildnum}=  Run Keyword If  %{TEST_VSPHERE_VER} == 60  Set Variable  3634791  ELSE  Set Variable  5318154
+    ${out}=  Deploy Nimbus vCenter Server Async  ${name} --useQaNgc  ${buildnum}
+    ${result}=  Wait For Process  ${out}
+    Log  ${result.stdout}
+    Log  ${result.stderr}
+
+    Open Connection  %{NIMBUS_GW}
+    Wait Until Keyword Succeeds  2 min  30 sec  Login  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}
+    ${vc-ip}=  Get IP  ${name}
+    Set Environment Variable  GOVC_INSECURE  1
+    Set Environment Variable  GOVC_USERNAME  Administrator@vsphere.local
+    Set Environment Variable  GOVC_PASSWORD  Admin!23
+    Set Environment Variable  GOVC_URL  ${vc-ip}
+    Log To Console  Successfully deployed %{NIMBUS_USER}-${name}. IP: ${vc-ip}
+    Close Connection
 
     # create a datacenter
     Log To Console  Create a datacenter on the VC
@@ -162,7 +195,7 @@ Deploy Vcsa
     ${out}=  Run  govc dvs.add -dvs=test-ds -pnic=vmnic1 -host.ip=%{ESX_HOST_IP} %{ESX_HOST_IP}
     Should Contain  ${out}  OK
 
-    Set Environment Variable  TEST_VC_NAME  ${vc}
+    Set Environment Variable  TEST_VC_NAME  %{NIMBUS_USER}-${name}
     Set Environment Variable  TEST_VC_IP  ${vc-ip}
     Set Environment Variable  TEST_URL_ARRAY  ${vc-ip}
     Set Environment Variable  TEST_USERNAME  Administrator@vsphere.local
@@ -206,65 +239,8 @@ Deploy Nimbus BrowserVm For NGC Testing
     Close connection
     [Return]  ${user}-${name}  ${ip}
 
-Deploy Nimbus ESXi Server For NGC Testing
-    [Arguments]  ${user}  ${password}  ${version}=3620759
-    ${name}=  Evaluate  'UITEST-ESX%{TEST_VSPHERE_VER}-' + str(random.randint(1000,9999))  modules=random
-    Log To Console  \nDeploying Nimbus ESXi server: ${name} using build ${version}
-    Open Connection  %{NIMBUS_GW}
-    Login  ${user}  ${password}
-
-    ${out}=  Execute Command  nimbus-esxdeploy ${name} --disk=48000000 --ssd=24000000 --memory=8192 --nics 2 ${version}
-    # Make sure the deploy actually worked
-    Should Contain  ${out}  To manage this VM use
-    # Now grab the IP address and return the name and ip for later use
-    @{out}=  Split To Lines  ${out}
-    :FOR  ${item}  IN  @{out}
-    \   ${status}  ${message}=  Run Keyword And Ignore Error  Should Contain  ${item}  IP is
-    \   Run Keyword If  '${status}' == 'PASS'  Set Suite Variable  ${line}  ${item}
-    @{gotIP}=  Split String  ${line}  ${SPACE}
-    ${ip}=  Remove String  @{gotIP}[5]  ,
-
-    # Let's set a password so govc doesn't complain
-    Remove Environment Variable  GOVC_PASSWORD
-    Remove Environment Variable  GOVC_USERNAME
-    Set Environment Variable  GOVC_INSECURE  1
-    Set Environment Variable  GOVC_URL  root:@${ip}
-    ${out}=  Run  govc host.account.update -id root -password e2eFunctionalTest
-    Should Be Empty  ${out}
-    Log To Console  Successfully deployed new ESXi server - ${user}-${name}
-    Close connection
-    [Return]  ${user}-${name}  ${ip}
-
-Deploy Nimbus vCenter Server For NGC Testing
-    [Arguments]  ${user}  ${password}  ${version}=3634791
-    ${name}=  Evaluate  'UITEST-VC%{TEST_VSPHERE_VER}-' + str(random.randint(1000,9999))  modules=random
-    Log To Console  \nDeploying Nimbus vCenter server: ${name} using build ${version}
-    Open Connection  %{NIMBUS_GW}
-    Login  ${user}  ${password}
-
-    ${out}=  Execute Command  nimbus-vcvadeploy --vcvaBuild ${version} --useQaNgc ${name}
-    # Make sure the deploy actually worked
-    Should Contain  ${out}  Overall Status: Succeeded
-    # Now grab the IP address and return the name and ip for later use
-    @{out}=  Split To Lines  ${out}
-    :FOR  ${item}  IN  @{out}
-    \   ${status}  ${message}=  Run Keyword And Ignore Error  Should Contain  ${item}  Cloudvm is running on IP
-    \   Run Keyword If  '${status}' == 'PASS'  Set Suite Variable  ${line}  ${item}
-    ${ip}=  Fetch From Right  ${line}  ${SPACE}
-
-    Set Environment Variable  GOVC_INSECURE  1
-    Set Environment Variable  GOVC_USERNAME  Administrator@vsphere.local
-    Set Environment Variable  GOVC_PASSWORD  Admin!23
-    Set Environment Variable  GOVC_URL  ${ip}
-    Log To Console  Successfully deployed new vCenter server - ${user}-${name}
-    Close connection
-    [Return]  ${user}-${name}  ${ip}
-
 *** Test Cases ***
 Check Variables
-    # Purpose of this test case is to make sure all environment variables are set correctly before the tests can be performed
-    # TODO: remove "Run Keyword And Return Status"s and Log statements when online
-
     ${isset_SHELL}=  Run Keyword And Return Status  Environment Variable Should Be Set  SHELL
     ${isset_DRONE_SERVER}=  Run Keyword And Return Status  Environment Variable Should Be Set  DRONE_SERVER
     ${isset_DRONE_TOKEN}=  Run Keyword And Return Status  Environment Variable Should Be Set  DRONE_TOKEN
@@ -284,6 +260,7 @@ Check Variables
     Log To Console  TEST_DATASTORE ${isset_TEST_DATASTORE}
     Log To Console  TEST_RESOURCE ${isset_TEST_RESOURCE}
     Log To Console  GOVC_INSECURE ${isset_GOVC_INSECURE}
+    Log To Console  TEST_VSPHERE_VER %{TEST_VSPHERE_VER}
     Should Be True  ${isset_SHELL} and ${isset_DRONE_SERVER} and ${isset_DRONE_TOKEN} and ${isset_NIMBUS_USER} and ${isset_NIMBUS_GW} and ${isset_TEST_DATASTORE} and ${isset_TEST_RESOURCE} and ${isset_GOVC_INSECURE} and %{TEST_VSPHERE_VER}
 
 Check Nimbus Machines

--- a/ui/installer/VCSA/configs
+++ b/ui/installer/VCSA/configs
@@ -1,33 +1,15 @@
-# Enter the IP of VCSA
-VCENTER_IP=""
+# WARNING: This file no longer should be edited by the user manually
+# If you see VIC_UI_HOST_URL and/or VIC_UI_HOST_THUMBPRINT empty,
+# please file an issue at https://github.com/vmware/vic
 
 # Change the VIC_UI_HOST_URL variable to the URL to the path where
 # the plugin zip files are located. For example, if com.vmware.vic-v1.1.0.zip is
 # available at https://192.168.1.5/com.vmware.vic-v1.1.0.zip,
 # simply type in https://192.168.1.5/
-#
-# NOTE: Installing the plugin by setting VIC_UI_HOST_URL to "NOURL" is deprecated
-# and therefore officially NOT supported. Please use it at your own risk.
 VIC_UI_HOST_URL=""
 
 # Enter the SHA-1 thumbprint of the web server hosting the plugin files.
 # Taking an example above, it should be the SHA-1 thumbprint of
 # the SSL certificate on https://192.168.1.5
 #
-# The fingerprint should be in the format of A0:B1:C2:... In case you retrieved
-# it from Google Chrome make sure to replace spaces with colons (:)
 VIC_UI_HOST_THUMBPRINT=""
-
-# NOTE: Use of the IS_VCENTER_5_5 variable is deprecated and therefore
-# officially NOT supported. Please use it at your own risk.
-# Set the value to 1 when:
-#
-# 1) You need to install the plugin to a vCenter Server 5.5 instance AND
-# 2) You set VIC_UI_HOST_URL to "NOURL"
-IS_VCENTER_5_5=0
-
-# Set the plugin type to install. If you are installing the plugin for the
-# vSphere Client (HTML5 Client), then leave the value as-is. If you are
-# installing it for the vSphere Web Client (Flex Client),
-# then set the value to "flex"
-PLUGIN_TYPE="html5"

--- a/ui/installer/VCSA/uninstall.sh
+++ b/ui/installer/VCSA/uninstall.sh
@@ -14,6 +14,13 @@
 # limitations under the License.
 #
 
+echo "-------------------------------------------------------------"
+echo "This script will uninstall vSphere Integrated Containers plugin"
+echo "for vSphere Client (HTML) and vSphere Web Client (Flex)."
+echo ""
+echo "Please provide connection information to the vCenter Server."
+echo "-------------------------------------------------------------"
+
 # check for the configs file
 if [[ ! -f "configs" ]] ; then
     echo "Error! Configs file is missing. Please try downloading the VIC UI installer again"
@@ -26,11 +33,8 @@ while IFS='' read -r line; do
     eval $line
 done < ./configs
 
-# check for the VC IP
-if [[ $VCENTER_IP == "" ]] ; then
-    echo "Error! vCenter IP cannot be empty. Please provide a valid IP in the configs file"
-    exit 1
-fi
+# replace space delimiters with colon delimiters
+VIC_UI_HOST_THUMBPRINT=$(echo $VIC_UI_HOST_THUMBPRINT | sed -e 's/[[:space:]]/\:/g')
 
 # check for the pllugin manifest file
 if [[ ! -f ../plugin-manifest ]] ; then
@@ -44,16 +48,15 @@ while IFS='' read -r p_line; do
     eval "$p_line"
 done < ../plugin-manifest
 
+read -p "Enter IP to target vCenter Server: " VCENTER_IP
 read -p "Enter your vCenter Administrator Username: " VCENTER_ADMIN_USERNAME
 echo -n "Enter your vCenter Administrator Password: "
 read -s VCENTER_ADMIN_PASSWORD
 echo ""
 
 OS=$(uname)
-PLUGIN_BUNDLES=''
 VCENTER_SDK_URL="https://${VCENTER_IP}/sdk/"
 COMMONFLAGS="--target $VCENTER_SDK_URL --user $VCENTER_ADMIN_USERNAME --password $VCENTER_ADMIN_PASSWORD"
-PLUGIN_FOLDERS=''
 
 if [[ $(echo $OS | grep -i "darwin") ]] ; then
     PLUGIN_MANAGER_BIN="../../vic-ui-darwin"
@@ -61,39 +64,82 @@ else
     PLUGIN_MANAGER_BIN="../../vic-ui-linux"
 fi
 
-check_prerequisite () {
-    # if PLUGIN_TYPE is not specified default to html5 plugin
-    if [[ $PLUGIN_TYPE = 'flex' ]] ; then
-        PLUGIN_TYPE=flex
-        key=$key_flex
-    else
-        PLUGIN_TYPE=html5
-        key=$key_h5c
+prompt_thumbprint_verification() {
+    read -p "Are you sure you trust the authenticity of this host (yes/no)? " SHOULD_ACCEPT_VC_FINGERPRINT
+    if [[ ! $(echo $SHOULD_ACCEPT_VC_FINGERPRINT | grep -woi "yes\|no") ]] ; then
+        echo Please answer either \"yes\" or \"no\"
+        prompt_thumbprint_verification
+        return
     fi
 
-    if [[ $(curl -v --head https://$VCENTER_IP -k 2>&1 | grep -i "could not resolve host") ]] ; then
-        echo "Error! Could not resolve the hostname. Please make sure you set VCENTER_IP correctly in the configuration file"
-        exit 1
+    if [[ $SHOULD_ACCEPT_VC_FINGERPRINT = "no" ]] ; then
+        read -p "Enter SHA-1 thumbprint of target VC: " VC_THUMBPRINT
     fi
 }
 
-parse_and_unregister_plugins () {
-    local plugin_flags="--key $key"
+check_prerequisite () {
+    # check if the provided VCENTER_IP is a valid vCenter Server host
+    local CURL_RESPONSE=$(curl -sLk https://$VCENTER_IP)
+    if [[ ! $(echo $CURL_RESPONSE | grep -oi "vmware vsphere") ]] ; then
+        echo "-------------------------------------------------------------"
+        echo "Error! vCenter Server was not found at host $VCENTER_IP"
+        cleanup
+        exit 1
+    fi
+
+    #retrieve VC thumbprint
+    VC_THUMBPRINT=$($PLUGIN_MANAGER_BIN info $COMMONFLAGS --key com.vmware.vic.noop 2>&1 | grep -o "(thumbprint.*)" | awk -F= '{print $2}' | sed 's/.$//')
+
+    # verify the thumbprint of VC
+    echo ""
+    echo "SHA-1 key fingerprint of host '$VCENTER_IP' is '$VC_THUMBPRINT'"
+    prompt_thumbprint_verification
+
+    # replace space delimiters with colon delimiters
+    VC_THUMBPRINT=$(echo $VC_THUMBPRINT | sed -e 's/[[:space:]]/\:/g')
+}
+
+unregister_plugin() {
+    local plugin_name=$1
+    local plugin_key=$2
     echo "-------------------------------------------------------------"
-    echo "Unregistering vCenter Server Extension..."
+    echo "Preparing to unregister vCenter Extension $plugin_name..."
     echo "-------------------------------------------------------------"
-    $PLUGIN_MANAGER_BIN remove $COMMONFLAGS $plugin_flags
+    local plugin_check_results=$($PLUGIN_MANAGER_BIN info $COMMONFLAGS --key $plugin_key --thumbprint $VC_THUMBPRINT 2>&1)
+    if [[ $(echo $plugin_check_results | grep -oi "fail\|error") ]] ; then
+        echo $plugin_check_results
+        echo "-------------------------------------------------------------"
+        echo "Error! Failed to check the status of plugin. Please see the message above"
+        exit 1
+    fi
+
+    if [[ $(echo $plugin_check_results | grep -oi "is not registered") ]] ; then
+        echo "Warning! Plugin with key '$plugin_key' is not registered with VC!"
+        echo "Uninstallation was skipped"
+        echo ""
+        return
+    fi
+
+    $PLUGIN_MANAGER_BIN remove --key $plugin_key $COMMONFLAGS --thumbprint $VC_THUMBPRINT
 
     if [[ $? > 0 ]] ; then
         echo "-------------------------------------------------------------"
-        echo "Error! Could not unregister plugin from vCenter Server. Please see the message above."
+        echo "Error! Could not unregister plugin with vCenter Server. Please see the message above"
+        cleanup
         exit 1
     fi
+    echo ""
+}
+
+parse_and_unregister_plugins () {
+    echo ""
+    unregister_plugin $name-FlexClient $key_flex
+    unregister_plugin $name-H5Client $key_h5c
 }
 
 check_prerequisite
 parse_and_unregister_plugins
 
 echo "--------------------------------------------------------------"
-echo "VIC UI unregistration was successful"
+echo "VIC Engine UI uninstaller exited successfully"
 echo ""

--- a/ui/installer/VCSA/upgrade.sh
+++ b/ui/installer/VCSA/upgrade.sh
@@ -1,5 +1,5 @@
-#!/bin/bash -e
-# Copyright 2016 VMware, Inc. All Rights Reserved.
+#!/bin/bash
+# Copyright 2017 VMware, Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,6 +14,269 @@
 # limitations under the License.
 #
 
-./install.sh --force
+cleanup () {
+    unset VCENTER_ADMIN_USERNAME
+    unset VCENTER_ADMIN_PASSWORD
+}
 
-exit 0
+echo "-------------------------------------------------------------"
+echo "This script will upgrade vSphere Integrated Containers plugin"
+echo "for vSphere Client (HTML) and vSphere Web Client (Flex)."
+echo ""
+echo "Please provide connection information to the vCenter Server."
+echo "-------------------------------------------------------------"
+
+# check for the configs file
+if [[ ! -f "configs" ]] ; then
+    echo "Error! Configs file is missing. Please try downloading the VIC UI installer again"
+    echo ""
+    cleanup
+    exit 1
+fi
+
+# load configs variable into env
+while IFS='' read -r line; do
+    eval $line
+done < ./configs
+
+# replace space delimiters with colon delimiters 
+VIC_UI_HOST_THUMBPRINT=$(echo $VIC_UI_HOST_THUMBPRINT | sed -e 's/[[:space:]]/\:/g')
+
+# check for the plugin manifest file
+if [[ ! -f ../plugin-manifest ]] ; then
+    echo "Error! Plugin manifest was not found!"
+    cleanup
+    exit 1
+fi
+
+# load plugin manifest into env
+while IFS='' read -r p_line; do
+    eval "$p_line"
+done < ../plugin-manifest
+
+read -p "Enter IP to target vCenter Server: " VCENTER_IP
+read -p "Enter your vCenter Administrator Username: " VCENTER_ADMIN_USERNAME
+echo -n "Enter your vCenter Administrator Password: "
+read -s VCENTER_ADMIN_PASSWORD
+echo ""
+
+OS=$(uname)
+VCENTER_SDK_URL="https://${VCENTER_IP}/sdk/"
+COMMONFLAGS="--target $VCENTER_SDK_URL --user $VCENTER_ADMIN_USERNAME --password $VCENTER_ADMIN_PASSWORD"
+
+# set binary to call based on os
+if [[ $(echo $OS | grep -i "darwin") ]] ; then
+    PLUGIN_MANAGER_BIN="../../vic-ui-darwin"
+else
+    PLUGIN_MANAGER_BIN="../../vic-ui-linux"
+fi
+
+# add a forward slash to VIC_UI_HOST_URL in case it misses it
+if [[ ${VIC_UI_HOST_URL: -1: 1} != "/" ]] ; then
+    VIC_UI_HOST_URL="$VIC_UI_HOST_URL/"
+fi
+
+prompt_thumbprint_verification() {
+    read -p "Are you sure you trust the authenticity of this host (yes/no)? " SHOULD_ACCEPT_VC_FINGERPRINT
+    if [[ ! $(echo $SHOULD_ACCEPT_VC_FINGERPRINT | grep -woi "yes\|no") ]] ; then
+        echo Please answer either \"yes\" or \"no\"
+        prompt_thumbprint_verification
+        return
+    fi
+
+    if [[ $SHOULD_ACCEPT_VC_FINGERPRINT = "no" ]] ; then
+        read -p "Enter SHA-1 thumbprint of target VC: " VC_THUMBPRINT
+    fi
+}
+
+check_prerequisite () {
+    # check if the provided VCENTER_IP is a valid vCenter Server host
+    local CURL_RESPONSE=$(curl -sLk https://$VCENTER_IP)
+    if [[ ! $(echo $CURL_RESPONSE | grep -oi "vmware vsphere") ]] ; then
+        echo "-------------------------------------------------------------"
+        echo "Error! vCenter Server was not found at host $VCENTER_IP"
+        cleanup
+        exit 1
+    fi
+
+    # retrieve VC thumbprint
+    VC_THUMBPRINT=$($PLUGIN_MANAGER_BIN info $COMMONFLAGS --key com.vmware.vic.noop 2>&1 | grep -o "(thumbprint.*)" | awk -F= '{print $2}' | sed 's/.$//')
+
+    # verify the thumbprint of VC
+    echo ""
+    echo "SHA-1 key fingerprint of host '$VCENTER_IP' is '$VC_THUMBPRINT'"
+    prompt_thumbprint_verification
+
+    # replace space delimiters with colon delimiters
+    VC_THUMBPRINT=$(echo $VC_THUMBPRINT | sed -e 's/[[:space:]]/\:/g')
+}
+
+# purpose of this function is to remove an outdated version of vic ui in case it's installed
+remove_old_key_installation () {
+    $PLUGIN_MANAGER_BIN remove $COMMONFLAGS --key com.vmware.vicui.Vicui > /dev/null 2> /dev/null
+}
+
+confirm_upgrade() {
+    read -p "Are you sure you want to continue (yes/no)? " ACCEPT_INSTALL
+    if [[ ! $(echo $ACCEPT_INSTALL | grep -woi "yes\|no") ]] ; then
+        echo Please answer either \"yes\" or \"no\"
+        confirm_upgrade
+        return
+    fi
+}
+
+confirm_fresh_install() {
+    read -p "Do you want to install the plugins (yes/no)? " ACCEPT_INSTALL
+    if [[ ! $(echo $ACCEPT_INSTALL | grep -woi "yes\|no") ]] ; then
+        echo Please answer either \"yes\" or \"no\"
+        confirm_fresh_install
+        return
+    fi
+}
+
+get_comparable_ver() {
+    local raw=$1
+    echo $raw | awk -F. '{print $1 * 100 + $2 * 10 + $3}'
+}
+
+check_existing_plugins() {
+    echo ""
+    echo "-------------------------------------------------------------"
+    echo "Checking existing plugins..."
+    echo "-------------------------------------------------------------"
+    local check_h5c=$($PLUGIN_MANAGER_BIN info $COMMONFLAGS --key $key_h5c --thumbprint $VC_THUMBPRINT 2>&1)
+    local check_flex=$($PLUGIN_MANAGER_BIN info $COMMONFLAGS --key $key_flex --thumbprint $VC_THUMBPRINT 2>&1)
+
+    if [[ $(echo $check_h5c | grep -oi "fail\|error") ]] ; then
+        echo $check_h5c
+        echo "-------------------------------------------------------------"
+        echo "Error! Failed to check the status of plugin. Please see the message above"
+        exit 1
+    fi
+
+    if [[ $(echo $check_flex | grep -oi "fail\|error") ]] ; then
+        echo $check_flex
+        echo "-------------------------------------------------------------"
+        echo "Error! Failed to check the status of plugin. Please see the message above"
+        exit 1
+    fi
+
+    local h5c_plugin_version=$(echo $check_h5c | grep -oi "[[:digit:]]\.[[:digit:]]\.[[:digit:]]")
+    local flex_plugin_version=$(echo $check_flex | grep -oi "[[:digit:]]\.[[:digit:]]\.[[:digit:]]")
+    local existing_version=""
+
+    if [[ -z $(echo $h5c_plugin_version$flex_plugin_version) ]] ; then
+        echo "No VIC Engine UI plugin was found on the target VC"
+        confirm_fresh_install
+        echo ""
+    else
+        # assuming user always keeps the both plugins at the same version
+        if [[ $(echo $check_h5c | grep -oi "is registered") ]] ; then
+            echo "Plugin with key '$key_h5c' is already registered with VC. (Version: $h5c_plugin_version)"
+            existing_version=$h5c_plugin_version
+        fi
+
+        if [[ $(echo $check_flex | grep -oi "is registered") ]] ; then
+            echo "Plugin with key '$key_flex' is already registered with VC (Version: $flex_plugin_version)"
+            existing_version=$flex_plugin_version
+        fi
+
+        echo "The version you are about to install is '$version'."
+        if [[ $(get_comparable_ver $existing_version) -ge $(get_comparable_ver $version) ]] ; then
+            echo ""
+            echo "You are trying to install plugins of an older or same version. For changes to take effect,"
+            echo "please restart the vSphere Web Client and vSphere Client services after upgrade is completed"
+            echo "For instructions, please refer to https://vmware.github.io/vic-product/assets/files/html/1.1/vic_vsphere_admin/ts_ui_not_appearing.html"
+        fi
+
+        echo ""
+        confirm_upgrade
+        echo ""
+    fi
+
+    if [[ $ACCEPT_INSTALL = "no" ]] ; then
+        echo "Error! Upgrade was cancelled by user"
+        exit 1
+    fi
+}
+
+upgrade_plugin() {
+    local plugin_name=$1
+    local plugin_key=$2
+    local plugin_url="${VIC_UI_HOST_URL}files/"
+    local plugin_flags="--version $version --summary $summary --company $company --url $plugin_url$plugin_key-v$version.zip"
+    echo "-------------------------------------------------------------"
+    echo "Preparing to upgrade vCenter Extension $1..."
+    echo "-------------------------------------------------------------"
+
+    $PLUGIN_MANAGER_BIN install --force \
+                                --key $plugin_key \
+                                --name $plugin_name $COMMONFLAGS $plugin_flags \
+                                --thumbprint $VC_THUMBPRINT \
+                                --server-thumbprint $VIC_UI_HOST_THUMBPRINT
+    if [[ $? > 0 ]] ; then
+        echo "-------------------------------------------------------------"
+        echo "Error! Could not register plugin with vCenter Server. Please see the message above"
+        cleanup
+        exit 1
+    fi
+    echo ""
+}
+
+parse_and_upgrade_plugins () {
+    upgrade_plugin $name-FlexClient $key_flex
+    upgrade_plugin $name-H5Client $key_h5c
+}
+
+verify_plugin_url() {
+    local plugin_key=$1
+    local PLUGIN_BASENAME=$plugin_key-v$version.zip
+
+    if [[ $BYPASS_PLUGIN_VERIFICATION ]] ; then
+        return
+    fi
+
+    if [[ ! $(echo ${VIC_UI_HOST_URL:0:5} | grep -i "https") ]] ; then
+        echo "-------------------------------------------------------------"
+        echo "Error! VIC_UI_HOST_URL should always start with 'https' in the configs file"
+        cleanup
+        exit 1
+    fi
+
+    if [[ -z $VIC_UI_HOST_THUMBPRINT ]] ; then
+        echo "-------------------------------------------------------------"
+        echo "Error! Please provide VIC_UI_HOST_THUMBPRINT in the configs file"
+        cleanup
+        exit 1
+    fi
+
+    local CURL_RESPONSE=$(curl --head $VIC_UI_HOST_URL$PLUGIN_BASENAME -k 2>&1)
+
+    if [[ $(echo $CURL_RESPONSE | grep -i "could not resolve\|fail") ]] ; then
+        echo "-------------------------------------------------------------"
+        echo "Error! Could not resolve the host provided. Please make sure the URL is correct"
+        cleanup
+        exit 1
+    fi
+
+    local RESPONSE_STATUS=$(echo $CURL_RESPONSE | grep -i "HTTP" | grep "4[[:digit:]][[:digit:]]\|500")
+    if [[ $(echo $RESPONSE_STATUS | grep -oi "404") ]] ; then
+        echo "-------------------------------------------------------------"
+        echo "Error! Plugin bundle was not found. Please make sure \"$PLUGIN_BASENAME\" is available at \"$VIC_UI_HOST_URL\", and retry installing the plugin"
+        cleanup
+        exit 1
+    fi
+}
+
+check_prerequisite
+remove_old_key_installation
+verify_plugin_url $key_flex
+verify_plugin_url $key_h5c
+check_existing_plugins
+parse_and_upgrade_plugins
+
+cleanup
+
+echo "--------------------------------------------------------------"
+echo "VIC Engine UI upgrader exited successfully"
+echo ""

--- a/ui/installer/vCenterForWindows/configs
+++ b/ui/installer/vCenterForWindows/configs
@@ -1,14 +1,14 @@
-REM Enter the IP of the server running vCenter for Windows
-SET target_vcenter_ip=
+REM WARNING: This file no longer should be edited by the user manually
+REM If you see VIC_UI_HOST_URL and/or VIC_UI_HOST_THUMBPRINT empty,
+REM please file an issue at https://github.com/vmware/vic
 
-REM Change the following line to the full URL of the path where the zip files are located
-REM For example, if vic-ui.zip is available at https://192.168.1.5/vic-ui-plugins/vic-ui.zip, type in: https://192.168.1.5/vic-ui-plugins/
-REM Note: each uploaded zip file will be accessed only once when the user logs into vSphere Web Client for the first time after successful installation
-SET vic_ui_host_url=NOURL
+REM Change the VIC_UI_HOST_URL variable to the URL to the path where
+REM the plugin zip files are located. For example, if com.vmware.vic-v1.1.0.zip is
+REM available at https://192.168.1.5/com.vmware.vic-v1.1.0.zip,
+REM simply type in https://192.168.1.5/
+SET vic_ui_host_url=
 
-REM If line 11 starts with "https", enter the SHA-1 thumbprint of the web server hosting the zip files
-REM The fingerprint should be in the format of A0:B1:C2:... In case you retrieved the fingerprint from Google Chrome make sure to replace spaces with colons (:)
+REM Enter the SHA-1 thumbprint of the web server hosting the plugin files.
+REM Taking an example above, it should be the SHA-1 thumbprint of
+REM the SSL certificate on https://192.168.1.5
 SET vic_ui_host_thumbprint=
-
-REM If you are installing the Flex plugin for vSphere Web Client, please update the value to 6.0, otherwise please leave the value as-is
-SET target_vc_version=6.5

--- a/ui/installer/vCenterForWindows/install.bat
+++ b/ui/installer/vCenterForWindows/install.bat
@@ -14,6 +14,8 @@ REM See the License for the specific language governing permissions and
 REM limitations under the License.
 
 SETLOCAL ENABLEEXTENSIONS
+SETLOCAL DISABLEDELAYEDEXPANSION
+
 SET me=%~n0
 SET parent=%~dp0
 
@@ -23,11 +25,19 @@ FOR /F "tokens=*" %%A IN (configs) DO (
     )
 )
 
-IF [%target_vcenter_ip%] == [] (
-    ECHO Error! vCenter IP cannot be empty. Please provide a valid IP in the configs file
-    GOTO:EOF
+IF NOT EXIST configs (
+    ECHO -------------------------------------------------------------
+    ECHO Error! Configs file is missing. Please try downloading the VIC UI installer again
+    EXIT /b 1
 )
 
+ECHO -------------------------------------------------------------
+ECHO This script will install vSphere Integrated Containers plugin
+ECHO for vSphere Client (HTML) and vSphere Web Client (Flex).
+ECHO.
+ECHO Please provide connection information to the vCenter Server.
+ECHO -------------------------------------------------------------
+SET /p target_vcenter_ip="Enter IP to target vCenter Server: "
 SET /p vcenter_username="Enter your vCenter Administrator Username: "
 SET "psCommand=powershell -Command "$pword = read-host 'Enter your vCenter Administrator Password' -AsSecureString ; ^
     $BSTR=[System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($pword); ^
@@ -38,66 +48,170 @@ SET plugin_manager_bin=%parent%..\..\vic-ui-windows.exe
 SET vcenter_reg_common_flags=--target https://%target_vcenter_ip%/sdk/ --user %vcenter_username% --password %vcenter_password%
 
 IF [%1] == [--force] (
-   SET vcenter_reg_common_flags=%vcenter_reg_common_flags% --force
+    SET force_install=1
+) ELSE (
+    SET force_install=0
 )
 
+REM read plugin-manifest
 FOR /F "tokens=1,2 delims==" %%A IN (..\plugin-manifest) DO (
     IF NOT %%A=="" (
         CALL SET %%A=%%B
     )
 )
 
-IF %target_vc_version% EQU 6.5 (
-    SET key=%key_h5c%
-) ELSE (
-    SET key=%key_flex%
+REM add a forward slash to vic_ui_host_url if its last character is not '/'
+IF [%vic_ui_host_url:~-1%] NEQ [/] (
+    SET vic_ui_host_url=%vic_ui_host_url%/
 )
 
-SET PLUGIN_FLAGS=--key %key:"=% --name %name% --version %version:"=% --summary %summary% --company %company%
-SET PLUGIN_URL=%vic_ui_host_url%%key%-v%version%.zip
-IF /I %vic_ui_host_url% NEQ NOURL (
-    IF %vic_ui_host_url:~-1,1% NEQ / (
-        SET vic_ui_host_url=%vic_ui_host_url%/
-    )
-
-    IF /I %vic_ui_host_url:~0,5%==https (
-        SET vcenter_reg_common_flags=%vcenter_reg_common_flags% --server-thumbprint %vic_ui_host_thumbprint%
-    )
-    SET PLUGIN_FLAGS=%PLUGIN_FLAGS% --url %PLUGIN_URL:"=%
-) ELSE (
-    SET PLUGIN_FLAGS=%PLUGIN_FLAGS% --url NOURL
+REM replace space delimiters with colon delimiters
+SETLOCAL ENABLEDELAYEDEXPANSION
+FOR /F "tokens=*" %%D IN ('ECHO %vic_ui_host_thumbprint%^| powershell -Command "$input.replace(' ', ':')"') DO (
+    SET vic_ui_host_thumbprint=%%D
 )
+SETLOCAL DISABLEDELAYEDEXPANSION
 
-ECHO Registering VIC UI Plugins...
+REM entry routine
+GOTO retrieve_vc_thumbprint
 
-"%plugin_manager_bin%" install %PLUGIN_FLAGS% %vcenter_reg_common_flags%
-IF %ERRORLEVEL% NEQ 0 (
+:retrieve_vc_thumbprint
+"%parent%..\..\vic-ui-windows.exe" info %vcenter_reg_common_flags% --key com.vmware.vic.noop > scratch.tmp 2> NUL
+TYPE scratch.tmp | findstr -c:"Failed to verify certificate" > NUL
+IF %ERRORLEVEL% EQU 0 (
+    SETLOCAL ENABLEDELAYEDEXPANSION
+    FOR /F "usebackq tokens=2 delims=(" %%B IN (scratch.tmp) DO SET vc_thumbprint=%%B
+    SET vc_thumbprint=!vc_thumbprint:~11,-1!
+    ECHO.
+    ECHO SHA-1 key fingerprint of host '%target_vcenter_ip%' is '!vc_thumbprint!'
+    GOTO validate_vc_thumbprint
+) ELSE (
+    TYPE scratch.tmp
+    ECHO -------------------------------------------------------------
     ECHO Error! Could not register plugin with vCenter Server. Please see the message above
-    GOTO:EOF
+    DEL scratch*.tmp 2>NUL
+    EXIT /b 1
 )
-ECHO.
-ECHO Installation of UI plugin succeeded
-ECHO.
 
-IF /I %vic_ui_host_url% EQU NOURL (
-    ECHO =============================
-    IF %target_vc_version% EQU 6.5 (
-        ECHO If you are installing the plugin for the vSphere Web Client (Flex Client^^^)
-        ECHO To finish installation, copy the com.vmware.vic* folder from \ui\vsphere-client-serenity to %VMWARE_CFG_DIR%\vsphere-client\vc-packages\vsphere-client-serenity. Create any missing folders in between if necessary.
-        ECHO Once all done, log out of vSphere Web Client and then log back in.
-        ECHO.
-        ECHO WARNING: If you are installing the plugin for the vSphere Client (H5 Client^^^)
-        ECHO The plugin won't install correctly without a web server for the vSphere Client at this moment.
-        ECHO Please see issue #4279 (https://github.com/vmware/vic/issues/4279^^^)
+:validate_vc_thumbprint
+SET /p accept_vc_thumbprint="Are you sure you trust the authenticity of this host [yes/no]? "
+IF /I [%accept_vc_thumbprint%] == [yes] (
+    SETLOCAL DISABLEDELAYEDEXPANSION
+    IF %force_install% NEQ 1 (
+        GOTO check_existing_plugins
     ) ELSE (
-        IF %target_vc_version% EQU 6.0 (
-            ECHO NEXT STEP for vCenter 6.0 users
-            ECHO With the current version of VIC running on vCenter for Windows, the com.vmware.vic.* folder needs to be manually copied from \ui\vsphere-client-serenity to %VMWARE_CFG_DIR%\vsphere-client\vc-packages\vsphere-client-serenity. If you have not done so, please copy it now.
-        ) ELSE (
-            ECHO NEXT STEP for vCenter 5.5 users
-            ECHO VIC UI may run on a vCenter 5.5 setup, but is NOT officially supported. Use it at your own risk. To proceed, copy the com.vmware.vic.* folder to %PROGRAMDATA%\VMware\vSphere Web Client\vc-packages\vsphere-client-serenity instead.
-        )
-        ECHO Once all done, log out of vSphere Web Client and then log back in.
+        GOTO parse_and_register_plugins
     )
-    ECHO =============================
 )
+IF /I [%accept_vc_thumbprint%] == [no] (
+    SET /p vc_thumbprint="Enter SHA-1 thumbprint of target VC: "
+    SETLOCAL DISABLEDELAYEDEXPANSION
+    IF %force_install% NEQ 1 (
+        GOTO check_existing_plugins
+    ) ELSE (
+        GOTO parse_and_register_plugins
+    )
+)
+ECHO Please answer either "yes" or "no"
+GOTO validate_vc_thumbprint
+
+:check_existing_plugins
+ECHO.
+ECHO -------------------------------------------------------------
+ECHO Checking existing plugins...
+ECHO -------------------------------------------------------------
+SET can_install_continue=1
+REM check for h5c plugin
+"%parent%..\..\vic-ui-windows.exe" info %vcenter_reg_common_flags% --key com.vmware.vic --thumbprint %vc_thumbprint% > scratch.tmp 2>&1
+REM check for connection failure
+TYPE scratch.tmp | findstr -c:"fail" > NUL
+IF %ERRORLEVEL% EQU 0 (
+    TYPE scratch.tmp
+    ECHO -------------------------------------------------------------
+    ECHO Error! Could not register plugin with vCenter Server. Please see the message above
+    DEL scratch*.tmp 2>NUL
+    EXIT /b 1
+)
+REM check if plugin (h5c) is not registered
+TYPE scratch.tmp | findstr -c:"is not registered" > NUL
+IF %ERRORLEVEL% GTR 0 (
+    SETLOCAL ENABLEDELAYEDEXPANSION
+    TYPE scratch.tmp | findstr -r -c:"Version.*" > scratch2.tmp
+    FOR /F "usebackq tokens=2 delims=INFO" %%C IN (scratch2.tmp) DO SET ver_string=%%C
+    ECHO com.vmware.vic is already registered. Version: !ver_string:~11!
+    REM force flag condition
+    SET can_install_continue=0
+    SETLOCAL DISABLEDELAYEDEXPANSION
+)
+REM check for flex plugin
+"%parent%..\..\vic-ui-windows.exe" info %vcenter_reg_common_flags% --key com.vmware.vic.ui --thumbprint %vc_thumbprint% > scratch.tmp 2>&1
+REM check for connection failure
+TYPE scratch.tmp | findstr -c:"fail" > NUL
+IF %ERRORLEVEL% EQU 0 (
+    TYPE scratch.tmp
+    ECHO -------------------------------------------------------------
+    ECHO Error! Could not register plugin with vCenter Server. Please see the message above
+    DEL scratch*.tmp 2>NUL
+    EXIT /b 1
+)
+REM check if plugin (flex) is not registered
+TYPE scratch.tmp | findstr -c:"is not registered" > NUL
+IF %ERRORLEVEL% GTR 0 (
+    SETLOCAL ENABLEDELAYEDEXPANSION
+    TYPE scratch.tmp | findstr -r -c:"Version.*" > scratch2.tmp
+    FOR /F "usebackq tokens=2 delims=INFO" %%C IN (scratch2.tmp) DO SET ver_string=%%C
+    ECHO com.vmware.vic.ui is already registered. Version: !ver_string:~11!
+    REM force flag condition
+    SET can_install_continue=0
+    SETLOCAL DISABLEDELAYEDEXPANSION
+)
+REM if either plugin is installed kill the script
+IF %can_install_continue% EQU 0 (
+    ECHO -------------------------------------------------------------
+    ECHO Error! At least one plugin is already registered with the target VC.
+    ECHO Run upgrade.bat, or install.bat --force instead.
+    DEL scratch*.tmp 2>NUL
+    EXIT /b 1
+)
+ECHO No VIC Engine UI plugin was detected. Continuing to install the plugins.
+GOTO parse_and_register_plugins
+
+:parse_and_register_plugins
+REM remove obsolete plugin key if it ever exists
+"%plugin_manager_bin%" remove %vcenter_reg_common_flags% --key com.vmware.vicui.Vicui --thumbprint %vc_thumbprint% > NUL 2> NUL
+ECHO.
+ECHO -------------------------------------------------------------
+ECHO Preparing to register vCenter Extension %name:"=%-H5Client...
+ECHO -------------------------------------------------------------
+SET plugin_reg_flags=%vcenter_reg_common_flags% --name "%name:"=%-H5Client" --thumbprint %vc_thumbprint% --version %version:"=% --summary %summary% --company %company% --key %key_h5c:"=% --url %vic_ui_host_url%files/%key_h5c:"=%-v%version:"=%.zip --server-thumbprint %vic_ui_host_thumbprint%
+IF %force_install% EQU 1 (
+    SET plugin_reg_flags=%plugin_reg_flags% --force
+)
+"%plugin_manager_bin%" install %plugin_reg_flags%
+IF %ERRORLEVEL% NEQ 0 (
+    ECHO -------------------------------------------------------------
+    ECHO Error! Could not register plugin with vCenter Server. Please see the message above
+    DEL scratch*.tmp 2>NUL
+    EXIT /b 1
+)
+ECHO.
+ECHO -------------------------------------------------------------
+ECHO Preparing to register vCenter Extension %name:"=%-FlexClient...
+ECHO -------------------------------------------------------------
+SET plugin_reg_flags=%vcenter_reg_common_flags% --name "%name:"=%-FlexClient" --thumbprint %vc_thumbprint% --version %version:"=% --summary %summary% --company %company% --key %key_flex:"=% --url %vic_ui_host_url%files/%key_flex:"=%-v%version:"=%.zip --server-thumbprint %vic_ui_host_thumbprint%
+IF %force_install% EQU 1 (
+    SET plugin_reg_flags=%plugin_reg_flags% --force
+)
+"%plugin_manager_bin%" install %plugin_reg_flags%
+IF %ERRORLEVEL% NEQ 0 (
+    ECHO -------------------------------------------------------------
+    ECHO Error! Could not register plugin with vCenter Server. Please see the message above
+    DEL scratch*.tmp 2>NUL
+    EXIT /b 1
+)
+GOTO end
+
+:end
+DEL scratch*.tmp 2>NUL
+ECHO --------------------------------------------------------------
+ECHO VIC Engine UI installer exited successfully

--- a/ui/installer/vCenterForWindows/upgrade.bat
+++ b/ui/installer/vCenterForWindows/upgrade.bat
@@ -13,4 +13,226 @@ REM WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 REM See the License for the specific language governing permissions and
 REM limitations under the License.
 
-install.bat --force
+SETLOCAL ENABLEEXTENSIONS
+SETLOCAL DISABLEDELAYEDEXPANSION
+
+SET me=%~n0
+SET parent=%~dp0
+
+FOR /F "tokens=*" %%A IN (configs) DO (
+    IF NOT %%A=="" (
+        %%A
+    )
+)
+
+IF NOT EXIST configs (
+    ECHO -------------------------------------------------------------
+    ECHO Error! Configs file is missing. Please try downloading the VIC UI installer again
+    EXIT /b 1
+)
+
+ECHO -------------------------------------------------------------
+ECHO This script will upgrade vSphere Integrated Containers plugin
+ECHO for vSphere Client (HTML) and vSphere Web Client (Flex).
+ECHO.
+ECHO Please provide connection information to the vCenter Server.
+ECHO -------------------------------------------------------------
+SET /p target_vcenter_ip="Enter IP to target vCenter Server: "
+SET /p vcenter_username="Enter your vCenter Administrator Username: "
+SET "psCommand=powershell -Command "$pword = read-host 'Enter your vCenter Administrator Password' -AsSecureString ; ^
+    $BSTR=[System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($pword); ^
+        [System.Runtime.InteropServices.Marshal]::PtrToStringAuto($BSTR)""
+FOR /f "usebackq delims=" %%p in (`%psCommand%`) do set vcenter_password=%%p
+
+SET plugin_manager_bin=%parent%..\..\vic-ui-windows.exe
+SET vcenter_reg_common_flags=--target https://%target_vcenter_ip%/sdk/ --user %vcenter_username% --password %vcenter_password%
+
+REM read plugin-manifest
+FOR /F "tokens=1,2 delims==" %%A IN (..\plugin-manifest) DO (
+    IF NOT %%A=="" (
+        CALL SET %%A=%%B
+    )
+)
+
+REM add a forward slash to vic_ui_host_url if its last character is not '/'
+IF [%vic_ui_host_url:~-1%] NEQ [/] (
+    SET vic_ui_host_url=%vic_ui_host_url%/
+)
+
+REM replace space delimiters with colon delimiters
+SETLOCAL ENABLEDELAYEDEXPANSION
+FOR /F "tokens=*" %%D IN ('ECHO %vic_ui_host_thumbprint%^| powershell -Command "$input.replace(' ', ':')"') DO (
+    SET vic_ui_host_thumbprint=%%D
+)
+SETLOCAL DISABLEDELAYEDEXPANSION
+
+REM entry routine
+GOTO retrieve_vc_thumbprint
+
+:retrieve_vc_thumbprint
+"%parent%..\..\vic-ui-windows.exe" info %vcenter_reg_common_flags% --key com.vmware.vic.noop > scratch.tmp 2> NUL
+TYPE scratch.tmp | findstr -c:"Failed to verify certificate" > NUL
+IF %ERRORLEVEL% EQU 0 (
+    SETLOCAL ENABLEDELAYEDEXPANSION
+    FOR /F "usebackq tokens=2 delims=(" %%B IN (scratch.tmp) DO SET vc_thumbprint=%%B
+    SET vc_thumbprint=!vc_thumbprint:~11,-1!
+    ECHO.
+    ECHO SHA-1 key fingerprint of host '%target_vcenter_ip%' is '!vc_thumbprint!'
+    GOTO validate_vc_thumbprint
+) ELSE (
+    TYPE scratch.tmp
+    ECHO -------------------------------------------------------------
+    ECHO Error! Could not register plugin with vCenter Server. Please see the message above
+    DEL scratch*.tmp 2>NUL
+    EXIT /b 1
+)
+
+:validate_vc_thumbprint
+SET /p accept_vc_thumbprint="Are you sure you trust the authenticity of this host [yes/no]? "
+IF /I [%accept_vc_thumbprint%] == [yes] (
+    SETLOCAL DISABLEDELAYEDEXPANSION
+    GOTO check_existing_plugins
+)
+IF /I [%accept_vc_thumbprint%] == [no] (
+    SET /p vc_thumbprint="Enter SHA-1 thumbprint of target VC: "
+    SETLOCAL DISABLEDELAYEDEXPANSION
+    GOTO check_existing_plugins
+)
+ECHO Please answer either "yes" or "no"
+GOTO validate_vc_thumbprint
+
+:check_existing_plugins
+ECHO.
+ECHO -------------------------------------------------------------
+ECHO Checking existing plugins...
+ECHO -------------------------------------------------------------
+SET plugins_installed=0
+REM check for h5c plugin
+"%parent%..\..\vic-ui-windows.exe" info %vcenter_reg_common_flags% --key com.vmware.vic --thumbprint %vc_thumbprint% > scratch.tmp 2>&1
+REM check for connection failure
+TYPE scratch.tmp | findstr -c:"fail" > NUL
+IF %ERRORLEVEL% EQU 0 (
+    TYPE scratch.tmp
+    ECHO -------------------------------------------------------------
+    ECHO Error! Could not register plugin with vCenter Server. Please see the message above
+    DEL scratch*.tmp 2>NUL
+    EXIT /b 1
+)
+REM check if plugin (h5c) is not registered
+TYPE scratch.tmp | findstr -c:"is not registered" > NUL
+IF %ERRORLEVEL% GTR 0 (
+    SETLOCAL ENABLEDELAYEDEXPANSION
+    TYPE scratch.tmp | findstr -r -c:"Version.*" > scratch2.tmp
+    FOR /F "usebackq tokens=2 delims=INFO" %%C IN (scratch2.tmp) DO SET ver_string=%%C
+    ECHO com.vmware.vic is already registered. Version: !ver_string:~11!
+    SET /A "plugins_installed=%plugins_installed%+1"
+    SET old_plugin_ver=!ver_string:~11!
+    SETLOCAL DISABLEDELAYEDEXPANSION
+)
+REM check for flex plugin
+"%parent%..\..\vic-ui-windows.exe" info %vcenter_reg_common_flags% --key com.vmware.vic.ui --thumbprint %vc_thumbprint% > scratch.tmp 2>&1
+REM check for connection failure
+TYPE scratch.tmp | findstr -c:"fail" > NUL
+IF %ERRORLEVEL% EQU 0 (
+    TYPE scratch.tmp
+    ECHO -------------------------------------------------------------
+    ECHO Error! Could not register plugin with vCenter Server. Please see the message above
+    DEL scratch*.tmp 2>NUL
+    EXIT /b 1
+)
+REM check if plugin (flex) is not registered
+TYPE scratch.tmp | findstr -c:"is not registered" > NUL
+IF %ERRORLEVEL% GTR 0 (
+    SETLOCAL ENABLEDELAYEDEXPANSION
+    TYPE scratch.tmp | findstr -r -c:"Version.*" > scratch2.tmp
+    FOR /F "usebackq tokens=2 delims=INFO" %%C IN (scratch2.tmp) DO SET ver_string=%%C
+    ECHO com.vmware.vic.ui is already registered. Version: !ver_string:~11!
+    SET /A "plugins_installed=%plugins_installed%+1"
+    SET old_plugin_ver=!ver_string:~11!
+    SETLOCAL DISABLEDELAYEDEXPANSION
+)
+REM no plugin is installed, prompt the user if the plugins should be installed fresh
+IF %plugins_installed% EQU 0 (
+    ECHO No VIC Engine UI plugin was found on the target VC
+    GOTO confirm_fresh_install
+) ELSE (
+    ECHO The version you are about to install is '%version:"=%'.
+    SETLOCAL ENABLEDELAYEDEXPANSION
+    FOR /F "usebackq tokens=1,2,3 delims=." %%m IN ('%version:"=%') DO (
+        SET /A "new_plugin_ver=%%m*100+%%n*10+%%o"
+    )
+    FOR /F "usebackq tokens=1,2,3 delims=." %%m IN ('%old_plugin_ver%') DO (
+        SET /A "old_plugin_ver=%%m*100+%%n*10+%%o"
+    )
+    IF !new_plugin_ver! LEQ !old_plugin_ver! (
+        ECHO.
+        ECHO You are trying to install plugins of an older or same version. For changes to take effect,
+        ECHO please restart the vSphere Web Client and vSphere Client services after upgrade is completed
+        ECHO For instructions, please refer to https://vmware.github.io/vic-product/assets/files/html/1.1/vic_vsphere_admin/ts_ui_not_appearing.html
+    )
+    SETLOCAL DISABLEDELAYEDEXPANSION
+    GOTO confirm_upgrade
+)
+
+:confirm_upgrade
+ECHO.
+SET /p accept_install="Are you sure you want to continue (yes/no)? "
+IF /I [%accept_install%] == [yes] (
+    GOTO parse_and_force_register_plugins
+)
+IF /I [%accept_install%] == [no] (
+    ECHO -------------------------------------------------------------
+    ECHO Error! Upgrade was cancelled by user
+    DEL scratch*.tmp 2>NUL
+    EXIT /b 1
+)
+ECHO Please answer either "yes" or "no"
+GOTO confirm_upgrade
+
+:confirm_fresh_install
+SET /p accept_install="Do you want to install the plugins [yes/no]? "
+IF /I [%accept_install%] == [yes] (
+    GOTO parse_and_force_register_plugins
+)
+IF /I [%accept_install%] == [no] (
+    ECHO -------------------------------------------------------------
+    ECHO Error! Upgrade was cancelled by user
+    DEL scratch*.tmp 2>NUL
+    EXIT /b 1
+)
+ECHO Please answer either "yes" or "no"
+GOTO confirm_fresh_install
+
+:parse_and_force_register_plugins
+REM remove obsolete plugin key if it ever exists
+"%plugin_manager_bin%" remove %vcenter_reg_common_flags% --key com.vmware.vicui.Vicui --thumbprint %vc_thumbprint% > NUL 2> NUL
+ECHO.
+ECHO -------------------------------------------------------------
+ECHO Preparing to register vCenter Extension %name:"=%-H5Client...
+ECHO -------------------------------------------------------------
+SET plugin_reg_flags=%vcenter_reg_common_flags% --force --name "%name:"=%-H5Client" --thumbprint %vc_thumbprint% --version %version:"=% --summary %summary% --company %company% --key %key_h5c:"=% --url %vic_ui_host_url%files/%key_h5c:"=%-v%version:"=%.zip --server-thumbprint %vic_ui_host_thumbprint%
+"%plugin_manager_bin%" install %plugin_reg_flags%
+IF %ERRORLEVEL% NEQ 0 (
+    ECHO -------------------------------------------------------------
+    ECHO Error! Could not register plugin with vCenter Server. Please see the message above
+    DEL scratch*.tmp 2>NUL
+    EXIT /b 1
+)
+ECHO.
+ECHO -------------------------------------------------------------
+ECHO Preparing to register vCenter Extension %name:"=%-FlexClient...
+ECHO -------------------------------------------------------------
+SET plugin_reg_flags=%vcenter_reg_common_flags% --force --name "%name:"=%-FlexClient" --thumbprint %vc_thumbprint% --version %version:"=% --summary %summary% --company %company% --key %key_flex:"=% --url %vic_ui_host_url%files/%key_flex:"=%-v%version:"=%.zip --server-thumbprint %vic_ui_host_thumbprint%
+"%plugin_manager_bin%" install %plugin_reg_flags%
+IF %ERRORLEVEL% NEQ 0 (
+    ECHO -------------------------------------------------------------
+    ECHO Error! Could not register plugin with vCenter Server. Please see the message above
+    DEL scratch*.tmp 2>NUL
+    EXIT /b 1
+)
+GOTO end
+
+:end
+DEL scratch*.tmp 2>NUL
+ECHO --------------------------------------------------------------
+ECHO VIC Engine UI upgrader exited successfully

--- a/ui/vic-ui-h5c/vic/src/vic-webapp/karma.conf.js
+++ b/ui/vic-ui-h5c/vic/src/vic-webapp/karma.conf.js
@@ -24,7 +24,6 @@ module.exports = function (config) {
     plugins: [
       require('karma-jasmine'),
       require('karma-chrome-launcher'),
-      require('karma-phantomjs-launcher2'),
       require('karma-jasmine-html-reporter'),
       require('karma-coverage-istanbul-reporter'),
       require('@angular/cli/plugins/karma')
@@ -44,9 +43,17 @@ module.exports = function (config) {
     colors: true,
     logLevel: config.LOG_INFO,
     autoWatch: true,
-    browsers: ['PhantomJS'],
-    client: {
-        captureConsole: false
+    browsers: ['ChromeNoSandboxHeadless'],
+    customLaunchers: {
+        ChromeNoSandboxHeadless: {
+            base: 'Chrome',
+            flags: [
+                '--no-sandbox',
+                '--headless',
+                '--disable-gpu',
+                '--remote-debugging-port=9222'
+            ]
+        }
     },
     singleRun: true,
     captureTimeout: 60000,


### PR DESCRIPTION
This is a second PR for #5552. Based on the requirements of the issue and discussions with @emlin the updated script will no longer require the user to edit the `configs` file before running `install.sh` or `install.bat`. For this to happen, two pre-requisites need to be satisfied:

1. The OVA appliance should modify the `configs` file at its boot such that the plugin URL and thumbprint information get populated.
2. `vic-ui` binary should be able to detect if there is any existing installation of VIC Engine UI and what version, if any. This is already taken care of in #5609 

One of the major changes this PR brings is that the installer, upgrader or uninstaller will now work  on the BOTH plugins (for Flex Client and H5 Client) so that the user no longer has to specify which plugin s/he wants to install/uninstall.

Next, it now requires the user to validate and accept the VC's thumbprint. If the user decides not to trust it, then s/he will be asked to enter one manually. Once the thumbprint is accepted, the `install.sh|bat` script will check for an existing plugin and WILL fail if there is any. This can be remedied by running `install.sh|bat --force`, or `upgrade.sh|bat`. `upgrade.sh|bat` will prompt the user what version is going to be installed and will warn the user if the version is the same as or less than the already installed version. `install.sh|bat --force` on the other hand will proceed to install the plugins directly after verifying the VC thumbprint. 

It is also made clear in the `configs` file that it should no longer be edited by the user manually, but in case it needs to, the thumbprint could have either `:` or ` ` delimiters, as the script will replace spaces with colons.