### PR TITLE
[specific ci=Group11-Upgrade] Align certificate flag names

### DIFF
--- a/cmd/vic-machine/common/certificate.go
+++ b/cmd/vic-machine/common/certificate.go
@@ -60,13 +60,13 @@ type CertFactory struct {
 func (c *CertFactory) CertFlags() []cli.Flag {
 	return []cli.Flag{
 		cli.StringFlag{
-			Name:        "key",
+			Name:        "tls-server-key",
 			Value:       "",
 			Usage:       "Virtual Container Host private key file (server certificate)",
 			Destination: &c.Skey,
 		},
 		cli.StringFlag{
-			Name:        "cert",
+			Name:        "tls-server-cert",
 			Value:       "",
 			Usage:       "Virtual Container Host x509 certificate file (server certificate)",
 			Destination: &c.Scert,
@@ -78,7 +78,7 @@ func (c *CertFactory) CertFlags() []cli.Flag {
 			Destination: &c.Cname,
 		},
 		cli.StringFlag{
-			Name:        "cert-path",
+			Name:        "tls-cert-path",
 			Value:       "",
 			Usage:       "The path to check for existing certificates and in which to save generated certificates. Defaults to './<vch name>/'",
 			Destination: &c.CertPath,
@@ -333,12 +333,12 @@ func (c *CertFactory) generateCertificates(server bool, client bool) ([]byte, *c
 	// generate the certs and keys with names conforming the default the docker client expects
 	files, err := ioutil.ReadDir(c.CertPath)
 	if len(files) > 0 {
-		return nil, nil, fmt.Errorf("Specified directory to store certificates is not empty. Specify a new path in which to store generated certificates using --cert-path or remove the contents of \"%s\" and run vic-machine again.", c.CertPath)
+		return nil, nil, fmt.Errorf("Specified directory to store certificates is not empty. Specify a new path in which to store generated certificates using --tls-cert-path or remove the contents of \"%s\" and run vic-machine again.", c.CertPath)
 	}
 
 	err = os.MkdirAll(c.CertPath, 0700)
 	if err != nil {
-		log.Errorf("Unable to make directory \"%s\" to hold certificates (set via --cert-path)", c.CertPath)
+		log.Errorf("Unable to make directory \"%s\" to hold certificates (set via --tls-cert-path)", c.CertPath)
 		return nil, nil, err
 	}
 

--- a/cmd/vic-machine/configure/configure.go
+++ b/cmd/vic-machine/configure/configure.go
@@ -251,7 +251,7 @@ func (c *Configure) processCertificates(client, public, management data.NetworkC
 
 	_, err := os.Lstat(c.certificates.CertPath)
 	if err == nil || os.IsExist(err) {
-		return fmt.Errorf("Specified or default certificate output location \"%s\" already exists. Specify a location that does not yet exist with --cert-path to continue or do not specify --tls-noverify if, instead, you want to load certificates from %s", c.certificates.CertPath, c.certificates.CertPath)
+		return fmt.Errorf("Specified or default certificate output location \"%s\" already exists. Specify a location that does not yet exist with --tls-cert-path to continue or do not specify --tls-noverify if, instead, you want to load certificates from %s", c.certificates.CertPath, c.certificates.CertPath)
 	}
 
 	var debug int

--- a/cmd/vic-machine/create/create.go
+++ b/cmd/vic-machine/create/create.go
@@ -610,7 +610,7 @@ func (c *Create) logArguments(cliContext *cli.Context) []string {
 			continue
 		}
 
-		if f == "cert" || f == "cert-path" || f == "key" || f == "registry-ca" || f == "tls-ca" {
+		if f == "tls-server-cert" || f == "tls-cert-path" || f == "tls-server-key" || f == "registry-ca" || f == "tls-ca" {
 			continue
 		}
 

--- a/cmd/vic-machine/inspect/inspect.go
+++ b/cmd/vic-machine/inspect/inspect.go
@@ -76,7 +76,7 @@ func (i *Inspect) Flags() []cli.Flag {
 			Destination: &i.Timeout,
 		},
 		cli.StringFlag{
-			Name:        "cert-path",
+			Name:        "tls-cert-path",
 			Value:       "",
 			Usage:       "The path to check for existing certificates. Defaults to './<vch name>/'",
 			Destination: &i.CertPath,

--- a/doc/user/usage.md
+++ b/doc/user/usage.md
@@ -244,7 +244,7 @@ ERRO[2016-11-07T19:53:44Z] --------------------
 ERRO[2016-11-07T19:53:44Z] vic-machine-linux failed: provide Common Name for server certificate
 ```
 
-The [`--cert-path`](#certificate-names-and---cert-path) option applies to all of the TLS configurations other than --no-tls.
+The [`--tls-cert-path`](#certificate-names-and---tls-cert-path) option applies to all of the TLS configurations other than --no-tls.
 
 
 #### Disabled, `--no-tls`
@@ -256,8 +256,8 @@ In this configuration the API endpoint has a certificate that clients will use t
 authentication or authorization of the client. If no certificate is provided then a self-signed certificate will be generated.
 
 If using a pre-created certificate, the following options are used:
-- `--key` - path to key file in PEM format
-- `--cert` - path to certificate file in PEM format
+- `--tls-server-key` - path to key file in PEM format
+- `--tls-server-cert` - path to certificate file in PEM format
 
 
 #### Mutual authentication (tlsverify)
@@ -284,16 +284,16 @@ or `--no-tlsverify` is specified.
 - `--client-network-ip` - IP or FQDN to use for the API endpoint
 
 
-#### Certificate names and `--cert-path`
+#### Certificate names and `--tls-cert-path`
 
-If using the `--key` and `--cert` options, any filename and path can be provided for the server certificate and key. However when generating certificates the following standard names are used:
+If using the `--tls-server-key` and `--tls-server-cert` options, any filename and path can be provided for the server certificate and key. However when generating certificates the following standard names are used:
 * server-cert.pem
 * server-key.pem
 * cert.pem
 * key.pem
 * ca.pem
 
-The default value of `--cert-path` is that of the `--name` parameter, in the current working directory, and is used as:
+The default value of `--tls-cert-path` is that of the `--name` parameter, in the current working directory, and is used as:
 1. the location to check for existing certificates, by the default names detailed above.
 2. the location to save generated certificates, which will occur only if existing certificates are not found
 

--- a/lib/install/management/inspect.go
+++ b/lib/install/management/inspect.go
@@ -135,13 +135,13 @@ func findCertPaths(vchName, certPath string) []string {
 	var possibleCertPaths []string
 
 	if certPath != "" {
-		log.Infof("cert-path supplied - only checking for certs in %s/", certPath)
+		log.Infof("--tls-cert-path supplied - only checking for certs in %s/", certPath)
 		possibleCertPaths = append(possibleCertPaths, certPath)
 		return possibleCertPaths
 	}
 
 	possibleCertPaths = append(possibleCertPaths, vchName, ".")
-	logMsg := fmt.Sprintf("cert-path not supplied - checking for certs in current directory, %s/", vchName)
+	logMsg := fmt.Sprintf("--tls-cert-path not supplied - checking for certs in current directory, %s/", vchName)
 
 	dockerConfPath := ""
 	user, err := user.Current()

--- a/tests/test-cases/Group6-VIC-Machine/6-09-Inspect.md
+++ b/tests/test-cases/Group6-VIC-Machine/6-09-Inspect.md
@@ -15,13 +15,13 @@ This test requires that a vSphere server is running and available
 2. Issue vic-machine inspect config command
 3. Issue vic-machine inspect config --format raw command
 4. Create a VCH with tlsverify
-5. Inspect the VCH without specifying --cert-path
-6. Inspect the VCH with a valid --cert-path
-7. Inspect the VCH with an invalid --cert-path
+5. Inspect the VCH without specifying --tls-cert-path
+6. Inspect the VCH with a valid --tls-cert-path
+7. Inspect the VCH with an invalid --tls-cert-path
 8. Create a VCH with --no-tls
-9. Inspect the VCH without specifying --cert-path
+9. Inspect the VCH without specifying --tls-cert-path
 10. Create a VCH with --no-tlsverify
-11. Inspect the VCH without specifying --cert-path
+11. Inspect the VCH without specifying --tls-cert-path
 
 # Expected Outcome:
 * Steps 1 should succeed, and output from step 2 and 3 should contain expected flags & values

--- a/tests/test-cases/Group6-VIC-Machine/6-09-Inspect.robot
+++ b/tests/test-cases/Group6-VIC-Machine/6-09-Inspect.robot
@@ -111,10 +111,10 @@ Verify inspect output for a full tls VCH
     ${output}=  Run  bin/vic-machine-linux inspect --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT}
     Should Contain  ${output}  DOCKER_CERT_PATH=${EXECDIR}/%{VCH-NAME}
 
-    ${output}=  Run  bin/vic-machine-linux inspect --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --cert-path=%{VCH-NAME}
+    ${output}=  Run  bin/vic-machine-linux inspect --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --tls-cert-path=%{VCH-NAME}
     Should Contain  ${output}  DOCKER_CERT_PATH=${EXECDIR}/%{VCH-NAME}
 
-    ${output}=  Run  bin/vic-machine-linux inspect --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --cert-path=fakeDir
+    ${output}=  Run  bin/vic-machine-linux inspect --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --tls-cert-path=fakeDir
     Should Not Contain  ${output}  DOCKER_CERT_PATH=${EXECDIR}/%{VCH-NAME}
     Should Contain  ${output}  Unable to find valid client certs
     Should Contain  ${output}  DOCKER_CERT_PATH must be provided in environment or certificates specified individually via CLI arguments

--- a/tests/test-cases/Group6-VIC-Machine/6-13-TLS.md
+++ b/tests/test-cases/Group6-VIC-Machine/6-13-TLS.md
@@ -31,7 +31,7 @@ vic-machine-linux create --name=${vch-name} --target=%{TEST_URL} \
 * Deployment succeeds
 * Regression tests pass
 
-## Create VCH - use custom --cert-path
+## Create VCH - use custom --tls-cert-path
 1. Issue the following command:
 ```
 vic-machine-linux create\
@@ -42,7 +42,7 @@ vic-machine-linux create\
     --image-store=%{TEST_DATASTORE}\
     --bridge-network=%{BRIDGE_NETWORK}\
     --public-network=%{PUBLIC_NETWORK}\
-    --cert-path=${EXECDIR}/foo-bar-certs/
+    --tls-cert-path=${EXECDIR}/foo-bar-certs/
 ```
 ### Expected Outcome
 * Certs are generated and stored in `foo-bar-cert`
@@ -102,7 +102,7 @@ vic-machine-linux create --name=${vch-name} --target="%{TEST_USERNAME}:%{TEST_PA
 1. Generate CA and wildcard server cert for DOMAIN
 2. Issue the following command to create the VCH with server cert and key
 ```
-bin/vic-machine-linux create --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --key "bundle/*.${domain}.key.pem" --cert "bundle/*.${domain}.cert.pem" --image-store=%{TEST_DATASTORE} --bridge-network=%{BRIDGE_NETWORK} --public-network=%{PUBLIC_NETWORK} ${vicmachinetls} --debug 1
+bin/vic-machine-linux create --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --tls-server-key "bundle/*.${domain}.key.pem" --tls-server-cert "bundle/*.${domain}.cert.pem" --image-store=%{TEST_DATASTORE} --bridge-network=%{BRIDGE_NETWORK} --public-network=%{PUBLIC_NETWORK} ${vicmachinetls} --debug 1
 ```
 
 ### Expected Outcome
@@ -116,7 +116,7 @@ bin/vic-machine-linux create --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TES
 1. Add root certificate to the system root CA store
 2. Issue the following command to create the VCH with a static IP, specified hostname, server cert, and key
 ```
-bin/vic-machine-linux create --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --key "bundle/*.${domain}.key.pem" --cert "bundle/*.${domain}.cert.pem" --image-store=%{TEST_DATASTORE} --bridge-network=%{BRIDGE_NETWORK} --public-network=%{PUBLIC_NETWORK} ${vicmachinetls} --debug 1
+bin/vic-machine-linux create --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --tls-server-key "bundle/*.${domain}.key.pem" --tls-server-cert "bundle/*.${domain}.cert.pem" --image-store=%{TEST_DATASTORE} --bridge-network=%{BRIDGE_NETWORK} --public-network=%{PUBLIC_NETWORK} ${vicmachinetls} --debug 1
 ```
 
 ### Expected Outcome
@@ -131,7 +131,7 @@ bin/vic-machine-linux create --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TES
 1. Add root certificate to the system root CA store
 2. Issue the following command to create the VCH with a static IP, specified hostname, server cert chain including intermediate CA cert, and server key
 ```
-bin/vic-machine-linux create --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --key "bundle/*.${domain}.key.pem" --cert "bundle/*.${domain}.cert.pem" --image-store=%{TEST_DATASTORE} --bridge-network=%{BRIDGE_NETWORK} --public-network=%{PUBLIC_NETWORK} ${vicmachinetls} --debug 1
+bin/vic-machine-linux create --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --tls-server-key "bundle/*.${domain}.key.pem" --tls-server-cert "bundle/*.${domain}.cert.pem" --image-store=%{TEST_DATASTORE} --bridge-network=%{BRIDGE_NETWORK} --public-network=%{PUBLIC_NETWORK} ${vicmachinetls} --debug 1
 ```
 
 ### Expected Outcome

--- a/tests/test-cases/Group6-VIC-Machine/6-13-TLS.robot
+++ b/tests/test-cases/Group6-VIC-Machine/6-13-TLS.robot
@@ -37,7 +37,7 @@ Create VCH - defaults custom cert path
     Run Keyword And Ignore Error  Cleanup Dangling VMs On Test Server
     Run Keyword And Ignore Error  Cleanup Datastore On Test Server
 
-    ${output}=  Run  bin/vic-machine-linux create ${vicmachinetls} --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --image-store=%{TEST_DATASTORE} --bridge-network=%{BRIDGE_NETWORK} --public-network=%{PUBLIC_NETWORK} --cert-path=${EXECDIR}/foo-bar-certs/ --insecure-registry harbor.ci.drone.local
+    ${output}=  Run  bin/vic-machine-linux create ${vicmachinetls} --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --image-store=%{TEST_DATASTORE} --bridge-network=%{BRIDGE_NETWORK} --public-network=%{PUBLIC_NETWORK} --tls-cert-path=${EXECDIR}/foo-bar-certs/ --insecure-registry harbor.ci.drone.local
     Should Contain  ${output}  --tlscacert="${EXECDIR}/foo-bar-certs/ca.pem" --tlscert="${EXECDIR}/foo-bar-certs/cert.pem" --tlskey="${EXECDIR}/foo-bar-certs/key.pem"
     Should Contain  ${output}  Generating CA certificate/key pair - private key in ${EXECDIR}/foo-bar-certs/ca-key.pem
     Should Contain  ${output}  Generating server certificate/key pair - private key in ${EXECDIR}/foo-bar-certs/server-key.pem
@@ -115,15 +115,15 @@ Create VCH - Invalid keys
     ${output}=  Run  bin/vic-machine-linux create --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --image-store=%{TEST_DATASTORE} --bridge-network=%{BRIDGE_NETWORK} --public-network=%{PUBLIC_NETWORK} ${vicmachinetls}
 
     # Invalid server key
-    ${output}=  Run  bin/vic-machine-linux create --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --image-store=%{TEST_DATASTORE} --bridge-network=%{BRIDGE_NETWORK} --public-network=%{PUBLIC_NETWORK} ${vicmachinetls} --tls-ca="./%{VCH-NAME}/ca.pem" --cert="./%{VCH-NAME}/server-cert.pem" --key="./%{VCH-NAME}/ca.pem"
+    ${output}=  Run  bin/vic-machine-linux create --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --image-store=%{TEST_DATASTORE} --bridge-network=%{BRIDGE_NETWORK} --public-network=%{PUBLIC_NETWORK} ${vicmachinetls} --tls-ca="./%{VCH-NAME}/ca.pem" --tls-server-cert="./%{VCH-NAME}/server-cert.pem" --tls-server-key="./%{VCH-NAME}/ca.pem"
     Should Contain  ${output}  found a certificate rather than a key in the PEM for the private key
 
     # Invalid server cert
-    ${output}=  Run  bin/vic-machine-linux create --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --image-store=%{TEST_DATASTORE} --bridge-network=%{BRIDGE_NETWORK} --public-network=%{PUBLIC_NETWORK} ${vicmachinetls} --tls-ca="./%{VCH-NAME}/ca.pem" --cert="./%{VCH-NAME}/server-key.pem" --key="./%{VCH-NAME}/server-key.pem"
+    ${output}=  Run  bin/vic-machine-linux create --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --image-store=%{TEST_DATASTORE} --bridge-network=%{BRIDGE_NETWORK} --public-network=%{PUBLIC_NETWORK} ${vicmachinetls} --tls-ca="./%{VCH-NAME}/ca.pem" --tls-server-cert="./%{VCH-NAME}/server-key.pem" --tls-server-key="./%{VCH-NAME}/server-key.pem"
     Should Contain  ${output}  did find a private key; PEM inputs may have been switched
 
     # Invalid CA
-    ${output}=  Run  bin/vic-machine-linux create --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --image-store=%{TEST_DATASTORE} --bridge-network=%{BRIDGE_NETWORK} --public-network=%{PUBLIC_NETWORK} ${vicmachinetls} --tls-ca="./%{VCH-NAME}/key.pem" --cert="./%{VCH-NAME}/server-cert.pem" --key="./%{VCH-NAME}/server-key.pem"
+    ${output}=  Run  bin/vic-machine-linux create --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --image-store=%{TEST_DATASTORE} --bridge-network=%{BRIDGE_NETWORK} --public-network=%{PUBLIC_NETWORK} ${vicmachinetls} --tls-ca="./%{VCH-NAME}/key.pem" --tls-server-cert="./%{VCH-NAME}/server-cert.pem" --tls-server-key="./%{VCH-NAME}/server-key.pem"
     Should Contain  ${output}  Unable to load certificate authority data
 
     Cleanup VIC Appliance On Test Server
@@ -174,7 +174,7 @@ Create VCH - Server cert with untrusted CA
     Log  ${out}
 
     # Run vic-machine install, supply server cert and key
-    ${output}=  Run  bin/vic-machine-linux create --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --key "bundle/*.${domain}.key.pem" --cert "bundle/*.${domain}.cert.pem" --image-store=%{TEST_DATASTORE} --bridge-network=%{BRIDGE_NETWORK} --public-network=%{PUBLIC_NETWORK} ${vicmachinetls} --debug 1
+    ${output}=  Run  bin/vic-machine-linux create --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --tls-server-key "bundle/*.${domain}.key.pem" --tls-server-cert "bundle/*.${domain}.cert.pem" --image-store=%{TEST_DATASTORE} --bridge-network=%{BRIDGE_NETWORK} --public-network=%{PUBLIC_NETWORK} ${vicmachinetls} --debug 1
     Log  ${output}
     Should Contain  ${output}  Loaded server certificate bundle
     Should Contain  ${output}  Unable to locate existing CA in cert path
@@ -212,7 +212,7 @@ Create VCH - Server cert with trusted CA
     Log  ${out}
 
     # Run vic-machine install, supply server cert and key
-    ${output}=  Run  bin/vic-machine-linux create --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --key "bundle/*.%{DOMAIN}.key.pem" --cert "bundle/*.%{DOMAIN}.cert.pem" --image-store=%{TEST_DATASTORE} --bridge-network=%{BRIDGE_NETWORK} --public-network=%{PUBLIC_NETWORK} ${vicmachinetls} --debug 1
+    ${output}=  Run  bin/vic-machine-linux create --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --tls-server-key "bundle/*.%{DOMAIN}.key.pem" --tls-server-cert "bundle/*.%{DOMAIN}.cert.pem" --image-store=%{TEST_DATASTORE} --bridge-network=%{BRIDGE_NETWORK} --public-network=%{PUBLIC_NETWORK} ${vicmachinetls} --debug 1
     Log  ${output}
     Should Contain  ${output}  Loaded server certificate bundle
     Should Contain  ${output}  Unable to locate existing CA in cert path

--- a/tests/test-cases/Group6-VIC-Machine/6-17-Configure-TLS.md
+++ b/tests/test-cases/Group6-VIC-Machine/6-17-Configure-TLS.md
@@ -33,6 +33,6 @@ Configure VCH - Run Configure Without Cert Options & Ensure Certs are Unchanged
 
 Configure VCH - Replace certificates with self-signed certificate using --no-tlsverify
 ===
-1) Calls configure against the existing VCH with --no-tlsverify and an empty --cert-path 
+1) Calls configure against the existing VCH with --no-tlsverify and an empty --tls-cert-path
 2) Checks that a self-signed certificate is generated
 3) Checks that the installed certificate is the self-signed one that we just generated

--- a/tests/test-cases/Group6-VIC-Machine/6-17-Configure-TLS.robot
+++ b/tests/test-cases/Group6-VIC-Machine/6-17-Configure-TLS.robot
@@ -26,7 +26,7 @@ Setup Test Environment
     Run Keyword And Ignore Error  Cleanup Dangling VMs On Test Server
     Run Keyword And Ignore Error  Cleanup Datastore On Test Server
 
-    ${output}=  Run  bin/vic-machine-linux create ${vicmachinetls} --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --image-store=%{TEST_DATASTORE} --bridge-network=%{BRIDGE_NETWORK} --public-network=%{PUBLIC_NETWORK} --cert-path=${EXECDIR}/foo-bar-certs/
+    ${output}=  Run  bin/vic-machine-linux create ${vicmachinetls} --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --image-store=%{TEST_DATASTORE} --bridge-network=%{BRIDGE_NETWORK} --public-network=%{PUBLIC_NETWORK} --tls-cert-path=${EXECDIR}/foo-bar-certs/
     Should Contain  ${output}  --tlscacert="${EXECDIR}/foo-bar-certs/ca.pem" --tlscert="${EXECDIR}/foo-bar-certs/cert.pem" --tlskey="${EXECDIR}/foo-bar-certs/key.pem"
     Should Contain  ${output}  Generating CA certificate/key pair - private key in ${EXECDIR}/foo-bar-certs/ca-key.pem
     Should Contain  ${output}  Generating server certificate/key pair - private key in ${EXECDIR}/foo-bar-certs/server-key.pem
@@ -55,7 +55,7 @@ Configure VCH - Server cert with untrusted CA
     Log  ${out}
 
     # Run vic-machine configure, supply server cert and key
-    ${output}=  Run  bin/vic-machine-linux configure --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --key "bundle/*.${domain}.key.pem" --cert "bundle/*.${domain}.cert.pem" ${vicmachinetls} --cert-path "out-bundle" --debug 1
+    ${output}=  Run  bin/vic-machine-linux configure --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --tls-server-key "bundle/*.${domain}.key.pem" --tls-server-cert "bundle/*.${domain}.cert.pem" ${vicmachinetls} --tls-cert-path "out-bundle" --debug 1
     Log  ${output}
     Should Contain  ${output}  Completed successfully
 
@@ -77,7 +77,7 @@ Configure VCH - Server cert with trusted CA
     Log  ${out}
 
     # Run vic-machine install, supply server cert and key
-    ${output}=  Run  bin/vic-machine-linux configure --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --key "bundle/*.%{DOMAIN}.key.pem" --cert "bundle/*.%{DOMAIN}.cert.pem" ${vicmachinetls} --debug 1
+    ${output}=  Run  bin/vic-machine-linux configure --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --tls-server-key "bundle/*.%{DOMAIN}.key.pem" --tls-server-cert "bundle/*.%{DOMAIN}.cert.pem" ${vicmachinetls} --debug 1
     Log  ${output}
     Should Contain  ${output}  Loaded server certificate bundle
     Should Contain  ${output}  Unable to locate existing CA in cert path
@@ -104,7 +104,7 @@ Configure VCH - Run Configure Without Cert Options & Ensure Certs Are Unchanged
 
     Run  rm -rf foo-bar-certs
     # Run vic-machine configure, supply server cert and key
-    ${output}=  Run  bin/vic-machine-linux configure --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --key "bundle/*.%{DOMAIN}.key.pem" --cert "bundle/*.%{DOMAIN}.cert.pem" ${vicmachinetls} --cert-path=foo-bar-certs --debug 1
+    ${output}=  Run  bin/vic-machine-linux configure --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --tls-server-key "bundle/*.%{DOMAIN}.key.pem" --tls-server-cert "bundle/*.%{DOMAIN}.cert.pem" ${vicmachinetls} --tls-cert-path=foo-bar-certs --debug 1
     Log  ${output}
     Should Contain  ${output}  Loaded server certificate bundle
     Should Contain  ${output}  Unable to locate existing CA in cert path
@@ -139,7 +139,7 @@ Configure VCH - Replace certificates with self-signed certificate using --no-tls
     Run Keyword If  '${domain}' == ''  Pass Execution  Skipping test - domain not set, won't generate keys
 
     Run  rm -rf foo-bar-certs
-    ${output}=  Run  bin/vic-machine-linux configure --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} ${vicmachinetls} --cert-path "foo-bar-certs" --debug 1 --no-tlsverify
+    ${output}=  Run  bin/vic-machine-linux configure --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} ${vicmachinetls} --tls-cert-path "foo-bar-certs" --debug 1 --no-tlsverify
 
     Should Contain  ${output}  Generating self-signed certificate/key pair - private key in foo-bar-certs/server-key.pem
 


### PR DESCRIPTION
Renames found instances of `--cert-path` to `--tls-cert-path`, `--key` to `--tls-server-key`, `--cert` to `--tls-server-cert`. Updates tests, docs, & actual code. Running tests to ensure no breakage. Used ack/emacs to help find everything and make sure I was meticulous. Not much more to say. Resolves issue #4901 .