### PR TITLE
Add query options helper in pkg/vsphere

### DIFF
--- a/lib/install/management/configure_test.go
+++ b/lib/install/management/configure_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/vmware/vic/lib/install/data"
 	"github.com/vmware/vic/pkg/vsphere/extraconfig"
 	"github.com/vmware/vic/pkg/vsphere/session"
+	"github.com/vmware/vic/pkg/vsphere/test"
 	"github.com/vmware/vic/pkg/vsphere/vm"
 )
 
@@ -48,15 +49,11 @@ func TestGuestInfoSecret(t *testing.T) {
 
 		var s *session.Session
 		if i == 0 {
-			s, err = getESXSession(ctx, server.URL.String())
+			s, err = test.SessionWithESX(ctx, server.URL.String())
 		} else {
-			s, err = getVPXSession(ctx, server.URL.String())
+			s, err = test.SessionWithVPX(ctx, server.URL.String())
 		}
 		if err != nil {
-			t.Fatal(err)
-		}
-
-		if s, err = s.Populate(ctx); err != nil {
 			t.Fatal(err)
 		}
 

--- a/lib/install/management/create_test.go
+++ b/lib/install/management/create_test.go
@@ -15,9 +15,9 @@
 package management
 
 import (
+	"context"
 	"net/url"
 	"testing"
-	"time"
 
 	log "github.com/Sirupsen/logrus"
 
@@ -26,8 +26,6 @@ import (
 	"github.com/vmware/vic/lib/install/data"
 	"github.com/vmware/vic/lib/install/validate"
 	"github.com/vmware/vic/pkg/vsphere/session"
-
-	"context"
 )
 
 func TestMain(t *testing.T) {
@@ -123,42 +121,6 @@ func getVPXData(vcURL *url.URL) *data.Data {
 	result.VolumeLocations["volume-store"] = testURL
 
 	return result
-}
-
-func getESXSession(ctx context.Context, service string) (*session.Session, error) {
-	config := &session.Config{
-		Service:        service,
-		Insecure:       true,
-		Keepalive:      time.Duration(5) * time.Minute,
-		DatacenterPath: "/ha-datacenter",
-		ClusterPath:    "*",
-		DatastorePath:  "/ha-datacenter/datastore/LocalDS_0",
-		PoolPath:       "/ha-datacenter/host/localhost.localdomain/Resources",
-	}
-
-	s, err := session.NewSession(config).Connect(ctx)
-	if err != nil {
-		return nil, err
-	}
-	return s, nil
-}
-
-func getVPXSession(ctx context.Context, service string) (*session.Session, error) {
-	config := &session.Config{
-		Service:        service,
-		Insecure:       true,
-		Keepalive:      time.Duration(5) * time.Minute,
-		DatacenterPath: "/DC0",
-		DatastorePath:  "/DC0/datastore/LocalDS_0",
-		PoolPath:       "/DC0/host/DC0_C0/Resources",
-		ClusterPath:    "/DC0/host/DC0_C0",
-	}
-
-	s, err := session.NewSession(config).Connect(ctx)
-	if err != nil {
-		return nil, err
-	}
-	return s, nil
 }
 
 func testCreateNetwork(ctx context.Context, sess *session.Session, conf *config.VirtualContainerHostConfigSpec, t *testing.T) {

--- a/pkg/vsphere/compute/rp_test.go
+++ b/pkg/vsphere/compute/rp_test.go
@@ -15,14 +15,13 @@
 package compute
 
 import (
+	"context"
 	"net/url"
 	"testing"
-	"time"
 
 	"github.com/vmware/govmomi/simulator"
 	"github.com/vmware/vic/pkg/vsphere/session"
-
-	"context"
+	"github.com/vmware/vic/pkg/vsphere/test"
 )
 
 func TestMain(t *testing.T) {
@@ -45,9 +44,9 @@ func TestMain(t *testing.T) {
 
 		var sess *session.Session
 		if i == 0 {
-			sess, err = getESXSession(ctx, s.URL.String())
+			sess, err = test.SessionWithESX(ctx, s.URL.String())
 		} else {
-			sess, err = getVPXSession(ctx, s.URL.String())
+			sess, err = test.SessionWithVPX(ctx, s.URL.String())
 		}
 		if err != nil {
 			t.Fatal(err)
@@ -57,50 +56,6 @@ func TestMain(t *testing.T) {
 		testGetChildVM(ctx, sess, t)
 		testGetCluster(ctx, sess, t)
 	}
-}
-
-func getESXSession(ctx context.Context, service string) (*session.Session, error) {
-	config := &session.Config{
-		Service:        service,
-		Insecure:       true,
-		Keepalive:      time.Duration(5) * time.Minute,
-		DatacenterPath: "/ha-datacenter",
-		ClusterPath:    "*",
-		DatastorePath:  "/ha-datacenter/datastore/LocalDS_0",
-		PoolPath:       "/ha-datacenter/host/localhost.localdomain/Resources",
-	}
-
-	s, err := session.NewSession(config).Connect(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	if s, err = s.Populate(ctx); err != nil {
-		return nil, err
-	}
-	return s, nil
-}
-
-func getVPXSession(ctx context.Context, service string) (*session.Session, error) {
-	config := &session.Config{
-		Service:        service,
-		Insecure:       true,
-		Keepalive:      time.Duration(5) * time.Minute,
-		DatacenterPath: "/DC0",
-		ClusterPath:    "/DC0/host/DC0_C0",
-		DatastorePath:  "/DC0/datastore/LocalDS_0",
-		PoolPath:       "/DC0/host/DC0_C0/Resources",
-	}
-
-	s, err := session.NewSession(config).Connect(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	if s, err = s.Populate(ctx); err != nil {
-		return nil, err
-	}
-	return s, nil
 }
 
 func testGetChildrenVMs(ctx context.Context, sess *session.Session, t *testing.T) {

--- a/pkg/vsphere/optmanager/optmanager.go
+++ b/pkg/vsphere/optmanager/optmanager.go
@@ -1,0 +1,41 @@
+// Copyright 2017 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package optmanager provides govmomi helpers for the OptionManager.
+package optmanager
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/vic/pkg/vsphere/session"
+)
+
+// QueryOptionValue uses the session client and OptionManager to look up the input option
+// and return the received value.
+func QueryOptionValue(ctx context.Context, s *session.Session, option string) (string, error) {
+	client := s.Vim25()
+	optMgr := object.NewOptionManager(client, *client.ServiceContent.Setting)
+	opts, err := optMgr.Query(ctx, option)
+	if err != nil {
+		return "", fmt.Errorf("error querying option %q: %s", option, err)
+	}
+
+	if len(opts) == 1 {
+		return fmt.Sprintf("%v", opts[0].GetOptionValue().Value), nil
+	}
+
+	return "", fmt.Errorf("%d values querying option %q", len(opts), option)
+}

--- a/pkg/vsphere/optmanager/optmanager_test.go
+++ b/pkg/vsphere/optmanager/optmanager_test.go
@@ -1,0 +1,65 @@
+// Copyright 2017 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package optmanager
+
+import (
+	"context"
+	"testing"
+
+	"github.com/vmware/govmomi/simulator"
+	"github.com/vmware/vic/pkg/vsphere/test"
+)
+
+func TestQueryOptionValue(t *testing.T) {
+	ctx := context.Background()
+
+	model := simulator.VPX()
+	defer model.Remove()
+	err := model.Create()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	server := model.Service.NewServer()
+	defer server.Close()
+
+	s, err := test.SessionWithVPX(ctx, server.URL.String())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Multiple value error
+	optValue, err := QueryOptionValue(ctx, s, "")
+	if err == nil {
+		t.Fatal("expected multiple value error")
+	}
+
+	// Invalid option
+	optValue, err = QueryOptionValue(ctx, s, "foo-bar")
+	if err == nil {
+		t.Fatal("expected invalid query error")
+	}
+
+	// Valid option
+	adminOptKey := "config.vpxd.sso.default.admin"
+	adminOptVal := "Administrator@vsphere.local"
+	optValue, err = QueryOptionValue(ctx, s, "config.vpxd.sso.default.admin")
+	if err != nil {
+		t.Fatalf("expected nil error, got: %s", err)
+	}
+	if optValue != adminOptVal {
+		t.Fatalf("expected value %s for query %q, got: %s", adminOptVal, adminOptKey, optValue)
+	}
+}

--- a/pkg/vsphere/session/session_test.go
+++ b/pkg/vsphere/session/session_test.go
@@ -15,12 +15,11 @@
 package session
 
 import (
+	"context"
 	"crypto/tls"
 	"strings"
 	"testing"
 	"time"
-
-	"context"
 
 	"github.com/vmware/govmomi/find"
 	"github.com/vmware/govmomi/simulator"

--- a/pkg/vsphere/test/test.go
+++ b/pkg/vsphere/test/test.go
@@ -1,4 +1,4 @@
-// Copyright 2016 VMware, Inc. All Rights Reserved.
+// Copyright 2016-2017 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -52,6 +52,52 @@ func Session(ctx context.Context, t *testing.T) *session.Session {
 		}
 	}
 	return s
+}
+
+// SessionWithESX returns a general-purpose ESX session for tests.
+func SessionWithESX(ctx context.Context, service string) (*session.Session, error) {
+	config := &session.Config{
+		Service:        service,
+		Insecure:       true,
+		Keepalive:      time.Duration(5) * time.Minute,
+		DatacenterPath: "/ha-datacenter",
+		ClusterPath:    "*",
+		DatastorePath:  "/ha-datacenter/datastore/LocalDS_0",
+		PoolPath:       "/ha-datacenter/host/localhost.localdomain/Resources",
+	}
+
+	s, err := session.NewSession(config).Connect(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	if s, err = s.Populate(ctx); err != nil {
+		return nil, err
+	}
+	return s, nil
+}
+
+// SessionWithVPX returns a general-purpose VPX session for tests.
+func SessionWithVPX(ctx context.Context, service string) (*session.Session, error) {
+	config := &session.Config{
+		Service:        service,
+		Insecure:       true,
+		Keepalive:      time.Duration(5) * time.Minute,
+		DatacenterPath: "/DC0",
+		ClusterPath:    "/DC0/host/DC0_C0",
+		DatastorePath:  "/DC0/datastore/LocalDS_0",
+		PoolPath:       "/DC0/host/DC0_C0/Resources",
+	}
+
+	s, err := session.NewSession(config).Connect(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	if s, err = s.Populate(ctx); err != nil {
+		return nil, err
+	}
+	return s, nil
 }
 
 // SpecConfig returns a spec.VirtualMachineConfigSpecConfig struct


### PR DESCRIPTION
Needed for obtaining the hostname of the vCenter host for the PSC command in the OVA. Towards #5551

(Follow-up to unmerged PR #5624)