### PR TITLE
Implement WriteArchive for the Archiver interface

### DIFF
--- a/lib/apiservers/portlayer/restapi/handlers/storage_handlers_test.go
+++ b/lib/apiservers/portlayer/restapi/handlers/storage_handlers_test.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/vmware/vic/lib/apiservers/portlayer/models"
 	"github.com/vmware/vic/lib/apiservers/portlayer/restapi/operations/storage"
+	"github.com/vmware/vic/lib/archive"
 	spl "github.com/vmware/vic/lib/portlayer/storage"
 	"github.com/vmware/vic/lib/portlayer/util"
 	"github.com/vmware/vic/pkg/trace"
@@ -121,6 +122,10 @@ func (m *MockVolumeStore) VolumesList(op trace.Operation) ([]*spl.Volume, error)
 	return list, nil
 }
 
+func (m *MockVolumeStore) Export(op trace.Operation, store *url.URL, child, ancestor string, spec *archive.FilterSpec, data bool) (io.ReadCloser, error) {
+	return nil, nil
+}
+
 // GetImageStore checks to see if a named image store exists and returls the
 // URL to it if so or error.
 func (c *MockDataStore) GetImageStore(op trace.Operation, storeName string) (*url.URL, error) {
@@ -145,6 +150,10 @@ func (c *MockDataStore) DeleteImageStore(op trace.Operation, storeName string) e
 }
 
 func (c *MockDataStore) ListImageStores(op trace.Operation) ([]*url.URL, error) {
+	return nil, nil
+}
+
+func (c *MockDataStore) Export(op trace.Operation, store *url.URL, child, ancestor string, spec *archive.FilterSpec, data bool) (io.ReadCloser, error) {
 	return nil, nil
 }
 

--- a/lib/archive/archiver.go
+++ b/lib/archive/archiver.go
@@ -1,0 +1,106 @@
+// Copyright 2017 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package archive
+
+import (
+	"fmt"
+	"io"
+	"net/url"
+
+	"github.com/vmware/vic/pkg/trace"
+)
+
+// FilterType specifies what type of filter to apply in a FilterSpec
+type FilterType int
+
+const (
+	// Include specifies a path inclusion.
+	// Note: An included path that sits under an excluded path should be included.
+	// Example: if / is excluded, and /files is included, /files should  be added to the archive.
+	Include = iota
+	// Exclude specifies a path exclusion.
+	Exclude
+	// Rebase specifies a path rebase.
+	// The rebase path is prepended to the path in the archive header.
+	Rebase
+	// Strip specifies a path strip.
+	// The inverse of a rebase, the path is stripped from the header path
+	// before writing to disk.
+	Strip
+)
+
+// FilterSpec describes rules for handling specified paths during archival
+type FilterSpec struct {
+	Inclusions map[string]struct{}
+	Exclusions map[string]struct{}
+	RebasePath string
+	StripPath  string
+}
+
+// Archiver defines an API for creating archives consisting of data that
+// exist between a child and parent layer, as well as unpacking archives
+// to container filesystems
+type Archiver interface {
+
+	// Export reads the delta between child and ancestor layers, returning
+	// the difference as a tar archive.
+	//
+	// store - the store containing the two layers
+	// id - must inherit from ancestor if ancestor is specified
+	// ancestor - the old layer against which to diff. If omitted, the entire filesystem will be included
+	// spec - describes filters on paths found in the data (include, exclude, rebase, strip)
+	// data - include file data in the tar archive if true, headers only otherwise
+	Export(op trace.Operation, store *url.URL, id, ancestor string, spec *FilterSpec, data bool) (io.ReadCloser, error)
+}
+
+// CreateFilterSpec creates a FilterSpec from a supplied map
+func CreateFilterSpec(op trace.Operation, spec map[string]FilterType) (*FilterSpec, error) {
+	var rebase, strip string
+
+	fs := &FilterSpec{
+		Inclusions: make(map[string]struct{}),
+		Exclusions: make(map[string]struct{}),
+	}
+
+	if spec == nil {
+		return fs, nil
+	}
+
+	for k, v := range spec {
+		switch v {
+		case Include:
+			fs.Inclusions[k] = struct{}{}
+		case Exclude:
+			fs.Exclusions[k] = struct{}{}
+		case Rebase:
+			if rebase != "" {
+				return nil, fmt.Errorf("Error creating filter spec: only one rebase path allowed")
+			}
+			rebase = k
+		case Strip:
+			if strip != "" {
+				return nil, fmt.Errorf("Error creating filter spec: only one strip path allowed")
+			}
+			strip = k
+		default:
+			return nil, fmt.Errorf("Invalid filter specification: %d", v)
+		}
+	}
+
+	fs.RebasePath = rebase
+	fs.StripPath = strip
+
+	return fs, nil
+}

--- a/lib/archive/diff.go
+++ b/lib/archive/diff.go
@@ -1,0 +1,179 @@
+// Copyright 2017 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package archive
+
+import (
+	"archive/tar"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"time"
+
+	docker "github.com/docker/docker/pkg/archive"
+
+	"github.com/vmware/vic/pkg/trace"
+)
+
+const (
+	// ChangeTypeKey defines the key for the type of diff change stored in the tar Xattrs header
+	ChangeTypeKey = "change_type"
+)
+
+// for sort.Sort
+type changesByPath []docker.Change
+
+func (c changesByPath) Less(i, j int) bool { return c[i].Path < c[j].Path }
+func (c changesByPath) Len() int           { return len(c) }
+func (c changesByPath) Swap(i, j int)      { c[j], c[i] = c[i], c[j] }
+
+// Diff produces a tar archive containing the differences between two filesystems
+func Diff(op trace.Operation, newDir, oldDir string, spec *FilterSpec, data bool) (io.ReadCloser, error) {
+
+	var err error
+	if spec == nil {
+		spec, err = CreateFilterSpec(op, nil)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	changes, err := docker.ChangesDirs(newDir, oldDir)
+	if err != nil {
+		return nil, err
+	}
+
+	sort.Sort(changesByPath(changes))
+
+	return Tar(op, newDir, changes, spec, data)
+}
+
+func Tar(op trace.Operation, dir string, changes []docker.Change, spec *FilterSpec, data bool) (io.ReadCloser, error) {
+	var (
+		err error
+		hdr *tar.Header
+	)
+
+	// Note: it is up to the caller to handle errors and the closing of the read side of the pipe
+	r, w := io.Pipe()
+	go func() {
+		tw := tar.NewWriter(w)
+		defer func() {
+			var cerr error
+			if cerr = tw.Close(); cerr != nil {
+				op.Errorf("Error closing tar writer: %s", cerr.Error())
+			}
+			if err == nil {
+				_ = w.CloseWithError(cerr)
+			} else {
+				_ = w.CloseWithError(err)
+			}
+			return
+		}()
+
+		for _, change := range changes {
+			if excluded(change.Path, spec) {
+				continue
+			}
+
+			hdr, err = createHeader(op, dir, change, spec)
+			if err != nil {
+				op.Errorf("Error creating header from change: %s", err.Error())
+				return
+			}
+
+			var f *os.File
+
+			if !data {
+				hdr.Size = 0
+			}
+
+			_ = tw.WriteHeader(hdr)
+
+			p := filepath.Join(dir, change.Path)
+			if hdr.Typeflag == tar.TypeReg && hdr.Size != 0 {
+				f, err = os.Open(p)
+				if err != nil {
+					if os.IsPermission(err) {
+						err = nil
+					}
+					return
+				}
+				if f != nil {
+					_, err = io.Copy(tw, f)
+					if err != nil {
+						op.Errorf("Error writing archive data: %s", err.Error())
+					}
+					_ = f.Close()
+				}
+			}
+		}
+	}()
+	return r, err
+}
+
+// handle exclusion/inclusion of paths
+func excluded(filePath string, spec *FilterSpec) bool {
+	for p := filePath; p != string(filepath.Separator); p = filepath.Dir(p) {
+		if _, ok := spec.Inclusions[p]; ok {
+			return false
+		}
+		if _, ok := spec.Exclusions[p]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+func createHeader(op trace.Operation, dir string, change docker.Change, spec *FilterSpec) (*tar.Header, error) {
+	var hdr *tar.Header
+	timestamp := time.Now()
+
+	switch change.Kind {
+	case docker.ChangeDelete:
+		whiteOutDir := filepath.Dir(change.Path)
+		whiteOutBase := filepath.Base(change.Path)
+		whiteOut := filepath.Join(whiteOutDir, docker.WhiteoutPrefix+whiteOutBase)
+		hdr = &tar.Header{
+			Name:       filepath.Join(spec.RebasePath, whiteOut),
+			ModTime:    timestamp,
+			AccessTime: timestamp,
+			ChangeTime: timestamp,
+		}
+	default:
+		fi, err := os.Stat(filepath.Join(dir, change.Path))
+		if err != nil {
+			op.Errorf("Error getting file info: %s", err.Error())
+			return nil, err
+		}
+
+		hdr, err = tar.FileInfoHeader(fi, change.Path)
+		if err != nil {
+			op.Errorf("Error getting file info header: %s", err.Error())
+			return nil, err
+		}
+
+		hdr.Name = filepath.Join(spec.RebasePath, change.Path)
+
+		if hdr.Typeflag == tar.TypeDir {
+			hdr.Name += "/"
+		}
+	}
+
+	hdr.Xattrs = make(map[string]string)
+	hdr.Xattrs[ChangeTypeKey] = change.Kind.String()
+
+	return hdr, nil
+}

--- a/lib/archive/diff_test.go
+++ b/lib/archive/diff_test.go
@@ -1,0 +1,625 @@
+// Copyright 2017 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package archive
+
+import (
+	"archive/tar"
+	"bytes"
+	"context"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/vmware/vic/pkg/trace"
+)
+
+var (
+	newDir, oldDir string
+	a, b           []byte
+	files          map[string][]string
+	directories    map[string]struct{}
+	err            error
+)
+
+func TestMain(m *testing.M) {
+
+	var err error
+
+	directories = make(map[string]struct{}, 4)
+	files = make(map[string][]string, 6)
+	files["original"] = []string{"/file1", "/file2", "/file3", "/file4",
+		"/original/file1", "/original/file2", "/original/remove",
+		"/exclude/excludeme", "/exclude/includeme", "/excludeme", "/include/excludeme", "/include/includeme"}
+	files["added"] = []string{"/added1", "/added2", "/add/file1", "/add/file2"}
+	files["changed"] = []string{"/file1", "/original/file2",
+		"/exclude/excludeme", "/exclude/includeme",
+		"/include/excludeme", "/include/includeme",
+		"/excludeme"}
+	files["removed"] = []string{"/file2", "/original/file1", "/original/remove"}
+	files["excluded"] = []string{"/exclude", "/excludeme", "/include/excludeme"}
+	files["included"] = []string{"/exclude/includeme", "/include/"}
+
+	newDir, err = ioutil.TempDir("", "mnt")
+	if err != nil {
+		return
+	}
+	defer os.RemoveAll(newDir)
+
+	oldDir, err = ioutil.TempDir("", "mnt")
+	if err != nil {
+		return
+	}
+	defer os.RemoveAll(oldDir)
+
+	a = []byte("The mollusk lingers with its wandering eye\n")
+	b = []byte("The waking of all creatures that live on the land\n")
+
+	for _, dir := range []string{"original", "add", "exclude", "include"} {
+		directories["/"+dir+"/"] = struct{}{}
+		if err = os.Mkdir(filepath.Join(oldDir, dir), 0777); err != nil {
+			log.Errorf("Failed to add directory: %s", err.Error())
+			return
+		}
+		if err = os.Mkdir(filepath.Join(newDir, dir), 0777); err != nil {
+			log.Errorf("Failed to add directory: %s", err.Error())
+			return
+		}
+	}
+
+	for _, file := range files["original"] {
+		if err = ioutil.WriteFile(filepath.Join(oldDir, file), a, 0777); err != nil {
+			log.Errorf("Failed to add file: %s", err.Error())
+			return
+		}
+		if err = ioutil.WriteFile(filepath.Join(newDir, file), a, 0777); err != nil {
+			log.Errorf("Failed to add file: %s", err.Error())
+			return
+		}
+	}
+	for _, file := range append(files["added"], files["changed"]...) {
+		if err = ioutil.WriteFile(filepath.Join(newDir, file), b, 0777); err != nil {
+			log.Errorf("Failed to add file: %s", err.Error())
+			return
+		}
+	}
+	for _, file := range files["removed"] {
+		if err = os.Remove(filepath.Join(newDir, file)); err != nil {
+			log.Errorf("Failed to remove file: %s", err.Error())
+			return
+		}
+	}
+
+	os.Exit(m.Run())
+}
+
+func TestDiff(t *testing.T) {
+	op := trace.NewOperation(context.Background(), "TestDiff")
+
+	tarFile, err := Diff(op, newDir, oldDir, nil, true)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	tarredFiles := make(map[string][]byte)
+	tr := tar.NewReader(tarFile)
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			op.Errorf("Error reading tar archive: %s", err.Error())
+		}
+
+		buf := bytes.NewBuffer([]byte{})
+		if _, err := io.Copy(buf, tr); !assert.NoError(t, err) {
+			return
+		}
+		tarredFiles[hdr.Name] = buf.Bytes()
+	}
+
+	all := append(files["added"], append(files["changed"], files["included"]...)...)
+	for _, file := range all {
+		f, ok := tarredFiles[file]
+		assert.True(t, ok, "Expected to find %s in tar archive", file)
+
+		// don't try to check the contents if its a directory
+		if _, ok := directories[file]; !ok {
+			assert.Equal(t, b, f, "Expected file contents \"%s\", but found \"%s\"", b, f)
+		}
+	}
+	for _, file := range files["removed"] {
+		wh := filepath.Join(filepath.Dir(file), ".wh."+filepath.Base(file))
+		_, ok := tarredFiles[wh]
+		assert.True(t, ok, "Expected to find whiteout file in archive: %s", wh)
+	}
+
+}
+
+func TestDiffNoAncestor(t *testing.T) {
+	op := trace.NewOperation(context.Background(), "TestDiffNoParent")
+
+	// test without ancestor
+	tarFile, err := Diff(op, newDir, "", nil, true)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	tarredFiles := make(map[string][]byte)
+	tr := tar.NewReader(tarFile)
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			op.Errorf("Error reading tar header: %s", err.Error())
+		}
+
+		buf := bytes.NewBuffer([]byte{})
+		if _, err := io.Copy(buf, tr); !assert.NoError(t, err) {
+			return
+		}
+		tarredFiles[hdr.Name] = buf.Bytes()
+		if hdr.Typeflag == tar.TypeDir {
+			directories[hdr.Name] = struct{}{}
+		}
+	}
+
+	all := append(files["added"], append(files["changed"], files["included"]...)...)
+	for _, file := range all {
+		f, ok := tarredFiles[file]
+		assert.True(t, ok, "Expected to find %s in tar archive", file)
+
+		// don't try to check the contents if its a directory
+		if _, ok := directories[file]; !ok {
+			assert.Equal(t, b, f, "Expected file contents \"%s\", but found \"%s\"", b, f)
+		}
+	}
+
+	for _, file := range files["removed"] {
+		wh := filepath.Join(filepath.Dir(file), ".wh."+filepath.Base(file))
+		_, ok := tarredFiles[wh]
+		assert.False(t, ok, "Expected not to find whiteout file in archive: %s", wh)
+	}
+}
+
+func TestDiffNoData(t *testing.T) {
+	op := trace.NewOperation(context.Background(), "TestDiffNoData")
+
+	tarFile, err := Diff(op, newDir, oldDir, nil, false)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	tarredFiles := make(map[string]string)
+	changeTypes := make(map[string]string)
+	tr := tar.NewReader(tarFile)
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if !assert.NoError(t, err) {
+			op.Errorf("Error reading tar header: %s", err.Error())
+		}
+
+		buf := bytes.NewBuffer([]byte{})
+		n, err := io.Copy(buf, tr)
+		if !assert.NoError(t, err) {
+			return
+		}
+		assert.EqualValues(t, 0, n, "Expected 0 bytes copied, got %d instead", n)
+		tarredFiles[hdr.Name] = string(buf.Bytes())
+		changeTypes[hdr.Name] = hdr.Xattrs[ChangeTypeKey]
+	}
+
+	for _, file := range files["added"] {
+		f, ok := tarredFiles[file]
+		ctype := changeTypes[file]
+		assert.True(t, ok, "Expected to find %s in tar archive", file)
+
+		// don't try to check the contents if its a directory
+		if _, ok := directories[file]; !ok {
+			assert.Equal(t, "", f, "Expected file contents \"%s\", but found \"%s\"", "", f)
+			assert.Equal(t, "A", ctype, "Expected change type \"%s\", but found \"%s\"", "A", ctype)
+		}
+	}
+	for _, file := range append(files["changed"], files["included"]...) {
+		f, ok := tarredFiles[file]
+		ctype := changeTypes[file]
+		assert.True(t, ok, "expected to find %s in tar archive", file)
+		// don't try to check the contents if its a directory
+		if _, ok := directories[file]; !ok {
+			assert.Equal(t, "", f, "expected file contents \"%s\", but found \"%s\"", "", f)
+			assert.Equal(t, "C", ctype, "expected change type \"%s\", but found \"%s\"", "C", ctype)
+		}
+	}
+	for _, file := range files["removed"] {
+		wh := filepath.Join(filepath.Dir(file), ".wh."+filepath.Base(file))
+		_, ok := tarredFiles[wh]
+		ctype, cok := changeTypes[wh]
+		assert.True(t, ok, "Expected to find whiteout file in archive: %s", wh)
+		assert.True(t, cok, "Expected to find change type for %s", wh)
+		assert.Equal(t, "D", ctype, "Expected change type \"%s\" but found \"%s\"", "D", ctype)
+	}
+}
+
+func TestDiffFilterSpec(t *testing.T) {
+	op := trace.NewOperation(context.Background(), "TestDiffFilterSpec")
+
+	filter := make(map[string]FilterType)
+	for _, path := range files["excluded"] {
+		filter[path] = Exclude
+	}
+	for _, path := range files["included"] {
+		filter[path] = Include
+	}
+
+	spec, err := CreateFilterSpec(op, filter)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	tarFile, err := Diff(op, newDir, oldDir, spec, true)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	tarredFiles := make(map[string][]byte)
+	tr := tar.NewReader(tarFile)
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			op.Errorf("Error reading tar archive: %s", err.Error())
+		}
+
+		buf := bytes.NewBuffer([]byte{})
+		if _, err := io.Copy(buf, tr); !assert.NoError(t, err) {
+			return
+		}
+		tarredFiles[hdr.Name] = buf.Bytes()
+	}
+
+	all := append(files["added"], files["included"]...)
+	for _, file := range all {
+		if file == string(filepath.Separator) {
+			continue
+		}
+		f, ok := tarredFiles[file]
+		assert.True(t, ok, "Expected to find %s in tar archive", file)
+
+		// don't try to check the contents if its a directory
+		if _, ok := directories[file]; !ok {
+			assert.Equal(t, b, f, "Expected file contents \"%s\", but found \"%s\"", b, f)
+		}
+	}
+	for _, file := range files["removed"] {
+		wh := filepath.Join(filepath.Dir(file), ".wh."+filepath.Base(file))
+		_, ok := tarredFiles[wh]
+		assert.True(t, ok, "Expected to find whiteout file in archive: %s", wh)
+	}
+	for _, file := range files["excluded"] {
+		_, ok := tarredFiles[file]
+		assert.False(t, ok, "Expected excluded file to be missing from archive: %s", file)
+	}
+}
+
+func TestDiffFilterSpecNoAncestor(t *testing.T) {
+	op := trace.NewOperation(context.Background(), "TestDiffFilterSpecNoParent")
+
+	filter := make(map[string]FilterType)
+	for _, path := range files["excluded"] {
+		filter[path] = Exclude
+	}
+	for _, path := range files["included"] {
+		filter[path] = Include
+	}
+
+	spec, err := CreateFilterSpec(op, filter)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	// test without ancestor
+	tarFile, err := Diff(op, newDir, "", spec, true)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	tarredFiles := make(map[string][]byte)
+	tr := tar.NewReader(tarFile)
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			op.Errorf("Error reading tar archive: %s", err.Error())
+		}
+
+		buf := bytes.NewBuffer([]byte{})
+		if _, err := io.Copy(buf, tr); !assert.NoError(t, err) {
+			return
+		}
+		tarredFiles[hdr.Name] = buf.Bytes()
+	}
+
+	all := append(files["added"], files["included"]...)
+	for _, file := range all {
+		f, ok := tarredFiles[file]
+		if file == string(filepath.Separator) {
+			continue
+		}
+		assert.True(t, ok, "Expected to find %s in tar archive", file)
+
+		// don't try to check the contents if its a directory
+		if _, ok := directories[file]; !ok {
+			assert.Equal(t, b, f, "Expected file contents \"%s\", but found \"%s\"", b, f)
+		}
+	}
+	for _, file := range files["removed"] {
+		wh := filepath.Join(filepath.Dir(file), ".wh."+filepath.Base(file))
+		_, ok := tarredFiles[wh]
+		assert.False(t, ok, "Expected not to find whiteout file in archive: %s", wh)
+	}
+	for _, file := range files["excluded"] {
+		_, ok := tarredFiles[file]
+		assert.False(t, ok, "Expected excluded file to be missing from archive: %s", file)
+	}
+}
+
+func TestDiffFilterSpecRebase(t *testing.T) {
+	op := trace.NewOperation(context.Background(), "TestDiffFilterSpecRebase")
+
+	filter := make(map[string]FilterType)
+	for _, path := range files["excluded"] {
+		filter[path] = Exclude
+	}
+	for _, path := range files["included"] {
+		filter[path] = Include
+	}
+	rebasePath := "/path/to/prefix"
+	filter[rebasePath] = Rebase
+
+	spec, err := CreateFilterSpec(op, filter)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	// test without ancestor
+	tarFile, err := Diff(op, newDir, oldDir, spec, true)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	tarredFiles := make(map[string][]byte)
+	tr := tar.NewReader(tarFile)
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			op.Errorf("Error reading tar archive: %s", err.Error())
+		}
+
+		buf := bytes.NewBuffer([]byte{})
+		if _, err := io.Copy(buf, tr); !assert.NoError(t, err) {
+			return
+		}
+		tarredFiles[hdr.Name] = buf.Bytes()
+	}
+
+	all := append(files["added"], files["included"]...)
+	for _, file := range all {
+		if file == string(filepath.Separator) {
+			continue
+		}
+
+		rebasedPath := filepath.Join(rebasePath, file)
+		var isDir bool
+		if _, isDir = directories[file]; isDir {
+			rebasedPath += "/"
+		}
+
+		f, ok := tarredFiles[rebasedPath]
+		assert.True(t, ok, "Expected to find %s in tar archive", rebasedPath)
+		if !isDir {
+			assert.Equal(t, b, f, "Expected file contents \"%s\", but found \"%s\"", b, f)
+		}
+	}
+	for _, file := range files["removed"] {
+		wh := filepath.Join(filepath.Dir(file), ".wh."+filepath.Base(file))
+		wh = filepath.Join(rebasePath, wh)
+		_, ok := tarredFiles[wh]
+		assert.True(t, ok, "Expected not to find whiteout file in archive: %s", wh)
+	}
+	for _, file := range files["excluded"] {
+		_, ok := tarredFiles[file]
+		assert.False(t, ok, "Expected excluded file to be missing from archive: %s", file)
+	}
+}
+
+func TestDiffFilterSpecRebaseNoData(t *testing.T) {
+	op := trace.NewOperation(context.Background(), "TestDiffFilterSpecRebase")
+
+	filter := make(map[string]FilterType)
+	for _, path := range files["excluded"] {
+		filter[path] = Exclude
+	}
+	for _, path := range files["included"] {
+		filter[path] = Include
+	}
+	rebasePath := "/path/to/prefix"
+	filter[rebasePath] = Rebase
+
+	spec, err := CreateFilterSpec(op, filter)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	tarFile, err := Diff(op, newDir, oldDir, spec, false)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	tarredFiles := make(map[string]struct{})
+	changeTypes := make(map[string]string)
+	tr := tar.NewReader(tarFile)
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if !assert.NoError(t, err) {
+			op.Errorf("Error reading tar header: %s", err.Error())
+		}
+
+		buf := bytes.NewBuffer([]byte{})
+		n, err := io.Copy(buf, tr)
+		if !assert.NoError(t, err) {
+			return
+		}
+		assert.EqualValues(t, 0, n, "Expected 0 bytes copied, got %d instead", n)
+		tarredFiles[hdr.Name] = struct{}{}
+		changeTypes[hdr.Name] = hdr.Xattrs[ChangeTypeKey]
+	}
+
+	for _, file := range files["added"] {
+
+		rebasedPath := filepath.Join(rebasePath, file)
+		var isDir bool
+		if _, isDir = directories[file]; isDir {
+			rebasedPath += "/"
+		}
+
+		_, ok := tarredFiles[rebasedPath]
+		ctype := changeTypes[rebasedPath]
+		assert.True(t, ok, "Expected to find %s in tar archive", file)
+
+		// don't try to check the contents if its a directory
+		if !isDir {
+			assert.Equal(t, "A", ctype, "Expected change type \"%s\", but found \"%s\"", "A", ctype)
+		}
+	}
+	for _, file := range append(files["changed"], files["included"]...) {
+
+		// don't check for excludes or whiteouts yet
+		base := filepath.Base(file)
+		if strings.HasSuffix(file, "excludeme") || strings.HasPrefix(base, ".wh.") {
+			continue
+		}
+
+		rebasedPath := filepath.Join(rebasePath, file)
+		var isDir bool
+		if _, isDir = directories[file]; isDir {
+			rebasedPath += "/"
+		}
+		_, ok := tarredFiles[rebasedPath]
+		ctype := changeTypes[rebasedPath]
+		assert.True(t, ok, "expected to find %s in tar archive", file)
+		// don't try to check the contents if its a directory
+		if !isDir {
+			assert.Equal(t, "C", ctype, "expected change type \"%s\", but found \"%s\"", "C", ctype)
+		}
+	}
+	for _, file := range files["removed"] {
+		wh := filepath.Join(filepath.Dir(file), ".wh."+filepath.Base(file))
+		wh = filepath.Join(rebasePath, wh)
+		_, ok := tarredFiles[wh]
+		ctype, cok := changeTypes[wh]
+		assert.True(t, ok, "Expected to find whiteout file in archive: %s", wh)
+		assert.True(t, cok, "Expected to find change type for %s", wh)
+		assert.Equal(t, "D", ctype, "Expected change type \"%s\" but found \"%s\"", "D", ctype)
+	}
+
+	for _, file := range files["excluded"] {
+		_, ok := tarredFiles[file]
+		assert.False(t, ok, "Expected excluded file to be missing from archive: %s", file)
+	}
+}
+
+func TestDiffCreateFilterSpec(t *testing.T) {
+	op := trace.NewOperation(context.Background(), "TestDiffCreateFilterSpec")
+
+	filter := make(map[string]FilterType)
+	for _, path := range files["excluded"] {
+		filter[path] = Exclude
+	}
+	for _, path := range files["included"] {
+		filter[path] = Include
+	}
+	rebasePath := "/path/to/prefix"
+	filter[rebasePath] = Rebase
+
+	stripPath := "/path/to/strip"
+	filter[stripPath] = Strip
+
+	spec, err := CreateFilterSpec(op, filter)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	for _, path := range files["included"] {
+		_, ok := spec.Inclusions[path]
+		assert.True(t, ok, "Expected to find %s in inclusions set", path)
+		_, ok = spec.Exclusions[path]
+		assert.False(t, ok, "Expected not to find %s in exclusions set", path)
+	}
+
+	for _, path := range files["excluded"] {
+		_, ok := spec.Exclusions[path]
+		assert.True(t, ok, "Expected to find %s in exclusions set", path)
+		_, ok = spec.Inclusions[path]
+		assert.False(t, ok, "Expected not to find %s in inclusions set", path)
+	}
+
+	assert.Equal(t, rebasePath, spec.RebasePath)
+	assert.Equal(t, stripPath, spec.StripPath)
+	e := "/path/to/extra/rebase"
+	filter[e] = Rebase
+
+	spec, err = CreateFilterSpec(op, filter)
+	assert.Nil(t, spec, "Expected nil spec")
+	assert.Error(t, err)
+	assert.EqualError(t, err, "Error creating filter spec: only one rebase path allowed")
+
+	delete(filter, e)
+
+	s := "/path/to/extra/strippath"
+	filter[s] = Strip
+	spec, err = CreateFilterSpec(op, filter)
+	assert.Nil(t, spec, "Expected nil spec")
+	assert.Error(t, err)
+	assert.EqualError(t, err, "Error creating filter spec: only one strip path allowed")
+
+	delete(filter, s)
+
+	filter[s] = 20
+	spec, err = CreateFilterSpec(op, filter)
+	assert.Nil(t, spec, "Expected nil spec")
+	assert.Error(t, err)
+	assert.EqualError(t, err, "Invalid filter specification: 20")
+}

--- a/lib/archive/untar.go
+++ b/lib/archive/untar.go
@@ -1,0 +1,135 @@
+// Copyright 2016-2017 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package archive
+
+import (
+	"archive/tar"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/vmware/vic/pkg/trace"
+)
+
+const (
+	// fileWriteFlags is a collection of flags configuring our writes for general tar behavior
+	//
+	// O_CREATE = Create file if it does not exist
+	// O_TRUNC = truncate file to 0 length if it does exist(overwrite the file)
+	// O_WRONLY = We use this since we do not intend to read, we only need to write.
+	fileWriteFlags = os.O_CREATE | os.O_TRUNC | os.O_WRONLY
+)
+
+// Untar untars the given tarstream(if it is a tar stream) on the local filesystem based on the unpackPath in the path spec
+//
+// the pathSpec will include the following elements
+// - include : any tar entry that has a path below(after stripping) the include path will be written
+// - strip : The strip string will indicate the
+// - exlude : marks paths that are to be excluded from the write operation
+// - target : marks the the write path that will be tacked onto the "unpackPath". e.g /tmp/unpack + /my/target/path = /tmp/unpack/my/target/path
+func Untar(op trace.Operation, tarStream io.ReadCloser, filter *FilterSpec, unpackPath string) error {
+	tr := tar.NewReader(tarStream)
+
+	strip := filter.StripPath
+	target := filter.TargetPath
+
+	if target == "" {
+		op.Debugf("Bad target path in FilterSpec (%#v)", filter)
+		return fmt.Errorf("Invalid write target specified")
+	}
+
+	if strip == "" {
+		op.Debugf("Strip path was set to \"\"")
+	}
+
+	if _, err := os.Stat(unpackPath); err != nil {
+		// the target unpack path does not exist. We should not get here.
+		op.Errorf("tar unpack target does not exist (%s)", unpackPath)
+		return err
+	}
+
+	finalTargetPath := filepath.Join(unpackPath, target)
+	op.Debugf("finalized target path for Tar unpack operation at (%s)", finalTargetPath)
+
+	// process the tarball onto the filesystem
+	for {
+		header, err := tr.Next()
+		if err == io.EOF {
+			// This indicates the end of the archive
+			tarStream.Close()
+			break
+		}
+		if err != nil {
+			return err
+		}
+
+		// skip excluded elements unless explicitly included
+		if excluded(header.Name, filter) {
+			continue
+		}
+
+		// fix up path
+		strippedTargetPath := strings.TrimPrefix(header.Name, strip)
+		writePath := filepath.Join(finalTargetPath, strippedTargetPath)
+
+		switch header.Typeflag {
+		case tar.TypeDir:
+			err = os.MkdirAll(writePath, header.FileInfo().Mode())
+			if err != nil {
+				return err
+			}
+			continue
+		case tar.TypeSymlink:
+
+			// NOTE: symbolic links cannot span mounts.
+			// This can cause us to create a regular file instead of
+			// a symlink. this behavior should be evaluated for a proper
+			// response, for now a regular file is made since that is the
+			// target of a sym link operation
+			err := os.Symlink(header.Linkname, writePath)
+			if err == nil {
+				continue
+			}
+			op.Infof("error from os symlink (%s)", err.Error())
+			fallthrough
+		default:
+			// we will treat the default as a regular file
+			targetDir, _ := filepath.Split(writePath)
+
+			// FIXME: this is a hack we must include the directory before this instead of excluding it. since the permissions could be different.
+			err = os.MkdirAll(targetDir, header.FileInfo().Mode())
+
+			err = func(path string, flags int, perm os.FileMode, tr *tar.Reader) error {
+				writtenTarFile, err := os.OpenFile(path, flags, perm)
+				if err != nil {
+					return nil
+				}
+				defer writtenTarFile.Close()
+
+				_, err = io.Copy(writtenTarFile, tr)
+				if err != nil {
+					return err
+				}
+				return nil
+			}(writePath, fileWriteFlags, header.FileInfo().Mode(), tr)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}

--- a/lib/archive/untar_test.go
+++ b/lib/archive/untar_test.go
@@ -1,0 +1,968 @@
+// Copyright 2016-2017 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package archive
+
+import (
+	"archive/tar"
+	"context"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/vmware/vic/pkg/trace"
+)
+
+var (
+	// L1 directories
+	path1dir1 = "/path1dir1"
+	path2dir1 = "/path2dir1"
+
+	// l1 files
+	l1file1 = "/file1"
+	l1file2 = "/file2"
+
+	// l2 directories
+	path1dir2 = filepath.Join(path1dir1, "path1dir2")
+	path1dir3 = filepath.Join(path1dir1, "path1dir3")
+	path2dir2 = filepath.Join(path2dir1, "path2dir2")
+	path2dir3 = filepath.Join(path2dir1, "path2dir3")
+
+	// l2 files
+	l2file1 = filepath.Join(path1dir1, "file1")
+	l2file2 = filepath.Join(path1dir1, "file2")
+	l2file3 = filepath.Join(path2dir1, "file1")
+	l2file4 = filepath.Join(path2dir1, "file2")
+
+	// l3 directories
+	path1dir4 = filepath.Join(path1dir3, "path1dir4")
+
+	// l3 files
+	l3file1 = filepath.Join(path1dir3, "file1")
+	l3file2 = filepath.Join(path2dir2, "file1")
+)
+
+func TestSimpleWrite(t *testing.T) {
+	op := trace.NewOperation(context.TODO(), "")
+
+	filesToWrite := prepareTarFileSlice()
+	tarBytes, err := tarFiles(filesToWrite)
+
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	tarStream := ioutil.NopCloser(tarBytes)
+
+	tempPath, err := ioutil.TempDir("", "write-unit-test")
+	defer os.RemoveAll(tempPath)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	op.Infof("%s", tempPath)
+
+	writetarget := "/"
+	specMap := make(map[string]FilterType)
+	specMap[writetarget] = Target
+
+	filterSpec, err := CreateFilterSpec(op, specMap)
+	if !assert.NoError(t, err) {
+		return
+	}
+	err = Untar(op, tarStream, filterSpec, tempPath)
+
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	for _, file := range filesToWrite {
+		pathToFile := filepath.Join(tempPath, writetarget, file.Name)
+		_, err = os.Stat(pathToFile)
+
+		if err != nil {
+			op.Infof("error for (%s) is (%s) ", file.Name, err.Error())
+		}
+
+		// In this test every file should have been written to the filesystem
+		if !assert.NoError(t, err) {
+			return
+		}
+	}
+
+}
+
+func TestSimpleWriteSymLink(t *testing.T) {
+	op := trace.NewOperation(context.TODO(), "")
+
+	writetarget := "/"
+	tempPath, err := ioutil.TempDir("", "write-unit-test")
+	defer os.RemoveAll(tempPath)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	filesToWrite := prepareTarFileSlice()
+
+	symLinks := []tarFile{}
+	// assemble standard file symlink
+	symlinkName := filepath.Join(path1dir1, "link1")
+	symlinkBody := filepath.Join("../", l1file1)
+	symLink := tarFile{
+		Name: symlinkName,
+		Type: tar.TypeSymlink,
+		Body: symlinkBody,
+	}
+	symLinks = append(symLinks, symLink)
+
+	// assemble broken symlink
+	brokenlinkName := filepath.Join(path1dir1, "BrokenSymLink")
+	brokenlinkBody := filepath.Join("../DOES_NOT_EXIST")
+	brokenLink := tarFile{
+		Name: brokenlinkName,
+		Type: tar.TypeSymlink,
+		Body: brokenlinkBody,
+	}
+	symLinks = append(symLinks, brokenLink)
+
+	dirlinkName := filepath.Join(path1dir1, "DirSymLink")
+	dirlinkBody := filepath.Join("../", path1dir1)
+	dirLink := tarFile{
+		Name: dirlinkName,
+		Type: tar.TypeSymlink,
+		Body: dirlinkBody,
+	}
+	symLinks = append(symLinks, dirLink)
+	op.Infof("Assembled list of test symlinks : (%s)", symLinks)
+	filesToWrite = append(filesToWrite, symLinks...)
+
+	tarBytes, err := tarFiles(filesToWrite)
+	if !assert.NoError(t, err) {
+		return
+	}
+	tarStream := ioutil.NopCloser(tarBytes)
+
+	op.Infof("%s", tempPath)
+
+	specMap := make(map[string]FilterType)
+	specMap[writetarget] = Target
+
+	filterSpec, err := CreateFilterSpec(op, specMap)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	err = Untar(op, tarStream, filterSpec, tempPath)
+
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	// expect file not found for broken links, assemble list.
+	NotExist := map[string]struct{}{
+		brokenlinkName: {},
+	}
+
+	for _, file := range filesToWrite {
+		pathToFile := filepath.Join(tempPath, writetarget, file.Name)
+		_, err = os.Stat(pathToFile)
+
+		if err != nil {
+			if _, ok := NotExist[file.Name]; ok && os.IsNotExist(err) {
+				// we expect and EOF only for the broken links in this test
+				continue
+			}
+			op.Infof("error for (%s) is (%s) ", file.Name, err.Error())
+		}
+
+		// In this test every file should have been written to the filesystem
+		if !assert.NoError(t, err) {
+			return
+		}
+	}
+
+}
+
+func TestSimpleWriteSymLinkNonRootTarget(t *testing.T) {
+	op := trace.NewOperation(context.TODO(), "")
+
+	writetarget := "/nonRootPath"
+	tempPath, err := ioutil.TempDir("", "write-unit-test")
+	defer os.RemoveAll(tempPath)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	filesToWrite := prepareTarFileSlice()
+
+	symLinks := []tarFile{}
+	// assemble standard file symlink
+	symlinkName := filepath.Join(path1dir1, "link1")
+	symlinkBody := filepath.Join("../", l1file1)
+	symLink := tarFile{
+		Name: symlinkName,
+		Type: tar.TypeSymlink,
+		Body: symlinkBody,
+	}
+	symLinks = append(symLinks, symLink)
+
+	// assemble broken symlink
+	brokenlinkName := filepath.Join(path1dir1, "BrokenSymLink")
+	brokenlinkBody := filepath.Join("../DOES_NOT_EXIST")
+	brokenLink := tarFile{
+		Name: brokenlinkName,
+		Type: tar.TypeSymlink,
+		Body: brokenlinkBody,
+	}
+	symLinks = append(symLinks, brokenLink)
+
+	dirlinkName := filepath.Join(path1dir1, "DirSymLink")
+	dirlinkBody := filepath.Join("../", path1dir1)
+	dirLink := tarFile{
+		Name: dirlinkName,
+		Type: tar.TypeSymlink,
+		Body: dirlinkBody,
+	}
+	symLinks = append(symLinks, dirLink)
+	op.Infof("Assembled list of test symlinks : (%s)", symLinks)
+	filesToWrite = append(filesToWrite, symLinks...)
+
+	tarBytes, err := tarFiles(filesToWrite)
+	if !assert.NoError(t, err) {
+		return
+	}
+	tarStream := ioutil.NopCloser(tarBytes)
+
+	op.Infof("%s", tempPath)
+
+	specMap := make(map[string]FilterType)
+	specMap[writetarget] = Target
+
+	filterSpec, err := CreateFilterSpec(op, specMap)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	err = Untar(op, tarStream, filterSpec, tempPath)
+
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	// expect file not found for broken links, assemble list.
+	NotExist := map[string]struct{}{
+		brokenlinkName: {},
+	}
+
+	for _, file := range filesToWrite {
+		pathToFile := filepath.Join(tempPath, writetarget, file.Name)
+
+		// it is important to note for this test that the behavior of os.Stat
+		// is to report the type of the target of a symlink. unless the link is broken.
+		_, err = os.Stat(pathToFile)
+
+		if err != nil {
+			if _, ok := NotExist[file.Name]; ok && os.IsNotExist(err) {
+				// we expect and EOF only for the broken links in this test
+				continue
+			}
+			op.Infof("error for (%s) is (%s) ", file.Name, err.Error())
+		}
+
+		// In this test every file should have been written to the filesystem
+		if !assert.NoError(t, err) {
+			return
+		}
+	}
+
+}
+
+func TestSimpleWriteNonRootTarget(t *testing.T) {
+	op := trace.NewOperation(context.TODO(), "")
+
+	filesToWrite := prepareTarFileSlice()
+	tarBytes, err := tarFiles(filesToWrite)
+
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	tarStream := ioutil.NopCloser(tarBytes)
+
+	tempPath, err := ioutil.TempDir("", "write-unit-test")
+	defer os.RemoveAll(tempPath)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	op.Infof("%s", tempPath)
+
+	writetarget := "/data/target"
+	specMap := make(map[string]FilterType)
+	specMap[writetarget] = Target
+
+	filterSpec, err := CreateFilterSpec(op, specMap)
+	if !assert.NoError(t, err) {
+		return
+	}
+	err = Untar(op, tarStream, filterSpec, tempPath)
+
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	for _, file := range filesToWrite {
+		pathToFile := filepath.Join(tempPath, writetarget, file.Name)
+		_, err = os.Stat(pathToFile)
+
+		if err != nil {
+			op.Infof("error for (%s) is (%s) ", file.Name, err.Error())
+		}
+
+		// In this test every file should have been written to the filesystem
+		if !assert.NoError(t, err) {
+			return
+		}
+	}
+
+}
+
+func TestSimpleExclusion(t *testing.T) {
+	op := trace.NewOperation(context.TODO(), "")
+
+	filesToWrite := prepareTarFileSlice()
+	tarBytes, err := tarFiles(filesToWrite)
+
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	tarStream := ioutil.NopCloser(tarBytes)
+
+	tempPath, err := ioutil.TempDir("", "write-unit-test")
+	defer os.RemoveAll(tempPath)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	op.Infof("%s", tempPath)
+
+	exclusions := []string{
+		path2dir1,
+	}
+
+	writetarget := "/"
+	specMap := make(map[string]FilterType)
+	specMap[writetarget] = Target
+
+	for _, v := range exclusions {
+		specMap[v] = Exclude
+	}
+
+	filterSpec, err := CreateFilterSpec(op, specMap)
+	if !assert.NoError(t, err) {
+		return
+	}
+	err = Untar(op, tarStream, filterSpec, tempPath)
+
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	// record the expected excluded items for checking.
+	expectedExcluded := map[string]struct{}{
+		path2dir1: {},
+		path2dir2: {},
+		path2dir3: {},
+		l2file3:   {},
+		l2file4:   {},
+		l3file2:   {},
+	}
+
+	for _, file := range filesToWrite {
+		pathToFile := filepath.Join(tempPath, writetarget, file.Name)
+		_, err = os.Stat(pathToFile)
+
+		if err != nil {
+
+			if os.IsNotExist(err) {
+				if _, ok := expectedExcluded[file.Name]; ok {
+					err = nil
+				} else {
+					// we did not want to exclude this but it was
+				}
+			} else {
+
+				// some other path error occurred, record it for test purposes
+				op.Infof("error for (%s) is (%s) ", file.Name, err.Error())
+			}
+
+		}
+
+		if !assert.NoError(t, err) {
+			return
+		}
+	}
+
+}
+
+func TestInclusionAfterExclusion(t *testing.T) {
+	op := trace.NewOperation(context.TODO(), "")
+
+	filesToWrite := prepareTarFileSlice()
+	tarBytes, err := tarFiles(filesToWrite)
+
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	tarStream := ioutil.NopCloser(tarBytes)
+
+	tempPath, err := ioutil.TempDir("", "write-unit-test")
+	defer os.RemoveAll(tempPath)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	op.Infof("%s", tempPath)
+
+	exclusions := []string{
+		path2dir1,
+	}
+
+	inclusions := []string{
+		l3file2,
+	}
+
+	writetarget := "/"
+	specMap := make(map[string]FilterType)
+	specMap[writetarget] = Target
+
+	for _, v := range exclusions {
+		specMap[v] = Exclude
+	}
+
+	for _, v := range inclusions {
+		specMap[v] = Include
+	}
+
+	filterSpec, err := CreateFilterSpec(op, specMap)
+	if !assert.NoError(t, err) {
+		return
+	}
+	err = Untar(op, tarStream, filterSpec, tempPath)
+
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	// record the expected excluded items for checking.
+	expectedExcluded := map[string]struct{}{
+		path2dir1: {},
+		path2dir3: {},
+		l2file3:   {},
+		l2file4:   {},
+	}
+
+	for _, file := range filesToWrite {
+		pathToFile := filepath.Join(tempPath, writetarget, file.Name)
+		_, err = os.Stat(pathToFile)
+
+		if err != nil {
+
+			if os.IsNotExist(err) {
+				if _, ok := expectedExcluded[file.Name]; ok {
+					err = nil
+				} else {
+					// we did not want to exclude this but it was
+				}
+			} else {
+
+				// some other path error occurred, record it for test purposes
+				op.Infof("error for (%s) is (%s) ", file.Name, err.Error())
+			}
+
+		}
+
+		if !assert.NoError(t, err) {
+			return
+		}
+	}
+
+}
+
+func TestMultiExclusion(t *testing.T) {
+	op := trace.NewOperation(context.TODO(), "")
+
+	filesToWrite := prepareTarFileSlice()
+	tarBytes, err := tarFiles(filesToWrite)
+
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	tarStream := ioutil.NopCloser(tarBytes)
+
+	tempPath, err := ioutil.TempDir("", "write-unit-test")
+	defer os.RemoveAll(tempPath)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	op.Infof("%s", tempPath)
+
+	exclusions := []string{
+		path2dir2,
+		path1dir3,
+	}
+
+	writetarget := "/"
+	specMap := make(map[string]FilterType)
+	specMap[writetarget] = Target
+
+	for _, v := range exclusions {
+		specMap[v] = Exclude
+	}
+
+	filterSpec, err := CreateFilterSpec(op, specMap)
+	if !assert.NoError(t, err) {
+		return
+	}
+	err = Untar(op, tarStream, filterSpec, tempPath)
+
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	// record the expected excluded items for checking.
+	expectedExcluded := map[string]struct{}{
+
+		// first exclusion
+		path2dir2: {},
+		l3file2:   {},
+
+		// second exclusion
+		path1dir3: {},
+		path1dir4: {},
+		l3file1:   {},
+	}
+
+	for _, file := range filesToWrite {
+		pathToFile := filepath.Join(tempPath, writetarget, file.Name)
+		_, err = os.Stat(pathToFile)
+
+		if err != nil {
+
+			if os.IsNotExist(err) {
+				if _, ok := expectedExcluded[file.Name]; ok {
+					err = nil
+				} else {
+					// we did not want to exclude this but it was
+				}
+			} else {
+
+				// some other path error occurred, record it for test purposes
+				op.Infof("error for (%s) is (%s) ", file.Name, err.Error())
+			}
+
+		}
+
+		if !assert.NoError(t, err) {
+			return
+		}
+	}
+
+}
+
+func TestMultiExclusionMultiInclusion(t *testing.T) {
+	op := trace.NewOperation(context.TODO(), "")
+
+	filesToWrite := prepareTarFileSlice()
+	tarBytes, err := tarFiles(filesToWrite)
+
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	tarStream := ioutil.NopCloser(tarBytes)
+
+	tempPath, err := ioutil.TempDir("", "write-unit-test")
+	defer os.RemoveAll(tempPath)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	op.Infof("%s", tempPath)
+
+	exclusions := []string{
+		path2dir2,
+		path1dir3,
+	}
+
+	inclusions := []string{
+		l3file1,
+		l3file2,
+	}
+
+	writetarget := "/"
+	specMap := make(map[string]FilterType)
+	specMap[writetarget] = Target
+
+	for _, v := range exclusions {
+		specMap[v] = Exclude
+	}
+
+	for _, v := range inclusions {
+		specMap[v] = Include
+	}
+
+	filterSpec, err := CreateFilterSpec(op, specMap)
+	if !assert.NoError(t, err) {
+		return
+	}
+	err = Untar(op, tarStream, filterSpec, tempPath)
+
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	// record the expected excluded items for checking.
+	expectedExcluded := map[string]struct{}{
+		path1dir4: {},
+	}
+
+	for _, file := range filesToWrite {
+		pathToFile := filepath.Join(tempPath, writetarget, file.Name)
+		_, err = os.Stat(pathToFile)
+
+		if err != nil {
+
+			if os.IsNotExist(err) {
+				if _, ok := expectedExcluded[file.Name]; ok {
+					err = nil
+				} else {
+					// we did not want to exclude this but it was
+				}
+			} else {
+
+				// some other path error occurred, record it for test purposes
+				op.Infof("error for (%s) is (%s) ", file.Name, err.Error())
+			}
+
+		}
+
+		if !assert.NoError(t, err) {
+			return
+		}
+	}
+
+}
+
+func TestMultiExclusionMultiInclusionDirectories(t *testing.T) {
+	op := trace.NewOperation(context.TODO(), "")
+
+	filesToWrite := prepareTarFileSlice()
+	tarBytes, err := tarFiles(filesToWrite)
+
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	tarStream := ioutil.NopCloser(tarBytes)
+
+	tempPath, err := ioutil.TempDir("", "write-unit-test")
+	defer os.RemoveAll(tempPath)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	op.Infof("%s", tempPath)
+
+	exclusions := []string{
+		path2dir1,
+		path1dir1,
+	}
+
+	inclusions := []string{
+		path1dir3,
+		path2dir2,
+	}
+
+	writetarget := "/"
+	specMap := make(map[string]FilterType)
+	specMap[writetarget] = Target
+
+	for _, v := range exclusions {
+		specMap[v] = Exclude
+	}
+
+	for _, v := range inclusions {
+		specMap[v] = Include
+	}
+
+	filterSpec, err := CreateFilterSpec(op, specMap)
+	if !assert.NoError(t, err) {
+		return
+	}
+	err = Untar(op, tarStream, filterSpec, tempPath)
+
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	// record the expected excluded items for checking.
+	expectedExcluded := map[string]struct{}{
+		// expected directory exclusions
+		path1dir1: {},
+		path1dir2: {},
+		path2dir1: {},
+		path2dir3: {},
+
+		// expected file exclusions
+		l2file1: {},
+		l2file2: {},
+		l2file3: {},
+		l2file4: {},
+	}
+
+	for _, file := range filesToWrite {
+		pathToFile := filepath.Join(tempPath, writetarget, file.Name)
+		_, err = os.Stat(pathToFile)
+
+		if err != nil {
+
+			if os.IsNotExist(err) {
+				if _, ok := expectedExcluded[file.Name]; ok {
+					err = nil
+				} else {
+					// we did not want to exclude this but it was
+				}
+			} else {
+
+				// some other path error occurred, record it for test purposes
+				op.Infof("error for (%s) is (%s) ", file.Name, err.Error())
+			}
+
+		}
+
+		if !assert.NoError(t, err) {
+			return
+		}
+	}
+
+}
+
+func TestMultiExclusionMultiInclusionDirectoriesNonRootTarget(t *testing.T) {
+	op := trace.NewOperation(context.TODO(), "")
+
+	filesToWrite := prepareTarFileSlice()
+	tarBytes, err := tarFiles(filesToWrite)
+
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	tarStream := ioutil.NopCloser(tarBytes)
+
+	tempPath, err := ioutil.TempDir("", "write-unit-test")
+	defer os.RemoveAll(tempPath)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	op.Infof("%s", tempPath)
+
+	exclusions := []string{
+		path2dir1,
+		path1dir1,
+	}
+
+	inclusions := []string{
+		path1dir3,
+		path2dir2,
+	}
+
+	writetarget := "/data/target"
+	specMap := make(map[string]FilterType)
+	specMap[writetarget] = Target
+
+	for _, v := range exclusions {
+		specMap[v] = Exclude
+	}
+
+	for _, v := range inclusions {
+		specMap[v] = Include
+	}
+
+	filterSpec, err := CreateFilterSpec(op, specMap)
+	if !assert.NoError(t, err) {
+		return
+	}
+	err = Untar(op, tarStream, filterSpec, tempPath)
+
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	// record the expected excluded items for checking.
+	expectedExcluded := map[string]struct{}{
+		// expected directory exclusions
+		path1dir1: {},
+		path1dir2: {},
+		path2dir1: {},
+		path2dir3: {},
+
+		// expected file exclusions
+		l2file1: {},
+		l2file2: {},
+		l2file3: {},
+		l2file4: {},
+	}
+
+	for _, file := range filesToWrite {
+		pathToFile := filepath.Join(tempPath, writetarget, file.Name)
+		_, err = os.Stat(pathToFile)
+
+		if err != nil {
+
+			if os.IsNotExist(err) {
+				if _, ok := expectedExcluded[file.Name]; ok {
+					err = nil
+				} else {
+					// we did not want to exclude this but it was
+				}
+			} else {
+
+				// some other path error occurred, record it for test purposes
+				op.Infof("error for (%s) is (%s) ", file.Name, err.Error())
+			}
+
+		}
+
+		if !assert.NoError(t, err) {
+			return
+		}
+	}
+
+}
+
+func prepareTarFileSlice() []tarFile {
+
+	defaultTestFileBody := "There is not a single vacant room throughout the entire infinite hotel."
+
+	// Tree structure of the test file structure.
+	// .
+	// ├── file1
+	// ├── file2
+	// ├── path1dir1
+	// │   ├── file1
+	// │   ├── file2
+	// │   ├── path1dir2
+	// │   └── path1dir3
+	// │       ├── file1
+	// │       └── path1dir4
+	// └── path2dir1
+	//     ├── file1
+	//     ├── file2
+	//     ├── path2dir2
+	//     │   └── file1
+	//     └── path2dir3
+
+	// This is an assembled default file structure to imitate an incoming tar stream
+	filesToWrite := []tarFile{
+		// level 1 directories
+		{
+			Name: path1dir1,
+			Type: tar.TypeDir,
+		},
+		{
+			Name: path2dir1,
+			Type: tar.TypeDir,
+		},
+		// level 1 files
+		{
+			Name: l1file1,
+			Type: tar.TypeReg,
+			Body: defaultTestFileBody,
+		},
+		{
+			Name: l1file2,
+			Type: tar.TypeReg,
+			Body: defaultTestFileBody,
+		},
+
+		// Level 2 directories
+		{
+			Name: path1dir2,
+			Type: tar.TypeDir,
+		},
+		{
+			Name: path1dir3,
+			Type: tar.TypeDir,
+		},
+		{
+			Name: path2dir2,
+			Type: tar.TypeDir,
+		},
+		{
+			Name: path2dir3,
+			Type: tar.TypeDir,
+		},
+
+		// level 2 files
+		{
+			Name: l2file1,
+			Type: tar.TypeReg,
+			Body: defaultTestFileBody,
+		},
+		{
+			Name: l2file2,
+			Type: tar.TypeReg,
+			Body: defaultTestFileBody,
+		},
+		{
+			Name: l2file3,
+			Type: tar.TypeReg,
+			Body: defaultTestFileBody,
+		},
+		{
+			Name: l2file4,
+			Type: tar.TypeReg,
+			Body: defaultTestFileBody,
+		},
+
+		// level 3 directories
+		{
+			Name: path1dir4,
+			Type: tar.TypeDir,
+		},
+
+		// level 3 files
+		{
+			Name: l3file1,
+			Type: tar.TypeReg,
+			Body: defaultTestFileBody,
+		},
+		{
+			Name: l3file2,
+			Type: tar.TypeReg,
+			Body: defaultTestFileBody,
+		},
+	}
+
+	return filesToWrite
+}

--- a/lib/portlayer/portlayer.go
+++ b/lib/portlayer/portlayer.go
@@ -1,4 +1,4 @@
-// Copyright 2016 VMware, Inc. All Rights Reserved.
+// Copyright 2016-2017 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -37,13 +37,7 @@ import (
 	"github.com/vmware/vic/pkg/vsphere/vm"
 )
 
-// API defines the interface the REST server used by the portlayer expects the
-// implementation side to export
-type API interface {
-	storage.ImageStorer
-	storage.VolumeStorer
-}
-
+// Init initializes portlayer components at startup
 func Init(ctx context.Context, sess *session.Session) error {
 	source, err := extraconfig.GuestInfoSource()
 	if err != nil {

--- a/lib/portlayer/storage/image.go
+++ b/lib/portlayer/storage/image.go
@@ -1,4 +1,4 @@
-// Copyright 2016 VMware, Inc. All Rights Reserved.
+// Copyright 2016-2017 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/vmware/vic/lib/archive"
 	"github.com/vmware/vic/lib/portlayer/util"
 	"github.com/vmware/vic/pkg/index"
 	"github.com/vmware/vic/pkg/trace"
@@ -73,6 +74,9 @@ type ImageStorer interface {
 	// use either by way of inheritance or because it's attached to a
 	// container, this will return an error.
 	DeleteImage(op trace.Operation, image *Image) (*Image, error)
+
+	// Archiver defines the Export and WriteArchive interface methods
+	archive.Archiver
 }
 
 // Image is the handle to identify an image layer on the backing store.  The

--- a/lib/portlayer/storage/image_cache.go
+++ b/lib/portlayer/storage/image_cache.go
@@ -1,4 +1,4 @@
-// Copyright 2016 VMware, Inc. All Rights Reserved.
+// Copyright 2016-2017 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ import (
 	"os"
 	"sync"
 
+	"github.com/vmware/vic/lib/archive"
 	"github.com/vmware/vic/lib/portlayer/util"
 	"github.com/vmware/vic/pkg/index"
 	"github.com/vmware/vic/pkg/trace"
@@ -230,6 +231,10 @@ func (c *NameLookupCache) WriteImage(op trace.Operation, parent *Image, ID strin
 	}
 
 	return i, nil
+}
+
+func (c *NameLookupCache) Export(op trace.Operation, store *url.URL, id, ancestor string, spec *archive.FilterSpec, data bool) (io.ReadCloser, error) {
+	return c.DataStore.Export(op, store, id, ancestor, spec, data)
 }
 
 // GetImage gets the specified image from the given store by retreiving it from the cache.

--- a/lib/portlayer/storage/image_cache.go
+++ b/lib/portlayer/storage/image_cache.go
@@ -237,6 +237,19 @@ func (c *NameLookupCache) Export(op trace.Operation, store *url.URL, id, ancesto
 	return c.DataStore.Export(op, store, id, ancestor, spec, data)
 }
 
+func (c *NameLookupCache) Import(op trace.Operation, store *url.URL, diskID string, spec *archive.FilterSpec, tarStream io.ReadCloser) error {
+	_, err := util.ImageStoreName(store)
+	if err != nil {
+		return err
+	}
+
+	if archiver, ok := c.DataStore.(archive.Archiver); ok {
+		return archiver.Import(op, store, diskID, spec, tarStream)
+	}
+
+	return fmt.Errorf("NameLookupCache does not implement Write")
+}
+
 // GetImage gets the specified image from the given store by retreiving it from the cache.
 func (c *NameLookupCache) GetImage(op trace.Operation, store *url.URL, ID string) (*Image, error) {
 	op.Debugf("Getting image %s from %s", ID, store.String())

--- a/lib/portlayer/storage/image_cache_test.go
+++ b/lib/portlayer/storage/image_cache_test.go
@@ -1,4 +1,4 @@
-// Copyright 2016 VMware, Inc. All Rights Reserved.
+// Copyright 2016-2017 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -27,6 +27,7 @@ import (
 	"github.com/Sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 
+	"github.com/vmware/vic/lib/archive"
 	"github.com/vmware/vic/lib/portlayer/util"
 	"github.com/vmware/vic/pkg/trace"
 )
@@ -149,6 +150,10 @@ func (c *MockDataStore) ListImages(op trace.Operation, store *url.URL, IDs []str
 func (c *MockDataStore) DeleteImage(op trace.Operation, image *Image) (*Image, error) {
 	delete(c.db[*image.Store], image.ID)
 	return image, nil
+}
+
+func (c *MockDataStore) Export(op trace.Operation, store *url.URL, child, ancestor string, spec *archive.FilterSpec, data bool) (io.ReadCloser, error) {
+	return nil, nil
 }
 
 func TestListImages(t *testing.T) {

--- a/lib/portlayer/storage/nfs/volume.go
+++ b/lib/portlayer/storage/nfs/volume.go
@@ -282,3 +282,7 @@ func (v *VolumeStore) getMetadata(op trace.Operation, ID string, target Target) 
 	op.Infof("Successfully read volume metadata at (%s)", metadataPath)
 	return info, nil
 }
+
+func Import(op trace.Operation, store *url.URL, id string, spec *archive.FilterSpec, tarStream io.ReadCloser) error {
+	return fmt.Errorf("Write for nfs volumes is not Implemented")
+}

--- a/lib/portlayer/storage/nfs/volume.go
+++ b/lib/portlayer/storage/nfs/volume.go
@@ -16,11 +16,13 @@ package nfs
 
 import (
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/url"
 	"os"
 	"path"
 
+	"github.com/vmware/vic/lib/archive"
 	"github.com/vmware/vic/lib/config/executor"
 	"github.com/vmware/vic/lib/portlayer/storage"
 	"github.com/vmware/vic/lib/portlayer/util"
@@ -52,6 +54,9 @@ type VolumeStore struct {
 
 	// Service selflink to volume store.
 	SelfLink *url.URL
+
+	// Archiver defines WriteArchive and Export interface methods
+	archive.Archiver
 }
 
 func NewVolumeStore(op trace.Operation, storeName string, mount MountServer) (*VolumeStore, error) {
@@ -200,6 +205,11 @@ func (v *VolumeStore) VolumesList(op trace.Operation) ([]*storage.Volume, error)
 	}
 
 	return volumes, nil
+}
+
+// Export creates and returns a tar archive containing data found between an nfs layer one or all of its ancestors
+func (v *VolumeStore) Export(op trace.Operation, store *url.URL, id, ancestor string, spec *archive.FilterSpec, data bool) (io.ReadCloser, error) {
+	return nil, fmt.Errorf("vSphere Integrated Containers does not yet implement Export for nfs volumes")
 }
 
 func (v *VolumeStore) writeMetadata(op trace.Operation, ID string, info map[string][]byte, target Target) error {

--- a/lib/portlayer/storage/volume.go
+++ b/lib/portlayer/storage/volume.go
@@ -22,6 +22,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/vmware/vic/lib/archive"
 	"github.com/vmware/vic/lib/config/executor"
 	"github.com/vmware/vic/lib/portlayer/util"
 	"github.com/vmware/vic/pkg/trace"
@@ -45,6 +46,9 @@ type VolumeStorer interface {
 
 	// Lists all volumes
 	VolumesList(op trace.Operation) ([]*Volume, error)
+
+	// Archiver defines the Import and Export interface methods
+	archive.Archiver
 }
 
 // Volume is the handle to identify a volume on the backing store.  The URI

--- a/lib/portlayer/storage/volume_cache.go
+++ b/lib/portlayer/storage/volume_cache.go
@@ -216,6 +216,21 @@ func (v *VolumeLookupCache) Export(op trace.Operation, store *url.URL, id, ances
 	return vs.Export(op, store, id, ancestor, spec, data)
 }
 
+func (v *VolumeLookupCache) Import(op trace.Operation, store *url.URL, id string, spec *archive.FilterSpec, tarStream io.ReadCloser) error {
+	storeName, err := util.VolumeStoreName(store)
+	if err != nil {
+		return err
+	}
+
+	vs, ok := v.volumeStores[storeName]
+	if !ok {
+		err := fmt.Errorf("Volume store not found: %s", storeName)
+		return err
+	}
+
+	return vs.Import(op, store, id, spec, tarStream)
+}
+
 // goto the volume store and repopulate the cache.
 func (v *VolumeLookupCache) rebuildCache(op trace.Operation) error {
 	op.Infof("Refreshing volume cache.")

--- a/lib/portlayer/storage/volume_cache_test.go
+++ b/lib/portlayer/storage/volume_cache_test.go
@@ -1,4 +1,4 @@
-// Copyright 2016 VMware, Inc. All Rights Reserved.
+// Copyright 2016-2017 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@ package storage
 
 import (
 	"fmt"
+	"io"
 	"net/url"
 	"os"
 	"sync"
@@ -25,6 +26,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/vmware/vic/lib/archive"
 	"github.com/vmware/vic/lib/portlayer/exec"
 	"github.com/vmware/vic/lib/portlayer/util"
 	"github.com/vmware/vic/pkg/trace"
@@ -102,6 +104,10 @@ func (m *MockVolumeStore) VolumesList(op trace.Operation) ([]*Volume, error) {
 	}
 
 	return list, nil
+}
+
+func (m *MockVolumeStore) Export(op trace.Operation, store *url.URL, child, ancestor string, spec *archive.FilterSpec, data bool) (io.ReadCloser, error) {
+	return nil, nil
 }
 
 func TestVolumeCreateGetListAndDelete(t *testing.T) {

--- a/lib/portlayer/storage/vsphere/vsphere.go
+++ b/lib/portlayer/storage/vsphere/vsphere.go
@@ -1,0 +1,34 @@
+// Copyright 2017 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vsphere
+
+import (
+	"io"
+)
+
+// cleanReader wraps an io.ReadCloser, calling the supplied cleanup function on Close()
+type cleanReader struct {
+	io.ReadCloser
+	clean func()
+}
+
+func (c *cleanReader) Read(p []byte) (int, error) {
+	return c.ReadCloser.Read(p)
+}
+
+func (c *cleanReader) Close() error {
+	defer c.clean()
+	return c.ReadCloser.Close()
+}


### PR DESCRIPTION
This PR will implement the WriteArchive funtion on the VolumeLookupCache, NameLookupCache, vsphere VolumeStore, and the Image Store. This will be needed for offline docker cp and possibly for docker commit. It will include unit tests for the untar function targetting all of the behaviors that we intend to have based on the design of the pathspec object by @jzt 

Fixes #5649