### PR TITLE
Avoid use of ObjectName for networks

### DIFF
--- a/cmd/vic-machine/converter/converter_test.go
+++ b/cmd/vic-machine/converter/converter_test.go
@@ -46,18 +46,18 @@ type testObject struct {
 	object.Common
 }
 
-func (c testObject) ObjectName(ctx context.Context) (string, error) {
+func (c testObject) Name() string {
 	switch c.Common.Reference().String() {
 	case "DistributedVirtualPortgroup:dvportgroup-357":
-		return "management", nil
+		return "management"
 	case "DistributedVirtualPortgroup:dvportgroup-358":
-		return "vm-network", nil
+		return "vm-network"
 	case "DistributedVirtualPortgroup:dvportgroup-55":
-		return "bridge", nil
+		return "bridge"
 	case "DistributedVirtualPortgroup:dvportgroup-56":
-		return "external", nil
+		return "external"
 	default:
-		return "unknown", nil
+		return "unknown"
 	}
 }
 

--- a/lib/install/validate/config_to_data.go
+++ b/lib/install/validate/config_to_data.go
@@ -387,13 +387,12 @@ func getNameFromID(ctx context.Context, finder Finder, mobID string) (string, er
 	if err != nil {
 		return "", err
 	}
+	// We can use Name() directly since InventoryPath is set
 	type common interface {
-		ObjectName(ctx context.Context) (string, error)
+		Name() string
 	}
-	name, err := obj.(common).ObjectName(ctx)
-	if err != nil {
-		return "", err
-	}
+	name := obj.(common).Name()
+
 	log.Debugf("%s name: %s", mobID, name)
 	return name, nil
 }


### PR DESCRIPTION
Since vmware/govmomi#734, object.Common.ObjectName() does not work for Network types.
This is due in part to mo.Network having its own "name" field, but ObjectName uses
the mo.ManagedEntity name field.  This can be fixed in govmomi, but for now making
this change in VIC behaves as the previous version did (using base of InventoryPath)
and saves a round trip for each network.
