### PR TITLE
Add more information about the mounts when populating the persona cache

### DIFF
--- a/lib/apiservers/portlayer/restapi/handlers/containers_handlers.go
+++ b/lib/apiservers/portlayer/restapi/handlers/containers_handlers.go
@@ -506,10 +506,13 @@ func convertContainerToContainerInfo(container *exec.ContainerInfo) *models.Cont
 	}
 
 	// Populate volume information
-	for volName := range container.ExecConfig.Mounts {
+	for volName, mountspec := range container.ExecConfig.Mounts {
 		vol := &models.VolumeConfig{
-			Name: volName,
+			Name:       volName,
+			MountPoint: mountspec.Path,
+			ReadWrite:  strings.Contains(strings.ToLower(mountspec.Mode), "rw"),
 		}
+
 		info.VolumeConfig = append(info.VolumeConfig, vol)
 	}
 


### PR DESCRIPTION
Based on some logging this information makes it back into the personality cache. Previously we were only returning the name of the volume after the VCH restarts. Now when the container cache in the personality is rehydrated we will also get `rw` and `mountpath` information for containers. This did however expose a bug in our `docker inspect` after a VCH restart which is reference below. This does not fix that bug, but should provide the needed information for the active `docker cp` work after a VCH restart. A separate PR will need to address the persona container cache missing additional information after a restart, as well as the broken `docker inspect` after VCH restart bugs. 

This PR is in partial reference to #5654 