### PR TITLE
Fix logging for restartable sessions

### DIFF
--- a/lib/tether/tether.go
+++ b/lib/tether/tether.go
@@ -294,67 +294,25 @@ func (t *tether) initializeSessions() error {
 		"Execs":    t.config.Execs,
 	}
 
-	var writer syslog.Writer
-
 	// we need to iterate over both sessions and execs
 	for name, m := range maps {
-
 		// Iterate over the Sessions and initialize them if needed
 		for id, session := range m {
-			// make it a func so that we can use defer
-			err := func() error {
-				session.Lock()
-				defer session.Unlock()
+			log.Debugf("Initializing session %s", id)
 
-				if session.wait != nil {
-					log.Warnf("Session %s already initialized", id)
-					return nil
-				}
-				log.Debugf("Initializing session %s", id)
-
+			session.Lock()
+			if session.wait != nil {
+				log.Warnf("Session %s already initialized", id)
+			} else {
 				if session.RunBlock {
 					log.Infof("Session %s wants attach capabilities. Creating its channel", id)
 					session.ClearToLaunch = make(chan struct{})
 				}
 
-				stdout, stderr, err := t.ops.SessionLog(session)
-				if err != nil {
-					detail := fmt.Errorf("failed to get log writer for session: %s", err)
-					session.Started = detail.Error()
-
-					return detail
-				}
-				session.Outwriter = stdout
-				session.Errwriter = stderr
-				session.Reader = dio.MultiReader()
-
 				session.wait = &sync.WaitGroup{}
 				session.extraconfigKey = name
-
-				if session.Diagnostics.SysLogConfig != nil {
-					cfg := session.Diagnostics.SysLogConfig
-					var w syslog.Writer
-					if writer == nil {
-						writer, err = syslog.Dial(cfg.Network, cfg.RAddr, syslog.Info|syslog.Daemon, fmt.Sprintf("%s", t.config.ID[:shortLen]))
-						if err != nil {
-							log.Warnf("could not connect to syslog server: %s", err)
-						}
-						w = writer
-					} else {
-						w = writer.WithTag(fmt.Sprintf("%s", t.config.ID[:shortLen]))
-					}
-
-					if w != nil {
-						stdout.Add(w)
-						stderr.Add(w.WithPriority(syslog.Err | syslog.Daemon))
-					}
-				}
-
-				return nil
-			}()
-			if err != nil {
-				return err
 			}
+			session.Unlock()
 		}
 	}
 	return nil
@@ -649,6 +607,42 @@ func (t *tether) handleSessionExit(session *SessionConfig) {
 	}
 }
 
+func (t *tether) loggingLocked(session *SessionConfig) error {
+	var writer syslog.Writer
+
+	stdout, stderr, err := t.ops.SessionLog(session)
+	if err != nil {
+		detail := fmt.Errorf("failed to get log writer for session: %s", err)
+		session.Started = detail.Error()
+
+		return detail
+	}
+	session.Outwriter = stdout
+	session.Errwriter = stderr
+	session.Reader = dio.MultiReader()
+
+	if session.Diagnostics.SysLogConfig != nil {
+		cfg := session.Diagnostics.SysLogConfig
+		var w syslog.Writer
+		if writer == nil {
+			writer, err = syslog.Dial(cfg.Network, cfg.RAddr, syslog.Info|syslog.Daemon, fmt.Sprintf("%s", t.config.ID[:shortLen]))
+			if err != nil {
+				log.Warnf("could not connect to syslog server: %s", err)
+			}
+			w = writer
+		} else {
+			w = writer.WithTag(fmt.Sprintf("%s", t.config.ID[:shortLen]))
+		}
+
+		if w != nil {
+			stdout.Add(w)
+			stderr.Add(w.WithPriority(syslog.Err | syslog.Daemon))
+		}
+	}
+
+	return nil
+}
+
 // launch will launch the command defined in the session.
 // This will return an error if the session fails to launch
 func (t *tether) launch(session *SessionConfig) error {
@@ -678,6 +672,12 @@ func (t *tether) launch(session *SessionConfig) error {
 			return err
 		}
 		session.Cmd.SysProcAttr = user
+	}
+
+	err = t.loggingLocked(session)
+	if err != nil {
+		log.Errorf("initializing logging for session failed with %s", err)
+		return err
 	}
 
 	session.Cmd.Env = t.ops.ProcessEnv(session.Cmd.Env)


### PR DESCRIPTION
```
... install VCH ...
...   vic-ssh   ...
root@ [ ~ ]# ps aux | grep port-layer
root       278  4.2  2.0 250696 42808 ?        Sl   22:41   0:00 /sbin/port-layer-server --host=localhost --port=2377
root@ [ ~ ]# kill -9 278
root@ [ ~ ]# ps aux | grep port-layer
root       291  1.0  1.8 238932 38344 ?        Sl   22:41   0:00 /sbin/docker-engine-server -port=2375 -port-layer-port=2377
root@ [ ~ ]# grep Serving /var/log/vic/port-layer.log
Jul 10 2017 22:41:17.337Z INFO  Serving port layer at http://127.0.0.1:2377
Jul 10 2017 22:41:46.726Z INFO  Serving port layer at http://127.0.0.1:2377
root@ [ ~ ]#
```

Fixes #5682