### PR TITLE
Fix whitelist matching in persona & vic-machine & whitelist test

### DIFF
--- a/tests/manual-test-cases/Group21-Registries/21-1-Whitelist.robot
+++ b/tests/manual-test-cases/Group21-Registries/21-1-Whitelist.robot
@@ -56,9 +56,12 @@ Get HTTPS Harbor Certificate
 *** Test Cases ***
 Basic Whitelisting
     # Install VCH with registry CA for whitelisted registry
+    Remove Environment Variable  GOVC_USERNAME
+    Remove Environment Variable  GOVC_PASSWORD
     ${output}=  Install VIC Appliance To Test Server  vol=default --whitelist-registry=%{HTTPS_HARBOR_IP} --registry-ca=./ca.crt
     Should Contain  ${output}  Secure registry %{HTTPS_HARBOR_IP} confirmed
     Should Contain  ${output}  Whitelist registries =
+    Get Docker Params  ${output}  true
 
     # Check docker info for whitelist info
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} info


### PR DESCRIPTION
Fixes a whitelist matching issue that was causing the whitelist nightly to fail ( #5538 ). First, `vic-machine` required a certain format in order for verification to function, and then secondly when using `docker` the user had to match the URL exactly, regardless as to whether the e.g. port/scheme were implicitly defined via the context.

This test was failing for 2 reasons. First, a bare IP was provided as a secure whitelisted registry. This should be allowed as secure implies https and port 443, so the user should not need to specify. This, however, was a format got eaten by the URL parser during validation.

Simply assuming the protocol fixed this issue, but then the whitelisted URL would need to be specified on the command line when using docker or matching would fail.

I've implemented an approach to fill the whitelist with the handful of representations a URL might take on when requested for whitelisting on the vic-machine commandline or referred to on the docker commandline. This way, the user doesn't need to be more explicit than necessary & whitelisting will work the way (s)he expects, rather than in the brittle manner that was previously occurring. I also suspect this will resolve #5622 although I need to do some testing to ensure. In any case, I believe fixing this bug was at a minimum a dependency of #5622