### PR TITLE
[specific ci=1-27-Docker-Login] Fix whitelist matching and whitelist test

### DIFF
--- a/lib/apiservers/engine/backends/system.go
+++ b/lib/apiservers/engine/backends/system.go
@@ -319,10 +319,8 @@ func (s *System) AuthenticateToRegistry(ctx context.Context, authConfig *types.A
 		registryAddress = registryAddress + "/v2/"
 	}
 
-	// TODO(jzt) Ensuring the scheme exists in the url happens at several places in our code.
-	// We should consolidate these into a common method to deal with this.
-	if !strings.HasPrefix(registryAddress, "https://") && !strings.HasPrefix(registryAddress, "http://") {
-		registryAddress = "https://" + registryAddress
+	if !strings.HasPrefix(registryAddress, "http") {
+		registryAddress = "//" + registryAddress
 	}
 
 	loginURL, err := url.Parse(registryAddress)

--- a/lib/config/dynamic/merger_test.go
+++ b/lib/config/dynamic/merger_test.go
@@ -78,18 +78,22 @@ func TestWhitelistMerger(t *testing.T) {
 		{
 			orig:  registry.ParseEntry("192.168.1.1:123"),
 			other: registry.ParseEntry("192.168.1.1"),
+			err:   assert.AnError,
 		},
 		{
 			orig:  registry.ParseEntry("192.168.1.1"),
 			other: registry.ParseEntry("192.168.1.1:123"),
+			res:   registry.ParseEntry("192.168.1.1"),
 		},
 		{
 			orig:  registry.ParseEntry("foo:123"),
 			other: registry.ParseEntry("foo"),
+			err:   assert.AnError,
 		},
 		{
 			orig:  registry.ParseEntry("foo"),
 			other: registry.ParseEntry("foo:123"),
+			res:   registry.ParseEntry("foo"),
 		},
 		{
 			orig:  registry.ParseEntry("http://foo"),
@@ -115,6 +119,7 @@ func TestWhitelistMerger(t *testing.T) {
 		{
 			orig:  registry.ParseEntry("https://foo"),
 			other: registry.ParseEntry("foo"),
+			err:   assert.AnError,
 		},
 	}
 

--- a/lib/install/validate/validator.go
+++ b/lib/install/validate/validator.go
@@ -642,11 +642,9 @@ func (v *Validator) reachableRegistries(ctx context.Context, input *data.Data, p
 			continue
 		}
 
-		var scheme string
-		if w.URL().Scheme == "" {
+		scheme := w.URL().Scheme
+		if scheme == "" {
 			scheme = "https"
-		} else {
-			scheme = w.URL().Scheme
 		}
 
 		if _, err = registry.Reachable(w.String(), scheme, "", "", pool, registryValidationTime, false); err != nil {

--- a/lib/install/validate/validator.go
+++ b/lib/install/validate/validator.go
@@ -642,7 +642,14 @@ func (v *Validator) reachableRegistries(ctx context.Context, input *data.Data, p
 			continue
 		}
 
-		if _, err = registry.Reachable(w.String(), w.URL().Scheme, "", "", pool, registryValidationTime, false); err != nil {
+		var scheme string
+		if w.URL().Scheme == "" {
+			scheme = "https"
+		} else {
+			scheme = w.URL().Scheme
+		}
+
+		if _, err = registry.Reachable(w.String(), scheme, "", "", pool, registryValidationTime, false); err != nil {
 			log.Warnf("Unable to confirm secure registry %s is a valid registry at this time.", w)
 		} else {
 			log.Debugf("Secure registry %s confirmed.", w)

--- a/pkg/registry/entry.go
+++ b/pkg/registry/entry.go
@@ -121,6 +121,9 @@ func (u *urlEntry) Contains(e Entry) bool {
 	case *urlEntry:
 		up := ensurePort(u.u)
 		ep := ensurePort(e.u)
+		if up.Port() == "" && ep.Port() != "" {
+			ep.Host = ep.Hostname()
+		}
 		return (u.u.Scheme == "" || u.u.Scheme == e.u.Scheme) &&
 			strings.HasPrefix(e.u.Path, u.u.Path) &&
 			glob.Glob(up.Host, ep.Host)
@@ -141,26 +144,10 @@ func (u *urlEntry) Match(s string) (result bool) {
 		return
 	}
 
-	if query.URL().Scheme != "" {
-		if u.URL().Scheme == "" {
-			query.URL().Scheme = u.URL().Scheme
-		}
-	} else if u.URL().Scheme != "" {
-		if query.URL().Scheme == "" {
-			u.URL().Scheme = query.URL().Scheme
-		}
-	}
-
-	if query.URL().Scheme == "" {
-		// this means both schemes are still empty and there is still no match
-		// last chance means ignoring the port; ensurePort inside Contains only works if a scheme is specified
-		if query.URL().Port() != "" {
-			query.URL().Host = query.URL().Hostname()
-		}
-
-		if u.URL().Port() != "" {
-			u.URL().Host = u.URL().Hostname()
-		}
+	if query.URL().Scheme != "" && u.URL().Scheme == "" {
+		query.URL().Scheme = u.URL().Scheme
+	} else if u.URL().Scheme != "" && query.URL().Scheme == "" {
+		u.URL().Scheme = query.URL().Scheme
 	}
 
 	return u.Contains(query)

--- a/pkg/registry/entry.go
+++ b/pkg/registry/entry.go
@@ -132,25 +132,23 @@ func (u *urlEntry) Contains(e Entry) bool {
 	return false
 }
 
-func (u *urlEntry) Match(s string) (result bool) {
+func (u *urlEntry) Match(s string) bool {
 	q := ParseEntry(s)
 	query, ok := q.(URLEntry)
 	if !ok {
 		return false
 	}
 
-	result = u.Contains(query)
-	if result {
-		return
+	// copy u to nu ("new u") so we don't modify the record
+	nu, _ := ParseEntry(u.String()).(URLEntry)
+
+	if query.URL().Scheme != "" && nu.URL().Scheme == "" {
+		query.URL().Scheme = nu.URL().Scheme
+	} else if nu.URL().Scheme != "" && query.URL().Scheme == "" {
+		nu.URL().Scheme = query.URL().Scheme
 	}
 
-	if query.URL().Scheme != "" && u.URL().Scheme == "" {
-		query.URL().Scheme = u.URL().Scheme
-	} else if u.URL().Scheme != "" && query.URL().Scheme == "" {
-		u.URL().Scheme = query.URL().Scheme
-	}
-
-	return u.Contains(query)
+	return nu.Contains(query)
 }
 
 func (u *urlEntry) String() string {

--- a/pkg/registry/entry_test.go
+++ b/pkg/registry/entry_test.go
@@ -188,12 +188,12 @@ func TestEntryMatch(t *testing.T) {
 		{
 			e:   ParseEntry("foo"),
 			s:   "foo:123",
-			res: false,
+			res: true,
 		},
 		{
 			e:   ParseEntry("192.168.1.1"),
 			s:   "192.168.1.1:123",
-			res: false,
+			res: true,
 		},
 		{
 			e:   ParseEntry("http://192.168.1.1"),
@@ -203,7 +203,7 @@ func TestEntryMatch(t *testing.T) {
 		{
 			e:   ParseEntry("http://192.168.1.1"),
 			s:   "192.168.1.1/foo/bar", // ambiguous scheme and entry is restricted to http, so no match
-			res: false,
+			res: true,
 		},
 		{
 			e:   ParseEntry("http://192.168.1.1"),

--- a/pkg/registry/entry_test.go
+++ b/pkg/registry/entry_test.go
@@ -200,7 +200,6 @@ func TestEntryMatch(t *testing.T) {
 			s:   "http://192.168.1.1",
 			res: true,
 		},
-
 		{
 			e:   ParseEntry("http://192.168.1.1"),
 			s:   "192.168.1.1/foo/bar",

--- a/pkg/registry/entry_test.go
+++ b/pkg/registry/entry_test.go
@@ -200,6 +200,7 @@ func TestEntryMatch(t *testing.T) {
 			s:   "http://192.168.1.1",
 			res: true,
 		},
+
 		{
 			e:   ParseEntry("http://192.168.1.1"),
 			s:   "192.168.1.1/foo/bar",

--- a/pkg/registry/entry_test.go
+++ b/pkg/registry/entry_test.go
@@ -202,7 +202,7 @@ func TestEntryMatch(t *testing.T) {
 		},
 		{
 			e:   ParseEntry("http://192.168.1.1"),
-			s:   "192.168.1.1/foo/bar", // ambiguous scheme and entry is restricted to http, so no match
+			s:   "192.168.1.1/foo/bar",
 			res: true,
 		},
 		{

--- a/pkg/registry/entry_test.go
+++ b/pkg/registry/entry_test.go
@@ -104,12 +104,12 @@ func TestEntryContains(t *testing.T) {
 		{
 			first:  ParseEntry("foo"),
 			second: ParseEntry("foo:123"),
-			res:    false,
+			res:    true,
 		},
 		{
 			first:  ParseEntry("192.168.1.1"),
 			second: ParseEntry("192.168.1.1:123"),
-			res:    false,
+			res:    true,
 		},
 	}
 

--- a/tests/manual-test-cases/Group21-Registries/21-1-Whitelist.robot
+++ b/tests/manual-test-cases/Group21-Registries/21-1-Whitelist.robot
@@ -56,9 +56,12 @@ Get HTTPS Harbor Certificate
 *** Test Cases ***
 Basic Whitelisting
     # Install VCH with registry CA for whitelisted registry
+    Remove Environment Variable  GOVC_USERNAME
+    Remove Environment Variable  GOVC_PASSWORD
     ${output}=  Install VIC Appliance To Test Server  vol=default --whitelist-registry=%{HTTPS_HARBOR_IP} --registry-ca=./ca.crt
     Should Contain  ${output}  Secure registry %{HTTPS_HARBOR_IP} confirmed
     Should Contain  ${output}  Whitelist registries =
+    Get Docker Params  ${output}  true
 
     # Check docker info for whitelist info
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} info
@@ -82,7 +85,7 @@ Basic Whitelisting
     Should Be Equal As Integers  ${rc}  0
 
     # Try to login and pull from docker hub (should fail)
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} login --username=victest --password=%{REGISTRY_PASSWORD}
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} login --username=victest --password=%{TEST_PASSWORD}
     Should Be Equal As Integers  ${rc}  1
     Should Contain  ${output}  Access denied to unauthorized registry
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} pull victest/busybox


### PR DESCRIPTION
Fixes the way that we do matching on user input against whitelist/blacklist when a user uses `docker login`, `docker push` and during validation in vic-machine. Resolves #5538 and maybe #5622 but I won't close #5622 until we have a test that demonstrates that it is also resolved.