### PR TITLE
Checking if writers/readers are not nil before closing them [specific ci=1-37-Docker-USER]

### DIFF
--- a/lib/tether/tether.go
+++ b/lib/tether/tether.go
@@ -549,20 +549,27 @@ func (t *tether) Register(name string, extension Extension) {
 func (t *tether) cleanupSession(session *SessionConfig) {
 	// close down the outputs
 	log.Debugf("Calling close on writers")
-	if err := session.Outwriter.Close(); err != nil {
-		log.Warnf("Close for Outwriter returned %s", err)
+	if session.Outwriter != nil {
+		if err := session.Outwriter.Close(); err != nil {
+			log.Warnf("Close for Outwriter returned %s", err)
+		}
 	}
 
 	// this is a little ugly, however ssh channel.Close will get invoked by these calls,
 	// whereas CloseWrite will be invoked by the OutWriter.Close so that goes first.
-	if err := session.Errwriter.Close(); err != nil {
-		log.Warnf("Close for Errwriter returned %s", err)
+	if session.Errwriter != nil {
+		if err := session.Errwriter.Close(); err != nil {
+			log.Warnf("Close for Errwriter returned %s", err)
+		}
 	}
+
 	// if we're calling this we don't care about truncation of pending input, so this is
 	// called last
-	log.Debugf("Calling close on reader")
-	if err := session.Reader.Close(); err != nil {
-		log.Warnf("Close for Reader returned %s", err)
+	if session.Reader != nil {
+		log.Debugf("Calling close on reader")
+		if err := session.Reader.Close(); err != nil {
+			log.Warnf("Close for Reader returned %s", err)
+		}
 	}
 
 	// close the signaling channel (it is nil for detached sessions) and set it to nil (for restart)


### PR DESCRIPTION
Fixes the failure here: https://ci.vcna.io/vmware/vic/12274

From `tether.debug`:
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x28 pc=0x8488db]

goroutine 25 [running]:
github.com/vmware/vic/lib/tether.(*tether).cleanupSession(0xc42012a070, 0xc420176000)
	/go/src/github.com/vmware/vic/lib/tether/tether.go:552 +0x6b
github.com/vmware/vic/lib/tether.(*tether).launch.func1(0xc420176000, 0xc42012a070)
	/go/src/github.com/vmware/vic/lib/tether/tether.go:659 +0x65
github.com/vmware/vic/lib/tether.(*tether).launch(0xc42012a070, 0xc420176000, 0xe7a660, 0xc4201e7400)
	/go/src/github.com/vmware/vic/lib/tether/tether.go:673 +0x34d
github.com/vmware/vic/lib/tether.(*tether).processSessions.func1(0xc4201e7310, 0xc4201ec180, 0xc42012a070, 0xc42011aed0, 0xc420117801, 0xc420176000)
	/go/src/github.com/vmware/vic/lib/tether/tether.go:412 +0x66
created by github.com/vmware/vic/lib/tether.(*tether).processSessions
	/go/src/github.com/vmware/vic/lib/tether/tether.go:415 +0x732
```