### PR TITLE
Add lib/archive GenerateFilterSpec implementation

### DIFF
--- a/lib/apiservers/engine/backends/archive.go
+++ b/lib/apiservers/engine/backends/archive.go
@@ -229,8 +229,8 @@ func NewArchiveStreamWriterMap(mounts []types.MountPoint, dest string) *ArchiveS
 		// file data.txt from local /mnt/A/data.txt will come to the persona as mnt/A/data.txt.
 		// Here, we must tell the portlayer to remove "mnt/A".  The key to determining whether to
 		// strip "A" or "mnt/A" is based on the container destination path.
-		isPrimary := !strings.Contains(aw.mountPoint.Destination, containerDestPath) || aw.mountPoint.Destination == containerDestPath
-		aw.filterSpec = vicarchive.GenerateFilterSpec(containerDestPath, aw.mountPoint.Destination, isPrimary, vicarchive.CopyTo)
+		isPrimary := !strings.Contains(aw.mountPoint.Destination, dest) || aw.mountPoint.Destination == dest
+		aw.filterSpec = vicarchive.GenerateFilterSpec(dest, aw.mountPoint.Destination, isPrimary, vicarchive.CopyTo)
 
 		writerMap.prefixTrie.Insert(patricia.Prefix(m.Destination), &aw)
 	}

--- a/lib/apiservers/engine/backends/archive.go
+++ b/lib/apiservers/engine/backends/archive.go
@@ -265,7 +265,7 @@ func NewArchiveStreamReaderMap(mounts []types.MountPoint, dest string) *ArchiveS
 		// Neither the volume nor the storage portlayer knows about /mnt/A.  The persona must tell
 		// the portlayer to rebase all files from this volume to the /mnt/A/ in the final tar stream.
 		if ar.mountPoint.Destination != "/" {
-			ar.filterSpec = vicarchive.GenerateFilterSpec(containerDestPath, ar.mountPoint.Destination, !strings.Contains(ar.mountPoint.Destination, containerDestPath), vicarchive.CopyTo)
+			ar.filterSpec = vicarchive.GenerateFilterSpec(containerDestPath, ar.mountPoint.Destination, !strings.Contains(ar.mountPoint.Destination, containerDestPath), vicarchive.CopyFrom)
 		}
 
 		readerMap.prefixTrie.Insert(patricia.Prefix(m.Destination), &ar)

--- a/lib/apiservers/engine/backends/archive.go
+++ b/lib/apiservers/engine/backends/archive.go
@@ -229,9 +229,8 @@ func NewArchiveStreamWriterMap(mounts []types.MountPoint, dest string) *ArchiveS
 		// file data.txt from local /mnt/A/data.txt will come to the persona as mnt/A/data.txt.
 		// Here, we must tell the portlayer to remove "mnt/A".  The key to determining whether to
 		// strip "A" or "mnt/A" is based on the container destination path.
-		if containerDestPath != "/" && strings.HasPrefix(aw.mountPoint.Destination, containerDestPath) {
-			aw.filterSpec = vicarchive.GenerateFilterSpec(containerDestPath, aw.mountPoint, !strings.Contains(aw.mountPoint, containerDestPath), vicarchive.CopyTo)
-		}
+		isPrimary := !strings.Contains(aw.mountPoint.Destination, containerDestPath) || aw.mountPoint.Destination == containerDestPath
+		aw.filterSpec = vicarchive.GenerateFilterSpec(containerDestPath, aw.mountPoint.Destination, isPrimary, vicarchive.CopyTo)
 
 		writerMap.prefixTrie.Insert(patricia.Prefix(m.Destination), &aw)
 	}
@@ -264,9 +263,8 @@ func NewArchiveStreamReaderMap(mounts []types.MountPoint, dest string) *ArchiveS
 		//
 		// Neither the volume nor the storage portlayer knows about /mnt/A.  The persona must tell
 		// the portlayer to rebase all files from this volume to the /mnt/A/ in the final tar stream.
-		if ar.mountPoint.Destination != "/" {
-			ar.filterSpec = vicarchive.GenerateFilterSpec(containerDestPath, ar.mountPoint.Destination, !strings.Contains(ar.mountPoint.Destination, containerDestPath), vicarchive.CopyFrom)
-		}
+		isPrimary := !strings.Contains(ar.mountPoint.Destination, dest) || ar.mountPoint.Destination == dest
+		ar.filterSpec = vicarchive.GenerateFilterSpec(dest, ar.mountPoint.Destination, isPrimary, vicarchive.CopyFrom)
 
 		readerMap.prefixTrie.Insert(patricia.Prefix(m.Destination), &ar)
 	}

--- a/lib/apiservers/engine/backends/container_proxy.go
+++ b/lib/apiservers/engine/backends/container_proxy.go
@@ -712,13 +712,14 @@ func (c *ContainerProxy) ArchiveExportReader(ctx context.Context, store, ancesto
 		// make sure we get out of io.Copy if context is canceled
 		select {
 		case <-ctx.Done():
+			// Attempt to tell the portlayer to cancel the stream.  This is one way of cancelling the
+			// stream.  The other way is for the caller of this function to close the returned CloseReader.
+			// Callers of this function should do one but not both.
+			pipeReader.Close()
+			transport.Close()
 		case <-done:
+			transport.Close()
 		}
-
-		// Attempt to tell the portlayer to cancel the stream.  This is one way of cancelling the
-		// stream.  The other way is for the caller of this function to close the returned CloseReader.
-		// Callers of this function should do one but not both.
-		pipeReader.Close()
 	}()
 
 	go func() {
@@ -788,13 +789,14 @@ func (c *ContainerProxy) ArchiveImportWriter(ctx context.Context, store, deviceI
 		// make sure we get out of io.Copy if context is canceled
 		select {
 		case <-ctx.Done():
+			// Attempt to shutdown the stream to the portlayer.  The other way to cancel the
+			// connection is to call close on the WriteCloser returned from this function.
+			// Callers of this function should do one but not both.
+			pipeWriter.Close()
+			transport.Close()
 		case <-done:
+			transport.Close()
 		}
-
-		// Attempt to shutdown the stream to the portlayer.  The other way to cancel the
-		// connection is to call close on the WriteCloser returned from this function.
-		// Callers of this function should do one but not both.
-		pipeWriter.Close()
 	}()
 
 	go func() {

--- a/lib/apiservers/engine/backends/container_proxy.go
+++ b/lib/apiservers/engine/backends/container_proxy.go
@@ -716,9 +716,7 @@ func (c *ContainerProxy) ArchiveExportReader(ctx context.Context, store, ancesto
 			// stream.  The other way is for the caller of this function to close the returned CloseReader.
 			// Callers of this function should do one but not both.
 			pipeReader.Close()
-			transport.Close()
 		case <-done:
-			transport.Close()
 		}
 	}()
 
@@ -793,9 +791,7 @@ func (c *ContainerProxy) ArchiveImportWriter(ctx context.Context, store, deviceI
 			// connection is to call close on the WriteCloser returned from this function.
 			// Callers of this function should do one but not both.
 			pipeWriter.Close()
-			transport.Close()
 		case <-done:
-			transport.Close()
 		}
 	}()
 

--- a/lib/archive/archiver.go
+++ b/lib/archive/archiver.go
@@ -167,39 +167,28 @@ func EncodeFilterSpec(op trace.Operation, spec *FilterSpec) (*string, error) {
 // If the spec is completely empty it will match everything.
 // If an inclusion is set, but not exclusion, then we'll only return matches for the inclusions.
 func (spec *FilterSpec) Excludes(op trace.Operation, filePath string) bool {
-	il := len(spec.Inclusions)
-	el := len(spec.Exclusions)
-
-	if il == 0 && el == 0 {
-		// empty spec means include everything
-		return false
-	}
-
-	inclusion := ""
-	exclusion := "/"
-
-	if il == 0 {
-		// if only exclusions are specified then default is include all others
-		inclusion = "/"
-	}
+	inclusionLength := -1
+	exclusionLength := -1
 
 	for path := range spec.Inclusions {
 		if strings.HasPrefix(filePath, path) {
-			if len(path) > len(inclusion) {
+			temp := len(path)
+			if temp > inclusionLength {
 				// more specific inclusion, so update
-				inclusion = path
+				inclusionLength = temp
 			}
 		}
 	}
 
 	for path := range spec.Exclusions {
 		if strings.HasPrefix(filePath, path) {
-			if len(path) > len(exclusion) {
+			temp := len(path)
+			if temp > exclusionLength {
 				// more specific exclusion, so update
-				exclusion = path
+				exclusionLength = temp
 			}
 		}
 	}
 
-	return len(inclusion) < len(exclusion)
+	return inclusionLength <= exclusionLength
 }

--- a/lib/archive/archiver.go
+++ b/lib/archive/archiver.go
@@ -168,13 +168,7 @@ func EncodeFilterSpec(op trace.Operation, spec *FilterSpec) (*string, error) {
 // If an inclusion is set, but not exclusion, then we'll only return matches for the inclusions.
 func (spec *FilterSpec) Excludes(op trace.Operation, filePath string) bool {
 	inclusionLength := -1
-	exclusionLength := -2
-
-	// This states that if inclusion has atleast one item set and there are no exclusions
-	// that we will report an include for all items.
-	if len(spec.Inclusions) > 0 && len(spec.Exclusions) == 0 {
-		inclusionLength = 0
-	}
+	exclusionLength := -1
 
 	for path := range spec.Inclusions {
 		if strings.HasPrefix(filePath, path) {

--- a/lib/archive/archiver.go
+++ b/lib/archive/archiver.go
@@ -168,7 +168,13 @@ func EncodeFilterSpec(op trace.Operation, spec *FilterSpec) (*string, error) {
 // If an inclusion is set, but not exclusion, then we'll only return matches for the inclusions.
 func (spec *FilterSpec) Excludes(op trace.Operation, filePath string) bool {
 	inclusionLength := -1
-	exclusionLength := -1
+	exclusionLength := -2
+
+	// This states that if inclusion has atleast one item set and there are no exclusions
+	// that we will report an include for all items.
+	if len(spec.Inclusions) > 0 && len(spec.Exclusions) == 0 {
+		inclusionLength = 0
+	}
 
 	for path := range spec.Inclusions {
 		if strings.HasPrefix(filePath, path) {

--- a/lib/archive/diff.go
+++ b/lib/archive/diff.go
@@ -57,8 +57,10 @@ func Diff(op trace.Operation, newDir, oldDir string, spec *FilterSpec, data bool
 	}
 
 	sort.Sort(changesByPath(changes))
+	op.Infof("FILESPEC:::: \n\n\n %#v", *spec)
 
-	return Tar(op, newDir, changes, spec, data, false)
+	op.Infof("LOOK HERE!!!!\n\n\n\n\n\n %s", changes)
+	return Tar(op, newDir, changes, spec, data, oldDir != "")
 }
 
 func Tar(op trace.Operation, dir string, changes []docker.Change, spec *FilterSpec, data bool, xattr bool) (io.ReadCloser, error) {
@@ -101,7 +103,7 @@ func Tar(op trace.Operation, dir string, changes []docker.Change, spec *FilterSp
 				break
 			}
 
-			if spec.Excludes(op, change.Path) {
+			if spec.Excludes(op, strings.TrimPrefix(change.Path, "/")) {
 				continue
 			}
 

--- a/lib/archive/diff.go
+++ b/lib/archive/diff.go
@@ -55,12 +55,15 @@ func Diff(op trace.Operation, newDir, oldDir string, spec *FilterSpec, data bool
 	if err != nil {
 		return nil, err
 	}
+	// this is in the case that we are part of a read that is crossing a mount point.
+	// It should be addressed by include/excludes.
+	changes = append(changes, docker.Change{Path: "/"})
 
 	sort.Sort(changesByPath(changes))
 	op.Infof("FILESPEC:::: \n\n\n %#v", *spec)
 
 	op.Infof("LOOK HERE!!!!\n\n\n\n\n\n %s", changes)
-	return Tar(op, newDir, changes, spec, data, oldDir != "")
+	return Tar(op, newDir, changes, spec, data, false)
 }
 
 func Tar(op trace.Operation, dir string, changes []docker.Change, spec *FilterSpec, data bool, xattr bool) (io.ReadCloser, error) {

--- a/lib/archive/unpack.go
+++ b/lib/archive/unpack.go
@@ -16,6 +16,7 @@ package archive
 
 import (
 	"archive/tar"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"

--- a/lib/archive/unpack.go
+++ b/lib/archive/unpack.go
@@ -16,7 +16,6 @@ package archive
 
 import (
 	"archive/tar"
-	"fmt"
 	"io"
 	"os"
 	"path/filepath"

--- a/lib/archive/util.go
+++ b/lib/archive/util.go
@@ -28,14 +28,14 @@ const (
 )
 
 // GenerateFilterSpec will populate the appropriate relative Rebase and Strip paths based on the supplied scenarios. Inclusion/Exclusion should be constructed separately.
-func GenerateFilterSpec(targetPath string, mountPoint string, primaryTarget bool, direction bool) FilterSpec {
+func GenerateFilterSpec(copyPath string, mountPoint string, primaryTarget bool, direction bool) FilterSpec {
 	var filter FilterSpec
 
 	// Note I know they are just booleans, if that changes then this statement will not need to.
 	if direction == CopyTo {
-		filter = generateCopyToFilterSpec(targetPath, mountPoint, primaryTarget)
+		filter = generateCopyToFilterSpec(copyPath, mountPoint, primaryTarget)
 	} else {
-		filter = generateCopyFromFilterSpec(targetPath, mountPoint, primaryTarget)
+		filter = generateCopyFromFilterSpec(copyPath, mountPoint, primaryTarget)
 	}
 
 	filter.Exclusions = make(map[string]struct{})
@@ -43,39 +43,39 @@ func GenerateFilterSpec(targetPath string, mountPoint string, primaryTarget bool
 	return filter
 }
 
-func generateCopyFromFilterSpec(targetPath string, mountPoint string, primaryTarget bool) FilterSpec {
+func generateCopyFromFilterSpec(copyPath string, mountPoint string, primaryTarget bool) FilterSpec {
 	var filter FilterSpec
 
 	//we only need the right most element.
-	_, first := filepath.Split(targetPath)
+	_, first := filepath.Split(copyPath)
 
 	// primary target was provided so we wil need to split the target and take the right most element for the rebase.
 	// then strip set the strip as the target path.
 	if primaryTarget {
 		filter.RebasePath = first
-		filter.StripPath = removeLeadingSlash(targetPath)
+		filter.StripPath = removeLeadingSlash(copyPath)
 		return filter
 	}
 
 	// non primary target was provided. in this case we will need rebase to include the right most member of the target(or "/") joined to the front of the mountPath - the target path. 3
-	filter.RebasePath = removeLeadingSlash(filepath.Join(first, strings.TrimPrefix(mountPoint, targetPath)))
+	filter.RebasePath = removeLeadingSlash(filepath.Join(first, strings.TrimPrefix(mountPoint, copyPath)))
 	filter.StripPath = ""
 	return filter
 }
 
-func generateCopyToFilterSpec(targetPath string, mountPoint string, primaryTarget bool) FilterSpec {
+func generateCopyToFilterSpec(copyPath string, mountPoint string, primaryTarget bool) FilterSpec {
 	var filter FilterSpec
 
 	// primary target was provided so we will need to rebase header assets for this mount to have the target in front for the write.
 	if primaryTarget {
-		filter.RebasePath = removeLeadingSlash(targetPath)
+		filter.RebasePath = removeLeadingSlash(copyPath)
 		filter.StripPath = ""
 		return filter
 	}
 
 	// non primary target, this implies that the asset header has part of the mount point path in it. We must strip out that part since the non primary target will be mounted and be looking at the world from it's own root "/"
 	filter.RebasePath = ""
-	filter.StripPath = removeLeadingSlash(strings.TrimPrefix(mountPoint, targetPath))
+	filter.StripPath = removeLeadingSlash(strings.TrimPrefix(mountPoint, copyPath))
 
 	return filter
 }

--- a/lib/archive/util.go
+++ b/lib/archive/util.go
@@ -53,7 +53,7 @@ func generateCopyFromFilterSpec(copyPath string, mountPoint string, primaryTarge
 	// then strip set the strip as the target path.
 	if primaryTarget {
 		filter.RebasePath = removeLeadingSlash(first)
-		filter.StripPath = removeLeadingSlash(strings.Trim(copyPath, mountPoint))
+		filter.StripPath = removeLeadingSlash(strings.TrimPrefix(copyPath, mountPoint))
 		return filter
 	}
 
@@ -68,7 +68,7 @@ func generateCopyToFilterSpec(copyPath string, mountPoint string, primaryTarget 
 
 	// primary target was provided so we will need to rebase header assets for this mount to have the target in front for the write.
 	if primaryTarget {
-		filter.RebasePath = removeLeadingSlash(strings.Trim(copyPath, mountPoint))
+		filter.RebasePath = removeLeadingSlash(strings.TrimPrefix(copyPath, mountPoint))
 		filter.StripPath = ""
 		return filter
 	}

--- a/lib/archive/util.go
+++ b/lib/archive/util.go
@@ -27,7 +27,7 @@ const (
 	CopyFrom = false
 )
 
-// GenerateFilterSpec will populate the appropriate relative Rebase and Strip paths based on the supplied scenarios. Inclusion/Exclusion should be constructed separately.
+// GenerateFilterSpec will populate the appropriate relative Rebase and Strip paths based on the supplied scenarios. Inclusion/Exclusion should be constructed separately. Please also note that any mount that exists before the copy target that is not primary and comes before the primary target will have a bogus filterspec, since it would not be written or read to.
 func GenerateFilterSpec(copyPath string, mountPoint string, primaryTarget bool, direction bool) FilterSpec {
 	var filter FilterSpec
 
@@ -52,8 +52,8 @@ func generateCopyFromFilterSpec(copyPath string, mountPoint string, primaryTarge
 	// primary target was provided so we wil need to split the target and take the right most element for the rebase.
 	// then strip set the strip as the target path.
 	if primaryTarget {
-		filter.RebasePath = first
-		filter.StripPath = removeLeadingSlash(copyPath)
+		filter.RebasePath = removeLeadingSlash(first)
+		filter.StripPath = removeLeadingSlash(strings.Trim(copyPath, mountPoint))
 		return filter
 	}
 
@@ -68,7 +68,7 @@ func generateCopyToFilterSpec(copyPath string, mountPoint string, primaryTarget 
 
 	// primary target was provided so we will need to rebase header assets for this mount to have the target in front for the write.
 	if primaryTarget {
-		filter.RebasePath = removeLeadingSlash(copyPath)
+		filter.RebasePath = removeLeadingSlash(strings.Trim(copyPath, mountPoint))
 		filter.StripPath = ""
 		return filter
 	}
@@ -80,11 +80,8 @@ func generateCopyToFilterSpec(copyPath string, mountPoint string, primaryTarget 
 	return filter
 }
 
-// removeLeadingSlash will remove the '/' form in front of a target path if it is not "/"
-// we use this to ensure relative pathing, except for when we assign '/'
+// removeLeadingSlash will remove the '/' from in front of a target path
+// we use this to ensure relative pathing
 func removeLeadingSlash(path string) string {
-	if strings.HasPrefix(path, "/") && path != "/" {
-		return strings.TrimPrefix(path, "/")
-	}
-	return path
+	return strings.TrimPrefix(path, "/")
 }

--- a/lib/archive/util.go
+++ b/lib/archive/util.go
@@ -1,0 +1,90 @@
+// Copyright 2016-2017 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package archive
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+const (
+	// CopyTo is used to indicate that the desired filter spec is for a CopyTo direction
+	CopyTo = true
+
+	// CopyFrom is used to indicate that the desired filter spec is for the CopyFrom direction
+	CopyFrom = false
+)
+
+// GenerateFilterSpec will populate the appropriate relative Rebase and Strip paths based on the supplied scenarios. Inclusion/Exclusion should be constructed separately.
+func GenerateFilterSpec(targetPath string, mountPoint string, primaryTarget bool, direction bool) FilterSpec {
+	var filter FilterSpec
+
+	// Note I know they are just booleans, if that changes then this statement will not need to.
+	if direction == CopyTo {
+		filter = generateCopyToFilterSpec(targetPath, mountPoint, primaryTarget)
+	} else {
+		filter = generateCopyFromFilterSpec(targetPath, mountPoint, primaryTarget)
+	}
+
+	filter.Exclusions = make(map[string]struct{})
+	filter.Inclusions = make(map[string]struct{})
+	return filter
+}
+
+func generateCopyFromFilterSpec(targetPath string, mountPoint string, primaryTarget bool) FilterSpec {
+	var filter FilterSpec
+
+	//we only need the right most element.
+	_, first := filepath.Split(targetPath)
+
+	// primary target was provided so we wil need to split the target and take the right most element for the rebase.
+	// then strip set the strip as the target path.
+	if primaryTarget {
+		filter.RebasePath = first
+		filter.StripPath = removeLeadingSlash(targetPath)
+		return filter
+	}
+
+	// non primary target was provided. in this case we will need rebase to include the right most member of the target(or "/") joined to the front of the mountPath - the target path. 3
+	filter.RebasePath = removeLeadingSlash(filepath.Join(first, strings.TrimPrefix(mountPoint, targetPath)))
+	filter.StripPath = ""
+	return filter
+}
+
+func generateCopyToFilterSpec(targetPath string, mountPoint string, primaryTarget bool) FilterSpec {
+	var filter FilterSpec
+
+	// primary target was provided so we will need to rebase header assets for this mount to have the target in front for the write.
+	if primaryTarget {
+		filter.RebasePath = removeLeadingSlash(targetPath)
+		filter.StripPath = ""
+		return filter
+	}
+
+	// non primary target, this implies that the asset header has part of the mount point path in it. We must strip out that part since the non primary target will be mounted and be looking at the world from it's own root "/"
+	filter.RebasePath = ""
+	filter.StripPath = removeLeadingSlash(strings.TrimPrefix(mountPoint, targetPath))
+
+	return filter
+}
+
+// removeLeadingSlash will remove the '/' form in front of a target path if it is not "/"
+// we use this to ensure relative pathing, except for when we assign '/'
+func removeLeadingSlash(path string) string {
+	if strings.HasPrefix(path, "/") && path != "/" {
+		return strings.TrimPrefix(path, "/")
+	}
+	return path
+}

--- a/lib/archive/util.go
+++ b/lib/archive/util.go
@@ -15,6 +15,7 @@
 package archive
 
 import (
+	"fmt"
 	"path/filepath"
 	"strings"
 )
@@ -84,4 +85,18 @@ func generateCopyToFilterSpec(copyPath string, mountPoint string, primaryTarget 
 // we use this to ensure relative pathing
 func removeLeadingSlash(path string) string {
 	return strings.TrimPrefix(path, "/")
+}
+
+func AddMountExclusions(currentMount string, filter *FilterSpec, mounts []string) error {
+	if filter == nil {
+		return fmt.Errorf("filterSpec for (%s) was nil, cannot add exclusions", currentMount)
+	}
+
+	for _, mount := range mounts {
+		if strings.HasPrefix(mount, currentMount) && currentMount != mount {
+			// exclusions are relative to the mount so the leading `/` should be removed unless we decide otherwise.
+			filter.Exclusions[removeLeadingSlash(strings.TrimPrefix(mount, currentMount))] = struct{}{}
+		}
+	}
+	return nil
 }

--- a/lib/archive/util.go
+++ b/lib/archive/util.go
@@ -32,6 +32,11 @@ const (
 func GenerateFilterSpec(copyPath string, mountPoint string, primaryTarget bool, direction bool) FilterSpec {
 	var filter FilterSpec
 
+	// NOTE: this solidifies that this function is very heavily designed for docker cp behavior.
+	// which is why this should mainly only be used by the docker personality
+	// scrub trailing '/' before passing copyPath along
+	copyPath = strings.TrimSuffix(copyPath, "/")
+
 	// Note I know they are just booleans, if that changes then this statement will not need to.
 	if direction == CopyTo {
 		filter = generateCopyToFilterSpec(copyPath, mountPoint, primaryTarget)

--- a/lib/archive/util.go
+++ b/lib/archive/util.go
@@ -96,10 +96,11 @@ func AddMountInclusionsExclusions(currentMount string, filter *FilterSpec, mount
 	}
 
 	if strings.HasPrefix(copyTarget, currentMount) {
+		filter.Exclusions[""] = struct{}{}
 		filter.Inclusions[removeLeadingSlash(strings.TrimPrefix(copyTarget, currentMount))] = struct{}{}
 	} else {
 		// this would be a mount that is after the target. It would mean we have to include root. then exclude any mounts after root.
-		filter.Inclusions["/"] = struct{}{}
+		filter.Inclusions[""] = struct{}{}
 	}
 
 	for _, mount := range mounts {

--- a/lib/archive/util.go
+++ b/lib/archive/util.go
@@ -95,7 +95,7 @@ func AddMountInclusionsExclusions(currentMount string, filter *FilterSpec, mount
 		return fmt.Errorf("either the inclusions or exclusions map was nil for (%s)", currentMount)
 	}
 
-	if strings.HasPrefix(copyTarget, currentMount) {
+	if strings.HasPrefix(copyTarget, currentMount) && copyTarget != currentMount {
 		filter.Exclusions[""] = struct{}{}
 		filter.Inclusions[removeLeadingSlash(strings.TrimPrefix(copyTarget, currentMount))] = struct{}{}
 	} else {

--- a/lib/archive/util_test.go
+++ b/lib/archive/util_test.go
@@ -1,0 +1,184 @@
+// Copyright 2016-2017 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package archive
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// COPY TO TESTS
+
+func TestComplexWriteSpec(t *testing.T) {
+	copyTarget := "/mnt/vols"
+	direction := CopyTo
+
+	mounts := []testMount{
+
+		{
+			mount:              "/",
+			CopyTarget:         copyTarget,
+			primaryMountTarget: true,
+			direction:          direction,
+		},
+		{
+			mount:              "/mnt/vols/A",
+			CopyTarget:         copyTarget,
+			primaryMountTarget: false,
+			direction:          direction,
+		},
+		{
+			mount:              "/mnt/vols/B",
+			CopyTarget:         copyTarget,
+			primaryMountTarget: false,
+			direction:          direction,
+		},
+		{
+			mount:              "/mnt/vols/A/subvols/AB",
+			CopyTarget:         copyTarget,
+			primaryMountTarget: false,
+			direction:          direction,
+		},
+	}
+
+	expectedFilterSpecs := map[string]FilterSpec{
+		"/": FilterSpec{
+			RebasePath: "mnt/vols",
+			StripPath:  "",
+			Exclusions: make(map[string]struct{}),
+			Inclusions: make(map[string]struct{}),
+		},
+		"/mnt/vols/A": FilterSpec{
+			RebasePath: "",
+			StripPath:  "A",
+			Exclusions: make(map[string]struct{}),
+			Inclusions: make(map[string]struct{}),
+		},
+		"/mnt/vols/B": FilterSpec{
+			RebasePath: "",
+			StripPath:  "B",
+			Exclusions: make(map[string]struct{}),
+			Inclusions: make(map[string]struct{}),
+		},
+		"/mnt/vols/A/subvols/AB": FilterSpec{
+			RebasePath: "",
+			StripPath:  "A/subvols/AB",
+			Exclusions: make(map[string]struct{}),
+			Inclusions: make(map[string]struct{}),
+		},
+	}
+
+	for _, v := range mounts {
+		actualFilterSpec := GenerateFilterSpec(v.CopyTarget, v.mount, v.primaryMountTarget, v.direction)
+		expectedFilterSpec := expectedFilterSpecs[v.mount]
+
+		if !assert.Equal(t, expectedFilterSpec.RebasePath, actualFilterSpec.RebasePath, "rebase path check failed (%s)", v.mount) {
+			return
+		}
+
+		if !assert.Equal(t, expectedFilterSpec.StripPath, actualFilterSpec.StripPath, "strip path check failed (%s)", v.mount) {
+			return
+		}
+
+	}
+
+}
+
+// COPY FROM TESTS
+
+func TestComplexReadSpec(t *testing.T) {
+	copyTarget := "/mnt/vols"
+	direction := CopyFrom
+
+	mounts := []testMount{
+
+		{
+			mount:              "/",
+			CopyTarget:         copyTarget,
+			primaryMountTarget: true,
+			direction:          direction,
+		},
+		{
+			mount:              "/mnt/vols/A",
+			CopyTarget:         copyTarget,
+			primaryMountTarget: false,
+			direction:          direction,
+		},
+		{
+			mount:              "/mnt/vols/B",
+			CopyTarget:         copyTarget,
+			primaryMountTarget: false,
+			direction:          direction,
+		},
+		{
+			mount:              "/mnt/vols/A/subvols/AB",
+			CopyTarget:         copyTarget,
+			primaryMountTarget: false,
+			direction:          direction,
+		},
+	}
+
+	expectedFilterSpecs := map[string]FilterSpec{
+		"/": FilterSpec{
+			RebasePath: "vols",
+			StripPath:  "mnt/vols",
+			Exclusions: make(map[string]struct{}),
+			Inclusions: make(map[string]struct{}),
+		},
+		"/mnt/vols/A": FilterSpec{
+			RebasePath: "vols/A",
+			StripPath:  "",
+			Exclusions: make(map[string]struct{}),
+			Inclusions: make(map[string]struct{}),
+		},
+		"/mnt/vols/B": FilterSpec{
+			RebasePath: "vols/B",
+			StripPath:  "",
+			Exclusions: make(map[string]struct{}),
+			Inclusions: make(map[string]struct{}),
+		},
+		"/mnt/vols/A/subvols/AB": FilterSpec{
+			RebasePath: "vols/A/subvols/AB",
+			StripPath:  "",
+			Exclusions: make(map[string]struct{}),
+			Inclusions: make(map[string]struct{}),
+		},
+	}
+
+	for _, v := range mounts {
+		actualFilterSpec := GenerateFilterSpec(v.CopyTarget, v.mount, v.primaryMountTarget, v.direction)
+		expectedFilterSpec := expectedFilterSpecs[v.mount]
+
+		if !assert.Equal(t, expectedFilterSpec.RebasePath, actualFilterSpec.RebasePath, "rebase path check failed (%s)", v.mount) {
+			return
+		}
+
+		if !assert.Equal(t, expectedFilterSpec.StripPath, actualFilterSpec.StripPath, "strip path check failed (%s)", v.mount) {
+			return
+		}
+
+	}
+
+}
+
+// test utility functions and structs
+
+type testMount struct {
+	mount              string
+	CopyTarget         string
+	primaryMountTarget bool
+	direction          bool
+}

--- a/lib/archive/util_test.go
+++ b/lib/archive/util_test.go
@@ -55,27 +55,79 @@ func TestComplexWriteSpec(t *testing.T) {
 	}
 
 	expectedFilterSpecs := map[string]FilterSpec{
-		"/": FilterSpec{
+		"/": {
 			RebasePath: "mnt/vols",
 			StripPath:  "",
 			Exclusions: make(map[string]struct{}),
 			Inclusions: make(map[string]struct{}),
 		},
-		"/mnt/vols/A": FilterSpec{
+		"/mnt/vols/A": {
 			RebasePath: "",
 			StripPath:  "A",
 			Exclusions: make(map[string]struct{}),
 			Inclusions: make(map[string]struct{}),
 		},
-		"/mnt/vols/B": FilterSpec{
+		"/mnt/vols/B": {
 			RebasePath: "",
 			StripPath:  "B",
 			Exclusions: make(map[string]struct{}),
 			Inclusions: make(map[string]struct{}),
 		},
-		"/mnt/vols/A/subvols/AB": FilterSpec{
+		"/mnt/vols/A/subvols/AB": {
 			RebasePath: "",
 			StripPath:  "A/subvols/AB",
+			Exclusions: make(map[string]struct{}),
+			Inclusions: make(map[string]struct{}),
+		},
+	}
+
+	for _, v := range mounts {
+		actualFilterSpec := GenerateFilterSpec(v.CopyTarget, v.mount, v.primaryMountTarget, v.direction)
+		expectedFilterSpec := expectedFilterSpecs[v.mount]
+
+		if !assert.Equal(t, expectedFilterSpec.RebasePath, actualFilterSpec.RebasePath, "rebase path check failed (%s)", v.mount) {
+			return
+		}
+
+		if !assert.Equal(t, expectedFilterSpec.StripPath, actualFilterSpec.StripPath, "strip path check failed (%s)", v.mount) {
+			return
+		}
+
+	}
+
+}
+
+func TestWriteIntoMountSpec(t *testing.T) {
+	copyTarget := "/mnt/vols/A/a/path"
+	direction := CopyTo
+
+	mounts := []testMount{
+		// "/" will exist but since it is past the write path we do not care about the filterspec. It will be filled out as a non primary target in any case. and is a non primary target that comes before the primary target.
+		{
+			mount:              "/",
+			CopyTarget:         copyTarget,
+			primaryMountTarget: false,
+			direction:          direction,
+		},
+		{
+			mount:              "/mnt/vols/A",
+			CopyTarget:         copyTarget,
+			primaryMountTarget: true,
+			direction:          direction,
+		},
+	}
+
+	expectedFilterSpecs := map[string]FilterSpec{
+		// not since this is past the copy target the filterspec will be completely bogus. The generateFilterSpec function assumes you have given it a target that lives along the CopyTarget. In our case here we have "/" as the mount point and the target as "/mnt/vols/A/a/path"
+		"/": {
+			RebasePath: "",
+			StripPath:  "",
+			Exclusions: make(map[string]struct{}),
+			Inclusions: make(map[string]struct{}),
+		},
+		"/mnt/vols/A": {
+			RebasePath: "a/path",
+			StripPath:  "",
 			Exclusions: make(map[string]struct{}),
 			Inclusions: make(map[string]struct{}),
 		},
@@ -132,27 +184,79 @@ func TestComplexReadSpec(t *testing.T) {
 	}
 
 	expectedFilterSpecs := map[string]FilterSpec{
-		"/": FilterSpec{
+		"/": {
 			RebasePath: "vols",
 			StripPath:  "mnt/vols",
 			Exclusions: make(map[string]struct{}),
 			Inclusions: make(map[string]struct{}),
 		},
-		"/mnt/vols/A": FilterSpec{
+		"/mnt/vols/A": {
 			RebasePath: "vols/A",
 			StripPath:  "",
 			Exclusions: make(map[string]struct{}),
 			Inclusions: make(map[string]struct{}),
 		},
-		"/mnt/vols/B": FilterSpec{
+		"/mnt/vols/B": {
 			RebasePath: "vols/B",
 			StripPath:  "",
 			Exclusions: make(map[string]struct{}),
 			Inclusions: make(map[string]struct{}),
 		},
-		"/mnt/vols/A/subvols/AB": FilterSpec{
+		"/mnt/vols/A/subvols/AB": {
 			RebasePath: "vols/A/subvols/AB",
 			StripPath:  "",
+			Exclusions: make(map[string]struct{}),
+			Inclusions: make(map[string]struct{}),
+		},
+	}
+
+	for _, v := range mounts {
+		actualFilterSpec := GenerateFilterSpec(v.CopyTarget, v.mount, v.primaryMountTarget, v.direction)
+		expectedFilterSpec := expectedFilterSpecs[v.mount]
+
+		if !assert.Equal(t, expectedFilterSpec.RebasePath, actualFilterSpec.RebasePath, "rebase path check failed (%s)", v.mount) {
+			return
+		}
+
+		if !assert.Equal(t, expectedFilterSpec.StripPath, actualFilterSpec.StripPath, "strip path check failed (%s)", v.mount) {
+			return
+		}
+
+	}
+
+}
+
+func TestReadIntoMountSpec(t *testing.T) {
+	copyTarget := "/mnt/vols/A/a/path"
+	direction := CopyFrom
+
+	mounts := []testMount{
+		// "/" will exist but since it is past the write path we do not care about the filterspec. It will be filled out as a non primary target in any case.
+		{
+			mount:              "/",
+			CopyTarget:         copyTarget,
+			primaryMountTarget: false,
+			direction:          direction,
+		},
+		{
+			mount:              "/mnt/vols/A",
+			CopyTarget:         copyTarget,
+			primaryMountTarget: true,
+			direction:          direction,
+		},
+	}
+
+	expectedFilterSpecs := map[string]FilterSpec{
+		// not since this is past the copy target the filterspec will be completely bogus. The generateFilterSpec function assumes you have given it a target that lives along the CopyTarget. In our case here we have "/" as the mount point and the target as "/mnt/vols/A/a/path"
+		"/": {
+			RebasePath: "path",
+			StripPath:  "",
+			Exclusions: make(map[string]struct{}),
+			Inclusions: make(map[string]struct{}),
+		},
+		"/mnt/vols/A": {
+			RebasePath: "path",
+			StripPath:  "a/path",
 			Exclusions: make(map[string]struct{}),
 			Inclusions: make(map[string]struct{}),
 		},

--- a/lib/archive/util_test.go
+++ b/lib/archive/util_test.go
@@ -418,10 +418,10 @@ func TestReadFileInMountSpec(t *testing.T) {
 
 }
 
-// ADD EXCLUSIONS TESTS
+// ADD INCLUSIONS/EXCLUSIONS TESTS
 
 func TestAddExclusionsNonNested(t *testing.T) {
-
+	copyTarget := "/mnt"
 	testMounts := []string{
 		"/",
 		"/mnt/A",
@@ -436,24 +436,49 @@ func TestAddExclusionsNonNested(t *testing.T) {
 				"mnt/B": {},
 				"mnt/C": {},
 			},
+			Inclusions: map[string]struct{}{
+				"/mnt": {},
+			},
 		},
 		"/mnt/A": FilterSpec{
 			Exclusions: make(map[string]struct{}),
+			Inclusions: map[string]struct{}{
+				"/": {},
+			},
 		},
 		"/mnt/B": FilterSpec{
 			Exclusions: make(map[string]struct{}),
+			Inclusions: map[string]struct{}{
+				"/": {},
+			},
 		},
 		"/mnt/C": FilterSpec{
 			Exclusions: make(map[string]struct{}),
+			Inclusions: map[string]struct{}{
+				"/": {},
+			},
 		},
 	}
 
 	for _, mount := range testMounts {
 		spec := FilterSpec{
 			Exclusions: make(map[string]struct{}),
+			Inclusions: make(map[string]struct{}),
 		}
 
-		AddMountExclusions(mount, &spec, testMounts)
+		err := AddMountInclusionsExclusions(mount, &spec, testMounts, copyTarget)
+
+		if !assert.Nil(t, err) {
+			return
+		}
+
+		for k := range expectedResults[mount].Inclusions {
+			_, ok := spec.Inclusions[k]
+
+			if !assert.True(t, ok, "did not find expected entry in inclusions map. ") {
+				return
+			}
+		}
 
 		expectedSpec := expectedResults[mount]
 		expectedLength := len(expectedSpec.Exclusions)
@@ -476,7 +501,7 @@ func TestAddExclusionsNonNested(t *testing.T) {
 }
 
 func TestAddExclusionsNestedMounts(t *testing.T) {
-
+	copyTarget := "/mnt"
 	testMounts := []string{
 		"/",
 		"/mnt/A",
@@ -495,27 +520,56 @@ func TestAddExclusionsNestedMounts(t *testing.T) {
 				"mnt/A/dir/AB": {},
 				"mnt/A/dir/AC": {},
 			},
+			Inclusions: map[string]struct{}{
+				"/mnt": {},
+			},
 		},
 		"/mnt/A": FilterSpec{
 			Exclusions: map[string]struct{}{
 				"dir/AB": {},
 				"dir/AC": {},
 			},
+			Inclusions: map[string]struct{}{
+				"/": {},
+			},
 		},
 		"/mnt/B": FilterSpec{
 			Exclusions: make(map[string]struct{}),
+			Inclusions: map[string]struct{}{
+				"/": {},
+			},
 		},
 		"/mnt/C": FilterSpec{
 			Exclusions: make(map[string]struct{}),
+			Inclusions: map[string]struct{}{
+				"/": {},
+			},
+		},
+		"/mnt/A/dir/AB": FilterSpec{
+			Exclusions: make(map[string]struct{}),
+			Inclusions: map[string]struct{}{
+				"/": {},
+			},
+		},
+		"/mnt/A/dir/AC": FilterSpec{
+			Exclusions: make(map[string]struct{}),
+			Inclusions: map[string]struct{}{
+				"/": {},
+			},
 		},
 	}
 
 	for _, mount := range testMounts {
 		spec := FilterSpec{
 			Exclusions: make(map[string]struct{}),
+			Inclusions: make(map[string]struct{}),
 		}
 
-		AddMountExclusions(mount, &spec, testMounts)
+		err := AddMountInclusionsExclusions(mount, &spec, testMounts, copyTarget)
+
+		if !assert.Nil(t, err) {
+			return
+		}
 
 		expectedSpec := expectedResults[mount]
 		expectedLength := len(expectedSpec.Exclusions)

--- a/lib/archive/util_test.go
+++ b/lib/archive/util_test.go
@@ -302,6 +302,81 @@ func TestComplexReadSpec(t *testing.T) {
 
 }
 
+func TestComplexReadWithEndingSlashSpec(t *testing.T) {
+	copyTarget := "/mnt/vols/"
+	direction := CopyFrom
+
+	mounts := []testMount{
+
+		{
+			mount:              "/",
+			CopyTarget:         copyTarget,
+			primaryMountTarget: true,
+			direction:          direction,
+		},
+		{
+			mount:              "/mnt/vols/A",
+			CopyTarget:         copyTarget,
+			primaryMountTarget: false,
+			direction:          direction,
+		},
+		{
+			mount:              "/mnt/vols/B",
+			CopyTarget:         copyTarget,
+			primaryMountTarget: false,
+			direction:          direction,
+		},
+		{
+			mount:              "/mnt/vols/A/subvols/AB",
+			CopyTarget:         copyTarget,
+			primaryMountTarget: false,
+			direction:          direction,
+		},
+	}
+
+	expectedFilterSpecs := map[string]FilterSpec{
+		"/": {
+			RebasePath: "vols",
+			StripPath:  "mnt/vols",
+			Exclusions: make(map[string]struct{}),
+			Inclusions: make(map[string]struct{}),
+		},
+		"/mnt/vols/A": {
+			RebasePath: "vols/A",
+			StripPath:  "",
+			Exclusions: make(map[string]struct{}),
+			Inclusions: make(map[string]struct{}),
+		},
+		"/mnt/vols/B": {
+			RebasePath: "vols/B",
+			StripPath:  "",
+			Exclusions: make(map[string]struct{}),
+			Inclusions: make(map[string]struct{}),
+		},
+		"/mnt/vols/A/subvols/AB": {
+			RebasePath: "vols/A/subvols/AB",
+			StripPath:  "",
+			Exclusions: make(map[string]struct{}),
+			Inclusions: make(map[string]struct{}),
+		},
+	}
+
+	for _, v := range mounts {
+		actualFilterSpec := GenerateFilterSpec(v.CopyTarget, v.mount, v.primaryMountTarget, v.direction)
+		expectedFilterSpec := expectedFilterSpecs[v.mount]
+
+		if !assert.Equal(t, expectedFilterSpec.RebasePath, actualFilterSpec.RebasePath, "rebase path check failed (%s)", v.mount) {
+			return
+		}
+
+		if !assert.Equal(t, expectedFilterSpec.StripPath, actualFilterSpec.StripPath, "strip path check failed (%s)", v.mount) {
+			return
+		}
+
+	}
+
+}
+
 func TestReadIntoMountSpec(t *testing.T) {
 	copyTarget := "/mnt/vols/A/a/path"
 	direction := CopyFrom

--- a/lib/archive/util_test.go
+++ b/lib/archive/util_test.go
@@ -418,6 +418,44 @@ func TestReadFileInMountSpec(t *testing.T) {
 
 }
 
+func TestReadAtMountBoundarySpec(t *testing.T) {
+	copyTarget := "/mnt/vols/A"
+	direction := CopyFrom
+
+	mounts := []testMount{
+		{
+			mount:              "/mnt/vols/A",
+			CopyTarget:         copyTarget,
+			primaryMountTarget: true,
+			direction:          direction,
+		},
+	}
+
+	expectedFilterSpecs := map[string]FilterSpec{
+		"/mnt/vols/A": {
+			RebasePath: "A",
+			StripPath:  "",
+			Exclusions: make(map[string]struct{}),
+			Inclusions: make(map[string]struct{}),
+		},
+	}
+
+	for _, v := range mounts {
+		actualFilterSpec := GenerateFilterSpec(v.CopyTarget, v.mount, v.primaryMountTarget, v.direction)
+		expectedFilterSpec := expectedFilterSpecs[v.mount]
+
+		if !assert.Equal(t, expectedFilterSpec.RebasePath, actualFilterSpec.RebasePath, "rebase path check failed (%s)", v.mount) {
+			return
+		}
+
+		if !assert.Equal(t, expectedFilterSpec.StripPath, actualFilterSpec.StripPath, "strip path check failed (%s)", v.mount) {
+			return
+		}
+
+	}
+
+}
+
 // ADD INCLUSIONS/EXCLUSIONS TESTS
 
 func TestAddExclusionsNonNested(t *testing.T) {
@@ -430,7 +468,7 @@ func TestAddExclusionsNonNested(t *testing.T) {
 	}
 
 	expectedResults := map[string]FilterSpec{
-		"/": FilterSpec{
+		"/": {
 			Exclusions: map[string]struct{}{
 				"mnt/A": {},
 				"mnt/B": {},
@@ -440,19 +478,19 @@ func TestAddExclusionsNonNested(t *testing.T) {
 				"/mnt": {},
 			},
 		},
-		"/mnt/A": FilterSpec{
+		"/mnt/A": {
 			Exclusions: make(map[string]struct{}),
 			Inclusions: map[string]struct{}{
 				"/": {},
 			},
 		},
-		"/mnt/B": FilterSpec{
+		"/mnt/B": {
 			Exclusions: make(map[string]struct{}),
 			Inclusions: map[string]struct{}{
 				"/": {},
 			},
 		},
-		"/mnt/C": FilterSpec{
+		"/mnt/C": {
 			Exclusions: make(map[string]struct{}),
 			Inclusions: map[string]struct{}{
 				"/": {},
@@ -512,7 +550,7 @@ func TestAddExclusionsNestedMounts(t *testing.T) {
 	}
 
 	expectedResults := map[string]FilterSpec{
-		"/": FilterSpec{
+		"/": {
 			Exclusions: map[string]struct{}{
 				"mnt/A":        {},
 				"mnt/B":        {},
@@ -524,7 +562,7 @@ func TestAddExclusionsNestedMounts(t *testing.T) {
 				"/mnt": {},
 			},
 		},
-		"/mnt/A": FilterSpec{
+		"/mnt/A": {
 			Exclusions: map[string]struct{}{
 				"dir/AB": {},
 				"dir/AC": {},
@@ -533,25 +571,25 @@ func TestAddExclusionsNestedMounts(t *testing.T) {
 				"/": {},
 			},
 		},
-		"/mnt/B": FilterSpec{
+		"/mnt/B": {
 			Exclusions: make(map[string]struct{}),
 			Inclusions: map[string]struct{}{
 				"/": {},
 			},
 		},
-		"/mnt/C": FilterSpec{
+		"/mnt/C": {
 			Exclusions: make(map[string]struct{}),
 			Inclusions: map[string]struct{}{
 				"/": {},
 			},
 		},
-		"/mnt/A/dir/AB": FilterSpec{
+		"/mnt/A/dir/AB": {
 			Exclusions: make(map[string]struct{}),
 			Inclusions: map[string]struct{}{
 				"/": {},
 			},
 		},
-		"/mnt/A/dir/AC": FilterSpec{
+		"/mnt/A/dir/AC": {
 			Exclusions: make(map[string]struct{}),
 			Inclusions: map[string]struct{}{
 				"/": {},

--- a/lib/archive/util_test.go
+++ b/lib/archive/util_test.go
@@ -688,19 +688,103 @@ func TestAddExclusionsNestedMounts(t *testing.T) {
 		expectedSpec := expectedResults[mount]
 		expectedLength := len(expectedSpec.Exclusions)
 		actualLength := len(spec.Exclusions)
-		if !assert.Equal(t, expectedLength, actualLength, "there were %d entries instead of %d for the exclusions generated for mount (%s)", expectedLength, actualLength, mount) {
+		if !assert.Equal(t, expectedLength, actualLength, "there were %d entries instead of %d for the exclusions generated for mount (%s)", actualLength, expectedLength, mount) {
+			return
+		}
+
+		expectedSpec = expectedResults[mount]
+		expectedLength = len(expectedSpec.Inclusions)
+		actualLength = len(spec.Inclusions)
+		if !assert.Equal(t, expectedLength, actualLength, "there were %d entries instead of %d for the inclusions generated for mount (%s)", actualLength, expectedLength, mount) {
 			return
 		}
 
 		for path := range expectedSpec.Exclusions {
 			_, ok := spec.Exclusions[path]
 
-			if !assert.True(t, ok, "Should have found (%s) in the exclusion map for %s \n exlusion map: %s", path, mount, spec.Exclusions) {
+			if !assert.True(t, ok, "Should have found (%s) in the exclusion map for %s \n exclusion map: %s", path, mount, spec.Exclusions) {
 				return
 			}
 
 		}
 
+		for path := range expectedSpec.Inclusions {
+			_, ok := spec.Inclusions[path]
+
+			if !assert.True(t, ok, "Should have found (%s) in the inclusion map for %s \n inclusion map: %s", path, mount, spec.Exclusions) {
+				return
+			}
+
+		}
+
+	}
+
+}
+
+func TestAddExclusionsMountTarget(t *testing.T) {
+	copyTarget := "/mnt/vols/A"
+	testMounts := []string{
+		"/",
+		"/mnt/vols/A",
+	}
+
+	expectedResults := map[string]FilterSpec{
+		"/mnt/vols/A": {
+			Exclusions: make(map[string]struct{}),
+			Inclusions: map[string]struct{}{
+				"": {},
+			},
+		},
+	}
+
+	for _, mount := range testMounts {
+
+		if mount == "/" {
+			continue
+		}
+
+		spec := FilterSpec{
+			Exclusions: make(map[string]struct{}),
+			Inclusions: make(map[string]struct{}),
+		}
+
+		err := AddMountInclusionsExclusions(mount, &spec, testMounts, copyTarget)
+
+		if !assert.Nil(t, err) {
+			return
+		}
+
+		expectedSpec := expectedResults[mount]
+		expectedLength := len(expectedSpec.Exclusions)
+		actualLength := len(spec.Exclusions)
+		if !assert.Equal(t, expectedLength, actualLength, "there were %d entries instead of %d for the exclusions generated for mount (%s)", actualLength, expectedLength, mount) {
+			return
+		}
+
+		expectedSpec = expectedResults[mount]
+		expectedLength = len(expectedSpec.Inclusions)
+		actualLength = len(spec.Inclusions)
+		if !assert.Equal(t, expectedLength, actualLength, "there were %d entries instead of %d for the inclusions generated for mount (%s)", actualLength, expectedLength, mount) {
+			return
+		}
+
+		for path := range expectedSpec.Exclusions {
+			_, ok := spec.Exclusions[path]
+
+			if !assert.True(t, ok, "Should have found (%s) in the exclusion map for %s \n exclusion map: %s", path, mount, spec.Exclusions) {
+				return
+			}
+
+		}
+
+		for path := range expectedSpec.Inclusions {
+			_, ok := spec.Inclusions[path]
+
+			if !assert.True(t, ok, "Should have found (%s) in the inclusion map for %s \n inclusion map: %s", path, mount, spec.Exclusions) {
+				return
+			}
+
+		}
 	}
 
 }

--- a/lib/archive/util_test.go
+++ b/lib/archive/util_test.go
@@ -627,6 +627,7 @@ func TestAddExclusionsNestedMounts(t *testing.T) {
 	expectedResults := map[string]FilterSpec{
 		"/": {
 			Exclusions: map[string]struct{}{
+				"":             {},
 				"mnt/A":        {},
 				"mnt/B":        {},
 				"mnt/C":        {},
@@ -634,7 +635,7 @@ func TestAddExclusionsNestedMounts(t *testing.T) {
 				"mnt/A/dir/AC": {},
 			},
 			Inclusions: map[string]struct{}{
-				"/mnt": {},
+				"mnt": {},
 			},
 		},
 		"/mnt/A": {
@@ -643,31 +644,31 @@ func TestAddExclusionsNestedMounts(t *testing.T) {
 				"dir/AC": {},
 			},
 			Inclusions: map[string]struct{}{
-				"/": {},
+				"": {},
 			},
 		},
 		"/mnt/B": {
 			Exclusions: make(map[string]struct{}),
 			Inclusions: map[string]struct{}{
-				"/": {},
+				"": {},
 			},
 		},
 		"/mnt/C": {
 			Exclusions: make(map[string]struct{}),
 			Inclusions: map[string]struct{}{
-				"/": {},
+				"": {},
 			},
 		},
 		"/mnt/A/dir/AB": {
 			Exclusions: make(map[string]struct{}),
 			Inclusions: map[string]struct{}{
-				"/": {},
+				"": {},
 			},
 		},
 		"/mnt/A/dir/AC": {
 			Exclusions: make(map[string]struct{}),
 			Inclusions: map[string]struct{}{
-				"/": {},
+				"": {},
 			},
 		},
 	}


### PR DESCRIPTION
GenerateFilterSpec can be used to create a filter spec with the appropriate `Rebase` and `Strip` targets. To generate the appropriate spec 4 aspects are need. These are described below:

- archive target path: This is the path which you will either unpack to or pack from. 
- mount point: this is the device mount point for the target runtime filesystem. (for the read write layer this would be "/", for some volume an example would be "/mnt/vol/A" or "/mydata". etc...)
- PrimaryTarget: this is a boolean indicating whether the given device path is the primary device for the Copy operation. The introspective question for this is "Am I mounted before the archive target path and am I involved with this copy operation?"
- operation direction: This is to designate whether this is a Copy From or a Copy To. Constants are included in the portlayer archive package. These are `archive.CopyFrom` and `archive.CopyTo`

based on these 4 inputs we are able to determine the appropriate Rebase and Strip path.