### PR TITLE
Implement Online Datasource

### DIFF
--- a/lib/apiservers/engine/backends/archive.go
+++ b/lib/apiservers/engine/backends/archive.go
@@ -20,13 +20,12 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"os"
 	"path"
 	"strings"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/tchap/go-patricia/patricia"
 
+	"github.com/docker/docker/pkg/archive"
 	"github.com/vmware/vic/lib/apiservers/engine/backends/cache"
 	viccontainer "github.com/vmware/vic/lib/apiservers/engine/backends/container"
 	vicarchive "github.com/vmware/vic/lib/archive"
@@ -34,48 +33,49 @@ import (
 	"github.com/vmware/vic/pkg/trace"
 
 	"github.com/docker/docker/api/types"
-	"github.com/docker/docker/pkg/archive"
 )
 
 // ContainerArchivePath creates an archive of the filesystem resource at the
 // specified path in the container identified by the given name. Returns a
 // tar archive of the resource and whether it was a directory or a single file.
-func (c *Container) ContainerArchivePath(name string, path string) (content io.ReadCloser, stat *types.ContainerPathStat, err error) {
+func (c *Container) ContainerArchivePath(name string, path string) (io.ReadCloser, *types.ContainerPathStat, error) {
 	defer trace.End(trace.Begin(name))
+	op := trace.NewOperation(context.Background(), "ContainerArchivePath: %s", name)
 
 	vc := cache.ContainerCache().GetContainer(name)
 	if vc == nil {
 		return nil, nil, NotFoundError(name)
 	}
 
-	var reader io.ReadCloser
-
-	reader, err = c.exportFromContainer(vc, path)
-	if err != nil && IsResourceInUse(err) {
-		log.Errorf("ContainerArchivePath failed, resource in use: %s", err.Error())
-		err = fmt.Errorf("Resource in use")
+	stat, err := c.ContainerStatPath(name, path)
+	if err != nil {
+		return nil, nil, InternalServerError(err.Error())
 	}
-	if err == nil || reader != nil {
-		content = reader
-	}
-	stat = nil
 
-	return
+	reader, err := c.exportFromContainer(op, vc, path)
+	if err != nil {
+		if IsResourceInUse(err) {
+			err = fmt.Errorf("ContainerArchivePath failed, resource in use: %s", err.Error())
+		}
+		return nil, nil, InternalServerError(err.Error())
+	}
+
+	return reader, stat, nil
 }
 
-func (c *Container) exportFromContainer(vc *viccontainer.VicContainer, path string) (io.ReadCloser, error) {
+func (c *Container) exportFromContainer(op trace.Operation, vc *viccontainer.VicContainer, path string) (io.ReadCloser, error) {
 	mounts := mountsFromContainer(vc)
 	mounts = append(mounts, types.MountPoint{Destination: "/"})
-	readerMap := NewArchiveStreamReaderMap(mounts, path)
+	readerMap := NewArchiveStreamReaderMap(op, mounts, path)
 
 	readers, err := readerMap.ReadersForSourcePath(c.containerProxy, vc.ContainerID, path)
 	if err != nil {
-		log.Errorf("Errors getting readers for export: %s", err.Error())
+		op.Errorf("Errors getting readers for export: %s", err.Error())
 		return nil, err
 	}
 
 	//FIXME: We need a multi reader that can be closed.  MultiReader returns a regular reader
-	log.Infof("Got %d archive readers", len(readers))
+	op.Infof("Got %d archive readers", len(readers))
 	finalTarReader := io.MultiReader(readers...)
 
 	return ioutil.NopCloser(finalTarReader), nil
@@ -101,33 +101,34 @@ func (c *Container) ContainerExport(name string, out io.Writer) error {
 // to be replaced with a non-directory and vice versa.
 func (c *Container) ContainerExtractToDir(name, path string, noOverwriteDirNonDir bool, content io.Reader) error {
 	defer trace.End(trace.Begin(name))
+	op := trace.NewOperation(context.Background(), "ContainerExtractToDir: %s", name)
 
 	vc := cache.ContainerCache().GetContainer(name)
 	if vc == nil {
 		return NotFoundError(name)
 	}
 
-	err := c.importToContainer(vc, path, content)
+	err := c.importToContainer(op, vc, path, content)
 	if err != nil && IsResourceInUse(err) {
-		log.Errorf("ContainerExtractToDir failed, resource in use: %s", err.Error())
+		op.Errorf("ContainerExtractToDir failed, resource in use: %s", err.Error())
 
-		err = fmt.Errorf("Resouce in use")
+		err = fmt.Errorf("Resource in use")
 	}
 
 	return err
 }
 
-func (c *Container) importToContainer(vc *viccontainer.VicContainer, target string, content io.Reader) error {
+func (c *Container) importToContainer(op trace.Operation, vc *viccontainer.VicContainer, target string, content io.Reader) error {
 	rawReader, err := archive.DecompressStream(content)
 	if err != nil {
-		log.Errorf("Input tar stream to ContainerExtractToDir not recognized: %s", err.Error())
+		op.Errorf("Input tar stream to ContainerExtractToDir not recognized: %s", err.Error())
 		return StreamFormatNotRecognized()
 	}
-	tarReader := tar.NewReader(rawReader)
 
+	tarReader := tar.NewReader(rawReader)
 	mounts := mountsFromContainer(vc)
 	mounts = append(mounts, types.MountPoint{Destination: "/"})
-	writerMap := NewArchiveStreamWriterMap(mounts, target)
+	writerMap := NewArchiveStreamWriterMap(op, mounts, target)
 	defer writerMap.Close() // This should shutdown all the stream connections to the portlayer.
 
 	for {
@@ -140,18 +141,18 @@ func (c *Container) importToContainer(vc *viccontainer.VicContainer, target stri
 		}
 
 		// Lookup the writer for that mount prefix
-		writer, err := writerMap.WriterForAsset(c.containerProxy, vc.ContainerID, target, *header)
+		tarWriter, err := writerMap.WriterForAsset(c.containerProxy, vc.ContainerID, target, *header)
 		if err != nil {
 			return err
 		}
 
-		tarWriter := tar.NewWriter(writer)
-		tarWriter.WriteHeader(header)
-		// do NOT call tarWriter.Close() or that will create the double nil record for end-of-archive
+		if err = tarWriter.WriteHeader(header); err != nil {
+			op.Errorf("Error while copying tar header %#v: %s", *header, err.Error())
+			return err
+		}
 
-		_, err = io.Copy(writer, tarReader)
-		if err != nil {
-			log.Errorf("Error while copying tar data for %s: %s", header.Name, err.Error())
+		if _, err = io.Copy(tarWriter, tarReader); err != nil {
+			op.Errorf("Error while copying tar data for %s: %s", header.Name, err.Error())
 			return err
 		}
 	}
@@ -161,13 +162,57 @@ func (c *Container) importToContainer(vc *viccontainer.VicContainer, target stri
 
 // ContainerStatPath stats the filesystem resource at the specified path in the
 // container identified by the given name.
-func (c *Container) ContainerStatPath(name string, path string) (stat *types.ContainerPathStat, err error) {
-	defer trace.End(trace.Begin(fmt.Sprintf("** statpath, name=%s, path=%s", name, path)))
+func (c *Container) ContainerStatPath(name string, srcPath string) (*types.ContainerPathStat, error) {
+	defer trace.End(trace.Begin(name))
+	op := trace.NewOperation(context.Background(), "ContainerStatPath: %s", name)
 
-	fakeStat := &types.ContainerPathStat{}
-	fakeStat.Mode = os.ModeDir
+	vc := cache.ContainerCache().GetContainer(name)
+	if vc == nil {
+		return nil, NotFoundError(name)
+	}
 
-	return fakeStat, nil
+	// treat stat like an export with no data
+	mounts := mountsFromContainer(vc)
+	mounts = append(mounts, types.MountPoint{Destination: "/"})
+	readerMap := NewArchiveStreamReaderMap(op, mounts, srcPath)
+	nodes, err := readerMap.FindArchiveReaders(srcPath)
+
+	// get the longest matching mount target
+	var primaryTarget *ArchiveReader
+	for _, node := range nodes {
+		if strings.HasPrefix(srcPath, node.mountPoint.Destination) && (primaryTarget == nil ||
+			len(node.mountPoint.Destination) > len(primaryTarget.mountPoint.Destination)) {
+			primaryTarget = node
+		}
+	}
+
+	primaryTarget.filterSpec.Inclusions = make(map[string]struct{})
+	primaryTarget.filterSpec.Exclusions = make(map[string]struct{})
+
+	inclusionPath := path.Join("/", strings.TrimPrefix(srcPath, primaryTarget.mountPoint.Destination))
+	exclusionPath := inclusionPath + "/"
+	primaryTarget.filterSpec.Inclusions[inclusionPath] = struct{}{}
+	primaryTarget.filterSpec.Exclusions[exclusionPath] = struct{}{}
+
+	var deviceID string
+	var store string
+	if primaryTarget.mountPoint.Destination == "/" {
+		// Special case. / refers to container VMDK and not a volume vmdk.
+		deviceID = vc.ContainerID
+		store = constants.ContainerStoreName
+	} else {
+		deviceID = primaryTarget.mountPoint.Name
+		store = constants.VolumeStoreName
+	}
+
+	stat, err := c.containerProxy.StatPath(op, store, deviceID, primaryTarget.filterSpec)
+	if err != nil {
+		op.Errorf("error getting statpath: %s", err.Error())
+		return nil, err
+	}
+
+	op.Debugf("online container stat path %#v", stat)
+	return stat, nil
 }
 
 //----------------------------------
@@ -178,22 +223,13 @@ type ArchiveWriter struct {
 	mountPoint types.MountPoint
 	filterSpec vicarchive.FilterSpec
 	writer     io.WriteCloser
-}
-
-type ArchiveReader struct {
-	mountPoint types.MountPoint
-	filterSpec vicarchive.FilterSpec
-	reader     io.ReadCloser
+	tarWriter  *tar.Writer
 }
 
 // ArchiveStreamWriterMap maps mount prefix to io.WriteCloser
 type ArchiveStreamWriterMap struct {
 	prefixTrie *patricia.Trie
-}
-
-// ArchiveStreamReaderMap maps mount prefix to io.ReadCloser
-type ArchiveStreamReaderMap struct {
-	prefixTrie *patricia.Trie
+	op         trace.Operation
 }
 
 // NewArchiveStreamWriterMap creates a new ArchiveStreamWriterMap.  The map contains all information
@@ -202,9 +238,10 @@ type ArchiveStreamReaderMap struct {
 //
 // mounts is the mount data from inspect
 // containerDestPath is the destination path in the container
-func NewArchiveStreamWriterMap(mounts []types.MountPoint, dest string) *ArchiveStreamWriterMap {
+func NewArchiveStreamWriterMap(op trace.Operation, mounts []types.MountPoint, dest string) *ArchiveStreamWriterMap {
 	writerMap := &ArchiveStreamWriterMap{}
 	writerMap.prefixTrie = patricia.NewTrie()
+	writerMap.op = op
 
 	for _, m := range mounts {
 		aw := ArchiveWriter{
@@ -231,13 +268,9 @@ func NewArchiveStreamWriterMap(mounts []types.MountPoint, dest string) *ArchiveS
 		// strip "A" or "mnt/A" is based on the container destination path.
 
 		// hickeng: the current logic is strip, then rebase for export - more efficient to collapse
-		// any reducdency here than apply to every tar entry when packing but skipping for now.
+		// any redundancy here than apply to every tar entry when packing but skipping for now.
 		aw.filterSpec.StripPath = aw.mountPoint.Destination
 		aw.filterSpec.RebasePath = strings.TrimPrefix(dest, aw.mountPoint.Destination)
-
-		// if containerDestPath != "/" && strings.HasPrefix(aw.mountPoint.Destination, containerDestPath) {
-		// 	aw.filterSpec.StripPath = strings.TrimPrefix(aw.mountPoint.Destination, containerDestPath)
-		// }
 
 		aw.filterSpec.Exclusions = make(map[string]struct{})
 		aw.filterSpec.Inclusions = make(map[string]struct{})
@@ -246,46 +279,6 @@ func NewArchiveStreamWriterMap(mounts []types.MountPoint, dest string) *ArchiveS
 	}
 
 	return writerMap
-}
-
-// NewArchiveStreamReaderMap creates a new ArchiveStreamReaderMap.  After the call, it contains
-// information to create readers for every volume mounts for the container
-//
-// mounts is the mount data from inspect
-func NewArchiveStreamReaderMap(mounts []types.MountPoint, dest string) *ArchiveStreamReaderMap {
-	readerMap := &ArchiveStreamReaderMap{}
-	readerMap.prefixTrie = patricia.NewTrie()
-
-	for _, m := range mounts {
-		ar := ArchiveReader{
-			mountPoint: m,
-			reader:     nil,
-		}
-
-		// If the mount point is not the root file system, we must tell the portlayer to rebase the
-		// files in the return tar stream with the mount point path since the volume does not know
-		// the path it is mounted to.  It only knows it's root file system.
-		//
-		//	e.g. mount A at /mnt/A with a file data.txt in A
-		//
-		//	/mnt/A/data.txt		<-- from container point of view
-		//	/data.txt			<-- from volume point of view
-		//
-		// Neither the volume nor the storage portlayer knows about /mnt/A.  The persona must tell
-		// the portlayer to rebase all files from this volume to the /mnt/A/ in the final tar stream.
-
-		// hickeng: the current logic is rebase, then strip for export - more efficient to collapse
-		// any reducdency here than apply to every tar entry when packing but skipping for now.
-		ar.filterSpec.RebasePath = ar.mountPoint.Destination
-		ar.filterSpec.StripPath = path.Join("/", path.Dir(dest))
-
-		ar.filterSpec.Exclusions = make(map[string]struct{})
-		ar.filterSpec.Inclusions = make(map[string]struct{})
-
-		readerMap.prefixTrie.Insert(patricia.Prefix(m.Destination), &ar)
-	}
-
-	return readerMap
 }
 
 // FindArchiveWriter finds the one writer that matches the asset name.  There should only be one
@@ -316,11 +309,11 @@ func (wm *ArchiveStreamWriterMap) FindArchiveWriter(containerDestPath, assetName
 	//
 	// In the above example, mount prefxi can only be determined by combining both the container destination path and
 	// the asset name, as the final destination includes a mounted volume.
-	combinedPath := path.Join(containerDestPath, assetName)
+	combinedPath := path.Join(path.Dir(containerDestPath), assetName)
 	prefix := patricia.Prefix(combinedPath)
 	err = wm.prefixTrie.VisitPrefixes(prefix, findPrefix)
 	if err != nil {
-		log.Errorf(err.Error())
+		wm.op.Errorf(err.Error())
 		return nil, fmt.Errorf("Failed to find a node for prefix %s: %s", containerDestPath, err.Error())
 	}
 
@@ -360,11 +353,10 @@ func (wm *ArchiveStreamWriterMap) FindArchiveWriter(containerDestPath, assetName
 //
 // As demonstrated above, the mount prefix and writer cannot be determined with just the
 // container destination path.  It must be combined with the actual asset's name.
-func (wm *ArchiveStreamWriterMap) WriterForAsset(proxy VicContainerProxy, cid, containerDestPath string, assetHeader tar.Header) (io.WriteCloser, error) {
+func (wm *ArchiveStreamWriterMap) WriterForAsset(proxy VicContainerProxy, cid, containerDestPath string, assetHeader tar.Header) (*tar.Writer, error) {
 	defer trace.End(trace.Begin(assetHeader.Name))
 
 	var err error
-	var streamWriter io.WriteCloser
 
 	aw, err := wm.FindArchiveWriter(containerDestPath, assetHeader.Name)
 	if err != nil {
@@ -374,7 +366,7 @@ func (wm *ArchiveStreamWriterMap) WriterForAsset(proxy VicContainerProxy, cid, c
 	// Perform the lazy initialization here.
 	if aw.writer == nil {
 		// lazy initialize.
-		log.Debugf("Lazily initializing import stream for %s", aw.mountPoint.Destination)
+		wm.op.Debugf("Lazily initializing import stream for %s", aw.mountPoint.Destination)
 		var deviceID string
 		var store string
 		if aw.mountPoint.Destination == "/" {
@@ -385,18 +377,17 @@ func (wm *ArchiveStreamWriterMap) WriterForAsset(proxy VicContainerProxy, cid, c
 			deviceID = aw.mountPoint.Name
 			store = constants.VolumeStoreName
 		}
-		streamWriter, err = proxy.ArchiveImportWriter(context.Background(), store, deviceID, aw.filterSpec)
+		rawWriter, err := proxy.ArchiveImportWriter(wm.op, store, deviceID, aw.filterSpec)
 		if err != nil {
 			err = fmt.Errorf("Unable to initialize import stream writer for mount prefix %s", aw.mountPoint.Destination)
-			log.Errorf(err.Error())
+			wm.op.Errorf(err.Error())
 			return nil, err
 		}
-		aw.writer = streamWriter
-	} else {
-		streamWriter = aw.writer
+		aw.writer = rawWriter
+		aw.tarWriter = tar.NewWriter(rawWriter)
 	}
 
-	return streamWriter, nil
+	return aw.tarWriter, nil
 }
 
 // Close visits all the archive writer in the trie and closes the actual io.WritCloser
@@ -406,12 +397,66 @@ func (wm *ArchiveStreamWriterMap) Close() {
 	closeStream := func(prefix patricia.Prefix, item patricia.Item) error {
 		if aw, ok := item.(*ArchiveWriter); ok && aw.writer != nil {
 			aw.writer.Close()
+			aw.tarWriter.Close()
 			aw.writer = nil
+			aw.tarWriter = nil
 		}
 		return nil
 	}
 
 	wm.prefixTrie.Visit(closeStream)
+}
+
+// ArchiveStreamReaderMap maps mount prefix to io.ReadCloser
+type ArchiveStreamReaderMap struct {
+	prefixTrie *patricia.Trie
+	op         trace.Operation
+}
+type ArchiveReader struct {
+	mountPoint types.MountPoint
+	filterSpec vicarchive.FilterSpec
+	reader     io.ReadCloser
+}
+
+// NewArchiveStreamReaderMap creates a new ArchiveStreamReaderMap.  After the call, it contains
+// information to create readers for every volume mounts for the container
+//
+// mounts is the mount data from inspect
+func NewArchiveStreamReaderMap(op trace.Operation, mounts []types.MountPoint, dest string) *ArchiveStreamReaderMap {
+	readerMap := &ArchiveStreamReaderMap{}
+	readerMap.prefixTrie = patricia.NewTrie()
+	readerMap.op = op
+
+	for _, m := range mounts {
+		ar := ArchiveReader{
+			mountPoint: m,
+			reader:     nil,
+		}
+
+		// If the mount point is not the root file system, we must tell the portlayer to rebase the
+		// files in the return tar stream with the mount point path since the volume does not know
+		// the path it is mounted to.  It only knows it's root file system.
+		//
+		//	e.g. mount A at /mnt/A with a file data.txt in A
+		//
+		//	/mnt/A/data.txt		<-- from container point of view
+		//	/data.txt			<-- from volume point of view
+		//
+		// Neither the volume nor the storage portlayer knows about /mnt/A.  The persona must tell
+		// the portlayer to rebase all files from this volume to the /mnt/A/ in the final tar stream.
+
+		// hickeng: the current logic is rebase, then strip for export - more efficient to collapse
+		// any reducdency here than apply to every tar entry when packing but skipping for now.
+		ar.filterSpec.RebasePath = ar.mountPoint.Destination
+		ar.filterSpec.StripPath = path.Join("/", path.Dir(dest))
+
+		ar.filterSpec.Exclusions = make(map[string]struct{})
+		ar.filterSpec.Inclusions = make(map[string]struct{})
+
+		readerMap.prefixTrie.Insert(patricia.Prefix(m.Destination), &ar)
+	}
+
+	return readerMap
 }
 
 // FindArchiveReaders finds all archive readers that are within the container source path.  For example,
@@ -456,7 +501,7 @@ func (rm *ArchiveStreamReaderMap) FindArchiveReaders(containerSourcePath string)
 	err = rm.prefixTrie.VisitSubtree(prefix, walkPrefixSubtree)
 	if err != nil {
 		msg := fmt.Sprintf("Failed to find a node for prefix %s: %s", containerSourcePath, err.Error())
-		log.Error(msg)
+		rm.op.Errorf(msg)
 		return nil, fmt.Errorf(msg)
 	}
 
@@ -467,7 +512,7 @@ func (rm *ArchiveStreamReaderMap) FindArchiveReaders(containerSourcePath string)
 	err = rm.prefixTrie.VisitPrefixes(prefix, findStartingPrefix)
 	if err != nil {
 		msg := fmt.Sprintf("Failed to find starting node for prefix %s: %s", containerSourcePath, err.Error())
-		log.Error(msg)
+		rm.op.Errorf(msg)
 		return nil, fmt.Errorf(msg)
 	}
 
@@ -488,7 +533,7 @@ func (rm *ArchiveStreamReaderMap) FindArchiveReaders(containerSourcePath string)
 		startingNode = nodes[0]
 	} else {
 		msg := fmt.Sprintf("Failed to find starting node for prefix %s: %s", containerSourcePath, err.Error())
-		log.Error(msg)
+		rm.op.Errorf(msg)
 		return nil, fmt.Errorf(msg)
 	}
 
@@ -498,72 +543,6 @@ func (rm *ArchiveStreamReaderMap) FindArchiveReaders(containerSourcePath string)
 	}
 
 	return nodes, nil
-}
-
-func (rm *ArchiveStreamReaderMap) buildFilterSpec(containerSourcePath string, nodes []*ArchiveReader, startingNode *ArchiveReader) error {
-	var err error
-
-	// Build an exclusion filter for each writer.  For example, the reader for / should not read
-	// from submounts as there are separate readers for those.
-	buildExclusion := func(path string, node *ArchiveReader) error {
-		childWalker := func(prefix patricia.Prefix, item patricia.Item) error {
-			if _, ok := item.(*ArchiveReader); !ok {
-				return fmt.Errorf("item not ArchiveReader")
-			}
-
-			ar, _ := item.(*ArchiveReader)
-			dest := ar.mountPoint.Destination
-			if dest != path {
-				node.filterSpec.Exclusions[dest] = struct{}{}
-			}
-			return nil
-		}
-
-		// prefix = current node's mount path
-		nodePrefix := patricia.Prefix(path)
-
-		err = rm.prefixTrie.VisitSubtree(nodePrefix, childWalker)
-		if err != nil {
-			msg := fmt.Sprintf("Failed to build exclusion filter for %s: %s", path, err.Error())
-			log.Error(msg)
-			return fmt.Errorf(msg)
-		}
-
-		return nil
-	}
-
-	for _, node := range nodes {
-		// Clear out existing exclusions and inclusions
-		node.filterSpec.Exclusions = make(map[string]struct{})
-		node.filterSpec.Inclusions = make(map[string]struct{})
-
-		err = buildExclusion(node.mountPoint.Destination, node)
-		if err != nil {
-			return err
-		}
-	}
-
-	// Add inclusion filter.  When there is an inclusion, there should be only one node in
-	// the slice that is returned.
-	//
-	//	Example 1:
-	//		containerSourcePath -	/file.txt
-	//
-	//		ArchiveReader path -	/
-	//		Inclusion filter -		file.txt
-	//
-	//	Example 2:
-	//		containerSourcePath -	/mnt/A/a/file.txt
-	//
-	//		ArchiveReader path -	/mnt/A
-	//		Inclusion filter -		a/file.txt
-	inclusionPath := strings.TrimPrefix(containerSourcePath, startingNode.mountPoint.Destination)
-	inclusionPath = strings.TrimPrefix(inclusionPath, "/")
-	if len(nodes) == 1 {
-		nodes[0].filterSpec.Inclusions[inclusionPath] = struct{}{}
-	}
-
-	return nil
 }
 
 // ReadersForSourcePath returns all an array of io.Reader for all the readers within a container source path.
@@ -607,14 +586,14 @@ func (rm *ArchiveStreamReaderMap) ReadersForSourcePath(proxy VicContainerProxy, 
 				node.filterSpec.Inclusions[subpath] = struct{}{}
 			}
 
-			log.Infof("Lazily initializing export stream for %s [%s]", node.mountPoint.Name, node.mountPoint.Destination)
-			reader, err := proxy.ArchiveExportReader(context.Background(), store, "", deviceID, "", true, node.filterSpec)
+			rm.op.Infof("Lazily initializing export stream for %s [%s]", node.mountPoint.Name, node.mountPoint.Destination)
+			reader, err := proxy.ArchiveExportReader(rm.op, store, "", deviceID, "", true, node.filterSpec)
 			if err != nil {
 				err = fmt.Errorf("Unable to initialize export stream reader for prefix %s", node.mountPoint.Destination)
-				log.Errorf(err.Error())
+				rm.op.Errorf(err.Error())
 				return nil, err
 			}
-			log.Infof("Lazy initialization created reader %#v", reader)
+			rm.op.Infof("Lazy initialization created reader %#v", reader)
 			streamReaders = append(streamReaders, reader)
 		} else {
 			streamReaders = append(streamReaders, node.reader)
@@ -622,7 +601,7 @@ func (rm *ArchiveStreamReaderMap) ReadersForSourcePath(proxy VicContainerProxy, 
 	}
 
 	if len(nodes) == 0 {
-		log.Infof("Found no archive readers for %s", containerSourcePath)
+		rm.op.Infof("Found no archive readers for %s", containerSourcePath)
 	}
 
 	return streamReaders, nil
@@ -641,4 +620,67 @@ func (rm *ArchiveStreamReaderMap) Close() {
 	}
 
 	rm.prefixTrie.Visit(closeStream)
+}
+
+func (rm *ArchiveStreamReaderMap) buildFilterSpec(containerSourcePath string, nodes []*ArchiveReader, startingNode *ArchiveReader) error {
+	var err error
+
+	// Build an exclusion filter for each writer.  For example, the reader for / should not read
+	// from submounts as there are separate readers for those.
+	buildExclusion := func(path string, node *ArchiveReader) error {
+		childWalker := func(prefix patricia.Prefix, item patricia.Item) error {
+			if _, ok := item.(*ArchiveReader); !ok {
+				return fmt.Errorf("item not ArchiveReader")
+			}
+
+			ar, _ := item.(*ArchiveReader)
+			dest := ar.mountPoint.Destination
+			if dest != path {
+				node.filterSpec.Exclusions[dest] = struct{}{}
+			}
+			return nil
+		}
+
+		// prefix = current node's mount path
+		nodePrefix := patricia.Prefix(path)
+
+		err = rm.prefixTrie.VisitSubtree(nodePrefix, childWalker)
+		if err != nil {
+			msg := fmt.Sprintf("Failed to build exclusion filter for %s: %s", path, err.Error())
+			rm.op.Errorf(msg)
+			return fmt.Errorf(msg)
+		}
+
+		return nil
+	}
+
+	for _, node := range nodes {
+		// Clear out existing exclusions and inclusions
+		node.filterSpec.Exclusions = make(map[string]struct{})
+		node.filterSpec.Inclusions = make(map[string]struct{})
+
+		err = buildExclusion(node.mountPoint.Destination, node)
+		if err != nil {
+			return err
+		}
+
+		// Add inclusion filter.  When there is an inclusion, there should be only one node in
+		// the slice that is returned.
+		//
+		//	Example 1:
+		//		containerSourcePath -	/file.txt
+		//
+		//		ArchiveReader path -	/
+		//		Inclusion filter -		file.txt
+		//
+		//	Example 2:
+		//		containerSourcePath -	/mnt/A/a/file.txt
+		//
+		//		ArchiveReader path -	/mnt/A
+		//		Inclusion filter -		a/file.txt
+		inclusionPath := path.Join("/", strings.TrimPrefix(containerSourcePath, node.mountPoint.Destination))
+		node.filterSpec.Inclusions[inclusionPath] = struct{}{}
+
+	}
+	return nil
 }

--- a/lib/apiservers/engine/backends/backends.go
+++ b/lib/apiservers/engine/backends/backends.go
@@ -26,6 +26,7 @@ import (
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/docker/docker/daemon/events"
+	"github.com/go-openapi/runtime"
 	rc "github.com/go-openapi/runtime/client"
 	"github.com/go-openapi/swag"
 
@@ -109,6 +110,10 @@ func Init(portLayerAddr, product string, config *config.VirtualContainerHostConf
 	}
 
 	t := rc.New(portLayerAddr, "/", []string{"http"})
+	t.Consumers["application/x-tar"] = runtime.ByteStreamConsumer()
+	t.Consumers["application/octet-stream"] = runtime.ByteStreamConsumer()
+	t.Producers["application/x-tar"] = runtime.ByteStreamProducer()
+	t.Producers["application/octet-stream"] = runtime.ByteStreamProducer()
 
 	portLayerClient = apiclient.New(t, nil)
 	portLayerServerAddr = portLayerAddr

--- a/lib/apiservers/engine/backends/container.go
+++ b/lib/apiservers/engine/backends/container.go
@@ -1279,6 +1279,7 @@ func (c *Container) ContainerWait(name string, timeout time.Duration) (int, erro
 // ContainerChanges returns a list of container fs changes
 func (c *Container) ContainerChanges(name string) ([]docker.Change, error) {
 	defer trace.End(trace.Begin(name))
+	op := trace.NewOperation(context.Background(), "ContainerChanges: %s", name)
 
 	vc := cache.ContainerCache().GetContainer(name)
 	if vc == nil {
@@ -1286,7 +1287,7 @@ func (c *Container) ContainerChanges(name string) ([]docker.Change, error) {
 	}
 	log.Debugf("Found %q in cache as %q", name, vc.ContainerID)
 
-	r, err := c.containerProxy.GetContainerChanges(context.Background(), vc)
+	r, err := c.containerProxy.GetContainerChanges(op, vc)
 	if err != nil {
 		return nil, InternalServerError(err.Error())
 	}

--- a/lib/apiservers/engine/backends/container_proxy.go
+++ b/lib/apiservers/engine/backends/container_proxy.go
@@ -33,12 +33,11 @@ package backends
 
 import (
 	"context"
-	"encoding/base64"
-	"encoding/json"
 	"fmt"
 	"io"
 	"net"
 	"net/http"
+	"os"
 	"strconv"
 	"strings"
 	"sync"
@@ -97,8 +96,9 @@ type VicContainerProxy interface {
 	StreamContainerLogs(ctx context.Context, name string, out io.Writer, started chan struct{}, showTimestamps bool, followLogs bool, since int64, tailLines int64) error
 	StreamContainerStats(ctx context.Context, config *convert.ContainerStatsConfig) error
 
-	ArchiveExportReader(ctx context.Context, store, ancestorStore, deviceID, ancestor string, data bool, filterSpec archive.FilterSpec) (io.ReadCloser, error)
-	ArchiveImportWriter(ctx context.Context, store, deviceID string, filterSpec archive.FilterSpec) (io.WriteCloser, error)
+	ArchiveExportReader(op trace.Operation, store, ancestorStore, deviceID, ancestor string, data bool, filterSpec archive.FilterSpec) (io.ReadCloser, error)
+	ArchiveImportWriter(op trace.Operation, store, deviceID string, filterSpec archive.FilterSpec) (io.WriteCloser, error)
+	StatPath(op trace.Operation, sotre, deviceID string, filterSpec archive.FilterSpec) (*types.ContainerPathStat, error)
 
 	Stop(vc *viccontainer.VicContainer, name string, seconds *int, unbound bool) error
 	State(vc *viccontainer.VicContainer) (*types.ContainerState, error)
@@ -107,7 +107,7 @@ type VicContainerProxy interface {
 	Resize(id string, height, width int32) error
 	Rename(vc *viccontainer.VicContainer, newName string) error
 
-	GetContainerChanges(ctx context.Context, vc *viccontainer.VicContainer) (io.ReadCloser, error)
+	GetContainerChanges(op trace.Operation, vc *viccontainer.VicContainer) (io.ReadCloser, error)
 
 	Handle(id, name string) (string, error)
 	Client() *client.PortLayer
@@ -151,6 +151,7 @@ const (
 	swaggerSubstringEOF                 = "EOF"
 	forceLogType                        = "json-file" //Use in inspect to allow docker logs to work
 	ShortIDLen                          = 12
+	archiveStreamBufSize                = 64 * 1024
 
 	DriverArgFlagKey      = "flags"
 	DriverArgContainerKey = "container"
@@ -475,7 +476,7 @@ func (c *ContainerProxy) AddLoggingToContainer(handle string, config types.Conta
 	return handle, nil
 }
 
-// AddInteractionToContainer adds interaction capabilies to a container, referenced by handle.
+// AddInteractionToContainer adds interaction capabilities to a container, referenced by handle.
 // If an error is return, the returned handle should not be used.
 //
 // returns:
@@ -502,7 +503,7 @@ func (c *ContainerProxy) AddInteractionToContainer(handle string, config types.C
 	return handle, nil
 }
 
-// BindInteraction enables interaction capabilies
+// BindInteraction enables interaction capabilities
 func (c *ContainerProxy) BindInteraction(handle string, name string, id string) (string, error) {
 	defer trace.End(trace.Begin(handle))
 
@@ -531,7 +532,7 @@ func (c *ContainerProxy) BindInteraction(handle string, name string, id string) 
 	return handle, nil
 }
 
-// UnbindInteraction disables interaction capabilies
+// UnbindInteraction disables interaction capabilities
 func (c *ContainerProxy) UnbindInteraction(handle string, name string, id string) (string, error) {
 	defer trace.End(trace.Begin(handle))
 
@@ -674,7 +675,7 @@ func (c *ContainerProxy) StreamContainerStats(ctx context.Context, config *conve
 	return nil
 }
 
-func (c *ContainerProxy) GetContainerChanges(ctx context.Context, vc *viccontainer.VicContainer) (io.ReadCloser, error) {
+func (c *ContainerProxy) GetContainerChanges(op trace.Operation, vc *viccontainer.VicContainer) (io.ReadCloser, error) {
 	host, err := sys.UUID()
 	if err != nil {
 		return nil, InternalServerError("Failed to determine host UUID")
@@ -686,7 +687,7 @@ func (c *ContainerProxy) GetContainerChanges(ctx context.Context, vc *viccontain
 		Exclusions: map[string]struct{}{},
 	}
 
-	r, err := c.ArchiveExportReader(ctx, constants.ContainerStoreName, host, vc.ContainerID, parent, false, spec)
+	r, err := c.ArchiveExportReader(op, constants.ContainerStoreName, host, vc.ContainerID, parent, false, spec)
 	if err != nil {
 		return nil, InternalServerError(err.Error())
 	}
@@ -696,48 +697,46 @@ func (c *ContainerProxy) GetContainerChanges(ctx context.Context, vc *viccontain
 
 // ArchiveExportReader streams a tar archive from the portlayer.  Once the stream is complete,
 // an io.Reader is returned and the caller can use that reader to parse the data.
-func (c *ContainerProxy) ArchiveExportReader(ctx context.Context, store, ancestorStore, deviceID, ancestor string, data bool, filterSpec archive.FilterSpec) (io.ReadCloser, error) {
+func (c *ContainerProxy) ArchiveExportReader(op trace.Operation, store, ancestorStore, deviceID, ancestor string, data bool, filterSpec archive.FilterSpec) (io.ReadCloser, error) {
 	defer trace.End(trace.Begin(deviceID))
 
 	if store == "" || deviceID == "" {
 		return nil, fmt.Errorf("ArchiveExportReader called with either empty store or deviceID")
 	}
 
-	var err error
-
 	pipeReader, pipeWriter := io.Pipe()
 
 	done := make(chan struct{})
 	go func() {
+
 		// make sure we get out of io.Copy if context is canceled
 		select {
-		case <-ctx.Done():
+		case <-op.Done():
+			// Attempt to tell the portlayer to cancel the stream.  This is one way of cancelling the
+			// stream.  The other way is for the caller of this function to close the returned CloseReader.
+			// Callers of this function should do one but not both.
+			pipeReader.Close()
 		case <-done:
+			pipeWriter.Close()
 		}
-
-		// Attempt to tell the portlayer to cancel the stream.  This is one way of cancelling the
-		// stream.  The other way is for the caller of this function to close the returned CloseReader.
-		// Callers of this function should do one but not both.
-		pipeReader.Close()
 	}()
 
 	go func() {
 		defer close(done)
 
-		params := storage.NewExportArchiveParamsWithContext(ctx).
+		params := storage.NewExportArchiveParamsWithContext(op).
 			WithStore(store).
 			WithAncestorStore(&ancestorStore).
 			WithDeviceID(deviceID).
 			WithAncestor(&ancestor).
 			WithData(data)
 
-		// Encode the filter spec
-		encodedFilter := ""
-		if valueBytes, merr := json.Marshal(filterSpec); merr == nil {
-			encodedFilter = base64.StdEncoding.EncodeToString(valueBytes)
-			params = params.WithFilterSpec(&encodedFilter)
-			log.Infof(" encodedFilter = %s", encodedFilter)
+		spec, err := archive.EncodeFilterSpec(op, &filterSpec)
+		if err != nil {
+			op.Errorf(err.Error())
+			pipeReader.CloseWithError(err)
 		}
+		params = params.WithFilterSpec(spec)
 
 		_, err = c.client.Storage.ExportArchive(params, pipeWriter)
 		if err != nil {
@@ -745,25 +744,23 @@ func (c *ContainerProxy) ArchiveExportReader(ctx context.Context, store, ancesto
 			switch err := err.(type) {
 			case *storage.ExportArchiveInternalServerError:
 				plErr := InternalServerError(fmt.Sprintf("Server error from archive reader for device %s", deviceID))
-				log.Errorf(plErr.Error())
+				op.Errorf(plErr.Error())
 				pipeWriter.CloseWithError(plErr)
 			case *storage.ImportArchiveLocked:
 				plErr := ResourceLockedError(fmt.Sprintf("Resource locked for device %s", deviceID))
-				log.Errorf(plErr.Error())
+				op.Errorf(plErr.Error())
 				pipeWriter.CloseWithError(plErr)
 			default:
 				//Check for EOF.  Since the connection, transport, and data handling are
 				//encapsulated inside of Swagger, we can only detect EOF by checking the
 				//error string
 				if strings.Contains(err.Error(), swaggerSubstringEOF) {
-					log.Debugf("swagger error %s", err.Error())
-					pipeWriter.Close()
+					op.Debugf("swagger error %s", err.Error())
 				} else {
+					op.Errorf(err.Error())
 					pipeWriter.CloseWithError(err)
 				}
 			}
-		} else {
-			pipeWriter.Close()
 		}
 	}()
 
@@ -772,14 +769,12 @@ func (c *ContainerProxy) ArchiveExportReader(ctx context.Context, store, ancesto
 
 // ArchiveImportWriter initializes a write stream for a path.  This is usually called
 // for gettine a writer during docker cp TO container.
-func (c *ContainerProxy) ArchiveImportWriter(ctx context.Context, store, deviceID string, filterSpec archive.FilterSpec) (io.WriteCloser, error) {
+func (c *ContainerProxy) ArchiveImportWriter(op trace.Operation, store, deviceID string, filterSpec archive.FilterSpec) (io.WriteCloser, error) {
 	defer trace.End(trace.Begin(deviceID))
 
 	if store == "" || deviceID == "" {
 		return nil, fmt.Errorf("ArchiveImportWriter called with either empty store or deviceID")
 	}
-
-	var err error
 
 	pipeReader, pipeWriter := io.Pipe()
 
@@ -787,61 +782,99 @@ func (c *ContainerProxy) ArchiveImportWriter(ctx context.Context, store, deviceI
 	go func() {
 		// make sure we get out of io.Copy if context is canceled
 		select {
-		case <-ctx.Done():
+		case <-op.Done():
+			// Attempt to shutdown the stream to the portlayer.  The other way to cancel the
+			// connection is to call close on the WriteCloser returned from this function.
+			// Callers of this function should do one but not both.
+			pipeWriter.Close()
 		case <-done:
 		}
 
-		// Attempt to shutdown the stream to the portlayer.  The other way to cancel the
-		// connection is to call close on the WriteCloser returned from this function.
-		// Callers of this function should do one but not both.
-		pipeWriter.Close()
 	}()
 
 	go func() {
 		defer close(done)
 
-		// encodedFilter and destination are not required (from swagge spec) because
+		// encodedFilter and destination are not required (from swagger spec) because
 		// they are allowed to be empty.
-		params := storage.NewImportArchiveParamsWithContext(ctx).
+		params := storage.NewImportArchiveParamsWithContext(op).
 			WithStore(store).
 			WithDeviceID(deviceID).
 			WithArchive(pipeReader)
 
-		// Encode the filter spec
-		encodedFilter := ""
-		if valueBytes, merr := json.Marshal(filterSpec); merr == nil {
-			encodedFilter = base64.StdEncoding.EncodeToString(valueBytes)
-			params = params.WithFilterSpec(&encodedFilter)
+		spec, err := archive.EncodeFilterSpec(op, &filterSpec)
+		if err != nil {
+			op.Errorf(err.Error())
+			pipeReader.CloseWithError(err)
 		}
+		params = params.WithFilterSpec(spec)
 
 		_, err = c.client.Storage.ImportArchive(params)
 		if err != nil {
 			switch err := err.(type) {
 			case *storage.ImportArchiveInternalServerError:
 				plErr := InternalServerError(fmt.Sprintf("Server error from archive writer for device %s", deviceID))
-				log.Errorf(plErr.Error())
+				op.Errorf(plErr.Error())
 				pipeReader.CloseWithError(plErr)
 			case *storage.ImportArchiveLocked:
 				plErr := ResourceLockedError(fmt.Sprintf("Resource locked for device %s", deviceID))
-				log.Errorf(plErr.Error())
+				op.Errorf(plErr.Error())
 				pipeReader.CloseWithError(plErr)
 			default:
 				//Check for EOF.  Since the connection, transport, and data handling are
 				//encapsulated inside of Swagger, we can only detect EOF by checking the
 				//error string
 				if strings.Contains(err.Error(), swaggerSubstringEOF) {
-					log.Errorf(err.Error())
-					pipeReader.Close()
+					op.Errorf(err.Error())
 				} else {
+					op.Errorf(err.Error())
 					pipeReader.CloseWithError(err)
 				}
 			}
-		} else {
-			pipeReader.Close()
 		}
 	}()
 
 	return pipeWriter, nil
+}
+
+// StatPath requests the portlayer to stat the filesystem resource at the
+// specified path in the container vc.
+func (c *ContainerProxy) StatPath(op trace.Operation, store, deviceID string, filterSpec archive.FilterSpec) (*types.ContainerPathStat, error) {
+	defer trace.End(trace.Begin(deviceID))
+
+	statPathParams := storage.
+		NewStatPathParamsWithContext(op).
+		WithStore(store).
+		WithDeviceID(deviceID)
+
+	spec, err := archive.EncodeFilterSpec(op, &filterSpec)
+	if err != nil {
+		op.Errorf(err.Error())
+		return nil, InternalServerError(err.Error())
+	}
+	statPathParams = statPathParams.WithFilterSpec(spec)
+
+	statPathOk, err := c.client.Storage.StatPath(statPathParams)
+	if err != nil {
+		op.Errorf(err.Error())
+		return nil, InternalServerError(err.Error())
+	}
+
+	stat := &types.ContainerPathStat{
+		Name:       statPathOk.Name,
+		Mode:       os.FileMode(statPathOk.Mode),
+		Size:       statPathOk.Size,
+		LinkTarget: statPathOk.LinkTarget,
+	}
+
+	var modTime time.Time
+	if err := modTime.GobDecode([]byte(statPathOk.ModTime)); err != nil {
+		op.Debugf("error getting mod time from statpath: %s", err.Error())
+	} else {
+		stat.Mtime = modTime
+	}
+
+	return stat, nil
 }
 
 // Stop will stop (shutdown) a VIC container.
@@ -1834,7 +1867,7 @@ func networkFromContainerInfo(vc *viccontainer.VicContainer, info *models.Contai
 
 // portMapFromVicContainer() constructs a docker portmap from both the container's
 // hostconfig and config (both stored in VicContainer).  They are added and modified
-// during docker create.  This function creates a new map that is adhere's to docker's
+// during docker create.  This function creates a new map that is adheres to docker's
 // structure for types.NetworkSettings.Ports.
 func portMapFromVicContainer(vc *viccontainer.VicContainer) nat.PortMap {
 	var portMap nat.PortMap

--- a/lib/apiservers/portlayer/restapi/configure_port_layer.go
+++ b/lib/apiservers/portlayer/restapi/configure_port_layer.go
@@ -114,6 +114,12 @@ func configureAPI(api *operations.PortLayerAPI) http.Handler {
 
 	api.BinConsumer = runtime.ByteStreamConsumer()
 
+	api.BinProducer = runtime.ByteStreamProducer()
+
+	api.TarConsumer = runtime.ByteStreamConsumer()
+
+	api.TarProducer = runtime.ByteStreamProducer()
+
 	api.JSONConsumer = runtime.JSONConsumer()
 
 	api.JSONProducer = runtime.JSONProducer()

--- a/lib/apiservers/portlayer/restapi/handlers/storage_handlers.go
+++ b/lib/apiservers/portlayer/restapi/handlers/storage_handlers.go
@@ -28,7 +28,7 @@ import (
 	"github.com/vmware/vic/lib/apiservers/portlayer/models"
 	"github.com/vmware/vic/lib/apiservers/portlayer/restapi/operations"
 	"github.com/vmware/vic/lib/apiservers/portlayer/restapi/operations/storage"
-	vicarchive "github.com/vmware/vic/lib/archive"
+	"github.com/vmware/vic/lib/archive"
 	epl "github.com/vmware/vic/lib/portlayer/exec"
 	spl "github.com/vmware/vic/lib/portlayer/storage"
 	"github.com/vmware/vic/lib/portlayer/storage/nfs"
@@ -110,6 +110,7 @@ func (h *StorageHandlersImpl) Configure(api *operations.PortLayerAPI, handlerCtx
 
 	api.StorageExportArchiveHandler = storage.ExportArchiveHandlerFunc(h.ExportArchive)
 	api.StorageImportArchiveHandler = storage.ImportArchiveHandlerFunc(h.ImportArchive)
+	api.StorageStatPathHandler = storage.StatPathHandlerFunc(h.StatPath)
 }
 
 func (h *StorageHandlersImpl) configureVolumeStores(op trace.Operation, handlerCtx *HandlerContext) {
@@ -535,15 +536,13 @@ func (h *StorageHandlersImpl) VolumeJoin(params storage.VolumeJoinParams) middle
 // ImportArchive takes an input tar archive and unpacks to destination
 func (h *StorageHandlersImpl) ImportArchive(params storage.ImportArchiveParams) middleware.Responder {
 	defer trace.End(trace.Begin(""))
-	defer params.Archive.Close()
 
 	id := params.DeviceID
 	op := trace.NewOperation(context.Background(), "ImportArchive: %s", id)
 
-	filterSpec, err := vicarchive.DecodeFilterSpec(op, params.FilterSpec)
+	filterSpec, err := archive.DecodeFilterSpec(op, params.FilterSpec)
 	if err != nil {
-		// hickeng: should be a 422 instead of 500
-		return storage.NewImportArchiveInternalServerError()
+		return storage.NewImportArchiveUnprocessableEntity()
 	}
 
 	store, ok := spl.GetImporter(params.Store)
@@ -567,7 +566,6 @@ func (h *StorageHandlersImpl) ImportArchive(params storage.ImportArchiveParams) 
 // ExportArchive creates a tar archive and returns to caller
 func (h *StorageHandlersImpl) ExportArchive(params storage.ExportArchiveParams) middleware.Responder {
 	defer trace.End(trace.Begin(""))
-
 	id := params.DeviceID
 	ancestor := ""
 	if params.Ancestor != nil {
@@ -576,10 +574,9 @@ func (h *StorageHandlersImpl) ExportArchive(params storage.ExportArchiveParams) 
 
 	op := trace.NewOperation(context.Background(), "ExportArchive: %s:%s", id, ancestor)
 
-	filterSpec, err := vicarchive.DecodeFilterSpec(op, params.FilterSpec)
+	filterSpec, err := archive.DecodeFilterSpec(op, params.FilterSpec)
 	if err != nil {
-		// hickeng: should be a 422 instead of 500
-		return storage.NewExportArchiveInternalServerError()
+		return storage.NewExportArchiveUnprocessableEntity()
 	}
 
 	store, ok := spl.GetExporter(params.Store)
@@ -601,6 +598,54 @@ func (h *StorageHandlersImpl) ExportArchive(params storage.ExportArchiveParams) 
 	}
 
 	return NewStreamOutputHandler("ExportArchive").WithPayload(NewFlushingReader(r), params.DeviceID, func() { r.Close() })
+}
+
+// StatPath returns file info on the target path of a container copy
+func (h *StorageHandlersImpl) StatPath(params storage.StatPathParams) middleware.Responder {
+	defer trace.End(trace.Begin(""))
+	op := trace.NewOperation(context.Background(), "StatPath: %s", params.DeviceID)
+
+	filterSpec, err := archive.DecodeFilterSpec(op, params.FilterSpec)
+	if err != nil {
+		return storage.NewStatPathUnprocessableEntity()
+	}
+
+	if len(filterSpec.Inclusions) != 1 {
+		return storage.NewStatPathUnprocessableEntity()
+	}
+
+	store, ok := spl.GetExporter(params.Store)
+	if !ok {
+		op.Errorf("Error getting exporter: %s", err.Error())
+		return storage.NewStatPathNotFound()
+	}
+
+	dataSource, err := store.NewDataSource(op, params.DeviceID)
+	if err != nil {
+		op.Errorf("Error getting data source: %s", err.Error())
+		return storage.NewStatPathInternalServerError()
+	}
+
+	fileStat, err := dataSource.Stat(op, filterSpec)
+	if err != nil {
+		op.Errorf("Error getting datasource stats: %s", err.Error())
+		return storage.NewStatPathInternalServerError()
+	}
+
+	modTimeBytes, err := fileStat.ModTime.GobEncode()
+	if err != nil {
+		return storage.NewStatPathUnprocessableEntity()
+	}
+
+	op.Debugf("found data successfully")
+	return storage.
+		NewStatPathOK().
+		WithMode(fileStat.Mode).
+		WithLinkTarget(fileStat.LinkTarget).
+		WithName(fileStat.Name).
+		WithSize(fileStat.Size).
+		WithModTime(string(modTimeBytes))
+
 }
 
 //utility functions

--- a/lib/apiservers/portlayer/swagger.json
+++ b/lib/apiservers/portlayer/swagger.json
@@ -182,9 +182,6 @@
 				"tags": [
 					"storage"
 				],
-				"consumes": [
-					"application/json"
-				],
 				"produces": [
 					"application/x-tar"
 				],
@@ -242,6 +239,12 @@
 					},
 					"404": {
 						"description": "Supplied target not found",
+						"schema": {
+							"$ref": "#/definitions/Error"
+						}
+					},
+					"422": {
+						"description": "Format error in supplied filter or archive",
 						"schema": {
 							"$ref": "#/definitions/Error"
 						}
@@ -335,6 +338,72 @@
 						"schema": {
 							"$ref": "#/definitions/Error"
 						}
+					}
+				}
+			},
+			"head": {
+				"description": "Fetches filesystem stats on the device id at the specified path",
+				"operationId": "StatPath",
+				"tags": [
+					"storage"
+				],
+				"parameters": [
+					{
+						"name": "store",
+						"in": "query",
+						"required": true,
+						"type": "string",
+						"x-nullable": false
+					},
+					{
+						"name": "deviceID",
+						"in": "query",
+						"required": true,
+						"type": "string",
+						"x-nullable": false
+					},
+					{
+						"name": "filterSpec",
+						"in": "query",
+						"required": false,
+						"type": "string",
+						"x-nullable": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"headers": {
+							"name": {
+								"type": "string",
+								"x-nullable": false
+							},
+							"mode": {
+								"type": "integer",
+								"format": "uint32"
+							},
+							"size": {
+								"type": "integer",
+								"format": "int64"
+							},
+							"linkTarget": {
+								"type": "string",
+								"x-nullable": false
+							},
+							"modTime": {
+								"type": "string",
+								"x-nullable": false
+							}
+						}
+					},
+					"422": {
+						"description": "Format error in supplied filter or archive"
+					},
+					"404": {
+						"description": "Supplied target not found"
+					},
+					"500": {
+						"description": "failed to export tar archive from target"
 					}
 				}
 			}

--- a/lib/archive/archiver.go
+++ b/lib/archive/archiver.go
@@ -167,39 +167,28 @@ func EncodeFilterSpec(op trace.Operation, spec *FilterSpec) (*string, error) {
 // If the spec is completely empty it will match everything.
 // If an inclusion is set, but not exclusion, then we'll only return matches for the inclusions.
 func (spec *FilterSpec) Excludes(op trace.Operation, filePath string) bool {
-	il := len(spec.Inclusions)
-	el := len(spec.Exclusions)
-
-	if il == 0 && el == 0 {
-		// empty spec means include everything
-		return false
-	}
-
-	inclusion := ""
-	exclusion := "/"
-
-	if il == 0 {
-		// if only exclusions are specified then default is include all others
-		inclusion = "/"
-	}
+	iLength := 0
+	eLength := 0
 
 	for path := range spec.Inclusions {
 		if strings.HasPrefix(filePath, path) {
-			if len(path) > len(inclusion) {
+			tempILength := len(path)
+			if tempILength > iLength {
 				// more specific inclusion, so update
-				inclusion = path
+				iLength = tempILength
 			}
 		}
 	}
 
 	for path := range spec.Exclusions {
 		if strings.HasPrefix(filePath, path) {
-			if len(path) > len(exclusion) {
+			tempELength := len(path)
+			if tempELength > eLength {
 				// more specific exclusion, so update
-				exclusion = path
+				eLength = tempELength
 			}
 		}
 	}
 
-	return len(inclusion) < len(exclusion)
+	return iLength < eLength
 }

--- a/lib/archive/diff_test.go
+++ b/lib/archive/diff_test.go
@@ -113,7 +113,7 @@ func TestMain(m *testing.M) {
 func TestDiff(t *testing.T) {
 	op := trace.NewOperation(context.Background(), "TestDiff")
 
-	tarFile, err := Diff(op, newDir, oldDir, nil, true)
+	tarFile, err := Diff(op, newDir, oldDir, nil, true, true)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -158,7 +158,7 @@ func TestDiffNoAncestor(t *testing.T) {
 	op := trace.NewOperation(context.Background(), "TestDiffNoParent")
 
 	// test without ancestor
-	tarFile, err := Diff(op, newDir, "", nil, true)
+	tarFile, err := Diff(op, newDir, "", nil, true, true)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -205,7 +205,7 @@ func TestDiffNoAncestor(t *testing.T) {
 func TestDiffNoData(t *testing.T) {
 	op := trace.NewOperation(context.Background(), "TestDiffNoData")
 
-	tarFile, err := Diff(op, newDir, oldDir, nil, false)
+	tarFile, err := Diff(op, newDir, oldDir, nil, false, true)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -281,7 +281,7 @@ func TestDiffFilterSpec(t *testing.T) {
 		return
 	}
 
-	tarFile, err := Diff(op, newDir, oldDir, spec, true)
+	tarFile, err := Diff(op, newDir, oldDir, spec, true, true)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -347,7 +347,7 @@ func TestDiffFilterSpecNoAncestor(t *testing.T) {
 	}
 
 	// test without ancestor
-	tarFile, err := Diff(op, newDir, "", spec, true)
+	tarFile, err := Diff(op, newDir, "", spec, true, true)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -415,7 +415,7 @@ func TestDiffFilterSpecRebase(t *testing.T) {
 	}
 
 	// test without ancestor
-	tarFile, err := Diff(op, newDir, oldDir, spec, true)
+	tarFile, err := Diff(op, newDir, oldDir, spec, true, true)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -488,7 +488,7 @@ func TestDiffFilterSpecRebaseNoData(t *testing.T) {
 		return
 	}
 
-	tarFile, err := Diff(op, newDir, oldDir, spec, false)
+	tarFile, err := Diff(op, newDir, oldDir, spec, false, true)
 	if !assert.NoError(t, err) {
 		return
 	}

--- a/lib/portlayer/storage/storage.go
+++ b/lib/portlayer/storage/storage.go
@@ -19,6 +19,7 @@ import (
 	"io"
 	"net/url"
 	"sync"
+	"time"
 
 	log "github.com/Sirupsen/logrus"
 
@@ -38,6 +39,14 @@ var (
 	importers map[string]Importer
 	exporters map[string]Exporter
 )
+
+type FileStat struct {
+	LinkTarget string
+	Mode       uint32
+	Name       string
+	Size       int64
+	ModTime    time.Time
+}
 
 func create(ctx context.Context, session *session.Session, pool *object.ResourcePool) error {
 	var err error
@@ -148,6 +157,9 @@ type DataSource interface {
 	//     nfs volume:  		 XDR-client
 	//     via guesttools:  	 toolbox client
 	Source() interface{}
+
+	// Stat returns os.stat or os.lstat information for the given filterspec.
+	Stat(op trace.Operation, spec *archive.FilterSpec) (*FileStat, error)
 }
 
 // DataSink defines the methods for importing data to a specific storage element from a tar stream

--- a/lib/portlayer/storage/volume.go
+++ b/lib/portlayer/storage/volume.go
@@ -96,7 +96,7 @@ func NewVolume(store *url.URL, ID string, info map[string][]byte, device Disk, c
 
 	vol := &Volume{
 		ID:       ID,
-		Label:    label(ID),
+		Label:    Label(ID),
 		Store:    store,
 		SelfLink: selflink,
 		Device:   device,
@@ -107,7 +107,7 @@ func NewVolume(store *url.URL, ID string, info map[string][]byte, device Disk, c
 }
 
 // given an ID, compute the volume's label
-func label(ID string) string {
+func Label(ID string) string {
 
 	// e2label's manpage says the label size is 16 chars
 	// #nosec: Use of weak cryptographic primitive

--- a/lib/portlayer/storage/vsphere/container.go
+++ b/lib/portlayer/storage/vsphere/container.go
@@ -146,11 +146,12 @@ func (c *ContainerStore) newDataSource(op trace.Operation, url *url.URL) (storag
 }
 
 func (c *ContainerStore) newOnlineDataSource(op trace.Operation, owner *vm.VirtualMachine, id string) (storage.DataSource, error) {
-	op.Debugf("Constructing toolbox data sink: %s.%s", owner.Reference(), id)
+	op.Debugf("Constructing toolbox data source: %s.%s", owner.Reference(), id)
 
 	return &ToolboxDataSource{
-		VM: owner,
-		ID: id,
+		VM:    owner,
+		ID:    id,
+		Clean: func() { return },
 	}, nil
 }
 
@@ -210,8 +211,9 @@ func (c *ContainerStore) newOnlineDataSink(op trace.Operation, owner *vm.Virtual
 	op.Debugf("Constructing toolbox data sink: %s.%s", owner.Reference(), id)
 
 	return &ToolboxDataSink{
-		VM: owner,
-		ID: id,
+		VM:    owner,
+		ID:    id,
+		Clean: func() { return },
 	}, nil
 }
 
@@ -274,7 +276,7 @@ func (c *ContainerStore) Export(op trace.Operation, id, ancestor string, spec *a
 		return nil, errors.New("mismatched datasource types")
 	}
 
-	tar, err := archive.Diff(op, fl.Name(), fr.Name(), spec, data)
+	tar, err := archive.Diff(op, fl.Name(), fr.Name(), spec, data, false)
 	if err != nil {
 		go closers()
 		return nil, err

--- a/lib/portlayer/storage/vsphere/export.go
+++ b/lib/portlayer/storage/vsphere/export.go
@@ -103,9 +103,9 @@ func (v *VolumeStore) newDataSource(op trace.Operation, url *url.URL) (storage.D
 
 func (v *VolumeStore) newOnlineDataSource(op trace.Operation, owner *vm.VirtualMachine, id string) (storage.DataSource, error) {
 	return &ToolboxDataSource{
-		VM: owner,
-		// TODO: there's some mangling that happens from volume id to disk label so this isn't currently correct
-		ID: id,
+		VM:    owner,
+		ID:    storage.Label(id),
+		Clean: func() { return },
 	}, nil
 }
 
@@ -126,7 +126,7 @@ func (i *ImageStore) Export(op trace.Operation, id, ancestor string, spec *archi
 		return l.Export(op, spec, data)
 	}
 
-	// for now we assume ancetor instead of entirely generic left/right
+	// for now we assume ancestor instead of entirely generic left/right
 	// this allows us to assume it's an image
 	r, err := i.NewDataSource(op, ancestor)
 	if err != nil {
@@ -150,7 +150,7 @@ func (i *ImageStore) Export(op trace.Operation, id, ancestor string, spec *archi
 		return nil, fmt.Errorf("mismatched datasource types: %T, %T", ls, rs)
 	}
 
-	tar, err := archive.Diff(op, fl.Name(), fr.Name(), spec, data)
+	tar, err := archive.Diff(op, fl.Name(), fr.Name(), spec, data, false)
 	if err != nil {
 		go closers()
 		return nil, err

--- a/lib/portlayer/storage/vsphere/toolbox_common.go
+++ b/lib/portlayer/storage/vsphere/toolbox_common.go
@@ -1,0 +1,74 @@
+// Copyright 2017 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vsphere
+
+import (
+	"fmt"
+	"path"
+
+	"github.com/vmware/govmomi/guest"
+	"github.com/vmware/govmomi/guest/toolbox"
+	"github.com/vmware/govmomi/vim25/types"
+	"github.com/vmware/vic/lib/archive"
+	"github.com/vmware/vic/pkg/trace"
+	"github.com/vmware/vic/pkg/vsphere/vm"
+)
+
+const (
+	DiskLabelQueryName  = "disk-label"
+	FilterSpecQueryName = "filter-spec"
+)
+
+// Parse Archive does something.
+func BuildArchiveUrl(op trace.Operation, disklabel, target string, fs *archive.FilterSpec) (string, error) {
+	encodedSpec, err := archive.EncodeFilterSpec(op, fs)
+	if err != nil {
+		return "", err
+	}
+	target = path.Join("/archive:/", target)
+
+	// if diskLabel is longer than 16 characters, then the function was passed a containerID
+	// use containerfs as the diskLabel
+	if len(disklabel) > 16 {
+		disklabel = "containerfs"
+	}
+
+	target += fmt.Sprintf("?%s=%s&%s=%s", DiskLabelQueryName, disklabel, FilterSpecQueryName, *encodedSpec)
+	op.Debugf("OnlineData* Url: %s", target)
+	return target, nil
+}
+
+// GetToolboxClient returns a toolbox client given a vm and id
+func GetToolboxClient(op trace.Operation, vm *vm.VirtualMachine, id string) (*toolbox.Client, error) {
+	opmgr := guest.NewOperationsManager(vm.Session.Client.Client, vm.Reference())
+	pm, err := opmgr.ProcessManager(op)
+	if err != nil {
+		op.Debugf("Failed to create new process manager ")
+		return nil, err
+	}
+	fm, err := opmgr.FileManager(op)
+	if err != nil {
+		op.Debugf("Failed to create new file manager ")
+		return nil, err
+	}
+
+	return &toolbox.Client{
+		ProcessManager: pm,
+		FileManager:    fm,
+		Authentication: &types.NamePasswordAuthentication{
+			Username: id,
+		},
+	}, nil
+}

--- a/lib/portlayer/storage/vsphere/toolbox_datasink.go
+++ b/lib/portlayer/storage/vsphere/toolbox_datasink.go
@@ -15,10 +15,10 @@
 package vsphere
 
 import (
-	"errors"
+	"compress/gzip"
 	"io"
 
-	"github.com/vmware/govmomi/guest"
+	"github.com/vmware/govmomi/vim25/soap"
 	"github.com/vmware/govmomi/vim25/types"
 	"github.com/vmware/vic/lib/archive"
 	"github.com/vmware/vic/pkg/trace"
@@ -39,30 +39,44 @@ func (t *ToolboxDataSink) Sink() interface{} {
 
 // Import writes `data` to the data sink associated with this DataSink
 func (t *ToolboxDataSink) Import(op trace.Operation, spec *archive.FilterSpec, data io.ReadCloser) error {
-	defer trace.End(trace.Begin(""))
+	defer trace.End(trace.Begin("toolbox import"))
 
-	// set up file manager
-	client := t.VM.Session.Client.Client
-	filemgr, err := guest.NewOperationsManager(client, t.VM.Reference()).FileManager(op)
+	client, err := GetToolboxClient(op, t.VM, t.ID)
 	if err != nil {
+		op.Debugf("Cannot get toolbox client: %s", err.Error())
 		return err
 	}
 
-	// authenticate client and parse container host/port
-	auth := types.NamePasswordAuthentication{
-		Username: t.ID,
+	target, err := BuildArchiveUrl(op, t.ID, spec.RebasePath, spec)
+	if err != nil {
+		op.Debugf("Cannot build archive url: %s", err.Error())
+		return err
 	}
 
-	_ = filemgr
-	_ = auth
+	// copy data to a gzip pipe for uploading
+	// guest tools requires data to be gzipped
+	r, w := io.Pipe()
+	go func() {
+		gZipWriter := gzip.NewWriter(w)
+		defer data.Close()
+		defer w.Close()
+		defer gZipWriter.Close()
 
-	return errors.New("toolbox import is not yet implemented")
+		_, _ = io.Copy(gZipWriter, data)
+		op.Debugf("finished copying data to gzip stream")
+	}()
+
+	// upload the gzip archive.
+	p := soap.DefaultUpload
+	err = client.Upload(op, r, target, p, &types.GuestPosixFileAttributes{}, true)
+	if err != nil {
+		op.Debugf("Upload error: %s", err.Error())
+	}
+	return err
 }
 
 func (t *ToolboxDataSink) Close() error {
-	if t.Clean != nil {
-		t.Clean()
-	}
+	t.Clean()
 
 	return nil
 }

--- a/lib/portlayer/storage/vsphere/toolbox_datasource.go
+++ b/lib/portlayer/storage/vsphere/toolbox_datasource.go
@@ -15,12 +15,12 @@
 package vsphere
 
 import (
-	"errors"
+	"archive/tar"
+	"compress/gzip"
 	"io"
 
-	"github.com/vmware/govmomi/guest"
-	"github.com/vmware/govmomi/vim25/types"
 	"github.com/vmware/vic/lib/archive"
+	"github.com/vmware/vic/lib/portlayer/storage"
 	"github.com/vmware/vic/pkg/trace"
 	"github.com/vmware/vic/pkg/vsphere/vm"
 )
@@ -39,30 +39,85 @@ func (t *ToolboxDataSource) Source() interface{} {
 
 // Export reads data from the associated data source and returns it as a tar archive
 func (t *ToolboxDataSource) Export(op trace.Operation, spec *archive.FilterSpec, data bool) (io.ReadCloser, error) {
-	defer trace.End(trace.Begin(""))
+	defer trace.End(trace.Begin("toolbox export"))
 
-	// set up file manager
-	client := t.VM.Session.Client.Client
-	filemgr, err := guest.NewOperationsManager(client, t.VM.Reference()).FileManager(op)
+	client, err := GetToolboxClient(op, t.VM, t.ID)
+	if err != nil {
+		op.Errorf("Cannot get toolbox client: %s", err.Error())
+		return nil, err
+	}
+
+	var readers []io.Reader
+	for inclusion := range spec.Inclusions {
+		// build a proper target
+		target, err := BuildArchiveUrl(op, t.ID, inclusion, spec)
+		if err != nil {
+			op.Errorf("Cannot build archive url: %s", err.Error())
+			return nil, err
+		}
+		tar, contentLength, err := client.Download(op, target)
+		if err != nil {
+			op.Errorf("Download error: %s", err.Error())
+			return nil, err
+		}
+		op.Debugf("Downloaded from %s with size %d", target, contentLength)
+		readers = append(readers, tar)
+
+	}
+	return gzip.NewReader(io.MultiReader(readers...))
+}
+
+// Export reads data from the associated data source and returns it as a tar archive
+func (t *ToolboxDataSource) Stat(op trace.Operation, spec *archive.FilterSpec) (*storage.FileStat, error) {
+	defer trace.End(trace.Begin("toolbox stat"))
+
+	client, err := GetToolboxClient(op, t.VM, t.ID)
+	if err != nil {
+		op.Errorf("Cannot get toolbox client: %s", err.Error())
+		return nil, err
+	}
+
+	// should only find a single path to stat, but make sure here.
+	var statPath string
+	for inclusion := range spec.Inclusions {
+		statPath = inclusion
+	}
+
+	target, err := BuildArchiveUrl(op, t.ID, statPath, spec)
+	if err != nil {
+		op.Errorf("Cannot build archive url: %s", err.Error())
+		return nil, err
+	}
+	statTar, _, err := client.Download(op, target)
+	if err != nil {
+		op.Errorf("Download error: %s", err.Error())
+		return nil, err
+	}
+	defer statTar.Close()
+
+	// decode from guest tools
+	gzr, err := gzip.NewReader(statTar)
+	if err != nil {
+		return nil, err
+	}
+	header, err := tar.NewReader(gzr).Next()
 	if err != nil {
 		return nil, err
 	}
 
-	// authenticate client and parse container host/port
-	auth := types.NamePasswordAuthentication{
-		Username: t.ID,
+	stat := &storage.FileStat{
+		Mode:       uint32(header.FileInfo().Mode()),
+		Name:       header.Name,
+		Size:       header.Size,
+		ModTime:    header.ModTime,
+		LinkTarget: header.Linkname,
 	}
 
-	_ = filemgr
-	_ = auth
-
-	return nil, errors.New("toolbox export is not yet implemented")
+	return stat, nil
 }
 
 func (t *ToolboxDataSource) Close() error {
-	if t.Clean != nil {
-		t.Clean()
-	}
+	t.Clean()
 
 	return nil
 }

--- a/pkg/vsphere/disk/disk_manager.go
+++ b/pkg/vsphere/disk/disk_manager.go
@@ -522,13 +522,19 @@ func (m *Manager) UnmountAndDetach(op trace.Operation, datastoreURI *object.Data
 func (m *Manager) InUse(op trace.Operation, config *VirtualDiskConfig, filter func(vm *mo.VirtualMachine) bool) ([]*vm.VirtualMachine, error) {
 	defer trace.End(trace.Begin(""))
 
-	if m.view == nil {
-		return nil, fmt.Errorf("ContainerView is nil")
+	mngr := view.NewManager(m.vm.Vim25())
+
+	// Create view of VirtualMachine objects under the VCH's resource pool
+	view2, err := mngr.CreateContainerView(op, m.vm.Session.Pool.Reference(), []string{"VirtualMachine"}, true)
+	if err != nil {
+		op.Errorf("failed to create view: %s", err)
+		return nil, err
 	}
+	defer view2.Destroy(op)
 
 	var mos []mo.VirtualMachine
 	// Retrieve needed properties of all machines under this view
-	err := m.view.Retrieve(op, []string{"VirtualMachine"}, []string{"name", "config.hardware", "runtime.powerState"}, &mos)
+	err = view2.Retrieve(op, []string{"VirtualMachine"}, []string{"name", "config.hardware", "runtime.powerState"}, &mos)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Fixes 5606, 5715, and 5570.

Supports Online Export/Import using DataSource and DataSink, overriding the default behavior of the toolbox's ArchiveFileHandler. Unpack and Diff are leveraged using DiskLabels in the tether.