### PR TITLE
Remove whiteout prefix in diff output

### DIFF
--- a/lib/apiservers/engine/backends/container.go
+++ b/lib/apiservers/engine/backends/container.go
@@ -22,6 +22,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"sync"
@@ -1315,6 +1316,9 @@ func (c *Container) ContainerChanges(name string) ([]docker.Change, error) {
 			change.Kind = docker.ChangeAdd
 		case "D":
 			change.Kind = docker.ChangeDelete
+			path := strings.TrimSuffix(change.Path, "/")
+			p := strings.TrimPrefix(filepath.Base(path), docker.WhiteoutPrefix)
+			change.Path = filepath.Join(filepath.Dir(path), p)
 		case "C":
 			change.Kind = docker.ChangeModify
 		default:


### PR DESCRIPTION
This is a quick fix to the output for deleted files that removes the whiteout prefix:

From 
```
A /NEW_FILE
A /a
A /b
C /etc/
C /etc/bash.bashrc
D /etc/.wh.bindresvport.blacklist
```
To:
```
A /NEW_FILE
A /a
A /b
C /etc/
C /etc/bash.bashrc
D /etc/bindresvport.blacklist
```
