### PR TITLE
Allow UI scripts to take VC params via command arguments

### DIFF
--- a/ui/installer/VCSA/install.sh
+++ b/ui/installer/VCSA/install.sh
@@ -14,23 +14,55 @@
 # limitations under the License.
 #
 
-cleanup () {
-    unset VCENTER_ADMIN_USERNAME
-    unset VCENTER_ADMIN_PASSWORD
-}
+read_vc_information () {
+    while getopts ":fi:u:p:" o; do
+        case "${o}" in
+            i)
+                VCENTER_IP=$OPTARG
+                ;;
+            u)
+                VCENTER_ADMIN_USERNAME=$OPTARG
+                ;;
+            p)
+                VCENTER_ADMIN_PASSWORD=$OPTARG
+                ;;
+            f)
+                FORCE_INSTALL=1
+                ;;
+            *)
+                echo Usage: $0 [-i vc_ip] [-u vc admin_username] [-p vc_admin_password] >&2
+                exit 1
+                ;;
+        esac
+    done
+    shift $((OPTIND-1))
 
-echo "-------------------------------------------------------------"
-echo "This script will install vSphere Integrated Containers plugin"
-echo "for vSphere Client (HTML) and vSphere Web Client (Flex)."
-echo ""
-echo "Please provide connection information to the vCenter Server."
-echo "-------------------------------------------------------------"
+    echo "-------------------------------------------------------------"
+    echo "This script will install vSphere Integrated Containers plugin"
+    echo "for vSphere Client (HTML) and vSphere Web Client (Flex)."
+    echo ""
+    echo "Please provide connection information to the vCenter Server."
+    echo "-------------------------------------------------------------"
+
+    if [ -z $VCENTER_IP ] ; then
+        read -p "Enter IP to target vCenter Server: " VCENTER_IP
+    fi
+
+    if [ -z $VCENTER_ADMIN_USERNAME ] ; then
+        read -p "Enter your vCenter Administrator Username: " VCENTER_ADMIN_USERNAME
+    fi
+
+    if [ -z $VCENTER_ADMIN_PASSWORD ] ; then
+        echo -n "Enter your vCenter Administrator Password: "
+        read -s VCENTER_ADMIN_PASSWORD
+        echo ""
+    fi
+}
 
 # check for the configs file
 if [[ ! -f "configs" ]] ; then
     echo "Error! Configs file is missing. Please try downloading the VIC UI installer again"
     echo ""
-    cleanup
     exit 1
 fi
 
@@ -39,13 +71,14 @@ while IFS='' read -r line; do
     eval $line
 done < ./configs
 
+read_vc_information $*
+
 # replace space delimiters with colon delimiters 
 VIC_UI_HOST_THUMBPRINT=$(echo $VIC_UI_HOST_THUMBPRINT | sed -e 's/[[:space:]]/\:/g')
 
 # check for the plugin manifest file
 if [[ ! -f ../plugin-manifest ]] ; then
     echo "Error! Plugin manifest was not found!"
-    cleanup
     exit 1
 fi
 
@@ -54,24 +87,9 @@ while IFS='' read -r p_line; do
     eval "$p_line"
 done < ../plugin-manifest
 
-read -p "Enter IP to target vCenter Server: " VCENTER_IP
-read -p "Enter your vCenter Administrator Username: " VCENTER_ADMIN_USERNAME
-echo -n "Enter your vCenter Administrator Password: "
-read -s VCENTER_ADMIN_PASSWORD
-echo ""
-
 OS=$(uname)
 VCENTER_SDK_URL="https://${VCENTER_IP}/sdk/"
 COMMONFLAGS="--target $VCENTER_SDK_URL --user $VCENTER_ADMIN_USERNAME --password $VCENTER_ADMIN_PASSWORD"
-
-case $1 in
-    "-f")
-        FORCE_INSTALL=1
-        ;;
-    "--force")
-        FORCE_INSTALL=1
-        ;;
-esac
 
 # set binary to call based on os
 if [[ $(echo $OS | grep -i "darwin") ]] ; then
@@ -104,7 +122,6 @@ check_prerequisite () {
     if [[ ! $(echo $CURL_RESPONSE | grep -oi "vmware vsphere") ]] ; then
         echo "-------------------------------------------------------------"
         echo "Error! vCenter Server was not found at host $VCENTER_IP"
-        cleanup
         exit 1
     fi
 
@@ -129,7 +146,7 @@ register_plugin() {
     local plugin_name=$1
     local plugin_key=$2
     local plugin_url="${VIC_UI_HOST_URL}files/"
-    local plugin_flags="--version $version --summary $summary --company $company --url $plugin_url$plugin_key-v$version.zip"
+    local plugin_flags="--version $version --company $company --url $plugin_url$plugin_key-v$version.zip"
     if [[ $FORCE_INSTALL -eq 1 ]] ; then
         plugin_flags="$plugin_flags --force"
     fi
@@ -139,13 +156,14 @@ register_plugin() {
     echo "-------------------------------------------------------------"
 
     $PLUGIN_MANAGER_BIN install --key $plugin_key \
-                                --name $plugin_name $COMMONFLAGS $plugin_flags \
+                                $COMMONFLAGS $plugin_flags \
                                 --thumbprint $VC_THUMBPRINT \
-                                --server-thumbprint $VIC_UI_HOST_THUMBPRINT
+                                --server-thumbprint $VIC_UI_HOST_THUMBPRINT \
+                                --name "$plugin_name" \
+                                --summary "Plugin for $plugin_name"
     if [[ $? > 0 ]] ; then
         echo "-------------------------------------------------------------"
         echo "Error! Could not register plugin with vCenter Server. Please see the message above"
-        cleanup
         exit 1
     fi
     echo ""
@@ -154,8 +172,8 @@ register_plugin() {
 parse_and_register_plugins () {
     echo ""
     if [[ $FORCE_INSTALL -eq 1 ]] ; then
-        register_plugin $name-FlexClient $key_flex
-        register_plugin $name-H5Client $key_h5c
+        register_plugin "$name-FlexClient" $key_flex
+        register_plugin "$name-H5Client" $key_h5c
         return
     fi
 
@@ -185,8 +203,8 @@ parse_and_register_plugins () {
     if [[ -z $(echo $h5c_plugin_version$flex_plugin_version) ]] ; then
         echo "No VIC Engine UI plugin was detected. Continuing to install the plugins."
         echo ""
-        register_plugin $name-FlexClient $key_flex
-        register_plugin $name-H5Client $key_h5c
+        register_plugin "$name-FlexClient" $key_flex
+        register_plugin "$name-H5Client" $key_h5c
     else
         # assuming user always keeps the both plugins at the same version
         if [[ $(echo $check_h5c | grep -oi "is registered") ]] ; then
@@ -199,7 +217,7 @@ parse_and_register_plugins () {
 
         echo "-------------------------------------------------------------"
         echo "Error! At least one plugin is already registered with the target VC."
-        echo "Run upgrade.sh, or install.sh --force instead."
+        echo "Please run upgrade.sh instead."
         echo ""
         exit 1
     fi
@@ -216,14 +234,12 @@ verify_plugin_url() {
     if [[ ! $(echo ${VIC_UI_HOST_URL:0:5} | grep -i "https") ]] ; then
         echo "-------------------------------------------------------------"
         echo "Error! VIC_UI_HOST_URL should always start with 'https' in the configs file"
-        cleanup
         exit 1
     fi
 
     if [[ -z $VIC_UI_HOST_THUMBPRINT ]] ; then
         echo "-------------------------------------------------------------"
         echo "Error! Please provide VIC_UI_HOST_THUMBPRINT in the configs file"
-        cleanup
         exit 1
     fi
 
@@ -232,7 +248,6 @@ verify_plugin_url() {
     if [[ $(echo $CURL_RESPONSE | grep -i "could not resolve\|fail") ]] ; then
         echo "-------------------------------------------------------------"
         echo "Error! Could not resolve the host provided. Please make sure the URL is correct"
-        cleanup
         exit 1
     fi
 
@@ -240,7 +255,6 @@ verify_plugin_url() {
     if [[ $(echo $RESPONSE_STATUS | grep -oi "404") ]] ; then
         echo "-------------------------------------------------------------"
         echo "Error! Plugin bundle was not found. Please make sure \"$PLUGIN_BASENAME\" is available at \"$VIC_UI_HOST_URL\", and retry installing the plugin"
-        cleanup
         exit 1
     fi
 }
@@ -250,8 +264,6 @@ remove_old_key_installation
 verify_plugin_url $key_flex
 verify_plugin_url $key_h5c
 parse_and_register_plugins
-
-cleanup
 
 echo "--------------------------------------------------------------"
 echo "VIC Engine UI installer exited successfully"


### PR DESCRIPTION
This PR allows for passing VC related parameters to install/uninstall/upgrade scripts via command arguments. Users can still use the interactive mode, but alternatively they can run commands as follows:

./install.(sh|bat) [-i vc_ip] [-u vc admin_username] [-p vc_admin_password]
./uninstall.(sh|bat) [-i vc_ip] [-u vc admin_username] [-p vc_admin_password]
./upgrade.(sh|bat) [-i vc_ip] [-u vc admin_username] [-p vc_admin_password]

Fixes #5749 