### PR TITLE
Concurrent copy

### DIFF
--- a/lib/portlayer/storage/data_sink.go
+++ b/lib/portlayer/storage/data_sink.go
@@ -80,6 +80,8 @@ func (m *MountDataSink) Import(op trace.Operation, spec *archive.FilterSpec, dat
 }
 
 func (m *MountDataSink) Close() error {
+	m.cleanOp.Infof("cleaning up after export")
+
 	m.Path.Close()
 	if m.Clean != nil {
 		m.Clean()

--- a/lib/portlayer/storage/vsphere/container.go
+++ b/lib/portlayer/storage/vsphere/container.go
@@ -236,7 +236,7 @@ func (c *ContainerStore) Export(op trace.Operation, id, ancestor string, spec *a
 	}
 
 	if ancestor == "" {
-		op.Infof("No ancester specified so following basic export path")
+		op.Infof("No ancestor specified so following basic export path")
 		return l.Export(op, spec, data)
 	}
 
@@ -249,11 +249,11 @@ func (c *ContainerStore) Export(op trace.Operation, id, ancestor string, spec *a
 		l.Close()
 		return nil, err
 	}
-	op.Debugf("Mapped ancester %s to %s", ancestor, img.String())
+	op.Debugf("Mapped ancestor %s to %s", ancestor, img.String())
 
 	r, err := c.newDataSource(op, img)
 	if err != nil {
-		op.Debugf("Unable to get datasource for ancester: %s", err)
+		op.Debugf("Unable to get datasource for ancestor: %s", err)
 
 		l.Close()
 		return nil, err

--- a/lib/portlayer/storage/vsphere/container.go
+++ b/lib/portlayer/storage/vsphere/container.go
@@ -68,6 +68,9 @@ func NewContainerStore(op trace.Operation, s *session.Session, imageResolver sto
 
 // URL converts the id of a resource to a URL
 func (c *ContainerStore) URL(op trace.Operation, id string) (*url.URL, error) {
+	// using diskfinder with a basic suffix match is an inefficient and potentially error prone way of doing this
+	// mapping, but until the container store has a structured means of knowing this information it's at least
+	// not going to be incorrect without an ID collision.
 	dsPath, err := c.DiskFinder(op, func(filename string) bool {
 		return strings.HasSuffix(filename, id+".vmdk")
 	})
@@ -138,6 +141,7 @@ func (c *ContainerStore) newDataSource(op trace.Operation, url *url.URL) (storag
 
 	f, err := os.Open(mountPath)
 	if err != nil {
+		cleanFunc()
 		return nil, err
 	}
 
@@ -199,6 +203,7 @@ func (c *ContainerStore) newDataSink(op trace.Operation, url *url.URL) (storage.
 
 	f, err := os.Open(mountPath)
 	if err != nil {
+		cleanFunc()
 		return nil, err
 	}
 

--- a/lib/portlayer/storage/vsphere/export.go
+++ b/lib/portlayer/storage/vsphere/export.go
@@ -94,6 +94,7 @@ func (v *VolumeStore) newDataSource(op trace.Operation, url *url.URL) (storage.D
 
 	f, err := os.Open(mountPath)
 	if err != nil {
+		cleanFunc()
 		return nil, err
 	}
 
@@ -130,13 +131,19 @@ func (i *ImageStore) Export(op trace.Operation, id, ancestor string, spec *archi
 	// this allows us to assume it's an image
 	r, err := i.NewDataSource(op, ancestor)
 	if err != nil {
+		op.Debugf("Unable to get datasource for ancester: %s", err)
+
 		l.Close()
 		return nil, err
 	}
 
-	closers := func() {
+	closers := func() error {
+		op.Debugf("Callback to io.Closer function for image delta export")
+
 		l.Close()
 		r.Close()
+
+		return nil
 	}
 
 	ls := l.Source()
@@ -156,7 +163,10 @@ func (i *ImageStore) Export(op trace.Operation, id, ancestor string, spec *archi
 		return nil, err
 	}
 
-	return tar, nil
+	return &storage.ProxyReadCloser{
+		ReadCloser: tar,
+		Closer:     closers,
+	}, nil
 }
 
 func (i *ImageStore) NewDataSource(op trace.Operation, id string) (storage.DataSource, error) {
@@ -176,6 +186,7 @@ func (i *ImageStore) newDataSource(op trace.Operation, url *url.URL) (storage.Da
 
 	f, err := os.Open(mountPath)
 	if err != nil {
+		cleanFunc()
 		return nil, err
 	}
 

--- a/lib/portlayer/storage/vsphere/export.go
+++ b/lib/portlayer/storage/vsphere/export.go
@@ -131,7 +131,7 @@ func (i *ImageStore) Export(op trace.Operation, id, ancestor string, spec *archi
 	// this allows us to assume it's an image
 	r, err := i.NewDataSource(op, ancestor)
 	if err != nil {
-		op.Debugf("Unable to get datasource for ancester: %s", err)
+		op.Debugf("Unable to get datasource for ancestor: %s", err)
 
 		l.Close()
 		return nil, err

--- a/lib/portlayer/storage/vsphere/image.go
+++ b/lib/portlayer/storage/vsphere/image.go
@@ -482,18 +482,22 @@ func (v *ImageStore) scratch(op trace.Operation, storeName string) error {
 
 	// Make the filesystem and set its label to defaultDiskLabel
 	if err = vmdisk.Mkfs(op, defaultDiskLabel); err != nil {
+		op.Errorf("Failed to create scratch filesystem: %s", err)
 		return err
 	}
 
 	if err = createBaseStructure(op, vmdisk); err != nil {
+		op.Errorf("Failed to create base filesystem structure: %s", err)
 		return err
 	}
 
 	if err = v.Detach(op, vmdisk.VirtualDiskConfig); err != nil {
+		op.Errorf("Failed to detach scratch image: %s", err)
 		return err
 	}
 
 	if err = v.writeManifest(op, storeName, portlayer.Scratch.ID, nil); err != nil {
+		op.Errorf("Failed to create manifest for scratch image: %s", err)
 		return err
 	}
 

--- a/lib/portlayer/storage/vsphere/image_test.go
+++ b/lib/portlayer/storage/vsphere/image_test.go
@@ -19,7 +19,6 @@ import (
 	"bytes"
 	"crypto/sha256"
 	"fmt"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"path"
@@ -585,12 +584,8 @@ func mountLayerRO(v *ImageStore, parent *portlayer.Image) (*disk.VirtualDisk, er
 		return nil, err
 	}
 
-	dir, err := ioutil.TempDir("", parent.ID+"ro")
+	_, err = roDisk.Mount(op, nil)
 	if err != nil {
-		return nil, err
-	}
-
-	if err := roDisk.Mount(op, dir, nil); err != nil {
 		return nil, err
 	}
 

--- a/lib/portlayer/storage/vsphere/import.go
+++ b/lib/portlayer/storage/vsphere/import.go
@@ -80,6 +80,7 @@ func (v *VolumeStore) newDataSink(op trace.Operation, url *url.URL) (storage.Dat
 
 	f, err := os.Open(mountPath)
 	if err != nil {
+		cleanFunc()
 		return nil, err
 	}
 
@@ -121,6 +122,7 @@ func (i *ImageStore) newDataSink(op trace.Operation, url *url.URL) (storage.Data
 
 	f, err := os.Open(mountPath)
 	if err != nil {
+		cleanFunc()
 		return nil, err
 	}
 

--- a/pkg/vsphere/disk/disk_ext4_test.go
+++ b/pkg/vsphere/disk/disk_ext4_test.go
@@ -15,8 +15,6 @@
 package disk
 
 import (
-	"io/ioutil"
-	"os"
 	"path"
 	"testing"
 
@@ -109,15 +107,8 @@ func TestCreateFS(t *testing.T) {
 		return
 	}
 
-	// make a tempdir to mount the fs to
-	dir, err := ioutil.TempDir("", "mnt")
-	if !assert.NoError(t, err) {
-		return
-	}
-	defer os.RemoveAll(dir)
-
 	// do the mount
-	err = d.Mount(op, dir, nil)
+	dir, err := d.Mount(op, nil)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -214,15 +205,8 @@ func TestAttachFS(t *testing.T) {
 		return
 	}
 
-	// make a tempdir to mount the fs to
-	dir, err := ioutil.TempDir("", "mnt")
-	if !assert.NoError(t, err) {
-		return
-	}
-	defer os.RemoveAll(dir)
-
 	// do the mount
-	err = d.Mount(op, dir, nil)
+	dir, err := d.Mount(op, nil)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -255,7 +239,7 @@ func TestAttachFS(t *testing.T) {
 	}
 
 	// do the mount
-	err = d.Mount(op, dir, nil)
+	dir, err = d.Mount(op, nil)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -284,7 +268,7 @@ func TestAttachFS(t *testing.T) {
 		}
 
 		// do the mount
-		err = d.Mount(op, dir, nil)
+		dir, err = d.Mount(op, nil)
 		if !assert.NoError(t, err) {
 			return
 		}

--- a/pkg/vsphere/disk/disk_manager_test.go
+++ b/pkg/vsphere/disk/disk_manager_test.go
@@ -370,7 +370,7 @@ func TestRefCounting(t *testing.T) {
 	assert.Equal(t, 2, d.attachedRefs.Count(), "%s has %d attach references but should have 2", d.DatastoreURI, d.attachedRefs.Count())
 
 	// reduce reference count by calling detach
-	assert.NoError(t, d.setDetached(op, vdm.Disks), "Error attempting to mark %s as detached", d.DatastoreURI)
+	d.setDetached(op, vdm.Disks)
 
 	assert.True(t, d.Attached(), "%s is not attached but should be", d.DatastoreURI)
 	assert.NoError(t, d.canBeDetached(), "%s should be detachable but is not", d.DatastoreURI)
@@ -392,7 +392,8 @@ func TestRefCounting(t *testing.T) {
 	}()
 
 	// initial mount
-	assert.NoError(t, d.Mount(op, dir, nil), "Error attempting to mount %s at %s", d.DatastoreURI, dir)
+	dir, err = d.Mount(op, nil)
+	assert.NoError(t, err, "Error attempting to mount %s at %s", d.DatastoreURI, dir)
 
 	mountPath, err := d.MountPath()
 	if !assert.NoError(t, err) {
@@ -406,7 +407,8 @@ func TestRefCounting(t *testing.T) {
 	assert.Equal(t, dir, mountPath, "%s is mounted at %s but should be mounted at %s", d.DatastoreURI, mountPath, dir)
 
 	// attempt another mount
-	assert.NoError(t, d.Mount(op, dir, nil), "Error attempting to mount %s at %s", d.DatastoreURI, dir)
+	dir, err = d.Mount(op, nil)
+	assert.NoError(t, err, "Error attempting to mount %s at %s", d.DatastoreURI, dir)
 
 	assert.True(t, d.Mounted(), "%s is not mounted but should be", d.DatastoreURI)
 	assert.Error(t, d.canBeDetached(), "%s should not be detachable but is", d.DatastoreURI)

--- a/pkg/vsphere/disk/util.go
+++ b/pkg/vsphere/disk/util.go
@@ -283,7 +283,8 @@ func findDiskByFilename(op trace.Operation, vm *vm.VirtualMachine, name string) 
 
 	if len(candidates) > 1 {
 		op.Errorf("Multiple disks match name: %s", name)
-		return nil, errors.Errorf("multiple disks match name: %s", name)
+		// returning the first allows doing something with it
+		return candidates[0], errors.Errorf("multiple disks match name: %s", name)
 	}
 
 	return candidates[0], nil


### PR DESCRIPTION
Updates to disk reference counting to handle concurrent attach case.
Currently exploits personality bug to get back end concurrency via: 
```
for i in {1..50};do docker cp bin/foo.txt offline:/; docker cp bin/bar offline:/;done
```

Does not yet handle accidental detection of the endpointVM as the online owner.

Towards: #5742 
