### PR TITLE
Please Ignore: Fix file copyTo case

### DIFF
--- a/lib/archive/archiver.go
+++ b/lib/archive/archiver.go
@@ -190,5 +190,5 @@ func (spec *FilterSpec) Excludes(op trace.Operation, filePath string) bool {
 		}
 	}
 
-	return inclusionLength <= exclusionLength
+	return inclusionLength < exclusionLength
 }

--- a/lib/archive/util_test.go
+++ b/lib/archive/util_test.go
@@ -874,7 +874,7 @@ func TestAddExclusionsRootTarget(t *testing.T) {
 	expectedResults := map[string]FilterSpec{
 		"/": {
 			Exclusions: map[string]struct{}{
-				"mnt/vols/A": struct{}{},
+				"mnt/vols/A": {},
 			},
 			Inclusions: map[string]struct{}{
 				"": {},


### PR DESCRIPTION
This will add some changes that will help with the file copyTo case. Some may not be quite necessary, but it is hard to tell until we merge the ContainerStatPath code. I have analyzed the raw tar that is output from `docker cp` to see what we can expect in various scenarios to date and I believe we will function against most after this change. ContainerStatPath directly affects the tar stream that we are handed so some cases will not be supported until we get that code path integrated. 