### PR TITLE
[specific ci=6-16-Config] display --debug option in vic-machine configure help

### DIFF
--- a/cmd/vic-machine/common/debug.go
+++ b/cmd/vic-machine/common/debug.go
@@ -24,13 +24,13 @@ type Debug struct {
 	Debug *int `cmd:"debug"`
 }
 
-func (d *Debug) DebugFlags() []cli.Flag {
+func (d *Debug) DebugFlags(hidden bool) []cli.Flag {
 	return []cli.Flag{
 		cli.GenericFlag{
 			Name:   "debug, v",
 			Value:  flags.NewOptionalInt(&d.Debug),
 			Usage:  "[0(default),1...n], 0 is disabled, 1 is enabled, >= 1 may alter behaviour",
-			Hidden: true,
+			Hidden: hidden,
 		},
 	}
 }

--- a/cmd/vic-machine/configure/configure.go
+++ b/cmd/vic-machine/configure/configure.go
@@ -101,7 +101,7 @@ func (c *Configure) Flags() []cli.Flag {
 	id := c.IDFlags()
 	volume := c.volStores.Flags()
 	compute := c.ComputeFlags()
-	debug := c.DebugFlags()
+	debug := c.DebugFlags(false)
 	cNetwork := c.cNetworks.CNetworkFlags(false)
 	proxies := c.proxies.ProxyFlags(false)
 	memory := c.VCHMemoryLimitFlags(false)

--- a/cmd/vic-machine/create/create.go
+++ b/cmd/vic-machine/create/create.go
@@ -321,7 +321,7 @@ func (c *Create) Flags() []cli.Flag {
 	cNetwork := c.containerNetworks.CNetworkFlags(true)
 	dns := c.dns.DNSFlags(true)
 	proxies := c.proxies.ProxyFlags(true)
-	debug := c.DebugFlags()
+	debug := c.DebugFlags(true)
 
 	// flag arrays are declared, now combined
 	var flags []cli.Flag

--- a/cmd/vic-machine/debug/debug.go
+++ b/cmd/vic-machine/debug/debug.go
@@ -87,7 +87,7 @@ func (d *Debug) Flags() []cli.Flag {
 	target := d.TargetFlags()
 	id := d.IDFlags()
 	compute := d.ComputeFlags()
-	debug := d.DebugFlags()
+	debug := d.DebugFlags(true)
 
 	// flag arrays are declared, now combined
 	var flags []cli.Flag

--- a/cmd/vic-machine/delete/delete.go
+++ b/cmd/vic-machine/delete/delete.go
@@ -64,7 +64,7 @@ func (d *Uninstall) Flags() []cli.Flag {
 	target := d.TargetFlags()
 	id := d.IDFlags()
 	compute := d.ComputeFlags()
-	debug := d.DebugFlags()
+	debug := d.DebugFlags(true)
 
 	// flag arrays are declared, now combined
 	var flags []cli.Flag

--- a/cmd/vic-machine/inspect/inspect.go
+++ b/cmd/vic-machine/inspect/inspect.go
@@ -86,7 +86,7 @@ func (i *Inspect) Flags() []cli.Flag {
 	target := i.TargetFlags()
 	id := i.IDFlags()
 	compute := i.ComputeFlags()
-	debug := i.DebugFlags()
+	debug := i.DebugFlags(true)
 
 	// flag arrays are declared, now combined
 	var flags []cli.Flag

--- a/cmd/vic-machine/list/list.go
+++ b/cmd/vic-machine/list/list.go
@@ -75,7 +75,7 @@ func (l *List) Flags() []cli.Flag {
 	target := l.TargetFlags()
 	// TODO: why not allow name as a filter, like most list operations
 	compute := l.ComputeFlagsNoName()
-	debug := l.DebugFlags()
+	debug := l.DebugFlags(true)
 
 	// flag arrays are declared, now combined
 	var flags []cli.Flag

--- a/cmd/vic-machine/update/firewall.go
+++ b/cmd/vic-machine/update/firewall.go
@@ -68,7 +68,7 @@ func (i *UpdateFw) Flags() []cli.Flag {
 
 	target := i.TargetFlags()
 	compute := i.ComputeFlagsNoName()
-	debug := i.DebugFlags()
+	debug := i.DebugFlags(true)
 
 	// flag arrays are declared, now combined
 	var flags []cli.Flag

--- a/cmd/vic-machine/upgrade/upgrade.go
+++ b/cmd/vic-machine/upgrade/upgrade.go
@@ -75,7 +75,7 @@ func (u *Upgrade) Flags() []cli.Flag {
 	id := u.IDFlags()
 	compute := u.ComputeFlags()
 	iso := u.ImageFlags(false)
-	debug := u.DebugFlags()
+	debug := u.DebugFlags(true)
 
 	// flag arrays are declared, now combined
 	var flags []cli.Flag

--- a/cmd/vic-ui/ui/ui.go
+++ b/cmd/vic-ui/ui/ui.go
@@ -110,7 +110,7 @@ func (p *Plugin) Flags() []cli.Flag {
 		},
 	}
 	flags = append(p.TargetFlags(), flags...)
-	flags = append(flags, p.DebugFlags()...)
+	flags = append(flags, p.DebugFlags(true)...)
 
 	return flags
 }
@@ -126,7 +126,7 @@ func (p *Plugin) InfoFlags() []cli.Flag {
 		},
 	}
 	flags = append(p.TargetFlags(), flags...)
-	flags = append(flags, p.DebugFlags()...)
+	flags = append(flags, p.DebugFlags(true)...)
 
 	return flags
 }

--- a/tests/test-cases/Group6-VIC-Machine/6-16-Config.robot
+++ b/tests/test-cases/Group6-VIC-Machine/6-16-Config.robot
@@ -20,6 +20,8 @@ Suite Teardown  Cleanup VIC Appliance On Test Server
 
 *** Test Cases ***
 Configure VCH debug state
+    ${output}=  Run  bin/vic-machine-linux configure --help
+    Should Contain  ${output}  --debug
     ${output}=  Check VM Guestinfo  %{VCH-NAME}  guestinfo.vice./init/diagnostics/debug
     Should Contain  ${output}  1
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} pull ${busybox}


### PR DESCRIPTION
fixes #5769 . 

By this PR, `--debug` option will show up in `vic-machine configure --help` but remain hidden in other `vic-machine` commands.