### PR TITLE
Implement Online Datasource [specific ci=Group1-Docker-Commands]

### DIFF
--- a/lib/apiservers/engine/backends/archive.go
+++ b/lib/apiservers/engine/backends/archive.go
@@ -40,56 +40,47 @@ import (
 	"github.com/docker/docker/pkg/archive"
 )
 
-const (
-	containerStoreName = "container"
-	volumeStoreName    = "volume"
-)
-
 // ContainerArchivePath creates an archive of the filesystem resource at the
 // specified path in the container identified by the given name. Returns a
 // tar archive of the resource and whether it was a directory or a single file.
-func (c *Container) ContainerArchivePath(name string, path string) (content io.ReadCloser, stat *types.ContainerPathStat, err error) {
+func (c *Container) ContainerArchivePath(name string, path string) (io.ReadCloser, *types.ContainerPathStat, error) {
 	defer trace.End(trace.Begin(name))
+	op := trace.NewOperation(context.Background(), "ContainerArchivePath: %s", name)
 
 	vc := cache.ContainerCache().GetContainer(name)
 	if vc == nil {
 		return nil, nil, NotFoundError(name)
 	}
 
-	stat, err = c.ContainerStatPath(name, path)
+	stat, err := c.ContainerStatPath(name, path)
 	if err != nil {
-		// error is wrapped in statpath already
-		return nil, nil, err
+		return nil, nil, InternalServerError(err.Error())
 	}
 
-	var reader io.ReadCloser
-
-	reader, err = c.exportFromContainer(vc, path)
-	if err != nil && IsResourceInUse(err) {
-		log.Errorf("ContainerArchivePath failed, resource in use: %s", err.Error())
-		err = fmt.Errorf("Resource in use")
+	reader, err := c.exportFromContainer(op, vc, path)
+	if err != nil {
+		if IsResourceInUse(err) {
+			err = fmt.Errorf("ContainerArchivePath failed, resource in use: %s", err.Error())
+		}
+		return nil, nil, InternalServerError(err.Error())
 	}
-	if err == nil || reader != nil {
-		content = reader
-	}
-	stat = nil
 
-	return
+	return reader, stat, nil
 }
 
-func (c *Container) exportFromContainer(vc *viccontainer.VicContainer, path string) (io.ReadCloser, error) {
+func (c *Container) exportFromContainer(op trace.Operation, vc *viccontainer.VicContainer, path string) (io.ReadCloser, error) {
 	mounts := mountsFromContainer(vc)
 	mounts = append(mounts, types.MountPoint{Destination: "/"})
-	readerMap := NewArchiveStreamReaderMap(mounts, path)
+	readerMap := NewArchiveStreamReaderMap(op, mounts, path)
 
 	readers, err := readerMap.ReadersForSourcePath(c.containerProxy, vc.ContainerID, path)
 	if err != nil {
-		log.Errorf("Errors getting readers for export: %s", err.Error())
+		op.Errorf("Errors getting readers for export: %s", err.Error())
 		return nil, err
 	}
 
 	//FIXME: We need a multi reader that can be closed.  MultiReader returns a regular reader
-	log.Infof("Got %d archive readers", len(readers))
+	op.Infof("Got %d archive readers", len(readers))
 	finalTarReader := io.MultiReader(readers...)
 
 	return ioutil.NopCloser(finalTarReader), nil
@@ -115,33 +106,36 @@ func (c *Container) ContainerExport(name string, out io.Writer) error {
 // to be replaced with a non-directory and vice versa.
 func (c *Container) ContainerExtractToDir(name, path string, noOverwriteDirNonDir bool, content io.Reader) error {
 	defer trace.End(trace.Begin(name))
+	op := trace.NewOperation(context.Background(), "ContainerExtractToDir: %s", name)
+
+	log.Debugf("Destination path %s", path)
 
 	vc := cache.ContainerCache().GetContainer(name)
 	if vc == nil {
 		return NotFoundError(name)
 	}
 
-	err := c.importToContainer(vc, path, content)
+	err := c.importToContainer(op, vc, path, content)
 	if err != nil && IsResourceInUse(err) {
-		log.Errorf("ContainerExtractToDir failed, resource in use: %s", err.Error())
+		op.Errorf("ContainerExtractToDir failed, resource in use: %s", err.Error())
 
-		err = fmt.Errorf("Resouce in use")
+		err = fmt.Errorf("Resource in use")
 	}
 
 	return err
 }
 
-func (c *Container) importToContainer(vc *viccontainer.VicContainer, target string, content io.Reader) error {
+func (c *Container) importToContainer(op trace.Operation, vc *viccontainer.VicContainer, target string, content io.Reader) error {
 	rawReader, err := archive.DecompressStream(content)
 	if err != nil {
-		log.Errorf("Input tar stream to ContainerExtractToDir not recognized: %s", err.Error())
+		op.Errorf("Input tar stream to ContainerExtractToDir not recognized: %s", err.Error())
 		return StreamFormatNotRecognized()
 	}
-	tarReader := tar.NewReader(rawReader)
 
+	tarReader := tar.NewReader(rawReader)
 	mounts := mountsFromContainer(vc)
 	mounts = append(mounts, types.MountPoint{Destination: "/"})
-	writerMap := NewArchiveStreamWriterMap(mounts, target)
+	writerMap := NewArchiveStreamWriterMap(op, mounts, target)
 	defer writerMap.Close() // This should shutdown all the stream connections to the portlayer.
 
 	for {
@@ -154,18 +148,18 @@ func (c *Container) importToContainer(vc *viccontainer.VicContainer, target stri
 		}
 
 		// Lookup the writer for that mount prefix
-		writer, err := writerMap.WriterForAsset(c.containerProxy, vc.ContainerID, target, *header)
+		tarWriter, err := writerMap.WriterForAsset(c.containerProxy, vc.ContainerID, target, *header)
 		if err != nil {
 			return err
 		}
 
-		tarWriter := tar.NewWriter(writer)
-		tarWriter.WriteHeader(header)
-		// do NOT call tarWriter.Close() or that will create the double nil record for end-of-archive
+		if err = tarWriter.WriteHeader(header); err != nil {
+			op.Errorf("Error while copying tar header %#v: %s", *header, err.Error())
+			return err
+		}
 
-		_, err = io.Copy(writer, tarReader)
-		if err != nil {
-			log.Errorf("Error while copying tar data for %s: %s", header.Name, err.Error())
+		if _, err = io.Copy(tarWriter, tarReader); err != nil {
+			op.Errorf("Error while copying tar data for %s: %s", header.Name, err.Error())
 			return err
 		}
 	}
@@ -189,7 +183,8 @@ func (c *Container) ContainerStatPath(name string, path string) (stat *types.Con
 	mounts := mountsFromContainer(vc)
 	mounts = append(mounts, types.MountPoint{Destination: "/"})
 
-	store, deviceID, fs := resolvePathWithMountPoints(mounts, path, vc.ContainerID)
+	primaryTarget := resolvePathWithMountPoints(op, mounts, path)
+	fs := primaryTarget.filterSpec
 	// check to see if the path is a mount point, if so, return fake path
 	if len(fs.Inclusions) == 1 {
 		if _, ok := fs.Inclusions[""]; ok {
@@ -202,6 +197,17 @@ func (c *Container) ContainerStatPath(name string, path string) (stat *types.Con
 			op.Debugf("faking container stat path %#v", stat)
 			return stat, nil
 		}
+	}
+
+	var deviceID string
+	var store string
+	if primaryTarget.mountPoint.Destination == "/" {
+		// Special case. / refers to container VMDK and not a volume vmdk.
+		deviceID = vc.ContainerID
+		store = constants.ContainerStoreName
+	} else {
+		deviceID = primaryTarget.mountPoint.Name
+		store = constants.VolumeStoreName
 	}
 
 	stat, err = c.containerProxy.StatPath(op, store, deviceID, fs)
@@ -223,26 +229,27 @@ func (c *Container) ContainerStatPath(name string, path string) (stat *types.Con
 // Docker cp utility
 //----------------------------------
 
-type ArchiveWriter struct {
-	mountPoint types.MountPoint
-	filterSpec vicarchive.FilterSpec
-	writer     io.WriteCloser
-}
-
 type ArchiveReader struct {
 	mountPoint types.MountPoint
 	filterSpec vicarchive.FilterSpec
 	reader     io.ReadCloser
 }
+type ArchiveStreamReaderMap struct {
+	prefixTrie *patricia.Trie
+	op         trace.Operation
+}
+
+type ArchiveWriter struct {
+	mountPoint types.MountPoint
+	filterSpec vicarchive.FilterSpec
+	writer     io.WriteCloser
+	tarWriter  *tar.Writer
+}
 
 // ArchiveStreamWriterMap maps mount prefix to io.WriteCloser
 type ArchiveStreamWriterMap struct {
 	prefixTrie *patricia.Trie
-}
-
-// ArchiveStreamReaderMap maps mount prefix to io.ReadCloser
-type ArchiveStreamReaderMap struct {
-	prefixTrie *patricia.Trie
+	op         trace.Operation
 }
 
 // NewArchiveStreamWriterMap creates a new ArchiveStreamWriterMap.  The map contains all information
@@ -251,9 +258,10 @@ type ArchiveStreamReaderMap struct {
 //
 // mounts is the mount data from inspect
 // containerDestPath is the destination path in the container
-func NewArchiveStreamWriterMap(mounts []types.MountPoint, dest string) *ArchiveStreamWriterMap {
+func NewArchiveStreamWriterMap(op trace.Operation, mounts []types.MountPoint, dest string) *ArchiveStreamWriterMap {
 	writerMap := &ArchiveStreamWriterMap{}
 	writerMap.prefixTrie = patricia.NewTrie()
+	writerMap.op = op
 
 	for _, m := range mounts {
 		aw := ArchiveWriter{
@@ -291,9 +299,10 @@ func NewArchiveStreamWriterMap(mounts []types.MountPoint, dest string) *ArchiveS
 // information to create readers for every volume mounts for the container
 //
 // mounts is the mount data from inspect
-func NewArchiveStreamReaderMap(mounts []types.MountPoint, dest string) *ArchiveStreamReaderMap {
+func NewArchiveStreamReaderMap(op trace.Operation, mounts []types.MountPoint, dest string) *ArchiveStreamReaderMap {
 	readerMap := &ArchiveStreamReaderMap{}
 	readerMap.prefixTrie = patricia.NewTrie()
+	readerMap.op = op
 
 	for _, m := range mounts {
 		ar := ArchiveReader{
@@ -349,11 +358,11 @@ func (wm *ArchiveStreamWriterMap) FindArchiveWriter(containerDestPath, assetName
 	//
 	// In the above example, mount prefxi can only be determined by combining both the container destination path and
 	// the asset name, as the final destination includes a mounted volume.
-	combinedPath := path.Join(containerDestPath, assetName)
+	combinedPath := path.Join(path.Dir(containerDestPath), assetName)
 	prefix := patricia.Prefix(combinedPath)
 	err = wm.prefixTrie.VisitPrefixes(prefix, findPrefix)
 	if err != nil {
-		log.Errorf(err.Error())
+		wm.op.Errorf(err.Error())
 		return nil, fmt.Errorf("Failed to find a node for prefix %s: %s", containerDestPath, err.Error())
 	}
 
@@ -393,11 +402,10 @@ func (wm *ArchiveStreamWriterMap) FindArchiveWriter(containerDestPath, assetName
 //
 // As demonstrated above, the mount prefix and writer cannot be determined with just the
 // container destination path.  It must be combined with the actual asset's name.
-func (wm *ArchiveStreamWriterMap) WriterForAsset(proxy VicContainerProxy, cid, containerDestPath string, assetHeader tar.Header) (io.WriteCloser, error) {
+func (wm *ArchiveStreamWriterMap) WriterForAsset(proxy VicContainerProxy, cid, containerDestPath string, assetHeader tar.Header) (*tar.Writer, error) {
 	defer trace.End(trace.Begin(assetHeader.Name))
 
 	var err error
-	var streamWriter io.WriteCloser
 
 	aw, err := wm.FindArchiveWriter(containerDestPath, assetHeader.Name)
 	if err != nil {
@@ -405,9 +413,9 @@ func (wm *ArchiveStreamWriterMap) WriterForAsset(proxy VicContainerProxy, cid, c
 	}
 
 	// Perform the lazy initialization here.
-	if aw.writer == nil {
+	if aw.writer == nil || aw.tarWriter == nil {
 		// lazy initialize.
-		log.Debugf("Lazily initializing import stream for %s", aw.mountPoint.Destination)
+		wm.op.Debugf("Lazily initializing import stream for %s", aw.mountPoint.Destination)
 		var deviceID string
 		var store string
 		if aw.mountPoint.Destination == "/" {
@@ -418,18 +426,17 @@ func (wm *ArchiveStreamWriterMap) WriterForAsset(proxy VicContainerProxy, cid, c
 			deviceID = aw.mountPoint.Name
 			store = constants.VolumeStoreName
 		}
-		streamWriter, err = proxy.ArchiveImportWriter(context.Background(), store, deviceID, aw.filterSpec)
+		rawWriter, err := proxy.ArchiveImportWriter(wm.op, store, deviceID, aw.filterSpec)
 		if err != nil {
 			err = fmt.Errorf("Unable to initialize import stream writer for mount prefix %s", aw.mountPoint.Destination)
-			log.Errorf(err.Error())
+			wm.op.Errorf(err.Error())
 			return nil, err
 		}
-		aw.writer = streamWriter
-	} else {
-		streamWriter = aw.writer
+		aw.writer = rawWriter
+		aw.tarWriter = tar.NewWriter(rawWriter)
 	}
 
-	return streamWriter, nil
+	return aw.tarWriter, nil
 }
 
 // Close visits all the archive writer in the trie and closes the actual io.WritCloser
@@ -439,7 +446,9 @@ func (wm *ArchiveStreamWriterMap) Close() {
 	closeStream := func(prefix patricia.Prefix, item patricia.Item) error {
 		if aw, ok := item.(*ArchiveWriter); ok && aw.writer != nil {
 			aw.writer.Close()
+			aw.tarWriter.Close()
 			aw.writer = nil
+			aw.tarWriter = nil
 		}
 		return nil
 	}
@@ -489,7 +498,7 @@ func (rm *ArchiveStreamReaderMap) FindArchiveReaders(containerSourcePath string)
 	err = rm.prefixTrie.VisitSubtree(prefix, walkPrefixSubtree)
 	if err != nil {
 		msg := fmt.Sprintf("Failed to find a node for prefix %s: %s", containerSourcePath, err.Error())
-		log.Error(msg)
+		rm.op.Errorf(msg)
 		return nil, fmt.Errorf(msg)
 	}
 
@@ -500,7 +509,7 @@ func (rm *ArchiveStreamReaderMap) FindArchiveReaders(containerSourcePath string)
 	err = rm.prefixTrie.VisitPrefixes(prefix, findStartingPrefix)
 	if err != nil {
 		msg := fmt.Sprintf("Failed to find starting node for prefix %s: %s", containerSourcePath, err.Error())
-		log.Error(msg)
+		rm.op.Errorf(msg)
 		return nil, fmt.Errorf(msg)
 	}
 
@@ -521,7 +530,7 @@ func (rm *ArchiveStreamReaderMap) FindArchiveReaders(containerSourcePath string)
 		startingNode = nodes[0]
 	} else {
 		msg := fmt.Sprintf("Failed to find starting node for prefix %s: %s", containerSourcePath, err.Error())
-		log.Error(msg)
+		rm.op.Errorf(msg)
 		return nil, fmt.Errorf(msg)
 	}
 
@@ -531,18 +540,6 @@ func (rm *ArchiveStreamReaderMap) FindArchiveReaders(containerSourcePath string)
 	}
 
 	return nodes, nil
-}
-
-func (rm *ArchiveStreamReaderMap) buildFilterSpec(containerSourcePath string, nodes []*ArchiveReader, startingNode *ArchiveReader) error {
-	mounts := []string{}
-	for _, node := range nodes {
-		mounts = append(mounts, node.mountPoint.Destination)
-	}
-
-	for _, node := range nodes {
-		vicarchive.AddMountInclusionsExclusions(node.mountPoint.Destination, &node.filterSpec, mounts, containerSourcePath)
-	}
-	return nil
 }
 
 // ReadersForSourcePath returns all an array of io.Reader for all the readers within a container source path.
@@ -582,14 +579,14 @@ func (rm *ArchiveStreamReaderMap) ReadersForSourcePath(proxy VicContainerProxy, 
 				deviceID = node.mountPoint.Name
 			}
 
-			log.Infof("Lazily initializing export stream for %s [%s]", node.mountPoint.Name, node.mountPoint.Destination)
-			reader, err := proxy.ArchiveExportReader(context.Background(), store, "", deviceID, "", true, node.filterSpec)
+			rm.op.Infof("Lazily initializing export stream for %s [%s]", node.mountPoint.Name, node.mountPoint.Destination)
+			reader, err := proxy.ArchiveExportReader(rm.op, store, "", deviceID, "", true, node.filterSpec)
 			if err != nil {
 				err = fmt.Errorf("Unable to initialize export stream reader for prefix %s", node.mountPoint.Destination)
-				log.Errorf(err.Error())
+				rm.op.Errorf(err.Error())
 				return nil, err
 			}
-			log.Infof("Lazy initialization created reader %#v", reader)
+			rm.op.Infof("Lazy initialization created reader %#v", reader)
 			streamReaders = append(streamReaders, reader)
 		} else {
 			streamReaders = append(streamReaders, node.reader)
@@ -597,7 +594,7 @@ func (rm *ArchiveStreamReaderMap) ReadersForSourcePath(proxy VicContainerProxy, 
 	}
 
 	if len(nodes) == 0 {
-		log.Infof("Found no archive readers for %s", containerSourcePath)
+		rm.op.Infof("Found no archive readers for %s", containerSourcePath)
 	}
 
 	return streamReaders, nil
@@ -619,11 +616,8 @@ func (rm *ArchiveStreamReaderMap) Close() {
 }
 
 // use mountpoints to strip the target to a relative path
-func resolvePathWithMountPoints(mounts []types.MountPoint, path, defaultDevice string) (string, string, vicarchive.FilterSpec) {
-	var fs vicarchive.FilterSpec
-	deviceID := defaultDevice
-	store := containerStoreName
-	mntpoint := ""
+func resolvePathWithMountPoints(op trace.Operation, mounts []types.MountPoint, path string) *ArchiveReader {
+	var primaryTarget *ArchiveReader
 
 	// trim / and . off from path and then append / to ensure the format is correct
 	for strings.HasPrefix(path, "/") {
@@ -635,29 +629,30 @@ func resolvePathWithMountPoints(mounts []types.MountPoint, path, defaultDevice s
 	for strings.HasSuffix(path, "/") {
 		path = strings.TrimSuffix(path, "/")
 	}
-
 	path = "/" + path
 
-	for _, mount := range mounts {
-		if strings.HasPrefix(path, mount.Destination) {
-			// path is exactly the mountpoint, not point in making a call to portlayer
-			if len(mount.Destination) > len(mntpoint) {
-				mntpoint = mount.Destination
-				if mntpoint != "/" {
-					deviceID = mount.Name
-					store = volumeStoreName
-				}
-			}
+	readerMap := NewArchiveStreamReaderMap(op, mounts, path)
+	nodes, _ := readerMap.FindArchiveReaders(path)
+
+	for _, node := range nodes {
+		if strings.HasPrefix(path, node.mountPoint.Destination) &&
+			(primaryTarget == nil || len(node.mountPoint.Destination) > len(primaryTarget.mountPoint.Destination)) {
+			primaryTarget = node
 		}
 	}
 
-	fs.RebasePath = mntpoint
-	fs.Inclusions = make(map[string]struct{})
-	fs.Exclusions = make(map[string]struct{})
-	includedPath := strings.TrimPrefix(path, mntpoint)
-	excludedPath := path + "/"
-	fs.Inclusions[includedPath] = struct{}{}
-	fs.Exclusions[excludedPath] = struct{}{}
+	return primaryTarget
 
-	return store, deviceID, fs
+}
+
+func (rm *ArchiveStreamReaderMap) buildFilterSpec(containerSourcePath string, nodes []*ArchiveReader, startingNode *ArchiveReader) error {
+	mounts := []string{}
+	for _, node := range nodes {
+		mounts = append(mounts, node.mountPoint.Destination)
+	}
+
+	for _, node := range nodes {
+		vicarchive.AddMountInclusionsExclusions(node.mountPoint.Destination, &node.filterSpec, mounts, containerSourcePath)
+	}
+	return nil
 }

--- a/lib/apiservers/engine/backends/commit.go
+++ b/lib/apiservers/engine/backends/commit.go
@@ -56,7 +56,7 @@ import (
 // The image can optionally be tagged into a repository.
 func (i *Image) Commit(name string, config *backend.ContainerCommitConfig) (imageID string, err error) {
 	defer trace.End(trace.Begin(name))
-
+	op := trace.NewOperation(context.Background(), "Commit")
 	// Look up the container name in the metadata cache to get long ID
 	vc := cache.ContainerCache().GetContainer(name)
 	if vc == nil {
@@ -91,7 +91,7 @@ func (i *Image) Commit(name string, config *backend.ContainerCommitConfig) (imag
 		return "", err
 	}
 
-	rc, err := containerEngine.containerProxy.GetContainerChanges(context.Background(), vc, true)
+	rc, err := containerEngine.containerProxy.GetContainerChanges(op, vc, true)
 	if err != nil {
 		return "", fmt.Errorf("Unable to initialize export stream reader for container %s", name)
 	}

--- a/lib/apiservers/engine/backends/container.go
+++ b/lib/apiservers/engine/backends/container.go
@@ -1279,13 +1279,14 @@ func (c *Container) ContainerWait(name string, timeout time.Duration) (int, erro
 // ContainerChanges returns a list of container fs changes
 func (c *Container) ContainerChanges(name string) ([]docker.Change, error) {
 	defer trace.End(trace.Begin(name))
+	op := trace.NewOperation(context.Background(), "ContainerChanges: %s", name)
 
 	vc := cache.ContainerCache().GetContainer(name)
 	if vc == nil {
 		return nil, NotFoundError(name)
 	}
 
-	r, err := c.containerProxy.GetContainerChanges(context.Background(), vc, false)
+	r, err := c.containerProxy.GetContainerChanges(op, vc, true)
 	if err != nil {
 		return nil, InternalServerError(err.Error())
 	}

--- a/lib/apiservers/engine/backends/container_proxy.go
+++ b/lib/apiservers/engine/backends/container_proxy.go
@@ -33,8 +33,6 @@ package backends
 
 import (
 	"context"
-	"encoding/base64"
-	"encoding/json"
 	"fmt"
 	"io"
 	"net"
@@ -98,8 +96,8 @@ type VicContainerProxy interface {
 	StreamContainerLogs(ctx context.Context, name string, out io.Writer, started chan struct{}, showTimestamps bool, followLogs bool, since int64, tailLines int64) error
 	StreamContainerStats(ctx context.Context, config *convert.ContainerStatsConfig) error
 
-	ArchiveExportReader(ctx context.Context, store, ancestorStore, deviceID, ancestor string, data bool, filterSpec archive.FilterSpec) (io.ReadCloser, error)
-	ArchiveImportWriter(ctx context.Context, store, deviceID string, filterSpec archive.FilterSpec) (io.WriteCloser, error)
+	ArchiveExportReader(op trace.Operation, store, ancestorStore, deviceID, ancestor string, data bool, filterSpec archive.FilterSpec) (io.ReadCloser, error)
+	ArchiveImportWriter(op trace.Operation, store, deviceID string, filterSpec archive.FilterSpec) (io.WriteCloser, error)
 	StatPath(op trace.Operation, sotre, deviceID string, filterSpec archive.FilterSpec) (*types.ContainerPathStat, error)
 
 	Stop(vc *viccontainer.VicContainer, name string, seconds *int, unbound bool) error
@@ -109,7 +107,7 @@ type VicContainerProxy interface {
 	Resize(id string, height, width int32) error
 	Rename(vc *viccontainer.VicContainer, newName string) error
 
-	GetContainerChanges(ctx context.Context, vc *viccontainer.VicContainer, data bool) (io.ReadCloser, error)
+	GetContainerChanges(op trace.Operation, vc *viccontainer.VicContainer, data bool) (io.ReadCloser, error)
 
 	Handle(id, name string) (string, error)
 	Client() *client.PortLayer
@@ -153,6 +151,7 @@ const (
 	swaggerSubstringEOF                 = "EOF"
 	forceLogType                        = "json-file" //Use in inspect to allow docker logs to work
 	ShortIDLen                          = 12
+	archiveStreamBufSize                = 64 * 1024
 
 	DriverArgFlagKey      = "flags"
 	DriverArgContainerKey = "container"
@@ -477,7 +476,7 @@ func (c *ContainerProxy) AddLoggingToContainer(handle string, config types.Conta
 	return handle, nil
 }
 
-// AddInteractionToContainer adds interaction capabilies to a container, referenced by handle.
+// AddInteractionToContainer adds interaction capabilities to a container, referenced by handle.
 // If an error is return, the returned handle should not be used.
 //
 // returns:
@@ -504,7 +503,7 @@ func (c *ContainerProxy) AddInteractionToContainer(handle string, config types.C
 	return handle, nil
 }
 
-// BindInteraction enables interaction capabilies
+// BindInteraction enables interaction capabilities
 func (c *ContainerProxy) BindInteraction(handle string, name string, id string) (string, error) {
 	defer trace.End(trace.Begin(handle))
 
@@ -533,7 +532,7 @@ func (c *ContainerProxy) BindInteraction(handle string, name string, id string) 
 	return handle, nil
 }
 
-// UnbindInteraction disables interaction capabilies
+// UnbindInteraction disables interaction capabilities
 func (c *ContainerProxy) UnbindInteraction(handle string, name string, id string) (string, error) {
 	defer trace.End(trace.Begin(handle))
 
@@ -676,9 +675,7 @@ func (c *ContainerProxy) StreamContainerStats(ctx context.Context, config *conve
 	return nil
 }
 
-// GetContainerChanges returns container changes from portlayer.
-// Set data to true will return file data, otherwise, only return file headers with change type.
-func (c *ContainerProxy) GetContainerChanges(ctx context.Context, vc *viccontainer.VicContainer, data bool) (io.ReadCloser, error) {
+func (c *ContainerProxy) GetContainerChanges(op trace.Operation, vc *viccontainer.VicContainer, data bool) (io.ReadCloser, error) {
 	host, err := sys.UUID()
 	if err != nil {
 		return nil, InternalServerError("Failed to determine host UUID")
@@ -690,7 +687,7 @@ func (c *ContainerProxy) GetContainerChanges(ctx context.Context, vc *viccontain
 		Exclusions: map[string]struct{}{},
 	}
 
-	r, err := c.ArchiveExportReader(ctx, constants.ContainerStoreName, host, vc.ContainerID, parent, data, spec)
+	r, err := c.ArchiveExportReader(op, constants.ContainerStoreName, host, vc.ContainerID, parent, data, spec)
 	if err != nil {
 		return nil, InternalServerError(err.Error())
 	}
@@ -700,46 +697,45 @@ func (c *ContainerProxy) GetContainerChanges(ctx context.Context, vc *viccontain
 
 // ArchiveExportReader streams a tar archive from the portlayer.  Once the stream is complete,
 // an io.Reader is returned and the caller can use that reader to parse the data.
-func (c *ContainerProxy) ArchiveExportReader(ctx context.Context, store, ancestorStore, deviceID, ancestor string, data bool, filterSpec archive.FilterSpec) (io.ReadCloser, error) {
+func (c *ContainerProxy) ArchiveExportReader(op trace.Operation, store, ancestorStore, deviceID, ancestor string, data bool, filterSpec archive.FilterSpec) (io.ReadCloser, error) {
 	defer trace.End(trace.Begin(deviceID))
 
 	if store == "" || deviceID == "" {
 		return nil, fmt.Errorf("ArchiveExportReader called with either empty store or deviceID")
 	}
 
-	var err error
-
 	pipeReader, pipeWriter := io.Pipe()
 
 	done := make(chan struct{})
 	go func() {
+
 		// make sure we get out of io.Copy if context is canceled
 		select {
-		case <-ctx.Done():
+		case <-op.Done():
 			// Attempt to tell the portlayer to cancel the stream.  This is one way of cancelling the
 			// stream.  The other way is for the caller of this function to close the returned CloseReader.
 			// Callers of this function should do one but not both.
 			pipeReader.Close()
+		case <-done:
 		}
 	}()
 
 	go func() {
 		defer close(done)
 
-		params := storage.NewExportArchiveParamsWithContext(ctx).
+		params := storage.NewExportArchiveParamsWithContext(op).
 			WithStore(store).
 			WithAncestorStore(&ancestorStore).
 			WithDeviceID(deviceID).
 			WithAncestor(&ancestor).
 			WithData(data)
 
-		// Encode the filter spec
-		encodedFilter := ""
-		if valueBytes, merr := json.Marshal(filterSpec); merr == nil {
-			encodedFilter = base64.StdEncoding.EncodeToString(valueBytes)
-			params = params.WithFilterSpec(&encodedFilter)
-			log.Infof(" encodedFilter = %s", encodedFilter)
+		spec, err := archive.EncodeFilterSpec(op, &filterSpec)
+		if err != nil {
+			op.Errorf(err.Error())
+			pipeReader.CloseWithError(err)
 		}
+		params = params.WithFilterSpec(spec)
 
 		_, err = c.client.Storage.ExportArchive(params, pipeWriter)
 		if err != nil {
@@ -747,20 +743,21 @@ func (c *ContainerProxy) ArchiveExportReader(ctx context.Context, store, ancesto
 			switch err := err.(type) {
 			case *storage.ExportArchiveInternalServerError:
 				plErr := InternalServerError(fmt.Sprintf("Server error from archive reader for device %s", deviceID))
-				log.Errorf(plErr.Error())
+				op.Errorf(plErr.Error())
 				pipeWriter.CloseWithError(plErr)
 			case *storage.ImportArchiveLocked:
 				plErr := ResourceLockedError(fmt.Sprintf("Resource locked for device %s", deviceID))
-				log.Errorf(plErr.Error())
+				op.Errorf(plErr.Error())
 				pipeWriter.CloseWithError(plErr)
 			default:
 				//Check for EOF.  Since the connection, transport, and data handling are
 				//encapsulated inside of Swagger, we can only detect EOF by checking the
 				//error string
 				if strings.Contains(err.Error(), swaggerSubstringEOF) {
-					log.Debugf("swagger error %s", err.Error())
+					op.Debugf("swagger error %s", err.Error())
 					pipeWriter.Close()
 				} else {
+					op.Errorf(err.Error())
 					pipeWriter.CloseWithError(err)
 				}
 			}
@@ -774,14 +771,12 @@ func (c *ContainerProxy) ArchiveExportReader(ctx context.Context, store, ancesto
 
 // ArchiveImportWriter initializes a write stream for a path.  This is usually called
 // for gettine a writer during docker cp TO container.
-func (c *ContainerProxy) ArchiveImportWriter(ctx context.Context, store, deviceID string, filterSpec archive.FilterSpec) (io.WriteCloser, error) {
+func (c *ContainerProxy) ArchiveImportWriter(op trace.Operation, store, deviceID string, filterSpec archive.FilterSpec) (io.WriteCloser, error) {
 	defer trace.End(trace.Begin(deviceID))
 
 	if store == "" || deviceID == "" {
 		return nil, fmt.Errorf("ArchiveImportWriter called with either empty store or deviceID")
 	}
-
-	var err error
 
 	pipeReader, pipeWriter := io.Pipe()
 
@@ -789,7 +784,7 @@ func (c *ContainerProxy) ArchiveImportWriter(ctx context.Context, store, deviceI
 	go func() {
 		// make sure we get out of io.Copy if context is canceled
 		select {
-		case <-ctx.Done():
+		case <-op.Done():
 			// Attempt to shutdown the stream to the portlayer.  The other way to cancel the
 			// connection is to call close on the WriteCloser returned from this function.
 			// Callers of this function should do one but not both.
@@ -801,39 +796,40 @@ func (c *ContainerProxy) ArchiveImportWriter(ctx context.Context, store, deviceI
 	go func() {
 		defer close(done)
 
-		// encodedFilter and destination are not required (from swagge spec) because
+		// encodedFilter and destination are not required (from swagger spec) because
 		// they are allowed to be empty.
-		params := storage.NewImportArchiveParamsWithContext(ctx).
+		params := storage.NewImportArchiveParamsWithContext(op).
 			WithStore(store).
 			WithDeviceID(deviceID).
 			WithArchive(pipeReader)
 
-		// Encode the filter spec
-		encodedFilter := ""
-		if valueBytes, merr := json.Marshal(filterSpec); merr == nil {
-			encodedFilter = base64.StdEncoding.EncodeToString(valueBytes)
-			params = params.WithFilterSpec(&encodedFilter)
+		spec, err := archive.EncodeFilterSpec(op, &filterSpec)
+		if err != nil {
+			op.Errorf(err.Error())
+			pipeReader.CloseWithError(err)
 		}
+		params = params.WithFilterSpec(spec)
 
 		_, err = c.client.Storage.ImportArchive(params)
 		if err != nil {
 			switch err := err.(type) {
 			case *storage.ImportArchiveInternalServerError:
 				plErr := InternalServerError(fmt.Sprintf("Server error from archive writer for device %s", deviceID))
-				log.Errorf(plErr.Error())
+				op.Errorf(plErr.Error())
 				pipeReader.CloseWithError(plErr)
 			case *storage.ImportArchiveLocked:
 				plErr := ResourceLockedError(fmt.Sprintf("Resource locked for device %s", deviceID))
-				log.Errorf(plErr.Error())
+				op.Errorf(plErr.Error())
 				pipeReader.CloseWithError(plErr)
 			default:
 				//Check for EOF.  Since the connection, transport, and data handling are
 				//encapsulated inside of Swagger, we can only detect EOF by checking the
 				//error string
 				if strings.Contains(err.Error(), swaggerSubstringEOF) {
-					log.Errorf(err.Error())
+					op.Errorf(err.Error())
 					pipeReader.Close()
 				} else {
+					op.Errorf(err.Error())
 					pipeReader.CloseWithError(err)
 				}
 			}
@@ -860,12 +856,12 @@ func (c *ContainerProxy) StatPath(op trace.Operation, store, deviceID string, fi
 		op.Errorf(err.Error())
 		return nil, InternalServerError(err.Error())
 	}
+	statPathParams = statPathParams.WithFilterSpec(spec)
 
-	statPathParams = statPathParams.WithFilterSpec(*spec)
 	statPathOk, err := c.client.Storage.StatPath(statPathParams)
 	if err != nil {
 		op.Errorf(err.Error())
-		return nil, err
+		return nil, InternalServerError(err.Error())
 	}
 
 	stat := &types.ContainerPathStat{
@@ -1875,7 +1871,7 @@ func networkFromContainerInfo(vc *viccontainer.VicContainer, info *models.Contai
 
 // portMapFromVicContainer() constructs a docker portmap from both the container's
 // hostconfig and config (both stored in VicContainer).  They are added and modified
-// during docker create.  This function creates a new map that is adhere's to docker's
+// during docker create.  This function creates a new map that is adheres to docker's
 // structure for types.NetworkSettings.Ports.
 func portMapFromVicContainer(vc *viccontainer.VicContainer) nat.PortMap {
 	var portMap nat.PortMap

--- a/lib/apiservers/engine/backends/container_proxy.go
+++ b/lib/apiservers/engine/backends/container_proxy.go
@@ -716,7 +716,6 @@ func (c *ContainerProxy) ArchiveExportReader(ctx context.Context, store, ancesto
 		// make sure we get out of io.Copy if context is canceled
 		select {
 		case <-ctx.Done():
-
 			// Attempt to tell the portlayer to cancel the stream.  This is one way of cancelling the
 			// stream.  The other way is for the caller of this function to close the returned CloseReader.
 			// Callers of this function should do one but not both.

--- a/lib/apiservers/portlayer/swagger.json
+++ b/lib/apiservers/portlayer/swagger.json
@@ -182,9 +182,6 @@
 				"tags": [
 					"storage"
 				],
-				"consumes": [
-					"application/json"
-				],
 				"produces": [
 					"application/x-tar"
 				],
@@ -242,6 +239,12 @@
 					},
 					"404": {
 						"description": "Supplied target not found",
+						"schema": {
+							"$ref": "#/definitions/Error"
+						}
+					},
+					"422": {
+						"description": "Format error in supplied filter or archive",
 						"schema": {
 							"$ref": "#/definitions/Error"
 						}
@@ -344,12 +347,6 @@
 				"tags": [
 					"storage"
 				],
-				"consumes": [
-					"application/json"
-				],
-				"produces": [
-					"application/json"
-				],
 				"parameters": [
 					{
 						"name": "store",
@@ -368,9 +365,9 @@
 					{
 						"name": "filterSpec",
 						"in": "query",
-						"required": true,
+						"required": false,
 						"type": "string",
-						"x-nullable": false
+						"x-nullable": true
 					}
 				],
 				"responses": {
@@ -399,14 +396,14 @@
 							}
 						}
 					},
-					"404": {
-						"description": "No such file/directory"
-					},
 					"422": {
 						"description": "Format error in supplied filter or archive"
 					},
+					"404": {
+						"description": "Supplied target not found"
+					},
 					"500": {
-						"description": "Failed to inspect target"
+						"description": "failed to export tar archive from target"
 					}
 				}
 			}

--- a/lib/archive/diff_test.go
+++ b/lib/archive/diff_test.go
@@ -113,7 +113,7 @@ func TestMain(m *testing.M) {
 func TestDiff(t *testing.T) {
 	op := trace.NewOperation(context.Background(), "TestDiff")
 
-	tarFile, err := Diff(op, newDir, oldDir, nil, true)
+	tarFile, err := Diff(op, newDir, oldDir, nil, true, true)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -158,7 +158,7 @@ func TestDiffNoAncestor(t *testing.T) {
 	op := trace.NewOperation(context.Background(), "TestDiffNoParent")
 
 	// test without ancestor
-	tarFile, err := Diff(op, newDir, "", nil, true)
+	tarFile, err := Diff(op, newDir, "", nil, true, true)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -205,7 +205,7 @@ func TestDiffNoAncestor(t *testing.T) {
 func TestDiffNoData(t *testing.T) {
 	op := trace.NewOperation(context.Background(), "TestDiffNoData")
 
-	tarFile, err := Diff(op, newDir, oldDir, nil, false)
+	tarFile, err := Diff(op, newDir, oldDir, nil, false, true)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -281,7 +281,7 @@ func TestDiffFilterSpec(t *testing.T) {
 		return
 	}
 
-	tarFile, err := Diff(op, newDir, oldDir, spec, true)
+	tarFile, err := Diff(op, newDir, oldDir, spec, true, true)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -347,7 +347,7 @@ func TestDiffFilterSpecNoAncestor(t *testing.T) {
 	}
 
 	// test without ancestor
-	tarFile, err := Diff(op, newDir, "", spec, true)
+	tarFile, err := Diff(op, newDir, "", spec, true, true)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -415,7 +415,7 @@ func TestDiffFilterSpecRebase(t *testing.T) {
 	}
 
 	// test without ancestor
-	tarFile, err := Diff(op, newDir, oldDir, spec, true)
+	tarFile, err := Diff(op, newDir, oldDir, spec, true, true)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -488,7 +488,7 @@ func TestDiffFilterSpecRebaseNoData(t *testing.T) {
 		return
 	}
 
-	tarFile, err := Diff(op, newDir, oldDir, spec, false)
+	tarFile, err := Diff(op, newDir, oldDir, spec, false, true)
 	if !assert.NoError(t, err) {
 		return
 	}

--- a/lib/portlayer/storage/data_source.go
+++ b/lib/portlayer/storage/data_source.go
@@ -19,9 +19,10 @@ import (
 	"io"
 	"os"
 
+	"path/filepath"
+
 	"github.com/vmware/vic/lib/archive"
 	"github.com/vmware/vic/pkg/trace"
-	"path/filepath"
 )
 
 // MountDataSource implements the DataSource interface for mounted devices
@@ -71,7 +72,7 @@ func (m *MountDataSource) Export(op trace.Operation, spec *archive.FilterSpec, d
 
 	// NOTE: this isn't actually diffing - it's just creating a tar. @jzt to explain why
 	op.Infof("Exporting data from %s", name)
-	rc, err := archive.Diff(op, name, "", spec, data)
+	rc, err := archive.Diff(op, name, "", spec, data, false)
 
 	// return the proxy regardless of error so that Close can be called
 	return &ProxyReadCloser{
@@ -83,10 +84,6 @@ func (m *MountDataSource) Export(op trace.Operation, spec *archive.FilterSpec, d
 // Export reads data from the associated data source and returns it as a tar archive
 func (m *MountDataSource) Stat(op trace.Operation, spec *archive.FilterSpec) (*FileStat, error) {
 	// retrieve relative path
-	if len(spec.Inclusions) != 1 {
-		op.Errorf("incorrect number of paths to stat --- ", len(spec.Inclusions))
-		return nil, errors.New("Incorrect number of paths to stat")
-	}
 
 	var targetPath string
 	for path := range spec.Inclusions {

--- a/lib/portlayer/storage/volume.go
+++ b/lib/portlayer/storage/volume.go
@@ -96,7 +96,7 @@ func NewVolume(store *url.URL, ID string, info map[string][]byte, device Disk, c
 
 	vol := &Volume{
 		ID:       ID,
-		Label:    label(ID),
+		Label:    Label(ID),
 		Store:    store,
 		SelfLink: selflink,
 		Device:   device,
@@ -107,7 +107,7 @@ func NewVolume(store *url.URL, ID string, info map[string][]byte, device Disk, c
 }
 
 // given an ID, compute the volume's label
-func label(ID string) string {
+func Label(ID string) string {
 
 	// e2label's manpage says the label size is 16 chars
 	// #nosec: Use of weak cryptographic primitive

--- a/lib/portlayer/storage/vsphere/container.go
+++ b/lib/portlayer/storage/vsphere/container.go
@@ -150,11 +150,12 @@ func (c *ContainerStore) newDataSource(op trace.Operation, url *url.URL) (storag
 }
 
 func (c *ContainerStore) newOnlineDataSource(op trace.Operation, owner *vm.VirtualMachine, id string) (storage.DataSource, error) {
-	op.Debugf("Constructing toolbox data sink: %s.%s", owner.Reference(), id)
+	op.Debugf("Constructing toolbox data source: %s.%s", owner.Reference(), id)
 
 	return &ToolboxDataSource{
-		VM: owner,
-		ID: id,
+		VM:    owner,
+		ID:    id,
+		Clean: func() { return },
 	}, nil
 }
 
@@ -215,8 +216,9 @@ func (c *ContainerStore) newOnlineDataSink(op trace.Operation, owner *vm.Virtual
 	op.Debugf("Constructing toolbox data sink: %s.%s", owner.Reference(), id)
 
 	return &ToolboxDataSink{
-		VM: owner,
-		ID: id,
+		VM:    owner,
+		ID:    id,
+		Clean: func() { return },
 	}, nil
 }
 
@@ -279,7 +281,7 @@ func (c *ContainerStore) Export(op trace.Operation, id, ancestor string, spec *a
 		return nil, errors.New("mismatched datasource types")
 	}
 
-	tar, err := archive.Diff(op, fl.Name(), fr.Name(), spec, data)
+	tar, err := archive.Diff(op, fl.Name(), fr.Name(), spec, data, false)
 	if err != nil {
 		go closers()
 		return nil, err

--- a/lib/portlayer/storage/vsphere/export.go
+++ b/lib/portlayer/storage/vsphere/export.go
@@ -104,9 +104,9 @@ func (v *VolumeStore) newDataSource(op trace.Operation, url *url.URL) (storage.D
 
 func (v *VolumeStore) newOnlineDataSource(op trace.Operation, owner *vm.VirtualMachine, id string) (storage.DataSource, error) {
 	return &ToolboxDataSource{
-		VM: owner,
-		// TODO: there's some mangling that happens from volume id to disk label so this isn't currently correct
-		ID: id,
+		VM:    owner,
+		ID:    storage.Label(id),
+		Clean: func() { return },
 	}, nil
 }
 
@@ -127,7 +127,7 @@ func (i *ImageStore) Export(op trace.Operation, id, ancestor string, spec *archi
 		return l.Export(op, spec, data)
 	}
 
-	// for now we assume ancetor instead of entirely generic left/right
+	// for now we assume ancestor instead of entirely generic left/right
 	// this allows us to assume it's an image
 	r, err := i.NewDataSource(op, ancestor)
 	if err != nil {
@@ -157,7 +157,7 @@ func (i *ImageStore) Export(op trace.Operation, id, ancestor string, spec *archi
 		return nil, fmt.Errorf("mismatched datasource types: %T, %T", ls, rs)
 	}
 
-	tar, err := archive.Diff(op, fl.Name(), fr.Name(), spec, data)
+	tar, err := archive.Diff(op, fl.Name(), fr.Name(), spec, data, false)
 	if err != nil {
 		go closers()
 		return nil, err

--- a/lib/portlayer/storage/vsphere/toolbox_common.go
+++ b/lib/portlayer/storage/vsphere/toolbox_common.go
@@ -1,0 +1,74 @@
+// Copyright 2017 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vsphere
+
+import (
+	"fmt"
+	"path"
+
+	"github.com/vmware/govmomi/guest"
+	"github.com/vmware/govmomi/guest/toolbox"
+	"github.com/vmware/govmomi/vim25/types"
+	"github.com/vmware/vic/lib/archive"
+	"github.com/vmware/vic/pkg/trace"
+	"github.com/vmware/vic/pkg/vsphere/vm"
+)
+
+const (
+	DiskLabelQueryName  = "disk-label"
+	FilterSpecQueryName = "filter-spec"
+)
+
+// Parse Archive does something.
+func BuildArchiveURL(op trace.Operation, disklabel, target string, fs *archive.FilterSpec) (string, error) {
+	encodedSpec, err := archive.EncodeFilterSpec(op, fs)
+	if err != nil {
+		return "", err
+	}
+	target = path.Join("/archive:/", target)
+
+	// if diskLabel is longer than 16 characters, then the function was passed a containerID
+	// use containerfs as the diskLabel
+	if len(disklabel) > 16 {
+		disklabel = "containerfs"
+	}
+
+	target += fmt.Sprintf("?%s=%s&%s=%s", DiskLabelQueryName, disklabel, FilterSpecQueryName, *encodedSpec)
+	op.Debugf("OnlineData* Url: %s", target)
+	return target, nil
+}
+
+// GetToolboxClient returns a toolbox client given a vm and id
+func GetToolboxClient(op trace.Operation, vm *vm.VirtualMachine, id string) (*toolbox.Client, error) {
+	opmgr := guest.NewOperationsManager(vm.Session.Client.Client, vm.Reference())
+	pm, err := opmgr.ProcessManager(op)
+	if err != nil {
+		op.Debugf("Failed to create new process manager ")
+		return nil, err
+	}
+	fm, err := opmgr.FileManager(op)
+	if err != nil {
+		op.Debugf("Failed to create new file manager ")
+		return nil, err
+	}
+
+	return &toolbox.Client{
+		ProcessManager: pm,
+		FileManager:    fm,
+		Authentication: &types.NamePasswordAuthentication{
+			Username: id,
+		},
+	}, nil
+}

--- a/lib/portlayer/storage/vsphere/toolbox_datasource.go
+++ b/lib/portlayer/storage/vsphere/toolbox_datasource.go
@@ -15,11 +15,10 @@
 package vsphere
 
 import (
-	"errors"
+	"archive/tar"
 	"io"
+	"io/ioutil"
 
-	"github.com/vmware/govmomi/guest"
-	"github.com/vmware/govmomi/vim25/types"
 	"github.com/vmware/vic/lib/archive"
 	"github.com/vmware/vic/lib/portlayer/storage"
 	"github.com/vmware/vic/pkg/trace"
@@ -40,34 +39,81 @@ func (t *ToolboxDataSource) Source() interface{} {
 
 // Export reads data from the associated data source and returns it as a tar archive
 func (t *ToolboxDataSource) Export(op trace.Operation, spec *archive.FilterSpec, data bool) (io.ReadCloser, error) {
-	defer trace.End(trace.Begin(""))
+	defer trace.End(trace.Begin("toolbox export"))
 
-	// set up file manager
-	client := t.VM.Session.Client.Client
-	filemgr, err := guest.NewOperationsManager(client, t.VM.Reference()).FileManager(op)
+	client, err := GetToolboxClient(op, t.VM, t.ID)
+	if err != nil {
+		op.Errorf("Cannot get toolbox client: %s", err.Error())
+		return nil, err
+	}
+
+	var readers []io.Reader
+	for inclusion := range spec.Inclusions {
+		// build a proper target
+		target, err := BuildArchiveURL(op, t.ID, inclusion, spec)
+		if err != nil {
+			op.Errorf("Cannot build archive url: %s", err.Error())
+			return nil, err
+		}
+		tar, contentLength, err := client.Download(op, target)
+		if err != nil {
+			op.Errorf("Download error: %s", err.Error())
+			return nil, err
+		}
+		op.Debugf("Downloaded from %s with size %d", target, contentLength)
+		readers = append(readers, tar)
+
+	}
+	return ioutil.NopCloser(io.MultiReader(readers...)), nil
+}
+
+// Export reads data from the associated data source and returns it as a tar archive
+func (t *ToolboxDataSource) Stat(op trace.Operation, spec *archive.FilterSpec) (*storage.FileStat, error) {
+	defer trace.End(trace.Begin("toolbox stat"))
+
+	client, err := GetToolboxClient(op, t.VM, t.ID)
+	if err != nil {
+		op.Errorf("Cannot get toolbox client: %s", err.Error())
+		return nil, err
+	}
+
+	// should only find a single path to stat, but make sure here.
+	var statPath string
+	for inclusion := range spec.Inclusions {
+		statPath = inclusion
+	}
+
+	target, err := BuildArchiveURL(op, t.ID, statPath, spec)
+	if err != nil {
+		op.Errorf("Cannot build archive url: %s", err.Error())
+		return nil, err
+	}
+	statTar, _, err := client.Download(op, target)
+	if err != nil {
+		op.Errorf("Download error: %s", err.Error())
+		return nil, err
+	}
+	defer statTar.Close()
+
+	// decode from guest tools
+	header, err := tar.NewReader(statTar).Next()
 	if err != nil {
 		return nil, err
 	}
 
-	// authenticate client and parse container host/port
-	auth := types.NamePasswordAuthentication{
-		Username: t.ID,
+	stat := &storage.FileStat{
+		Mode:       uint32(header.FileInfo().Mode()),
+		Name:       header.Name,
+		Size:       header.Size,
+		ModTime:    header.ModTime,
+		LinkTarget: header.Linkname,
 	}
 
-	_ = filemgr
-	_ = auth
-
-	return nil, errors.New("toolbox export is not yet implemented")
-}
-
-func (m *ToolboxDataSource) Stat(op trace.Operation, spec *archive.FilterSpec) (*storage.FileStat, error) {
-	return nil, errors.New("toolbox stat is not yet implemented")
+	return stat, nil
 }
 
 func (t *ToolboxDataSource) Close() error {
-	if t.Clean != nil {
-		t.Clean()
-	}
+	t.Clean()
 
 	return nil
 }

--- a/pkg/vsphere/disk/disk_manager.go
+++ b/pkg/vsphere/disk/disk_manager.go
@@ -538,13 +538,19 @@ func (m *Manager) UnmountAndDetach(op trace.Operation, datastoreURI *object.Data
 func (m *Manager) InUse(op trace.Operation, config *VirtualDiskConfig, filter func(vm *mo.VirtualMachine) bool) ([]*vm.VirtualMachine, error) {
 	defer trace.End(trace.Begin(""))
 
-	if m.view == nil {
-		return nil, fmt.Errorf("ContainerView is nil")
+	mngr := view.NewManager(m.vm.Vim25())
+
+	// Create view of VirtualMachine objects under the VCH's resource pool
+	view2, err := mngr.CreateContainerView(op, m.vm.Session.Pool.Reference(), []string{"VirtualMachine"}, true)
+	if err != nil {
+		op.Errorf("failed to create view: %s", err)
+		return nil, err
 	}
+	defer view2.Destroy(op)
 
 	var mos []mo.VirtualMachine
 	// Retrieve needed properties of all machines under this view
-	err := m.view.Retrieve(op, []string{"VirtualMachine"}, []string{"name", "config.hardware", "runtime.powerState"}, &mos)
+	err = view2.Retrieve(op, []string{"VirtualMachine"}, []string{"name", "config.hardware", "runtime.powerState"}, &mos)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Implements Online Docker CP, including ContainerStatPath, using
Guest Tools and the Toolbox. These changes also introduce storage
handlers for Docker CP implementations of Export/Import Archive
and personality code for ContainerArchivePath and
ContainerExtractToDir. Fixes 5606, 5715,  and 5570.