### PR TITLE
Implement docker push image/manifest building and upload manager

### DIFF
--- a/cmd/imagec/main.go
+++ b/cmd/imagec/main.go
@@ -165,7 +165,7 @@ func main() {
 
 		options.Outstream = os.Stdout
 
-		ic := imagec.NewImageC(options, streamformatter.NewJSONStreamFormatter())
+		ic := imagec.NewImageC(options, streamformatter.NewJSONStreamFormatter(), nil)
 		if err := ic.PullImage(); err != nil {
 			log.Fatalf("Pulling image failed due to %s\n", err)
 		}

--- a/lib/apiservers/engine/backends/backends.go
+++ b/lib/apiservers/engine/backends/backends.go
@@ -62,6 +62,7 @@ var (
 
 	vchConfig        dynConfig
 	RegistryCertPool *x509.CertPool
+	archiveProxy     VicArchiveProxy
 
 	eventService *events.Events
 )
@@ -131,6 +132,8 @@ func Init(portLayerAddr, product string, config *config.VirtualContainerHostConf
 		log.Errorf("Failed to create image store")
 		return err
 	}
+
+	archiveProxy = NewArchiveProxy()
 
 	eventService = events.New()
 

--- a/lib/apiservers/engine/backends/cache/repo_cache.go
+++ b/lib/apiservers/engine/backends/cache/repo_cache.go
@@ -54,6 +54,7 @@ type Repo interface {
 
 	Save() error
 	GetImageID(layerID string) string
+	GetLayerID(imageID string) string
 	Tags(imageID string) []string
 	Digests(imageID string) []string
 	AddReference(ref reference.Named, imageID string, force bool, layerID string, save bool) error
@@ -322,6 +323,21 @@ func (store *repoCache) GetImageID(layerID string) string {
 		imageID = image
 	}
 	return imageID
+}
+
+// GetLayerID returns the leaf layer ID for an imageID
+func (store *repoCache) GetLayerID(imageID string) string {
+	defer trace.End(trace.Begin(imageID))
+
+	store.mu.RLock()
+	defer store.mu.RUnlock()
+
+	layerID := ""
+	if layer, exist := store.images[imageID]; exist {
+		layerID = layer
+	}
+
+	return layerID
 }
 
 // Get returns the imageID for a parsed reference

--- a/lib/apiservers/engine/backends/commit.go
+++ b/lib/apiservers/engine/backends/commit.go
@@ -190,7 +190,7 @@ func getImagec(config *backend.ContainerCommitConfig) (*imagec.ImageC, error) {
 		options.Host = portLayerServer
 	}
 
-	ic := imagec.NewImageC(options, streamformatter.NewJSONStreamFormatter())
+	ic := imagec.NewImageC(options, streamformatter.NewJSONStreamFormatter(), nil)
 	if imageRef != nil {
 		ic.ParseReference()
 	}

--- a/lib/apiservers/engine/backends/container_test.go
+++ b/lib/apiservers/engine/backends/container_test.go
@@ -42,7 +42,6 @@ import (
 	plclient "github.com/vmware/vic/lib/apiservers/portlayer/client"
 	plscopes "github.com/vmware/vic/lib/apiservers/portlayer/client/scopes"
 	plmodels "github.com/vmware/vic/lib/apiservers/portlayer/models"
-	"github.com/vmware/vic/lib/archive"
 	"github.com/vmware/vic/lib/metadata"
 )
 
@@ -356,14 +355,6 @@ func (m *MockContainerProxy) AttachStreams(ctx context.Context, ac *AttachConfig
 
 func (m *MockContainerProxy) StreamContainerStats(ctx context.Context, config *convert.ContainerStatsConfig) error {
 	return nil
-}
-
-func (m *MockContainerProxy) ArchiveExportReader(ctx context.Context, store, ancestorStore, deviceID, ancestor string, data bool, filterSpec archive.FilterSpec) (io.ReadCloser, error) {
-	return nil, nil
-}
-
-func (m *MockContainerProxy) ArchiveImportWriter(ctx context.Context, store, deviceID string, filterSpec archive.FilterSpec) (io.WriteCloser, error) {
-	return nil, nil
 }
 
 func (m *MockContainerProxy) GetContainerChanges(ctx context.Context, vc *viccontainer.VicContainer, data bool) (io.ReadCloser, error) {

--- a/lib/apiservers/engine/backends/errors.go
+++ b/lib/apiservers/engine/backends/errors.go
@@ -72,6 +72,14 @@ func NotFoundError(msg string) error {
 	return derr.NewRequestNotFoundError(fmt.Errorf("No such container: %s", msg))
 }
 
+func ImageNotFoundError(image, tag string) error {
+	return derr.NewRequestNotFoundError(fmt.Errorf("An image does not exist locally with the tag: %s", image))
+}
+
+func TagNotFoundError(image, tag string) error {
+	return derr.NewRequestNotFoundError(fmt.Errorf("tag does not exist: %s:%s", image, tag))
+}
+
 // ResourceLockedError returns a 423 http status
 func ResourceLockedError(msg string) error {
 	return derr.NewErrorWithStatusCode(fmt.Errorf("Resource locked: %s", msg), http.StatusLocked)

--- a/lib/apiservers/engine/backends/image.go
+++ b/lib/apiservers/engine/backends/image.go
@@ -393,7 +393,7 @@ func (i *Image) PullImage(ctx context.Context, image, tag string, metaHeaders ma
 		options.Host,
 		portLayerServer)
 
-	ic := imagec.NewImageC(options, streamformatter.NewJSONStreamFormatter())
+	ic := imagec.NewImageC(options, streamformatter.NewJSONStreamFormatter(), SimpleArchiveReader)
 	err = ic.PullImage()
 	if err != nil {
 		return err
@@ -403,10 +403,6 @@ func (i *Image) PullImage(ctx context.Context, image, tag string, metaHeaders ma
 	actor := CreateImageEventActorWithAttributes(image, "", map[string]string{})
 	EventService().Log("pull", eventtypes.ImageEventType, actor)
 	return nil
-}
-
-func (i *Image) PushImage(ctx context.Context, image, tag string, metaHeaders map[string][]string, authConfig *types.AuthConfig, outStream io.Writer) error {
-	return fmt.Errorf("%s does not yet implement image.PushImage", ProductName())
 }
 
 func (i *Image) SearchRegistryForImages(ctx context.Context, filtersArgs string, term string, limit int, authConfig *types.AuthConfig, metaHeaders map[string][]string) (*registry.SearchResults, error) {

--- a/lib/apiservers/engine/backends/push.go
+++ b/lib/apiservers/engine/backends/push.go
@@ -1,0 +1,144 @@
+// Copyright 2017 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissi[ons and
+// limitations under the License.
+
+package backends
+
+import (
+	"fmt"
+	"io"
+	"net/url"
+	"os"
+	"strings"
+
+	log "github.com/Sirupsen/logrus"
+	"golang.org/x/net/context"
+
+	"github.com/vmware/vic/lib/apiservers/engine/backends/cache"
+	vicarchive "github.com/vmware/vic/lib/archive"
+	"github.com/vmware/vic/lib/imagec"
+	"github.com/vmware/vic/pkg/trace"
+	"github.com/vmware/vic/pkg/vsphere/sys"
+
+	"github.com/docker/distribution/digest"
+	"github.com/docker/docker/api/types"
+	eventtypes "github.com/docker/docker/api/types/events"
+	"github.com/docker/docker/pkg/streamformatter"
+	"github.com/docker/docker/reference"
+)
+
+// PushImage initiates a push operation on the repository named localName.
+func (i *Image) PushImage(ctx context.Context, image, tag string, metaHeaders map[string][]string, authConfig *types.AuthConfig, outStream io.Writer) error {
+	defer trace.End(trace.Begin(fmt.Sprintf("%s:%s", image, tag)))
+
+	_, err := cache.ImageCache().Get(image)
+	if err != nil {
+		return ImageNotFoundError(image, tag)
+	}
+
+	//***** Code from Docker 1.13 PullImage to convert image and tag to a ref
+	image = strings.TrimSuffix(image, ":")
+
+	ref, err := reference.ParseNamed(image)
+	if err != nil {
+		return err
+	}
+
+	if tag != "" {
+		// The "tag" could actually be a digest.
+		var dgst digest.Digest
+		dgst, err = digest.ParseDigest(tag)
+		if err == nil {
+			ref, err = reference.WithDigest(reference.TrimNamed(ref), dgst)
+		} else {
+			ref, err = reference.WithTag(ref, tag)
+		}
+		if err != nil {
+			return err
+		}
+	}
+	//*****
+
+	// create url from hostname
+	hostnameURL, err := url.Parse(ref.Hostname())
+	if err != nil || hostnameURL.Hostname() == "" {
+		hostnameURL, err = url.Parse("//" + ref.Hostname())
+		if err != nil {
+			log.Infof("Error parsing hostname %s during registry access: %s", ref.Hostname(), err.Error())
+		}
+	}
+
+	options := imagec.Options{
+		Destination: os.TempDir(),
+		Reference:   ref,
+		Timeout:     imagec.DefaultHTTPTimeout,
+		Outstream:   outStream,
+	}
+
+	// Check if url is contained within set of whitelisted or insecure registries
+	whitelistOk, _, insecureOk := vchConfig.RegistryCheck(ctx, hostnameURL)
+	if !whitelistOk {
+		err = fmt.Errorf("Access denied to unauthorized registry (%s) while VCH is in whitelist mode", hostnameURL.Host)
+		log.Errorf(err.Error())
+		sf := streamformatter.NewJSONStreamFormatter()
+		outStream.Write(sf.FormatError(err))
+		return nil
+	}
+	options.InsecureAllowHTTP = insecureOk
+
+	options.RegistryCAs = RegistryCertPool
+
+	if authConfig != nil {
+		if len(authConfig.Username) > 0 {
+			options.Username = authConfig.Username
+		}
+		if len(authConfig.Password) > 0 {
+			options.Password = authConfig.Password
+		}
+	}
+
+	portLayerServer := PortLayerServer()
+
+	if portLayerServer != "" {
+		options.Host = portLayerServer
+	}
+
+	log.Infof("PushImage: reference: %s, %s, portlayer: %#v",
+		options.Reference,
+		options.Host,
+		portLayerServer)
+
+	ic := imagec.NewImageC(options, streamformatter.NewJSONStreamFormatter(), SimpleArchiveReader)
+	err = ic.PushImage()
+	if err != nil {
+		return err
+	}
+
+	//TODO:  Need repo name as second parameter.  Leave blank for now
+	actor := CreateImageEventActorWithAttributes(image, "", map[string]string{})
+	EventService().Log("push", eventtypes.ImageEventType, actor)
+	return nil
+}
+
+// SimpleArchiveReader is a simplified archive reader that imageC can use to get a stream from the portlayer
+// without knowing about the portlayer
+func SimpleArchiveReader(ctx context.Context, layerID, parentLayerID string) (io.ReadCloser, error) {
+	var filterSpec vicarchive.FilterSpec
+
+	host, err := sys.UUID()
+	if err != nil {
+		return nil, err
+	}
+
+	return archiveProxy.ArchiveExportReader(ctx, host, host, layerID, parentLayerID, true, filterSpec)
+}

--- a/lib/imagec/imagec.go
+++ b/lib/imagec/imagec.go
@@ -15,20 +15,25 @@
 package imagec
 
 import (
-	"context"
+	"compress/gzip"
 	"crypto/sha256"
 	"crypto/x509"
 	"encoding/json"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"net/url"
 	"os"
 	"path"
 	"strings"
 	"time"
 
+	"golang.org/x/net/context"
+
 	log "github.com/Sirupsen/logrus"
 
+	"github.com/docker/distribution"
+	"github.com/docker/distribution/digest"
 	"github.com/docker/distribution/manifest/schema2"
 	docker "github.com/docker/docker/image"
 	dockerLayer "github.com/docker/docker/layer"
@@ -41,6 +46,7 @@ import (
 	"github.com/vmware/vic/lib/apiservers/engine/backends/cache"
 	"github.com/vmware/vic/lib/apiservers/portlayer/models"
 	"github.com/vmware/vic/lib/metadata"
+	"github.com/vmware/vic/lib/portlayer/storage"
 	urlfetcher "github.com/vmware/vic/pkg/fetcher"
 	"github.com/vmware/vic/pkg/trace"
 	"github.com/vmware/vic/pkg/vsphere/sys"
@@ -49,6 +55,7 @@ import (
 // ImageC is responsible for pulling docker images from a repository
 type ImageC struct {
 	Options
+	Pusher
 
 	// https://raw.githubusercontent.com/docker/docker/master/distribution/pull_v2.go
 	sf             *streamformatter.StreamFormatter
@@ -56,16 +63,21 @@ type ImageC struct {
 
 	// ImageLayers are sourced from the manifest file
 	ImageLayers []*ImageWithMeta
+
 	// ImageID is the docker ImageID calculated during download
 	ImageID string
 }
 
 // NewImageC returns a new instance of ImageC
-func NewImageC(options Options, strfmtr *streamformatter.StreamFormatter) *ImageC {
+func NewImageC(options Options, strfmtr *streamformatter.StreamFormatter, getArchiveReader GetArchiveReader) *ImageC {
 	return &ImageC{
 		Options:        options,
 		sf:             strfmtr,
 		progressOutput: strfmtr.NewProgressOutput(options.Outstream, false),
+		Pusher: Pusher{
+			streamMap:     make(map[string]*ArchiveStream),
+			ArchiveReader: getArchiveReader,
+		},
 	}
 }
 
@@ -123,12 +135,34 @@ type ImageWithMeta struct {
 	Downloading bool
 }
 
+// ArchiveStream is used during image push
+type ArchiveStream struct {
+	layerFile     *os.File
+	size          int64
+	digest        string
+	layerID       string
+	parentLayerID string
+}
+
+// Pusher contains all "prepared" data needed to push an image
+type Pusher struct {
+	PushManifest schema2.Manifest
+	streamMap    map[string]*ArchiveStream
+
+	// Function from imagec caller to get archive reader.  This reduce the need for imageC
+	// from knowing about the portlayer and persona.
+	ArchiveReader GetArchiveReader
+}
+
+type GetArchiveReader func(ctx context.Context, layerID, parentLayerID string) (io.ReadCloser, error)
+
 func (i *ImageWithMeta) String() string {
 	return stringid.TruncateID(i.Layer.BlobSum)
 }
 
 var (
 	ldm *LayerDownloader
+	lum *LayerUploader
 )
 
 const (
@@ -157,6 +191,7 @@ const (
 
 func init() {
 	ldm = NewLayerDownloader()
+	lum = NewLayerUploader()
 }
 
 // ParseReference parses the -reference parameter and populate options struct
@@ -463,10 +498,68 @@ func (ic *ImageC) CreateImageConfig(images []*ImageWithMeta) (metadata.ImageConf
 
 // PullImage pulls an image from docker hub
 func (ic *ImageC) PullImage() error {
-
-	// ctx
 	ctx, cancel := context.WithTimeout(ctx, ic.Options.Timeout)
 	defer cancel()
+
+	// Authenticate, get URL, get token
+	if err := ic.prepareTransfer(ctx); err != nil {
+		return err
+	}
+
+	// Output message
+	tagOrDigest := tagOrDigest(ic.Reference, ic.Tag)
+	progress.Message(ic.progressOutput, "", tagOrDigest+": Pulling from "+ic.Image)
+
+	// Pull the image manifest
+	if err := ic.pullManifest(ctx); err != nil {
+		return err
+	}
+
+	// Get layers to download from manifest
+	layers, err := ic.LayersToDownload()
+
+	log.Infof("Manifest for image = %#v", ic.ImageManifestSchema1)
+	if err != nil {
+		return err
+	}
+	ic.ImageLayers = layers
+
+	// Download all the layers
+	if err := ldm.DownloadLayers(ctx, ic); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// PushImage pushes an image to a registry
+func (ic *ImageC) PushImage() error {
+	ctx, cancel := context.WithTimeout(ctx, ic.Options.Timeout)
+	defer cancel()
+
+	// Output message
+	progress.Message(ic.progressOutput, "", "The push refers to a repository ["+ic.Image+"]")
+
+	// Prep layers and manifest.  Note, this does not completely finish the manifest.  Blob sums
+	// must be calculated as we read the layers, and layer readers are lazily created on demand.
+	if err := ic.PrepareManifestAndLayers(); err != nil {
+		return err
+	}
+
+	// Upload all the layers
+	if err := lum.UploadLayers(ctx, ic); err != nil {
+		return err
+	}
+
+	if err := ic.FinalizeManifest(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// prepareTransfer Looks up URLs and fetch auth token
+func (ic *ImageC) prepareTransfer(ctx context.Context) error {
 
 	// Parse the -reference parameter
 	ic.ParseReference()
@@ -530,9 +623,11 @@ func (ic *ImageC) PullImage() error {
 		ic.Token = token
 	}
 
-	tagOrDigest := tagOrDigest(ic.Reference, ic.Tag)
-	progress.Message(ic.progressOutput, "", tagOrDigest+": Pulling from "+ic.Image)
+	return nil
+}
 
+// pullManifest attempts to pull manifest for an image.  Attempts to get schema 2 but will fall back to schema 1.
+func (ic *ImageC) pullManifest(ctx context.Context) error {
 	// Get the schema1 manifest
 	manifest, digest, err := FetchImageManifest(ctx, ic.Options, 1, ic.progressOutput)
 	if err != nil {
@@ -552,12 +647,19 @@ func (ic *ImageC) PullImage() error {
 		return fmt.Errorf("Error pulling manifest schema 1")
 	}
 
+	if schema1 != nil {
+		log.Infof("pullManifest - schema 1: %#v", schema1)
+	}
 	ic.ImageManifestSchema1 = schema1
 	ic.ManifestDigest = digest
 
+	// Attempt to get schema2 manifest
 	manifest, digest, err = FetchImageManifest(ctx, ic.Options, 2, ic.progressOutput)
 	if err == nil {
 		if schema2, ok := manifest.(*schema2.DeserializedManifest); ok {
+			if schema2 != nil {
+				log.Infof("pullManifest - schema 2: %#v", schema2)
+			}
 			ic.ImageManifestSchema2 = schema2
 
 			// Override the manifest digest as Docker uses schema 2, unless the image
@@ -569,16 +671,259 @@ func (ic *ImageC) PullImage() error {
 		}
 	}
 
-	layers, err := ic.LayersToDownload()
-	if err != nil {
-		return err
-	}
-	ic.ImageLayers = layers
+	log.Infof("pullManifest - digest: %s", ic.ManifestDigest)
 
-	err = ldm.DownloadLayers(ctx, ic)
+	return nil
+}
+
+// PrepareManifestAndLayers creates the manifest and layers for an image to be pushed.
+func (ic *ImageC) PrepareManifestAndLayers() error {
+	defer trace.End(trace.Begin(""))
+
+	// get id of image from the reference
+	id, err := cache.RepositoryCache().Get(ic.Options.Reference)
 	if err != nil {
+		return fmt.Errorf("Could not retrieve image id from repository cache using reference: %s", err)
+	}
+
+	pusher := &ic.Pusher
+
+	// get the leaf layerID from repo cache using the image id
+	layerID := cache.RepositoryCache().GetLayerID(id)
+
+	// get the layer (ImageWithMeta) from the layer cache using the layer id
+	layer, err := LayerCache().Get(layerID)
+	if err != nil {
+		return fmt.Errorf("Unable to get top layer id for image %s", id)
+	}
+
+	// Build a layers history slice and add layers to stream map
+	var layersHistory []*ImageWithMeta
+	layersHistory = append(layersHistory, layer)
+
+	// use the leaf layer to walk the chain of layers down to the base parent (scratch)
+	for {
+		pusher.streamMap[layerID] = &ArchiveStream{
+			layerID:       layerID,
+			parentLayerID: layer.Image.Parent,
+		}
+
+		log.Infof("Image data for layer %s = %#v", layerID, *layer.Image)
+
+		// Check for scratch ID
+		if layer.Image.Parent == storage.Scratch.ID {
+			break
+		}
+
+		// set the layer to the parent layer
+		layerID = layer.Image.Parent
+		layer, err = LayerCache().Get(layerID)
+		if err != nil {
+			return fmt.Errorf("Unable to get metadata for layer %s", layerID)
+		}
+
+		layersHistory = append(layersHistory, layer)
+	}
+
+	log.Infof("streamMap = %#v", pusher.streamMap)
+
+	// Create a docker image from our (VIC's) image config
+	_, configDigest, configSize, err := ic.dockerImageFromVicImage(layersHistory)
+	if err != nil {
+		return fmt.Errorf("Could not build docker image from VIC image history: %s", err.Error())
+	}
+
+	// calculate image ID
+	log.Infof("Image ID: sha256:%s", configDigest)
+	digest := "sha256:" + digest.Digest(configDigest)
+
+	// build out PushManifest with all generated components
+	pusher.PushManifest = schema2.Manifest{
+		Versioned: schema2.SchemaVersion,
+		Config: distribution.Descriptor{
+			MediaType: schema2.MediaTypeImageConfig,
+			Size:      configSize,
+			Digest:    digest,
+		},
+	}
+
+	log.Infof("schema 2 manifest: %#v", pusher.PushManifest)
+
+	return nil
+}
+
+// FinalizeManifest builds the layer information in the manifest.  This information cannot
+// be determined till the layer tar streams were read and pushed.
+func (ic *ImageC) FinalizeManifest() error {
+	defer trace.End(trace.Begin(""))
+
+	pusher := ic.Pusher
+
+	var layers []distribution.Descriptor
+	for _, stream := range pusher.streamMap {
+		var layer distribution.Descriptor
+
+		log.Infof("Finalizing manifest, stream: %#v", stream)
+		layer.Digest = digest.Digest(stream.digest)
+		layer.Size = stream.size
+		layer.MediaType = schema2.MediaTypeLayer
+
+		layers = append(layers, layer)
+	}
+
+	pusher.PushManifest.Layers = layers
+
+	log.Infof("Final manifest = %#v", pusher.PushManifest)
+
+	return nil
+}
+
+func (ic *ImageC) pushManifest(ctx context.Context) error {
+	if err := PutImageManifest(ctx, ic.Pusher, ic.Options, ic.progressOutput); err != nil {
 		return err
 	}
 
 	return nil
+}
+
+// dockerImageFromVicImage takes a slice of VIC image with meta and returns a docker.Image,
+// the calculated digest of that struct, the size of the config
+func (ic *ImageC) dockerImageFromVicImage(images []*ImageWithMeta) (*docker.Image, string, int64, error) {
+	image := docker.V1Image{}
+	rootFS := docker.NewRootFS()
+	history := make([]docker.History, 0, len(images))
+	var size int64
+
+	// step through layers to get command history and diffID from oldest to newest
+	for i := len(images) - 1; i >= 0; i-- {
+		layer := images[i]
+		if err := json.Unmarshal([]byte(layer.Meta), &image); err != nil {
+			return nil, "", 0, fmt.Errorf("Failed to unmarshall layer history: %s", err)
+		}
+		h := docker.History{
+			Created:   image.Created,
+			Author:    image.Author,
+			CreatedBy: strings.Join(image.ContainerConfig.Cmd, " "),
+			Comment:   image.Comment,
+		}
+
+		// is this an empty layer?
+		if layer.DiffID == dockerLayer.DigestSHA256EmptyTar.String() {
+			h.EmptyLayer = true
+		} else {
+			// if not empty, add diffID to rootFS
+			rootFS.DiffIDs = append(rootFS.DiffIDs, dockerLayer.DiffID(layer.DiffID))
+		}
+		history = append(history, h)
+		size += layer.Size
+	}
+
+	// result is constructed without unused fields
+	result := &docker.Image{
+		V1Image: docker.V1Image{
+			Comment:         image.Comment,
+			Created:         image.Created,
+			Container:       image.Container,
+			ContainerConfig: image.ContainerConfig,
+			DockerVersion:   image.DockerVersion,
+			Author:          image.Author,
+			Config:          image.Config,
+			Architecture:    image.Architecture,
+			OS:              image.OS,
+		},
+		RootFS:  rootFS,
+		History: history,
+	}
+
+	imageConfigBytes, err := result.MarshalJSON()
+	if err != nil {
+		return nil, "", 0, fmt.Errorf("Failed to marshall image metadata: %s", err)
+	}
+
+	digest := fmt.Sprintf("%x", sha256.Sum256(imageConfigBytes))
+	configSize := int64(len(imageConfigBytes))
+
+	return result, digest, configSize, nil
+}
+
+// GetReaderForLayer returns a io.ReadCloser for the data from the archive stream.  The
+// archive stream reads the layer data from the portlayer.  It is written to a temp file
+// in order to obtain the digest before actual upload.
+func (p *Pusher) GetReaderForLayer(layerID string) (*ArchiveStream, io.ReadCloser, error) {
+	defer trace.End(trace.Begin(layerID))
+
+	stream, ok := p.streamMap[layerID]
+	if !ok {
+		return nil, nil, fmt.Errorf("Couldn't find stream for layer %s", layerID)
+	}
+
+	// Check if we have a function to retrieve the stream
+	if p.ArchiveReader == nil {
+		return nil, nil, fmt.Errorf("No archive reader function provided to ImageC")
+	}
+
+	//Initialize an archive stream from the portlayer for the layer
+	ar, err := p.ArchiveReader(context.Background(), layerID, p.streamMap[layerID].parentLayerID)
+	if err != nil || ar == nil {
+		return nil, nil, fmt.Errorf("Failed to get reader for layer %s", layerID)
+	}
+	defer ar.Close()
+
+	log.Infof("Obtain archive reader for layer %s, parent %s", layerID, p.streamMap[layerID].parentLayerID)
+
+	f, err := ioutil.TempFile("", "")
+	if err != nil {
+		msg := fmt.Sprintf("Failed to create tmp file: %s", err.Error())
+		log.Info(msg)
+		return nil, nil, fmt.Errorf(msg)
+	}
+
+	log.Infof("Writing layer to temp file %s", f.Name())
+
+	blobSum := sha256.New()
+	mw := io.MultiWriter(f, blobSum)
+	gzipWriter := gzip.NewWriter(mw)
+	defer func() {
+		if gzipWriter != nil {
+			gzipWriter.Close()
+		}
+	}()
+
+	written, err := io.Copy(gzipWriter, ar)
+	if err != io.EOF && err != nil {
+		f.Close()
+		os.Remove(f.Name())
+
+		msg := fmt.Sprintf("Fail to write layer stream to tmpfile: %s", err.Error())
+		log.Info(msg)
+		return nil, nil, fmt.Errorf(msg)
+	}
+
+	// Close the file to finalize the gz file
+	gzipWriter.Flush()
+	f.Sync()
+	f.Close()
+
+	lf, err := os.Open(f.Name())
+	if err != nil {
+		return nil, nil, err
+	}
+	stream.layerFile = lf
+	stream.size = written
+	stream.digest = fmt.Sprintf("%x", blobSum.Sum(nil))
+
+	log.Infof("Read stream: %#v", stream)
+
+	return stream, lf, nil
+}
+
+// Close closes and clears out the archive reader
+func (a *ArchiveStream) Close() {
+	if a.layerFile == nil {
+		return
+	}
+
+	log.Infof("Closing stream for layer %s", a.layerID)
+	a.layerFile.Close()
+	// os.Remove(a.layerFile.Name())
 }

--- a/lib/imagec/upload.go
+++ b/lib/imagec/upload.go
@@ -1,0 +1,149 @@
+// Copyright 2017 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissi[ons and
+// limitations under the License.
+
+package imagec
+
+import (
+	"context"
+
+	log "github.com/Sirupsen/logrus"
+
+	"github.com/docker/docker/distribution/xfer"
+	"github.com/docker/docker/pkg/progress"
+	"github.com/docker/docker/pkg/streamformatter"
+
+	"github.com/vmware/vic/pkg/trace"
+)
+
+// LayerUploader uploads layers
+type LayerUploader struct {
+	tm xfer.TransferManager
+}
+
+type uploadTransfer struct {
+	xfer.Transfer
+
+	err error
+}
+
+const (
+	maxUploadAttempts    = 5
+	maxConcurrentUploads = 3
+)
+
+// NewLayerUploader creates a new LayerUploader
+func NewLayerUploader() *LayerUploader {
+	return &LayerUploader{
+		tm: xfer.NewTransferManager(maxConcurrentUploads),
+	}
+}
+
+// UploadLayers starts the upload of all layers contained in the ImageC argument
+func (lum *LayerUploader) UploadLayers(ctx context.Context, ic *ImageC) error {
+	defer trace.End(trace.Begin(""))
+
+	var (
+		uploads        []*uploadTransfer
+		currTransfer   = make(map[string]*uploadTransfer)
+		sf             = streamformatter.NewJSONStreamFormatter()
+		progressOutput = &serialProgressOutput{
+			c:   make(chan prog, 100),
+			out: sf.NewProgressOutput(ic.Outstream, false),
+		}
+	)
+
+	go progressOutput.run()
+	defer progressOutput.stop()
+
+	pusher := ic.Pusher
+	log.Infof("There are %d layers to upload", len(pusher.streamMap))
+	for _, stream := range pusher.streamMap {
+		progress.Update(progressOutput, stream.layerID, "Preparing")
+
+		// Check if already uploading
+		if _, present := currTransfer[stream.layerID]; present {
+			continue
+		}
+
+		log.Infof("Making transfer function for %s...", stream.layerID)
+		xferFunc := lum.makeUploadFunc(ic, stream.layerID)
+		log.Infof("Starting transfer... function = %#v", xferFunc)
+		upload, watcher := lum.tm.Transfer(stream.layerID, xferFunc, progressOutput)
+		log.Infof("Tracking transfer...")
+		defer upload.Release(watcher)
+		uploads = append(uploads, upload.(*uploadTransfer))
+		currTransfer[stream.layerID] = upload.(*uploadTransfer)
+	}
+
+	for _, upload := range uploads {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-upload.Transfer.Done():
+			if upload.err != nil {
+				return upload.err
+			}
+		}
+	}
+
+	return nil
+}
+
+func (lum *LayerUploader) makeUploadFunc(ic *ImageC, layerID string) xfer.DoFunc {
+	return func(progressChan chan<- progress.Progress, start <-chan struct{}, inactive chan<- struct{}) xfer.Transfer {
+		u := &uploadTransfer{
+			Transfer: xfer.NewTransfer(),
+		}
+
+		log.Infof("Getting stream reader from upload function")
+		aStream, reader, err := ic.Pusher.GetReaderForLayer(layerID)
+		if err != nil {
+			u.err = err
+			return u
+		}
+
+		go func() {
+			select {
+			case <-u.Transfer.Done():
+				reader.Close()
+			}
+		}()
+
+		go func() {
+			log.Info("About to upload...")
+			defer func() {
+				close(progressChan)
+				aStream.Close()
+			}()
+
+			progressOutput := progress.ChanOutput(progressChan)
+
+			select {
+			case <-start:
+			default:
+				progress.Update(progressOutput, layerID, "Waiting")
+				<-start
+			}
+
+			// PushImageBlob will handle retries and backoff
+			err := PushImageBlob(u.Transfer.Context(), ic.Options, aStream, reader, progressOutput)
+			if err != nil {
+				log.Errorf("Error pushing image blob for %s/%s: %s", ic.Image, layerID, err)
+				return
+			}
+		}()
+
+		return u
+	}
+}

--- a/tests/test-cases/Group3-Docker-Compose/3-04-Docker-Compose-Test.robot
+++ b/tests/test-cases/Group3-Docker-Compose/3-04-Docker-Compose-Test.robot
@@ -1,3 +1,17 @@
+# Copyright 2017 VMware, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#	http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License
+
 *** Settings ***
 Documentation  Test 3-04 - Docker Compose Test
 Resource  ../../resources/Util.robot


### PR DESCRIPTION
Added ability to build image/manifest and pull layer tars to support docker push.

- Implemented PushImage which mirrors PullImage.
- Refactored some imagec.go to make code easier to read/understand and reuse
- Added manifest building using Sophies's initial work as base.
- Added an upload manager based on Docker's upload manager.
- Added ability to pull layer diff tars from the new archive streamers.
- Added Cheng's initial backend work.
- Refactored the archive streamers out of container proxy in order for other
  code to get access to them.

Resolves #5312 and #4754