### PR TITLE
[full ci] Limit the number of soap requests in flight

### DIFF
--- a/lib/portlayer/exec/container.go
+++ b/lib/portlayer/exec/container.go
@@ -596,6 +596,8 @@ func (c *Container) Remove(ctx context.Context, sess *session.Session) error {
 				log.Errorf("Error while attempting to unregister container VM: %s", err)
 				return err
 			}
+		case *types.ConcurrentAccess:
+			log.Warnf("DeleteExceptDisks failed with ConcurrentAccess error. Ignoring it.")
 		default:
 			log.Debugf("Fault while attempting to destroy vm: %#v", f.Fault())
 			c.updateState(existingState)

--- a/lib/portlayer/exec/container.go
+++ b/lib/portlayer/exec/container.go
@@ -597,6 +597,8 @@ func (c *Container) Remove(ctx context.Context, sess *session.Session) error {
 				return err
 			}
 		case *types.ConcurrentAccess:
+			// We are getting ConcurrentAccess errors from DeleteExceptDisks - even though we don't set ChangeVersion in that path
+			// We are ignoring the error because in reality the operation finishes successfully.
 			log.Warnf("DeleteExceptDisks failed with ConcurrentAccess error. Ignoring it.")
 		default:
 			log.Debugf("Fault while attempting to destroy vm: %#v", f.Fault())

--- a/pkg/vsphere/datastore/datastore.go
+++ b/pkg/vsphere/datastore/datastore.go
@@ -100,6 +100,14 @@ func NewHelperFromURL(ctx context.Context, s *session.Session, u *url.URL) (*Hel
 	return d, nil
 }
 
+func NewHelperFromSession(ctx context.Context, s *session.Session) *Helper {
+	return &Helper{
+		ds: s.Datastore,
+		s:  s,
+		fm: object.NewFileManager(s.Vim25()),
+	}
+}
+
 // GetDatastores returns a map of datastores given a map of names and urls
 func GetDatastores(ctx context.Context, s *session.Session, dsURLs map[string]*url.URL) (map[string]*Helper, error) {
 	stores := make(map[string]*Helper)

--- a/pkg/vsphere/session/session.go
+++ b/pkg/vsphere/session/session.go
@@ -26,7 +26,10 @@ package session
 
 import (
 	"fmt"
+	"net/http"
 	"net/url"
+	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -45,6 +48,10 @@ import (
 	"github.com/vmware/vic/lib/config"
 	"github.com/vmware/vic/pkg/errors"
 	"github.com/vmware/vic/pkg/vsphere/extraconfig"
+)
+
+const (
+	defaultMaxInFlight = 16
 )
 
 // Config contains the configuration used to create a Session.
@@ -84,6 +91,32 @@ type Session struct {
 	VMFolder *object.Folder
 
 	Finder *find.Finder
+}
+
+// RoundTripFunc alias
+type RoundTripFunc func(*http.Request) (*http.Response, error)
+
+// RoundTrip method
+func (rt RoundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) {
+	return rt(r)
+}
+
+// LimitConcurrency limits how many requests can be processed at once
+func LimitConcurrency(rt http.RoundTripper, limit int) http.RoundTripper {
+	limiter := make(chan struct{}, limit)
+
+	return RoundTripFunc(func(r *http.Request) (*http.Response, error) {
+		// reserve a slot
+		limiter <- struct{}{}
+
+		// free the slot
+		defer func() {
+			<-limiter
+		}()
+
+		// use the given round tripper
+		return rt.RoundTrip(r)
+	})
 }
 
 // NewSession creates a new Session struct. If config is nil,
@@ -180,8 +213,19 @@ func (s *Session) Connect(ctx context.Context) (*Session, error) {
 
 	soapClient.SetThumbprint(soapURL.Host, s.Thumbprint)
 
-	// TODO: option to set http.Client.Transport.TLSClientConfig.RootCAs
+	maxInFlight := defaultMaxInFlight
+	if e := os.Getenv("VIC_MAX_IN_FLIGHT"); e != "" {
+		if i, err := strconv.Atoi(e); err == nil {
+			maxInFlight = i
+		}
+	}
+	// Limit the concurrenty of SOAP requests
+	if t, ok := soapClient.Transport.(*http.Transport); ok {
+		t.MaxIdleConnsPerHost = maxInFlight
+	}
+	soapClient.Transport = LimitConcurrency(soapClient.Transport, maxInFlight)
 
+	// TODO: option to set http.Client.Transport.TLSClientConfig.RootCAs
 	vimClient, err := vim25.NewClient(ctx, soapClient)
 	if err != nil {
 		return nil, SoapClientError{

--- a/pkg/vsphere/tasks/waiter.go
+++ b/pkg/vsphere/tasks/waiter.go
@@ -121,7 +121,6 @@ func isRetryError(op trace.Operation, err error) bool {
 		default:
 			logSoapFault(op, f)
 			return false
-
 		}
 	}
 
@@ -154,20 +153,18 @@ func isRetryError(op trace.Operation, err error) bool {
 			return true
 		default:
 			logFault(op, err.Fault())
+			return false
 		}
 	default:
-		if f, ok := err.(types.HasFault); ok {
-			logFault(op, f.Fault())
-		} else {
-			// retry the temporary errors
-			t, ok := err.(temporary)
-			if ok && t.Temporary() {
-				return true
-			}
-			logError(op, err)
+		// retry the temporary errors
+		t, ok := err.(temporary)
+		if ok && t.Temporary() {
+			logExpectedError(op, err)
+			return true
 		}
+		logError(op, err)
+		return false
 	}
-	return false
 }
 
 // Helper Functions
@@ -185,4 +182,8 @@ func logError(op trace.Operation, err error) {
 
 func logExpectedFault(op trace.Operation, kind string, fault interface{}) {
 	op.Debugf("task retry on expected %s fault: %#v", kind, fault)
+}
+
+func logExpectedError(op trace.Operation, err error) {
+	op.Debugf("task retry on expected error %s", err)
 }

--- a/pkg/vsphere/tasks/waiter.go
+++ b/pkg/vsphere/tasks/waiter.go
@@ -61,7 +61,6 @@ func Wait(ctx context.Context, f func(context.Context) (Task, error)) error {
 //    })
 func WaitForResult(ctx context.Context, f func(context.Context) (Task, error)) (*types.TaskInfo, error) {
 	var err error
-	var info *types.TaskInfo
 	var backoffFactor int64 = 1
 
 	op, err := trace.FromContext(ctx)
@@ -71,10 +70,11 @@ func WaitForResult(ctx context.Context, f func(context.Context) (Task, error)) (
 
 	for {
 		var t Task
+		var info *types.TaskInfo
+
 		if t, err = f(op); err == nil {
-			info, err = t.WaitForResult(op, nil)
-			if err == nil {
-				return info, err
+			if info, err = t.WaitForResult(op, nil); err == nil {
+				return info, nil
 			}
 		}
 

--- a/pkg/vsphere/tasks/waiter.go
+++ b/pkg/vsphere/tasks/waiter.go
@@ -169,11 +169,11 @@ func isRetryError(op trace.Operation, err error) bool {
 
 // Helper Functions
 func logFault(op trace.Operation, fault types.BaseMethodFault) {
-	op.Errorf("unexpected fault on task retry : %#v", fault)
+	op.Errorf("unexpected fault on task retry: %#v", fault)
 }
 
 func logSoapFault(op trace.Operation, fault types.AnyType) {
-	op.Debugf("unexpected soap fault on task retry : %s", fault)
+	op.Debugf("unexpected soap fault on task retry: %s", fault)
 }
 
 func logError(op trace.Operation, err error) {

--- a/pkg/vsphere/vm/vm.go
+++ b/pkg/vsphere/vm/vm.go
@@ -29,7 +29,6 @@ import (
 
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/property"
-	"github.com/vmware/govmomi/task"
 	"github.com/vmware/govmomi/vim25/methods"
 	"github.com/vmware/govmomi/vim25/mo"
 	"github.com/vmware/govmomi/vim25/types"
@@ -265,19 +264,7 @@ func (vm *VirtualMachine) DeleteExceptDisks(ctx context.Context) (*object.Task, 
 	disks := devices.SelectByType(&types.VirtualDisk{})
 	err = vm.RemoveDevice(ctx, true, disks...)
 	if err != nil {
-		switch f := err.(type) {
-		case task.Error:
-			switch f.Fault().(type) {
-			case *types.ConcurrentAccess:
-				log.Errorf("RemoveDevice failed for %s with ConcurrentAccess error. Ignoring it", vm)
-			default:
-				log.Errorf("RemoveDevice failed for %s", vm)
-				return nil, err
-			}
-		default:
-			log.Errorf("RemoveDevice failed for %s", vm)
-			return nil, err
-		}
+		return nil, err
 	}
 
 	return vm.Destroy(ctx)


### PR DESCRIPTION
Otherwise ESXi starts to kick us out and most of the portlayer code
cannot handle the error and fails to reconnect as of this moment.

This also protects ESXi from us.

Problem found while testing with following;

```bash
#!/bin/bash
COUNT=50

docker pull busybox

for i in $(seq $COUNT);
do
    docker create -t --name $i busybox /bin/sleep $i > /dev/null &
done

read -p "Press any key to continue"

for i in $(seq $COUNT);
do
    docker rm $i > /dev/null &
done
```

Helps #1723
Helps #5157
