### PR TITLE
[specific ci=1-42-Docker-Push] Add cross repository blob mount to docker push

### DIFF
--- a/cmd/imagec/main.go
+++ b/cmd/imagec/main.go
@@ -167,11 +167,18 @@ func main() {
 
 		ic := imagec.NewImageC(options, streamformatter.NewJSONStreamFormatter(), nil)
 		if err := ic.PullImage(); err != nil {
-			log.Fatalf("Pulling image failed due to %s\n", err)
+			log.Fatalf("Pulling image failed: %s", err)
 		}
 	} else if imageCOptions.operation == PushImage {
-		log.Errorf("The operation '%s' is not implemented\n", PushImage)
+		options := imageCOptions.options
+
+		options.Outstream = os.Stdout
+
+		ic := imagec.NewImageC(options, streamformatter.NewJSONStreamFormatter(), nil)
+		if err := ic.PushImage(); err != nil {
+			log.Fatalf("Pushing image failed: %s", err)
+		}
 	} else {
-		log.Errorf("The operation '%s' is not valid\n", imageCOptions.operation)
+		log.Errorf("The operation '%s' is not valid", imageCOptions.operation)
 	}
 }

--- a/lib/imagec/docker.go
+++ b/lib/imagec/docker.go
@@ -49,6 +49,8 @@ const (
 	// DigestSHA256EmptyTar is the canonical sha256 digest of empty tar file -
 	// (1024 NULL bytes)
 	DigestSHA256EmptyTar = string(dlayer.DigestSHA256EmptyTar)
+
+	MaxMountAttempts = 4
 )
 
 // FSLayer is a container struct for BlobSums defined in an image manifest
@@ -474,13 +476,9 @@ func getManifestDigest(content []byte, ref reference.Named) (string, error) {
 	log.Debugf("Manifest Digest: %v", digest)
 	return string(digest), nil
 }
-
 func PushImageBlob(ctx context.Context, options Options, as *ArchiveStream, layerReader io.ReadCloser, po progress.Output) (err error) {
 	defer trace.End(trace.Begin(options.Image))
 
-	// input arguments from caller:
-	// diffID: the sha256sum of decompressed layer
-	//diffID := "sha256:27144aa8f1b9e066514d7f765909367584e552915d0d4bc2f5b7438ba7d1033a"
 	layerID := ShortID(as.layerID)
 
 	// The workflow: (https://docs.docker.com/registry/spec/api/#pushing-an-image)
@@ -518,27 +516,7 @@ func PushImageBlob(ctx context.Context, options Options, as *ArchiveStream, laye
 		return nil
 	}
 
-	// obtain a list of repositories for cross repo blob mount
-	oauthURL, err := LearnAuthURLForRepoList(options, po)
-	if err != nil {
-		return err
-	}
-
-	token, err := FetchToken(ctx, options, oauthURL, po)
-	if err != nil {
-		return fmt.Errorf("failed to fetch OAuth token: %s", err)
-	}
-
-	transporterForRepoList := urlfetcher.NewURLTransporter(urlfetcher.Options{
-		Timeout:            options.Timeout,
-		Username:           options.Username,
-		Password:           options.Password,
-		Token:              token,
-		InsecureSkipVerify: options.InsecureSkipVerify,
-		RootCAs:            options.RegistryCAs,
-	})
-
-	repoList, err := ObtainRepoList(transporterForRepoList, options, po)
+	repoList, err := ObtainSourceRepoList(as.layerID, options.Reference)
 	if err != nil {
 		log.Errorf("Failed to fetch repo list: %s", err)
 	} else {
@@ -548,7 +526,6 @@ func PushImageBlob(ctx context.Context, options Options, as *ArchiveStream, laye
 				return fmt.Errorf("failed during CrossRepoBlobMount: %s", err)
 			}
 			if mounted {
-				progress.Update(po, layerID, "Layer already mounted")
 				return nil
 			}
 		}
@@ -563,20 +540,56 @@ func PushImageBlob(ctx context.Context, options Options, as *ArchiveStream, laye
 	}
 	log.Infof("The upload url is: %s", uploadURL)
 
-	defer func() {
-		if err != nil {
-			if err2 := CancelUpload(ctx, transporter, uploadURL, po); err2 != nil {
-				log.Errorf("Failed during CancelUpload: %s", err2)
-			}
-		}
-	}()
-
 	if err = UploadLayer(ctx, transporter, pushDigest, uploadURL, layerReader, po); err != nil {
+		if err2 := CancelUpload(ctx, transporter, uploadURL, po); err2 != nil {
+			log.Errorf("Failed during CancelUpload: %s", err2)
+		}
 		return err
 	}
 	progress.Update(po, layerID, "Pushed")
 
 	return nil
+}
+
+func ObtainSourceRepoList(layerID string, targetRepo reference.Named) ([]string, error) {
+	defer trace.End(trace.Begin(layerID))
+
+	layer, err := LayerCache().Get(layerID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to obtain source repo list: %s", err)
+	}
+	if layer.V2Meta == nil || len(layer.V2Meta) == 0 {
+		log.Debugf("layer.V2Meta does not exist or is empty")
+		return nil, nil
+	}
+
+	var repoList []string
+	var repo string
+
+	for _, meta := range layer.V2Meta {
+		repo = meta.SourceRepository
+
+		// Do not consider repos not in the same registry
+		sourceRepo, err := reference.ParseNamed(meta.SourceRepository)
+		if err != nil || targetRepo.Hostname() != sourceRepo.Hostname() {
+			continue
+		}
+		// Do not consider the target repository
+		if repo == targetRepo.FullName() {
+			continue
+		}
+		repoList = append(repoList, sourceRepo.RemoteName())
+	}
+
+	if repoList != nil && len(repoList) > MaxMountAttempts {
+		repoList = append(repoList[:MaxMountAttempts-1])
+	}
+
+	if repoList != nil {
+		log.Debugf("RepoList: %+v", repoList)
+	}
+
+	return repoList, nil
 }
 
 func CrossRepoBlobMount(ctx context.Context, layerID, digest string, options Options, repoList []string, po progress.Output) (bool, error) {
@@ -627,6 +640,7 @@ func CrossRepoBlobMount(ctx context.Context, layerID, digest string, options Opt
 		}
 		if mounted {
 			progress.Updatef(po, layerID, "Mounted from %s", repo)
+			log.Debugf("Layer %s mounted from %s", layerID, repo)
 			break
 		}
 	}
@@ -666,37 +680,6 @@ func LearnAuthURLForPush(options Options, po progress.Output) (*url.URL, error) 
 
 	if err != nil {
 		return nil, err
-	}
-
-	if err == nil && transporter.IsStatusUnauthorized() {
-		return transporter.ExtractOAuthURL(hdr.Get("www-authenticate"), url)
-	}
-
-	return nil, fmt.Errorf("Unexpected http code: %d, URL: %s", transporter.Status(), url)
-}
-
-func LearnAuthURLForRepoList(options Options, po progress.Output) (*url.URL, error) {
-	defer trace.End(trace.Begin(options.Reference.String()))
-
-	url, err := url.Parse(options.Registry)
-	if err != nil {
-		return nil, err
-	}
-
-	url.Path = path.Join(url.Path, "_catalog")
-	log.Debugf("obtainRepolist URL: %s", url)
-
-	transporter := urlfetcher.NewURLTransporter(urlfetcher.Options{
-		Timeout:            options.Timeout,
-		Username:           options.Username,
-		Password:           options.Password,
-		InsecureSkipVerify: options.InsecureSkipVerify,
-		RootCAs:            options.RegistryCAs,
-	})
-
-	hdr, err := transporter.GetHeaderOnly(ctx, url, nil, po)
-	if err != nil {
-		return nil, fmt.Errorf("failed to fetch auth url for ObtainRepoList: %s", err)
 	}
 
 	if err == nil && transporter.IsStatusUnauthorized() {
@@ -751,43 +734,6 @@ func LearnAuthURLForBlobMount(options Options, digest, repo string, po progress.
 	}
 
 	return nil, fmt.Errorf("Unexpected http code: %d, URL: %s", transporter.Status(), composedURL)
-}
-
-func ObtainRepoList(transporter *urlfetcher.URLTransporter, options Options, po progress.Output) ([]string, error) {
-	defer trace.End(trace.Begin(options.Reference.String()))
-
-	url, err := url.Parse(options.Registry)
-	if err != nil {
-		return nil, err
-	}
-
-	url.Path = path.Join(url.Path, "_catalog")
-	log.Debugf("obtainRepolist URL: %s", url)
-
-	_, data, err := transporter.GetBytes(ctx, url, nil, po)
-	if err != nil {
-		return nil, fmt.Errorf("failed to fetch repo list: %s", err)
-	}
-
-	if transporter.IsStatusOK() {
-		log.Debugf("ObtainRepoList: %+v", data)
-
-		var dat map[string][]string
-
-		if err = json.Unmarshal(data, &dat); err != nil {
-			return nil, fmt.Errorf("failed to unmarshal repo list: %s", err)
-		}
-
-		log.Debugf("The repo list is %+v", dat["repositories"])
-		return dat["repositories"], nil
-	}
-
-	if transporter.IsStatusUnauthorized() {
-		// it is possible that the current user does not have enough permission, so return nil
-		return nil, nil
-	}
-
-	return nil, fmt.Errorf("Unexpected http code: %d, URL: %s", transporter.Status(), url)
 }
 
 // PutImageManifest simply pushes the manifest up to the registry.

--- a/lib/imagec/docker.go
+++ b/lib/imagec/docker.go
@@ -1018,6 +1018,7 @@ func getManifestSchema2Reader(manifest schema2.Manifest) (io.Reader, *schema2.De
 	}
 
 	data, err := dm.MarshalJSON()
+	//data, err := json.Marshal(manifest)
 	if err != nil {
 		msg := fmt.Sprintf("unable to marshal DeserializedManifest: %s", err)
 		log.Error(msg)

--- a/lib/imagec/docker.go
+++ b/lib/imagec/docker.go
@@ -34,12 +34,12 @@ import (
 	"github.com/docker/distribution/manifest/schema2"
 	dlayer "github.com/docker/docker/layer"
 	"github.com/docker/docker/pkg/archive"
+	"github.com/docker/docker/pkg/ioutils"
 	"github.com/docker/docker/pkg/progress"
 	"github.com/docker/docker/pkg/stringid"
 	"github.com/docker/docker/reference"
 	"github.com/docker/libtrust"
 
-	"github.com/docker/docker/pkg/ioutils"
 	urlfetcher "github.com/vmware/vic/pkg/fetcher"
 	registryutils "github.com/vmware/vic/pkg/registry"
 	"github.com/vmware/vic/pkg/trace"

--- a/lib/imagec/imagec.go
+++ b/lib/imagec/imagec.go
@@ -944,7 +944,7 @@ func (p *Pusher) GetReaderForLayer(layerID string) (*ArchiveStream, io.ReadClose
 	}
 	stream.layerFile = lf
 	stream.size = written
-	stream.digest = fmt.Sprintf("%x", blobSum.Sum(nil))
+	stream.digest = fmt.Sprintf("sha256:%x", blobSum.Sum(nil))
 
 	log.Infof("Read stream: %#v", stream)
 

--- a/lib/imagec/imagec_test.go
+++ b/lib/imagec/imagec_test.go
@@ -33,12 +33,16 @@ import (
 	"github.com/docker/distribution"
 	"github.com/docker/distribution/digest"
 	"github.com/docker/distribution/manifest/schema2"
+	dmetadata "github.com/docker/docker/distribution/metadata"
 	"github.com/docker/docker/pkg/streamformatter"
 	"github.com/docker/docker/reference"
 	"github.com/stretchr/testify/assert"
 
+	"github.com/vmware/vic/lib/apiservers/engine/backends/cache"
 	"github.com/vmware/vic/lib/apiservers/portlayer/models"
+	"github.com/vmware/vic/lib/portlayer/storage"
 	urlfetcher "github.com/vmware/vic/pkg/fetcher"
+	"github.com/vmware/vic/pkg/uid"
 )
 
 const (
@@ -742,4 +746,73 @@ func TestPrepareManifestAndLayers(t *testing.T) {
 		assert.Equal(t, expectedManifest.SchemaVersion, actualManifest.SchemaVersion, "Schema version of the manifest.Versioned is incorrect for mock #%d", i)
 
 	}
+}
+
+func TestUpdateV2MetaData(t *testing.T) {
+	layerCache = &LCache{
+		layers: make(map[string]*ImageWithMeta),
+	}
+
+	// Add some fake data to the layer cache
+	layer1 := &ImageWithMeta{
+		Image: &models.Image{
+			ID:     uid.New().String(),
+			Parent: storage.Scratch.ID,
+		},
+		V2Meta: []dmetadata.V2Metadata{{
+			SourceRepository: "docker.io/library/busybox",
+		}},
+	}
+	layerCache.Add(layer1)
+
+	layer2 := &ImageWithMeta{
+		Image: &models.Image{
+			ID:     uid.New().String(),
+			Parent: layer1.ID,
+		},
+		V2Meta: []dmetadata.V2Metadata{{
+			SourceRepository: "docker.io/library/busybox",
+		}},
+	}
+	layerCache.Add(layer2)
+
+	ref, err := reference.ParseNamed("busybox:latest")
+	if err != nil {
+		t.Error(err.Error())
+	}
+	imageID := uid.New()
+
+	err = cache.RepositoryCache().AddReference(ref, imageID.String(), false, layer2.ID, false)
+	if err != nil {
+		t.Error(err.Error())
+	}
+
+	err = cache.RepositoryCache().AddReference(ref, imageID.String(), false, layer1.ID, false)
+	if err != nil {
+		t.Error(err.Error())
+	}
+
+	// try to update V2MetaData
+	newSourceRepo := "docker.io/library/busybox"
+
+	err = UpdateV2MetaData(ref, newSourceRepo)
+	assert.NoError(t, err, "UpdataeV2MetaData failed: %s", err)
+
+	l1, err := LayerCache().Get(layer1.ID)
+	if err != nil {
+		t.Error(err.Error())
+	}
+	assert.Equal(t, 1, len(l1.V2Meta), "The number of source repositories should be one!")
+
+	// try to update V2MetaData
+	newSourceRepo = "docker.io/test/anotherBusybox"
+
+	err = UpdateV2MetaData(ref, newSourceRepo)
+	assert.NoError(t, err, "UpdataeV2MetaData failed: %s", err)
+
+	l2, err := LayerCache().Get(layer2.ID)
+	if err != nil {
+		t.Error(err.Error())
+	}
+	assert.Equal(t, 2, len(l2.V2Meta), "The number of source repositories should be two!")
 }

--- a/lib/imagec/upload.go
+++ b/lib/imagec/upload.go
@@ -132,7 +132,7 @@ func (lum *LayerUploader) makeUploadFunc(ic *ImageC, layerID string) xfer.DoFunc
 			select {
 			case <-start:
 			default:
-				progress.Update(progressOutput, layerID, "Waiting")
+				progress.Update(progressOutput, ShortID(layerID), "Waiting")
 				<-start
 			}
 

--- a/lib/imagec/upload.go
+++ b/lib/imagec/upload.go
@@ -69,7 +69,7 @@ func (lum *LayerUploader) UploadLayers(ctx context.Context, ic *ImageC) error {
 	pusher := ic.Pusher
 	log.Infof("There are %d layers to upload", len(pusher.streamMap))
 	for _, stream := range pusher.streamMap {
-		progress.Update(progressOutput, stream.layerID, "Preparing")
+		progress.Update(progressOutput, ShortID(stream.layerID), "Preparing")
 
 		// Check if already uploading
 		if _, present := currTransfer[stream.layerID]; present {


### PR DESCRIPTION
- add `[]V2MetaData` (from vanilla docker) to `ImageWithMeta` to record the source repositories of each layer. Then we can obtain a list of source repositories to mount the layer from during docker push. If the layer to be uploaded can be mount from one of these source repos, there is no need to actually upload the layer to the original target repo. This is called `cross repository blob mount`.

- update the V2MetaData of each layer after an image has been successfully pulled or pushed.

- currently only the `SourceRepository` attribute in `V2MetaData` is used for `cross repo blob mount`. However, I leave `Digest` and `HMAC` there to be consistent with vanilla docker and for future optimization, since vanilla docker uses such information to choose the mount candidates from the list of source repos more intelligently and avoid unnecessary mount trials.