### PR TITLE
[skip ci] More unique names to limit collision possibilities

### DIFF
--- a/tests/manual-test-cases/Group5-Functional-Tests/5-1-Distributed-Switch.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-1-Distributed-Switch.robot
@@ -25,7 +25,7 @@ ${datacenter}=  ha-datacenter
 Test
     Log To Console  \nStarting test...
 
-    ${vc}=  Evaluate  'VC-' + str(random.randint(1000,9999))  modules=random
+    ${vc}=  Evaluate  'VC-' + str(random.randint(1000,9999)) + str(time.clock())  modules=random,time
     ${pid}=  Deploy Nimbus vCenter Server Async  ${vc}
     Set Suite Variable  ${VC}  ${vc}
 

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-2-Cluster.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-2-Cluster.robot
@@ -20,7 +20,7 @@ Suite Teardown  Run Keyword And Ignore Error  Nimbus Cleanup  ${list}
 *** Test Cases ***
 Test
     Log To Console  \nStarting test...
-    ${vc}=  Evaluate  'VC-' + str(random.randint(1000,9999))  modules=random
+    ${vc}=  Evaluate  'VC-' + str(random.randint(1000,9999)) + str(time.clock())  modules=random,time
     ${pid}=  Deploy Nimbus vCenter Server Async  ${vc}
 
     &{esxes}=  Deploy Multiple Nimbus ESXi Servers in Parallel  3  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}  ${ESX_VERSION}

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-5-Heterogeneous-ESXi.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-5-Heterogeneous-ESXi.robot
@@ -20,7 +20,7 @@ Suite Teardown  Run Keyword And Ignore Error  Nimbus Cleanup  ${list}
 *** Test Cases ***
 Test
     Log To Console  \nStarting test...
-    ${vc}=  Evaluate  'VC-' + str(random.randint(1000,9999))  modules=random
+    ${vc}=  Evaluate  'VC-' + str(random.randint(1000,9999)) + str(time.clock())  modules=random,time
     ${pid-vc}=  Deploy Nimbus vCenter Server Async  ${vc}
     Set Global Variable  @{list}  %{NIMBUS_USER}-${vc}
 

--- a/tests/resources/Nimbus-Util.robot
+++ b/tests/resources/Nimbus-Util.robot
@@ -22,20 +22,22 @@ ${NIMBUS_ESX_PASSWORD}  e2eFunctionalTest
 
 *** Keywords ***
 Fetch IP
-  [Arguments]  ${name}
-  ${out}=  Execute Command  nimbus-ctl ip %{NIMBUS_USER}-${name} | grep %{NIMBUS_USER}-${name}
-  Should Not Be Empty  ${out}
-  [Return]  ${out}
+    [Arguments]  ${name}
+    ${out}=  Execute Command  nimbus-ctl ip %{NIMBUS_USER}-${name} | grep %{NIMBUS_USER}-${name}
+    Should Not Be Empty  ${out}
+    ${len}=  Get Line Count  ${out}
+    Should Be Equal As Integers  ${len}  1
+    [Return]  ${out}
 
 Get IP
-  [Arguments]  ${name}
-  ${out}=  Wait Until Keyword Succeeds  10x  1 minute  Fetch IP  ${name}
-  ${ip}=  Fetch From Right  ${out}  ${SPACE}
-  [Return]  ${ip}
+    [Arguments]  ${name}
+    ${out}=  Wait Until Keyword Succeeds  10x  1 minute  Fetch IP  ${name}
+    ${ip}=  Fetch From Right  ${out}  ${SPACE}
+    [Return]  ${ip}
 
 Deploy Nimbus ESXi Server
     [Arguments]  ${user}  ${password}  ${version}=${ESX_VERSION}  ${tls_disabled}=True
-    ${name}=  Evaluate  'ESX-' + str(random.randint(1000,9999))  modules=random
+    ${name}=  Evaluate  'ESX-' + str(random.randint(1000,9999)) + str(time.clock())  modules=random,time
     Log To Console  \nDeploying Nimbus ESXi server: ${name}
     Open Connection  %{NIMBUS_GW}
     Wait Until Keyword Succeeds  2 min  30 sec  Login  ${user}  ${password}
@@ -85,7 +87,7 @@ Deploy Multiple Nimbus ESXi Servers in Parallel
     @{names}=  Create List
     ${num}=  Convert To Integer  ${number}
     :FOR  ${x}  IN RANGE  ${num}
-    \     ${name}=  Evaluate  'ESX-' + str(random.randint(1000,9999))  modules=random
+    \     ${name}=  Evaluate  'ESX-' + str(random.randint(1000,9999)) + str(time.clock())  modules=random,time
     \     Append To List  ${names}  ${name}
 
     Open Connection  %{NIMBUS_GW}
@@ -119,7 +121,7 @@ Deploy Multiple Nimbus ESXi Servers in Parallel
 
 Deploy Nimbus vCenter Server
     [Arguments]  ${user}  ${password}  ${version}=${VC_VERSION}
-    ${name}=  Evaluate  'VC-' + str(random.randint(1000,9999))  modules=random
+    ${name}=  Evaluate  'VC-' + str(random.randint(1000,9999)) + str(time.clock())  modules=random,time
     Log To Console  \nDeploying Nimbus vCenter server: ${name}
     Open Connection  %{NIMBUS_GW}
     Wait Until Keyword Succeeds  2 min  30 sec  Login  ${user}  ${password}
@@ -266,7 +268,7 @@ Create a VSAN Cluster
 Create a Simple VC Cluster
     [Arguments]  ${datacenter}=ha-datacenter  ${cluster}=cls  ${esx_number}=3  ${network}=True
     Log To Console  \nStarting simple VC cluster deploy...
-    ${vc}=  Evaluate  'VC-' + str(random.randint(1000,9999))  modules=random
+    ${vc}=  Evaluate  'VC-' + str(random.randint(1000,9999)) + str(time.clock())  modules=random,time
     ${pid}=  Deploy Nimbus vCenter Server Async  ${vc}
 
     &{esxes}=  Deploy Multiple Nimbus ESXi Servers in Parallel  ${esx_number}  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}  ${ESX_VERSION}
@@ -376,7 +378,7 @@ Get Vsphere Version
 
 Deploy Nimbus NFS Datastore
     [Arguments]  ${user}  ${password}  ${additional-args}=
-    ${name}=  Evaluate  'NFS-' + str(random.randint(1000,9999))  modules=random
+    ${name}=  Evaluate  'NFS-' + str(random.randint(1000,9999)) + str(time.clock())  modules=random,time
     Log To Console  \nDeploying Nimbus NFS server: ${name}
     Open Connection  %{NIMBUS_GW}
     Wait Until Keyword Succeeds  2 min  30 sec  Login  ${user}  ${password}


### PR DESCRIPTION
fixes #5539 

This test failed due to a name collision, which should not happen as nimbus has a globally, unique namespace across pods - but it did, because... nimbus. We already have lease limit set to 1 day now, so we should only need to reduce the likelihood of name collision within a single run during the day.  So now tack on a time constraint as well. In order for a collision to happen the following will need to occur:
1. previous test failed to cleanup
2. 1/10,000 chance
3. Test also runs at the exact same time (in nanoseconds)

We discussed in our meeting about attempting a delete of the name prior to creation, but that actually adds extra load on nimbus infra, so I opted not to go that route.