### PR TITLE
Resolve chown errors with missing tar headers [specific ci=Group1-Docker-Commands] 

### DIFF
--- a/lib/apiservers/engine/backends/archive_test.go
+++ b/lib/apiservers/engine/backends/archive_test.go
@@ -235,7 +235,7 @@ func TestFindArchiveReaders(t *testing.T) {
 					rebase:  "etc",
 					strip:   "etc",
 					exclude: []string{""},
-					include: "etc/",
+					include: "etc",
 				},
 			},
 		},

--- a/lib/archive/util.go
+++ b/lib/archive/util.go
@@ -97,7 +97,7 @@ func AddMountInclusionsExclusions(currentMount string, filter *FilterSpec, mount
 
 	if strings.HasPrefix(copyTarget, currentMount) && copyTarget != currentMount {
 		filter.Exclusions[""] = struct{}{}
-		filter.Inclusions[removeLeadingSlash(strings.TrimPrefix(copyTarget, currentMount))] = struct{}{}
+		filter.Inclusions[removeSlashes(strings.TrimPrefix(copyTarget, currentMount))] = struct{}{}
 	} else {
 		// this would be a mount that is after the target. It would mean we have to include root. then exclude any mounts after root.
 		filter.Inclusions[""] = struct{}{}
@@ -116,4 +116,10 @@ func AddMountInclusionsExclusions(currentMount string, filter *FilterSpec, mount
 // we use this to ensure relative pathing
 func removeLeadingSlash(path string) string {
 	return strings.TrimPrefix(path, "/")
+}
+
+// removeSlashes will remove a leading and trailing '/' from
+// the target path
+func removeSlashes(path string) string {
+	return strings.TrimPrefix(strings.TrimSuffix(path, "/"), "/")
 }

--- a/lib/portlayer/storage/vsphere/import.go
+++ b/lib/portlayer/storage/vsphere/import.go
@@ -79,7 +79,7 @@ offline:
 			}
 		}
 
-		online, err := v.newOnlineDataSink(op, o)
+		online, err := v.newOnlineDataSink(op, o, id)
 		if online != nil {
 			return online, err
 		}
@@ -106,8 +106,12 @@ func (v *VolumeStore) newDataSink(op trace.Operation, url *url.URL) (storage.Dat
 	return storage.NewMountDataSink(op, f, cleanFunc), nil
 }
 
-func (v *VolumeStore) newOnlineDataSink(op trace.Operation, owner *vm.VirtualMachine) (storage.DataSink, error) {
-	return nil, errors.New("online sink not yet supported - expecting this to be a common toolbox implementation")
+func (v *VolumeStore) newOnlineDataSink(op trace.Operation, owner *vm.VirtualMachine, id string) (storage.DataSink, error) {
+	return &ToolboxDataSink{
+		VM:    owner,
+		ID:    storage.Label(id),
+		Clean: func() { return },
+	}, nil
 }
 
 func (i *ImageStore) Import(op trace.Operation, id string, spec *archive.FilterSpec, tarStream io.ReadCloser) error {


### PR DESCRIPTION
Fixes #5715 and fixes #5716 

#### Background
During a CopyFrom, docker will throw chown errors if the destination directory doesn't exist, and the source directory header is not included in the tar archive.

e.g. 
```bash
$ al-docker cp nginx:/usr/share/nginx/html test1
$ al-docker cp nginx:/usr/share/nginx/html/ test2
chown /Users/morrisjason/go/src/github.com/vmware/vic/test2: operation not permitted
$
```

This pr fixes the second case, where directory headers were missing from the tar archive when a trailing slash was included in the source path. 
It also fixes the the auth bug that didn't allow online volume copies.

Fixes: #5716 