### PR TITLE
[specific ci=1-39-Docker-Stats] Sample vm metrics in sets of 50 vms

### DIFF
--- a/lib/apiservers/engine/backends/convert/stats.go
+++ b/lib/apiservers/engine/backends/convert/stats.go
@@ -163,7 +163,9 @@ func (cs *ContainerStats) Listen() *io.PipeWriter {
 						cs.config.Cancel()
 					}
 					// send the decoded metric for transform and encoding
-					metric <- vmm
+					if cs.IsListening() {
+						metric <- vmm
+					}
 				}
 			}
 		}

--- a/pkg/trace/operation.go
+++ b/pkg/trace/operation.go
@@ -112,6 +112,10 @@ func (o Operation) Err() error {
 	return nil
 }
 
+func (o *Operation) ID() string {
+	return o.id
+}
+
 func (o *Operation) Infof(format string, args ...interface{}) {
 	Logger.Infof("%s: %s", o.header(), fmt.Sprintf(format, args...))
 }


### PR DESCRIPTION
To avoid degraded performance vSphere recommends that calls to
performanceManager not exceed 50 ManagedObjectRefs.  The vm
metrics service will enforce that maximum.

This doesn't fix, but helps with #5290 
