### PR TITLE
Add tar stripper for combining tar streams [specific ci=1-43-Docker-CP-Offline]

### DIFF
--- a/lib/archive/stripper.go
+++ b/lib/archive/stripper.go
@@ -1,0 +1,156 @@
+// Copyright 2017 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package archive
+
+import (
+	"archive/tar"
+	"io"
+
+	"github.com/vmware/vic/pkg/trace"
+)
+
+// Stripper strips the end-of-archive entries from a tar stream
+type Stripper struct {
+	// op allows threaded tracing
+	op trace.Operation
+
+	// be opinionated about the type of the source
+	source *tar.Reader
+}
+
+// NewStripper returns a WriterTo that will strip the trailing end-of-archive bytes
+// from the supplied tar stream.
+// It implements io.Reader only so that it can be passed to io.Copy
+func NewStripper(op trace.Operation, reader *tar.Reader) *Stripper {
+	return &Stripper{
+		op:     op,
+		source: reader,
+	}
+}
+
+// Read is implemented solely so this can be provided to io.Copy as an io.Reader.
+// This works on the assumption of io.Copy making use of the WriterTo implementation.
+func (s *Stripper) Read(b []byte) (int, error) {
+	panic("io.Reader usage not supported - intended use is as io.WriterTo")
+}
+
+// WriteTo is the primary function, allowing easy use of the underlying tar stream without
+// requiring chunking and assocated tracking to another buffer size.
+func (s *Stripper) WriteTo(w io.Writer) (sum int64, err error) {
+	// TODO: should we nil s.source on error then handle a post-error call? What's the expected
+	// semantic?
+
+	tw := tar.NewWriter(w)
+
+	for {
+		var header *tar.Header
+		header, err = s.source.Next()
+		if err == io.EOF {
+			// do NOT call tarwriter.Close()
+			s.op.Debugf("Stripper dropping end of archive")
+			return
+		}
+
+		if err != nil {
+			s.op.Errorf("Error reading archive header: %s", err)
+			return
+		}
+
+		err = tw.WriteHeader(header)
+		if err != nil {
+			s.op.Errorf("Error writing tar header: %s", err)
+			return
+		}
+
+		var n int64
+		n, err = io.Copy(tw, s.source)
+		sum += n
+		if err != nil {
+			s.op.Errorf("Error copying file data: %s", err)
+			return
+		}
+
+		tw.Flush()
+	}
+}
+
+// eofReader copied from io package to support MultiWriterTo variant
+type eofReader struct{}
+
+func (eofReader) WriteTo(w io.Writer) (int64, error) {
+	return 0, io.EOF
+}
+
+func (eofReader) Read(b []byte) (int, error) {
+	return 0, io.EOF
+}
+
+func (eofReader) ReadFrom(r io.Reader) (int64, error) {
+	return 0, io.EOF
+}
+
+// multiStripper based off io.MultiReader but delegating to io.WriterTo
+// instead of performing buffer copy
+type multiReader struct {
+	readers []io.Reader
+}
+
+func (mr *multiReader) Read(p []byte) (n int, err error) {
+	panic("io.Reader usage not supported - intended use is as io.WriterTo")
+}
+
+func (mr *multiReader) WriteTo(w io.Writer) (sum int64, err error) {
+	for len(mr.readers) > 0 {
+		var n int64
+
+		n, err = io.Copy(w, mr.readers[0])
+		sum += n
+
+		// io.Copy strips EOF
+		if err == io.EOF || err == nil {
+			mr.readers[0] = eofReader{} // permit earlier GC
+			mr.readers = mr.readers[1:]
+		}
+
+		if n > 0 || err != io.EOF {
+			if err == io.EOF && len(mr.readers) > 0 {
+				// Don't return EOF yet. More readers remain.
+				err = nil
+				continue
+			}
+
+			break
+		}
+	}
+
+	if err == nil {
+		err = io.EOF
+	}
+	return
+}
+
+// Close allows this to be a Closer as well - specific to expected usage but necessary.
+func (mr *multiReader) Close() error {
+	return nil
+}
+
+// MultiReader is based off the io.MultiReader but will make use of WriteTo or
+// ReadFrom delegation and ONLY supports usage via the WriteTo method on itself.
+// It is specifically intended to be passed to io.Copy
+func MultiReader(readers ...io.Reader) io.ReadCloser {
+	r := make([]io.Reader, len(readers))
+	copy(r, readers)
+	return &multiReader{r}
+}

--- a/lib/archive/stripper_test.go
+++ b/lib/archive/stripper_test.go
@@ -1,0 +1,320 @@
+// Copyright 2017 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package archive
+
+import (
+	"archive/tar"
+	"context"
+	"fmt"
+	"io"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/vmware/vic/pkg/trace"
+	"github.com/vmware/vic/pkg/uid"
+)
+
+// generateArchive takes a number of files and a file size and generates a tar archive
+// based on that data. It returns:
+// index of entry names in the archive
+// archive byte stream
+func generateArchive(name string, num, size int) ([]string, io.Reader) {
+	r, w := io.Pipe()
+	tw := tar.NewWriter(w)
+
+	// stable reference for expected archive entries
+	index := make([]string, num)
+	for i := 0; i < num; i++ {
+		index[i] = string(uid.New())
+	}
+
+	// our file contents are zeros - this is the worst case for stripping trailing headers
+	zeros := make([]byte, size)
+
+	go func() {
+		for i := 0; i < num; i++ {
+			// we only really care about two things in the header
+			hdr := &tar.Header{
+				Name: index[i],
+				Size: int64(size),
+			}
+
+			fmt.Printf("Writing header for file %s:%d\n", name, i)
+			err := tw.WriteHeader(hdr)
+			if err != nil {
+				panic(err)
+			}
+
+			fmt.Printf("Writing data for file %s:%d\n", name, i)
+			n, err := tw.Write(zeros)
+			if err != nil {
+				panic(err)
+			}
+			if n != size {
+				panic(fmt.Sprintf("Failed to write all bytes: %d != %d", n, size))
+			}
+		}
+
+		// add the end-of-archive
+		tw.Close()
+		w.Close()
+	}()
+
+	return index, r
+}
+
+// TestSingleStripper ensures that basic function (stripping end-of-archive footer) works as
+// expected. I found no real way, when using the TarReader to actually assert that the footer
+// has been dropped so this is left to assert correct passthrough of archive data and the
+// dropping of the footer is asserted by the multistream cases.
+func TestSingleStripper(t *testing.T) {
+	size := 2048
+	count := 5
+	index, reader := generateArchive("single", count, size)
+
+	source := tar.NewReader(reader)
+	stripper := NewStripper(trace.NewOperation(context.Background(), "strip"), source)
+
+	pr, pw := io.Pipe()
+	tr := tar.NewReader(pr)
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		n, err := io.Copy(pw, stripper)
+		pw.Close()
+
+		wg.Done()
+		fmt.Printf("Done copying from stripper: %d, %s\n", n, err)
+		if !assert.Equal(t, io.EOF, err, "Expected EOF") {
+			t.FailNow()
+		}
+
+	}()
+
+	for i := 0; i <= len(index); i++ {
+		fmt.Printf("Reading header for file %d\n", i)
+		header, err := tr.Next()
+		if err == io.EOF {
+			fmt.Printf("End-of-file")
+			// TODO: is this pass or fail?
+			return
+		}
+
+		if err != nil {
+			fmt.Printf("Error from archive: %s\n", err)
+			t.FailNow()
+		}
+
+		if !assert.NotEqual(t, i, len(index), "Expected EOF after index exhausted") {
+			t.FailNow()
+		}
+
+		if !assert.Equal(t, header.Name, index[i], "Expected header name to match index") {
+			t.FailNow()
+		}
+		if !assert.Equal(t, header.Size, int64(size), "Expected file size in header to match target generated size") {
+			t.FailNow()
+		}
+
+		// make the buf just that little bit bigger to allow for errrors in the copy if they would occur
+		buf := make([]byte, size+10)
+
+		fmt.Printf("Reading data for file %d\n", i)
+		n, err := tr.Read(buf)
+
+		if !assert.NoError(t, err, "No expected errors from file data copy") {
+			t.FailNow()
+		}
+		if !assert.Equal(t, n, size, "Expected file data size to match target generated size") {
+			t.FailNow()
+		}
+	}
+
+	wg.Wait()
+}
+
+// TestConjoinedStrippers ensures that the footer is correctly dropped from a stripped archive
+// and that a TarReader continues to provide headers from the following conjoined streams.
+func TestConjoinedStrippers(t *testing.T) {
+	size := 2048
+	count := 3
+	multiplicity := 3
+
+	indices := make([][]string, multiplicity)
+	strippers := make([]io.Reader, multiplicity)
+
+	for m := 0; m < multiplicity; m++ {
+		var reader io.Reader
+		indices[m], reader = generateArchive(fmt.Sprintf("archive-%d", m), count, size)
+		source := tar.NewReader(reader)
+		strippers[m] = NewStripper(trace.NewOperation(context.Background(), fmt.Sprintf("strip-%d", m)), source)
+	}
+
+	conjoined := MultiReader(strippers...)
+
+	pr, pw := io.Pipe()
+	tr := tar.NewReader(pr)
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		n, err := io.Copy(pw, conjoined)
+		pw.Close()
+
+		wg.Done()
+		fmt.Printf("Done copying from strippers: %d, %s\n", n, err)
+		if !assert.Equal(t, io.EOF, err, "Expected EOF") {
+			t.FailNow()
+		}
+	}()
+
+	expectedEntries := count * multiplicity
+	for i := 0; i <= expectedEntries; i++ {
+		fmt.Printf("Reading header for file %d\n", i)
+		header, err := tr.Next()
+		if err == io.EOF {
+			fmt.Printf("End-of-file\n")
+			// TODO: is this pass or fail?
+			return
+		}
+
+		if err != nil {
+			fmt.Printf("Error from archive: %s\n", err)
+			t.FailNow()
+		}
+
+		if !assert.NotEqual(t, i, expectedEntries, "Expected EOF after index exhausted") {
+			t.FailNow()
+		}
+
+		member := i / count
+		entry := i % count
+
+		if !assert.Equal(t, header.Name, indices[member][entry], "Expected header name to match index") {
+			t.FailNow()
+		}
+		if !assert.Equal(t, header.Size, int64(size), "Expected file size in header to match target generated size") {
+			t.FailNow()
+		}
+
+		// make the buf just that little bit bigger to allow for errrors in the copy if they would occur
+		buf := make([]byte, size+10)
+
+		fmt.Printf("Reading data for file %d\n", i)
+		n, err := tr.Read(buf)
+
+		if !assert.NoError(t, err, "No expected errors from file data copy") {
+			t.FailNow()
+		}
+		if !assert.Equal(t, n, size, "Expected file data size to match target generated size") {
+			t.FailNow()
+		}
+	}
+
+	wg.Wait()
+}
+
+// TestConjoinedStrippersWithCloser ensures that we can conjoin readers, multiple strippers and a regular, in order to get
+// the end-of-archive footer as the finale. We have a wait group to ensure that all routines have finished before declaring
+// success.
+func TestConjoinedStrippersWithCloser(t *testing.T) {
+	size := 2048
+	count := 3
+	multiplicity := 3
+
+	indices := make([][]string, multiplicity)
+	readers := make([]io.Reader, multiplicity)
+
+	for m := 0; m < multiplicity; m++ {
+		var reader io.Reader
+		indices[m], reader = generateArchive(fmt.Sprintf("archive-%d", m), count, size)
+		source := tar.NewReader(reader)
+
+		if m < multiplicity-1 {
+			fmt.Printf("added stripper\n")
+			readers[m] = NewStripper(trace.NewOperation(context.Background(), fmt.Sprintf("strip-%d", m)), source)
+		} else {
+			fmt.Printf("added raw\n")
+			readers[m] = reader
+		}
+	}
+
+	conjoined := MultiReader(readers...)
+
+	pr, pw := io.Pipe()
+	tr := tar.NewReader(pr)
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		n, err := io.Copy(pw, conjoined)
+		pw.Close()
+
+		wg.Done()
+		fmt.Printf("Done copying from all sources: %d, %s\n", n, err)
+		if !assert.Equal(t, io.EOF, err, "Expected EOF") {
+			t.FailNow()
+		}
+	}()
+
+	expectedEntries := count * multiplicity
+	for i := 0; i <= expectedEntries; i++ {
+		fmt.Printf("Reading header for file %d\n", i)
+		header, err := tr.Next()
+		if err == io.EOF {
+			fmt.Printf("End-of-file\n")
+
+			wg.Wait()
+			return
+		}
+
+		if err != nil {
+			fmt.Printf("Error from archive: %s\n", err)
+			t.FailNow()
+		}
+
+		if !assert.NotEqual(t, i, expectedEntries, "Expected EOF after index exhausted") {
+			t.FailNow()
+		}
+
+		member := i / count
+		entry := i % count
+
+		if !assert.Equal(t, header.Name, indices[member][entry], "Expected header name to match index") {
+			t.FailNow()
+		}
+		if !assert.Equal(t, header.Size, int64(size), "Expected file size in header to match target generated size") {
+			t.FailNow()
+		}
+
+		// make the buf just that little bit bigger to allow for errrors in the copy if they would occur
+		buf := make([]byte, size+10)
+
+		fmt.Printf("Reading data for file %d\n", i)
+		n, err := tr.Read(buf)
+
+		if !assert.NoError(t, err, "No expected errors from file data copy") {
+			t.FailNow()
+		}
+		if !assert.Equal(t, n, size, "Expected file data size to match target generated size") {
+			t.FailNow()
+		}
+	}
+
+	wg.Wait()
+}

--- a/pkg/vsphere/disk/disk.go
+++ b/pkg/vsphere/disk/disk.go
@@ -258,6 +258,7 @@ func (d *VirtualDisk) Mount(op trace.Operation, options []string) (string, error
 		return "", err
 	}
 
+	opts := strings.Join(options, ";")
 	if !d.mounted() {
 		path, err := ioutil.TempDir("", "mnt")
 		if err != nil {
@@ -272,12 +273,12 @@ func (d *VirtualDisk) Mount(op trace.Operation, options []string) (string, error
 		}
 
 		d.mountPath = path
+		d.mountOpts = opts
 	} else {
 		// basic santiy check for matching options - we don't want to share a r/o mount
 		// if the request was for r/w. Ideally we'd just mount this at a different location with the
 		// requested options but that requires separate ref counting.
 		// TODO: support differing mount opts
-		opts := strings.Join(options, ";")
 		if d.mountOpts != opts {
 			op.Errorf("Unable to use mounted disk due to differing options: %s != %s", d.mountOpts, opts)
 			return "", fmt.Errorf("incompatible mount options for disk reuse")


### PR DESCRIPTION
Adds a tar aware stripper that drops the end of archive records. Adds a
multi reader that can expliot it.
