### PR TITLE
Fix broken docker diff

### DIFF
--- a/lib/apiservers/engine/backends/container.go
+++ b/lib/apiservers/engine/backends/container.go
@@ -1286,7 +1286,7 @@ func (c *Container) ContainerChanges(name string) ([]docker.Change, error) {
 		return nil, NotFoundError(name)
 	}
 
-	r, err := c.containerProxy.GetContainerChanges(op, vc, true)
+	r, err := c.containerProxy.GetContainerChanges(op, vc, false)
 	if err != nil {
 		return nil, InternalServerError(err.Error())
 	}
@@ -1307,7 +1307,6 @@ func (c *Container) ContainerChanges(name string) ([]docker.Change, error) {
 			return []docker.Change{}, InternalServerError(err.Error())
 		}
 
-		log.Infof("Got header %s", hdr.Name)
 		change := docker.Change{
 			Path: hdr.Name,
 		}

--- a/lib/archive/diff.go
+++ b/lib/archive/diff.go
@@ -42,7 +42,6 @@ func (c changesByPath) Swap(i, j int)      { c[j], c[i] = c[i], c[j] }
 
 // Diff produces a tar archive containing the differences between two filesystems
 func Diff(op trace.Operation, newDir, oldDir string, spec *FilterSpec, data bool, xattr bool) (io.ReadCloser, error) {
-
 	var err error
 	if spec == nil {
 		spec, err = CreateFilterSpec(op, nil)

--- a/lib/portlayer/storage/vsphere/container.go
+++ b/lib/portlayer/storage/vsphere/container.go
@@ -314,7 +314,10 @@ func (c *ContainerStore) Export(op trace.Operation, id, ancestor string, spec *a
 		return nil, errors.New("mismatched datasource types")
 	}
 
-	tar, err := archive.Diff(op, fl.Name(), fr.Name(), spec, data, false)
+	// if we want data, include the xattrs, otherwise assume diff
+	xattrs := !data
+
+	tar, err := archive.Diff(op, fl.Name(), fr.Name(), spec, data, xattrs)
 	if err != nil {
 		go closers()
 		return nil, err

--- a/lib/portlayer/storage/vsphere/container.go
+++ b/lib/portlayer/storage/vsphere/container.go
@@ -314,7 +314,7 @@ func (c *ContainerStore) Export(op trace.Operation, id, ancestor string, spec *a
 		return nil, errors.New("mismatched datasource types")
 	}
 
-	// if we want data, include the xattrs, otherwise assume diff
+	// if we want data, exclude the xattrs, otherwise assume diff
 	xattrs := !data
 
 	tar, err := archive.Diff(op, fl.Name(), fr.Name(), spec, data, xattrs)

--- a/lib/portlayer/storage/vsphere/export.go
+++ b/lib/portlayer/storage/vsphere/export.go
@@ -175,7 +175,7 @@ func (i *ImageStore) Export(op trace.Operation, id, ancestor string, spec *archi
 		return nil, fmt.Errorf("mismatched datasource types: %T, %T", ls, rs)
 	}
 
-	// if we want data, include the xattrs, otherwise assume diff
+	// if we want data, exclude the xattrs, otherwise assume diff
 	xattrs := !data
 
 	tar, err := archive.Diff(op, fl.Name(), fr.Name(), spec, data, xattrs)

--- a/lib/portlayer/storage/vsphere/export.go
+++ b/lib/portlayer/storage/vsphere/export.go
@@ -175,7 +175,10 @@ func (i *ImageStore) Export(op trace.Operation, id, ancestor string, spec *archi
 		return nil, fmt.Errorf("mismatched datasource types: %T, %T", ls, rs)
 	}
 
-	tar, err := archive.Diff(op, fl.Name(), fr.Name(), spec, data, false)
+	// if we want data, include the xattrs, otherwise assume diff
+	xattrs := !data
+
+	tar, err := archive.Diff(op, fl.Name(), fr.Name(), spec, data, xattrs)
 	if err != nil {
 		go closers()
 		return nil, err

--- a/pkg/vsphere/disk/disk_manager.go
+++ b/pkg/vsphere/disk/disk_manager.go
@@ -509,7 +509,7 @@ func (m *Manager) AttachAndMount(op trace.Operation, datastoreURI *object.Datast
 	}
 
 	// don't update access time - that would cause the diff operation to mutate the filesystem
-	opts := []string{"noatime", ""}
+	opts := []string{"noatime"}
 	if !persistent {
 		opts = append(opts, "ro")
 	}

--- a/pkg/vsphere/disk/disk_manager.go
+++ b/pkg/vsphere/disk/disk_manager.go
@@ -508,7 +508,14 @@ func (m *Manager) AttachAndMount(op trace.Operation, datastoreURI *object.Datast
 		return "", err
 	}
 
-	return d.Mount(op, nil)
+	// don't update access time - that would cause the diff operation to mutate the filesystem
+	opts := []string{"noatime", ""}
+	if !persistent {
+		opts = append(opts, "ro")
+	}
+
+	return d.Mount(op, opts)
+
 }
 
 // UnmountAndDetach unmounts and detaches a disk, subsequently cleaning the mount path


### PR DESCRIPTION
Xattrs were being excluded, which are required for diff to work. This fix adds the xattrs in all cases where the data is not requested (for now, just diff).