### PR TITLE
Initial integration tests for docker diff [specific ci=1-42-Docker-Diff]

### DIFF
--- a/lib/archive/diff.go
+++ b/lib/archive/diff.go
@@ -84,7 +84,6 @@ func Tar(op trace.Operation, dir string, changes []docker.Change, spec *FilterSp
 				op.Errorf("Error closing tar writer: %s", cerr.Error())
 			}
 			if err == nil {
-				op.Debugf("Closing down tar writer with clean exit: %s", cerr)
 				_ = w.CloseWithError(cerr)
 			} else {
 				op.Debugf("Closing down tar writer with error during tar: %s", err)

--- a/tests/test-cases/Group1-Docker-Commands/1-42-Docker-Diff.md
+++ b/tests/test-cases/Group1-Docker-Commands/1-42-Docker-Diff.md
@@ -1,0 +1,26 @@
+Test 1-42 - Docker Diff
+=======
+
+# Purpose:
+To verify that docker diff command is supported by VIC appliance
+
+# References:
+[1 - Docker Command Line Reference](https://docs.docker.com/engine/reference/commandline/diff/)
+
+# Environment:
+This test requires that a vSphere server is running and available
+
+# Test Steps:
+1. Deploy VIC appliance to vSphere server
+2. Issue docker create busybox /bin/sh -c "touch a b c; rm -rf /tmp; adduser -D krusty"
+3. Issue docker start <containerID> to the VIC appliance
+4. Issue docker diff <containerID> to the VIC appliance
+5. Verify a, b, c were created, /tmp was deleted and /etc/hosts was modified
+
+# Expected Outcome:
+* Step 2 should complete without error, and the response should be the containerID
+* Step 3 should run to completion without output
+* Step 4 should produce the expected output reflecting the container filesystem changes
+
+# Possible Problems:
+None

--- a/tests/test-cases/Group1-Docker-Commands/1-42-Docker-Diff.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-42-Docker-Diff.robot
@@ -1,0 +1,44 @@
+# Copyright 2017 VMware, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#	http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License
+
+*** Settings ***
+Documentation  Test 1-42 - Docker Diff
+Resource  ../../resources/Util.robot
+Suite Setup  Install VIC Appliance To Test Server
+Suite Teardown  Cleanup VIC Appliance On Test Server
+
+*** Test Cases ***
+Make changes to busybox image
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} pull busybox
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${id}=  Run And Return Rc And Output  docker %{VCH-PARAMS} create busybox /bin/sh -c "touch a b c; rm -rf /tmp; adduser -D krusty"
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${id}=  Run And Return Rc And Output  docker %{VCH-PARAMS} start ${id}
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} diff ${id}
+    Should Be Equal As Integers  ${rc}  0
+    Should Contain  ${output}  A a
+    Should Contain  ${output}  A b
+    Should Contain  ${output}  A c
+    Should Contain  ${output}  D tmp
+    Should Contain  ${output}  C /etc/passwd
+    Should Contain  ${output}  C etc
+    Should Contain  ${output}  C etc/group
+    Should Contain  ${output}  A etc/group-
+    Should Contain  ${output}  C etc/passwd
+    Should Contain  ${output}  A etc/passwd-
+    Should Contain  ${output}  C etc/shadow
+    Should Contain  ${output}  A etc/shadow-
+    Should Contain  ${output}  C home
+    Should Contain  ${output}  A home/krusty


### PR DESCRIPTION
We saw a regression in `docker diff` in the docker cp feature branch that was tricky to discover without a basic integration test. Raising the priority enough to add this basic test to prevent future regressions while we iterate.