### PR TITLE
Refactor archive proxy out of persona's backend

### DIFF
--- a/lib/apiservers/engine/backends/backends.go
+++ b/lib/apiservers/engine/backends/backends.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/vmware/vic/lib/apiservers/engine/backends/cache"
 	"github.com/vmware/vic/lib/apiservers/engine/backends/container"
+	vicproxy "github.com/vmware/vic/lib/apiservers/engine/proxy"
 	apiclient "github.com/vmware/vic/lib/apiservers/portlayer/client"
 	"github.com/vmware/vic/lib/apiservers/portlayer/client/containers"
 	"github.com/vmware/vic/lib/apiservers/portlayer/client/misc"
@@ -62,6 +63,7 @@ var (
 
 	vchConfig        dynConfig
 	RegistryCertPool *x509.CertPool
+	archiveProxy     vicproxy.VicArchiveProxy
 
 	eventService *events.Events
 )
@@ -131,6 +133,8 @@ func Init(portLayerAddr, product string, config *config.VirtualContainerHostConf
 		log.Errorf("Failed to create image store")
 		return err
 	}
+
+	archiveProxy = vicproxy.NewArchiveProxy(portLayerClient)
 
 	eventService = events.New()
 

--- a/lib/apiservers/engine/backends/container_proxy.go
+++ b/lib/apiservers/engine/backends/container_proxy.go
@@ -33,8 +33,6 @@ package backends
 
 import (
 	"context"
-	"encoding/base64"
-	"encoding/json"
 	"fmt"
 	"io"
 	"net"
@@ -96,9 +94,6 @@ type VicContainerProxy interface {
 	AttachStreams(ctx context.Context, ac *AttachConfig, stdin io.ReadCloser, stdout, stderr io.Writer) error
 	StreamContainerLogs(ctx context.Context, name string, out io.Writer, started chan struct{}, showTimestamps bool, followLogs bool, since int64, tailLines int64) error
 	StreamContainerStats(ctx context.Context, config *convert.ContainerStatsConfig) error
-
-	ArchiveExportReader(ctx context.Context, store, ancestorStore, deviceID, ancestor string, data bool, filterSpec archive.FilterSpec) (io.ReadCloser, error)
-	ArchiveImportWriter(ctx context.Context, store, deviceID string, filterSpec archive.FilterSpec) (io.WriteCloser, error)
 
 	Stop(vc *viccontainer.VicContainer, name string, seconds *int, unbound bool) error
 	State(vc *viccontainer.VicContainer) (*types.ContainerState, error)
@@ -700,161 +695,12 @@ func (c *ContainerProxy) GetContainerChanges(ctx context.Context, vc *viccontain
 		Exclusions: map[string]struct{}{},
 	}
 
-	r, err := c.ArchiveExportReader(ctx, constants.ContainerStoreName, host, vc.ContainerID, parent, data, spec)
+	r, err := archiveProxy.ArchiveExportReader(ctx, constants.ContainerStoreName, host, vc.ContainerID, parent, data, spec)
 	if err != nil {
 		return nil, InternalServerError(err.Error())
 	}
 
 	return r, nil
-}
-
-// ArchiveExportReader streams a tar archive from the portlayer.  Once the stream is complete,
-// an io.Reader is returned and the caller can use that reader to parse the data.
-func (c *ContainerProxy) ArchiveExportReader(ctx context.Context, store, ancestorStore, deviceID, ancestor string, data bool, filterSpec archive.FilterSpec) (io.ReadCloser, error) {
-	defer trace.End(trace.Begin(deviceID))
-
-	if store == "" || deviceID == "" {
-		return nil, fmt.Errorf("ArchiveExportReader called with either empty store or deviceID")
-	}
-
-	var err error
-
-	pipeReader, pipeWriter := io.Pipe()
-
-	done := make(chan struct{})
-	go func() {
-		// make sure we get out of io.Copy if context is canceled
-		select {
-		case <-ctx.Done():
-
-			// Attempt to tell the portlayer to cancel the stream.  This is one way of cancelling the
-			// stream.  The other way is for the caller of this function to close the returned CloseReader.
-			// Callers of this function should do one but not both.
-			pipeReader.Close()
-		}
-	}()
-
-	go func() {
-		defer close(done)
-
-		params := storage.NewExportArchiveParamsWithContext(ctx).
-			WithStore(store).
-			WithAncestorStore(&ancestorStore).
-			WithDeviceID(deviceID).
-			WithAncestor(&ancestor).
-			WithData(data)
-
-		// Encode the filter spec
-		encodedFilter := ""
-		if valueBytes, merr := json.Marshal(filterSpec); merr == nil {
-			encodedFilter = base64.StdEncoding.EncodeToString(valueBytes)
-			params = params.WithFilterSpec(&encodedFilter)
-			log.Infof(" encodedFilter = %s", encodedFilter)
-		}
-
-		_, err = c.client.Storage.ExportArchive(params, pipeWriter)
-		if err != nil {
-			log.Errorf("Error from ExportArchive: %s", err.Error())
-			switch err := err.(type) {
-			case *storage.ExportArchiveInternalServerError:
-				plErr := InternalServerError(fmt.Sprintf("Server error from archive reader for device %s", deviceID))
-				log.Errorf(plErr.Error())
-				pipeWriter.CloseWithError(plErr)
-			case *storage.ImportArchiveLocked:
-				plErr := ResourceLockedError(fmt.Sprintf("Resource locked for device %s", deviceID))
-				log.Errorf(plErr.Error())
-				pipeWriter.CloseWithError(plErr)
-			default:
-				//Check for EOF.  Since the connection, transport, and data handling are
-				//encapsulated inside of Swagger, we can only detect EOF by checking the
-				//error string
-				if strings.Contains(err.Error(), swaggerSubstringEOF) {
-					log.Debugf("swagger error %s", err.Error())
-					pipeWriter.Close()
-				} else {
-					pipeWriter.CloseWithError(err)
-				}
-			}
-		} else {
-			pipeWriter.Close()
-		}
-	}()
-
-	return pipeReader, nil
-}
-
-// ArchiveImportWriter initializes a write stream for a path.  This is usually called
-// for gettine a writer during docker cp TO container.
-func (c *ContainerProxy) ArchiveImportWriter(ctx context.Context, store, deviceID string, filterSpec archive.FilterSpec) (io.WriteCloser, error) {
-	defer trace.End(trace.Begin(deviceID))
-
-	if store == "" || deviceID == "" {
-		return nil, fmt.Errorf("ArchiveImportWriter called with either empty store or deviceID")
-	}
-
-	var err error
-
-	pipeReader, pipeWriter := io.Pipe()
-
-	done := make(chan struct{})
-	go func() {
-		// make sure we get out of io.Copy if context is canceled
-		select {
-		case <-ctx.Done():
-		case <-done:
-		}
-
-		// Attempt to shutdown the stream to the portlayer.  The other way to cancel the
-		// connection is to call close on the WriteCloser returned from this function.
-		// Callers of this function should do one but not both.
-		pipeWriter.Close()
-	}()
-
-	go func() {
-		defer close(done)
-
-		// encodedFilter and destination are not required (from swagge spec) because
-		// they are allowed to be empty.
-		params := storage.NewImportArchiveParamsWithContext(ctx).
-			WithStore(store).
-			WithDeviceID(deviceID).
-			WithArchive(pipeReader)
-
-		// Encode the filter spec
-		encodedFilter := ""
-		if valueBytes, merr := json.Marshal(filterSpec); merr == nil {
-			encodedFilter = base64.StdEncoding.EncodeToString(valueBytes)
-			params = params.WithFilterSpec(&encodedFilter)
-		}
-
-		_, err = c.client.Storage.ImportArchive(params)
-		if err != nil {
-			switch err := err.(type) {
-			case *storage.ImportArchiveInternalServerError:
-				plErr := InternalServerError(fmt.Sprintf("Server error from archive writer for device %s", deviceID))
-				log.Errorf(plErr.Error())
-				pipeReader.CloseWithError(plErr)
-			case *storage.ImportArchiveLocked:
-				plErr := ResourceLockedError(fmt.Sprintf("Resource locked for device %s", deviceID))
-				log.Errorf(plErr.Error())
-				pipeReader.CloseWithError(plErr)
-			default:
-				//Check for EOF.  Since the connection, transport, and data handling are
-				//encapsulated inside of Swagger, we can only detect EOF by checking the
-				//error string
-				if strings.Contains(err.Error(), swaggerSubstringEOF) {
-					log.Errorf(err.Error())
-					pipeReader.Close()
-				} else {
-					pipeReader.CloseWithError(err)
-				}
-			}
-		} else {
-			pipeReader.Close()
-		}
-	}()
-
-	return pipeWriter, nil
 }
 
 // Stop will stop (shutdown) a VIC container.

--- a/lib/apiservers/engine/backends/container_test.go
+++ b/lib/apiservers/engine/backends/container_test.go
@@ -42,7 +42,6 @@ import (
 	plclient "github.com/vmware/vic/lib/apiservers/portlayer/client"
 	plscopes "github.com/vmware/vic/lib/apiservers/portlayer/client/scopes"
 	plmodels "github.com/vmware/vic/lib/apiservers/portlayer/models"
-	"github.com/vmware/vic/lib/archive"
 	"github.com/vmware/vic/lib/metadata"
 )
 
@@ -356,14 +355,6 @@ func (m *MockContainerProxy) AttachStreams(ctx context.Context, ac *AttachConfig
 
 func (m *MockContainerProxy) StreamContainerStats(ctx context.Context, config *convert.ContainerStatsConfig) error {
 	return nil
-}
-
-func (m *MockContainerProxy) ArchiveExportReader(ctx context.Context, store, ancestorStore, deviceID, ancestor string, data bool, filterSpec archive.FilterSpec) (io.ReadCloser, error) {
-	return nil, nil
-}
-
-func (m *MockContainerProxy) ArchiveImportWriter(ctx context.Context, store, deviceID string, filterSpec archive.FilterSpec) (io.WriteCloser, error) {
-	return nil, nil
 }
 
 func (m *MockContainerProxy) GetContainerChanges(ctx context.Context, vc *viccontainer.VicContainer, data bool) (io.ReadCloser, error) {

--- a/lib/apiservers/engine/backends/errors.go
+++ b/lib/apiservers/engine/backends/errors.go
@@ -72,6 +72,14 @@ func NotFoundError(msg string) error {
 	return derr.NewRequestNotFoundError(fmt.Errorf("No such container: %s", msg))
 }
 
+func ImageNotFoundError(image, tag string) error {
+	return derr.NewRequestNotFoundError(fmt.Errorf("An image does not exist locally with the tag: %s", image))
+}
+
+func TagNotFoundError(image, tag string) error {
+	return derr.NewRequestNotFoundError(fmt.Errorf("tag does not exist: %s:%s", image, tag))
+}
+
 // ResourceLockedError returns a 423 http status
 func ResourceLockedError(msg string) error {
 	return derr.NewErrorWithStatusCode(fmt.Errorf("Resource locked: %s", msg), http.StatusLocked)

--- a/lib/apiservers/engine/proxy/archive.go
+++ b/lib/apiservers/engine/proxy/archive.go
@@ -1,0 +1,188 @@
+// Copyright 2017 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package proxy
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+
+	log "github.com/Sirupsen/logrus"
+
+	"github.com/vmware/vic/lib/apiservers/portlayer/client"
+	"github.com/vmware/vic/lib/apiservers/portlayer/client/storage"
+	vicarchive "github.com/vmware/vic/lib/archive"
+	"github.com/vmware/vic/pkg/trace"
+)
+
+type VicArchiveProxy interface {
+	ArchiveExportReader(ctx context.Context, store, ancestorStore, deviceID, ancestor string, data bool, filterSpec vicarchive.FilterSpec) (io.ReadCloser, error)
+	ArchiveImportWriter(ctx context.Context, store, deviceID string, filterSpec vicarchive.FilterSpec) (io.WriteCloser, error)
+}
+
+//------------------------------------
+// ArchiveProxy
+//------------------------------------
+
+type ArchiveProxy struct {
+	client *client.PortLayer
+}
+
+func NewArchiveProxy(client *client.PortLayer) VicArchiveProxy {
+	return &ArchiveProxy{client: client}
+}
+
+// ArchiveExportReader streams a tar archive from the portlayer.  Once the stream is complete,
+// an io.Reader is returned and the caller can use that reader to parse the data.
+func (a *ArchiveProxy) ArchiveExportReader(ctx context.Context, store, ancestorStore, deviceID, ancestor string, data bool, filterSpec vicarchive.FilterSpec) (io.ReadCloser, error) {
+	defer trace.End(trace.Begin(deviceID))
+
+	if store == "" || deviceID == "" {
+		return nil, fmt.Errorf("ArchiveExportReader called with either empty store or deviceID")
+	}
+
+	var err error
+
+	pipeReader, pipeWriter := io.Pipe()
+
+	go func() {
+		// make sure we get out of io.Copy if context is canceled
+		select {
+		case <-ctx.Done():
+			// Attempt to tell the portlayer to cancel the stream.  This is one way of cancelling the
+			// stream.  The other way is for the caller of this function to close the returned CloseReader.
+			// Callers of this function should do one but not both.
+			err := pipeReader.Close()
+			if err != nil {
+				log.Errorf("Error closing pipereader in ArchiveExportReader: %s", err.Error())
+			}
+		}
+	}()
+
+	go func() {
+		params := storage.NewExportArchiveParamsWithContext(ctx).
+			WithStore(store).
+			WithAncestorStore(&ancestorStore).
+			WithDeviceID(deviceID).
+			WithAncestor(&ancestor).
+			WithData(data)
+
+		// Encode the filter spec
+		encodedFilter := ""
+		if valueBytes, merr := json.Marshal(filterSpec); merr == nil {
+			encodedFilter = base64.StdEncoding.EncodeToString(valueBytes)
+			params = params.WithFilterSpec(&encodedFilter)
+			log.Infof(" encodedFilter = %s", encodedFilter)
+		}
+
+		_, err = a.client.Storage.ExportArchive(params, pipeWriter)
+		if err != nil {
+			log.Errorf("Error from ExportArchive: %s", err.Error())
+			switch err := err.(type) {
+			case *storage.ExportArchiveInternalServerError:
+				plErr := InternalServerError(fmt.Sprintf("Server error from archive reader for device %s", deviceID))
+				log.Errorf(plErr.Error())
+				pipeWriter.CloseWithError(plErr)
+			case *storage.ImportArchiveLocked:
+				plErr := ResourceLockedError(fmt.Sprintf("Resource locked for device %s", deviceID))
+				log.Errorf(plErr.Error())
+				pipeWriter.CloseWithError(plErr)
+			default:
+				//Check for EOF.  Since the connection, transport, and data handling are
+				//encapsulated inside of Swagger, we can only detect EOF by checking the
+				//error string
+				if strings.Contains(err.Error(), swaggerSubstringEOF) {
+					log.Debugf("swagger error %s", err.Error())
+					pipeWriter.Close()
+				} else {
+					pipeWriter.CloseWithError(err)
+				}
+			}
+		} else {
+			pipeWriter.Close()
+		}
+	}()
+
+	return pipeReader, nil
+}
+
+// ArchiveImportWriter initializes a write stream for a path.  This is usually called
+// for getting a writer during docker cp TO container.
+func (a *ArchiveProxy) ArchiveImportWriter(ctx context.Context, store, deviceID string, filterSpec vicarchive.FilterSpec) (io.WriteCloser, error) {
+	defer trace.End(trace.Begin(deviceID))
+
+	if store == "" || deviceID == "" {
+		return nil, fmt.Errorf("ArchiveImportWriter called with either empty store or deviceID")
+	}
+
+	var err error
+
+	pipeReader, pipeWriter := io.Pipe()
+
+	go func() {
+		// make sure we get out of io.Copy if context is canceled
+		select {
+		case <-ctx.Done():
+			pipeWriter.Close()
+		}
+	}()
+
+	go func() {
+		// encodedFilter and destination are not required (from swagge spec) because
+		// they are allowed to be empty.
+		params := storage.NewImportArchiveParamsWithContext(ctx).
+			WithStore(store).
+			WithDeviceID(deviceID).
+			WithArchive(pipeReader)
+
+		// Encode the filter spec
+		encodedFilter := ""
+		if valueBytes, merr := json.Marshal(filterSpec); merr == nil {
+			encodedFilter = base64.StdEncoding.EncodeToString(valueBytes)
+			params = params.WithFilterSpec(&encodedFilter)
+		}
+
+		_, err = a.client.Storage.ImportArchive(params)
+		if err != nil {
+			switch err := err.(type) {
+			case *storage.ImportArchiveInternalServerError:
+				plErr := InternalServerError(fmt.Sprintf("Server error from archive writer for device %s", deviceID))
+				log.Errorf(plErr.Error())
+				pipeReader.CloseWithError(plErr)
+			case *storage.ImportArchiveLocked:
+				plErr := ResourceLockedError(fmt.Sprintf("Resource locked for device %s", deviceID))
+				log.Errorf(plErr.Error())
+				pipeReader.CloseWithError(plErr)
+			default:
+				//Check for EOF.  Since the connection, transport, and data handling are
+				//encapsulated inside of Swagger, we can only detect EOF by checking the
+				//error string
+				if strings.Contains(err.Error(), swaggerSubstringEOF) {
+					log.Errorf(err.Error())
+					pipeReader.Close()
+				} else {
+					pipeReader.CloseWithError(err)
+				}
+			}
+		} else {
+			pipeReader.Close()
+		}
+	}()
+
+	return pipeWriter, nil
+}

--- a/lib/apiservers/engine/proxy/common.go
+++ b/lib/apiservers/engine/proxy/common.go
@@ -1,0 +1,19 @@
+// Copyright 2017 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package proxy
+
+const (
+	swaggerSubstringEOF = "EOF"
+)

--- a/lib/apiservers/engine/proxy/errors.go
+++ b/lib/apiservers/engine/proxy/errors.go
@@ -1,0 +1,32 @@
+// Copyright 2017 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package proxy
+
+import (
+	"fmt"
+	"net/http"
+
+	derr "github.com/docker/docker/api/errors"
+)
+
+// InternalServerError returns a 500 docker error on a portlayer error.
+func InternalServerError(msg string) error {
+	return derr.NewErrorWithStatusCode(fmt.Errorf("Server error from portlayer: %s", msg), http.StatusInternalServerError)
+}
+
+// ResourceLockedError returns a 423 http status
+func ResourceLockedError(msg string) error {
+	return derr.NewErrorWithStatusCode(fmt.Errorf("Resource locked: %s", msg), http.StatusLocked)
+}

--- a/lib/imagec/imagec.go
+++ b/lib/imagec/imagec.go
@@ -15,7 +15,6 @@
 package imagec
 
 import (
-	"context"
 	"crypto/sha256"
 	"crypto/x509"
 	"encoding/json"
@@ -28,6 +27,7 @@ import (
 	"time"
 
 	log "github.com/Sirupsen/logrus"
+	"golang.org/x/net/context"
 
 	"github.com/docker/distribution/manifest/schema2"
 	docker "github.com/docker/docker/image"
@@ -41,6 +41,7 @@ import (
 	"github.com/vmware/vic/lib/apiservers/engine/backends/cache"
 	"github.com/vmware/vic/lib/apiservers/portlayer/models"
 	"github.com/vmware/vic/lib/metadata"
+	"github.com/vmware/vic/lib/portlayer/storage"
 	urlfetcher "github.com/vmware/vic/pkg/fetcher"
 	"github.com/vmware/vic/pkg/trace"
 	"github.com/vmware/vic/pkg/vsphere/sys"
@@ -56,6 +57,7 @@ type ImageC struct {
 
 	// ImageLayers are sourced from the manifest file
 	ImageLayers []*ImageWithMeta
+
 	// ImageID is the docker ImageID calculated during download
 	ImageID string
 }
@@ -152,7 +154,6 @@ const (
 
 	// attribute update actions
 	Add = iota + 1
-	Remove
 )
 
 func init() {
@@ -463,10 +464,77 @@ func (ic *ImageC) CreateImageConfig(images []*ImageWithMeta) (metadata.ImageConf
 
 // PullImage pulls an image from docker hub
 func (ic *ImageC) PullImage() error {
-
-	// ctx
 	ctx, cancel := context.WithTimeout(ctx, ic.Options.Timeout)
 	defer cancel()
+
+	// Authenticate, get URL, get token
+	if err := ic.prepareTransfer(ctx); err != nil {
+		return err
+	}
+
+	// Output message
+	tagOrDigest := tagOrDigest(ic.Reference, ic.Tag)
+	progress.Message(ic.progressOutput, "", tagOrDigest+": Pulling from "+ic.Image)
+
+	// Pull the image manifest
+	if err := ic.pullManifest(ctx); err != nil {
+		return err
+	}
+	log.Infof("Manifest for image = %#v", ic.ImageManifestSchema1)
+
+	// Get layers to download from manifest
+	layers, err := ic.LayersToDownload()
+	if err != nil {
+		return err
+	}
+	ic.ImageLayers = layers
+
+	// Download all the layers
+	if err := ldm.DownloadLayers(ctx, ic); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// ListLayer prints out the layers for an image to progress.  This is used by imagec standalone binary
+// for debug/validation.
+func (ic *ImageC) ListLayers() error {
+	defer trace.End(trace.Begin(""))
+
+	ctx, cancel := context.WithTimeout(ctx, ic.Options.Timeout)
+	defer cancel()
+
+	// Authenticate, get URL, get token
+	if err := ic.prepareTransfer(ctx); err != nil {
+		return err
+	}
+
+	// Output message
+	tagOrDigest := tagOrDigest(ic.Reference, ic.Tag)
+	progress.Message(ic.progressOutput, "", tagOrDigest+": Fetching layers from "+ic.Image)
+
+	// Pull the image manifest
+	if err := ic.pullManifest(ctx); err != nil {
+		return err
+	}
+
+	// Get layers to download from manifest
+	layers, err := ic.LayersToDownload()
+	if err != nil {
+		return err
+	}
+
+	progress.Message(ic.progressOutput, "", storage.Scratch.ID)
+	for i := len(layers) - 1; i >= 0; i-- {
+		progress.Message(ic.progressOutput, "", layers[i].ID)
+	}
+
+	return nil
+}
+
+// prepareTransfer Looks up URLs and fetch auth token
+func (ic *ImageC) prepareTransfer(ctx context.Context) error {
 
 	// Parse the -reference parameter
 	ic.ParseReference()
@@ -530,11 +598,31 @@ func (ic *ImageC) PullImage() error {
 		ic.Token = token
 	}
 
-	tagOrDigest := tagOrDigest(ic.Reference, ic.Tag)
-	progress.Message(ic.progressOutput, "", tagOrDigest+": Pulling from "+ic.Image)
+	return nil
+}
+
+// pullManifest attempts to pull manifest for an image.  Attempts to get schema 2 but will fall back to schema 1.
+func (ic *ImageC) pullManifest(ctx context.Context) error {
+	// Attempt to get schema2 manifest
+	manifest, digest, err := FetchImageManifest(ctx, ic.Options, 2, ic.progressOutput)
+	if err == nil {
+		if schema2, ok := manifest.(*schema2.DeserializedManifest); ok {
+			if schema2 != nil {
+				log.Infof("pullManifest - schema 2: %#v", schema2)
+			}
+			ic.ImageManifestSchema2 = schema2
+
+			// Override the manifest digest as Docker uses schema 2, unless the image
+			// is pulled by digest since we only support pull-by-digest for schema 1.
+			// TODO(anchal): this check should be removed once issue #5187 is implemented.
+			if _, ok := ic.Reference.(reference.Canonical); !ok {
+				ic.ManifestDigest = digest
+			}
+		}
+	}
 
 	// Get the schema1 manifest
-	manifest, digest, err := FetchImageManifest(ctx, ic.Options, 1, ic.progressOutput)
+	manifest, digest, err = FetchImageManifest(ctx, ic.Options, 1, ic.progressOutput)
 	if err != nil {
 		log.Infof(err.Error())
 		switch err := err.(type) {
@@ -554,31 +642,6 @@ func (ic *ImageC) PullImage() error {
 
 	ic.ImageManifestSchema1 = schema1
 	ic.ManifestDigest = digest
-
-	manifest, digest, err = FetchImageManifest(ctx, ic.Options, 2, ic.progressOutput)
-	if err == nil {
-		if schema2, ok := manifest.(*schema2.DeserializedManifest); ok {
-			ic.ImageManifestSchema2 = schema2
-
-			// Override the manifest digest as Docker uses schema 2, unless the image
-			// is pulled by digest since we only support pull-by-digest for schema 1.
-			// TODO(anchal): this check should be removed once issue #5187 is implemented.
-			if _, ok := ic.Reference.(reference.Canonical); !ok {
-				ic.ManifestDigest = digest
-			}
-		}
-	}
-
-	layers, err := ic.LayersToDownload()
-	if err != nil {
-		return err
-	}
-	ic.ImageLayers = layers
-
-	err = ldm.DownloadLayers(ctx, ic)
-	if err != nil {
-		return err
-	}
 
 	return nil
 }

--- a/lib/portlayer/storage/storage.go
+++ b/lib/portlayer/storage/storage.go
@@ -39,6 +39,11 @@ var (
 	exporters map[string]Exporter
 )
 
+func init() {
+	importers = make(map[string]Importer)
+	exporters = make(map[string]Exporter)
+}
+
 func create(ctx context.Context, session *session.Session, pool *object.ResourcePool) error {
 	var err error
 
@@ -64,9 +69,6 @@ func Init(ctx context.Context, session *session.Session, pool *object.ResourcePo
 		log.Debugf("Decoded VCH config for storage: %#v", Config)
 
 		err = create(ctx, session, pool)
-
-		importers = make(map[string]Importer)
-		exporters = make(map[string]Exporter)
 	})
 	return err
 }


### PR DESCRIPTION
Refactor the archive proxy out of the persona's backend so that imagec
binary can use it to access the diff stream from the portlayer.  This
will be used to help validate docker commit.  It will also be used in
docker push in the future.

Added fix for storage portlayer that prevented streaming of diff
archives between two layers.

Added listlayers command to imagec binary to list all layers for an
image.

Small refactor of imagec.go.

Resolves #5741 and #5847