### PR TITLE
Add cancellation to export path [full ci]

### DIFF
--- a/lib/archive/stripper_test.go
+++ b/lib/archive/stripper_test.go
@@ -87,7 +87,7 @@ func TestSingleStripper(t *testing.T) {
 	index, reader := generateArchive("single", count, size)
 
 	source := tar.NewReader(reader)
-	stripper := NewStripper(trace.NewOperation(context.Background(), "strip"), source)
+	stripper := NewStripper(trace.NewOperation(context.Background(), "strip"), source, nil)
 
 	pr, pw := io.Pipe()
 	tr := tar.NewReader(pr)
@@ -100,7 +100,7 @@ func TestSingleStripper(t *testing.T) {
 
 		wg.Done()
 		fmt.Printf("Done copying from stripper: %d, %s\n", n, err)
-		if !assert.Equal(t, io.EOF, err, "Expected EOF") {
+		if !assert.NoError(t, err, "Expected nil error from io.Copy on end-of-file") {
 			t.FailNow()
 		}
 
@@ -162,7 +162,7 @@ func TestConjoinedStrippers(t *testing.T) {
 		var reader io.Reader
 		indices[m], reader = generateArchive(fmt.Sprintf("archive-%d", m), count, size)
 		source := tar.NewReader(reader)
-		strippers[m] = NewStripper(trace.NewOperation(context.Background(), fmt.Sprintf("strip-%d", m)), source)
+		strippers[m] = NewStripper(trace.NewOperation(context.Background(), fmt.Sprintf("strip-%d", m)), source, nil)
 	}
 
 	conjoined := MultiReader(strippers...)
@@ -178,7 +178,7 @@ func TestConjoinedStrippers(t *testing.T) {
 
 		wg.Done()
 		fmt.Printf("Done copying from strippers: %d, %s\n", n, err)
-		if !assert.Equal(t, io.EOF, err, "Expected EOF") {
+		if !assert.NoError(t, err, "Expected nil error from io.Copy on end-of-file") {
 			t.FailNow()
 		}
 	}()
@@ -247,7 +247,7 @@ func TestConjoinedStrippersWithCloser(t *testing.T) {
 
 		if m < multiplicity-1 {
 			fmt.Printf("added stripper\n")
-			readers[m] = NewStripper(trace.NewOperation(context.Background(), fmt.Sprintf("strip-%d", m)), source)
+			readers[m] = NewStripper(trace.NewOperation(context.Background(), fmt.Sprintf("strip-%d", m)), source, nil)
 		} else {
 			fmt.Printf("added raw\n")
 			readers[m] = reader
@@ -267,7 +267,7 @@ func TestConjoinedStrippersWithCloser(t *testing.T) {
 
 		wg.Done()
 		fmt.Printf("Done copying from all sources: %d, %s\n", n, err)
-		if !assert.Equal(t, io.EOF, err, "Expected EOF") {
+		if !assert.NoError(t, err, "Expected nil error from io.Copy on end-of-file") {
 			t.FailNow()
 		}
 	}()

--- a/lib/portlayer/storage/data_sink.go
+++ b/lib/portlayer/storage/data_sink.go
@@ -80,7 +80,7 @@ func (m *MountDataSink) Import(op trace.Operation, spec *archive.FilterSpec, dat
 }
 
 func (m *MountDataSink) Close() error {
-	m.cleanOp.Infof("cleaning up after export")
+	m.cleanOp.Infof("cleaning up after import")
 
 	m.Path.Close()
 	if m.Clean != nil {

--- a/pkg/trace/operation.go
+++ b/pkg/trace/operation.go
@@ -171,6 +171,22 @@ func WithDeadline(parent *Operation, expiration time.Time, format string, args .
 	return op, cancelFunc
 }
 
+// WithCancel
+func WithCancel(parent *Operation, format string, args ...interface{}) (Operation, context.CancelFunc) {
+	ctx, cancelFunc := context.WithCancel(parent.Context)
+	op := parent.newChild(ctx, fmt.Sprintf(format, args...))
+
+	return op, cancelFunc
+}
+
+// WithValue
+func WithValue(parent *Operation, key, val interface{}, format string, args ...interface{}) Operation {
+	ctx := context.WithValue(parent.Context, key, val)
+	op := parent.newChild(ctx, fmt.Sprintf(format, args...))
+
+	return op
+}
+
 // FromOperation creates a child operation from the one supplied
 // uses the same context as the parent
 func FromOperation(parent Operation, format string, args ...interface{}) Operation {

--- a/pkg/vsphere/disk/disk_manager.go
+++ b/pkg/vsphere/disk/disk_manager.go
@@ -469,7 +469,7 @@ func (m *Manager) detach(op trace.Operation, disk *types.VirtualDisk) error {
 		return t, er
 	})
 
-	if err != nil {
+	if err == nil {
 		select {
 		case <-m.maxAttached:
 		default:


### PR DESCRIPTION
Ensures that cancel is called on the portlayer export archive path so as
to close data files in use. This is necessary to permit unmount of
filesystems, although I believe the disk detech would succeed regardless.

This adds a waitgroup context value in order to coordinate completion of
cancel operations for child calls.

Still experiencing an issue whereby the personality does not disconnect
one of the device streams.
