### PR TITLE
Replace ${VC_LICENSE} with %{VC_LICENSE} in test 5-3-ELM

### DIFF
--- a/tests/manual-test-cases/Group5-Functional-Tests/5-3-Enhanced-Linked-Mode.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-3-Enhanced-Linked-Mode.robot
@@ -97,8 +97,8 @@ Test
     Set Environment Variable  GOVC_PASSWORD  Admin!23
 
     # Update vCenter license
-    Add Vsphere License  ${VC_LICENSE}
-    Assign vCenter License  ${VC_LICENSE}
+    Add Vsphere License  %{VC_LICENSE}
+    Assign vCenter License  %{VC_LICENSE}
 
     # First VC cluster
     Log To Console  Create a datacenter on the VC
@@ -129,8 +129,8 @@ Test
     Set Environment Variable  GOVC_URL  ${vc2-ip}
 
     # Update vCenter license
-    Add Vsphere License  ${VC_LICENSE}
-    Assign vCenter License  ${VC_LICENSE}
+    Add Vsphere License  %{VC_LICENSE}
+    Assign vCenter License  %{VC_LICENSE}
 
     Log To Console  Create a datacenter on the VC
     ${out}=  Run  govc datacenter.create ha-datacenter


### PR DESCRIPTION
Fixes #5866 

We set `VC_LICENSE` in the test secrets file. This env variables should be used as `%{VC_LICENSE}` instead of `${VC_LICENSE}`.