### PR TITLE
More optimal path for online stat

### DIFF
--- a/lib/archive/archiver.go
+++ b/lib/archive/archiver.go
@@ -164,9 +164,13 @@ func EncodeFilterSpec(op trace.Operation, spec *FilterSpec) (*string, error) {
 }
 
 // Excludes returns true if the provided filter excludes the provided filepath
-// If the spec is completely empty it will match everything.
+// If the spec is completely empty it will include everything.
 // If an inclusion is set, but not exclusion, then we'll only return matches for the inclusions.
 func (spec *FilterSpec) Excludes(op trace.Operation, filePath string) bool {
+	if spec == nil {
+		return false
+	}
+
 	inclusionLength := -1
 	exclusionLength := -1
 

--- a/lib/portlayer/storage/vsphere/toolbox_common.go
+++ b/lib/portlayer/storage/vsphere/toolbox_common.go
@@ -27,12 +27,14 @@ import (
 )
 
 const (
-	DiskLabelQueryName  = "disk-label"
-	FilterSpecQueryName = "filter-spec"
+	DiskLabelQueryName   = "disk-label"
+	FilterSpecQueryName  = "filter-spec"
+	SkipRecurseQueryName = "skip-recurse"
+	SkipDataQueryName    = "skip-data"
 )
 
 // Parse Archive does something.
-func BuildArchiveURL(op trace.Operation, disklabel, target string, fs *archive.FilterSpec) (string, error) {
+func BuildArchiveURL(op trace.Operation, disklabel, target string, fs *archive.FilterSpec, recurse, data bool) (string, error) {
 	encodedSpec, err := archive.EncodeFilterSpec(op, fs)
 	if err != nil {
 		return "", err
@@ -45,7 +47,8 @@ func BuildArchiveURL(op trace.Operation, disklabel, target string, fs *archive.F
 		disklabel = "containerfs"
 	}
 
-	target += fmt.Sprintf("?%s=%s&%s=%s", DiskLabelQueryName, disklabel, FilterSpecQueryName, *encodedSpec)
+	// note that the query parameters a SkipX for recurse and data so values are inverted
+	target += fmt.Sprintf("?%s=%s&%s=%s&%s=%t&%s=%t", DiskLabelQueryName, disklabel, FilterSpecQueryName, *encodedSpec, SkipRecurseQueryName, !recurse, SkipDataQueryName, !data)
 	op.Debugf("OnlineData* Url: %s", target)
 	return target, nil
 }

--- a/lib/portlayer/storage/vsphere/toolbox_datasink.go
+++ b/lib/portlayer/storage/vsphere/toolbox_datasink.go
@@ -46,7 +46,7 @@ func (t *ToolboxDataSink) Import(op trace.Operation, spec *archive.FilterSpec, d
 		return err
 	}
 
-	target, err := BuildArchiveURL(op, t.ID, spec.RebasePath, spec)
+	target, err := BuildArchiveURL(op, t.ID, spec.RebasePath, spec, true, true)
 	if err != nil {
 		op.Debugf("Cannot build archive url: %s", err.Error())
 		return err


### PR DESCRIPTION
* Don't transfer data when stat'ing file
* Don't recurse when stat'ing directories
* Abort tar archive write from online container on EOF/closed pipe.