### PR TITLE
Add ordered manner to tether mount handling

### DIFF
--- a/lib/tether/tether.go
+++ b/lib/tether/tether.go
@@ -253,7 +253,7 @@ func (t *tether) setNetworks() error {
 
 func (t *tether) setMounts() error {
 	// provides a lookup from path to volume reference.
-	NameLookupMap := make(map[string]string, 0, len(t.config.Mounts))
+	NameLookupMap := make(map[string]string, 0)
 	mounts := make([]string, 0, len(t.config.Mounts))
 	for k, v := range t.config.Mounts {
 		mounts = append(mounts, v.Path)
@@ -277,7 +277,7 @@ func (t *tether) setMounts() error {
 			return fmt.Errorf("unsupported volume mount type for %s: %s", targetRef, mountTarget.Source.Scheme)
 		}
 	}
-
+	return nil
 }
 
 func (t *tether) populateVolumes() error {

--- a/lib/tether/tether.go
+++ b/lib/tether/tether.go
@@ -25,6 +25,7 @@ import (
 	"os/exec"
 	"os/signal"
 	"path"
+	"sort"
 	"sync"
 	"syscall"
 	"time"
@@ -251,20 +252,32 @@ func (t *tether) setNetworks() error {
 }
 
 func (t *tether) setMounts() error {
+	// provides a lookup from path to volume reference.
+	NameLookupMap := make(map[string]string, 0, len(t.config.Mounts))
+	mounts := make([]string, 0, len(t.config.Mounts))
 	for k, v := range t.config.Mounts {
-		switch v.Source.Scheme {
+		mounts = append(mounts, v.Path)
+		NameLookupMap[v.Path] = k
+	}
+	// Order the mount paths so that we are doing them in shortest order first.
+	sort.Strings(mounts)
+
+	for _, v := range mounts {
+		targetRef := NameLookupMap[v]
+		mountTarget := t.config.Mounts[targetRef]
+		switch mountTarget.Source.Scheme {
 		case "label":
 			// this could block indefinitely while waiting for a volume to present
-			t.ops.MountLabel(context.Background(), v.Source.Path, v.Path)
+			t.ops.MountLabel(context.Background(), mountTarget.Source.Path, mountTarget.Path)
 
 		case "nfs":
-			t.ops.MountTarget(context.Background(), v.Source, v.Path, v.Mode)
+			t.ops.MountTarget(context.Background(), mountTarget.Source, mountTarget.Path, mountTarget.Mode)
 
 		default:
-			return fmt.Errorf("unsupported volume mount type for %s: %s", k, v.Source.Scheme)
+			return fmt.Errorf("unsupported volume mount type for %s: %s", targetRef, mountTarget.Source.Scheme)
 		}
 	}
-	return t.populateVolumes()
+
 }
 
 func (t *tether) populateVolumes() error {

--- a/tests/test-cases/Group1-Docker-Commands/1-44-Docker-CP-Online.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-44-Docker-CP-Online.robot
@@ -115,16 +115,19 @@ Copy a file and directory from host to online container
     Should Not Contain  ${output}  Error
 
 Copy a directory from host to online container, dst is a volume
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -d -it --name online -v vol1:/vol1 ${busybox}
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -d -it --name online-copyto -v vol1:/vol1 ${busybox}
     Should Be Equal As Integers  ${rc}  0
     Should Not Contain  ${output}  Error
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} cp ${CURDIR}/bar online:/vol1/
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} cp ${CURDIR}/bar online-copyto:/vol1/
     Should Be Equal As Integers  ${rc}  0
     Should Not Contain  ${output}  Error
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} exec online ls /vol1
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} exec online-copyto ls /vol1
     Should Be Equal As Integers  ${rc}  0
     Should Not Contain  ${output}  Error
     Should Contain  ${output}  bar
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} stop online-copyto
+    Should Be Equal As Integers  ${rc}  0
+    Should Not Contain  ${output}  Error
 
 Copy a file from host to offline container, dst is a volume shared with an online container
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} create -i --name offline -v vol1:/vol1 ${busybox}


### PR DESCRIPTION
`docker create -v vol1:/some/path -v vol2:/some/path/further/down busybox` should have it's volumes mounted in the right order at boot time. This Means that the tether will no longer non-deterministically appply mounts during container start time. 