### PR TITLE
[specific ci=1-19-Docker-Volume-Create] Add unintentional removal of call to populate volumes

### DIFF
--- a/lib/tether/tether.go
+++ b/lib/tether/tether.go
@@ -277,6 +277,8 @@ func (t *tether) setMounts() error {
 			return fmt.Errorf("unsupported volume mount type for %s: %s", targetRef, mountTarget.Source.Scheme)
 		}
 	}
+
+	// FIXME: populateVolumes() does not handle the nested volume case properly.
 	return t.populateVolumes()
 }
 

--- a/lib/tether/tether.go
+++ b/lib/tether/tether.go
@@ -277,7 +277,7 @@ func (t *tether) setMounts() error {
 			return fmt.Errorf("unsupported volume mount type for %s: %s", targetRef, mountTarget.Source.Scheme)
 		}
 	}
-	return nil
+	return t.populateVolumes()
 }
 
 func (t *tether) populateVolumes() error {

--- a/tests/test-cases/Group1-Docker-Commands/1-19-Docker-Volume-Create.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-19-Docker-Volume-Create.robot
@@ -176,22 +176,22 @@ Docker volume create with possibly invalid name
     Should Be Equal As Strings  ${output}  Error response from daemon: volume name "test???" includes invalid characters, only "[a-zA-Z0-9][a-zA-Z0-9_.-]" are allowed
 
 Docker volume verify anonymous volume contains base image files
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run jakedsouza/group-1-19-docker-verify-volume-files:1.0 ls /etc/example
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run --name verify-anon-1 jakedsouza/group-1-19-docker-verify-volume-files:1.0 ls /etc/example
     Should Be Equal As Integers  ${rc}  0
     Should Contain  ${output}  thisshouldexist
     Should Contain  ${output}  testfile.txt
 
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run jakedsouza/group-1-19-docker-verify-volume-files:1.0 cat /etc/example/testfile.txt
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run --name verify-anon-2 jakedsouza/group-1-19-docker-verify-volume-files:1.0 cat /etc/example/testfile.txt
     Should Be Equal As Integers  ${rc}  0
     Should Contain  ${output}  TestFile
 
 Docker volume verify named volume contains base image files
-	${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -v test15:/etc/example jakedsouza/group-1-19-docker-verify-volume-files:1.0 cat /etc/example/testfile.txt
+	${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run --name verify-named-1 -v test15:/etc/example jakedsouza/group-1-19-docker-verify-volume-files:1.0 cat /etc/example/testfile.txt
     Should Be Equal As Integers  ${rc}  0
     Should Contain  ${output}  TestFile
 
 	# Verify file is copied to volumeA
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -v test15:/mnt/test15 jakedsouza/group-1-19-docker-verify-volume-files:1.0 cat /mnt/test15/testfile.txt
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run --name verify-named-2 -v test15:/mnt/test15 jakedsouza/group-1-19-docker-verify-volume-files:1.0 cat /mnt/test15/testfile.txt
     Should Be Equal As Integers  ${rc}  0
     Should Contain  ${output}  TestFile
 


### PR DESCRIPTION
The call to our populateVolumes function was unintentionally removed while adding proper mount ordering. I have added it back in and made a slight improvement to the tests for supporting that we do in fact copy r/w layer info to the volumes before start. 