### PR TITLE
Obtain cached portlayer container state without a lock

### DIFF
--- a/lib/portlayer/exec/container_cache.go
+++ b/lib/portlayer/exec/container_cache.go
@@ -65,8 +65,10 @@ func (conCache *containerCache) Containers(state *State) []*Container {
 		if !isContainerID(id) {
 			continue
 		}
-
-		if state == nil || *state == con.CurrentState() {
+		// filter by container state
+		// DO NOT use container.CurrentState as that can
+		// cause cache deadlocks
+		if state == nil || *state == con.State() {
 			containers = append(containers, con)
 		}
 	}


### PR DESCRIPTION
A lock was used when obtaining the current state of a
container which would cause a deadlock in certain parallel
portLayer operations.  Now the cache will obtain without
a container lock.

Fixes #5736