### PR TITLE
[skip ci] Ensure that all hosts are valid in Hetero test

### DIFF
--- a/tests/manual-test-cases/Group5-Functional-Tests/5-5-Heterogeneous-ESXi.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-5-Heterogeneous-ESXi.robot
@@ -86,7 +86,7 @@ Test
 
     ${name}  ${ip}=  Deploy Nimbus NFS Datastore  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}
 
-    ${out}=  Run  govc datastore.create -mode readWrite -type nfs -name nfsDatastore -remote-host ${ip} -remote-path /store cls
+    ${out}=  Run  govc datastore.create -mode readWrite -type nfs -name nfsDatastore -remote-host ${ip} -remote-path /store /ha-datacenter/host/cls
     Should Be Empty  ${out}
 
     Set Environment Variable  TEST_DATASTORE  nfsDatastore

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-5-Heterogeneous-ESXi.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-5-Heterogeneous-ESXi.robot
@@ -81,9 +81,15 @@ Test
     Set Environment Variable  TEST_PASSWORD  Admin\!23
     Set Environment Variable  BRIDGE_NETWORK  bridge
     Set Environment Variable  PUBLIC_NETWORK  vm-network
-    Set Environment Variable  TEST_DATASTORE  datastore1
     Set Environment Variable  TEST_RESOURCE  cls
     Set Environment Variable  TEST_TIMEOUT  30m
+
+    ${name}  ${ip}=  Deploy Nimbus NFS Datastore  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}
+
+    ${out}=  Run  govc datastore.create -mode readWrite -type nfs -name nfsDatastore -remote-host ${ip} -remote-path /store cls
+    Should Be Empty  ${out}
+
+    Set Environment Variable  TEST_DATASTORE  nfsDatastore
 
     Install VIC Appliance To Test Server  certs=${false}  vol=default
 


### PR DESCRIPTION
fixes #5840 

Haven't really seen the failure in 5840 before, it truncated super early like it hung on a docker pull indefinitely, so I don't really have anything to go on from that perspective. But at a minimum we do want to eliminate the warning in vic-machine as we want all hosts to have access to a shared datastore, so this PR at least addresses that.  If we see the weird truncation in 5840 again, then we should reopen it and address it somehow.