### PR TITLE
Don't run goimport on swagger files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -221,9 +221,10 @@ gopath:
 vendored := $(shell find . -type f -name '*.go' -not -path "./vendor/*")
 goimports: $(GOIMPORTS)
 	@echo checking go imports...
-	@! $(GOIMPORTS) -local github.com/vmware -d $$(test -e ./swagger-gen.log &&\
-			comm -12 <(echo "$(vendored)" | sort) \
-							 <(for x in $$(cat swagger-gen.log | grep creating | cut -d" " -f4 | sed -e "s/\"\(.*\)\"/\1/g"); do find . -name "$x"; done | sort) \
+	@! $(GOIMPORTS) -local github.com/vmware -d $$(test -e ./swagger-gen.log \
+			&& comm -12 <(echo "$(vendored)" | sort) \
+							 <(for x in $$(cat swagger-gen.log | grep creating | cut -d" " -f4 | sed -e "s/\"\(.*\)\"/\1/g");\
+										do find . -name "$x"; done | sort) \
 			|| echo "$(vendored)") 2>&1 | egrep -v '^$$'
 
 gofmt:
@@ -482,7 +483,9 @@ clean:
 	@rm -rf ./lib/apiservers/portlayer/cmd/
 	@rm -rf ./lib/apiservers/portlayer/models/
 	@rm -rf ./lib/apiservers/portlayer/restapi/operations/
-	@rm -rf ./lib/config/dynamic/admiral/
+	@rm -rf ./lib/config/dynamic/admiral/client
+	@rm -rf ./lib/config/dynamic/admiral/models
+	@rm -rf ./lib/config/dynamic/admiral/operations
 
 	@rm -f *.log
 	@rm -f *.pem

--- a/Makefile
+++ b/Makefile
@@ -223,7 +223,7 @@ goimports: $(GOIMPORTS)
 	@echo checking go imports...
 	@! $(GOIMPORTS) -local github.com/vmware -d $$(test -e ./swagger-gen.log \
 			&& comm -12 <(echo "$(vendored)" | sort) \
-							 <(for x in $$(cat swagger-gen.log | grep creating | cut -d" " -f4 | sed -e "s/\"\(.*\)\"/\1/g");\
+			            <(for x in $$(cat swagger-gen.log | grep creating | cut -d" " -f4 | sed -e "s/\"\(.*\)\"/\1/g");\
 										do find . -name "$x"; done | sort) \
 			|| echo "$(vendored)") 2>&1 | egrep -v '^$$'
 

--- a/Makefile
+++ b/Makefile
@@ -224,7 +224,7 @@ goimports: $(GOIMPORTS)
 	@! $(GOIMPORTS) -local github.com/vmware -d $$(test -e ./swagger-gen.log \
 			&& comm -12 <(echo "$(vendored)" | sort) \
 			            <(for x in $$(cat swagger-gen.log | grep creating | cut -d" " -f4 | sed -e "s/\"\(.*\)\"/\1/g");\
-										do find . -name "$x"; done | sort) \
+			              	do find . -name "$x"; done | sort) \
 			|| echo "$(vendored)") 2>&1 | egrep -v '^$$'
 
 gofmt:

--- a/Makefile
+++ b/Makefile
@@ -218,9 +218,13 @@ golint: $(GOLINT)
 gopath:
 	@echo -n $(GOPATH)
 
+vendored := $(shell find . -type f -name '*.go' -not -path "./vendor/*")
 goimports: $(GOIMPORTS)
 	@echo checking go imports...
-	@! $(GOIMPORTS) -local github.com/vmware -d $$(find . -type f -name '*.go' -not -path "./vendor/*") 2>&1 | egrep -v '^$$'
+	@! $(GOIMPORTS) -local github.com/vmware -d $$(test -e ./swagger-gen.log &&\
+			comm -12 <(echo "$(vendored)" | sort) \
+							 <(for x in $$(cat swagger-gen.log | grep creating | cut -d" " -f4 | sed -e "s/\"\(.*\)\"/\1/g"); do find . -name "$x"; done | sort) \
+			|| echo "$(vendored)") 2>&1 | egrep -v '^$$'
 
 gofmt:
 	@echo checking gofmt...
@@ -478,6 +482,7 @@ clean:
 	@rm -rf ./lib/apiservers/portlayer/cmd/
 	@rm -rf ./lib/apiservers/portlayer/models/
 	@rm -rf ./lib/apiservers/portlayer/restapi/operations/
+	@rm -rf ./lib/config/dynamic/admiral/
 
 	@rm -f *.log
 	@rm -f *.pem


### PR DESCRIPTION
Before this change my VM would take 10+ minutes to run goimports. This cuts that runtime down by an order of magnitude:

```
~/go/src/github.com/vmware/vic vic-machine-leaks-sessions* 2m 8s
❯ time vic-build goimports
Generating dependency set for cmd/imagec/
Generating dependency set for cmd/vic-machine/
Generating dependency set for cmd/vicadmin/
Generating dependency set for cmd/port-layer-server/
Generating dependency set for cmd/vic-dns/
Generating dependency set for cmd/tether/
Generating dependency set for cmd/vic-ui/
Generating dependency set for cmd/docker/
Generating dependency set for cmd/vic-init/
Generating dependency set for cmd/rpctool/
Generating dependency set for cmd/gandalf/
building /go/bin/goimports...
checking go imports...
vic-build goimports  0.01s user 0.01s system 0% cpu 1:35.29 total
```

Still not _great_ but I can personally live with this, however I could not live with 10-15 minute build times LOL