### PR TITLE
[skip ci] Move nightly console logs into bundle and gracefully kill process

### DIFF
--- a/tests/manual-test-cases/Group5-Functional-Tests/5-5-Heterogeneous-ESXi.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-5-Heterogeneous-ESXi.robot
@@ -37,7 +37,9 @@ Test
     Append To List  ${list}  ${esx3}
 
     # Finish vCenter deploy
-    ${output}=  Wait For Process  ${pid-vc}
+    ${output}=  Wait For Process  ${pid-vc}  timeout=40 minutes  on_timeout=terminate
+    Log  ${output.stdout}
+    Log  ${output.stderr}
     Should Contain  ${output.stdout}  Overall Status: Succeeded
 
     Open Connection  %{NIMBUS_GW}

--- a/tests/nightly/nightly-autorun.sh
+++ b/tests/nightly/nightly-autorun.sh
@@ -27,6 +27,10 @@ git fetch https://github.com/vmware/vic master
 git pull
 
 # Kick off the nightly
-now=$(date +"%m_%d_%Y")
-mkdir -p /home/vicadmin/nightly-log/
-sudo -E ./tests/nightly/nightly-kickoff.sh > /home/vicadmin/nightly-log/nightly_$now.txt 2>&1
+echo "Removing VIC directory if present"
+echo "Cleanup logs from previous run"
+
+rm -rf *.zip *.log
+rm -rf bin 60 65
+
+sudo -E ./tests/nightly/nightly-kickoff.sh > ./nightly_console.log 2>&1

--- a/tests/nightly/nightly-kickoff.sh
+++ b/tests/nightly/nightly-kickoff.sh
@@ -34,12 +34,6 @@ nightly_list_var="5-1-Distributed-Switch \
 13-2-vMotion-Container \
 21-1-Whitelist"
 
-echo "Removing VIC directory if present"
-echo "Cleanup logs from previous run"
-
-rm -rf *.zip *.log
-rm -rf bin 60 65
-
 input=$(gsutil ls -l gs://vic-engine-builds/vic_* | grep -v TOTAL | sort -k2 -r | head -n1 | xargs | cut -d ' ' -f 3 | cut -d '/' -f 4)
 buildNumber=${input:4}
 

--- a/tests/nightly/upload-logs.sh
+++ b/tests/nightly/upload-logs.sh
@@ -25,7 +25,7 @@ outfile="functional_logs_"$1".zip"
 echo $Build
 echo $outfile
 
-/usr/bin/zip -9 -r $outfile 60 65
+/usr/bin/zip -9 -r $outfile 60 65 nightly_console.log
 
 # GC credentials
 keyfile="/root/vic-ci-logs.key"


### PR DESCRIPTION
fixes #5518 

This test failed due to timeout that AFAICT the deploy VC attempt just hung for over an hour until drone killed it. This moves the console logging into the log bundle so that we can use that for debugging purposes without having to track it down on the executor server and it gracefully terminates the VC deploy if it takes an inordinate amount of time in the future and logs the outputs so that hopefully we can debug further in the future if this happens.