### PR TITLE
Speed up goimports

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -221,9 +221,10 @@ gopath:
 vendored := $(shell find . -type f -name '*.go' -not -path "./vendor/*")
 goimports: $(GOIMPORTS)
 	@echo checking go imports...
-	@! $(GOIMPORTS) -local github.com/vmware -d $$(test -e ./swagger-gen.log &&\
-			comm -12 <(echo "$(vendored)" | sort) \
-							 <(for x in $$(cat swagger-gen.log | grep creating | cut -d" " -f4 | sed -e "s/\"\(.*\)\"/\1/g"); do find . -name "$x"; done | sort) \
+	@! $(GOIMPORTS) -local github.com/vmware -d $$(test -e ./swagger-gen.log \
+			&& comm -12 <(echo "$(vendored)" | sort) \
+							 <(for x in $$(cat swagger-gen.log | grep creating | cut -d" " -f4 | sed -e "s/\"\(.*\)\"/\1/g");\
+										do find . -name "$x"; done | sort) \
 			|| echo "$(vendored)") 2>&1 | egrep -v '^$$'
 
 gofmt:
@@ -482,7 +483,9 @@ clean:
 	@rm -rf ./lib/apiservers/portlayer/cmd/
 	@rm -rf ./lib/apiservers/portlayer/models/
 	@rm -rf ./lib/apiservers/portlayer/restapi/operations/
-	@rm -rf ./lib/config/dynamic/admiral/
+	@rm -rf ./lib/config/dynamic/admiral/client
+	@rm -rf ./lib/config/dynamic/admiral/models
+	@rm -rf ./lib/config/dynamic/admiral/operations
 
 	@rm -f *.log
 	@rm -f *.pem

--- a/Makefile
+++ b/Makefile
@@ -223,7 +223,7 @@ goimports: $(GOIMPORTS)
 	@echo checking go imports...
 	@! $(GOIMPORTS) -local github.com/vmware -d $$(test -e ./swagger-gen.log \
 			&& comm -12 <(echo "$(vendored)" | sort) \
-							 <(for x in $$(cat swagger-gen.log | grep creating | cut -d" " -f4 | sed -e "s/\"\(.*\)\"/\1/g");\
+			            <(for x in $$(cat swagger-gen.log | grep creating | cut -d" " -f4 | sed -e "s/\"\(.*\)\"/\1/g");\
 										do find . -name "$x"; done | sort) \
 			|| echo "$(vendored)") 2>&1 | egrep -v '^$$'
 

--- a/Makefile
+++ b/Makefile
@@ -223,7 +223,7 @@ goimports: $(GOIMPORTS)
 	@! goimports -local github.com/vmware -d $$(\
 		 comm -23 <(find . -type f -name '*.go' -not -path "./vendor/*" | sort) \
 		          <(grep creating swagger-gen.log | awk '{print $$6 $$4};' | sed -e "s-\"\(.*\)\"-\./\1-g" | sed "s-\"\"-/-g" | sort)) \
-     | egrep -v '^$$'
+		 | egrep -v '^$$'
 
 gofmt:
 	@echo checking gofmt...

--- a/Makefile
+++ b/Makefile
@@ -218,14 +218,12 @@ golint: $(GOLINT)
 gopath:
 	@echo -n $(GOPATH)
 
-vendored := $(shell find . -type f -name '*.go' -not -path "./vendor/*")
 goimports: $(GOIMPORTS)
 	@echo checking go imports...
-	@! $(GOIMPORTS) -local github.com/vmware -d $$(test -e ./swagger-gen.log \
-			&& comm -12 <(echo "$(vendored)" | sort) \
-			            <(for x in $$(cat swagger-gen.log | grep creating | cut -d" " -f4 | sed -e "s/\"\(.*\)\"/\1/g");\
-			              	do find . -name "$x"; done | sort) \
-			|| echo "$(vendored)") 2>&1 | egrep -v '^$$'
+	@! goimports -local github.com/vmware -d $$(\
+		 comm -23 <(find . -type f -name '*.go' -not -path "./vendor/*" | sort) \
+		          <(grep creating swagger-gen.log | awk '{print $$6 $$4};' | sed -e "s-\"\(.*\)\"-\./\1-g" | sed "s-\"\"-/-g" | sort)) \
+     | egrep -v '^$$'
 
 gofmt:
 	@echo checking gofmt...

--- a/Makefile
+++ b/Makefile
@@ -220,7 +220,7 @@ gopath:
 
 goimports: $(GOIMPORTS)
 	@echo checking go imports...
-	@! goimports -local github.com/vmware -d $$(\
+	@! $(GOIMPORTS) -local github.com/vmware -d $$(\
 		 comm -23 <(find . -type f -name '*.go' -not -path "./vendor/*" | sort) \
 		          <(grep creating swagger-gen.log | awk '{print $$6 $$4};' | sed -e "s-\"\(.*\)\"-\./\1-g" | sed "s-\"\"-/-g" | sort)) \
 		 | egrep -v '^$$'

--- a/Makefile
+++ b/Makefile
@@ -224,7 +224,7 @@ goimports: $(GOIMPORTS)
 	@! $(GOIMPORTS) -local github.com/vmware -d $$(test -e ./swagger-gen.log \
 			&& comm -12 <(echo "$(vendored)" | sort) \
 			            <(for x in $$(cat swagger-gen.log | grep creating | cut -d" " -f4 | sed -e "s/\"\(.*\)\"/\1/g");\
-										do find . -name "$x"; done | sort) \
+			              	do find . -name "$x"; done | sort) \
 			|| echo "$(vendored)") 2>&1 | egrep -v '^$$'
 
 gofmt:

--- a/Makefile
+++ b/Makefile
@@ -218,9 +218,13 @@ golint: $(GOLINT)
 gopath:
 	@echo -n $(GOPATH)
 
+vendored := $(shell find . -type f -name '*.go' -not -path "./vendor/*")
 goimports: $(GOIMPORTS)
 	@echo checking go imports...
-	@! $(GOIMPORTS) -local github.com/vmware -d $$(find . -type f -name '*.go' -not -path "./vendor/*") 2>&1 | egrep -v '^$$'
+	@! $(GOIMPORTS) -local github.com/vmware -d $$(test -e ./swagger-gen.log &&\
+			comm -12 <(echo "$(vendored)" | sort) \
+							 <(for x in $$(cat swagger-gen.log | grep creating | cut -d" " -f4 | sed -e "s/\"\(.*\)\"/\1/g"); do find . -name "$x"; done | sort) \
+			|| echo "$(vendored)") 2>&1 | egrep -v '^$$'
 
 gofmt:
 	@echo checking gofmt...
@@ -478,6 +482,7 @@ clean:
 	@rm -rf ./lib/apiservers/portlayer/cmd/
 	@rm -rf ./lib/apiservers/portlayer/models/
 	@rm -rf ./lib/apiservers/portlayer/restapi/operations/
+	@rm -rf ./lib/config/dynamic/admiral/
 
 	@rm -f *.log
 	@rm -f *.pem


### PR DESCRIPTION
New Swagger-generated code is slowing down the goimports call in `make` to over ten minutes.
Now it is very fast.

Here is a successful run:
```
❯ time vic-build goimports
Generating dependency set for cmd/imagec/
Generating dependency set for cmd/vic-machine/
Generating dependency set for cmd/vicadmin/
Generating dependency set for cmd/port-layer-server/
Generating dependency set for cmd/vic-dns/
Generating dependency set for cmd/tether/
Generating dependency set for cmd/vic-ui/
Generating dependency set for cmd/docker/
Generating dependency set for cmd/vic-init/
Generating dependency set for cmd/rpctool/
Generating dependency set for cmd/gandalf/
building /go/bin/goimports...
checking go imports...
vic-build goimports  0.01s user 0.01s system 0% cpu 7.418 total
```

Here's a run where it catches a broken import:
```
❯ time vic-build goimports
Generating dependency set for cmd/imagec/
Generating dependency set for cmd/vic-machine/
Generating dependency set for cmd/vicadmin/
Generating dependency set for cmd/port-layer-server/
Generating dependency set for cmd/vic-dns/
Generating dependency set for cmd/tether/
Generating dependency set for cmd/vic-ui/
Generating dependency set for cmd/docker/
Generating dependency set for cmd/vic-init/
Generating dependency set for cmd/rpctool/
Generating dependency set for cmd/gandalf/
building /go/bin/goimports...
checking go imports...
diff -u ./pkg/vsphere/session/session.go.orig ./pkg/vsphere/session/session.go
--- ./pkg/vsphere/session/session.go.orig	2017-08-03 16:30:03.229598528 +0000
+++ ./pkg/vsphere/session/session.go	2017-08-03 16:30:03.229598528 +0000
@@ -33,6 +33,7 @@
 	log "github.com/Sirupsen/logrus"
 
 	"context"
+
 	"github.com/vmware/govmomi"
 	"github.com/vmware/govmomi/find"
 	"github.com/vmware/govmomi/object"
Makefile:222: recipe for target 'goimports' failed
make: *** [goimports] Error 1
vic-build goimports  0.01s user 0.04s system 0% cpu 9.995 total
```

ahh, much better. :)

Also I added the new Swagger generated files to `clean`.