### PR TITLE
[specific ci=1-39-Docker-Stats] Simplify docker stats CPU robot test

### DIFF
--- a/tests/test-cases/Group1-Docker-Commands/1-39-Docker-Stats.md
+++ b/tests/test-cases/Group1-Docker-Commands/1-39-Docker-Stats.md
@@ -13,7 +13,7 @@ This test requires that a vSphere server is running and available
 2. Run Stats no-stream for running container
 3. Run Stats with no-stream all which will return stats for running and stopped containers
 4. Verify the API memory output against govc
-5. Verify the API CPU output against govc
+5. Verify the API CPU output
 6. Run Stats with no-stream for a non-existent container
 7. Run Stats with no-stream for a stopped container
 8. Verify basic API network and disk output
@@ -25,8 +25,7 @@ This test requires that a vSphere server is running and available
    of greater than 5%
 3. Return stats for all containers -- will fail if output is missing either container
 4. Compare API results vs. govc result for memory accuracy -- will fail if variation greater than 1000 bytes
-5. Compare API results vs. govc result for CPU accuracy -- will fail if API value not present in past
-   six govc readings
+5. Verify that CPU fields are present - fails if missing
 6. Failure with error message
 7. Output should include the stopped container short id
 8. Fails if either the default network or disk are missing

--- a/tests/test-cases/Group1-Docker-Commands/1-39-Docker-Stats.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-39-Docker-Stats.robot
@@ -99,12 +99,11 @@ Stats API Memory Validation
     Should Be True  ${diff} < 1000
 
 Stats API CPU Validation
-    ${rc}  ${apiCPU}=  Run And Return Rc And Output  curl -sk --cert %{DOCKER_CERT_PATH}/cert.pem --key %{DOCKER_CERT_PATH}/key.pem -H "Accept: application/json" -H "Content-Type: application/json" -X GET https://%{VCH-IP}:%{VCH-PORT}/containers/%{STRESSED}/stats?stream=false | jq -r .cpu_stats.cpu_usage.percpu_usage[0]
+    ${rc}  ${apiCPU}=  Run And Return Rc And Output  curl -sk --cert %{DOCKER_CERT_PATH}/cert.pem --key %{DOCKER_CERT_PATH}/key.pem -H "Accept: application/json" -H "Content-Type: application/json" -X GET https://%{VCH-IP}:%{VCH-PORT}/containers/%{STRESSED}/stats?stream=false
     Should Be Equal As Integers  ${rc}  0
-    ${stress}=  Get Container ShortID  %{STRESSED}
-    ${rc}  ${vmomiCPU}=  Run And Return Rc And Output  govc metric.sample -json %{VM-PATH} cpu.usagemhz.average | jq -r .Sample[].Value[0].Value[]
-    Should Be Equal As Integers  ${rc}  0
-    Should Contain  ${vmomiCPU}  ${apiCPU}
+    Should Contain  ${apiCPU}  cpu_stats
+    Should Contain  ${apiCPU}  cpu_usage
+    Should Contain  ${apiCPU}  total_usage
 
 Stats No Stream Non-Existent Container
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} stats --no-stream fake


### PR DESCRIPTION
Removes data validation of CPU stats and instead tests
presence of CPU information.

Fixes #5530