### PR TITLE
[specific ci=1-*Docker-CP-*] Add retry to all toolbox cp and stat operations

### DIFF
--- a/lib/apiservers/engine/backends/archive.go
+++ b/lib/apiservers/engine/backends/archive.go
@@ -163,6 +163,7 @@ func (c *Container) importToContainer(op trace.Operation, vc *viccontainer.VicCo
 			break
 		}
 		if err != nil {
+			op.Errorf("Error reading tar header from client archive: %s", err)
 			return err
 		}
 
@@ -180,6 +181,10 @@ func (c *Container) importToContainer(op trace.Operation, vc *viccontainer.VicCo
 		if _, err = io.Copy(tarWriter, tarReader); err != nil {
 			op.Errorf("Error while copying tar data for %s: %s", header.Name, err.Error())
 			return err
+		}
+		// TODO: change this to log level 3
+		if vchConfig.Cfg.Diagnostics.DebugLevel >= 1 {
+			op.Debugf("Wrote entry: %s", header.Name)
 		}
 	}
 

--- a/lib/apiservers/portlayer/restapi/handlers/storage_handlers.go
+++ b/lib/apiservers/portlayer/restapi/handlers/storage_handlers.go
@@ -563,6 +563,7 @@ func (h *StorageHandlersImpl) ImportArchive(params storage.ImportArchiveParams) 
 	}
 
 	err = store.Import(op, id, filterSpec, params.Archive)
+
 	if err != nil {
 		op.Errorf("import failed: %s", err)
 		if os.IsNotExist(err) {

--- a/lib/archive/stripper.go
+++ b/lib/archive/stripper.go
@@ -58,7 +58,6 @@ func (s *Stripper) WriteTo(w io.Writer) (sum int64, err error) {
 	// semantic?
 
 	tw := tar.NewWriter(w)
-	defer tw.Flush()
 	for {
 		var header *tar.Header
 		header, err = s.source.Next()

--- a/lib/archive/stripper.go
+++ b/lib/archive/stripper.go
@@ -58,14 +58,13 @@ func (s *Stripper) WriteTo(w io.Writer) (sum int64, err error) {
 	// semantic?
 
 	tw := tar.NewWriter(w)
-
+	defer tw.Flush()
 	for {
 		var header *tar.Header
 		header, err = s.source.Next()
 		if err == io.EOF {
 			// do NOT call tarwriter.Close() and drop the EOF for io.Copy behaviour
 			err = nil
-
 			s.op.Debugf("Stripper dropping end of archive")
 			return
 		}

--- a/lib/portlayer/storage/vsphere/toolbox_common.go
+++ b/lib/portlayer/storage/vsphere/toolbox_common.go
@@ -107,11 +107,6 @@ func isInvalidStateError(err error) bool {
 		case *types.InvalidState:
 			return true
 		}
-	default:
-		if _, ok := err.(types.HasFault); ok {
-			// log this at the very least.
-			return false
-		}
 	}
 	return false
 }

--- a/lib/portlayer/storage/vsphere/toolbox_datasink.go
+++ b/lib/portlayer/storage/vsphere/toolbox_datasink.go
@@ -16,7 +16,6 @@ package vsphere
 
 import (
 	"io"
-	"time"
 
 	"github.com/vmware/govmomi/vim25/soap"
 	"github.com/vmware/govmomi/vim25/types"

--- a/lib/portlayer/storage/vsphere/toolbox_datasink.go
+++ b/lib/portlayer/storage/vsphere/toolbox_datasink.go
@@ -56,17 +56,12 @@ func (t *ToolboxDataSink) Import(op trace.Operation, spec *archive.FilterSpec, d
 
 	// upload the gzip archive.
 	p := soap.DefaultUpload
-	// These numbers are somewhat arbitrary best guesses
-	retryConf := retry.NewBackoffConfig()
-	retryConf.MaxElapsedTime = time.Second * 30
-	retryConf.InitialInterval = time.Millisecond * 500
-	retryConf.MaxInterval = time.Second * 5
 
 	retryFunc := func() error {
 		return client.Upload(op, data, target, p, &types.GuestPosixFileAttributes{}, true)
 	}
 
-	err = retry.DoWithConfig(retryFunc, isInvalidStateError, retryConf)
+	err = retry.DoWithConfig(retryFunc, isInvalidStateError, toolboxRetryConf)
 
 	if err != nil {
 		op.Debugf("Upload error: %s", err.Error())

--- a/lib/portlayer/storage/vsphere/toolbox_datasource.go
+++ b/lib/portlayer/storage/vsphere/toolbox_datasource.go
@@ -58,13 +58,6 @@ func (t *ToolboxDataSource) Export(op trace.Operation, spec *archive.FilterSpec,
 			op.Errorf("Cannot build archive url: %s", err.Error())
 			return nil, err
 		}
-
-		// These numbers are somewhat arbitrary best guesses
-		retryConf := retry.NewBackoffConfig()
-		retryConf.MaxElapsedTime = time.Second * 30
-		retryConf.InitialInterval = time.Millisecond * 500
-		retryConf.MaxInterval = time.Second * 5
-
 		var tar io.ReadCloser
 		var contentLength int64
 
@@ -74,7 +67,7 @@ func (t *ToolboxDataSource) Export(op trace.Operation, spec *archive.FilterSpec,
 			return retryErr
 		}
 
-		err = retry.DoWithConfig(retryFunc, isInvalidStateError, retryConf)
+		err = retry.DoWithConfig(retryFunc, isInvalidStateError, toolboxRetryConf)
 		if err != nil {
 			op.Errorf("Download error: %s", err.Error())
 			return nil, err
@@ -121,12 +114,6 @@ func (t *ToolboxDataSource) Stat(op trace.Operation, spec *archive.FilterSpec) (
 		return nil, err
 	}
 
-	// These numbers are somewhat arbitrary best guesses
-	retryConf := retry.NewBackoffConfig()
-	retryConf.MaxElapsedTime = time.Second * 30
-	retryConf.InitialInterval = time.Millisecond * 500
-	retryConf.MaxInterval = time.Second * 5
-
 	var statTar io.ReadCloser
 
 	retryFunc := func() error {
@@ -135,7 +122,7 @@ func (t *ToolboxDataSource) Stat(op trace.Operation, spec *archive.FilterSpec) (
 		return retryErr
 	}
 
-	err = retry.DoWithConfig(retryFunc, isInvalidStateError, retryConf)
+	err = retry.DoWithConfig(retryFunc, isInvalidStateError, toolboxRetryConf)
 	if err != nil {
 		op.Errorf("Download error: %s", err.Error())
 		return nil, err

--- a/lib/portlayer/storage/vsphere/toolbox_datasource.go
+++ b/lib/portlayer/storage/vsphere/toolbox_datasource.go
@@ -19,7 +19,6 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
-	"time"
 
 	"github.com/vmware/vic/lib/archive"
 	"github.com/vmware/vic/lib/portlayer/storage"

--- a/pkg/vsphere/tasks/waiter.go
+++ b/pkg/vsphere/tasks/waiter.go
@@ -108,10 +108,10 @@ func isRetryError(op trace.Operation, err error) bool {
 		switch f := soap.ToSoapFault(err).VimFault().(type) {
 		case types.TaskInProgress:
 			return true
-		case *types.NetworkDisruptedAndConfigRolledBack:
+		case types.NetworkDisruptedAndConfigRolledBack:
 			logExpectedFault(op, soapFault, f)
 			return true
-		case *types.InvalidArgument:
+		case types.InvalidArgument:
 			logExpectedFault(op, soapFault, f)
 			return true
 		default:

--- a/tests/test-cases/Group1-Docker-Commands/1-44-Docker-CP-Online.md
+++ b/tests/test-cases/Group1-Docker-Commands/1-44-Docker-CP-Online.md
@@ -52,8 +52,8 @@ This test requires that a vSphere server is running and available
 39. Run a container called subVol with 2 volumes attached to it
 40. Issue docker cp ./mnt subVol:/ to the new VIC appliance
 41. Inspect subVol:/mnt, subVol:/mnt/vol1 and subVol:/mnt/vol2 to verify that the copy operation succeeded
-42. Issue docker cp subVol:/mnt ./result to the new VIC appliance
-43. Inspect ./result on the host to verify that copy succeeded and remove it afterwards
+42. Issue docker cp subVol:/mnt ./result1 to the new VIC appliance
+43. Inspect ./result1 on the host to verify that copy succeeded and remove it afterwards
 44. Remove subVol
 45. Run a detached container called subVol_on with one volume attached to it
 46. Create a container called subVol_off with a volume that's shared with the online container subVol_on
@@ -61,8 +61,8 @@ This test requires that a vSphere server is running and available
 48. Stop subVol_on container
 49. Start subVol_off to inspect subVol_off:/mnt, subVol_off:/mnt/vol1 and subVol_off:/mnt/vol2 to verify the copy operation succeeded
 50. Stop subVol and start subVol_on
-51. Issue docker cp subVol_off:/mnt ./result to the new VIC appliance
-52. Inspect ./result on the host to verify that copy succeeded and remove it afterwards
+51. Issue docker cp subVol_off:/mnt ./result2 to the new VIC appliance
+52. Inspect ./result2 on the host to verify that copy succeeded and remove it afterwards
 53. Remove subVol_off and subVol_on
 54. Clean up created files, directories and volumes
 

--- a/tests/test-cases/Group1-Docker-Commands/1-44-Docker-CP-Online.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-44-Docker-CP-Online.robot
@@ -185,7 +185,7 @@ Concurrent copy: create processes to copy a small file from host to online conta
     :FOR  ${idx}  IN RANGE  0  10
     \   Should Contain  ${output}  foo-${idx}
 
-Concurrent copy: repeat copy a large file from host to offline container several times
+Concurrent copy: repeat copy a large file from host to online container several times
     ${pids}=  Create List
     Log To Console  \nIssue 10 docker cp commands for large file
     :FOR  ${idx}  IN RANGE  0  10
@@ -204,7 +204,7 @@ Concurrent copy: repeat copy a large file from host to offline container several
     :FOR  ${idx}  IN RANGE  0  10
     \   Should Contain  ${output}  lg-${idx}
 
-Concurrent copy: repeat copy a large file from offline container to host several times
+Concurrent copy: repeat copy a large file from online container to host several times
     ${pids}=  Create List
     Log To Console  \nIssue 10 docker cp commands for large file
     :FOR  ${idx}  IN RANGE  0  10

--- a/tests/test-cases/Group1-Docker-Commands/1-44-Docker-CP-Online.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-44-Docker-CP-Online.robot
@@ -239,15 +239,16 @@ Sub volumes: copy from host to an online container, dst includes several volumes
     Should Contain  ${output}  /mnt/vol2/v2.txt
 
 Sub volumes: copy from online container to host, src includes several volumes
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} cp subVol:/mnt ${CURDIR}/result
+    Remove Directory  ${CURDIR}/result1  recursive=True
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} cp subVol:/mnt ${CURDIR}/result1
     Should Be Equal As Integers  ${rc}  0
     Should Not Contain  ${output}  Error
-    OperatingSystem.Directory Should Exist  ${CURDIR}/result/vol1
-    OperatingSystem.Directory Should Exist  ${CURDIR}/result/vol2
-    OperatingSystem.File Should Exist  ${CURDIR}/result/root.txt
-    OperatingSystem.File Should Exist  ${CURDIR}/result/vol1/v1.txt
-    OperatingSystem.File Should Exist  ${CURDIR}/result/vol2/v2.txt
-    Remove Directory  ${CURDIR}/result  recursive=True
+    OperatingSystem.Directory Should Exist  ${CURDIR}/result1/vol1
+    OperatingSystem.Directory Should Exist  ${CURDIR}/result1/vol2
+    OperatingSystem.File Should Exist  ${CURDIR}/result1/root.txt
+    OperatingSystem.File Should Exist  ${CURDIR}/result1/vol1/v1.txt
+    OperatingSystem.File Should Exist  ${CURDIR}/result1/vol2/v2.txt
+    Remove Directory  ${CURDIR}/result1  recursive=True
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} rm -f subVol
     Should Be Equal As Integers  ${rc}  0
     Should Not Contain  ${output}  Error
@@ -277,15 +278,16 @@ Sub volumes: copy from host to an offline container, dst includes a shared vol w
     Should Not Contain  ${output}  Error
 
 Sub volumes: copy from an offline container to host, src includes a shared vol with an online container
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} cp subVol_off:/mnt ${CURDIR}/result
+    Remove Directory  ${CURDIR}/result2  recursive=True
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} cp subVol_off:/mnt ${CURDIR}/result2
     Should Be Equal As Integers  ${rc}  0
     Should Not Contain  ${output}  Error
-    OperatingSystem.Directory Should Exist  ${CURDIR}/result/vol1
-    OperatingSystem.Directory Should Exist  ${CURDIR}/result/vol2
-    OperatingSystem.File Should Exist  ${CURDIR}/result/root.txt
-    OperatingSystem.File Should Exist  ${CURDIR}/result/vol1/v1.txt
-    OperatingSystem.File Should Exist  ${CURDIR}/result/vol2/v2.txt
-    Remove Directory  ${CURDIR}/result  recursive=True
+    OperatingSystem.Directory Should Exist  ${CURDIR}/result2/vol1
+    OperatingSystem.Directory Should Exist  ${CURDIR}/result2/vol2
+    OperatingSystem.File Should Exist  ${CURDIR}/result2/root.txt
+    OperatingSystem.File Should Exist  ${CURDIR}/result2/vol1/v1.txt
+    OperatingSystem.File Should Exist  ${CURDIR}/result2/vol2/v2.txt
+    Remove Directory  ${CURDIR}/result2  recursive=True
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} rm -f subVol_off
     Should Be Equal As Integers  ${rc}  0
     Should Not Contain  ${output}  Error


### PR DESCRIPTION
This change should make us more resilient to the `InvalidStat` fault. Allowing more stability for cp operations against an online container.