### PR TITLE
Disable nonpersistent disk use [ci specific=1-43-*Offline]

### DIFF
--- a/pkg/vsphere/disk/util.go
+++ b/pkg/vsphere/disk/util.go
@@ -282,7 +282,7 @@ func findDiskByFilename(op trace.Operation, vm *vm.VirtualMachine, name string, 
 	}
 
 	if len(candidates) == 0 {
-		op.Infof("No disks match name: %s", name)
+		op.Infof("No disks match name and persistence: %s, %t", name, persistent)
 		return nil, os.ErrNotExist
 	}
 

--- a/tests/test-cases/Group1-Docker-Commands/1-43-Docker-CP-Offline.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-43-Docker-CP-Offline.robot
@@ -206,6 +206,7 @@ Concurrent copy: repeat copy a large file from host to offline container several
     Should Be Equal As Integers  ${rc}  0
     Should Not Contain  ${output}  Error
 
+# NOTE: this test depends on the prior test passing as it uses the copied files from that test as the source files for this test
 Concurrent copy: repeat copy a large file from offline container to host several times
     ${pids}=  Create List
     Log To Console  \nIssue 10 docker cp commands for large file


### PR DESCRIPTION
For now we need to disable non-persistent disk use as Stat and Import
clash against each other. Stat requests non-persistent, Import requires
persistent. We concurrent copyTo operations this results in a transient
failure due to the disk being attached non-persistent and held by multiple
Stat calls, but an Import call needed it in persistent mode.
Until/unless we have an ability to wait for the disk to become available
for a different mode we cannot be this granular.
This also disables r/o mount for the read only case as we do not yet
support per mount ref counts - it's all tied to the base disk so mounting
the same disk in two locations, one read/only one not isn't feasible.
