### PR TITLE
Avoid data loss in guest copy retry [specific ci=1-4*]

### DIFF
--- a/cmd/imagec/main.go
+++ b/cmd/imagec/main.go
@@ -35,6 +35,7 @@ import (
 	apiclient "github.com/vmware/vic/lib/apiservers/portlayer/client"
 	vicarchive "github.com/vmware/vic/lib/archive"
 	"github.com/vmware/vic/lib/imagec"
+	optrace "github.com/vmware/vic/pkg/trace"
 	"github.com/vmware/vic/pkg/version"
 	"github.com/vmware/vic/pkg/vsphere/sys"
 )
@@ -226,8 +227,9 @@ func writeArchiveFile(archiveProxy proxy.VicArchiveProxy, layerID, parentID, arc
 		return err
 	}
 
+	op := optrace.NewOperation(context.Background(), "export layer %s:%s", layerID, parentID)
 	//Initialize an archive stream from the portlayer for the layer
-	ar, err := archiveProxy.ArchiveExportReader(context.Background(), host, host, layerID, parentID, true, filterSpec)
+	ar, err := archiveProxy.ArchiveExportReader(op, host, host, layerID, parentID, true, filterSpec)
 	if err != nil || ar == nil {
 		return fmt.Errorf("Failed to get reader for layer %s", layerID)
 	}

--- a/lib/apiservers/engine/proxy/archive.go
+++ b/lib/apiservers/engine/proxy/archive.go
@@ -15,15 +15,12 @@
 package proxy
 
 import (
-	"context"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
 	"strings"
 	"sync"
-
-	log "github.com/Sirupsen/logrus"
 
 	"github.com/vmware/vic/lib/apiservers/portlayer/client"
 	"github.com/vmware/vic/lib/apiservers/portlayer/client/storage"
@@ -32,8 +29,8 @@ import (
 )
 
 type VicArchiveProxy interface {
-	ArchiveExportReader(ctx context.Context, store, ancestorStore, deviceID, ancestor string, data bool, filterSpec vicarchive.FilterSpec) (io.ReadCloser, error)
-	ArchiveImportWriter(ctx context.Context, store, deviceID string, filterSpec vicarchive.FilterSpec, wg *sync.WaitGroup, errchan chan error) (io.WriteCloser, error)
+	ArchiveExportReader(op trace.Operation, store, ancestorStore, deviceID, ancestor string, data bool, filterSpec vicarchive.FilterSpec) (io.ReadCloser, error)
+	ArchiveImportWriter(op trace.Operation, store, deviceID string, filterSpec vicarchive.FilterSpec, wg *sync.WaitGroup, errchan chan error) (io.WriteCloser, error)
 }
 
 //------------------------------------
@@ -50,7 +47,7 @@ func NewArchiveProxy(client *client.PortLayer) VicArchiveProxy {
 
 // ArchiveExportReader streams a tar archive from the portlayer.  Once the stream is complete,
 // an io.Reader is returned and the caller can use that reader to parse the data.
-func (a *ArchiveProxy) ArchiveExportReader(ctx context.Context, store, ancestorStore, deviceID, ancestor string, data bool, filterSpec vicarchive.FilterSpec) (io.ReadCloser, error) {
+func (a *ArchiveProxy) ArchiveExportReader(op trace.Operation, store, ancestorStore, deviceID, ancestor string, data bool, filterSpec vicarchive.FilterSpec) (io.ReadCloser, error) {
 	defer trace.End(trace.Begin(deviceID))
 
 	if store == "" || deviceID == "" {
@@ -64,19 +61,19 @@ func (a *ArchiveProxy) ArchiveExportReader(ctx context.Context, store, ancestorS
 	go func() {
 		// make sure we get out of io.Copy if context is canceled
 		select {
-		case <-ctx.Done():
+		case <-op.Done():
 			// Attempt to tell the portlayer to cancel the stream.  This is one way of cancelling the
 			// stream.  The other way is for the caller of this function to close the returned CloseReader.
 			// Callers of this function should do one but not both.
 			err := pipeReader.Close()
 			if err != nil {
-				log.Errorf("Error closing pipereader in ArchiveExportReader: %s", err.Error())
+				op.Errorf("Error closing pipereader in ArchiveExportReader: %s", err.Error())
 			}
 		}
 	}()
 
 	go func() {
-		params := storage.NewExportArchiveParamsWithContext(ctx).
+		params := storage.NewExportArchiveParamsWithContext(op).
 			WithStore(store).
 			WithAncestorStore(&ancestorStore).
 			WithDeviceID(deviceID).
@@ -88,31 +85,31 @@ func (a *ArchiveProxy) ArchiveExportReader(ctx context.Context, store, ancestorS
 		if valueBytes, merr := json.Marshal(filterSpec); merr == nil {
 			encodedFilter = base64.StdEncoding.EncodeToString(valueBytes)
 			params = params.WithFilterSpec(&encodedFilter)
-			log.Infof(" encodedFilter = %s", encodedFilter)
+			op.Infof(" encodedFilter = %s", encodedFilter)
 		}
 
 		_, err = a.client.Storage.ExportArchive(params, pipeWriter)
 		if err != nil {
-			log.Errorf("Error from ExportArchive: %s", err.Error())
+			op.Errorf("Error from ExportArchive: %s", err.Error())
 			switch err := err.(type) {
 			case *storage.ExportArchiveInternalServerError:
 				plErr := InternalServerError(fmt.Sprintf("Server error from archive reader for device %s", deviceID))
-				log.Errorf(plErr.Error())
+				op.Errorf(plErr.Error())
 				pipeWriter.CloseWithError(plErr)
 			case *storage.ExportArchiveLocked:
 				plErr := ResourceLockedError(fmt.Sprintf("Resource locked for device %s", deviceID))
-				log.Errorf(plErr.Error())
+				op.Errorf(plErr.Error())
 				pipeWriter.CloseWithError(plErr)
 			case *storage.ExportArchiveUnprocessableEntity:
 				plErr := InternalServerError("failed to process given path")
-				log.Errorf(plErr.Error())
+				op.Errorf(plErr.Error())
 				pipeWriter.CloseWithError(plErr)
 			default:
 				//Check for EOF.  Since the connection, transport, and data handling are
 				//encapsulated inside of Swagger, we can only detect EOF by checking the
 				//error string
 				if strings.Contains(err.Error(), swaggerSubstringEOF) {
-					log.Debugf("swagger error %s", err.Error())
+					op.Debugf("swagger error %s", err.Error())
 					pipeWriter.Close()
 				} else {
 					pipeWriter.CloseWithError(err)
@@ -128,7 +125,7 @@ func (a *ArchiveProxy) ArchiveExportReader(ctx context.Context, store, ancestorS
 
 // ArchiveImportWriter initializes a write stream for a path.  This is usually called
 // for getting a writer during docker cp TO container.
-func (a *ArchiveProxy) ArchiveImportWriter(ctx context.Context, store, deviceID string, filterSpec vicarchive.FilterSpec, wg *sync.WaitGroup, errchan chan error) (io.WriteCloser, error) {
+func (a *ArchiveProxy) ArchiveImportWriter(op trace.Operation, store, deviceID string, filterSpec vicarchive.FilterSpec, wg *sync.WaitGroup, errchan chan error) (io.WriteCloser, error) {
 	defer trace.End(trace.Begin(deviceID))
 
 	if store == "" || deviceID == "" {
@@ -142,7 +139,7 @@ func (a *ArchiveProxy) ArchiveImportWriter(ctx context.Context, store, deviceID 
 	go func() {
 		// make sure we get out of io.Copy if context is canceled
 		select {
-		case <-ctx.Done():
+		case <-op.Done():
 			pipeWriter.Close()
 		}
 	}()
@@ -151,14 +148,14 @@ func (a *ArchiveProxy) ArchiveImportWriter(ctx context.Context, store, deviceID 
 	go func() {
 		var plErr error
 		defer func() {
-			log.Debugf("Stream for device %s has returned from PL. Err received is %v ", deviceID, plErr)
+			op.Debugf("Stream for device %s has returned from PL. Err received is %v ", deviceID, plErr)
 			errchan <- plErr
 			wg.Done()
 		}()
 
 		// encodedFilter and destination are not required (from swagge spec) because
 		// they are allowed to be empty.
-		params := storage.NewImportArchiveParamsWithContext(ctx).
+		params := storage.NewImportArchiveParamsWithContext(op).
 			WithStore(store).
 			WithDeviceID(deviceID).
 			WithArchive(pipeReader)
@@ -175,19 +172,19 @@ func (a *ArchiveProxy) ArchiveImportWriter(ctx context.Context, store, deviceID 
 			switch err := err.(type) {
 			case *storage.ImportArchiveInternalServerError:
 				plErr = InternalServerError(fmt.Sprintf("error writing files to device %s", deviceID))
-				log.Errorf(plErr.Error())
+				op.Errorf(plErr.Error())
 				pipeReader.CloseWithError(plErr)
 			case *storage.ImportArchiveLocked:
 				plErr = ResourceLockedError(fmt.Sprintf("resource locked for device %s", deviceID))
-				log.Errorf(plErr.Error())
+				op.Errorf(plErr.Error())
 				pipeReader.CloseWithError(plErr)
 			case *storage.ImportArchiveNotFound:
 				plErr = ResourceNotFoundError("file or directory")
-				log.Errorf(plErr.Error())
+				op.Errorf(plErr.Error())
 				pipeReader.CloseWithError(plErr)
 			case *storage.ImportArchiveUnprocessableEntity:
 				plErr = InternalServerError("failed to process given path")
-				log.Errorf(plErr.Error())
+				op.Errorf(plErr.Error())
 				pipeReader.CloseWithError(plErr)
 			default:
 				//Check for EOF.  Since the connection, transport, and data handling are
@@ -195,7 +192,7 @@ func (a *ArchiveProxy) ArchiveImportWriter(ctx context.Context, store, deviceID 
 				//error string
 				plErr = err
 				if strings.Contains(err.Error(), swaggerSubstringEOF) {
-					log.Errorf(err.Error())
+					op.Error(err)
 					pipeReader.Close()
 				} else {
 					pipeReader.CloseWithError(err)

--- a/pkg/vsphere/disk/disk_manager.go
+++ b/pkg/vsphere/disk/disk_manager.go
@@ -624,7 +624,14 @@ func (m *Manager) DiskFinder(op trace.Operation, filter func(p string) bool) (st
 	// iterate over them to see whether they have the disk we want
 	for i := range mos {
 		mo := mos[i]
+
 		op.Debugf("Working on vm %q", mo.Name)
+
+		// observed empty fields here when copying to all 14 volumes on a cVM so being paranoid
+		if mo.Config == nil || mo.Config.Hardware.Device == nil {
+			op.Warnf("Skipping disk presence check for %q: failed to retrieve vm config", mo.Name)
+			continue
+		}
 
 		for _, device := range mo.Config.Hardware.Device {
 			label := device.GetVirtualDevice().DeviceInfo.GetDescription().Label


### PR DESCRIPTION
Adds nil checks for an occasional missing mo.Config data, and the
buffering of data before calling client.Upload to preserve data for a
retry in case of guest operation collision.

Adds operation trace back into personality archive for concurrent debug.

TODO: needs a check for max mem size vs file or at least knowledge of what
happens when a file exceeding available appliance memory needs buffering