### PR TITLE
[specific ci=6-09-Inspect] Fix vic-machine integration test cleanup

### DIFF
--- a/tests/test-cases/Group6-VIC-Machine/6-09-Inspect.robot
+++ b/tests/test-cases/Group6-VIC-Machine/6-09-Inspect.robot
@@ -147,6 +147,8 @@ Verify inspect output for a full tls VCH
     Should Contain  ${output}  Unable to find valid client certs
     Should Contain  ${output}  DOCKER_CERT_PATH must be provided in environment or certificates specified individually via CLI arguments
 
+    Cleanup VIC Appliance On Test Server
+
 Verify inspect output for a --no-tls VCH
     Set Test Environment Variables
     ${output}=  Run  bin/vic-machine-linux create --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --image-store=%{TEST_DATASTORE} --bridge-network=%{BRIDGE_NETWORK} --public-network=%{PUBLIC_NETWORK} --no-tls


### PR DESCRIPTION
This change fixes a regression from commit 5028f88 where a VCH was
not being cleaned up after a 6-09-Inspect robot test.

Regression: https://github.com/vmware/vic/commit/5028f88518afafd58e32abcf65ed700ee6c25e68#diff-80d5e5f03b22c62caaf2258e06a1b10aL122

See build https://ci.vcna.io/vmware/vic/12949 for leftover artifacts in
that test.
