### PR TITLE
Support waiting on iptables processes

### DIFF
--- a/cmd/tether/main_test.go
+++ b/cmd/tether/main_test.go
@@ -138,6 +138,10 @@ func (m *mockery) Stop() error {
 func (m *mockery) Register(name string, config tether.Extension) {
 }
 
+func (m *mockery) LaunchUtility(fn func() (*os.Process, error)) (<-chan int, error) {
+	return nil, nil
+}
+
 // Test reloading via signal helper
 func TestReload(t *testing.T) {
 	m := &mockery{make(chan bool)}

--- a/cmd/tether/main_test.go
+++ b/cmd/tether/main_test.go
@@ -79,13 +79,13 @@ func createFakeDevices() error {
 func testSetup(t *testing.T) *Mocker {
 	var err error
 
-	mocker := tetherTestSetup(t)
-
 	pathPrefix, err = ioutil.TempDir("", path.Base(t.Name()))
 	if err != nil {
 		fmt.Println(err)
 		t.Error(err)
 	}
+
+	mocker := tetherTestSetup(t)
 
 	err = os.MkdirAll(pathPrefix, 0777)
 	if err != nil {
@@ -138,7 +138,7 @@ func (m *mockery) Stop() error {
 func (m *mockery) Register(name string, config tether.Extension) {
 }
 
-func (m *mockery) LaunchUtility(fn func() (*os.Process, error)) (<-chan int, error) {
+func (m *mockery) LaunchUtility(fn tether.UtilityFn) (<-chan int, error) {
 	return nil, nil
 }
 

--- a/cmd/tether/net_linux_test.go
+++ b/cmd/tether/net_linux_test.go
@@ -1,0 +1,126 @@
+// Copyright 2016 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build linux
+
+package main
+
+import (
+	"fmt"
+	"strconv"
+	"testing"
+
+	"github.com/vishvananda/netlink"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/vmware/vic/lib/config/executor"
+	"github.com/vmware/vic/lib/tether"
+	"github.com/vmware/vic/pkg/vsphere/extraconfig"
+)
+
+// Utility method to add an interface to Mocked
+// This assigns the interface name and returns the "slot" as a string
+func AddInterface(name string, mocker *Mocker) string {
+	mocker.maxSlot++
+
+	mocker.Interfaces[name] = &Interface{
+		LinkAttrs: netlink.LinkAttrs{
+			Name:  name,
+			Index: mocker.maxSlot,
+		},
+		Up: true,
+	}
+
+	return strconv.Itoa(mocker.maxSlot)
+}
+
+func TestOutboundRuleAndCmd(t *testing.T) {
+	mocker := testSetup(t)
+	defer testTeardown(t, mocker)
+
+	bridge := AddInterface("eth1", mocker)
+
+	ip, _ := netlink.ParseIPNet("172.16.0.2/24")
+	gwIP, _ := netlink.ParseIPNet("172.16.0.1/24")
+
+	cfg := executor.ExecutorConfig{
+		ExecutorConfigCommon: executor.ExecutorConfigCommon{
+			ID:   "outboundrule",
+			Name: "tether_test_executor",
+		},
+		Diagnostics: executor.Diagnostics{
+			DebugLevel: 3,
+		},
+		Networks: map[string]*executor.NetworkEndpoint{
+			"bridge": {
+				Common: executor.Common{
+					ID: bridge,
+					// interface rename
+					Name: "bridge",
+				},
+				Network: executor.ContainerNetwork{
+					Common: executor.Common{
+						Name: "bridge",
+					},
+					Default: true,
+					Gateway: *gwIP,
+				},
+				Static: true,
+				IP:     ip,
+			},
+		},
+
+		Sessions: map[string]*executor.SessionConfig{
+			"outboundrule": {
+				Common: executor.Common{
+					ID:   "outboundrule",
+					Name: "tether_test_session",
+				},
+				Tty:    false,
+				Active: true,
+
+				Cmd: executor.Cmd{
+					// test relative path
+					Path: "./date",
+					Args: []string{"./date", "--reference=/"},
+					Env:  []string{"PATH="},
+					Dir:  "/bin",
+				},
+			},
+		},
+	}
+
+	_, src, _ := StartTether(t, &cfg, mocker)
+
+	fmt.Println("Waiting for tether start")
+	<-mocker.Started
+
+	// wait for tether to exit
+	fmt.Println("Waiting for tether exit")
+	<-mocker.Cleaned
+
+	result := tether.ExecutorConfig{}
+	extraconfig.Decode(src, &result)
+
+	// confirm outbound rules configured
+	// this should modify state depending on prior rule state
+
+	// confirm command ran - necessary to detect early exit due to net config error
+	// TODO: this should be modifed to fail if the last rule to be configured hasn't completed with expected output
+	// when this is run. Pending mocked iptables interface
+	assert.Equal(t, "true", result.Sessions["outboundrule"].Started, "Expected command to have been started successfully")
+	assert.Equal(t, 0, result.Sessions["outboundrule"].ExitStatus, "Expected command to have exited cleanly")
+
+}

--- a/cmd/tether/net_linux_test.go
+++ b/cmd/tether/net_linux_test.go
@@ -1,4 +1,4 @@
-// Copyright 2016 VMware, Inc. All Rights Reserved.
+// Copyright 2017 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -21,18 +21,17 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/vishvananda/netlink"
-
 	"github.com/stretchr/testify/assert"
+	"github.com/vishvananda/netlink"
 
 	"github.com/vmware/vic/lib/config/executor"
 	"github.com/vmware/vic/lib/tether"
 	"github.com/vmware/vic/pkg/vsphere/extraconfig"
 )
 
-// Utility method to add an interface to Mocked
+// addInterface utility method to add an interface to Mocked
 // This assigns the interface name and returns the "slot" as a string
-func AddInterface(name string, mocker *Mocker) string {
+func addInterface(name string, mocker *Mocker) string {
 	mocker.maxSlot++
 
 	mocker.Interfaces[name] = &Interface{
@@ -50,7 +49,7 @@ func TestOutboundRuleAndCmd(t *testing.T) {
 	mocker := testSetup(t)
 	defer testTeardown(t, mocker)
 
-	bridge := AddInterface("eth1", mocker)
+	bridge := addInterface("eth1", mocker)
 
 	ip, _ := netlink.ParseIPNet("172.16.0.2/24")
 	gwIP, _ := netlink.ParseIPNet("172.16.0.1/24")

--- a/cmd/tether/ops_linux.go
+++ b/cmd/tether/ops_linux.go
@@ -373,7 +373,7 @@ func allowPingTraffic(ctx context.Context, t *tether.BaseOperations, ifaceName s
 		ICMPType:        netfilter.EchoReply,
 		SourceAddresses: sourceAddresses,
 	}).Commit(ctx)
-	if err := invoke(t, fn, err, "allow poing outbound"); err != nil {
+	if err := invoke(t, fn, err, "allow ping outbound"); err != nil {
 		return err
 	}
 	return nil

--- a/cmd/tether/ops_linux_test.go
+++ b/cmd/tether/ops_linux_test.go
@@ -1,4 +1,4 @@
-// Copyright 2016 VMware, Inc. All Rights Reserved.
+// Copyright 2017 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -26,6 +26,9 @@ import (
 	"github.com/vmware/vic/pkg/trace"
 )
 
+// This has been copied from lib/tether/ but should be split into a common base package that is
+// dedicated to mocking these operations. We cannot reference lib/tether/*_test elements from
+// outside that package.
 type Interface struct {
 	netlink.LinkAttrs
 	Up    bool

--- a/cmd/tether/ops_linux_test.go
+++ b/cmd/tether/ops_linux_test.go
@@ -1,0 +1,158 @@
+// Copyright 2016 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build linux
+
+package main
+
+import (
+	"errors"
+	"fmt"
+	"syscall"
+
+	"github.com/vishvananda/netlink"
+
+	"github.com/vmware/vic/pkg/trace"
+)
+
+type Interface struct {
+	netlink.LinkAttrs
+	Up    bool
+	Addrs []netlink.Addr
+}
+
+func (t *Interface) Attrs() *netlink.LinkAttrs {
+	return &t.LinkAttrs
+}
+
+func (t *Interface) Type() string {
+	return "mocked"
+}
+
+func (t *Mocker) LinkByName(name string) (netlink.Link, error) {
+	defer trace.End(trace.Begin(fmt.Sprintf("Getting link by name %s", name)))
+
+	return t.Interfaces[name], nil
+}
+
+func (t *Mocker) LinkSetName(link netlink.Link, name string) error {
+	defer trace.End(trace.Begin(fmt.Sprintf("Renaming %s to %s", link.Attrs().Name, name)))
+
+	iface := link.(*Interface)
+	_, ok := t.Interfaces[name]
+	if ok {
+		return fmt.Errorf("Interface with name %s already exists", name)
+	}
+
+	oldName := iface.Name
+	iface.Name = name
+	// make sure there's no period where the interface isn't "present"
+	t.Interfaces[name] = iface
+	delete(t.Interfaces, oldName)
+
+	return nil
+}
+
+func (t *Mocker) LinkSetDown(link netlink.Link) error {
+	defer trace.End(trace.Begin(fmt.Sprintf("Bringing %s down", link.Attrs().Name)))
+
+	iface := link.(*Interface)
+	iface.Up = false
+	// TODO: should this drop addresses?
+	return nil
+}
+
+func (t *Mocker) LinkSetUp(link netlink.Link) error {
+	defer trace.End(trace.Begin(fmt.Sprintf("Bringing %s up", link.Attrs().Name)))
+
+	iface := link.(*Interface)
+	iface.Up = true
+	return nil
+}
+
+func (t *Mocker) LinkSetAlias(link netlink.Link, alias string) error {
+	defer trace.End(trace.Begin(fmt.Sprintf("Adding alias %s to %s", alias, link.Attrs().Name)))
+
+	iface := link.(*Interface)
+	iface.Alias = alias
+	return nil
+}
+
+func (t *Mocker) AddrList(link netlink.Link, family int) ([]netlink.Addr, error) {
+	defer trace.End(trace.Begin(""))
+
+	iface := link.(*Interface)
+	return iface.Addrs, nil
+}
+
+func (t *Mocker) AddrAdd(link netlink.Link, addr *netlink.Addr) error {
+	defer trace.End(trace.Begin(fmt.Sprintf("Adding %s to %s", addr.String(), link.Attrs().Name)))
+
+	iface := link.(*Interface)
+
+	for _, adr := range iface.Addrs {
+		if addr.IP.String() == adr.IP.String() {
+			return syscall.EEXIST
+		}
+	}
+
+	iface.Addrs = append(iface.Addrs, *addr)
+	return nil
+}
+
+func (t *Mocker) AddrDel(link netlink.Link, addr *netlink.Addr) error {
+	iface := link.(*Interface)
+
+	for i, adr := range iface.Addrs {
+		if addr.IP.String() == adr.IP.String() {
+			iface.Addrs = append(iface.Addrs[:i], iface.Addrs[i+1:]...)
+			return nil
+		}
+	}
+
+	return syscall.EADDRNOTAVAIL
+}
+
+func (t *Mocker) RouteAdd(route *netlink.Route) error {
+	defer trace.End(trace.Begin("no implemented"))
+
+	// currently ignored
+	return nil
+}
+
+func (t *Mocker) RouteDel(route *netlink.Route) error {
+	defer trace.End(trace.Begin("no implemented"))
+
+	// currently ignored
+	return nil
+}
+
+func (t *Mocker) RuleList(int) ([]netlink.Rule, error) {
+	defer trace.End(trace.Begin("not implemented"))
+
+	return nil, nil
+}
+
+func (t *Mocker) LinkBySlot(slot int32) (netlink.Link, error) {
+	defer trace.End(trace.Begin(""))
+
+	id := int(slot)
+	for _, intf := range t.Interfaces {
+		if intf.Attrs().Index == id {
+			return intf, nil
+		}
+	}
+
+	return nil, errors.New("no such interface")
+}

--- a/cmd/tether/tether_test.go
+++ b/cmd/tether/tether_test.go
@@ -126,7 +126,7 @@ func (t *Mocker) SetHostname(hostname string, aliases ...string) error {
 	return nil
 }
 
-func (t *Mocker) SetupFirewall(*tether.ExecutorConfig) error {
+func (t *Mocker) SetupFirewall(ctx context.Context, config *tether.ExecutorConfig) error {
 	return nil
 }
 

--- a/cmd/tether/tether_test.go
+++ b/cmd/tether/tether_test.go
@@ -23,9 +23,11 @@ import (
 	"net"
 	"net/url"
 	"os"
+	"path"
 	"testing"
 
 	log "github.com/Sirupsen/logrus"
+	"github.com/vishvananda/netlink"
 	"golang.org/x/crypto/ssh"
 
 	"github.com/vmware/vic/lib/config/executor"
@@ -57,6 +59,11 @@ type Mocker struct {
 	// session output gets logged here
 	SessionLogBuffer bytes.Buffer
 
+	// track the number of interfaces for a run
+	maxSlot int
+	// the interfaces in the system indexed by name
+	Interfaces map[string]netlink.Link
+
 	// the hostname of the system
 	Hostname string
 	// the ip configuration for name index networks
@@ -86,13 +93,15 @@ func (t *Mocker) Reload(config *tether.ExecutorConfig) error {
 	return nil
 }
 
-func (t *Mocker) Setup(_ tether.Config) error {
-	return nil
+func (t *Mocker) Setup(config tether.Config) error {
+	return t.Base.Setup(config)
 }
 
 func (t *Mocker) Cleanup() error {
+	err := t.Base.Cleanup()
 	close(t.Cleaned)
-	return nil
+
+	return err
 }
 
 func (t *Mocker) Log() (io.Writer, error) {
@@ -127,15 +136,19 @@ func (t *Mocker) SetHostname(hostname string, aliases ...string) error {
 }
 
 func (t *Mocker) SetupFirewall(ctx context.Context, config *tether.ExecutorConfig) error {
+	err := setupFirewall(ctx, &t.Base, config)
+	// NOTE: we squash errors from here for now because it's almost certain to fail
+	// in absence of a mock for the iptables update
+	if err != nil {
+		log.Error(err)
+	}
+
 	return nil
 }
 
 // Apply takes the network endpoint configuration and applies it to the system
 func (t *Mocker) Apply(endpoint *tether.NetworkEndpoint) error {
-	defer trace.End(trace.Begin("mocking endpoint configuration for " + endpoint.Network.Name))
-	t.IPs[endpoint.Network.Name] = endpoint.Assigned.IP
-
-	return nil
+	return tether.ApplyEndpoint(t, &t.Base, endpoint)
 }
 
 // MountLabel performs a mount with the source treated as a disk label
@@ -175,22 +188,44 @@ func (t *Mocker) Fork() error {
 	return errors.New("Fork test not implemented")
 }
 
+// LaunchUtility uses the underlying implementation for launching and tracking utility processes
+func (t *Mocker) LaunchUtility(fn tether.UtilityFn) (<-chan int, error) {
+	return t.Base.LaunchUtility(fn)
+}
+
+func (t *Mocker) HandleUtilityExit(pid, exitCode int) bool {
+	return t.Base.HandleUtilityExit(pid, exitCode)
+}
+
 // TestMain simply so we have control of debugging level and somewhere to call package wide test setup
 func TestMain(m *testing.M) {
 	log.SetLevel(log.DebugLevel)
-
-	// replace the Sys variable with a mock
-	tether.Sys = system.System{
-		Hosts:      &tether.MockHosts{},
-		ResolvConf: &tether.MockResolvConf{},
-		Syscall:    &tether.MockSyscall{},
-		Root:       os.TempDir(),
-	}
 
 	retCode := m.Run()
 
 	// call with result of m.Run()
 	os.Exit(retCode)
+}
+
+func StartTether(t *testing.T, cfg *executor.ExecutorConfig, mocker *Mocker) (tether.Tether, extraconfig.DataSource, extraconfig.DataSink) {
+	store := extraconfig.New()
+	sink := store.Put
+	src := store.Get
+	extraconfig.Encode(sink, cfg)
+	log.Debugf("Test configuration: %#v", sink)
+
+	tthr = tether.New(src, sink, mocker)
+	tthr.Register("mocker", mocker)
+
+	// run the tether to service the attach
+	go func() {
+		erR := tthr.Start()
+		if erR != nil {
+			t.Error(erR)
+		}
+	}()
+
+	return tthr, src, sink
 }
 
 func StartAttachTether(t *testing.T, cfg *executor.ExecutorConfig, mocker *Mocker) (tether.Tether, extraconfig.DataSource, net.Conn) {
@@ -228,9 +263,23 @@ func tetherTestSetup(t *testing.T) *Mocker {
 
 	// use the mock ops - fresh one each time as tests might apply different mocked calls
 	mocker := Mocker{
-		Started: make(chan bool),
-		Cleaned: make(chan bool),
+		Started:    make(chan bool),
+		Cleaned:    make(chan bool),
+		Interfaces: make(map[string]netlink.Link, 0),
 	}
+
+	// replace the Sys variable with a mock
+	tether.Sys = system.NewWithRoot(pathPrefix)
+	tether.Sys.Syscall = &tether.MockSyscall{}
+
+	tether.BindSys = system.NewWithRoot(path.Join(pathPrefix, "/.tether"))
+	tether.BindSys.Syscall = &tether.MockSyscall{}
+
+	// ensure that the sys and bindsys root exists
+	// #nosec
+	os.MkdirAll(tether.Sys.Root, 0700)
+	// #nosec
+	os.MkdirAll(tether.BindSys.Root, 0700)
 
 	return &mocker
 }

--- a/cmd/vic-init/ops_linux.go
+++ b/cmd/vic-init/ops_linux.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 
@@ -29,7 +30,7 @@ const (
 	publicIfaceName = "public"
 )
 
-func (t *operations) SetupFirewall(config *tether.ExecutorConfig) error {
+func (t *operations) SetupFirewall(ctx context.Context, config *tether.ExecutorConfig) error {
 	// get the public interface name
 	l, err := netlink.LinkByName(publicIfaceName)
 	if l == nil {

--- a/cmd/vic-init/tether_test.go
+++ b/cmd/vic-init/tether_test.go
@@ -128,7 +128,7 @@ func (t *Mocker) SetHostname(hostname string, aliases ...string) error {
 	return nil
 }
 
-func (t *Mocker) SetupFirewall(*tether.ExecutorConfig) error {
+func (t *Mocker) SetupFirewall(cxt context.Context, conf *tether.ExecutorConfig) error {
 	return nil
 }
 

--- a/cmd/vic-init/tether_test.go
+++ b/cmd/vic-init/tether_test.go
@@ -178,6 +178,15 @@ func (t *Mocker) Fork() error {
 	return errors.New("Fork test not implemented")
 }
 
+// LaunchUtility uses the underlying implementation for launching and tracking utility processes
+func (t *Mocker) LaunchUtility(fn tether.UtilityFn) (<-chan int, error) {
+	return t.Base.LaunchUtility(fn)
+}
+
+func (t *Mocker) HandleUtilityExit(pid, exitCode int) bool {
+	return t.Base.HandleUtilityExit(pid, exitCode)
+}
+
 // TestMain simply so we have control of debugging level and somewhere to call package wide test setup
 func TestMain(m *testing.M) {
 	log.SetLevel(log.DebugLevel)

--- a/lib/system/system.go
+++ b/lib/system/system.go
@@ -22,6 +22,8 @@
 package system
 
 import (
+	"path"
+
 	"github.com/vmware/vic/lib/etcconf"
 	"github.com/vmware/vic/pkg/vsphere/sys"
 )
@@ -43,6 +45,20 @@ func New() System {
 		ResolvConf: etcconf.NewResolvConf(""), // default resolv.conf file, e.g. /etc/resolv.conf on linux
 		Syscall:    &syscallImpl{},            // the syscall interface
 		Root:       "/",                       // the system root path
+		UUID:       id,
+	}
+}
+
+// NewWithRoot takes a path at which to set the "root" of the system.
+// This will cause the hosts and resolv.conf files to be in their default paths, but
+// relative to that root
+func NewWithRoot(root string) System {
+	id, _ := sys.UUID()
+	return System{
+		Hosts:      etcconf.NewHosts(path.Join(root, etcconf.HostsPath)),           // default hosts files, e.g. /etc/hosts on linux
+		ResolvConf: etcconf.NewResolvConf(path.Join(root, etcconf.ResolvConfPath)), // default resolv.conf file, e.g. /etc/resolv.conf on linux
+		Syscall:    &syscallImpl{},                                                 // the syscall interface
+		Root:       root,                                                           // the system root path
 		UUID:       id,
 	}
 }

--- a/lib/tether/config.go
+++ b/lib/tether/config.go
@@ -46,6 +46,9 @@ type ExecutorConfig struct {
 	// Set of child PIDs created by us.
 	pids map[int]*SessionConfig `vic:"0.1" scope:"read-only" recurse:"depth=0"`
 
+	// set of child PIDs for one-off non-persistent processes
+	utilityPids map[int]chan int
+
 	// Sessions is the set of sessions currently hosted by this executor
 	// These are keyed by session ID
 	Sessions map[string]*SessionConfig `vic:"0.1" scope:"read-only" key:"sessions"`

--- a/lib/tether/config.go
+++ b/lib/tether/config.go
@@ -46,9 +46,6 @@ type ExecutorConfig struct {
 	// Set of child PIDs created by us.
 	pids map[int]*SessionConfig `vic:"0.1" scope:"read-only" recurse:"depth=0"`
 
-	// set of child PIDs for one-off non-persistent processes
-	utilityPids map[int]chan int
-
 	// Sessions is the set of sessions currently hosted by this executor
 	// These are keyed by session ID
 	Sessions map[string]*SessionConfig `vic:"0.1" scope:"read-only" key:"sessions"`

--- a/lib/tether/interfaces.go
+++ b/lib/tether/interfaces.go
@@ -23,6 +23,9 @@ import (
 	"github.com/vmware/vic/pkg/dio"
 )
 
+// UtilityFn is the sigature of a function that can be used to launch a utility process
+type UtilityFn func() (*os.Process, error)
+
 // Operations defines the set of operations that Tether depends upon. These are split out for:
 // * portability
 // * dependency injection (primarily for testing)
@@ -47,7 +50,7 @@ type Operations interface {
 	ProcessEnv(env []string) []string
 	// LaunchUtility starts a process and provides a way to block on completion and retrieve
 	// it's exit code. This is needed to co-exist with a childreaper.
-	LaunchUtility(fn func() (*os.Process, error)) (<-chan int, error)
+	LaunchUtility(UtilityFn) (<-chan int, error)
 	// HandleUtilityExit will process the utility exit. If the pid cannot be matched to a launched
 	// utility process then this returns false and does nothing.
 	HandleUtilityExit(pid, exitCode int) bool

--- a/lib/tether/interfaces.go
+++ b/lib/tether/interfaces.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"io"
 	"net/url"
+	"os"
 
 	"github.com/vmware/vic/pkg/dio"
 )
@@ -33,7 +34,7 @@ type Operations interface {
 	Log() (io.Writer, error)
 
 	SetHostname(hostname string, aliases ...string) error
-	SetupFirewall(config *ExecutorConfig) error
+	SetupFirewall(ctx context.Context, config *ExecutorConfig) error
 	Apply(endpoint *NetworkEndpoint) error
 	MountLabel(ctx context.Context, label, target string) error
 	MountTarget(ctx context.Context, source url.URL, target string, mountOptions string) error
@@ -52,6 +53,7 @@ type Tether interface {
 	Stop() error
 	Reload()
 	Register(name string, ext Extension)
+	LaunchUtility(fn func() (*os.Process, error)) (<-chan int, error)
 }
 
 // Extension is a very simple extension interface for supporting code that need to be

--- a/lib/tether/interfaces.go
+++ b/lib/tether/interfaces.go
@@ -45,6 +45,12 @@ type Operations interface {
 	// Returns a function to invoke after the session state has been persisted
 	HandleSessionExit(config *ExecutorConfig, session *SessionConfig) func()
 	ProcessEnv(env []string) []string
+	// LaunchUtility starts a process and provides a way to block on completion and retrieve
+	// it's exit code. This is needed to co-exist with a childreaper.
+	LaunchUtility(fn func() (*os.Process, error)) (<-chan int, error)
+	// HandleUtilityExit will process the utility exit. If the pid cannot be matched to a launched
+	// utility process then this returns false and does nothing.
+	HandleUtilityExit(pid, exitCode int) bool
 }
 
 // Tether presents the consumption interface for code needing to run a tether
@@ -53,7 +59,6 @@ type Tether interface {
 	Stop() error
 	Reload()
 	Register(name string, ext Extension)
-	LaunchUtility(fn func() (*os.Process, error)) (<-chan int, error)
 }
 
 // Extension is a very simple extension interface for supporting code that need to be

--- a/lib/tether/netfilter/netfilter_linux.go
+++ b/lib/tether/netfilter/netfilter_linux.go
@@ -161,7 +161,6 @@ func (r *Rule) args() ([]string, error) {
 }
 
 func iptables(ctx context.Context, args []string) (tether.UtilityFn, error) {
-	args = append(args, "-w")
 	logrus.Infof("Execing iptables %q", args)
 
 	// #nosec: Subprocess launching with variable

--- a/lib/tether/netfilter/netfilter_linux.go
+++ b/lib/tether/netfilter/netfilter_linux.go
@@ -25,6 +25,8 @@ import (
 	"syscall"
 
 	"github.com/Sirupsen/logrus"
+
+	"github.com/vmware/vic/lib/tether"
 )
 
 //
@@ -171,6 +173,31 @@ func iptables(ctx context.Context, args []string) error {
 			Chroot: "/.tether",
 		},
 	}
+
+	if t := ctx.Value(tether.TetherKey{}); t != nil {
+		t, ok := t.(tether.Tether)
+		if !ok {
+			return errors.New("couldn't cast a tether object")
+		}
+
+		exitChannel, err := t.LaunchUtility(func() (*os.Process, error) {
+			return os.StartProcess(cmd.Path, cmd.Args, &os.ProcAttr{
+				Dir: cmd.Dir,
+				Sys: cmd.SysProcAttr,
+			})
+		})
+		if err != nil {
+			// can log the pid in launchUtilityProcess instead
+			logrus.Errorf("iptables %q error: %s", args, err)
+			return err
+		}
+
+		<-exitChannel
+		return nil
+	}
+	// tether wasn't passed in -- do it the old way
+	logrus.Debugln("No tether object provided to iptables call")
+
 	proc, err := os.StartProcess(cmd.Path, cmd.Args, &os.ProcAttr{
 		Dir: cmd.Dir,
 		Sys: cmd.SysProcAttr,
@@ -179,7 +206,6 @@ func iptables(ctx context.Context, args []string) error {
 	if err != nil {
 		logrus.Errorf("iptables %q (Pid %v) error: %s", args, proc.Pid, err.Error())
 	}
-
 	return err
 }
 

--- a/lib/tether/ops_linux.go
+++ b/lib/tether/ops_linux.go
@@ -105,11 +105,6 @@ type Netlink interface {
 	LinkBySlot(slot int32) (netlink.Link, error)
 }
 
-// func init() {
-// 	Sys.Hosts = etcconf.NewHosts(hostsPathBindSrc)
-// 	Sys.ResolvConf = etcconf.NewResolvConf(resolvConfPathBindSrc)
-// }
-
 func (t *BaseOperations) LinkByName(name string) (netlink.Link, error) {
 	return netlink.LinkByName(name)
 }

--- a/lib/tether/ops_linux.go
+++ b/lib/tether/ops_linux.go
@@ -532,10 +532,10 @@ func (t *BaseOperations) updateNameservers(endpoint *NetworkEndpoint) error {
 func (t *BaseOperations) Apply(endpoint *NetworkEndpoint) error {
 	defer trace.End(trace.Begin("applying endpoint configuration for " + endpoint.Network.Name))
 
-	return apply(t, t, endpoint)
+	return ApplyEndpoint(t, t, endpoint)
 }
 
-func apply(nl Netlink, t *BaseOperations, endpoint *NetworkEndpoint) error {
+func ApplyEndpoint(nl Netlink, t *BaseOperations, endpoint *NetworkEndpoint) error {
 	if endpoint.configured {
 		log.Infof("skipping applying config for network %s as it has been applied already", endpoint.Network.Name)
 		return nil // already applied
@@ -1084,11 +1084,11 @@ func createBindSrcTarget(files map[string]os.FileMode) error {
 // process while in the presence of an embedded child reaper.
 // The function passed in will be launched under lock and MUST NOT wait for the process to
 // exit. It's expected the function be a closure wrapped around StartProcess or similar.
-func (t *BaseOperations) LaunchUtility(fn func() (*os.Process, error)) (<-chan int, error) {
+func (t *BaseOperations) LaunchUtility(fn UtilityFn) (<-chan int, error) {
 	return launchUtility(t, fn)
 }
 
-func launchUtility(t *BaseOperations, fn func() (*os.Process, error)) (<-chan int, error) {
+func launchUtility(t *BaseOperations, fn UtilityFn) (<-chan int, error) {
 	t.utilityPidMutex.Lock()
 	defer t.utilityPidMutex.Unlock()
 

--- a/lib/tether/tether.go
+++ b/lib/tether/tether.go
@@ -467,21 +467,21 @@ type TetherKey struct{}
 func (t *tether) Start() error {
 	defer trace.End(trace.Begin("main tether loop"))
 
+	defer func() {
+		e := recover()
+		if e != nil {
+			log.Errorf("Panic in main tether loop: %s: %s", e, debug.Stack())
+			// continue panicing now it's logged
+			panic(e)
+		}
+	}()
+
 	// do the initial setup and start the extensions
 	if err := t.setup(); err != nil {
 		log.Errorf("Failed to run setup: %s", err)
 		return err
 	}
 	defer t.cleanup()
-
-	defer func() {
-		// NOTE: this must not be checked in - results in unknown states as
-		// we're suppressing the panic from rolling up the stack
-		e := recover()
-		if e != nil {
-			log.Errorf("Logging panic: %s: %s", e, debug.Stack())
-		}
-	}()
 
 	// initial entry, so seed this
 	t.reload <- struct{}{}

--- a/lib/tether/tether.go
+++ b/lib/tether/tether.go
@@ -514,7 +514,7 @@ func (t *tether) Start() error {
 		extraconfig.Encode(t.sink, t.config)
 
 		// setup the firewall
-		if err := retryOnError(func() error { return t.ops.SetupFirewall(context.WithValue(t.ctx, TetherKey{}, t), t.config) }, 5); err != nil {
+		if err := retryOnError(func() error { return t.ops.SetupFirewall(t.ctx, t.config) }, 5); err != nil {
 			err = fmt.Errorf("Couldn't set up container-network firewall: %v", err)
 			log.Error(err)
 			return err

--- a/lib/tether/tether_linux.go
+++ b/lib/tether/tether_linux.go
@@ -140,10 +140,18 @@ func (t *tether) childReaper() error {
 
 						t.handleSessionExit(session)
 						session.Unlock()
-					} else {
-						// This is an adopted zombie. The Wait4 call already clean it up from the kernel
-						log.Warnf("Reaped zombie process PID %d", pid)
+						continue
 					}
+
+					pidChannel, ok := t.removeUtilityPid(pid)
+					log.Debugf("Remove utility pid: %d ok: %t", pid, ok)
+					if ok {
+						exitCode := status.ExitStatus()
+						pidChannel <- exitCode
+						close(pidChannel)
+						continue
+					}
+					log.Warnf("Reaped zombie process PID %d", pid)
 				}
 			}()
 		}

--- a/lib/tether/tether_linux.go
+++ b/lib/tether/tether_linux.go
@@ -203,7 +203,7 @@ func lookPath(file string, env []string, dir string) (string, error) {
 		file = fmt.Sprintf("%s%c%s", dir, os.PathSeparator, file)
 		err := findExecutable(file)
 		if err == nil {
-			return file, nil
+			return filepath.Clean(file), nil
 		}
 		return "", err
 	}
@@ -212,7 +212,7 @@ func lookPath(file string, env []string, dir string) (string, error) {
 	if strings.Contains(file, "/") {
 		err := findExecutable(file)
 		if err == nil {
-			return file, nil
+			return filepath.Clean(file), nil
 		}
 		return "", err
 	}
@@ -236,7 +236,7 @@ func lookPath(file string, env []string, dir string) (string, error) {
 		}
 		path := dir + "/" + file
 		if err := findExecutable(path); err == nil {
-			return path, nil
+			return filepath.Clean(path), nil
 		}
 	}
 

--- a/lib/tether/tether_test.go
+++ b/lib/tether/tether_test.go
@@ -117,6 +117,10 @@ func (t *Mocker) Log() (io.Writer, error) {
 	return os.Stdout, nil
 }
 
+func (t *Mocker) SetupFirewall(cxt context.Context, conf *ExecutorConfig) error {
+	return nil
+}
+
 func (t *Mocker) SessionLog(session *SessionConfig) (dio.DynamicMultiWriter, dio.DynamicMultiWriter, error) {
 	return dio.MultiWriter(&t.SessionLogBuffer), dio.MultiWriter(&t.SessionLogBuffer), nil
 }
@@ -142,10 +146,6 @@ func (t *Mocker) SetHostname(hostname string, aliases ...string) error {
 	// that would exercise the file modification paths, however it's much less generalizable
 	t.Hostname = hostname
 	t.Aliases = aliases
-	return nil
-}
-
-func (t *Mocker) SetupFirewall(*ExecutorConfig) error {
 	return nil
 }
 

--- a/tests/test-cases/Group1-Docker-Commands/1-24-Docker-Link.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-24-Docker-Link.robot
@@ -20,75 +20,73 @@ Resource  ../../resources/Util.robot
 
 *** Test Cases ***
 Link and alias
-    ${status}=  Get State Of Github Issue  5921
-    Run Keyword If  '${status}' == 'closed'  Fail  Test 1-24-Docker-Link.robot needs to be updated now that Issue #5921 has been resolved
-    # # link support for container on bridge network only
-    # ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -itd --name foo busybox
-    # Should Be Equal As Integers  ${rc}  0
-    # Should Not Contain  ${output}  Error
+    # link support for container on bridge network only
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -itd --name foo busybox
+    Should Be Equal As Integers  ${rc}  0
+    Should Not Contain  ${output}  Error
 
-    # ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run --link foo:bar busybox ping -c1 bar
-    # Should Be Equal As Integers  ${rc}  0
-    # Should Not Contain  ${output}  Error
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run --link foo:bar busybox ping -c1 bar
+    Should Be Equal As Integers  ${rc}  0
+    Should Not Contain  ${output}  Error
 
-    # ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} network create jedi
-    # Should Be Equal As Integers  ${rc}  0
-    # Should Not Contain  ${output}  Error
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} network create jedi
+    Should Be Equal As Integers  ${rc}  0
+    Should Not Contain  ${output}  Error
 
-    # ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} pull ${busybox}
-    # Should Be Equal As Integers  ${rc}  0
-    # Should Not Contain  ${output}  Error
-    # ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} pull ${debian}
-    # Should Be Equal As Integers  ${rc}  0
-    # Should Not Contain  ${output}  Error
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} pull ${busybox}
+    Should Be Equal As Integers  ${rc}  0
+    Should Not Contain  ${output}  Error
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} pull ${debian}
+    Should Be Equal As Integers  ${rc}  0
+    Should Not Contain  ${output}  Error
 
-    # ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -it -d --net jedi --name first busybox
-    # Should Be Equal As Integers  ${rc}  0
-    # Should Not Contain  ${output}  Error
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -it -d --net jedi --name first busybox
+    Should Be Equal As Integers  ${rc}  0
+    Should Not Contain  ${output}  Error
 
-    # ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run --net jedi debian ping -c1 first
-    # Should Be Equal As Integers  ${rc}  0
-    # Should Not Contain  ${output}  Error
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run --net jedi debian ping -c1 first
+    Should Be Equal As Integers  ${rc}  0
+    Should Not Contain  ${output}  Error
 
-    # # cannot reach first from another network
-    # ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run debian ping -c1 first
-    # Should Not Be Equal As Integers  ${rc}  0
-    # Should contain  ${output}  unknown host
+    # cannot reach first from another network
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run debian ping -c1 first
+    Should Not Be Equal As Integers  ${rc}  0
+    Should contain  ${output}  unknown host
 
-    # # the link
-    # ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run --net jedi --link first:1st debian ping -c1 1st
-    # Should Be Equal As Integers  ${rc}  0
-    # Should Not Contain  ${output}  Error
+    # the link
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run --net jedi --link first:1st debian ping -c1 1st
+    Should Be Equal As Integers  ${rc}  0
+    Should Not Contain  ${output}  Error
 
-    # # cannot reach first using c1 from another container
-    # # first run a container that has the alias "c1" for the "first" container
-    # ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -itd --net jedi --link first:1st busybox
-    # Should Be Equal As Integers  ${rc}  0
-    # Should Not Contain  ${output}  Error
-    # # check if we can use alias "c1" from another container
-    # ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run --net jedi debian ping -c1 1st
-    # Should Not Be Equal As Integers  ${rc}  0
-    # Should contain  ${output}  unknown host
+    # cannot reach first using c1 from another container
+    # first run a container that has the alias "c1" for the "first" container
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -itd --net jedi --link first:1st busybox
+    Should Be Equal As Integers  ${rc}  0
+    Should Not Contain  ${output}  Error
+    # check if we can use alias "c1" from another container
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run --net jedi debian ping -c1 1st
+    Should Not Be Equal As Integers  ${rc}  0
+    Should contain  ${output}  unknown host
 
-    # ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -it -d --net jedi --net-alias 2nd busybox
-    # Should Be Equal As Integers  ${rc}  0
-    # Should Not Contain  ${output}  Error
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -it -d --net jedi --net-alias 2nd busybox
+    Should Be Equal As Integers  ${rc}  0
+    Should Not Contain  ${output}  Error
 
-    # # the alias
-    # ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run --net jedi debian ping -c1 2nd
-    # Should Be Equal As Integers  ${rc}  0
-    # Should Not Contain  ${output}  Error
+    # the alias
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run --net jedi debian ping -c1 2nd
+    Should Be Equal As Integers  ${rc}  0
+    Should Not Contain  ${output}  Error
 
-    # # another container with same network alias
-    # ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -it -d --net jedi --net-alias 2nd busybox
-    # Should Be Equal As Integers  ${rc}  0
-    # Should Not Contain  ${output}  Error
+    # another container with same network alias
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -it -d --net jedi --net-alias 2nd busybox
+    Should Be Equal As Integers  ${rc}  0
+    Should Not Contain  ${output}  Error
 
-    # ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run --net jedi --name lookup busybox nslookup 2nd
-    # Should Be Equal As Integers  ${rc}  0
-    # Should Not Contain  ${output}  Error
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run --net jedi --name lookup busybox nslookup 2nd
+    Should Be Equal As Integers  ${rc}  0
+    Should Not Contain  ${output}  Error
 
-    # ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} logs lookup
-    # Should Be Equal As Integers  ${rc}  0
-    # Should Contain  ${output}  Address 1
-    # Should Contain  ${output}  Address 2
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} logs lookup
+    Should Be Equal As Integers  ${rc}  0
+    Should Contain  ${output}  Address 1
+    Should Contain  ${output}  Address 2

--- a/tests/test-cases/Group1-Docker-Commands/1-24-Docker-Link.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-24-Docker-Link.robot
@@ -15,8 +15,8 @@
 *** Settings ***
 Documentation  Test 1-24 - Docker Link
 Resource  ../../resources/Util.robot
-#Suite Setup  Install VIC Appliance To Test Server
-# Suite Teardown  Cleanup VIC Appliance On Test Server
+Suite Setup  Install VIC Appliance To Test Server
+Suite Teardown  Cleanup VIC Appliance On Test Server
 
 *** Test Cases ***
 Link and alias

--- a/tests/test-cases/Group1-Docker-Commands/1-36-Docker-Rename.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-36-Docker-Rename.robot
@@ -15,8 +15,8 @@
 *** Settings ***
 Documentation  Test 1-36 - Docker Rename
 Resource  ../../resources/Util.robot
-#Suite Setup  Install VIC Appliance To Test Server
-#Suite Teardown  Cleanup VIC Appliance On Test Server
+Suite Setup  Install VIC Appliance To Test Server
+Suite Teardown  Cleanup VIC Appliance On Test Server
 
 *** Test Cases ***
 Rename a non-existent container

--- a/tests/test-cases/Group1-Docker-Commands/1-36-Docker-Rename.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-36-Docker-Rename.robot
@@ -20,120 +20,118 @@ Resource  ../../resources/Util.robot
 
 *** Test Cases ***
 Rename a non-existent container
-    ${status}=  Get State Of Github Issue  5921
-    Run Keyword If  '${status}' == 'closed'  Fail  Test 1-36-Docker-Rename.robot needs to be updated now that Issue #5921 has been resolved
-#     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} rename foo bar
-#     Should Not Be Equal As Integers  ${rc}  0
-#     Should Contain  ${output}  No such container: foo
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} rename foo bar
+    Should Not Be Equal As Integers  ${rc}  0
+    Should Contain  ${output}  No such container: foo
 
-# Rename a created container
-#     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} pull ${busybox}
-#     Should Be Equal As Integers  ${rc}  0
-#     Should Not Contain  ${output}  Error
-#     ${rc}  ${contID}=  Run And Return Rc And Output  docker %{VCH-PARAMS} create --name cont1-name1 ${busybox}
-#     Should Be Equal As Integers  ${rc}  0
-#     Should Not Contain  ${contID}  Error
-#     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} rename cont1-name1 cont1-name2
-#     Should Be Equal As Integers  ${rc}  0
-#     Should Not Contain  ${output}  Error
-#     Verify Container Rename  cont1-name1  cont1-name2  ${contID}
+Rename a created container
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} pull ${busybox}
+    Should Be Equal As Integers  ${rc}  0
+    Should Not Contain  ${output}  Error
+    ${rc}  ${contID}=  Run And Return Rc And Output  docker %{VCH-PARAMS} create --name cont1-name1 ${busybox}
+    Should Be Equal As Integers  ${rc}  0
+    Should Not Contain  ${contID}  Error
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} rename cont1-name1 cont1-name2
+    Should Be Equal As Integers  ${rc}  0
+    Should Not Contain  ${output}  Error
+    Verify Container Rename  cont1-name1  cont1-name2  ${contID}
 
-# Rename a running container
-#     ${rc}  ${contID}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -dit --name cont2-name1 ${busybox}
-#     Should Be Equal As Integers  ${rc}  0
-#     Should Not Contain  ${contID}  Error
-#     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} rename cont2-name1 cont2-name2
-#     Should Be Equal As Integers  ${rc}  0
-#     Should Not Contain  ${output}  Error
-#     Verify Container Rename  cont2-name1  cont2-name2  ${contID}
+Rename a running container
+    ${rc}  ${contID}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -dit --name cont2-name1 ${busybox}
+    Should Be Equal As Integers  ${rc}  0
+    Should Not Contain  ${contID}  Error
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} rename cont2-name1 cont2-name2
+    Should Be Equal As Integers  ${rc}  0
+    Should Not Contain  ${output}  Error
+    Verify Container Rename  cont2-name1  cont2-name2  ${contID}
 
-# Rename a stopped container
-#     ${rc}  ${contID}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -dit --name cont3-name1 ${busybox}
-#     Should Be Equal As Integers  ${rc}  0
-#     Should Not Contain  ${contID}  Error
-#     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} stop cont3-name1
-#     Should Be Equal As Integers  ${rc}  0
-#     Should Not Contain  ${output}  Error
-#     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} rename cont3-name1 cont3-name2
-#     Should Be Equal As Integers  ${rc}  0
-#     Should Not Contain  ${output}  Error
-#     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} start cont3-name2
-#     Should Be Equal As Integers  ${rc}  0
-#     Should Not Contain  ${output}  Error
-#     Verify Container Rename  cont3-name1  cont3-name2  ${contID}
+Rename a stopped container
+    ${rc}  ${contID}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -dit --name cont3-name1 ${busybox}
+    Should Be Equal As Integers  ${rc}  0
+    Should Not Contain  ${contID}  Error
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} stop cont3-name1
+    Should Be Equal As Integers  ${rc}  0
+    Should Not Contain  ${output}  Error
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} rename cont3-name1 cont3-name2
+    Should Be Equal As Integers  ${rc}  0
+    Should Not Contain  ${output}  Error
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} start cont3-name2
+    Should Be Equal As Integers  ${rc}  0
+    Should Not Contain  ${output}  Error
+    Verify Container Rename  cont3-name1  cont3-name2  ${contID}
 
-# Rename a container with an empty name
-#     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} create --name cont4 ${busybox}
-#     Should Be Equal As Integers  ${rc}  0
-#     Should Not Contain  ${output}  Error
-#     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} rename cont4 ""
-#     Should Not Be Equal As Integers  ${rc}  0
-#     Should Contain  ${output}  Neither old nor new names may be empty
+Rename a container with an empty name
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} create --name cont4 ${busybox}
+    Should Be Equal As Integers  ${rc}  0
+    Should Not Contain  ${output}  Error
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} rename cont4 ""
+    Should Not Be Equal As Integers  ${rc}  0
+    Should Contain  ${output}  Neither old nor new names may be empty
 
-# Rename a container with a claimed name
-#     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} create --name cont5 ${busybox}
-#     Should Be Equal As Integers  ${rc}  0
-#     Should Not Contain  ${output}  Error
-#     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} create --name cont6 ${busybox}
-#     Should Be Equal As Integers  ${rc}  0
-#     Should Not Contain  ${output}  Error
-#     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} rename cont5 cont5
-#     Should Not Be Equal As Integers  ${rc}  0
-#     Should Contain  ${output}  Error
-#     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} rename cont5 cont6
-#     Should Not Be Equal As Integers  ${rc}  0
-#     Should Contain  ${output}  Error
+Rename a container with a claimed name
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} create --name cont5 ${busybox}
+    Should Be Equal As Integers  ${rc}  0
+    Should Not Contain  ${output}  Error
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} create --name cont6 ${busybox}
+    Should Be Equal As Integers  ${rc}  0
+    Should Not Contain  ${output}  Error
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} rename cont5 cont5
+    Should Not Be Equal As Integers  ${rc}  0
+    Should Contain  ${output}  Error
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} rename cont5 cont6
+    Should Not Be Equal As Integers  ${rc}  0
+    Should Contain  ${output}  Error
 
-# Name resolution for a created container after renaming+starting it
-#     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} create --name cont7-name1 ${busybox} /bin/top
-#     Should Be Equal As Integers  ${rc}  0
-#     Should Not Contain  ${output}  Error
-#     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} rename cont7-name1 cont7-name2
-#     Should Be Equal As Integers  ${rc}  0
-#     Should Not Contain  ${output}  Error
-#     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} start cont7-name2
-#     Should Be Equal As Integers  ${rc}  0
-#     Should Not Contain  ${output}  Error
-#     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run --link cont7-name2:cont7alias ${busybox} ping -c2 cont7alias
-#     Should Be Equal As Integers  ${rc}  0
-#     Should Contain  ${output}  2 packets transmitted, 2 packets received
-#     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run ${busybox} ping -c2 cont7-name2
-#     Should Be Equal As Integers  ${rc}  0
-#     Should Contain  ${output}  2 packets transmitted, 2 packets received
+Name resolution for a created container after renaming+starting it
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} create --name cont7-name1 ${busybox} /bin/top
+    Should Be Equal As Integers  ${rc}  0
+    Should Not Contain  ${output}  Error
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} rename cont7-name1 cont7-name2
+    Should Be Equal As Integers  ${rc}  0
+    Should Not Contain  ${output}  Error
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} start cont7-name2
+    Should Be Equal As Integers  ${rc}  0
+    Should Not Contain  ${output}  Error
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run --link cont7-name2:cont7alias ${busybox} ping -c2 cont7alias
+    Should Be Equal As Integers  ${rc}  0
+    Should Contain  ${output}  2 packets transmitted, 2 packets received
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run ${busybox} ping -c2 cont7-name2
+    Should Be Equal As Integers  ${rc}  0
+    Should Contain  ${output}  2 packets transmitted, 2 packets received
 
-# Name resolution for a running container after renaming+restarting it
-#     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -dit --name cont8-name1 ${busybox}
-#     Should Be Equal As Integers  ${rc}  0
-#     Should Not Contain  ${output}  Error
-#     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} rename cont8-name1 cont8-name2
-#     Should Be Equal As Integers  ${rc}  0
-#     Should Not Contain  ${output}  Error
-#     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} stop cont8-name2
-#     Should Be Equal As Integers  ${rc}  0
-#     Should Not Contain  ${output}  Error
-#     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} start cont8-name2
-#     Should Be Equal As Integers  ${rc}  0
-#     Should Not Contain  ${output}  Error
-#     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run --link cont8-name2:cont8alias ${busybox} ping -c2 cont8alias
-#     Should Be Equal As Integers  ${rc}  0
-#     Should Contain  ${output}  2 packets transmitted, 2 packets received
-#     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run ${busybox} ping -c2 cont8-name2
-#     Should Be Equal As Integers  ${rc}  0
-#     Should Contain  ${output}  2 packets transmitted, 2 packets received
+Name resolution for a running container after renaming+restarting it
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -dit --name cont8-name1 ${busybox}
+    Should Be Equal As Integers  ${rc}  0
+    Should Not Contain  ${output}  Error
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} rename cont8-name1 cont8-name2
+    Should Be Equal As Integers  ${rc}  0
+    Should Not Contain  ${output}  Error
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} stop cont8-name2
+    Should Be Equal As Integers  ${rc}  0
+    Should Not Contain  ${output}  Error
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} start cont8-name2
+    Should Be Equal As Integers  ${rc}  0
+    Should Not Contain  ${output}  Error
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run --link cont8-name2:cont8alias ${busybox} ping -c2 cont8alias
+    Should Be Equal As Integers  ${rc}  0
+    Should Contain  ${output}  2 packets transmitted, 2 packets received
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run ${busybox} ping -c2 cont8-name2
+    Should Be Equal As Integers  ${rc}  0
+    Should Contain  ${output}  2 packets transmitted, 2 packets received
 
-# Name resolution for a running container after renaming it
-#     ${status}=  Get State Of Github Issue  4375
-#     Run Keyword If  '${status}' == 'closed'  Fail  Test 1-35-Docker-Rename needs to be updated now that #4375 is closed
+Name resolution for a running container after renaming it
+    ${status}=  Get State Of Github Issue  4375
+    Run Keyword If  '${status}' == 'closed'  Fail  Test 1-35-Docker-Rename needs to be updated now that #4375 is closed
 
-#     # ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -dit --name cont9-name1 busybox
-#     # Should Be Equal As Integers  ${rc}  0
-#     # Should Not Contain  ${output}  Error
-#     # ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} rename cont9-name1 cont9-name2
-#     # Should Be Equal As Integers  ${rc}  0
-#     # Should Not Contain  ${output}  Error
-#     # ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run --link cont9-name2:cont9alias busybox ping -c2 cont9alias
-#     # Should Be Equal As Integers  ${rc}  0
-#     # Should Contain  ${output}  2 packets transmitted, 2 packets received
-#     # ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run busybox ping -c2 cont9-name2
-#     # Should Be Equal As Integers  ${rc}  0
-#     # Should Contain  ${output}  2 packets transmitted, 2 packets received
+    # ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -dit --name cont9-name1 busybox
+    # Should Be Equal As Integers  ${rc}  0
+    # Should Not Contain  ${output}  Error
+    # ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} rename cont9-name1 cont9-name2
+    # Should Be Equal As Integers  ${rc}  0
+    # Should Not Contain  ${output}  Error
+    # ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run --link cont9-name2:cont9alias busybox ping -c2 cont9alias
+    # Should Be Equal As Integers  ${rc}  0
+    # Should Contain  ${output}  2 packets transmitted, 2 packets received
+    # ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run busybox ping -c2 cont9-name2
+    # Should Be Equal As Integers  ${rc}  0
+    # Should Contain  ${output}  2 packets transmitted, 2 packets received

--- a/tests/test-cases/Group6-VIC-Machine/6-07-Create-Network.robot
+++ b/tests/test-cases/Group6-VIC-Machine/6-07-Create-Network.robot
@@ -15,7 +15,7 @@
 *** Settings ***
 Documentation  Test 6-07 - Verify vic-machine create network function
 Resource  ../../resources/Util.robot
-# Test Teardown  Run Keyword If Test Failed  Cleanup VIC Appliance On Test Server
+Test Teardown  Run Keyword If Test Failed  Cleanup VIC Appliance On Test Server
 
 *** Keywords ***
 Cleanup Container Firewalls Test

--- a/tests/test-cases/Group6-VIC-Machine/6-07-Create-Network.robot
+++ b/tests/test-cases/Group6-VIC-Machine/6-07-Create-Network.robot
@@ -30,584 +30,582 @@ Cleanup Container Firewalls Test
 
 *** Test Cases ***
 Public network - default
-    ${status}=  Get State Of Github Issue  5921
-    Run Keyword If  '${status}' == 'closed'  Fail  Test 6-07-Create-Network.robot needs to be updated now that Issue #5921 has been resolved
-#     Set Test Environment Variables
-#     # Attempt to cleanup old/canceled tests
-#     Run Keyword And Ignore Error  Cleanup Dangling VMs On Test Server
-#     Run Keyword And Ignore Error  Cleanup Datastore On Test Server
-
-#     ${output}=  Run  bin/vic-machine-linux create --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --image-store=%{TEST_DATASTORE} --bridge-network=%{BRIDGE_NETWORK} ${vicmachinetls} --insecure-registry harbor.ci.drone.local
-#     Should Contain  ${output}  Installer completed successfully
-#     Get Docker Params  ${output}  ${true}
-#     Log To Console  Installer completed successfully: %{VCH-NAME}
+    Set Test Environment Variables
+    # Attempt to cleanup old/canceled tests
+    Run Keyword And Ignore Error  Cleanup Dangling VMs On Test Server
+    Run Keyword And Ignore Error  Cleanup Datastore On Test Server
 
-#     ${info}=  Get VM Info  %{VCH-NAME}
-#     Should Contain  ${info}  VM Network
-
-#     Run Regression Tests
-#     Cleanup VIC Appliance On Test Server
-
-# Public network - invalid
-#     Set Test Environment Variables
-#     # Attempt to cleanup old/canceled tests
-#     Run Keyword And Ignore Error  Cleanup Dangling VMs On Test Server
-#     Run Keyword And Ignore Error  Cleanup Datastore On Test Server
+    ${output}=  Run  bin/vic-machine-linux create --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --image-store=%{TEST_DATASTORE} --bridge-network=%{BRIDGE_NETWORK} ${vicmachinetls} --insecure-registry harbor.ci.drone.local
+    Should Contain  ${output}  Installer completed successfully
+    Get Docker Params  ${output}  ${true}
+    Log To Console  Installer completed successfully: %{VCH-NAME}
 
-#     # Guarantee port group doesn't already exist
-#     Run  govc host.portgroup.remove 'AAAAAAAAAA'
-
-#     ${output}=  Run  bin/vic-machine-linux create --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --image-store=%{TEST_DATASTORE} --public-network=AAAAAAAAAA ${vicmachinetls}
+    ${info}=  Get VM Info  %{VCH-NAME}
+    Should Contain  ${info}  VM Network
 
-#     Should Contain  ${output}  --public-network: network 'AAAAAAAAAA' not found
-#     Should Contain  ${output}  vic-machine-linux create failed
-
-# Public network - invalid vCenter
-#     Pass execution  Test not implemented
-
-# Public network - DHCP
-#     Pass execution  Test not implemented
-
-# Public network - valid
-#     Pass execution  Test not implemented
-
-# Management network - none
-#     Set Test Environment Variables
-#     # Attempt to cleanup old/canceled tests
-#     Run Keyword And Ignore Error  Cleanup Dangling VMs On Test Server
-#     Run Keyword And Ignore Error  Cleanup Datastore On Test Server
+    Run Regression Tests
+    Cleanup VIC Appliance On Test Server
 
-#     ${output}=  Run  bin/vic-machine-linux create --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --image-store=%{TEST_DATASTORE} --bridge-network=%{BRIDGE_NETWORK} --public-network=%{PUBLIC_NETWORK} ${vicmachinetls} --insecure-registry harbor.ci.drone.local
-#     Should Contain  ${output}  Installer completed successfully
-#     ${status}=  Run Keyword And Return Status  Should Contain  ${output}  Network role "management" is sharing NIC with "public"
-#     ${status2}=  Run Keyword And Return Status  Should Contain  ${output}  Network role "public" is sharing NIC with "management"
-#     ${status3}=  Run Keyword And Return Status  Should Contain  ${output}  Network role "public" is sharing NIC with "client"
-#     ${status4}=  Run Keyword And Return Status  Should Contain  ${output}  Network role "management" is sharing NIC with "client"
-#     Should Be True  ${status} | ${status2} | ${status3} | ${status4}
-#     Get Docker Params  ${output}  ${true}
-#     Log To Console  Installer completed successfully: %{VCH-NAME}
+Public network - invalid
+    Set Test Environment Variables
+    # Attempt to cleanup old/canceled tests
+    Run Keyword And Ignore Error  Cleanup Dangling VMs On Test Server
+    Run Keyword And Ignore Error  Cleanup Datastore On Test Server
 
-#     Run Regression Tests
-#     Cleanup VIC Appliance On Test Server
+    # Guarantee port group doesn't already exist
+    Run  govc host.portgroup.remove 'AAAAAAAAAA'
 
-# Management network - invalid
-#     Set Test Environment Variables
-#     # Attempt to cleanup old/canceled tests
-#     Run Keyword And Ignore Error  Cleanup Dangling VMs On Test Server
-#     Run Keyword And Ignore Error  Cleanup Datastore On Test Server
+    ${output}=  Run  bin/vic-machine-linux create --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --image-store=%{TEST_DATASTORE} --public-network=AAAAAAAAAA ${vicmachinetls}
 
-#     # Guarantee port group doesn't already exist
-#     Run  govc host.portgroup.remove 'AAAAAAAAAA'
+    Should Contain  ${output}  --public-network: network 'AAAAAAAAAA' not found
+    Should Contain  ${output}  vic-machine-linux create failed
+
+Public network - invalid vCenter
+    Pass execution  Test not implemented
 
-#     ${output}=  Run  bin/vic-machine-linux create --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --image-store=%{TEST_DATASTORE} --management-network=AAAAAAAAAA ${vicmachinetls}
+Public network - DHCP
+    Pass execution  Test not implemented
 
-#     Should Contain  ${output}  --management-network: network 'AAAAAAAAAA' not found
-#     Should Contain  ${output}  vic-machine-linux create failed
+Public network - valid
+    Pass execution  Test not implemented
+
+Management network - none
+    Set Test Environment Variables
+    # Attempt to cleanup old/canceled tests
+    Run Keyword And Ignore Error  Cleanup Dangling VMs On Test Server
+    Run Keyword And Ignore Error  Cleanup Datastore On Test Server
 
-# Management network - invalid vCenter
-#     Pass execution  Test not implemented
+    ${output}=  Run  bin/vic-machine-linux create --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --image-store=%{TEST_DATASTORE} --bridge-network=%{BRIDGE_NETWORK} --public-network=%{PUBLIC_NETWORK} ${vicmachinetls} --insecure-registry harbor.ci.drone.local
+    Should Contain  ${output}  Installer completed successfully
+    ${status}=  Run Keyword And Return Status  Should Contain  ${output}  Network role "management" is sharing NIC with "public"
+    ${status2}=  Run Keyword And Return Status  Should Contain  ${output}  Network role "public" is sharing NIC with "management"
+    ${status3}=  Run Keyword And Return Status  Should Contain  ${output}  Network role "public" is sharing NIC with "client"
+    ${status4}=  Run Keyword And Return Status  Should Contain  ${output}  Network role "management" is sharing NIC with "client"
+    Should Be True  ${status} | ${status2} | ${status3} | ${status4}
+    Get Docker Params  ${output}  ${true}
+    Log To Console  Installer completed successfully: %{VCH-NAME}
 
-# Management network - unreachable
-#     Pass execution  Test not implemented
+    Run Regression Tests
+    Cleanup VIC Appliance On Test Server
 
-# Management network - valid
-#     Set Test Environment Variables
-#     # Attempt to cleanup old/canceled tests
-#     Run Keyword And Ignore Error  Cleanup Dangling VMs On Test Server
-#     Run Keyword And Ignore Error  Cleanup Datastore On Test Server
+Management network - invalid
+    Set Test Environment Variables
+    # Attempt to cleanup old/canceled tests
+    Run Keyword And Ignore Error  Cleanup Dangling VMs On Test Server
+    Run Keyword And Ignore Error  Cleanup Datastore On Test Server
 
-#     ${output}=  Run  bin/vic-machine-linux create --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --image-store=%{TEST_DATASTORE} --bridge-network=%{BRIDGE_NETWORK} --management-network=%{PUBLIC_NETWORK} ${vicmachinetls} --insecure-registry harbor.ci.drone.local
-#     Should Contain  ${output}  Installer completed successfully
-#     Get Docker Params  ${output}  ${true}
-#     Log To Console  Installer completed successfully: %{VCH-NAME}
+    # Guarantee port group doesn't already exist
+    Run  govc host.portgroup.remove 'AAAAAAAAAA'
 
-#     Run Regression Tests
-#     Cleanup VIC Appliance On Test Server
+    ${output}=  Run  bin/vic-machine-linux create --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --image-store=%{TEST_DATASTORE} --management-network=AAAAAAAAAA ${vicmachinetls}
 
-# Connectivity Bridge to Public
-#     Set Test Environment Variables
-#     # Attempt to cleanup old/canceled tests
-#     Run Keyword And Ignore Error  Cleanup Dangling VMs On Test Server
-#     Run Keyword And Ignore Error  Cleanup Datastore On Test Server
+    Should Contain  ${output}  --management-network: network 'AAAAAAAAAA' not found
+    Should Contain  ${output}  vic-machine-linux create failed
 
-#     ${out}=  Run  govc host.portgroup.remove bridge
-#     ${out}=  Run  govc host.portgroup.remove vm-network
+Management network - invalid vCenter
+    Pass execution  Test not implemented
 
-#     Log To Console  Create a public portgroup.
-#     ${out}=  Run  govc host.portgroup.add -vswitch vSwitchLAN vm-network
+Management network - unreachable
+    Pass execution  Test not implemented
 
-#     Log To Console  Create a bridge portgroup.
-#     ${out}=  Run  govc host.portgroup.add -vswitch vSwitchLAN bridge
+Management network - valid
+    Set Test Environment Variables
+    # Attempt to cleanup old/canceled tests
+    Run Keyword And Ignore Error  Cleanup Dangling VMs On Test Server
+    Run Keyword And Ignore Error  Cleanup Datastore On Test Server
 
-#     ${output}=  Run  bin/vic-machine-linux create --debug 1 --name=%{VCH-NAME} --target=%{TEST_URL}%{TEST_DATACENTER} --thumbprint=%{TEST_THUMBPRINT} --user=%{TEST_USERNAME} --image-store=%{TEST_DATASTORE} --password=%{TEST_PASSWORD} --force=true --bridge-network=bridge --public-network=vm-network --compute-resource=%{TEST_RESOURCE} --container-network vm-network --container-network-firewall vm-network:published --no-tlsverify --insecure-registry harbor.ci.drone.local
+    ${output}=  Run  bin/vic-machine-linux create --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --image-store=%{TEST_DATASTORE} --bridge-network=%{BRIDGE_NETWORK} --management-network=%{PUBLIC_NETWORK} ${vicmachinetls} --insecure-registry harbor.ci.drone.local
+    Should Contain  ${output}  Installer completed successfully
+    Get Docker Params  ${output}  ${true}
+    Log To Console  Installer completed successfully: %{VCH-NAME}
 
-#     Should Contain  ${output}  Installer completed successfully
-#     Get Docker Params  ${output}  ${true}
-#     Log To Console  Installer completed successfully: %{VCH-NAME}
+    Run Regression Tests
+    Cleanup VIC Appliance On Test Server
 
-#     # this container will listen on :8000 and we're passing the -p option to the VCH so it should be exposed
-#     Log To Console  Creating public container.
-#     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -d --net=vm-network -p 8000 --name p1 ${busybox} nc -l -p 8000
-#     Should Be Equal As Integers  ${rc}  0
+Connectivity Bridge to Public
+    Set Test Environment Variables
+    # Attempt to cleanup old/canceled tests
+    Run Keyword And Ignore Error  Cleanup Dangling VMs On Test Server
+    Run Keyword And Ignore Error  Cleanup Datastore On Test Server
 
-#     Log To Console  Getting IP for public container
-#     ${ip}=  Run  docker %{VCH-PARAMS} inspect --format '{{range .NetworkSettings.Networks}}{{.IPAddress }}{{end}}' p1
+    ${out}=  Run  govc host.portgroup.remove bridge
+    ${out}=  Run  govc host.portgroup.remove vm-network
 
-#     Log To Console  Connecting to container on external network from container bridged network
-#     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run --net bridge ${busybox} nc ${ip} 8000
-#     Should Be Equal As Integers  ${rc}  0
-#     Should Not Contain  ${output}  Error:
+    Log To Console  Create a public portgroup.
+    ${out}=  Run  govc host.portgroup.add -vswitch vSwitchLAN vm-network
 
-#     # nc is listening, but since we didn't pass the -p flag to docker, the port should not be exposed.
-#     Log To Console  Creating public container with no ports exposed.
-#     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -d --net=vm-network --name p2 ${busybox} nc -l -p 8000
-#     Should Be Equal As Integers  ${rc}  0
+    Log To Console  Create a bridge portgroup.
+    ${out}=  Run  govc host.portgroup.add -vswitch vSwitchLAN bridge
 
-#     Log To Console  Getting IP for public container
-#     ${ip}=  Run  docker %{VCH-PARAMS} inspect --format '{{range .NetworkSettings.Networks}}{{.IPAddress }}{{end}}' p2
+    ${output}=  Run  bin/vic-machine-linux create --debug 1 --name=%{VCH-NAME} --target=%{TEST_URL}%{TEST_DATACENTER} --thumbprint=%{TEST_THUMBPRINT} --user=%{TEST_USERNAME} --image-store=%{TEST_DATASTORE} --password=%{TEST_PASSWORD} --force=true --bridge-network=bridge --public-network=vm-network --compute-resource=%{TEST_RESOURCE} --container-network vm-network --container-network-firewall vm-network:published --no-tlsverify --insecure-registry harbor.ci.drone.local
 
-#     # we expect this to fail since the port wasn't exposed
-#     Log To Console  Connecting to container on external network from container bridged network
-#     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run --net bridge ${busybox} nc ${ip} 8000
-#     Should Not Be Equal As Integers  ${rc}  0
+    Should Contain  ${output}  Installer completed successfully
+    Get Docker Params  ${output}  ${true}
+    Log To Console  Installer completed successfully: %{VCH-NAME}
 
-#     Log To Console  Port connection test from bridge to public networks succeeded.
+    # this container will listen on :8000 and we're passing the -p option to the VCH so it should be exposed
+    Log To Console  Creating public container.
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -d --net=vm-network -p 8000 --name p1 ${busybox} nc -l -p 8000
+    Should Be Equal As Integers  ${rc}  0
 
-#     Cleanup VIC Appliance On Test Server
+    Log To Console  Getting IP for public container
+    ${ip}=  Run  docker %{VCH-PARAMS} inspect --format '{{range .NetworkSettings.Networks}}{{.IPAddress }}{{end}}' p1
 
-# Connectivity Bridge to Management
-#     Set Test Environment Variables
-#     # Attempt to cleanup old/canceled tests
-#     Run Keyword And Ignore Error  Cleanup Dangling VMs On Test Server
-#     Run Keyword And Ignore Error  Cleanup Datastore On Test Server
+    Log To Console  Connecting to container on external network from container bridged network
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run --net bridge ${busybox} nc ${ip} 8000
+    Should Be Equal As Integers  ${rc}  0
+    Should Not Contain  ${output}  Error:
 
-#     ${out}=  Run  govc host.portgroup.remove bridge
-#     ${out}=  Run  govc host.portgroup.remove management
+    # nc is listening, but since we didn't pass the -p flag to docker, the port should not be exposed.
+    Log To Console  Creating public container with no ports exposed.
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -d --net=vm-network --name p2 ${busybox} nc -l -p 8000
+    Should Be Equal As Integers  ${rc}  0
 
-#     Log To Console  Create a bridge portgroup
-#     ${out}=  Run  govc host.portgroup.add -vswitch vSwitchLAN bridge
+    Log To Console  Getting IP for public container
+    ${ip}=  Run  docker %{VCH-PARAMS} inspect --format '{{range .NetworkSettings.Networks}}{{.IPAddress }}{{end}}' p2
 
-#     Log To Console  Create a management portgroup.
-#     ${out}=  Run  govc host.portgroup.add -vswitch vSwitchLAN management
+    # we expect this to fail since the port wasn't exposed
+    Log To Console  Connecting to container on external network from container bridged network
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run --net bridge ${busybox} nc ${ip} 8000
+    Should Not Be Equal As Integers  ${rc}  0
 
-#     ${output}=  Run  bin/vic-machine-linux create --debug 1 --name=%{VCH-NAME} --target=%{TEST_URL}%{TEST_DATACENTER} --thumbprint=%{TEST_THUMBPRINT} --user=%{TEST_USERNAME} --image-store=%{TEST_DATASTORE} --password=%{TEST_PASSWORD} --force=true --bridge-network=bridge --compute-resource=%{TEST_RESOURCE} --container-network management --container-network vm-network --container-network-ip-range=management:10.10.10.0/24 --container-network-gateway=management:10.10.10.1/24 --no-tlsverify --insecure-registry harbor.ci.drone.local
+    Log To Console  Port connection test from bridge to public networks succeeded.
 
-#     Should Contain  ${output}  Installer completed successfully
-#     Get Docker Params  ${output}  ${true}
-#     Log To Console  Installer completed successfully: %{VCH-NAME}
+    Cleanup VIC Appliance On Test Server
 
-#     Log To Console  Creating management container
-#     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -d --net=management --name m1 ${busybox} /bin/top
-#     Should Be Equal As Integers  ${rc}  0
+Connectivity Bridge to Management
+    Set Test Environment Variables
+    # Attempt to cleanup old/canceled tests
+    Run Keyword And Ignore Error  Cleanup Dangling VMs On Test Server
+    Run Keyword And Ignore Error  Cleanup Datastore On Test Server
 
-#     Log To Console  Starting management container
-#     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} start m1
-#     Should Be Equal As Integers  ${rc}  0
-#     Should Not Contain  ${output}  Error:
+    ${out}=  Run  govc host.portgroup.remove bridge
+    ${out}=  Run  govc host.portgroup.remove management
 
-#     Log To Console  Creating bridge container
-#     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -d --net=bridge --name b1 ${busybox} /bin/top
-#     Should Be Equal As Integers  ${rc}  0
+    Log To Console  Create a bridge portgroup
+    ${out}=  Run  govc host.portgroup.add -vswitch vSwitchLAN bridge
 
-#     Log To Console  Starting bridge container
-#     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} start b1
-#     Should Be Equal As Integers  ${rc}  0
-#     Should Not Contain  ${output}  Error:
+    Log To Console  Create a management portgroup.
+    ${out}=  Run  govc host.portgroup.add -vswitch vSwitchLAN management
 
-#     Log To Console  Getting IP for management container
-#     ${ip}=  Run  docker %{VCH-PARAMS} inspect --format '{{range .NetworkSettings.Networks}}{{.IPAddress }}{{end}}' m1
+    ${output}=  Run  bin/vic-machine-linux create --debug 1 --name=%{VCH-NAME} --target=%{TEST_URL}%{TEST_DATACENTER} --thumbprint=%{TEST_THUMBPRINT} --user=%{TEST_USERNAME} --image-store=%{TEST_DATASTORE} --password=%{TEST_PASSWORD} --force=true --bridge-network=bridge --compute-resource=%{TEST_RESOURCE} --container-network management --container-network vm-network --container-network-ip-range=management:10.10.10.0/24 --container-network-gateway=management:10.10.10.1/24 --no-tlsverify --insecure-registry harbor.ci.drone.local
 
-#     Log To Console  Pinging from bridge to management container.
-#     ${id}=  Run  docker %{VCH-PARAMS} run -d ${busybox} ping -c 30 ${ip}
+    Should Contain  ${output}  Installer completed successfully
+    Get Docker Params  ${output}  ${true}
+    Log To Console  Installer completed successfully: %{VCH-NAME}
 
-#     Log To Console  Attach to running container.
-#     ${out}=  Run  docker %{VCH-PARAMS} attach ${id}
+    Log To Console  Creating management container
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -d --net=management --name m1 ${busybox} /bin/top
+    Should Be Equal As Integers  ${rc}  0
 
-#     Should Contain  ${out}  100% packet loss
-#     Log To Console  Ping test succeeded.
+    Log To Console  Starting management container
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} start m1
+    Should Be Equal As Integers  ${rc}  0
+    Should Not Contain  ${output}  Error:
 
-#     Cleanup VIC Appliance On Test Server
+    Log To Console  Creating bridge container
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -d --net=bridge --name b1 ${busybox} /bin/top
+    Should Be Equal As Integers  ${rc}  0
 
-# Bridge network - vCenter none
-#     Run Keyword If  '%{HOST_TYPE}' == 'ESXi'  Pass Execution  Test skipped on ESXi
+    Log To Console  Starting bridge container
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} start b1
+    Should Be Equal As Integers  ${rc}  0
+    Should Not Contain  ${output}  Error:
 
-#     Set Test Environment Variables
-#     # Attempt to cleanup old/canceled tests
-#     Run Keyword And Ignore Error  Cleanup Dangling VMs On Test Server
-#     Run Keyword And Ignore Error  Cleanup Datastore On Test Server
+    Log To Console  Getting IP for management container
+    ${ip}=  Run  docker %{VCH-PARAMS} inspect --format '{{range .NetworkSettings.Networks}}{{.IPAddress }}{{end}}' m1
 
-#     ${output}=  Run  bin/vic-machine-linux create --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --image-store=%{TEST_DATASTORE} ${vicmachinetls}
-#     Should Contain  ${output}  ERROR
-#     Should Contain  ${output}  An existing distributed port group must be specified for bridge network on vCenter
+    Log To Console  Pinging from bridge to management container.
+    ${id}=  Run  docker %{VCH-PARAMS} run -d ${busybox} ping -c 30 ${ip}
 
-#     # Delete the portgroup added by env vars keyword
-#     Cleanup VCH Bridge Network  %{VCH-NAME}
+    Log To Console  Attach to running container.
+    ${out}=  Run  docker %{VCH-PARAMS} attach ${id}
 
-# Bridge network - ESX none
-#     Run Keyword If  '%{HOST_TYPE}' == 'VC'  Pass Execution  Test skipped on VC
+    Should Contain  ${out}  100% packet loss
+    Log To Console  Ping test succeeded.
 
-#     Set Test Environment Variables
-#     # Attempt to cleanup old/canceled tests
-#     Run Keyword And Ignore Error  Cleanup Dangling VMs On Test Server
-#     Run Keyword And Ignore Error  Cleanup Datastore On Test Server
+    Cleanup VIC Appliance On Test Server
 
-#     ${output}=  Run  bin/vic-machine-linux create --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --image-store=%{TEST_DATASTORE} ${vicmachinetls} --insecure-registry harbor.ci.drone.local
-#     Should Contain  ${output}  Installer completed successfully
-#     Get Docker Params  ${output}  ${true}
-#     Log To Console  Installer completed successfully: %{VCH-NAME}
+Bridge network - vCenter none
+    Run Keyword If  '%{HOST_TYPE}' == 'ESXi'  Pass Execution  Test skipped on ESXi
 
-#     Run Regression Tests
-#     Cleanup VIC Appliance On Test Server
+    Set Test Environment Variables
+    # Attempt to cleanup old/canceled tests
+    Run Keyword And Ignore Error  Cleanup Dangling VMs On Test Server
+    Run Keyword And Ignore Error  Cleanup Datastore On Test Server
 
-# Bridge network - create bridge network if it doesn't exist
-#     Run Keyword If  '%{HOST_TYPE}' == 'VC'  Pass Execution  Test not applicable on vCenter
-#     # ESX should automatically create the bridge switch & port group AAAAAAAAAA, but vCenter would fail with unknown network error
+    ${output}=  Run  bin/vic-machine-linux create --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --image-store=%{TEST_DATASTORE} ${vicmachinetls}
+    Should Contain  ${output}  ERROR
+    Should Contain  ${output}  An existing distributed port group must be specified for bridge network on vCenter
 
-#     Set Test Environment Variables
-#     # Attempt to cleanup old/canceled tests
-#     Run Keyword And Ignore Error  Cleanup Dangling VMs On Test Server
-#     Run Keyword And Ignore Error  Cleanup Datastore On Test Server
+    # Delete the portgroup added by env vars keyword
+    Cleanup VCH Bridge Network  %{VCH-NAME}
 
-#     # Guarantee port group doesn't already exist
-#     Run  govc host.portgroup.remove 'AAAAAAAAAA'
-#     Run  govc host.vswitch.remove 'AAAAAAAAAA'
+Bridge network - ESX none
+    Run Keyword If  '%{HOST_TYPE}' == 'VC'  Pass Execution  Test skipped on VC
 
-#     ${output}=  Run  bin/vic-machine-linux create --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --image-store=%{TEST_DATASTORE} --bridge-network=AAAAAAAAAA ${vicmachinetls} --insecure-registry harbor.ci.drone.local
-#     Should Contain  ${output}  Installer completed successfully
-#     Get Docker Params  ${output}  ${true}
-#     Log To Console  Installer completed successfully: %{VCH-NAME}
+    Set Test Environment Variables
+    # Attempt to cleanup old/canceled tests
+    Run Keyword And Ignore Error  Cleanup Dangling VMs On Test Server
+    Run Keyword And Ignore Error  Cleanup Datastore On Test Server
 
-#     Run Regression Tests
-#     Cleanup VIC Appliance On Test Server
+    ${output}=  Run  bin/vic-machine-linux create --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --image-store=%{TEST_DATASTORE} ${vicmachinetls} --insecure-registry harbor.ci.drone.local
+    Should Contain  ${output}  Installer completed successfully
+    Get Docker Params  ${output}  ${true}
+    Log To Console  Installer completed successfully: %{VCH-NAME}
 
-#     Run  govc host.portgroup.remove 'AAAAAAAAAA'
-#     Run  govc host.vswitch.remove 'AAAAAAAAAA'
+    Run Regression Tests
+    Cleanup VIC Appliance On Test Server
 
-# Bridge network - invalid vCenter
-#     Run Keyword If  '%{HOST_TYPE}' == 'ESXi'  Pass Execution  Test skipped on ESXi
+Bridge network - create bridge network if it doesn't exist
+    Run Keyword If  '%{HOST_TYPE}' == 'VC'  Pass Execution  Test not applicable on vCenter
+    # ESX should automatically create the bridge switch & port group AAAAAAAAAA, but vCenter would fail with unknown network error
 
-#     Pass execution  Test not implemented
+    Set Test Environment Variables
+    # Attempt to cleanup old/canceled tests
+    Run Keyword And Ignore Error  Cleanup Dangling VMs On Test Server
+    Run Keyword And Ignore Error  Cleanup Datastore On Test Server
 
-# Bridge network - non-DPG
-#     Run Keyword If  '%{HOST_TYPE}' == 'ESXi'  Pass Execution  Test skipped on ESXi
+    # Guarantee port group doesn't already exist
+    Run  govc host.portgroup.remove 'AAAAAAAAAA'
+    Run  govc host.vswitch.remove 'AAAAAAAAAA'
 
-#     Pass execution  Test not implemented
+    ${output}=  Run  bin/vic-machine-linux create --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --image-store=%{TEST_DATASTORE} --bridge-network=AAAAAAAAAA ${vicmachinetls} --insecure-registry harbor.ci.drone.local
+    Should Contain  ${output}  Installer completed successfully
+    Get Docker Params  ${output}  ${true}
+    Log To Console  Installer completed successfully: %{VCH-NAME}
 
-# Bridge network - valid
-#     Set Test Environment Variables
-#     # Attempt to cleanup old/canceled tests
-#     Run Keyword And Ignore Error  Cleanup Dangling VMs On Test Server
-#     Run Keyword And Ignore Error  Cleanup Datastore On Test Server
+    Run Regression Tests
+    Cleanup VIC Appliance On Test Server
 
-#     ${output}=  Run  bin/vic-machine-linux create --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --image-store=%{TEST_DATASTORE} --bridge-network=%{BRIDGE_NETWORK} ${vicmachinetls} --insecure-registry harbor.ci.drone.local
-#     Should Contain  ${output}  Installer completed successfully
-#     Get Docker Params  ${output}  ${true}
-#     Log To Console  Installer completed successfully: %{VCH-NAME}
+    Run  govc host.portgroup.remove 'AAAAAAAAAA'
+    Run  govc host.vswitch.remove 'AAAAAAAAAA'
 
-#     Run Regression Tests
-#     Cleanup VIC Appliance On Test Server
+Bridge network - invalid vCenter
+    Run Keyword If  '%{HOST_TYPE}' == 'ESXi'  Pass Execution  Test skipped on ESXi
 
-# Bridge network - reused port group
-#     Set Test Environment Variables
-#     # Attempt to cleanup old/canceled tests
-#     Run Keyword And Ignore Error  Cleanup Dangling VMs On Test Server
-#     Run Keyword And Ignore Error  Cleanup Datastore On Test Server
+    Pass execution  Test not implemented
 
-#     ${output}=  Run  bin/vic-machine-linux create --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --image-store=%{TEST_DATASTORE} --bridge-network=%{BRIDGE_NETWORK} --public-network=%{BRIDGE_NETWORK} ${vicmachinetls}
-#     Should Contain  ${output}  the bridge network must not be shared with another network role
+Bridge network - non-DPG
+    Run Keyword If  '%{HOST_TYPE}' == 'ESXi'  Pass Execution  Test skipped on ESXi
 
-#     ${output}=  Run  bin/vic-machine-linux create --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --image-store=%{TEST_DATASTORE} --bridge-network=%{BRIDGE_NETWORK} --management-network=%{BRIDGE_NETWORK} ${vicmachinetls}
-#     Should Contain  ${output}  the bridge network must not be shared with another network role
+    Pass execution  Test not implemented
 
-#     ${output}=  Run  bin/vic-machine-linux create --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --image-store=%{TEST_DATASTORE} --bridge-network=%{BRIDGE_NETWORK} --client-network=%{BRIDGE_NETWORK} ${vicmachinetls}
-#     Should Contain  ${output}  the bridge network must not be shared with another network role
+Bridge network - valid
+    Set Test Environment Variables
+    # Attempt to cleanup old/canceled tests
+    Run Keyword And Ignore Error  Cleanup Dangling VMs On Test Server
+    Run Keyword And Ignore Error  Cleanup Datastore On Test Server
 
-#     # Delete the portgroup added by env vars keyword
-#     Cleanup VCH Bridge Network  %{VCH-NAME}
+    ${output}=  Run  bin/vic-machine-linux create --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --image-store=%{TEST_DATASTORE} --bridge-network=%{BRIDGE_NETWORK} ${vicmachinetls} --insecure-registry harbor.ci.drone.local
+    Should Contain  ${output}  Installer completed successfully
+    Get Docker Params  ${output}  ${true}
+    Log To Console  Installer completed successfully: %{VCH-NAME}
 
-# Bridge network - invalid IP settings
-#     Set Test Environment Variables
-#     # Attempt to cleanup old/canceled tests
-#     Run Keyword And Ignore Error  Cleanup Dangling VMs On Test Server
-#     Run Keyword And Ignore Error  Cleanup Datastore On Test Server
+    Run Regression Tests
+    Cleanup VIC Appliance On Test Server
 
-#     ${output}=  Run  bin/vic-machine-linux create --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --image-store=%{TEST_DATASTORE} --bridge-network=%{BRIDGE_NETWORK} --bridge-network-range 1.1.1.1 ${vicmachinetls}
-#     Should Contain  ${output}  Error parsing bridge network ip range
+Bridge network - reused port group
+    Set Test Environment Variables
+    # Attempt to cleanup old/canceled tests
+    Run Keyword And Ignore Error  Cleanup Dangling VMs On Test Server
+    Run Keyword And Ignore Error  Cleanup Datastore On Test Server
 
-#     # Delete the portgroup added by env vars keyword
-#     Cleanup VCH Bridge Network  %{VCH-NAME}
+    ${output}=  Run  bin/vic-machine-linux create --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --image-store=%{TEST_DATASTORE} --bridge-network=%{BRIDGE_NETWORK} --public-network=%{BRIDGE_NETWORK} ${vicmachinetls}
+    Should Contain  ${output}  the bridge network must not be shared with another network role
 
-# Bridge network - invalid bridge network range
-#     Set Test Environment Variables
-#     # Attempt to cleanup old/canceled tests
-#     Run Keyword And Ignore Error  Cleanup Dangling VMs On Test Server
-#     Run Keyword And Ignore Error  Cleanup Datastore On Test Server
+    ${output}=  Run  bin/vic-machine-linux create --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --image-store=%{TEST_DATASTORE} --bridge-network=%{BRIDGE_NETWORK} --management-network=%{BRIDGE_NETWORK} ${vicmachinetls}
+    Should Contain  ${output}  the bridge network must not be shared with another network role
 
-#     ${output}=  Run  bin/vic-machine-linux create --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --image-store=%{TEST_DATASTORE} --bridge-network=%{BRIDGE_NETWORK} --bridge-network-range 1.1.1.1/17 ${vicmachinetls}
-#     Should Contain  ${output}  --bridge-network-range must be /16 or larger network
+    ${output}=  Run  bin/vic-machine-linux create --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --image-store=%{TEST_DATASTORE} --bridge-network=%{BRIDGE_NETWORK} --client-network=%{BRIDGE_NETWORK} ${vicmachinetls}
+    Should Contain  ${output}  the bridge network must not be shared with another network role
 
-#     # Delete the portgroup added by env vars keyword
-#     Cleanup VCH Bridge Network  %{VCH-NAME}
+    # Delete the portgroup added by env vars keyword
+    Cleanup VCH Bridge Network  %{VCH-NAME}
 
-# Bridge network - valid with IP range
-#     Pass execution  Test not implemented
+Bridge network - invalid IP settings
+    Set Test Environment Variables
+    # Attempt to cleanup old/canceled tests
+    Run Keyword And Ignore Error  Cleanup Dangling VMs On Test Server
+    Run Keyword And Ignore Error  Cleanup Datastore On Test Server
 
-# Container network - space in network name invalid
-#     Set Test Environment Variables
-#     # Attempt to cleanup old/canceled tests
-#     Run Keyword And Ignore Error  Cleanup Dangling VMs On Test Server
-#     Run Keyword And Ignore Error  Cleanup Datastore On Test Server
+    ${output}=  Run  bin/vic-machine-linux create --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --image-store=%{TEST_DATASTORE} --bridge-network=%{BRIDGE_NETWORK} --bridge-network-range 1.1.1.1 ${vicmachinetls}
+    Should Contain  ${output}  Error parsing bridge network ip range
 
-#     ${output}=  Run  bin/vic-machine-linux create --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --image-store=%{TEST_DATASTORE} --bridge-network=bridge --container-network 'VM Network With Spaces' ${vicmachinetls}
-#     Should Contain  ${output}  A network alias must be supplied when network name "VM Network With Spaces" contains spaces.
-#     Should Contain  ${output}  vic-machine-linux create failed
+    # Delete the portgroup added by env vars keyword
+    Cleanup VCH Bridge Network  %{VCH-NAME}
 
-#     ${output}=  Run  bin/vic-machine-linux create --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --image-store=%{TEST_DATASTORE} --bridge-network=bridge --container-network 'VM Network With Spaces': ${vicmachinetls}
-#     Should Contain  ${output}  A network alias must be supplied when network name "VM Network With Spaces:" contains spaces.
-#     Should Contain  ${output}  vic-machine-linux create failed
+Bridge network - invalid bridge network range
+    Set Test Environment Variables
+    # Attempt to cleanup old/canceled tests
+    Run Keyword And Ignore Error  Cleanup Dangling VMs On Test Server
+    Run Keyword And Ignore Error  Cleanup Datastore On Test Server
 
-#     ${output}=  Run  bin/vic-machine-linux create --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --image-store=%{TEST_DATASTORE} --bridge-network=bridge --container-network 'vm-network':'vm network' ${vicmachinetls}
-#     Should Contain  ${output}  The network alias supplied in "vm-network:vm network" cannot contain spaces.
-#     Should Contain  ${output}  vic-machine-linux create failed
+    ${output}=  Run  bin/vic-machine-linux create --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --image-store=%{TEST_DATASTORE} --bridge-network=%{BRIDGE_NETWORK} --bridge-network-range 1.1.1.1/17 ${vicmachinetls}
+    Should Contain  ${output}  --bridge-network-range must be /16 or larger network
 
-#     # Delete the portgroup added by env vars keyword
-#     Cleanup VCH Bridge Network  %{VCH-NAME}
+    # Delete the portgroup added by env vars keyword
+    Cleanup VCH Bridge Network  %{VCH-NAME}
 
-# Container network - space in network name valid
-#     Set Test Environment Variables
-#     # Attempt to cleanup old/canceled tests
-#     Run Keyword And Ignore Error  Cleanup Dangling VMs On Test Server
-#     Run Keyword And Ignore Error  Cleanup Datastore On Test Server
+Bridge network - valid with IP range
+    Pass execution  Test not implemented
 
-#     Log To Console  Create a portgroup with a space in it's name
-#     ${out}=  Run  govc host.portgroup.add -vswitch vSwitchLAN 'VM Network With Spaces'
+Container network - space in network name invalid
+    Set Test Environment Variables
+    # Attempt to cleanup old/canceled tests
+    Run Keyword And Ignore Error  Cleanup Dangling VMs On Test Server
+    Run Keyword And Ignore Error  Cleanup Datastore On Test Server
 
-#     Log To Console  Create a bridge portgroup.
-#     ${out}=  Run  govc host.portgroup.add -vswitch vSwitchLAN bridge
+    ${output}=  Run  bin/vic-machine-linux create --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --image-store=%{TEST_DATASTORE} --bridge-network=bridge --container-network 'VM Network With Spaces' ${vicmachinetls}
+    Should Contain  ${output}  A network alias must be supplied when network name "VM Network With Spaces" contains spaces.
+    Should Contain  ${output}  vic-machine-linux create failed
 
-#     ${output}=  Run  bin/vic-machine-linux create --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --image-store=%{TEST_DATASTORE} --bridge-network=bridge --container-network 'VM Network With Spaces':vmnet --insecure-registry harbor.ci.drone.local ${vicmachinetls}
-#     Should Contain  ${output}  Installer completed successfully
-#     Get Docker Params  ${output}  ${true}
-#     Log To Console  Installer completed successfully: %{VCH-NAME}
+    ${output}=  Run  bin/vic-machine-linux create --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --image-store=%{TEST_DATASTORE} --bridge-network=bridge --container-network 'VM Network With Spaces': ${vicmachinetls}
+    Should Contain  ${output}  A network alias must be supplied when network name "VM Network With Spaces:" contains spaces.
+    Should Contain  ${output}  vic-machine-linux create failed
 
-#     Run Regression Tests
+    ${output}=  Run  bin/vic-machine-linux create --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --image-store=%{TEST_DATASTORE} --bridge-network=bridge --container-network 'vm-network':'vm network' ${vicmachinetls}
+    Should Contain  ${output}  The network alias supplied in "vm-network:vm network" cannot contain spaces.
+    Should Contain  ${output}  vic-machine-linux create failed
 
-#     ${output}=  Run  docker %{VCH-PARAMS} network ls
-#     Should Contain  ${output}  vmnet
+    # Delete the portgroup added by env vars keyword
+    Cleanup VCH Bridge Network  %{VCH-NAME}
 
-#     # Clean up port groups
-#     ${out}=  Run  govc host.portgroup.remove 'VM Network With Spaces'
-#     ${out}=  Run  govc host.portgroup.remove 'bridge'
+Container network - space in network name valid
+    Set Test Environment Variables
+    # Attempt to cleanup old/canceled tests
+    Run Keyword And Ignore Error  Cleanup Dangling VMs On Test Server
+    Run Keyword And Ignore Error  Cleanup Datastore On Test Server
 
-#     # Delete the portgroup added by env vars keyword
-#     Cleanup VCH Bridge Network  %{VCH-NAME}
-#     Cleanup VIC Appliance On Test Server
+    Log To Console  Create a portgroup with a space in it's name
+    ${out}=  Run  govc host.portgroup.add -vswitch vSwitchLAN 'VM Network With Spaces'
 
-# Container Firewalls
-#     Set Test Environment Variables
-#     # Attempt to cleanup old/canceled tests
-#     Run Keyword And Ignore Error  Cleanup Dangling VMs On Test Server
-#     Run Keyword And Ignore Error  Cleanup Datastore On Test Server
+    Log To Console  Create a bridge portgroup.
+    ${out}=  Run  govc host.portgroup.add -vswitch vSwitchLAN bridge
 
-#     # Set the only teardown for this test to cleanup both portgroups and VCH, regardless of test outcome.
-#     [Teardown]  Cleanup Container Firewalls Test
+    ${output}=  Run  bin/vic-machine-linux create --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --image-store=%{TEST_DATASTORE} --bridge-network=bridge --container-network 'VM Network With Spaces':vmnet --insecure-registry harbor.ci.drone.local ${vicmachinetls}
+    Should Contain  ${output}  Installer completed successfully
+    Get Docker Params  ${output}  ${true}
+    Log To Console  Installer completed successfully: %{VCH-NAME}
 
-#     ${out}=  Run  govc host.portgroup.remove bridge
-#     ${out}=  Run  govc host.portgroup.remove open-net
-#     ${out}=  Run  govc host.portgroup.remove closed-net
-#     ${out}=  Run  govc host.portgroup.remove published-net
-#     ${out}=  Run  govc host.portgroup.remove outbound-net
-#     ${out}=  Run  govc host.portgroup.remove peers-net-1
-#     ${out}=  Run  govc host.portgroup.remove peers-net-2
+    Run Regression Tests
 
-#     Log To Console  Create port groups
-#     ${out}=  Run  govc host.portgroup.add -vswitch vSwitchLAN bridge
-#     ${out}=  Run  govc host.portgroup.add -vswitch vSwitchLAN open-net
-#     ${out}=  Run  govc host.portgroup.add -vswitch vSwitchLAN closed-net
-#     ${out}=  Run  govc host.portgroup.add -vswitch vSwitchLAN published-net
-#     ${out}=  Run  govc host.portgroup.add -vswitch vSwitchLAN outbound-net
-#     ${out}=  Run  govc host.portgroup.add -vswitch vSwitchLAN peers-net-1
-#     ${out}=  Run  govc host.portgroup.add -vswitch vSwitchLAN peers-net-2
+    ${output}=  Run  docker %{VCH-PARAMS} network ls
+    Should Contain  ${output}  vmnet
 
-#     ${createcommand}=  catenate  SEPARATOR=\ \ 
-#     ...  bin/vic-machine-linux create --debug 1 --name=%{VCH-NAME}
-#     ...  --target=%{TEST_URL}%{TEST_DATACENTER} --thumbprint=%{TEST_THUMBPRINT}
-#     ...  --user=%{TEST_USERNAME} --image-store=%{TEST_DATASTORE} --password=%{TEST_PASSWORD}
-#     ...  --force=true --bridge-network=bridge --compute-resource=%{TEST_RESOURCE} --no-tlsverify
-#     ...  --insecure-registry harbor.ci.drone.local
-#     ...  --container-network open-net --container-network-firewall open-net:open
-#     ...  --container-network closed-net --container-network-firewall closed-net:closed
-#     ...  --container-network outbound-net --container-network-firewall outbound-net:outbound
-#     ...  --container-network published-net --container-network-firewall published-net:published
-#     ...  --container-network peers-net-1 --container-network-firewall peers-net-1:peers
-#     ...  --container-network-ip-range peers-net-1:10.10.10.0/24 --container-network-gateway peers-net-1:10.10.10.1/24
-#     ...  --container-network peers-net-2 --container-network-firewall peers-net-2:peers
-#     ...  --container-network-ip-range peers-net-2:192.168.0.0/16 --container-network-gateway peers-net-2:192.168.0.1/16
+    # Clean up port groups
+    ${out}=  Run  govc host.portgroup.remove 'VM Network With Spaces'
+    ${out}=  Run  govc host.portgroup.remove 'bridge'
 
-#     ${output}=  Run  ${createcommand}
+    # Delete the portgroup added by env vars keyword
+    Cleanup VCH Bridge Network  %{VCH-NAME}
+    Cleanup VIC Appliance On Test Server
 
-#     Should Contain  ${output}  Installer completed successfully
-#     Get Docker Params  ${output}  ${true}
-#     Log To Console  Installer completed successfully: %{VCH-NAME}
+Container Firewalls
+    Set Test Environment Variables
+    # Attempt to cleanup old/canceled tests
+    Run Keyword And Ignore Error  Cleanup Dangling VMs On Test Server
+    Run Keyword And Ignore Error  Cleanup Datastore On Test Server
 
-#     ### OPEN FIREWALL ###
-#     Log To Console  Checking Open Firewall
-#     # Create an open container listening on port 1234
-#     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -d --net=open-net --name p1 ${busybox} nc -l -p 1234
-#     Should Be Equal As Integers  ${rc}  0
+    # Set the only teardown for this test to cleanup both portgroups and VCH, regardless of test outcome.
+    [Teardown]  Cleanup Container Firewalls Test
 
-#     ${ip}=  Run  docker %{VCH-PARAMS} inspect --format '{{range .NetworkSettings.Networks}}{{.IPAddress }}{{end}}' p1
+    ${out}=  Run  govc host.portgroup.remove bridge
+    ${out}=  Run  govc host.portgroup.remove open-net
+    ${out}=  Run  govc host.portgroup.remove closed-net
+    ${out}=  Run  govc host.portgroup.remove published-net
+    ${out}=  Run  govc host.portgroup.remove outbound-net
+    ${out}=  Run  govc host.portgroup.remove peers-net-1
+    ${out}=  Run  govc host.portgroup.remove peers-net-2
 
-#     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run --net bridge ${busybox} nc ${ip} 1234
-#     Should Be Equal As Integers  ${rc}  0
-#     Should Not Contain  ${output}  Error:
+    Log To Console  Create port groups
+    ${out}=  Run  govc host.portgroup.add -vswitch vSwitchLAN bridge
+    ${out}=  Run  govc host.portgroup.add -vswitch vSwitchLAN open-net
+    ${out}=  Run  govc host.portgroup.add -vswitch vSwitchLAN closed-net
+    ${out}=  Run  govc host.portgroup.add -vswitch vSwitchLAN published-net
+    ${out}=  Run  govc host.portgroup.add -vswitch vSwitchLAN outbound-net
+    ${out}=  Run  govc host.portgroup.add -vswitch vSwitchLAN peers-net-1
+    ${out}=  Run  govc host.portgroup.add -vswitch vSwitchLAN peers-net-2
 
-#     ### CLOSED FIREWALL ###
-#     Log To Console  Checking Closed Firewall
+    ${createcommand}=  catenate  SEPARATOR=\ \ 
+    ...  bin/vic-machine-linux create --debug 1 --name=%{VCH-NAME}
+    ...  --target=%{TEST_URL}%{TEST_DATACENTER} --thumbprint=%{TEST_THUMBPRINT}
+    ...  --user=%{TEST_USERNAME} --image-store=%{TEST_DATASTORE} --password=%{TEST_PASSWORD}
+    ...  --force=true --bridge-network=bridge --compute-resource=%{TEST_RESOURCE} --no-tlsverify
+    ...  --insecure-registry harbor.ci.drone.local
+    ...  --container-network open-net --container-network-firewall open-net:open
+    ...  --container-network closed-net --container-network-firewall closed-net:closed
+    ...  --container-network outbound-net --container-network-firewall outbound-net:outbound
+    ...  --container-network published-net --container-network-firewall published-net:published
+    ...  --container-network peers-net-1 --container-network-firewall peers-net-1:peers
+    ...  --container-network-ip-range peers-net-1:10.10.10.0/24 --container-network-gateway peers-net-1:10.10.10.1/24
+    ...  --container-network peers-net-2 --container-network-firewall peers-net-2:peers
+    ...  --container-network-ip-range peers-net-2:192.168.0.0/16 --container-network-gateway peers-net-2:192.168.0.1/16
 
-#     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -d --net=closed-net --name shouldfail -p 123 ${busybox} nc -l -p 1234
-#     Should Contain  ${output}  Ports cannot be published via
-#     Should Not Be Equal As Integers  ${rc}  0
+    ${output}=  Run  ${createcommand}
 
-#     # Create a closed container listening on port 1234.
-#     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -d --net=closed-net --name p2 ${busybox} nc -l -p 1234
-#     Should Be Equal As Integers  ${rc}  0
+    Should Contain  ${output}  Installer completed successfully
+    Get Docker Params  ${output}  ${true}
+    Log To Console  Installer completed successfully: %{VCH-NAME}
 
-#     ${ip}=  Run  docker %{VCH-PARAMS} inspect --format '{{range .NetworkSettings.Networks}}{{.IPAddress }}{{end}}' p2
+    ### OPEN FIREWALL ###
+    Log To Console  Checking Open Firewall
+    # Create an open container listening on port 1234
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -d --net=open-net --name p1 ${busybox} nc -l -p 1234
+    Should Be Equal As Integers  ${rc}  0
 
-#     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run --net=bridge ${busybox} nc ${ip} 1234
-#     Should Not Be Equal As Integers  ${rc}  0
+    ${ip}=  Run  docker %{VCH-PARAMS} inspect --format '{{range .NetworkSettings.Networks}}{{.IPAddress }}{{end}}' p1
+
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run --net bridge ${busybox} nc ${ip} 1234
+    Should Be Equal As Integers  ${rc}  0
+    Should Not Contain  ${output}  Error:
+
+    ### CLOSED FIREWALL ###
+    Log To Console  Checking Closed Firewall
+
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -d --net=closed-net --name shouldfail -p 123 ${busybox} nc -l -p 1234
+    Should Contain  ${output}  Ports cannot be published via
+    Should Not Be Equal As Integers  ${rc}  0
+
+    # Create a closed container listening on port 1234.
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -d --net=closed-net --name p2 ${busybox} nc -l -p 1234
+    Should Be Equal As Integers  ${rc}  0
+
+    ${ip}=  Run  docker %{VCH-PARAMS} inspect --format '{{range .NetworkSettings.Networks}}{{.IPAddress }}{{end}}' p2
+
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run --net=bridge ${busybox} nc ${ip} 1234
+    Should Not Be Equal As Integers  ${rc}  0
     
-#     # Create a container on a bridge and closed network listening on port 1234.
-#     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} create --net=bridge --name closedbridge ${busybox} nc -l -p 1234
-#     Should Be Equal As Integers  ${rc}  0
+    # Create a container on a bridge and closed network listening on port 1234.
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} create --net=bridge --name closedbridge ${busybox} nc -l -p 1234
+    Should Be Equal As Integers  ${rc}  0
 
-#     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} network connect closed-net closedbridge
-#     Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} network connect closed-net closedbridge
+    Should Be Equal As Integers  ${rc}  0
 
-#     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} start closedbridge
-#     Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} start closedbridge
+    Should Be Equal As Integers  ${rc}  0
 
-#     ${ip}=  Run  docker %{VCH-PARAMS} inspect --format '{{.NetworkSettings.Networks.bridge.IPAddress}}' closedbridge
+    ${ip}=  Run  docker %{VCH-PARAMS} inspect --format '{{.NetworkSettings.Networks.bridge.IPAddress}}' closedbridge
 
-#     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run --net=bridge ${busybox} nc ${ip} 1234
-#     Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run --net=bridge ${busybox} nc ${ip} 1234
+    Should Be Equal As Integers  ${rc}  0
 
-#     ### OUTBOUND FIREWALL ###
-#     Log To Console  Checking Outbound Firewall
-#     # Create an outbound-only container listening on port 1234.
-#     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -d --net=outbound-net --name p3 ${busybox} nc -l -p 1234
-#     Should Be Equal As Integers  ${rc}  0
+    ### OUTBOUND FIREWALL ###
+    Log To Console  Checking Outbound Firewall
+    # Create an outbound-only container listening on port 1234.
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -d --net=outbound-net --name p3 ${busybox} nc -l -p 1234
+    Should Be Equal As Integers  ${rc}  0
 
-#     ${ip}=  Run  docker %{VCH-PARAMS} inspect --format '{{range .NetworkSettings.Networks}}{{.IPAddress }}{{end}}' p3
+    ${ip}=  Run  docker %{VCH-PARAMS} inspect --format '{{range .NetworkSettings.Networks}}{{.IPAddress }}{{end}}' p3
 
-#     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run --net=outbound ${busybox} nc ${ip} 1234
-#     Should Not Be Equal As Integers  ${rc}  0
-#     # The connection should not be established. However, an outbound network should be able to connect to an open network.
-#     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -d --net=open-net --name p4 ${busybox} nc -l -p 1234
-#     Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run --net=outbound ${busybox} nc ${ip} 1234
+    Should Not Be Equal As Integers  ${rc}  0
+    # The connection should not be established. However, an outbound network should be able to connect to an open network.
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -d --net=open-net --name p4 ${busybox} nc -l -p 1234
+    Should Be Equal As Integers  ${rc}  0
 
-#     ${ip}=  Run  docker %{VCH-PARAMS} inspect --format '{{range .NetworkSettings.Networks}}{{.IPAddress }}{{end}}' p4
+    ${ip}=  Run  docker %{VCH-PARAMS} inspect --format '{{range .NetworkSettings.Networks}}{{.IPAddress }}{{end}}' p4
 
-#     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run --net=outbound-net ${busybox} nc ${ip} 1234
-#     Should Be Equal As Integers  ${rc}  0
-#     Should Not Contain  ${output}  Error:
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run --net=outbound-net ${busybox} nc ${ip} 1234
+    Should Be Equal As Integers  ${rc}  0
+    Should Not Contain  ${output}  Error:
 
-#     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} create --net=bridge --name out1 ${busybox} nc -l -p 1234
-#     Should Be Equal As Integers  ${rc}  0
-#     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} network connect outbound-net out1
-#     Should Be Equal As Integers  ${rc}  0
-#     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} start out1
-#     Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} create --net=bridge --name out1 ${busybox} nc -l -p 1234
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} network connect outbound-net out1
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} start out1
+    Should Be Equal As Integers  ${rc}  0
 
-#     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} create --net=bridge --name out2 ${busybox} nc out1 1234
-#     Should Be Equal As Integers  ${rc}  0
-#     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} network connect outbound-net out2 
-#     Should Be Equal As Integers  ${rc}  0
-#     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} start out2
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} create --net=bridge --name out2 ${busybox} nc out1 1234
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} network connect outbound-net out2 
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} start out2
 
-#     ### PUBLISHED FIREWALL ###
-#     Log To Console  Checking Published Firewall
-#     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -d --net=published-net -p 1337 --name p5 ${busybox} nc -l -p 1337
-#     Should Be Equal As Integers  ${rc}  0
+    ### PUBLISHED FIREWALL ###
+    Log To Console  Checking Published Firewall
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -d --net=published-net -p 1337 --name p5 ${busybox} nc -l -p 1337
+    Should Be Equal As Integers  ${rc}  0
 
-#     ${ip}=  Run  docker %{VCH-PARAMS} inspect --format '{{range .NetworkSettings.Networks}}{{.IPAddress }}{{end}}' p5
+    ${ip}=  Run  docker %{VCH-PARAMS} inspect --format '{{range .NetworkSettings.Networks}}{{.IPAddress }}{{end}}' p5
 
-#     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run --net=outbound-net ${busybox} nc ${ip} 1337
-#     Should Be Equal As Integers  ${rc}  0
-#     Should Not Contain  ${output}  Error:
-#     # Connection should be established on the open port. Let's try a closed one now...
-#     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -d --net=published-net -p 1337 --name p6 ${busybox} nc -l -p 1337
-#     Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run --net=outbound-net ${busybox} nc ${ip} 1337
+    Should Be Equal As Integers  ${rc}  0
+    Should Not Contain  ${output}  Error:
+    # Connection should be established on the open port. Let's try a closed one now...
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -d --net=published-net -p 1337 --name p6 ${busybox} nc -l -p 1337
+    Should Be Equal As Integers  ${rc}  0
 
-#     ${ip}=  Run  docker %{VCH-PARAMS} inspect --format '{{range .NetworkSettings.Networks}}{{.IPAddress }}{{end}}' p6
+    ${ip}=  Run  docker %{VCH-PARAMS} inspect --format '{{range .NetworkSettings.Networks}}{{.IPAddress }}{{end}}' p6
 
-#     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run --net=outbound-net ${busybox} nc ${ip} 404
-#     Should Not Be Equal As Integers  ${rc}  0
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run --net=outbound-net ${busybox} nc ${ip} 404
+    Should Not Be Equal As Integers  ${rc}  0
 
-#     ### PEERS FIREWALL ###
-#     Log To Console  Checking Peers Firewall
-#     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -d --net=peers-net-1 --name p7 ${busybox} nc -l -p 1234
-#     Should Be Equal As Integers  ${rc}  0
+    ### PEERS FIREWALL ###
+    Log To Console  Checking Peers Firewall
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -d --net=peers-net-1 --name p7 ${busybox} nc -l -p 1234
+    Should Be Equal As Integers  ${rc}  0
 
-#     ${ip}=  Run  docker %{VCH-PARAMS} inspect --format '{{range .NetworkSettings.Networks}}{{.IPAddress }}{{end}}' p7
+    ${ip}=  Run  docker %{VCH-PARAMS} inspect --format '{{range .NetworkSettings.Networks}}{{.IPAddress }}{{end}}' p7
 
-#     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run --net=peers-net-1 ${busybox} nc ${ip} 1234
-#     Should Be Equal As Integers  ${rc}  0
-#     Should Not Contain  ${output}  Error:
-#     # Connection should be established on the peer network. Let's try a non-peer now...
-#     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -d --net=peers-net-1 --name p8 ${busybox} nc -l -p 1234
-#     Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run --net=peers-net-1 ${busybox} nc ${ip} 1234
+    Should Be Equal As Integers  ${rc}  0
+    Should Not Contain  ${output}  Error:
+    # Connection should be established on the peer network. Let's try a non-peer now...
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -d --net=peers-net-1 --name p8 ${busybox} nc -l -p 1234
+    Should Be Equal As Integers  ${rc}  0
 
-#     ${ip}=  Run  docker %{VCH-PARAMS} inspect --format '{{range .NetworkSettings.Networks}}{{.IPAddress }}{{end}}' p8
+    ${ip}=  Run  docker %{VCH-PARAMS} inspect --format '{{range .NetworkSettings.Networks}}{{.IPAddress }}{{end}}' p8
 
-#     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run --net=peers-net-2 ${busybox} nc ${ip} 1234
-#     Should Not Be Equal As Integers  ${rc}  0
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run --net=peers-net-2 ${busybox} nc ${ip} 1234
+    Should Not Be Equal As Integers  ${rc}  0
 
-# Container network invalid 1
-#     Pass execution  Test not implemented
+Container network invalid 1
+    Pass execution  Test not implemented
 
-# Container network invalid 2
-#     Pass execution  Test not implemented
+Container network invalid 2
+    Pass execution  Test not implemented
 
-# Container network 1
-#     Pass execution  Test not implemented
+Container network 1
+    Pass execution  Test not implemented
 
-# Container network 2
-#     Pass execution  Test not implemented
+Container network 2
+    Pass execution  Test not implemented
 
-# Network mapping invalid
-#     Pass execution  Test not implemented
+Network mapping invalid
+    Pass execution  Test not implemented
 
-# Network mapping gateway invalid
-#     Pass execution  Test not implemented
+Network mapping gateway invalid
+    Pass execution  Test not implemented
 
-# Network mapping IP invalid
-#     Pass execution  Test not implemented
+Network mapping IP invalid
+    Pass execution  Test not implemented
 
-# DNS format invalid
-#     Pass execution  Test not implemented
+DNS format invalid
+    Pass execution  Test not implemented
 
-# Network mapping
-#     Pass execution  Test not implemented
+Network mapping
+    Pass execution  Test not implemented
 
-# VCH static IP - Static public
-#     Pass execution  Test not implemented
+VCH static IP - Static public
+    Pass execution  Test not implemented
 
-# VCH static IP - Static client
-#     Pass execution  Test not implemented
+VCH static IP - Static client
+    Pass execution  Test not implemented
 
-# VCH static IP - Static management
-#     Pass execution  Test not implemented
+VCH static IP - Static management
+    Pass execution  Test not implemented
 
-# VCH static IP - different port groups 1
-#     Pass execution  Test not implemented
+VCH static IP - different port groups 1
+    Pass execution  Test not implemented
 
-# VCH static IP - different port groups 2
-#     Pass execution  Test not implemented
+VCH static IP - different port groups 2
+    Pass execution  Test not implemented
 
-# VCH static IP - same port group
-#     Pass execution  Test not implemented
+VCH static IP - same port group
+    Pass execution  Test not implemented
 
-# VCH static IP - same subnet for multiple port groups
-#     Pass execution  Test not implemented
+VCH static IP - same subnet for multiple port groups
+    Pass execution  Test not implemented


### PR DESCRIPTION
* Restores the ability to run tether unit tests as non-root
* Adds methods to launch and wait on processes avoiding racing with the
  reaper
* Adds unit test glue to support exercising the firewall logic
* Re-enables squashed ping tests.

Does NOT currently provide firewall unit tests in the absence of mocking
for the actual invocation.

This PR is heavily based off @gigawhitlocks PR, but needing to push it
through CI urgently so raised again here.