### PR TITLE
Move toolbox archive from lib/tether to cmd/tether [full ci]

### DIFF
--- a/cmd/tether/main_linux.go
+++ b/cmd/tether/main_linux.go
@@ -15,25 +15,38 @@
 package main
 
 import (
+	"archive/tar"
+	"context"
+	"io"
+	"net/url"
 	"os"
 	"os/signal"
 	"path"
 	"runtime/debug"
+	"strconv"
 	"strings"
 	"syscall"
 
 	log "github.com/Sirupsen/logrus"
 
+	dar "github.com/docker/docker/pkg/archive"
+
+	"github.com/vmware/govmomi/toolbox/hgfs"
+	"github.com/vmware/vic/lib/archive"
+	"github.com/vmware/vic/lib/portlayer/storage/vsphere"
 	"github.com/vmware/vic/lib/tether"
 	viclog "github.com/vmware/vic/pkg/log"
 	"github.com/vmware/vic/pkg/trace"
 	"github.com/vmware/vic/pkg/vsphere/extraconfig"
 )
 
-var tthr tether.Tether
+var (
+	tthr                  tether.Tether
+	defaultArchiveHandler = hgfs.NewArchiveHandler().(*hgfs.ArchiveHandler)
+)
 
 func init() {
-	// Initiliaze logger with default TextFormatter
+	// Initialize logger with default TextFormatter
 	log.SetFormatter(viclog.NewTextFormatter())
 
 	// use the same logger for trace and other logging
@@ -95,7 +108,13 @@ func main() {
 	tthr.Register("Attach", sshserver)
 
 	// register the toolbox extension
-	tthr.Register("Toolbox", tether.NewToolbox().InContainer())
+	toolbox := tether.NewToolbox().InContainer()
+	cmd := toolbox.Service.Command
+	cmd.FileServer.RegisterFileHandler(hgfs.ArchiveScheme, &hgfs.ArchiveHandler{
+		Read:  toolboxOverrideArchiveRead,
+		Write: toolboxOverrideArchiveWrite,
+	})
+	tthr.Register("Toolbox", toolbox)
 
 	err = tthr.Start()
 	if err != nil {
@@ -133,4 +152,117 @@ func startSignalHandler() {
 			}
 		}
 	}()
+}
+
+// toolboxOverrideArchiveRead is the online DataSink Override Handler
+func toolboxOverrideArchiveRead(u *url.URL, tr *tar.Reader) error {
+
+	// special behavior when using disk-labels and filterspec
+	diskLabel := u.Query().Get(vsphere.DiskLabelQueryName)
+	filterSpec := u.Query().Get(vsphere.FilterSpecQueryName)
+	if diskLabel != "" && filterSpec != "" {
+		op := trace.NewOperation(context.Background(), "ToolboxOnlineDataSink: %s", u.String())
+		op.Debugf("Reading from tar archive to path %s: %s", u.Path, u.String())
+		spec, err := archive.DecodeFilterSpec(op, &filterSpec)
+		if err != nil {
+			op.Errorf(err.Error())
+			return err
+		}
+		diskPath, err := MountDiskLabel(diskLabel)
+		if err != nil {
+			op.Errorf(err.Error())
+			return err
+		}
+		defer UnmountDiskLabel(op, diskPath)
+
+		// no need to join on u.Path here. u.Path == spec.Rebase, but
+		// Unpack will rebase tar headers for us. :thumbsup:
+		err = archive.Unpack(op, tr, spec, diskPath)
+		if err != nil {
+			op.Errorf(err.Error())
+		}
+		op.Debugf("Finished reading from tar archive to path %s: %s", u.Path, u.String())
+		return err
+	}
+	return defaultArchiveHandler.Read(u, tr)
+
+}
+
+// toolboxOverrideArchiveWrite is the Online DataSource Override Handler
+func toolboxOverrideArchiveWrite(u *url.URL, tw *tar.Writer) error {
+
+	// special behavior when using disk-labels and filterspec
+	diskLabel := u.Query().Get(vsphere.DiskLabelQueryName)
+	filterSpec := u.Query().Get(vsphere.FilterSpecQueryName)
+
+	skiprecurse, _ := strconv.ParseBool(u.Query().Get(vsphere.SkipRecurseQueryName))
+	skipdata, _ := strconv.ParseBool(u.Query().Get(vsphere.SkipDataQueryName))
+
+	if diskLabel != "" && filterSpec != "" {
+		op := trace.NewOperation(context.Background(), "ToolboxOnlineDataSource: %s", u.String())
+		op.Debugf("Writing to archive from %s: %s", u.Path, u.String())
+
+		spec, err := archive.DecodeFilterSpec(op, &filterSpec)
+		if err != nil {
+			op.Errorf(err.Error())
+			return err
+		}
+
+		// get the container fs mount
+		diskPath, err := MountDiskLabel(diskLabel)
+		if err != nil {
+			op.Errorf(err.Error())
+			return err
+		}
+		defer UnmountDiskLabel(op, diskPath)
+
+		var rc io.ReadCloser
+		if skiprecurse {
+			// we only want a single file - this is a hack while we're abusing Diff, but
+			// accomplish this by generating a single entry ChangeSet
+			changes := []dar.Change{
+				{
+					Kind: dar.ChangeModify,
+					Path: u.Path,
+				},
+			}
+
+			rc, err = archive.Tar(op, diskPath, changes, spec, !skipdata, false)
+		} else {
+			rc, err = archive.Diff(op, diskPath, "", spec, !skipdata, false)
+		}
+
+		if err != nil {
+			op.Errorf(err.Error())
+			return err
+		}
+
+		tr := tar.NewReader(rc)
+		defer rc.Close()
+		for {
+			hdr, err := tr.Next()
+			if err == io.EOF {
+				op.Debugf("Finished writing to archive from %s: %s with error %#v", u.Path, u.String(), err)
+				break
+			}
+			if err != nil {
+				op.Errorf("error writing tar: %s", err.Error())
+				return err
+			}
+			op.Debugf("Writing header: %#s", *hdr)
+			err = tw.WriteHeader(hdr)
+			if err != nil {
+				op.Errorf("error writing tar header: %s", err.Error())
+				return err
+			}
+			_, err = io.Copy(tw, tr)
+			if err != nil {
+				op.Errorf("error writing tar contents: %s", err.Error())
+				return err
+			}
+		}
+
+		return nil
+	}
+	return defaultArchiveHandler.Write(u, tw)
 }

--- a/cmd/tether/ops_linux.go
+++ b/cmd/tether/ops_linux.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"os"
 	"path"
 	"strconv"
@@ -379,4 +380,45 @@ func portToRule(p string) (*netfilter.Rule, error) {
 	rule.FromPort = port
 
 	return rule, nil
+}
+
+// MountDiskLabel mounts a device based on it's label name located
+// in /dev/disk/by-label
+func MountDiskLabel(label string) (string, error) {
+	// We know the vmdk will always be attached at '/'
+	if label == "containerfs" {
+		return "/", nil
+	}
+
+	// otherwise, label represents a volume that needs to be mounted
+	path := path.Join("/dev/disk/by-label/", label)
+	_, err := os.Lstat(path)
+	// label does not exist
+	if err != nil {
+		return "", err
+	}
+
+	// label exists, mount the device to a tmp directory
+	tmpDir, err := ioutil.TempDir("", fmt.Sprintf("toolbox-%s", label))
+	if err := tether.Sys.Syscall.Mount(path, tmpDir, tether.Ext4FileSystemType, syscall.MS_NOATIME, ""); err != nil {
+		return "", fmt.Errorf("failed to mount %s to %s: %s", path, tmpDir, err)
+	}
+
+	return tmpDir, nil
+}
+
+// UnmountDiskLabel is intended to be used after MountDiskLabel. It unmounts the disk at
+// unmountPath from the container filesystem.
+func UnmountDiskLabel(op trace.Operation, unmountPath string) {
+	// don't unmount the root vmdk
+	if unmountPath == "/" {
+		return
+	}
+
+	// unmount the disk from the temporary directory
+	if err := tether.Sys.Syscall.Unmount(unmountPath, syscall.MNT_DETACH); err != nil {
+		op.Errorf("failed to unmount %s: %s", unmountPath, err.Error())
+	}
+	// finally, remove the temporary directory
+	os.Remove(unmountPath)
 }

--- a/lib/portlayer/storage/vsphere/toolbox_datasink.go
+++ b/lib/portlayer/storage/vsphere/toolbox_datasink.go
@@ -60,7 +60,7 @@ func (t *ToolboxDataSink) Import(op trace.Operation, spec *archive.FilterSpec, d
 	// NOW: need a check that size doesn't exceed available memory - and error recommending offline
 	// copy as alternative
 	buf := new(bytes.Buffer)
-	_, err = io.Copy(buf, data)
+	n, err := io.Copy(buf, data)
 	if err != nil {
 		op.Errorf("Unable to buffer archive data for upload")
 		return err
@@ -68,6 +68,7 @@ func (t *ToolboxDataSink) Import(op trace.Operation, spec *archive.FilterSpec, d
 
 	// upload the gzip archive.
 	p := soap.DefaultUpload
+	p.ContentLength = n
 
 	retryFunc := func() error {
 		return client.Upload(op, buf, target, p, &types.GuestPosixFileAttributes{}, true)

--- a/lib/tether/ops_linux.go
+++ b/lib/tether/ops_linux.go
@@ -70,7 +70,7 @@ const (
 
 	pciDevPath         = "/sys/bus/pci/devices"
 	nfsFileSystemType  = "nfs"
-	ext4FileSystemType = "ext4"
+	Ext4FileSystemType = "ext4"
 	bridgeTableNumber  = 201
 )
 
@@ -743,7 +743,7 @@ func (t *BaseOperations) MountLabel(ctx context.Context, label, target string) e
 		return errors.New(detail)
 	}
 
-	if err := Sys.Syscall.Mount(label, target, ext4FileSystemType, syscall.MS_NOATIME, ""); err != nil {
+	if err := Sys.Syscall.Mount(label, target, Ext4FileSystemType, syscall.MS_NOATIME, ""); err != nil {
 		// consistent with MountFileSystem
 		detail := fmt.Sprintf("mounting %s on %s failed: %s", label, target, err)
 		return errors.New(detail)
@@ -822,7 +822,7 @@ func (t *BaseOperations) CopyExistingContent(source string) error {
 	// mount the parent directory of the source to bindDir
 	// e.g if source is /foo/bar, mount /foo to ./bindDir
 	log.Debugf("mounting %s on %s", parentDir, bindDir)
-	if err := Sys.Syscall.Mount(parentDir, bindDir, ext4FileSystemType, syscall.MS_BIND, ""); err != nil {
+	if err := Sys.Syscall.Mount(parentDir, bindDir, Ext4FileSystemType, syscall.MS_BIND, ""); err != nil {
 		log.Errorf("error mounting to %s: %+v", bindDir, err)
 		return err
 	}

--- a/lib/tether/toolbox.go
+++ b/lib/tether/toolbox.go
@@ -17,31 +17,18 @@
 package tether
 
 import (
-	"archive/tar"
-	"context"
 	"errors"
 	"fmt"
-	"io"
-	"io/ioutil"
-	"net/url"
-	"os"
-	"path"
-	"strconv"
 	"sync"
 	"syscall"
 	"time"
 
 	log "github.com/Sirupsen/logrus"
-	dar "github.com/docker/docker/pkg/archive"
 	"golang.org/x/crypto/ssh"
 
 	"github.com/vmware/govmomi/toolbox"
-	"github.com/vmware/govmomi/toolbox/hgfs"
 	"github.com/vmware/govmomi/toolbox/vix"
 	"github.com/vmware/vic/cmd/tether/msgs"
-	"github.com/vmware/vic/lib/archive"
-	"github.com/vmware/vic/lib/portlayer/storage/vsphere"
-	"github.com/vmware/vic/pkg/trace"
 )
 
 // Toolbox is a tether extension that wraps toolbox.Service
@@ -58,10 +45,6 @@ type Toolbox struct {
 
 	stop chan struct{}
 }
-
-var (
-	defaultArchiveHandler = hgfs.NewArchiveHandler().(*hgfs.ArchiveHandler)
-)
 
 // NewToolbox returns a tether.Extension that wraps the vsphere/toolbox service
 func NewToolbox() *Toolbox {
@@ -146,11 +129,6 @@ func (t *Toolbox) InContainer() *Toolbox {
 	cmd := t.Service.Command
 	cmd.Authenticate = t.containerAuthenticate
 	cmd.ProcessStartCommand = t.containerStartCommand
-
-	cmd.FileServer.RegisterFileHandler(hgfs.ArchiveScheme, &hgfs.ArchiveHandler{
-		Read:  toolboxOverrideArchiveRead,
-		Write: toolboxOverrideArchiveWrite,
-	})
 
 	return t
 }
@@ -262,154 +240,4 @@ func (t *Toolbox) halt() error {
 	log.Warnf("killing %s", session.ID)
 
 	return session.Cmd.Process.Kill()
-}
-
-// toolboxOverrideArchiveRead is the online DataSink Override Handler
-func toolboxOverrideArchiveRead(u *url.URL, tr *tar.Reader) error {
-
-	// special behavior when using disk-labels and filterspec
-	diskLabel := u.Query().Get(vsphere.DiskLabelQueryName)
-	filterSpec := u.Query().Get(vsphere.FilterSpecQueryName)
-	if diskLabel != "" && filterSpec != "" {
-		op := trace.NewOperation(context.Background(), "ToolboxOnlineDataSink: %s", u.String())
-		op.Debugf("Reading from tar archive to path %s: %s", u.Path, u.String())
-		spec, err := archive.DecodeFilterSpec(op, &filterSpec)
-		if err != nil {
-			op.Errorf(err.Error())
-			return err
-		}
-		diskPath, err := mountDiskLabel(diskLabel)
-		if err != nil {
-			op.Errorf(err.Error())
-			return err
-		}
-		defer unmount(op, diskPath)
-
-		// no need to join on u.Path here. u.Path == spec.Rebase, but
-		// Unpack will rebase tar headers for us. :thumbsup:
-		err = archive.Unpack(op, tr, spec, diskPath)
-		if err != nil {
-			op.Errorf(err.Error())
-		}
-		op.Debugf("Finished reading from tar archive to path %s: %s", u.Path, u.String())
-		return err
-	}
-	return defaultArchiveHandler.Read(u, tr)
-
-}
-
-// toolboxOverrideArchiveWrite is the Online DataSource Override Handler
-func toolboxOverrideArchiveWrite(u *url.URL, tw *tar.Writer) error {
-
-	// special behavior when using disk-labels and filterspec
-	diskLabel := u.Query().Get(vsphere.DiskLabelQueryName)
-	filterSpec := u.Query().Get(vsphere.FilterSpecQueryName)
-
-	skiprecurse, _ := strconv.ParseBool(u.Query().Get(vsphere.SkipRecurseQueryName))
-	skipdata, _ := strconv.ParseBool(u.Query().Get(vsphere.SkipDataQueryName))
-
-	if diskLabel != "" && filterSpec != "" {
-		op := trace.NewOperation(context.Background(), "ToolboxOnlineDataSource: %s", u.String())
-		op.Debugf("Writing to archive from %s: %s", u.Path, u.String())
-
-		spec, err := archive.DecodeFilterSpec(op, &filterSpec)
-		if err != nil {
-			op.Errorf(err.Error())
-			return err
-		}
-
-		// get the container fs mount
-		diskPath, err := mountDiskLabel(diskLabel)
-		if err != nil {
-			op.Errorf(err.Error())
-			return err
-		}
-		defer unmount(op, diskPath)
-
-		var rc io.ReadCloser
-		if skiprecurse {
-			// we only want a single file - this is a hack while we're abusing Diff, but
-			// accomplish this by generating a single entry ChangeSet
-			changes := []dar.Change{
-				{
-					Kind: dar.ChangeModify,
-					Path: u.Path,
-				},
-			}
-
-			rc, err = archive.Tar(op, diskPath, changes, spec, !skipdata, false)
-		} else {
-			rc, err = archive.Diff(op, diskPath, "", spec, !skipdata, false)
-		}
-
-		if err != nil {
-			op.Errorf(err.Error())
-			return err
-		}
-
-		tr := tar.NewReader(rc)
-		defer rc.Close()
-		for {
-			hdr, err := tr.Next()
-			if err == io.EOF {
-				op.Debugf("Finished writing to archive from %s: %s with error %#v", u.Path, u.String(), err)
-				break
-			}
-			if err != nil {
-				op.Errorf("error writing tar: %s", err.Error())
-				return err
-			}
-			op.Debugf("Writing header: %#s", *hdr)
-			err = tw.WriteHeader(hdr)
-			if err != nil {
-				op.Errorf("error writing tar header: %s", err.Error())
-				return err
-			}
-			_, err = io.Copy(tw, tr)
-			if err != nil {
-				op.Errorf("error writing tar contents: %s", err.Error())
-				return err
-			}
-		}
-
-		return nil
-	}
-	return defaultArchiveHandler.Write(u, tw)
-}
-
-func mountDiskLabel(label string) (string, error) {
-	// We know the vmdk will always be attached at '/'
-	if label == "containerfs" {
-		return "/", nil
-	}
-
-	// otherwise, label represents a volume that needs to be mounted
-	path := path.Join("/dev/disk/by-label/", label)
-	_, err := os.Lstat(path)
-	// label does not exist
-	if err != nil {
-		return "", err
-	}
-
-	// label exists, mount the device to a tmp directory
-	tmpDir, err := ioutil.TempDir("", fmt.Sprintf("toolbox-%s", label))
-	if err := Sys.Syscall.Mount(path, tmpDir, ext4FileSystemType, syscall.MS_NOATIME, ""); err != nil {
-		return "", fmt.Errorf("failed to mount %s to %s: %s", path, tmpDir, err)
-	}
-
-	return tmpDir, nil
-}
-
-func unmount(op trace.Operation, unmountPath string) {
-	// don't unmount the root vmdk
-	if unmountPath == "/" {
-		return
-	}
-
-	// unmount the disk from the temporary directory
-	if err := Sys.Syscall.Unmount(unmountPath, syscall.MNT_DETACH); err != nil {
-		op.Errorf("failed to unmount %s: %s", unmountPath, err.Error())
-	}
-	// finally, remove the temporary directory
-	os.Remove(unmountPath)
 }


### PR DESCRIPTION
Migrates online toolbox archive code from lib/tether
to cmd/tether. This ensures that we do not override the
file handlers on the applianceVM, only the containerVM.
Fixes #5933.

Passing CP tests locally, the most directly affected tests. 
Running full CI to make sure there aren't any hidden issues with my tether changes.