### PR TITLE
[skip ci] retry logic to add the VC license

### DIFF
--- a/tests/manual-test-cases/Group5-Functional-Tests/5-3-Enhanced-Linked-Mode.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-3-Enhanced-Linked-Mode.robot
@@ -97,8 +97,8 @@ Test
     Set Environment Variable  GOVC_PASSWORD  Admin!23
 
     # Update vCenter license
-    Add Vsphere License  %{VC_LICENSE}
-    Assign vCenter License  %{VC_LICENSE}
+    Wait Until Keyword Succeeds  5x  30 seconds  Add Vsphere License  %{VC_LICENSE}
+    Wait Until Keyword Succeeds  5x  30 seconds  Assign vCenter License  %{VC_LICENSE}
 
     # First VC cluster
     Log To Console  Create a datacenter on the VC
@@ -129,8 +129,8 @@ Test
     Set Environment Variable  GOVC_URL  ${vc2-ip}
 
     # Update vCenter license
-    Add Vsphere License  %{VC_LICENSE}
-    Assign vCenter License  %{VC_LICENSE}
+    Wait Until Keyword Succeeds  5x  30 seconds  Add Vsphere License  %{VC_LICENSE}
+    Wait Until Keyword Succeeds  5x  30 seconds  Assign vCenter License  %{VC_LICENSE}
 
     Log To Console  Create a datacenter on the VC
     ${out}=  Run  govc datacenter.create ha-datacenter


### PR DESCRIPTION
Seeing intermittent issues with the Enhanced-Linked-Mode nightly test while adding/assigning the VC license. Adding the retry logic to make it a bit robust.

```
Running command 'govc license.add <key>
${out} = govc: ServerFaultCode: Access to perform the operation was denied.
```
