### PR TITLE
Populate /dev/random entropy using haveged

### DIFF
--- a/cmd/tether/main_linux.go
+++ b/cmd/tether/main_linux.go
@@ -97,6 +97,9 @@ func main() {
 	// register the toolbox extension
 	tthr.Register("Toolbox", tether.NewToolbox().InContainer())
 
+	// register the executor extension
+	tthr.Register("Haveged", tether.NewHaveged())
+
 	err = tthr.Start()
 	if err != nil {
 		log.Error(err)

--- a/cmd/tether/main_linux.go
+++ b/cmd/tether/main_linux.go
@@ -98,7 +98,7 @@ func main() {
 	tthr.Register("Toolbox", tether.NewToolbox().InContainer())
 
 	// register the executor extension
-	tthr.Register("Haveged", tether.NewHaveged())
+	tthr.Register("Haveged", NewHaveged())
 
 	err = tthr.Start()
 	if err != nil {

--- a/isos/bootstrap/bootstrap
+++ b/isos/bootstrap/bootstrap
@@ -37,7 +37,7 @@ if mount -t ext4 /dev/disk/by-label/containerfs ${MOUNTPOINT}; then
     # report the guest disabling the CPU
     mount -t tmpfs -o size=64m tmpfs ${MOUNTPOINT}/.tether/
 
-    # enable full system functionality in the container 
+    # enable full system functionality in the container
     ln -s lib64 ${MOUNTPOINT}/.tether/lib
     mkdir -p ${MOUNTPOINT}/.tether/{lib64,usr/lib/iptables,run}
 
@@ -72,6 +72,9 @@ if mount -t ext4 /dev/disk/by-label/containerfs ${MOUNTPOINT}; then
     cp -a /lib/libm.* /lib/libm-* /lib/libgcc_s* /lib/libip*tc* /lib/libxtables* /lib/libdl* /lib/libc.so* /lib/libc-* ${MOUNTPOINT}/.tether/lib
     cp -a /lib64/ld-* ${MOUNTPOINT}/.tether/lib64
     cp -r /usr/lib/iptables ${MOUNTPOINT}/.tether/usr/lib/
+
+    cp /lib/libhavege.so.1  ${MOUNTPOINT}/.tether/lib
+    cp /usr/sbin/haveged ${MOUNTPOINT}/.tether/
 
     echo 'tether tmpfs size after copying libraries: '
     df -k ${MOUNTPOINT}/.tether

--- a/lib/tether/executer.go
+++ b/lib/tether/executer.go
@@ -1,0 +1,77 @@
+// Copyright 2017 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tether
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+
+	"github.com/Sirupsen/logrus"
+)
+
+// Executor is a tether extension that wraps command
+type Executor struct {
+	p    *os.Process
+	exec func() (*os.Process, error)
+}
+
+// NewExecutor returns a tether.Extension that wraps the executor service
+func NewExecutor() *Executor {
+	return &Executor{}
+}
+
+// NewHaveged returns a tether.Extension that wraps haveged
+func NewHaveged() *Executor {
+	return &Executor{
+		exec: func() (*os.Process, error) {
+			args := []string{"/.tether/lib/ld-linux-x86-64.so.2", "--library-path", "/.tether/lib", "/.tether/haveged", "-w", "1024", "-v", "1", "-F"}
+			// #nosec: Subprocess launching with variable
+			cmd := exec.Command(args[0], args[1:]...)
+
+			logrus.Infof("Starting haveged with args: %q", args)
+			if err := cmd.Start(); err != nil {
+				logrus.Errorf("Starting haveged failed with %q", err.Error())
+				return nil, err
+			}
+			return cmd.Process, nil
+		},
+	}
+}
+
+// Start implementation of the tether.Extension interface
+func (e *Executor) Start() error {
+	logrus.Infof("Starting haveged")
+
+	var err error
+	e.p, err = e.exec()
+	return err
+}
+
+// Stop implementation of the tether.Extension interface
+func (e *Executor) Stop() error {
+	logrus.Infof("Stopping haveged")
+
+	if e.p != nil {
+		return e.p.Kill()
+	}
+	return fmt.Errorf("haveged process is missing")
+}
+
+// Reload implementation of the tether.Extension interface
+func (e *Executor) Reload(config *ExecutorConfig) error {
+	// haveged doesn't support reloading
+	return nil
+}


### PR DESCRIPTION
Introducing the rngd (RDRAND) means having a very strict dependency on
the Broadwell architecture, which is roughly two years old.

Instead start carrying haveged with bootstrap and start it via tether.

Fixes #5680
