### PR TITLE
Inspect all property changes before exiting WaitForKeyInExtraConfig

### DIFF
--- a/pkg/vsphere/vm/vm.go
+++ b/pkg/vsphere/vm/vm.go
@@ -172,7 +172,7 @@ func (vm *VirtualMachine) WaitForExtraConfig(ctx context.Context, waitFunc func(
 
 	// Wait on config.extraConfig
 	// https://www.vmware.com/support/developer/vc-sdk/visdk2xpubs/ReferenceGuide/vim.vm.ConfigInfo.html
-	err := property.Wait(ctx, p, vm.Reference(), []string{object.PropRuntimePowerState, "config.extraConfig"}, waitFunc)
+	err := property.Wait(ctx, p, vm.Reference(), []string{"config.extraConfig", object.PropRuntimePowerState}, waitFunc)
 	if err != nil {
 		log.Errorf("Property collector error: %s", err)
 		return err
@@ -203,8 +203,8 @@ func (vm *VirtualMachine) WaitForKeyInExtraConfig(ctx context.Context, key strin
 					}
 				}
 			case types.VirtualMachinePowerState:
+				// Give up if the vm has powered off
 				if v != types.VirtualMachinePowerStatePoweredOn {
-					// Give up if the vm has powered off
 					msg := "powered off"
 					if v == types.VirtualMachinePowerStateSuspended {
 						// Unlikely, but possible if the VM was suspended out-of-band
@@ -214,7 +214,6 @@ func (vm *VirtualMachine) WaitForKeyInExtraConfig(ctx context.Context, key strin
 					return true
 				}
 			}
-
 		}
 		return false
 	}

--- a/pkg/vsphere/vm/vm_test.go
+++ b/pkg/vsphere/vm/vm_test.go
@@ -332,7 +332,6 @@ func TestWaitForKeyInExtraConfig(t *testing.T) {
 
 	opt := &types.OptionValue{Key: "foo", Value: "bar"}
 	obj := simulator.Map.Get(vm.Reference()).(*simulator.VirtualMachine)
-	obj.Config.ExtraConfig = append(obj.Config.ExtraConfig, opt)
 
 	val, err := vm.WaitForKeyInExtraConfig(ctx, opt.Key)
 
@@ -340,6 +339,7 @@ func TestWaitForKeyInExtraConfig(t *testing.T) {
 		t.Error("expected error")
 	}
 
+	obj.Config.ExtraConfig = append(obj.Config.ExtraConfig, opt)
 	obj.Summary.Runtime.PowerState = types.VirtualMachinePowerStatePoweredOn
 
 	val, err = vm.WaitForKeyInExtraConfig(ctx, opt.Key)


### PR DESCRIPTION
There are cases where a container starts up and shuts down very quickly.  We
treated this case as early termination because the tether failed to initialize.
However, in quick to shut down containers, the tether may have initialized and
written out return codes, but we read the power off before we read the codes.
We now read the status code before the power state changes in WaitForKeyInExtraConfig.
This should allow us to not misinterpret quick ending containers.

Resolves #5629