### PR TITLE
Updated ESX and vCenter build numbers for Nimbus deployments.

### DIFF
--- a/tests/nightly/nightly-kickoff.sh
+++ b/tests/nightly/nightly-kickoff.sh
@@ -116,7 +116,7 @@ for i in $nightly_list_var; do
     #Clean up any previous runs creds
     rm -rf VCH-0-*
     echo "Executing nightly test $i on vSphere 6.0"
-    drone exec --trusted -e test="pybot --variable ESX_VERSION:ob-5251623 --variable VC_VERSION:ob-5112509 -d 60/$i --suite $i tests/manual-test-cases/" -E $nightly_secrets_file --yaml .drone.nightly.yml
+    drone exec --trusted -e test="pybot --variable ESX_VERSION:ob-5572656 --variable VC_VERSION:ob-5318172 -d 60/$i --suite $i tests/manual-test-cases/" -E $nightly_secrets_file --yaml .drone.nightly.yml
 
     if [ $? -eq 0 ]
     then

--- a/tests/resources/Nimbus-Util.robot
+++ b/tests/resources/Nimbus-Util.robot
@@ -16,8 +16,8 @@
 Documentation  This resource contains any keywords related to using the Nimbus cluster
 
 *** Variables ***
-${ESX_VERSION}  ob-4564106  #6.5 RTM
-${VC_VERSION}  ob-4602587   #6.5 RTM
+${ESX_VERSION}  ob-5969303  #6.5 RTM vsphere65u1
+${VC_VERSION}  ob-5973321   #6.5 RTM vsphere65u1
 ${NIMBUS_ESX_PASSWORD}  e2eFunctionalTest
 
 *** Keywords ***


### PR DESCRIPTION
Fixes #5868 

As part of #5868, these systems were updated manually:

All 6.5 ESXs have been updated to build 5969303.
This includes 4 CI machines and the 4 in our longevity system.

VC for 6.5 longevity system updated to build 5973321

All 6.0 ESXs have been updated to build 5572656
This includes 4 CI machines and the 4 in our longevity system.

VC for 6.0 longevity system updated to build 5318172