### PR TITLE
Remove not exercised stdin code

### DIFF
--- a/cmd/tether/attach_test.go
+++ b/cmd/tether/attach_test.go
@@ -615,13 +615,11 @@ func TestEcho(t *testing.T) {
 
 	// unblock before grabbing stdout - this should buffer in ssh
 	sshSession.Unblock()
-	stdin := sshSession.Stdin()
 	stdout := sshSession.Stdout()
 	stderr := sshSession.Stderr()
 
 	doneStdout := make(chan bool)
 	doneStderr := make(chan bool)
-	doneStdin := make(chan bool)
 
 	// read from session into buffer
 	bufout := &bytes.Buffer{}
@@ -638,18 +636,6 @@ func TestEcho(t *testing.T) {
 		log.Debug("stderr copy complete")
 		doneStderr <- true
 	}()
-
-	// nothing being sent, but is attached
-	pr, _, err := os.Pipe()
-	assert.NoError(t, err)
-	go func() {
-		io.Copy(stdin, pr)
-		log.Debug("stdin copy complete")
-		doneStdin <- true
-	}()
-
-	// seeing if premature close of stdin causes problems
-	sshSession.CloseStdin()
 
 	// wait for the close to propagate
 	<-doneStdout

--- a/cmd/tether/net_linux_test.go
+++ b/cmd/tether/net_linux_test.go
@@ -46,6 +46,8 @@ func addInterface(name string, mocker *Mocker) string {
 }
 
 func TestOutboundRuleAndCmd(t *testing.T) {
+	t.Skip("https://github.com/vmware/vic/issues/5965")
+
 	mocker := testSetup(t)
 	defer testTeardown(t, mocker)
 

--- a/cmd/tether/tether_test.go
+++ b/cmd/tether/tether_test.go
@@ -24,6 +24,7 @@ import (
 	"net/url"
 	"os"
 	"path"
+	"sync"
 	"testing"
 
 	log "github.com/Sirupsen/logrus"
@@ -74,6 +75,8 @@ type Mocker struct {
 	WindowCol uint32
 	WindowRow uint32
 	Signal    ssh.Signal
+
+	once sync.Once
 }
 
 // Start implements the extension method
@@ -88,8 +91,10 @@ func (t *Mocker) Stop() error {
 
 // Reload implements the extension method
 func (t *Mocker) Reload(config *tether.ExecutorConfig) error {
-	// the tether has definitely finished it's startup by the time we hit this
-	close(t.Started)
+	t.once.Do(func() {
+		// the tether has definitely finished it's startup by the time we hit this
+		close(t.Started)
+	})
 	return nil
 }
 


### PR DESCRIPTION
The session ends way before we have a chance to call ClostStdin().
Since session cleanup tears down the connection, we end up with a leaking
goroutine.

Seen in https://ci.vcna.io/vmware/vic/13043