### PR TITLE
Implement diff integration negative test

### DIFF
--- a/lib/apiservers/engine/backends/container.go
+++ b/lib/apiservers/engine/backends/container.go
@@ -1308,7 +1308,7 @@ func (c *Container) ContainerChanges(name string) ([]docker.Change, error) {
 		}
 
 		change := docker.Change{
-			Path: hdr.Name,
+			Path: filepath.Join("/", hdr.Name),
 		}
 		switch hdr.Xattrs[archive.ChangeTypeKey] {
 		case "A":

--- a/tests/test-cases/Group1-Docker-Commands/1-42-Docker-Diff.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-42-Docker-Diff.robot
@@ -28,17 +28,21 @@ Make changes to busybox image
     Should Be Equal As Integers  ${rc}  0
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} diff ${id}
     Should Be Equal As Integers  ${rc}  0
-    Should Contain  ${output}  A a
-    Should Contain  ${output}  A b
-    Should Contain  ${output}  A c
-    Should Contain  ${output}  D tmp
-    Should Contain  ${output}  C etc/passwd
-    Should Contain  ${output}  C etc
-    Should Contain  ${output}  C etc/group
-    Should Contain  ${output}  A etc/group-
-    Should Contain  ${output}  C etc/passwd
-    Should Contain  ${output}  A etc/passwd-
-    Should Contain  ${output}  C etc/shadow
-    Should Contain  ${output}  A etc/shadow-
-    Should Contain  ${output}  C home
-    Should Contain  ${output}  A home/krusty
+    Should Contain  ${output}  A /a
+    Should Contain  ${output}  A /b
+    Should Contain  ${output}  A /c
+    Should Contain  ${output}  D /tmp
+    Should Contain  ${output}  C /etc/passwd
+    Should Contain  ${output}  C /etc
+    Should Contain  ${output}  C /etc/group
+    Should Contain  ${output}  A /etc/group-
+    Should Contain  ${output}  C /etc/passwd
+    Should Contain  ${output}  A /etc/passwd-
+    Should Contain  ${output}  C /etc/shadow
+    Should Contain  ${output}  A /etc/shadow-
+    Should Contain  ${output}  C /home
+    Should Contain  ${output}  A /home/krusty
+    Should Not Contain  ${output}  hostname
+    Should Not Contain  ${output}  hosts
+    Should Not Contain  ${output}  resolv.conf
+    Should Not Contain  ${output}  .tether


### PR DESCRIPTION
This change adds the negative test to make sure files we don't want appearing in diffs don't show up that we've added to the scratch layer. Files added to scratch in the future should have accompanying checks in this integration test.

Fixes #5759