### PR TITLE
Going back to old (6.0) ESX and VC build numbers for now - nightly tests

### DIFF
--- a/tests/nightly/nightly-kickoff.sh
+++ b/tests/nightly/nightly-kickoff.sh
@@ -116,7 +116,7 @@ for i in $nightly_list_var; do
     #Clean up any previous runs creds
     rm -rf VCH-0-*
     echo "Executing nightly test $i on vSphere 6.0"
-    drone exec --trusted -e test="pybot --variable ESX_VERSION:ob-5572656 --variable VC_VERSION:ob-5318172 -d 60/$i --suite $i tests/manual-test-cases/" -E $nightly_secrets_file --yaml .drone.nightly.yml
+    drone exec --trusted -e test="pybot --variable ESX_VERSION:ob-5251623 --variable VC_VERSION:ob-5112509 -d 60/$i --suite $i tests/manual-test-cases/" -E $nightly_secrets_file --yaml .drone.nightly.yml
 
     if [ $? -eq 0 ]
     then


### PR DESCRIPTION
Nimbus doesn't completely like the newer builds yet.  
Only changing the 6.0 test build numbers.