### PR TITLE
[skip ci] Removing the vSphere license add

### DIFF
--- a/tests/manual-test-cases/Group5-Functional-Tests/5-3-Enhanced-Linked-Mode.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-3-Enhanced-Linked-Mode.robot
@@ -96,10 +96,6 @@ Test
     Set Environment Variable  GOVC_USERNAME  administrator@vsphere.local
     Set Environment Variable  GOVC_PASSWORD  Admin!23
 
-    # Update vCenter license
-    Wait Until Keyword Succeeds  5x  30 seconds  Add Vsphere License  %{VC_LICENSE}
-    Wait Until Keyword Succeeds  5x  30 seconds  Assign vCenter License  %{VC_LICENSE}
-
     # First VC cluster
     Log To Console  Create a datacenter on the VC
     ${out}=  Run  govc datacenter.create ha-datacenter
@@ -127,10 +123,6 @@ Test
 
     # Second VC cluster
     Set Environment Variable  GOVC_URL  ${vc2-ip}
-
-    # Update vCenter license
-    Wait Until Keyword Succeeds  5x  30 seconds  Add Vsphere License  %{VC_LICENSE}
-    Wait Until Keyword Succeeds  5x  30 seconds  Assign vCenter License  %{VC_LICENSE}
 
     Log To Console  Create a datacenter on the VC
     ${out}=  Run  govc datacenter.create ha-datacenter


### PR DESCRIPTION
Fixes #5261 

The govc license code was added as a workaround for a cluster add failure but this introduced an intermittent permissions issue on the nimbus setup. So removing the temporary workaround to make the test more reliable.
