### PR TITLE
[specific ci=1-17-Docker-Network-Connect] Add integration test for a container pinging itself when connected to multiple containers

### DIFF
--- a/isos/bootstrap/bootstrap
+++ b/isos/bootstrap/bootstrap
@@ -75,12 +75,19 @@ if mount -t ext4 /dev/disk/by-label/containerfs ${MOUNTPOINT}; then
     cp /lib/libhavege.so.1  ${MOUNTPOINT}/.tether/lib
     cp /usr/sbin/haveged ${MOUNTPOINT}/.tether/
 
+    # Create VIC chain
     iptables -N VIC
+    # Set the default policy on all chains to drop traffic
     iptables -P INPUT DROP
     iptables -P OUTPUT DROP
     iptables -P FORWARD DROP
+    # Direct any incoming/outgoing traffic immediately to VIC chain
     iptables -A INPUT -j VIC
     iptables -A OUTPUT -j VIC
+    # Always allow traffic on loopback interface
+    iptables -A INPUT -i lo -j ACCEPT
+    iptables -A OUTPUT -o lo -j ACCEPT
+    iptables -A FORWARD -i lo -o lo -j ACCEPT
 
     echo 'tether tmpfs size after copying libraries: '
     df -k ${MOUNTPOINT}/.tether

--- a/tests/test-cases/Group1-Docker-Commands/1-17-Docker-Network-Connect.md
+++ b/tests/test-cases/Group1-Docker-Commands/1-17-Docker-Network-Connect.md
@@ -12,67 +12,76 @@ This test requires that a vSphere server is running and available
 
 # Test Steps:
 1. Deploy VIC appliance to vSphere server
-2. Issue docker network create test-network
-3. Issue docker create busybox ifconfig
-4. Issue docker network connect test-network <containerID>
-5. Issue docker start <containerID>
-6. Issue docker logs <containerID>
-7. Issue docker network connect test-network fakeContainer
-8. Issue docker network connect fakeNetwork <containerID>
 
-9. Issue docker network create cross1-network
-10. Issue docker network create cross1-network2
-11. Issue docker create --net cross1-network --name cross1-container busybox /bin/top
-12. Issue docker network connect cross1-network2 <containerID>
-13. Issue docker start <containerID>
-14. Issue docker create --net cross1-network --name cross1-container2 debian ping -c2 cross1-container
-15. Issue docker network connect cross1-network2 <containerID>
-16. Issue docker start <containerID>
-17. Issue docker logs --follow cross1-container2
+2. Issue docker network create cross1-network
+3. Issue docker network create cross1-network2
+4. Issue docker create --net cross1-network --name cross1-container busybox /bin/top
+5. Issue docker network connect cross1-network2 <containerID>
+6. Issue docker start <containerID>
+7. Issue docker create --net cross1-network --name cross1-container2 debian ping -c2 cross1-container
+8. Issue docker network connect cross1-network2 <containerID>
+9. Issue docker start <containerID>
+10. Issue docker logs --follow cross1-container2
+11. Issue docker create --name cross1-container3 --net cross1-network busybox ping -c2 cross1-container3
+12. Issue docker network connect cross1-network2 cross1-container3
+13. Issue docker start cross1-container3
+14. Issue docker logs --follow cross1-container3
 
-18. Issue docker network create cross2-network
-19. Issue docker network create cross1-network2
-20. Issue docker run -itd --net cross2-network --name cross2-container busybox /bin/top
-21. Get the above container's IP - ${ip}
-22. Issue docker run --net cross2-network2 --name cross2-container2 debian ping -c2 ${ip}
-23. Issue docker logs --follow cross2-container2
-24. Issue docker run -d --net cross2-network -p 8080:80 nginx
+15. Issue docker network create test-network
+16. Issue docker create busybox ifconfig
+17. Issue docker network connect test-network <containerID>
+18. Issue docker start <containerID>
+19. Issue docker logs <containerID>
+20. Issue docker network connect test-network fakeContainer
+21. Issue docker network connect fakeNetwork <containerID>
+
+22. Issue docker network create cross2-network
+23. Issue docker network create cross1-network2
+24. Issue docker run -itd --net cross2-network --name cross2-container busybox /bin/top
 25. Get the above container's IP - ${ip}
-26. Issue docker run --net cross2-network2 --name cross2-container3 debian ping -c2 ${ip}
-27. Issue docker logs --follow cross2-container3
+26. Issue docker run --net cross2-network2 --name cross2-container2 debian ping -c2 ${ip}
+27. Issue docker logs --follow cross2-container2
+28. Issue docker run -d --net cross2-network -p 8080:80 nginx
+29. Get the above container's IP - ${ip}
+30. Issue docker run --net cross2-network2 --name cross2-container3 debian ping -c2 ${ip}
+31. Issue docker logs --follow cross2-container3
 
-28. Issue docker network create --internal internal-net
-29. Issue docker run --net internal-net busybox ping -c1 www.google.com
-30. Issue docker network create public-net
-31. Issue docker run --net internal-net --net public-net busybox ping -c2 www.google.com
-32. Issue docker run -itd --net internal-net busybox
-33. Get the above container's IP - ${ip}
-34. Issue docker run --net internal-net busybox ping -c2 ${ip}
+32. Issue docker network create --internal internal-net
+33. Issue docker run --net internal-net busybox ping -c1 www.google.com
+34. Issue docker network create public-net
+35. Issue docker run --net internal-net --net public-net busybox ping -c2 www.google.com
+36. Issue docker run -itd --net internal-net busybox
+37. Get the above container's IP - ${ip}
+38. Issue docker run --net internal-net busybox ping -c2 ${ip}
 
 # Expected Outcome:
-* Step 4 should complete successfully
-* Step 6 should print the results of the ifconfig command and there should be two network interfaces in the container(eth0, eth1)
-* Step 7 should result in an error with the following message:  
+* Steps 2-9 should return without errors
+* Step 10's output should contain "2 packets transmitted, 2 packets received"
+* Steps 11-13 should return without errors
+* Step 14's output should contain "2 packets transmitted, 2 packets received"
+
+* Step 15-17 should complete successfully
+* Step 19 should print the results of the ifconfig command and there should be two network interfaces in the container(eth0, eth1)
+* Step 20 should result in an error with the following message:
 ```
 Error response from daemon: No such container: fakeContainer
 ```
-* Step 8 should result in an error with the following message:  
+* Step 21 should result in an error with the following message:
 ```
 Error response from daemon: network fakeNetwork not found
 ```
-* Steps 9-16 should return without errors
-* Step 17's output should contain "2 packets transmitted, 2 packets received"
-* Steps 18-22 should return without errors
-* Step 23's output should contain "2 packets transmitted, 0 packets received, 100% packet loss"
-* Steps 24-26 should return without errors
-* Step 27's output should include "2 packets transmitted, 0 packets received, 100% packet loss"
 
-* Step 28 should return without an error
-* Step 29 should return with a non-zero exit code and the output should contain "Network is unreachable"
-* Step 30 should return without an error
-* Step 31's output should contain "2 packets transmitted, 2 packets received"
-* Steps 32-33 should return without errors
-* Step 34's output should contain "2 packets transmitted, 2 packets received"
+* Steps 22-26 should return without errors
+* Step 27's output should contain "2 packets transmitted, 0 packets received, 100% packet loss"
+* Steps 28-30 should return without errors
+* Step 31's output should include "2 packets transmitted, 0 packets received, 100% packet loss"
+
+* Step 32 should return without an error
+* Step 33 should return with a non-zero exit code and the output should contain "Network is unreachable"
+* Step 34 should return without an error
+* Step 35's output should contain "2 packets transmitted, 2 packets received"
+* Steps 36-37 should return without errors
+* Step 38's output should contain "2 packets transmitted, 2 packets received"
 
 # Possible Problems:
 None

--- a/tests/test-cases/Group1-Docker-Commands/1-17-Docker-Network-Connect.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-17-Docker-Network-Connect.robot
@@ -19,12 +19,31 @@ Suite Setup  Install VIC Appliance To Test Server  certs=${false}
 Suite Teardown  Cleanup VIC Appliance On Test Server
 
 *** Test Cases ***
+Container ping itself when created on multiple bridge networks
+    ${status}=  Get State Of Github Issue  5660
+    Run Keyword If  '${status}' == 'closed'  Fail  Test 1-07-Docker-Network-Connect.robot needs to be updated now that Issue #5660 has been resolved
+    
+    #${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} network create bridge1
+    #Should Be Equal As Integers  ${rc}  0
+    #${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} network create bridge2
+    #Should Be Equal As Integers  ${rc}  0
+    #${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} pull ${busybox}
+    #Should Be Equal As Integers  ${rc}  0
+    #${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} create --name test1 --net bridge1 ${busybox} ping -c2 test1
+    #Should Be Equal As Integers  ${rc}  0
+    #${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} network connect bridge2 test1
+    #Should Be Equal As Integers  ${rc}  0
+    #${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} start test1
+    #Should Be Equal As Integers  ${rc}  0
+    #${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} logs --follow test1
+    #Should Be Equal As Integers  ${rc}  0
+    #Should Contain  ${output}  2 packets transmitted, 2 packets received
+
 Connect container to a new network
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} network create test-network
     Should Be Equal As Integers  ${rc}  0
-    ${rc}  ${containerID}=  Run And Return Rc And Output  docker %{VCH-PARAMS} pull ${busybox}
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} pull ${busybox}
     Should Be Equal As Integers  ${rc}  0
-
     ${rc}  ${containerID}=  Run And Return Rc And Output  docker %{VCH-PARAMS} create ${busybox} ip -4 addr show eth0
     Should Be Equal As Integers  ${rc}  0
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} network connect test-network ${containerID}

--- a/tests/test-cases/Group1-Docker-Commands/1-17-Docker-Network-Connect.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-17-Docker-Network-Connect.robot
@@ -19,7 +19,7 @@ Suite Setup  Install VIC Appliance To Test Server  certs=${false}
 Suite Teardown  Cleanup VIC Appliance On Test Server
 
 *** Test Cases ***
-Connect containers to multiple networks overlapping
+Connect containers to multiple bridge networks overlapping
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} network create cross1-network
     Should Be Equal As Integers  ${rc}  0
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} network create cross1-network2


### PR DESCRIPTION
Fixes #5660 

#5660 requires that a fresh VCH creates two bridge networks. So I move `Connect containers to multiple networks overlapping` to be the first sub-test in this test case.

The firewall rules in bootstrap are from PR #5991 . So it can go in after 5991 is merged.