### PR TITLE
Fix the additional-args parameter

### DIFF
--- a/tests/manual-test-cases/Group21-Registries/21-1-Whitelist.robot
+++ b/tests/manual-test-cases/Group21-Registries/21-1-Whitelist.robot
@@ -94,7 +94,7 @@ Basic Whitelisting
 
 Check Login to Insecure Registry (http)
     # Install VCH w/o specifying insecure registry
-    ${output}=  Install VIC Appliance To Test Server  vol=default --registry-ca=./ca.crt
+    ${output}=  Install VIC Appliance To Test Server  additional-args=--registry-ca=./ca.crt
     Should Not Contain  ${output}  Insecure registry %{HTTP_HARBOR_IP} confirmed
     Get Docker Params  ${output}  true
 

--- a/tests/manual-test-cases/Group21-Registries/21-1-Whitelist.robot
+++ b/tests/manual-test-cases/Group21-Registries/21-1-Whitelist.robot
@@ -94,7 +94,7 @@ Basic Whitelisting
 
 Check Login to Insecure Registry (http)
     # Install VCH w/o specifying insecure registry
-    ${output}=  Install VIC Appliance To Test Server  additional-args=--registry-ca=./ca.crt
+    ${output}=  Install VIC Appliance To Test Server  vol=default --registry-ca=./ca.crt
     Should Not Contain  ${output}  Insecure registry %{HTTP_HARBOR_IP} confirmed
     Get Docker Params  ${output}  true
 

--- a/tests/resources/VCH-Util.robot
+++ b/tests/resources/VCH-Util.robot
@@ -159,7 +159,7 @@ Get Docker Params
     Run Keyword If  ${tls_enabled} == ${true}  Set Environment Variable  COMPOSE-PARAMS  -H ${dockerHost}
 
 Install VIC Appliance To Test Server
-    [Arguments]  ${vic-machine}=bin/vic-machine-linux  ${appliance-iso}=bin/appliance.iso  ${bootstrap-iso}=bin/bootstrap.iso  ${certs}=${true}  ${vol}=default  ${cleanup}=${true}  ${additional-args}=  
+    [Arguments]  ${vic-machine}=bin/vic-machine-linux  ${appliance-iso}=bin/appliance.iso  ${bootstrap-iso}=bin/bootstrap.iso  ${certs}=${true}  ${vol}=default  ${cleanup}=${true}  ${additional-args}=${EMPTY}
     Set Test Environment Variables
     # disable firewall
     Run Keyword If  '%{HOST_TYPE}' == 'ESXi'  Run  govc host.esxcli network firewall set -e false


### PR DESCRIPTION
fixes #5799 

This mis-defined parameter was causing the additional-args to not work as expected.  It was overwriting the vic-machine parameter instead, which ended up not running vic-machine at all.