### PR TITLE
[skip ci] Specify plugin and lease correctly to avoid nomem error and lease issues

### DIFF
--- a/tests/resources/Nimbus-Util.robot
+++ b/tests/resources/Nimbus-Util.robot
@@ -219,7 +219,7 @@ Gather Host IPs
 
 Create a VSAN Cluster
     Log To Console  \nStarting basic VSAN cluster deploy...
-    ${out}=  Deploy Nimbus Testbed  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}  --lease=1 --noStatsDump --noSupportBundles --vcvaBuild ${VC_VERSION} --esxPxeDir ${ESX_VERSION} --esxBuild ${ESX_VERSION} --testbedName vcqa-vsan-simple-pxeBoot-vcva --runName vic-vmotion
+    ${out}=  Deploy Nimbus Testbed  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}  --plugin testng --lease 1 --noStatsDump --noSupportBundles --vcvaBuild ${VC_VERSION} --esxPxeDir ${ESX_VERSION} --esxBuild ${ESX_VERSION} --testbedName vcqa-vsan-simple-pxeBoot-vcva --runName vic-vmotion
     Should Contain  ${out}  .vcva-${VC_VERSION}' is up. IP:
     ${out}=  Split To Lines  ${out}
     :FOR  ${line}  IN  @{out}


### PR DESCRIPTION
fixes #5879 

As per the bugzilla bug, by specifying plugin it will reduce the memory footprint of this test. It will speed it up as well as avoid the nomem error.  I threw in a fix to the lease specification as well, it seems that the testbed command needs spaced parameters while the esxdeploy and vcsadeploy need equal signs.