### PR TITLE
[full ci] Add timeout to pull command and gather logs on failure

### DIFF
--- a/tests/manual-test-cases/Group5-Functional-Tests/5-4-High-Availability.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-4-High-Availability.robot
@@ -16,6 +16,7 @@
 Documentation  Test 5-4 - High Availability
 Resource  ../../resources/Util.robot
 Suite Teardown  Nimbus Cleanup  ${list}
+Test Teardown  Run Keyword If Test Failed  Gather Logs From Test Server
 
 *** Variables ***
 ${esx_number}=  3

--- a/tests/resources/Docker-Util.robot
+++ b/tests/resources/Docker-Util.robot
@@ -25,6 +25,7 @@ Run Docker Info
 
 Pull image
     [Arguments]  ${image}
+    [Timeout]  10 minutes
     Log To Console  \nRunning docker pull ${image}...
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} pull ${image}
     Log  ${output}


### PR DESCRIPTION
fixes #5839 

Add a timeout to the pull image command in case that is hangs indefinitely again we can at least gather logs and get more information to debug further.  As it stands, there is not much to go on other than the pull image *likely* hung for > 30 minutes for some reason.