### PR TITLE
Filter vmdk backing files from vic-machine delete path

### DIFF
--- a/lib/install/management/store_files.go
+++ b/lib/install/management/store_files.go
@@ -179,6 +179,13 @@ func (d *Dispatcher) deleteFilesIteratively(m *object.DatastoreFileManager, ds *
 func (d *Dispatcher) deleteVMFSFiles(m *object.DatastoreFileManager, ds *object.Datastore, dsPath string) error {
 	defer trace.End(trace.Begin(dsPath))
 
+	for _, ext := range []string{"-delta.vmdk", "-flat.vmdk"} {
+		if strings.HasSuffix(dsPath, ext) {
+			// Skip backing files as Delete() will do so via DeleteVirtualDisk
+			return nil
+		}
+	}
+
 	if err := m.Delete(d.ctx, dsPath); err != nil {
 		log.Debugf("Failed to delete %q: %s", dsPath, err)
 	}


### PR DESCRIPTION
vic-machine delete removes files 1 at a time to workaround a vSAN bug
that prevented us from deleting the entire directory.
However, the call to govmomi/object.DatastoreFileManager.Delete dispatches to
DeleteVirtualDisk, which removes both the descriptor and the backing file.
vic-machine also tries to delete the backing file, which fails.
vic-machine does not fail in this case, but the errors can be seen in the VC/hostd
file logs and task history.

A proper fix would be one of:
- Require VC build that includes the vSAN fix and go back to deleting the image
directory in 1 call

- Provide FileQuery filter to SearchDatastore so we only delete virtual disks 1 at time,
then remove the image directory to remove metadata files and subdirectories.

Fixes #5648
