### PR TITLE
Capitalize hostsPath for hosts_darwin and hosts_windows

### DIFF
--- a/lib/etcconf/hosts_darwin.go
+++ b/lib/etcconf/hosts_darwin.go
@@ -14,4 +14,4 @@
 
 package etcconf
 
-const hostsPath = "/etc/hosts"
+const HostsPath = "/etc/hosts"

--- a/lib/etcconf/hosts_windows.go
+++ b/lib/etcconf/hosts_windows.go
@@ -14,4 +14,4 @@
 
 package etcconf
 
-const hostsPath = "c:\\Windows\\System32\\Drivers\\etc\\hosts"
+const HostsPath = "c:\\Windows\\System32\\Drivers\\etc\\hosts"


### PR DESCRIPTION
We saw the following error in one of the PR builds:
```
building vic-machine windows...
# github.com/vmware/vic/lib/etcconf
lib/etcconf/hosts.go:73: undefined: HostsPath
Makefile:394: recipe for target 'bin/vic-machine-windows.exe' failed
make: *** [bin/vic-machine-windows.exe] Error 2
```
This is because we only have `hostsPath` in `hosts_windows.go` but `HostsPath` is expected. 