### PR TITLE
Manually rescan the scsi bus if needed

### DIFF
--- a/pkg/vsphere/disk/util_test.go
+++ b/pkg/vsphere/disk/util_test.go
@@ -1,0 +1,33 @@
+// Copyright 2017 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package disk
+
+import (
+	"os"
+	"runtime"
+	"testing"
+)
+
+func TestScsiScan(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.SkipNow()
+	}
+
+	err := scsiScan()
+	if err != nil && os.IsNotExist(err) {
+		// ignoring "permission denied" or "read-only file system" errors
+		t.Error(err)
+	}
+}


### PR DESCRIPTION
The VCH is configured for auto-scanning of the scsi bus,
but we have had cases where new devices are not picked up.

Run a manual scan if we don't see the device present.

Fixes #2340
