### PR TITLE
[specific ci=1-02-Docker-Pull] Grab out error message body for nonretryable client errors and all other unexpected http code

### DIFF
--- a/pkg/fetcher/fetcher.go
+++ b/pkg/fetcher/fetcher.go
@@ -444,6 +444,8 @@ func (u *URLFetcher) buildRegistryErrMsg(url *url.URL, respBody io.ReadCloser) s
 
 // extractErrResponseMessage extracts `message` field from error response body stream.
 func extractErrResponseMessage(rdr io.ReadCloser) (string, error) {
+	defer rdr.Close()
+
 	out := bytes.NewBuffer(nil)
 	_, err := io.Copy(out, rdr)
 	if err != nil {

--- a/pkg/fetcher/fetcher.go
+++ b/pkg/fetcher/fetcher.go
@@ -442,8 +442,13 @@ func (u *URLFetcher) buildRegistryErrMsg(url *url.URL, respBody io.ReadCloser) s
 	return errMsg
 }
 
+// malformedJsonErrFormat is the error format for malformed json response body
+// used in function extractErrResponseMessage
+var malformedJsonErrFormat = fmt.Errorf("error response json has unconventional format")
+
 // extractErrResponseMessage extracts `message` field from error response body stream.
 func extractErrResponseMessage(rdr io.ReadCloser) (string, error) {
+	// close the stream after done
 	defer rdr.Close()
 
 	out := bytes.NewBuffer(nil)
@@ -465,7 +470,7 @@ func extractErrResponseMessage(rdr io.ReadCloser) (string, error) {
 
 	if len(errResponse.Errors) == 0 {
 		log.Debugf("Error response wrong format. Response body: %s", string(res))
-		return "", fmt.Errorf("error response json has unconventional format")
+		return "", malformedJsonErrFormat
 	}
 
 	// grab out every error message
@@ -483,7 +488,7 @@ func extractErrResponseMessage(rdr io.ReadCloser) (string, error) {
 
 	// if no message available, treat it as a malformed json error
 	if len(errString) == 0 {
-		return "", fmt.Errorf("error response json has unconventional format")
+		return "", malformedJsonErrFormat
 	}
 
 	return errString, nil

--- a/pkg/fetcher/fetcher.go
+++ b/pkg/fetcher/fetcher.go
@@ -444,7 +444,7 @@ func (u *URLFetcher) buildRegistryErrMsg(url *url.URL, respBody io.ReadCloser) s
 
 // malformedJsonErrFormat is the error format for malformed json response body
 // used in function extractErrResponseMessage
-var malformedJsonErrFormat = fmt.Errorf("error response json has unconventional format")
+var errJsonFormat = fmt.Errorf("error response json has unconventional format")
 
 // extractErrResponseMessage extracts `message` field from error response body stream.
 func extractErrResponseMessage(rdr io.ReadCloser) (string, error) {
@@ -470,7 +470,7 @@ func extractErrResponseMessage(rdr io.ReadCloser) (string, error) {
 
 	if len(errResponse.Errors) == 0 {
 		log.Debugf("Error response wrong format. Response body: %s", string(res))
-		return "", malformedJsonErrFormat
+		return "", errJsonFormat
 	}
 
 	// grab out every error message
@@ -488,7 +488,7 @@ func extractErrResponseMessage(rdr io.ReadCloser) (string, error) {
 
 	// if no message available, treat it as a malformed json error
 	if len(errString) == 0 {
-		return "", malformedJsonErrFormat
+		return "", errJsonFormat
 	}
 
 	return errString, nil

--- a/pkg/fetcher/fetcher.go
+++ b/pkg/fetcher/fetcher.go
@@ -444,7 +444,7 @@ func (u *URLFetcher) buildRegistryErrMsg(url *url.URL, respBody io.ReadCloser) s
 
 // malformedJsonErrFormat is the error format for malformed json response body
 // used in function extractErrResponseMessage
-var errJsonFormat = fmt.Errorf("error response json has unconventional format")
+var errJSONFormat = fmt.Errorf("error response json has unconventional format")
 
 // extractErrResponseMessage extracts `message` field from error response body stream.
 func extractErrResponseMessage(rdr io.ReadCloser) (string, error) {
@@ -470,7 +470,7 @@ func extractErrResponseMessage(rdr io.ReadCloser) (string, error) {
 
 	if len(errResponse.Errors) == 0 {
 		log.Debugf("Error response wrong format. Response body: %s", string(res))
-		return "", errJsonFormat
+		return "", errJSONFormat
 	}
 
 	// grab out every error message
@@ -488,7 +488,7 @@ func extractErrResponseMessage(rdr io.ReadCloser) (string, error) {
 
 	// if no message available, treat it as a malformed json error
 	if len(errString) == 0 {
-		return "", errJsonFormat
+		return "", errJSONFormat
 	}
 
 	return errString, nil

--- a/pkg/fetcher/fetcher.go
+++ b/pkg/fetcher/fetcher.go
@@ -100,10 +100,9 @@ type URLFetcher struct {
 	options Options
 }
 
-// RegistryErrorRespBody struct
-// struct for unmarshalling json error response body by containers registry
-// error response json is assumed to follow Docker API convention (field `details` is dropped)
-// see: https://docs.docker.com/registry/spec/api/#errors
+// RegistryErrorRespBody is used for unmarshaling json error response body from image registries.
+// Error response json is assumed to follow Docker API convention (field `details` is dropped).
+// See: https://docs.docker.com/registry/spec/api/#errors
 type RegistryErrorRespBody struct {
 	Errors []struct {
 		Code    string
@@ -298,7 +297,7 @@ func (u *URLFetcher) fetch(ctx context.Context, url *url.URL, reqHdrs *http.Head
 	}
 
 	// FIXME: handle StatusTemporaryRedirect and StatusFound
-	// for all other unexpected http code, grab the message out if there is one (#5951)
+	// for all other unexpected http codes, grab the message out if there is one (#5951)
 	if !u.IsStatusOK() {
 		err := fmt.Errorf(u.buildRegistryErrMsg(u.StatusCode, url, res.Body))
 		return nil, nil, err
@@ -429,8 +428,8 @@ func (u *URLFetcher) IsNonretryableClientError() bool {
 		s != http.StatusLocked && s != http.StatusTooManyRequests
 }
 
-// Build error message for unexpected http code (nonretryable client errors and all other errors)
-// extract message details from response body stream if there is one
+// buildRegistryErrMsg builds error message for unexpected http code (nonretryable client errors and all other errors)
+// and extracts message details from response body stream if there is one (#5951).
 func (u *URLFetcher) buildRegistryErrMsg(httpStatusCode int, url *url.URL, respBody io.ReadCloser) string {
 	errMsg := fmt.Sprintf("Unexpected http code: %d (%s), URL: %s", httpStatusCode, http.StatusText(httpStatusCode), url)
 
@@ -440,12 +439,10 @@ func (u *URLFetcher) buildRegistryErrMsg(httpStatusCode int, url *url.URL, respB
 	}
 
 	errMsg += fmt.Sprintf(", Message: %s", errDetail)
-
 	return errMsg
 }
 
-// Extract message from error response body (#5951)
-// The error response body is assumed to follow the convention of Docker
+// extractErrResponseMessage extracts `message` field from error response body json (#5951).
 func (u *URLFetcher) extractErrResponseMessage(rdr io.ReadCloser) (string, error) {
 	out := bytes.NewBuffer(nil)
 	_, err := io.Copy(out, rdr)

--- a/pkg/fetcher/fetcher.go
+++ b/pkg/fetcher/fetcher.go
@@ -463,7 +463,7 @@ func (u *URLFetcher) extractErrResponseMessage(rdr io.ReadCloser) (string, error
 
 	if len(errResponse.Errors) == 0 {
 		log.Debugf("Error response wrong format. Response body: %s", string(res))
-		return "", fmt.Errorf("Error response wrong format")
+		return "", fmt.Errorf("error response json has unconventional format")
 	}
 
 	// grab out every error message

--- a/pkg/fetcher/fetcher.go
+++ b/pkg/fetcher/fetcher.go
@@ -282,7 +282,7 @@ func (u *URLFetcher) fetch(ctx context.Context, url *url.URL, reqHdrs *http.Head
 		}
 
 		// for all other non-retryable client error, grab the error message if there is one (#5951)
-		err, msg := u.extractMsgBody(res.Body)
+		msg, err := u.extractMsgBody(res.Body)
 		if err != nil {
 			err = fmt.Errorf("Nonretryable error '%s (%d)': URL %s", http.StatusText(u.StatusCode), u.StatusCode, url)
 		} else {
@@ -297,7 +297,7 @@ func (u *URLFetcher) fetch(ctx context.Context, url *url.URL, reqHdrs *http.Head
 	// for all other unexpected http code, grab the message out if there is one (#5951)
 	if !u.IsStatusOK() {
 
-		err, msg := u.extractMsgBody(res.Body)
+		msg, err := u.extractMsgBody(res.Body)
 		if err != nil {
 			err = fmt.Errorf("Unexpected http code: %d, URL %s", u.StatusCode, url)
 		} else {
@@ -432,13 +432,13 @@ func (u *URLFetcher) IsNonretryableClientError() bool {
 		s != http.StatusLocked && s != http.StatusTooManyRequests
 }
 
-func (u *URLFetcher) extractMsgBody(rdr io.ReadCloser) (error, string) {
+func (u *URLFetcher) extractMsgBody(rdr io.ReadCloser) (string, error) {
 	out := bytes.NewBuffer(nil)
 	_, err := io.Copy(out, rdr)
 	if err != nil {
-		return err, ""
+		return "", err
 	}
-	return nil, string(out.Bytes())
+	return string(out.Bytes()), nil
 
 }
 

--- a/pkg/fetcher/fetcher.go
+++ b/pkg/fetcher/fetcher.go
@@ -439,7 +439,9 @@ func (u *URLFetcher) buildRegistryErrMsg(httpStatusCode int, url *url.URL, respB
 		return errMsg
 	}
 
-	return fmt.Sprintf(errMsg + ", Message: %s", errDetail)
+	errMsg += fmt.Sprintf(", Message: %s", errDetail)
+
+	return errMsg
 }
 
 // Extract message from error response body (#5951)

--- a/pkg/fetcher/fetcher.go
+++ b/pkg/fetcher/fetcher.go
@@ -39,7 +39,6 @@ import (
 
 	"github.com/vmware/vic/pkg/trace"
 	"github.com/vmware/vic/pkg/version"
-	"github.com/smartystreets/goconvey/web/server/messaging"
 )
 
 const (

--- a/pkg/fetcher/fetcher.go
+++ b/pkg/fetcher/fetcher.go
@@ -433,7 +433,7 @@ func (u *URLFetcher) IsNonretryableClientError() bool {
 func (u *URLFetcher) buildRegistryErrMsg(url *url.URL, respBody io.ReadCloser) string {
 	errMsg := fmt.Sprintf("Unexpected http code: %d (%s), URL: %s", u.StatusCode, http.StatusText(u.StatusCode), url)
 
-	errDetail, err := u.extractErrResponseMessage(respBody)
+	errDetail, err := extractErrResponseMessage(respBody)
 	if err != nil {
 		return errMsg
 	}
@@ -442,8 +442,8 @@ func (u *URLFetcher) buildRegistryErrMsg(url *url.URL, respBody io.ReadCloser) s
 	return errMsg
 }
 
-// extractErrResponseMessage extracts `message` field from error response body json (#5951).
-func (u *URLFetcher) extractErrResponseMessage(rdr io.ReadCloser) (string, error) {
+// extractErrResponseMessage extracts `message` field from error response body stream.
+func extractErrResponseMessage(rdr io.ReadCloser) (string, error) {
 	out := bytes.NewBuffer(nil)
 	_, err := io.Copy(out, rdr)
 	if err != nil {

--- a/pkg/fetcher/fetcher_test.go
+++ b/pkg/fetcher/fetcher_test.go
@@ -19,11 +19,12 @@ import (
 	"io/ioutil"
 	"testing"
 
+	"fmt"
 	"github.com/stretchr/testify/assert"
 )
 
 const (
-	ErrJsonStr401 = `{
+	errJsonStr401 = `{
 	"errors":
 		[{"code":"UNAUTHORIZED",
 		  "message":"authentication required",
@@ -31,7 +32,7 @@ const (
 		}]
 	}
 	`
-	MultipleErrJsonStr = `{
+	multipleErrJsonStr = `{
 	"errors":
 		[{"code":"UNAUTHORIZED",
 		  "message":"authentication required",
@@ -43,68 +44,65 @@ const (
 		}]
 	}
 	`
-	RandomStr                    = `random`
-	RandomJsonStr                = `{"nope":"nope"}`
-	ErrJsonWithEmptyErrorsField  = `{"errors":[]}`
-	ErrJsonWithNoMessageField    = `{"errors":[{"code":"nope","detail":"nope"}]}`
-	ErrJsonWithEmptyMessageField = `{"errors":[{"code":"nope","message":""},{"message":""}]}`
+	unexpectedStr                = `random`
+	unexpectedJsonStr            = `{"nope":"nope"}`
+	errJsonWithEmptyErrorsField  = `{"errors":[]}`
+	errJsonWithNoMessageField    = `{"errors":[{"code":"nope","detail":"nope"}]}`
+	errJsonWithEmptyMessageField = `{"errors":[{"code":"nope","message":""},{"message":""}]}`
 )
 
 func TestExtractErrResponseMessage(t *testing.T) {
 	// Test set up: create the io streams for testing purposes
 	// multiple streams needed: these streams only have read ends
-	singleErrTestStream := ioutil.NopCloser(bytes.NewReader([]byte(ErrJsonStr401)))
-	multipleErrTestStream := ioutil.NopCloser(bytes.NewReader([]byte(MultipleErrJsonStr)))
-	randomStrTestStream := ioutil.NopCloser(bytes.NewReader([]byte(RandomStr)))
-	malformedJSONTestStream := ioutil.NopCloser(bytes.NewReader([]byte(RandomJsonStr)))
-	emptyErrorsJSONTestStream := ioutil.NopCloser(bytes.NewReader([]byte(ErrJsonWithEmptyErrorsField)))
-	noMessageJSONTestStream := ioutil.NopCloser(bytes.NewReader([]byte(ErrJsonWithNoMessageField)))
-	emptyMessageJSONTestStream := ioutil.NopCloser(bytes.NewReader([]byte(ErrJsonWithEmptyMessageField)))
+	singleErrTestStream := ioutil.NopCloser(bytes.NewReader([]byte(errJsonStr401)))
+	multipleErrTestStream := ioutil.NopCloser(bytes.NewReader([]byte(multipleErrJsonStr)))
+	unexpectedStrTestStream := ioutil.NopCloser(bytes.NewReader([]byte(unexpectedStr)))
+	malformedJSONTestStream := ioutil.NopCloser(bytes.NewReader([]byte(unexpectedJsonStr)))
+	emptyErrorsJSONTestStream := ioutil.NopCloser(bytes.NewReader([]byte(errJsonWithEmptyErrorsField)))
+	noMessageJSONTestStream := ioutil.NopCloser(bytes.NewReader([]byte(errJsonWithNoMessageField)))
+	emptyMessageJSONTestStream := ioutil.NopCloser(bytes.NewReader([]byte(errJsonWithEmptyMessageField)))
+
+	// expected error message upon malformed json to check against
+	malformedJsonErrFormat := fmt.Errorf("error response json has unconventional format")
 
 	// Test 1: single error message extraction
 	msg, err := extractErrResponseMessage(singleErrTestStream)
 	assert.Nil(t, err, "test: (single error message) extraction should success for well-formatted error json")
-	assert.NotNil(t, msg, "test: (single error message) message extracted for well-formatted error json")
 	assert.Equal(t, "authentication required", msg,
 		"test: (single error message) extracted message: %s; expected: authentication required", msg)
 
 	// Test 2: multiple error message extraction
 	msg, err = extractErrResponseMessage(multipleErrTestStream)
 	assert.Nil(t, err, "test: (multiple error messages) extraction should success for well-formatted error json")
-	assert.NotNil(t, msg, "test: (multiple error messages) message extracted for well-formatted error json")
 	assert.Equal(t, "authentication required, image not found", msg,
 		"test: (multiple error messages) extracted message: %s; expected: authentication required, image not found", msg)
 
 	// Test 3: random string in the stream that is not a json
-	msg, err = extractErrResponseMessage(randomStrTestStream)
+	msg, err = extractErrResponseMessage(unexpectedStrTestStream)
 	assert.Equal(t, "", msg, "test: (non-json string) no message should be extracted")
 	assert.NotNil(t, err, "test: (non-json string) extraction should fail")
 
 	// Test 4: malformed json string
 	msg, err = extractErrResponseMessage(malformedJSONTestStream)
 	assert.Equal(t, "", msg, "test: (malformed json string) no message should be extracted")
-	assert.NotNil(t, err, "test: (malformed json string) extraction should fail")
-	assert.Equal(t, "error response json has unconventional format", err.Error(),
-		"test: (malformed json string) error: error response json has unconventional format; expected error: %s", err.Error())
+	assert.Equal(t, malformedJsonErrFormat, err,
+		"test: (malformed json string) error: %s; expected error: %s", err, malformedJsonErrFormat)
 
 	// Test 5: malformed json with empty `errors` field
 	msg, err = extractErrResponseMessage(emptyErrorsJSONTestStream)
 	assert.Equal(t, "", msg, "test: (malformed json string, empty errors field) no message should be extracted")
-	assert.NotNil(t, err, "test: (malformed json string, empty errors field) extraction should fail")
-	assert.Equal(t, "error response json has unconventional format", err.Error(),
-		"test: (malformed json string, empty errors field) error: %s; expected error: error response json has unconventional format", err.Error())
+	assert.Equal(t, malformedJsonErrFormat, err,
+		"test: (malformed json string, empty errors field) error: %s; expected error: %s", err, malformedJsonErrFormat)
 
 	// Test 6: malformed json with no `message` field
 	msg, err = extractErrResponseMessage(noMessageJSONTestStream)
 	assert.Equal(t, "", msg, "test: (malformed json string, no message field) no message should be extracted")
-	assert.NotNil(t, err, "test: (malformed json string, no message field) extraction should fail")
-	assert.Equal(t, "error response json has unconventional format", err.Error(),
-		"test: (malformed json string, no message field) error: %s; expected error: error response json has unconventional format", err.Error())
+	assert.Equal(t, malformedJsonErrFormat, err,
+		"test: (malformed json string, no message field) error: %s; expected error: %s", err, malformedJsonErrFormat)
 
 	// Test 7: malformed json with empty string in `message` field
 	msg, err = extractErrResponseMessage(emptyMessageJSONTestStream)
 	assert.Equal(t, "", msg, "test: (malformed json string, empty message field) no message should be extracted")
-	assert.NotNil(t, err, "test: (malformed json string, empty message field) extraction should fail")
-	assert.Equal(t, "error response json has unconventional format", err.Error(),
-		"test: (malformed json string, empty message field) error: %s; expected error: error response json has unconventional format", err.Error())
+	assert.Equal(t, malformedJsonErrFormat, err,
+		"test: (malformed json string, empty message field) error: %s; expected error: %s", err, malformedJsonErrFormat)
 }

--- a/pkg/fetcher/fetcher_test.go
+++ b/pkg/fetcher/fetcher_test.go
@@ -18,8 +18,6 @@ import (
 	"bytes"
 	"io/ioutil"
 	"testing"
-
-	"fmt"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -62,9 +60,6 @@ func TestExtractErrResponseMessage(t *testing.T) {
 	noMessageJSONTestStream := ioutil.NopCloser(bytes.NewReader([]byte(errJsonWithNoMessageField)))
 	emptyMessageJSONTestStream := ioutil.NopCloser(bytes.NewReader([]byte(errJsonWithEmptyMessageField)))
 
-	// expected error message upon malformed json to check against
-	malformedJsonErrFormat := fmt.Errorf("error response json has unconventional format")
-
 	// Test 1: single error message extraction
 	msg, err := extractErrResponseMessage(singleErrTestStream)
 	assert.Nil(t, err, "test: (single error message) extraction should success for well-formatted error json")
@@ -86,7 +81,7 @@ func TestExtractErrResponseMessage(t *testing.T) {
 	msg, err = extractErrResponseMessage(malformedJSONTestStream)
 	assert.Equal(t, "", msg, "test: (malformed json string) no message should be extracted")
 	assert.Equal(t, malformedJsonErrFormat, err,
-		"test: (malformed json string) error: %s; expected error: %s", err, malformedJsonErrFormat)
+		"test: (malformed json string) error: %s; expected error: %s", err, )
 
 	// Test 5: malformed json with empty `errors` field
 	msg, err = extractErrResponseMessage(emptyErrorsJSONTestStream)

--- a/pkg/fetcher/fetcher_test.go
+++ b/pkg/fetcher/fetcher_test.go
@@ -56,10 +56,10 @@ func TestExtractErrResponseMessage(t *testing.T) {
 	singleErrTestStream := ioutil.NopCloser(bytes.NewReader([]byte(ErrJsonStr401)))
 	multipleErrTestStream := ioutil.NopCloser(bytes.NewReader([]byte(MultipleErrJsonStr)))
 	randomStrTestStream := ioutil.NopCloser(bytes.NewReader([]byte(RandomStr)))
-	malformedJsonTestStream := ioutil.NopCloser(bytes.NewReader([]byte(RandomJsonStr)))
-	emptyErrorsJsonTestStream := ioutil.NopCloser(bytes.NewReader([]byte(ErrJsonWithEmptyErrorsField)))
-	noMessageJsonTestStream := ioutil.NopCloser(bytes.NewReader([]byte(ErrJsonWithNoMessageField)))
-	emptyMessageJsonTestStream := ioutil.NopCloser(bytes.NewReader([]byte(ErrJsonWithEmptyMessageField)))
+	malformedJSONTestStream := ioutil.NopCloser(bytes.NewReader([]byte(RandomJsonStr)))
+	emptyErrorsJSONTestStream := ioutil.NopCloser(bytes.NewReader([]byte(ErrJsonWithEmptyErrorsField)))
+	noMessageJSONTestStream := ioutil.NopCloser(bytes.NewReader([]byte(ErrJsonWithNoMessageField)))
+	emptyMessageJSONTestStream := ioutil.NopCloser(bytes.NewReader([]byte(ErrJsonWithEmptyMessageField)))
 
 	// Test 1: single error message extraction
 	msg, err := extractErrResponseMessage(singleErrTestStream)
@@ -81,28 +81,28 @@ func TestExtractErrResponseMessage(t *testing.T) {
 	assert.NotNil(t, err, "test: (non-json string) extraction should fail")
 
 	// Test 4: malformed json string
-	msg, err = extractErrResponseMessage(malformedJsonTestStream)
+	msg, err = extractErrResponseMessage(malformedJSONTestStream)
 	assert.Equal(t, "", msg, "test: (malformed json string) no message should be extracted")
 	assert.NotNil(t, err, "test: (malformed json string) extraction should fail")
 	assert.Equal(t, "error response json has unconventional format", err.Error(),
 		"test: (malformed json string) error: error response json has unconventional format; expected error: %s", err.Error())
 
 	// Test 5: malformed json with empty `errors` field
-	msg, err = extractErrResponseMessage(emptyErrorsJsonTestStream)
+	msg, err = extractErrResponseMessage(emptyErrorsJSONTestStream)
 	assert.Equal(t, "", msg, "test: (malformed json string, empty errors field) no message should be extracted")
 	assert.NotNil(t, err, "test: (malformed json string, empty errors field) extraction should fail")
 	assert.Equal(t, "error response json has unconventional format", err.Error(),
 		"test: (malformed json string, empty errors field) error: %s; expected error: error response json has unconventional format", err.Error())
 
 	// Test 6: malformed json with no `message` field
-	msg, err = extractErrResponseMessage(noMessageJsonTestStream)
+	msg, err = extractErrResponseMessage(noMessageJSONTestStream)
 	assert.Equal(t, "", msg, "test: (malformed json string, no message field) no message should be extracted")
 	assert.NotNil(t, err, "test: (malformed json string, no message field) extraction should fail")
 	assert.Equal(t, "error response json has unconventional format", err.Error(),
 		"test: (malformed json string, no message field) error: %s; expected error: error response json has unconventional format", err.Error())
 
 	// Test 7: malformed json with empty string in `message` field
-	msg, err = extractErrResponseMessage(emptyMessageJsonTestStream)
+	msg, err = extractErrResponseMessage(emptyMessageJSONTestStream)
 	assert.Equal(t, "", msg, "test: (malformed json string, empty message field) no message should be extracted")
 	assert.NotNil(t, err, "test: (malformed json string, empty message field) extraction should fail")
 	assert.Equal(t, "error response json has unconventional format", err.Error(),

--- a/pkg/fetcher/fetcher_test.go
+++ b/pkg/fetcher/fetcher_test.go
@@ -1,0 +1,116 @@
+// Copyright 2017 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fetcher
+
+import (
+	"bytes"
+	"io/ioutil"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	ErrJsonStr401 = `
+	{"errors":
+		[{"code":"UNAUTHORIZED",
+		  "message":"authentication required",
+		  "detail":[{"Type":"repository","Class":"","Name":"library/jiowengew","Action":"pull"}]
+		}]
+	}`
+
+	MultipleErrJsonStr = `
+	{"errors":
+		[{"code":"UNAUTHORIZED",
+		  "message":"authentication required",
+		  "detail":[{"Type":"repository","Class":"","Name":"library/jiowengew","Action":"pull"}]
+		},
+		{"code":"NOTFOUND",
+		 "message": "image not found",
+		 "detail": "image not found"
+		}]
+	}
+	`
+
+	RandomStr = `random`
+
+	RandomJsonStr = `{"nope":"nope"}`
+
+	ErrJsonWithEmptyErrorsField = `{"errors":[]}`
+
+	ErrJsonWithNoMessageField = `{"errors":[{"code":"nope","detail":"nope"}]}`
+
+	ErrJsonWithEmptyMessageField = `{"errors":[{"code":"nope","message":""},{"message":""}]}`
+)
+
+func TestExtractErrResponseMessage(t *testing.T) {
+
+	// Test set up: create the io streams for testing purposes
+	// multiple streams needed: these streams only have read ends
+	singleErrTestStream := ioutil.NopCloser(bytes.NewReader([]byte(ErrJsonStr401)))
+	multipleErrTestStream := ioutil.NopCloser(bytes.NewReader([]byte(MultipleErrJsonStr)))
+	randomStrTestStream := ioutil.NopCloser(bytes.NewReader([]byte(RandomStr)))
+	malformedJsonTestStream := ioutil.NopCloser(bytes.NewReader([]byte(RandomJsonStr)))
+	emptyErrorsJsonTestStream := ioutil.NopCloser(bytes.NewReader([]byte(ErrJsonWithEmptyErrorsField)))
+	noMessageJsonTestStream := ioutil.NopCloser(bytes.NewReader([]byte(ErrJsonWithNoMessageField)))
+	emptyMessageJsonTestStream := ioutil.NopCloser(bytes.NewReader([]byte(ErrJsonWithEmptyMessageField)))
+
+	// Test 1: single error message extraction
+	msg, err := extractErrResponseMessage(singleErrTestStream)
+	assert.Nil(t, err, "test: (single error message) extraction should success for well-formatted error json")
+	assert.NotNil(t, msg, "test: (single error message) message extracted for well-formatted error json")
+	assert.Equal(t, "authentication required", msg,
+		"test: (single error message) extracted message: %s; expected: authentication required", msg)
+
+	// Test 2: multiple error message extraction
+	msg, err = extractErrResponseMessage(multipleErrTestStream)
+	assert.Nil(t, err, "test: (multiple error messages) extraction should success for well-formatted error json")
+	assert.NotNil(t, msg, "test: (multiple error messages) message extracted for well-formatted error json")
+	assert.Equal(t, "authentication required, image not found", msg,
+		"test: (multiple error messages) extracted message: %s; expected: authentication required, image not found", msg)
+
+	// Test 3: random string in the stream that is not a json
+	msg, err = extractErrResponseMessage(randomStrTestStream)
+	assert.Equal(t, "", msg, "test: (non-json string) no message should be extracted")
+	assert.NotNil(t, err, "test: (non-json string) extraction should fail")
+
+	// Test 4: malformed json string
+	msg, err = extractErrResponseMessage(malformedJsonTestStream)
+	assert.Equal(t, "", msg, "test: (malformed json string) no message should be extracted")
+	assert.NotNil(t, err, "test: (malformed json string) extraction should fail")
+	assert.Equal(t, "error response json has unconventional format", err.Error(),
+		"test: (malformed json string) error: error response json has unconventional format; expected error: %s", err.Error())
+
+	// Test 5: malformed json with empty `errors` field
+	msg, err = extractErrResponseMessage(emptyErrorsJsonTestStream)
+	assert.Equal(t, "", msg, "test: (malformed json string, empty errors field) no message should be extracted")
+	assert.NotNil(t, err, "test: (malformed json string, empty errors field) extraction should fail")
+	assert.Equal(t, "error response json has unconventional format", err.Error(),
+		"test: (malformed json string, empty errors field) error: %s; expected error: error response json has unconventional format", err.Error())
+
+	// Test 6: malformed json with no `message` field
+	msg, err = extractErrResponseMessage(noMessageJsonTestStream)
+	assert.Equal(t, "", msg, "test: (malformed json string, no message field) no message should be extracted")
+	assert.NotNil(t, err, "test: (malformed json string, no message field) extraction should fail")
+	assert.Equal(t, "error response json has unconventional format", err.Error(),
+		"test: (malformed json string, no message field) error: %s; expected error: error response json has unconventional format", err.Error())
+
+	// Test 7: malformed json with empty string in `message` field
+	msg, err = extractErrResponseMessage(emptyMessageJsonTestStream)
+	assert.Equal(t, "", msg, "test: (malformed json string, empty message field) no message should be extracted")
+	assert.NotNil(t, err, "test: (malformed json string, empty message field) extraction should fail")
+	assert.Equal(t, "error response json has unconventional format", err.Error(),
+		"test: (malformed json string, empty message field) error: %s; expected error: error response json has unconventional format", err.Error())
+}

--- a/pkg/fetcher/fetcher_test.go
+++ b/pkg/fetcher/fetcher_test.go
@@ -16,9 +16,9 @@ package fetcher
 
 import (
 	"bytes"
+	"github.com/stretchr/testify/assert"
 	"io/ioutil"
 	"testing"
-	"github.com/stretchr/testify/assert"
 )
 
 const (
@@ -80,24 +80,24 @@ func TestExtractErrResponseMessage(t *testing.T) {
 	// Test 4: malformed json string
 	msg, err = extractErrResponseMessage(malformedJSONTestStream)
 	assert.Equal(t, "", msg, "test: (malformed json string) no message should be extracted")
-	assert.Equal(t, malformedJsonErrFormat, err,
-		"test: (malformed json string) error: %s; expected error: %s", err, )
+	assert.Equal(t, errJsonFormat, err,
+		"test: (malformed json string) error: %s; expected error: %s", err)
 
 	// Test 5: malformed json with empty `errors` field
 	msg, err = extractErrResponseMessage(emptyErrorsJSONTestStream)
 	assert.Equal(t, "", msg, "test: (malformed json string, empty errors field) no message should be extracted")
-	assert.Equal(t, malformedJsonErrFormat, err,
-		"test: (malformed json string, empty errors field) error: %s; expected error: %s", err, malformedJsonErrFormat)
+	assert.Equal(t, errJsonFormat, err,
+		"test: (malformed json string, empty errors field) error: %s; expected error: %s", err, errJsonFormat)
 
 	// Test 6: malformed json with no `message` field
 	msg, err = extractErrResponseMessage(noMessageJSONTestStream)
 	assert.Equal(t, "", msg, "test: (malformed json string, no message field) no message should be extracted")
-	assert.Equal(t, malformedJsonErrFormat, err,
-		"test: (malformed json string, no message field) error: %s; expected error: %s", err, malformedJsonErrFormat)
+	assert.Equal(t, errJsonFormat, err,
+		"test: (malformed json string, no message field) error: %s; expected error: %s", err, errJsonFormat)
 
 	// Test 7: malformed json with empty string in `message` field
 	msg, err = extractErrResponseMessage(emptyMessageJSONTestStream)
 	assert.Equal(t, "", msg, "test: (malformed json string, empty message field) no message should be extracted")
-	assert.Equal(t, malformedJsonErrFormat, err,
-		"test: (malformed json string, empty message field) error: %s; expected error: %s", err, malformedJsonErrFormat)
+	assert.Equal(t, errJsonFormat, err,
+		"test: (malformed json string, empty message field) error: %s; expected error: %s", err, errJsonFormat)
 }

--- a/pkg/fetcher/fetcher_test.go
+++ b/pkg/fetcher/fetcher_test.go
@@ -23,16 +23,16 @@ import (
 )
 
 const (
-	ErrJsonStr401 = `
-	{"errors":
+	ErrJsonStr401 = `{
+	"errors":
 		[{"code":"UNAUTHORIZED",
 		  "message":"authentication required",
 		  "detail":[{"Type":"repository","Class":"","Name":"library/jiowengew","Action":"pull"}]
 		}]
-	}`
-
-	MultipleErrJsonStr = `
-	{"errors":
+	}
+	`
+	MultipleErrJsonStr = `{
+	"errors":
 		[{"code":"UNAUTHORIZED",
 		  "message":"authentication required",
 		  "detail":[{"Type":"repository","Class":"","Name":"library/jiowengew","Action":"pull"}]
@@ -43,20 +43,14 @@ const (
 		}]
 	}
 	`
-
-	RandomStr = `random`
-
-	RandomJsonStr = `{"nope":"nope"}`
-
-	ErrJsonWithEmptyErrorsField = `{"errors":[]}`
-
-	ErrJsonWithNoMessageField = `{"errors":[{"code":"nope","detail":"nope"}]}`
-
+	RandomStr                    = `random`
+	RandomJsonStr                = `{"nope":"nope"}`
+	ErrJsonWithEmptyErrorsField  = `{"errors":[]}`
+	ErrJsonWithNoMessageField    = `{"errors":[{"code":"nope","detail":"nope"}]}`
 	ErrJsonWithEmptyMessageField = `{"errors":[{"code":"nope","message":""},{"message":""}]}`
 )
 
 func TestExtractErrResponseMessage(t *testing.T) {
-
 	// Test set up: create the io streams for testing purposes
 	// multiple streams needed: these streams only have read ends
 	singleErrTestStream := ioutil.NopCloser(bytes.NewReader([]byte(ErrJsonStr401)))

--- a/pkg/fetcher/fetcher_test.go
+++ b/pkg/fetcher/fetcher_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 const (
-	errJsonStr401 = `{
+	errJSONStr401 = `{
 	"errors":
 		[{"code":"UNAUTHORIZED",
 		  "message":"authentication required",
@@ -31,7 +31,7 @@ const (
 		}]
 	}
 	`
-	multipleErrJsonStr = `{
+	multipleErrJSONStr = `{
 	"errors":
 		[{"code":"UNAUTHORIZED",
 		  "message":"authentication required",
@@ -44,22 +44,22 @@ const (
 	}
 	`
 	unexpectedStr                = `random`
-	unexpectedJsonStr            = `{"nope":"nope"}`
-	errJsonWithEmptyErrorsField  = `{"errors":[]}`
-	errJsonWithNoMessageField    = `{"errors":[{"code":"nope","detail":"nope"}]}`
-	errJsonWithEmptyMessageField = `{"errors":[{"code":"nope","message":""},{"message":""}]}`
+	unexpectedJSONStr            = `{"nope":"nope"}`
+	errJSONWithEmptyErrorsField  = `{"errors":[]}`
+	errJSONWithNoMessageField    = `{"errors":[{"code":"nope","detail":"nope"}]}`
+	errJSONWithEmptyMessageField = `{"errors":[{"code":"nope","message":""},{"message":""}]}`
 )
 
 func TestExtractErrResponseMessage(t *testing.T) {
 	// Test set up: create the io streams for testing purposes
 	// multiple streams needed: these streams only have read ends
-	singleErrTestStream := ioutil.NopCloser(bytes.NewReader([]byte(errJsonStr401)))
-	multipleErrTestStream := ioutil.NopCloser(bytes.NewReader([]byte(multipleErrJsonStr)))
+	singleErrTestStream := ioutil.NopCloser(bytes.NewReader([]byte(errJSONStr401)))
+	multipleErrTestStream := ioutil.NopCloser(bytes.NewReader([]byte(multipleErrJSONStr)))
 	unexpectedStrTestStream := ioutil.NopCloser(bytes.NewReader([]byte(unexpectedStr)))
-	malformedJSONTestStream := ioutil.NopCloser(bytes.NewReader([]byte(unexpectedJsonStr)))
-	emptyErrorsJSONTestStream := ioutil.NopCloser(bytes.NewReader([]byte(errJsonWithEmptyErrorsField)))
-	noMessageJSONTestStream := ioutil.NopCloser(bytes.NewReader([]byte(errJsonWithNoMessageField)))
-	emptyMessageJSONTestStream := ioutil.NopCloser(bytes.NewReader([]byte(errJsonWithEmptyMessageField)))
+	malformedJSONTestStream := ioutil.NopCloser(bytes.NewReader([]byte(unexpectedJSONStr)))
+	emptyErrorsJSONTestStream := ioutil.NopCloser(bytes.NewReader([]byte(errJSONWithEmptyErrorsField)))
+	noMessageJSONTestStream := ioutil.NopCloser(bytes.NewReader([]byte(errJSONWithNoMessageField)))
+	emptyMessageJSONTestStream := ioutil.NopCloser(bytes.NewReader([]byte(errJSONWithEmptyMessageField)))
 
 	// Test 1: single error message extraction
 	msg, err := extractErrResponseMessage(singleErrTestStream)
@@ -81,24 +81,24 @@ func TestExtractErrResponseMessage(t *testing.T) {
 	// Test 4: malformed json string
 	msg, err = extractErrResponseMessage(malformedJSONTestStream)
 	assert.Equal(t, "", msg, "test: (malformed json string) no message should be extracted")
-	assert.Equal(t, errJsonFormat, err,
+	assert.Equal(t, errJSONFormat, err,
 		"test: (malformed json string) error: %s; expected error: %s", err)
 
 	// Test 5: malformed json with empty `errors` field
 	msg, err = extractErrResponseMessage(emptyErrorsJSONTestStream)
 	assert.Equal(t, "", msg, "test: (malformed json string, empty errors field) no message should be extracted")
-	assert.Equal(t, errJsonFormat, err,
-		"test: (malformed json string, empty errors field) error: %s; expected error: %s", err, errJsonFormat)
+	assert.Equal(t, errJSONFormat, err,
+		"test: (malformerrJsonFormated json string, empty errors field) error: %s; expected error: %s", err, errJSONFormat)
 
 	// Test 6: malformed json with no `message` field
 	msg, err = extractErrResponseMessage(noMessageJSONTestStream)
 	assert.Equal(t, "", msg, "test: (malformed json string, no message field) no message should be extracted")
-	assert.Equal(t, errJsonFormat, err,
-		"test: (malformed json string, no message field) error: %s; expected error: %s", err, errJsonFormat)
+	assert.Equal(t, errJSONFormat, err,
+		"test: (malformed json string, no message field) error: %s; expected error: %s", err, errJSONFormat)
 
 	// Test 7: malformed json with empty string in `message` field
 	msg, err = extractErrResponseMessage(emptyMessageJSONTestStream)
 	assert.Equal(t, "", msg, "test: (malformed json string, empty message field) no message should be extracted")
-	assert.Equal(t, errJsonFormat, err,
-		"test: (malformed json string, empty message field) error: %s; expected error: %s", err, errJsonFormat)
+	assert.Equal(t, errJSONFormat, err,
+		"test: (malformed json string, empty message field) error: %s; expected error: %s", err, errJSONFormat)
 }

--- a/pkg/fetcher/fetcher_test.go
+++ b/pkg/fetcher/fetcher_test.go
@@ -16,9 +16,10 @@ package fetcher
 
 import (
 	"bytes"
-	"github.com/stretchr/testify/assert"
 	"io/ioutil"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 const (


### PR DESCRIPTION
Fixes #5951 
<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[  ] There is an associated issue that is labelled
[  ] Code is up-to-date with the `master` branch
[  ] You've successfully run `make test` locally
[  ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/vmware/vic/blob/master/.github/CONTRIBUTING.md
-->

<!--
To trigger a custom build with this PR, include one of these in the PR's title or commit messages:
- To skip running tests (e.g. for a work-in-progress PR), add `[ci skip]` or `[skip ci]`
to the commit message or the PR title.
- To run the full test suite, use `[full ci]`.
- To run _one_ integration test or group, use `[specific ci=$test]`. Examples:
  - To run the `1-01-Docker-Info` suite: `[specific ci=1-01-Docker-Info]`
  - To run all suites under the `Group1-Docker-Commands` group: `[specific ci=Group1-Docker-Commands]`
-->
