### PR TITLE
[specific ci=1-17-Docker-Network-Connect] Prioritize internal networks in /etc/resolv.conf

### DIFF
--- a/lib/config/executor/network_interface.go
+++ b/lib/config/executor/network_interface.go
@@ -44,6 +44,9 @@ type NetworkEndpoint struct {
 
 	// The list of exposed ports on the container
 	Ports []string `vic:"0.1" scope:"read-only" key:"ports"`
+
+	// whether or not this represents an internal network
+	Internal bool `vic:"0.1" scope:"read-only" key:"internal"`
 }
 
 // ContainerNetwork is the data needed on a per container basis both for vSphere to ensure it's attached

--- a/lib/portlayer/network/context.go
+++ b/lib/portlayer/network/context.go
@@ -726,6 +726,7 @@ func (c *Context) bindContainer(h *exec.Handle) ([]*Endpoint, error) {
 		}
 		ne.Network.Gateway = net.IPNet{IP: e.Gateway(), Mask: e.Subnet().Mask}
 		ne.Network.Nameservers = make([]net.IP, len(s.dns))
+		ne.Internal = s.Internal()
 		copy(ne.Network.Nameservers, s.dns)
 
 		// mark the external network as default

--- a/lib/tether/config.go
+++ b/lib/tether/config.go
@@ -162,6 +162,9 @@ type NetworkEndpoint struct {
 
 	Ports []string `vic:"0.1" scope:"read-only" key:"ports"`
 
+	// is this endpoint connected to an internal network?
+	Internal bool `vic:"0.1" scope:"read-only" key:"internal"`
+
 	// whether the network config was successfully applied
 	configured bool `vic:"0.1" scope:"read-only" recurse:"depth=0"`
 }

--- a/lib/tether/tether.go
+++ b/lib/tether/tether.go
@@ -251,8 +251,18 @@ func (t *tether) setHostname() error {
 }
 
 func (t *tether) setNetworks() error {
+	var networks []*NetworkEndpoint
+	// prioritize internal networks
 	for _, v := range t.config.Networks {
-		if err := t.ops.Apply(v); err != nil {
+		if !v.Internal {
+			networks = append(networks, v)
+		} else {
+			networks = append([]*NetworkEndpoint{v}, networks...)
+		}
+	}
+
+	for _, network := range networks {
+		if err := t.ops.Apply(network); err != nil {
 			return fmt.Errorf("failed to apply network endpoint config: %s", err)
 		}
 	}

--- a/lib/tether/tether.go
+++ b/lib/tether/tether.go
@@ -254,10 +254,10 @@ func (t *tether) setNetworks() error {
 	var networks []*NetworkEndpoint
 	// prioritize internal networks
 	for _, v := range t.config.Networks {
-		if !v.Internal {
-			networks = append(networks, v)
+		if v.Internal {
+			t.ops.Apply(v)
 		} else {
-			networks = append([]*NetworkEndpoint{v}, networks...)
+			networks = append(networks, v)
 		}
 	}
 

--- a/lib/tether/tether.go
+++ b/lib/tether/tether.go
@@ -255,7 +255,9 @@ func (t *tether) setNetworks() error {
 	// prioritize internal networks
 	for _, v := range t.config.Networks {
 		if v.Internal {
-			t.ops.Apply(v)
+			if err := t.ops.Apply(v); err != nil {
+				return fmt.Errorf("failed to apply network endpoint config: %s", err)
+			}
 		} else {
 			networks = append(networks, v)
 		}

--- a/lib/tether/tether.go
+++ b/lib/tether/tether.go
@@ -252,6 +252,7 @@ func (t *tether) setHostname() error {
 
 func (t *tether) setNetworks() error {
 
+	// internal networks must be applied first
 	for _, network := range t.config.Networks {
 		if !network.Internal {
 			continue

--- a/lib/tether/tether.go
+++ b/lib/tether/tether.go
@@ -251,23 +251,24 @@ func (t *tether) setHostname() error {
 }
 
 func (t *tether) setNetworks() error {
-	var networks []*NetworkEndpoint
-	// prioritize internal networks
-	for _, v := range t.config.Networks {
-		if v.Internal {
-			if err := t.ops.Apply(v); err != nil {
-				return fmt.Errorf("failed to apply network endpoint config: %s", err)
-			}
-		} else {
-			networks = append(networks, v)
-		}
-	}
 
-	for _, network := range networks {
+	for _, network := range t.config.Networks {
+		if !network.Internal {
+			continue
+		}
 		if err := t.ops.Apply(network); err != nil {
 			return fmt.Errorf("failed to apply network endpoint config: %s", err)
 		}
 	}
+	for _, network := range t.config.Networks {
+		if network.Internal {
+			continue
+		}
+		if err := t.ops.Apply(network); err != nil {
+			return fmt.Errorf("failed to apply network endpoint config: %s", err)
+		}
+	}
+
 	return nil
 }
 

--- a/tests/test-cases/Group1-Docker-Commands/1-15-Docker-Network-Create.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-15-Docker-Network-Create.robot
@@ -60,7 +60,7 @@ Create internal network
 Check Connectivity Between Containers On Internal Network
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -d --name foo --net internal-network ubuntu:latest sleep 2000
     Log  ${output}
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} create -it --name bar --net %{BRIDGE_NETWORK} -p 80 ubuntu:latest ping -c3 foo
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} create -it --name bar --net %{PUBLIC_NETWORK} -p 80 ubuntu:latest ping -c3 foo
     Log  ${output}
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} network connect internal-network bar
     Log  ${output}

--- a/tests/test-cases/Group1-Docker-Commands/1-15-Docker-Network-Create.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-15-Docker-Network-Create.robot
@@ -39,7 +39,7 @@ Network create with label
 Create already created network
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} network create test-network
     Should Be Equal As Integers  ${rc}  1
-    Should Contain  ${output}  already exists 
+    Should Contain  ${output}  already exists
 
 Create overlay network
     ${status}=  Get State Of Github Issue  1222
@@ -55,20 +55,3 @@ Create internal network
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} network inspect -f '{{.Internal}}' internal-network
     Should Be Equal As Integers  ${rc}  0
     Should Be Equal As Strings  ${output}  true
-
-
-Check Connectivity Between Containers On Internal Network
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -d --name foo --net internal-network ubuntu:latest sleep 2000
-    Log  ${output}
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} create -it --name bar --net %{PUBLIC_NETWORK} -p 80 ubuntu:latest ping -c3 foo
-    Log  ${output}
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} network connect internal-network bar
-    Log  ${output}
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} start -ai bar
-    Log  ${output}
-    Should Be Equal As Integers  ${rc}  0
-    Should Contain  ${output}  PING foo
-    Should Contain  ${output}  64 bytes from
-    Should Contain  ${output}  icmp_seq=1
-    Should Contain  ${output}  icmp_seq=2
-    Should Contain  ${output}  icmp_seq=3

--- a/tests/test-cases/Group1-Docker-Commands/1-15-Docker-Network-Create.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-15-Docker-Network-Create.robot
@@ -55,3 +55,16 @@ Create internal network
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} network inspect -f '{{.Internal}}' internal-network
     Should Be Equal As Integers  ${rc}  0
     Should Be Equal As Strings  ${output}  true
+
+
+Check Connectivity Between Containers On Internal Network
+    Run  docker %{VCH-PARAMS} run -d --name foo --net internal-network bensdoings/ifconfig sleep 1000
+    Run  docker %{VCH-PARAMS} create -it --name bar --net bridge -p 80 bensdoings/ifconfig ping -c3 foo
+    Run  docker %{VCH-PARAMS} network connect internal-network bar
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} start -ai bar
+    Should Be Equal As Integers  ${rc}  0
+    Should Contain  ${output}  PING foo
+    Should Contain  ${output}  64 bytes from
+    Should Contain  ${output}  icmp_seq=1
+    Should Contain  ${output}  icmp_seq=2
+    Should Contain  ${output}  icmp_seq=3

--- a/tests/test-cases/Group1-Docker-Commands/1-15-Docker-Network-Create.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-15-Docker-Network-Create.robot
@@ -65,6 +65,7 @@ Check Connectivity Between Containers On Internal Network
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} network connect internal-network bar
     Log  ${output}
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} start -ai bar
+    Log  ${output}
     Should Be Equal As Integers  ${rc}  0
     Should Contain  ${output}  PING foo
     Should Contain  ${output}  64 bytes from

--- a/tests/test-cases/Group1-Docker-Commands/1-15-Docker-Network-Create.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-15-Docker-Network-Create.robot
@@ -58,11 +58,11 @@ Create internal network
 
 
 Check Connectivity Between Containers On Internal Network
-    ${output}=  Run And Return Output  docker %{VCH-PARAMS} run -d --name foo --net internal-network ubuntu:latest sleep 1000
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -d --name foo --net internal-network ubuntu:latest sleep 2000
     Log  ${output}
-    ${output}=  Run And Return Output  docker %{VCH-PARAMS} create -it --name bar --net bridge -p 80 ubuntu:latest ping -c3 foo
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} create -it --name bar --net %{BRIDGE_NETWORK} -p 80 ubuntu:latest ping -c3 foo
     Log  ${output}
-    ${output}=  Run And Return Output  docker %{VCH-PARAMS} network connect internal-network bar
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} network connect internal-network bar
     Log  ${output}
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} start -ai bar
     Should Be Equal As Integers  ${rc}  0

--- a/tests/test-cases/Group1-Docker-Commands/1-15-Docker-Network-Create.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-15-Docker-Network-Create.robot
@@ -58,9 +58,12 @@ Create internal network
 
 
 Check Connectivity Between Containers On Internal Network
-    Run  docker %{VCH-PARAMS} run -d --name foo --net internal-network bensdoings/ifconfig sleep 1000
-    Run  docker %{VCH-PARAMS} create -it --name bar --net bridge -p 80 bensdoings/ifconfig ping -c3 foo
-    Run  docker %{VCH-PARAMS} network connect internal-network bar
+    ${output}=  Run And Return Output  docker %{VCH-PARAMS} run -d --name foo --net internal-network ubuntu:latest sleep 1000
+    Log  ${output}
+    ${output}=  Run And Return Output  docker %{VCH-PARAMS} create -it --name bar --net bridge -p 80 ubuntu:latest ping -c3 foo
+    Log  ${output}
+    ${output}=  Run And Return Output  docker %{VCH-PARAMS} network connect internal-network bar
+    Log  ${output}
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} start -ai bar
     Should Be Equal As Integers  ${rc}  0
     Should Contain  ${output}  PING foo

--- a/tests/test-cases/Group1-Docker-Commands/1-17-Docker-Network-Connect.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-17-Docker-Network-Connect.robot
@@ -146,20 +146,21 @@ Connect containers to an internal network
     Should Contain  ${output}  2 packets transmitted, 2 packets received
 
 Check Name Resolution Between Containers On Internal Network
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -d --name foo --net internal-net alpine:latest sleep 2000
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -d --name foo --net internal-net alpine:latest sleep 5000
     Log  ${output}
     Should Be Equal As Integers  ${rc}  0
 
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} create -it --name bar --net public-net -p 80 alpine:latest /bin/ping -c3 foo
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} create -it --name baz --net public-net -p 80 alpine:latest ping -c3 foo
     Log  ${output}
     Should Be Equal As Integers  ${rc}  0
 
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} network connect internal-net bar
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} network connect internal-net baz
     Log  ${output}
     Should Be Equal As Integers  ${rc}  0
 
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} start -ai bar
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} start -ai baz
     Log  ${output}
+
     Should Be Equal As Integers  ${rc}  0
     Should Contain  ${output}  PING foo
     Should Contain  ${output}  3 packets transmitted, 3 packets received

--- a/tests/test-cases/Group1-Docker-Commands/1-17-Docker-Network-Connect.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-17-Docker-Network-Connect.robot
@@ -19,111 +19,111 @@ Suite Setup  Install VIC Appliance To Test Server  certs=${false}
 Suite Teardown  Cleanup VIC Appliance On Test Server
 
 *** Test Cases ***
-# Connect containers to multiple bridge networks overlapping
-#     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} network create cross1-network
-#     Should Be Equal As Integers  ${rc}  0
-#     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} network create cross1-network2
-#     Should Be Equal As Integers  ${rc}  0
+Connect containers to multiple bridge networks overlapping
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} network create cross1-network
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} network create cross1-network2
+    Should Be Equal As Integers  ${rc}  0
 
-#     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} pull ${busybox}
-#     Should Be Equal As Integers  ${rc}  0
-#     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} pull ${debian}
-#     Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} pull ${busybox}
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} pull ${debian}
+    Should Be Equal As Integers  ${rc}  0
 
-#     ${rc}  ${containerID}=  Run And Return Rc And Output  docker %{VCH-PARAMS} create --net cross1-network --name cross1-container ${busybox} /bin/top
-#     Should Be Equal As Integers  ${rc}  0
-#     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} network connect cross1-network2 ${containerID}
-#     Should Be Equal As Integers  ${rc}  0
-#     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} start ${containerID}
-#     Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${containerID}=  Run And Return Rc And Output  docker %{VCH-PARAMS} create --net cross1-network --name cross1-container ${busybox} /bin/top
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} network connect cross1-network2 ${containerID}
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} start ${containerID}
+    Should Be Equal As Integers  ${rc}  0
 
-#     ${rc}  ${containerID}=  Run And Return Rc And Output  docker %{VCH-PARAMS} create --net cross1-network --name cross1-container2 ${debian} ping -c2 cross1-container
-#     Should Be Equal As Integers  ${rc}  0
-#     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} network connect cross1-network2 ${containerID}
-#     Should Be Equal As Integers  ${rc}  0
-#     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} start ${containerID}
-#     Should Be Equal As Integers  ${rc}  0
-#     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} logs --follow cross1-container2
-#     Should Be Equal As Integers  ${rc}  0
-#     Should Contain  ${output}  2 packets transmitted, 2 packets received
+    ${rc}  ${containerID}=  Run And Return Rc And Output  docker %{VCH-PARAMS} create --net cross1-network --name cross1-container2 ${debian} ping -c2 cross1-container
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} network connect cross1-network2 ${containerID}
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} start ${containerID}
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} logs --follow cross1-container2
+    Should Be Equal As Integers  ${rc}  0
+    Should Contain  ${output}  2 packets transmitted, 2 packets received
 
-#     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} create --name cross1-container3 --net cross1-network ${busybox} ping -c2 cross1-container3
-#     Should Be Equal As Integers  ${rc}  0
-#     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} network connect cross1-network2 cross1-container3
-#     Should Be Equal As Integers  ${rc}  0
-#     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} start cross1-container3
-#     Should Be Equal As Integers  ${rc}  0
-#     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} logs --follow cross1-container3
-#     Should Be Equal As Integers  ${rc}  0
-#     Should Contain  ${output}  2 packets transmitted, 2 packets received
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} create --name cross1-container3 --net cross1-network ${busybox} ping -c2 cross1-container3
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} network connect cross1-network2 cross1-container3
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} start cross1-container3
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} logs --follow cross1-container3
+    Should Be Equal As Integers  ${rc}  0
+    Should Contain  ${output}  2 packets transmitted, 2 packets received
 
-# Connect container to a new network
-#     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} network create test-network
-#     Should Be Equal As Integers  ${rc}  0
-#     ${rc}  ${containerID}=  Run And Return Rc And Output  docker %{VCH-PARAMS} create ${busybox} ip -4 addr show eth0
-#     Should Be Equal As Integers  ${rc}  0
-#     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} network connect test-network ${containerID}
-#     Should Be Equal As Integers  ${rc}  0
-#     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} start ${containerID}
-#     Should Be Equal As Integers  ${rc}  0
-#     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} logs --follow ${containerID}
-#     Should Be Equal As Integers  ${rc}  0
-#     ${ips}=  Get Lines Containing String  ${output}  inet
-#     @{lines}=  Split To Lines  ${ips}
-#     Length Should Be  ${lines}  2
+Connect container to a new network
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} network create test-network
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${containerID}=  Run And Return Rc And Output  docker %{VCH-PARAMS} create ${busybox} ip -4 addr show eth0
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} network connect test-network ${containerID}
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} start ${containerID}
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} logs --follow ${containerID}
+    Should Be Equal As Integers  ${rc}  0
+    ${ips}=  Get Lines Containing String  ${output}  inet
+    @{lines}=  Split To Lines  ${ips}
+    Length Should Be  ${lines}  2
 
-# Connect to non-existent container
-#     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} network connect test-network fakeContainer
-#     Should Be Equal As Integers  ${rc}  1
-#     Should Contain  ${output}  not found
+Connect to non-existent container
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} network connect test-network fakeContainer
+    Should Be Equal As Integers  ${rc}  1
+    Should Contain  ${output}  not found
 
-# Connect to non-existent network
-#     ${rc}  ${containerID}=  Run And Return Rc And Output  docker %{VCH-PARAMS} pull ${busybox}
-#     Should Be Equal As Integers  ${rc}  0
+Connect to non-existent network
+    ${rc}  ${containerID}=  Run And Return Rc And Output  docker %{VCH-PARAMS} pull ${busybox}
+    Should Be Equal As Integers  ${rc}  0
 
-#     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} create --name connectTest3 ${busybox} ifconfig
-#     Should Be Equal As Integers  ${rc}  0
-#     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} network connect fakeNetwork connectTest3
-#     Should Be Equal As Integers  ${rc}  1
-#     Should Contain  ${output}  not found
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} create --name connectTest3 ${busybox} ifconfig
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} network connect fakeNetwork connectTest3
+    Should Be Equal As Integers  ${rc}  1
+    Should Contain  ${output}  not found
 
-# Connect containers to multiple networks non-overlapping
-#     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} network create cross2-network
-#     Should Be Equal As Integers  ${rc}  0
-#     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} network create cross2-network2
-#     Should Be Equal As Integers  ${rc}  0
+Connect containers to multiple networks non-overlapping
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} network create cross2-network
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} network create cross2-network2
+    Should Be Equal As Integers  ${rc}  0
 
-#     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} pull ${busybox}
-#     Should Be Equal As Integers  ${rc}  0
-#     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} pull ${debian}
-#     Should Be Equal As Integers  ${rc}  0
-#     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} pull ${nginx}
-#     Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} pull ${busybox}
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} pull ${debian}
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} pull ${nginx}
+    Should Be Equal As Integers  ${rc}  0
 
-#     ${rc}  ${containerID}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -itd --net cross2-network --name cross2-container ${busybox} /bin/top
-#     Should Be Equal As Integers  ${rc}  0
-#     ${ip}=  Get Container IP  %{VCH-PARAMS}  ${containerID}  cross2-network
+    ${rc}  ${containerID}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -itd --net cross2-network --name cross2-container ${busybox} /bin/top
+    Should Be Equal As Integers  ${rc}  0
+    ${ip}=  Get Container IP  %{VCH-PARAMS}  ${containerID}  cross2-network
 
-#     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run --net cross2-network2 --name cross2-container2 ${debian} ping -c2 ${ip}
-#     Should Not Be Equal As Integers  ${rc}  0
-#     Should Contain  ${output}  2 packets transmitted, 0 packets received, 100% packet loss
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run --net cross2-network2 --name cross2-container2 ${debian} ping -c2 ${ip}
+    Should Not Be Equal As Integers  ${rc}  0
+    Should Contain  ${output}  2 packets transmitted, 0 packets received, 100% packet loss
 
-#     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} logs --follow cross2-container2
-#     Should Be Equal As Integers  ${rc}  0
-#     Should Contain  ${output}  2 packets transmitted, 0 packets received, 100% packet loss
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} logs --follow cross2-container2
+    Should Be Equal As Integers  ${rc}  0
+    Should Contain  ${output}  2 packets transmitted, 0 packets received, 100% packet loss
 
-#     # verify that an exposed port on the container does not break down bridge isolation
-#     ${rc}  ${containerID}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -d --net cross2-network -p 8080:80 ${nginx}
-#     Should Be Equal As Integers  ${rc}  0
+    # verify that an exposed port on the container does not break down bridge isolation
+    ${rc}  ${containerID}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -d --net cross2-network -p 8080:80 ${nginx}
+    Should Be Equal As Integers  ${rc}  0
 
-#     ${ip}=  Get Container IP  %{VCH-PARAMS}  ${containerID}  cross2-network
-#     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run --net cross2-network2 --name cross2-container3 ${debian} ping -c2 ${ip}
-#     Should Not Be Equal As Integers  ${rc}  0
-#     Should Contain  ${output}  2 packets transmitted, 0 packets received, 100% packet loss
+    ${ip}=  Get Container IP  %{VCH-PARAMS}  ${containerID}  cross2-network
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run --net cross2-network2 --name cross2-container3 ${debian} ping -c2 ${ip}
+    Should Not Be Equal As Integers  ${rc}  0
+    Should Contain  ${output}  2 packets transmitted, 0 packets received, 100% packet loss
 
-#     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} logs --follow cross2-container3
-#     Should Be Equal As Integers  ${rc}  0
-#     Should Contain  ${output}  2 packets transmitted, 0 packets received, 100% packet loss
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} logs --follow cross2-container3
+    Should Be Equal As Integers  ${rc}  0
+    Should Contain  ${output}  2 packets transmitted, 0 packets received, 100% packet loss
 
 Connect containers to an internal network
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} network create --internal internal-net

--- a/tests/test-cases/Group1-Docker-Commands/1-17-Docker-Network-Connect.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-17-Docker-Network-Connect.robot
@@ -19,111 +19,111 @@ Suite Setup  Install VIC Appliance To Test Server  certs=${false}
 Suite Teardown  Cleanup VIC Appliance On Test Server
 
 *** Test Cases ***
-Connect containers to multiple bridge networks overlapping
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} network create cross1-network
-    Should Be Equal As Integers  ${rc}  0
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} network create cross1-network2
-    Should Be Equal As Integers  ${rc}  0
+# Connect containers to multiple bridge networks overlapping
+#     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} network create cross1-network
+#     Should Be Equal As Integers  ${rc}  0
+#     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} network create cross1-network2
+#     Should Be Equal As Integers  ${rc}  0
 
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} pull ${busybox}
-    Should Be Equal As Integers  ${rc}  0
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} pull ${debian}
-    Should Be Equal As Integers  ${rc}  0
+#     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} pull ${busybox}
+#     Should Be Equal As Integers  ${rc}  0
+#     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} pull ${debian}
+#     Should Be Equal As Integers  ${rc}  0
 
-    ${rc}  ${containerID}=  Run And Return Rc And Output  docker %{VCH-PARAMS} create --net cross1-network --name cross1-container ${busybox} /bin/top
-    Should Be Equal As Integers  ${rc}  0
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} network connect cross1-network2 ${containerID}
-    Should Be Equal As Integers  ${rc}  0
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} start ${containerID}
-    Should Be Equal As Integers  ${rc}  0
+#     ${rc}  ${containerID}=  Run And Return Rc And Output  docker %{VCH-PARAMS} create --net cross1-network --name cross1-container ${busybox} /bin/top
+#     Should Be Equal As Integers  ${rc}  0
+#     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} network connect cross1-network2 ${containerID}
+#     Should Be Equal As Integers  ${rc}  0
+#     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} start ${containerID}
+#     Should Be Equal As Integers  ${rc}  0
 
-    ${rc}  ${containerID}=  Run And Return Rc And Output  docker %{VCH-PARAMS} create --net cross1-network --name cross1-container2 ${debian} ping -c2 cross1-container
-    Should Be Equal As Integers  ${rc}  0
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} network connect cross1-network2 ${containerID}
-    Should Be Equal As Integers  ${rc}  0
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} start ${containerID}
-    Should Be Equal As Integers  ${rc}  0
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} logs --follow cross1-container2
-    Should Be Equal As Integers  ${rc}  0
-    Should Contain  ${output}  2 packets transmitted, 2 packets received
+#     ${rc}  ${containerID}=  Run And Return Rc And Output  docker %{VCH-PARAMS} create --net cross1-network --name cross1-container2 ${debian} ping -c2 cross1-container
+#     Should Be Equal As Integers  ${rc}  0
+#     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} network connect cross1-network2 ${containerID}
+#     Should Be Equal As Integers  ${rc}  0
+#     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} start ${containerID}
+#     Should Be Equal As Integers  ${rc}  0
+#     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} logs --follow cross1-container2
+#     Should Be Equal As Integers  ${rc}  0
+#     Should Contain  ${output}  2 packets transmitted, 2 packets received
 
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} create --name cross1-container3 --net cross1-network ${busybox} ping -c2 cross1-container3
-    Should Be Equal As Integers  ${rc}  0
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} network connect cross1-network2 cross1-container3
-    Should Be Equal As Integers  ${rc}  0
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} start cross1-container3
-    Should Be Equal As Integers  ${rc}  0
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} logs --follow cross1-container3
-    Should Be Equal As Integers  ${rc}  0
-    Should Contain  ${output}  2 packets transmitted, 2 packets received
+#     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} create --name cross1-container3 --net cross1-network ${busybox} ping -c2 cross1-container3
+#     Should Be Equal As Integers  ${rc}  0
+#     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} network connect cross1-network2 cross1-container3
+#     Should Be Equal As Integers  ${rc}  0
+#     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} start cross1-container3
+#     Should Be Equal As Integers  ${rc}  0
+#     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} logs --follow cross1-container3
+#     Should Be Equal As Integers  ${rc}  0
+#     Should Contain  ${output}  2 packets transmitted, 2 packets received
 
-Connect container to a new network
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} network create test-network
-    Should Be Equal As Integers  ${rc}  0
-    ${rc}  ${containerID}=  Run And Return Rc And Output  docker %{VCH-PARAMS} create ${busybox} ip -4 addr show eth0
-    Should Be Equal As Integers  ${rc}  0
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} network connect test-network ${containerID}
-    Should Be Equal As Integers  ${rc}  0
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} start ${containerID}
-    Should Be Equal As Integers  ${rc}  0
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} logs --follow ${containerID}
-    Should Be Equal As Integers  ${rc}  0
-    ${ips}=  Get Lines Containing String  ${output}  inet
-    @{lines}=  Split To Lines  ${ips}
-    Length Should Be  ${lines}  2
+# Connect container to a new network
+#     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} network create test-network
+#     Should Be Equal As Integers  ${rc}  0
+#     ${rc}  ${containerID}=  Run And Return Rc And Output  docker %{VCH-PARAMS} create ${busybox} ip -4 addr show eth0
+#     Should Be Equal As Integers  ${rc}  0
+#     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} network connect test-network ${containerID}
+#     Should Be Equal As Integers  ${rc}  0
+#     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} start ${containerID}
+#     Should Be Equal As Integers  ${rc}  0
+#     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} logs --follow ${containerID}
+#     Should Be Equal As Integers  ${rc}  0
+#     ${ips}=  Get Lines Containing String  ${output}  inet
+#     @{lines}=  Split To Lines  ${ips}
+#     Length Should Be  ${lines}  2
 
-Connect to non-existent container
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} network connect test-network fakeContainer
-    Should Be Equal As Integers  ${rc}  1
-    Should Contain  ${output}  not found
+# Connect to non-existent container
+#     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} network connect test-network fakeContainer
+#     Should Be Equal As Integers  ${rc}  1
+#     Should Contain  ${output}  not found
 
-Connect to non-existent network
-    ${rc}  ${containerID}=  Run And Return Rc And Output  docker %{VCH-PARAMS} pull ${busybox}
-    Should Be Equal As Integers  ${rc}  0
+# Connect to non-existent network
+#     ${rc}  ${containerID}=  Run And Return Rc And Output  docker %{VCH-PARAMS} pull ${busybox}
+#     Should Be Equal As Integers  ${rc}  0
 
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} create --name connectTest3 ${busybox} ifconfig
-    Should Be Equal As Integers  ${rc}  0
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} network connect fakeNetwork connectTest3
-    Should Be Equal As Integers  ${rc}  1
-    Should Contain  ${output}  not found
+#     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} create --name connectTest3 ${busybox} ifconfig
+#     Should Be Equal As Integers  ${rc}  0
+#     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} network connect fakeNetwork connectTest3
+#     Should Be Equal As Integers  ${rc}  1
+#     Should Contain  ${output}  not found
 
-Connect containers to multiple networks non-overlapping
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} network create cross2-network
-    Should Be Equal As Integers  ${rc}  0
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} network create cross2-network2
-    Should Be Equal As Integers  ${rc}  0
+# Connect containers to multiple networks non-overlapping
+#     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} network create cross2-network
+#     Should Be Equal As Integers  ${rc}  0
+#     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} network create cross2-network2
+#     Should Be Equal As Integers  ${rc}  0
 
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} pull ${busybox}
-    Should Be Equal As Integers  ${rc}  0
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} pull ${debian}
-    Should Be Equal As Integers  ${rc}  0
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} pull ${nginx}
-    Should Be Equal As Integers  ${rc}  0
+#     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} pull ${busybox}
+#     Should Be Equal As Integers  ${rc}  0
+#     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} pull ${debian}
+#     Should Be Equal As Integers  ${rc}  0
+#     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} pull ${nginx}
+#     Should Be Equal As Integers  ${rc}  0
 
-    ${rc}  ${containerID}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -itd --net cross2-network --name cross2-container ${busybox} /bin/top
-    Should Be Equal As Integers  ${rc}  0
-    ${ip}=  Get Container IP  %{VCH-PARAMS}  ${containerID}  cross2-network
+#     ${rc}  ${containerID}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -itd --net cross2-network --name cross2-container ${busybox} /bin/top
+#     Should Be Equal As Integers  ${rc}  0
+#     ${ip}=  Get Container IP  %{VCH-PARAMS}  ${containerID}  cross2-network
 
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run --net cross2-network2 --name cross2-container2 ${debian} ping -c2 ${ip}
-    Should Not Be Equal As Integers  ${rc}  0
-    Should Contain  ${output}  2 packets transmitted, 0 packets received, 100% packet loss
+#     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run --net cross2-network2 --name cross2-container2 ${debian} ping -c2 ${ip}
+#     Should Not Be Equal As Integers  ${rc}  0
+#     Should Contain  ${output}  2 packets transmitted, 0 packets received, 100% packet loss
 
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} logs --follow cross2-container2
-    Should Be Equal As Integers  ${rc}  0
-    Should Contain  ${output}  2 packets transmitted, 0 packets received, 100% packet loss
+#     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} logs --follow cross2-container2
+#     Should Be Equal As Integers  ${rc}  0
+#     Should Contain  ${output}  2 packets transmitted, 0 packets received, 100% packet loss
 
-    # verify that an exposed port on the container does not break down bridge isolation
-    ${rc}  ${containerID}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -d --net cross2-network -p 8080:80 ${nginx}
-    Should Be Equal As Integers  ${rc}  0
+#     # verify that an exposed port on the container does not break down bridge isolation
+#     ${rc}  ${containerID}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -d --net cross2-network -p 8080:80 ${nginx}
+#     Should Be Equal As Integers  ${rc}  0
 
-    ${ip}=  Get Container IP  %{VCH-PARAMS}  ${containerID}  cross2-network
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run --net cross2-network2 --name cross2-container3 ${debian} ping -c2 ${ip}
-    Should Not Be Equal As Integers  ${rc}  0
-    Should Contain  ${output}  2 packets transmitted, 0 packets received, 100% packet loss
+#     ${ip}=  Get Container IP  %{VCH-PARAMS}  ${containerID}  cross2-network
+#     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run --net cross2-network2 --name cross2-container3 ${debian} ping -c2 ${ip}
+#     Should Not Be Equal As Integers  ${rc}  0
+#     Should Contain  ${output}  2 packets transmitted, 0 packets received, 100% packet loss
 
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} logs --follow cross2-container3
-    Should Be Equal As Integers  ${rc}  0
-    Should Contain  ${output}  2 packets transmitted, 0 packets received, 100% packet loss
+#     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} logs --follow cross2-container3
+#     Should Be Equal As Integers  ${rc}  0
+#     Should Contain  ${output}  2 packets transmitted, 0 packets received, 100% packet loss
 
 Connect containers to an internal network
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} network create --internal internal-net
@@ -152,16 +152,14 @@ Check Name Resolution Between Containers On Internal Network
     Log  ${output}
     Should Be Equal As Integers  ${rc}  0
 
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} create -it --name baz --net pubnet -p 80 alpine:latest ping -c3 foo
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} create -i --name baz --net pubnet -p 80 alpine:latest ping -c3 foo
     Log  ${output}
-    Should Be Equal As Integers  ${rc}  0
 
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} network connect mynet baz
     Log  ${output}
-    Should Be Equal As Integers  ${rc}  0
 
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} start -ai baz
-    Log To Console  ${output}
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} start -i baz
+    Log  ${output}
 
     Should Be Equal As Integers  ${rc}  0
     Should Contain  ${output}  PING foo

--- a/tests/test-cases/Group1-Docker-Commands/1-17-Docker-Network-Connect.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-17-Docker-Network-Connect.robot
@@ -146,7 +146,7 @@ Connect containers to an internal network
     Should Contain  ${output}  2 packets transmitted, 2 packets received
 
 Check Name Resolution Between Containers On Internal Network
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -d --name foo --net internal-network ubuntu:latest sleep 2000
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -d --name foo --net internal-net ubuntu:latest sleep 2000
     Log  ${output}
     Should Be Equal As Integers  ${rc}  0
 
@@ -154,7 +154,7 @@ Check Name Resolution Between Containers On Internal Network
     Log  ${output}
     Should Be Equal As Integers  ${rc}  0
 
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} network connect internal-network bar
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} network connect internal-net bar
     Log  ${output}
     Should Be Equal As Integers  ${rc}  0
 

--- a/tests/test-cases/Group1-Docker-Commands/1-17-Docker-Network-Connect.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-17-Docker-Network-Connect.robot
@@ -164,3 +164,4 @@ Check Name Resolution Between Containers On Internal Network
     Should Be Equal As Integers  ${rc}  0
     Should Contain  ${output}  PING foo
     Should Contain  ${output}  3 packets transmitted, 3 packets received
+

--- a/tests/test-cases/Group1-Docker-Commands/1-17-Docker-Network-Connect.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-17-Docker-Network-Connect.robot
@@ -146,11 +146,11 @@ Connect containers to an internal network
     Should Contain  ${output}  2 packets transmitted, 2 packets received
 
 Check Name Resolution Between Containers On Internal Network
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -d --name foo --net internal-net ubuntu:latest sleep 2000
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -d --name foo --net internal-net alpine:latest sleep 2000
     Log  ${output}
     Should Be Equal As Integers  ${rc}  0
 
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} create -it --name bar --net public-net -p 80 ubuntu:latest /bin/bash -c 'cat /etc/resolv.conf && ping -c3 foo'
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} create -it --name bar --net public-net -p 80 alpine:latest ping -c3 foo
     Log  ${output}
     Should Be Equal As Integers  ${rc}  0
 

--- a/tests/test-cases/Group1-Docker-Commands/1-17-Docker-Network-Connect.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-17-Docker-Network-Connect.robot
@@ -164,4 +164,3 @@ Check Name Resolution Between Containers On Internal Network
     Should Be Equal As Integers  ${rc}  0
     Should Contain  ${output}  PING foo
     Should Contain  ${output}  3 packets transmitted, 3 packets received
-

--- a/tests/test-cases/Group1-Docker-Commands/1-17-Docker-Network-Connect.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-17-Docker-Network-Connect.robot
@@ -150,7 +150,7 @@ Check Name Resolution Between Containers On Internal Network
     Log  ${output}
     Should Be Equal As Integers  ${rc}  0
 
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} create -it --name bar --net public-net -p 80 alpine:latest ping -c3 foo
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} create -it --name bar --net public-net -p 80 alpine:latest /bin/ping -c3 foo
     Log  ${output}
     Should Be Equal As Integers  ${rc}  0
 

--- a/tests/test-cases/Group1-Docker-Commands/1-17-Docker-Network-Connect.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-17-Docker-Network-Connect.robot
@@ -144,3 +144,22 @@ Connect containers to an internal network
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run --net internal-net ${busybox} ping -c2 ${ip}
     Should Be Equal As Integers  ${rc}  0
     Should Contain  ${output}  2 packets transmitted, 2 packets received
+
+Check Name Resolution Between Containers On Internal Network
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -d --name foo --net internal-network ubuntu:latest sleep 2000
+    Log  ${output}
+    Should Be Equal As Integers  ${rc}  0
+
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} create -it --name bar --net public-net -p 80 ubuntu:latest /bin/bash -c 'cat /etc/resolv.conf && ping -c3 foo'
+    Log  ${output}
+    Should Be Equal As Integers  ${rc}  0
+
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} network connect internal-network bar
+    Log  ${output}
+    Should Be Equal As Integers  ${rc}  0
+
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} start -ai bar
+    Log  ${output}
+    Should Be Equal As Integers  ${rc}  0
+    Should Contain  ${output}  PING foo
+    Should Contain  ${output}  3 packets transmitted, 3 packets received

--- a/tests/test-cases/Group1-Docker-Commands/1-17-Docker-Network-Connect.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-17-Docker-Network-Connect.robot
@@ -146,20 +146,22 @@ Connect containers to an internal network
     Should Contain  ${output}  2 packets transmitted, 2 packets received
 
 Check Name Resolution Between Containers On Internal Network
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -d --name foo --net internal-net alpine:latest sleep 5000
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} network create --internal mynet
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} network create pubnet
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -d --name foo --net mynet alpine:latest sleep 10000
     Log  ${output}
     Should Be Equal As Integers  ${rc}  0
 
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} create -it --name baz --net public-net -p 80 alpine:latest ping -c3 foo
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} create -it --name baz --net pubnet -p 80 alpine:latest ping -c3 foo
     Log  ${output}
     Should Be Equal As Integers  ${rc}  0
 
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} network connect internal-net baz
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} network connect mynet baz
     Log  ${output}
     Should Be Equal As Integers  ${rc}  0
 
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} start -ai baz
-    Log  ${output}
+    Log To Console  ${output}
 
     Should Be Equal As Integers  ${rc}  0
     Should Contain  ${output}  PING foo


### PR DESCRIPTION
Adds a boolean to let us know if a networkendpoint is for an internal network & uses this additional metadata to prioritize the ordering of /etc/resolv.conf in order to resolve #5738 

I've been testing like so:

```bash
 /home/ian/go/src/github.com/vmware/vic/bin/vic-machine-linux delete --target $(testbed-ip) --user Administrator@vsphere.local  --password xxx --name ian-vch --thumbprint=$(testbed-thumbprint) --force \
      && /home/ian/go/src/github.com/vmware/vic/bin/vic-machine-linux create --target $(testbed-ip)/vcqaDC --user Administrator@vsphere.local  --password xxx --name ian-vch --image-store=sharedVmfs-0 --tls-cname="*.eng.vmware.com" --bridge-network=bridge  --thumbprint=$(testbed-thumbprint) --debug=2 --timeout=15m \
      && vic-env \
      && docker network create --internal mynet \
      && docker run -d --name foo --net mynet bensdoings/ifconfig sleep 1000 \
      && docker create -it --name bar --net bridge -p 80 bensdoings/ifconfig ping -c3 foo \
      && docker network connect mynet bar \
      && docker start -ai bar
```

(for reference, `vic-env` is just the following to set docker env vars, nothing fancy)

```bash
vic-env () {
	vch="$@" 
	[[ $vch = "" ]] && vch=$vch_default_name 
	for x in $(cat $GOPATH/src/github.com/vmware/vic/"$vch"/"$vch".env)
	do
		export $x
	done
	docker info
}
```

Ran this successfully 5 times in a row; considering /etc/resolv.conf has 2 nameservers in this scenario that gives us a 1/2 chance of getting the ordering right randomly (as was happening before) on each run, so the chance of getting it right by chance 5 times in a row is 1/32 or 3.125% chance... I'd say it's fixed. Still need to write a test, which I will add to the PR over the weekend (tomorrow probably).