### PR TITLE
[specific ci=1-44-Docker-CP-Online]return error if nfs volume mount failed

### DIFF
--- a/lib/tether/tether.go
+++ b/lib/tether/tether.go
@@ -303,11 +303,15 @@ func (t *tether) setMounts() error {
 		switch mountTarget.Source.Scheme {
 		case "label":
 			// this could block indefinitely while waiting for a volume to present
-			t.ops.MountLabel(context.Background(), mountTarget.Source.Path, mountTarget.Path)
-
+			// return error if mount volume failed, to fail container start
+			if err := t.ops.MountLabel(context.Background(), mountTarget.Source.Path, mountTarget.Path); err != nil {
+				return err
+			}
 		case "nfs":
-			t.ops.MountTarget(context.Background(), mountTarget.Source, mountTarget.Path, mountTarget.Mode)
-
+			// return error if mount nfs volume failed, to fail container start, so user knows there is something wrong
+			if err := t.ops.MountTarget(context.Background(), mountTarget.Source, mountTarget.Path, mountTarget.Mode); err != nil {
+				return err
+			}
 		default:
 			return fmt.Errorf("unsupported volume mount type for %s: %s", targetRef, mountTarget.Source.Scheme)
 		}


### PR DESCRIPTION
fixes #5942 

Based on discussion this afternoon with @matthewavery @anchal-agrawal @mhagen-vmware @mdubya66 , we don't want to have nfs volume mount failed silently as described in issue #4850, cause in the case, if user didn't realize the volume is not mounted, and continue to write to the volume store, the data will eventually go to container r/w layer, and after container is gone, the data is lost permanently.

So the decision for 1.2 is that we fail the container if nfs volume mount failed. With this fix, if volume store mount failed in tether, container will quit immediately, and vm is powered off with following error:

```
docker: Error response from daemon: Server error from portlayer: unable to wait for process launch s
Aug 21 2017 22:20:20.581Z INFO  Environment saved in testnfs2/testnfs2.env                           │tatus: container VM has unexpectedly powered off.
```
Do not get back the real error message is because we lack of channel to get tether error from PL, that should be addressed in #4850 in future release.

