### PR TITLE
Check for power off after kill regardless of startGuestProgram() return

### DIFF
--- a/lib/portlayer/exec/base.go
+++ b/lib/portlayer/exec/base.go
@@ -248,20 +248,23 @@ func (c *containerBase) kill(ctx context.Context) error {
 	log.Infof("sending kill -%s %s", sig, c.ExecConfig.ID)
 
 	err := c.startGuestProgram(timeout, "kill", sig)
-	if err == nil {
-		log.Infof("waiting %s for %s to power off", wait, c.ExecConfig.ID)
-		err := c.vm.WaitForPowerState(timeout, types.VirtualMachinePowerStatePoweredOff)
-		if err == nil {
-			return nil // VM has powered off
-		}
-
-		if timeout.Err() != nil {
-			log.Warnf("timeout (%s) waiting for %s to power off via SIG%s", wait, c.ExecConfig.ID, sig)
-		}
+	if err == nil && timeout.Err() != nil {
+		log.Warnf("timeout (%s) waiting for %s to power off via SIG%s", wait, c.ExecConfig.ID, sig)
 	}
-
 	if err != nil {
 		log.Warnf("killing %s attempt resulted in: %s", c.ExecConfig.ID, err)
+	}
+
+	// Even if startGuestProgram failed above, it may actually have executed.  If the container came up and then
+	// we kill it before VC gets a chance to detect the toolbox, vSphere can execute the kill but report an
+	// error 3016 indicating the guest toolbox wasn't found.  If we then try to poweroff, it may throw vSphere
+	// into an invalid transition and will need to recover.  If we try to grab properties at this time, the
+	// power state may be incorrect.  We work around this by waiting on the power state, regardless of error
+	// from startGuestProgram. https://github.com/vmware/vic/issues/5803
+	log.Infof("waiting %s for %s to power off", wait, c.ExecConfig.ID)
+	err = c.vm.WaitForPowerState(timeout, types.VirtualMachinePowerStatePoweredOff)
+	if err == nil {
+		return nil // VM has powered off
 	}
 
 	log.Warnf("killing %s via hard power off", c.ExecConfig.ID)
@@ -296,7 +299,9 @@ func (c *containerBase) shutdown(ctx context.Context, waitTime *int32) error {
 
 		err := c.startGuestProgram(timeout, "kill", sig)
 		if err != nil {
-			return fmt.Errorf("%s: %s", msg, err)
+			// Just warn and proceed to waiting for power state per issue https://github.com/vmware/vic/issues/5803
+			// Description above in function kill()
+			log.Warnf("%s: %s", msg, err)
 		}
 
 		log.Infof("waiting %s for %s to power off", wait, c.ExecConfig.ID)


### PR DESCRIPTION
If a container VM starts up and we stop it before VC detects the toolbox, startGuestProgram
returns an error 3016 even if the toolbox executed and the VM was powered off.  When this
happens, we try to power off the VM, throwing vSphere into an invalid state transition, which
it needs to recover from.  During this time, we have seen refreshing properties return invalid
powerstate value and prevents us from reading the exit code in portlayer's commit code.

To prevent this, we now wait to see if the container VM powered off after startGuestProgram,
regardless if it returns an error.

Resolves #5803

<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[  ] There is an associated issue that is labelled
[  ] Code is up-to-date with the `master` branch
[  ] You've successfully run `make test` locally
[  ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/vmware/vic/blob/master/.github/CONTRIBUTING.md
-->

Fixes #

<!--
To trigger a custom build with this PR, include one of these in the PR's title or commit messages:
- To skip running tests (e.g. for a work-in-progress PR), add `[ci skip]` or `[skip ci]`
to the commit message or the PR title.
- To run the full test suite, use `[full ci]`.
- To run _one_ integration test or group, use `[specific ci=$test]`. Examples:
  - To run the `1-01-Docker-Info` suite: `[specific ci=1-01-Docker-Info]`
  - To run all suites under the `Group1-Docker-Commands` group: `[specific ci=Group1-Docker-Commands]`
-->
