### PR TITLE
Fix broken H5 Client plugin on vSphere 6.5u1

### DIFF
--- a/ui/vic-ui-h5c/build-deployable.xml
+++ b/ui/vic-ui-h5c/build-deployable.xml
@@ -72,7 +72,6 @@
    <!-- taking out compile-flex-project -->
    <target name="make-deployable" depends="check-sdks,compile-angular-app,compile-html-project">
       <copy file="${VSPHERE_SDK_HOME}/libs/vim25.jar" tofile="${H5_PROJECT_UI_HOME}/target/vic/plugins/vim25.jar"/>
-      <copy file="${VSPHERE_H5C_SDK_HOME}/vsphere-ui/server/repository/usr/vlsiCore.jar" tofile="${H5_PROJECT_UI_HOME}/target/vic/plugins/vlsiCore.jar"/>
       <delete dir="${basedir}/../installer/plugin-packages"/>
       <zip basedir="${H5_PROJECT_UI_HOME}/target/vic" destfile="${PACKAGE_NAME}"/>
       <copy todir="${PACKAGE_HOME}/${pluginPackage(id)}-v${pluginPackage(version)}">

--- a/ui/vic-ui-h5c/vic/src/main/webapp/plugin.xml
+++ b/ui/vic-ui-h5c/vic/src/main/webapp/plugin.xml
@@ -157,41 +157,10 @@
             </propertyConditions>
         </metadata>
     </extension>
-    <!-- Extension Point for VCH view -->
-    <extensionPoint id="com.vmware.vic.extpoint-vch">
-        <objectType class="com.vmware.vise.mvc.model.ViewSpec"/>
-    </extensionPoint>
-    <!-- Extension Point for Container view -->
-    <extensionPoint id="com.vmware.vic.extpoint-container">
-        <objectType class="com.vmware.vise.mvc.model.ViewSpec"/>
-    </extensionPoint>
     <!-- Tab specs definition for VCH view -->
     <extension id="com.vmware.vic.customtab-vch">
         <extendedPoint>com.vmware.vic.objectView.views</extendedPoint>
-        <hostedPoint>com.vmware.vic.extpoint-vch</hostedPoint>
         <precedingExtension>com.vmware.vic.vchSummaryView</precedingExtension>
-        <object>
-            <name>#{vic_workspace.vch.tab.label}</name>
-            <contentSpec>
-                <url>resources/ui/views/tabs/TabContent.html</url>
-            </contentSpec>
-        </object>
-    </extension>
-    <!-- Tab specs definition for Container view -->
-    <extension id="com.vmware.vic.customtab-container">
-        <extendedPoint>com.vmware.vic.objectView.views</extendedPoint>
-        <hostedPoint>com.vmware.vic.extpoint-container</hostedPoint>
-        <precedingExtension>com.vmware.vic.customVchView</precedingExtension>
-        <object>
-            <name>#{vic_workspace.container.tab.label}</name>
-            <contentSpec>
-                <url>resources/ui/views/tabs/TabContent.html</url>
-            </contentSpec>
-        </object>
-    </extension>
-    <!-- Tab instance for VCH view -->
-    <extension id="com.vmware.vic.customVchView">
-        <extendedPoint>com.vmware.vic.extpoint-vch</extendedPoint>
         <object>
             <name>#{vic_workspace.vch.tab.label}</name>
             <componentClass className="com.vmware.vsphere.client.htmlbridge.HtmlView">
@@ -203,9 +172,10 @@
             </componentClass>
         </object>
     </extension>
-    <!-- Tab instance for Container view -->
-    <extension id="com.vmware.vic.customContainerView">
-        <extendedPoint>com.vmware.vic.extpoint-container</extendedPoint>
+    <!-- Tab specs definition for Container view -->
+    <extension id="com.vmware.vic.customtab-container">
+        <extendedPoint>com.vmware.vic.objectView.views</extendedPoint>
+        <precedingExtension>com.vmware.vic.customVchView</precedingExtension>
         <object>
             <name>#{vic_workspace.container.tab.label}</name>
             <componentClass className="com.vmware.vsphere.client.htmlbridge.HtmlView">


### PR DESCRIPTION
This PR fixes a customer-found issue where the H5 Client plugin for VIC Engine was not showing up in the H5 Client that ships with the latest release of vSphere (6.5u1). This fix ensures that the plugin is deployed successfully and behaves the same as before on previous builds of vSphere 6.5. It was also tested on a 6.5.0d VCSA instance to ensure backwards compatibility.

It should be noted, however, that there is an internal bug filed against H5 Client that affects the normal operation of the plugin after successful deployment of it. The workaround suggested is to restart the H5 Client service.