### PR TITLE
[skip ci] Nightly console log upload fix

### DIFF
--- a/tests/nightly/nightly-autorun.sh
+++ b/tests/nightly/nightly-autorun.sh
@@ -30,7 +30,7 @@ git pull
 echo "Removing VIC directory if present"
 echo "Cleanup logs from previous run"
 
-rm -rf *.zip *.log
-rm -rf bin 60 65
+sudo rm -rf *.zip *.log
+sudo rm -rf bin 60 65
 
-sudo -E ./tests/nightly/nightly-kickoff.sh > ./nightly_console.log 2>&1
+sudo -E ./tests/nightly/nightly-kickoff.sh > ./nightly_console.txt 2>&1

--- a/tests/nightly/upload-logs.sh
+++ b/tests/nightly/upload-logs.sh
@@ -25,7 +25,7 @@ outfile="functional_logs_"$1".zip"
 echo $Build
 echo $outfile
 
-/usr/bin/zip -9 -r $outfile 60 65 nightly_console.log
+/usr/bin/zip -9 -r $outfile 60 65 nightly_console.txt
 
 # GC credentials
 keyfile="/root/vic-ci-logs.key"


### PR DESCRIPTION
Updating the console log extension to .txt in order to be properly copied to the tarball. Also adding sudo to ensure the logs from previous run is cleaned up.