### PR TITLE
[skip ci] Switch this test to check for disabled method

### DIFF
--- a/tests/manual-test-cases/Group5-Functional-Tests/5-14-Remove-Container-OOB.md
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-14-Remove-Container-OOB.md
@@ -14,11 +14,10 @@ This test requires access to VMware Nimbus cluster for dynamic ESXi and vCenter 
 1. Deploy a new vCenter with a simple cluster
 2. Install the VIC appliance into one of the clusters
 3. Run docker run -itd busybox /bin/top
-4. Remove the container vm OOB
-5. Run docker run -itd busybox /bin/top
+4. Attempt to remove the container vm OOB
 
 # Expected Outcome:
-Step 5 should result in success and the container created should behave as expected
+Step 4 should result in and error and a message stating that OOB deletion is disabled on VIC
 
 # Possible Problems:
 None

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-14-Remove-Container-OOB.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-14-Remove-Container-OOB.robot
@@ -24,10 +24,11 @@ Docker run an image from a container that was removed OOB
 
     Install VIC Appliance To Test Server
 
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} pull busybox
+    ${rc}  ${out}=  Run And Return Rc And Output  docker %{VCH-PARAMS} pull busybox
     Should Be Equal As Integers  ${rc}  0
     ${rc}  ${container}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -itd --name removeOOB busybox /bin/top
     Should Be Equal As Integers  ${rc}  0
-    Destroy VM OOB  removeOOB*
-    ${rc}  ${container}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -itd busybox /bin/top
-    Should Be Equal As Integers  ${rc}  0
+
+    ${rc}  ${out}=  Run And Return Rc And Output  govc vm.destroy %{VCH-NAME}/removeOOB*
+    Should Not Be Equal As Integers  ${rc}  0
+    Should Contain  ${out}  govc: ServerFaultCode: The method is disabled by 'VIC'


### PR DESCRIPTION
Our fix for the underlying issue was to disable the ability to remove a container OOB, so the underlying issue is still present just masked. It doesn't make sense to bypass our "fix" and allow the OOB delete to then just get the same failure as we originally worked around.