### PR TITLE
[specific ci=1-02-Docker-Pull] Show Harbor error response detail to client side

### DIFF
--- a/pkg/fetcher/fetcher.go
+++ b/pkg/fetcher/fetcher.go
@@ -474,7 +474,7 @@ func extractErrResponseMessage(rdr io.ReadCloser) (string, error) {
 	var errResponse RegistryErrorRespBody
 	err = json.Unmarshal(res, &errResponse)
 	if err != nil || len(errResponse.Errors) == 0 {
-		log.Debugf("Error response has irregular format. Response body: %s", string(res))
+		log.Infof("Error response has irregular format. Response body: %s", string(res))
 		return "", errJSONFormat
 	}
 


### PR DESCRIPTION
Extend on pr #6067 
For error response from Harbor registry (like 412), the error message now shows up on the client side.

Upon a 412 (precondition failed) from Harbor due to unsigned image:
before the change, the client sees:
```
Unexpected http code 412
```
Now, the client sees:
```
Unexpected http code: 412 (Precondition Failed), URL: ..., Message: The image is not signed in Notary.
```
also the complete error response body json string is included in the debug log.

(related issues:
original issue https://github.com/vmware/vic/issues/5951
Opened this pr because Harbor's err json does not match Docker's https://github.com/vmware/harbor/issues/3124)
