### PR TITLE
[specific ci=6-07-Create-Network] Fix bad portmapping from container network after VCH restart bug

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -311,7 +311,7 @@ $(imagec): $(call godeps,cmd/imagec/*.go) $(portlayerapi-client)
 	@echo building imagec...
 	@$(TIME) $(GO) build $(RACE)  $(ldflags) -o ./$@ ./$(dir $<)
 
-$(docker-engine-api): $$(call godeps,cmd/docker/*.go) $(portlayerapi-client) $(admiralapi-client)
+$(docker-engine-api): $(portlayerapi-client) $(admiralapi-client) $$(call godeps,cmd/docker/*.go)
 ifeq ($(OS),linux)
 	@echo Building docker-engine-api server...
 	@$(TIME) $(GO) build $(RACE) -ldflags "$(LDFLAGS)" -o $@ ./cmd/docker
@@ -347,7 +347,7 @@ $(portlayerapi-server): $(PORTLAYER_DEPS) $(SWAGGER)
 	@$(SWAGGER) generate server --exclude-main -A PortLayer --target lib/apiservers/portlayer -f lib/apiservers/portlayer/swagger.json 2>>swagger-gen.log
 	@echo done regenerating swagger models and operations for Portlayer API server...
 
-$(portlayerapi): $$(call godeps,cmd/port-layer-server/*.go) $(portlayerapi-server) $(portlayerapi-client)
+$(portlayerapi): $(portlayerapi-server) $(portlayerapi-client) $$(call godeps,cmd/port-layer-server/*.go)
 	@echo building Portlayer API server...
 	@$(TIME) $(GO) build $(RACE) -ldflags "$(LDFLAGS)" -o $@ ./cmd/port-layer-server
 

--- a/lib/apiservers/engine/backends/backends.go
+++ b/lib/apiservers/engine/backends/backends.go
@@ -321,7 +321,7 @@ func setPortMapping(info *models.ContainerInfo, backend *Container, container *c
 		return err
 	}
 	for _, e := range endpointsOK.Payload {
-		if len(e.Ports) > 0 {
+		if len(e.Ports) > 0 && e.Scope == "bridge" {
 			if err = MapPorts(container.HostConfig, e, container.ContainerID); err != nil {
 				log.Errorf(err.Error())
 				return err

--- a/lib/apiservers/engine/backends/backends.go
+++ b/lib/apiservers/engine/backends/backends.go
@@ -43,6 +43,7 @@ import (
 	"github.com/vmware/vic/lib/config/dynamic"
 	"github.com/vmware/vic/lib/config/dynamic/admiral"
 	"github.com/vmware/vic/lib/imagec"
+	"github.com/vmware/vic/lib/portlayer/constants"
 	"github.com/vmware/vic/pkg/errors"
 	"github.com/vmware/vic/pkg/registry"
 	"github.com/vmware/vic/pkg/vsphere/session"
@@ -321,7 +322,7 @@ func setPortMapping(info *models.ContainerInfo, backend *Container, container *c
 		return err
 	}
 	for _, e := range endpointsOK.Payload {
-		if len(e.Ports) > 0 && e.Scope == "bridge" {
+		if len(e.Ports) > 0 && e.Scope == constants.BridgeScopeType {
 			if err = MapPorts(container.HostConfig, e, container.ContainerID); err != nil {
 				log.Errorf(err.Error())
 				return err

--- a/tests/test-cases/Group6-VIC-Machine/6-07-Create-Network.robot
+++ b/tests/test-cases/Group6-VIC-Machine/6-07-Create-Network.robot
@@ -582,7 +582,7 @@ Reset VCH doesn't cause unintentionally exposed ports from container network
     Run Keyword And Ignore Error  Cleanup Dangling VMs On Test Server
     Run Keyword And Ignore Error  Cleanup Datastore On Test Server
 
-    ${output}=  Run  bin/vic-machine-linux create --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --image-store=%{TEST_DATASTORE} --bridge-network=bridge --container-network "vm-network":vmnet ${vicmachinetls}
+    ${output}=  Run  bin/vic-machine-linux create --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --image-store=%{TEST_DATASTORE} --bridge-network=bridge --container-network "VM Network":vmnet ${vicmachinetls}
     Log  ${output}
     Should Contain  ${output}  Installer completed successfully
     Get Docker Params  ${output}  ${true}

--- a/tests/test-cases/Group6-VIC-Machine/6-07-Create-Network.robot
+++ b/tests/test-cases/Group6-VIC-Machine/6-07-Create-Network.robot
@@ -427,7 +427,7 @@ Container Firewalls
     ${out}=  Run  govc host.portgroup.add -vswitch vSwitchLAN peers-net-1
     ${out}=  Run  govc host.portgroup.add -vswitch vSwitchLAN peers-net-2
 
-    ${createcommand}=  catenate  SEPARATOR=\ \
+    ${createcommand}=  catenate  SEPARATOR=\ \ 
     ...  bin/vic-machine-linux create --debug 1 --name=%{VCH-NAME}
     ...  --target=%{TEST_URL}%{TEST_DATACENTER} --thumbprint=%{TEST_THUMBPRINT}
     ...  --user=%{TEST_USERNAME} --image-store=%{TEST_DATASTORE} --password=%{TEST_PASSWORD}

--- a/tests/test-cases/Group6-VIC-Machine/6-07-Create-Network.robot
+++ b/tests/test-cases/Group6-VIC-Machine/6-07-Create-Network.robot
@@ -616,7 +616,6 @@ Reset VCH doesn't cause unintentionally exposed ports from container network
     Should Not Contain  ${output}  ->80/tcp
 
     # Delete the portgroup added by env vars keyword
-    Cleanup VCH Bridge Network  %{VCH-NAME}
     Cleanup VIC Appliance On Test Server
 
 


### PR DESCRIPTION
Resolves #6091 , includes a test (gotta update the .md file) 

I have hardcoded the string (`"bridge"` in `backends.go`) at the moment -- @jzt do you know if there's a constants package in the personality or if I should include the portlayer/constants.go file? My intuition is that this is to be avoided, so it's hardcoded until I'm told otherwise. 

Also there's a small ordering change to the `Makefile` that I've included which is unrelated (sorry! bad form, I know), but prevents a problem I have building locally about 1/2 the time, where the Swagger defs aren't ready when `godeps` runs and then `godeps` fails. I've heard of a few others having this problem, I believe. Doesn't change the behavior, just ordering.

Also, there's discussion in #6091 about showing the correct exposed port also, but I think that should go in a new issue, frankly. Step 1) fix bug. Step 2) enhance feature. IMHO.