### PR TITLE
[skip ci] Implement REST API handler to return the version 

### DIFF
--- a/lib/apiservers/service/restapi/configure_vic_machine.go
+++ b/lib/apiservers/service/restapi/configure_vic_machine.go
@@ -23,6 +23,7 @@ import (
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/tylerb/graceful"
 
+	"github.com/vmware/vic/lib/apiservers/service/restapi/handlers"
 	"github.com/vmware/vic/lib/apiservers/service/restapi/operations"
 )
 
@@ -61,9 +62,7 @@ func configureAPI(api *operations.VicMachineAPI) http.Handler {
 	})
 
 	// GET /container/version
-	api.GetVersionHandler = operations.GetVersionHandlerFunc(func(params operations.GetVersionParams) middleware.Responder {
-		return middleware.NotImplemented("operation .GetVersion has not yet been implemented")
-	})
+	api.GetVersionHandler = &handlers.VersionGet{}
 
 	// POST /container/target/{target}
 	api.PostTargetTargetHandler = operations.PostTargetTargetHandlerFunc(func(params operations.PostTargetTargetParams, principal interface{}) middleware.Responder {

--- a/lib/apiservers/service/restapi/handlers/version_get.go
+++ b/lib/apiservers/service/restapi/handlers/version_get.go
@@ -1,0 +1,30 @@
+// Copyright 2017 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package handlers
+
+import (
+	"github.com/go-openapi/runtime/middleware"
+
+	"github.com/vmware/vic/lib/apiservers/service/restapi/operations"
+	"github.com/vmware/vic/pkg/version"
+)
+
+// VersionGet is the handler for accessing the version information for the service
+type VersionGet struct {
+}
+
+func (h *VersionGet) Handle(params operations.GetVersionParams) middleware.Responder {
+	return operations.NewGetVersionOK().WithPayload(version.GetBuild().ShortVersion())
+}


### PR DESCRIPTION
Resolves #6016.

Note: this change builds on #6132 and, once approved, I would like this to land as the third commit on `feature/vic-machine-service`.