### PR TITLE
[skip ci] Define REST API handlers for listing VCHs

### DIFF
--- a/lib/apiservers/service/restapi/configure_vic_machine.go
+++ b/lib/apiservers/service/restapi/configure_vic_machine.go
@@ -51,9 +51,7 @@ func configureAPI(api *operations.VicMachineAPI) http.Handler {
 	api.TxtProducer = runtime.TextProducer()
 
 	// Applies when the Authorization header is set with the Basic scheme
-	api.BasicAuth = func(user string, pass string) (interface{}, error) {
-		return nil, errors.NotImplemented("basic auth  (basic) has not yet been implemented")
-	}
+	api.BasicAuth = handlers.BasicAuth
 
 	// GET /container
 	api.GetHandler = operations.GetHandlerFunc(func(params operations.GetParams) middleware.Responder {
@@ -71,9 +69,7 @@ func configureAPI(api *operations.VicMachineAPI) http.Handler {
 	})
 
 	// GET /container/target/{target}/vch
-	api.GetTargetTargetVchHandler = operations.GetTargetTargetVchHandlerFunc(func(params operations.GetTargetTargetVchParams, principal interface{}) middleware.Responder {
-		return middleware.NotImplemented("operation .GetTargetTargetVch has not yet been implemented")
-	})
+	api.GetTargetTargetVchHandler = &handlers.VCHListGet{}
 
 	// POST /container/target/{target}/vch
 	api.PostTargetTargetVchHandler = operations.PostTargetTargetVchHandlerFunc(func(params operations.PostTargetTargetVchParams, principal interface{}) middleware.Responder {
@@ -111,9 +107,7 @@ func configureAPI(api *operations.VicMachineAPI) http.Handler {
 	})
 
 	// GET /container/target/{target}/datacenter/{datacenter}/vch
-	api.GetTargetTargetDatacenterDatacenterVchHandler = operations.GetTargetTargetDatacenterDatacenterVchHandler(func(params operations.GetTargetTargetDatacenterDatacenterVchHandler, principal interface{}) middleware.Responder {
-		return middleware.NotImplemented("operation .GetTargetTargetDatacenterDatacenterVchHandler has not yet been implemented")
-	})
+	api.GetTargetTargetDatacenterDatacenterVchHandler = &handlers.VCHDatacenterListGet{}
 
 	// POST /container/target/{target}/datacenter/{datacenter}/vch
 	api.PostTargetTargetDatacenterDatacenterVchHandler = operations.PostTargetTargetDatacenterDatacenterVchHandlerFunc(func(params operations.PostTargetTargetDatacenterDatacenterVchParams, principal interface{}) middleware.Responder {

--- a/lib/apiservers/service/restapi/handlers/authentication.go
+++ b/lib/apiservers/service/restapi/handlers/authentication.go
@@ -1,0 +1,24 @@
+// Copyright 2017 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package handlers
+
+type Credentials struct {
+	user string
+	pass string
+}
+
+func BasicAuth(user string, pass string) (interface{}, error) {
+	return Credentials{user: user, pass: pass}, nil
+}

--- a/lib/apiservers/service/restapi/handlers/util/error.go
+++ b/lib/apiservers/service/restapi/handlers/util/error.go
@@ -1,0 +1,56 @@
+// Copyright 2017 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+func StatusCode(err error) int {
+	e, ok := err.(statusCode)
+	if !ok {
+		return 500
+	}
+
+	return e.Code()
+}
+
+func NewError(code int, message string) error {
+	return &httpError{code: code, message: message}
+}
+
+func WrapError(code int, err error) error {
+	return &wrappedError{error: err, code: code}
+}
+
+// Pattern based on https://dave.cheney.net/2016/04/27/dont-just-check-errors-handle-them-gracefully
+
+type statusCode interface {
+	Code() int
+}
+
+type httpError struct {
+	code    int
+	message string
+}
+
+func (e *httpError) Code() int {
+	return e.code
+}
+
+func (e *httpError) Error() string {
+	return e.message
+}
+
+type wrappedError struct {
+	error
+	code int
+}

--- a/lib/apiservers/service/restapi/handlers/vch_list_get.go
+++ b/lib/apiservers/service/restapi/handlers/vch_list_get.go
@@ -1,0 +1,213 @@
+// Copyright 2017 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package handlers
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"path"
+
+	"github.com/docker/docker/opts"
+	"github.com/go-openapi/runtime/middleware"
+
+	"github.com/vmware/vic/cmd/vic-machine/common"
+	"github.com/vmware/vic/lib/apiservers/service/models"
+	"github.com/vmware/vic/lib/apiservers/service/restapi/handlers/util"
+	"github.com/vmware/vic/lib/apiservers/service/restapi/operations"
+	"github.com/vmware/vic/lib/install/data"
+	"github.com/vmware/vic/lib/install/management"
+	"github.com/vmware/vic/lib/install/validate"
+	"github.com/vmware/vic/pkg/version"
+	"github.com/vmware/vic/pkg/vsphere/vm"
+)
+
+// VCHListGet is the handler for listing VCHs
+type VCHListGet struct {
+}
+
+// VCHListGet is the handler for listing VCHs within a Datacenter
+type VCHDatacenterListGet struct {
+}
+
+func (h *VCHListGet) Handle(params operations.GetTargetTargetVchParams, principal interface{}) middleware.Responder {
+	d := buildData(
+		url.URL{Host: params.Target},
+		principal.(Credentials).user,
+		principal.(Credentials).pass,
+		params.Thumbprint,
+		nil,
+		params.ComputeResource)
+
+	vchs, err := handle(params.HTTPRequest.Context(), d)
+	if err != nil {
+		return operations.NewGetTargetTargetVchDefault(util.StatusCode(err)).WithPayload(&models.Error{Message: err.Error()})
+	}
+
+	return operations.NewGetTargetTargetVchOK().WithPayload(operations.GetTargetTargetVchOKBody{Vchs: vchs})
+}
+
+func (h *VCHDatacenterListGet) Handle(params operations.GetTargetTargetDatacenterDatacenterVchParams, principal interface{}) middleware.Responder {
+	d := buildData(
+		url.URL{Host: params.Target},
+		principal.(Credentials).user,
+		principal.(Credentials).pass,
+		params.Thumbprint,
+		&params.Datacenter,
+		params.ComputeResource)
+
+	vchs, err := handle(params.HTTPRequest.Context(), d)
+	if err != nil {
+		return operations.NewGetTargetTargetVchDefault(util.StatusCode(err)).WithPayload(&models.Error{Message: err.Error()})
+	}
+
+	return operations.NewGetTargetTargetVchOK().WithPayload(operations.GetTargetTargetVchOKBody{Vchs: vchs})
+}
+
+func handle(ctx context.Context, d *data.Data) ([]*models.VCHListItem, error) {
+	validator, err := validateTarget(ctx, d)
+	if err != nil {
+		return nil, util.WrapError(400, err)
+	}
+
+	executor := management.NewDispatcher(validator.Context, validator.Session, nil, false)
+	vchs, err := executor.SearchVCHs(validator.ClusterPath)
+	if err != nil {
+		return nil, util.NewError(500, fmt.Sprintf("Failed to search VCHs in %s: %s", validator.ResourcePoolPath, err))
+	}
+
+	return vchsToModels(ctx, vchs, executor), nil
+}
+
+func buildData(url url.URL, user string, pass string, thumbprint *string, datacenter *string, computeResource *string) *data.Data {
+	d := data.Data{
+		Target: &common.Target{
+			URL:      &url,
+			User:     user,
+			Password: &pass,
+		},
+	}
+
+	if datacenter != nil {
+		// TODO: Convert ID to Name or update underlying code to accept ID
+		d.Target.URL.Path = *datacenter
+	}
+
+	if thumbprint != nil {
+		d.Thumbprint = *thumbprint
+	}
+
+	if computeResource != nil {
+		d.ComputeResourcePath = *computeResource
+	}
+
+	return &d
+}
+
+func validateTarget(ctx context.Context, d *data.Data) (*validate.Validator, error) {
+	if err := d.HasCredentials(); err != nil {
+		return nil, fmt.Errorf("Invalid Credentials: %s", err)
+	}
+
+	validator, err := validate.NewValidator(ctx, d)
+	if err != nil {
+		return nil, fmt.Errorf("Validation Error: %s", err)
+	}
+	// If dc is not set, and multiple datacenter is available, vic-machine ls will list VCHs under all datacenters.
+	validator.AllowEmptyDC()
+
+	_, err = validator.ValidateTarget(ctx, d)
+	if err != nil {
+		return nil, fmt.Errorf("Target validation failed: %s", err)
+	}
+	_, err = validator.ValidateCompute(ctx, d, false)
+	if err != nil {
+		return nil, fmt.Errorf("Compute resource validation failed: %s", err)
+	}
+
+	return validator, nil
+}
+
+// Copied from list.go, and appears to be present other places. TODO: deduplicate
+func upgradeStatusMessage(ctx context.Context, vch *vm.VirtualMachine, installerVer *version.Build, vchVer *version.Build) string {
+	if sameVer := installerVer.Equal(vchVer); sameVer {
+		return "Up to date"
+	}
+
+	upgrading, err := vch.VCHUpdateStatus(ctx)
+	if err != nil {
+		return fmt.Sprintf("Unknown: %s", err)
+	}
+	if upgrading {
+		return "Upgrade in progress"
+	}
+
+	canUpgrade, err := installerVer.IsNewer(vchVer)
+	if err != nil {
+		return fmt.Sprintf("Unknown: %s", err)
+	}
+	if canUpgrade {
+		return fmt.Sprintf("Upgradeable to %s", installerVer.ShortVersion())
+	}
+
+	oldInstaller, err := installerVer.IsOlder(vchVer)
+	if err != nil {
+		return fmt.Sprintf("Unknown: %s", err)
+	}
+	if oldInstaller {
+		return fmt.Sprintf("VCH has newer version")
+	}
+
+	// can't get here
+	return "Invalid upgrade status"
+}
+
+func vchsToModels(ctx context.Context, vchs []*vm.VirtualMachine, executor *management.Dispatcher) []*models.VCHListItem {
+	installerVer := version.GetBuild()
+	payload := make([]*models.VCHListItem, 0)
+	for _, vch := range vchs {
+		var version *version.Build
+		var dockerHost string
+		var adminPortal string
+		if vchConfig, err := executor.GetNoSecretVCHConfig(vch); err == nil {
+			version = vchConfig.Version
+
+			if public := vchConfig.ExecutorConfig.Networks["public"]; public != nil {
+				if public_ip := public.Assigned.IP; public_ip != nil {
+					var docker_port = opts.DefaultTLSHTTPPort
+					if vchConfig.HostCertificate.IsNil() {
+						docker_port = opts.DefaultHTTPPort
+					}
+
+					dockerHost = fmt.Sprintf("%s:%d", public_ip, docker_port)
+					adminPortal = fmt.Sprintf("https://%s:2378", public_ip)
+				}
+			}
+		}
+
+		name := path.Base(vch.InventoryPath)
+
+		model := &models.VCHListItem{ID: vch.Reference().Value, Name: name, AdminPortal: adminPortal, DockerHost: dockerHost}
+
+		if version != nil {
+			model.Version = version.ShortVersion()
+			model.UpgradeStatus = upgradeStatusMessage(ctx, vch, installerVer, version)
+		}
+
+		payload = append(payload, model)
+	}
+
+	return payload
+}


### PR DESCRIPTION
Introduce a pair of handlers for listing information about VCHs, optionally scoped to a compute resource or datacenter.

Include basic authentication and error handling, which should be improved on as development continues.

Resolves #6026.

Note: this change builds on #6154 and, once approved, I would like this to land as the fourth commit on `feature/vic-machine-service`.