### PR TITLE
[specific ci=3-03-Docker-Compose-Basic] Wait until container removed from network after docker-compose kill

### DIFF
--- a/tests/test-cases/Group3-Docker-Compose/3-03-Docker-Compose-Basic.robot
+++ b/tests/test-cases/Group3-Docker-Compose/3-03-Docker-Compose-Basic.robot
@@ -17,6 +17,7 @@ Documentation  Test 3-03 - Docker Compose Basic
 Resource  ../../resources/Util.robot
 Suite Setup  Install VIC Appliance To Test Server  certs=${true}
 Suite Teardown  Cleanup VIC Appliance On Test Server
+Test Teardown  Cleanup Orphan Containers
 
 *** Variables ***
 ${yml}  version: "2"\nservices:\n${SPACE}web:\n${SPACE}${SPACE}image: python:2.7\n${SPACE}${SPACE}ports:\n${SPACE}${SPACE}- "5000:5000"\n${SPACE}${SPACE}depends_on:\n${SPACE}${SPACE}- redis\n${SPACE}redis:\n${SPACE}${SPACE}image: redis\n${SPACE}${SPACE}ports:\n${SPACE}${SPACE}- "5001:5001"
@@ -31,6 +32,17 @@ Check Compose Logs
     Should Be Equal As Integers  ${rc}  0
     Should Contain  ${output}  PING aaa
     Should Not Contain  ${output}  bad address 'aaa'
+
+Cleanup Orphan Containers
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} ps -a
+    Should Be Equal As Integers  ${rc}  0
+    Log  ${output}
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} network inspect vic_default
+    Should Be Equal As Integers  ${rc}  0
+    Log  ${output}
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} rm -f $(docker %{VCH-PARAMS} -a -q)
+    Should Be Equal As Integers  ${rc}  0
+    Log  ${output}
 
 *** Test Cases ***
 Compose basic
@@ -49,6 +61,9 @@ Compose basic
     Log  ${output}
     Should Be Equal As Integers  ${rc}  0
     ${rc}  ${output}=  Run And Return Rc And Output  docker-compose %{COMPOSE-PARAMS} --file basic-compose.yml stop
+    Log  ${output}
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${output}=  Run And Return Rc And Output  docker-compose %{COMPOSE-PARAMS} --file basic-compose.yml ps
     Log  ${output}
     Should Be Equal As Integers  ${rc}  0
 

--- a/tests/test-cases/Group3-Docker-Compose/3-03-Docker-Compose-Basic.robot
+++ b/tests/test-cases/Group3-Docker-Compose/3-03-Docker-Compose-Basic.robot
@@ -40,7 +40,7 @@ Cleanup Orphan Containers
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} network inspect vic_default
     Should Be Equal As Integers  ${rc}  0
     Log  ${output}
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} rm -f $(docker %{VCH-PARAMS} -a -q)
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} rm -f $(docker %{VCH-PARAMS} ps -a -q)
     Should Be Equal As Integers  ${rc}  0
     Log  ${output}
 

--- a/tests/test-cases/Group3-Docker-Compose/3-03-Docker-Compose-Basic.robot
+++ b/tests/test-cases/Group3-Docker-Compose/3-03-Docker-Compose-Basic.robot
@@ -71,6 +71,14 @@ Compose kill
     Log  ${out}
     Should Be Equal As Integers  ${rc}  0
 
+    ${rc}  ${out}=  Run And Return Rc And Output  docker %{VCH-PARAMS} ps -a
+    Log  ${out}
+    Should Be Equal As Integers  ${rc}  0
+
+    ${rc}  ${out}=  Run And Return Rc And Output  docker %{VCH-PARAMS} network inspect vic_default
+    Log  ${out}
+    Should Be Equal As Integers  ${rc}  0
+
     Wait Until Keyword Succeeds  1 min  5 sec  Check Container Removed From Network  vic_redis_1  vic_default
 
     ${rc}  ${out}=  Run And Return Rc And Output  docker-compose %{COMPOSE-PARAMS} -f basic-compose.yml down

--- a/tests/test-cases/Group3-Docker-Compose/3-03-Docker-Compose-Basic.robot
+++ b/tests/test-cases/Group3-Docker-Compose/3-03-Docker-Compose-Basic.robot
@@ -35,8 +35,8 @@ Check Compose Logs
 Check Container Removed From Network
     [Arguments]  ${name}  ${network}
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} network inspect ${network} | jq '.[] | .Containers | .[] | .Name'
-    Should Be Equal As Integers  ${rc}  0
     Log  ${output}
+    Should Be Equal As Integers  ${rc}  0
     Should Not Contain  ${output}  ${name}
 
 *** Test Cases ***
@@ -75,11 +75,7 @@ Compose kill
     Log  ${out}
     Should Be Equal As Integers  ${rc}  0
 
-    ${rc}  ${out}=  Run And Return Rc And Output  docker %{VCH-PARAMS} network inspect vic_default
-    Log  ${out}
-    Should Be Equal As Integers  ${rc}  0
-
-    Wait Until Keyword Succeeds  1 min  5 sec  Check Container Removed From Network  vic_redis_1  vic_default
+    Wait Until Keyword Succeeds  3 min  5 sec  Check Container Removed From Network  vic_redis_1  vic_default
 
     ${rc}  ${out}=  Run And Return Rc And Output  docker-compose %{COMPOSE-PARAMS} -f basic-compose.yml down
     Log  ${out}

--- a/tests/test-cases/Group3-Docker-Compose/3-03-Docker-Compose-Basic.robot
+++ b/tests/test-cases/Group3-Docker-Compose/3-03-Docker-Compose-Basic.robot
@@ -71,7 +71,7 @@ Compose kill
     Log  ${out}
     Should Be Equal As Integers  ${rc}  0
 
-    Wait Until Keyword Succeeds  10 sec  1 sec  Check Container Removed From Network  vic_redis_1  vic_default
+    Wait Until Keyword Succeeds  1 min  5 sec  Check Container Removed From Network  vic_redis_1  vic_default
 
     ${rc}  ${out}=  Run And Return Rc And Output  docker-compose %{COMPOSE-PARAMS} -f basic-compose.yml down
     Log  ${out}


### PR DESCRIPTION
Fixes #5948 . 

Based on the discussion here https://github.com/vmware/vic/issues/5948#issuecomment-326182552, `docker-compose kill redis` may leave the container `vic_redis_1` on the network `vic_default` for some time until the vic engine receives a vsphere event of container being poweredoff, then the vic-engine would unbind the container from the network. 

Therefore, in this PR, we wait until the container is actually removed the network before `docker-compose down` to avoid the failure that `network has active endpoints`. In addition, I've also added more logs in this test to help debug in case the failure occurs again.