### PR TITLE
Run only upgrade and regression tests on tag event

### DIFF
--- a/tests/integration-test.sh
+++ b/tests/integration-test.sh
@@ -23,19 +23,22 @@ dpkg -l > package.list
 
 buildinfo=$(drone build info vmware/vic $DRONE_BUILD_NUMBER)
 
-if [[ $DRONE_BRANCH == "master" || $DRONE_BRANCH == *"refs/tags"* || $DRONE_BRANCH == "releases/"* ]] && [[ $DRONE_REPO == "vmware/vic" ]] && [[ $DRONE_BUILD_EVENT == "push" || $DRONE_BUILD_EVENT == "tag" ]]; then
+if [[ $DRONE_BRANCH == "master" || $DRONE_BRANCH == "releases/"* ]] && [[ $DRONE_REPO == "vmware/vic" ]] && [[ $DRONE_BUILD_EVENT == "push" ]]; then
     echo "Running full CI for $DRONE_BUILD_EVENT on $DRONE_BRANCH"
-	pybot --removekeywords TAG:secret --exclude skip tests/test-cases
+    pybot --removekeywords TAG:secret --exclude skip tests/test-cases
+elif [[ $DRONE_BRANCH == *"refs/tags"* ]] && [[ $DRONE_REPO == "vmware/vic" ]] && [[ $DRONE_BUILD_EVENT == "tag" ]]; then
+    echo "Running only Group11-Upgrade and 7-01-Regression for $DRONE_BUILD_EVENT on $DRONE_BRANCH"
+    pybot --removekeywords TAG:secret --suite Group11-Upgrade --suite 7-01-Regression tests/test-cases
 elif grep -q "\[full ci\]" <(drone build info vmware/vic $DRONE_BUILD_NUMBER); then
     echo "Running full CI as per commit message"
-	pybot --removekeywords TAG:secret --exclude skip tests/test-cases
+    pybot --removekeywords TAG:secret --exclude skip tests/test-cases
 elif (echo $buildinfo | grep -q "\[specific ci="); then
     echo "Running specific CI as per commit message"
-	buildtype=$(echo $buildinfo | grep "\[specific ci=")
+    buildtype=$(echo $buildinfo | grep "\[specific ci=")
     testsuite=$(echo $buildtype | awk -v FS="(=|])" '{print $2}')
     pybot --removekeywords TAG:secret --suite $testsuite --suite 7-01-Regression tests/test-cases
 else
-        echo "Running regressions"
+    echo "Running regressions"
     pybot --removekeywords TAG:secret --exclude skip --include regression tests/test-cases
 fi
 


### PR DESCRIPTION
This change borrows the `specific ci` logic to run only `Group11-Upgrade` and `7-01-Regression` tests on a tag build (`tag` event on a `*refs/tags*` branch).