### PR TITLE
[specific ci=Group6-VIC-Machine] Update debug log level to improve perfomance

### DIFF
--- a/cmd/docker/main.go
+++ b/cmd/docker/main.go
@@ -156,9 +156,14 @@ func handleFlags() bool {
 func initLogging() error {
 	logcfg := viclog.NewLoggingConfig()
 	if *cli.debug || vchConfig.Diagnostics.DebugLevel > 0 {
-		logcfg.Level = log.DebugLevel
 		trace.Logger.Level = log.DebugLevel
 		syslog.Logger.Level = log.DebugLevel
+	}
+
+	if vchConfig.Diagnostics.DebugLevel == 0 {
+		logcfg.Level = log.InfoLevel
+	} else {
+		logcfg.Level = log.DebugLevel
 	}
 
 	if vchConfig.Diagnostics.SysLogConfig != nil {

--- a/cmd/port-layer-server/main.go
+++ b/cmd/port-layer-server/main.go
@@ -88,9 +88,14 @@ func main() {
 
 	logcfg := viclog.NewLoggingConfig()
 	if vchConfig.Diagnostics.DebugLevel > 0 {
-		logcfg.Level = log.DebugLevel
 		trace.Logger.Level = log.DebugLevel
 		syslog.Logger.Level = log.DebugLevel
+	}
+
+	if vchConfig.Diagnostics.DebugLevel == 0 {
+		logcfg.Level = log.InfoLevel
+	} else {
+		logcfg.Level = log.DebugLevel
 	}
 
 	if vchConfig.Diagnostics.DebugLevel > 3 {

--- a/cmd/vic-machine/common/debug.go
+++ b/cmd/vic-machine/common/debug.go
@@ -29,7 +29,7 @@ func (d *Debug) DebugFlags(hidden bool) []cli.Flag {
 		cli.GenericFlag{
 			Name:   "debug, v",
 			Value:  flags.NewOptionalInt(&d.Debug),
-			Usage:  "[0(default),1...n], 0 is disabled, 1 is enabled, >= 1 may alter behaviour",
+			Usage:  "[0...n], 0 is disabled, 1 is enabled, >= 1 may alter behaviour",
 			Hidden: hidden,
 		},
 	}

--- a/cmd/vic-machine/create/create.go
+++ b/cmd/vic-machine/create/create.go
@@ -40,8 +40,6 @@ const (
 	MaxVirtualMachineNameLen = 80
 	// Max permitted length of Virtual Switch name
 	MaxDisplayNameLen = 31
-	// Default debug level in create
-	DefaultDebug = 1
 )
 
 var EntireOptionHelpTemplate = `NAME:
@@ -677,8 +675,7 @@ func (c *Create) Run(clic *cli.Context) (err error) {
 	log.Infof("### Installing VCH ####")
 
 	if c.Debug.Debug == nil {
-		// set default value to 1, to avoid additional step to collect logs
-		debug := DefaultDebug
+		debug := validate.DefaultDebug
 		c.Debug.Debug = &debug
 	}
 	if *c.Debug.Debug > 0 {

--- a/cmd/vicadmin/vicadm.go
+++ b/cmd/vicadmin/vicadm.go
@@ -120,9 +120,14 @@ func Init() {
 
 	logcfg := viclog.NewLoggingConfig()
 	if vchConfig.Diagnostics.DebugLevel > 0 {
-		logcfg.Level = log.DebugLevel
 		trace.Logger.Level = log.DebugLevel
 		syslog.Logger.Level = log.DebugLevel
+	}
+
+	if vchConfig.Diagnostics.DebugLevel == 0 {
+		logcfg.Level = log.InfoLevel
+	} else {
+		logcfg.Level = log.DebugLevel
 	}
 
 	if vchConfig.Diagnostics.SysLogConfig != nil {
@@ -591,7 +596,9 @@ func main() {
 	rootConfig.Thumbprint = vchConfig.TargetThumbprint
 	rootConfig.DatastorePath = vchConfig.Storage.ImageStores[0].Host
 
-	if vchConfig.Diagnostics.DebugLevel > 0 {
+	if vchConfig.Diagnostics.DebugLevel == 0 {
+		log.SetLevel(log.InfoLevel)
+	} else {
 		log.SetLevel(log.DebugLevel)
 		log.Info("Setting debug logging")
 	}

--- a/lib/install/validate/config_to_data.go
+++ b/lib/install/validate/config_to_data.go
@@ -36,6 +36,9 @@ import (
 const (
 	httpProxy  = "HTTP_PROXY"
 	httpsProxy = "HTTPS_PROXY"
+
+	// Value of debug flag during create if --debug not set
+	DefaultDebug = -1
 )
 
 // Finder is defined for easy to test
@@ -214,7 +217,13 @@ func NewDataFromConfig(ctx context.Context, finder Finder, conf *config.VirtualC
 		return
 	}
 
-	d.Debug.Debug = &conf.Diagnostics.DebugLevel
+	if conf.Diagnostics.DebugLevel == DefaultDebug {
+		// Hide the output from inspect if debug level is -1
+		debug := 0
+		d.Debug.Debug = &debug
+	} else {
+		d.Debug.Debug = &conf.Diagnostics.DebugLevel
+	}
 	if conf.ExecutorConfig.Networks[config.PublicNetworkName] != nil {
 		d.DNS = conf.ExecutorConfig.Networks[config.PublicNetworkName].Network.Nameservers
 	}

--- a/tests/test-cases/Group6-VIC-Machine/6-04-Create-Basic.md
+++ b/tests/test-cases/Group6-VIC-Machine/6-04-Create-Basic.md
@@ -101,7 +101,6 @@ vic-machine create --name=<VCH_NAME> --target=<TEST_URL> \
 
 ### Expected Outcome
 * Deployment succeed
-* VCH is deployed with debug enabled
 * Regression test pass
 
 

--- a/tests/test-cases/Group6-VIC-Machine/6-04-Create-Basic.robot
+++ b/tests/test-cases/Group6-VIC-Machine/6-04-Create-Basic.robot
@@ -58,6 +58,7 @@ Create VCH - custom base disk
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} rm -f customDiskContainer
     Should Be Equal As Integers  ${rc}  0
 
+
     Run Regression Tests
     Cleanup VIC Appliance On Test Server
 
@@ -126,9 +127,6 @@ Create VCH - defaults
     Run Keyword If  '%{HOST_TYPE}' == 'ESXi'  Should Contain  ${output}  Installer completed successfully
     Run Keyword If  '%{HOST_TYPE}' == 'ESXi'  Get Docker Params  ${output}  ${true}
     Log To Console  Installer completed successfully: %{VCH-NAME}
-
-    ${output}=  Run  bin/vic-machine-linux inspect config --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT}
-    Should Contain  ${output}  --debug=1
 
     Run Regression Tests
     Cleanup VIC Appliance On Test Server


### PR DESCRIPTION
Vic-machine with NO value set for --debug flag will continue to set all
components to log level info except the persona, portlayer, and vicadmin
servers.

Vic-machine with explicit settings for --debug flag will respect the level
for all components.

Resolves #6183