### PR TITLE
[skip ci] Remove dangling container during network rm

### DIFF
--- a/lib/portlayer/network/context.go
+++ b/lib/portlayer/network/context.go
@@ -1270,16 +1270,19 @@ func (c *Context) DeleteScope(ctx context.Context, name string) error {
 	}
 
 	// remove dangling endpoints
-	for _, eps := range s.Endpoints() {
-		if exec.Containers.Container(eps.ID().String()) == nil {
-			log.Debugf("Remove dangling endpoint (%s)", eps.ID().String())
-			if err = s.RemoveContainer(eps.Container()); err != nil {
-				return fmt.Errorf("failed to remove dangling endpoint (%s): %s", eps.ID().String(), err.Error())
+	if exec.Containers != nil {
+		for _, eps := range s.Endpoints() {
+			if exec.Containers.Container(eps.ID().String()) == nil {
+				log.Debugf("Remove dangling endpoint (%s)", eps.ID().String())
+				if err = s.RemoveContainer(eps.Container()); err != nil {
+					return fmt.Errorf("failed to remove dangling endpoint (%s): %s", eps.ID().String(), err.Error())
+				}
 			}
-		} else {
-			log.Errorf("%s has active endpoint (%s)", s.Name(), eps.ID().String())
-			return fmt.Errorf("%s has active endpoints", s.Name())
 		}
+	}
+
+	if len(s.Endpoints()) != 0 {
+		return fmt.Errorf("%s has active endpoints", s.Name())
 	}
 
 	var allZeros, allOnes net.IP

--- a/lib/portlayer/network/context.go
+++ b/lib/portlayer/network/context.go
@@ -1269,8 +1269,17 @@ func (c *Context) DeleteScope(ctx context.Context, name string) error {
 		return fmt.Errorf("cannot remove builtin scope")
 	}
 
-	if len(s.Endpoints()) != 0 {
-		return fmt.Errorf("%s has active endpoints", s.Name())
+	// remove dangling endpoints
+	for _, eps := range s.Endpoints() {
+		if exec.Containers.Container(eps.ID().String()) == nil {
+			log.Debugf("Remove dangling endpoint (%s)", eps.ID().String())
+			if err = s.RemoveContainer(eps.Container()); err != nil {
+				return fmt.Errorf("failed to remove dangling endpoint (%s): %s", eps.ID().String(), err.Error())
+			}
+		} else {
+			log.Errorf("%s has active endpoint (%s)", s.Name(), eps.ID().String())
+			return fmt.Errorf("%s has active endpoints", s.Name())
+		}
 	}
 
 	var allZeros, allOnes net.IP


### PR DESCRIPTION
Fixes #5948 . 

The reason we observe `network has active endpoints` failure during `docker-compose down` is because that a container is already removed from the PL container cached but still exists in the network layer container cache. We refer to such a container as a `dangling` container on the network.

In this PR, when `network rm` is called, we remove these dangling containers (if any).