### PR TITLE
[specific ci=1-14-Docker-Kill] publish containerPoweredOff event after kill

### DIFF
--- a/lib/portlayer/exec/container.go
+++ b/lib/portlayer/exec/container.go
@@ -452,7 +452,11 @@ func (c *Container) Signal(ctx context.Context, num int64) error {
 	}
 
 	if num == int64(syscall.SIGKILL) {
-		return c.containerBase.kill(ctx)
+		err := c.containerBase.kill(ctx)
+		if err == nil {
+			publishContainerEvent(c.ExecConfig.ID, time.Now(), events.ContainerPoweredOff)
+		}
+		return err
 	}
 
 	return c.startGuestProgram(ctx, "kill", fmt.Sprintf("%d", num))


### PR DESCRIPTION
Fixes #5948 

This PR should be able to at least alleviate the failure seen in our recent compost tests.

In the issue, when the VMPoweredOff event was to be processed, the container had already been removed from cache; therefore, we couldn't unbind the container from network. In this PR, we publish the containerPoweredOff event as soon as it is killed. This should guarantee that the container can be unbound from network most of the time. But it still does not fully resolve the race condition.

I think the race condition revealed by the compose test is quite general in our code and we need a comprehensive design for how to handle the async events, instead of changing our current logic for `network rm` and/or `container rm` as a fix. 


