### PR TITLE
[skip ci] Switch to debug zero and use additional args

### DIFF
--- a/tests/manual-test-cases/Group14-Longevity/14-1-Longevity.robot
+++ b/tests/manual-test-cases/Group14-Longevity/14-1-Longevity.robot
@@ -23,10 +23,10 @@ Longevity
     :FOR  ${idx}  IN RANGE  0  48
     \   ${rand}=  Evaluate  random.randint(10, 50)  modules=random
     \   Log To Console  \nLoop: ${idx}
-    \   Install VIC Appliance To Test Server  vol=default %{STATIC_VCH_OPTIONS}
+    \   Install VIC Appliance To Test Server  debug=0  additional-args=%{STATIC_VCH_OPTIONS}
     \   Repeat Keyword  ${rand} times  Run Regression Tests
     \   Cleanup VIC Appliance On Test Server
     \   ${rand}=  Evaluate  random.randint(10, 50)  modules=random
-    \   Install VIC Appliance To Test Server  certs=${true}  vol=default %{STATIC_VCH_OPTIONS}
+    \   Install VIC Appliance To Test Server  debug=0  certs=${true}  additional-args=%{STATIC_VCH_OPTIONS}
     \   Repeat Keyword  ${rand} times  Run Regression Tests
     \   Cleanup VIC Appliance On Test Server

--- a/tests/manual-test-cases/Group14-Longevity/14-2-Longevity-Single-VCH.robot
+++ b/tests/manual-test-cases/Group14-Longevity/14-2-Longevity-Single-VCH.robot
@@ -20,7 +20,7 @@ Test Teardown  Run Keyword If Test Failed  Run  govc logs.download
 *** Test Cases ***
 Longevity - Single - VCH
     # Just install with certs, as it is our most common expected install path
-    Install VIC Appliance To Test Server  certs=${true}  vol=default %{STATIC_VCH_OPTIONS}
+    Install VIC Appliance To Test Server  debug=0  certs=${true}  additional-args=%{STATIC_VCH_OPTIONS}
     # Each regression test takes about 1-2 minutes, so round down and call it a minute
     # 2880 is the number of minutes in 2 days
     :FOR  ${idx}  IN RANGE  0  2880
@@ -29,6 +29,6 @@ Longevity - Single - VCH
     
     Cleanup VIC Appliance On Test Server
     
-    Install VIC Appliance To Test Server  certs=${true}  vol=default %{STATIC_VCH_OPTIONS}
+    Install VIC Appliance To Test Server  debug=0  certs=${true}  additional-args=%{STATIC_VCH_OPTIONS}
     Run Regression Tests
     Cleanup VIC Appliance On Test Server


### PR DESCRIPTION
Debug 0 is more accurate to how customers should/will be using VIC.