### PR TITLE
[full ci] Add a test timeout within the drone timeout limit

### DIFF
--- a/tests/resources/Util.robot
+++ b/tests/resources/Util.robot
@@ -33,5 +33,3 @@ Resource  OVA-Util.robot
 Resource  Cert-Util.robot
 
 Variables  dynamic-vars.py
-
-Test Timeout    25 minutes

--- a/tests/resources/Util.robot
+++ b/tests/resources/Util.robot
@@ -33,3 +33,5 @@ Resource  OVA-Util.robot
 Resource  Cert-Util.robot
 
 Variables  dynamic-vars.py
+
+Test Timeout    25 minutes

--- a/tests/test-cases/Group1-Docker-Commands/1-01-Docker-Info.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-01-Docker-Info.robot
@@ -17,6 +17,7 @@ Documentation  Test 1-01 - Docker Info
 Resource  ../../resources/Util.robot
 Suite Setup  Install VIC Appliance To Test Server
 Suite Teardown  Cleanup VIC Appliance On Test Server
+Test Timeout  20 minutes
 
 *** Keywords ***
 Get resource pool CPU and mem limits

--- a/tests/test-cases/Group1-Docker-Commands/1-02-Docker-Pull.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-02-Docker-Pull.robot
@@ -17,6 +17,7 @@ Documentation  Test 1-02 - Docker Pull
 Resource  ../../resources/Util.robot
 Suite Setup  Install VIC Appliance To Test Server
 Suite Teardown  Cleanup VIC Appliance On Test Server
+Test Timeout  20 minutes
 
 *** Test Cases ***
 Pull nginx

--- a/tests/test-cases/Group1-Docker-Commands/1-03-Docker-Images.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-03-Docker-Images.robot
@@ -17,6 +17,7 @@ Documentation  Test 1-03 - Docker Images
 Resource  ../../resources/Util.robot
 Suite Setup  Install VIC Appliance To Test Server
 Suite Teardown  Cleanup VIC Appliance On Test Server
+Test Timeout  20 minutes
 
 *** Test Cases ***
 Simple images

--- a/tests/test-cases/Group1-Docker-Commands/1-04-Docker-Create.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-04-Docker-Create.robot
@@ -17,6 +17,7 @@ Documentation  Test 1-04 - Docker Create
 Resource  ../../resources/Util.robot
 Suite Setup  Install VIC Appliance To Test Server
 Suite Teardown  Cleanup VIC Appliance On Test Server
+Test Timeout  20 minutes
 
 *** Test Cases ***
 Simple creates

--- a/tests/test-cases/Group1-Docker-Commands/1-05-Docker-Start.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-05-Docker-Start.robot
@@ -17,6 +17,7 @@ Documentation  Test 1-05 - Docker Start
 Resource  ../../resources/Util.robot
 Suite Setup  Install VIC Appliance To Test Server
 Suite Teardown  Cleanup VIC Appliance On Test Server
+Test Timeout  20 minutes
 
 *** Test Cases ***
 Simple start

--- a/tests/test-cases/Group1-Docker-Commands/1-06-Docker-Run.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-06-Docker-Run.robot
@@ -17,6 +17,7 @@ Documentation  Test 1-06 - Docker Run
 Resource  ../../resources/Util.robot
 Suite Setup  Install VIC Appliance To Test Server
 Suite Teardown  Cleanup VIC Appliance On Test Server
+Test Timeout  20 minutes
 
 *** Keywords ***
 Make sure container starts

--- a/tests/test-cases/Group1-Docker-Commands/1-07-Docker-Stop.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-07-Docker-Stop.robot
@@ -17,6 +17,7 @@ Documentation  Test 1-07 - Docker Stop
 Resource  ../../resources/Util.robot
 Suite Setup  Install VIC Appliance To Test Server
 Suite Teardown  Cleanup VIC Appliance On Test Server
+Test Timeout  20 minutes
 
 *** Keywords ***
 Trap Signal Command

--- a/tests/test-cases/Group1-Docker-Commands/1-08-Docker-Logs.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-08-Docker-Logs.robot
@@ -17,6 +17,7 @@ Documentation  Test 1-08 - Docker Logs
 Resource  ../../resources/Util.robot
 Suite Setup  Install VIC with version to Test Server  7315
 Suite Teardown  Cleanup VIC Appliance On Test Server
+Test Timeout  20 minutes
 
 *** Keywords ***
 Grep Logs And Count Lines

--- a/tests/test-cases/Group1-Docker-Commands/1-09-Docker-Attach.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-09-Docker-Attach.robot
@@ -17,6 +17,7 @@ Documentation  Test 1-09 - Docker Attach
 Resource  ../../resources/Util.robot
 Suite Setup  Install VIC Appliance To Test Server
 Suite Teardown  Cleanup VIC Appliance On Test Server
+Test Timeout  20 minutes
 
 *** Test Cases ***
 Basic attach

--- a/tests/test-cases/Group1-Docker-Commands/1-10-Docker-PS.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-10-Docker-PS.robot
@@ -17,6 +17,7 @@ Documentation  Test 1-10 - Docker PS
 Resource  ../../resources/Util.robot
 Suite Setup  Install VIC Appliance To Test Server
 Suite Teardown  Cleanup VIC Appliance On Test Server
+Test Timeout  20 minutes
 
 *** Keywords ***
 Assert VM Power State

--- a/tests/test-cases/Group1-Docker-Commands/1-11-Docker-RM.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-11-Docker-RM.robot
@@ -17,6 +17,7 @@ Documentation  Test 1-11 - Docker RM
 Resource  ../../resources/Util.robot
 Suite Setup  Install VIC Appliance To Test Server
 Suite Teardown  Cleanup VIC Appliance On Test Server
+Test Timeout  20 minutes
 
 *** Keywords ***
 Check That VM Is Removed

--- a/tests/test-cases/Group1-Docker-Commands/1-12-Docker-RMI.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-12-Docker-RMI.robot
@@ -17,6 +17,7 @@ Documentation  Test 1-12 - Docker RMI
 Resource  ../../resources/Util.robot
 Suite Setup  Install VIC Appliance To Test Server
 Suite Teardown  Cleanup VIC Appliance On Test Server
+Test Timeout  20 minutes
 
 *** Test Cases ***
 Basic docker pull, restart, and remove image

--- a/tests/test-cases/Group1-Docker-Commands/1-13-Docker-Version.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-13-Docker-Version.robot
@@ -17,6 +17,7 @@ Documentation  Test 1-13 - Docker Version
 Resource  ../../resources/Util.robot
 Suite Setup  Install VIC Appliance To Test Server
 Suite Teardown  Cleanup VIC Appliance On Test Server
+Test Timeout  20 minutes
 
 *** Test Cases ***
 Simple Docker Version

--- a/tests/test-cases/Group1-Docker-Commands/1-14-Docker-Kill.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-14-Docker-Kill.robot
@@ -17,6 +17,7 @@ Documentation  Test 1-14 - Docker Kill
 Resource  ../../resources/Util.robot
 Suite Setup  Install VIC Appliance To Test Server
 Suite Teardown  Cleanup VIC Appliance On Test Server
+Test Timeout  20 minutes
 
 *** Keywords ***
 Trap Signal Command

--- a/tests/test-cases/Group1-Docker-Commands/1-15-Docker-Network-Create.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-15-Docker-Network-Create.robot
@@ -17,6 +17,7 @@ Documentation  Test 1-15 - Docker Network Create
 Resource  ../../resources/Util.robot
 Suite Setup  Install VIC Appliance To Test Server
 Suite Teardown  Cleanup VIC Appliance On Test Server
+Test Timeout  20 minutes
 
 *** Test Cases ***
 Basic network create

--- a/tests/test-cases/Group1-Docker-Commands/1-16-Docker-Network-LS.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-16-Docker-Network-LS.robot
@@ -17,6 +17,7 @@ Documentation  Test 1-16 - Docker Network LS
 Resource  ../../resources/Util.robot
 Suite Setup  Install VIC Appliance To Test Server  certs=${false}
 Suite Teardown  Cleanup VIC Appliance On Test Server
+Test Timeout  20 minutes
 
 *** Test Cases ***
 Basic network ls

--- a/tests/test-cases/Group1-Docker-Commands/1-17-Docker-Network-Connect.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-17-Docker-Network-Connect.robot
@@ -17,6 +17,7 @@ Documentation  Test 1-17 - Docker Network Connect
 Resource  ../../resources/Util.robot
 Suite Setup  Install VIC Appliance To Test Server  certs=${false}
 Suite Teardown  Cleanup VIC Appliance On Test Server
+Test Timeout  20 minutes
 
 *** Test Cases ***
 Connect containers to multiple bridge networks overlapping

--- a/tests/test-cases/Group1-Docker-Commands/1-18-Docker-Network-RM.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-18-Docker-Network-RM.robot
@@ -17,6 +17,7 @@ Documentation  Test 1-18 - Docker Network RM
 Resource  ../../resources/Util.robot
 Suite Setup  Install VIC Appliance To Test Server
 Suite Teardown  Cleanup VIC Appliance On Test Server
+Test Timeout  20 minutes
 
 *** Test Cases ***
 Basic network remove

--- a/tests/test-cases/Group1-Docker-Commands/1-19-Docker-Volume-Create.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-19-Docker-Volume-Create.robot
@@ -17,6 +17,7 @@ Documentation  Test 1-19 - Docker Volume Create
 Resource  ../../resources/Util.robot
 Suite Setup  Install VIC Appliance To Test Server
 Suite Teardown  Cleanup VIC Appliance On Test Server
+Test Timeout  20 minutes
 
 *** Test Cases ***
 Simple docker volume create

--- a/tests/test-cases/Group1-Docker-Commands/1-20-Docker-Volume-Inspect.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-20-Docker-Volume-Inspect.robot
@@ -17,6 +17,7 @@ Documentation  Test 1-20 - Docker Volume Inspect
 Resource  ../../resources/Util.robot
 Suite Setup  Install VIC Appliance To Test Server
 Suite Teardown  Cleanup VIC Appliance On Test Server
+Test Timeout  20 minutes
 
 *** Test Cases ***
 Simple docker volume inspect

--- a/tests/test-cases/Group1-Docker-Commands/1-21-Docker-Volume-LS.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-21-Docker-Volume-LS.robot
@@ -17,6 +17,7 @@ Documentation  Test 1-21 - Docker Volume LS
 Resource  ../../resources/Util.robot
 Suite Setup  Install VIC Appliance To Test Server
 Suite Teardown  Cleanup VIC Appliance On Test Server
+Test Timeout  20 minutes
 
 *** Test Cases ***
 Simple volume ls

--- a/tests/test-cases/Group1-Docker-Commands/1-22-Docker-Volume-RM.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-22-Docker-Volume-RM.robot
@@ -17,6 +17,7 @@ Documentation  Test 1-22 - Docker Volume RM
 Resource  ../../resources/Util.robot
 Suite Setup  Install VIC Appliance To Test Server
 Suite Teardown  Cleanup VIC Appliance On Test Server
+Test Timeout  20 minutes
 
 *** Test Cases ***
 Simple volume rm

--- a/tests/test-cases/Group1-Docker-Commands/1-23-Docker-Inspect.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-23-Docker-Inspect.robot
@@ -17,6 +17,7 @@ Documentation  Test 1-23 - Docker Inspect
 Resource  ../../resources/Util.robot
 Suite Setup  Install VIC Appliance To Test Server  certs=${false}
 Suite Teardown  Cleanup VIC Appliance On Test Server
+Test Timeout  20 minutes
 
 *** Test Cases ***
 Simple docker inspect of image

--- a/tests/test-cases/Group1-Docker-Commands/1-24-Docker-Link.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-24-Docker-Link.robot
@@ -17,6 +17,7 @@ Documentation  Test 1-24 - Docker Link
 Resource  ../../resources/Util.robot
 Suite Setup  Install VIC Appliance To Test Server
 Suite Teardown  Cleanup VIC Appliance On Test Server
+Test Timeout  20 minutes
 
 *** Test Cases ***
 Link and alias

--- a/tests/test-cases/Group1-Docker-Commands/1-25-Docker-Port-Map.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-25-Docker-Port-Map.robot
@@ -17,6 +17,7 @@ Documentation  Test 1-25 - Docker Port Map
 Resource  ../../resources/Util.robot
 Suite Setup  Install VIC Appliance To Test Server  certs=${false}
 Suite Teardown  Cleanup VIC Appliance On Test Server
+Test Timeout  20 minutes
 
 *** Test Cases ***
 Create container with port mappings

--- a/tests/test-cases/Group1-Docker-Commands/1-26-Docker-Hello-World.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-26-Docker-Hello-World.robot
@@ -17,6 +17,7 @@ Documentation  Test 1-26 - Docker Hello World
 Resource  ../../resources/Util.robot
 Suite Setup  Install VIC Appliance To Test Server
 Suite Teardown  Cleanup VIC Appliance On Test Server
+Test Timeout  20 minutes
 
 *** Test Cases ***
 Hello world

--- a/tests/test-cases/Group1-Docker-Commands/1-27-Docker-Login.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-27-Docker-Login.robot
@@ -17,6 +17,7 @@ Documentation  Test 1-27 - Docker Login
 Resource  ../../resources/Util.robot
 Suite Setup  Install VIC Appliance To Test Server  certs=${false}
 Suite Teardown  Cleanup VIC Appliance On Test Server
+Test Timeout  20 minutes
 
 *** Test Cases ***
 Docker login and pull from docker.io

--- a/tests/test-cases/Group1-Docker-Commands/1-28-Docker-Secret.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-28-Docker-Secret.robot
@@ -17,6 +17,7 @@ Documentation  Test 1-28 - Docker Secret
 Resource  ../../resources/Util.robot
 Suite Setup  Install VIC Appliance To Test Server  certs=${false}
 Suite Teardown  Cleanup VIC Appliance On Test Server
+Test Timeout  20 minutes
 
 *** Variables ***
 ${fake-secret}  test

--- a/tests/test-cases/Group1-Docker-Commands/1-29-Docker-Checkpoint.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-29-Docker-Checkpoint.robot
@@ -17,6 +17,7 @@ Documentation  Test 1-29 - Docker Checkpoint
 Resource  ../../resources/Util.robot
 Suite Setup  Install VIC Appliance To Test Server  certs=${false}
 Suite Teardown  Cleanup VIC Appliance On Test Server
+Test Timeout  20 minutes
 
 *** Test Cases ***
 Docker checkpoint create

--- a/tests/test-cases/Group1-Docker-Commands/1-30-Docker-Deploy.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-30-Docker-Deploy.robot
@@ -17,6 +17,7 @@ Documentation  Test 1-30 - Docker Deploy
 Resource  ../../resources/Util.robot
 Suite Setup  Install VIC Appliance To Test Server  certs=${false}
 Suite Teardown  Cleanup VIC Appliance On Test Server
+Test Timeout  20 minutes
 
 *** Test Cases ***
 Docker deploy

--- a/tests/test-cases/Group1-Docker-Commands/1-31-Docker-Node.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-31-Docker-Node.robot
@@ -17,6 +17,7 @@ Documentation  Test 1-31 - Docker Node
 Resource  ../../resources/Util.robot
 Suite Setup  Install VIC Appliance To Test Server  certs=${false}
 Suite Teardown  Cleanup VIC Appliance On Test Server
+Test Timeout  20 minutes
 
 *** Test Cases ***
 Docker node demote

--- a/tests/test-cases/Group1-Docker-Commands/1-32-Docker-Plugin.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-32-Docker-Plugin.robot
@@ -17,6 +17,7 @@ Documentation  Test 1-32 - Docker plugin
 Resource  ../../resources/Util.robot
 Suite Setup  Install VIC Appliance To Test Server  certs=${false}
 Suite Teardown  Cleanup VIC Appliance On Test Server
+Test Timeout  20 minutes
 
 *** Test Cases ***
 Docker plugin install

--- a/tests/test-cases/Group1-Docker-Commands/1-33-Docker-Service.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-33-Docker-Service.robot
@@ -17,6 +17,7 @@ Documentation  Test 1-33 - Docker Service
 Resource  ../../resources/Util.robot
 Suite Setup  Install VIC Appliance To Test Server  certs=${false}
 Suite Teardown  Cleanup VIC Appliance On Test Server
+Test Timeout  20 minutes
 
 *** Test Cases ***
 Docker service create 

--- a/tests/test-cases/Group1-Docker-Commands/1-34-Docker-Stack.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-34-Docker-Stack.robot
@@ -17,6 +17,7 @@ Documentation  Test 1-34 - Docker Stack
 Resource  ../../resources/Util.robot
 Suite Setup  Install VIC Appliance To Test Server  certs=${false}
 Suite Teardown  Cleanup VIC Appliance On Test Server
+Test Timeout  20 minutes
 
 *** Test Cases ***
 #Docker stack deploy

--- a/tests/test-cases/Group1-Docker-Commands/1-35-Docker-Swarm.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-35-Docker-Swarm.robot
@@ -17,6 +17,7 @@ Documentation  Test 1-35 - Docker Swarm
 Resource  ../../resources/Util.robot
 Suite Setup  Install VIC Appliance To Test Server  certs=${false}
 Suite Teardown  Cleanup VIC Appliance On Test Server
+Test Timeout  20 minutes
 
 *** Test Cases ***
 Docker swarm init

--- a/tests/test-cases/Group1-Docker-Commands/1-36-Docker-Rename.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-36-Docker-Rename.robot
@@ -17,6 +17,7 @@ Documentation  Test 1-36 - Docker Rename
 Resource  ../../resources/Util.robot
 Suite Setup  Install VIC Appliance To Test Server
 Suite Teardown  Cleanup VIC Appliance On Test Server
+Test Timeout  20 minutes
 
 *** Test Cases ***
 Rename a non-existent container

--- a/tests/test-cases/Group1-Docker-Commands/1-37-Docker-USER.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-37-Docker-USER.robot
@@ -17,6 +17,7 @@ Documentation   Test 1-37 - Docker Run As USER
 Resource        ../../resources/Util.robot
 Suite Setup     Install VIC Appliance To Test Server
 Suite Teardown  Cleanup VIC Appliance On Test Server
+Test Timeout  20 minutes
 
 *** Test Cases ***
 Run Image Specifying NewUser in NewGroup

--- a/tests/test-cases/Group1-Docker-Commands/1-38-Docker-Exec.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-38-Docker-Exec.robot
@@ -17,6 +17,7 @@ Documentation  Test 1-38 - Docker Exec
 Resource  ../../resources/Util.robot
 Suite Setup  Install VIC Appliance To Test Server
 Suite Teardown  Cleanup VIC Appliance On Test Server
+Test Timeout  20 minutes
 
 *** Test Cases ***
 Exec -d

--- a/tests/test-cases/Group1-Docker-Commands/1-39-Docker-Stats.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-39-Docker-Stats.robot
@@ -17,6 +17,7 @@ Documentation   Test 1-39 - Docker Stats
 Resource        ../../resources/Util.robot
 Suite Setup     Install VIC Appliance To Test Server
 Suite Teardown  Cleanup VIC Appliance On Test Server
+Test Timeout  20 minutes
 
 *** Keywords ***
 Get Average Active Memory

--- a/tests/test-cases/Group1-Docker-Commands/1-40-Docker-Restart.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-40-Docker-Restart.robot
@@ -17,6 +17,7 @@ Documentation   Test 1-40 - Docker Restart
 Resource        ../../resources/Util.robot
 Suite Setup     Install VIC Appliance To Test Server
 Suite Teardown  Cleanup VIC Appliance On Test Server
+Test Timeout  20 minutes
 
 *** Keywords ***
 

--- a/tests/test-cases/Group1-Docker-Commands/1-41-Docker-Commit.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-41-Docker-Commit.robot
@@ -17,6 +17,7 @@ Documentation  Test 1-41 - Docker Commit
 Resource  ../../resources/Util.robot
 Suite Setup  Install VIC Appliance To Test Server
 Suite Teardown  Cleanup VIC Appliance On Test Server
+Test Timeout  20 minutes
 
 *** Test Cases ***
 Commit nano to image

--- a/tests/test-cases/Group1-Docker-Commands/1-42-Docker-Diff.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-42-Docker-Diff.robot
@@ -17,6 +17,7 @@ Documentation  Test 1-42 - Docker Diff
 Resource  ../../resources/Util.robot
 Suite Setup  Install VIC Appliance To Test Server
 Suite Teardown  Cleanup VIC Appliance On Test Server
+Test Timeout  20 minutes
 
 *** Test Cases ***
 Make changes to busybox image

--- a/tests/test-cases/Group1-Docker-Commands/1-43-Docker-CP-Offline.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-43-Docker-CP-Offline.robot
@@ -17,6 +17,7 @@ Documentation  Test 1-43 - Docker CP Offline
 Resource  ../../resources/Util.robot
 Suite Setup  Set up test files and install VIC appliance to test server
 Suite Teardown  Clean up test files and VIC appliance to test server
+Test Timeout  20 minutes
 
 *** Keywords ***
 Set up test files and install VIC appliance to test server

--- a/tests/test-cases/Group1-Docker-Commands/1-44-Docker-CP-Online.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-44-Docker-CP-Online.robot
@@ -17,6 +17,7 @@ Documentation  Test 1-44 - Docker CP Online
 Resource  ../../resources/Util.robot
 Suite Setup  Set up test files and install VIC appliance to test server
 Suite Teardown  Clean up test files and VIC appliance to test server
+Test Timeout  20 minutes
 
 *** Keywords ***
 Set up test files and install VIC appliance to test server


### PR DESCRIPTION
We are seeing more and more drone inactivity timeouts within our CI tests, this forces a kill before hitting that timeout so that we can collect logs.