### PR TITLE
[specific ci=Group10-VCH-Restart] toolbox: avoid race when closing channels on stop

### DIFF
--- a/vendor/github.com/vmware/govmomi/toolbox/service.go
+++ b/vendor/github.com/vmware/govmomi/toolbox/service.go
@@ -164,6 +164,7 @@ func (s *Service) Start() error {
 		for {
 			select {
 			case <-s.stop:
+				s.stopChannel()
 				return
 			case <-time.After(time.Millisecond * 10 * s.delay):
 				if err = s.checkReset(); err != nil {
@@ -197,8 +198,6 @@ func (s *Service) Start() error {
 // Stop cancels the RPC listener routine created via Start
 func (s *Service) Stop() {
 	close(s.stop)
-
-	s.stopChannel()
 }
 
 // Wait blocks until Start returns, allowing any current RPC in progress to complete.


### PR DESCRIPTION
It was possible for the Stop() method close the RPC channels when
the main loop was in the middle of Send/Receive.
