### PR TITLE
toolbox: avoid race when closing channels on stop

### DIFF
--- a/vendor/github.com/vmware/govmomi/toolbox/service.go
+++ b/vendor/github.com/vmware/govmomi/toolbox/service.go
@@ -164,6 +164,7 @@ func (s *Service) Start() error {
 		for {
 			select {
 			case <-s.stop:
+				s.stopChannel()
 				return
 			case <-time.After(time.Millisecond * 10 * s.delay):
 				if err = s.checkReset(); err != nil {
@@ -197,8 +198,6 @@ func (s *Service) Start() error {
 // Stop cancels the RPC listener routine created via Start
 func (s *Service) Stop() {
 	close(s.stop)
-
-	s.stopChannel()
 }
 
 // Wait blocks until Start returns, allowing any current RPC in progress to complete.

--- a/vendor/manifest
+++ b/vendor/manifest
@@ -1070,7 +1070,7 @@
 			"importpath": "github.com/vmware/govmomi",
 			"repository": "https://github.com/vmware/govmomi",
 			"vcs": "git",
-			"revision": "6ce8848e808c01db99dea4064068cebe230b11a5",
+			"revision": "17b8c9ccb7f8c7b015d44c4ea39305c970a7bf31",
 			"branch": "master",
 			"notests": true
 		},


### PR DESCRIPTION
It was possible for the Stop() method close the RPC channels when
the main loop was in the middle of Send/Receive.
