### PR TITLE
[specific ci=1-07-Docker-Stop] Detect VM poweredoff state to avoid hard poweroff during docker stop

### DIFF
--- a/lib/apiservers/engine/backends/container.go
+++ b/lib/apiservers/engine/backends/container.go
@@ -109,6 +109,7 @@ const (
 	// Default timeout to stop a container if not specified in container config
 	DefaultStopTimeout = 10
 
+	// maximum elapsed time for retry
 	maxElapsedTime = 2 * time.Minute
 )
 
@@ -1252,7 +1253,7 @@ func (c *Container) ContainerStop(name string, seconds *int) error {
 	config := retry.NewBackoffConfig()
 	config.MaxElapsedTime = maxElapsedTime
 	if err := retry.DoWithConfig(operation, IsConflictError, config); err != nil {
-		return ConflictError(err.Error()+" --- Retrying the operation may resolve the issue.")
+		return ConflictError(err.Error() + " --- Retrying the operation may resolve the issue.")
 	}
 
 	actor := CreateContainerEventActorWithAttributes(vc, map[string]string{})

--- a/lib/apiservers/engine/backends/container.go
+++ b/lib/apiservers/engine/backends/container.go
@@ -1253,7 +1253,7 @@ func (c *Container) ContainerStop(name string, seconds *int) error {
 	config := retry.NewBackoffConfig()
 	config.MaxElapsedTime = maxElapsedTime
 	if err := retry.DoWithConfig(operation, IsConflictError, config); err != nil {
-		return ConflictError(err.Error() + " --- Retrying the operation may resolve the issue.")
+		return err
 	}
 
 	actor := CreateContainerEventActorWithAttributes(vc, map[string]string{})

--- a/lib/portlayer/exec/base.go
+++ b/lib/portlayer/exec/base.go
@@ -34,7 +34,11 @@ import (
 	"github.com/vmware/vic/pkg/vsphere/vm"
 
 	log "github.com/Sirupsen/logrus"
+	"strings"
 )
+
+// The full string should be "The attempted operation cannot be performed in the current state (Powered off)"
+const opNotPerformedPoweredOff = "current state (Powered off)"
 
 // NotYetExistError is returned when a call that requires a VM exist is made
 type NotYetExistError struct {
@@ -253,6 +257,10 @@ func (c *containerBase) kill(ctx context.Context) error {
 	}
 	if err != nil {
 		log.Warnf("killing %s attempt resulted in: %s", c.ExecConfig.ID, err)
+
+		if strings.Contains(err.Error(), opNotPerformedPoweredOff) {
+			return nil
+		}
 	}
 
 	// Even if startGuestProgram failed above, it may actually have executed.  If the container came up and then
@@ -302,6 +310,12 @@ func (c *containerBase) shutdown(ctx context.Context, waitTime *int32) error {
 			// Just warn and proceed to waiting for power state per issue https://github.com/vmware/vic/issues/5803
 			// Description above in function kill()
 			log.Warnf("%s: %s", msg, err)
+			
+			// If the error tells us "The attempted operation cannot be performed in the current state (Powered off)", we can safely
+			// return nil and avoid hard poweroff (issues #6236 and #6252)
+			if strings.Contains(err.Error(), opNotPerformedPoweredOff) {
+				return nil
+			}
 		}
 
 		log.Infof("waiting %s for %s to power off", wait, c.ExecConfig.ID)

--- a/lib/portlayer/exec/base.go
+++ b/lib/portlayer/exec/base.go
@@ -17,6 +17,7 @@ package exec
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"golang.org/x/crypto/ssh"
@@ -34,7 +35,6 @@ import (
 	"github.com/vmware/vic/pkg/vsphere/vm"
 
 	log "github.com/Sirupsen/logrus"
-	"strings"
 )
 
 // The full string should be "The attempted operation cannot be performed in the current state (Powered off)"

--- a/lib/portlayer/exec/base.go
+++ b/lib/portlayer/exec/base.go
@@ -311,7 +311,8 @@ func (c *containerBase) shutdown(ctx context.Context, waitTime *int32) error {
 			log.Warnf("%s: %s", msg, err)
 
 			// If the error tells us "The attempted operation cannot be performed in the current state (Powered off)" (InvalidPowerState),
-			// we can safely return nil and avoid hard poweroff (issues #6236 and #6252)
+			// we can avoid hard poweroff (issues #6236 and #6252). Here we wait for the power state changes instead of return
+			// immediately to avoid excess vSphere queries
 			if isInvalidPowerStateError(err) {
 				killed = true
 			}

--- a/lib/portlayer/exec/base.go
+++ b/lib/portlayer/exec/base.go
@@ -310,7 +310,7 @@ func (c *containerBase) shutdown(ctx context.Context, waitTime *int32) error {
 			// Just warn and proceed to waiting for power state per issue https://github.com/vmware/vic/issues/5803
 			// Description above in function kill()
 			log.Warnf("%s: %s", msg, err)
-			
+
 			// If the error tells us "The attempted operation cannot be performed in the current state (Powered off)", we can safely
 			// return nil and avoid hard poweroff (issues #6236 and #6252)
 			if strings.Contains(err.Error(), opNotPerformedPoweredOff) {


### PR DESCRIPTION
Fixes #6236 

- this PR avoids the subsequent c.poweroff() if the previous `SIGKILL` or `SIGTERM` already bring the containerVM down.

- this PR increases the maximum elapsed time to 2min for the retry logic during `containerStop()` in backend/container.go

- this PR may also help with #6252 