### PR TITLE
Fix panic when vSphere session goes away

### DIFF
--- a/cmd/vicadmin/server.go
+++ b/cmd/vicadmin/server.go
@@ -168,10 +168,11 @@ func (s *server) Authenticated(link string, handler func(http.ResponseWriter, *h
 	defer trace.End(trace.Begin(""))
 
 	authHandler := func(w http.ResponseWriter, r *http.Request) {
-		// #nosec: Errors unhandled.
-		websession, _ := s.uss.cookies.Get(r, sessionCookieKey) // ignore error because it is okay if it doesn't exist
+		// #nosec: Errors unhandled because it is okay if the cookie doesn't exist.
+		websession, _ := s.uss.cookies.Get(r, sessionCookieKey)
 
-		if len(r.TLS.PeerCertificates) > 0 { // the user is authenticated by certificate at connection time
+		if len(r.TLS.PeerCertificates) > 0 {
+			// the user is authenticated by certificate at connection time
 			log.Infof("Authenticated connection via client certificate with serial %s from %s", r.TLS.PeerCertificates[0].SerialNumber, r.RemoteAddr)
 			key := uuid.New().String()
 

--- a/cmd/vicadmin/vicadm.go
+++ b/cmd/vicadmin/vicadm.go
@@ -560,8 +560,8 @@ func (s *server) getSessionFromRequest(ctx context.Context, r *http.Request) (*s
 	if d, ok = sessionData.Values[sessionKey]; !ok {
 		return nil, fmt.Errorf("User-provided cookie did not contain a session ID -- it is corrupt or tampered")
 	}
-	session, err := s.uss.VSphere(ctx, d.(string))
-	return session, err
+	c, err := s.uss.VSphere(ctx, d.(string))
+	return c, err
 }
 
 type flushWriter struct {

--- a/cmd/vicadmin/vicadm.go
+++ b/cmd/vicadmin/vicadm.go
@@ -560,8 +560,8 @@ func (s *server) getSessionFromRequest(ctx context.Context, r *http.Request) (*s
 	if d, ok = sessionData.Values[sessionKey]; !ok {
 		return nil, fmt.Errorf("User-provided cookie did not contain a session ID -- it is corrupt or tampered")
 	}
-	c, err := s.uss.VSphere(ctx, d.(string))
-	return c, err
+	session, err := s.uss.VSphere(ctx, d.(string))
+	return session, err
 }
 
 type flushWriter struct {


### PR DESCRIPTION
Wrote a new function that supposedly refreshes the vSphere session when it goes away but the user's session w/ vicadmin is still valid. It actually does not do this, however in the case the vSphere session goes away, we now redirect to logout after returning an error, instead of the panic seen  previously. Will expand this to do what it says it does, after I figure out if we need to persist a token for re-auth or something like that, as it currently does not refresh because we (rightly) strip user credentials after we establish the first session, so they are not present at refresh time.

Tested this by logging in, nuking vSphere sessions via `govc`, and trying to download container logs. Instead of a panic we now get this:

```
Sep 11 2017 22:44:32.088Z WARN  Unable to connect: SDK URL () could not be parsed: %!s(<nil>)
Sep 11 2017 22:44:32.088Z DEBUG [ END ] [main.(*UserSession).Refresh:42] [48.622µs] 
Sep 11 2017 22:44:32.088Z ERROR Failed to get vSphere session while bundling container logs due to error: couldn't refresh vSphere session; got error: SDK URL () could not be parsed: %!s(<nil>)
```

The error is handled correctly and the user is redirected to the login page.