### PR TITLE
Fix for attach hang during RemoveInteraction

### DIFF
--- a/lib/portlayer/attach/communication/lazy.go
+++ b/lib/portlayer/attach/communication/lazy.go
@@ -50,3 +50,11 @@ func (l *LazySessionInteractor) Initialize() (SessionInteractor, error) {
 	}
 	return l.si, nil
 }
+
+// Cleanup returns either an initialized connection, or nil if it was never initialized
+func (l *LazySessionInteractor) Cleanup() (SessionInteractor, error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	return l.si, nil
+}


### PR DESCRIPTION
This changes the logic on the RemoveInteraction path to:
1. avoid initializing an uninitialized connection solely so it can be Closed
2. moves the potentially complex operation outside of the mutex code
that is only intended to protect access to the map.

This is missing:
1. knowledge of why the mux blocked indefinitely.
2. tests that would exercise this path reliably

Towards: #6281
