### PR TITLE
Enforce container naming convention specified in appliance config

### DIFF
--- a/cmd/vic-machine/common/container.go
+++ b/cmd/vic-machine/common/container.go
@@ -1,0 +1,41 @@
+// Copyright 2016 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"gopkg.in/urfave/cli.v1"
+)
+
+type ContainerConfig struct {
+	// NameConvention
+	ContainerNameConvention string `cmd:"container-name-convention"`
+}
+
+func (c *ContainerConfig) ContainerFlags() []cli.Flag {
+	return []cli.Flag{
+		// container naming convention
+		cli.StringFlag{
+			Name:        "container-name-convention, cnc",
+			Value:       "",
+			Usage:       "Provide a naming convention. Allows a token of '{name}' or '{id}', that will be replaced.",
+			Destination: &c.ContainerNameConvention,
+			Hidden:      true,
+		},
+		// other container flags to to added"
+		// default container memory
+		// default container cpu
+		// default container network
+	}
+}

--- a/cmd/vic-machine/configure/configure.go
+++ b/cmd/vic-machine/configure/configure.go
@@ -101,6 +101,7 @@ func (c *Configure) Flags() []cli.Flag {
 	id := c.IDFlags()
 	volume := c.volStores.Flags()
 	compute := c.ComputeFlags()
+	container := c.ContainerFlags()
 	debug := c.DebugFlags(false)
 	cNetwork := c.cNetworks.CNetworkFlags(false)
 	proxies := c.proxies.ProxyFlags(false)
@@ -111,7 +112,7 @@ func (c *Configure) Flags() []cli.Flag {
 
 	// flag arrays are declared, now combined
 	var flags []cli.Flag
-	for _, f := range [][]cli.Flag{target, ops, id, compute, volume, dns, cNetwork, memory, cpu, certificates, registries, proxies, util, debug} {
+	for _, f := range [][]cli.Flag{target, ops, id, compute, container, volume, dns, cNetwork, memory, cpu, certificates, registries, proxies, util, debug} {
 		flags = append(flags, f...)
 	}
 
@@ -190,6 +191,10 @@ func (c *Configure) copyChangedConf(o *config.VirtualContainerHostConfigSpec, n 
 
 	if c.cNetworks.IsSet {
 		o.ContainerNetworks = n.ContainerNetworks
+	}
+
+	if c.Data.ContainerNameConvention != "" {
+		o.ContainerNameConvention = c.Data.ContainerNameConvention
 	}
 
 	// Copy the new volume store configuration directly since it has the merged

--- a/cmd/vic-machine/create/create.go
+++ b/cmd/vic-machine/create/create.go
@@ -316,6 +316,7 @@ func (c *Create) Flags() []cli.Flag {
 	target := c.TargetFlags()
 	ops := c.OpsCredentials.Flags(true)
 	compute := c.ComputeFlags()
+	container := c.ContainerFlags()
 	volume := c.volumeStores.Flags()
 	iso := c.ImageFlags(true)
 	cNetwork := c.containerNetworks.CNetworkFlags(true)
@@ -325,7 +326,7 @@ func (c *Create) Flags() []cli.Flag {
 
 	// flag arrays are declared, now combined
 	var flags []cli.Flag
-	for _, f := range [][]cli.Flag{target, compute, ops, create, volume, dns, networks, cNetwork, memory, cpu, tls, registries, proxies, syslog, iso, util, debug, help} {
+	for _, f := range [][]cli.Flag{target, compute, ops, create, container, volume, dns, networks, cNetwork, memory, cpu, tls, registries, proxies, syslog, iso, util, debug, help} {
 		flags = append(flags, f...)
 	}
 

--- a/isos/base/utils.sh
+++ b/isos/base/utils.sh
@@ -246,7 +246,7 @@ generate_iso() {
             return 5
         }
 
-        echo "Embedding build version ${VERSION} (use BUILD_VERSION to override)"
+        echo "Embedding build version ${VERSION} (use BUILD_NUMBER environment variable to override)"
         sed -i -e "s/\${VERSION}/${VERSION}/" xorriso-options.cfg
 
         # deleting the file first seems to be necessary in some cases

--- a/lib/apiservers/engine/backends/container.go
+++ b/lib/apiservers/engine/backends/container.go
@@ -1730,7 +1730,11 @@ func (c *Container) ContainerRename(oldName, newName string) error {
 		return derr.NewRequestConflictError(err)
 	}
 
-	if err := c.containerProxy.Rename(vc, newName); err != nil {
+	renameOp := func() error {
+		return c.containerProxy.Rename(vc, newName)
+	}
+
+	if err := retry.Do(renameOp, IsConflictError); err != nil {
 		log.Errorf("Rename error: %s", err)
 		cache.ContainerCache().ReleaseName(newName)
 		return err
@@ -1974,10 +1978,11 @@ func validateCreateConfig(config *types.ContainerCreateConfig) error {
 	}
 
 	// Was a name provided - if not create a friendly name
+	generatedName := namesgenerator.GetRandomName(0)
 	if config.Name == "" {
 		//TODO: Assume we could have a name collison here : need to
 		// provide validation / retry CDG June 9th 2016
-		config.Name = namesgenerator.GetRandomName(0)
+		config.Name = generatedName
 	}
 
 	return nil

--- a/lib/config/virtual_container_host.go
+++ b/lib/config/virtual_container_host.go
@@ -36,9 +36,10 @@ const (
 	// VM is the VM name - i.e. [ds] {vm}/{vm}.vmx
 	VM PatternToken = "{vm}"
 	// ID is the container ID for the VM
-	ID = "{id}"
+	ID PatternToken = "{id}"
 	// Name is the container name of the VM
-	Name = "{name}"
+	Name PatternToken = "{name}"
+
 	// ID represents the VCH in creating status, which helps to identify VCH VM which still does not have a valid VM moref set
 	CreatingVCH = "CreatingVCH"
 

--- a/lib/install/data/data.go
+++ b/lib/install/data/data.go
@@ -38,6 +38,7 @@ type Data struct {
 	common.Debug
 	common.Compute
 	common.VCHID
+	common.ContainerConfig
 
 	OpsCredentials common.OpsCredentials
 
@@ -354,6 +355,8 @@ func (d *Data) CopyNonEmpty(src *Data) error {
 	d.DNS = src.DNS
 
 	d.RegistryCAs = src.RegistryCAs
+
+	d.ContainerConfig.ContainerNameConvention = src.ContainerConfig.ContainerNameConvention
 
 	return nil
 }

--- a/lib/install/validate/config_to_data.go
+++ b/lib/install/validate/config_to_data.go
@@ -237,6 +237,8 @@ func NewDataFromConfig(ctx context.Context, finder Finder, conf *config.VirtualC
 			return
 		}
 	}
+
+	d.ContainerNameConvention = conf.ContainerNameConvention
 	return
 }
 

--- a/lib/install/validate/validator.go
+++ b/lib/install/validate/validator.go
@@ -355,6 +355,18 @@ func (v *Validator) basics(ctx context.Context, input *data.Data, conf *config.V
 		log.Debugf("Setting scratch image size to %d KB in VCHConfig", conf.ScratchSize)
 	}
 
+	if input.ContainerNameConvention != "" {
+		// ensure token is present
+		if !strings.Contains(input.ContainerNameConvention, string(config.ID)) && !strings.Contains(input.ContainerNameConvention, string(config.Name)) {
+			v.NoteIssue(errors.Errorf("Container name convention must include %s or %s token", config.ID, config.Name))
+		}
+		// guard against both -- possibly we want to allow, but for now only allow one
+		if strings.Contains(input.ContainerNameConvention, string(config.ID)) && strings.Contains(input.ContainerNameConvention, string(config.Name)) {
+			v.NoteIssue(errors.Errorf("Container name convention only allows one token, either %s or %s", config.ID, config.Name))
+		}
+	}
+
+	conf.ContainerNameConvention = input.ContainerNameConvention
 }
 
 func (v *Validator) checkSessionSet() []string {

--- a/lib/portlayer/exec/handle.go
+++ b/lib/portlayer/exec/handle.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"strings"
 	"sync"
 	"time"
 
@@ -149,7 +150,13 @@ func (h *Handle) Rename(newName string) *Handle {
 		ID:   h.ExecConfig.ID,
 		Name: newName,
 	}
-	h.Spec.Spec().Name = util.DisplayName(s)
+	// Only rename on vSphere when the containerNameConvention is name
+	var convention string
+	if strings.Contains(Config.ContainerNameConvention, "{name}") {
+		convention = Config.ContainerNameConvention
+	}
+
+	h.Spec.Spec().Name = util.DisplayName(s, convention)
 
 	return h
 }
@@ -343,7 +350,7 @@ func Create(ctx context.Context, vmomiSession *session.Session, config *Containe
 		specconfig.VMPathName = fmt.Sprintf("[%s] %s/%s.vmx", vmomiSession.Datastore.Name(), specconfig.ID, specconfig.ID)
 	}
 
-	specconfig.VMFullName = util.DisplayName(specconfig)
+	specconfig.VMFullName = util.DisplayName(specconfig, Config.ContainerNameConvention)
 
 	// log only core portions
 	s := specconfig


### PR DESCRIPTION
This is #6265 but applied to master. @cgtexmex contribued a chunk of this
code and will be picking it up from here.

Provides basic container naming convention via {id} and {name} tokens.
The naming is enforced only on vSphere and will not be visible via
the docker client.

Adds retry logic in rename call for ConflictError case

Missing:
1. tests
2. checks on the vSAN impact of changing the displayName like this
(might have to be non-vSAN only).
3. documentation

Towards: #6267 

