### PR TITLE
Correct remove interaction exit path [full ci]

### DIFF
--- a/lib/portlayer/attach/communication/connector.go
+++ b/lib/portlayer/attach/communication/connector.go
@@ -203,6 +203,11 @@ func (c *Connector) RemoveInteraction(id string) error {
 	}
 	c.mutex.Unlock()
 
+	// the !ok case, but let's check the actual condition that impacts us
+	if v == nil {
+		return nil
+	}
+
 	conn, err := v.Cleanup()
 	if conn != nil {
 		err = conn.Close()


### PR DESCRIPTION
Corrects the exit path for RemoveInteraction.

Not sure how to test this as the repeated attach/detach/restart tests I tried for the original issue didn't catch it.

Fixes #6371