### PR TITLE
Collect VCH logs before reboot in nightly NFS

### DIFF
--- a/tests/manual-test-cases/Group5-Functional-Tests/5-22-NFS-Volume.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-22-NFS-Volume.robot
@@ -277,6 +277,9 @@ Docker Inspect Mount Data after Reboot
 
     Verify Volume Inspect Info  Before VM Reboot  ${mntDataTestContainer}  ${checkList}
 
+    # Gather logs before rebooting
+    Run Keyword And Continue On Failure  Gather Logs From Test Server  -before-reboot
+
     Reboot VM and Verify Basic VCH Info
 
     Verify Volume Inspect Info  After VM Reboot  ${mntDataTestContainer}  ${checkList}

--- a/tests/resources/VCH-Util.robot
+++ b/tests/resources/VCH-Util.robot
@@ -242,15 +242,17 @@ Portlayer Log Should Match Regexp
 
 Gather Logs From Test Server
     [Tags]  secret
+    [Arguments]  ${name-suffix}=${EMPTY}
+
     Run Keyword And Continue On Failure  Run  zip %{VCH-NAME}-certs -r %{VCH-NAME}
     ${out}=  Run  curl -k -D vic-admin-cookies -Fusername=%{TEST_USERNAME} -Fpassword=%{TEST_PASSWORD} %{VIC-ADMIN}/authentication
     Log  ${out}
-    ${out}=  Run  curl -k -b vic-admin-cookies %{VIC-ADMIN}/container-logs.zip -o ${SUITE NAME}-%{VCH-NAME}-container-logs.zip
+    ${out}=  Run  curl -k -b vic-admin-cookies %{VIC-ADMIN}/container-logs.zip -o ${SUITE NAME}-%{VCH-NAME}-container-logs${name-suffix}.zip
     Log  ${out}
     Remove File  vic-admin-cookies
-    ${out}=  Run  govc datastore.download %{VCH-NAME}/vmware.log %{VCH-NAME}-vmware.log
+    ${out}=  Run  govc datastore.download %{VCH-NAME}/vmware.log %{VCH-NAME}-vmware${name-suffix}.log
     Should Contain  ${out}  OK
-    Run Keyword If  '%{HOST_TYPE}' == 'ESXi'  Run  govc logs -log=vmkernel -n=10000 > vmkernel.log
+    Run Keyword If  '%{HOST_TYPE}' == 'ESXi'  Run  govc logs -log=vmkernel -n=10000 > vmkernel${name-suffix}.log
 
 Check For The Proper Log Files
     [Arguments]  ${container}


### PR DESCRIPTION
This commit adds a mechanism to supply an optional suffix for the
log files, so multiple sets of logs can be downloaded during an
integration test run. The default behavior of the Robot keyword for
collecting logs is unchanged.

Fixes #6126

The log artifacts now look like:
![logs](https://user-images.githubusercontent.com/4361620/30565246-33d4bbf6-9c8d-11e7-8cea-7df5abe34e63.png)
