### PR TITLE
[skip ci] Expose the vic-machine API via https

### DIFF
--- a/lib/apiservers/service/swagger.json
+++ b/lib/apiservers/service/swagger.json
@@ -11,7 +11,8 @@
   },
   "basePath": "/container",
   "schemes": [
-    "http"
+    "http",
+    "https"
   ],
   "consumes": [
     "application/json"


### PR DESCRIPTION
Notes:
 * To disable https for testing, invoke the server with --scheme http
 * To configure https, use --tls-port, --tls-certificate, and --tls-key

Requires #6462.