### PR TITLE
[specific ci=6-04-Create-Basic] Fix 6-04-Create-Basic test for vCenter

### DIFF
--- a/tests/test-cases/Group6-VIC-Machine/6-04-Create-Basic.robot
+++ b/tests/test-cases/Group6-VIC-Machine/6-04-Create-Basic.robot
@@ -219,12 +219,17 @@ Create VCH - Existing VM name
     Should Be Equal As Integers  ${rc}  0
 
     ${output}=  Run  bin/vic-machine-linux create --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --image-store=%{TEST_DATASTORE} --bridge-network=%{BRIDGE_NETWORK} --public-network=%{PUBLIC_NETWORK} ${vicmachinetls}
-    Get Docker Params  ${output}  ${true}
     Log  ${output}
-    Should Contain  ${output}  Installer completed successfully
-    Log To Console  Installer completed successfully: %{VCH-NAME}
 
-    Run Keyword And Ignore Error  Cleanup VIC Appliance On Test Server
+    # VCH creation should succeed on ESXi
+    Run Keyword If  '%{HOST_TYPE}' == 'ESXi'  Get Docker Params  ${output}  ${true}
+    Run Keyword If  '%{HOST_TYPE}' == 'ESXi'  Should Contain  ${output}  Installer completed successfully
+    Run Keyword If  '%{HOST_TYPE}' == 'ESXi'  Log To Console  Installer completed successfully: %{VCH-NAME}
+    Run Keyword If  '%{HOST_TYPE}' == 'ESXi'  Run Keyword And Ignore Error  Cleanup VIC Appliance On Test Server
+
+    # VCH creation should fail on VC
+    Run Keyword If  '%{HOST_TYPE}' == 'VC'  Should Contain  ${output}  The name '%{VCH-NAME}' already exists.
+
     ${rc}  ${output}=  Run And Return Rc And Output  govc vm.destroy %{VCH-NAME}
     Should Be Equal As Integers  ${rc}  0
     Cleanup VCH Bridge Network  %{VCH-NAME}


### PR DESCRIPTION
This commit modifies the `Create VCH - Existing VM name` integration
test to expect success when running on ESXi and failure when
running on vCenter. Running `govc vm.create` on vCenter creates a
vApp and a subsequent VCH create with the same name fails since
the name already exists.

Fixes #6440