### PR TITLE
[specific ci=Group1-Docker-Commands] Optimize Docker Command tests to one VCH

### DIFF
--- a/.drone.local.yml
+++ b/.drone.local.yml
@@ -34,9 +34,11 @@ pipeline:
       GS_PROJECT_ID: ${GS_PROJECT_ID}
       GS_CLIENT_EMAIL: ${GS_CLIENT_EMAIL}
       GS_PRIVATE_KEY: ${GS_PRIVATE_KEY}
+      DEBUG_VCH:  ${DEBUG_VCH}
       DOMAIN: ${DOMAIN}
     commands:
       - tests/integration-test.sh
-      #- pybot tests/test-cases/Group1-Docker-Commands/1-13-Docker-Version.robot
+      # - pybot tests/test-cases/Group1-Docker-Commands
+      # - pybot tests/test-cases/Group1-Docker-Commands/1-01-Docker-Info.robot
     volumes:
       - /tmp

--- a/tests/README.md
+++ b/tests/README.md
@@ -31,6 +31,29 @@ Use ./local-integration-test.sh
     PUBLIC_NETWORK=public
   ```
 
+  If you want to use an existing VCH to run a test (e.g. any of the group 1 tests) on, add the following secret to the secrets file:
+
+  ```
+    TARGET_VCH=<name of an existing VCH>
+  ```
+
+  The above TARGET_VCH is best used for tests where you do not want to exercise vic-machine's create/delete operations.  The Group 1 tests is a great example.  Their main goal is to test docker commands.
+
+  If TARGET_VCH is not specified, and you have a group initializer and cleanup file (see the group 1 tests), there is another variable to control whether use a shared VCH.
+
+  ```
+    MULTI_VCH=<1 for enable>
+  ```
+
+  Enabling MULTI_VCH forces each suite to install a new VCH and cleans it up at the end of the test.  If the test is in 'single vch' mode, it will respect the group initializer and cleanup file.  If the initializer creates the shared VCH, then all tests will use that shared VCH.  If TARGET_VCH exist, MULTI_VCH is ignored.
+
+  ```
+    DEBUG_VCH=<1 to enable>
+  ```
+
+  Enabling DEBUG_VCH will log existing docker images and containers on a VCH at the start of a test suite.
+
+
 * Execute Drone from the project root directory:
 
   Drone will run based on `.drone.local.yml` - defaults should be fine, edit as needed
@@ -59,3 +82,16 @@ Use ./local-integration-test.sh
 
 * [Automated Test Suite Documentation](test-cases/TestGroups.md)
 * [Manual Test Suite Documentation](manual-test-cases/TestGroups.md)
+
+## Tips on running tests more efficiently
+
+Here are some recommendations that will make running tests more effective.
+
+1. If a group of tests do not need an independent VCH to run on, there is a facility to use a single VCH for the entire group.  The Group 1 tests utilizes this facility.  To utilize this in a group (a folder of robot files),
+    - Add an __init__.robot file as the first robot file in your group.  This special init file should install the VCH and save the VCH-NAME to environment variable REUSE-VCH.  The bootrap file also needs to save the VCH to the removal exception list.
+    - Every robot file should neither assume a group-wide VCH.  It should install and remove a VCH for it's own use.  This allows the single robot file to be properly targeted for testing as a single test or as part of a group of test (with group-wide VCH).  When a group wide VCH is in use, the exception list will bypass the per-robot file VCH install and removal.
+    - Write individual tests within a robot file with NO assumption of a standalone VCH.  Assume a shared VCH.  This will allow the
+    tests to run in either shared VCH or standalone VCH mode.
+    - Add a cleanup.robot file that handles cleaning up the group-wide VCH.  It needs to remove the group-wide VCH-NAME from the cleanup exception list.
+2. Write all tests within robot file with the assumption that the VCH is in shared mode.  Don't assume there are no previously created containers and images.  If a robot file needs this precondition, make sure the suite setup cleans out the VCH before running any test.
+3. If there is an existing VCH available, it is possible to bypass the VCH installation/deletion by adding a TARGET_VCH into the list of test secrets.

--- a/tests/resources/Docker-Util.robot
+++ b/tests/resources/Docker-Util.robot
@@ -202,3 +202,117 @@ Verify Volume Inspect Info
 
     :FOR  ${item}  IN  @{checkList}
     \   Should Contain  ${mountInfo}  ${item}
+
+Log All Containers
+    ${rc}  ${out}=  Run And Return Rc And Output  docker %{VCH-PARAMS} ps -a
+    Run Keyword If  ${rc} != 0  Log To Console  Remaining containers - ${out}
+
+Do Images Exist
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} images -q
+    ${len}=  Get Length  ${output}
+    Return From Keyword If  ${len} == 0  ${false}
+    [Return]  ${true}
+
+Do Containers Exist
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} ps -a -q
+    ${len}=  Get Length  ${output}
+    Return From Keyword If  ${len} == 0  ${false}
+    [Return]  ${true}
+
+Do Volumes Exist
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} volume ls -q
+    ${len}=  Get Length  ${output}
+    Return From Keyword If  ${len} == 0  ${false}
+    [Return]  ${true}
+
+Do Networks Exist
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} networks ls -q
+    ${len}=  Get Length  ${output}
+    Return From Keyword If  ${len} == 0  ${false}
+    [Return]  ${true}
+
+Remove All Containers
+    ${exist}=  Do Containers Exist
+    Run Keyword If  ${exist}  Log To Console  Stopping and removing all containers from %{VCH-NAME}
+    Return From Keyword If  ${exist} == ${false}  0
+
+    # Run Keyword If  ${exist}  Kill All Containers
+    Run Keyword If  ${exist}  Run  docker %{VCH-PARAMS} rm -f $(docker %{VCH-PARAMS} ps -a -q)
+
+    ${exist}=  Do Containers Exist
+    Return From Keyword If  ${exist} == ${false}  0
+    Run Keyword If  ${exist}  Log All Containers
+    [Return]  1
+
+Stop All Containers
+    Run  docker %{VCH-PARAMS} stop $(docker %{VCH-PARAMS} ps -q)
+
+Kill All Containers
+    Run  docker %{VCH-PARAMS} kill $(docker %{VCH-PARAMS} ps -q)
+
+Remove All Images
+    ${exist}=  Do Images Exist
+    Run Keyword If  ${exist}  Log To Console  Removing all images from %{VCH-NAME}
+    
+    Return From Keyword If  ${exist} == ${false}  0
+    Run Keyword If  ${exist}  Remove All Containers
+    Run Keyword If  ${exist}  Run  docker %{VCH-PARAMS} rmi $(docker %{VCH-PARAMS} images -q)
+
+    ${exist}=  Do Images Exist
+    Return From Keyword If  ${exist} == ${false}  0
+    [Return]  1
+
+Remove All Volumes
+    ${exist}=  Do Volumes Exist
+    Run Keyword If  ${exist}  Log To Console  Removing all volumes from %{VCH-NAME}
+
+    Return From Keyword If  ${exist} == ${false}  0
+    Run Keyword If  ${exist}  Run  docker %{VCH-PARAMS} volume rm $(docker %{VCH-PARAMS} volume ls -q)
+
+    ${exist}=  Do Volumes Exist
+    Return From Keyword If  ${exist} == ${false}  0
+    [Return]  1
+
+Remove All Container Networks
+    ${exist}=  Do Networks Exist
+    Run Keyword If  ${exist}  Log To Console  Removing all container networks from %{VCH-NAME}
+
+    Return From Keyword If  ${exist} == ${false}  0
+    Run Keyword If  ${exist}  Run  docker %{VCH-PARAMS} network rm $(docker %{VCH-PARAMS} network ls -q)
+
+    ${exist}=  Do Networks Exist
+    Return From Keyword If  ${exist} == ${false}  0
+    [Return]  1
+    
+Add List To Dictionary
+    [Arguments]  ${dict}  ${list}
+    : FOR  ${item}  IN  @{list}
+    \    Set To Dictionary  ${dict}  ${item}  1
+
+List Existing Images On VCH
+    # Get list of image IDs
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} images -q
+    ${len}=  Get Length  ${output}
+    Run Keyword If  ${len} != 0  Log To Console  Found images on %{VCH-NAME}:
+    ${image_ids}=  Run Keyword If  ${rc} == 0  Split String  ${output}
+    ${tags_dict}=  Create Dictionary
+    : FOR  ${id}  IN  @{image_ids}
+    \    ${rc}  ${repotags}=  Run And Return Rc And Output  docker %{VCH-PARAMS} inspect --format='{{.RepoTags}}' --type=image ${id}
+    \    ${clean_tags}  Strip String  ${repotags}  characters=[]
+    \    ${tags}=  Split String  ${clean_tags}
+    \    Add List To Dictionary  ${tags_dict}  ${tags}
+
+    : FOR  ${tag}  IN  @{tags_dict.keys()}
+    \    Log To Console  \t${tag}
+
+List Running Containers On VCH    
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} ps -q
+    Log To Console  ${EMPTY}
+    ${len}=  Get Length  ${output}
+    Run Keyword If  ${len} != 0  Log To Console  Found running containers on %{VCH-NAME}:
+    ...  ELSE  Log To Console  No running containers on %{VCH-NAME}
+    Return From Keyword If  ${len} == 0
+
+    ${cids}=  Run Keyword If  ${len} != 0  Split String  ${output}
+    : FOR  ${id}  IN  @{cids}
+    \    Log To Console  \t${id}

--- a/tests/resources/VCH-Util.robot
+++ b/tests/resources/VCH-Util.robot
@@ -37,6 +37,7 @@ Set Test Environment Variables
     Set Environment Variable  GOVC_URL  %{TEST_URL}
     Set Environment Variable  GOVC_USERNAME  %{TEST_USERNAME}
     Set Environment Variable  GOVC_PASSWORD  %{TEST_PASSWORD}
+
     # TODO: need an integration/vic-test image update to include the about.cert command
     #${rc}  ${thumbprint}=  Run And Return Rc And Output  govc about.cert -k | jq -r .ThumbprintSHA1
     ${rc}  ${thumbprint}=  Run And Return Rc And Output  openssl s_client -connect $(govc env -x GOVC_URL_HOST):443 </dev/null 2>/dev/null | openssl x509 -fingerprint -noout | cut -d= -f2
@@ -163,6 +164,99 @@ Get Docker Params
     Run Keyword If  ${tls_enabled} == ${true}  Set Environment Variable  COMPOSE_TLS_VERSION  TLSv1_2
     Run Keyword If  ${tls_enabled} == ${true}  Set Environment Variable  COMPOSE-PARAMS  -H ${dockerHost}
 
+Convert List to String
+    [Arguments]  @{list}
+    Should Not Be Empty  ${list}
+    ${list-string}=  Set Variable  ${EMPTY}
+    :FOR  ${item}  IN  @{list}
+    \   ${list-was-empty}=  Set Variable If  '${list-string}' == '${EMPTY}'  ${True}  ${false}
+    \   ${list-string}=  Run Keyword If  ${list-was-empty}  Set Variable  ${item}
+    \   ...  ELSE  Catenate  SEPARATOR=|  ${list-string}  ${item}
+
+    [Return]  ${list-string}
+
+Add VCH to Removal Exception List
+    [Arguments]  ${vch}=${EMPTY}
+    ${exceptions-string}=  Get Environment Variable  VM_EXCEPTIONS  ${EMPTY}
+    @{exceptions-list}=  Run Keyword If  '${exceptions-string}' == '${EMPTY}'  Create List
+    @{exceptions-list}=  Run Keyword Unless  '${exceptions-string}' == '${EMPTY}'  Split String  ${exceptions-string}  separator=|
+
+    ${set}=  Create Dictionary
+    Add List To Dictionary  ${set}  ${exceptions-list}
+    Set To Dictionary  ${set}  ${vch}  1
+
+    ${exceptions-list}=  Set Variable  ${set.keys()}
+
+    # Append To List  ${exceptions-list}  ${vch}
+    ${list-string}=  Convert List To String  @{exceptions-list}
+    Set Environment Variable  VM_EXCEPTIONS  ${list-string}
+    Log To Console  Saved '${list-string}' to removal exceptions
+
+Remove VCH from Removal Exception List
+    [Arguments]  ${vch}=${EMPTY}
+    ${exceptions-string}=  Get Environment Variable  VM_EXCEPTIONS  ${EMPTY}
+    Return From Keyword If  '${exceptions-string}' == '${EMPTY}'  No Exceptions Found 
+    @{exceptions-list}=  Run Keyword Unless  '${exceptions-string}' == '${EMPTY}'  Split String  ${exceptions-string}  separator=|
+    ${idx}=  Get Index From List  ${exceptions-list}  ${vch}
+    Remove From List  ${exceptions-list}  ${idx}
+    ${len}=  Get Length  ${exceptions-list}
+    ${list-string}=  Run Keyword If  ${len} != 0  Convert List To String  @{exceptions-list}
+    ...  ELSE  Set Variable  ${EMPTY}
+    Set Environment Variable  VM_EXCEPTIONS  ${list-string}
+
+Check If VCH Is In Exception
+    [Arguments]  ${vch}=${EMPTY}  ${exceptions}=${EMPTY}
+    ${exceptions}=  Run Keyword If  '${exceptions}' == '${EMPTY}'  Get Environment Variable  VM_EXCEPTIONS  ${EMPTY}
+    ...  ELSE  Set Variable  ${exceptions}
+    Return From Keyword If  '${exceptions}' == '${EMPTY}'  ${false}
+    ${excluded}=  Set Variable  ${false}
+    ${exceptions-list}=  Split String  ${exceptions}  separator=|
+    : FOR  ${vm-exclude}  IN  @{exceptions-list}
+    \    Continue For Loop If  '${vm-exclude}' != '${vch}'
+    \    ${excluded}=  Set Variable  ${true}
+    \    Exit For Loop
+
+    [Return]  ${excluded}
+
+Dump Docker Debug Data From VCH
+    Log To Console  **********
+    List Existing Images On VCH
+    List Running Containers On VCH
+    Log To Console  **********
+
+Use Target VIC Appliance
+    # Use a VIC appliance created outside of CI
+    [Arguments]  ${target-vch}=${EMPTY}
+    Return From Keyword If  '${target-vch}' == '${EMPTY}'  ${False}
+
+    ${debug-vch}=  Get Environment Variable  DEBUG_VCH  ${EMPTY}
+    Set Test Environment Variables
+    Set Environment Variable  VCH-NAME  ${target-vch}
+    Log To Console  Reusing existing vch: ${target-vch}
+    Run VIC Machine Inspect Command
+    Add VCH to Removal Exception List  vch=${target-vch}
+    Run Keyword If  '${debug-vch}' != '${EMPTY}'  Dump Docker Debug Data From VCH
+
+    [Return]  ${True}
+
+Conditional Install VIC Appliance To Test Server
+    [Arguments]  ${certs}=${true}  ${init}=${False}
+    ${target-vch}=  Get Environment Variable  TARGET_VCH  ${EMPTY}
+    ${multi-vch}=  Get Environment Variable  MULTI_VCH  ${EMPTY}
+
+    # If TARGET_VCH was defined, use that VCH for tests and exit
+    Run Keyword If  '${target-vch}' != '${EMPTY}'  Use Target VIC Appliance  target-vch=${target-vch}
+    Return From Keyword If  '${target-vch}' != '${EMPTY}'  ${True}
+
+    Install VIC Appliance To Test Server  certs=${certs}
+
+    # If MULT_VCH set to 1, then we are in multi VCH mode, otherwise, we are in single VCH mode
+    ${single-vch-mode}=  Run Keyword If  '${multi-vch}' == '1'  Set Variable  ${False}
+    ...  ELSE  Set Variable  ${True}
+
+    # In single vch mode, save VCH name to TARGET_VCH and add VCH to exception removal list
+    Run Keyword If  ${init}  Set Environment Variable  TARGET_VCH  %{VCH-NAME}
+ 
 Install VIC Appliance To Test Server
     [Arguments]  ${vic-machine}=bin/vic-machine-linux  ${appliance-iso}=bin/appliance.iso  ${bootstrap-iso}=bin/bootstrap.iso  ${certs}=${true}  ${vol}=default  ${cleanup}=${true}  ${debug}=1  ${additional-args}=${EMPTY}
     Set Test Environment Variables
@@ -291,6 +385,10 @@ Scrape Logs For the Password
 Cleanup VIC Appliance On Test Server
     Log To Console  Gathering logs from the test server %{VCH-NAME}
     Gather Logs From Test Server
+    Wait Until Keyword Succeeds  3x  5 seconds  Remove All Containers
+    # Exit from Cleanup if VCH-NAME is currently in exception list
+    ${exclude}=  Check If VCH Is In Exception  vch=%{VCH-NAME}
+    Return From Keyword If  ${exclude}
     Log To Console  Deleting the VCH appliance %{VCH-NAME}
     ${output}=  Run VIC Machine Delete Command
     Run Keyword And Ignore Error  Cleanup VCH Bridge Network  %{VCH-NAME}
@@ -312,11 +410,16 @@ Remove VC Distributed Portgroup
 
 Cleanup Datastore On Test Server
     ${out}=  Run  govc datastore.ls
+    ${exceptions}=  Get Environment Variable  VM_EXCEPTIONS  ${EMPTY}
     ${items}=  Split To Lines  ${out}
     :FOR  ${item}  IN  @{items}
     \   ${build}=  Split String  ${item}  -
     \   # Skip any item that is not associated with integration tests
     \   Continue For Loop If  '@{build}[0]' != 'VCH'
+    \   # Skip any item in the exception list
+    \   @{name}=  Split String  ${item}  -VOL
+    \   ${skip}=  Check If VCH Is In Exception  vch=@{name}[0]  exceptions=${exceptions}
+    \   Continue For Loop If  ${skip}
     \   # Skip any item that is still running
     \   ${state}=  Get State Of Drone Build  @{build}[1]
     \   Continue For Loop If  '${state}' == 'running'
@@ -326,12 +429,15 @@ Cleanup Datastore On Test Server
 
 Cleanup Dangling VMs On Test Server
     ${out}=  Run  govc ls vm
+    ${exceptions}=  Get Environment Variable  VM_EXCEPTIONS  ${EMPTY}
     ${vms}=  Split To Lines  ${out}
     :FOR  ${vm}  IN  @{vms}
     \   ${vm}=  Fetch From Right  ${vm}  /
     \   ${build}=  Split String  ${vm}  -
     \   # Skip any VM that is not associated with integration tests
     \   Continue For Loop If  '@{build}[0]' != 'VCH'
+    \   ${skip}=  Check If VCH Is In Exception  vch=${vm}  exceptions=${exceptions}
+    \   Continue For Loop If  ${skip}
     \   # Skip any VM that is still running
     \   ${state}=  Get State Of Drone Build  @{build}[1]
     \   Continue For Loop If  '${state}' == 'running'
@@ -342,12 +448,16 @@ Cleanup Dangling VMs On Test Server
 
 Cleanup Dangling Resource Pools On Test Server
     ${out}=  Run  govc ls host/*/Resources/*
+    ${exceptions}=  Get Environment Variable  VM_EXCEPTIONS  ${EMPTY}
     ${pools}=  Split To Lines  ${out}
     :FOR  ${pool}  IN  @{pools}
     \   ${shortPool}=  Fetch From Right  ${pool}  /
     \   ${build}=  Split String  ${shortPool}  -
     \   # Skip any pool that is not associated with integration tests
     \   Continue For Loop If  '@{build}[0]' != 'VCH'
+    \   # Skip Resource Pools belonging to VCHs in the exception list
+    \   ${skip}=  Check If VCH Is In Exception  vch=${shortPool}  exceptions=${exceptions}
+    \   Continue For Loop If  ${skip}
     \   # Skip any pool that is still running
     \   ${state}=  Get State Of Drone Build  @{build}[1]
     \   Continue For Loop If  '${state}' == 'running'
@@ -357,12 +467,17 @@ Cleanup Dangling Resource Pools On Test Server
 
 Cleanup Dangling Networks On Test Server
     ${out}=  Run  govc ls network
+    ${exceptions}=  Get Environment Variable  VM_EXCEPTIONS  ${EMPTY}
     ${nets}=  Split To Lines  ${out}
     :FOR  ${net}  IN  @{nets}
     \   ${net}=  Fetch From Right  ${net}  /
     \   ${build}=  Split String  ${net}  -
     \   # Skip any Network that is not associated with integration tests
     \   Continue For Loop If  '@{build}[0]' != 'VCH'
+    \   # Skip any Network that is attached to a VCH in the exception list
+    \   @{name}=  Split String  ${net}  -bridge
+    \   ${skip}=  Check If VCH Is In Exception  vch=@{name}[0]  exceptions=${exceptions}
+    \   Continue For Loop If  ${skip}
     \   # Skip any Network that is still running
     \   ${state}=  Get State Of Drone Build  @{build}[1]
     \   Continue For Loop If  '${state}' == 'running'
@@ -370,12 +485,17 @@ Cleanup Dangling Networks On Test Server
 
 Cleanup Dangling vSwitches On Test Server
     ${out}=  Run Keyword If  '%{HOST_TYPE}' == 'ESXi'  Run  govc host.vswitch.info | grep VCH
+    ${exceptions}=  Get Environment Variable  VM_EXCEPTIONS  ${EMPTY}
     ${nets}=  Split To Lines  ${out}
     :FOR  ${net}  IN  @{nets}
     \   ${net}=  Fetch From Right  ${net}  ${SPACE}
     \   ${build}=  Split String  ${net}  -
     \   # Skip any vSwitch that is not associated with integration tests
     \   Continue For Loop If  '@{build}[0]' != 'VCH'
+    \   # Skip any switch that is attached to a VCH in the exception list
+    \   @{name}=  Split String  ${net}  -bridge
+    \   ${skip}=  Check If VCH Is In Exception  vch=@{name}[0]  exceptions=${exceptions}
+    \   Continue For Loop If  ${skip}
     \   # Skip any vSwitch that is still running
     \   ${state}=  Get State Of Drone Build  @{build}[1]
     \   Continue For Loop If  '${state}' == 'running'
@@ -430,12 +550,12 @@ Get VCH ID
 
 # VCH upgrade helpers
 Install VIC with version to Test Server
-    [Arguments]  ${version}=7315  ${insecureregistry}=
+    [Arguments]  ${version}=7315  ${insecureregistry}=  ${cleanup}=${true}
     Log To Console  \nDownloading vic ${version} from gcp...
     ${rc}  ${output}=  Run And Return Rc And Output  wget https://storage.googleapis.com/vic-engine-builds/vic_${version}.tar.gz -O vic.tar.gz
     ${rc}  ${output}=  Run And Return Rc And Output  tar zxvf vic.tar.gz
     Set Environment Variable  TEST_TIMEOUT  20m0s
-    Install VIC Appliance To Test Server  vic-machine=./vic/vic-machine-linux  appliance-iso=./vic/appliance.iso  bootstrap-iso=./vic/bootstrap.iso  certs=${false}  vol=default ${insecureregistry}
+    Install VIC Appliance To Test Server  vic-machine=./vic/vic-machine-linux  appliance-iso=./vic/appliance.iso  bootstrap-iso=./vic/bootstrap.iso  certs=${false}  cleanup=${cleanup}  vol=default ${insecureregistry}
 
     Set Environment Variable  VIC-ADMIN  %{VCH-IP}:2378
     Set Environment Variable  INITIAL-VERSION  ${version}

--- a/tests/test-cases/Group1-Docker-Commands/1-01-Docker-Info.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-01-Docker-Info.robot
@@ -15,7 +15,7 @@
 *** Settings ***
 Documentation  Test 1-01 - Docker Info
 Resource  ../../resources/Util.robot
-Suite Setup  Install VIC Appliance To Test Server
+Suite Setup  Conditional Install VIC Appliance To Test Server
 Suite Teardown  Cleanup VIC Appliance On Test Server
 Test Timeout  20 minutes
 

--- a/tests/test-cases/Group1-Docker-Commands/1-02-Docker-Pull.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-02-Docker-Pull.robot
@@ -15,7 +15,7 @@
 *** Settings ***
 Documentation  Test 1-02 - Docker Pull
 Resource  ../../resources/Util.robot
-Suite Setup  Install VIC Appliance To Test Server
+Suite Setup  Conditional Install VIC Appliance To Test Server
 Suite Teardown  Cleanup VIC Appliance On Test Server
 Test Timeout  20 minutes
 

--- a/tests/test-cases/Group1-Docker-Commands/1-03-Docker-Images.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-03-Docker-Images.robot
@@ -15,7 +15,7 @@
 *** Settings ***
 Documentation  Test 1-03 - Docker Images
 Resource  ../../resources/Util.robot
-Suite Setup  Install VIC Appliance To Test Server
+Suite Setup  Conditional Install VIC Appliance To Test Server
 Suite Teardown  Cleanup VIC Appliance On Test Server
 Test Timeout  20 minutes
 
@@ -30,16 +30,18 @@ Simple images
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} pull busybox:1.27.0
     Should Be Equal As Integers  ${rc}  0
     Should Not Contain  ${output}  Error
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} images
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} images | cut -d ' ' -f 1 | grep busybox
     Should Be Equal As Integers  ${rc}  0
     Should Not Contain  ${output}  Error
-    Should Contain X Times  ${output}  busybox  3
+    ${count}=  Get Count  ${output}  busybox
+    Should Be True  ${count} >= 3
 
 All images
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} images -a
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} images -a | cut -d ' ' -f 1 | grep busybox
     Should Be Equal As Integers  ${rc}  0
     Should Not Contain  ${output}  Error
-    Should Contain X Times  ${output}  busybox  3
+    ${count}=  Get Count  ${output}  busybox
+    Should Be True  ${count} >= 3
 
 Quiet images
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} images -q
@@ -47,14 +49,16 @@ Quiet images
     Should Not Contain  ${output}  Error
     Should Not Contain  ${output}  busybox
     @{lines}=  Split To Lines  ${output}
-    Length Should Be  ${lines}  3
+    ${count}=  Get Length  ${lines}
+    Should Be True  ${count} >= 3
     Length Should Be  @{lines}[1]  12
 
 No-trunc images
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} images --no-trunc
     Should Be Equal As Integers  ${rc}  0
     Should Not Contain  ${output}  Error
-    Should Contain X Times  ${output}  busybox  3
+    ${count}=  Get Count  ${output}  busybox
+    Should Be True  ${count} >= 3
     @{lines}=  Split To Lines  ${output}
     @{line}=  Split String  @{lines}[2]
     Length Should Be  @{line}[2]  64
@@ -64,16 +68,18 @@ Filter images before
     Should Be Equal As Integers  ${rc}  0
     Should Not Contain  ${output}  Error
     @{lines}=  Split To Lines  ${output}
-    Length Should Be  ${lines}  3
     Should Contain  ${output}  1.27.0
+    ${count}=  Get Length  ${lines}
+    Should Be True  ${count} >= 3
 
 Filter images since
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} images -f since=busybox:1.27.0
     Should Be Equal As Integers  ${rc}  0
     Should Not Contain  ${output}  Error
     @{lines}=  Split To Lines  ${output}
-    Length Should Be  ${lines}  3
-    Should Contain  ${output}  latest
+    ${count}=  Get Length  ${lines}
+    Should Be True  ${count} > 0
+    Should Contain  ${output}  1.27.1
 
 Tag images
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} tag busybox busybox:cdg

--- a/tests/test-cases/Group1-Docker-Commands/1-04-Docker-Create.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-04-Docker-Create.robot
@@ -15,7 +15,7 @@
 *** Settings ***
 Documentation  Test 1-04 - Docker Create
 Resource  ../../resources/Util.robot
-Suite Setup  Install VIC Appliance To Test Server
+Suite Setup  Conditional Install VIC Appliance To Test Server
 Suite Teardown  Cleanup VIC Appliance On Test Server
 Test Timeout  20 minutes
 

--- a/tests/test-cases/Group1-Docker-Commands/1-05-Docker-Start.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-05-Docker-Start.robot
@@ -15,7 +15,7 @@
 *** Settings ***
 Documentation  Test 1-05 - Docker Start
 Resource  ../../resources/Util.robot
-Suite Setup  Install VIC Appliance To Test Server
+Suite Setup  Conditional Install VIC Appliance To Test Server
 Suite Teardown  Cleanup VIC Appliance On Test Server
 Test Timeout  20 minutes
 

--- a/tests/test-cases/Group1-Docker-Commands/1-06-Docker-Run.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-06-Docker-Run.robot
@@ -15,7 +15,7 @@
 *** Settings ***
 Documentation  Test 1-06 - Docker Run
 Resource  ../../resources/Util.robot
-Suite Setup  Install VIC Appliance To Test Server
+Suite Setup  Conditional Install VIC Appliance To Test Server
 Suite Teardown  Cleanup VIC Appliance On Test Server
 Test Timeout  20 minutes
 

--- a/tests/test-cases/Group1-Docker-Commands/1-07-Docker-Stop.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-07-Docker-Stop.robot
@@ -15,7 +15,7 @@
 *** Settings ***
 Documentation  Test 1-07 - Docker Stop
 Resource  ../../resources/Util.robot
-Suite Setup  Install VIC Appliance To Test Server
+Suite Setup  Conditional Install VIC Appliance To Test Server
 Suite Teardown  Cleanup VIC Appliance On Test Server
 Test Timeout  20 minutes
 

--- a/tests/test-cases/Group1-Docker-Commands/1-08-Docker-Logs.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-08-Docker-Logs.robot
@@ -15,7 +15,7 @@
 *** Settings ***
 Documentation  Test 1-08 - Docker Logs
 Resource  ../../resources/Util.robot
-Suite Setup  Install VIC with version to Test Server  7315
+Suite Setup  Install VIC with version to Test Server  version=7315
 Suite Teardown  Cleanup VIC Appliance On Test Server
 Test Timeout  20 minutes
 

--- a/tests/test-cases/Group1-Docker-Commands/1-09-Docker-Attach.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-09-Docker-Attach.robot
@@ -15,7 +15,7 @@
 *** Settings ***
 Documentation  Test 1-09 - Docker Attach
 Resource  ../../resources/Util.robot
-Suite Setup  Install VIC Appliance To Test Server
+Suite Setup  Conditional Install VIC Appliance To Test Server
 Suite Teardown  Cleanup VIC Appliance On Test Server
 Test Timeout  20 minutes
 

--- a/tests/test-cases/Group1-Docker-Commands/1-10-Docker-PS.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-10-Docker-PS.robot
@@ -15,7 +15,7 @@
 *** Settings ***
 Documentation  Test 1-10 - Docker PS
 Resource  ../../resources/Util.robot
-Suite Setup  Install VIC Appliance To Test Server
+Suite Setup  Conditional Install VIC Appliance To Test Server
 Suite Teardown  Cleanup VIC Appliance On Test Server
 Test Timeout  20 minutes
 
@@ -107,6 +107,9 @@ Docker ps powerOn container OOB
     Power On VM OOB  jojo*
 
     Wait Until Keyword Succeeds  10x  6s  Assert Number Of Containers  ${len+1}
+
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} stop jojo
+    Should Be Equal As Integers  ${rc}  0
 
 Docker ps powerOff container OOB
     ${rc}  ${container}=  Run And Return Rc And Output  docker %{VCH-PARAMS} create --name koko ${busybox} /bin/top

--- a/tests/test-cases/Group1-Docker-Commands/1-11-Docker-RM.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-11-Docker-RM.robot
@@ -15,7 +15,7 @@
 *** Settings ***
 Documentation  Test 1-11 - Docker RM
 Resource  ../../resources/Util.robot
-Suite Setup  Install VIC Appliance To Test Server
+Suite Setup  Conditional Install VIC Appliance To Test Server
 Suite Teardown  Cleanup VIC Appliance On Test Server
 Test Timeout  20 minutes
 

--- a/tests/test-cases/Group1-Docker-Commands/1-12-Docker-RMI.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-12-Docker-RMI.robot
@@ -15,7 +15,7 @@
 *** Settings ***
 Documentation  Test 1-12 - Docker RMI
 Resource  ../../resources/Util.robot
-Suite Setup  Install VIC Appliance To Test Server
+Suite Setup  Run Keywords  Conditional Install VIC Appliance To Test Server  Remove All Containers
 Suite Teardown  Cleanup VIC Appliance On Test Server
 Test Timeout  20 minutes
 
@@ -41,9 +41,11 @@ Basic docker pull, restart, and remove image
 
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} rmi ${busybox}
     Should Be Equal As Integers  ${rc}  0
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} images
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} images ${busybox}:latest
     Should Be Equal As Integers  ${rc}  0
     Should Not Contain  ${output}  busybox
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} images ${alpine}:latest
+    Should Be Equal As Integers  ${rc}  0
     Should Contain  ${output}  alpine
 
 Remove image with a removed container
@@ -55,7 +57,7 @@ Remove image with a removed container
     Should Be Equal As Integers  ${rc}  0
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} rmi ${busybox}
     Should Be Equal As Integers  ${rc}  0
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} images
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} images ${busybox}:latest
     Should Be Equal As Integers  ${rc}  0
     Should Not Contain  ${output}  busybox
 

--- a/tests/test-cases/Group1-Docker-Commands/1-13-Docker-Version.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-13-Docker-Version.robot
@@ -15,7 +15,7 @@
 *** Settings ***
 Documentation  Test 1-13 - Docker Version
 Resource  ../../resources/Util.robot
-Suite Setup  Install VIC Appliance To Test Server
+Suite Setup  Conditional Install VIC Appliance To Test Server
 Suite Teardown  Cleanup VIC Appliance On Test Server
 Test Timeout  20 minutes
 

--- a/tests/test-cases/Group1-Docker-Commands/1-14-Docker-Kill.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-14-Docker-Kill.robot
@@ -15,7 +15,7 @@
 *** Settings ***
 Documentation  Test 1-14 - Docker Kill
 Resource  ../../resources/Util.robot
-Suite Setup  Install VIC Appliance To Test Server
+Suite Setup  Conditional Install VIC Appliance To Test Server
 Suite Teardown  Cleanup VIC Appliance On Test Server
 Test Timeout  20 minutes
 

--- a/tests/test-cases/Group1-Docker-Commands/1-15-Docker-Network-Create.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-15-Docker-Network-Create.robot
@@ -15,7 +15,7 @@
 *** Settings ***
 Documentation  Test 1-15 - Docker Network Create
 Resource  ../../resources/Util.robot
-Suite Setup  Install VIC Appliance To Test Server
+Suite Setup  Run Keywords  Conditional Install VIC Appliance To Test Server  Remove All Container Networks
 Suite Teardown  Cleanup VIC Appliance On Test Server
 Test Timeout  20 minutes
 

--- a/tests/test-cases/Group1-Docker-Commands/1-16-Docker-Network-LS.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-16-Docker-Network-LS.robot
@@ -15,7 +15,7 @@
 *** Settings ***
 Documentation  Test 1-16 - Docker Network LS
 Resource  ../../resources/Util.robot
-Suite Setup  Install VIC Appliance To Test Server  certs=${false}
+Suite Setup  Run Keywords  Conditional Install VIC Appliance To Test Server  Remove All Container Networks
 Suite Teardown  Cleanup VIC Appliance On Test Server
 Test Timeout  20 minutes
 

--- a/tests/test-cases/Group1-Docker-Commands/1-17-Docker-Network-Connect.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-17-Docker-Network-Connect.robot
@@ -15,7 +15,7 @@
 *** Settings ***
 Documentation  Test 1-17 - Docker Network Connect
 Resource  ../../resources/Util.robot
-Suite Setup  Install VIC Appliance To Test Server  certs=${false}
+Suite Setup  Run Keywords  Conditional Install VIC Appliance To Test Server  Remove All Container Networks
 Suite Teardown  Cleanup VIC Appliance On Test Server
 Test Timeout  20 minutes
 

--- a/tests/test-cases/Group1-Docker-Commands/1-18-Docker-Network-RM.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-18-Docker-Network-RM.robot
@@ -15,7 +15,7 @@
 *** Settings ***
 Documentation  Test 1-18 - Docker Network RM
 Resource  ../../resources/Util.robot
-Suite Setup  Install VIC Appliance To Test Server
+Suite Setup  Run Keywords  Conditional Install VIC Appliance To Test Server  Remove All Container Networks
 Suite Teardown  Cleanup VIC Appliance On Test Server
 Test Timeout  20 minutes
 

--- a/tests/test-cases/Group1-Docker-Commands/1-19-Docker-Volume-Create.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-19-Docker-Volume-Create.robot
@@ -15,7 +15,7 @@
 *** Settings ***
 Documentation  Test 1-19 - Docker Volume Create
 Resource  ../../resources/Util.robot
-Suite Setup  Install VIC Appliance To Test Server
+Suite Setup  Conditional Install VIC Appliance To Test Server
 Suite Teardown  Cleanup VIC Appliance On Test Server
 Test Timeout  20 minutes
 

--- a/tests/test-cases/Group1-Docker-Commands/1-20-Docker-Volume-Inspect.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-20-Docker-Volume-Inspect.robot
@@ -15,7 +15,7 @@
 *** Settings ***
 Documentation  Test 1-20 - Docker Volume Inspect
 Resource  ../../resources/Util.robot
-Suite Setup  Install VIC Appliance To Test Server
+Suite Setup  Run Keywords  Conditional Install VIC Appliance To Test Server  Remove All Volumes
 Suite Teardown  Cleanup VIC Appliance On Test Server
 Test Timeout  20 minutes
 

--- a/tests/test-cases/Group1-Docker-Commands/1-21-Docker-Volume-LS.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-21-Docker-Volume-LS.robot
@@ -15,7 +15,7 @@
 *** Settings ***
 Documentation  Test 1-21 - Docker Volume LS
 Resource  ../../resources/Util.robot
-Suite Setup  Install VIC Appliance To Test Server
+Suite Setup  Run Keywords  Conditional Install VIC Appliance To Test Server  Remove All Volumes
 Suite Teardown  Cleanup VIC Appliance On Test Server
 Test Timeout  20 minutes
 

--- a/tests/test-cases/Group1-Docker-Commands/1-22-Docker-Volume-RM.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-22-Docker-Volume-RM.robot
@@ -15,7 +15,7 @@
 *** Settings ***
 Documentation  Test 1-22 - Docker Volume RM
 Resource  ../../resources/Util.robot
-Suite Setup  Install VIC Appliance To Test Server
+Suite Setup  Run Keywords  Conditional Install VIC Appliance To Test Server  Remove All Volumes
 Suite Teardown  Cleanup VIC Appliance On Test Server
 Test Timeout  20 minutes
 

--- a/tests/test-cases/Group1-Docker-Commands/1-23-Docker-Inspect.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-23-Docker-Inspect.robot
@@ -15,7 +15,7 @@
 *** Settings ***
 Documentation  Test 1-23 - Docker Inspect
 Resource  ../../resources/Util.robot
-Suite Setup  Install VIC Appliance To Test Server  certs=${false}
+Suite Setup  Conditional Install VIC Appliance To Test Server
 Suite Teardown  Cleanup VIC Appliance On Test Server
 Test Timeout  20 minutes
 

--- a/tests/test-cases/Group1-Docker-Commands/1-24-Docker-Link.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-24-Docker-Link.robot
@@ -15,7 +15,7 @@
 *** Settings ***
 Documentation  Test 1-24 - Docker Link
 Resource  ../../resources/Util.robot
-Suite Setup  Install VIC Appliance To Test Server
+Suite Setup  Conditional Install VIC Appliance To Test Server
 Suite Teardown  Cleanup VIC Appliance On Test Server
 Test Timeout  20 minutes
 

--- a/tests/test-cases/Group1-Docker-Commands/1-25-Docker-Port-Map.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-25-Docker-Port-Map.robot
@@ -15,7 +15,7 @@
 *** Settings ***
 Documentation  Test 1-25 - Docker Port Map
 Resource  ../../resources/Util.robot
-Suite Setup  Install VIC Appliance To Test Server  certs=${false}
+Suite Setup  Conditional Install VIC Appliance To Test Server
 Suite Teardown  Cleanup VIC Appliance On Test Server
 Test Timeout  20 minutes
 

--- a/tests/test-cases/Group1-Docker-Commands/1-26-Docker-Hello-World.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-26-Docker-Hello-World.robot
@@ -15,7 +15,7 @@
 *** Settings ***
 Documentation  Test 1-26 - Docker Hello World
 Resource  ../../resources/Util.robot
-Suite Setup  Install VIC Appliance To Test Server
+Suite Setup  Conditional Install VIC Appliance To Test Server
 Suite Teardown  Cleanup VIC Appliance On Test Server
 Test Timeout  20 minutes
 

--- a/tests/test-cases/Group1-Docker-Commands/1-27-Docker-Login.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-27-Docker-Login.robot
@@ -15,7 +15,7 @@
 *** Settings ***
 Documentation  Test 1-27 - Docker Login
 Resource  ../../resources/Util.robot
-Suite Setup  Install VIC Appliance To Test Server  certs=${false}
+Suite Setup  Conditional Install VIC Appliance To Test Server
 Suite Teardown  Cleanup VIC Appliance On Test Server
 Test Timeout  20 minutes
 

--- a/tests/test-cases/Group1-Docker-Commands/1-28-Docker-Secret.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-28-Docker-Secret.robot
@@ -15,7 +15,7 @@
 *** Settings ***
 Documentation  Test 1-28 - Docker Secret
 Resource  ../../resources/Util.robot
-Suite Setup  Install VIC Appliance To Test Server  certs=${false}
+Suite Setup  Conditional Install VIC Appliance To Test Server
 Suite Teardown  Cleanup VIC Appliance On Test Server
 Test Timeout  20 minutes
 

--- a/tests/test-cases/Group1-Docker-Commands/1-29-Docker-Checkpoint.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-29-Docker-Checkpoint.robot
@@ -15,7 +15,7 @@
 *** Settings ***
 Documentation  Test 1-29 - Docker Checkpoint
 Resource  ../../resources/Util.robot
-Suite Setup  Install VIC Appliance To Test Server  certs=${false}
+Suite Setup  Conditional Install VIC Appliance To Test Server
 Suite Teardown  Cleanup VIC Appliance On Test Server
 Test Timeout  20 minutes
 

--- a/tests/test-cases/Group1-Docker-Commands/1-30-Docker-Deploy.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-30-Docker-Deploy.robot
@@ -15,7 +15,7 @@
 *** Settings ***
 Documentation  Test 1-30 - Docker Deploy
 Resource  ../../resources/Util.robot
-Suite Setup  Install VIC Appliance To Test Server  certs=${false}
+Suite Setup  Conditional Install VIC Appliance To Test Server
 Suite Teardown  Cleanup VIC Appliance On Test Server
 Test Timeout  20 minutes
 

--- a/tests/test-cases/Group1-Docker-Commands/1-31-Docker-Node.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-31-Docker-Node.robot
@@ -15,7 +15,7 @@
 *** Settings ***
 Documentation  Test 1-31 - Docker Node
 Resource  ../../resources/Util.robot
-Suite Setup  Install VIC Appliance To Test Server  certs=${false}
+Suite Setup  Conditional Install VIC Appliance To Test Server
 Suite Teardown  Cleanup VIC Appliance On Test Server
 Test Timeout  20 minutes
 

--- a/tests/test-cases/Group1-Docker-Commands/1-32-Docker-Plugin.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-32-Docker-Plugin.robot
@@ -15,7 +15,7 @@
 *** Settings ***
 Documentation  Test 1-32 - Docker plugin
 Resource  ../../resources/Util.robot
-Suite Setup  Install VIC Appliance To Test Server  certs=${false}
+Suite Setup  Conditional Install VIC Appliance To Test Server
 Suite Teardown  Cleanup VIC Appliance On Test Server
 Test Timeout  20 minutes
 

--- a/tests/test-cases/Group1-Docker-Commands/1-33-Docker-Service.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-33-Docker-Service.robot
@@ -15,7 +15,7 @@
 *** Settings ***
 Documentation  Test 1-33 - Docker Service
 Resource  ../../resources/Util.robot
-Suite Setup  Install VIC Appliance To Test Server  certs=${false}
+Suite Setup  Conditional Install VIC Appliance To Test Server
 Suite Teardown  Cleanup VIC Appliance On Test Server
 Test Timeout  20 minutes
 

--- a/tests/test-cases/Group1-Docker-Commands/1-34-Docker-Stack.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-34-Docker-Stack.robot
@@ -15,7 +15,7 @@
 *** Settings ***
 Documentation  Test 1-34 - Docker Stack
 Resource  ../../resources/Util.robot
-Suite Setup  Install VIC Appliance To Test Server  certs=${false}
+Suite Setup  Conditional Install VIC Appliance To Test Server
 Suite Teardown  Cleanup VIC Appliance On Test Server
 Test Timeout  20 minutes
 

--- a/tests/test-cases/Group1-Docker-Commands/1-35-Docker-Swarm.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-35-Docker-Swarm.robot
@@ -15,7 +15,7 @@
 *** Settings ***
 Documentation  Test 1-35 - Docker Swarm
 Resource  ../../resources/Util.robot
-Suite Setup  Install VIC Appliance To Test Server  certs=${false}
+Suite Setup  Conditional Install VIC Appliance To Test Server
 Suite Teardown  Cleanup VIC Appliance On Test Server
 Test Timeout  20 minutes
 

--- a/tests/test-cases/Group1-Docker-Commands/1-36-Docker-Rename.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-36-Docker-Rename.robot
@@ -15,7 +15,7 @@
 *** Settings ***
 Documentation  Test 1-36 - Docker Rename
 Resource  ../../resources/Util.robot
-Suite Setup  Install VIC Appliance To Test Server
+Suite Setup  Conditional Install VIC Appliance To Test Server
 Suite Teardown  Cleanup VIC Appliance On Test Server
 Test Timeout  20 minutes
 

--- a/tests/test-cases/Group1-Docker-Commands/1-37-Docker-USER.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-37-Docker-USER.robot
@@ -15,7 +15,7 @@
 *** Settings ***
 Documentation   Test 1-37 - Docker Run As USER
 Resource        ../../resources/Util.robot
-Suite Setup     Install VIC Appliance To Test Server
+Suite Setup  Conditional Install VIC Appliance To Test Server
 Suite Teardown  Cleanup VIC Appliance On Test Server
 Test Timeout  20 minutes
 

--- a/tests/test-cases/Group1-Docker-Commands/1-38-Docker-Exec.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-38-Docker-Exec.robot
@@ -15,7 +15,7 @@
 *** Settings ***
 Documentation  Test 1-38 - Docker Exec
 Resource  ../../resources/Util.robot
-Suite Setup  Install VIC Appliance To Test Server
+Suite Setup  Conditional Install VIC Appliance To Test Server
 Suite Teardown  Cleanup VIC Appliance On Test Server
 Test Timeout  20 minutes
 

--- a/tests/test-cases/Group1-Docker-Commands/1-39-Docker-Stats.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-39-Docker-Stats.robot
@@ -15,7 +15,7 @@
 *** Settings ***
 Documentation   Test 1-39 - Docker Stats
 Resource        ../../resources/Util.robot
-Suite Setup     Install VIC Appliance To Test Server
+Suite Setup  Conditional Install VIC Appliance To Test Server
 Suite Teardown  Cleanup VIC Appliance On Test Server
 Test Timeout  20 minutes
 

--- a/tests/test-cases/Group1-Docker-Commands/1-40-Docker-Restart.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-40-Docker-Restart.robot
@@ -15,7 +15,7 @@
 *** Settings ***
 Documentation   Test 1-40 - Docker Restart
 Resource        ../../resources/Util.robot
-Suite Setup     Install VIC Appliance To Test Server
+Suite Setup  Conditional Install VIC Appliance To Test Server
 Suite Teardown  Cleanup VIC Appliance On Test Server
 Test Timeout  20 minutes
 

--- a/tests/test-cases/Group1-Docker-Commands/1-41-Docker-Commit.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-41-Docker-Commit.robot
@@ -15,7 +15,7 @@
 *** Settings ***
 Documentation  Test 1-41 - Docker Commit
 Resource  ../../resources/Util.robot
-Suite Setup  Install VIC Appliance To Test Server
+Suite Setup  Conditional Install VIC Appliance To Test Server
 Suite Teardown  Cleanup VIC Appliance On Test Server
 Test Timeout  20 minutes
 

--- a/tests/test-cases/Group1-Docker-Commands/1-42-Docker-Diff.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-42-Docker-Diff.robot
@@ -15,7 +15,7 @@
 *** Settings ***
 Documentation  Test 1-42 - Docker Diff
 Resource  ../../resources/Util.robot
-Suite Setup  Install VIC Appliance To Test Server
+Suite Setup  Conditional Install VIC Appliance To Test Server
 Suite Teardown  Cleanup VIC Appliance On Test Server
 Test Timeout  20 minutes
 

--- a/tests/test-cases/Group1-Docker-Commands/1-43-Docker-CP-Offline.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-43-Docker-CP-Offline.robot
@@ -21,7 +21,8 @@ Test Timeout  20 minutes
 
 *** Keywords ***
 Set up test files and install VIC appliance to test server
-    Install VIC Appliance To Test Server
+    Conditional Install VIC Appliance To Test Server
+    Remove All Volumes
     Create File  ${CURDIR}/foo.txt   hello world
     Create File  ${CURDIR}/content   fake file content for testing only
     Create Directory  ${CURDIR}/bar

--- a/tests/test-cases/Group1-Docker-Commands/1-44-Docker-CP-Online.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-44-Docker-CP-Online.robot
@@ -21,7 +21,8 @@ Test Timeout  20 minutes
 
 *** Keywords ***
 Set up test files and install VIC appliance to test server
-    Install VIC Appliance To Test Server
+    Conditional Install VIC Appliance To Test Server
+    Remove All Volumes
     Create File  ${CURDIR}/foo.txt   hello world
     Create File  ${CURDIR}/content   fake file content for testing only
     Create Directory  ${CURDIR}/bar

--- a/tests/test-cases/Group1-Docker-Commands/1-999-Cleanup.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-999-Cleanup.robot
@@ -1,0 +1,59 @@
+# Copyright 2017 VMware, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#	http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License
+
+*** Settings ***
+Documentation  Test 1-100 - Cleanup
+Resource  ../../resources/Util.robot
+Suite Setup  Cleanup Docker Commands Tests
+Suite Teardown  Finalize Docker Commands Tests
+Test Timeout  20 minutes
+
+*** Keywords ***
+Is Single VCH Mode
+    # If TARGET_VCH not present when running group, track that we're installing a single VCH here.
+    # This allows the cleanup suite to know that it can clean up the VCH
+    ${multi-vch}=  Get Environment Variable  MULTI_VCH  ${EMPTY}
+
+    ${single-vch-mode}=  Run Keyword If  '${multi-vch}' == '1'  Set Variable  ${False}
+    ...  ELSE  Set Variable  ${True}
+
+    [Return]  ${single-vch-mode}
+
+Cleanup Docker Commands Tests
+    Log To Console  Cleaning up docker command tests
+
+    ${single-vch-mode}=  Run Keyword  Is Single VCH Mode
+
+    Run Keyword If  ${single-vch-mode} == ${True}  Conditional Install VIC Appliance To Test Server
+
+Finalize Docker Commands Tests
+    Log To Console  Finalizing up docker command tests
+
+    ${single-vch-mode}=  Run Keyword  Is Single VCH Mode
+
+    Run Keyword If  ${single-vch-mode} == ${True}  Cleanup VIC Appliance On Test Server
+
+*** Test Cases ***
+Prepare to Cleanup Group
+    ${single-vch-mode}=  Run Keyword  Is Single VCH Mode
+ 
+    # Helps cleans up the Group 1 test suite instead of solely depending on vic-machine
+    Run Keyword If  ${single-vch-mode} == ${True}  Remove All Containers
+    Run Keyword If  ${single-vch-mode} == ${True}  Remove All Images
+
+    # This step allows the teardown to remove the VCH.  This only occurs if CLEANUP_GROUP was set
+    # by an initializer suite.
+    ${cleanup-group}=  Get Environment Variable  CLEANUP_GROUP  ${EMPTY}
+    Run Keyword If  ${single-vch-mode} == ${True}  Run Keyword If  '${cleanup-group}' == '1'  Remove VCH From Removal Exception List  vch=%{VCH-NAME}  
+    

--- a/tests/test-cases/Group1-Docker-Commands/__init__.robot
+++ b/tests/test-cases/Group1-Docker-Commands/__init__.robot
@@ -1,0 +1,37 @@
+# Copyright 2017 VMware, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#	http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License
+
+*** Settings ***
+Documentation  Group 1 Shared VCH Initializer
+Resource  ../../resources/Util.robot
+Suite Setup  Setup Docker Commands Tests
+Test Timeout  20 minutes
+
+*** Keywords ***
+Setup Docker Commands Tests
+    # If TARGET_VCH not present when running group, track that we're installing a single VCH here.
+    # This allows the cleanup suite to know that it can clean up the VCH
+    ${target-vch}=  Get Environment Variable  TARGET_VCH  ${EMPTY}
+    ${multi-vch}=  Get Environment Variable  MULTI_VCH  ${EMPTY}
+
+    ${single-vch-mode}=  Run Keyword If  '${multi-vch}' == '1'  Set Variable  ${False}
+    ...  ELSE  Set Variable  ${True}
+
+    Set Environment Variable  CLEANUP_GROUP  0
+
+    Run Keyword If  '${target-vch}' == '${EMPTY}'  Run Keyword If  ${single-vch-mode} == ${True}  Set Environment Variable  CLEANUP_GROUP  1
+
+    Run Keyword If  '${target-vch}' == '${EMPTY}'  Run Keyword If  ${single-vch-mode} != ${True}  Log To Console  Bypassing shared VCH install because tests are in multi-VCH mode.
+    Run Keyword If  '${target-vch}' != '${EMPTY}'  Log To Console  Detected Target VCH ${target-vch}
+    Run Keyword If  ${single-vch-mode} == ${True}  Conditional Install VIC Appliance To Test Server  init=${True}


### PR DESCRIPTION
Migrate the tests to using a single VCH if running as a group.
There are still some test files that install their a new VCH.
Some of those tests should be re-examined to determine if they
really need a new VCH.

A bootstrap and cleanup robot file is required to initiate and
clean up a group of tests.  The infrastructure does not prevent
single test file from running normally.

To initiate "one VCH" mode, REUSE-VCH env variable must be
set to the VCH name in the bootstrap file.  Also, the VCH name
must be added to the removal exception list.

1. Added exception list to prevent VCH from getting "cleaned up"
2. Modify cleanup code to ignore assets linked to the exception list
3. Clean up containers with docker before cleaning up VIC appliance
4. Fix tests with dependencies on it running on its own VCH
5. Added a few docker utility keywords
6. Add DEBUG_VCH secret to allow using an existing VCH created outside of CI

Resolves #6301 