### PR TITLE
Fix minor issues in error handler util [specific ci=Group23-Vic-Machine-Service]

### DIFF
--- a/lib/apiservers/service/restapi/handlers/util/error.go
+++ b/lib/apiservers/service/restapi/handlers/util/error.go
@@ -24,11 +24,11 @@ func StatusCode(err error) int {
 }
 
 func NewError(code int, message string) error {
-	return &httpError{code: code, message: message}
+	return httpError{code: code, message: message}
 }
 
 func WrapError(code int, err error) error {
-	return &wrappedError{error: err, code: code}
+	return wrappedError{error: err, code: code}
 }
 
 // Pattern based on https://dave.cheney.net/2016/04/27/dont-just-check-errors-handle-them-gracefully
@@ -42,15 +42,23 @@ type httpError struct {
 	message string
 }
 
-func (e *httpError) Code() int {
+func (e httpError) Code() int {
 	return e.code
 }
 
-func (e *httpError) Error() string {
+func (e httpError) Error() string {
 	return e.message
 }
 
 type wrappedError struct {
 	error
 	code int
+}
+
+func (e wrappedError) Code() int {
+	return e.code
+}
+
+func (e wrappedError) Error() string {
+	return e.error.Error()
 }

--- a/lib/apiservers/service/restapi/handlers/util/error_test.go
+++ b/lib/apiservers/service/restapi/handlers/util/error_test.go
@@ -1,0 +1,64 @@
+// Copyright 2017 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestNewError(t *testing.T) {
+	e := NewError(123, "new error")
+	c := StatusCode(e)
+
+	if c != 123 {
+		t.Errorf("Status code was %d, not 123.", c)
+	}
+
+	if e.Error() != "new error" {
+		t.Error("NewError did not preserve message.")
+	}
+}
+
+func TestWrappedError(t *testing.T) {
+	e := WrapError(234, fmt.Errorf("fmt error"))
+	c := StatusCode(e)
+
+	if c != 234 {
+		t.Errorf("Status code was %d, not 234.", c)
+	}
+
+	if e.Error() != "fmt error" {
+		t.Error("WrapError did not preserve message.")
+	}
+}
+
+func TestDoublyWrappedError(t *testing.T) {
+	e := WrapError(234, WrapError(123, fmt.Errorf("fmt error")))
+	c := StatusCode(e)
+
+	if c != 234 {
+		t.Errorf("Status code was %d, not 234.", c)
+	}
+}
+
+func TestStatusCodeFallback(t *testing.T) {
+	e := fmt.Errorf("fmt error")
+	c := StatusCode(e)
+
+	if c != 500 {
+		t.Errorf("Default status code was %d, not 500.", c)
+	}
+}


### PR DESCRIPTION
Switch from pointer receiver to value receiver and add missing methods for `wrappedError` to ensure error handling code works as designed.

Introduce unit tests to verify behavior.
