### PR TITLE
Define end-to-end tests for VCH listing endpoint [specific ci=Group23-Vic-Machine-Service]

### DIFF
--- a/lib/apiservers/service/restapi/handlers/common.go
+++ b/lib/apiservers/service/restapi/handlers/common.go
@@ -55,7 +55,7 @@ func buildData(ctx context.Context, url url.URL, user string, pass string, thumb
 
 		datacenterObject, err := validator.Session.Finder.ObjectReference(ctx, datacenterManagedObjectReference)
 		if err != nil {
-			return nil, util.WrapError(500, err)
+			return nil, util.WrapError(404, err)
 		}
 
 		d.Target.URL.Path = datacenterObject.(*object.Datacenter).InventoryPath

--- a/tests/resources/Group23-VIC-Machine-Service-Util.robot
+++ b/tests/resources/Group23-VIC-Machine-Service-Util.robot
@@ -37,9 +37,10 @@ Get Path
 
 
 Get Path Under Target
-    [Arguments]    ${path}
+    [Arguments]    ${path}    @{query}
+    ${fullQuery}=    Catenate    SEPARATOR=&    thumbprint=%{TEST_THUMBPRINT}    @{query}
     ${auth}=    Evaluate    base64.b64encode("%{TEST_USERNAME}:%{TEST_PASSWORD}")    modules=base64
-    ${RC}  ${OUTPUT}=    Run And Return Rc And Output    curl -s -w "\n\%{http_code}\n" -X GET "http://127.0.0.1:${HTTP_PORT}/container/target/%{TEST_URL}/${PATH}?thumbprint=%{TEST_THUMBPRINT}" -H "Accept: application/json" -H "Authorization: Basic ${auth}"
+    ${RC}  ${OUTPUT}=    Run And Return Rc And Output    curl -s -w "\n\%{http_code}\n" -X GET "http://127.0.0.1:${HTTP_PORT}/container/target/%{TEST_URL}/${PATH}?${fullQuery}" -H "Accept: application/json" -H "Authorization: Basic ${auth}"
     ${OUTPUT}    ${STATUS}=    Split String From Right    ${OUTPUT}    \n    1
     Set Test Variable    ${RC}
     Set Test Variable    ${OUTPUT}

--- a/tests/test-cases/Group23-VIC-Machine-Service/23-02-VCH-List.md
+++ b/tests/test-cases/Group23-VIC-Machine-Service/23-02-VCH-List.md
@@ -1,0 +1,26 @@
+Test 23-02 - VCH List
+=======
+
+# Purpose:
+To verify vic-machine-server can return a list of VCHs including the expected information
+
+# References:
+1. [The design document](../../../doc/design/vic-machine/service.md)
+
+# Environment:
+This test requires a vSphere system where VCHs can be deployed 
+
+# Test Steps:
+1. Deploy a VCH
+2. Get a list of all VCHs
+3. Get a list of all VCHs in the test datacenter
+4. Attempt to list all VCHs in an invalid datacenter
+5. Attempt to list all VCHs in an invalid compute resource
+6. Attempt to list all VCHs in an invalid datacenter and compute resource
+
+# Expected Outcome:
+* The results of 2-3 should contain the VCH created in 1, with the correct ID.
+* The requests in 4-6 should result in an appropriate error message.
+
+# Possible Problems:
+None known

--- a/tests/test-cases/Group23-VIC-Machine-Service/23-02-VCH-List.robot
+++ b/tests/test-cases/Group23-VIC-Machine-Service/23-02-VCH-List.robot
@@ -1,0 +1,99 @@
+# Copyright 2017 VMware, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#	http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License
+
+*** Settings ***
+Documentation     Test 23-02 - VCH List
+Resource          ../../resources/Util.robot
+Resource          ../../resources/Group23-VIC-Machine-Service-Util.robot
+Suite Setup       Setup
+Suite Teardown    Teardown
+Default Tags
+
+
+*** Keywords ***
+Setup
+    Start VIC Machine Server
+    Install VIC Appliance To Test Server
+
+
+Teardown
+    Cleanup VIC Appliance On Test Server
+    Terminate All Processes    kill=True
+
+
+Get VCH List
+    Get Path Under Target    vch
+
+
+Get VCH List Within Datacenter
+    ${dcID}=    Get Datacenter ID
+    Get Path Under Target    datacenter/${dcID}/vch
+
+
+Verify VCH List
+    ${expectedId}=    Get VCH ID    %{VCH-NAME}
+    ${actualId}=  Run    echo '${OUTPUT}' | jq -r '.vchs[] | select(.name=="%{VCH-NAME}").id'
+    Should Be Equal    ${expectedId}    ${actualId}
+
+    ${admin_portal}=  Run    echo '${OUTPUT}' | jq -r '.vchs[] | select(.name=="%{VCH-NAME}").admin_portal'
+    Should Not Be Empty    ${admin_portal}
+
+    ${docker_host}=  Run    echo '${OUTPUT}' | jq -r '.vchs[] | select(.name=="%{VCH-NAME}").docker_host'
+    Should Not Be Empty    ${docker_host}
+
+    ${upgrade_status}=  Run    echo '${OUTPUT}' | jq -r '.vchs[] | select(.name=="%{VCH-NAME}").upgrade_status'
+    Should Not Be Empty    ${upgrade_status}
+
+    ${version}=  Run    echo '${OUTPUT}' | jq -r '.vchs[] | select(.name=="%{VCH-NAME}").version'
+    Should Not Be Empty    ${version}
+
+
+*** Test Cases ***
+Get VCH List
+    Get VCH List
+
+    Verify Return Code
+    Verify Status Ok
+    Verify VCH List
+
+
+Get VCH List Within Datacenter
+    Get VCH List Within Datacenter
+
+    Verify Return Code
+    Verify Status Ok
+    Verify VCH List
+
+# TODO: Add test for compute resource (once relevant code is updated to use ID instead of name)
+# TODO: Add test for compute resource within datacenter (once relevant code is updated to use ID instead of name)
+
+Get VCH List Within Invalid Datacenter
+    Get Path Under Target    datacenter/INVALID/vch
+
+    Verify Return Code
+    Verify Status    404
+
+
+Get VCH List Within Invalid Compute Resource
+    Get Path Under Target    vch    compute-resource=INVALID
+
+    Verify Return Code
+    Verify Status    400
+
+
+Get VCH List Within Invalid Datacenter and Compute Resource
+    Get Path Under Target    datacenter/INVALID/vch    compute-resource=INVALID
+
+    Verify Return Code
+    Verify Status    404


### PR DESCRIPTION
Introduce a robot suite for the VCH listing endpoints leveraging the group-scoped keywords introduced for other API tests.

Test the successful operation of the endpoints as well as common error cases.

Resolves #6028.