### PR TITLE
 Include appropriate CORS headers

### DIFF
--- a/lib/apiservers/service/restapi/configure_vic_machine.go
+++ b/lib/apiservers/service/restapi/configure_vic_machine.go
@@ -21,6 +21,7 @@ import (
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/runtime/middleware"
+	"github.com/rs/cors"
 	"github.com/tylerb/graceful"
 
 	"github.com/vmware/vic/lib/apiservers/service/restapi/handlers"
@@ -162,5 +163,16 @@ func setupMiddlewares(handler http.Handler) http.Handler {
 // The middleware configuration happens before anything, this middleware also applies to serving the swagger.json document.
 // So this is a good place to plug in a panic handling middleware, logging and metrics
 func setupGlobalMiddleware(handler http.Handler) http.Handler {
-	return handler
+	// These settings have security implications. These settings should not be changed without appropriate review.
+	// For more information, see the relevant section of the design document:
+	// https://github.com/vmware/vic/blob/7f575392df99642c5edd8f539a74fe9c89155b00/doc/design/vic-machine/service.md#cross-origin-requests--cross-site-request-forgery
+	c := cors.New(cors.Options{
+		AllowedOrigins:   []string{"*"},
+		AllowedHeaders:   []string{"Authorization", "Content-Type", "User-Agent"},
+		AllowedMethods:   []string{"HEAD", "GET", "POST", "PUT", "PATCH", "DELETE"},
+		ExposedHeaders:   []string{"Content-Length"},
+		AllowCredentials: false,
+	})
+
+	return c.Handler(handler)
 }


### PR DESCRIPTION
(Note: This PR builds on #6497; 4f555cb is the only new commit.)

Because the vSphere H5 client plugin and the `vic-machine-server` will be served from different hosts, the H5 client plugin will be making cross-origin requests. As these would normally be prevented by the browser's same-origin policy, the service must support responding to all requests (including preflight requests) with the appropriate CORS headers.

Resolves #6038.
