### PR TITLE
Report a better message for container remove if host ESX disconnected

### DIFF
--- a/lib/apiservers/engine/backends/container.go
+++ b/lib/apiservers/engine/backends/container.go
@@ -788,6 +788,11 @@ func (c *Container) ContainerRm(name string, config *types.ContainerRmConfig) er
 			return InternalServerError(err.Payload.Message)
 		case *containers.ContainerRemoveConflict:
 			return derr.NewRequestConflictError(fmt.Errorf("You cannot remove a running container. Stop the container before attempting removal or use -f"))
+		case *containers.ContainerRemoveInternalServerError:
+			if err.Payload == nil || err.Payload.Message == "" {
+				return InternalServerError(err.Error())
+			}
+			return InternalServerError(err.Payload.Message)
 		default:
 			return InternalServerError(err.Error())
 		}

--- a/lib/apiservers/portlayer/restapi/handlers/containers_handlers.go
+++ b/lib/apiservers/portlayer/restapi/handlers/containers_handlers.go
@@ -260,7 +260,7 @@ func (handler *ContainersHandlersImpl) RemoveContainerHandler(params containers.
 				switch f.Fault().(type) {
 				case *types.HostNotConnected:
 					p := &models.Error{Message: "Couldn't remove container. The ESX host is temporarily disconnected. Please try again later."}
-					return containers.NewContainerRemoveDefault(http.StatusInternalServerError).WithPayload(p)
+					return containers.NewContainerRemoveInternalServerError().WithPayload(p)
 				}
 			}
 			return containers.NewContainerRemoveInternalServerError()

--- a/lib/apiservers/portlayer/restapi/handlers/containers_handlers.go
+++ b/lib/apiservers/portlayer/restapi/handlers/containers_handlers.go
@@ -32,7 +32,6 @@ import (
 	"github.com/go-openapi/runtime/middleware"
 
 	"github.com/vmware/govmomi/vim25/types"
-
 	"github.com/vmware/vic/lib/apiservers/portlayer/models"
 	"github.com/vmware/vic/lib/apiservers/portlayer/restapi/operations"
 	"github.com/vmware/vic/lib/apiservers/portlayer/restapi/operations/containers"

--- a/lib/apiservers/portlayer/restapi/handlers/containers_handlers.go
+++ b/lib/apiservers/portlayer/restapi/handlers/containers_handlers.go
@@ -31,6 +31,8 @@ import (
 	log "github.com/Sirupsen/logrus"
 	"github.com/go-openapi/runtime/middleware"
 
+	"github.com/vmware/govmomi/vim25/types"
+
 	"github.com/vmware/vic/lib/apiservers/portlayer/models"
 	"github.com/vmware/vic/lib/apiservers/portlayer/restapi/operations"
 	"github.com/vmware/vic/lib/apiservers/portlayer/restapi/operations/containers"
@@ -43,8 +45,6 @@ import (
 	"github.com/vmware/vic/pkg/trace"
 	"github.com/vmware/vic/pkg/uid"
 	"github.com/vmware/vic/pkg/version"
-
-	"github.com/vmware/govmomi/vim25/types"
 )
 
 const (
@@ -260,7 +260,8 @@ func (handler *ContainersHandlersImpl) RemoveContainerHandler(params containers.
 			if f, ok := err.(types.HasFault); ok {
 				switch f.Fault().(type) {
 				case *types.HostNotConnected:
-					return containers.NewContainerRemoveDefault(500).WithPayload(&models.Error{Message: "Couldn't remove container. The ESX host is temporarily disconnected. Please try again later."})
+					p := &models.Error{Message: "Couldn't remove container. The ESX host is temporarily disconnected. Please try again later."}
+					return containers.NewContainerRemoveDefault(http.StatusInternalServerError).WithPayload(p)
 				}
 			}
 			return containers.NewContainerRemoveInternalServerError()

--- a/lib/apiservers/portlayer/restapi/handlers/containers_handlers.go
+++ b/lib/apiservers/portlayer/restapi/handlers/containers_handlers.go
@@ -257,11 +257,10 @@ func (handler *ContainersHandlersImpl) RemoveContainerHandler(params containers.
 		case exec.RemovePowerError:
 			return containers.NewContainerRemoveConflict().WithPayload(&models.Error{Message: err.Error()})
 		default:
-			f, ok := err.(types.HasFault)
-			if ok {
+			if f, ok := err.(types.HasFault); ok {
 				switch f.Fault().(type) {
 				case *types.HostNotConnected:
-					return containers.NewContainerRemoveDefault(501).WithPayload(&models.Error{Message: "Couldn't remove container because the host the container is placed on is not connected"})
+					return containers.NewContainerRemoveDefault(501).WithPayload(&models.Error{Message: "Couldn't remove container.  The ESX host is temporarily disconnected.  Please try again later."})
 				}
 			}
 			return containers.NewContainerRemoveInternalServerError()

--- a/lib/apiservers/portlayer/restapi/handlers/containers_handlers.go
+++ b/lib/apiservers/portlayer/restapi/handlers/containers_handlers.go
@@ -260,7 +260,7 @@ func (handler *ContainersHandlersImpl) RemoveContainerHandler(params containers.
 			if f, ok := err.(types.HasFault); ok {
 				switch f.Fault().(type) {
 				case *types.HostNotConnected:
-					return containers.NewContainerRemoveDefault(501).WithPayload(&models.Error{Message: "Couldn't remove container.  The ESX host is temporarily disconnected.  Please try again later."})
+					return containers.NewContainerRemoveDefault(500).WithPayload(&models.Error{Message: "Couldn't remove container. The ESX host is temporarily disconnected. Please try again later."})
 				}
 			}
 			return containers.NewContainerRemoveInternalServerError()

--- a/lib/apiservers/portlayer/swagger.json
+++ b/lib/apiservers/portlayer/swagger.json
@@ -1570,10 +1570,10 @@
 						}
 					},
 					"500": {
-						  "description": "server error",
-              "schema": {
-                  "$ref": "#/definitions/Error"
-						  }
+            "description": "server error",
+            "schema": {
+                "$ref": "#/definitions/Error"
+            }
 					},
 					"default": {
 						"description": "Error",

--- a/lib/apiservers/portlayer/swagger.json
+++ b/lib/apiservers/portlayer/swagger.json
@@ -1570,10 +1570,10 @@
 						}
 					},
 					"500": {
-            "description": "server error",
-            "schema": {
-                "$ref": "#/definitions/Error"
-            }
+						"description": "server error",
+						"schema": {
+						"$ref": "#/definitions/Error"
+						}
 					},
 					"default": {
 						"description": "Error",

--- a/lib/apiservers/portlayer/swagger.json
+++ b/lib/apiservers/portlayer/swagger.json
@@ -1570,7 +1570,10 @@
 						}
 					},
 					"500": {
-						"description": "server error"
+						  "description": "server error",
+              "schema": {
+                  "$ref": "#/definitions/Error"
+						  }
 					},
 					"default": {
 						"description": "Error",

--- a/lib/apiservers/portlayer/swagger.json
+++ b/lib/apiservers/portlayer/swagger.json
@@ -1572,7 +1572,7 @@
 					"500": {
 						"description": "server error",
 						"schema": {
-						"$ref": "#/definitions/Error"
+							"$ref": "#/definitions/Error"
 						}
 					},
 					"default": {


### PR DESCRIPTION
…host that has gone away

ok my commit message is too long but that's the gist of it.

Before the issue could be seen by running a container, stopping it, powering off the host it was deployed to, and then trying to do docker rm, and we would see an error like this on the command line:
```
Server error from portlayer: [DELETE /containers/{id}][500] containerRemoveInternalServerError 
```

Now, instead, we get this output after trying to `rm` a stopped container from a powered off host:

```
~ 43s
❯  docker -H sc-rdops-vm05-dhcp-151-213.eng.vmware.com:2376 --tlsverify --tlscacert="ian-vch/ca.pem" --tlscert="ian-vch/cert.pem" --tlskey="ian-vch/key.pem" rm brave_golick
Error response from daemon: Server error from portlayer: Couldn't remove container because the host the container is placed on is not connected
```

No test for this (yet) because we need VC in order to reproduce this, but I can either create an issue to create a test when CI v2 is ready or I can write a manual test