### PR TITLE
NFS fixes for volume store and volume creation

### DIFF
--- a/lib/install/management/appliance.go
+++ b/lib/install/management/appliance.go
@@ -790,7 +790,7 @@ func isPortLayerRunning(res *http.Response, conf *config.VirtualContainerHostCon
 
 	allVolumeStoresPresent := confirmVolumeStores(conf, volumeStoresLine)
 	if !allVolumeStoresPresent {
-		log.Warn("Some Volume Stores that were specified were not successfully created, Please check the above output for more information. More Information on failed volume store targets can also be found in the portlayer logs found at the vic admin endpoint.")
+		log.Error("Not all configured volume stores are online - check port layer log via vicadmin")
 	}
 
 	for _, status := range sysInfo.SystemStatus {
@@ -814,7 +814,7 @@ func confirmVolumeStores(conf *config.VirtualContainerHostConfigSpec, rawVolumeS
 	result := true
 	for k := range conf.VolumeLocations {
 		if _, ok := establishedVolumeStores[k]; !ok {
-			log.Warnf("VolumeStore (%s) specified was not able to be established in the portlayer. Please check network and nfs server configurations.", k)
+			log.Errorf("VolumeStore (%s) cannot be brought online - check network, nfs server, and --volume-store configurations", k)
 			result = false
 		}
 	}

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-22-NFS-Volume.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-22-NFS-Volume.robot
@@ -112,10 +112,8 @@ VIC Appliance Install with Read Only NFS Volume
     # Will only produce a warning in VCH creation output
     ${output}=  Install VIC Appliance To Test Server  certs=${false}  additional-args=--volume-store="nfs://${NFS_READONLY_IP}/exports/storage1?uid=0&gid=0:${nfsReadOnlyVolumeStore}"
     Should Contain  ${output}  Installer completed successfully
-    Should Contain  ${output}  VolumeStore (${nfsReadOnlyVolumeStore}) specified was not able to be established in the portlayer. Please check network and nfs server configurations.
-    Should Contain  ${output}  Some Volume Stores that were specified were not successfully created,
-    Should Contain  ${output}  Please check the above output for more information.
-    Should Contain  ${output}  More Information on failed volume store targets can also be found in the portlayer logs found at the vic admin endpoint.
+    Should Contain  ${output}  VolumeStore (${nfsReadOnlyVolumeStore}) cannot be brought online - check network, nfs server, and --volume-store configurations
+    Should Contain  ${output}  Not all configured volume stores are online - check port layer log via vicadmin
 
     ${rc}  ${volumeOutput}=  Run And Return Rc And Output  docker %{VCH-PARAMS} volume create --opt VolumeStore=${nfsReadOnlyVolumeStore}
     Should Be Equal As Integers  ${rc}  1
@@ -126,7 +124,7 @@ VIC Appliance Install With Fake NFS Server
 
     # Will only produce a warning in VCH creation output
     ${output}=  Install VIC Appliance To Test Server  certs=${false}  additional-args=--volume-store="nfs://${nfs_bogon_ip}/store?uid=0&gid=0:${nfsFakeVolumeStore}"
-    Should Contain  ${output}  VolumeStore (${nfsFakeVolumeStore}) specified was not able to be established in the portlayer. Please check network and nfs server configurations.
+    Should Contain  ${output}  VolumeStore (${nfsReadOnlyVolumeStore}) cannot be brought online - check network, nfs server, and --volume-store configurations
 
 VIC Appliance Install With Correct NFS Server
     Setup ENV Variables for VIC Appliance Install

--- a/vendor/github.com/vmware/go-nfs-client/nfs/example/test/main.go
+++ b/vendor/github.com/vmware/go-nfs-client/nfs/example/test/main.go
@@ -139,7 +139,7 @@ func main() {
 	}
 
 	if len(outDirs) != baseDirCount {
-		log.Fatalf("directory shoudl be empty of our created files!")
+		log.Fatalf("directory should be empty of our created files!")
 	}
 
 	if err = mount.Unmount(); err != nil {

--- a/vendor/github.com/vmware/go-nfs-client/nfs/example/test/main.go
+++ b/vendor/github.com/vmware/go-nfs-client/nfs/example/test/main.go
@@ -47,6 +47,13 @@ func main() {
 	}
 	defer v.Close()
 
+	// discover any system files such as lost+found or .snapshot
+	dirs, err := ls(v, ".")
+	if err != nil {
+		log.Fatalf("ls: %s", err.Error())
+	}
+	baseDirCount := len(dirs)
+
 	if _, err = v.Mkdir(dir, 0775); err != nil {
 		log.Fatalf("mkdir error: %v", err)
 	}
@@ -65,14 +72,14 @@ func main() {
 		log.Fatalf("mkdir error: %v", err)
 	}
 
-	dirs, err := ls(v, ".")
+	dirs, err = ls(v, ".")
 	if err != nil {
 		log.Fatalf("ls: %s", err.Error())
 	}
 
-	// check the length.  There should only be 1 entry in the target (aside from . and ..)
-	if len(dirs) != 3 {
-		log.Fatalf("expected 3 dirs, got %d", len(dirs))
+	// check the length.  There should only be 1 entry in the target (aside from . and .., et al)
+	if len(dirs) != 1+baseDirCount {
+		log.Fatalf("expected %d dirs, got %d", 1+baseDirCount, len(dirs))
 	}
 
 	// 10 MB file
@@ -131,8 +138,8 @@ func main() {
 		log.Fatalf("ls: %s", err.Error())
 	}
 
-	if len(outDirs) != 2 {
-		log.Fatalf("directory shoudl be empty!")
+	if len(outDirs) != baseDirCount {
+		log.Fatalf("directory shoudl be empty of our created files!")
 	}
 
 	if err = mount.Unmount(); err != nil {
@@ -140,6 +147,7 @@ func main() {
 	}
 
 	mount.Close()
+	util.Infof("Completed tests")
 }
 
 func testFileRW(v *nfs.Target, name string, filesize uint64) error {
@@ -162,9 +170,9 @@ func testFileRW(v *nfs.Target, name string, filesize uint64) error {
 	t := io.TeeReader(f, h)
 
 	// Copy filesize
-	_, err = io.CopyN(wr, t, int64(filesize))
+	n, err := io.CopyN(wr, t, int64(filesize))
 	if err != nil {
-		util.Errorf("error copying: %s", err.Error())
+		util.Errorf("error copying: n=%d, %s", n, err.Error())
 		return err
 	}
 	expectedSum := h.Sum(nil)

--- a/vendor/github.com/vmware/go-nfs-client/nfs/rpc/client.go
+++ b/vendor/github.com/vmware/go-nfs-client/nfs/rpc/client.go
@@ -144,7 +144,7 @@ retry:
 		case ProgUnavail:
 			return nil, fmt.Errorf("rpc: PROG_UNAVAIL - server does not recognize the program number")
 		case ProgMismatch:
-			return nil, fmt.Errorf("rpc: PROG_MISMATCH - program version does not exist on the")
+			return nil, fmt.Errorf("rpc: PROG_MISMATCH - program version does not exist on the server")
 		case ProcUnavail:
 			return nil, fmt.Errorf("rpc: PROC_UNAVAIL - unrecognized procedure number")
 		case GarbageArgs:

--- a/vendor/manifest
+++ b/vendor/manifest
@@ -1062,7 +1062,7 @@
 			"importpath": "github.com/vmware/go-nfs-client",
 			"repository": "https://github.com/vmware/go-nfs-client",
 			"vcs": "git",
-			"revision": "492894f630f2f2e2c38de9d6e076c6c801dc3362",
+			"revision": "7592fd7d851fefba0758fec6bfcf2f363f56d4da",
 			"branch": "master",
 			"notests": true
 		},

--- a/vendor/manifest
+++ b/vendor/manifest
@@ -1062,7 +1062,7 @@
 			"importpath": "github.com/vmware/go-nfs-client",
 			"repository": "https://github.com/vmware/go-nfs-client",
 			"vcs": "git",
-			"revision": "7592fd7d851fefba0758fec6bfcf2f363f56d4da",
+			"revision": "42fca177a36031d648551c751de1daf5f55dd4f0",
 			"branch": "master",
 			"notests": true
 		},


### PR DESCRIPTION
Updates go-nfs-client to pick up protocol fixes for most paths when dealing
with sparse server replies (discriminated union support).

Adds error logging in nfs volume creation paths.

Tests would require NFS servers that are not Linux kernel based as that impl
seems to be very tolerant and doesn't exploit the sparsity elements of NFS
protocol aggressively.
Testing was performed against NetApp simulator ONTAP9.1

Dropping the requirement for fine detail error reporting via vic-machine.
It's problematic without completing the structured status reporting that's
been deferred.

Notes:
- Observed an NFS3ERR_ACCES failure in local nested deployment if omitting
`uid`, `gid`, and `proto` args. This turns out to be because the default uid/gid
is 1000/1000. The problem here is that this needs to be inferred from the logs
because the ACCES error never propagates to the user directly.

Fixes #6500 
