### PR TITLE
[skip ci]Remove drone from nightly and allow for nimbus retries

### DIFF
--- a/tests/manual-test-cases/Group13-vMotion/13-1-vMotion-VCH-Appliance.robot
+++ b/tests/manual-test-cases/Group13-vMotion/13-1-vMotion-VCH-Appliance.robot
@@ -15,7 +15,7 @@
 *** Settings ***
 Documentation  Test 13-1 - vMotion VCH Appliance
 Resource  ../../resources/Util.robot
-Suite Setup  Create a VSAN Cluster
+Suite Setup  Wait Until Keyword Succeeds  10x  10m  Create a VSAN Cluster
 Suite Teardown  Run Keyword And Ignore Error  Nimbus Cleanup  ${list}
 Test Teardown  Gather Logs From Test Server 
 

--- a/tests/manual-test-cases/Group13-vMotion/13-1-vMotion-VCH-Appliance.robot
+++ b/tests/manual-test-cases/Group13-vMotion/13-1-vMotion-VCH-Appliance.robot
@@ -55,7 +55,7 @@ Test Teardown  Gather Logs From Test Server
 
 Step 6-9
     Set Test Variable  ${user}  %{NIMBUS_USER}
-    Set Global Variable  @{list}  ${user}-vic-vmotion-13-1.vcva-${VC_VERSION}  ${user}-vic-vmotion-13-1.esx.0  ${user}-vic-vmotion-13-1.esx.1  ${user}-vic-vmotion-13-1.esx.2  ${user}-vic-vmotion-13-1.esx.3  ${user}-vic-vmotion-13-1.nfs.0  ${user}-vic-vmotion-13-1.iscsi.0
+    Set Suite Variable  @{list}  ${user}-vic-vmotion-13-1.vcva-${VC_VERSION}  ${user}-vic-vmotion-13-1.esx.0  ${user}-vic-vmotion-13-1.esx.1  ${user}-vic-vmotion-13-1.esx.2  ${user}-vic-vmotion-13-1.esx.3  ${user}-vic-vmotion-13-1.nfs.0  ${user}-vic-vmotion-13-1.iscsi.0
     Install VIC Appliance To Test Server
     Run Regression Tests
     ${host}=  Get VM Host Name  %{VCH-NAME}/%{VCH-NAME}

--- a/tests/manual-test-cases/Group13-vMotion/13-1-vMotion-VCH-Appliance.robot
+++ b/tests/manual-test-cases/Group13-vMotion/13-1-vMotion-VCH-Appliance.robot
@@ -15,7 +15,7 @@
 *** Settings ***
 Documentation  Test 13-1 - vMotion VCH Appliance
 Resource  ../../resources/Util.robot
-Suite Setup  Wait Until Keyword Succeeds  10x  10m  Create a VSAN Cluster
+Suite Setup  Wait Until Keyword Succeeds  10x  10m  Create a VSAN Cluster  vic-vmotion-13-1
 Suite Teardown  Run Keyword And Ignore Error  Nimbus Cleanup  ${list}
 Test Teardown  Gather Logs From Test Server 
 
@@ -55,7 +55,7 @@ Test Teardown  Gather Logs From Test Server
 
 Step 6-9
     Set Test Variable  ${user}  %{NIMBUS_USER}
-    Set Global Variable  @{list}  ${user}-vic-vmotion.vcva-${VC_VERSION}  ${user}-vic-vmotion.esx.0  ${user}-vic-vmotion.esx.1  ${user}-vic-vmotion.esx.2  ${user}-vic-vmotion.esx.3  ${user}-vic-vmotion.nfs.0  ${user}-vic-vmotion.iscsi.0
+    Set Global Variable  @{list}  ${user}-vic-vmotion-13-1.vcva-${VC_VERSION}  ${user}-vic-vmotion-13-1.esx.0  ${user}-vic-vmotion-13-1.esx.1  ${user}-vic-vmotion-13-1.esx.2  ${user}-vic-vmotion-13-1.esx.3  ${user}-vic-vmotion-13-1.nfs.0  ${user}-vic-vmotion-13-1.iscsi.0
     Install VIC Appliance To Test Server
     Run Regression Tests
     ${host}=  Get VM Host Name  %{VCH-NAME}/%{VCH-NAME}

--- a/tests/manual-test-cases/Group13-vMotion/13-2-vMotion-Container.robot
+++ b/tests/manual-test-cases/Group13-vMotion/13-2-vMotion-Container.robot
@@ -22,7 +22,7 @@ Test Teardown  Cleanup VIC Appliance On Test Server
 *** Test Cases ***
 Test
     Set Test Variable  ${user}  %{NIMBUS_USER}
-    Set Global Variable  @{list}  ${user}-vic-vmotion-13-2.vcva-${VC_VERSION}  ${user}-vic-vmotion-13-2.esx.0  ${user}-vic-vmotion-13-2.esx.1  ${user}-vic-vmotion-13-2.esx.2  ${user}-vic-vmotion-13-2.esx.3  ${user}-vic-vmotion-13-2.nfs.0  ${user}-vic-vmotion-13-2.iscsi.0
+    Set Suite Variable  @{list}  ${user}-vic-vmotion-13-2.vcva-${VC_VERSION}  ${user}-vic-vmotion-13-2.esx.0  ${user}-vic-vmotion-13-2.esx.1  ${user}-vic-vmotion-13-2.esx.2  ${user}-vic-vmotion-13-2.esx.3  ${user}-vic-vmotion-13-2.nfs.0  ${user}-vic-vmotion-13-2.iscsi.0
     Install VIC Appliance To Test Server
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} pull busybox
     Should Be Equal As Integers  ${rc}  0

--- a/tests/manual-test-cases/Group13-vMotion/13-2-vMotion-Container.robot
+++ b/tests/manual-test-cases/Group13-vMotion/13-2-vMotion-Container.robot
@@ -15,14 +15,14 @@
 *** Settings ***
 Documentation  Test 13-2 - vMotion Container
 Resource  ../../resources/Util.robot
-Suite Setup  Wait Until Keyword Succeeds  10x  10m  Create a VSAN Cluster
+Suite Setup  Wait Until Keyword Succeeds  10x  10m  Create a VSAN Cluster  vic-vmotion-13-2
 Suite Teardown  Run Keyword And Ignore Error  Nimbus Cleanup  ${list}
 Test Teardown  Cleanup VIC Appliance On Test Server
 
 *** Test Cases ***
 Test
     Set Test Variable  ${user}  %{NIMBUS_USER}
-    Set Global Variable  @{list}  ${user}-vic-vmotion.vcva-${VC_VERSION}  ${user}-vic-vmotion.esx.0  ${user}-vic-vmotion.esx.1  ${user}-vic-vmotion.esx.2  ${user}-vic-vmotion.esx.3  ${user}-vic-vmotion.nfs.0  ${user}-vic-vmotion.iscsi.0
+    Set Global Variable  @{list}  ${user}-vic-vmotion-13-2.vcva-${VC_VERSION}  ${user}-vic-vmotion-13-2.esx.0  ${user}-vic-vmotion-13-2.esx.1  ${user}-vic-vmotion-13-2.esx.2  ${user}-vic-vmotion-13-2.esx.3  ${user}-vic-vmotion-13-2.nfs.0  ${user}-vic-vmotion-13-2.iscsi.0
     Install VIC Appliance To Test Server
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} pull busybox
     Should Be Equal As Integers  ${rc}  0

--- a/tests/manual-test-cases/Group13-vMotion/13-2-vMotion-Container.robot
+++ b/tests/manual-test-cases/Group13-vMotion/13-2-vMotion-Container.robot
@@ -15,7 +15,7 @@
 *** Settings ***
 Documentation  Test 13-2 - vMotion Container
 Resource  ../../resources/Util.robot
-Suite Setup  Create a VSAN Cluster
+Suite Setup  Wait Until Keyword Succeeds  10x  10m  Create a VSAN Cluster
 Suite Teardown  Run Keyword And Ignore Error  Nimbus Cleanup  ${list}
 Test Teardown  Cleanup VIC Appliance On Test Server
 

--- a/tests/manual-test-cases/Group21-Registries/21-1-Whitelist.robot
+++ b/tests/manual-test-cases/Group21-Registries/21-1-Whitelist.robot
@@ -23,7 +23,7 @@ Test Teardown  Run Keyword If Test Failed  Cleanup VIC Appliance On Test Server
 *** Keywords ***
 Simple ESXi Setup
     ${esx}  ${esx-ip}=  Deploy Nimbus ESXi Server  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}
-    Set Global Variable  @{list}  ${esx}
+    Set Suite Variable  @{list}  ${esx}
 
     Set Environment Variable  TEST_URL_ARRAY  ${esx-ip}
     Set Environment Variable  TEST_URL  ${esx-ip}

--- a/tests/manual-test-cases/Group21-Registries/21-1-Whitelist.robot
+++ b/tests/manual-test-cases/Group21-Registries/21-1-Whitelist.robot
@@ -21,7 +21,7 @@ Suite Teardown  Nimbus Cleanup  ${list}
 Test Teardown  Run Keyword If Test Failed  Cleanup VIC Appliance On Test Server
 
 *** Keywords ***
-Setup Harbor
+Simple ESXi Setup
     ${esx}  ${esx-ip}=  Deploy Nimbus ESXi Server  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}
     Set Global Variable  @{list}  ${esx}
 
@@ -36,6 +36,9 @@ Setup Harbor
     Remove Environment Variable  TEST_RESOURCE
     Remove Environment Variable  BRIDGE_NETWORK
     Remove Environment Variable  PUBLIC_NETWORK
+
+Setup Harbor
+    Wait Until Keyword Succeeds  10x  10m  Simple ESXi Setup
 
     # Install a Harbor server with HTTPS a Harbor server with HTTP
     Install Harbor To Test Server  protocol=https  name=harbor-https

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-1-Distributed-Switch.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-1-Distributed-Switch.robot
@@ -33,7 +33,7 @@ Distributed Switch Setup
     @{esx_names}=  Get Dictionary Keys  ${esxes}
     @{esx_ips}=  Get Dictionary Values  ${esxes}
 
-    Set Suite Variable  @{list}  ${esx_names}  ${vc}
+    Set Suite Variable  @{list}  @{esx_names}[0]  @{esx_names}[1]  @{esx_names}[2]  ${vc}
 
     # Finish vCenter deploy
     ${output}=  Wait For Process  ${pid}

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-1-Distributed-Switch.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-1-Distributed-Switch.robot
@@ -71,6 +71,7 @@ Distributed Switch Setup
     Set Environment Variable  PUBLIC_NETWORK  vm-network
     Set Environment Variable  TEST_RESOURCE  /ha-datacenter/host/@{esx_ips}[0]/Resources
     Set Environment Variable  TEST_TIMEOUT  30m
+    Set Environment Variable  TEST_DATASTORE  datastore1
 
 *** Test Cases ***
 Test

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-1-Distributed-Switch.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-1-Distributed-Switch.robot
@@ -15,22 +15,20 @@
 *** Settings ***
 Documentation  Test 5-1 - Distributed Switch
 Resource  ../../resources/Util.robot
+Suite Setup  Wait Until Keyword Succeeds  10x  10m  Distributed Switch Setup
 Suite Teardown  Run Keyword And Ignore Error  Nimbus Cleanup  ${list}
 
 *** Variables ***
 ${esx_number}=  3
 ${datacenter}=  ha-datacenter
 
-*** Test Cases ***
-Test
-    Log To Console  \nStarting test...
-
+*** Keywords ***
+Distributed Switch Setup
     ${vc}=  Evaluate  'VC-' + str(random.randint(1000,9999)) + str(time.clock())  modules=random,time
     ${pid}=  Deploy Nimbus vCenter Server Async  ${vc}
     Set Suite Variable  ${VC}  ${vc}
 
-    # Let's make 5 because it is free and in parallel, but only use 3 of them
-    &{esxes}=  Deploy Multiple Nimbus ESXi Servers in Parallel  5  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}
+    &{esxes}=  Deploy Multiple Nimbus ESXi Servers in Parallel  3  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}
     @{esx_names}=  Get Dictionary Keys  ${esxes}
     @{esx_ips}=  Get Dictionary Values  ${esxes}
 
@@ -64,7 +62,6 @@ Test
     \   Should Contain  ${out}  OK
     \   Wait Until Keyword Succeeds  5x  15 seconds  Add Host To Distributed Switch  @{esx_ips}[${IDX}]
 
-
     Log To Console  Deploy VIC to the VC cluster
     Set Environment Variable  TEST_URL_ARRAY  ${vc_ip}
     Set Environment Variable  TEST_USERNAME  Administrator@vsphere.local
@@ -74,6 +71,8 @@ Test
     Set Environment Variable  TEST_RESOURCE  /ha-datacenter/host/@{esx_ips}[0]/Resources
     Set Environment Variable  TEST_TIMEOUT  30m
 
+*** Test Cases ***
+Test
+    Log To Console  \nStarting test...
     Install VIC Appliance To Test Server
-
     Run Regression Tests

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-1-Distributed-Switch.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-1-Distributed-Switch.robot
@@ -24,6 +24,7 @@ ${datacenter}=  ha-datacenter
 
 *** Keywords ***
 Distributed Switch Setup
+    Run Keyword And Ignore Error  Nimbus Cleanup  ${list}  ${false}
     ${vc}=  Evaluate  'VC-' + str(random.randint(1000,9999)) + str(time.clock())  modules=random,time
     ${pid}=  Deploy Nimbus vCenter Server Async  ${vc}
     Set Suite Variable  ${VC}  ${vc}
@@ -32,7 +33,7 @@ Distributed Switch Setup
     @{esx_names}=  Get Dictionary Keys  ${esxes}
     @{esx_ips}=  Get Dictionary Values  ${esxes}
 
-    Set Global Variable  @{list}  ${esx_names}  ${vc}
+    Set Suite Variable  @{list}  ${esx_names}  ${vc}
 
     # Finish vCenter deploy
     ${output}=  Wait For Process  ${pid}

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-10-Multiple-Datacenter.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-10-Multiple-Datacenter.robot
@@ -75,3 +75,5 @@ Test
     Log To Console  \nStarting test...
     Install VIC Appliance To Test Server  certs=${false}  vol=default
     Run Regression Tests
+    Remove Environment Variable  TEST_DATACENTER
+    Remove Environment Variable  GOVC_DATASTORE

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-10-Multiple-Datacenter.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-10-Multiple-Datacenter.robot
@@ -29,6 +29,7 @@ Combine Dictionaries
     [Return]  ${dict1}
 
 Multiple Datacenter Setup
+    Run Keyword And Ignore Error  Nimbus Cleanup  ${list}  ${false}
     &{esxes}=  Create Dictionary
     ${num_of_esxes}=  Evaluate  2
     :FOR  ${i}  IN RANGE  3
@@ -52,8 +53,7 @@ Multiple Datacenter Setup
     ${esx2-ip}=  Get From List  ${esx-ips}  1
 
     ${esx3}  ${esx4}  ${esx5}  ${vc}  ${esx3-ip}  ${esx4-ip}  ${esx5-ip}  ${vc-ip}=  Create a Simple VC Cluster  datacenter1  cls1
-
-    Set Global Variable  @{list}  ${esx1}  ${esx2}  ${esx3}  ${esx4}  ${esx5}  ${vc}
+    Set Suite Variable  @{list}  ${esx1}  ${esx2}  ${esx3}  ${esx4}  ${esx5}  ${vc}
 
     Log To Console  Create datacenter2 on the VC
     ${out}=  Run  govc datacenter.create datacenter2

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-10-Multiple-Datacenter.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-10-Multiple-Datacenter.robot
@@ -76,4 +76,4 @@ Test
     Install VIC Appliance To Test Server  certs=${false}  vol=default
     Run Regression Tests
     Remove Environment Variable  TEST_DATACENTER
-    Remove Environment Variable  GOVC_DATASTORE
+    Remove Environment Variable  GOVC_DATACENTER

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-10-Multiple-Datacenter.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-10-Multiple-Datacenter.robot
@@ -15,6 +15,7 @@
 *** Settings ***
 Documentation  Test 5-10 - Multiple Datacenters
 Resource  ../../resources/Util.robot
+Suite Setup  Wait Until Keyword Succeeds  10x  10m  Multiple Datacenter Setup
 Suite Teardown  Run Keyword And Ignore Error  Nimbus Cleanup  ${list}
 
 *** Keywords ***
@@ -27,9 +28,7 @@ Combine Dictionaries
     \    Set To Dictionary  ${dict1}  ${key}  ${elem}
     [Return]  ${dict1}
 
-*** Test Cases ***
-Test
-    Log To Console  \nStarting test...
+Multiple Datacenter Setup
     &{esxes}=  Create Dictionary
     ${num_of_esxes}=  Evaluate  2
     :FOR  ${i}  IN RANGE  3
@@ -70,6 +69,9 @@ Test
 
     Set Environment Variable  TEST_DATACENTER  /datacenter1
     Set Environment Variable  GOVC_DATACENTER  /datacenter1
-    Install VIC Appliance To Test Server  certs=${false}  vol=default
 
+*** Test Cases ***
+Test
+    Log To Console  \nStarting test...
+    Install VIC Appliance To Test Server  certs=${false}  vol=default
     Run Regression Tests

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-11-Multiple-Cluster.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-11-Multiple-Cluster.robot
@@ -15,6 +15,7 @@
 *** Settings ***
 Documentation  Test 5-11 - Multiple Clusters
 Resource  ../../resources/Util.robot
+Suite Setup  Wait Until Keyword Succeeds  10x  10m  Multiple Cluster Setup
 Suite Teardown  Run Keyword And Ignore Error  Nimbus Cleanup  ${list}
 
 *** Keywords ***
@@ -27,9 +28,7 @@ Combine Dictionaries
     \    Set To Dictionary  ${dict1}  ${key}  ${elem}
     [Return]  ${dict1}
 
-*** Test Cases ***
-Test
-    Log To Console  \nStarting test...
+Multiple Cluster Setup
     &{esxes}=  Create Dictionary
     ${num_of_esxes}=  Evaluate  2
     :FOR  ${i}  IN RANGE  3
@@ -67,6 +66,11 @@ Test
     Should Be Empty  ${out}
     ${out}=  Run  govc cluster.add -hostname=${esx2-ip} -username=root -dc=datacenter1 -cluster=cls3 -password=e2eFunctionalTest -noverify=true
     Should Contain  ${out}  OK
+
+*** Test Cases ***
+Test
+    Log To Console  \nStarting test...
+    
 
     Install VIC Appliance To Test Server  certs=${false}  vol=default
 

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-11-Multiple-Cluster.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-11-Multiple-Cluster.robot
@@ -29,6 +29,7 @@ Combine Dictionaries
     [Return]  ${dict1}
 
 Multiple Cluster Setup
+    Run Keyword And Ignore Error  Nimbus Cleanup  ${list}  ${false}
     &{esxes}=  Create Dictionary
     ${num_of_esxes}=  Evaluate  2
     :FOR  ${i}  IN RANGE  3
@@ -52,8 +53,7 @@ Multiple Cluster Setup
     ${esx2-ip}=  Get From List  ${esx-ips}  1
 
     ${esx3}  ${esx4}  ${esx5}  ${vc}  ${esx3-ip}  ${esx4-ip}  ${esx5-ip}  ${vc-ip}=  Create a Simple VC Cluster  datacenter1  cls1
-
-    Set Global Variable  @{list}  ${esx1}  ${esx2}  ${esx3}  ${esx4}  ${esx5}  ${vc}
+    Set Suite Variable  @{list}  ${esx1}  ${esx2}  ${esx3}  ${esx4}  ${esx5}  ${vc}
 
     Log To Console  Create cluster2 on the VC
     ${out}=  Run  govc cluster.create cls2

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-12-Multiple-VLAN.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-12-Multiple-VLAN.robot
@@ -21,8 +21,9 @@ Test Teardown  Cleanup VIC Appliance On Test Server
 
 *** Keywords ***
 Multiple VLAN Setup
+    Run Keyword And Ignore Error  Nimbus Cleanup  ${list}  ${false}
     ${esx1}  ${esx2}  ${esx3}  ${vc}  ${esx1-ip}  ${esx2-ip}  ${esx3-ip}  ${vc-ip}=  Create a Simple VC Cluster  multi-vlan-1  cls
-    Set Global Variable  @{list}  ${esx1}  ${esx2}  ${esx3}  ${vc}
+    Set Suite Variable  @{list}  ${esx1}  ${esx2}  ${esx3}  ${vc}
 
 *** Test Cases ***
 Test1

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-12-Multiple-VLAN.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-12-Multiple-VLAN.robot
@@ -15,7 +15,7 @@
 *** Settings ***
 Documentation  Test 5-12 - Multiple VLAN
 Resource  ../../resources/Util.robot
-Suite Setup  Multiple VLAN Setup
+Suite Setup  Wait Until Keyword Succeeds  10x  10m  Multiple VLAN Setup
 Suite Teardown  Run Keyword And Ignore Error  Nimbus Cleanup  ${list}
 Test Teardown  Cleanup VIC Appliance On Test Server
 

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-13-Invalid-ESXi-Install.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-13-Invalid-ESXi-Install.robot
@@ -20,18 +20,22 @@ Suite Teardown  Run Keyword And Ignore Error  Nimbus Cleanup  ${list}
 
 *** Keywords ***
 Invalid ESXi Install Setup
+    Run Keyword And Ignore Error  Nimbus Cleanup  ${list}  ${false}
     Set Suite Variable  ${datacenter}  datacenter1
     Set Suite Variable  ${cluster}  cls
 
     ${esx1}  ${esx1-ip}=  Deploy Nimbus ESXi Server  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}
     Set Suite Variable  ${ESX1}  ${esx1}
+    Set Suite Variable  ${esx1-ip}  ${esx1-ip}
     ${esx2}  ${esx2-ip}=  Deploy Nimbus ESXi Server  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}
     Set Suite Variable  ${ESX2}  ${esx2}
+    Set Suite Variable  ${esx2-ip}  ${esx2-ip}
     
     ${vc}  ${vc-ip}=  Deploy Nimbus vCenter Server  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}
     Set Suite Variable  ${VC}  ${vc}
+    Set Suite Variable  ${vc-ip}  ${vc-ip}
 
-    Set Global Variable  @{list}  ${esx1}  ${esx2}  ${vc}
+    Set Suite Variable  @{list}  ${esx1}  ${esx2}  ${vc}
 
     Log To Console  Create a datacenter on the VC
     ${out}=  Run  govc datacenter.create ${datacenter}

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-13-Invalid-ESXi-Install.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-13-Invalid-ESXi-Install.robot
@@ -15,10 +15,11 @@
 *** Settings ***
 Documentation  Test 5-13 - Invalid ESXi Install
 Resource  ../../resources/Util.robot
+Suite Setup  Wait Until Keyword Succeeds  10x  10m  Invalid ESXi Install Setup
 Suite Teardown  Run Keyword And Ignore Error  Nimbus Cleanup  ${list}
 
-*** Test Cases ***
-Test
+*** Keywords ***
+Invalid ESXi Install Setup
     Set Suite Variable  ${datacenter}  datacenter1
     Set Suite Variable  ${cluster}  cls
 
@@ -66,5 +67,7 @@ Test
     ${out}=  Run  govc cluster.change -drs-enabled /${datacenter}/host/${cluster}
     Should Be Empty  ${out}
 
+*** Test Cases ***
+Test
     ${out}=  Run  bin/vic-machine-linux create --target ${esx1-ip} --user root --password e2eFunctionalTest --no-tls --name VCH-invalid-test --force --timeout 30m
     Should Contain  ${out}  Target is managed by vCenter server "${vc-ip}", please change --target to vCenter server address or select a standalone ESXi

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-14-Remove-Container-OOB.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-14-Remove-Container-OOB.robot
@@ -20,8 +20,9 @@ Suite Teardown  Run Keyword And Ignore Error  Nimbus Cleanup  ${list}
 
 *** Keywords ***
 Remove Container OOB Setup
+    Run Keyword And Ignore Error  Nimbus Cleanup  ${list}  ${false}
     ${esx1}  ${esx2}  ${esx3}  ${vc}  ${esx1-ip}  ${esx2-ip}  ${esx3-ip}  ${vc-ip}=  Create a Simple VC Cluster
-    Set Global Variable  @{list}  ${esx1}  ${esx2}  ${esx3}  ${vc}
+    Set Suite Variable  @{list}  ${esx1}  ${esx2}  ${esx3}  ${vc}
 
 *** Test Cases ***
 Docker run an image from a container that was removed OOB

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-14-Remove-Container-OOB.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-14-Remove-Container-OOB.robot
@@ -15,13 +15,16 @@
 *** Settings ***
 Documentation  Test 5-14 - Remove Container OOB
 Resource  ../../resources/Util.robot
+Suite Setup  Wait Until Keyword Succeeds  10x  10m  Remove Container OOB Setup
 Suite Teardown  Run Keyword And Ignore Error  Nimbus Cleanup  ${list}
 
-*** Test Cases ***
-Docker run an image from a container that was removed OOB
+*** Keywords ***
+Remove Container OOB Setup
     ${esx1}  ${esx2}  ${esx3}  ${vc}  ${esx1-ip}  ${esx2-ip}  ${esx3-ip}  ${vc-ip}=  Create a Simple VC Cluster
     Set Global Variable  @{list}  ${esx1}  ${esx2}  ${esx3}  ${vc}
 
+*** Test Cases ***
+Docker run an image from a container that was removed OOB
     Install VIC Appliance To Test Server
 
     ${rc}  ${out}=  Run And Return Rc And Output  docker %{VCH-PARAMS} pull busybox

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-15-NFS-Datastore.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-15-NFS-Datastore.robot
@@ -21,8 +21,8 @@ Suite Teardown  Run Keyword And Ignore Error  Nimbus Cleanup  ${list}
 *** Keywords ***
 NFS Datastore Setup
     Run Keyword And Ignore Error  Nimbus Cleanup  ${list}  ${false}
-    ${esx3}  ${esx4}  ${esx5}  ${vc}  ${esx3-ip}  ${esx4-ip}  ${esx5-ip}  ${vc-ip}=  Create a Simple VC Cluster  datacenter1  cls1
-    Set Suite Variable  @{list}  ${esx1}  ${esx2}  ${esx3}  ${esx4}  ${esx5}  ${vc}
+    ${esx1}  ${esx2}  ${esx3}  ${vc}  ${esx1-ip}  ${esx2-ip}  ${esx3-ip}  ${vc-ip}=  Create a Simple VC Cluster  datacenter1  cls1
+    Set Suite Variable  @{list}  ${esx1}  ${esx2}  ${esx3}  ${vc}
 
     ${name}  ${ip}=  Deploy Nimbus NFS Datastore  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}
 

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-15-NFS-Datastore.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-15-NFS-Datastore.robot
@@ -26,7 +26,7 @@ NFS Datastore Setup
 
     ${name}  ${ip}=  Deploy Nimbus NFS Datastore  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}
 
-    ${out}=  Run  govc datastore.create -mode readWrite -type nfs -name nfsDatastore -remote-host ${ip} -remote-path /store cls
+    ${out}=  Run  govc datastore.create -mode readWrite -type nfs -name nfsDatastore -remote-host ${ip} -remote-path /store cls1
     Should Be Empty  ${out}
 
     Set Environment Variable  TEST_DATASTORE  nfsDatastore

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-15-NFS-Datastore.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-15-NFS-Datastore.robot
@@ -20,9 +20,9 @@ Suite Teardown  Run Keyword And Ignore Error  Nimbus Cleanup  ${list}
 
 *** Keywords ***
 NFS Datastore Setup
+    Run Keyword And Ignore Error  Nimbus Cleanup  ${list}  ${false}
     ${esx3}  ${esx4}  ${esx5}  ${vc}  ${esx3-ip}  ${esx4-ip}  ${esx5-ip}  ${vc-ip}=  Create a Simple VC Cluster  datacenter1  cls1
-
-    Set Global Variable  @{list}  ${esx1}  ${esx2}  ${esx3}  ${esx4}  ${esx5}  ${vc}
+    Set Suite Variable  @{list}  ${esx1}  ${esx2}  ${esx3}  ${esx4}  ${esx5}  ${vc}
 
     ${name}  ${ip}=  Deploy Nimbus NFS Datastore  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}
 

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-15-NFS-Datastore.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-15-NFS-Datastore.robot
@@ -15,11 +15,11 @@
 *** Settings ***
 Documentation  Test 5-15 - NFS Datastore
 Resource  ../../resources/Util.robot
+Suite Setup  Wait Until Keyword Succeeds  10x  10m  NFS Datastore Setup
 Suite Teardown  Run Keyword And Ignore Error  Nimbus Cleanup  ${list}
 
-*** Test Cases ***
-Test
-    Log To Console  \nStarting test...
+*** Keywords ***
+NFS Datastore Setup
     ${esx3}  ${esx4}  ${esx5}  ${vc}  ${esx3-ip}  ${esx4-ip}  ${esx5-ip}  ${vc-ip}=  Create a Simple VC Cluster  datacenter1  cls1
 
     Set Global Variable  @{list}  ${esx1}  ${esx2}  ${esx3}  ${esx4}  ${esx5}  ${vc}
@@ -30,6 +30,10 @@ Test
     Should Be Empty  ${out}
 
     Set Environment Variable  TEST_DATASTORE  nfsDatastore
+
+*** Test Cases ***
+Test
+    Log To Console  \nStarting test...
     Install VIC Appliance To Test Server
 
     Run Regression Tests

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-16-iSCSI-Datastore.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-16-iSCSI-Datastore.robot
@@ -63,6 +63,7 @@ iSCSI Datastore Setup
     Set Environment Variable  TEST_PASSWORD  Admin\!23
     Set Environment Variable  BRIDGE_NETWORK  bridge
     Set Environment Variable  PUBLIC_NETWORK  vm-network
+    Remove Environment Variable  TEST_DATACENTER
     Set Environment Variable  TEST_DATASTORE  sharedVmfs-0
     Set Environment Variable  TEST_RESOURCE  cls
     Set Environment Variable  TEST_TIMEOUT  30m

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-16-iSCSI-Datastore.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-16-iSCSI-Datastore.robot
@@ -15,10 +15,11 @@
 *** Settings ***
 Documentation  Test 5-16 - iSCSI Datastore
 Resource  ../../resources/Util.robot
-Test Teardown  Run Keyword And Ignore Error  Nimbus Cleanup  ${list}
+Suite Setup  Wait Until Keyword Succeeds  10x  10s  iSCSI Datastore Setup
+Suite Teardown  Run Keyword And Ignore Error  Nimbus Cleanup  ${list}
 
-*** Test Cases ***
-iSCSI Datastore
+*** Keywords ***
+iSCSI Datastore Setup
     ${name}=  Evaluate  'vic-iscsi-' + str(random.randint(1000,9999))  modules=random
     ${out}=  Deploy Nimbus Testbed  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}  --customizeTestbed '/esx desiredPassword=e2eFunctionalTest' --noSupportBundles --vcvaBuild ${VC_VERSION} --esxBuild ${ESX_VERSION} --testbedName vcqa-sdrs-iscsi-fullInstall-vcva --runName vic-iscsi
     Set Global Variable  @{list}  %{NIMBUS_USER}-vic-iscsi.vcva-${VC_VERSION}  %{NIMBUS_USER}-vic-iscsi.esx.0  %{NIMBUS_USER}-vic-iscsi.esx.1  %{NIMBUS_USER}-vic-iscsi.iscsi.0
@@ -65,6 +66,7 @@ iSCSI Datastore
     Set Environment Variable  TEST_RESOURCE  cls
     Set Environment Variable  TEST_TIMEOUT  30m
 
+*** Test Cases ***
+iSCSI Datastore
     Install VIC Appliance To Test Server
-
     Run Regression Tests

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-16-iSCSI-Datastore.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-16-iSCSI-Datastore.robot
@@ -20,9 +20,10 @@ Suite Teardown  Run Keyword And Ignore Error  Nimbus Cleanup  ${list}
 
 *** Keywords ***
 iSCSI Datastore Setup
+    Run Keyword And Ignore Error  Nimbus Cleanup  ${list}  ${false}
     ${name}=  Evaluate  'vic-iscsi-' + str(random.randint(1000,9999))  modules=random
     ${out}=  Deploy Nimbus Testbed  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}  --customizeTestbed '/esx desiredPassword=e2eFunctionalTest' --noSupportBundles --vcvaBuild ${VC_VERSION} --esxBuild ${ESX_VERSION} --testbedName vcqa-sdrs-iscsi-fullInstall-vcva --runName vic-iscsi
-    Set Global Variable  @{list}  %{NIMBUS_USER}-vic-iscsi.vcva-${VC_VERSION}  %{NIMBUS_USER}-vic-iscsi.esx.0  %{NIMBUS_USER}-vic-iscsi.esx.1  %{NIMBUS_USER}-vic-iscsi.iscsi.0
+    Set Suite Variable  @{list}  %{NIMBUS_USER}-vic-iscsi.vcva-${VC_VERSION}  %{NIMBUS_USER}-vic-iscsi.esx.0  %{NIMBUS_USER}-vic-iscsi.esx.1  %{NIMBUS_USER}-vic-iscsi.iscsi.0
     Should Contain  ${out}  "deployment_result"=>"PASS"
 
     ${out}=  Execute Command  nimbus-ctl ip %{NIMBUS_USER}-vic-iscsi.vcva-${VC_VERSION} | grep %{NIMBUS_USER}-vic-iscsi.vcva-${VC_VERSION}

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-17-FC-Datastore.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-17-FC-Datastore.robot
@@ -20,9 +20,10 @@ Suite Teardown  Run Keyword And Ignore Error  Nimbus Cleanup  ${list}
 
 *** Keywords ***
 FC Datastore Setup
+    Run Keyword And Ignore Error  Nimbus Cleanup  ${list}  ${false}
     ${name}=  Evaluate  'vic-fc-' + str(random.randint(1000,9999))  modules=random
     ${out}=  Deploy Nimbus Testbed  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}  --customizeTestbed '/esx desiredPassword=e2eFunctionalTest' --noSupportBundles --vcvaBuild ${VC_VERSION} --esxBuild ${ESX_VERSION} --testbedName vcqa-sdrs-fc-fullInstall-vcva --runName vic-fc
-    Set Global Variable  @{list}  %{NIMBUS_USER}-vic-fc.vcva-${VC_VERSION}  %{NIMBUS_USER}-vic-fc.esx.0  %{NIMBUS_USER}-vic-fc.esx.1  %{NIMBUS_USER}-vic-fc.fc.0
+    Set Suite Variable  @{list}  %{NIMBUS_USER}-vic-fc.vcva-${VC_VERSION}  %{NIMBUS_USER}-vic-fc.esx.0  %{NIMBUS_USER}-vic-fc.esx.1  %{NIMBUS_USER}-vic-fc.fc.0
     Should Contain  ${out}  "deployment_result"=>"PASS"
 
     ${out}=  Execute Command  nimbus-ctl ip %{NIMBUS_USER}-vic-fc.vcva-${VC_VERSION} | grep %{NIMBUS_USER}-vic-fc.vcva-${VC_VERSION}

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-17-FC-Datastore.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-17-FC-Datastore.robot
@@ -15,10 +15,11 @@
 *** Settings ***
 Documentation  Test 5-17 - FC Datastore
 Resource  ../../resources/Util.robot
-Test Teardown  Run Keyword And Ignore Error  Nimbus Cleanup  ${list}
+Suite Setup  Wait Until Keyword Succeeds  10x  10m  FC Datastore Setup
+Suite Teardown  Run Keyword And Ignore Error  Nimbus Cleanup  ${list}
 
-*** Test Cases ***
-FC Datastore
+*** Keywords ***
+FC Datastore Setup
     ${name}=  Evaluate  'vic-fc-' + str(random.randint(1000,9999))  modules=random
     ${out}=  Deploy Nimbus Testbed  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}  --customizeTestbed '/esx desiredPassword=e2eFunctionalTest' --noSupportBundles --vcvaBuild ${VC_VERSION} --esxBuild ${ESX_VERSION} --testbedName vcqa-sdrs-fc-fullInstall-vcva --runName vic-fc
     Set Global Variable  @{list}  %{NIMBUS_USER}-vic-fc.vcva-${VC_VERSION}  %{NIMBUS_USER}-vic-fc.esx.0  %{NIMBUS_USER}-vic-fc.esx.1  %{NIMBUS_USER}-vic-fc.fc.0
@@ -65,6 +66,7 @@ FC Datastore
     Set Environment Variable  TEST_RESOURCE  cls
     Set Environment Variable  TEST_TIMEOUT  30m
 
+*** Test Cases ***
+FC Datastore
     Install VIC Appliance To Test Server
-
     Run Regression Tests

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-17-FC-Datastore.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-17-FC-Datastore.robot
@@ -63,6 +63,7 @@ FC Datastore Setup
     Set Environment Variable  TEST_PASSWORD  Admin\!23
     Set Environment Variable  BRIDGE_NETWORK  bridge
     Set Environment Variable  PUBLIC_NETWORK  vm-network
+    Remove Environment Variable  TEST_DATACENTER
     Set Environment Variable  TEST_DATASTORE  sharedVmfs-0
     Set Environment Variable  TEST_RESOURCE  cls
     Set Environment Variable  TEST_TIMEOUT  30m

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-18-Datastore-Cluster-SDRS.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-18-Datastore-Cluster-SDRS.robot
@@ -15,12 +15,13 @@
 *** Settings ***
 Documentation  Test 5-18 - Datastore Cluster SDRS
 Resource  ../../resources/Util.robot
+Suite Setup  Wait Until Keyword Succeeds  10x  10m  SDRS Datastore Setup
 Test Teardown  Run Keyword And Ignore Error  Nimbus Cleanup  ${list}
 
-*** Test Cases ***
-SDRS Datastore
+*** Keywords ***
+SDRS Datastore Setup
     Pass Execution  VIC does not support SDRS yet, see issue #2729
-    ${out}=  Deploy Nimbus Testbed  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}  --customizeTestbed '/esx desiredPassword=e2eFunctionalTest' --noSupportBundles --vcvaBuild ${VC_VERSION} --esxBuild ${ESX_VERSION} --testbedName vcqa-sdrs-fc-fullInstall-vcva --runName vic-fc
+    {out}=  Deploy Nimbus Testbed  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}  --customizeTestbed '/esx desiredPassword=e2eFunctionalTest' --noSupportBundles --vcvaBuild ${VC_VERSION} --esxBuild ${ESX_VERSION} --testbedName vcqa-sdrs-fc-fullInstall-vcva --runName vic-fc
     Set Global Variable  @{list}  %{NIMBUS_USER}-vic-fc.vcva-${VC_VERSION}  %{NIMBUS_USER}-vic-fc.esx.0  %{NIMBUS_USER}-vic-fc.esx.1  %{NIMBUS_USER}-vic-fc.fc.0
     Should Contain  ${out}  "deployment_result"=>"PASS"
 
@@ -68,6 +69,7 @@ SDRS Datastore
     Set Environment Variable  TEST_RESOURCE  cls
     Set Environment Variable  TEST_TIMEOUT  30m
 
+*** Test Cases ***
+SDRS Datastore
     Install VIC Appliance To Test Server
-
     Run Regression Tests

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-18-Datastore-Cluster-SDRS.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-18-Datastore-Cluster-SDRS.robot
@@ -15,14 +15,14 @@
 *** Settings ***
 Documentation  Test 5-18 - Datastore Cluster SDRS
 Resource  ../../resources/Util.robot
-Suite Setup  Wait Until Keyword Succeeds  10x  10m  SDRS Datastore Setup
-Test Teardown  Run Keyword And Ignore Error  Nimbus Cleanup  ${list}
+#Suite Setup  Wait Until Keyword Succeeds  10x  10m  SDRS Datastore Setup
+#Test Teardown  Run Keyword And Ignore Error  Nimbus Cleanup  ${list}
 
 *** Keywords ***
 SDRS Datastore Setup
-    Pass Execution  VIC does not support SDRS yet, see issue #2729
+    Run Keyword And Ignore Error  Nimbus Cleanup  ${list}  ${false}
     {out}=  Deploy Nimbus Testbed  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}  --customizeTestbed '/esx desiredPassword=e2eFunctionalTest' --noSupportBundles --vcvaBuild ${VC_VERSION} --esxBuild ${ESX_VERSION} --testbedName vcqa-sdrs-fc-fullInstall-vcva --runName vic-fc
-    Set Global Variable  @{list}  %{NIMBUS_USER}-vic-fc.vcva-${VC_VERSION}  %{NIMBUS_USER}-vic-fc.esx.0  %{NIMBUS_USER}-vic-fc.esx.1  %{NIMBUS_USER}-vic-fc.fc.0
+    Set Suite Variable  @{list}  %{NIMBUS_USER}-vic-fc.vcva-${VC_VERSION}  %{NIMBUS_USER}-vic-fc.esx.0  %{NIMBUS_USER}-vic-fc.esx.1  %{NIMBUS_USER}-vic-fc.fc.0
     Should Contain  ${out}  "deployment_result"=>"PASS"
 
     ${out}=  Execute Command  nimbus-ctl ip %{NIMBUS_USER}-vic-fc.vcva-${VC_VERSION} | grep %{NIMBUS_USER}-vic-fc.vcva-${VC_VERSION}
@@ -71,5 +71,6 @@ SDRS Datastore Setup
 
 *** Test Cases ***
 SDRS Datastore
+    Pass Execution  VIC does not support SDRS yet, see issue #2729
     Install VIC Appliance To Test Server
     Run Regression Tests

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-19-ROBO-SKU.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-19-ROBO-SKU.robot
@@ -15,12 +15,12 @@
 *** Settings ***
 Documentation  Test 5-19 - ROBO SKU
 Resource  ../../resources/Util.robot
-Suite Setup  Wait Until Keyword Succeeds  10x  10m  ROBO SKU Setup
-Suite Teardown  Run Keyword And Ignore Error  Nimbus Cleanup  ${list}
+#Suite Setup  Wait Until Keyword Succeeds  10x  10m  ROBO SKU Setup
+#Suite Teardown  Run Keyword And Ignore Error  Nimbus Cleanup  ${list}
 
 *** Keywords ***
 ROBO SKU Setup
-    Pass Execution  VIC does not support ROBO SKU yet, waiting on a valid license with serial support for this to work
+    Run Keyword And Ignore Error  Nimbus Cleanup  ${list}  ${false}
     ${esx1}  ${esx1-ip}=  Deploy Nimbus ESXi Server  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}
     Set Suite Variable  ${ESX1}  ${esx1}
     ${esx2}  ${esx2-ip}=  Deploy Nimbus ESXi Server  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}
@@ -31,7 +31,7 @@ ROBO SKU Setup
     ${vc}  ${vc-ip}=  Deploy Nimbus vCenter Server  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}
     Set Suite Variable  ${VC}  ${vc}
 
-    Set Global Variable  @{list}  ${esx1}  ${esx2}  ${esx3}  ${vc}
+    Set Suite Variable  @{list}  ${esx1}  ${esx2}  ${esx3}  ${vc}
 
     Log To Console  Create a datacenter on the VC
     ${out}=  Run  govc datacenter.create ha-datacenter
@@ -71,6 +71,7 @@ ROBO SKU Setup
 
 *** Test Cases ***
 Test
-    Log To Console  \nStarting test...
-    Install VIC Appliance To Test Server
-    Run Regression Tests
+    Log To Console  VIC does not support ROBO SKU yet, waiting on a valid license with serial support for this to work
+    #Log To Console  \nStarting test...
+    #Install VIC Appliance To Test Server
+    #Run Regression Tests

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-19-ROBO-SKU.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-19-ROBO-SKU.robot
@@ -15,11 +15,12 @@
 *** Settings ***
 Documentation  Test 5-19 - ROBO SKU
 Resource  ../../resources/Util.robot
+Suite Setup  Wait Until Keyword Succeeds  10x  10m  ROBO SKU Setup
 Suite Teardown  Run Keyword And Ignore Error  Nimbus Cleanup  ${list}
 
-*** Test Cases ***
-Test
-    Log To Console  \nStarting test...
+*** Keywords ***
+ROBO SKU Setup
+    Pass Execution  VIC does not support ROBO SKU yet, waiting on a valid license with serial support for this to work
     ${esx1}  ${esx1-ip}=  Deploy Nimbus ESXi Server  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}
     Set Suite Variable  ${ESX1}  ${esx1}
     ${esx2}  ${esx2-ip}=  Deploy Nimbus ESXi Server  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}
@@ -68,7 +69,8 @@ Test
     Set Environment Variable  TEST_RESOURCE  /ha-datacenter/host/${esx1-ip}/Resources
     Set Environment Variable  TEST_TIMEOUT  30m
 
-    #Waiting on a valid license with serial support for this to work
-    #Install VIC Appliance To Test Server
-
-    #Run Regression Tests
+*** Test Cases ***
+Test
+    Log To Console  \nStarting test...
+    Install VIC Appliance To Test Server
+    Run Regression Tests

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-2-Cluster.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-2-Cluster.robot
@@ -15,11 +15,11 @@
 *** Settings ***
 Documentation  Test 5-2 - Cluster
 Resource  ../../resources/Util.robot
+Suite Setup  Wait Until Keyword Succeeds  10x  10m  Cluster Setup
 Suite Teardown  Run Keyword And Ignore Error  Nimbus Cleanup  ${list}
 
-*** Test Cases ***
-Test
-    Log To Console  \nStarting test...
+*** Keywords ***
+Cluster Setup
     Log To Console  \nWait until Nimbus is at least available...
     Open Connection  %{NIMBUS_GW}
     Wait Until Keyword Succeeds  10 min  30 sec  Login  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}
@@ -85,6 +85,8 @@ Test
     Set Environment Variable  TEST_RESOURCE  cls
     Set Environment Variable  TEST_TIMEOUT  30m
 
+*** Test Cases ***
+Test
+    Log To Console  \nStarting test...
     Install VIC Appliance To Test Server
-
     Run Regression Tests

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-2-Cluster.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-2-Cluster.robot
@@ -24,6 +24,7 @@ Cluster Setup
     Open Connection  %{NIMBUS_GW}
     Wait Until Keyword Succeeds  10 min  30 sec  Login  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}
     Close Connection
+    Run Keyword And Ignore Error  Nimbus Cleanup  ${list}  ${false}
     ${vc}=  Evaluate  'VC-' + str(random.randint(1000,9999)) + str(time.clock())  modules=random,time
     ${pid}=  Deploy Nimbus vCenter Server Async  ${vc}
 
@@ -31,7 +32,7 @@ Cluster Setup
     @{esx_names}=  Get Dictionary Keys  ${esxes}
     @{esx_ips}=  Get Dictionary Values  ${esxes}
 
-    Set Global Variable  @{list}  %{NIMBUS_USER}-@{esx_names}[0]  %{NIMBUS_USER}-@{esx_names}[1]  %{NIMBUS_USER}-@{esx_names}[2]  %{NIMBUS_USER}-${vc}
+    Set Suite Variable  @{list}  %{NIMBUS_USER}-@{esx_names}[0]  %{NIMBUS_USER}-@{esx_names}[1]  %{NIMBUS_USER}-@{esx_names}[2]  %{NIMBUS_USER}-${vc}
 
     # Finish vCenter deploy
     ${output}=  Wait For Process  ${pid}

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-2-Cluster.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-2-Cluster.robot
@@ -82,6 +82,7 @@ Cluster Setup
     Set Environment Variable  TEST_PASSWORD  Admin\!23
     Set Environment Variable  BRIDGE_NETWORK  bridge
     Set Environment Variable  PUBLIC_NETWORK  vm-network
+    Remove Environment Variable  TEST_DATACENTER
     Set Environment Variable  TEST_DATASTORE  datastore1
     Set Environment Variable  TEST_RESOURCE  cls
     Set Environment Variable  TEST_TIMEOUT  30m

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-20-Restore-Starting-State.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-20-Restore-Starting-State.robot
@@ -15,11 +15,12 @@
 *** Settings ***
 Documentation  Test 5-20 - Restore Starting State
 Resource  ../../resources/Util.robot
-Suite Setup  Install VIC Appliance To Test Server
-Suite Teardown  Cleanup VIC Appliance On Test Server
+#Suite Setup  Install VIC Appliance To Test Server
+#Suite Teardown  Cleanup VIC Appliance On Test Server
 
 *** Test Cases ***
 Restore Container Starting State on Restart
+    Pass Execution  Not sure why this test case is here, but it needs to be re-implemented to work in Nimbus
 	# enable firewall
 	Run  govc host.esxcli network firewall set -e true
 	${out}=  Run  docker %{VCH-PARAMS} pull busybox

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-21-Datastore-Path.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-21-Datastore-Path.robot
@@ -24,9 +24,10 @@ ${dsScheme}=  ds://
 
 *** Keywords ***
 Setup Suite ESX
+    Run Keyword And Ignore Error  Nimbus Cleanup  ${list}  ${false}
     ${esx1}  ${esx1-ip}=  Deploy Nimbus ESXi Server  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}
-    Set Global Variable  ${ESX1}  ${esx1}
-    Set Global Variable  @{list}  ${esx1}
+    Set Suite Variable  ${ESX1}  ${esx1}
+    Set Suite Variable  @{list}  ${esx1}
 
     Log To Console  Deploy VIC Appliance To ESX
     Set Environment Variable  TEST_URL_ARRAY  ${esx1-ip}

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-21-Datastore-Path.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-21-Datastore-Path.robot
@@ -15,7 +15,7 @@
 *** Settings ***
 Documentation    Test 5-21 - Datastore-Path
 Resource  ../../resources/Util.robot
-Suite Setup  Setup Suite ESX
+Suite Setup  Wait Until Keyword Succeeds  10x  10m  Setup Suite ESX
 Suite Teardown  Run Keyword And Ignore Error  Nimbus Cleanup  ${list}
 
 *** Variables ***

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-22-NFS-Volume.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-22-NFS-Volume.robot
@@ -34,6 +34,7 @@ ${mntNamed}=  /mnt/named
 
 *** Keywords ***
 Setup ESX And NFS Suite
+    Run Keyword And Ignore Error  Nimbus Cleanup  ${list}  ${false}
     Log To Console  \nStarting test...
 
     ${esx1}  ${esx1_ip}=  Deploy Nimbus ESXi Server  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}
@@ -42,12 +43,12 @@ Setup ESX And NFS Suite
 
     ${nfs_readonly}  ${nfs_readonly_ip}=  Deploy Nimbus NFS Datastore  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}  additional-args=--disk 5000000 --disk 5000000 --mountOpt ro --nfsOpt ro --mountPoint=storage1 --mountPoint=storage2
 
-    Set Global Variable  @{list}  ${esx1}  ${nfs}
-    Set Global Variable  ${ESX1}  ${esx1}
-    Set Global Variable  ${ESX1_IP}  ${esx1_ip}
-    Set Global Variable  ${NFS_IP}  ${nfs_ip}
-    Set Global Variable  ${NFS}  ${nfs}
-    Set Global Variable  ${NFS_READONLY_IP}  ${nfs_readonly_ip}
+    Set Suite Variable  @{list}  ${esx1}  ${nfs}
+    Set Suite Variable  ${ESX1}  ${esx1}
+    Set Suite Variable  ${ESX1_IP}  ${esx1_ip}
+    Set Suite Variable  ${NFS_IP}  ${nfs_ip}
+    Set Suite Variable  ${NFS}  ${nfs}
+    Set Suite Variable  ${NFS_READONLY_IP}  ${nfs_readonly_ip}
 
 Setup ENV Variables for VIC Appliance Install
     Log To Console  \nSetup Environment Variables for VIC Appliance To ESX\n

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-22-NFS-Volume.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-22-NFS-Volume.robot
@@ -15,7 +15,7 @@
 *** Settings ***
 Documentation  Test 5-22 - NFS Volume
 Resource  ../../resources/Util.robot
-Suite Setup  Setup ESX And NFS Suite
+Suite Setup  Wait Until Keyword Succeeds  10x  10m  Setup ESX And NFS Suite
 Suite Teardown  Run Keyword And Ignore Error  Nimbus Cleanup  ${list}
 
 

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-23-Resource-Pool-Install.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-23-Resource-Pool-Install.robot
@@ -15,16 +15,17 @@
 *** Settings ***
 Documentation  Test 5-23 - Resource Pool Install
 Resource  ../../resources/Util.robot
+Suite Setup  Wait Until Keyword Succeeds  10x  10m  Resource Pool Install Setup
 Suite Teardown  Run Keyword And Ignore Error  Nimbus Cleanup  ${list}
 Test Teardown  Cleanup VIC Appliance On Test Server
+
+*** Keywords ***
+Resource Pool Install Setup
+    ${esx1}  ${esx2}  ${esx3}  ${vc}  ${esx1-ip}  ${esx2-ip}  ${esx3-ip}  ${vc-ip}=  Create a Simple VC Cluster  datacenter  cls
+    Set Global Variable  @{list}  ${esx1}  ${esx2}  ${esx3}  ${vc}
 
 *** Test Cases ***
 Test
     Log To Console  \nStarting test...
-    ${esx1}  ${esx2}  ${esx3}  ${vc}  ${esx1-ip}  ${esx2-ip}  ${esx3-ip}  ${vc-ip}=  Create a Simple VC Cluster  datacenter  cls
-
-    Set Global Variable  @{list}  ${esx1}  ${esx2}  ${esx3}  ${vc}
-
     Install VIC Appliance To Test Server  additional-args=--use-rp
-
     Run Regression Tests

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-23-Resource-Pool-Install.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-23-Resource-Pool-Install.robot
@@ -21,8 +21,9 @@ Test Teardown  Cleanup VIC Appliance On Test Server
 
 *** Keywords ***
 Resource Pool Install Setup
+    Run Keyword And Ignore Error  Nimbus Cleanup  ${list}  ${false}
     ${esx1}  ${esx2}  ${esx3}  ${vc}  ${esx1-ip}  ${esx2-ip}  ${esx3-ip}  ${vc-ip}=  Create a Simple VC Cluster  datacenter  cls
-    Set Global Variable  @{list}  ${esx1}  ${esx2}  ${esx3}  ${vc}
+    Set Suite Variable  @{list}  ${esx1}  ${esx2}  ${esx3}  ${vc}
 
 *** Test Cases ***
 Test

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-3-Enhanced-Linked-Mode.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-3-Enhanced-Linked-Mode.robot
@@ -15,6 +15,7 @@
 *** Settings ***
 Documentation  Test 5-3 - Enhanced Linked Mode
 Resource  ../../resources/Util.robot
+Suite Setup  Wait Until Keyword Succeeds  10x  10m  Enhanced Link Mode Setup
 Suite Teardown  Run Keyword And Ignore Error  Nimbus Cleanup  ${list}
 
 *** Keywords ***
@@ -27,10 +28,9 @@ Combine Dictionaries
     \    Set To Dictionary  ${dict1}  ${key}  ${elem}
     [Return]  ${dict1}
 
-*** Test Cases ***
-Test
+Enhanced Link Mode Setup
     ${name}=  Evaluate  'els-' + str(random.randint(1000,9999))  modules=random
-    Set Test Variable  ${user}  %{NIMBUS_USER}
+    Set Suite Variable  ${user}  %{NIMBUS_USER}
     Log To Console  \nDeploying Nimbus Testbed: ${name}
 
     ${pid}=  Run Secret SSHPASS command  %{NIMBUS_USER}  '%{NIMBUS_PASSWORD}'  'nimbus-testbeddeploy --lease=1 --noStatsDump --noSupportBundles --plugin test-vpx --testbedName test-vpx-m2n2-vcva-3esx-pxeBoot-8gbmem --vcvaBuild ${VC_VERSION} --esxPxeDir ${ESX_VERSION} --runName ${name}'
@@ -68,19 +68,19 @@ Test
     :FOR  ${line}  IN  @{output}
     \   ${status}=  Run Keyword And Return Status  Should Contain  ${line}  ${name}.vc.0' is up. IP:
     \   ${ip}=  Run Keyword If  ${status}  Fetch From Right  ${line}  ${SPACE}
-    \   Run Keyword If  ${status}  Set Test Variable  ${vc1-ip}  ${ip}
+    \   Run Keyword If  ${status}  Set Suite Variable  ${vc1-ip}  ${ip}
     \   ${status}=  Run Keyword And Return Status  Should Contain  ${line}  ${name}.vc.1' is up. IP:
     \   ${ip}=  Run Keyword If  ${status}  Fetch From Right  ${line}  ${SPACE}
-    \   Run Keyword If  ${status}  Set Test Variable  ${vc2-ip}  ${ip}
+    \   Run Keyword If  ${status}  Set Suite Variable  ${vc2-ip}  ${ip}
     \   ${status}=  Run Keyword And Return Status  Should Contain  ${line}  ${name}.esx.0' is up. IP:
     \   ${ip}=  Run Keyword If  ${status}  Fetch From Right  ${line}  ${SPACE}
-    \   Run Keyword If  ${status}  Set Test Variable  ${esx1-ip}  ${ip}
+    \   Run Keyword If  ${status}  Set Suite Variable  ${esx1-ip}  ${ip}
     \   ${status}=  Run Keyword And Return Status  Should Contain  ${line}  ${name}.esx.1' is up. IP:
     \   ${ip}=  Run Keyword If  ${status}  Fetch From Right  ${line}  ${SPACE}
-    \   Run Keyword If  ${status}  Set Test Variable  ${esx2-ip}  ${ip}
+    \   Run Keyword If  ${status}  Set Suite Variable  ${esx2-ip}  ${ip}
     \   ${status}=  Run Keyword And Return Status  Should Contain  ${line}  ${name}.esx.2' is up. IP:
     \   ${ip}=  Run Keyword If  ${status}  Fetch From Right  ${line}  ${SPACE}
-    \   Run Keyword If  ${status}  Set Test Variable  ${esx3-ip}  ${ip}
+    \   Run Keyword If  ${status}  Set Suite Variable  ${esx3-ip}  ${ip}
 
     Set Global Variable  @{list}  ${esx1}  ${esx2}  ${esx3}  ${user}-${name}.vc.0  ${user}-${name}.vc.1  ${user}-${name}.vc.2  ${user}-${name}.vc.3  ${user}-${name}.nfs.0  ${user}-${name}.esx.0  ${user}-${name}.esx.1  ${user}-${name}.esx.2
 
@@ -161,6 +161,7 @@ Test
     Set Environment Variable  TEST_RESOURCE  cls
     Set Environment Variable  TEST_TIMEOUT  30m
 
+*** Test Cases ***
+Test
     Install VIC Appliance To Test Server
-
     Run Regression Tests

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-3-Enhanced-Linked-Mode.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-3-Enhanced-Linked-Mode.robot
@@ -29,6 +29,7 @@ Combine Dictionaries
     [Return]  ${dict1}
 
 Enhanced Link Mode Setup
+    Run Keyword And Ignore Error  Nimbus Cleanup  ${list}  ${false}
     ${name}=  Evaluate  'els-' + str(random.randint(1000,9999))  modules=random
     Set Suite Variable  ${user}  %{NIMBUS_USER}
     Log To Console  \nDeploying Nimbus Testbed: ${name}
@@ -82,7 +83,7 @@ Enhanced Link Mode Setup
     \   ${ip}=  Run Keyword If  ${status}  Fetch From Right  ${line}  ${SPACE}
     \   Run Keyword If  ${status}  Set Suite Variable  ${esx3-ip}  ${ip}
 
-    Set Global Variable  @{list}  ${esx1}  ${esx2}  ${esx3}  ${user}-${name}.vc.0  ${user}-${name}.vc.1  ${user}-${name}.vc.2  ${user}-${name}.vc.3  ${user}-${name}.nfs.0  ${user}-${name}.esx.0  ${user}-${name}.esx.1  ${user}-${name}.esx.2
+    Set Suite Variable  @{list}  ${esx1}  ${esx2}  ${esx3}  ${user}-${name}.vc.0  ${user}-${name}.vc.1  ${user}-${name}.vc.2  ${user}-${name}.vc.3  ${user}-${name}.nfs.0  ${user}-${name}.esx.0  ${user}-${name}.esx.1  ${user}-${name}.esx.2
 
     Remove Environment Variable  GOVC_PASSWORD
     Remove Environment Variable  GOVC_USERNAME

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-3-Enhanced-Linked-Mode.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-3-Enhanced-Linked-Mode.robot
@@ -158,6 +158,7 @@ Enhanced Link Mode Setup
     Set Environment Variable  TEST_PASSWORD  Admin\!23
     Set Environment Variable  BRIDGE_NETWORK  bridge
     Set Environment Variable  PUBLIC_NETWORK  vm-network
+    Remove Environment Variable  TEST_DATACENTER
     Set Environment Variable  TEST_DATASTORE  datastore1
     Set Environment Variable  TEST_RESOURCE  cls
     Set Environment Variable  TEST_TIMEOUT  30m

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-4-High-Availability.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-4-High-Availability.robot
@@ -155,6 +155,7 @@ High Availability Setup
     Set Environment Variable  BRIDGE_NETWORK  bridge
     Set Environment Variable  PUBLIC_NETWORK  vm-network
     Set Environment Variable  TEST_RESOURCE  cls
+    Remove Environment Variable  TEST_DATACENTER
     Set Environment Variable  TEST_DATASTORE  nfsDatastore
     Set Environment Variable  TEST_TIMEOUT  30m
 

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-4-High-Availability.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-4-High-Availability.robot
@@ -90,6 +90,7 @@ Run Regression Test With More Log Information
     Scrape Logs For The Password
 
 High Availability Setup
+    Run Keyword And Ignore Error  Nimbus Cleanup  ${list}  ${false}
     ${vc}=  Evaluate  'VC-' + str(random.randint(1000,9999)) + str(time.clock())  modules=random,time
     ${pid}=  Deploy Nimbus vCenter Server Async  ${vc}
     Set Suite Variable  ${VC}  ${vc}
@@ -101,7 +102,7 @@ High Availability Setup
     @{esx_names}=  Get Dictionary Keys  ${esxes}
     @{esx_ips}=  Get Dictionary Values  ${esxes}
 
-    Set Global Variable  @{list}  ${esx_names}  ${vc}
+    Set Suite Variable  @{list}  ${esx_names}  ${vc}
 
     # Finish vCenter deploy
     ${output}=  Wait For Process  ${pid}

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-4-High-Availability.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-4-High-Availability.robot
@@ -15,6 +15,7 @@
 *** Settings ***
 Documentation  Test 5-4 - High Availability
 Resource  ../../resources/Util.robot
+Suite Setup  Wait Until Keyword Succeeds  10x  10m  High Availability Setup
 Suite Teardown  Nimbus Cleanup  ${list}
 Test Teardown  Run Keyword If Test Failed  Gather Logs From Test Server
 
@@ -88,8 +89,7 @@ Run Regression Test With More Log Information
 
     Scrape Logs For The Password
 
-*** Test Cases ***
-Test
+High Availability Setup
     ${vc}=  Evaluate  'VC-' + str(random.randint(1000,9999)) + str(time.clock())  modules=random,time
     ${pid}=  Deploy Nimbus vCenter Server Async  ${vc}
     Set Suite Variable  ${VC}  ${vc}
@@ -157,8 +157,9 @@ Test
     Set Environment Variable  TEST_DATASTORE  nfsDatastore
     Set Environment Variable  TEST_TIMEOUT  30m
 
+*** Test Cases ***
+Test
     Install VIC Appliance To Test Server  certs=${false}  vol=default
-
     Run Regression Tests
 
     # have a few containers running and stopped for when we

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-5-Heterogeneous-ESXi.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-5-Heterogeneous-ESXi.robot
@@ -15,11 +15,11 @@
 *** Settings ***
 Documentation  Test 5-1 - Distributed Switch
 Resource  ../../resources/Util.robot
+Suite Setup  Wait Until Keyword Succeeds  10x  10m  Heterogenous ESXi Setup
 Suite Teardown  Run Keyword And Ignore Error  Nimbus Cleanup  ${list}
 
-*** Test Cases ***
-Test
-    Log To Console  \nStarting test...
+*** Keywords ***
+Heterogenous ESXi Setup
     ${vc}=  Evaluate  'VC-' + str(random.randint(1000,9999)) + str(time.clock())  modules=random,time
     ${pid-vc}=  Deploy Nimbus vCenter Server Async  ${vc}
     Set Global Variable  @{list}  %{NIMBUS_USER}-${vc}
@@ -100,6 +100,8 @@ Test
 
     Set Environment Variable  TEST_DATASTORE  nfsDatastore
 
+*** Test Cases ***
+Test
+    Log To Console  \nStarting test...
     Install VIC Appliance To Test Server  certs=${false}  vol=default
-
     Run Regression Tests

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-5-Heterogeneous-ESXi.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-5-Heterogeneous-ESXi.robot
@@ -20,9 +20,10 @@ Suite Teardown  Run Keyword And Ignore Error  Nimbus Cleanup  ${list}
 
 *** Keywords ***
 Heterogenous ESXi Setup
+    Run Keyword And Ignore Error  Nimbus Cleanup  ${list}  ${false}
     ${vc}=  Evaluate  'VC-' + str(random.randint(1000,9999)) + str(time.clock())  modules=random,time
     ${pid-vc}=  Deploy Nimbus vCenter Server Async  ${vc}
-    Set Global Variable  @{list}  %{NIMBUS_USER}-${vc}
+    Set Suite Variable  @{list}  %{NIMBUS_USER}-${vc}
 
     Run Keyword And Ignore Error  Cleanup Nimbus PXE folder  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}
     ${esx1}  ${esx1-ip}=  Deploy Nimbus ESXi Server  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}  3029944

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-5-Heterogeneous-ESXi.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-5-Heterogeneous-ESXi.robot
@@ -91,6 +91,7 @@ Heterogenous ESXi Setup
     Set Environment Variable  TEST_PASSWORD  Admin\!23
     Set Environment Variable  BRIDGE_NETWORK  bridge
     Set Environment Variable  PUBLIC_NETWORK  vm-network
+    Remove Environment Variable  TEST_DATACENTER
     Set Environment Variable  TEST_RESOURCE  cls
     Set Environment Variable  TEST_TIMEOUT  30m
 

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-6-1-VSAN-Simple.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-6-1-VSAN-Simple.robot
@@ -20,6 +20,7 @@ Suite Teardown  Run Keyword And Ignore Error  Nimbus Cleanup  ${list}
 
 *** Keywords ***
 Simple VSAN Setup
+    Run Keyword And Ignore Error  Nimbus Cleanup  ${list}  ${false}
     ${name}=  Evaluate  'vic-vsan-' + str(random.randint(1000,9999))  modules=random
     Set Suite Variable  ${user}  %{NIMBUS_USER}
     ${out}=  Deploy Nimbus Testbed  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}  --plugin testng --vcfvtBuildPath /dbc/pa-dbc1111/mhagen/ --noSupportBundles --vcvaBuild ${VC_VERSION} --esxPxeDir ${ESX_VERSION} --esxBuild ${ESX_VERSION} --testbedName vic-vsan-simple-pxeBoot-vcva --runName ${name}
@@ -31,7 +32,7 @@ Simple VSAN Setup
     \   Run Keyword If  ${status}  Set Suite Variable  ${vc-ip}  ${ip}
     \   Exit For Loop If  ${status}
 
-    Set Global Variable  @{list}  ${user}-${name}.vcva-${VC_VERSION}  ${user}-${name}.esx.0  ${user}-${name}.esx.1  ${user}-${name}.esx.2  ${user}-${name}.esx.3  ${user}-${name}.nfs.0  ${user}-${name}.iscsi.0
+    Set Suite Variable  @{list}  ${user}-${name}.vcva-${VC_VERSION}  ${user}-${name}.esx.0  ${user}-${name}.esx.1  ${user}-${name}.esx.2  ${user}-${name}.esx.3  ${user}-${name}.nfs.0  ${user}-${name}.iscsi.0
 
     Log To Console  Set environment variables up for GOVC
     Set Environment Variable  GOVC_URL  ${vc-ip}

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-6-1-VSAN-Simple.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-6-1-VSAN-Simple.robot
@@ -15,19 +15,20 @@
 *** Settings ***
 Documentation  Test 5-6-1 - VSAN-Simple
 Resource  ../../resources/Util.robot
-Test Teardown  Run Keyword And Ignore Error  Nimbus Cleanup  ${list}
+Suite Setup  Wait Until Keyword Succeeds  10x  10m  Simple VSAN Setup
+Suite Teardown  Run Keyword And Ignore Error  Nimbus Cleanup  ${list}
 
-*** Test Cases ***
-Simple VSAN
+*** Keywords ***
+Simple VSAN Setup
     ${name}=  Evaluate  'vic-vsan-' + str(random.randint(1000,9999))  modules=random
-    Set Test Variable  ${user}  %{NIMBUS_USER}
+    Set Suite Variable  ${user}  %{NIMBUS_USER}
     ${out}=  Deploy Nimbus Testbed  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}  --plugin testng --vcfvtBuildPath /dbc/pa-dbc1111/mhagen/ --noSupportBundles --vcvaBuild ${VC_VERSION} --esxPxeDir ${ESX_VERSION} --esxBuild ${ESX_VERSION} --testbedName vic-vsan-simple-pxeBoot-vcva --runName ${name}
     Should Contain  ${out}  "deployment_result"=>"PASS"
     ${out}=  Split To Lines  ${out}
     :FOR  ${line}  IN  @{out}
     \   ${status}=  Run Keyword And Return Status  Should Contain  ${line}  .vcva-${VC_VERSION}' is up. IP:
     \   ${ip}=  Run Keyword If  ${status}  Fetch From Right  ${line}  ${SPACE}
-    \   Run Keyword If  ${status}  Set Test Variable  ${vc-ip}  ${ip}
+    \   Run Keyword If  ${status}  Set Suite Variable  ${vc-ip}  ${ip}
     \   Exit For Loop If  ${status}
 
     Set Global Variable  @{list}  ${user}-${name}.vcva-${VC_VERSION}  ${user}-${name}.esx.0  ${user}-${name}.esx.1  ${user}-${name}.esx.2  ${user}-${name}.esx.3  ${user}-${name}.nfs.0  ${user}-${name}.iscsi.0
@@ -53,13 +54,13 @@ Simple VSAN
     Set Environment Variable  TEST_RESOURCE  cls
     Set Environment Variable  TEST_TIMEOUT  15m
 
+*** Test Cases ***
+Simple VSAN
     ${out}=  Run  govc datastore.vsan.dom.ls -ds %{TEST_DATASTORE} -l -o
     Should Be Empty  ${out}
 
     Install VIC Appliance To Test Server
-
     Run Regression Tests
-
     Cleanup VIC Appliance On Test Server
 
     ${out}=  Run  govc datastore.vsan.dom.ls -ds %{TEST_DATASTORE} -l -o

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-6-1-VSAN-Simple.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-6-1-VSAN-Simple.robot
@@ -51,6 +51,7 @@ Simple VSAN Setup
     Set Environment Variable  TEST_PASSWORD  Admin\!23
     Set Environment Variable  BRIDGE_NETWORK  bridge
     Set Environment Variable  PUBLIC_NETWORK  vm-network
+    Remove Environment Variable  TEST_DATACENTER
     Set Environment Variable  TEST_DATASTORE  vsanDatastore
     Set Environment Variable  TEST_RESOURCE  cls
     Set Environment Variable  TEST_TIMEOUT  15m

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-6-2-VSAN-Complex.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-6-2-VSAN-Complex.robot
@@ -20,6 +20,7 @@ Suite Teardown  Run Keyword And Ignore Error  Nimbus Cleanup  ${list}
 
 *** Keywords ***
 VSAN Complex Setup
+    Run Keyword And Ignore Error  Nimbus Cleanup  ${list}  ${false}
     ${name}=  Evaluate  'vic-vsan-complex-' + str(random.randint(1000,9999))  modules=random
     Set Suite Variable  ${user}  %{NIMBUS_USER}
     ${out}=  Deploy Nimbus Testbed  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}  --plugin testng --vcfvtBuildPath /dbc/pa-dbc1111/mhagen/ --noSupportBundles --vcvaBuild ${VC_VERSION} --esxPxeDir ${ESX_VERSION} --esxBuild ${ESX_VERSION} --testbedName vic-vsan-complex-pxeBoot-vcva --runName ${name}
@@ -31,7 +32,7 @@ VSAN Complex Setup
     \   Run Keyword If  ${status}  Set Suite Variable  ${vc-ip}  ${ip}
     \   Exit For Loop If  ${status}
 
-    Set Global Variable  @{list}  ${user}-${name}.vcva-${VC_VERSION}  ${user}-${name}.esx.0  ${user}-${name}.esx.1  ${user}-${name}.esx.2  ${user}-${name}.esx.3  ${user}-${name}.esx.4  ${user}-${name}.esx.5  ${user}-${name}.esx.6  ${user}-${name}.esx.7  ${user}-${name}.nfs.0  ${user}-${name}.iscsi.0
+    Set Suite Variable  @{list}  ${user}-${name}.vcva-${VC_VERSION}  ${user}-${name}.esx.0  ${user}-${name}.esx.1  ${user}-${name}.esx.2  ${user}-${name}.esx.3  ${user}-${name}.esx.4  ${user}-${name}.esx.5  ${user}-${name}.esx.6  ${user}-${name}.esx.7  ${user}-${name}.nfs.0  ${user}-${name}.iscsi.0
 
     Log To Console  Set environment variables up for GOVC
     Set Environment Variable  GOVC_URL  ${vc-ip}

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-6-2-VSAN-Complex.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-6-2-VSAN-Complex.robot
@@ -53,6 +53,7 @@ VSAN Complex Setup
     Set Environment Variable  PUBLIC_NETWORK  vm-network
     ${datastore}=  Run  govc ls -t Datastore host/cluster-vsan-1/* | grep -v local | cut -d '/' -f 6 | sort | uniq | grep vsan
     Set Environment Variable  TEST_DATASTORE  "${datastore}"
+    Remove Environment Variable  TEST_DATACENTER
     Set Environment Variable  TEST_RESOURCE  cluster-vsan-1
     Set Environment Variable  TEST_TIMEOUT  30m
 

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-6-2-VSAN-Complex.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-6-2-VSAN-Complex.robot
@@ -15,28 +15,20 @@
 *** Settings ***
 Documentation  Test 5-6-2 - VSAN-Complex
 Resource  ../../resources/Util.robot
-Test Teardown  VSAN Cleanup
+Suite Setup  Wait Until Keyword Succeeds  10x  10m  VSAN Complex Setup
+Suite Teardown  Run Keyword And Ignore Error  Nimbus Cleanup  ${list}
 
 *** Keywords ***
-VSAN Cleanup
-    Cleanup VIC Appliance On Test Server
-
-    ${out}=  Run  govc datastore.vsan.dom.ls -ds %{TEST_DATASTORE} -l -o
-    Should Be Empty  ${out}
-
-    Nimbus Cleanup  ${list}  ${false}
-
-*** Test Cases ***
-Complex VSAN
+VSAN Complex Setup
     ${name}=  Evaluate  'vic-vsan-complex-' + str(random.randint(1000,9999))  modules=random
-    Set Test Variable  ${user}  %{NIMBUS_USER}
+    Set Suite Variable  ${user}  %{NIMBUS_USER}
     ${out}=  Deploy Nimbus Testbed  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}  --plugin testng --vcfvtBuildPath /dbc/pa-dbc1111/mhagen/ --noSupportBundles --vcvaBuild ${VC_VERSION} --esxPxeDir ${ESX_VERSION} --esxBuild ${ESX_VERSION} --testbedName vic-vsan-complex-pxeBoot-vcva --runName ${name}
     Should Contain  ${out}  "deployment_result"=>"PASS"
     ${out}=  Split To Lines  ${out}
     :FOR  ${line}  IN  @{out}
     \   ${status}=  Run Keyword And Return Status  Should Contain  ${line}  .vcva-${VC_VERSION}' is up. IP:
     \   ${ip}=  Run Keyword If  ${status}  Fetch From Right  ${line}  ${SPACE}
-    \   Run Keyword If  ${status}  Set Test Variable  ${vc-ip}  ${ip}
+    \   Run Keyword If  ${status}  Set Suite Variable  ${vc-ip}  ${ip}
     \   Exit For Loop If  ${status}
 
     Set Global Variable  @{list}  ${user}-${name}.vcva-${VC_VERSION}  ${user}-${name}.esx.0  ${user}-${name}.esx.1  ${user}-${name}.esx.2  ${user}-${name}.esx.3  ${user}-${name}.esx.4  ${user}-${name}.esx.5  ${user}-${name}.esx.6  ${user}-${name}.esx.7  ${user}-${name}.nfs.0  ${user}-${name}.iscsi.0
@@ -63,9 +55,14 @@ Complex VSAN
     Set Environment Variable  TEST_RESOURCE  cluster-vsan-1
     Set Environment Variable  TEST_TIMEOUT  30m
 
+*** Test Cases ***
+Complex VSAN
     ${out}=  Run  govc datastore.vsan.dom.ls -ds %{TEST_DATASTORE} -l -o
     Should Be Empty  ${out}
 
     Install VIC Appliance To Test Server
-
     Run Regression Tests
+    Cleanup VIC Appliance On Test Server
+
+    ${out}=  Run  govc datastore.vsan.dom.ls -ds %{TEST_DATASTORE} -l -o
+    Should Be Empty  ${out}

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-7-NSX.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-7-NSX.robot
@@ -29,6 +29,7 @@ Test
     Set Environment Variable  TEST_PASSWORD  Admin\!23
     Set Environment Variable  BRIDGE_NETWORK  vxw-dvs-53-virtualwire-1-sid-5001-nsx-switch
     Set Environment Variable  PUBLIC_NETWORK  'VM Network'
+    Remove Environment Variable  TEST_DATACENTER
     Set Environment Variable  TEST_DATASTORE  vsanDatastore
     Set Environment Variable  TEST_RESOURCE  cls
     Set Environment Variable  TEST_TIMEOUT  30m

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-8-DRS.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-8-DRS.robot
@@ -15,11 +15,11 @@
 *** Settings ***
 Documentation  Test 5-8 - DRS
 Resource  ../../resources/Util.robot
+Suite Setup  Wait Until Keyword Succeeds  10x  10m  DRS Setup
 Suite Teardown  Nimbus Cleanup  ${list}
 
-*** Test Cases ***
-Test
-    Log To Console  \nStarting test...
+*** Keywords ***
+DRS Setup
     ${esx1}  ${esx1-ip}=  Deploy Nimbus ESXi Server  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}
     Set Suite Variable  ${ESX1}  ${esx1}
     ${esx2}  ${esx2-ip}=  Deploy Nimbus ESXi Server  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}
@@ -73,6 +73,9 @@ Test
     Set Environment Variable  TEST_RESOURCE  cls
     Set Environment Variable  TEST_TIMEOUT  30m
 
+*** Test Cases ***
+Test
+    Log To Console  \nStarting test...
     ${status}  ${message}=  Run Keyword And Ignore Error  Install VIC Appliance To Test Server  certs=${false}  vol=default
     Should Contain  ${message}  DRS must be enabled to use VIC
     Should Be Equal As Strings  ${status}  FAIL

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-8-DRS.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-8-DRS.robot
@@ -70,6 +70,7 @@ DRS Setup
     Set Environment Variable  TEST_PASSWORD  Admin\!23
     Set Environment Variable  BRIDGE_NETWORK  bridge
     Set Environment Variable  PUBLIC_NETWORK  vm-network
+    Remove Environment Variable  TEST_DATACENTER
     Set Environment Variable  TEST_DATASTORE  datastore1
     Set Environment Variable  TEST_RESOURCE  cls
     Set Environment Variable  TEST_TIMEOUT  30m

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-8-DRS.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-8-DRS.robot
@@ -20,6 +20,7 @@ Suite Teardown  Nimbus Cleanup  ${list}
 
 *** Keywords ***
 DRS Setup
+    Run Keyword And Ignore Error  Nimbus Cleanup  ${list}  ${false}
     ${esx1}  ${esx1-ip}=  Deploy Nimbus ESXi Server  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}
     Set Suite Variable  ${ESX1}  ${esx1}
     ${esx2}  ${esx2-ip}=  Deploy Nimbus ESXi Server  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}
@@ -30,7 +31,7 @@ DRS Setup
     ${vc}  ${vc-ip}=  Deploy Nimbus vCenter Server  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}
     Set Suite Variable  ${VC}  ${vc}
 
-    Set Global Variable  @{list}  ${esx1}  ${esx2}  ${esx3}  ${vc}
+    Set Suite Variable  @{list}  ${esx1}  ${esx2}  ${esx3}  ${vc}
 
     Log To Console  Create a datacenter on the VC
     ${out}=  Run  govc datacenter.create ha-datacenter

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-9-Private-Registry.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-9-Private-Registry.robot
@@ -15,8 +15,8 @@
 *** Settings ***
 Documentation  Test 5-9 - Private Registry
 Resource  ../../resources/Util.robot
-Suite Setup  Private Registry Setup
-Suite Teardown  Private Registry Cleanup
+#Suite Setup  Private Registry Setup
+#Suite Teardown  Private Registry Cleanup
 
 *** Keywords ***
 Private Registry Setup
@@ -51,11 +51,13 @@ Pull image
 
 *** Test Cases ***
 Pull an image from non-default repo
+    Pass Execution  This test needs to be re-written
     Install VIC Appliance To Test Server  vol=default --insecure-registry 172.17.0.1:5000
     Wait Until Keyword Succeeds  5x  15 seconds  Pull image  172.17.0.1:5000/busybox
     Cleanup VIC Appliance On Test Server
 
 Pull image from non-whitelisted repo
+    Pass Execution  This test needs to be re-written
     Install VIC Appliance To Test Server  vol=default
     ${rc}  ${output}=  Run And Return Rc And Output  docker ${params} pull 172.17.0.1:5000/busybox
     Should Contain  ${output}  Error response from daemon: Head https://172.17.0.1:5000/v2/: http: server gave HTTP response to HTTPS client

--- a/tests/nightly/nightly-autorun.sh
+++ b/tests/nightly/nightly-autorun.sh
@@ -14,23 +14,21 @@
 # limitations under the License.
 #
 
-# Get the latest code from vic-internal repo for nightly_test_secrets.yml file
-cd ~/internal-repo/vic-internal
+# Get the latest code from vic-internal repo for nightly_secrets.sh file
+cd ~/vic-internal
 git clean -fd
 git fetch
 git pull
+source nightly_secrets.sh
 
 # Get the latest code from vmware/vic repo
-cd ~/go/src/github.com/vmware/vic
+cd ~/vic
 git clean -fd
 git fetch https://github.com/vmware/vic master
 git pull
 
 # Kick off the nightly
-echo "Removing VIC directory if present"
 echo "Cleanup logs from previous run"
-
-sudo rm -rf *.zip *.log
-sudo rm -rf bin 60 65
+sudo rm -rf *.zip *.log bin 60 65
 
 sudo -E ./tests/nightly/nightly-kickoff.sh > ./nightly_console.txt 2>&1

--- a/tests/nightly/nightly-kickoff.sh
+++ b/tests/nightly/nightly-kickoff.sh
@@ -89,13 +89,13 @@ DATE=`date +%m_%d_%H_%M_`
 nightlystatus=()
 count=0
 
-nightly_secrets_file="/home/vicadmin/internal-repo/vic-internal/nightly_secrets.yml"
+source /home/vicadmin/internal-repo/vic-internal/nightly_secrets.sh
 
 for i in $nightly_list_var; do
     #Clean up any previous runs creds
     rm -rf VCH-0-*
     echo "Executing nightly test $i vSphere 6.5"
-    drone exec --trusted -e test="pybot -d 65/$i --suite $i tests/manual-test-cases/" -E $nightly_secrets_file --yaml .drone.nightly.yml
+    pybot -d 65/$i --suite $i tests/manual-test-cases/
 
     if [ $? -eq 0 ]
     then
@@ -116,7 +116,7 @@ for i in $nightly_list_var; do
     #Clean up any previous runs creds
     rm -rf VCH-0-*
     echo "Executing nightly test $i on vSphere 6.0"
-    drone exec --trusted -e test="pybot --variable ESX_VERSION:ob-5251623 --variable VC_VERSION:ob-5112509 -d 60/$i --suite $i tests/manual-test-cases/" -E $nightly_secrets_file --yaml .drone.nightly.yml
+    pybot --variable ESX_VERSION:ob-5251623 --variable VC_VERSION:ob-5112509 -d 60/$i --suite $i tests/manual-test-cases/
 
     if [ $? -eq 0 ]
     then
@@ -152,7 +152,7 @@ done
 
 echo "Global Nightly Test Status $buildStatus"
 
-drone exec --trusted -e test="sh tests/nightly/upload-logs.sh $DATE$input" -E $nightly_secrets_file --yaml .drone.nightly.yml
+sh tests/nightly/upload-logs.sh $DATE$input
 
 rm nightly_mail.html
 

--- a/tests/nightly/nightly-kickoff.sh
+++ b/tests/nightly/nightly-kickoff.sh
@@ -89,8 +89,6 @@ DATE=`date +%m_%d_%H_%M_`
 nightlystatus=()
 count=0
 
-source /home/vicadmin/internal-repo/vic-internal/nightly_secrets.sh
-
 for i in $nightly_list_var; do
     #Clean up any previous runs creds
     rm -rf VCH-0-*

--- a/tests/resources/Nimbus-Util.robot
+++ b/tests/resources/Nimbus-Util.robot
@@ -110,7 +110,7 @@ Deploy Multiple Nimbus ESXi Servers in Parallel
     :FOR  ${name}  IN  @{names}
     \    ${ip}=  Get IP  ${name}
     \    ${ip}=  Evaluate  $ip if $ip else ''
-    \    Run Keyword If  '${ip}'  Set To Dictionary  ${ips}  ${name}  ${ip}
+    \    Run Keyword If  '${ip}'  Set To Dictionary  ${ips}  ${user}-${name}  ${ip}
 
     # Let's set a password so govc doesn't complain
     ${just_ips}=  Get Dictionary Values  ${ips}

--- a/tests/resources/Nimbus-Util.robot
+++ b/tests/resources/Nimbus-Util.robot
@@ -224,6 +224,7 @@ Gather Host IPs
 Create a VSAN Cluster
     [Arguments]  ${name}=vic-vmotion
     Log To Console  \nStarting basic VSAN cluster deploy...
+    Run Keyword And Ignore Error  Nimbus Cleanup  ${list}  ${false}
     ${out}=  Deploy Nimbus Testbed  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}  --plugin testng --lease 1 --noStatsDump --noSupportBundles --vcvaBuild ${VC_VERSION} --esxPxeDir ${ESX_VERSION} --esxBuild ${ESX_VERSION} --testbedName vcqa-vsan-simple-pxeBoot-vcva --runName ${name}
     Should Contain  ${out}  .vcva-${VC_VERSION}' is up. IP:
     ${out}=  Split To Lines  ${out}

--- a/tests/resources/Nimbus-Util.robot
+++ b/tests/resources/Nimbus-Util.robot
@@ -62,6 +62,7 @@ Deploy Nimbus ESXi Server
     # Let's set a password so govc doesn't complain
     Remove Environment Variable  GOVC_PASSWORD
     Remove Environment Variable  GOVC_USERNAME
+    Remove Environment Variable  GOVC_DATASTORE
     Set Environment Variable  GOVC_INSECURE  1
     Set Environment Variable  GOVC_URL  root:@${ip}
     ${out}=  Run  govc host.account.update -id root -password ${NIMBUS_ESX_PASSWORD}
@@ -75,6 +76,7 @@ Set Host Password
     [Arguments]  ${ip}  ${NIMBUS_ESX_PASSWORD}
     Remove Environment Variable  GOVC_PASSWORD
     Remove Environment Variable  GOVC_USERNAME
+    Remove Environment Variable  GOVC_DATASTORE
     Set Environment Variable  GOVC_INSECURE  1
     Set Environment Variable  GOVC_URL  root:@${ip}
     ${out}=  Run  govc host.account.update -id root -password ${NIMBUS_ESX_PASSWORD}

--- a/tests/resources/Nimbus-Util.robot
+++ b/tests/resources/Nimbus-Util.robot
@@ -192,6 +192,7 @@ Kill Nimbus Server
     Open Connection  %{NIMBUS_GW}
     Wait Until Keyword Succeeds  2 min  30 sec  Login  ${user}  ${password}
     ${out}=  Execute Command  nimbus-ctl kill ${name}
+    Log  ${out}
     Close connection
 
 Cleanup Nimbus PXE folder

--- a/tests/resources/Nimbus-Util.robot
+++ b/tests/resources/Nimbus-Util.robot
@@ -62,7 +62,7 @@ Deploy Nimbus ESXi Server
     # Let's set a password so govc doesn't complain
     Remove Environment Variable  GOVC_PASSWORD
     Remove Environment Variable  GOVC_USERNAME
-    Remove Environment Variable  GOVC_DATASTORE
+    Remove Environment Variable  GOVC_DATACENTER
     Set Environment Variable  GOVC_INSECURE  1
     Set Environment Variable  GOVC_URL  root:@${ip}
     ${out}=  Run  govc host.account.update -id root -password ${NIMBUS_ESX_PASSWORD}
@@ -76,7 +76,7 @@ Set Host Password
     [Arguments]  ${ip}  ${NIMBUS_ESX_PASSWORD}
     Remove Environment Variable  GOVC_PASSWORD
     Remove Environment Variable  GOVC_USERNAME
-    Remove Environment Variable  GOVC_DATASTORE
+    Remove Environment Variable  GOVC_DATACENTER
     Set Environment Variable  GOVC_INSECURE  1
     Set Environment Variable  GOVC_URL  root:@${ip}
     ${out}=  Run  govc host.account.update -id root -password ${NIMBUS_ESX_PASSWORD}

--- a/tests/resources/Nimbus-Util.robot
+++ b/tests/resources/Nimbus-Util.robot
@@ -221,8 +221,9 @@ Gather Host IPs
     \   ${idx}=  Evaluate  ${idx}+1
 
 Create a VSAN Cluster
+    [Arguments]  ${name}=vic-vmotion
     Log To Console  \nStarting basic VSAN cluster deploy...
-    ${out}=  Deploy Nimbus Testbed  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}  --plugin testng --lease 1 --noStatsDump --noSupportBundles --vcvaBuild ${VC_VERSION} --esxPxeDir ${ESX_VERSION} --esxBuild ${ESX_VERSION} --testbedName vcqa-vsan-simple-pxeBoot-vcva --runName vic-vmotion
+    ${out}=  Deploy Nimbus Testbed  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}  --plugin testng --lease 1 --noStatsDump --noSupportBundles --vcvaBuild ${VC_VERSION} --esxPxeDir ${ESX_VERSION} --esxBuild ${ESX_VERSION} --testbedName vcqa-vsan-simple-pxeBoot-vcva --runName ${name}
     Should Contain  ${out}  .vcva-${VC_VERSION}' is up. IP:
     ${out}=  Split To Lines  ${out}
     :FOR  ${line}  IN  @{out}

--- a/tests/resources/Nimbus-Util.robot
+++ b/tests/resources/Nimbus-Util.robot
@@ -180,6 +180,7 @@ Deploy Nimbus Testbed
 
     :FOR  ${IDX}  IN RANGE  1  5
     \   ${out}=  Execute Command  nimbus-testbeddeploy --lease=1 ${testbed}
+    \   Log  ${out}
     \   # Make sure the deploy actually worked
     \   ${status}=  Run Keyword And Return Status  Should Contain  ${out}  "deployment_result"=>"PASS"
     \   Return From Keyword If  ${status}  ${out}


### PR DESCRIPTION
Several changes within this PR:
1. Eliminate drone from the process, which simplifies and eliminates the 60m hard timeout
2. Add a very long retry for Nimbus setup, can be easily increased even further if needed - the goal being will continue to retry forever until the nimbus setup portion passes at least to eliminate false failures.
3. We were leaking VMs from most of our tests, made some changes to improve that situation in our cleanup
4. De-scoped some of our global variables into suite variables as they did not need to be that encompassing, and need it to prep for parallel testing eventually
5. Fixed many of our tests that are run regularly that were actually broken.

fixes #6519 
