### PR TITLE
[skip ci] Add note about build number in upgrade tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,12 @@ From the root directory of the `vic` repository run `drone exec --repo.trusted`
 
     *Solution:* Delete everything under `$GOPATH/pkg/linux_amd64/github.com/vmware/vic` and re-run `make all`.
 
+3.  `vic-machine upgrade` integration tests fail due to `BUILD_NUMBER` being set incorrectly when building locally
+
+    *Cause:* `vic-machine` checks the build number of its binary to determine upgrade status and a locally-built `vic-machine` binary may not have the `BUILD_NUMBER` set correctly. Upon running `vic-machine upgrade`, it may fail with the message `foo-VCH has same or newer version x than installer version y. No upgrade is available.`
+
+    *Solution:* Set `BUILD_NUMBER` to a high number at the top of the `Makefile` - `BUILD_NUMBER ?= 9999999999`. Then, re-build binaries - `sudo make distclean && sudo make clean && sudo make all` and run `vic-machine upgrade` with the new binary.
+
 ## Integration Tests
 
 [VIC Engine Integration Test Suite](tests/README.md) includes instructions to run locally.

--- a/tests/test-cases/Group1-Docker-Commands/1-08-Docker-Logs.md
+++ b/tests/test-cases/Group1-Docker-Commands/1-08-Docker-Logs.md
@@ -72,4 +72,6 @@ Error: No such container: fakeContainer
 ```
 
 # Possible Problems:
-None
+* This suite may fail when run locally due to a `vic-machine upgrade` issue. Since `vic-machine` checks the build number of its binary to determine upgrade status and a locally-built `vic-machine` binary may not have the `BUILD_NUMBER` set correctly, `vic-machine upgrade` may fail with the message `foo-VCH has same or newer version x than installer version y. No upgrade is available.` To resolve this, follow these steps:
+  * Set `BUILD_NUMBER` to a high number at the top of the `Makefile` - `BUILD_NUMBER ?= 9999999999`
+  * Re-build binaries - `sudo make distclean && sudo make clean && sudo make all`

--- a/tests/test-cases/Group11-Upgrade/11-01-Upgrade.md
+++ b/tests/test-cases/Group11-Upgrade/11-01-Upgrade.md
@@ -38,6 +38,9 @@ does not support rename
 * All other steps should result in success
 
 # Possible Problems:
-Upgrade test will upgrade VCH from build 7315, because that build has VCH restart and configuration restart features done.
-Before GA, if there is any VCH configuration change, please bump upgrade from version, and be sure to add cases to cover those changes.
-After GA, the upgrade from version will be GA release version.
+* Upgrade test will upgrade VCH from build 7315, because that build has VCH restart and configuration restart features done.
+* Before GA, if there is any VCH configuration change, please bump upgrade from version, and be sure to add cases to cover those changes.
+* After GA, the upgrade from version will be GA release version.
+* This suite may fail when run locally due to a `vic-machine upgrade` issue. Since `vic-machine` checks the build number of its binary to determine upgrade status and a locally-built `vic-machine` binary may not have the `BUILD_NUMBER` set correctly, `vic-machine upgrade` may fail with the message `foo-VCH has same or newer version x than installer version y. No upgrade is available.` To resolve this, follow these steps:
+  * Set `BUILD_NUMBER` to a high number at the top of the `Makefile` - `BUILD_NUMBER ?= 9999999999`
+  * Re-build binaries - `sudo make distclean && sudo make clean && sudo make all`

--- a/tests/test-cases/Group11-Upgrade/11-02-Upgrade-Exec.md
+++ b/tests/test-cases/Group11-Upgrade/11-02-Upgrade-Exec.md
@@ -19,3 +19,8 @@ This test requires that a vSphere server is running and available
 # Expected Outcome:
 * Step 5 should fail
 * All other steps should result in success
+
+# Possible Problems:
+* This suite may fail when run locally due to a `vic-machine upgrade` issue. Since `vic-machine` checks the build number of its binary to determine upgrade status and a locally-built `vic-machine` binary may not have the `BUILD_NUMBER` set correctly, `vic-machine upgrade` may fail with the message `foo-VCH has same or newer version x than installer version y. No upgrade is available.` To resolve this, follow these steps:
+  * Set `BUILD_NUMBER` to a high number at the top of the `Makefile` - `BUILD_NUMBER ?= 9999999999`
+  * Re-build binaries - `sudo make distclean && sudo make clean && sudo make all`

--- a/tests/test-cases/Group11-Upgrade/11-03-Upgrade-InsecureRegistry.md
+++ b/tests/test-cases/Group11-Upgrade/11-03-Upgrade-InsecureRegistry.md
@@ -31,3 +31,8 @@ This test requires that a vSphere server is running and available
 
 # Expected Outcome:
 * Able to pull given test image through VCH successfully both before and after upgrade
+
+# Possible Problems:
+* This suite may fail when run locally due to a `vic-machine upgrade` issue. Since `vic-machine` checks the build number of its binary to determine upgrade status and a locally-built `vic-machine` binary may not have the `BUILD_NUMBER` set correctly, `vic-machine upgrade` may fail with the message `foo-VCH has same or newer version x than installer version y. No upgrade is available.` To resolve this, follow these steps:
+  * Set `BUILD_NUMBER` to a high number at the top of the `Makefile` - `BUILD_NUMBER ?= 9999999999`
+  * Re-build binaries - `sudo make distclean && sudo make clean && sudo make all`

--- a/tests/test-cases/Group11-Upgrade/11-04-Upgrade-UpdateInProgress.md
+++ b/tests/test-cases/Group11-Upgrade/11-04-Upgrade-UpdateInProgress.md
@@ -23,3 +23,8 @@ This test requires that a vSphere server is running and available
 * In step 6, output should contain "Completed successfully"
 * In step 7, output should contain "Upgrade/configure in progress"
 * In step 8, output should not contain "Upgrade/configure in progress"
+
+# Possible Problems:
+* This suite may fail when run locally due to a `vic-machine upgrade` issue. Since `vic-machine` checks the build number of its binary to determine upgrade status and a locally-built `vic-machine` binary may not have the `BUILD_NUMBER` set correctly, `vic-machine upgrade` may fail with the message `foo-VCH has same or newer version x than installer version y. No upgrade is available.` To resolve this, follow these steps:
+  * Set `BUILD_NUMBER` to a high number at the top of the `Makefile` - `BUILD_NUMBER ?= 9999999999`
+  * Re-build binaries - `sudo make distclean && sudo make clean && sudo make all`

--- a/tests/test-cases/Group11-Upgrade/11-05-Configure.md
+++ b/tests/test-cases/Group11-Upgrade/11-05-Configure.md
@@ -14,3 +14,8 @@ This test requires that a vSphere server is running and available
 
 # Expected Outcome:
 * Step 3 should get expected error
+
+# Possible Problems:
+* This suite may fail when run locally due to a `vic-machine upgrade` issue. Since `vic-machine` checks the build number of its binary to determine upgrade status and a locally-built `vic-machine` binary may not have the `BUILD_NUMBER` set correctly, `vic-machine upgrade` may fail with the message `foo-VCH has same or newer version x than installer version y. No upgrade is available.` To resolve this, follow these steps:
+  * Set `BUILD_NUMBER` to a high number at the top of the `Makefile` - `BUILD_NUMBER ?= 9999999999`
+  * Re-build binaries - `sudo make distclean && sudo make clean && sudo make all`


### PR DESCRIPTION
This commit adds a troubleshooting note about setting `BUILD_NUMBER`
for the `vic-machine` binary so that upgrade tests that rely on a
larger upgrade-to `vic-machine` build number can pass when the test
is run locally.

Towards #6482