### PR TITLE
[skip ci] Move lease renewal to within the test case

### DIFF
--- a/tests/manual-test-cases/Group5-Functional-Tests/5-7-NSX.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-7-NSX.robot
@@ -18,6 +18,13 @@ Resource  ../../resources/Util.robot
 
 *** Test Cases ***
 Test
+    Log To Console  \nWait until Nimbus is at least available...
+    Open Connection  %{NIMBUS_GW}
+    Wait Until Keyword Succeeds  10 min  30 sec  Login  %{NIMBUS2_USER}  %{NIMBUS2_PASSWORD}
+    ${out}=  Execute Command  nimbus-ctl --lease 5 extend_lease '*'
+    Log  ${out}
+    Close Connection    
+
     Log To Console  Set environment variables up for GOVC
     Set Environment Variable  GOVC_URL  10.160.21.102
     Set Environment Variable  GOVC_USERNAME  Administrator@vsphere.local


### PR DESCRIPTION
Move the lease renewal from a cron job within a single system to the test cases itself so that it is more independent of the system it is run on. I have also added the 2nd nimbus service account to the secrets file.