### PR TITLE
[specific ci=Group23-Vic-Machine-Service] Update create API to stream a creation log to the VCH's datastore folder

### DIFF
--- a/lib/apiservers/service/restapi/handlers/vch_create.go
+++ b/lib/apiservers/service/restapi/handlers/vch_create.go
@@ -48,7 +48,7 @@ import (
 )
 
 const (
-	LogFile = "vic-machine.log"
+	LogFile = "vic-machine.log" // name of local log file
 )
 
 // VCHCreate is the handler for creating a VCH

--- a/lib/apiservers/service/restapi/handlers/vch_create.go
+++ b/lib/apiservers/service/restapi/handlers/vch_create.go
@@ -48,7 +48,7 @@ import (
 )
 
 const (
-	LogFile = "vic-machine.log" // name of local log file
+	logFile = "vic-machine.log" // name of local log file
 )
 
 // VCHCreate is the handler for creating a VCH
@@ -137,7 +137,7 @@ func setUpLogger() *os.File {
 
 	// Write to local log file
 	// #nosec: Expect file permissions to be 0600 or less
-	localLogFile, err := os.OpenFile(LogFile, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0644)
+	localLogFile, err := os.OpenFile(logFile, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0644)
 	if err == nil {
 		logs = append(logs, localLogFile)
 	}

--- a/lib/apiservers/service/restapi/handlers/vch_create.go
+++ b/lib/apiservers/service/restapi/handlers/vch_create.go
@@ -17,12 +17,15 @@ package handlers
 import (
 	"context"
 	"fmt"
+	"io"
 	"math"
 	"net"
 	"net/url"
+	"os"
 	"path"
 	"strings"
 
+	log "github.com/Sirupsen/logrus"
 	"github.com/docker/go-units"
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/go-openapi/strfmt"
@@ -38,8 +41,14 @@ import (
 	"github.com/vmware/vic/lib/install/data"
 	"github.com/vmware/vic/lib/install/management"
 	"github.com/vmware/vic/lib/install/validate"
+	"github.com/vmware/vic/lib/install/vchlog"
 	"github.com/vmware/vic/pkg/ip"
+	viclog "github.com/vmware/vic/pkg/log"
 	"github.com/vmware/vic/pkg/version"
+)
+
+const (
+	LogFile = "vic-machine.log"
 )
 
 // VCHCreate is the handler for creating a VCH
@@ -51,6 +60,12 @@ type VCHDatacenterCreate struct {
 }
 
 func (h *VCHCreate) Handle(params operations.PostTargetTargetVchParams, principal interface{}) middleware.Responder {
+	// Set up VCH create logger
+	localLogFile := setUpLogger()
+	// Close the two logging streams when done
+	defer vchlog.Close()
+	defer localLogFile.Close()
+
 	d, err := buildData(params.HTTPRequest.Context(),
 		url.URL{Host: params.Target},
 		principal.(Credentials).user,
@@ -81,6 +96,12 @@ func (h *VCHCreate) Handle(params operations.PostTargetTargetVchParams, principa
 }
 
 func (h *VCHDatacenterCreate) Handle(params operations.PostTargetTargetDatacenterDatacenterVchParams, principal interface{}) middleware.Responder {
+	// Set up VCH create logger
+	localLogFile := setUpLogger()
+	// Close the two logging streams when done
+	defer vchlog.Close()
+	defer localLogFile.Close()
+
 	d, err := buildData(params.HTTPRequest.Context(),
 		url.URL{Host: params.Target},
 		principal.(Credentials).user,
@@ -108,6 +129,32 @@ func (h *VCHDatacenterCreate) Handle(params operations.PostTargetTargetDatacente
 	}
 
 	return operations.NewPostTargetTargetDatacenterDatacenterVchCreated().WithPayload(operations.PostTargetTargetDatacenterDatacenterVchCreatedBody{Task: task})
+}
+
+func setUpLogger() *os.File {
+	vchlog.Init()
+	logs := []io.Writer{}
+
+	// Write to local log file
+	// #nosec: Expect file permissions to be 0600 or less
+	localLogFile, err := os.OpenFile(LogFile, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0644)
+	if err == nil {
+		logs = append(logs, localLogFile)
+	}
+
+	// Also write logs to pipe streaming to VCH datastore
+	logs = append(logs, vchlog.GetPipe())
+	// Set log level to debug
+	log.SetLevel(log.DebugLevel)
+	// Initiliaze logger with default TextFormatter
+	log.SetFormatter(viclog.NewTextFormatter())
+	// SetOutput to io.MultiWriter so that we can log to stdout and a file
+	log.SetOutput(io.MultiWriter(logs...))
+
+	// Fire the logger
+	go vchlog.Run()
+
+	return localLogFile
 }
 
 func buildCreate(ctx context.Context, d *data.Data, finder *find.Finder, vch *models.VCH) (*create.Create, error) {


### PR DESCRIPTION
Fixes #6510 

Now during the POST request to vic-machine server is processing and VCH is creating, vic-machine logs are streamed real-time to VCH datastore folder (after VCH datastore folder is available), and to local log file named `vic-machine.log`. 

**Pending an integration test that checks the creation log file is streamed to datastore after POST request returns**