### PR TITLE
Add specific tag to busybox in regression tests

### DIFF
--- a/tests/resources/Docker-Util.robot
+++ b/tests/resources/Docker-Util.robot
@@ -50,6 +50,8 @@ Hit Nginx Endpoint
 Get Container IP
     [Arguments]  ${docker-params}  ${id}  ${network}=default  ${dockercmd}=docker
     ${rc}  ${ip}=  Run And Return Rc And Output  ${dockercmd} ${docker-params} network inspect ${network} | jq '.[0].Containers."${id}".IPv4Address' | cut -d \\" -f 2 | cut -d \\/ -f 1
+    # this comment fixes syntax highlighting from unmatched quotation mark above "
+
     Should Be Equal As Integers  ${rc}  0
     [Return]  ${ip}
 
@@ -123,15 +125,15 @@ Verify Container Rename
     Should Contain  ${output}  ${vmName}
 
 Run Regression Tests
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} pull ${busybox}
-    Should Be Equal As Integers  ${rc}  0
+    Pull image  ${busybox}:1.27
+
     # Pull an image that has been pulled already
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} pull ${busybox}
-    Should Be Equal As Integers  ${rc}  0
+    Pull image  ${busybox}:1.27
+
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} images
     Should Be Equal As Integers  ${rc}  0
     Should Contain  ${output}  busybox
-    ${rc}  ${container}=  Run And Return Rc And Output  docker %{VCH-PARAMS} create ${busybox} /bin/top
+    ${rc}  ${container}=  Run And Return Rc And Output  docker %{VCH-PARAMS} create ${busybox}:1.27 /bin/top
     Should Be Equal As Integers  ${rc}  0
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} start ${container}
     Should Be Equal As Integers  ${rc}  0
@@ -155,9 +157,9 @@ Run Regression Tests
     Should Not Contain  ${output}  /bin/top
 
     # Check for regression for #1265
-    ${rc}  ${container1}=  Run And Return Rc And Output  docker %{VCH-PARAMS} create -it ${busybox} /bin/top
+    ${rc}  ${container1}=  Run And Return Rc And Output  docker %{VCH-PARAMS} create -it ${busybox}:1.27 /bin/top
     Should Be Equal As Integers  ${rc}  0
-    ${rc}  ${container2}=  Run And Return Rc And Output  docker %{VCH-PARAMS} create -it ${busybox}
+    ${rc}  ${container2}=  Run And Return Rc And Output  docker %{VCH-PARAMS} create -it ${busybox}:1.27
     Should Be Equal As Integers  ${rc}  0
     ${shortname}=  Get Substring  ${container2}  1  12
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} ps -a
@@ -168,7 +170,7 @@ Run Regression Tests
     ${rc}=  Run And Return Rc  docker %{VCH-PARAMS} rm ${container2}
     Should Be Equal As Integers  ${rc}  0
 
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} rmi ${busybox}
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} rmi ${busybox}:1.27
     Should Be Equal As Integers  ${rc}  0
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} images
     Should Be Equal As Integers  ${rc}  0


### PR DESCRIPTION
Resolves #6131. We believe that occasionally the image
may be updated upstream, which would cause a layer to change during our pull
when a specific image tag is not specified. Since longevity runs the regression
tests in a loop, it is more likely that this could happen during longevity,
so this change adds a specific tag to the regression tests so that if the
latest tag's images are updated, our longevity tests will not be affected.