### PR TITLE
[specific ci=Group1-Docker-Commands] Ensure unique container names during create

### DIFF
--- a/lib/apiservers/engine/backends/cache/container_cache.go
+++ b/lib/apiservers/engine/backends/cache/container_cache.go
@@ -148,8 +148,8 @@ func (cc *CCache) GetContainerFromExec(eid string) *container.VicContainer {
 	return nil
 }
 
-// here we assume that the newName is already reserved by Reservename
-// so no need to check the existence of a container with the new name
+// UpdateContainerName assumes that the newName is already reserved by ReserveName
+// so no need to check the existence of a container with the new name.
 func (cc *CCache) UpdateContainerName(oldName, newName string) error {
 	cc.m.Lock()
 	defer cc.m.Unlock()
@@ -168,7 +168,7 @@ func (cc *CCache) UpdateContainerName(oldName, newName string) error {
 	return nil
 }
 
-// ReserveName is used during a container rename operation to prevent concurrent
+// ReserveName is used during a container create/rename operation to prevent concurrent
 // container create/rename operations from grabbing the new name.
 func (cc *CCache) ReserveName(container *container.VicContainer, name string) error {
 	cc.m.Lock()
@@ -183,8 +183,9 @@ func (cc *CCache) ReserveName(container *container.VicContainer, name string) er
 	return nil
 }
 
-// ReleaseName is used during a container rename operation to allow concurrent
-// container create/rename operations to use the name.
+// ReleaseName is used during a container rename operation to allow concurrent container
+// create/rename operations to use the name. It is also used during a failed create
+// operation to allow subsequent create operations to use that name.
 func (cc *CCache) ReleaseName(name string) {
 	cc.m.Lock()
 	defer cc.m.Unlock()

--- a/tests/test-cases/Group1-Docker-Commands/1-04-Docker-Create.md
+++ b/tests/test-cases/Group1-Docker-Commands/1-04-Docker-Create.md
@@ -42,6 +42,8 @@ This test requires that a vSphere server is running and available
 29. Create a container using a rest api call without HostConfig in the form data
 30. Create a container, then check the vm display name in vsphere through govc
 31. Create a container, then check the vm Destroy_Task method is disabled in VC through govc
+32. Create two containers with the same name in parallel, then check that only one attempt is successful
+33. Remove the container from Step 32 by name and create another container with the same name
 
 # Expected Outcome:
 * Steps 3-7 should all return without error and printing the container ID on return
@@ -59,6 +61,8 @@ This test requires that a vSphere server is running and available
 * Step 29 should return without error.
 * Step 30 should show that the VM display name equals to containerName-containerShortID and datastore folder name equal to containerID
 * Step 31 should show that the VM Destroy_Task method is disabled in VC
+* Step 32 should have one container create process succeed and the other fail with an error
+* Step 33 should succeed
 
 # Possible Problems:
 None

--- a/tests/test-cases/Group1-Docker-Commands/1-04-Docker-Create.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-04-Docker-Create.robot
@@ -208,3 +208,34 @@ Create disables VC destroy
     Should Be Equal As Integers  ${rc}  0
     Run Keyword If  '%{HOST_TYPE}' == 'VC'  Should Contain  ${output}  Destroy_Task
     Run Keyword If  '%{HOST_TYPE}' == 'ESXi'  Should Not Contain  ${output}  Destroy_Task
+
+Parallel creates with same container name
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} pull ${busybox}
+    Should Be Equal As Integers  ${rc}  0
+
+    ${suffix}=  Evaluate  '%{DRONE_BUILD_NUMBER}-' + str(random.randint(1000,9999))  modules=random
+    Set Test Variable  ${name}  testDuplicates-${suffix}
+    ${pid1}=  Start Process  docker %{VCH-PARAMS} create --name ${name} ${busybox}  shell=True
+    ${pid2}=  Start Process  docker %{VCH-PARAMS} create --name ${name} ${busybox}  shell=True
+    ${res1}=  Wait For Process  ${pid1}
+    ${res2}=  Wait For Process  ${pid2}
+
+    # Only one process should succeed
+    Run Keyword If  ${res1.rc} == 0  Should Not Be Equal As Integers  ${res2.rc}  0
+    Run Keyword If  ${res2.rc} == 0  Should Not Be Equal As Integers  ${res1.rc}  0
+
+    ${status1}  ${out1}=  Run Keyword And Ignore Error  Should Contain  ${res1.stderr}  is already in use
+    ${status2}  ${out2}=  Run Keyword And Ignore Error  Should Contain  ${res2.stderr}  is already in use
+    # Only and only one process's stderr should contain the error message
+    Run Keyword If  '${status1}' == 'PASS'  Should Not Be Equal  '${status2}'  'PASS'
+    Run Keyword If  '${status2}' == 'PASS'  Should Not Be Equal  '${status1}'  'PASS'
+
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} ps -f status=created
+    Should Be Equal As Integers  ${rc}  0
+    Should Contain X Times  ${output}  ${name}  1
+
+    # Verify that remove and re-create works for the same name
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} rm ${name}
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} create --name ${name} ${busybox}
+    Should Be Equal As Integers  ${rc}  0


### PR DESCRIPTION
This commit modifies the container create logic in the docker persona
to ensure that containers have unique names, specially during a
parallel container create operation with the same name.

Earlier, the duplicate name check took place at the start of the
create operation, but the name wasn't tracked in the persona cache
until the create operation had succeeded in the portlayer. This made
it possible for multiple containers to have the same name if created
in parallel. Now, the container create function uses the ReserveName
function in the persona's container cache once the container object
representation has been created in the persona. If the container
fails to be created in the portlayer, the name is released.

Fixes #6261