### PR TITLE
[specific ci=1-23-Docker-Inspect] Fix 1-23-Docker-Inspect test for local test runs

### DIFF
--- a/tests/test-cases/Group1-Docker-Commands/1-23-Docker-Inspect.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-23-Docker-Inspect.robot
@@ -37,7 +37,8 @@ Docker inspect image specifying type
 Docker inspect image specifying incorrect type
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} inspect --type=container ${busybox}
     Should Be Equal As Integers  ${rc}  1
-    Should Contain  ${output}  Error: No such container: harbor.ci.drone.local/library/busybox
+    ${out}=  Run Keyword If  '${busybox}' == 'busybox'  Should Contain  ${output}  Error: No such container: busybox
+    ${out}=  Run Keyword Unless  '${busybox}' == 'busybox'  Should Contain  ${output}  Error: No such container: harbor.ci.drone.local/library/busybox
 
 Simple docker inspect of container
     ${rc}  ${container}=  Run And Return Rc And Output  docker %{VCH-PARAMS} create ${busybox}


### PR DESCRIPTION
This commit modifies the 'Docker inspect image specifying incorrect
type' integration test case to expect the correct error output from
a docker inspect operation depending on whether the test is being run
locally or in CI. The test will now expect the Harbor image name in the
error output only when the test is run in CI.

Fixes #6432