### PR TITLE
[skip ci]Fix variable used for test

### DIFF
--- a/tests/manual-test-cases/Group5-Functional-Tests/5-22-NFS-Volume.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-22-NFS-Volume.robot
@@ -124,7 +124,7 @@ VIC Appliance Install With Fake NFS Server
 
     # Will only produce a warning in VCH creation output
     ${output}=  Install VIC Appliance To Test Server  certs=${false}  additional-args=--volume-store="nfs://${nfs_bogon_ip}/store?uid=0&gid=0:${nfsFakeVolumeStore}"
-    Should Contain  ${output}  VolumeStore (${nfsReadOnlyVolumeStore}) cannot be brought online - check network, nfs server, and --volume-store configurations
+    Should Contain  ${output}  VolumeStore (${nfsFakeVolumeStore}) cannot be brought online - check network, nfs server, and --volume-store configurations
 
 VIC Appliance Install With Correct NFS Server
     Setup ENV Variables for VIC Appliance Install


### PR DESCRIPTION
This fixed the current nightly test failure detailed in the provided log bundle. Namely that the `nfsReadOnlyVolumeStore` var was used in a place that needed the `nfsFakeVolumeStore` for the success check. This has been rectified and confirmed twice on vsphere 6.0 ad 6.5 testbeds. This should be resolved now. 