### PR TITLE
[specific ci=1-11-Docker-RM] Fix 1-11-Docker-RM OOB test for vCenter

### DIFF
--- a/tests/test-cases/Group1-Docker-Commands/1-11-Docker-RM.md
+++ b/tests/test-cases/Group1-Docker-Commands/1-11-Docker-RM.md
@@ -38,7 +38,11 @@ Error response from daemon: Conflict, You cannot remove a running container. Sto
 ```
 Error response from daemon: No such container: fakeContainer
 ```
-* Step 14 should result in the following error:  
+* Step 13 should succeed on ESXi and fail on vCenter with the following error:
+```
+govc: ServerFaultCode: The method is disabled by 'VIC'
+```
+* When run on standalone ESXi, step 14 should result in the following error:  
 ```
 Error response from daemon: No such container: test
 ```

--- a/tests/test-cases/Group1-Docker-Commands/1-11-Docker-RM.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-11-Docker-RM.robot
@@ -91,7 +91,10 @@ Remove a container deleted out of band
     ${rc}  ${output}=  Run Keyword If  '%{HOST_TYPE}' == 'ESXi'  Run And Return Rc And Output  govc vm.destroy "testRMOOB*"
     Run Keyword If  '%{HOST_TYPE}' == 'ESXi'  Should Be Equal As Integers  ${rc}  0
     ${rc}  ${output}=  Run Keyword If  '%{HOST_TYPE}' == 'VC'  Run And Return Rc And Output  govc vm.destroy %{VCH-NAME}/"testRMOOB*"
-    Run Keyword If  '%{HOST_TYPE}' == 'VC'  Should Be Equal As Integers  ${rc}  0
+    Run Keyword If  '%{HOST_TYPE}' == 'VC'  Should Not Be Equal As Integers  ${rc}  0
+    Run Keyword If  '%{HOST_TYPE}' == 'VC'  Should Contain  ${output}  govc: ServerFaultCode: The method is disabled by 'VIC'
+    Pass Execution If  '%{HOST_TYPE}' == 'VC'  Remaining steps not applicable on VC - skipping
+
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} rm testRMOOB
     Should Be Equal As Integers  ${rc}  1
     Should Contain  ${output}  Error response from daemon: No such container: testRMOOB


### PR DESCRIPTION
This commit modifies the 'Remove a container deleted out of band' test
to expect the OOB govc vm.destroy command to fail on vCenter, since the
operation is disabled on vCenter. See #4965 and #2928.

Fixes #6430 

Also see https://github.com/vmware/vic/blob/master/tests/manual-test-cases/Group5-Functional-Tests/5-14-Remove-Container-OOB.robot#L28