### PR TITLE
[specific ci=Group23-Vic-Machine-Service] syslog support added to VCH create and inspect API

### DIFF
--- a/cmd/vic-machine/create/create.go
+++ b/cmd/vic-machine/create/create.go
@@ -79,7 +79,7 @@ type Create struct {
 
 	Proxies common.Proxies
 
-	syslogAddr string
+	SyslogAddr string
 
 	executor *management.Dispatcher
 }
@@ -271,7 +271,7 @@ func (c *Create) Flags() []cli.Flag {
 			Name:        "syslog-address",
 			Value:       "",
 			Usage:       "Address of the syslog server to send Virtual Container Host logs to. Must be in the format transport://host[:port], where transport is udp or tcp. port defaults to 514 if not specified",
-			Destination: &c.syslogAddr,
+			Destination: &c.SyslogAddr,
 			Hidden:      true,
 		},
 	}
@@ -416,7 +416,7 @@ func (c *Create) processParams() error {
 	c.HTTPProxy = hproxy
 	c.HTTPSProxy = sproxy
 
-	if err := c.processSyslog(); err != nil {
+	if err := c.ProcessSyslog(); err != nil {
 		return err
 	}
 
@@ -543,12 +543,12 @@ func (c *Create) ProcessNetwork(network *data.NetworkConfig, netName, pgName, st
 	return nil
 }
 
-func (c *Create) processSyslog() error {
-	if len(c.syslogAddr) == 0 {
+func (c *Create) ProcessSyslog() error {
+	if len(c.SyslogAddr) == 0 {
 		return nil
 	}
 
-	u, err := url.Parse(c.syslogAddr)
+	u, err := url.Parse(c.SyslogAddr)
 	if err != nil {
 		return err
 	}

--- a/lib/apiservers/service/restapi/handlers/vch_cert_get.go
+++ b/lib/apiservers/service/restapi/handlers/vch_cert_get.go
@@ -93,7 +93,7 @@ func getVCHCert(op trace.Operation, d *data.Data) (*config.RawCertificate, error
 	}
 
 	if vchConfig.HostCertificate.IsNil() {
-		return nil, util.NewError(404, fmt.Sprintf("No certificate found for VCH %s", d.ID))
+		return nil, util.NewError(http.StatusNotFound, fmt.Sprintf("No certificate found for VCH %s", d.ID))
 	}
 
 	return vchConfig.HostCertificate, nil

--- a/lib/apiservers/service/restapi/handlers/vch_create.go
+++ b/lib/apiservers/service/restapi/handlers/vch_create.go
@@ -419,7 +419,7 @@ func buildCreate(ctx context.Context, d *data.Data, finder *find.Finder, vch *mo
 			}
 		}
 
-		if vch.SyslogAddr.String() != ""{
+		if vch.SyslogAddr != "" {
 			c.SyslogAddr = vch.SyslogAddr.String()
 			if err := c.ProcessSyslog(); err != nil {
 				return nil, util.NewError(http.StatusBadRequest, fmt.Sprintf("Error processing syslog server address: %s", err))

--- a/lib/apiservers/service/restapi/handlers/vch_create.go
+++ b/lib/apiservers/service/restapi/handlers/vch_create.go
@@ -419,7 +419,7 @@ func buildCreate(ctx context.Context, d *data.Data, finder *find.Finder, vch *mo
 			}
 		}
 
-		if len(vch.SyslogAddr) > 0 {
+		if vch.SyslogAddr.String() != ""{
 			c.SyslogAddr = vch.SyslogAddr.String()
 			if err := c.ProcessSyslog(); err != nil {
 				return nil, util.NewError(http.StatusBadRequest, fmt.Sprintf("Error processing syslog server address: %s", err))

--- a/lib/apiservers/service/restapi/handlers/vch_create.go
+++ b/lib/apiservers/service/restapi/handlers/vch_create.go
@@ -420,7 +420,7 @@ func buildCreate(ctx context.Context, d *data.Data, finder *find.Finder, vch *mo
 		}
 
 		if len(vch.SyslogAddr) > 0 {
-			c.SyslogAddr = vch.SyslogAddr
+			c.SyslogAddr = vch.SyslogAddr.String()
 			if err := c.ProcessSyslog(); err != nil {
 				return nil, util.NewError(http.StatusBadRequest, fmt.Sprintf("Error processing syslog server address: %s", err))
 			}

--- a/lib/apiservers/service/restapi/handlers/vch_get.go
+++ b/lib/apiservers/service/restapi/handlers/vch_get.go
@@ -263,7 +263,7 @@ func vchToModel(vch *vm.VirtualMachine, d *data.Data, executor *management.Dispa
 
 	// syslog_addr: syslog server address
 	if syslogConfig := vchConfig.Diagnostics.SysLogConfig; syslogConfig != nil {
-		model.SyslogAddr = syslogConfig.Network + "://" + syslogConfig.RAddr
+		model.SyslogAddr = strfmt.URI(syslogConfig.Network + "://" + syslogConfig.RAddr)
 	}
 
 	return model, nil

--- a/lib/apiservers/service/restapi/handlers/vch_list_get.go
+++ b/lib/apiservers/service/restapi/handlers/vch_list_get.go
@@ -30,6 +30,7 @@ import (
 	"github.com/vmware/vic/lib/install/management"
 	"github.com/vmware/vic/pkg/version"
 	"github.com/vmware/vic/pkg/vsphere/vm"
+	"net/http"
 )
 
 // VCHListGet is the handler for listing VCHs
@@ -83,13 +84,13 @@ func (h *VCHDatacenterListGet) Handle(params operations.GetTargetTargetDatacente
 func listVCHs(ctx context.Context, d *data.Data) ([]*models.VCHListItem, error) {
 	validator, err := validateTarget(ctx, d)
 	if err != nil {
-		return nil, util.WrapError(400, err)
+		return nil, util.WrapError(http.StatusBadRequest, err)
 	}
 
 	executor := management.NewDispatcher(validator.Context, validator.Session, nil, false)
 	vchs, err := executor.SearchVCHs(validator.ClusterPath)
 	if err != nil {
-		return nil, util.NewError(500, fmt.Sprintf("Failed to search VCHs in %s: %s", validator.ResourcePoolPath, err))
+		return nil, util.NewError(http.StatusInternalServerError, fmt.Sprintf("Failed to search VCHs in %s: %s", validator.ResourcePoolPath, err))
 	}
 
 	return vchsToModels(ctx, vchs, executor), nil

--- a/lib/apiservers/service/restapi/handlers/vch_list_get.go
+++ b/lib/apiservers/service/restapi/handlers/vch_list_get.go
@@ -17,6 +17,7 @@ package handlers
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"net/url"
 	"path"
 
@@ -30,7 +31,6 @@ import (
 	"github.com/vmware/vic/lib/install/management"
 	"github.com/vmware/vic/pkg/version"
 	"github.com/vmware/vic/pkg/vsphere/vm"
-	"net/http"
 )
 
 // VCHListGet is the handler for listing VCHs

--- a/lib/apiservers/service/swagger.json
+++ b/lib/apiservers/service/swagger.json
@@ -798,6 +798,9 @@
               "type": "string"
             }
           }
+        },
+        "syslog_addr": {
+          "type": "string"
         }
       }
     },

--- a/lib/apiservers/service/swagger.json
+++ b/lib/apiservers/service/swagger.json
@@ -802,7 +802,7 @@
         "syslog_addr": {
           "type": "string",
           "format": "uri",
-          "pattern": "^((tc|ud)p)|((tc|ud)p6).*"
+          "pattern": "^(tc|ud)p:\/\/.*"
         }
       }
     },

--- a/lib/apiservers/service/swagger.json
+++ b/lib/apiservers/service/swagger.json
@@ -800,7 +800,9 @@
           }
         },
         "syslog_addr": {
-          "type": "string"
+          "type": "string",
+          "format": "uri",
+          "pattern": "^(tc|ud)p.*"
         }
       }
     },

--- a/lib/apiservers/service/swagger.json
+++ b/lib/apiservers/service/swagger.json
@@ -802,7 +802,7 @@
         "syslog_addr": {
           "type": "string",
           "format": "uri",
-          "pattern": "^(tc|ud)p.*"
+          "pattern": "^((tc|ud)p)|((tc|ud)p6).*"
         }
       }
     },


### PR DESCRIPTION
Fixes #6476 

syslog support is now added to vic-machine create API and inspect API.

**Details**
1. vic-machine create API
POST request body includes a `syslog_addr` field of type string that specifies the syslog server address.
`syslog_addr` must have format `transport://host[:port]`, where transport is udp or tcp (ipv6 is not officially supported yet)
(For example: `tcp://127.0.0.1:4444`)

An example of vic-machine create API request body:
```
{
	"name": "vch-test-1",
	"storage":{
		"image_stores":["ds://datastore1"]
	},
	"network":{
		"bridge":{
			"ip_range":"172.16.0.0/12",
			"port_group":{"name":"bridge"}
		},
		"public":{
			"port_group":{"name":"vm-network"}
		},
		"management":{
			"port_group":{"name":"management"}
		}
	},
	"auth":{
		"no_tls":true
	},
	"syslog_addr": "tcp://127.0.0.1:4444"
}
```

2. vic-machine inspect API
The response body of POST request now includes a field `syslog_addr` field of type string that includes the syslog server address that the user is specified when the VCH is first created.

Example vic-machine inspect GET response body:
```
{
  "auth": {
    "client": {
      "certificate_authorities": []
    }
  },
  "compute": {
    "cpu": {
      "shares": {
        "level": "normal"
      }
    },
    "memory": {
      "shares": {
        "level": "normal"
      }
    },
    "resource": {
      "id": "resgroup-v35"
    }
  },
  "endpoint": {
    "cpu": {
      "sockets": 1
    },
    "memory": {
      "units": "MiB",
      "value": 2048
    },
    "operations_credentials": {}
  },
  "name": "vch-test-1",
  "network": {
    "bridge": {
      "ip_range": "172.16.0.0/12",
      "port_group": {
        "id": "dvportgroup-23"
      }
    },
    "client": {
      "nameservers": [],
      "port_group": {
        "id": "dvportgroup-22"
      }
    },
    "container": [],
    "management": {
      "nameservers": [],
      "port_group": {
        "id": "dvportgroup-21"
      }
    },
    "public": {
      "nameservers": [],
      "port_group": {
        "id": "dvportgroup-22"
      }
    }
  },
  "registry": {
    "blacklist": null,
    "certificate_authorities": [],
    "insecure": [],
    "whitelist": []
  },
  "runtime": {
    "admin_portal": "https://10.160.213.153:2378",
    "docker_host": "10.160.213.153:2375",
    "power_state": "poweredOn",
    "upgrade_status": "Up to date"
  },
  "storage": {
    "base_image_size": {
      "units": "KiB",
      "value": 8000000
    },
    "image_stores": [
      "ds://datastore1/vch-test-1"
    ],
    "volume_stores": []
  },
  "syslog_addr": "tcp://127.0.0.1:4444",
  "version": "v1.2.0-rc1-0-a3b3132"
}
```

**Remaining work**
Pending integration tests that checks if syslog server configuration on create and inspect, and unit tests.
Will be integrated after create API test and inspect API test are ready. 
(tracking story: #6018 )