### PR TITLE
Correct comment in vic-machine-server Dockerfile [skip ci]

### DIFF
--- a/cmd/vic-machine-server/Dockerfile
+++ b/cmd/vic-machine-server/Dockerfile
@@ -1,7 +1,7 @@
 # Building:
 # from vic root directory
 # docker build --no-cache -t vic-machine-server -f cmd/vic-machine-server/Dockerfile .
-# docker tag vic-test gcr.io/eminent-nation-87317/vic-machine-server:1.x
+# docker tag vic-machine-server gcr.io/eminent-nation-87317/vic-machine-server:1.x
 # gcloud auth login
 # gcloud docker -- push gcr.io/eminent-nation-87317/vic-machine-server:1.x
 


### PR DESCRIPTION
Fix a minor copy & paste error in the vic-machine-server Dockerfile.