### PR TITLE
Automate longevity test deployment and execution

### DIFF
--- a/tests/longevity-tests/Dockerfile.6.0
+++ b/tests/longevity-tests/Dockerfile.6.0
@@ -1,3 +1,17 @@
+# Copyright 2017 VMware, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#	http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License
+
 FROM longevity-base
 ENV GOVC_URL=bart.eng.vmware.com
 ENV TEST_URL_ARRAY=bart.eng.vmware.com

--- a/tests/longevity-tests/Dockerfile.6.0
+++ b/tests/longevity-tests/Dockerfile.6.0
@@ -1,0 +1,4 @@
+FROM longevity-base
+ENV GOVC_URL=bart.eng.vmware.com
+ENV TEST_URL_ARRAY=bart.eng.vmware.com
+ENV STATIC_VCH_OPTIONS="--public-network-ip 10.17.109.6/24 --public-network-gateway 10.17.109.253 --dns-server 10.118.81.1"

--- a/tests/longevity-tests/Dockerfile.6.5
+++ b/tests/longevity-tests/Dockerfile.6.5
@@ -1,0 +1,4 @@
+FROM longevity-base
+ENV GOVC_URL=blinky.eng.vmware.com
+ENV TEST_URL_ARRAY=blinky.eng.vmware.com
+ENV STATIC_VCH_OPTIONS="--public-network-ip 10.17.109.7/24 --public-network-gateway 10.17.109.253 --dns-server 10.118.81.1"

--- a/tests/longevity-tests/Dockerfile.6.5
+++ b/tests/longevity-tests/Dockerfile.6.5
@@ -1,3 +1,17 @@
+# Copyright 2017 VMware, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#	http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License
+
 FROM longevity-base
 ENV GOVC_URL=blinky.eng.vmware.com
 ENV TEST_URL_ARRAY=blinky.eng.vmware.com

--- a/tests/longevity-tests/Dockerfile.foundation
+++ b/tests/longevity-tests/Dockerfile.foundation
@@ -1,3 +1,17 @@
+# Copyright 2017 VMware, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#	http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License
+
 FROM gcr.io/eminent-nation-87317/vic-integration-test:1.36
 RUN mkdir -p /go/src/github.com/vmware/vic
 COPY secrets /go/src/github.com/vmware/vic

--- a/tests/longevity-tests/Dockerfile.foundation
+++ b/tests/longevity-tests/Dockerfile.foundation
@@ -1,0 +1,16 @@
+FROM gcr.io/eminent-nation-87317/vic-integration-test:1.36
+RUN mkdir -p /go/src/github.com/vmware/vic
+COPY secrets /go/src/github.com/vmware/vic
+ENV LONGEVITY=1
+ENV GOVC_INSECURE=1
+ENV GOVC_USERNAME=administrator@vsphere.local
+ENV GOVC_DATASTORE=vsanDatastore
+ENV TEST_DATASTORE=vsanDatastore
+ENV TEST_USERNAME=administrator@vsphere.local
+ENV TEST_TIMEOUT=3m
+ENV TEST_RESOURCE=cls
+ENV DOMAIN=
+ENV BRIDGE_NETWORK=bridge
+ENV EXTERNAL_NETWORK=vm-network
+ENV DRONE_SERVER=http://ci.vmware.run
+ENV DOCKER_API_VERSION=1.23

--- a/tests/longevity-tests/get-and-start-harbor.bash
+++ b/tests/longevity-tests/get-and-start-harbor.bash
@@ -1,0 +1,40 @@
+#!/bin/bash
+set -e
+
+if [ $# -ne 1 ]; then
+    echo "Usage: $0 harbor-version"
+    exit 1
+fi
+version=$1
+pushd /home/$USER
+[ -e harbor ] \
+    && echo "/home/$USER/harbor exists. Delete it if you want to install a newer version and re-run $0" \
+    && pushd harbor && docker-compose start && popd && exit 0
+
+echo "Pulling down version ${version} of Harbor..."
+wget https://github.com/vmware/harbor/releases/download/v${version}/harbor-online-installer-v${version}.tgz -qO - | tar xz
+pushd harbor
+echo "Configuring Harbor"
+sed -i.bak 's/hostname = reg.mydomain.com/hostname = harbor.longevity/g' harbor.cfg
+if [[ ! $(grep harbor.longevity /etc/hosts) ]]; then
+    echo "Adding harbor.longevity to /etc/hosts"
+    sudo sh -c 'echo "127.0.0.1  harbor.longevity" >> /etc/hosts'
+fi
+
+echo "Installing & starting Harbor"
+sudo ./install.sh
+popd
+popd
+
+echo "Preparing Harbor..."
+echo "Logging in..."
+docker login harbor.longevity --username=admin --password="Harbor12345"
+echo "Pulling some images to put in Harbor and putting them in Harbor.."
+
+pushd /home/$USER/vic/tests/resources
+for image in $(python -c "vars=__import__('dynamic-vars'); print(\" \".join(vars.images))"); do
+    docker pull $image
+    docker tag $image harbor.longevity/library/${image}
+    docker push harbor.longevity/library/${image}
+done
+popd

--- a/tests/longevity-tests/get-and-start-harbor.bash
+++ b/tests/longevity-tests/get-and-start-harbor.bash
@@ -1,3 +1,17 @@
+# Copyright 2017 VMware, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#	http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License
+
 #!/bin/bash
 set -e
 

--- a/tests/longevity-tests/run-longevity.bash
+++ b/tests/longevity-tests/run-longevity.bash
@@ -1,0 +1,94 @@
+#!/bin/bash
+pushd /home/$USER/longevity-tests
+set -e
+if [ $# -ne 1 ] && [ $# -ne 2 ]; then
+    echo "Usage: $0 target-cluster optional-harbor-version"
+    exit 1
+fi
+
+if [[ $1 != "6.0" && $1 != "6.5" ]]; then
+    echo "Please specify a target cluster. One of: 6.0, 6.5"
+    exit 1
+fi
+
+if [[ ! $(grep dns /etc/docker/daemon.json) ]]; then
+    echo "NOTE: /etc/docker/daemon.json should contain
+{
+ \"dns\": [\"10.118.81.1\", \"10.16.188.210\"]
+}
+
+ in order for this script to function behind VMW's firewall.
+
+ If the file does not exist, create it & restart the docker daemon before
+ attempting to run this script
+"
+    exit 1
+fi
+
+target="$1"
+
+# set an output directory
+odir="/home/$USER/vic-longevity-test-output-$(date -Iminute | sed 's/:/_/g')"
+
+
+# set up harbor if necessary
+if [[ $(docker ps | grep harbor) == "" ]]; then
+    if [[ $2 != "" ]]; then
+        hversion=$2
+    else
+        hversion="1.2.0"
+        echo "No Harbor version specified. Using default $hversion"
+    fi
+    ./get-and-start-harbor.bash $hversion
+fi
+
+echo "Building container images...."
+docker build -q -t longevity-base -f Dockerfile.foundation .
+docker build -q -t tests-"$target" -f Dockerfile."${target}" .
+
+# get latest tests
+pushd /home/$USER
+if [ ! -e vic ]; then
+    git clone https://github.com/vmware/vic vic
+else
+    pushd vic
+    git checkout master && git pull
+    popd
+fi
+
+# remove old binaries
+pushd /home/$USER/vic
+rm -rf bin && mkdir bin
+
+pushd bin
+input=$(gsutil ls -l gs://vic-engine-builds/vic_* | grep -v TOTAL | sort -k2 -r | head -n1 | xargs | cut -d ' ' -f 3 | cut -d '/' -f 4)
+echo "Downloading VIC build $input..."
+wget https://storage.googleapis.com/vic-engine-builds/$input -qO - | tar xz
+mv vic/* .
+rmdir vic
+popd
+
+
+echo "Creating container..."
+testsContainer=$(docker create -it\
+                        -w /go/src/github.com/vmware/vic/ \
+                        -v "$odir":/tmp/ -e GOVC_URL="$ip" \
+                        tests-"$target" \
+                        bash -c \
+                        ". secrets && pybot -d /tmp/ /go/src/github.com/vmware/vic/tests/manual-test-cases/Group14-Longevity/14-1-Longevity.robot;\
+                 mv *-container-logs.zip /tmp/ 2>/dev/null; \
+                 mv VCH-*-vmware.log /tmp/ 2>/dev/null; \
+                 mv vic-machine.log /tmp/ 2>/dev/null; \
+                 mv index.html* /tmp/ 2>/dev/null; \
+                 mv VCH-* /tmp/ 2>/dev/null")
+
+echo "Copying code and binaries into container...."
+docker cp /home/$USER/vic $testsContainer:/go/src/github.com/vmware/
+
+echo "Running tests.."
+echo "Run docker attach $testsContainer to interact with the container or use docker logs -f to simply view test output as the tests run"
+docker start $testsContainer
+
+echo "Output can be found in $odir"
+popd
+popd

--- a/tests/longevity-tests/run-longevity.bash
+++ b/tests/longevity-tests/run-longevity.bash
@@ -1,3 +1,17 @@
+# Copyright 2017 VMware, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#	http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License
+
 #!/bin/bash
 pushd /home/$USER/longevity-tests
 set -e

--- a/tests/longevity-tests/secrets
+++ b/tests/longevity-tests/secrets
@@ -1,0 +1,6 @@
+#!/bin/bash  
+export  DRONE_TOKEN=
+export GITHUB_AUTOMATION_API_KEY=
+export SLACK_URL=
+export TEST_PASSWORD=
+export GOVC_PASSWORD=

--- a/tests/longevity-tests/secrets
+++ b/tests/longevity-tests/secrets
@@ -1,4 +1,18 @@
-#!/bin/bash  
+# Copyright 2017 VMware, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#	http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License
+
+#!/bin/bash
 export  DRONE_TOKEN=
 export GITHUB_AUTOMATION_API_KEY=
 export SLACK_URL=

--- a/tests/resources/dynamic-vars.py
+++ b/tests/resources/dynamic-vars.py
@@ -2,9 +2,8 @@ import os
 
 IS_LOCAL = False if (os.environ.has_key("DRONE_BUILD_NUMBER") and (int(os.environ['DRONE_BUILD_NUMBER']) != 0)) else True
 
-BUSYBOX =  'busybox' if IS_LOCAL else 'harbor.ci.drone.local/library/busybox'
-ALPINE =  'alpine' if IS_LOCAL else 'harbor.ci.drone.local/library/alpine'
-NGINX =  'nginx' if IS_LOCAL else 'harbor.ci.drone.local/library/nginx'
-DEBIAN =  'debian' if IS_LOCAL else 'harbor.ci.drone.local/library/debian'
-UBUNTU =  'ubuntu' if IS_LOCAL else 'harbor.ci.drone.local/library/ubuntu'
-REDIS =  'redis' if IS_LOCAL else 'harbor.ci.drone.local/library/redis'
+images = ['busybox', 'alpine', 'nginx','debian', 'ubuntu', 'redis']
+
+for image in images:
+    name = image if IS_LOCAL else 'harbor.ci.drone.local/library/{}'.format(image)
+    exec("{} = '{}'".format(image.upper(), name))

--- a/tests/resources/dynamic-vars.py
+++ b/tests/resources/dynamic-vars.py
@@ -1,9 +1,32 @@
 import os
+from enum import Enum
 
-IS_LOCAL = False if (os.environ.has_key("DRONE_BUILD_NUMBER") and (int(os.environ['DRONE_BUILD_NUMBER']) != 0)) else True
 
-images = ['busybox', 'alpine', 'nginx','debian', 'ubuntu', 'redis']
+class TestEnvironment(Enum):
+    LOCAL = 0
+    DRONE = 1
+    LONGEVITY = 2
 
+
+def getEnvironment():
+    if (os.environ.has_key("DRONE_BUILD_NUMBER") and (int(os.environ['DRONE_BUILD_NUMBER']) != 0)):
+        return TestEnvironment.DRONE
+    elif os.environ.has_key("LONGEVITY"):
+        return TestEnvironment.LONGEVITY
+    else:
+        return TestEnvironment.LOCAL
+
+def getName(image):
+    environment = getEnvironment()
+    if environment == TestEnvironment.DRONE:
+        return 'harbor.ci.drone.local/library/{}'.format(image)
+    elif environment == TestEnvironment.LONGEVITY:
+        return 'harbor.longevity/library/{}'.format(image)
+    else:
+        return image
+
+# this global variable (images) is used by the Longevity scripts. If you change this, change those!
+# and don't inline it!
+images = ['busybox:latest', 'tomcat:1.2.1', 'busybox', 'alpine', 'nginx','debian', 'ubuntu', 'redis']
 for image in images:
-    name = image if IS_LOCAL else 'harbor.ci.drone.local/library/{}'.format(image)
-    exec("{} = '{}'".format(image.upper(), name))
+    exec("{} = '{}'".format(image.upper().replace(':', '_').replace('.', '_'), getName(image)))

--- a/tests/resources/dynamic-vars.py
+++ b/tests/resources/dynamic-vars.py
@@ -17,16 +17,12 @@ def getEnvironment():
         return TestEnvironment.LOCAL
 
 def getName(image):
-    environment = getEnvironment()
-    if environment == TestEnvironment.DRONE:
-        return 'harbor.ci.drone.local/library/{}'.format(image)
-    elif environment == TestEnvironment.LONGEVITY:
-        return 'harbor.longevity/library/{}'.format(image)
-    else:
-        return image
+    return {TestEnvironment.DRONE: 'harbor.ci.drone.local/library/{}'.format(image),
+            TestEnvironment.LONGEVITY: 'harbor.longevity/library/{}'.format(image),
+            TestEnvironment.LOCAL: image}[getEnvironment()]
 
 # this global variable (images) is used by the Longevity scripts. If you change this, change those!
 # and don't inline it!
-images = ['busybox:latest', 'tomcat:1.2.1', 'busybox', 'alpine', 'nginx','debian', 'ubuntu', 'redis']
+images = ['busybox', 'alpine', 'nginx','debian', 'ubuntu', 'redis']
 for image in images:
     exec("{} = '{}'".format(image.upper().replace(':', '_').replace('.', '_'), getName(image)))

--- a/tests/resources/dynamic-vars.py
+++ b/tests/resources/dynamic-vars.py
@@ -1,3 +1,17 @@
+# Copyright 2017 VMware, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#	http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License
+
 import os
 from enum import Enum
 


### PR DESCRIPTION
Small change in this PR, big change in how we run Longevity tests. The following scripts are available on the Longevity box, and maybe they should be checked in also (**edit:** I've gone ahead and checked these in under `tests/longevity-tests`), but I'm going to just post them as such for now so that can be decided. I'll add them to this PR if requested, with the secrets censored out like they are here, but of course on the actual infra we have the secrets in place.

In the PR itself, I've done a small refactor on dynamic_vars.py to allow 2 things:

1) new images can be added by just adding them to the list and calling it a day. they now will get assigned to the appropriate variable names dynamically.

2) since we also have a list of images after this change, I can use the list to populate Harbor with the necessary images in Longevity, dynamically. If we add or remove images, nothing will need to be done to update Longevity.

Also I have updated the howto in Confluence to reference the new way of doing this. 

Resolves #6131 (final commit message will reflect this) by moving our Longevity procedure from manual to automated and adds deployment of Harbor to that procedure, which should prevent us from having layers changed upstream during pull events, which is what we believe caused the hanging behavior witnessed in that issue.

(**edit** scripts were in the description but since I stripped the secrets and checked them in, they're in the diff now)