### PR TITLE
[specific ci=Group6-VIC-Machine] --container-store option removed from vic-machine CLI

### DIFF
--- a/cmd/vic-machine/create/create.go
+++ b/cmd/vic-machine/create/create.go
@@ -130,15 +130,6 @@ func (c *Create) Flags() []cli.Flag {
 			Destination: &c.ScratchSize,
 			Hidden:      true,
 		},
-
-		// container disk
-		cli.StringFlag{
-			Name:        "container-store, cs",
-			Value:       "",
-			Usage:       "Container datastore path - not supported yet, defaults to image datastore",
-			Destination: &c.ContainerDatastoreName,
-			Hidden:      true,
-		},
 	}
 
 	networks := []cli.Flag{

--- a/lib/install/data/data.go
+++ b/lib/install/data/data.go
@@ -50,7 +50,6 @@ type Data struct {
 
 	ImageDatastorePath     string              `cmd:"image-store"`
 	VolumeLocations        map[string]*url.URL `cmd:"volume-store" label:"value-key"`
-	ContainerDatastoreName string
 
 	BridgeNetworkName string        `cmd:"bridge-network"`
 	ClientNetwork     NetworkConfig `cmd:"client-network"`

--- a/lib/install/data/data.go
+++ b/lib/install/data/data.go
@@ -48,8 +48,8 @@ type Data struct {
 	RegistryCAs []byte
 	common.Images
 
-	ImageDatastorePath     string              `cmd:"image-store"`
-	VolumeLocations        map[string]*url.URL `cmd:"volume-store" label:"value-key"`
+	ImageDatastorePath string              `cmd:"image-store"`
+	VolumeLocations    map[string]*url.URL `cmd:"volume-store" label:"value-key"`
 
 	BridgeNetworkName string        `cmd:"bridge-network"`
 	ClientNetwork     NetworkConfig `cmd:"client-network"`


### PR DESCRIPTION
Fixes #5118 

The `--container-store` option is now removed from CLI