### PR TITLE
[specific ci=Group23-VIC-Machine-Service] Accept session clone ticket via request header

### DIFF
--- a/cmd/vic-machine/common/target.go
+++ b/cmd/vic-machine/common/target.go
@@ -30,9 +30,10 @@ import (
 type Target struct {
 	URL *url.URL `cmd:"target"`
 
-	User       string
-	Password   *string
-	Thumbprint string `cmd:"thumbprint"`
+	User        string
+	Password    *string
+	CloneTicket string
+	Thumbprint  string `cmd:"thumbprint"`
 }
 
 func NewTarget() *Target {
@@ -74,6 +75,12 @@ func (t *Target) TargetFlags() []cli.Flag {
 func (t *Target) HasCredentials() error {
 	if t.URL == nil {
 		return cli.NewExitError("--target argument must be specified", 1)
+	}
+
+	// assume if a vsphere session key exists, we want to use that instead of user/pass
+	if t.CloneTicket != "" {
+		t.URL.User = nil // necessary?
+		return nil
 	}
 
 	var urlUser string

--- a/lib/apiservers/service/restapi/configure_vic_machine.go
+++ b/lib/apiservers/service/restapi/configure_vic_machine.go
@@ -55,6 +55,8 @@ func configureAPI(api *operations.VicMachineAPI) http.Handler {
 	// Applies when the Authorization header is set with the Basic scheme
 	api.BasicAuth = handlers.BasicAuth
 
+	api.SessionAuth = handlers.SessionAuth
+
 	// GET /container
 	api.GetHandler = operations.GetHandlerFunc(func(params operations.GetParams) middleware.Responder {
 		return middleware.NotImplemented("operation .Get has not yet been implemented")
@@ -174,7 +176,7 @@ func setupGlobalMiddleware(handler http.Handler) http.Handler {
 	// https://github.com/vmware/vic/blob/7f575392df99642c5edd8f539a74fe9c89155b00/doc/design/vic-machine/service.md#cross-origin-requests--cross-site-request-forgery
 	c := cors.New(cors.Options{
 		AllowedOrigins:   []string{"*"},
-		AllowedHeaders:   []string{"Authorization", "Content-Type", "User-Agent"},
+		AllowedHeaders:   []string{"Authorization", "Content-Type", "User-Agent", "X-VMWARE-TICKET"},
 		AllowedMethods:   []string{"HEAD", "GET", "POST", "PUT", "PATCH", "DELETE"},
 		ExposedHeaders:   []string{"Content-Length"},
 		AllowCredentials: false,

--- a/lib/apiservers/service/restapi/handlers/authentication.go
+++ b/lib/apiservers/service/restapi/handlers/authentication.go
@@ -19,6 +19,14 @@ type Credentials struct {
 	pass string
 }
 
+type Session struct {
+	ticket string
+}
+
 func BasicAuth(user string, pass string) (interface{}, error) {
 	return Credentials{user: user, pass: pass}, nil
+}
+
+func SessionAuth(ticket string) (interface{}, error) {
+	return Session{ticket: ticket}, nil
 }

--- a/lib/apiservers/service/restapi/handlers/vch_cert_get.go
+++ b/lib/apiservers/service/restapi/handlers/vch_cert_get.go
@@ -17,7 +17,6 @@ package handlers
 import (
 	"fmt"
 	"net/http"
-	"net/url"
 
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/runtime/middleware"
@@ -35,13 +34,14 @@ type VCHCertGet struct{}
 type VCHDatacenterCertGet struct{}
 
 func (h *VCHCertGet) Handle(params operations.GetTargetTargetVchVchIDCertificateParams, principal interface{}) middleware.Responder {
-	d, err := buildData(params.HTTPRequest.Context(),
-		url.URL{Host: params.Target},
-		principal.(Credentials).user,
-		principal.(Credentials).pass,
-		params.Thumbprint,
-		nil,
-		nil)
+	op := trace.NewOperation(params.HTTPRequest.Context(), "VCHCertGet: %s", params.VchID)
+
+	b := buildDataParams{
+		target:     params.Target,
+		thumbprint: params.Thumbprint,
+	}
+
+	d, err := buildData(op, b, principal)
 	if err != nil {
 		return operations.NewGetTargetTargetVchVchIDCertificateDefault(
 			util.StatusCode(err)).WithPayload(&models.Error{Message: err.Error()})
@@ -49,7 +49,6 @@ func (h *VCHCertGet) Handle(params operations.GetTargetTargetVchVchIDCertificate
 
 	d.ID = params.VchID
 
-	op := trace.NewOperation(params.HTTPRequest.Context(), "vch: %s", params.VchID)
 	c, err := getVCHCert(op, d)
 	if err != nil {
 		return operations.NewGetTargetTargetVchVchIDCertificateDefault(
@@ -61,13 +60,15 @@ func (h *VCHCertGet) Handle(params operations.GetTargetTargetVchVchIDCertificate
 }
 
 func (h *VCHDatacenterCertGet) Handle(params operations.GetTargetTargetDatacenterDatacenterVchVchIDCertificateParams, principal interface{}) middleware.Responder {
-	d, err := buildData(params.HTTPRequest.Context(),
-		url.URL{Host: params.Target},
-		principal.(Credentials).user,
-		principal.(Credentials).pass,
-		params.Thumbprint,
-		&params.Datacenter,
-		nil)
+	op := trace.NewOperation(params.HTTPRequest.Context(), "VCHDatacenterCertGet: %s", params.VchID)
+
+	b := buildDataParams{
+		target:     params.Target,
+		thumbprint: params.Thumbprint,
+		datacenter: &params.Datacenter,
+	}
+
+	d, err := buildData(op, b, principal)
 	if err != nil {
 		return operations.NewGetTargetTargetDatacenterDatacenterVchVchIDCertificateDefault(
 			util.StatusCode(err)).WithPayload(&models.Error{Message: err.Error()})
@@ -75,7 +76,6 @@ func (h *VCHDatacenterCertGet) Handle(params operations.GetTargetTargetDatacente
 
 	d.ID = params.VchID
 
-	op := trace.NewOperation(params.HTTPRequest.Context(), "vch: %s", params.VchID)
 	c, err := getVCHCert(op, d)
 	if err != nil {
 		return operations.NewGetTargetTargetDatacenterDatacenterVchVchIDCertificateDefault(

--- a/lib/apiservers/service/restapi/handlers/vch_get.go
+++ b/lib/apiservers/service/restapi/handlers/vch_get.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"net"
 	"net/http"
-	"net/url"
 	"strings"
 
 	"github.com/docker/docker/opts"
@@ -51,20 +50,20 @@ type VCHDatacenterGet struct {
 }
 
 func (h *VCHGet) Handle(params operations.GetTargetTargetVchVchIDParams, principal interface{}) middleware.Responder {
-	d, err := buildData(params.HTTPRequest.Context(),
-		url.URL{Host: params.Target},
-		principal.(Credentials).user,
-		principal.(Credentials).pass,
-		params.Thumbprint,
-		nil,
-		nil)
+	op := trace.NewOperation(params.HTTPRequest.Context(), "VCHGet: %s", params.VchID)
+
+	b := buildDataParams{
+		target:     params.Target,
+		thumbprint: params.Thumbprint,
+	}
+
+	d, err := buildData(op, b, principal)
 	if err != nil {
 		return operations.NewGetTargetTargetVchVchIDDefault(util.StatusCode(err)).WithPayload(&models.Error{Message: err.Error()})
 	}
 
 	d.ID = params.VchID
 
-	op := trace.NewOperation(params.HTTPRequest.Context(), "vch: %s", params.VchID)
 	vch, err := getVCH(op, d)
 	if err != nil {
 		return operations.NewGetTargetTargetVchVchIDDefault(util.StatusCode(err)).WithPayload(&models.Error{Message: err.Error()})
@@ -74,20 +73,21 @@ func (h *VCHGet) Handle(params operations.GetTargetTargetVchVchIDParams, princip
 }
 
 func (h *VCHDatacenterGet) Handle(params operations.GetTargetTargetDatacenterDatacenterVchVchIDParams, principal interface{}) middleware.Responder {
-	d, err := buildData(params.HTTPRequest.Context(),
-		url.URL{Host: params.Target},
-		principal.(Credentials).user,
-		principal.(Credentials).pass,
-		params.Thumbprint,
-		&params.Datacenter,
-		nil)
+	op := trace.NewOperation(params.HTTPRequest.Context(), "VCHDatacenterGet: %s", params.VchID)
+
+	b := buildDataParams{
+		target:     params.Target,
+		thumbprint: params.Thumbprint,
+		datacenter: &params.Datacenter,
+	}
+
+	d, err := buildData(op, b, principal)
 	if err != nil {
 		return operations.NewGetTargetTargetDatacenterDatacenterVchVchIDDefault(util.StatusCode(err)).WithPayload(&models.Error{Message: err.Error()})
 	}
 
 	d.ID = params.VchID
 
-	op := trace.NewOperation(params.HTTPRequest.Context(), "vch: %s", params.VchID)
 	vch, err := getVCH(op, d)
 	if err != nil {
 		return operations.NewGetTargetTargetDatacenterDatacenterVchVchIDDefault(util.StatusCode(err)).WithPayload(&models.Error{Message: err.Error()})

--- a/lib/apiservers/service/restapi/handlers/vch_list_get.go
+++ b/lib/apiservers/service/restapi/handlers/vch_list_get.go
@@ -17,7 +17,6 @@ package handlers
 import (
 	"fmt"
 	"net/http"
-	"net/url"
 	"path"
 
 	"github.com/docker/docker/opts"
@@ -37,23 +36,24 @@ import (
 type VCHListGet struct {
 }
 
-// VCHListGet is the handler for listing VCHs within a Datacenter
+// VCHDatacenterListGet is the handler for listing VCHs within a Datacenter
 type VCHDatacenterListGet struct {
 }
 
 func (h *VCHListGet) Handle(params operations.GetTargetTargetVchParams, principal interface{}) middleware.Responder {
-	d, err := buildData(params.HTTPRequest.Context(),
-		url.URL{Host: params.Target},
-		principal.(Credentials).user,
-		principal.(Credentials).pass,
-		params.Thumbprint,
-		nil,
-		params.ComputeResource)
+	op := trace.NewOperation(params.HTTPRequest.Context(), "VCHListGet")
+
+	b := buildDataParams{
+		target:          params.Target,
+		thumbprint:      params.Thumbprint,
+		computeResource: params.ComputeResource,
+	}
+
+	d, err := buildData(op, b, principal)
 	if err != nil {
 		return operations.NewGetTargetTargetVchDefault(util.StatusCode(err)).WithPayload(&models.Error{Message: err.Error()})
 	}
 
-	op := trace.NewOperation(params.HTTPRequest.Context(), "vch_list get handler")
 	vchs, err := listVCHs(op, d)
 	if err != nil {
 		return operations.NewGetTargetTargetVchDefault(util.StatusCode(err)).WithPayload(&models.Error{Message: err.Error()})
@@ -63,18 +63,20 @@ func (h *VCHListGet) Handle(params operations.GetTargetTargetVchParams, principa
 }
 
 func (h *VCHDatacenterListGet) Handle(params operations.GetTargetTargetDatacenterDatacenterVchParams, principal interface{}) middleware.Responder {
-	d, err := buildData(params.HTTPRequest.Context(),
-		url.URL{Host: params.Target},
-		principal.(Credentials).user,
-		principal.(Credentials).pass,
-		params.Thumbprint,
-		&params.Datacenter,
-		params.ComputeResource)
+	op := trace.NewOperation(params.HTTPRequest.Context(), "VCHDatacenterListGet")
+
+	b := buildDataParams{
+		target:          params.Target,
+		thumbprint:      params.Thumbprint,
+		datacenter:      &params.Datacenter,
+		computeResource: params.ComputeResource,
+	}
+
+	d, err := buildData(op, b, principal)
 	if err != nil {
 		return operations.NewGetTargetTargetVchDefault(util.StatusCode(err)).WithPayload(&models.Error{Message: err.Error()})
 	}
 
-	op := trace.NewOperation(params.HTTPRequest.Context(), "vch_list get handler")
 	vchs, err := listVCHs(op, d)
 	if err != nil {
 		return operations.NewGetTargetTargetVchDefault(util.StatusCode(err)).WithPayload(&models.Error{Message: err.Error()})

--- a/lib/apiservers/service/restapi/handlers/vch_log_get.go
+++ b/lib/apiservers/service/restapi/handlers/vch_log_get.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"fmt"
 	"net/http"
-	"net/url"
 	"sort"
 	"strings"
 
@@ -48,19 +47,19 @@ type VCHDatacenterLogGet struct {
 }
 
 func (h *VCHLogGet) Handle(params operations.GetTargetTargetVchVchIDLogParams, principal interface{}) middleware.Responder {
-	d, err := buildData(params.HTTPRequest.Context(),
-		url.URL{Host: params.Target},
-		principal.(Credentials).user,
-		principal.(Credentials).pass,
-		params.Thumbprint,
-		nil,
-		nil)
+	op := trace.NewOperation(params.HTTPRequest.Context(), "VCHLogGet: %s", params.VchID)
+
+	b := buildDataParams{
+		target:     params.Target,
+		thumbprint: params.Thumbprint,
+	}
+
+	d, err := buildData(op, b, principal)
 	if err != nil {
 		return operations.NewGetTargetTargetVchVchIDLogDefault(util.StatusCode(err)).WithPayload(&models.Error{Message: err.Error()})
 	}
 
 	d.ID = params.VchID
-	op := trace.NewOperation(params.HTTPRequest.Context(), "vch: %s", params.VchID)
 
 	helper, err := getDatastoreHelper(op, d)
 	if err != nil {
@@ -81,19 +80,20 @@ func (h *VCHLogGet) Handle(params operations.GetTargetTargetVchVchIDLogParams, p
 }
 
 func (h *VCHDatacenterLogGet) Handle(params operations.GetTargetTargetDatacenterDatacenterVchVchIDLogParams, principal interface{}) middleware.Responder {
-	d, err := buildData(params.HTTPRequest.Context(),
-		url.URL{Host: params.Target},
-		principal.(Credentials).user,
-		principal.(Credentials).pass,
-		params.Thumbprint,
-		&params.Datacenter,
-		nil)
+	op := trace.NewOperation(params.HTTPRequest.Context(), "VCHDatacenterLogGet: %s", params.VchID)
+
+	b := buildDataParams{
+		target:     params.Target,
+		thumbprint: params.Thumbprint,
+		datacenter: &params.Datacenter,
+	}
+
+	d, err := buildData(op, b, principal)
 	if err != nil {
 		return operations.NewGetTargetTargetDatacenterDatacenterVchVchIDLogDefault(util.StatusCode(err)).WithPayload(&models.Error{Message: err.Error()})
 	}
 
 	d.ID = params.VchID
-	op := trace.NewOperation(params.HTTPRequest.Context(), "vch: %s", params.VchID)
 
 	helper, err := getDatastoreHelper(op, d)
 	if err != nil {

--- a/lib/apiservers/service/swagger.json
+++ b/lib/apiservers/service/swagger.json
@@ -967,9 +967,15 @@
   "securityDefinitions": {
     "basic": {
       "type": "basic"
+    },
+    "session": {
+      "type": "apiKey",
+      "in": "header",
+      "name": "X-VMWARE-TICKET"
     }
   },
   "security": [
-    {"basic": []}
+    {"basic": []},
+    {"session": []}
   ]
 }

--- a/lib/install/validate/validator.go
+++ b/lib/install/validate/validator.go
@@ -139,6 +139,8 @@ func NewValidator(ctx context.Context, input *data.Data) (*Validator, error) {
 
 	sessionconfig.Service = tURL.String()
 
+	sessionconfig.CloneTicket = input.CloneTicket
+
 	v.Session = session.NewSession(sessionconfig)
 	v.Session.UserAgent = version.UserAgent("vic-machine")
 	v.Session, err = v.Session.Connect(v.Context)


### PR DESCRIPTION
This change allows the vic-machine-server to accept  a vSphere session clone ticket in the `X-VMWARE-TICKET` header of incoming requests. This ticket is used by govmomi to clone the user's session to allow the vic-machine-server govmomi client to make vSphere requests on the user's behalf.

The govmomi changes in this PR will be moved to a PR in the govmomi repo once I've verified that this is the proper approach.

Fixes #6033 