### PR TITLE
Make CI parsing more robust

### DIFF
--- a/tests/integration-test.sh
+++ b/tests/integration-test.sh
@@ -35,7 +35,7 @@ elif grep -q "\[full ci\]" <(drone build info vmware/vic $DRONE_BUILD_NUMBER); t
 elif (echo $buildinfo | grep -q "\[specific ci="); then
     echo "Running specific CI as per commit message"
     buildtype=$(echo $buildinfo | grep "\[specific ci=")
-    testsuite=$(echo $buildtype | awk -v FS="(=|])" '{print $2}')
+    testsuite=$(echo $buildtype | awk -F"\[specific ci=" '{sub(/\].*/,"",$2);print $2}')
     pybot --removekeywords TAG:secret --suite $testsuite --suite 7-01-Regression tests/test-cases
 else
     echo "Running regressions"


### PR DESCRIPTION
The integration-test.sh script parses the first (summary) line of commit messages for hints like "`[full ci]`", "`[skip ci]`" or "`[specific ci=...]`".

Prior to this change, commit messages containing one or more "`]`" or "`=`" characters before a "`[specific ci=...]`" hint would be parsed incorrectly.

This change makes the parsing for more robust. Now, it will consistently extract the value between the first instance of "`[specific ci=`" and the first subsequent "`]`" character.
