### PR TITLE
Avoid a panic when a managed object is omitted

### DIFF
--- a/lib/apiservers/service/restapi/handlers/vch_create.go
+++ b/lib/apiservers/service/restapi/handlers/vch_create.go
@@ -465,6 +465,10 @@ func fromNetworkAddress(m *models.NetworkAddress) string {
 }
 
 func fromManagedObject(op trace.Operation, finder *find.Finder, t string, m *models.ManagedObject) (string, error) {
+	if m == nil {
+		return "", nil
+	}
+
 	if m.ID != "" {
 		managedObjectReference := types.ManagedObjectReference{Type: t, Value: m.ID}
 		element, err := finder.Element(op, managedObjectReference)


### PR DESCRIPTION
This change ensures that omitted (i.e., nil) managed objects are correctly handled in calls to the VCH creation API.

This allows for a more minimal set of fields to be supplied.