### PR TITLE
Always process ops credentials in VCH creation API [specific ci=Group23-Vic-Machine-Service]

### DIFF
--- a/lib/apiservers/service/restapi/handlers/vch_create.go
+++ b/lib/apiservers/service/restapi/handlers/vch_create.go
@@ -399,9 +399,9 @@ func buildCreate(op trace.Operation, d *data.Data, finder *find.Finder, vch *mod
 					OpsPassword: &opsPassword,
 				}
 			}
-			if err := c.OpsCredentials.ProcessOpsCredentials(true, c.Target.User, c.Target.Password); err != nil {
-				return nil, util.WrapError(http.StatusBadRequest, err)
-			}
+		}
+		if err := c.OpsCredentials.ProcessOpsCredentials(true, c.Target.User, c.Target.Password); err != nil {
+			return nil, util.WrapError(http.StatusBadRequest, err)
 		}
 
 		if vch.Registry != nil {


### PR DESCRIPTION
This change moves the logic which processes operations credentials up a level so that they will always be processed, even if no endpoint settings are provided.

Note that this was discovered while working on #6019 and will be tested as a part of #6527.
