### PR TITLE
Propagate validation in VCH creation API [specific ci=Group23-Vic-Machine-Service]

### DIFF
--- a/lib/apiservers/service/restapi/handlers/vch_create.go
+++ b/lib/apiservers/service/restapi/handlers/vch_create.go
@@ -426,6 +426,16 @@ func buildCreate(op trace.Operation, d *data.Data, finder *find.Finder, vch *mod
 
 func handleCreate(op trace.Operation, c *create.Create, validator *validate.Validator) (*strfmt.URI, error) {
 	vchConfig, err := validator.Validate(validator.Context, c.Data)
+	if err != nil {
+		issues := validator.GetIssues()
+		messages := make([]string, 0, len(issues))
+		for _, issue := range issues {
+			messages = append(messages, issue.Error())
+		}
+
+		return nil, util.NewError(400, fmt.Sprintf("Failed to validate VCH: %s", strings.Join(messages, ", ")))
+	}
+
 	vConfig := validator.AddDeprecatedFields(validator.Context, vchConfig, c.Data)
 
 	// TODO: make this configurable


### PR DESCRIPTION
As a part of handling a VCH creation API request, we pass the desired VCH configuration to the validator code.

When the validator returns an error, we should report it to the user.

This will be tested as a part of #6019.

Fixes #6547 
