### PR TITLE
Properly extract CPU speed in VCH creation handler

### DIFF
--- a/lib/apiservers/service/restapi/handlers/vch_create.go
+++ b/lib/apiservers/service/restapi/handlers/vch_create.go
@@ -556,7 +556,7 @@ func mhzFromValueHertz(m *models.ValueHertz) *int {
 	v := float64(m.Value.Value)
 
 	var mhzs float64
-	switch m.Units {
+	switch m.Value.Units {
 	case models.ValueHertzUnitsHz:
 		mhzs = v / float64(units.MB)
 	case models.ValueHertzUnitsKHz:


### PR DESCRIPTION
Because JSON and Go have different models for inheritance, properly interpreting the structure of the API parameters can be confusing.

In this case, we need to reference the nested units variable from the "subclass" instead of the units variable in the parent, which will always have its zero value (the empty string).

Note that this was discovered while working on #6019 and will be tested as a part of #6527.