### PR TITLE
[specific ci=Group23-VIC-Machine-Service] container-name-convention support added to vic-machine API

### DIFF
--- a/lib/apiservers/service/restapi/handlers/vch_create.go
+++ b/lib/apiservers/service/restapi/handlers/vch_create.go
@@ -429,6 +429,10 @@ func buildCreate(op trace.Operation, d *data.Data, finder *find.Finder, vch *mod
 				return nil, util.NewError(http.StatusBadRequest, fmt.Sprintf("Error processing syslog server address: %s", err))
 			}
 		}
+
+		if vch.Container != nil && vch.Container.NameConvention != "" {
+			c.ContainerNameConvention = vch.Container.NameConvention
+		}
 	}
 
 	return c, nil

--- a/lib/apiservers/service/restapi/handlers/vch_get.go
+++ b/lib/apiservers/service/restapi/handlers/vch_get.go
@@ -273,6 +273,11 @@ func vchToModel(op trace.Operation, vch *vm.VirtualMachine, d *data.Data, execut
 		model.SyslogAddr = strfmt.URI(syslogConfig.Network + "://" + syslogConfig.RAddr)
 	}
 
+	model.Container = &models.VCHContainer{}
+	if vchConfig.ContainerNameConvention != "" {
+		model.Container.NameConvention = vchConfig.ContainerNameConvention
+	}
+
 	return model, nil
 }
 

--- a/lib/apiservers/service/swagger.json
+++ b/lib/apiservers/service/swagger.json
@@ -819,6 +819,15 @@
           "type": "string",
           "format": "uri",
           "pattern": "^(tc|ud)p:\/\/.*"
+        },
+        "container": {
+          "type": "object",
+          "properties": {
+            "name_convention": {
+              "type": "string",
+              "pattern": "^.*(\\{id\\}|\\{name\\}).*"
+            }
+          }
         }
       }
     },

--- a/tests/test-cases/Group23-VIC-Machine-Service/23-03-VCH-Create.robot
+++ b/tests/test-cases/Group23-VIC-Machine-Service/23-03-VCH-Create.robot
@@ -128,7 +128,7 @@ Create minimal VCH within datacenter
 
 
 Create complex VCH
-    Create VCH    '{"name":"%{VCH-NAME}-api-test-complex","debug":3,"compute":{"cpu":{"limit":{"units":"MHz","value":2345},"reservation":{"units":"GHz","value":2},"shares":{"level":"high"}},"memory":{"limit":{"units":"MiB","value":1200},"reservation":{"units":"MiB","value":501},"shares":{"number":81910}},"resource":{"name":"%{TEST_RESOURCE}"}},"endpoint":{"cpu":{"sockets":2},"memory":{"units":"MiB","value":3072}},"storage":{"image_stores":["ds://%{TEST_DATASTORE}"],"volume_stores":[{"datastore":"ds://%{TEST_DATASTORE}/test-volumes/foo","label":"foo"}],"base_image_size":{"units":"B","value":16000000}},"network":{"bridge":{"ip_range":"172.16.0.0/12","port_group":{"name":"%{BRIDGE_NETWORK}"}},"public":{"port_group":{"name":"${PUBLIC_NETWORK}"}}},"registry":{"image_fetch_proxy":{"http":"http://example.com","https":"https://example.com"},"insecure":["https://insecure.example.com"],"whitelist":["10.0.0.0/8"]},"auth":{"server":{"generate":{"cname":"vch.example.com","organization":["VMware, Inc."],"size":{"value":2048,"units":"bits"}}},"client":{"no_tls_verify": true}},"syslog_addr":"tcp://syslog.example.com:4444"}'
+    Create VCH    '{"name":"%{VCH-NAME}-api-test-complex","debug":3,"compute":{"cpu":{"limit":{"units":"MHz","value":2345},"reservation":{"units":"GHz","value":2},"shares":{"level":"high"}},"memory":{"limit":{"units":"MiB","value":1200},"reservation":{"units":"MiB","value":501},"shares":{"number":81910}},"resource":{"name":"%{TEST_RESOURCE}"}},"endpoint":{"cpu":{"sockets":2},"memory":{"units":"MiB","value":3072}},"storage":{"image_stores":["ds://%{TEST_DATASTORE}"],"volume_stores":[{"datastore":"ds://%{TEST_DATASTORE}/test-volumes/foo","label":"foo"}],"base_image_size":{"units":"B","value":16000000}},"network":{"bridge":{"ip_range":"172.16.0.0/12","port_group":{"name":"%{BRIDGE_NETWORK}"}},"public":{"port_group":{"name":"${PUBLIC_NETWORK}"}}},"registry":{"image_fetch_proxy":{"http":"http://example.com","https":"https://example.com"},"insecure":["https://insecure.example.com"],"whitelist":["10.0.0.0/8"]},"auth":{"server":{"generate":{"cname":"vch.example.com","organization":["VMware, Inc."],"size":{"value":2048,"units":"bits"}}},"client":{"no_tls_verify": true}},"syslog_addr":"tcp://syslog.example.com:4444", "container": {"name_convention": "container-{id}"}}'
 
     Verify Return Code
     Verify Status Created
@@ -200,6 +200,8 @@ Create complex VCH
 
     Property Should Be Equal        .runtime.power_state                 poweredOn
     Property Should Be Equal        .runtime.upgrade_status              Up to date
+
+    Property Should Be Equal        .container.name_convention           container-{id}
 
     [Teardown]    Run Secret VIC Machine Delete Command    %{VCH-NAME}-api-test-complex
 


### PR DESCRIPTION
Fixes #6503 

container-name-convention support is now added to vic-machine create API and inspect API.

**Details**
1. vic-machine create API
POST request body includes a `container` object that specifies the configurations for containers on the VCH such as network, CPU, memory (not implemented yet). Within `container` field, `name_convention` field is a string that specifies a naming convention for vSphere display names for containers. 
`name_convention` must contain either `{id}` or `{name}` as token (including both tokens in naming convention is currently not supported).
For example, if the naming convention is `container-{id}` and there's a container running on the VCH, the vSphere display name for this container would be `container-short_id` where `short_id` is the short ID of that container. 
Note that this only changes the display names of containers on vSphere, not actual Docker container names.

An example of vic-machine create API request body:
```
{
	"name": "vch-test-1",
	"storage":{
		"image_stores":["ds://datastore1"]
	},
	"network":{
		"bridge":{
			"ip_range":"172.16.0.0/12",
			"port_group":{"name":"bridge"}
		},
		"public":{
			"port_group":{"name":"vm-network"}
		},
	},
	"auth":{
		"no_tls":true
	},
	"container": {
                "name_convention":"container-{id}"
        }
}
```

2. vic-machine inspect API
The response body of POST request now includes a field `name_convention` field under `container` of type string that specifies the vSphere display naming convention for containers running on the VCH.

Example vic-machine inspect GET response body:
```
{
  "auth": {
    "client": {
      "certificate_authorities": []
    }
  },
  "compute": {
    "cpu": {
      "shares": {
        "level": "normal"
      }
    },
    "memory": {
      "shares": {
        "level": "normal"
      }
    },
    "resource": {
      "id": "resgroup-v35"
    }
  },
  "container":{
      "name_convention": "container-{id}",
  },
  "endpoint": {
    "cpu": {
      "sockets": 1
    },
    "memory": {
      "units": "MiB",
      "value": 2048
    },
    "operations_credentials": {}
  },
  "name": "vch-test-1",
  "network": {
    "bridge": {
      "ip_range": "172.16.0.0/12",
      "port_group": {
        "id": "dvportgroup-23"
      }
    },
    "client": {
      "nameservers": [],
      "port_group": {
        "id": "dvportgroup-22"
      }
    },
    "container": [],
    "management": {
      "nameservers": [],
      "port_group": {
        "id": "dvportgroup-21"
      }
    },
    "public": {
      "nameservers": [],
      "port_group": {
        "id": "dvportgroup-22"
      }
    }
  },
  "registry": {
    "blacklist": null,
    "certificate_authorities": [],
    "insecure": [],
    "whitelist": []
  },
  "runtime": {
    "admin_portal": "https://10.160.213.153:2378",
    "docker_host": "10.160.213.153:2375",
    "power_state": "poweredOn",
    "upgrade_status": "Up to date"
  },
  "storage": {
    "base_image_size": {
      "units": "KiB",
      "value": 8000000
    },
    "image_stores": [
      "ds://datastore1/vch-test-1"
    ],
    "volume_stores": []
  },
  "version": "v1.2.0-rc1-0-a3b3132"
}
```

**Remaining work**
In integration test, verify container naming convention with docker 