### PR TITLE
[specific ci=Group23-VIC-Machine-Service] Format VCH creation log API response to text/plain

### DIFF
--- a/lib/apiservers/service/restapi/handlers/vch_log_get.go
+++ b/lib/apiservers/service/restapi/handlers/vch_log_get.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/go-openapi/runtime/middleware"
 
-	"github.com/vmware/vic/lib/apiservers/service/models"
 	"github.com/vmware/vic/lib/apiservers/service/restapi/handlers/util"
 	"github.com/vmware/vic/lib/apiservers/service/restapi/operations"
 	"github.com/vmware/vic/lib/install/data"
@@ -56,24 +55,24 @@ func (h *VCHLogGet) Handle(params operations.GetTargetTargetVchVchIDLogParams, p
 
 	d, err := buildData(op, b, principal)
 	if err != nil {
-		return operations.NewGetTargetTargetVchVchIDLogDefault(util.StatusCode(err)).WithPayload(&models.Error{Message: err.Error()})
+		return operations.NewGetTargetTargetVchVchIDLogDefault(util.StatusCode(err)).WithPayload(err.Error())
 	}
 
 	d.ID = params.VchID
 
 	helper, err := getDatastoreHelper(op, d)
 	if err != nil {
-		return operations.NewGetTargetTargetVchVchIDLogDefault(util.StatusCode(err)).WithPayload(&models.Error{Message: err.Error()})
+		return operations.NewGetTargetTargetVchVchIDLogDefault(util.StatusCode(err)).WithPayload(err.Error())
 	}
 
 	logFilePaths, err := getAllLogFilePaths(op, helper)
 	if err != nil {
-		return operations.NewGetTargetTargetVchVchIDLogDefault(util.StatusCode(err)).WithPayload(&models.Error{Message: err.Error()})
+		return operations.NewGetTargetTargetVchVchIDLogDefault(util.StatusCode(err)).WithPayload(err.Error())
 	}
 
 	output, err := getContentFromLogFiles(op, helper, logFilePaths)
 	if err != nil {
-		return operations.NewGetTargetTargetVchVchIDLogDefault(util.StatusCode(err)).WithPayload(&models.Error{Message: err.Error()})
+		return operations.NewGetTargetTargetVchVchIDLogDefault(util.StatusCode(err)).WithPayload(err.Error())
 	}
 
 	return operations.NewGetTargetTargetVchVchIDLogOK().WithPayload(output)
@@ -90,24 +89,24 @@ func (h *VCHDatacenterLogGet) Handle(params operations.GetTargetTargetDatacenter
 
 	d, err := buildData(op, b, principal)
 	if err != nil {
-		return operations.NewGetTargetTargetDatacenterDatacenterVchVchIDLogDefault(util.StatusCode(err)).WithPayload(&models.Error{Message: err.Error()})
+		return operations.NewGetTargetTargetDatacenterDatacenterVchVchIDLogDefault(util.StatusCode(err)).WithPayload(err.Error())
 	}
 
 	d.ID = params.VchID
 
 	helper, err := getDatastoreHelper(op, d)
 	if err != nil {
-		return operations.NewGetTargetTargetDatacenterDatacenterVchVchIDLogDefault(util.StatusCode(err)).WithPayload(&models.Error{Message: err.Error()})
+		return operations.NewGetTargetTargetDatacenterDatacenterVchVchIDLogDefault(util.StatusCode(err)).WithPayload(err.Error())
 	}
 
 	logFilePaths, err := getAllLogFilePaths(op, helper)
 	if err != nil {
-		return operations.NewGetTargetTargetDatacenterDatacenterVchVchIDLogDefault(util.StatusCode(err)).WithPayload(&models.Error{Message: err.Error()})
+		return operations.NewGetTargetTargetDatacenterDatacenterVchVchIDLogDefault(util.StatusCode(err)).WithPayload(err.Error())
 	}
 
 	output, err := getContentFromLogFiles(op, helper, logFilePaths)
 	if err != nil {
-		return operations.NewGetTargetTargetDatacenterDatacenterVchVchIDLogDefault(util.StatusCode(err)).WithPayload(&models.Error{Message: err.Error()})
+		return operations.NewGetTargetTargetDatacenterDatacenterVchVchIDLogDefault(util.StatusCode(err)).WithPayload(err.Error())
 	}
 
 	return operations.NewGetTargetTargetDatacenterDatacenterVchVchIDLogOK().WithPayload(output)

--- a/lib/apiservers/service/swagger.json
+++ b/lib/apiservers/service/swagger.json
@@ -198,6 +198,7 @@
       "get": {
         "summary": "Access log messages for a VCH",
         "description": "Making a `GET` request on /log under a VCH resource will return the log messages for vic-machine processes on a VCH",
+        "produces": [ "text/plain" ],
         "parameters": [
           { "$ref": "#/parameters/target" },
           { "$ref": "#/parameters/vch-id" },
@@ -205,7 +206,7 @@
         ],
         "responses": {
           "200": { "$ref": "#/responses/vch-log" },
-          "default": { "$ref": "#/responses/error" }
+          "default": { "$ref": "#/responses/error-plain" }
         }
       }
     },
@@ -373,6 +374,7 @@
       "get": {
         "summary": "Access log messages for a VCH in a particular datacenter",
         "description": "Making a `GET` request on /log under a VCH resource will return the log messages for vic-machine processes on a VCH.",
+        "produces": [ "text/plain" ],
         "parameters": [
           { "$ref": "#/parameters/target" },
           { "$ref": "#/parameters/datacenter" },
@@ -381,7 +383,7 @@
         ],
         "responses": {
           "200": { "$ref": "#/responses/vch-log" },
-          "default": { "$ref": "#/responses/error" }
+          "default": { "$ref": "#/responses/error-plain" }
         }
       }
     }
@@ -920,6 +922,12 @@
     "error": {
       "description": "An error occurred",
       "schema": { "$ref": "#/definitions/Error" }
+    },
+    "error-plain": {
+      "description": "An error occurred",
+      "schema": {
+        "type": "string"
+      }
     },
     "metadata": {
       "description": "VIC metadata information",

--- a/tests/test-cases/Group23-VIC-Machine-Service/23-05-VCH-Logs.robot
+++ b/tests/test-cases/Group23-VIC-Machine-Service/23-05-VCH-Logs.robot
@@ -47,7 +47,12 @@ Delete Log File From VCH Datastore
 
 
 Verify Log
+    Output Should Contain    /n
     Output Should Contain    Installer completed successfully
+
+
+Verify Error String
+    Should Be String         ${OUTPUT}
 
 
 *** Test Cases ***
@@ -79,5 +84,6 @@ Get VCH Creation log errors with 404 after log file is deleted
 
     Get VCH Log Within Datacenter    ${id}
 
+    Verify Error String
     Verify Return Code
     Verify Status Not Found


### PR DESCRIPTION
Fixes #6598 

The VCH creation handler log output `text/plain` format (log messages upon 200 response code, and error string in all other HTTP error codes).

A snippet of how the handler response looks like upon 200:
```
Oct 10 2017 14:28:43.865-07:00 DEBUG Creating VMOMI session with thumbprint E6:57:47:95:CD:A4:BE:C9:10:9B:94:47:8D:57:59:07:EE:AA:F1:93
Oct 10 2017 14:28:44.300-07:00 DEBUG Session Environment Info: 
Oct 10 2017 14:28:44.300-07:00 DEBUG vSphere resource cache populating...
Oct 10 2017 14:28:44.410-07:00 DEBUG Cached dc: 
Oct 10 2017 14:28:44.577-07:00 DEBUG Cached cluster: 
Oct 10 2017 14:28:44.851-07:00 DEBUG Cached host: 
Oct 10 2017 14:28:45.028-07:00 DEBUG Cached pool: 
Oct 10 2017 14:28:45.080-07:00 DEBUG Cached folders: 
Oct 10 2017 14:28:45.080-07:00 DEBUG Error count populating vSphere cache: (1)
Oct 10 2017 14:28:45.080-07:00 DEBUG new validator Session.Populate: Failure finding ds (): default datastore resolves to multiple instances, please specify
Oct 10 2017 14:28:45.080-07:00 INFO  Validating target
```
Upon HTTP error codes: 
```
"No log file available in datastore folder"
```

Integration tests are added to verify output containing log messages is multi-line, and error response is of string type.
