### PR TITLE
Correct ps output and restart/nat behaviour

### DIFF
--- a/lib/apiservers/engine/backends/backends.go
+++ b/lib/apiservers/engine/backends/backends.go
@@ -313,9 +313,9 @@ func setPortMapping(info *models.ContainerInfo, backend *Container, container *c
 		log.Infof("container state is nil")
 		return nil
 	}
+
 	if info.ContainerConfig.State != "Running" || len(container.HostConfig.PortBindings) == 0 {
-		log.Infof("Container info state: %s", info.ContainerConfig.State)
-		log.Infof("container portbinding: %+v", container.HostConfig.PortBindings)
+		log.Infof("No need to restore port bindings, state: %s, portbinding: %+v", info.ContainerConfig.State, container.HostConfig.PortBindings)
 		return nil
 	}
 
@@ -328,7 +328,7 @@ func setPortMapping(info *models.ContainerInfo, backend *Container, container *c
 	}
 	for _, e := range endpointsOK.Payload {
 		if len(e.Ports) > 0 && e.Scope == constants.BridgeScopeType {
-			if err = MapPorts(container.HostConfig, e, container.ContainerID); err != nil {
+			if err = MapPorts(container, e, container.ContainerID); err != nil {
 				log.Errorf(err.Error())
 				return err
 			}

--- a/lib/apiservers/engine/backends/container/viccontainer.go
+++ b/lib/apiservers/engine/backends/container/viccontainer.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	containertypes "github.com/docker/docker/api/types/container"
+	"github.com/docker/go-connections/nat"
 )
 
 // VicContainer is VIC's abridged version of Docker's container object.
@@ -29,6 +30,7 @@ type VicContainer struct {
 	ContainerID string
 	Config      *containertypes.Config //Working copy of config (with overrides from container create)
 	HostConfig  *containertypes.HostConfig
+	NATMap      nat.PortMap // the endpoint NAT mappings only
 
 	m        sync.RWMutex
 	execs    map[string]struct{}

--- a/lib/apiservers/engine/backends/container_test.go
+++ b/lib/apiservers/engine/backends/container_test.go
@@ -40,6 +40,7 @@ import (
 	plscopes "github.com/vmware/vic/lib/apiservers/portlayer/client/scopes"
 	plmodels "github.com/vmware/vic/lib/apiservers/portlayer/models"
 	"github.com/vmware/vic/lib/archive"
+	"github.com/vmware/vic/lib/config/executor"
 	"github.com/vmware/vic/lib/metadata"
 	"github.com/vmware/vic/pkg/trace"
 )
@@ -720,14 +721,19 @@ func TestPortInformation(t *testing.T) {
 	mockHostConfig.PortBindings = portMap
 
 	mockContainerInfo.ContainerConfig = mockContainerConfig
-	mockContainerInfo.HostConfig = &plmodels.HostConfig{
-		Ports: []string{"8000/tcp"},
+	mockContainerInfo.Endpoints = []*plmodels.EndpointConfig{
+		{
+			Direct: true,
+			Trust:  executor.Published.String(),
+			Ports:  []string{"8000/tcp"},
+		},
 	}
 
 	ips := []string{"192.168.1.1"}
 
 	co := viccontainer.NewVicContainer()
 	co.HostConfig = mockHostConfig
+	co.NATMap = portMap
 	co.ContainerID = containerID
 	co.Name = "bar"
 	cache.ContainerCache().AddContainer(co)

--- a/lib/apiservers/engine/backends/eventmonitor.go
+++ b/lib/apiservers/engine/backends/eventmonitor.go
@@ -243,7 +243,7 @@ func (p DockerEventPublisher) PublishEvent(event plevents.BaseEvent) {
 			attrs["exitCode"] = code
 			actor := CreateContainerEventActorWithAttributes(vc, attrs)
 			EventService().Log(containerDieEvent, eventtypes.ContainerEventType, actor)
-			if err := UnmapPorts(vc.ContainerID, vc.HostConfig); err != nil {
+			if err := UnmapPorts(vc.ContainerID, vc); err != nil {
 				log.Errorf("Event Monitor failed to unmap ports for container(%s): %s - eventID(%s)", containerShortID, err, event.ID)
 			}
 
@@ -265,7 +265,7 @@ func (p DockerEventPublisher) PublishEvent(event plevents.BaseEvent) {
 		// pop the destroy event...
 		actor := CreateContainerEventActorWithAttributes(vc, attrs)
 		EventService().Log(containerDestroyEvent, eventtypes.ContainerEventType, actor)
-		if err := UnmapPorts(vc.ContainerID, vc.HostConfig); err != nil {
+		if err := UnmapPorts(vc.ContainerID, vc); err != nil {
 			log.Errorf("Event Monitor failed to unmap ports for container(%s): %s - eventID(%s)", containerShortID, err, event.ID)
 		}
 		// remove from the container cache...

--- a/lib/apiservers/portlayer/restapi/handlers/scopes_handlers.go
+++ b/lib/apiservers/portlayer/restapi/handlers/scopes_handlers.go
@@ -387,7 +387,7 @@ func toEndpointConfig(e *network.Endpoint) *models.EndpointConfig {
 	ports := e.Ports()
 	ecports := make([]string, len(ports))
 	for i, p := range e.Ports() {
-		ecports[i] = p.String()
+		ecports[i] = p.FullString()
 	}
 
 	return &models.EndpointConfig{

--- a/lib/apiservers/portlayer/swagger.json
+++ b/lib/apiservers/portlayer/swagger.json
@@ -3020,6 +3020,14 @@
 					"items": {
 						"type": "string"
 					}
+				},
+				"trust": {
+					"x-nullable": false,
+					"type": "string"
+				},
+				"direct": {
+					"x-nullable": false,
+					"type": "boolean"
 				}
 			}
 		},
@@ -3400,15 +3408,6 @@
 				},
 				"reservation": {
 					"$ref": "#/definitions/ReservationConfig"
-				},
-				"address": {
-					"type": "string"
-				},
-				"ports": {
-					"type": "array",
-					"items": {
-						"type": "string"
-					}
 				}
 			}
 		},

--- a/lib/config/executor/container_vm.go
+++ b/lib/config/executor/container_vm.go
@@ -320,6 +320,8 @@ func ParseTrustLevel(value string) (TrustLevel, error) {
 		trust = Outbound
 	case "peers":
 		trust = Peers
+	case "":
+		trust = Unspecified
 	default:
 		return Unspecified, fmt.Errorf("Unrecognized container trust level %s.", value)
 	}

--- a/lib/portlayer/network/context.go
+++ b/lib/portlayer/network/context.go
@@ -723,18 +723,16 @@ func (c *Context) bindContainer(op trace.Operation, h *exec.Handle) ([]*Endpoint
 			return nil, err
 		}
 
-		ports, _, err := nat.ParsePortSpecs(ne.Ports)
-		if err != nil {
-			return nil, err
-		}
-		for p := range ports {
-			var port Port
-			if port, err = ParsePort(string(p)); err != nil {
+		for i := range ne.Ports {
+			mappings, err := nat.ParsePortSpec(ne.Ports[i])
+			if err != nil {
 				return nil, err
 			}
-
-			if err = e.addPort(port); err != nil {
-				return nil, err
+			for j := range mappings {
+				port := PortFromMapping(mappings[j])
+				if err = e.addPort(port); err != nil {
+					return nil, err
+				}
 			}
 		}
 

--- a/lib/portlayer/network/port.go
+++ b/lib/portlayer/network/port.go
@@ -17,6 +17,7 @@ package network
 import (
 	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/docker/go-connections/nat"
 )
@@ -24,6 +25,13 @@ import (
 type Port string
 
 const NilPort = Port("")
+
+// PortFromMapping constructs the full form of a port mapping
+// This has been added to help migrate towards consistent data returns for Endpoint structures
+func PortFromMapping(mapping nat.PortMapping) Port {
+	p := fmt.Sprintf("%s:%s", mapping.Binding.HostPort, string(mapping.Port))
+	return Port(p)
+}
 
 func ParsePort(p string) (Port, error) {
 	if _, err := Port(p).Port(); err != nil {
@@ -38,12 +46,14 @@ func ParsePort(p string) (Port, error) {
 }
 
 func (p Port) Proto() string {
-	proto, _ := nat.SplitProtoPort(string(p))
+	parts := strings.Split(string(p), ":")
+	proto, _ := nat.SplitProtoPort(parts[len(parts)-1])
 	return proto
 }
 
 func (p Port) Port() (uint16, error) {
-	_, port := nat.SplitProtoPort(string(p))
+	parts := strings.Split(string(p), ":")
+	_, port := nat.SplitProtoPort(parts[len(parts)-1])
 	if port == "" {
 		return 0, fmt.Errorf("bad port spec %s", p)
 	}
@@ -57,5 +67,10 @@ func (p Port) Port() (uint16, error) {
 }
 
 func (p Port) String() string {
+	parts := strings.Split(string(p), ":")
+	return string(parts[len(parts)-1])
+}
+
+func (p Port) FullString() string {
 	return string(p)
 }

--- a/lib/vspc/config.go
+++ b/lib/vspc/config.go
@@ -1,0 +1,23 @@
+// Copyright 2017 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vspc
+
+var Config Configuration
+
+// Configuration is a slice of the VCH config that is relevant to the vSPC
+type Configuration struct {
+	// Turn on debug logging
+	DebugLevel int `vic:"0.1" scope:"read-only" key:"init/diagnostics/debug"`
+}

--- a/lib/vspc/vspc.go
+++ b/lib/vspc/vspc.go
@@ -23,7 +23,6 @@ import (
 
 	log "github.com/Sirupsen/logrus"
 
-	"github.com/vmware/vic/lib/config"
 	"github.com/vmware/vic/lib/constants"
 	"github.com/vmware/vic/pkg/telnet"
 	"github.com/vmware/vic/pkg/trace"
@@ -119,7 +118,6 @@ type Vspc struct {
 func NewVspc() *Vspc {
 	defer trace.End(trace.Begin("new vspc"))
 
-	var vchconfig config.VirtualContainerHostConfigSpec
 	vchIP, err := lookupVCHIP()
 	if err != nil {
 		log.Fatalf("cannot retrieve vch-endpoint ip: %v", err)
@@ -151,8 +149,8 @@ func NewVspc() *Vspc {
 
 	// load the vchconfig to get debug level
 	if src, err := extraconfig.GuestInfoSource(); err == nil {
-		extraconfig.Decode(src, &vchconfig)
-		if vchconfig.Diagnostics.DebugLevel > 2 {
+		extraconfig.Decode(src, &Config)
+		if Config.DebugLevel > 2 {
 			vspc.verbose = true
 		}
 	}

--- a/tests/resources/Docker-Util.robot
+++ b/tests/resources/Docker-Util.robot
@@ -49,7 +49,7 @@ Hit Nginx Endpoint
 
 Get Container IP
     [Arguments]  ${docker-params}  ${id}  ${network}=default  ${dockercmd}=docker
-    ${rc}  ${ip}=  Run And Return Rc And Output  ${dockercmd} ${docker-params} network inspect ${network} | jq '.[0].Containers."${id}".IPv4Address' | cut -d \\" -f 2 | cut -d \\/ -f 1
+    ${rc}  ${ip}=  Run And Return Rc And Output  ${dockercmd} ${docker-params} inspect --format='{{(index .NetworkSettings.Networks "${network}").IPAddress}}' ${id}
     Should Be Equal As Integers  ${rc}  0
     [Return]  ${ip}
 

--- a/tests/test-cases/Group10-VCH-Restart/10-01-VCH-Restart.md
+++ b/tests/test-cases/Group10-VCH-Restart/10-01-VCH-Restart.md
@@ -18,7 +18,7 @@ This test requires that a vSphere server is running and available
 8. Check container service in specified port
 9. Start container with same port
 10. Deploy VIC appliance with open container network
-11. Create container on the open network, and create contaienr with port mapping
+11. Create container on the open network, and create container with port mapping
 12. Reboot VCH
 13. Check container service in specified port
 14. Create container with volume and then reboot VCH

--- a/tests/test-cases/Group10-VCH-Restart/10-01-VCH-Restart.md
+++ b/tests/test-cases/Group10-VCH-Restart/10-01-VCH-Restart.md
@@ -17,15 +17,21 @@ This test requires that a vSphere server is running and available
 7. Issue docker stop, start and ls
 8. Check container service in specified port
 9. Start container with same port
-10. Create container with volume and then reboot VCH
-11. Inspect container to check volume info
+10. Deploy VIC appliance with open container network
+11. Create container on the open network, and create contaienr with port mapping
+12. Reboot VCH
+13. Check container service in specified port
+14. Create container with volume and then reboot VCH
+15. Inspect container to check volume info
 
 # Expected Outcome:
 * VCH should reboot within a reasonable amount of time
 * After VCH restart, network ls should have the previously created network listed
 * Step 6, 7 and 8 should result in success
 * Step 9 should result in false
-* Step 10-11 should result in success
+* Step 12 (VCH reboot with open container network) should succeed within a reasonable amount of time
+* Step 13 would result in success
+* Step 14-15 should result in success
 
 #Possible Problems:
 None

--- a/tests/test-cases/Group10-VCH-Restart/10-01-VCH-Restart.robot
+++ b/tests/test-cases/Group10-VCH-Restart/10-01-VCH-Restart.robot
@@ -15,8 +15,8 @@
 *** Settings ***
 Documentation  Test 10-01 - VCH Restart
 Resource  ../../resources/Util.robot
-Suite Setup  Install VIC Appliance To Test Server
-Suite Teardown  Cleanup VIC Appliance On Test Server
+Test Setup  Install VIC Appliance To Test Server
+Test Teardown  Cleanup VIC Appliance On Test Server
 Default Tags
 
 *** Keywords ***
@@ -32,6 +32,20 @@ Launch Container
     Should Be Equal As Integers  ${rc}  0
     ${id}=  Get Line  ${output}  -1
     [Return]  ${id}
+
+Launch Container With Port Forwarding
+    [Arguments]  ${name}  ${port1}  ${port2}  ${network}=default
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} create -it -p ${port1}:80 -p ${port2}:80 --name ${name} --net ${network} ${nginx}
+    Should Be Equal As Integers  ${rc}  0
+    Should Not Contain  ${output}  Error
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} start ${name}
+    Should Be Equal As Integers  ${rc}  0
+    Should Not Contain  ${output}  Error
+
+Check Nginx Port Forwarding
+    [Arguments]  ${port1}  ${port2}
+    Wait Until Keyword Succeeds  20x  5 seconds  Hit Nginx Endpoint  %{VCH-IP}  ${port1}
+    Wait Until Keyword Succeeds  20x  5 seconds  Hit Nginx Endpoint  %{VCH-IP}  ${port2}
 
 *** Test Cases ***
 Created Network And Images Persists As Well As Containers Are Discovered With Correct IPs
@@ -63,27 +77,14 @@ Created Network And Images Persists As Well As Containers Are Discovered With Co
     ${rc}=  Run And Return Rc  docker %{VCH-PARAMS} exec bar-c2 ping -c3 bar-c1
     Should Be Equal As Integers  ${rc}  0
 
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} create -it -p 10000:80 -p 10001:80 --name webserver ${nginx}
-    Should Be Equal As Integers  ${rc}  0
-    Should Not Contain  ${output}  Error
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} start webserver
-    Should Be Equal As Integers  ${rc}  0
-    Should Not Contain  ${output}  Error
-    Wait Until Keyword Succeeds  20x  5 seconds  Hit Nginx Endpoint  %{VCH-IP}  10000
-    Wait Until Keyword Succeeds  20x  5 seconds  Hit Nginx Endpoint  %{VCH-IP}  10001
+    Launch Container With Port Forwarding  webserver  10000  10001
+    Check Nginx Port Forwarding  10000  10001
 
     # Gather logs before rebooting
     Run Keyword And Continue On Failure  Gather Logs From Test Server  -before-reboot-1
 
     Reboot VM  %{VCH-NAME}
-
-    Log To Console  Getting VCH IP ...
-    ${new-vch-ip}=  Get VM IP  %{VCH-NAME}
-    Log To Console  New VCH IP is ${new-vch-ip}
-    Replace String  %{VCH-PARAMS}  %{VCH-IP}  ${new-vch-ip}
-
-    # wait for docker info to succeed
-    Wait Until Keyword Succeeds  20x  5 seconds  Run Docker Info  %{VCH-PARAMS}
+    Wait For VCH Initialization  20x  10 seconds
 
     # name resolution should work on the foo and bar networks
     ${rc}=  Run And Return Rc  docker %{VCH-PARAMS} exec foo-c1 ping -c3 foo-c2
@@ -133,8 +134,7 @@ Created Network And Images Persists As Well As Containers Are Discovered With Co
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} start ${bridge-exited}
     Should Be Equal As Integers  ${rc}  0
 
-    Wait Until Keyword Succeeds  20x  5 seconds  Hit Nginx Endpoint  %{VCH-IP}  10000
-    Wait Until Keyword Succeeds  20x  5 seconds  Hit Nginx Endpoint  %{VCH-IP}  10001
+    Check Nginx Port Forwarding  10000  10001
 
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} create -it -p 10000:80 -p 10001:80 --name webserver1 ${nginx}
     Should Be Equal As Integers  ${rc}  0
@@ -147,6 +147,66 @@ Created Network And Images Persists As Well As Containers Are Discovered With Co
     # if this fails, very likely the default gateway on the VCH is not set
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} pull ${alpine}
     Should Be Equal As Integers  ${rc}  0
+
+
+Container on Open Network And Port Forwarding Persist After Reboot
+    [Setup]     NONE
+
+    Set Test Environment Variables
+
+    Log To Console  Create Port Groups For Container network
+    ${out}=  Run Keyword If  '%{HOST_TYPE}' == 'ESXi'  Run  govc host.portgroup.add -vswitch vSwitchLAN open-net
+
+    ${createcommand}=  catenate  SEPARATOR=\ \
+    ...  bin/vic-machine-linux create --debug 1 --name=%{VCH-NAME}
+    ...  --target=%{TEST_URL}%{TEST_DATACENTER} --thumbprint=%{TEST_THUMBPRINT}
+    ...  --user=%{TEST_USERNAME} --image-store=%{TEST_DATASTORE} --password=%{TEST_PASSWORD}
+    ...  --force=true --bridge-network=bridge --compute-resource=%{TEST_RESOURCE} --no-tlsverify --no-tls
+    ...  --container-network=open-net --container-network-firewall=open-net:open
+
+    ${output}=  Run  ${createcommand}
+
+    Should Contain  ${output}  Installer completed successfully
+    Get Docker Params  ${output}  ${true}
+    Log To Console  Installer completed successfully: %{VCH-NAME}
+
+    # Create a container on the open network
+    ${open-running}=  Launch Container  vch-restart-open-running  open-net
+    ${open-exited}=  Launch Container  vch-restart-open-exited  open-net  ls
+
+    # Create nginx on the open network and bridge network
+    Launch Container With Port Forwarding  webserver-open  10000  10001  open-net
+    Launch Container with Port Forwarding  webserver-bridge  10002  10003  bridge
+    Check Nginx Port Forwarding  10002  10003
+
+    # Reboot VCH
+    Reboot VM  %{VCH-NAME}
+    Wait For VCH Initialization  20x  10 seconds
+
+    # Check if the open container is persisted
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} inspect ${open-running} | jq '.[0].State.Status'
+    Should Be Equal As Integers  ${rc}  0
+    Should Be Equal  ${output}  \"running\"
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} inspect ${open-running} | jq '.[0].HostConfig.PortBindings'
+    Should Be Equal As Integers  ${rc}  0
+    Should Be Equal  $[output}  \"{}\"
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} inspect ${open-exited} | jq -r '.[0].State.Status'
+    Should Be Equal As Integers  ${rc}  0
+    Should Be Equal  ${output}  \"exited\"
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} start ${open-exited}
+    Should Be Equal As Integers  ${rc}  0
+
+    # Check port forwarding on bridge container after reboot
+    Check Nginx Port Forwarding  10002  10003
+
+    # Check port forwarding on open container not reachable from endpoint VM
+    ${rc1}  ${output1}=  Run And Return Rc And Output  wget %{VCH-IP}:10000
+    ${rc2}  ${output2}=  Run And Return Rc And Output  wget %{VCH-IP}:10001
+    Should Not Be Equal As Integers  ${rc1}  0
+    Should Not Be Equal As Integers  ${rc2}  0
+
+    [Teardown]     Run VIC Machine Delete Command
+
 
 Create VCH attach disk and reboot
     ${rc}=  Run And Return Rc  govc vm.disk.create -vm=%{VCH-NAME} -name=%{VCH-NAME}/deleteme -size "16M"


### PR DESCRIPTION
PR #6557 addressing IP output in docker ps listings was incorrect
if connecting to a container network with network connect, after having
created container with a bridge network.

Also updates the robot utility function `Get Container IP` to use container
inspect which is populated with DHCP addresses, where the network inspect
entry for the same endpoint is not. Prior to this change that function was
returning an empty string and the tests using it were written such that they
pass if `Get Container IP` fails in that manner.

Example output:
```
$ docker run -d -p 8080 --net=bridge --name=bridge_only tomcat:alpine
8ad3acab10fea51921ac7a01e0dfa8021b0fe2610d6aff2b8a4351aead32bf2d
$ docker run -d -p 8080 --net=external --name=published_only tomcat:alpine
60ce369b115d16220b9428741c20e3229be42c83fa28407b051d209540a0e17f
$ docker run -d -p 80:8080 --net=external --name=published_redirect tomcat:alpine
b3c9be5bc6560924b384da125dd334618a96d228d45eaf09f193be8b498db839
$ docker run -d -p 8080 --net=open --name=open_only tomcat:alpine
4ec055fc5389f435d8640a9a352bbf23116f21f9c46cd33f31e36e7abb43297a
$ docker run -d -p 80:8080 --net=open --name=open_redirect tomcat:alpine
187f1a94af8b7610a319a9a7370f4214c9bfa902415933173cbc11d7ee40ac49
$ docker create -p 80:8080 --net=bridge --name=bridge_first tomcat:alpine
2e63a2e59fe8f21cac26ff45260e5d452a2bf6afd2b1ea78d35d7c4c4b7c9531
$ docker network connect external bridge_first
$ docker start bridge_first
bridge_first
$ docker ps
CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS              PORTS                                                NAMES
2e63a2e59fe8        tomcat:alpine       "catalina.sh run"   5 minutes ago       Up 20 seconds       192.168.78.127:80->8080/tcp                          bridge_first
187f1a94af8b        tomcat:alpine       "catalina.sh run"   5 minutes ago       Up About a minute   192.168.78.200:0->0/*, 192.168.78.200:80->8080/tcp   open_redirect
4ec055fc5389        tomcat:alpine       "catalina.sh run"   6 minutes ago       Up 2 minutes        192.168.78.203:0->0/*                                open_only
b3c9be5bc656        tomcat:alpine       "catalina.sh run"   7 minutes ago       Up 2 minutes        192.168.78.201:80->8080/tcp                          published_redirect
60ce369b115d        tomcat:alpine       "catalina.sh run"   7 minutes ago       Up 3 minutes        192.168.78.202:8080->8080/tcp                        published_only
8ad3acab10fe        tomcat:alpine       "catalina.sh run"   9 minutes ago       Up 4 minutes        192.168.78.127:32768->8080/tcp                       bridge_only
$ docker port bridge_only
8080/tcp -> 192.168.78.127:32768
$ docker port published_only
8080/tcp -> 192.168.78.202:8080/
$ docker port published_redirect
8080/tcp -> 192.168.78.201:80
$ docker port open_only
8080/tcp -> 192.168.78.203:8080/
$ docker port open_redirect
8080/tcp -> 192.168.78.200:80
$ docker port bridge_first
8080/tcp -> 192.168.78.127:80
$
```

This is a little larger than I would like at this point for a limited minor release, however I'm short on time to separate out the crucial from the optional in this existing PR.

We may be able to simply drop this line https://github.com/vmware/vic/blob/290938c440744bf05894e0220f057fecf875bae1/lib/apiservers/portlayer/restapi/handlers/containers_handlers.go#L623 and address the problem that @malikkal reported, however I think we'll still have some issues with spurious iptables forwarding after restart.

@anchal-agrawal has identified an issue with the PR when reporting ports for containers that were created prior to upgrade and started after, if the primary network is bridge and secondary network is a container-network.


Followup: #6557
Towards: #5776
Fixes: #7091 #7084 
