### PR TITLE
[specific ci=1-11-Docker-RM] Add support for docker rm -v

### DIFF
--- a/lib/apiservers/engine/backends/container_proxy.go
+++ b/lib/apiservers/engine/backends/container_proxy.go
@@ -104,6 +104,7 @@ type VicContainerProxy interface {
 	Signal(vc *viccontainer.VicContainer, sig uint64) error
 	Resize(id string, height, width int32) error
 	Rename(vc *viccontainer.VicContainer, newName string) error
+	Remove(vc *viccontainer.VicContainer, config *types.ContainerRmConfig) error
 
 	GetContainerChanges(op trace.Operation, vc *viccontainer.VicContainer, data bool) (io.ReadCloser, error)
 
@@ -371,9 +372,9 @@ func (c *ContainerProxy) AddVolumesToContainer(handle string, config types.Conta
 		return "", InternalServerError("ContainerProxy.AddVolumesToContainer failed to create a portlayer client")
 	}
 
-	//Volume Attachment Section
+	// Volume Attachment Section
 	log.Debugf("ContainerProxy.AddVolumesToContainer - VolumeSection")
-	log.Debugf("Raw Volume arguments : binds:  %#v : volumes : %#v", config.HostConfig.Binds, config.Config.Volumes)
+	log.Debugf("Raw volume arguments: binds:  %#v, volumes: %#v", config.HostConfig.Binds, config.Config.Volumes)
 
 	// Collect all volume mappings. In a docker create/run, they
 	// can be anonymous (-v /dir) or specific (-v vol-name:/dir).
@@ -388,8 +389,7 @@ func (c *ContainerProxy) AddVolumesToContainer(handle string, config types.Conta
 	if err != nil {
 		return handle, BadRequestError(err.Error())
 	}
-
-	log.Infof("Finalized Volume list : %#v", volList)
+	log.Infof("Finalized volume list: %#v", volList)
 
 	if len(config.Config.Volumes) > 0 {
 		// override anonymous volume list with generated volume id
@@ -405,8 +405,7 @@ func (c *ContainerProxy) AddVolumesToContainer(handle string, config types.Conta
 
 	// Create and join volumes.
 	for _, fields := range volList {
-
-		//we only set these here for volumes made on a docker create
+		// We only set these here for volumes made on a docker create
 		volumeData := make(map[string]string)
 		volumeData[DriverArgFlagKey] = fields.Flags
 		volumeData[DriverArgContainerKey] = config.Name
@@ -1196,9 +1195,71 @@ func (c *ContainerProxy) Rename(vc *viccontainer.VicContainer, newName string) e
 	return nil
 }
 
+// Remove calls the portlayer's ContainerRemove handler to remove the container and its
+// anonymous volumes if the remove flag is set.
+func (c *ContainerProxy) Remove(vc *viccontainer.VicContainer, config *types.ContainerRmConfig) error {
+	if c.client == nil {
+		return InternalServerError("ContainerProxy.Remove failed to get a portlayer client")
+	}
+
+	id := vc.ContainerID
+	_, err := c.client.Containers.ContainerRemove(containers.NewContainerRemoveParamsWithContext(ctx).WithID(id))
+	if err != nil {
+		switch err := err.(type) {
+		case *containers.ContainerRemoveNotFound:
+			// Remove container from persona cache, but don't return error to the user.
+			cache.ContainerCache().DeleteContainer(id)
+			return nil
+		case *containers.ContainerRemoveDefault:
+			return InternalServerError(err.Payload.Message)
+		case *containers.ContainerRemoveConflict:
+			return derr.NewRequestConflictError(fmt.Errorf("You cannot remove a running container. Stop the container before attempting removal or use -f"))
+		case *containers.ContainerRemoveInternalServerError:
+			if err.Payload == nil || err.Payload.Message == "" {
+				return InternalServerError(err.Error())
+			}
+			return InternalServerError(err.Payload.Message)
+		default:
+			return InternalServerError(err.Error())
+		}
+	}
+
+	// Once the container is removed, remove anonymous volumes (vc.Config.Volumes) if
+	// the remove flag is set.
+	if config.RemoveVolume && len(vc.Config.Volumes) > 0 {
+		removeAnonContainerVols(c.client, id, vc.Config.Volumes)
+	}
+
+	return nil
+}
+
 //----------
 // Utility Functions
 //----------
+
+// removeAnonContainerVols removes anonymous volumes joined to a container. It is invoked
+// once the said container has been removed. It fetches a list of volumes that are joined
+// to at least one other container, and calls the portlayer to remove this container's
+// anonymous volumes if they are dangling. Errors, if any, are only logged.
+func removeAnonContainerVols(pl *client.PortLayer, cID string, volumes map[string]struct{}) {
+	joinedVols, err := fetchJoinedVolumes()
+	if err != nil {
+		log.Warnf("Unable to obtain joined volumes from portlayer, skipping removing anonymous volumes for %s: %s", cID, err.Error())
+		return
+	}
+
+	for vol := range volumes {
+		// Extract the volume ID from the full mount path, which is of form "id:mountpath:flags" - see getMountString().
+		volFields := strings.SplitN(vol, ":", 2)
+		volName := volFields[0]
+		if _, joined := joinedVols[volName]; !joined {
+			_, err := pl.Storage.RemoveVolume(storage.NewRemoveVolumeParamsWithContext(ctx).WithName(volName))
+			if err != nil {
+				log.Debugf("Unable to remove anonymous volume %s in container %s: %s", volName, cID, err.Error())
+			}
+		}
+	}
+}
 
 func dockerContainerCreateParamsToTask(id string, cc types.ContainerCreateConfig) *tasks.JoinParams {
 	config := &models.TaskJoinConfig{}
@@ -1841,6 +1902,8 @@ func ContainerInfoToVicContainer(info models.ContainerInfo) *viccontainer.VicCon
 	return vc
 }
 
+// getMountString returns a colon-delimited string containing a volume's name/ID, mount
+// point and flags.
 func getMountString(mounts ...string) string {
 	return strings.Join(mounts, ":")
 }

--- a/lib/apiservers/engine/backends/container_test.go
+++ b/lib/apiservers/engine/backends/container_test.go
@@ -350,6 +350,10 @@ func (m *MockContainerProxy) Rename(vc *viccontainer.VicContainer, newName strin
 	return nil
 }
 
+func (m *MockContainerProxy) Remove(vc *viccontainer.VicContainer, config *types.ContainerRmConfig) error {
+	return nil
+}
+
 func (m *MockContainerProxy) AttachStreams(ctx context.Context, ac *AttachConfig, clStdin io.ReadCloser, clStdout, clStderr io.Writer) error {
 	return nil
 }

--- a/tests/test-cases/Group1-Docker-Commands/1-11-Docker-RM.md
+++ b/tests/test-cases/Group1-Docker-Commands/1-11-Docker-RM.md
@@ -26,9 +26,20 @@ This test requires that a vSphere server is running and available
 13. Remove the containerVM out-of-band using govc
 14. Issue docker rm test to the VIC appliance
 15. Issue docker rm to container created with an unknown executable
+16. Create a container with an anonymous and a named volume
+17. Issue docker rm -v to the container from Step 16
+18. Issue volume ls to the VIC appliance
+19. Create a container with an anonymous volume
+20. Create a container with Step 19's anonymous volume as a named volume
+21. Issue docker rm -v to the container from Step 19
+22. Issue volume ls to the VIC appliance
+23. Issue docker rm -v to the container from Step 20
+24. Issue volume ls to the VIC appliance
+25. Run a container with the volume from Step 19's volume
+26. Issue docker rm to the container from Step 25
 
 # Expected Outcome:
-* Steps 2-8,12,15 should complete without error
+* Steps 2-8,12,15-26 should complete without error
 * Step 3,6,10 should result in the container being removed from the VIC appliance
 * Step 9 should result in the following error:  
 ```
@@ -46,6 +57,9 @@ govc: ServerFaultCode: The method is disabled by 'VIC'
 ```
 Error response from daemon: No such container: test
 ```
+* Step 17's output should contain the named volume but not the anonymous volume from Step 16
+* Step 22's output should contain the volume used in steps 19 and 20
+* Step 24's output should contain the volume used in steps 19 and 20
 
 # Possible Problems:
 None

--- a/tests/test-cases/Group1-Docker-Commands/1-11-Docker-RM.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-11-Docker-RM.robot
@@ -108,3 +108,50 @@ Remove a container created with unknown executable
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} rm ${container}
     Should Be Equal As Integers  ${rc}  0
     Wait Until Keyword Succeeds  10x  6s  Check That VM Is Removed  ${container}
+
+Remove a container and its anonymous volumes
+    ${suffix}=  Evaluate  '%{DRONE_BUILD_NUMBER}-' + str(random.randint(1000,9999))  modules=random
+    Set Test Variable  ${namedvol}  namedvol-${suffix}
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} pull ${busybox}
+    Should Be Equal As Integers  ${rc}  0
+
+    # Verify that for a container with an anon and a named vol, only the anon vol gets removed
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} volume create ${namedvol}
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${c1}=  Run And Return Rc And Output  docker %{VCH-PARAMS} create -v /foo -v ${namedvol}:/bar ${busybox}
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} inspect ${c1} | jq -c '.[0].Mounts'
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${vol1}=  Run And Return Rc And Output  echo '${output}' | jq -r '.[0].Name'
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${vol2}=  Run And Return Rc And Output  echo '${output}' | jq -r '.[1].Name'
+    Should Be Equal As Integers  ${rc}  0
+    ${anonvol}=  Set Variable If  '${vol1}' == '${namedvol}'  ${vol2}  ${vol1}
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} rm -v ${c1}
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} volume ls
+    Should Be Equal As Integers  ${rc}  0
+    Should Not Contain  ${output}  ${anonvol}
+    Should Contain  ${output}  ${namedvol}
+
+    # Verify that for a container with an anon vol and another container with that vol as a named vol, the vol isn't removed
+    ${rc}  ${c2}=  Run And Return Rc And Output  docker %{VCH-PARAMS} create -v /foo ${busybox}
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${anonvol}=  Run And Return Rc And Output  docker %{VCH-PARAMS} inspect ${c2} | jq -r '.[0].Mounts[0].Name'
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${c3}=  Run And Return Rc And Output  docker %{VCH-PARAMS} create -v ${anonvol}:/bar ${busybox}
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} rm -v ${c2}
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} volume ls
+    Should Contain  ${output}  ${anonvol}
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} rm -v ${c3}
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} volume ls
+    Should Contain  ${output}  ${anonvol}
+
+    # Verify that the above volume can be used by containers
+    ${rc}  ${c4}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -d -v ${anonvol}:/bar ${busybox} /bin/ls
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} rm ${c4}
+    Should Be Equal As Integers  ${rc}  0


### PR DESCRIPTION
This commit adds support in the Docker personality for the 'docker rm
-v' command, which removes the container and also any anonymous
volumes joined to it. If an anonymous volume is in use by another
container, it is not removed. Named volumes (specified by name in the
create/run command) are not deleted.

Fixes #6262