### PR TITLE
Fix version file in VCH log bundle

### DIFF
--- a/cmd/vicadmin/vicadm.go
+++ b/cmd/vicadmin/vicadm.go
@@ -205,7 +205,7 @@ type versionReader string
 
 func (path versionReader) open() (entry, error) {
 	defer trace.End(trace.Begin(string(path)))
-	return newBytesEntry(string(path), []byte(version.Version)), nil
+	return newBytesEntry(string(path), []byte(version.GetBuild().ShortVersion())), nil
 }
 
 type commandReader string

--- a/cmd/vicadmin/vicadm_test.go
+++ b/cmd/vicadmin/vicadm_test.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"archive/tar"
+	"bytes"
 	"compress/gzip"
 	"crypto/tls"
 	"flag"
@@ -29,11 +30,13 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 
 	vchconfig "github.com/vmware/vic/lib/config"
+	"github.com/vmware/vic/pkg/version"
 	"github.com/vmware/vic/pkg/vsphere/test/env"
 )
 
@@ -290,4 +293,22 @@ func TestFindSeekPos(t *testing.T) {
 		log.Printf("Test case #%d: ", i)
 		testSeek(t, st, td)
 	}
+}
+
+func TestVersionReaderOpen(t *testing.T) {
+	version.Version = "1.2.1"
+	version.BuildNumber = "12345"
+	version.GitCommit = "abcdefg"
+
+	var vReader versionReader
+	en, err := vReader.open()
+	assert.NoError(t, err)
+	buf := new(bytes.Buffer)
+	buf.ReadFrom(en)
+	fullVersion := buf.String()
+	versionFields := strings.SplitN(fullVersion, "-", 3)
+	assert.Equal(t, len(versionFields), 3)
+	assert.Equal(t, versionFields[0], version.Version)
+	assert.Equal(t, versionFields[1], version.BuildNumber)
+	assert.Equal(t, versionFields[2], version.GitCommit)
 }


### PR DESCRIPTION
This commit fixes the contents of the VERSION file in the log bundle
downloaded from VCH admin. Previously, it contained only the git tag.
With this change, it contains the short version which is of the format
"gittag-buildnumber-commit".

Fixes #6688