### PR TITLE
Add operation id to vSphere calls

### DIFF
--- a/lib/apiservers/engine/backends/eventmonitor.go
+++ b/lib/apiservers/engine/backends/eventmonitor.go
@@ -39,6 +39,7 @@ import (
 	"github.com/vmware/vic/lib/apiservers/portlayer/client/events"
 	plevents "github.com/vmware/vic/lib/portlayer/event/events"
 	"github.com/vmware/vic/pkg/trace"
+	"github.com/vmware/vic/pkg/uid"
 )
 
 const (
@@ -211,19 +212,22 @@ func (m *PortlayerEventMonitor) monitor() error {
 	return nil
 }
 
-// publishEvent() translate a portlayer event into a Docker event if the event is for a
-// known container and publishes them to Docker event subscribers.
+// PublishEvent translates select portlayer container events into Docker events
+// and publishes to subscribers
 func (p DockerEventPublisher) PublishEvent(event plevents.BaseEvent) {
-	defer trace.End(trace.Begin(""))
+	// create a shortID for the container for logging purposes
+	containerShortID := uid.Parse(event.Ref).Truncate()
+	defer trace.End(trace.Begin(fmt.Sprintf("Event Monitor received eventID(%s) for container(%s) - %s", event.ID, containerShortID, event.Event)))
 
 	vc := cache.ContainerCache().GetContainer(event.Ref)
 	if vc == nil {
-		log.Warnf("Received portlayer event %s for container %s but not found in cache", event.Event, event.Ref)
+		log.Warnf("Event Monitor received eventID(%s) but container(%s) not in cache", event.ID, containerShortID)
 		return
 	}
 
+	// docker event attributes
 	var attrs map[string]string
-	// TODO: move to a container.OnEvent() so that container drives the necessary changes based on event activity
+
 	switch event.Event {
 	case plevents.ContainerStopped,
 		plevents.ContainerPoweredOff,
@@ -234,13 +238,13 @@ func (p DockerEventPublisher) PublishEvent(event plevents.BaseEvent) {
 			// get the containerEngine
 			code, _ := NewContainerBackend().containerProxy.exitCode(vc)
 
-			log.Infof("Sending die event for container %s - code: %s", vc.ContainerID, code)
+			log.Infof("Sending die event for container(%s) with exitCode[%s] - eventID(%s)", containerShortID, code, event.ID)
 			// if the docker client is unable to convert the code to an int the client will return 125
 			attrs["exitCode"] = code
 			actor := CreateContainerEventActorWithAttributes(vc, attrs)
 			EventService().Log(containerDieEvent, eventtypes.ContainerEventType, actor)
 			if err := UnmapPorts(vc.ContainerID, vc.HostConfig); err != nil {
-				log.Errorf("Failed to unmap ports for container %s: %s", vc.ContainerID, err)
+				log.Errorf("Event Monitor failed to unmap ports for container(%s): %s - eventID(%s)", containerShortID, err, event.ID)
 			}
 
 			// auto-remove if required
@@ -252,7 +256,7 @@ func (p DockerEventPublisher) PublishEvent(event plevents.BaseEvent) {
 
 				err := NewContainerBackend().ContainerRm(vc.Name, config)
 				if err != nil {
-					log.Errorf("Failed to remove container %s: %s", vc.ContainerID, err)
+					log.Errorf("Event Monitor failed to remove container(%s) - eventID(%s): %s", containerShortID, event.ID, err)
 				}
 			}
 		}()
@@ -262,7 +266,7 @@ func (p DockerEventPublisher) PublishEvent(event plevents.BaseEvent) {
 		actor := CreateContainerEventActorWithAttributes(vc, attrs)
 		EventService().Log(containerDestroyEvent, eventtypes.ContainerEventType, actor)
 		if err := UnmapPorts(vc.ContainerID, vc.HostConfig); err != nil {
-			log.Errorf("Failed to unmap ports for container %s: %s", vc.ContainerID, err)
+			log.Errorf("Event Monitor failed to unmap ports for container(%s): %s - eventID(%s)", containerShortID, err, event.ID)
 		}
 		// remove from the container cache...
 		cache.ContainerCache().DeleteContainer(vc.ContainerID)

--- a/lib/apiservers/portlayer/restapi/handlers/scopes_handlers.go
+++ b/lib/apiservers/portlayer/restapi/handlers/scopes_handlers.go
@@ -301,7 +301,8 @@ func (handler *ScopesHandlersImpl) ScopesBindContainer(params scopes.BindContain
 }
 
 func (handler *ScopesHandlersImpl) ScopesUnbindContainer(params scopes.UnbindContainerParams) middleware.Responder {
-	defer trace.End(trace.Begin(fmt.Sprintf("handle(%s)", params.Handle)))
+	op := trace.NewOperation(context.Background(), params.Handle)
+	defer trace.End(trace.Begin(fmt.Sprintf("handle(%s)", params.Handle), op))
 
 	h := exec.GetHandle(params.Handle)
 	if h == nil {
@@ -310,7 +311,7 @@ func (handler *ScopesHandlersImpl) ScopesUnbindContainer(params scopes.UnbindCon
 
 	var endpoints []*network.Endpoint
 	var err error
-	if endpoints, err = handler.netCtx.UnbindContainer(h); err != nil {
+	if endpoints, err = handler.netCtx.UnbindContainer(op, h); err != nil {
 		switch err := err.(type) {
 		case network.ResourceNotFoundError:
 			return scopes.NewUnbindContainerNotFound().WithPayload(errorPayload(err))

--- a/lib/install/management/debug.go
+++ b/lib/install/management/debug.go
@@ -29,12 +29,9 @@ import (
 func (d *Dispatcher) DebugVCH(vch *vm.VirtualMachine, conf *config.VirtualContainerHostConfigSpec, password, authorizedKey string) error {
 	defer trace.End(trace.Begin(conf.Name))
 
-	op, err := trace.FromContext(d.ctx)
-	if err != nil {
-		op = trace.NewOperation(d.ctx, "enable appliance debug")
-	}
+	op := trace.FromContext(d.ctx, "enable appliance debug")
 
-	err = d.enableSSH(op, vch, password, authorizedKey)
+	err := d.enableSSH(op, vch, password, authorizedKey)
 	if err != nil {
 		op.Errorf("Unable to enable ssh on the VCH appliance VM: %s", err)
 		return err
@@ -46,10 +43,7 @@ func (d *Dispatcher) DebugVCH(vch *vm.VirtualMachine, conf *config.VirtualContai
 }
 
 func (d *Dispatcher) enableSSH(ctx context.Context, vch *vm.VirtualMachine, password, authorizedKey string) error {
-	op, err := trace.FromContext(ctx)
-	if err != nil {
-		op = trace.NewOperation(ctx, "enable ssh in appliance")
-	}
+	op := trace.FromContext(ctx, "enable ssh in appliance")
 
 	state, err := vch.PowerState(op)
 	if err != nil {
@@ -68,7 +62,7 @@ func (d *Dispatcher) enableSSH(ctx context.Context, vch *vm.VirtualMachine, pass
 		return err
 	}
 
-	pm, err := d.opManager(ctx, vch)
+	pm, err := d.opManager(op, vch)
 	if err != nil {
 		err = errors.Errorf("Unable to manage processes in appliance VM: %s", err)
 		op.Errorf("%s", err)
@@ -89,7 +83,7 @@ func (d *Dispatcher) enableSSH(ctx context.Context, vch *vm.VirtualMachine, pass
 		return err
 	}
 
-	_, err = d.opManagerWait(ctx, pm, &auth, pid)
+	_, err = d.opManagerWait(op, pm, &auth, pid)
 	if err != nil {
 		err = errors.Errorf("Unable to check enable SSH status: %s", err)
 		op.Errorf("%s", err)
@@ -113,7 +107,7 @@ func (d *Dispatcher) enableSSH(ctx context.Context, vch *vm.VirtualMachine, pass
 		return err
 	}
 
-	_, err = d.opManagerWait(ctx, pm, &auth, pid)
+	_, err = d.opManagerWait(op, pm, &auth, pid)
 	if err != nil {
 		err = errors.Errorf("Unable to check enable passwd status: %s", err)
 		op.Errorf("%s", err)

--- a/lib/migration/migrator.go
+++ b/lib/migration/migrator.go
@@ -16,7 +16,6 @@ package migration
 
 import (
 	"context"
-	"fmt"
 	"strconv"
 
 	"github.com/vmware/vic/lib/migration/errors"
@@ -24,7 +23,6 @@ import (
 	"github.com/vmware/vic/lib/migration/manager"
 	// imported for the side effect
 	_ "github.com/vmware/vic/lib/migration/plugins"
-	"github.com/vmware/vic/pkg/trace"
 	"github.com/vmware/vic/pkg/vsphere/session"
 )
 
@@ -74,7 +72,6 @@ func dataIsOlder(data map[string]string, target string, verKey string) (bool, er
 }
 
 func migrateConfig(ctx context.Context, s *session.Session, data map[string]string, target string, verKey string) (map[string]string, bool, error) {
-	defer trace.End(trace.Begin(fmt.Sprintf("target: %s, version key: %s", target, verKey)))
 
 	dst := make(map[string]string)
 	for k, v := range data {

--- a/lib/portlayer/event/collector/vsphere/vm_event.go
+++ b/lib/portlayer/event/collector/vsphere/vm_event.go
@@ -15,9 +15,11 @@
 package vsphere
 
 import (
-	"github.com/vmware/vic/lib/portlayer/event/events"
+	"strconv"
 
 	"github.com/vmware/govmomi/vim25/types"
+
+	"github.com/vmware/vic/lib/portlayer/event/events"
 )
 
 type VMEvent struct {
@@ -52,7 +54,7 @@ func NewVMEvent(be types.BaseEvent) *VMEvent {
 	return &VMEvent{
 		&events.BaseEvent{
 			Event:       ee,
-			ID:          int(e.Key),
+			ID:          strconv.Itoa(int(e.Key)),
 			Detail:      e.FullFormattedMessage,
 			Ref:         e.Vm.Vm.String(),
 			CreatedTime: e.CreatedTime,

--- a/lib/portlayer/event/collector/vsphere/vm_event_test.go
+++ b/lib/portlayer/event/collector/vsphere/vm_event_test.go
@@ -15,6 +15,7 @@
 package vsphere
 
 import (
+	"strconv"
 	"testing"
 	"time"
 
@@ -34,7 +35,7 @@ func TestNewEvent(t *testing.T) {
 	assert.NotNil(t, vme)
 	assert.Equal(t, events.ContainerPoweredOn, vme.String())
 	assert.Equal(t, vm.String(), vme.Reference())
-	assert.Equal(t, k, vme.EventID())
+	assert.Equal(t, strconv.Itoa(k), vme.EventID())
 	assert.Equal(t, msg, vme.Message())
 	assert.Equal(t, "vsphere.VMEvent", vme.Topic())
 	assert.Equal(t, tt, vme.Created())

--- a/lib/portlayer/event/events/base_event.go
+++ b/lib/portlayer/event/events/base_event.go
@@ -26,13 +26,13 @@ type EventType string
 type BaseEvent struct {
 	Type        EventType
 	Event       string
-	ID          int
+	ID          string
 	Detail      string
 	Ref         string
 	CreatedTime time.Time
 }
 
-func (be *BaseEvent) EventID() int {
+func (be *BaseEvent) EventID() string {
 	return be.ID
 }
 
@@ -48,6 +48,7 @@ func (be *BaseEvent) Message() string {
 func (be *BaseEvent) Reference() string {
 	return be.Ref
 }
+
 func (be *BaseEvent) Created() time.Time {
 	return be.CreatedTime
 }

--- a/lib/portlayer/event/events/base_event_test.go
+++ b/lib/portlayer/event/events/base_event_test.go
@@ -30,13 +30,13 @@ func TestNewEventType(t *testing.T) {
 func TestBaseEvent(t *testing.T) {
 	be := &BaseEvent{
 		Event:  "PoweredOn",
-		ID:     12,
+		ID:     "12",
 		Detail: "VM 123 PoweredOn",
 		Ref:    "vm:12",
 	}
 
 	assert.Equal(t, "PoweredOn", be.String())
-	assert.Equal(t, 12, be.EventID())
+	assert.Equal(t, "12", be.EventID())
 	assert.Equal(t, "VM 123 PoweredOn", be.Message())
 	assert.Equal(t, "vm:12", be.Reference())
 

--- a/lib/portlayer/event/events/events.go
+++ b/lib/portlayer/event/events/events.go
@@ -21,7 +21,7 @@ import (
 type Event interface {
 	EventTopic
 	// id of event
-	EventID() int
+	EventID() string
 	// event (PowerOn, PowerOff, etc)
 	String() string
 	// reference evented object

--- a/lib/portlayer/event/manager.go
+++ b/lib/portlayer/event/manager.go
@@ -18,11 +18,11 @@ import (
 	"fmt"
 	"sync"
 
-	log "github.com/Sirupsen/logrus"
-
 	"github.com/vmware/vic/lib/portlayer/event/collector"
 	"github.com/vmware/vic/lib/portlayer/event/events"
 	"github.com/vmware/vic/pkg/trace"
+
+	log "github.com/Sirupsen/logrus"
 )
 
 type Manager struct {
@@ -69,10 +69,10 @@ func NewEventManager(collectors ...collector.Collector) *Manager {
 			subs := mgr.subs.subscribers[e.Topic()]
 			mgr.subs.mu.RUnlock()
 
-			log.Debugf("Found %d subscribers to id: %d - %s: %s", len(subs), e.EventID(), e.Topic(), e.Message())
+			log.Debugf("Found %d subscribers to %s: %s - %s", len(subs), e.EventID(), e.Topic(), e.Message())
 
 			for sub, s := range subs {
-				log.Debugf("Event manager calling back to %s for %d - %s: %s", sub, e.EventID(), e.Topic(), e.Message())
+				log.Debugf("Event manager calling back to %s for Event(%s): %s", sub, e.EventID(), e.Topic())
 				s.onEvent(e)
 			}
 		}

--- a/lib/portlayer/event/subscriber_test.go
+++ b/lib/portlayer/event/subscriber_test.go
@@ -15,7 +15,7 @@
 package event
 
 import (
-	"fmt"
+	"strconv"
 	"testing"
 	"time"
 
@@ -61,17 +61,17 @@ func (m *mockCollector) Name() string {
 }
 
 type mockEvent struct {
-	id int
+	id string
 }
 
 // id of event
-func (e *mockEvent) EventID() int {
+func (e *mockEvent) EventID() string {
 	return e.id
 }
 
 // event (PowerOn, PowerOff, etc)
 func (e *mockEvent) String() string {
-	return fmt.Sprintf("%d", e.id)
+	return e.id
 }
 
 // reference evented object
@@ -111,7 +111,7 @@ func TestSuspendQueue(t *testing.T) {
 			assert.True(t, s.IsSuspended())
 			suspended = true
 		}
-		c.c(&mockEvent{id: i})
+		c.c(&mockEvent{id: strconv.Itoa(i)})
 	}
 
 	select {
@@ -155,7 +155,7 @@ func TestSuspendDiscard(t *testing.T) {
 	s.Suspend(false)
 	assert.True(t, s.IsSuspended())
 	for i := 0; i < 50; i++ {
-		c.c(&mockEvent{id: i})
+		c.c(&mockEvent{id: strconv.Itoa(i)})
 	}
 
 	<-time.After(5 * time.Second)
@@ -180,7 +180,7 @@ func TestSuspendOverflow(t *testing.T) {
 	s.Suspend(true)
 	assert.True(t, s.IsSuspended())
 	for i := 0; i < maxEventQueueSize+1; i++ {
-		c.c(&mockEvent{id: i})
+		c.c(&mockEvent{id: strconv.Itoa(i)})
 	}
 
 	select {

--- a/lib/portlayer/exec/base.go
+++ b/lib/portlayer/exec/base.go
@@ -33,8 +33,6 @@ import (
 	"github.com/vmware/vic/pkg/vsphere/extraconfig/vmomi"
 	"github.com/vmware/vic/pkg/vsphere/tasks"
 	"github.com/vmware/vic/pkg/vsphere/vm"
-
-	log "github.com/Sirupsen/logrus"
 )
 
 // NotYetExistError is returned when a call that requires a VM exist is made
@@ -104,10 +102,10 @@ func (c *containerBase) VMReference() types.ManagedObjectReference {
 }
 
 // unlocked refresh of container state
-func (c *containerBase) refresh(ctx context.Context) error {
-	base, err := c.updates(ctx)
+func (c *containerBase) refresh(op trace.Operation) error {
+	base, err := c.updates(op)
 	if err != nil {
-		log.Errorf("Update: unable to update container %s: %s", c, err)
+		op.Errorf("Update: unable to update container %s: %s", c, err)
 		return err
 	}
 
@@ -117,8 +115,8 @@ func (c *containerBase) refresh(ctx context.Context) error {
 }
 
 // updates acquires updates from the infrastructure without holding a lock
-func (c *containerBase) updates(ctx context.Context) (*containerBase, error) {
-	defer trace.End(trace.Begin(c.ExecConfig.ID))
+func (c *containerBase) updates(op trace.Operation) (*containerBase, error) {
+	defer trace.End(trace.Begin(c.ExecConfig.ID, op))
 
 	var o mo.VirtualMachine
 
@@ -128,10 +126,10 @@ func (c *containerBase) updates(ctx context.Context) (*containerBase, error) {
 	}
 
 	if c.Config != nil {
-		log.Debugf("Update: for %s, refreshing from change version %s", c, c.Config.ChangeVersion)
+		op.Debugf("Update: for %s, refreshing from change version %s", c, c.Config.ChangeVersion)
 	}
 
-	if err := c.vm.Properties(ctx, c.vm.Reference(), []string{"config", "runtime"}, &o); err != nil {
+	if err := c.vm.Properties(op, c.vm.Reference(), []string{"config", "runtime"}, &o); err != nil {
 		return nil, err
 	}
 
@@ -149,7 +147,7 @@ func (c *containerBase) updates(ctx context.Context) (*containerBase, error) {
 		return nil, fmt.Errorf("Update: change version %s failed assertion extraconfig id != nil", o.Config.ChangeVersion)
 	}
 
-	log.Debugf("Update: for %s, change version %s, extraconfig id: %+v", c, o.Config.ChangeVersion, containerExecKeyValues["guestinfo.vice./common/id"])
+	op.Debugf("Update: for %s, change version %s, extraconfig id: %+v", c, o.Config.ChangeVersion, containerExecKeyValues["guestinfo.vice./common/id"])
 	// #nosec: Errors unhandled.
 	base.DataVersion, _ = migration.ContainerDataVersion(containerExecKeyValues)
 	migratedConf, base.Migrated, base.MigrationError = migration.MigrateContainerConfig(containerExecKeyValues)
@@ -158,35 +156,35 @@ func (c *containerBase) updates(ctx context.Context) (*containerBase, error) {
 	return base, nil
 }
 
-func (c *containerBase) ReloadConfig(ctx context.Context) error {
-	defer trace.End(trace.Begin(c.ExecConfig.ID))
+func (c *containerBase) ReloadConfig(op trace.Operation) error {
+	defer trace.End(trace.Begin(c.ExecConfig.ID, op))
 
-	return c.startGuestProgram(ctx, "reload", "")
+	return c.startGuestProgram(op, "reload", "")
 }
 
 // WaitForExec waits exec'ed task to set started field or timeout
-func (c *containerBase) WaitForExec(ctx context.Context, id string) error {
-	defer trace.End(trace.Begin(id))
+func (c *containerBase) WaitForExec(op trace.Operation, id string) error {
+	defer trace.End(trace.Begin(id, op))
 
-	return c.waitForExec(ctx, id)
+	return c.waitForExec(op, id)
 }
 
 // WaitForSession waits non-exec'ed task to set started field or timeout
 func (c *containerBase) WaitForSession(ctx context.Context, id string) error {
-	defer trace.End(trace.Begin(id))
+	defer trace.End(trace.Begin(id, ctx))
 
 	return c.waitForSession(ctx, id)
 }
 
-func (c *containerBase) startGuestProgram(ctx context.Context, name string, args string) error {
+func (c *containerBase) startGuestProgram(op trace.Operation, name string, args string) error {
 	// make sure we have vm
 	if c.vm == nil {
 		return NotYetExistError{c.ExecConfig.ID}
 	}
 
-	defer trace.End(trace.Begin(c.ExecConfig.ID + ":" + name))
+	defer trace.End(trace.Begin(c.ExecConfig.ID+":"+name, op))
 	o := guest.NewOperationsManager(c.vm.Client.Client, c.vm.Reference())
-	m, err := o.ProcessManager(ctx)
+	m, err := o.ProcessManager(op)
 	if err != nil {
 		return err
 	}
@@ -200,13 +198,13 @@ func (c *containerBase) startGuestProgram(ctx context.Context, name string, args
 		Username: c.ExecConfig.ID,
 	}
 
-	_, err = m.StartProgram(ctx, &auth, &spec)
+	_, err = m.StartProgram(op, &auth, &spec)
 
 	return err
 }
 
-func (c *containerBase) start(ctx context.Context) error {
-	defer trace.End(trace.Begin(c.ExecConfig.ID))
+func (c *containerBase) start(op trace.Operation) error {
+	defer trace.End(trace.Begin(c.ExecConfig.ID, op))
 
 	// make sure we have vm
 	if c.vm == nil {
@@ -214,14 +212,14 @@ func (c *containerBase) start(ctx context.Context) error {
 	}
 
 	// Power on
-	_, err := c.vm.WaitForResult(ctx, func(ctx context.Context) (tasks.Task, error) {
-		return c.vm.PowerOn(ctx)
+	_, err := c.vm.WaitForResult(op, func(op context.Context) (tasks.Task, error) {
+		return c.vm.PowerOn(op)
 	})
 
 	return err
 }
 
-func (c *containerBase) stop(ctx context.Context, waitTime *int32) error {
+func (c *containerBase) stop(op trace.Operation, waitTime *int32) error {
 	// make sure we have vm
 	if c.vm == nil {
 		return NotYetExistError{c.ExecConfig.ID}
@@ -230,35 +228,35 @@ func (c *containerBase) stop(ctx context.Context, waitTime *int32) error {
 	// get existing state and set to stopping
 	// if there's a failure we'll revert to existing
 
-	err := c.shutdown(ctx, waitTime)
+	err := c.shutdown(op, waitTime)
 	if err == nil {
 		return nil
 	}
 
-	log.Warnf("stopping %s via hard power off due to: %s", c, err)
+	op.Warnf("stopping %s via hard power off due to: %s", c, err.Error())
 
-	return c.poweroff(ctx)
+	return c.poweroff(op)
 }
 
-func (c *containerBase) kill(ctx context.Context) error {
+func (c *containerBase) kill(op trace.Operation) error {
 	// make sure we have vm
 	if c.vm == nil {
 		return NotYetExistError{c.ExecConfig.ID}
 	}
 
 	wait := 10 * time.Second // default
-	timeout, cancel := context.WithTimeout(ctx, wait)
+	timeout, cancel := trace.WithTimeout(&op, wait, "kill")
 	defer cancel()
 
 	sig := string(ssh.SIGKILL)
-	log.Infof("sending kill -%s %s", sig, c)
+	timeout.Infof("sending kill -%s %s", sig, c)
 
 	err := c.startGuestProgram(timeout, "kill", sig)
 	if err == nil && timeout.Err() != nil {
-		log.Warnf("timeout (%s) waiting for %s to power off via SIG%s", wait, c, sig)
+		timeout.Warnf("timeout (%s) waiting for %s to power off via SIG%s", wait, c, sig)
 	}
 	if err != nil {
-		log.Warnf("killing %s attempt resulted in: %s", c, err)
+		timeout.Warnf("killing %s attempt resulted in: %s", c, err.Error())
 
 		if isInvalidPowerStateError(err) {
 			return nil
@@ -271,19 +269,19 @@ func (c *containerBase) kill(ctx context.Context) error {
 	// into an invalid transition and will need to recover.  If we try to grab properties at this time, the
 	// power state may be incorrect.  We work around this by waiting on the power state, regardless of error
 	// from startGuestProgram. https://github.com/vmware/vic/issues/5803
-	log.Infof("waiting %s for %s to power off", wait, c)
+	timeout.Infof("waiting %s for %s to power off", wait, c)
 	err = c.vm.WaitForPowerState(timeout, types.VirtualMachinePowerStatePoweredOff)
 	if err == nil {
 		return nil // VM has powered off
 	}
 
-	log.Warnf("killing %s via hard power off", c)
+	timeout.Warnf("killing %s via hard power off", c)
 
 	// stop wait time is not applied for the hard kill
-	return c.poweroff(ctx)
+	return c.poweroff(op)
 }
 
-func (c *containerBase) shutdown(ctx context.Context, waitTime *int32) error {
+func (c *containerBase) shutdown(op trace.Operation, waitTime *int32) error {
 	// make sure we have vm
 	if c.vm == nil {
 		return NotYetExistError{c.ExecConfig.ID}
@@ -304,16 +302,16 @@ func (c *containerBase) shutdown(ctx context.Context, waitTime *int32) error {
 
 	for _, sig := range stop {
 		msg := fmt.Sprintf("sending kill -%s %s", sig, c)
-		log.Info(msg)
+		op.Infof(msg)
 
-		timeout, cancel := context.WithTimeout(ctx, wait)
+		timeout, cancel := trace.WithTimeout(&op, wait, "shutdown")
 		defer cancel()
 
 		err := c.startGuestProgram(timeout, "kill", sig)
 		if err != nil {
 			// Just warn and proceed to waiting for power state per issue https://github.com/vmware/vic/issues/5803
 			// Description above in function kill()
-			log.Warnf("%s: %s", msg, err)
+			timeout.Warnf("%s: %s", msg, err)
 
 			// If the error tells us "The attempted operation cannot be performed in the current state (Powered off)" (InvalidPowerState),
 			// we can avoid hard poweroff (issues #6236 and #6252). Here we wait for the power state changes instead of return
@@ -323,7 +321,7 @@ func (c *containerBase) shutdown(ctx context.Context, waitTime *int32) error {
 			}
 		}
 
-		log.Infof("waiting %s for %s to power off", wait, c)
+		timeout.Infof("waiting %s for %s to power off", wait, c)
 		err = c.vm.WaitForPowerState(timeout, types.VirtualMachinePowerStatePoweredOff)
 		if err == nil {
 			return nil // VM has powered off
@@ -333,7 +331,7 @@ func (c *containerBase) shutdown(ctx context.Context, waitTime *int32) error {
 			return err // error other than timeout
 		}
 
-		log.Warnf("timeout (%s) waiting for %s to power off via SIG%s", wait, c, sig)
+		timeout.Warnf("timeout (%s) waiting for %s to power off via SIG%s", wait, c, sig)
 
 		if killed {
 			return nil
@@ -343,14 +341,14 @@ func (c *containerBase) shutdown(ctx context.Context, waitTime *int32) error {
 	return fmt.Errorf("failed to shutdown %s via kill signals %s", c, stop)
 }
 
-func (c *containerBase) poweroff(ctx context.Context) error {
+func (c *containerBase) poweroff(op trace.Operation) error {
 	// make sure we have vm
 	if c.vm == nil {
 		return NotYetExistError{c.ExecConfig.ID}
 	}
 
-	_, err := c.vm.WaitForResult(ctx, func(ctx context.Context) (tasks.Task, error) {
-		return c.vm.PowerOff(ctx)
+	_, err := c.vm.WaitForResult(op, func(op context.Context) (tasks.Task, error) {
+		return c.vm.PowerOff(op)
 	})
 
 	if err != nil {
@@ -360,10 +358,10 @@ func (c *containerBase) poweroff(ctx context.Context) error {
 			switch terr := terr.Fault().(type) {
 			case *types.InvalidPowerState:
 				if terr.ExistingState == types.VirtualMachinePowerStatePoweredOff {
-					log.Warnf("power off %s task skipped (state was already %s)", c, terr.ExistingState)
+					op.Warnf("power off %s task skipped (state was already %s)", c, terr.ExistingState)
 					return nil
 				}
-				log.Warnf("invalid power state during power off: %s", terr.ExistingState)
+				op.Warnf("invalid power state during power off: %s", terr.ExistingState)
 
 			case *types.GenericVmConfigFault:
 
@@ -371,14 +369,14 @@ func (c *containerBase) poweroff(ctx context.Context) error {
 				if len(terr.FaultMessage) > 0 {
 					k := terr.FaultMessage[0].Key
 					if k == vmNotSuspendedKey || k == vmPoweringOffKey {
-						log.Infof("power off %s task skipped due to guest shutdown", c)
+						op.Infof("power off %s task skipped due to guest shutdown", c)
 						return nil
 					}
 				}
-				log.Warnf("generic vm config fault during power off: %#v", terr)
+				op.Warnf("generic vm config fault during power off: %#v", terr)
 
 			default:
-				log.Warnf("hard power off failed due to: %#v", terr)
+				op.Warnf("hard power off failed due to: %#v", terr)
 			}
 		}
 
@@ -389,7 +387,7 @@ func (c *containerBase) poweroff(ctx context.Context) error {
 }
 
 func (c *containerBase) waitForPowerState(ctx context.Context, max time.Duration, state types.VirtualMachinePowerState) (bool, error) {
-	defer trace.End(trace.Begin(c.ExecConfig.ID))
+	defer trace.End(trace.Begin(c.ExecConfig.ID, ctx))
 
 	timeout, cancel := context.WithTimeout(ctx, max)
 	defer cancel()
@@ -403,19 +401,19 @@ func (c *containerBase) waitForPowerState(ctx context.Context, max time.Duration
 }
 
 func (c *containerBase) waitForSession(ctx context.Context, id string) error {
-	defer trace.End(trace.Begin(id))
+	defer trace.End(trace.Begin(id, ctx))
 
 	// guestinfo key that we want to wait for
 	key := extraconfig.CalculateKeys(c.ExecConfig, fmt.Sprintf("Sessions.%s.Started", id), "")[0]
 	return c.waitFor(ctx, key)
 }
 
-func (c *containerBase) waitForExec(ctx context.Context, id string) error {
-	defer trace.End(trace.Begin(id))
+func (c *containerBase) waitForExec(op trace.Operation, id string) error {
+	defer trace.End(trace.Begin(id, op))
 
 	// guestinfo key that we want to wait for
 	key := extraconfig.CalculateKeys(c.ExecConfig, fmt.Sprintf("Execs.%s.Started", id), "")[0]
-	return c.waitFor(ctx, key)
+	return c.waitFor(op, key)
 }
 
 func (c *containerBase) waitFor(ctx context.Context, key string) error {

--- a/lib/portlayer/exec/commit.go
+++ b/lib/portlayer/exec/commit.go
@@ -27,13 +27,11 @@ import (
 	"github.com/vmware/vic/pkg/vsphere/session"
 	"github.com/vmware/vic/pkg/vsphere/tasks"
 	"github.com/vmware/vic/pkg/vsphere/vm"
-
-	log "github.com/Sirupsen/logrus"
 )
 
 // Commit executes the requires steps on the handle
-func Commit(ctx context.Context, sess *session.Session, h *Handle, waitTime *int32) error {
-	defer trace.End(trace.Begin(h.ExecConfig.ID))
+func Commit(op trace.Operation, sess *session.Session, h *Handle, waitTime *int32) error {
+	defer trace.End(trace.Begin(h.ExecConfig.ID, op))
 
 	c := Containers.Container(h.ExecConfig.ID)
 	creation := h.vm == nil
@@ -60,27 +58,27 @@ func Commit(ctx context.Context, sess *session.Session, h *Handle, waitTime *int
 		var err error
 		if sess.IsVC() && Config.VirtualApp.ResourcePool != nil {
 			// Create the vm
-			res, err = tasks.WaitForResult(ctx, func(ctx context.Context) (tasks.Task, error) {
-				return Config.VirtualApp.CreateChildVM(ctx, *h.Spec.Spec(), nil)
+			res, err = tasks.WaitForResult(op, func(op context.Context) (tasks.Task, error) {
+				return Config.VirtualApp.CreateChildVM(op, *h.Spec.Spec(), nil)
 			})
 		} else {
 			// Create the vm
-			res, err = tasks.WaitForResult(ctx, func(ctx context.Context) (tasks.Task, error) {
-				return sess.VMFolder.CreateVM(ctx, *h.Spec.Spec(), Config.ResourcePool, nil)
+			res, err = tasks.WaitForResult(op, func(op context.Context) (tasks.Task, error) {
+				return sess.VMFolder.CreateVM(op, *h.Spec.Spec(), Config.ResourcePool, nil)
 			})
 		}
 
 		if err != nil {
-			log.Errorf("An error occurred while waiting for a creation operation to complete. Spec was %+v", *h.Spec.Spec())
+			op.Errorf("An error occurred while waiting for a creation operation to complete. Spec was %+v", *h.Spec.Spec())
 			return err
 		}
 
-		h.vm = vm.NewVirtualMachine(ctx, sess, res.Result.(types.ManagedObjectReference))
-		h.vm.DisableDestroy(ctx)
+		h.vm = vm.NewVirtualMachine(op, sess, res.Result.(types.ManagedObjectReference))
+		h.vm.DisableDestroy(op)
 		c = newContainer(&h.containerBase)
 		Containers.Put(c)
 		// inform of creation irrespective of remaining operations
-		publishContainerEvent(c.ExecConfig.ID, time.Now().UTC(), events.ContainerCreated)
+		publishContainerEvent(op, c.ExecConfig.ID, time.Now().UTC(), events.ContainerCreated)
 
 		// clear the spec as we've acted on it - this prevents a reconfigure from occurring in follow-on
 		// processing
@@ -90,32 +88,32 @@ func Commit(ctx context.Context, sess *session.Session, h *Handle, waitTime *int
 	// if we're stopping the VM, do so before the reconfigure to preserve the extraconfig
 	if h.TargetState() == StateStopped {
 		if h.Runtime == nil {
-			log.Warnf("Commit called with incomplete runtime state for %s", h.ExecConfig.ID)
+			op.Warnf("Commit called with incomplete runtime state for %s", h.ExecConfig.ID)
 		}
 
 		if h.Runtime != nil && h.Runtime.PowerState == types.VirtualMachinePowerStatePoweredOff {
-			log.Infof("Dropping duplicate power off operation for %s", h.ExecConfig.ID)
+			op.Infof("Dropping duplicate power off operation for %s", h.ExecConfig.ID)
 		} else {
 			// stop the container
-			if err := c.stop(ctx, waitTime); err != nil {
+			if err := c.stop(op, waitTime); err != nil {
 				return err
 			}
 
 			// we must refresh now to get the new ChangeVersion - this is used to gate on powerstate in the reconfigure
 			// because we cannot set the ExtraConfig if the VM is powered on. There is still a race here unfortunately because
 			// tasks don't appear to contain the new ChangeVersion
-			h.refresh(ctx)
+			h.refresh(op)
 
 			// inform of state change irrespective of remaining operations - but allow remaining operations to complete first
 			// to avoid data race on container config
-			defer publishContainerEvent(h.ExecConfig.ID, time.Now().UTC(), events.ContainerStopped)
+			defer publishContainerEvent(op, h.ExecConfig.ID, time.Now().UTC(), events.ContainerStopped)
 		}
 	}
 
 	// reconfigure operation
 	if h.Spec != nil {
 		if h.Runtime == nil {
-			log.Errorf("Refusing to perform reconfigure operation with incomplete runtime state for %s", h.ExecConfig.ID)
+			op.Errorf("Refusing to perform reconfigure operation with incomplete runtime state for %s", h.ExecConfig.ID)
 		} else {
 			// ensure that our logic based on Runtime state remains valid
 
@@ -126,40 +124,40 @@ func Commit(ctx context.Context, sess *session.Session, h *Handle, waitTime *int
 			// For the power off path this depends on handle.refresh() having been called to update the ChangeVersion
 			s := h.Spec.Spec()
 
-			log.Infof("Reconfigure: attempting update to %s with change version %q (%s)", h.ExecConfig.ID, s.ChangeVersion, h.Runtime.PowerState)
+			op.Infof("Reconfigure: attempting update to %s with change version %q (%s)", h.ExecConfig.ID, s.ChangeVersion, h.Runtime.PowerState)
 
 			// nilify ExtraConfig if container configuration is migrated
 			// in this case, VCH and container are in different version. Migrated configuration cannot be written back to old container, to avoid data loss in old version's container
 			if h.Migrated {
-				log.Debugf("Reconfigure: dropping extraconfig as configuration of container %s is migrated", h.ExecConfig.ID)
+				op.Debugf("Reconfigure: dropping extraconfig as configuration of container %s is migrated", h.ExecConfig.ID)
 				s.ExtraConfig = nil
 			}
 
 			// address the race between power operation and refresh of config (and therefore ChangeVersion) in StateStopped block above
 			if s.ExtraConfig != nil && h.TargetState() == StateStopped && h.Runtime.PowerState != types.VirtualMachinePowerStatePoweredOff {
 				detail := fmt.Sprintf("Reconfigure: collision of concurrent operations - expected power state poweredOff, found %s", h.Runtime.PowerState)
-				log.Warn(detail)
+				op.Warnf(detail)
 
 				// log out current vm power state and runtime power state got from refresh, to see if there is anything mismatch,
 				// cause in issue #6127, we see the runtime power state is not updated even after 1 minute
-				ps, _ := h.vm.PowerState(ctx)
-				log.Debugf("Container %s power state: %s, runtime power state: %s", h.ExecConfig.ID, ps, h.Runtime.PowerState)
+				ps, _ := h.vm.PowerState(op)
+				op.Debugf("Container %s power state: %s, runtime power state: %s", h.ExecConfig.ID, ps, h.Runtime.PowerState)
 				// this should cause a second attempt at the power op. This could result repeated contention that fails to resolve, but the randomness in the backoff and the tight timing
 				// to hit this scenario should mean it will resolve in a reasonable timeframe.
 				return ConcurrentAccessError{errors.New(detail)}
 			}
 
-			_, err := h.vm.WaitForResult(ctx, func(ctx context.Context) (tasks.Task, error) {
-				return h.vm.Reconfigure(ctx, *s)
+			_, err := h.vm.WaitForResult(op, func(op context.Context) (tasks.Task, error) {
+				return h.vm.Reconfigure(op, *s)
 			})
 			if err != nil {
-				log.Errorf("Reconfigure: failed update to %s with change version %s: %+v", h.ExecConfig.ID, s.ChangeVersion, err)
+				op.Errorf("Reconfigure: failed update to %s with change version %s: %+v", h.ExecConfig.ID, s.ChangeVersion, err)
 
 				// Check whether we get ConcurrentAccess and wrap it if needed
 				if f, ok := err.(types.HasFault); ok {
 					switch f.Fault().(type) {
 					case *types.ConcurrentAccess:
-						log.Errorf("Reconfigure: failed update to %s due to ConcurrentAccess, our change version %s", h.ExecConfig.ID, s.ChangeVersion)
+						op.Errorf("Reconfigure: failed update to %s due to ConcurrentAccess, our change version %s", h.ExecConfig.ID, s.ChangeVersion)
 
 						return ConcurrentAccessError{err}
 					}
@@ -167,10 +165,10 @@ func Commit(ctx context.Context, sess *session.Session, h *Handle, waitTime *int
 				return err
 			}
 
-			log.Infof("Reconfigure: committed update to %s with change version: %s", h.ExecConfig.ID, s.ChangeVersion)
+			op.Infof("Reconfigure: committed update to %s with change version: %s", h.ExecConfig.ID, s.ChangeVersion)
 
 			// trigger a configuration reload in the container if needed
-			err = reloadConfig(ctx, h, c)
+			err = reloadConfig(op, h, c)
 			if err != nil {
 				return err
 			}
@@ -180,31 +178,31 @@ func Commit(ctx context.Context, sess *session.Session, h *Handle, waitTime *int
 	// best effort update of container cache using committed state - this will not reflect the power on below, however
 	// this is primarily for updating ExtraConfig state.
 	if !creation {
-		defer c.RefreshFromHandle(ctx, h)
+		defer c.RefreshFromHandle(op, h)
 	}
 
 	if h.TargetState() == StateRunning {
 		if h.Runtime != nil && h.Runtime.PowerState == types.VirtualMachinePowerStatePoweredOn {
-			log.Infof("Dropping duplicate power on operation for %s", h.ExecConfig.ID)
+			op.Infof("Dropping duplicate power on operation for %s", h.ExecConfig.ID)
 			return nil
 		}
 
 		if h.Runtime == nil && !creation {
-			log.Warnf("Commit called with incomplete runtime state for %s", h.ExecConfig.ID)
+			op.Warnf("Commit called with incomplete runtime state for %s", h.ExecConfig.ID)
 		}
 
 		// start the container
-		if err := c.start(ctx); err != nil {
+		if err := c.start(op); err != nil {
 			// We observed that PowerOn_Task could get stuck on VC time to time even though the VM was starting fine on the host ESXi.
 			// Eventually the task was getting timed out (After 20 min.) and that was setting the container state back to Stopped.
 			// During that time VC was not generating any other event so the persona listener was getting nothing.
 			// This new event is for signaling the eventmonitor so that it can autoremove the container after this failure.
-			publishContainerEvent(h.ExecConfig.ID, time.Now().UTC(), events.ContainerFailed)
+			publishContainerEvent(op, h.ExecConfig.ID, time.Now().UTC(), events.ContainerFailed)
 			return err
 		}
 
-		// inform of creation irrespective of remaining operations
-		publishContainerEvent(h.ExecConfig.ID, time.Now().UTC(), events.ContainerStarted)
+		// publish started event
+		publishContainerEvent(op, h.ExecConfig.ID, time.Now().UTC(), events.ContainerStarted)
 	}
 
 	return nil
@@ -215,18 +213,18 @@ func Commit(ctx context.Context, sess *session.Session, h *Handle, waitTime *int
 // reloadConfig is responsible for triggering a guest_reconfigure in order to perform an operation on a running cVM
 // this function needs to be resilient to intermittent config errors and task errors, but will pass concurrent
 // modification issues back immediately.
-func reloadConfig(ctx context.Context, h *Handle, c *Container) error {
+func reloadConfig(op trace.Operation, h *Handle, c *Container) error {
 
-	log.Infof("Attempting to perform a guest reconfigure operation on (%s)", h.ExecConfig.ID)
+	op.Infof("Attempting to perform a guest reconfigure operation on (%s)", h.ExecConfig.ID)
 	retryFunc := func() error {
 		if h.reload && h.Runtime != nil && h.Runtime.PowerState == types.VirtualMachinePowerStatePoweredOn {
-			err := c.ReloadConfig(ctx)
+			err := c.ReloadConfig(op)
 
 			if err != nil {
-				log.Debugf("Error occurred during an attempt to reload the container config for an exec operation: (%s)", err)
+				op.Debugf("Error occurred during an attempt to reload the container config for an exec operation: (%s)", err)
 
 				// we will request the powerstate directly(this could be very costly without the vmomi gateway)
-				state, err := c.vm.PowerState(ctx)
+				state, err := c.vm.PowerState(op)
 				if err != nil && state == types.VirtualMachinePowerStatePoweredOff {
 					// TODO: probably should make this error a specific type such as PowerOffDuringExecError( or a better name ofcourse)
 					return fmt.Errorf("container(%s) was powered down during the requested operation.", h.ExecConfig.ID)
@@ -242,7 +240,7 @@ func reloadConfig(ctx context.Context, h *Handle, c *Container) error {
 
 	err := retry.Do(retryFunc, isIntermittentFailure)
 	if err != nil {
-		log.Debugf("Failed an exec operation with err: %s", err)
+		op.Debugf("Failed an exec operation with err: %s", err)
 		return err
 	}
 	return nil

--- a/lib/portlayer/exec/exec.go
+++ b/lib/portlayer/exec/exec.go
@@ -25,9 +25,11 @@ import (
 
 	"github.com/vmware/govmomi/find"
 	"github.com/vmware/govmomi/object"
+
 	"github.com/vmware/vic/lib/portlayer/event"
 	"github.com/vmware/vic/lib/portlayer/event/collector/vsphere"
 	"github.com/vmware/vic/lib/portlayer/event/events"
+	"github.com/vmware/vic/pkg/trace"
 	"github.com/vmware/vic/pkg/vsphere/extraconfig"
 	"github.com/vmware/vic/pkg/vsphere/session"
 )
@@ -133,13 +135,16 @@ func Init(ctx context.Context, sess *session.Session, source extraconfig.DataSou
 }
 
 // publishContainerEvent will publish a ContainerEvent to the vic event stream
-func publishContainerEvent(id string, created time.Time, eventType string) {
+func publishContainerEvent(op trace.Operation, id string, created time.Time, eventType string) {
 	if Config.EventManager == nil || eventType == "" {
 		return
 	}
 
 	ce := &events.ContainerEvent{
 		BaseEvent: &events.BaseEvent{
+			// containerEvents are a construct of vic, so lets set the
+			// ID equal to the operation that created the event
+			ID:          op.ID(),
 			Ref:         id,
 			CreatedTime: created,
 			Event:       eventType,

--- a/lib/portlayer/exec/exec_test.go
+++ b/lib/portlayer/exec/exec_test.go
@@ -15,6 +15,7 @@
 package exec
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -24,6 +25,7 @@ import (
 	"github.com/vmware/vic/lib/portlayer/event"
 	"github.com/vmware/vic/lib/portlayer/event/collector/vsphere"
 	"github.com/vmware/vic/lib/portlayer/event/events"
+	"github.com/vmware/vic/pkg/trace"
 )
 
 var containerEvents []events.Event
@@ -75,7 +77,7 @@ func TestPublishContainerEvent(t *testing.T) {
 	container.SetState(StateRunning)
 	Containers.Put(container)
 
-	publishContainerEvent(id, time.Now().UTC(), events.ContainerPoweredOff)
+	publishContainerEvent(trace.NewOperation(context.Background(), "container"), id, time.Now().UTC(), events.ContainerPoweredOff)
 	time.Sleep(time.Millisecond * 30)
 
 	assert.Equal(t, 1, len(containerEvents))

--- a/lib/portlayer/logging/logging.go
+++ b/lib/portlayer/logging/logging.go
@@ -41,32 +41,33 @@ func Init(ctx context.Context) error {
 			events.NewEventType(vsphere.VMEvent{}).Topic(),
 			"logging",
 			func(ie events.Event) {
-				eventCallback(ctx, ie)
+				eventCallback(ie)
 			})
 	})
 	return nil
 }
 
 // listens migrated events and connects the file backed serial ports
-func eventCallback(ctx context.Context, ie events.Event) {
+func eventCallback(ie events.Event) {
 	defer trace.End(trace.Begin(""))
 
 	switch ie.String() {
 	case events.ContainerMigrated,
 		events.ContainerMigratedByDrs:
-		log.Debugf("Received %s event", ie)
+		op := trace.NewOperation(context.Background(), "LoggingEvent")
+		op.Debugf("Logging processing eventID(%s): %s", ie.EventID(), ie)
 
 		// grab the container from the cache
 		container := exec.Containers.Container(ie.Reference())
 		if container == nil {
-			log.Errorf("Container %s not found. Dropping the event %s from Logging subsystem.", ie.Reference(), ie)
+			op.Errorf("Container %s not found. Dropping the event %s from Logging subsystem.", ie.Reference(), ie)
 			return
 		}
 
 		operation := func() error {
 			var err error
 
-			handle := container.NewHandle(ctx)
+			handle := container.NewHandle(op)
 			if handle == nil {
 				err = fmt.Errorf("Handle for %s cannot be created", ie.Reference())
 				log.Error(err)
@@ -76,19 +77,19 @@ func eventCallback(ctx context.Context, ie events.Event) {
 
 			// set them to true
 			if handle, err = toggle(handle, true); err != nil {
-				log.Errorf("Failed to toggle logging after %s event for container %s: %s", ie, ie.Reference(), err)
+				op.Errorf("Failed to toggle logging after %s event for container %s: %s", ie, ie.Reference(), err)
 				return err
 			}
 
-			if err = handle.Commit(ctx, nil, nil); err != nil {
-				log.Errorf("Failed to commit handle after getting %s event for container %s: %s", ie, ie.Reference(), err)
+			if err = handle.Commit(op, nil, nil); err != nil {
+				op.Errorf("Failed to commit handle after getting %s event for container %s: %s", ie, ie.Reference(), err)
 				return err
 			}
 			return nil
 		}
 
 		if err := retry.Do(operation, exec.IsConcurrentAccessError); err != nil {
-			log.Errorf("Multiple attempts failed to commit handle after getting %s event for container %s: %s", ie, ie.Reference(), err)
+			op.Errorf("Multiple attempts failed to commit handle after getting %s event for container %s: %s", ie, ie.Reference(), err)
 		}
 	}
 

--- a/lib/portlayer/network/context.go
+++ b/lib/portlayer/network/context.go
@@ -911,8 +911,8 @@ func (c *Context) removeAliases(aliases []string, con *Container) {
 
 // RemoveIDFromScopes removes the container from the scopes but doesn't touch the runtime state
 // Because of that it requires an id
-func (c *Context) RemoveIDFromScopes(id string) ([]*Endpoint, error) {
-	defer trace.End(trace.Begin(""))
+func (c *Context) RemoveIDFromScopes(op trace.Operation, id string) ([]*Endpoint, error) {
+	defer trace.End(trace.Begin("", op))
 
 	c.Lock()
 	defer c.Unlock()
@@ -951,8 +951,8 @@ func (c *Context) RemoveIDFromScopes(id string) ([]*Endpoint, error) {
 
 // UnbindContainer removes the container from the scopes and clears out the assigned IP
 // Because of that, it requires a handle
-func (c *Context) UnbindContainer(h *exec.Handle) ([]*Endpoint, error) {
-	defer trace.End(trace.Begin(""))
+func (c *Context) UnbindContainer(op trace.Operation, h *exec.Handle) ([]*Endpoint, error) {
+	defer trace.End(trace.Begin("", op))
 	c.Lock()
 	defer c.Unlock()
 

--- a/lib/portlayer/network/context_test.go
+++ b/lib/portlayer/network/context_test.go
@@ -40,6 +40,7 @@ import (
 	"github.com/vmware/vic/lib/spec"
 	"github.com/vmware/vic/pkg/ip"
 	"github.com/vmware/vic/pkg/kvstore"
+	"github.com/vmware/vic/pkg/trace"
 	"github.com/vmware/vic/pkg/uid"
 	"github.com/vmware/vic/pkg/vsphere/extraconfig"
 )
@@ -875,7 +876,8 @@ func TestContextBindUnbindContainer(t *testing.T) {
 
 	// test UnbindContainer
 	for i, te := range tests {
-		eps, err := ctx.UnbindContainer(te.h)
+		op := trace.NewOperation(context.Background(), "Testing..")
+		eps, err := ctx.UnbindContainer(op, te.h)
 		if te.err != nil {
 			if err == nil {
 				t.Fatalf("%d: ctx.UnbindContainer(%s) => nil, want err", i, te.h)
@@ -1224,7 +1226,8 @@ func TestAliases(t *testing.T) {
 	t.Logf("containers: %#v", ctx.containers)
 
 	c := containers["c2"]
-	_, err = ctx.UnbindContainer(c)
+	op := trace.NewOperation(context.Background(), "unbind")
+	_, err = ctx.UnbindContainer(op, c)
 	assert.NoError(t, err)
 	// verify aliases are gone
 	assert.Nil(t, ctx.Container(c.ExecConfig.ID))

--- a/lib/portlayer/network/network.go
+++ b/lib/portlayer/network/network.go
@@ -120,23 +120,26 @@ func Init(ctx context.Context, sess *session.Session, source extraconfig.DataSou
 func handleEvent(netctx *Context, ie events.Event) {
 	switch ie.String() {
 	case events.ContainerPoweredOff:
-		handle := exec.GetContainer(context.Background(), uid.Parse(ie.Reference()))
+		op := trace.NewOperation(context.Background(), fmt.Sprintf("handleEvent(%s)", ie.EventID()))
+		op.Infof("Handling Event: %s", ie.EventID())
+		// grab the operation from the event
+		handle := exec.GetContainer(op, uid.Parse(ie.Reference()))
 		if handle == nil {
-			_, err := netctx.RemoveIDFromScopes(ie.Reference())
+			_, err := netctx.RemoveIDFromScopes(op, ie.Reference())
 			if err != nil {
-				log.Errorf("Failed to remove container %s scope: %s", ie.Reference(), err)
+				op.Errorf("Failed to remove container %s scope: %s", ie.Reference(), err)
 			}
 			return
 		}
 		defer handle.Close()
 
-		if _, err := netctx.UnbindContainer(handle); err != nil {
-			log.Warnf("Failed to unbind container %s: %s", ie.Reference(), err)
+		if _, err := netctx.UnbindContainer(op, handle); err != nil {
+			op.Warnf("Failed to unbind container %s: %s", ie.Reference(), err)
 			return
 		}
 
-		if err := handle.Commit(context.Background(), nil, nil); err != nil {
-			log.Warnf("Failed to commit handle after network unbind for container %s: %s", ie.Reference(), err)
+		if err := handle.Commit(op, nil, nil); err != nil {
+			op.Warnf("Failed to commit handle after network unbind for container %s: %s", ie.Reference(), err)
 		}
 
 	}

--- a/pkg/trace/operation_test.go
+++ b/pkg/trace/operation_test.go
@@ -39,11 +39,7 @@ func TestContextUnpack(t *testing.T) {
 			ctx := NewOperation(context.TODO(), "testmsg")
 
 			// unpack an Operation via the context using it's Values fields
-			c, err := FromContext(ctx)
-
-			if !assert.NoError(t, err) || !assert.NotNil(t, c) {
-				return
-			}
+			c := FromContext(ctx, "test")
 			c.Infof("test info message %d", i)
 		}(i) // fix race in test
 	}

--- a/pkg/trace/trace.go
+++ b/pkg/trace/trace.go
@@ -15,12 +15,16 @@
 package trace
 
 import (
+	"context"
+	"fmt"
 	"os"
 	"runtime"
+	"strings"
 	"time"
 
 	"github.com/Sirupsen/logrus"
 
+	"github.com/vmware/govmomi/vim25/types"
 	"github.com/vmware/vic/pkg/log"
 )
 
@@ -47,9 +51,10 @@ var Logger = &logrus.Logger{
 
 // trace object used to grab run-time state
 type Message struct {
-	msg      string
-	funcName string
-	lineNo   int
+	msg         string
+	funcName    string
+	lineNo      int
+	operationID string
 
 	startTime time.Time
 }
@@ -62,30 +67,50 @@ func (t *Message) delta() time.Duration {
 }
 
 // begin a trace from this stack frame less the skip.
-func newTrace(msg string, skip int) *Message {
+func newTrace(msg string, skip int, opID string) *Message {
 	pc, _, line, ok := runtime.Caller(skip)
 	if !ok {
 		return nil
 	}
 
-	name := runtime.FuncForPC(pc).Name()
+	// lets only return the func name from the repo (vic)
+	// down - i.e. vic/lib/etc vs. github.com/vmware/vic/lib/etc
+	// if github.com/vmware doesn't match then the original is returned
+	name := strings.TrimPrefix(runtime.FuncForPC(pc).Name(), "github.com/vmware/")
 
-	return &Message{
-		msg:       msg,
-		funcName:  name,
-		lineNo:    line,
+	message := Message{
+		msg:      msg,
+		funcName: name,
+		lineNo:   line,
+
 		startTime: time.Now(),
 	}
+
+	// if we have an operationID then format the output
+	if opID != "" {
+		message.operationID = fmt.Sprintf("op=%s", opID)
+	}
+
+	return &message
 }
 
 // Begin starts the trace.  Msg is the msg to log.
-func Begin(msg string) *Message {
+// context provided to allow tracing of operationID
+// context added as optional to avoid breaking current usage
+func Begin(msg string, ctx ...context.Context) *Message {
 	if tracingEnabled && Logger.Level >= logrus.DebugLevel {
-		if t := newTrace(msg, 2); t != nil {
+		var opID string
+		// populate operationID if provided
+		if len(ctx) == 1 {
+			if id, ok := ctx[0].Value(types.ID{}).(string); ok {
+				opID = id
+			}
+		}
+		if t := newTrace(msg, 2, opID); t != nil {
 			if msg == "" {
-				Logger.Debugf("[BEGIN] [%s:%d]", t.funcName, t.lineNo)
+				Logger.Debugf("[BEGIN] %s [%s:%d]", t.operationID, t.funcName, t.lineNo)
 			} else {
-				Logger.Debugf("[BEGIN] [%s:%d] %s", t.funcName, t.lineNo, t.msg)
+				Logger.Debugf("[BEGIN] %s [%s:%d] %s", t.operationID, t.funcName, t.lineNo, t.msg)
 			}
 			return t
 
@@ -99,5 +124,5 @@ func End(t *Message) {
 	if t == nil {
 		return
 	}
-	Logger.Debugf("[ END ] [%s:%d] [%s] %s", t.funcName, t.lineNo, t.delta(), t.msg)
+	Logger.Debugf("[ END ] %s [%s:%d] [%s] %s", t.operationID, t.funcName, t.lineNo, t.delta(), t.msg)
 }

--- a/pkg/vsphere/tasks/waiter.go
+++ b/pkg/vsphere/tasks/waiter.go
@@ -63,10 +63,7 @@ func WaitForResult(ctx context.Context, f func(context.Context) (Task, error)) (
 	var err error
 	var backoffFactor int64 = 1
 
-	op, err := trace.FromContext(ctx)
-	if err != nil {
-		op = trace.NewOperation(ctx, "WaitForResult")
-	}
+	op := trace.FromContext(ctx, "WaitForResult")
 
 	for {
 		var t Task

--- a/pkg/vsphere/vm/vm.go
+++ b/pkg/vsphere/vm/vm.go
@@ -33,6 +33,7 @@ import (
 	"github.com/vmware/govmomi/vim25/mo"
 	"github.com/vmware/govmomi/vim25/types"
 
+	"github.com/vmware/vic/pkg/trace"
 	"github.com/vmware/vic/pkg/vsphere/extraconfig/vmomi"
 	"github.com/vmware/vic/pkg/vsphere/session"
 	"github.com/vmware/vic/pkg/vsphere/tasks"
@@ -179,6 +180,8 @@ func (vm *VirtualMachine) WaitForKeyInExtraConfig(ctx context.Context, key strin
 	var detail string
 	var poweredOff error
 
+	op := trace.FromContext(ctx, "WaitForKey")
+
 	waitFunc := func(pc []types.PropertyChange) bool {
 		for _, c := range pc {
 			if c.Op != types.PropertyChangeOpAssign {
@@ -213,7 +216,7 @@ func (vm *VirtualMachine) WaitForKeyInExtraConfig(ctx context.Context, key strin
 		return false
 	}
 
-	err := vm.WaitForExtraConfig(ctx, waitFunc)
+	err := vm.WaitForExtraConfig(op, waitFunc)
 	if err == nil && poweredOff != nil {
 		err = poweredOff
 	}
@@ -486,7 +489,10 @@ func (vm *VirtualMachine) WaitForResult(ctx context.Context, f func(context.Cont
 }
 
 func (vm *VirtualMachine) Properties(ctx context.Context, r types.ManagedObjectReference, ps []string, o *mo.VirtualMachine) error {
-	log.Debugf("get vm properties %s of vm %s", ps, r)
+	// lets ensure we have an operation
+	op := trace.FromContext(ctx, "VM Properties")
+	defer trace.End(trace.Begin(fmt.Sprintf("VM(%s) Properties(%s)", r, ps), op))
+
 	contains := false
 	for i := range ps {
 		if ps[i] == "summary" || ps[i] == "summary.runtime" {
@@ -500,20 +506,20 @@ func (vm *VirtualMachine) Properties(ctx context.Context, r types.ManagedObjectR
 	} else {
 		newps = append(newps, ps...)
 	}
-	log.Debugf("properties: %s", newps)
-	if err := vm.VirtualMachine.Properties(ctx, r, newps, o); err != nil {
+	op.Debugf("properties: %s", newps)
+	if err := vm.VirtualMachine.Properties(op, r, newps, o); err != nil {
 		return err
 	}
 	if o.Summary.Runtime.ConnectionState != types.VirtualMachineConnectionStateInvalid {
 		return nil
 	}
-	log.Infof("vm %s is in invalid state", r)
-	if err := vm.fixVM(ctx); err != nil {
-		log.Errorf("Failed to fix vm %s: %s", vm.Reference(), err)
+	op.Infof("vm %s is in invalid state", r)
+	if err := vm.fixVM(op); err != nil {
+		op.Errorf("Failed to fix vm %s: %s", vm.Reference(), err)
 		return &InvalidState{r: vm.Reference()}
 	}
-	log.Debugf("Retry properties query %s of vm %s", ps, vm.Reference())
-	return vm.VirtualMachine.Properties(ctx, vm.Reference(), ps, o)
+
+	return vm.VirtualMachine.Properties(op, vm.Reference(), ps, o)
 }
 
 func (vm *VirtualMachine) Parent(ctx context.Context) (*types.ManagedObjectReference, error) {


### PR DESCRIPTION
Increases use of `trace.Operation` and passes the operation id to vSphere resulting in vic
operation observability within vSphere logging.

Fixes #2739 

