### PR TITLE
Implement API handler for VCH deletion [specific ci=Group23-VIC-Machine-Service]

### DIFF
--- a/cmd/vic-machine/delete/delete.go
+++ b/cmd/vic-machine/delete/delete.go
@@ -163,7 +163,7 @@ func (d *Uninstall) Run(clic *cli.Context) (err error) {
 		log.Warnf("VCH version %q is different than installer version %s. Force delete will attempt to remove everything related to the installed VCH", vchConfig.Version.ShortVersion(), installerBuild.ShortVersion())
 	}
 
-	if err = executor.DeleteVCH(vchConfig); err != nil {
+	if err = executor.DeleteVCH(vchConfig, nil, nil); err != nil {
 		executor.CollectDiagnosticLogs()
 		log.Errorf("%s", err)
 		return errors.New("delete failed")

--- a/lib/apiservers/service/restapi/configure_vic_machine.go
+++ b/lib/apiservers/service/restapi/configure_vic_machine.go
@@ -107,9 +107,7 @@ func configureAPI(api *operations.VicMachineAPI) http.Handler {
 	})
 
 	// DELETE /container/target/{target}/vch/{vch-id}
-	api.DeleteTargetTargetVchVchIDHandler = operations.DeleteTargetTargetVchVchIDHandlerFunc(func(params operations.DeleteTargetTargetVchVchIDParams, principal interface{}) middleware.Responder {
-		return middleware.NotImplemented("operation .DeleteTargetTargetVchVchID has not yet been implemented")
-	})
+	api.DeleteTargetTargetVchVchIDHandler = &handlers.VCHDelete{}
 
 	// POST /container/target/{target}/datacenter/{datacenter}
 	api.PostTargetTargetDatacenterDatacenterHandler = operations.PostTargetTargetDatacenterDatacenterHandlerFunc(func(params operations.PostTargetTargetDatacenterDatacenterParams, principal interface{}) middleware.Responder {
@@ -141,9 +139,7 @@ func configureAPI(api *operations.VicMachineAPI) http.Handler {
 	})
 
 	// DELETE /container/target/{target}/datacenter/{datacenter}/vch/{vch-id}
-	api.DeleteTargetTargetDatacenterDatacenterVchVchIDHandler = operations.DeleteTargetTargetDatacenterDatacenterVchVchIDHandlerFunc(func(params operations.DeleteTargetTargetDatacenterDatacenterVchVchIDParams, principal interface{}) middleware.Responder {
-		return middleware.NotImplemented("operation .DeleteTargetTargetDatacenterDatacenterVchVchID has not yet been implemented")
-	})
+	api.DeleteTargetTargetDatacenterDatacenterVchVchIDHandler = &handlers.VCHDatacenterDelete{}
 
 	api.ServerShutdown = func() {}
 

--- a/lib/apiservers/service/restapi/handlers/vch_delete.go
+++ b/lib/apiservers/service/restapi/handlers/vch_delete.go
@@ -1,0 +1,127 @@
+// Copyright 2017 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package handlers
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/go-openapi/runtime/middleware"
+
+	"github.com/vmware/vic/lib/apiservers/service/models"
+	"github.com/vmware/vic/lib/apiservers/service/restapi/handlers/util"
+	"github.com/vmware/vic/lib/apiservers/service/restapi/operations"
+	"github.com/vmware/vic/lib/install/data"
+	"github.com/vmware/vic/lib/install/management"
+	"github.com/vmware/vic/lib/install/validate"
+	"github.com/vmware/vic/pkg/trace"
+	"github.com/vmware/vic/pkg/version"
+)
+
+// VCHDelete is the handler for deleting a VCH
+type VCHDelete struct {
+}
+
+// VCHDatacenterDelete is the handler for deleting a VCH within a Datacenter
+type VCHDatacenterDelete struct {
+}
+
+func (h *VCHDelete) Handle(params operations.DeleteTargetTargetVchVchIDParams, principal interface{}) middleware.Responder {
+	op := trace.NewOperation(params.HTTPRequest.Context(), "VCHDelete: %s", params.VchID)
+
+	b := buildDataParams{
+		target:     params.Target,
+		thumbprint: params.Thumbprint,
+	}
+
+	d, err := buildData(op, b, principal)
+	if err != nil {
+		return operations.NewDeleteTargetTargetVchVchIDDefault(util.StatusCode(err)).WithPayload(&models.Error{Message: err.Error()})
+	}
+
+	d.ID = params.VchID
+
+	err = deleteVCH(op, d, params.DeletionSpecification)
+	if err != nil {
+		return operations.NewDeleteTargetTargetVchVchIDDefault(util.StatusCode(err)).WithPayload(&models.Error{Message: err.Error()})
+	}
+
+	return operations.NewDeleteTargetTargetVchVchIDAccepted()
+}
+
+func (h *VCHDatacenterDelete) Handle(params operations.DeleteTargetTargetDatacenterDatacenterVchVchIDParams, principal interface{}) middleware.Responder {
+	op := trace.NewOperation(params.HTTPRequest.Context(), "VCHDelete: %s", params.VchID)
+
+	b := buildDataParams{
+		target:     params.Target,
+		thumbprint: params.Thumbprint,
+		datacenter: &params.Datacenter,
+	}
+
+	d, err := buildData(op, b, principal)
+	if err != nil {
+		return operations.NewDeleteTargetTargetDatacenterDatacenterVchVchIDDefault(util.StatusCode(err)).WithPayload(&models.Error{Message: err.Error()})
+	}
+
+	d.ID = params.VchID
+
+	err = deleteVCH(op, d, params.DeletionSpecification)
+	if err != nil {
+		return operations.NewDeleteTargetTargetDatacenterDatacenterVchVchIDDefault(util.StatusCode(err)).WithPayload(&models.Error{Message: err.Error()})
+	}
+
+	return operations.NewDeleteTargetTargetDatacenterDatacenterVchVchIDAccepted()
+}
+
+func deleteVCH(op trace.Operation, d *data.Data, specification *models.DeletionSpecification) error {
+	validator, err := validateTarget(op, d)
+	if err != nil {
+		return util.WrapError(http.StatusBadRequest, err)
+	}
+
+	if specification == nil {
+		specification = &models.DeletionSpecification{}
+	}
+
+	executor := management.NewDispatcher(validator.Context, validator.Session, nil, false)
+	vch, err := executor.NewVCHFromID(d.ID)
+	if err != nil {
+		return util.NewError(http.StatusNotFound, fmt.Sprintf("Failed to find VCH: %s", err))
+	}
+
+	err = validate.SetDataFromVM(validator.Context, validator.Session.Finder, vch, d)
+	if err != nil {
+		return util.NewError(http.StatusInternalServerError, fmt.Sprintf("Failed to load VCH data: %s", err))
+	}
+
+	vchConfig, err := executor.GetNoSecretVCHConfig(vch)
+	if err != nil {
+		return util.NewError(http.StatusInternalServerError, fmt.Sprintf("Failed to load VCH data: %s", err))
+	}
+
+	// compare vch version and vic-machine version
+	installerBuild := version.GetBuild()
+	if vchConfig.Version == nil || !installerBuild.Equal(vchConfig.Version) {
+		err = fmt.Errorf("VCH version %q is different than API version %s", vchConfig.Version.ShortVersion(), installerBuild.ShortVersion())
+		return util.WrapError(http.StatusBadRequest, err)
+	}
+
+	err = executor.DeleteVCH(vchConfig, specification.Containers, specification.VolumeStores)
+	if err != nil {
+		return util.NewError(http.StatusInternalServerError, fmt.Sprintf("Failed to delete VCH: %s", err))
+	}
+
+	return nil
+}

--- a/lib/apiservers/service/restapi/handlers/vch_get.go
+++ b/lib/apiservers/service/restapi/handlers/vch_get.go
@@ -106,7 +106,7 @@ func getVCH(op trace.Operation, d *data.Data) (*models.VCH, error) {
 	executor := management.NewDispatcher(validator.Context, validator.Session, nil, false)
 	vch, err := executor.NewVCHFromID(d.ID)
 	if err != nil {
-		return nil, util.NewError(http.StatusInternalServerError, fmt.Sprintf("Failed to inspect VCH: %s", err))
+		return nil, util.NewError(http.StatusNotFound, fmt.Sprintf("Failed to inspect VCH: %s", err))
 	}
 
 	err = validate.SetDataFromVM(validator.Context, validator.Session.Finder, vch, d)

--- a/lib/apiservers/service/swagger.json
+++ b/lib/apiservers/service/swagger.json
@@ -166,6 +166,7 @@
         "parameters": [
           { "$ref": "#/parameters/target" },
           { "$ref": "#/parameters/vch-id" },
+          { "$ref": "#/parameters/deletion-specification" },
           { "$ref": "#/parameters/thumbprint" }
         ],
         "responses": {
@@ -340,6 +341,7 @@
           { "$ref": "#/parameters/target" },
           { "$ref": "#/parameters/datacenter" },
           { "$ref": "#/parameters/vch-id" },
+          { "$ref": "#/parameters/deletion-specification" },
           { "$ref": "#/parameters/thumbprint" }
         ],
         "responses": {
@@ -848,6 +850,27 @@
     "VCH_List": {
       "type": "array",
       "items": { "$ref": "#/definitions/VCH_List_Item" }
+    },
+    "Deletion_Specification": {
+      "type": "object",
+      "properties": {
+        "containers": {
+          "type": "string",
+          "enum": [
+            "off",
+            "all"
+          ],
+          "default": "off"
+        },
+        "volume_stores": {
+          "type": "string",
+          "enum": [
+            "none",
+            "all"
+          ],
+          "default": "none"
+        }
+      }
     }
   },
   "parameters": {
@@ -879,6 +902,15 @@
       "in": "query",
       "description": "Compute resource path",
       "type": "string"
+    },
+    "deletion-specification": {
+      "name": "deletion-specification",
+      "in": "body",
+      "description": "Information about the deletion operation",
+      "required": false,
+      "schema": {
+        "$ref": "#/definitions/Deletion_Specification"
+      }
     },
     "thumbprint": {
       "name": "thumbprint",
@@ -959,7 +991,7 @@
       }
     },
     "vsphere-task": {
-      "description": "A vSphere task",
+      "description": "A vSphere task for work that is occurring asynchronously, or null if the operation is complete.",
       "schema": {
         "type": "object",
         "properties": {

--- a/lib/install/management/create_test.go
+++ b/lib/install/management/create_test.go
@@ -181,7 +181,7 @@ func testDeleteVolumeStores(ctx context.Context, sess *session.Session, conf *co
 		force:   true,
 	}
 
-	if removed := d.deleteVolumeStoreIfForced(conf); removed != numVols {
+	if removed := d.deleteVolumeStoreIfForced(conf, nil); removed != numVols {
 		t.Errorf("Did not successfully remove all specified volumes")
 	}
 

--- a/lib/install/management/delete.go
+++ b/lib/install/management/delete.go
@@ -31,7 +31,7 @@ import (
 	"github.com/vmware/vic/pkg/vsphere/vm"
 )
 
-func (d *Dispatcher) DeleteVCH(conf *config.VirtualContainerHostConfigSpec) error {
+func (d *Dispatcher) DeleteVCH(conf *config.VirtualContainerHostConfigSpec, containers *string, volumeStores *string) error {
 	defer trace.End(trace.Begin(conf.Name))
 
 	var errs []string
@@ -46,7 +46,7 @@ func (d *Dispatcher) DeleteVCH(conf *config.VirtualContainerHostConfigSpec) erro
 		return nil
 	}
 
-	if err = d.DeleteVCHInstances(vmm, conf); err != nil {
+	if err = d.DeleteVCHInstances(vmm, conf, containers); err != nil {
 		// if container delete failed, do not remove anything else
 		log.Infof("Specify --force to force delete")
 		return err
@@ -56,7 +56,7 @@ func (d *Dispatcher) DeleteVCH(conf *config.VirtualContainerHostConfigSpec) erro
 		errs = append(errs, err.Error())
 	}
 
-	d.deleteVolumeStoreIfForced(conf) // logs errors but doesn't ever bail out if it has an issue
+	d.deleteVolumeStoreIfForced(conf, volumeStores) // logs errors but doesn't ever bail out if it has an issue
 
 	if err = d.deleteNetworkDevices(vmm, conf); err != nil {
 		errs = append(errs, err.Error())
@@ -84,8 +84,10 @@ func (d *Dispatcher) getComputeResource(vmm *vm.VirtualMachine, conf *config.Vir
 	var rpRef types.ManagedObjectReference
 	var err error
 
+	ignoreFailureToFindComputeResources := d.force
+
 	if len(conf.ComputeResources) == 0 {
-		if !d.force {
+		if !ignoreFailureToFindComputeResources {
 			err = errors.Errorf("Cannot find compute resources from configuration")
 			return nil, err
 		}
@@ -188,8 +190,11 @@ func (d *Dispatcher) detachAttachedDisks(v *vm.VirtualMachine) error {
 	return err
 }
 
-func (d *Dispatcher) DeleteVCHInstances(vmm *vm.VirtualMachine, conf *config.VirtualContainerHostConfigSpec) error {
+func (d *Dispatcher) DeleteVCHInstances(vmm *vm.VirtualMachine, conf *config.VirtualContainerHostConfigSpec, containers *string) error {
 	defer trace.End(trace.Begin(conf.Name))
+
+	deletePoweredOnContainers := d.force || (containers != nil && *containers == "all")
+	ignoreFailureToFindImageStores := d.force
 
 	log.Infof("Removing VMs")
 
@@ -208,7 +213,7 @@ func (d *Dispatcher) DeleteVCHInstances(vmm *vm.VirtualMachine, conf *config.Vir
 		return err
 	}
 
-	if d.session.Datastore, err = d.getImageDatastore(vmm, conf, d.force); err != nil {
+	if d.session.Datastore, err = d.getImageDatastore(vmm, conf, ignoreFailureToFindImageStores); err != nil {
 		return err
 	}
 
@@ -232,7 +237,7 @@ func (d *Dispatcher) DeleteVCHInstances(vmm *vm.VirtualMachine, conf *config.Vir
 		wg.Add(1)
 		go func(child *vm.VirtualMachine) {
 			defer wg.Done()
-			if err = d.deleteVM(child, d.force); err != nil {
+			if err = d.deleteVM(child, deletePoweredOnContainers); err != nil {
 				mu.Lock()
 				errs = append(errs, err.Error())
 				mu.Unlock()

--- a/lib/install/management/delete.go
+++ b/lib/install/management/delete.go
@@ -31,7 +31,21 @@ import (
 	"github.com/vmware/vic/pkg/vsphere/vm"
 )
 
-func (d *Dispatcher) DeleteVCH(conf *config.VirtualContainerHostConfigSpec, containers *string, volumeStores *string) error {
+type DeleteContainers int
+
+const (
+	AllContainers DeleteContainers = iota
+	PoweredOffContainers
+)
+
+type DeleteVolumeStores int
+
+const (
+	AllVolumeStores DeleteVolumeStores = iota
+	NoVolumeStores
+)
+
+func (d *Dispatcher) DeleteVCH(conf *config.VirtualContainerHostConfigSpec, containers *DeleteContainers, volumeStores *DeleteVolumeStores) error {
 	defer trace.End(trace.Begin(conf.Name))
 
 	var errs []string
@@ -190,10 +204,10 @@ func (d *Dispatcher) detachAttachedDisks(v *vm.VirtualMachine) error {
 	return err
 }
 
-func (d *Dispatcher) DeleteVCHInstances(vmm *vm.VirtualMachine, conf *config.VirtualContainerHostConfigSpec, containers *string) error {
+func (d *Dispatcher) DeleteVCHInstances(vmm *vm.VirtualMachine, conf *config.VirtualContainerHostConfigSpec, containers *DeleteContainers) error {
 	defer trace.End(trace.Begin(conf.Name))
 
-	deletePoweredOnContainers := d.force || (containers != nil && *containers == "all")
+	deletePoweredOnContainers := d.force || (containers != nil && *containers == AllContainers)
 	ignoreFailureToFindImageStores := d.force
 
 	log.Infof("Removing VMs")

--- a/lib/install/management/delete_test.go
+++ b/lib/install/management/delete_test.go
@@ -167,7 +167,7 @@ func testDeleteVCH(v *validate.Validator, conf *config.VirtualContainerHostConfi
 		force:   false,
 	}
 	// failed to get vm FolderName, that will eventually cause panic in simulator to delete empty datastore file
-	if err := d.DeleteVCH(conf); err != nil {
+	if err := d.DeleteVCH(conf, nil, nil); err != nil {
 		t.Errorf("Failed to get VCH: %s", err)
 		return
 	}

--- a/lib/install/management/store_files.go
+++ b/lib/install/management/store_files.go
@@ -303,11 +303,11 @@ func (d *Dispatcher) createVolumeStores(conf *config.VirtualContainerHostConfigS
 }
 
 // returns # of removed stores
-func (d *Dispatcher) deleteVolumeStoreIfForced(conf *config.VirtualContainerHostConfigSpec, volumeStores *string) (removed int) {
+func (d *Dispatcher) deleteVolumeStoreIfForced(conf *config.VirtualContainerHostConfigSpec, volumeStores *DeleteVolumeStores) (removed int) {
 	defer trace.End(trace.Begin(""))
 	removed = 0
 
-	deleteVolumeStores := d.force || (volumeStores != nil && *volumeStores == "all")
+	deleteVolumeStores := d.force || (volumeStores != nil && *volumeStores == AllVolumeStores)
 
 	if !deleteVolumeStores {
 		if len(conf.VolumeLocations) == 0 {

--- a/lib/install/management/store_files.go
+++ b/lib/install/management/store_files.go
@@ -303,11 +303,13 @@ func (d *Dispatcher) createVolumeStores(conf *config.VirtualContainerHostConfigS
 }
 
 // returns # of removed stores
-func (d *Dispatcher) deleteVolumeStoreIfForced(conf *config.VirtualContainerHostConfigSpec) (removed int) {
+func (d *Dispatcher) deleteVolumeStoreIfForced(conf *config.VirtualContainerHostConfigSpec, volumeStores *string) (removed int) {
 	defer trace.End(trace.Begin(""))
 	removed = 0
 
-	if !d.force {
+	deleteVolumeStores := d.force || (volumeStores != nil && *volumeStores == "all")
+
+	if !deleteVolumeStores {
 		if len(conf.VolumeLocations) == 0 {
 			return 0
 		}
@@ -365,7 +367,7 @@ func (d *Dispatcher) deleteVolumeStoreIfForced(conf *config.VirtualContainerHost
 		}
 
 		datastore := datastores[0]
-		if _, err := d.deleteDatastoreFiles(datastore, dsURL.Path, d.force); err != nil {
+		if _, err := d.deleteDatastoreFiles(datastore, dsURL.Path, deleteVolumeStores); err != nil {
 			log.Errorf("Failed to delete volume store %q on Datastore %q at path %q", label, dsURL.Host, dsURL.Path)
 		} else {
 			removed++

--- a/tests/resources/Group23-VIC-Machine-Service-Util.robot
+++ b/tests/resources/Group23-VIC-Machine-Service-Util.robot
@@ -58,6 +58,16 @@ Post Path Under Target
     Set Test Variable    ${OUTPUT}
     Set Test Variable    ${STATUS}
 
+Delete Path Under Target
+    [Arguments]    ${path}    ${data}=''    @{query}
+    ${fullQuery}=    Catenate    SEPARATOR=&    thumbprint=%{TEST_THUMBPRINT}    @{query}
+    ${auth}=    Evaluate    base64.b64encode("%{TEST_USERNAME}:%{TEST_PASSWORD}")    modules=base64
+    ${RC}  ${OUTPUT}=    Run And Return Rc And Output    curl -s -w "\n\%{http_code}\n" -X DELETE "http://127.0.0.1:${HTTP_PORT}/container/target/%{TEST_URL}/${PATH}?${fullQuery}" -H "Accept: application/json" -H "Authorization: Basic ${auth}" -H "Content-Type: application/json" --data ${data}
+    ${OUTPUT}    ${STATUS}=    Split String From Right    ${OUTPUT}    \n    1
+    Set Test Variable    ${RC}
+    Set Test Variable    ${OUTPUT}
+    Set Test Variable    ${STATUS}
+
 
 Verify Return Code
     Should Be Equal As Integers    ${RC}    0
@@ -73,11 +83,20 @@ Verify Status Ok
 Verify Status Created
     Verify Status    201
 
+Verify Status Accepted
+    Verify Status    202
+
 Verify Status Bad Request
     Verify Status    400
 
 Verify Status Not Found
     Verify Status    404
+
+Verify Status Unprocessable Entity
+    Verify Status    422
+
+Verify Status Internal Server Error
+    Verify Status    500
 
 
 Output Should Contain

--- a/tests/resources/VCH-Util.robot
+++ b/tests/resources/VCH-Util.robot
@@ -260,6 +260,11 @@ Conditional Install VIC Appliance To Test Server
 Install VIC Appliance To Test Server
     [Arguments]  ${vic-machine}=bin/vic-machine-linux  ${appliance-iso}=bin/appliance.iso  ${bootstrap-iso}=bin/bootstrap.iso  ${certs}=${true}  ${vol}=default  ${cleanup}=${true}  ${debug}=1  ${additional-args}=${EMPTY}
     Set Test Environment Variables
+    ${output}=  Install VIC Appliance To Test Server With Current Environment Variables  ${vic-machine}  ${appliance-iso}  ${bootstrap-iso}  ${certs}  ${vol}  ${cleanup}  ${debug}  ${additional-args}
+    [Return]  ${output}
+
+Install VIC Appliance To Test Server With Current Environment Variables
+    [Arguments]  ${vic-machine}=bin/vic-machine-linux  ${appliance-iso}=bin/appliance.iso  ${bootstrap-iso}=bin/bootstrap.iso  ${certs}=${true}  ${vol}=default  ${cleanup}=${true}  ${debug}=1  ${additional-args}=${EMPTY}
     # disable firewall
     Run Keyword If  '%{HOST_TYPE}' == 'ESXi'  Run  govc host.esxcli network firewall set -e false
     # Attempt to cleanup old/canceled tests

--- a/tests/test-cases/Group23-VIC-Machine-Service/23-08-VCH-Delete.md
+++ b/tests/test-cases/Group23-VIC-Machine-Service/23-08-VCH-Delete.md
@@ -1,0 +1,248 @@
+Test 23-08 - VCH Delete
+=======================
+
+#### Purpose:
+To verify vic-machine-server deletes the correct set of objects as a part of an API call
+
+#### References:
+1. [VIC Machine Service API Design Doc](../../../doc/design/vic-machine/service.md)
+
+#### Environment:
+This suite requires a vSphere system where VCHs can be deployed with default and named volume stores.
+
+
+Basic Validation
+----------------
+
+###  1. Delete VCH
+
+#### Test Steps:
+1. Create a VCH
+2. Issue a delete request without a body
+3. Verify that the VCH no longer exists
+
+#### Expected Outcome:
+* The VCH is deleted
+
+
+###  2. Delete VCH within datacenter
+
+#### Test Steps:
+1. Create a VCH
+2. Issue a delete request without a body to the datacenter-scoped handler
+3. Verify that the VCH no longer exists
+
+#### Expected Outcome:
+* The VCH is deleted
+
+
+###  3. Delete the correct VCH
+
+#### Test Steps:
+1. Create two VCHs
+2. Issue a delete request for one VCH
+3. Verify that the deleted VCH no longer exists
+4. Verify that the other VCH still exists
+
+#### Expected Outcome:
+* Only the expected VCH is deleted
+
+
+###  4. Delete invalid VCH
+
+#### Test Steps:
+1. Create a VCH
+2. Issue a delete request for a non-existent VCH
+3. Verify that the VCH still exists
+
+#### Expected Outcome:
+* The erroneous deletion returns a 404 Not Found without side effects
+
+
+###  5. Delete VCH in invalid datacenter
+
+#### Test Steps:
+1. Create a VCH
+2. Issue a deletion request for that VCH scoped to an invalid datacenter
+3. Verify that the VCH still exists
+
+#### Expected Outcome:
+* The erroneous deletion returns a 404 Not Found without side effects
+
+
+###  6. Delete with invalid bodies
+
+#### Test Steps:
+1. Create a VCH
+2. Issue a delete request for that VCH with a malformed body
+3. Issue a delete request for that VCH with an invalid value for the `containers` element
+4. Issue a delete request for that VCH with an invalid value for the `volume_stores` element
+5. Issue a delete request for that VCH with a valid value for the `volume_stores` element, but an invalid value for the `containers` element
+6. Issue a delete request for that VCH with a valid value for the `containers` element, but an invalid value for the `volume_stores` element
+7. Verify that the VCH still exists
+
+#### Expected Outcome:
+* Each erroneous deletion returns a 422 Unprocessable Entity without side effects
+
+
+With Containers
+---------------
+
+###  7. Delete VCH with powered off container
+
+#### Test Steps:
+1. Create a VCH with a powered off container
+2. Issue a delete request without a body
+3. Verify that the VCH no longer exists
+4. Verify that the powered off container VM no longer exists
+
+#### Expected Outcome:
+* The VCH and powered off container are both deleted
+
+
+###  8. Delete VCH with powered off container deletes files
+
+#### Test Steps:
+1. Create a VCH with a powered off container
+2. Issue a delete request without a body
+3. Verify that the files for the powered off container VM no longer exist
+4. Verify that the VCH no longer exists
+
+#### Expected Outcome:
+* The VCH and powered off container are both deleted
+
+
+###  9. Delete VCH without deleting powered on container
+
+#### Test Steps:
+1. Create a VCH with a powered off container and a powered on container
+2. Issue a delete request without a body
+3. Verify that the VCH still exists
+4. Verify that the powered on container VM still exists
+5. Verify that the powered off container VM no longer exists
+
+#### Expected Outcome:
+* The powered off container is deleted, but the deletion fails with a 500 Internal Server Error and the VCH and powered on container both remain
+
+
+### 10. Delete VCH explicitly without deleting powered on container
+
+#### Test Steps:
+1. Create a VCH with a powered off container and a powered on container
+2. Issue a delete request with a body expressing that only powered off containers should be deleted
+3. Verify that the VCH still exists
+4. Verify that the powered on container VM still exists
+5. Verify that the powered off container VM no longer exists
+
+#### Expected Outcome:
+* The powered off container is deleted, but the deletion fails with a 500 Internal Server Error and the VCH and powered on container both remain
+
+
+### 11. Delete VCH and delete powered on container
+
+#### Test Steps:
+1. Create a VCH with a powered off container and a powered on container
+2. Issue a delete request with a body expressing that all containers should be deleted
+3. Verify that the VCH still exists
+4. Verify that the powered on container VM no longer exists
+5. Verify that the powered off container VM no longer exists
+
+#### Expected Outcome:
+* The VCH and both containers are deleted
+
+
+With Volumes
+------------
+
+Note: Because it is more difficult to verify the existence or deletion of anonymous volumes, they are not included in the following tests. If the deletion code is ever updated to treat different types of volumes differently, tests should be added.
+
+### 12. Delete VCH and powered off containers and volumes
+
+#### Test Steps:
+1. Create a VCH with a named volume store
+2. Create a powered off container that has a named volume on the default volume store
+3. Create a powered off container that has a named volume on the named volume store
+4. Issue a delete request with a body expressing that powered off containers and volume stores should be deleted
+5. Verify that the VCH no longer exists
+6. Verify that the container VMs no longer exist
+7. Verify that the volume stores and volumes no longer exist
+
+#### Expected Outcome:
+* The VCH, both containers, both volume stores, and both are deleted
+
+
+### 13. Delete VCH and powered on containers and volumes
+
+#### Test Steps:
+1. Create a VCH with a named volume store
+2. Create a powered on container that has a named volume on the default volume store
+3. Create a powered on container that has a named volume on the named volume store
+4. Issue a delete request with a body expressing that all containers and volume stores should be deleted
+5. Verify that the VCH no longer exists
+6. Verify that the container VMs no longer exist
+7. Verify that the volume stores and volumes no longer exist
+
+#### Expected Outcome:
+* The VCH, both containers, both volume stores, and both are deleted
+
+
+### 14. Delete VCH and powered off container and preserve volumes
+
+#### Test Steps:
+1. Create a VCH with a named volume store
+2. Create a powered off container that has a named volume on the default volume store
+3. Create a powered off container that has a named volume on the named volume store
+4. Issue a delete request with a body expressing that powered off containers, but not volume stores, should be deleted
+5. Verify that the VCH no longer exists
+6. Verify that the container VMs no longer exist
+7. Verify that the volume stores and volumes still exist
+8. Create a new VCH re-using the same volume stores
+9. Create a powered off container re-using the named volume on the default volume store
+10. Create a powered off container re-using the named volume on the named volume store
+
+#### Expected Outcome:
+* The VCH and both containers are deleted, but both volume stores and volumes are preserved and re-usable
+
+
+### 15. Delete VCH and powered on container but preserve volume
+
+#### Test Steps:
+1. Create a VCH with a named volume store
+2. Create a powered on container that has a named volume on the default volume store
+3. Issue a delete request with a body expressing that all containers, but not volume stores, should be deleted
+4. Verify that the VCH no longer exists
+5. Verify that the container VM no longer exists
+6. Verify that the volume store and volume still exists
+7. Create a new VCH re-using the same volume store
+8. Create a powered off container re-using the named volume on the default volume store
+
+#### Expected Outcome:
+* The VCH and container are deleted, but the volume store and volume are preserved and re-usable
+
+
+### 16. Delete VCH and preserve powered on container and volumes
+
+#### Test Steps:
+1. Create a VCH with a named volume store
+2. Create a powered on container that has a named volume on the default volume store
+3. Issue a delete request with a body expressing that neither powered on containers nor volume stores should be deleted
+4. Verify that the VCH still exists
+5. Verify that the container VM still exists
+6. Verify that the volume store and volume still exist
+
+#### Expected Outcome:
+* The deletion fails with a 500 Internal Server Error and the VCH, powered on container, volume store, and volume all remain
+
+
+### 17. Delete VCH and preserve powered on container and fail to delete volumes
+
+#### Test Steps:
+1. Create a VCH with a named volume store
+2. Create a powered on container that has a named volume on the default volume store
+3. Issue a delete request with a body expressing that volume stores, but not powered on containers, should be deleted
+4. Verify that the VCH still exists
+5. Verify that the container VM still exists
+6. Verify that the volume store and volume still exist
+
+#### Expected Outcome:
+* The deletion fails with a 500 Internal Server Error and the VCH, powered on container, volume store, and volume all remain

--- a/tests/test-cases/Group23-VIC-Machine-Service/23-08-VCH-Delete.robot
+++ b/tests/test-cases/Group23-VIC-Machine-Service/23-08-VCH-Delete.robot
@@ -1,0 +1,629 @@
+# Copyright 2017 VMware, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#	http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License
+
+*** Settings ***
+Documentation     Test 23-03 - VCH Create
+Resource          ../../resources/Util.robot
+Resource          ../../resources/Group23-VIC-Machine-Service-Util.robot
+Suite Setup       Start VIC Machine Server
+Suite Teardown    Terminate All Processes    kill=True
+Test Setup        Install And Prepare VIC Appliance
+Default Tags
+
+
+*** Keywords ***
+Pull Busybox
+    Run Docker Command    pull ${busybox}
+    Verify Return Code
+    Output Should Not Contain    Error
+
+Install And Prepare VIC Appliance
+    Install VIC Appliance To Test Server
+    Pull Busybox
+
+Re-Install And Prepare VIC Appliance
+    Install VIC Appliance To Test Server With Current Environment Variables
+    Pull Busybox
+
+Install And Prepare VIC Appliance With Volume Stores
+    Set Test Environment Variables
+    Set Test Variable    ${VOLUME_STORE_PATH}    %{VCH-NAME}-VOL-foo
+    Set Test Variable    ${VOLUME_STORE_NAME}    foo
+
+    Re-Install And Prepare VIC Appliance With Volume Stores
+
+Re-Install And Prepare VIC Appliance With Volume Stores
+    Install VIC Appliance To Test Server With Current Environment Variables    additional-args=--volume-store=%{TEST_DATASTORE}/${VOLUME_STORE_PATH}:${VOLUME_STORE_NAME}
+    Pull Busybox
+
+
+Get VCH ID ${name}
+    Get Path Under Target    vch
+    ${id}=    Run    echo '${OUTPUT}' | jq -r '.vchs[] | select(.name=="${name}").id'
+    [Return]    ${id}
+
+
+Run Docker Command
+    [Arguments]    ${command}
+
+    ${RC}  ${OUTPUT}=    Run And Return Rc And Output    docker %{VCH-PARAMS} ${command}
+    Set Test Variable    ${RC}
+    Set Test Variable    ${OUTPUT}
+
+
+Start Last Container
+    Run Docker Command    start ${OUTPUT}
+    Verify Return Code
+    Output Should Not Contain    Error:
+
+
+Populate VCH with Powered Off Container
+    ${POWERED_OFF_CONTAINER_NAME}=  Generate Random String  15
+
+    Run Docker Command    create --name ${POWERED_OFF_CONTAINER_NAME} ${busybox} /bin/top
+    Verify Return Code
+    Output Should Not Contain    Error
+
+    Set Test Variable    ${POWERED_OFF_CONTAINER_NAME}
+
+Populate VCH with Powered On Container
+    ${POWERED_ON_CONTAINER_NAME}=  Generate Random String  15
+
+    Run Docker Command    create --name ${POWERED_ON_CONTAINER_NAME} ${busybox} /bin/top
+    Verify Return Code
+    Output Should Not Contain    Error
+
+    Start Last Container
+
+    Set Test Variable    ${POWERED_ON_CONTAINER_NAME}
+
+
+Populate VCH with Named Volume on Default Volume Store Attached to Powered Off Container
+    ${BASE}=  Generate Random String  15
+
+    Set Test Variable    ${OFF_NV_DVS_VOLUME_NAME}       ${BASE}-nv-dvs
+    Set Test Variable    ${OFF_NV_DVS_CONTAINER_NAME}    ${BASE}-c-nv-dvs
+
+    Run Docker Command    volume create --name ${OFF_NV_DVS_VOLUME_NAME}
+    Verify Return Code
+    Output Should Not Contain    Error
+
+    Run Docker Command    create --name ${OFF_NV_DVS_CONTAINER_NAME} -v ${OFF_NV_DVS_VOLUME_NAME}:/volume ${busybox} /bin/top
+    Verify Return Code
+    Output Should Not Contain    Error
+
+Populate VCH with Named Volume on Named Volume Store Attached to Powered Off Container
+    ${BASE}=  Generate Random String  15
+
+    Set Test Variable    ${OFF_NV_NVS_VOLUME_NAME}       ${BASE}-nv-nvs
+    Set Test Variable    ${OFF_NV_NVS_CONTAINER_NAME}    ${BASE}-c-nv-nvs
+
+    Run Docker Command    volume create --name ${OFF_NV_NVS_VOLUME_NAME} --opt VolumeStore=${VOLUME_STORE_NAME}
+    Verify Return Code
+    Output Should Not Contain    Error
+
+    Run Docker Command    create --name ${OFF_NV_NVS_CONTAINER_NAME} -v ${OFF_NV_NVS_VOLUME_NAME}:/volume ${busybox} /bin/top
+    Verify Return Code
+    Output Should Not Contain    Error
+
+Populate VCH with Named Volume on Default Volume Store Attached to Powered On Container
+    ${BASE}=  Generate Random String  15
+
+    Set Test Variable    ${ON_NV_DVS_VOLUME_NAME}       ${BASE}-nv-dvs-on
+    Set Test Variable    ${ON_NV_DVS_CONTAINER_NAME}    ${BASE}-c-nv-dvs-on
+
+    Run Docker Command    volume create --name ${ON_NV_DVS_VOLUME_NAME}
+    Verify Return Code
+    Output Should Not Contain    Error
+
+    Run Docker Command    create --name ${ON_NV_DVS_CONTAINER_NAME} -v ${ON_NV_DVS_VOLUME_NAME}:/volume ${busybox} /bin/top
+    Verify Return Code
+    Output Should Not Contain    Error
+
+    Start Last Container
+
+Populate VCH with Named Volume on Named Volume Store Attached to Powered On Container
+    ${BASE}=  Generate Random String  15
+
+    Set Test Variable    ${ON_NV_NVS_VOLUME_NAME}       ${BASE}-nv-nvs-on
+    Set Test Variable    ${ON_NV_NVS_CONTAINER_NAME}    ${BASE}-c-nv-nvs-on
+
+    Run Docker Command    volume create --name ${ON_NV_NVS_VOLUME_NAME} --opt VolumeStore=${VOLUME_STORE_NAME}
+    Verify Return Code
+    Output Should Not Contain    Error
+
+    Run Docker Command    create --name ${ON_NV_NVS_CONTAINER_NAME} -v ${ON_NV_NVS_VOLUME_NAME}:/volume ${busybox} /bin/top
+    Verify Return Code
+    Output Should Not Contain    Error
+
+    Start Last Container
+
+
+Verify Container Exists
+    [Arguments]    ${name}
+
+    ${vm}=    Run    govc vm.info -json=true ${name}-* | jq '.VirtualMachines | length'
+    Should Be Equal As Integers       ${vm}    1
+
+Verify Container Not Exists
+    [Arguments]    ${name}
+
+    ${vm}=    Run    govc vm.info -json=true ${name}-* | jq '.VirtualMachines | length'
+    Should Be Equal As Integers       ${vm}    0
+
+
+Verify VCH Exists
+    [Arguments]    ${path}    ${name}=%{VCH-NAME}
+
+    Get Path Under Target             ${path}
+    Verify Return Code
+    Verify Status Ok
+
+    ${rp}=    Run    govc ls -json=true host/*/Resources/${name} | jq '.elements | length'
+    ${vm}=    Run    govc vm.info -json=true ${name} | jq '.VirtualMachines | length'
+    ${ds}=    Run    govc datastore.ls ${name}
+
+    Should Be Equal As Integers       ${rp}    1
+    Should Be Equal As Integers       ${vm}    1
+    Should Not Contain                ${ds}    was not found
+
+Verify VCH Not Exists
+    [Arguments]    ${path}    ${name}=%{VCH-NAME}
+
+    Get Path Under Target             ${path}
+    Verify Return Code
+    Verify Status Not Found
+
+    ${rp}=    Run    govc ls -json=true host/*/Resources/${name} | jq '.elements | length'
+    ${vm}=    Run    govc vm.info -json=true ${name} | jq '.VirtualMachines | length'
+    ${ds}=    Run    govc datastore.ls ${name}
+
+    Should Be Equal As Integers       ${rp}    0
+    Should Be Equal As Integers       ${vm}    0
+    Should Contain                    ${ds}    was not found
+
+
+Verify Volume Exists
+    [Arguments]    ${volume}    ${name}
+
+    ${ds}=    Run    govc datastore.ls ${volume}/volumes/${name}
+
+    Should Not Contain                ${ds}    was not found
+
+Verify Volume Not Exists
+    [Arguments]    ${volume}    ${name}
+
+    ${ds}=    Run    govc datastore.ls ${volume}/volumes/${name}
+
+    Should Contain                    ${ds}    was not found
+
+Verify Volume Store Exists
+    [Arguments]    ${name}
+
+    ${ds}=    Run    govc datastore.ls ${name}
+
+    Should Not Contain                ${ds}    was not found
+
+Verify Volume Store Not Exists
+    [Arguments]    ${name}
+
+    ${ds}=    Run    govc datastore.ls ${name}
+
+    Should Contain                    ${ds}    was not found
+
+
+*** Test Cases ***
+Delete VCH
+    ${id}=    Get VCH ID %{VCH-NAME}
+
+    Verify VCH Exists                 vch/${id}
+
+    Delete Path Under Target          vch/${id}
+    Verify Return Code
+    Verify Status Accepted
+
+    Verify VCH Not Exists             vch/${id}
+
+
+Delete VCH within datacenter
+    ${dc}=    Get Datacenter ID
+    ${id}=    Get VCH ID %{VCH-NAME}
+
+    Verify VCH Exists                 datacenter/${dc}/vch/${id}
+
+    Delete Path Under Target          datacenter/${dc}/vch/${id}
+    Verify Return Code
+    Verify Status Accepted
+
+    Verify VCH Not Exists             datacenter/${dc}/vch/${id}
+
+
+Delete the correct VCH
+    ${one}=    Get VCH ID %{VCH-NAME}
+    ${old}=    Set Variable    %{VCH-NAME}
+
+    Install VIC Appliance To Test Server
+
+    ${two}=    Get VCH ID %{VCH-NAME}
+
+    Should Not Be Equal As Integers    ${one}    ${two}
+
+    Verify VCH Exists                 vch/${one}    ${old}
+    Verify VCH Exists                 vch/${two}
+
+    Delete Path Under Target          vch/${one}
+    Verify Return Code
+    Verify Status Accepted
+
+    Verify VCH Not Exists             vch/${one}    ${old}
+    Verify VCH Exists                 vch/${two}
+
+
+Delete invalid VCH
+    ${id}=    Get VCH ID %{VCH-NAME}
+
+    Delete Path Under Target           vch/INVALID
+    Verify Return Code
+    Verify Status Not Found
+
+    Verify VCH Exists                  vch/${id}
+
+    [Teardown]    Cleanup VIC Appliance On Test Server
+
+
+Delete VCH in invalid datacenter
+    ${id}=    Get VCH ID %{VCH-NAME}
+
+    Delete Path Under Target           datacenter/INVALID/vch/${id}
+    Verify Return Code
+    Verify Status Not Found
+
+    Verify VCH Exists                  vch/${id}
+
+    [Teardown]    Cleanup VIC Appliance On Test Server
+
+
+Delete with invalid bodies
+    ${id}=    Get VCH ID %{VCH-NAME}
+
+    Delete Path Under Target           vch/${id}    '{"invalid"}'
+    Verify Return Code
+    Verify Status Bad Request
+
+    Delete Path Under Target           vch/${id}    '{"containers":"invalid"}'
+    Verify Return Code
+    Verify Status Unprocessable Entity
+    Output Should Contain              containers
+
+    Delete Path Under Target           vch/${id}    '{"volume_stores":"invalid"}'
+    Verify Return Code
+    Verify Status Unprocessable Entity
+    Output Should Contain              volume_stores
+
+    Delete Path Under Target           vch/${id}    '{"containers":"invalid", "volume_stores":"all"}'
+    Verify Return Code
+    Verify Status Unprocessable Entity
+    Output Should Contain              containers
+
+    Delete Path Under Target           vch/${id}    '{"containers":"all", "volume_stores":"invalid"}'
+    Verify Return Code
+    Verify Status Unprocessable Entity
+    Output Should Contain              volume_stores
+
+    Verify VCH Exists                  vch/${id}
+
+    [Teardown]    Cleanup VIC Appliance On Test Server
+
+
+Delete VCH with powered off container
+    ${id}=    Get VCH ID %{VCH-NAME}
+
+    Populate VCH with Powered Off Container
+
+    Verify Container Exists           ${POWERED_OFF_CONTAINER_NAME}
+    Verify VCH Exists                 vch/${id}
+
+    Delete Path Under Target          vch/${id}
+    Verify Return Code
+    Verify Status Accepted
+
+    Verify VCH Not Exists             vch/${id}
+    Verify Container Not Exists       ${POWERED_OFF_CONTAINER_NAME}
+
+
+Delete VCH with powered off container deletes files
+    ${id}=    Get VCH ID %{VCH-NAME}
+
+    Populate VCH with Powered Off Container
+
+    Verify VCH Exists                 vch/${id}
+
+    Run Docker Command    inspect ${POWERED_OFF_CONTAINER_NAME}
+    ${uuid}=                          Run      echo '${OUTPUT}' | jq -r '.[0].Id'
+    ${ds}=                            Run      govc datastore.ls ${uuid}
+    Should Not Contain                ${ds}    was not found
+
+    Delete Path Under Target          vch/${id}
+    Verify Return Code
+    Verify Status Accepted
+
+    ${ds}=                            Run      govc datastore.ls ${uuid}
+    Should Contain                    ${ds}    was not found
+
+    Verify VCH Not Exists             vch/${id}
+
+
+Delete VCH without deleting powered on container
+    ${id}=    Get VCH ID %{VCH-NAME}
+
+    Populate VCH with Powered On Container
+    Populate VCH with Powered Off Container
+
+    Verify Container Exists           ${POWERED_ON_CONTAINER_NAME}
+    Verify Container Exists           ${POWERED_OFF_CONTAINER_NAME}
+    Verify VCH Exists                 vch/${id}
+
+    Delete Path Under Target          vch/${id}
+    Verify Return Code
+    Verify Status Internal Server Error
+
+    Verify VCH Exists                 vch/${id}
+    Verify Container Exists           ${POWERED_ON_CONTAINER_NAME}
+    Verify Container Not Exists       ${POWERED_OFF_CONTAINER_NAME}
+
+    [Teardown]    Cleanup VIC Appliance On Test Server
+
+
+Delete VCH explicitly without deleting powered on container
+    ${id}=    Get VCH ID %{VCH-NAME}
+
+    Populate VCH with Powered On Container
+    Populate VCH with Powered Off Container
+
+    Verify Container Exists           ${POWERED_ON_CONTAINER_NAME}
+    Verify Container Exists           ${POWERED_OFF_CONTAINER_NAME}
+    Verify VCH Exists                 vch/${id}
+
+    Delete Path Under Target          vch/${id}    '{"containers":"off"}'
+    Verify Return Code
+    Verify Status Internal Server Error
+
+    Verify VCH Exists                 vch/${id}
+    Verify Container Exists           ${POWERED_ON_CONTAINER_NAME}
+    Verify Container Not Exists       ${POWERED_OFF_CONTAINER_NAME}
+
+    [Teardown]    Cleanup VIC Appliance On Test Server
+
+
+Delete VCH and delete powered on container
+    ${id}=    Get VCH ID %{VCH-NAME}
+
+    Populate VCH with Powered On Container
+    Populate VCH with Powered Off Container
+
+    Verify Container Exists           ${POWERED_ON_CONTAINER_NAME}
+    Verify Container Exists           ${POWERED_OFF_CONTAINER_NAME}
+    Verify VCH Exists                 vch/${id}
+
+    Delete Path Under Target          vch/${id}    '{"containers":"all"}'
+    Verify Return Code
+    Verify Status Accepted
+
+    Verify VCH Not Exists             vch/${id}
+    Verify Container Not Exists       ${POWERED_ON_CONTAINER_NAME}
+    Verify Container Not Exists       ${POWERED_OFF_CONTAINER_NAME}
+
+
+Delete VCH and powered off containers and volumes
+    [Setup]    Install And Prepare VIC Appliance With Volume Stores
+    ${id}=    Get VCH ID %{VCH-NAME}
+
+    Verify VCH Exists                 vch/${id}
+
+    Populate VCH with Named Volume on Default Volume Store Attached to Powered Off Container
+
+    Verify Container Exists           ${OFF_NV_DVS_CONTAINER_NAME}
+    Verify Volume Store Exists        %{VCH-NAME}-VOL
+    Verify Volume Exists              %{VCH-NAME}-VOL                 ${OFF_NV_DVS_VOLUME_NAME}
+
+    Populate VCH with Named Volume on Named Volume Store Attached to Powered Off Container
+
+    Verify Container Exists           ${OFF_NV_NVS_CONTAINER_NAME}
+    Verify Volume Store Exists        ${VOLUME_STORE_PATH}
+    Verify Volume Exists              ${VOLUME_STORE_PATH}            ${OFF_NV_NVS_VOLUME_NAME}
+
+    Delete Path Under Target          vch/${id}    '{"containers":"off","volume_stores":"all"}'
+    Verify Return Code
+    Verify Status Accepted
+
+    Verify VCH Not Exists             vch/${id}
+
+    Verify Container Not Exists       ${OFF_NV_DVS_CONTAINER_NAME}
+    Verify Volume Store Not Exists    %{VCH-NAME}-VOL
+    Verify Volume Not Exists          %{VCH-NAME}-VOL                ${OFF_NV_DVS_VOLUME_NAME}
+
+    Verify Container Not Exists       ${OFF_NV_NVS_CONTAINER_NAME}
+    Verify Volume Store Not Exists    ${VOLUME_STORE_PATH}
+    Verify Volume Not Exists          ${VOLUME_STORE_PATH}           ${OFF_NV_NVS_VOLUME_NAME}
+
+
+Delete VCH and powered on containers and volumes
+    [Setup]    Install And Prepare VIC Appliance With Volume Stores
+    ${id}=    Get VCH ID %{VCH-NAME}
+
+    Verify VCH Exists                 vch/${id}
+
+    Populate VCH with Named Volume on Default Volume Store Attached to Powered On Container
+
+    Verify Container Exists           ${ON_NV_DVS_CONTAINER_NAME}
+    Verify Volume Store Exists        %{VCH-NAME}-VOL
+    Verify Volume Exists              %{VCH-NAME}-VOL                ${ON_NV_DVS_VOLUME_NAME}
+
+    Populate VCH with Named Volume on Named Volume Store Attached to Powered On Container
+
+    Verify Container Exists           ${ON_NV_NVS_CONTAINER_NAME}
+    Verify Volume Store Exists        ${VOLUME_STORE_PATH}
+    Verify Volume Exists              ${VOLUME_STORE_PATH}           ${ON_NV_NVS_VOLUME_NAME}
+
+    Delete Path Under Target          vch/${id}    '{"containers":"all","volume_stores":"all"}'
+    Verify Return Code
+    Verify Status Accepted
+
+    Verify VCH Not Exists             vch/${id}
+
+    Verify Container Not Exists       ${ON_NV_DVS_CONTAINER_NAME}
+    Verify Volume Store Not Exists    %{VCH-NAME}-VOL
+    Verify Volume Not Exists          %{VCH-NAME}-VOL                ${ON_NV_DVS_VOLUME_NAME}
+
+    Verify Container Not Exists       ${ON_NV_NVS_CONTAINER_NAME}
+    Verify Volume Store Not Exists    ${VOLUME_STORE_PATH}
+    Verify Volume Not Exists          ${VOLUME_STORE_PATH}           ${ON_NV_NVS_VOLUME_NAME}
+
+
+Delete VCH and powered off container and preserve volumes
+    [Setup]    Install And Prepare VIC Appliance With Volume Stores
+    ${id}=    Get VCH ID %{VCH-NAME}
+
+    Verify VCH Exists                 vch/${id}
+
+    Populate VCH with Named Volume on Default Volume Store Attached to Powered Off Container
+
+    Verify Container Exists           ${OFF_NV_DVS_CONTAINER_NAME}
+    Verify Volume Store Exists        %{VCH-NAME}-VOL
+    Verify Volume Exists              %{VCH-NAME}-VOL                ${OFF_NV_DVS_VOLUME_NAME}
+
+    Populate VCH with Named Volume on Named Volume Store Attached to Powered Off Container
+
+    Verify Container Exists           ${OFF_NV_NVS_CONTAINER_NAME}
+    Verify Volume Store Exists        ${VOLUME_STORE_PATH}
+    Verify Volume Exists              ${VOLUME_STORE_PATH}           ${OFF_NV_NVS_VOLUME_NAME}
+
+    Delete Path Under Target          vch/${id}    '{"containers":"off","volume_stores":"none"}'
+    Verify Return Code
+    Verify Status Accepted
+
+    Verify VCH Not Exists             vch/${id}
+
+    Verify Container Not Exists       ${OFF_NV_DVS_CONTAINER_NAME}
+    Verify Volume Store Exists        %{VCH-NAME}-VOL
+    Verify Volume Exists              %{VCH-NAME}-VOL                ${OFF_NV_DVS_VOLUME_NAME}
+
+    Verify Container Not Exists       ${OFF_NV_NVS_CONTAINER_NAME}
+    Verify Volume Store Exists        ${VOLUME_STORE_PATH}
+    Verify Volume Exists              ${VOLUME_STORE_PATH}           ${OFF_NV_NVS_VOLUME_NAME}
+
+    # Re-use preserved volumes
+    Re-Install And Prepare VIC Appliance With Volume Stores
+    ${id}=    Get VCH ID %{VCH-NAME}
+
+    Verify VCH Exists                 vch/${id}
+
+    Run Docker Command    create --name ${OFF_NV_DVS_CONTAINER_NAME} -v ${OFF_NV_DVS_VOLUME_NAME}:/volume ${busybox} /bin/top
+    Verify Return Code
+    Output Should Not Contain    Error
+
+    Verify Container Exists           ${OFF_NV_DVS_CONTAINER_NAME}
+    Verify Volume Store Exists        %{VCH-NAME}-VOL
+    Verify Volume Exists              %{VCH-NAME}-VOL                ${OFF_NV_DVS_VOLUME_NAME}
+
+    Run Docker Command    create --name ${OFF_NV_NVS_CONTAINER_NAME} -v ${OFF_NV_NVS_VOLUME_NAME}:/volume ${busybox} /bin/top
+    Verify Return Code
+    Output Should Not Contain    Error
+
+    Verify Container Exists           ${OFF_NV_NVS_CONTAINER_NAME}
+    Verify Volume Store Exists        ${VOLUME_STORE_PATH}
+    Verify Volume Exists              ${VOLUME_STORE_PATH}           ${OFF_NV_NVS_VOLUME_NAME}
+
+
+Delete VCH and powered on container but preserve volume
+    [Setup]    Install And Prepare VIC Appliance With Volume Stores
+    ${id}=    Get VCH ID %{VCH-NAME}
+
+    Verify VCH Exists                 vch/${id}
+
+    Populate VCH with Named Volume on Default Volume Store Attached to Powered On Container
+
+    Verify Container Exists           ${ON_NV_DVS_CONTAINER_NAME}
+    Verify Volume Store Exists        %{VCH-NAME}-VOL
+    Verify Volume Exists              %{VCH-NAME}-VOL                ${ON_NV_DVS_VOLUME_NAME}
+
+    Delete Path Under Target          vch/${id}    '{"containers":"all","volume_stores":"none"}'
+    Verify Return Code
+    Verify Status Accepted
+
+    Verify VCH Not Exists             vch/${id}
+
+    Verify Container Not Exists       ${ON_NV_DVS_CONTAINER_NAME}
+    Verify Volume Store Exists        %{VCH-NAME}-VOL
+    Verify Volume Exists              %{VCH-NAME}-VOL                ${ON_NV_DVS_VOLUME_NAME}
+
+    # Re-use preserved volume
+    Re-Install And Prepare VIC Appliance
+    ${id}=    Get VCH ID %{VCH-NAME}
+
+    Verify VCH Exists                 vch/${id}
+
+    Run Docker Command    create --name ${ON_NV_DVS_CONTAINER_NAME} -v ${ON_NV_DVS_VOLUME_NAME}:/volume ${busybox} /bin/top
+    Verify Return Code
+    Output Should Not Contain    Error
+
+    Verify Container Exists           ${ON_NV_DVS_CONTAINER_NAME}
+    Verify Volume Store Exists        %{VCH-NAME}-VOL
+    Verify Volume Exists              %{VCH-NAME}-VOL                ${ON_NV_DVS_VOLUME_NAME}
+
+
+Delete VCH and preserve powered on container and volumes
+    [Setup]    Install And Prepare VIC Appliance With Volume Stores
+    ${id}=    Get VCH ID %{VCH-NAME}
+
+    Verify VCH Exists                 vch/${id}
+
+    Populate VCH with Named Volume on Default Volume Store Attached to Powered On Container
+
+    Verify Container Exists           ${ON_NV_DVS_CONTAINER_NAME}
+    Verify Volume Store Exists        %{VCH-NAME}-VOL
+    Verify Volume Exists              %{VCH-NAME}-VOL                ${ON_NV_DVS_VOLUME_NAME}
+
+    Delete Path Under Target          vch/${id}    '{"containers":"off","volume_stores":"none"}'
+    Verify Return Code
+    Verify Status Internal Server Error
+
+    Verify VCH Exists                 vch/${id}
+
+    Verify Container Exists           ${ON_NV_DVS_CONTAINER_NAME}
+    Verify Volume Store Exists        %{VCH-NAME}-VOL
+    Verify Volume Exists              %{VCH-NAME}-VOL                ${ON_NV_DVS_VOLUME_NAME}
+
+
+Delete VCH and preserve powered on container and fail to delete volumes
+    [Setup]    Install And Prepare VIC Appliance With Volume Stores
+    ${id}=    Get VCH ID %{VCH-NAME}
+
+    Verify VCH Exists                 vch/${id}
+
+    Populate VCH with Named Volume on Default Volume Store Attached to Powered On Container
+
+    Verify Container Exists           ${ON_NV_DVS_CONTAINER_NAME}
+    Verify Volume Store Exists        %{VCH-NAME}-VOL
+    Verify Volume Exists              %{VCH-NAME}-VOL                ${ON_NV_DVS_VOLUME_NAME}
+
+    Delete Path Under Target          vch/${id}    '{"containers":"off","volume_stores":"all"}'
+    Verify Return Code
+    Verify Status Internal Server Error
+
+    Verify VCH Exists                 vch/${id}
+
+    Verify Container Exists           ${ON_NV_DVS_CONTAINER_NAME}
+    Verify Volume Store Exists        %{VCH-NAME}-VOL
+    Verify Volume Exists              %{VCH-NAME}-VOL                ${ON_NV_DVS_VOLUME_NAME}


### PR DESCRIPTION
Introduce a pair of handlers for deleting VCHs within a vSphere target or datacenter. By default, deletion includes the VCH and powered off containers. Deletion may optionally include powered on containers and/or volume stores as well.

If any containers remain, the VCH is not deleted. If the VCH is not deleted, the response includes a non-2xx status code.

Define a suite of end-to-end tests which verify the intended deletion behavior. End-to-end tests do not attempt to verify the behavior of concurrent operations.

Fixes #6137
Fixes #6139