### PR TITLE
VCH Creation API: Stop writing key files to disk [full ci]

### DIFF
--- a/lib/apiservers/service/restapi/handlers/vch_create.go
+++ b/lib/apiservers/service/restapi/handlers/vch_create.go
@@ -369,6 +369,8 @@ func buildCreate(op trace.Operation, d *data.Data, finder *find.Finder, vch *mod
 					c.Certs.Org = vch.Auth.Server.Generate.Organization
 					c.Certs.KeySize = fromValueBits(vch.Auth.Server.Generate.Size)
 
+					c.Certs.NoSaveToDisk = true
+
 					if err := c.Certs.ProcessCertificates(c.DisplayName, c.Force, 0); err != nil {
 						return nil, util.NewError(http.StatusBadRequest, fmt.Sprintf("Error generating certificates: %s", err))
 					}


### PR DESCRIPTION
When creating a VCH via the API, we should not write key/certificate files to the API server's disk.

This change introduces the behavior as a flag so that it could be exposed as an option for the CLI at some point in the future, but does not expose it at this time.

Resolves #6650 
