### PR TITLE
[specific ci=1-07-Docker-Stop] Do not cause the test to fail in the case if exit code mismatch

### DIFF
--- a/tests/test-cases/Group1-Docker-Commands/1-07-Docker-Stop.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-07-Docker-Stop.robot
@@ -82,7 +82,9 @@ Basic docker stop w/ unclean exit from running process
     Should Be Equal As Integers  ${rc}  0
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} inspect ${container} | jq '.[]|.["State"]|.["ExitCode"]'
     Should Be Equal As Integers  ${rc}  0
-    Should Be Equal As Integers  ${output}  143
+    ${status}=  Get State Of Github Issue  6614
+    Run Keyword If  '${status}' == 'closed'  Fail  Test 1-07-Docker-Stop.robot needs to be updated now that Issue #6614 has been resolved
+    #Should Be Equal As Integers  ${output}  143
 
 Stop a container with SIGKILL using default grace period
     ${rc}=  Run And Return Rc  docker %{VCH-PARAMS} pull ${busybox}


### PR DESCRIPTION
From our discussion/decision here: 
https://github.com/vmware/vic/issues/6614#issuecomment-342601920