### PR TITLE
[specific ci=1-11-Docker-RM] Force remove container in 1-11-Docker-RM test

### DIFF
--- a/tests/test-cases/Group1-Docker-Commands/1-11-Docker-RM.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-11-Docker-RM.robot
@@ -149,5 +149,5 @@ Remove a container and its anonymous volumes
     # Verify that the above volume can be used by containers
     ${rc}  ${c4}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -d -v ${anonvol}:/bar ${busybox} /bin/ls
     Should Be Equal As Integers  ${rc}  0
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} rm ${c4}
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} rm -f ${c4}
     Should Be Equal As Integers  ${rc}  0


### PR DESCRIPTION
This commit makes the 'Remove a container and its anonymous volume'
test case more robust by force-removing the container that runs the
/bin/ls command, since it's possible for the container to not have
powered off fully and the container state to not have updated to
'Stopped' before the remove command is issued in the test.

Before this change, it was possible for the test to fail if the
container state wasn't updated on time. This was seen in CI build
14551 for PR #6665.

Since that test snippet's intent (verify that the anonymous volume
can be used by a new container) is unaffected by how the container
is removed, this change is valid.

Enhances #6262