### PR TITLE
Add support for new "vic-machine" flag to init Roles/Permission for ops-user, not exposed

### DIFF
--- a/cmd/vic-machine/common/ops_credentials.go
+++ b/cmd/vic-machine/common/ops_credentials.go
@@ -31,6 +31,7 @@ type OpsCredentials struct {
 	OpsUser     *string `cmd:"ops-user"`
 	OpsPassword *string
 	IsSet       bool
+	GrantPerms  bool
 }
 
 func (o *OpsCredentials) Flags(hidden bool) []cli.Flag {
@@ -66,13 +67,17 @@ func (o *OpsCredentials) ProcessOpsCredentials(isCreateOp bool, adminUser string
 			if adminPassword == nil {
 				return errors.New("Unable to use nil password from administrative user for operations user")
 			}
-
 			o.OpsPassword = adminPassword
+			// If using the admin user don't init roles and Permissions
+			o.GrantPerms = false
 			return nil
 		}
 	} else {
 		if o.OpsUser != nil {
 			o.IsSet = true
+		} else {
+			// If using the admin user don't init roles and Permissions
+			o.GrantPerms = false
 		}
 	}
 

--- a/lib/config/virtual_container_host.go
+++ b/lib/config/virtual_container_host.go
@@ -55,6 +55,8 @@ const (
 	GeneralHTTPSProxy  = "HTTPS_PROXY"
 	VICAdminHTTPProxy  = "VICADMIN_HTTP_PROXY"
 	VICAdminHTTPSProxy = "VICADMIN_HTTPS_PROXY"
+
+	AddPerms = "ADD"
 )
 
 // Can we just treat the VCH appliance as a containerVM booting off a specific bootstrap image
@@ -95,6 +97,9 @@ type VirtualContainerHostConfigSpec struct {
 
 	// configuration for vic-machine
 	CreateBridgeNetwork bool `vic:"0.1" scope:"read-only" key:"create_bridge_network"`
+
+	// grant ops-user permissions, string instead of bool for future enhancements
+	GrantPermsLevel string `vic:"0.1" scope:"read-only" key:"grant_permissions"`
 
 	// vic-machine create options used to create or reconfigure the VCH
 	VicMachineCreateOptions []string `vic:"0.1" scope:"read-only" key:"vic_machine_create_options"`
@@ -246,6 +251,14 @@ func (t *VirtualContainerHostConfigSpec) SetIsCreating(creating bool) {
 // IsCreating is checking if this configuration is for one creating VCH VM
 func (t *VirtualContainerHostConfigSpec) IsCreating() bool {
 	return t.ExecutorConfig.ID == CreatingVCH
+}
+
+func (t *VirtualContainerHostConfigSpec) SetGrantPerms() {
+	t.GrantPermsLevel = AddPerms
+}
+
+func (t *VirtualContainerHostConfigSpec) ShouldGrantPerms() bool {
+	return t.GrantPermsLevel == AddPerms
 }
 
 // AddNetwork adds a network that will be configured on the appliance VM

--- a/lib/install/management/configure.go
+++ b/lib/install/management/configure.go
@@ -111,6 +111,12 @@ func (d *Dispatcher) Configure(vch *vm.VirtualMachine, conf *config.VirtualConta
 	}
 
 	if err = d.update(conf, settings, isConfigureOp); err == nil {
+		if conf.ShouldGrantPerms() {
+			err = GrantOpsUserPerms(d.ctx, d.session.Vim25(), conf)
+			if err != nil {
+				return errors.Errorf("Cannot init ops-user permissions, failure: %s. Exiting...", err)
+			}
+		}
 		// compatible with old version's upgrade snapshot name
 		if oldSnapshot != nil && (vm.IsConfigureSnapshot(oldSnapshot, ConfigurePrefix) || vm.IsConfigureSnapshot(oldSnapshot, UpgradePrefix)) {
 			d.retryDeleteSnapshotByRef(&oldSnapshot.Snapshot, oldSnapshot.Name, conf.Name)

--- a/lib/install/management/create.go
+++ b/lib/install/management/create.go
@@ -64,6 +64,13 @@ func (d *Dispatcher) CreateVCH(conf *config.VirtualContainerHostConfigSpec, sett
 		return errors.Errorf("Uploading images failed with %s. Exiting...", err)
 	}
 
+	if conf.ShouldGrantPerms() {
+		err = GrantOpsUserPerms(d.ctx, d.session.Vim25(), conf)
+		if err != nil {
+			return errors.Errorf("Cannot init ops-user permissions, failure: %s. Exiting...", err)
+		}
+	}
+
 	return d.startAppliance(conf)
 }
 

--- a/lib/install/management/rbac_conf.go
+++ b/lib/install/management/rbac_conf.go
@@ -1,0 +1,143 @@
+// Copyright 2016-2017 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package management
+
+import (
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+var rolePrefix = "vic-vch-"
+
+var RoleVCenter = types.AuthorizationRole{
+	Name: "vcenter",
+	Privilege: []string{
+		"Datastore.Config",
+	},
+}
+
+var RoleDataCenter = types.AuthorizationRole{
+	Name: "datacenter",
+	Privilege: []string{
+		"Datastore.Config",
+		"Datastore.FileManagement",
+		"VirtualMachine.Config.AddNewDisk",
+		"VirtualMachine.Config.AdvancedConfig",
+		"VirtualMachine.Config.RemoveDisk",
+		"VirtualMachine.Inventory.Create",
+		"VirtualMachine.Inventory.Delete",
+	},
+}
+
+var RoleCluster = types.AuthorizationRole{
+	Name: "cluster",
+	Privilege: []string{
+		"Datastore.AllocateSpace",
+		"Datastore.Browse",
+		"Datastore.Config",
+		"Datastore.DeleteFile",
+		"Datastore.FileManagement",
+		"Host.Config.SystemManagement",
+	},
+}
+
+var RoleDataStore = types.AuthorizationRole{
+	Name: "datastore",
+	Privilege: []string{
+		"Datastore.AllocateSpace",
+		"Datastore.Browse",
+		"Datastore.Config",
+		"Datastore.DeleteFile",
+		"Datastore.FileManagement",
+		"Host.Config.SystemManagement",
+	},
+}
+
+var RoleNetwork = types.AuthorizationRole{
+	Name: "network",
+	Privilege: []string{
+		"Network.Assign",
+	},
+}
+
+var RoleEndpoint = types.AuthorizationRole{
+	Name: "endpoint",
+	Privilege: []string{
+		"DVPortgroup.Modify",
+		"DVPortgroup.PolicyOp",
+		"DVPortgroup.ScopeOp",
+		"Resource.AssignVMToPool",
+		"VirtualMachine.Config.AddExistingDisk",
+		"VirtualMachine.Config.AddNewDisk",
+		"VirtualMachine.Config.AddRemoveDevice",
+		"VirtualMachine.Config.AdvancedConfig",
+		"VirtualMachine.Config.EditDevice",
+		"VirtualMachine.Config.RemoveDisk",
+		"VirtualMachine.Config.Rename",
+		"VirtualMachine.GuestOperations.Execute",
+		"VirtualMachine.Interact.DeviceConnection",
+		"VirtualMachine.Interact.PowerOff",
+		"VirtualMachine.Interact.PowerOn",
+		"VirtualMachine.Inventory.Create",
+		"VirtualMachine.Inventory.Delete",
+		"VirtualMachine.Inventory.Register",
+		"VirtualMachine.Inventory.Unregister",
+	},
+}
+
+// Configuration for the ops-user
+var OpsUserRBACConf = RBACConfig{
+	Resources: []RBACResource{
+		{
+			Type:      VCenter,
+			Propagate: false,
+			Role:      RoleVCenter,
+		},
+		{
+			Type:      Datacenter,
+			Propagate: true,
+			Role:      RoleDataCenter,
+		},
+		{
+			Type:      Cluster,
+			Propagate: true,
+			Role:      RoleDataStore,
+		},
+		{
+			Type:      DatastoreFolder,
+			Propagate: true,
+			Role:      RoleDataStore,
+		},
+		{
+			Type:      Datastore,
+			Propagate: false,
+			Role:      RoleDataStore,
+		},
+		{
+			Type:      VSANDatastore,
+			Propagate: false,
+			Role:      RoleDataStore,
+		},
+		{
+			Type:      Network,
+			Propagate: true,
+			Role:      RoleNetwork,
+		},
+		{
+			Type:      Endpoint,
+			Propagate: true,
+			Role:      RoleEndpoint,
+		},
+	},
+}

--- a/lib/install/management/rbac_test.go
+++ b/lib/install/management/rbac_test.go
@@ -111,7 +111,7 @@ func TestOpsUserPermsSimulatorVPX(t *testing.T) {
 	count := initRoles(ctx, t, am)
 
 	defer cleanup(ctx, t, am, true)
-	require.Equal(t, roleCount, count, "Incorrect number of roles: expcted %d, actual %d", roleCount, count)
+	require.Equal(t, roleCount, count, "Incorrect number of roles: expected %d, actual %d", roleCount, count)
 
 	c := sess.Client
 	// Find the Datacenter

--- a/lib/install/validate/validator.go
+++ b/lib/install/validate/validator.go
@@ -440,6 +440,11 @@ func (v *Validator) credentials(ctx context.Context, input *data.Data, conf *con
 	conf.Token = *input.OpsCredentials.OpsPassword
 	conf.TargetThumbprint = input.Thumbprint
 
+	if input.OpsCredentials.GrantPerms {
+		// Set Grant Permissions level
+		conf.SetGrantPerms()
+	}
+
 	// Discard anything other than these URL fields for the target
 	stripped := &url.URL{
 		Scheme: u.Scheme,

--- a/lib/install/validate/validator_test.go
+++ b/lib/install/validate/validator_test.go
@@ -148,6 +148,12 @@ func TestMain(t *testing.T) {
 			t.Fatal(err)
 		}
 
+		opsUser := "ops-user-name"
+		opsPassword := "ops-user-password"
+		input.OpsCredentials.OpsUser = &opsUser
+		input.OpsCredentials.OpsPassword = &opsPassword
+		input.OpsCredentials.GrantPerms = true
+
 		validator, err := NewValidator(ctx, input)
 		if err != nil {
 			t.Errorf("Failed to new validator: %s", err)
@@ -287,6 +293,7 @@ func testTargets(v *Validator, input *data.Data, conf *config.VirtualContainerHo
 	assert.Nil(t, u.User)
 	assert.NotEmpty(t, conf.Token)
 	assert.NotEmpty(t, conf.Username)
+	assert.Equal(t, conf.GrantPermsLevel, config.AddPerms)
 }
 
 func testStorage(v *Validator, input *data.Data, conf *config.VirtualContainerHostConfigSpec, t *testing.T) {


### PR DESCRIPTION
In addition to the new flag, various bug fixes including the correct set of minimum permissions to run a container.

Fixes #6505 addendum

Issue: #6502 tracks the addition of the Nightly/Integration Test