### PR TITLE
Extract constants for magic values [specific ci=Group23-VIC-Machine-Service]

### DIFF
--- a/cmd/vic-machine/create/create.go
+++ b/cmd/vic-machine/create/create.go
@@ -28,6 +28,7 @@ import (
 	"gopkg.in/urfave/cli.v1"
 
 	"github.com/vmware/vic/cmd/vic-machine/common"
+	"github.com/vmware/vic/lib/constants"
 	"github.com/vmware/vic/lib/install/data"
 	"github.com/vmware/vic/lib/install/management"
 	"github.com/vmware/vic/lib/install/validate"
@@ -126,7 +127,7 @@ func (c *Create) Flags() []cli.Flag {
 		},
 		cli.StringFlag{
 			Name:        "base-image-size",
-			Value:       "8GB",
+			Value:       constants.DefaultBaseImageScratchSize,
 			Usage:       "Specify the size of the base image from which all other images are created e.g. 8GB/8000MB",
 			Destination: &c.ScratchSize,
 			Hidden:      true,
@@ -220,7 +221,7 @@ func (c *Create) Flags() []cli.Flag {
 	memory = append(memory,
 		cli.IntFlag{
 			Name:        "endpoint-memory",
-			Value:       2048,
+			Value:       constants.DefaultEndpointMemoryMB,
 			Usage:       "Memory for the VCH endpoint VM, in MB. Does not impact resources allocated per container.",
 			Hidden:      true,
 			Destination: &c.MemoryMB,

--- a/lib/apiservers/service/restapi/handlers/util/error.go
+++ b/lib/apiservers/service/restapi/handlers/util/error.go
@@ -14,10 +14,12 @@
 
 package util
 
+import "net/http"
+
 func StatusCode(err error) int {
 	e, ok := err.(statusCode)
 	if !ok {
-		return 500
+		return http.StatusInternalServerError
 	}
 
 	return e.Code()

--- a/lib/apiservers/service/restapi/handlers/util/error_test.go
+++ b/lib/apiservers/service/restapi/handlers/util/error_test.go
@@ -16,6 +16,7 @@ package util
 
 import (
 	"fmt"
+	"net/http"
 	"testing"
 )
 
@@ -58,7 +59,7 @@ func TestStatusCodeFallback(t *testing.T) {
 	e := fmt.Errorf("fmt error")
 	c := StatusCode(e)
 
-	if c != 500 {
+	if c != http.StatusInternalServerError {
 		t.Errorf("Default status code was %d, not 500.", c)
 	}
 }

--- a/lib/apiservers/service/restapi/handlers/vch_create.go
+++ b/lib/apiservers/service/restapi/handlers/vch_create.go
@@ -37,6 +37,7 @@ import (
 	"github.com/vmware/vic/lib/apiservers/service/restapi/handlers/util"
 	"github.com/vmware/vic/lib/apiservers/service/restapi/operations"
 	"github.com/vmware/vic/lib/config/executor"
+	"github.com/vmware/vic/lib/constants"
 	"github.com/vmware/vic/lib/install/data"
 	"github.com/vmware/vic/lib/install/management"
 	"github.com/vmware/vic/lib/install/validate"
@@ -349,7 +350,7 @@ func buildCreate(op trace.Operation, d *data.Data, finder finder, vch *models.VC
 				c.VolumeLocations = volumeLocations
 			}
 
-			c.ScratchSize = "8GB"
+			c.ScratchSize = constants.DefaultBaseImageScratchSize
 			if vch.Storage.BaseImageSize != nil {
 				c.ScratchSize = fromValueBytesMetric(vch.Storage.BaseImageSize)
 			}
@@ -387,7 +388,7 @@ func buildCreate(op trace.Operation, d *data.Data, finder finder, vch *models.VC
 			}
 		}
 
-		c.MemoryMB = 2048
+		c.MemoryMB = constants.DefaultEndpointMemoryMB
 		if vch.Endpoint != nil {
 			if vch.Endpoint.Memory != nil {
 				c.MemoryMB = *mbFromValueBytes(vch.Endpoint.Memory)

--- a/lib/constants/install.go
+++ b/lib/constants/install.go
@@ -1,0 +1,20 @@
+// Copyright 2017 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package constants
+
+const (
+	DefaultBaseImageScratchSize = "8GB"
+	DefaultEndpointMemoryMB     = 2048
+)


### PR DESCRIPTION
Extract constants for several "magic values" identified during review of the merge commit for the VCH creation API feature branch.

See also: #6665