### PR TITLE
VCH Management API: Remove registry blacklist

### DIFF
--- a/lib/apiservers/service/restapi/handlers/vch_create.go
+++ b/lib/apiservers/service/restapi/handlers/vch_create.go
@@ -407,8 +407,6 @@ func buildCreate(op trace.Operation, d *data.Data, finder *find.Finder, vch *mod
 			c.InsecureRegistries = vch.Registry.Insecure
 			c.WhitelistRegistries = vch.Registry.Whitelist
 
-			//TODO (#6713): params.Vch.Registry.Blacklist
-
 			c.RegistryCAs = fromPemCertificates(vch.Registry.CertificateAuthorities)
 
 			if vch.Registry.ImageFetchProxy != nil {

--- a/lib/apiservers/service/restapi/handlers/vch_get.go
+++ b/lib/apiservers/service/restapi/handlers/vch_get.go
@@ -235,7 +235,6 @@ func vchToModel(op trace.Operation, vch *vm.VirtualMachine, d *data.Data, execut
 	model.Registry = &models.VCHRegistry{
 		Insecure:               vchConfig.Registry.InsecureRegistries,
 		Whitelist:              vchConfig.Registry.RegistryWhitelist,
-		Blacklist:              vchConfig.Registry.RegistryBlacklist,
 		CertificateAuthorities: asPemCertificates(vchConfig.Certificate.RegistryCertificateAuthorities),
 		ImageFetchProxy:        asImageFetchProxy(vchConfig.ExecutorConfig.Sessions[config.VicAdminService], config.VICAdminHTTPProxy, config.VICAdminHTTPSProxy),
 	}

--- a/lib/apiservers/service/swagger.json
+++ b/lib/apiservers/service/swagger.json
@@ -775,12 +775,6 @@
                 "type": "string"
               }
             },
-            "blacklist": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
             "certificate_authorities": {
               "type": "array",
               "items": { "$ref": "#/definitions/X509_Data" }


### PR DESCRIPTION
Registry blacklist functionality was designed, but has not been fully
implemented in the engine. Remove references to it from the API.

Fixes #6713 