### PR TITLE
[specific ci=22-10-logstash] Reenable logstash robot test

### DIFF
--- a/tests/test-cases/Group22-Docker-Apps/22-10-logstash.robot
+++ b/tests/test-cases/Group22-Docker-Apps/22-10-logstash.robot
@@ -33,8 +33,6 @@ Logstash with stdin and stdout mapped
     Wait Until Keyword Succeeds  10x  6s  Check logstash logs  log1  Successfully started Logstash API endpoint
 
 Logstash with mapped volume log file
-    ${status}=  Get State Of Github Issue  6386
-    Run Keyword If  '${status}' == 'closed'  Fail  Test 22-10-logstash.robot needs to be updated now that Issue #6384 has been resolved
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} volume create --name=vol1
     Should Be Equal As Integers  ${rc}  0
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -d --rm -v vol1:/mydata ${busybox} sh -c "echo 'Initial log message' > /mydata/my.log"

--- a/tests/test-cases/Group22-Docker-Apps/22-10-logstash.robot
+++ b/tests/test-cases/Group22-Docker-Apps/22-10-logstash.robot
@@ -38,11 +38,11 @@ Logstash with mapped volume log file
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -d --rm -v vol1:/mydata ${busybox} sh -c "echo 'Initial log message' > /mydata/my.log"
     Should Be Equal As Integers  ${rc}  0
 
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run --name ${log_container} -dit -v vol1:/logs logstash -e 'input { file { path => "/logs/my.log" start_position => "beginning" } } output { stdout { } }'
-    Log  ${output}
+    ${rc}  ${logstash_container}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -dit -v vol1:/logs logstash -e 'input { file { path => "/logs/my.log" start_position => "beginning" } } output { stdout { } }'
+    Log  ${logstash_container}
     Should Be Equal As Integers  ${rc}  0
-    Wait Until Keyword Succeeds  10x  6s  Check logstash logs  log2  Initial log message
+    Wait Until Keyword Succeeds  10x  6s  Check logstash logs  ${logstash_container}  Initial log message
 
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} exec ${log_container} sh -c "echo 'Another exciting log message' >> /logs/my.log"
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} exec ${logstash_container} sh -c "echo 'Another exciting log message' >> /logs/my.log"
     Should Be Equal As Integers  ${rc}  0
-    Wait Until Keyword Succeeds  10x  6s  Check logstash logs  log2  Another exciting log message
+    Wait Until Keyword Succeeds  10x  6s  Check logstash logs  ${logstash_container}  Another exciting log message

--- a/tests/test-cases/Group22-Docker-Apps/22-10-logstash.robot
+++ b/tests/test-cases/Group22-Docker-Apps/22-10-logstash.robot
@@ -38,7 +38,6 @@ Logstash with mapped volume log file
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -d --rm -v vol1:/mydata ${busybox} sh -c "echo 'Initial log message' > /mydata/my.log"
     Should Be Equal As Integers  ${rc}  0
 
-    ${log_container}=  Set Variable  log2
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run --name ${log_container} -dit -v vol1:/logs logstash -e 'input { file { path => "/logs/my.log" start_position => "beginning" } } output { stdout { } }'
     Log  ${output}
     Should Be Equal As Integers  ${rc}  0


### PR DESCRIPTION
This turned out to be working as expected when the test was written. To avoid trying to use the same volume on two containers, I changed to using `exec` to add the expected input to the logfile on the logstash server. 

Fixes #6386