### PR TITLE
Support container network trust level in VCH API [specific ci=Group23-VIC-Machine-Service]

### DIFF
--- a/lib/apiservers/service/restapi/handlers/vch_get.go
+++ b/lib/apiservers/service/restapi/handlers/vch_get.go
@@ -36,6 +36,7 @@ import (
 	"github.com/vmware/vic/lib/install/data"
 	"github.com/vmware/vic/lib/install/management"
 	"github.com/vmware/vic/lib/install/validate"
+	"github.com/vmware/vic/pkg/ip"
 	"github.com/vmware/vic/pkg/trace"
 	"github.com/vmware/vic/pkg/version"
 	"github.com/vmware/vic/pkg/vsphere/vm"
@@ -175,7 +176,8 @@ func vchToModel(op trace.Operation, vch *vm.VirtualMachine, d *data.Data, execut
 					Address:             asIPAddress(value.Gateway.IP),
 					RoutingDestinations: []models.IPRange{asIPRange(&value.Gateway)},
 				},
-				IPRanges: *asIPRanges(&value.Destinations),
+				IPRanges: *rangesAsIPRanges(&value.Pools),
+				Firewall: value.TrustLevel.String(),
 			})
 		}
 	}
@@ -362,6 +364,15 @@ func asIPRanges(networks *[]net.IPNet) *[]models.IPRange {
 	m := make([]models.IPRange, 0, len(*networks))
 	for _, value := range *networks {
 		m = append(m, asIPRange(&value))
+	}
+
+	return &m
+}
+
+func rangesAsIPRanges(networks *[]ip.Range) *[]models.IPRange {
+	m := make([]models.IPRange, 0, len(*networks))
+	for _, value := range *networks {
+		m = append(m, asIPRange(value.Network()))
 	}
 
 	return &m

--- a/lib/apiservers/service/swagger.json
+++ b/lib/apiservers/service/swagger.json
@@ -593,6 +593,16 @@
         "alias": {
           "type": "string"
         },
+        "firewall": {
+          "type": "string",
+          "enum": [
+            "closed",
+            "outbound",
+            "peers",
+            "published",
+            "open"
+          ]
+        },
         "nameservers": {
           "type": "array",
           "items": { "$ref": "#/definitions/IP_Address" }

--- a/tests/test-cases/Group23-VIC-Machine-Service/23-03-VCH-Create.robot
+++ b/tests/test-cases/Group23-VIC-Machine-Service/23-03-VCH-Create.robot
@@ -128,7 +128,7 @@ Create minimal VCH within datacenter
 
 
 Create complex VCH
-    Create VCH    '{"name":"%{VCH-NAME}-api-test-complex","debug":3,"compute":{"cpu":{"limit":{"units":"MHz","value":2345},"reservation":{"units":"GHz","value":2},"shares":{"level":"high"}},"memory":{"limit":{"units":"MiB","value":1200},"reservation":{"units":"MiB","value":501},"shares":{"number":81910}},"resource":{"name":"%{TEST_RESOURCE}"}},"endpoint":{"cpu":{"sockets":2},"memory":{"units":"MiB","value":3072}},"storage":{"image_stores":["ds://%{TEST_DATASTORE}"],"volume_stores":[{"datastore":"ds://%{TEST_DATASTORE}/test-volumes/foo","label":"foo"}],"base_image_size":{"units":"B","value":16000000}},"network":{"bridge":{"ip_range":"172.16.0.0/12","port_group":{"name":"%{BRIDGE_NETWORK}"}},"public":{"port_group":{"name":"${PUBLIC_NETWORK}"}}},"registry":{"image_fetch_proxy":{"http":"http://example.com","https":"https://example.com"},"insecure":["https://insecure.example.com"],"whitelist":["10.0.0.0/8"]},"auth":{"server":{"generate":{"cname":"vch.example.com","organization":["VMware, Inc."],"size":{"value":2048,"units":"bits"}}},"client":{"no_tls_verify": true}},"syslog_addr":"tcp://syslog.example.com:4444", "container": {"name_convention": "container-{id}"}}'
+    Create VCH    '{"name":"%{VCH-NAME}-api-test-complex","debug":3,"compute":{"cpu":{"limit":{"units":"MHz","value":2345},"reservation":{"units":"GHz","value":2},"shares":{"level":"high"}},"memory":{"limit":{"units":"MiB","value":1200},"reservation":{"units":"MiB","value":501},"shares":{"number":81910}},"resource":{"name":"%{TEST_RESOURCE}"}},"endpoint":{"cpu":{"sockets":2},"memory":{"units":"MiB","value":3072}},"storage":{"image_stores":["ds://%{TEST_DATASTORE}"],"volume_stores":[{"datastore":"ds://%{TEST_DATASTORE}/test-volumes/foo","label":"foo"}],"base_image_size":{"units":"B","value":16000000}},"network":{"bridge":{"ip_range":"172.16.0.0/12","port_group":{"name":"%{BRIDGE_NETWORK}"}},"container":[{"alias":"vic-containers","firewall":"outbound","nameservers":["8.8.8.8","8.8.4.4"],"port_group":{"name":"${PUBLIC_NETWORK}"},"gateway":{"address":"203.0.113.1","routing_destinations":["203.0.113.1/24"]},"ip_ranges":["203.0.113.8/31"]}],"public":{"port_group":{"name":"${PUBLIC_NETWORK}"}}},"registry":{"image_fetch_proxy":{"http":"http://example.com","https":"https://example.com"},"insecure":["https://insecure.example.com"],"whitelist":["10.0.0.0/8"]},"auth":{"server":{"generate":{"cname":"vch.example.com","organization":["VMware, Inc."],"size":{"value":2048,"units":"bits"}}},"client":{"no_tls_verify": true}},"syslog_addr":"tcp://syslog.example.com:4444", "container": {"name_convention": "container-{id}"}}'
 
     Verify Return Code
     Verify Status Created
@@ -153,6 +153,12 @@ Create complex VCH
     Output Should Contain    --base-image-size=16MB
 
     Output Should Contain    --bridge-network=%{BRIDGE_NETWORK}
+    Output Should Contain    --container-network=${PUBLIC_NETWORK}:vic-containers
+    Output Should Contain    --container-network-gateway=${PUBLIC_NETWORK}:203.0.113.1/24
+    Output Should Contain    --container-network-ip-range=${PUBLIC_NETWORK}:203.0.113.8/31
+    Output Should Contain    --container-network-dns=${PUBLIC_NETWORK}:8.8.8.8
+    Output Should Contain    --container-network-dns=${PUBLIC_NETWORK}:8.8.4.4
+    Output Should Contain    --container-network-firewall=${PUBLIC_NETWORK}:outbound
 
     Output Should Contain    --insecure-registry=https://insecure.example.com
     Output Should Contain    --whitelist-registry=10.0.0.0/8
@@ -197,6 +203,14 @@ Create complex VCH
     Property Should Be Equal        .auth.server.private_key.pem         null
 
     Property Should Be Equal        .network.bridge.ip_range             172.16.0.0/12
+    Property Should Be Equal        .network.container[0].alias          vic-containers
+    Property Should Be Equal        .network.container[0].firewall       outbound
+    Property Should Be Equal        .network.container[0].ip_ranges      203.0.113.8/31
+
+    Property Should Be Equal        .network.container[0].nameservers[0]                8.8.8.8
+    Property Should Be Equal        .network.container[0].nameservers[1]                8.8.4.4
+    Property Should Be Equal        .network.container[0].gateway.address               203.0.113.1
+    Property Should Be Equal        .network.container[0].gateway.routing_destinations  203.0.113.1/24
 
     Property Should Be Equal        .runtime.power_state                 poweredOn
     Property Should Be Equal        .runtime.upgrade_status              Up to date


### PR DESCRIPTION
The `vic-machine` CLI supports specifying a "trust level" for each container network using the `--container-network-firewall` option.

Support the same functionality in the API.

Additionally, fix a small bug with the way ip ranges for container networks are returned by the inspect API.

Fixes #6740 