### PR TITLE
List client address for accessing services in API [specific ci=Group23-VIC-Machine-Service]

### DIFF
--- a/lib/apiservers/service/restapi/handlers/vch_get.go
+++ b/lib/apiservers/service/restapi/handlers/vch_get.go
@@ -22,7 +22,6 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/docker/docker/opts"
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/go-openapi/strfmt"
 
@@ -254,19 +253,7 @@ func vchToModel(op trace.Operation, vch *vm.VirtualMachine, d *data.Data, execut
 	}
 	model.Runtime.PowerState = string(powerState)
 
-	if public := vchConfig.ExecutorConfig.Networks["public"]; public != nil {
-		if publicIP := public.Assigned.IP; publicIP != nil {
-			var dockerPort string
-			if !vchConfig.HostCertificate.IsNil() {
-				dockerPort = fmt.Sprintf("%d", opts.DefaultTLSHTTPPort)
-			} else {
-				dockerPort = fmt.Sprintf("%d", opts.DefaultHTTPPort)
-			}
-
-			model.Runtime.DockerHost = fmt.Sprintf("%s:%s", publicIP, dockerPort)
-			model.Runtime.AdminPortal = fmt.Sprintf("https://%s:2378", publicIP)
-		}
-	}
+	model.Runtime.DockerHost, model.Runtime.AdminPortal = getAddresses(vchConfig)
 
 	// syslog_addr: syslog server address
 	if syslogConfig := vchConfig.Diagnostics.SysLogConfig; syslogConfig != nil {

--- a/lib/apiservers/service/restapi/handlers/vch_list_get.go
+++ b/lib/apiservers/service/restapi/handlers/vch_list_get.go
@@ -19,7 +19,6 @@ import (
 	"net/http"
 	"path"
 
-	"github.com/docker/docker/opts"
 	"github.com/go-openapi/runtime/middleware"
 
 	"github.com/vmware/vic/lib/apiservers/service/models"
@@ -109,18 +108,7 @@ func vchsToModels(op trace.Operation, vchs []*vm.VirtualMachine, executor *manag
 		var adminPortal string
 		if vchConfig, err := executor.GetNoSecretVCHConfig(vch); err == nil {
 			version = vchConfig.Version
-
-			if public := vchConfig.ExecutorConfig.Networks["public"]; public != nil {
-				if publicIP := public.Assigned.IP; publicIP != nil {
-					var dockerPort = opts.DefaultTLSHTTPPort
-					if vchConfig.HostCertificate.IsNil() {
-						dockerPort = opts.DefaultHTTPPort
-					}
-
-					dockerHost = fmt.Sprintf("%s:%d", publicIP, dockerPort)
-					adminPortal = fmt.Sprintf("https://%s:2378", publicIP)
-				}
-			}
+			dockerHost, adminPortal = getAddresses(vchConfig)
 		}
 
 		name := path.Base(vch.InventoryPath)

--- a/lib/constants/constants.go
+++ b/lib/constants/constants.go
@@ -24,6 +24,7 @@ import (
 /* VCH constants */
 const (
 	SerialOverLANPort  = 2377
+	VchAdminPortalPort = 2378
 	AttachServerPort   = 2379
 	ManagementHostName = "management.localhost"
 	ClientHostName     = "client.localhost"

--- a/lib/install/management/inspect.go
+++ b/lib/install/management/inspect.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/vmware/govmomi/vim25/types"
 	"github.com/vmware/vic/lib/config"
+	"github.com/vmware/vic/lib/constants"
 	"github.com/vmware/vic/pkg/certificate"
 	"github.com/vmware/vic/pkg/errors"
 	"github.com/vmware/vic/pkg/ip"
@@ -165,7 +166,7 @@ func (d *Dispatcher) ShowVCH(conf *config.VirtualContainerHostConfigSpec, key st
 
 	log.Infof("")
 	log.Infof("VCH Admin Portal:")
-	log.Infof("https://%s:2378", d.HostIP)
+	log.Infof("https://%s:%d", d.HostIP, constants.VchAdminPortalPort)
 
 	log.Infof("")
 	publicIP := conf.ExecutorConfig.Networks["public"].Assigned.IP


### PR DESCRIPTION
Use the client network address, not the public network address, when displaying the admin portal URI and the docker host information as a part of API responses.

Additionally, eliminate related code duplication.

Fixes #6728