### PR TITLE
[skip ci] Fix resource pool issue and change in nimbus requiring plugin option

### DIFF
--- a/tests/manual-test-cases/Group5-Functional-Tests/5-14-Remove-Container-OOB.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-14-Remove-Container-OOB.robot
@@ -33,6 +33,6 @@ Docker run an image from a container that was removed OOB
     ${rc}  ${container}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -itd --name removeOOB busybox /bin/top
     Should Be Equal As Integers  ${rc}  0
 
-    ${rc}  ${out}=  Run And Return Rc And Output  govc vm.destroy %{VCH-NAME}/removeOOB*
+    ${rc}  ${out}=  Run And Return Rc And Output  govc vm.destroy removeOOB*
     Should Not Be Equal As Integers  ${rc}  0
     Should Contain  ${out}  govc: ServerFaultCode: The method is disabled by 'VIC'

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-16-iSCSI-Datastore.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-16-iSCSI-Datastore.robot
@@ -22,7 +22,7 @@ Suite Teardown  Run Keyword And Ignore Error  Nimbus Cleanup  ${list}
 iSCSI Datastore Setup
     Run Keyword And Ignore Error  Nimbus Cleanup  ${list}  ${false}
     ${name}=  Evaluate  'vic-iscsi-' + str(random.randint(1000,9999))  modules=random
-    ${out}=  Deploy Nimbus Testbed  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}  --customizeTestbed '/esx desiredPassword=e2eFunctionalTest' --noSupportBundles --vcvaBuild ${VC_VERSION} --esxBuild ${ESX_VERSION} --testbedName vcqa-sdrs-iscsi-fullInstall-vcva --runName vic-iscsi
+    ${out}=  Deploy Nimbus Testbed  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}  --plugin testng --customizeTestbed '/esx desiredPassword=e2eFunctionalTest' --noSupportBundles --vcvaBuild ${VC_VERSION} --esxBuild ${ESX_VERSION} --testbedName vcqa-sdrs-iscsi-fullInstall-vcva --runName vic-iscsi
     Set Suite Variable  @{list}  %{NIMBUS_USER}-vic-iscsi.vcva-${VC_VERSION}  %{NIMBUS_USER}-vic-iscsi.esx.0  %{NIMBUS_USER}-vic-iscsi.esx.1  %{NIMBUS_USER}-vic-iscsi.iscsi.0
     Should Contain  ${out}  "deployment_result"=>"PASS"
 

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-17-FC-Datastore.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-17-FC-Datastore.robot
@@ -22,7 +22,7 @@ Suite Teardown  Run Keyword And Ignore Error  Nimbus Cleanup  ${list}
 FC Datastore Setup
     Run Keyword And Ignore Error  Nimbus Cleanup  ${list}  ${false}
     ${name}=  Evaluate  'vic-fc-' + str(random.randint(1000,9999))  modules=random
-    ${out}=  Deploy Nimbus Testbed  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}  --customizeTestbed '/esx desiredPassword=e2eFunctionalTest' --noSupportBundles --vcvaBuild ${VC_VERSION} --esxBuild ${ESX_VERSION} --testbedName vcqa-sdrs-fc-fullInstall-vcva --runName vic-fc
+    ${out}=  Deploy Nimbus Testbed  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}  --plugin testng --customizeTestbed '/esx desiredPassword=e2eFunctionalTest' --noSupportBundles --vcvaBuild ${VC_VERSION} --esxBuild ${ESX_VERSION} --testbedName vcqa-sdrs-fc-fullInstall-vcva --runName vic-fc
     Set Suite Variable  @{list}  %{NIMBUS_USER}-vic-fc.vcva-${VC_VERSION}  %{NIMBUS_USER}-vic-fc.esx.0  %{NIMBUS_USER}-vic-fc.esx.1  %{NIMBUS_USER}-vic-fc.fc.0
     Should Contain  ${out}  "deployment_result"=>"PASS"
 


### PR DESCRIPTION
Regression from our vApp removal change and Nimbus made a change last week to require all testbeds use the plugin option.