### PR TITLE
Fix logging to op logging

### DIFF
--- a/lib/apiservers/portlayer/restapi/handlers/task_handlers.go
+++ b/lib/apiservers/portlayer/restapi/handlers/task_handlers.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"strings"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/go-openapi/runtime/middleware"
 
 	"github.com/vmware/vic/lib/apiservers/portlayer/models"

--- a/lib/apiservers/portlayer/restapi/handlers/task_handlers.go
+++ b/lib/apiservers/portlayer/restapi/handlers/task_handlers.go
@@ -99,7 +99,7 @@ func (handler *TaskHandlersImpl) JoinHandler(params tasks.JoinParams) middleware
 
 	handleprime, err := task.Join(&op, handle, sessionConfig)
 	if err != nil {
-		log.Errorf("%s", err.Error())
+		op.Errorf("%s", err.Error())
 
 		return tasks.NewJoinInternalServerError().WithPayload(
 			&models.Error{Message: err.Error()},
@@ -125,7 +125,7 @@ func (handler *TaskHandlersImpl) BindHandler(params tasks.BindParams) middleware
 
 	handleprime, err := task.Bind(&op, handle, params.Config.ID)
 	if err != nil {
-		log.Errorf("%s", err.Error())
+		op.Errorf("%s", err.Error())
 
 		return tasks.NewBindInternalServerError().WithPayload(
 			&models.Error{Message: err.Error()},
@@ -152,7 +152,7 @@ func (handler *TaskHandlersImpl) UnbindHandler(params tasks.UnbindParams) middle
 
 	handleprime, err := task.Unbind(&op, handle, params.Config.ID)
 	if err != nil {
-		log.Errorf("%s", err.Error())
+		op.Errorf("%s", err.Error())
 
 		return tasks.NewUnbindInternalServerError().WithPayload(
 			&models.Error{Message: err.Error()},
@@ -178,7 +178,7 @@ func (handler *TaskHandlersImpl) RemoveHandler(params tasks.RemoveParams) middle
 
 	handleprime, err := task.Remove(&op, handle, params.Config.ID)
 	if err != nil {
-		log.Errorf("%s", err.Error())
+		op.Errorf("%s", err.Error())
 
 		return tasks.NewRemoveInternalServerError().WithPayload(
 			&models.Error{Message: err.Error()},
@@ -204,7 +204,7 @@ func (handler *TaskHandlersImpl) InspectHandler(params tasks.InspectParams) midd
 
 	t, err := task.Inspect(&op, handle, params.Config.ID)
 	if err != nil {
-		log.Errorf("%s", err.Error())
+		op.Errorf("%s", err.Error())
 
 		if _, ok := err.(task.TaskPowerStateError); ok {
 			return tasks.NewInspectConflict().WithPayload(
@@ -261,7 +261,7 @@ func (handler *TaskHandlersImpl) WaitHandler(params tasks.WaitParams) middleware
 	// wait task to set started field to something
 	err := task.Wait(&op, handle, params.Config.ID)
 	if err != nil {
-		log.Errorf("%s", err.Error())
+		op.Errorf("%s", err.Error())
 
 		return tasks.NewWaitInternalServerError().WithPayload(
 			&models.Error{Message: err.Error()},


### PR DESCRIPTION
Noticed some missed `op.log` style changes in the exec handlers. Threw this together really fast to address it. 