### PR TITLE
Include ISO files in server docker image [specific ci=Group23-VIC-Machine-Service]

### DIFF
--- a/cmd/vic-machine-server/Dockerfile
+++ b/cmd/vic-machine-server/Dockerfile
@@ -19,6 +19,10 @@ ENV TLS_PRIVATE_KEY=/certs/server.key.pem
 EXPOSE 80
 EXPOSE 443
 
-COPY bin/vic-machine-server /usr/local/bin/
+WORKDIR /opt/vmware/vsphere-integrated-containers/
 
-ENTRYPOINT /usr/local/bin/vic-machine-server
+COPY bin/vic-machine-server bin/
+COPY bin/appliance.iso .
+COPY bin/bootstrap.iso .
+
+ENTRYPOINT bin/vic-machine-server


### PR DESCRIPTION
Additionally, move the binary to a subdirectory of opt to allow the ISO files to be packaged with it.

See also:
 * http://www.tldp.org/LDP/Linux-Filesystem-Hierarchy/html/opt.html

Fixes #6761 

---

Tested manually by building the image, running it locally, using `curl` to invoke the VCH creation API, and verifying that the log contained:
```
Nov 14 2017 20:27:30.177Z INFO  Uploading images for container
Nov 14 2017 20:27:30.177Z INFO  	"bootstrap.iso"
Nov 14 2017 20:27:30.177Z INFO  	"appliance.iso"
```