### PR TITLE
Add unit tests for VCH create

### DIFF
--- a/cmd/vic-machine/create/create.go
+++ b/cmd/vic-machine/create/create.go
@@ -31,6 +31,7 @@ import (
 	"github.com/vmware/vic/lib/install/data"
 	"github.com/vmware/vic/lib/install/management"
 	"github.com/vmware/vic/lib/install/validate"
+
 	"github.com/vmware/vic/pkg/errors"
 	"github.com/vmware/vic/pkg/trace"
 )
@@ -65,7 +66,7 @@ type Create struct {
 	*data.Data
 	Certs             common.CertFactory
 	containerNetworks common.CNetworks
-	registries        common.Registries
+	Registries        common.Registries
 
 	volumeStores common.VolumeStores
 
@@ -243,17 +244,17 @@ func (c *Create) Flags() []cli.Flag {
 		Hidden:      true,
 	})
 
-	registries := c.registries.Flags()
+	registries := c.Registries.Flags()
 	registries = append(registries,
 		cli.StringSliceFlag{
 			Name:  "insecure-registry, dir",
-			Value: &c.registries.InsecureRegistriesArg,
+			Value: &c.Registries.InsecureRegistriesArg,
 			Usage: "Specify a list of permitted insecure registry server addresses",
 		})
 	registries = append(registries,
 		cli.StringSliceFlag{
 			Name:  "whitelist-registry, wr",
-			Value: &c.registries.WhitelistRegistriesArg,
+			Value: &c.Registries.WhitelistRegistriesArg,
 			Usage: "Specify a list of permitted whitelist registry server addresses (insecure addresses still require the --insecure-registry option in addition)",
 		})
 
@@ -317,7 +318,7 @@ func (c *Create) Flags() []cli.Flag {
 	return flags
 }
 
-func (c *Create) processParams() error {
+func (c *Create) ProcessParams() error {
 	defer trace.End(trace.Begin(""))
 
 	if err := c.HasCredentials(); err != nil {
@@ -348,21 +349,21 @@ func (c *Create) processParams() error {
 		return err
 	}
 
-	if err := c.ProcessBridgeNetwork(); err != nil {
+	if err = c.ProcessBridgeNetwork(); err != nil {
 		return err
 	}
 
-	if err := c.ProcessNetwork(&c.Data.ClientNetwork, "client", c.ClientNetworkName,
+	if err = c.ProcessNetwork(&c.Data.ClientNetwork, "client", c.ClientNetworkName,
 		c.ClientNetworkIP, c.ClientNetworkGateway); err != nil {
 		return err
 	}
 
-	if err := c.ProcessNetwork(&c.Data.PublicNetwork, "public", c.PublicNetworkName,
+	if err = c.ProcessNetwork(&c.Data.PublicNetwork, "public", c.PublicNetworkName,
 		c.PublicNetworkIP, c.PublicNetworkGateway); err != nil {
 		return err
 	}
 
-	if err := c.ProcessNetwork(&c.Data.ManagementNetwork, "management", c.ManagementNetworkName,
+	if err = c.ProcessNetwork(&c.Data.ManagementNetwork, "management", c.ManagementNetworkName,
 		c.ManagementNetworkIP, c.ManagementNetworkGateway); err != nil {
 		return err
 	}
@@ -372,11 +373,11 @@ func (c *Create) processParams() error {
 	}
 
 	// must come after client network processing as it checks for static IP on that interface
-	if err := c.processCertificates(); err != nil {
+	if err = c.processCertificates(); err != nil {
 		return err
 	}
 
-	if err := common.CheckUnsupportedCharsDatastore(c.ImageDatastorePath); err != nil {
+	if err = common.CheckUnsupportedCharsDatastore(c.ImageDatastorePath); err != nil {
 		return cli.NewExitError(fmt.Sprintf("--image-store contains unsupported characters: %s Allowed characters are alphanumeric, space and symbols - _ ( ) / :", err), 1)
 	}
 
@@ -385,13 +386,13 @@ func (c *Create) processParams() error {
 		return err
 	}
 
-	if err := c.registries.ProcessRegistries(); err != nil {
+	if err = c.Registries.ProcessRegistries(); err != nil {
 		return err
 	}
 
-	c.InsecureRegistries = c.registries.InsecureRegistries
-	c.WhitelistRegistries = c.registries.WhitelistRegistries
-	c.RegistryCAs = c.registries.RegistryCAs
+	c.InsecureRegistries = c.Registries.InsecureRegistries
+	c.WhitelistRegistries = c.Registries.WhitelistRegistries
+	c.RegistryCAs = c.Registries.RegistryCAs
 
 	hproxy, sproxy, err := c.Proxies.ProcessProxies()
 	if err != nil {
@@ -400,7 +401,7 @@ func (c *Create) processParams() error {
 	c.HTTPProxy = hproxy
 	c.HTTPSProxy = sproxy
 
-	if err := c.ProcessSyslog(); err != nil {
+	if err = c.ProcessSyslog(); err != nil {
 		return err
 	}
 
@@ -677,7 +678,7 @@ func (c *Create) Run(clic *cli.Context) (err error) {
 		err = common.LogErrorIfAny(clic, err)
 	}()
 
-	if err = c.processParams(); err != nil {
+	if err = c.ProcessParams(); err != nil {
 		return err
 	}
 

--- a/cmd/vic-machine/create/create.go
+++ b/cmd/vic-machine/create/create.go
@@ -31,7 +31,6 @@ import (
 	"github.com/vmware/vic/lib/install/data"
 	"github.com/vmware/vic/lib/install/management"
 	"github.com/vmware/vic/lib/install/validate"
-
 	"github.com/vmware/vic/pkg/errors"
 	"github.com/vmware/vic/pkg/trace"
 )

--- a/lib/apiservers/service/restapi/handlers/vch_create_test.go
+++ b/lib/apiservers/service/restapi/handlers/vch_create_test.go
@@ -1,0 +1,303 @@
+// Copyright 2017 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package handlers
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"reflect"
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	cli "gopkg.in/urfave/cli.v1"
+
+	"github.com/vmware/govmomi/list"
+	"github.com/vmware/govmomi/vim25/types"
+	"github.com/vmware/vic/cmd/vic-machine/common"
+	"github.com/vmware/vic/cmd/vic-machine/create"
+	"github.com/vmware/vic/lib/apiservers/service/models"
+	"github.com/vmware/vic/pkg/trace"
+)
+
+type mockFinder struct {
+	path string
+}
+
+func (mf mockFinder) Element(ctx context.Context, t types.ManagedObjectReference) (*list.Element, error) {
+	return &list.Element{
+		Path: t.Value,
+	}, nil
+}
+
+func TestFromManagedObject(t *testing.T) {
+	op := trace.NewOperation(context.Background(), "TestFromManagedObject")
+	var m *models.ManagedObject
+
+	expected := ""
+	actual, err := fromManagedObject(op, nil, "t", m)
+	assert.NoError(t, err, "Expected nil error, got %#v", err)
+	assert.Equal(t, expected, actual)
+
+	m = &models.ManagedObject{
+		Name: "testManagedObject",
+	}
+
+	mf := mockFinder{}
+
+	expected = m.Name
+	actual, err = fromManagedObject(op, mf, "t", m)
+	assert.NoError(t, err, "Expected nil error, got %#v", err)
+	assert.Equal(t, expected, actual)
+
+	m.ID = "testID"
+
+	expected = m.ID
+	actual, err = fromManagedObject(op, mf, "t", m)
+	assert.NoError(t, err, "Expected nil error, got %#v", err)
+	assert.Equal(t, expected, actual)
+
+	m.Name = ""
+
+	expected = m.ID
+	actual, err = fromManagedObject(op, mf, "t", m)
+	assert.NoError(t, err, "Expected nil error, got %#v", err)
+	assert.Equal(t, expected, actual)
+}
+
+func TestFromCIDR(t *testing.T) {
+	var m models.CIDR
+
+	expected := ""
+	actual := fromCIDR(&m)
+	assert.Equal(t, expected, actual)
+
+	m = "10.10.1.0/32"
+
+	expected = string(m)
+	actual = fromCIDR(&m)
+	assert.Equal(t, expected, actual)
+}
+
+func TestFromGateway(t *testing.T) {
+	var m *models.Gateway
+
+	expected := ""
+	actual := fromGateway(m)
+	assert.Equal(t, expected, actual)
+
+	m = &models.Gateway{
+		Address: "192.168.31.37",
+		RoutingDestinations: []models.CIDR{
+			"192.168.1.1/24",
+			"172.17.0.1/24",
+		},
+	}
+
+	expected = "192.168.1.1/24,172.17.0.1/24:192.168.31.37"
+	actual = fromGateway(m)
+	assert.Equal(t, expected, actual)
+}
+
+func TestCreateVCH(t *testing.T) {
+	vch := &models.VCH{
+		Name:  "test-vch",
+		Debug: 3,
+		Compute: &models.VCHCompute{
+			Resource: &models.ManagedObject{
+				Name: "TestCluster",
+			},
+		},
+		Storage: &models.VCHStorage{
+			ImageStores: []string{
+				"ds://test/datastore",
+			},
+		},
+		Network: &models.VCHNetwork{
+			Bridge: &models.VCHNetworkBridge{
+				IPRange: "17.16.0.0/12",
+				PortGroup: &models.ManagedObject{
+					ID:   "bridge", // required for mocked finder to work
+					Name: "bridge",
+				},
+			},
+			Public: &models.Network{
+				PortGroup: &models.ManagedObject{
+					ID:   "public", // required for mock finder to work
+					Name: "public",
+				},
+			},
+		},
+		Registry: &models.VCHRegistry{
+			ImageFetchProxy: &models.VCHRegistryImageFetchProxy{
+				HTTP:  "http://example.com",
+				HTTPS: "https://example.com",
+			},
+			Insecure: []string{
+				"https://insecure.example.com",
+			},
+			Whitelist: []string{
+				"10.0.0.0/8",
+			},
+		},
+		Auth: &models.VCHAuth{
+			Server: &models.VCHAuthServer{
+				Generate: &models.VCHAuthServerGenerate{
+					Cname: "vch.example.com",
+					Organization: []string{
+						"VMware, Inc.",
+					},
+					Size: &models.ValueBits{
+						Value: models.Value{Value: 2048},
+						Units: "bits",
+					},
+				},
+			},
+		},
+		SyslogAddr: "tcp://syslog.example.com:4444",
+		Container: &models.VCHContainer{
+			NameConvention: "container-{id}",
+		},
+	}
+
+	op := trace.NewOperation(context.Background(), "testing")
+	defer func() {
+		err := os.RemoveAll("test-vch")
+		assert.NoError(t, err, "Error removing temp directory: %s", err)
+	}()
+
+	principal := Credentials{
+		user: "testuser",
+		pass: "testpass",
+	}
+
+	tp := "thumbprint"
+	params := buildDataParams{
+		target:     "10.10.1.2",
+		thumbprint: &tp,
+	}
+	data, err := buildData(op, params, principal)
+	assert.NoError(t, err, "Expected no error")
+	// TODO(jzt): assert data struct is as expected
+
+	ca := newCreate()
+	ca.Data = data
+	ca.DisplayName = "test-vch"
+	err = ca.ProcessParams()
+	assert.NoError(t, err, "Error while processing params: %s", err)
+	op.Infof("ca EnvFile: %s", ca.Certs.EnvFile)
+
+	mf := mockFinder{}
+
+	cb, err := buildCreate(op, data, mf, vch)
+	assert.NoError(t, err, "Error while processing params: %s", err)
+
+	a := reflect.ValueOf(ca).Elem()
+	b := reflect.ValueOf(cb).Elem()
+
+	if err = compare(a, b, 0); err != nil {
+		t.Fatalf("Error comparing create structs: %s", err)
+	}
+}
+
+func newCreate() *create.Create {
+	debug := 3
+	ca := create.NewCreate()
+	ca.Debug = common.Debug{Debug: &debug}
+	ca.Compute = common.Compute{DisplayName: "TestCluster"}
+	ca.ImageDatastorePath = "ds://test/datastore"
+	ca.BridgeIPRange = "17.16.0.0/12"
+	ca.BridgeNetworkName = "bridge"
+	ca.PublicNetworkName = "public"
+	ca.Certs.Cname = "vch.example.com"
+	ca.Certs.Org = cli.StringSlice{"VMware, Inc."}
+	ca.Certs.KeySize = 2048
+	httpProxy := "http://example.com"
+	httpsProxy := "https://example.com"
+	ca.Proxies = common.Proxies{
+		HTTPProxy:  &httpProxy,
+		HTTPSProxy: &httpsProxy,
+	}
+	ca.Registries = common.Registries{
+		InsecureRegistriesArg:  cli.StringSlice{"https://insecure.example.com"},
+		WhitelistRegistriesArg: cli.StringSlice{"10.0.0.0/8"},
+	}
+	ca.SyslogAddr = "tcp://syslog.example.com:4444"
+	ca.ContainerNameConvention = "container-{id}"
+	ca.Certs.CertPath = "test-vch"
+	ca.Certs.NoSaveToDisk = true
+
+	return ca
+}
+
+func compare(a, b reflect.Value, index int) (err error) {
+	switch a.Kind() {
+	case reflect.Invalid, reflect.Uint8: // skip uint8 as generated cert data is not expected to match
+		// NOP
+	case reflect.Ptr:
+		ae := a.Elem()
+		be := b.Elem()
+		if !ae.IsValid() != !be.IsValid() {
+			return fmt.Errorf("Expected pointer validity to match for for %s", a.Type().Name())
+		}
+		return compare(ae, be, index)
+	case reflect.Interface:
+		return compare(a.Elem(), b.Elem(), index)
+	case reflect.Struct:
+		for i := 0; i < a.NumField(); i++ {
+			if err = compare(a.Field(i), b.Field(i), i); err != nil {
+				fmt.Printf("Field name a: %s, b: %s, index: %d\n", a.Type().Field(i).Name, b.Type().Field(i).Name, i)
+				return err
+			}
+		}
+	case reflect.Slice:
+		m := min(a.Len(), b.Len())
+		for i := 0; i < m; i++ {
+			if err = compare(a.Index(i), b.Index(i), i); err != nil {
+				return err
+			}
+		}
+	case reflect.Map:
+		keys := []string{}
+		for _, key := range a.MapKeys() {
+			keys = append(keys, key.String())
+		}
+		sort.Strings(keys)
+		for i, key := range keys {
+			if err = compare(a.MapIndex(reflect.ValueOf(key)), b.MapIndex(reflect.ValueOf(key)), i); err != nil {
+				return err
+			}
+		}
+	case reflect.String:
+		if a.String() != b.String() {
+			return fmt.Errorf("String fields not equal: %s != %s", a.String(), b.String())
+		}
+	default:
+		if a.CanInterface() && b.CanInterface() {
+			if a.Interface() != b.Interface() {
+				return fmt.Errorf("Elements are not equal: %#v != %#v", a.Interface(), b.Interface())
+			}
+		}
+	}
+	return nil
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}


### PR DESCRIPTION
This main purpose of this change is to test the `buildCreate` function in vch_create.go, to verify that the `Create` struct that is generated matches the same struct that would be generated using the CLI.

There are some tests around help functions as well.

Fixes #6018