### PR TITLE
Enable --ops-grant-perms in vic-machine. Add nightly and unit tests

### DIFF
--- a/cmd/vic-machine/common/ops_credentials_test.go
+++ b/cmd/vic-machine/common/ops_credentials_test.go
@@ -60,4 +60,45 @@ func TestProcessOpsCredentials(t *testing.T) {
 	configureOps.OpsUser = nil
 	err = configureOps.ProcessOpsCredentials(isCreateOp, "", nil)
 	assert.NotNil(t, err)
+
+	// Test correct grant permissions
+	createOps = &OpsCredentials{}
+	createOps.OpsUser = &opsUser
+	createOps.OpsPassword = &opsPassword
+	grantPerms := true
+	createOps.GrantPerms = &grantPerms
+	err = createOps.ProcessOpsCredentials(true, adminUser, &adminPassword)
+	assert.NoError(t, err)
+	assert.Equal(t, *createOps.OpsUser, opsUser)
+	assert.Equal(t, *createOps.OpsPassword, opsPassword)
+	assert.True(t, *createOps.GrantPerms)
+
+	// Create Negative test: grantPerms is set to true but there is no ops-user,
+	// grantPerms should be reset to false
+	createOps = &OpsCredentials{}
+	createOps.OpsUser = nil
+	createOps.OpsPassword = nil
+	grantPerms = true
+	createOps.GrantPerms = &grantPerms
+	err = createOps.ProcessOpsCredentials(true, adminUser, &adminPassword)
+	assert.Error(t, err)
+
+	// Create Negative test: grantPerms is set to true but there is no ops-user,
+	// grantPerms should be reset to false
+	createOps = &OpsCredentials{}
+	createOps.OpsUser = nil
+	createOps.OpsPassword = nil
+	grantPerms = false
+	createOps.GrantPerms = &grantPerms
+	err = createOps.ProcessOpsCredentials(true, adminUser, &adminPassword)
+	assert.NoError(t, err)
+	assert.Nil(t, createOps.GrantPerms)
+
+	// Configure test: grantPerms is set to true but there is no ops-user,
+	// grantPerms should be true as the ops-user may come from the config
+	grantPerms = true
+	createOps.GrantPerms = &grantPerms
+	err = createOps.ProcessOpsCredentials(false, adminUser, &adminPassword)
+	assert.NoError(t, err)
+	assert.True(t, *createOps.GrantPerms)
 }

--- a/lib/config/virtual_container_host.go
+++ b/lib/config/virtual_container_host.go
@@ -257,6 +257,10 @@ func (t *VirtualContainerHostConfigSpec) SetGrantPerms() {
 	t.GrantPermsLevel = AddPerms
 }
 
+func (t *VirtualContainerHostConfigSpec) ClearGrantPerms() {
+	t.GrantPermsLevel = ""
+}
+
 func (t *VirtualContainerHostConfigSpec) ShouldGrantPerms() bool {
 	return t.GrantPermsLevel == AddPerms
 }

--- a/lib/install/validate/validator.go
+++ b/lib/install/validate/validator.go
@@ -440,9 +440,15 @@ func (v *Validator) credentials(ctx context.Context, input *data.Data, conf *con
 	conf.Token = *input.OpsCredentials.OpsPassword
 	conf.TargetThumbprint = input.Thumbprint
 
-	if input.OpsCredentials.GrantPerms {
-		// Set Grant Permissions level
-		conf.SetGrantPerms()
+	// If Grant Perms has  been explicitly requested (either true or false)
+	// set it to the new value. Otherwise leave the value in conf as it is
+	if input.OpsCredentials.GrantPerms != nil {
+		if *input.OpsCredentials.GrantPerms {
+			// Set Grant Permissions level
+			conf.SetGrantPerms()
+		} else {
+			conf.ClearGrantPerms()
+		}
 	}
 
 	// Discard anything other than these URL fields for the target

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-25-OPS-User-Grant.md
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-25-OPS-User-Grant.md
@@ -1,0 +1,21 @@
+Test 5-25 - OPS User Grant
+=======
+
+# Purpose:
+To verify that VIC works properly when a VCH is installed with the option to create the proper permissions for the OPS-user
+
+# Environment:
+This test requires access to VMware Nimbus cluster for dynamic ESXi and vCenter creation
+
+# Test Steps:
+1. Deploy a new vCenter with a simple cluster
+2. Create Local OPS User on VC
+3. Give the Local OPS User ReadOnly Role on /
+3. Install the VIC appliance into the cluster with the --ops-grant-perms option
+4. Run a variety of docker operation on the VCH
+
+# Expected Outcome:
+All test steps should complete without error
+
+# Possible Problems:
+None

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-25-OPS-User-Grant.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-25-OPS-User-Grant.robot
@@ -1,0 +1,70 @@
+# Copyright 2016-2017 VMware, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#	http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License
+
+*** Settings ***
+Documentation  Test 5-25 - OPS-User-Grant
+Resource  ../../resources/Util.robot
+Suite Setup  Wait Until Keyword Succeeds  10x  10m  Ops User Create
+Suite Teardown  Run Keyword And Ignore Error  Nimbus Cleanup  ${list}
+
+*** Keywords ***
+Ops User Create
+    Run Keyword And Ignore Error  Nimbus Cleanup  ${list}  ${false}
+    Set Suite Variable  ${datacenter}  datacenter1
+    Set Suite Variable  ${cluster}  cls1
+    ${esx1}  ${esx2}  ${esx3}  ${vc}  ${esx1-ip}  ${esx2-ip}  ${esx3-ip}  ${vc-ip}=  Create a Simple VC Cluster  ${datacenter}  ${cluster}
+    Log To Console  Finished Creating Cluster ${vc}
+    Set Suite Variable  @{list}  ${esx1}  ${esx2}  ${esx3}  %{NIMBUS_USER}-${vc}
+    ${vc}=  Set Variable  vcname
+
+    Set Suite Variable  ${ops_user_base_name}  vch-user
+    Set Suite Variable  ${ops_user_domain}  vsphere.local
+    ${ops_user_name}=  Catenate  SEPARATOR=@  ${ops_user_base_name}  ${ops_user_domain}
+    Log To Console  Base User Name: ${ops_user_base_name}
+    Log To Console  Full User Name: ${ops_user_name}
+
+    Set Suite Variable  ${ops_user_name}
+    Set Suite Variable  ${ops_user_password}  Admin!23
+    Set Suite Variable  ${vc_admin_password}  Admin!23
+
+    Log To Console  Setting up ops-user: ${ops_user_name}
+    ${rc}  ${output}=  Run And Return Rc And Output  sshpass -p vmware ssh -o StrictHostKeyChecking=no root@${vc-ip} /usr/lib/vmware-vmafd/bin/dir-cli user create --account ${ops_user_base_name} --user-password ${ops_user_password} --first-name ${ops_user_base_name} --last-name ${ops_user_domain} --password ${vc_admin_password}
+    Log  User Create ${ops_user_name}, rc: ${rc}, output: ${output}
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${output}=  Run And Return Rc And Output  sshpass -p vmware ssh -o StrictHostKeyChecking=no root@${vc-ip} /usr/lib/vmware-vmafd/bin/dir-cli user find-by-name --account ${ops_user_base_name} --password ${vc_admin_password}
+    Log  User Find ${ops_user_base_name}, rc: ${rc}, output: ${output}
+    Should Be Equal As Integers  ${rc}  0
+
+    Log To Console  Running govc to set permissions ..
+    ${out}=  Run  govc permissions.set -principal ${ops_user_name} -role ReadOnly -propagate=false /
+    Should Be Empty  ${out}
+    ${out}=  Run  govc role.usage
+    Log  Output, govc role.usage: ${out}
+
+*** Test Cases ***
+Test
+    Log To Console  \nStarting test...
+    Install VIC Appliance To Test Server  additional-args=--ops-user ${ops_user_name} --ops-password ${ops_user_password} --ops-grant-perms
+
+    # Run a govc test to check that access is denied on some resources
+    Log To Console  Running govc to set drs-enabled, it should fail
+    ${rc}  ${output}=  Run And Return Rc And Output  GOVC_USERNAME=${ops_user_name} GOVC_PASSWORD=${ops_user_password} govc cluster.change -drs-enabled /${datacenter}/host/${cluster}
+    Log  Govc output: ${output}
+    Should Be Equal As Integers  ${rc}  1
+    Should Contain  ${output}  Permission to perform this operation was denied
+
+
+    Run Regression Tests
+
+    Cleanup VIC Appliance On Test Server


### PR DESCRIPTION
Fixes #6691

During create the --ops-grant-perms flag must be used in combination with the argument --ops-user. Otherwise the flag is left undefined and the granting is not performed. During configure, priority goes to the value stored in the SpecConfig, unless there is a specific request from the command line. The flag --ops-grant-perms=false can be used to turn it off while --ops-grant-perms can be used to turn it on.
