### PR TITLE
Support operation-specific logger configuration

### DIFF
--- a/pkg/trace/operation.go
+++ b/pkg/trace/operation.go
@@ -130,7 +130,11 @@ func (o *Operation) ID() string {
 }
 
 func (o *Operation) Infof(format string, args ...interface{}) {
-	msg := fmt.Sprintf(format, args...)
+	o.Info(fmt.Sprintf(format, args...))
+}
+
+func (o *Operation) Info(args ...interface{}) {
+	msg := fmt.Sprint(args...)
 
 	Logger.Infof("%s: %s", o.header(), msg)
 
@@ -139,12 +143,12 @@ func (o *Operation) Infof(format string, args ...interface{}) {
 	}
 }
 
-func (o *Operation) Info(args ...interface{}) {
-	o.Infof(fmt.Sprint(args...))
+func (o *Operation) Debugf(format string, args ...interface{}) {
+	o.Debug(fmt.Sprintf(format, args...))
 }
 
-func (o *Operation) Debugf(format string, args ...interface{}) {
-	msg := fmt.Sprintf(format, args...)
+func (o *Operation) Debug(args ...interface{}) {
+	msg := fmt.Sprint(args...)
 
 	Logger.Debugf("%s: %s", o.header(), msg)
 
@@ -153,12 +157,12 @@ func (o *Operation) Debugf(format string, args ...interface{}) {
 	}
 }
 
-func (o *Operation) Debug(args ...interface{}) {
-	o.Debugf(fmt.Sprint(args...))
+func (o *Operation) Warnf(format string, args ...interface{}) {
+	o.Warn(fmt.Sprintf(format, args...))
 }
 
-func (o *Operation) Warnf(format string, args ...interface{}) {
-	msg := fmt.Sprintf(format, args...)
+func (o *Operation) Warn(args ...interface{}) {
+	msg := fmt.Sprint(args...)
 
 	Logger.Warnf("%s: %s", o.header(), msg)
 
@@ -167,12 +171,12 @@ func (o *Operation) Warnf(format string, args ...interface{}) {
 	}
 }
 
-func (o *Operation) Warn(args ...interface{}) {
-	o.Warnf(fmt.Sprint(args...))
+func (o *Operation) Errorf(format string, args ...interface{}) {
+	o.Error(fmt.Sprintf(format, args...))
 }
 
-func (o *Operation) Errorf(format string, args ...interface{}) {
-	msg := fmt.Sprintf(format, args...)
+func (o *Operation) Error(args ...interface{}) {
+	msg := fmt.Sprint(args...)
 
 	Logger.Errorf("%s: %s", o.header(), msg)
 
@@ -181,22 +185,18 @@ func (o *Operation) Errorf(format string, args ...interface{}) {
 	}
 }
 
-func (o *Operation) Error(args ...interface{}) {
-	o.Errorf(fmt.Sprint(args...))
+func (o *Operation) Panicf(format string, args ...interface{}) {
+	o.Panic(fmt.Sprintf(format, args...))
 }
 
-func (o *Operation) Panicf(format string, args ...interface{}) {
-	msg := fmt.Sprintf(format, args...)
+func (o *Operation) Panic(args ...interface{}) {
+	msg := fmt.Sprint(args...)
 
 	Logger.Panicf("%s: %s", o.header(), msg)
 
 	if o.Logger != nil {
 		o.Logger.Panic(msg)
 	}
-}
-
-func (o *Operation) Panic(args ...interface{}) {
-	o.Panicf(fmt.Sprint(args...))
 }
 
 func (o *Operation) newChild(ctx context.Context, msg string) Operation {

--- a/pkg/trace/operation.go
+++ b/pkg/trace/operation.go
@@ -130,50 +130,73 @@ func (o *Operation) ID() string {
 }
 
 func (o *Operation) Infof(format string, args ...interface{}) {
-	Logger.Infof("%s: %s", o.header(), fmt.Sprintf(format, args...))
+	msg := fmt.Sprintf(format, args...)
+
+	Logger.Infof("%s: %s", o.header(), msg)
 
 	if o.Logger != nil {
-		o.Logger.Infof("%s: %s", o.header(), fmt.Sprintf(format, args...))
+		o.Logger.Info(msg)
 	}
+}
+
+func (o *Operation) Info(args ...interface{}) {
+	o.Infof(fmt.Sprint(args...))
 }
 
 func (o *Operation) Debugf(format string, args ...interface{}) {
-	Logger.Debugf("%s: %s", o.header(), fmt.Sprintf(format, args...))
+	msg := fmt.Sprintf(format, args...)
+
+	Logger.Debugf("%s: %s", o.header(), msg)
 
 	if o.Logger != nil {
-		o.Logger.Debugf("%s: %s", o.header(), fmt.Sprintf(format, args...))
+		o.Logger.Debug(msg)
 	}
+}
+
+func (o *Operation) Debug(args ...interface{}) {
+	o.Debugf(fmt.Sprint(args...))
 }
 
 func (o *Operation) Warnf(format string, args ...interface{}) {
-	Logger.Warnf("%s: %s", o.header(), fmt.Sprintf(format, args...))
+	msg := fmt.Sprintf(format, args...)
+
+	Logger.Warnf("%s: %s", o.header(), msg)
 
 	if o.Logger != nil {
-		o.Logger.Warnf("%s: %s", o.header(), fmt.Sprintf(format, args...))
+		o.Logger.Warn(msg)
 	}
+}
+
+func (o *Operation) Warn(args ...interface{}) {
+	o.Warnf(fmt.Sprint(args...))
 }
 
 func (o *Operation) Errorf(format string, args ...interface{}) {
-	Logger.Errorf("%s: %s", o.header(), fmt.Sprintf(format, args...))
+	msg := fmt.Sprintf(format, args...)
+
+	Logger.Errorf("%s: %s", o.header(), msg)
 
 	if o.Logger != nil {
-		o.Logger.Errorf("%s: %s", o.header(), fmt.Sprintf(format, args...))
+		o.Logger.Error(msg)
 	}
 }
 
-func (o *Operation) Error(err error) {
-	Logger.Errorf("%s: %s", o.header(), err.Error())
-	if o.Logger != nil {
-		o.Logger.Errorf("%s: %s", o.header(), err.Error())
-	}
+func (o *Operation) Error(args ...interface{}) {
+	o.Errorf(fmt.Sprint(args...))
 }
 
 func (o *Operation) Panicf(format string, args ...interface{}) {
-	Logger.Panicf("%s: %s", o.header(), fmt.Sprintf(format, args...))
+	msg := fmt.Sprintf(format, args...)
+
+	Logger.Panicf("%s: %s", o.header(), msg)
 
 	if o.Logger != nil {
-		o.Logger.Panicf("%s: %s", o.header(), fmt.Sprintf(format, args...))
+		o.Logger.Panic(msg)
 	}
+}
+
+func (o *Operation) Panic(args ...interface{}) {
+	o.Panicf(fmt.Sprint(args...))
 }
 
 func (o *Operation) newChild(ctx context.Context, msg string) Operation {

--- a/pkg/trace/operation_test.go
+++ b/pkg/trace/operation_test.go
@@ -168,13 +168,13 @@ var cases = map[string]logrus.Level{
 }
 
 // buildMatcher creates a testify MatchedBy function for the supplied operation
-func buildMatcher(op Operation, shouldContainOpId bool) func(entry *logrus.Entry) bool {
+func buildMatcher(op Operation, shouldContainOpID bool) func(entry *logrus.Entry) bool {
 	return func(entry *logrus.Entry) bool {
-		if shouldContainOpId && !strings.Contains(entry.Message, op.id) {
+		if shouldContainOpID && !strings.Contains(entry.Message, op.id) {
 			return false // Log message should have contained the operation id, but did not
 		}
 
-		if !shouldContainOpId && strings.Contains(entry.Message, op.id) {
+		if !shouldContainOpID && strings.Contains(entry.Message, op.id) {
 			return false // Log message should not have contained the operation id, but did
 		}
 

--- a/pkg/trace/operation_test.go
+++ b/pkg/trace/operation_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/Sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 )
 
 func TestContextUnpack(t *testing.T) {
@@ -135,4 +136,160 @@ func TestSanity(t *testing.T) {
 	if !assert.Error(t, err) {
 		return
 	}
+}
+
+// MockHook is a testify mock that can be registered as a logrus hook
+type MockHook struct {
+	mock.Mock
+}
+
+// Levels indicates that the mock log hook supports all log levels
+func (m *MockHook) Levels() []logrus.Level {
+	return logrus.AllLevels
+}
+
+// Fire records that it has been called and returns an error if configured
+func (m *MockHook) Fire(entry *logrus.Entry) error {
+	args := m.Called(entry)
+
+	return args.Error(0)
+}
+
+// cases defines the set of messages we expect to see and the level we expect to see each at
+var cases = map[string]logrus.Level{
+	"DebugfMessage": logrus.DebugLevel,
+	"InfofMessage":  logrus.InfoLevel,
+	"WarnfMessage":  logrus.WarnLevel,
+	"ErrorfMessage": logrus.ErrorLevel,
+	"ErrorMessage":  logrus.ErrorLevel,
+}
+
+// buildMatcher creates a testify MatchedBy function for the supplied operation
+func buildMatcher(op Operation) func(entry *logrus.Entry) bool {
+	return func(entry *logrus.Entry) bool {
+		if !strings.Contains(entry.Message, op.id) {
+			return false // Log messages should always contain the operation id
+		}
+
+		for message, level := range cases {
+			if entry.Level == level && strings.Contains(entry.Message, message) {
+				return true
+			}
+		}
+		return false
+	}
+}
+
+// TestLogging demonstrates that log messages are relayed from the Operation to the Logger global
+func TestLogging(t *testing.T) {
+	original := Logger
+	defer func() { Logger = original }()
+	Logger = logrus.New()
+
+	op := NewOperation(context.Background(), "TestOperation")
+
+	m := new(MockHook)
+	Logger.Hooks.Add(m)
+	Logger.Level = logrus.DebugLevel
+
+	m.On("Fire", mock.MatchedBy(buildMatcher(op))).Return(nil)
+
+	op.Debugf("DebugfMessage")
+	op.Infof("InfofMessage")
+	op.Warnf("WarnfMessage")
+	op.Errorf("ErrorfMessage")
+	op.Error(fmt.Errorf("ErrorMessage"))
+
+	m.AssertExpectations(t)
+	m.AssertNumberOfCalls(t, "Fire", 5)
+}
+
+// TestLogMuxing verifies that an operation-specific Logger can be configured and that both it and
+// the global Logger receive messages when logging methods are called on Operation
+func TestLogMuxing(t *testing.T) {
+	original := Logger
+	defer func() { Logger = original }()
+	Logger = logrus.New()
+
+	op := NewOperation(context.Background(), "TestOperation")
+
+	gm := new(MockHook)
+	Logger.Hooks.Add(gm)
+	Logger.Level = logrus.DebugLevel
+
+	lm := new(MockHook)
+	op.Logger = logrus.New()
+	op.Logger.Hooks.Add(lm)
+	op.Logger.Level = logrus.DebugLevel
+
+	gm.On("Fire", mock.MatchedBy(buildMatcher(op))).Return(nil)
+	lm.On("Fire", mock.MatchedBy(buildMatcher(op))).Return(nil)
+
+	op.Debugf("DebugfMessage")
+	op.Infof("InfofMessage")
+	op.Warnf("WarnfMessage")
+	op.Errorf("ErrorfMessage")
+	op.Error(fmt.Errorf("ErrorMessage"))
+
+	gm.AssertExpectations(t)
+	gm.AssertNumberOfCalls(t, "Fire", 5)
+
+	lm.AssertExpectations(t)
+	lm.AssertNumberOfCalls(t, "Fire", 5)
+}
+
+// TestLogIsolation verifies that an operation-specific Loggers are actually operation-specific
+func TestLogIsolation(t *testing.T) {
+	op1 := NewOperation(context.Background(), "TestOperation")
+	op2 := NewOperation(context.Background(), "TestOperation")
+
+	lm1 := new(MockHook)
+	op1.Logger = logrus.New()
+	op1.Logger.Hooks.Add(lm1)
+	op1.Logger.Level = logrus.DebugLevel
+
+	lm2 := new(MockHook)
+	op2.Logger = logrus.New()
+	op2.Logger.Hooks.Add(lm2)
+	op2.Logger.Level = logrus.DebugLevel
+
+	lm1.On("Fire", mock.MatchedBy(buildMatcher(op1))).Return(nil)
+
+	op1.Debugf("DebugfMessage")
+	op1.Infof("InfofMessage")
+	op1.Warnf("WarnfMessage")
+	op1.Errorf("ErrorfMessage")
+	op1.Error(fmt.Errorf("ErrorMessage"))
+
+	lm1.AssertExpectations(t)
+	lm1.AssertNumberOfCalls(t, "Fire", 5)
+
+	lm2.AssertExpectations(t)
+	lm2.AssertNumberOfCalls(t, "Fire", 0)
+}
+
+// TestLogInheritance verifies that an operation-specific Loggers are inherited by children
+func TestLogInheritance(t *testing.T) {
+	op := NewOperation(context.Background(), "TestOperation")
+
+	lm := new(MockHook)
+	op.Logger = logrus.New()
+	op.Logger.Hooks.Add(lm)
+	op.Logger.Level = logrus.DebugLevel
+
+	c1, _ := WithCancel(&op, "CancelChild")
+	c2 := WithValue(&c1, "foo", "bar", "ValueChild")
+	c3 := FromOperation(c2, "NormalChild")
+	c4 := FromContext(c3, "NotAChild")
+
+	lm.On("Fire", mock.MatchedBy(buildMatcher(op))).Return(nil)
+
+	op.Debugf("DebugfMessage")
+	c1.Infof("InfofMessage")
+	c2.Warnf("WarnfMessage")
+	c3.Errorf("ErrorfMessage")
+	c4.Error(fmt.Errorf("ErrorMessage"))
+
+	lm.AssertExpectations(t)
+	lm.AssertNumberOfCalls(t, "Fire", 5)
 }

--- a/pkg/trace/operation_test.go
+++ b/pkg/trace/operation_test.go
@@ -189,8 +189,7 @@ func buildMatcher(op Operation, shouldContainOpId bool) func(entry *logrus.Entry
 
 // TestLogging demonstrates that log messages are relayed from the Operation to the Logger global
 func TestLogging(t *testing.T) {
-	original := Logger
-	defer func() { Logger = original }()
+	defer func(original *logrus.Logger) { Logger = original }(Logger)
 	Logger = logrus.New()
 
 	op := NewOperation(context.Background(), "TestOperation")
@@ -217,8 +216,7 @@ func TestLogging(t *testing.T) {
 // TestLogMuxing verifies that an operation-specific Logger can be configured and that both it and
 // the global Logger receive messages when logging methods are called on Operation
 func TestLogMuxing(t *testing.T) {
-	original := Logger
-	defer func() { Logger = original }()
+	defer func(original *logrus.Logger) { Logger = original }(Logger)
 	Logger = logrus.New()
 
 	op := NewOperation(context.Background(), "TestOperation")
@@ -293,7 +291,7 @@ func TestLogInheritance(t *testing.T) {
 	c1, _ := WithCancel(&op, "CancelChild")
 	c2 := WithValue(&c1, "foo", "bar", "ValueChild")
 	c3 := FromOperation(c2, "NormalChild")
-	c4 := FromContext(c3, "NotAChild")
+	c4 := FromContext(c3, "(Should == c3)")
 
 	lm.On("Fire", mock.MatchedBy(buildMatcher(op, false))).Return(nil)
 


### PR DESCRIPTION
For some use cases (such as the API), it may be useful to multiplex all log messages for a given operation to an additional location.

Introduce support for this functionality and related unit tests.

Additionally, fix a minor bug in the `FromContext` method: Previously, an argument which was already an operation would hit the first case, unnecessarily resulting in a new operation.

Related: #6612