### PR TITLE
[specific ci=Group1-Docker-Commands] Use nanoseconds in container create timestamps

### DIFF
--- a/lib/apiservers/engine/backends/container.go
+++ b/lib/apiservers/engine/backends/container.go
@@ -1632,7 +1632,7 @@ payloadLoop:
 		c := &types.Container{
 			ID:      t.ContainerConfig.ContainerID,
 			Image:   repo,
-			Created: t.ContainerConfig.CreateTime,
+			Created: time.Unix(0, t.ContainerConfig.CreateTime).Unix(),
 			Status:  dockerState.Status,
 			Names:   names,
 			Command: cmd,

--- a/lib/apiservers/engine/backends/container_proxy.go
+++ b/lib/apiservers/engine/backends/container_proxy.go
@@ -1556,7 +1556,7 @@ func ContainerInfoToDockerContainerInspect(vc *viccontainer.VicContainer, info *
 		inspectJSON.LogPath = info.ContainerConfig.LogPath
 		inspectJSON.RestartCount = int(info.ContainerConfig.RestartCount)
 		inspectJSON.ID = info.ContainerConfig.ContainerID
-		inspectJSON.Created = time.Unix(info.ContainerConfig.CreateTime, 0).Format(time.RFC3339Nano)
+		inspectJSON.Created = time.Unix(0, info.ContainerConfig.CreateTime).Format(time.RFC3339Nano)
 		if len(info.ContainerConfig.Names) > 0 {
 			inspectJSON.Name = fmt.Sprintf("/%s", info.ContainerConfig.Names[0])
 		}

--- a/lib/apiservers/engine/backends/container_test.go
+++ b/lib/apiservers/engine/backends/container_test.go
@@ -16,13 +16,12 @@ package backends
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"net/http"
 	"testing"
 	"time"
-
-	"context"
 
 	derr "github.com/docker/docker/api/errors"
 	"github.com/docker/docker/api/types"
@@ -31,9 +30,8 @@ import (
 	dnetwork "github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/reference"
 	"github.com/docker/go-connections/nat"
-	"github.com/stretchr/testify/assert"
-
 	"github.com/go-openapi/runtime"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/vmware/vic/lib/apiservers/engine/backends/cache"
 	viccontainer "github.com/vmware/vic/lib/apiservers/engine/backends/container"

--- a/lib/apiservers/engine/backends/filter/container.go
+++ b/lib/apiservers/engine/backends/filter/container.go
@@ -69,7 +69,7 @@ func IncludeContainer(listContext *ContainerListContext, container *models.Conta
 		// Is the containers exitCode in the validatedList?
 		_, ok := listContext.exitAllowed[listContext.ExitCode]
 
-		// only include conainter whose exit code is in the list and that's
+		// only include container whose exit code is in the list and that's
 		// not currently running and has been started previously
 		// note "Running" state is congruent with PortLayer and not docker
 		if !ok || container.ContainerConfig.State == "Running" || container.ProcessConfig.StartTime == 0 {

--- a/lib/apiservers/portlayer/restapi/handlers/containers_handlers.go
+++ b/lib/apiservers/portlayer/restapi/handlers/containers_handlers.go
@@ -77,15 +77,13 @@ func (handler *ContainersHandlersImpl) Configure(api *operations.PortLayerAPI, h
 
 // CreateHandler creates a new container
 func (handler *ContainersHandlersImpl) CreateHandler(params containers.CreateParams) middleware.Responder {
-	defer trace.End(trace.Begin(""))
+	id := uid.New().String()
+	defer trace.End(trace.Begin(id))
 
 	var err error
 
 	session := handler.handlerCtx.Session
-
 	ctx := context.Background()
-
-	id := uid.New().String()
 
 	// Init key for tether
 	// #nosec: RSA keys should be at least 2048 bits
@@ -105,7 +103,7 @@ func (handler *ContainersHandlersImpl) CreateHandler(params containers.CreatePar
 			ID:   id,
 			Name: params.CreateConfig.Name,
 		},
-		CreateTime: time.Now().UTC().Unix(),
+		CreateTime: time.Now().UTC().UnixNano(),
 		Version:    version.GetBuild(),
 		Key:        pem.EncodeToMemory(&privateKeyBlock),
 		LayerID:    params.CreateConfig.Layer,

--- a/lib/apiservers/portlayer/swagger.json
+++ b/lib/apiservers/portlayer/swagger.json
@@ -3307,7 +3307,8 @@
 					"type": "string"
 				},
 				"createTime": {
-					"type": "integer"
+					"type": "integer",
+					"format": "int64"
 				},
 				"names": {
 					"type": "array",

--- a/lib/migration/feature/feature.go
+++ b/lib/migration/feature/feature.go
@@ -24,6 +24,10 @@ const (
 	VicadminProxyVarRenameVersion
 	InsecureRegistriesTypeChangeVersion
 
+	// ContainerCreateTimestampVersion represents the data version where a container's
+	// create time is stored in nanoseconds (previously seconds) in the portlayer.
+	ContainerCreateTimestampVersion
+
 	// Add new feature flag here
 
 	// MaxPluginVersion must be the last

--- a/lib/migration/plugins/init.go
+++ b/lib/migration/plugins/init.go
@@ -22,4 +22,5 @@ import (
 	_ "github.com/vmware/vic/lib/migration/plugins/plugin5"
 	_ "github.com/vmware/vic/lib/migration/plugins/plugin7"
 	_ "github.com/vmware/vic/lib/migration/plugins/plugin8"
+	_ "github.com/vmware/vic/lib/migration/plugins/plugin9"
 )

--- a/lib/migration/plugins/plugin1/commonSpecForVCH.go
+++ b/lib/migration/plugins/plugin1/commonSpecForVCH.go
@@ -18,12 +18,11 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/vmware/vic/lib/migration/feature"
-	"github.com/vmware/vic/lib/migration/manager"
-
 	log "github.com/Sirupsen/logrus"
 
 	"github.com/vmware/vic/lib/migration/errors"
+	"github.com/vmware/vic/lib/migration/feature"
+	"github.com/vmware/vic/lib/migration/manager"
 	"github.com/vmware/vic/pkg/trace"
 	"github.com/vmware/vic/pkg/vsphere/extraconfig"
 	"github.com/vmware/vic/pkg/vsphere/session"

--- a/lib/migration/plugins/plugin2/commonSpecForContainer.go
+++ b/lib/migration/plugins/plugin2/commonSpecForContainer.go
@@ -18,12 +18,11 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/vmware/vic/lib/migration/feature"
-	"github.com/vmware/vic/lib/migration/manager"
-
 	log "github.com/Sirupsen/logrus"
 
 	"github.com/vmware/vic/lib/migration/errors"
+	"github.com/vmware/vic/lib/migration/feature"
+	"github.com/vmware/vic/lib/migration/manager"
 	"github.com/vmware/vic/pkg/trace"
 	"github.com/vmware/vic/pkg/vsphere/extraconfig"
 	"github.com/vmware/vic/pkg/vsphere/session"

--- a/lib/migration/plugins/plugin9/container_create_timestamp.go
+++ b/lib/migration/plugins/plugin9/container_create_timestamp.go
@@ -1,0 +1,81 @@
+// Copyright 2017 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package plugin9
+
+import (
+	"context"
+	"fmt"
+
+	log "github.com/Sirupsen/logrus"
+
+	"github.com/vmware/vic/lib/migration/errors"
+	"github.com/vmware/vic/lib/migration/feature"
+	"github.com/vmware/vic/lib/migration/manager"
+	"github.com/vmware/vic/pkg/trace"
+	"github.com/vmware/vic/pkg/vsphere/extraconfig"
+	"github.com/vmware/vic/pkg/vsphere/session"
+)
+
+const target = manager.ContainerConfigure
+
+func init() {
+	defer trace.End(trace.Begin(fmt.Sprintf("Registering plugin %s:%d", target, feature.ContainerCreateTimestampVersion)))
+	if err := manager.Migrator.Register(feature.ContainerCreateTimestampVersion, target, &ContainerCreateTimestampVersion{}); err != nil {
+		log.Errorf("Failed to register plugin %s:%d, %s", target, feature.ContainerCreateTimestampVersion, err)
+		panic(err)
+	}
+}
+
+// ContainerCreateTimestampVersion is a plugin to convert stored container create timestamps
+// in seconds to nanoseconds in the container configuration.
+type ContainerCreateTimestampVersion struct {
+}
+
+// ExecutorConfig is used to update the container create time from seconds to nanoseconds.
+type ExecutorConfig struct {
+	CreateTime int64 `vic:"0.1" scope:"read-write" key:"createtime"`
+}
+
+// Migrate converts the stored container create timestamp (in seconds) to nanoseconds.
+func (c *ContainerCreateTimestampVersion) Migrate(ctx context.Context, s *session.Session, data interface{}) error {
+	defer trace.End(trace.Begin(fmt.Sprintf("ContainerCreateTimestampVersion version %d", feature.ContainerCreateTimestampVersion)))
+	if data == nil {
+		return nil
+	}
+	mapData, ok := data.(map[string]string)
+	if !ok {
+		// Log the error here and return nil so that other plugins can proceed.
+		log.Errorf("Migration data format is not map: %+v", data)
+		return nil
+	}
+	oldStruct := &ExecutorConfig{}
+	result := extraconfig.Decode(extraconfig.MapSource(mapData), oldStruct)
+	log.Debugf("The oldStruct is %+v", oldStruct)
+	if result == nil {
+		return &errors.DecodeError{Err: fmt.Errorf("decode oldStruct %+v failed", oldStruct)}
+	}
+
+	// Convert create timestamp to nanoseconds for older containers that use seconds.
+	oldStruct.CreateTime *= 1e9
+
+	cfg := make(map[string]string)
+	extraconfig.Encode(extraconfig.MapSink(cfg), oldStruct)
+
+	for k, v := range cfg {
+		log.Debugf("New data: %s:%s", k, v)
+		mapData[k] = v
+	}
+	return nil
+}

--- a/lib/migration/plugins/plugin9/container_create_timestamp_test.go
+++ b/lib/migration/plugins/plugin9/container_create_timestamp_test.go
@@ -1,0 +1,49 @@
+// Copyright 2017 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package plugin9
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/vmware/vic/lib/config/executor"
+	"github.com/vmware/vic/pkg/vsphere/extraconfig"
+)
+
+// TestMigrateContainerCreateTimestamp tests this package's ContainerCreateTimestampVersion.Migrate.
+func TestMigrateContainerCreateTimestamp(t *testing.T) {
+	secSinceEpoch := int64(1510950922)
+	oldCreateTime := secSinceEpoch
+	newCreateTime := secSinceEpoch * 1e9
+	layerID := "abcdefg"
+	execConfig := executor.ExecutorConfig{
+		CreateTime: oldCreateTime,
+		// Supply an extra field that's not accessed in the plugin9 migrator to
+		// ensure that unneeded fields aren't dropped from the returned data.
+		LayerID: layerID,
+	}
+
+	c := ContainerCreateTimestampVersion{}
+	mapData := make(map[string]string)
+	extraconfig.Encode(extraconfig.MapSink(mapData), execConfig)
+
+	err := c.Migrate(nil, nil, mapData)
+	assert.NoError(t, err)
+
+	newConf := extraconfig.Decode(extraconfig.MapSource(mapData), execConfig)
+	assert.Equal(t, newCreateTime, newConf.(executor.ExecutorConfig).CreateTime)
+	assert.Equal(t, layerID, newConf.(executor.ExecutorConfig).LayerID)
+}

--- a/lib/migration/plugins/plugins.md
+++ b/lib/migration/plugins/plugins.md
@@ -2,36 +2,38 @@
 
 ## Who and When to develop a data migration plugin
 
-As [upgrade design](../../../doc/design/upgrade.md) mentioned, every developer who changed configuration from VCH appliance configuration, container vm configuration, or key/value store, whatever it is, they should add data migration plugin here.
+As [upgrade design](../../../doc/design/vic-machine/upgrade.md) mentioned, every developer who changed configuration from VCH appliance configuration, container vm configuration, or key/value store, whatever it is, they should add data migration plugin here.
 
 ## How to develop a data migration plugin
 
 ### VM guestinfo changes including VCH appliance and container VM
 
-- Be sure to check if there is file conflict with other's commit. If there is conflict, that means others had plugin check in as well, make sure you did not use same version number with others
-- Create one package in this directory for your plugin
-- Add plugin files to the new package
+- Check if there is a file conflict with someone else's commit. If there is a conflict, that means there's another plugin being developed at the time - ensure that you do not use same plugin version number.
+- Create a new package in the _lib/migration/plugins_ directory for your new plugin, say _pluginX_.
+- Add a new constant for the plugin version in _lib/migration/feature/feature.go_.
+- Add plugin files to the new package.
 - Your plugin might rely on previous version and current version, if you need the whole VCH appliance or container configuration definition, copy them to package lib/migration/config, with correct new package created. For example, if you are working on migration from version 4 to version 5, create a package named v4 if there is no one existing, and copy all old configuration files to there, and create a new package v5,  copy all new configuration files to v5 package. Remember to update package name.
 - If only a few attributes are touched, you could define that piece of attribute definition in your plugin package, without whole configuration files copied in the above step. Which can save binary size, and also configuration encodeing/decoding time.
 - Develop plugin based on your specific change, read the input data, decoding to acceptable format, and change value inside of them. stop_singal_rename_sample.go is one VCH appliance configuration change sample, you can follow that to write your own plugin.
-- register your plugin to data migration framework, and put the function in package init() method.
+- Register your plugin to data migration framework, and put the function in package _pluginX_'s init() method.
   * Register appliance data migration plugin to manager.ApplianceConfigure category
   * Register container data migration plugin to manager.ContainerConfigure category
-  * The two kinds of plugs target for different data, be sure the type is selected correctly in registration.
-- Add import of your package in init.go in this package, to make sure the plugin is registered dynamically.
+  * The two plugin targets are for different data, ensure that the type is selected correctly in registration.
+- *Important:* add import of your _pluginX_ package in init.go of the _plugin_ package to ensure that _pluginX_ is registered dynamically.
 
 ### key/value store changes
 
-- Be sure to check if there is file conflict with other's commit. If there is conflict, that means others had plugin check in as well, make sure you did not use same version number with others
-- Create one package in this directory for your plugin
-- Add your plugin files to the new package
+- Check if there is a file conflict with someone else's commit. If there is a conflict, that means there's another plugin being developed at the time - ensure that you do not use same plugin version number.
+- Create a new package in the _lib/migration/plugins_ directory for your new plugin, say _pluginX_.
+- Add a new constant for the plugin version in _lib/migration/feature/feature.go_.
+- Add your plugin files to the new package.
 - Develop plugin based on your specific change.
   * Create new key/value store file in datastore, instead of change in existing file. The new file for new version, e.g. v4, could use file name as XXX.v4, to differentiate with old version's file.
   * Copy all existing key/values to the new file, and update to the new file directly.
   * Write to new datastore file only, because old file is still correct if migration failed eventually.
-- register your plugin to data migration framework, and put the function in package init() method.
-  * Register key/value store data migration plugin to manager.ApplianceConfigure category
-- Add import of your package in init.go in this package, to make sure the plugin is registered dynamically.
+- Register your plugin to data migration framework, and put the function in package _pluginX_'s init() method.
+  * Register key/value store data migration plugin to manager.ApplianceConfigure category.
+- *Important:* add import of your _pluginX_ package in init.go of the _plugin_ package to ensure that _pluginX_ is registered dynamically.
 
 Note:
 - Plugin version should be greater than 0

--- a/tests/test-cases/Group11-Upgrade/11-01-Upgrade.md
+++ b/tests/test-cases/Group11-Upgrade/11-01-Upgrade.md
@@ -16,25 +16,27 @@ This test requires that a vSphere server is running and available
 6. Create a named volume
 7. Create a container with a mounted anonymous and named volume
 8. Upgrade VCH to latest version
-9. Verify that the volumes are still there using inspect
-10. Roll back to the previous version
-11. Upgrade again to the upgraded version
-12. Verify that the volumes are still there using inspect
-13. Check the previous created container and image are still there
-14. Attempt to rename an old container created with a VCH that doesn't support rename.
-15. Rename a new container created with a VCH that supports rename.
-16. Check the previous created container's display name and datastore folder name
-17. Check the display name and datastore folder name of a new container created after VCH upgrade
+9. Check that one of the older VCH's containers has a create timestamp in seconds, and one from the upgraded VCH uses nanoseconds
+10. Check that the above two containers have valid human-readable create times in docker ps output
+11. Verify that the volumes are still there using inspect
+12. Roll back to the previous version
+13. Upgrade again to the upgraded version
+14. Verify that the volumes are still there using inspect
+15. Check the previous created container and image are still there
+15. Attempt to rename an old container created with a VCH that doesn't support rename
+16. Rename a new container created with a VCH that supports rename
+17. Check the previous created container's display name and datastore folder name
+18. Check the display name and datastore folder name of a new container created after VCH upgrade
 
 # Expected Outcome:
 * Step 5 should fail with timeout
-* Step 14 should result in an error containing the following message:
+* Step 15 should result in an error containing the following message:
 ```
 does not support rename
 ```
-* Step 15 should succeed and the container's new name should be present in ps, inspect and govc vm.info output.
-* Step 16 should show that both the container's display name and datastore folder name are containerName-containerID
-* Step 17 should show that (1) on a non-vsan setup, the container's display name is containerName-containerShortID while the datastore folder name is containerID, or (2) on a vsan setup, both the container's display name and datastore folder name are containerName-containerShortID
+* Step 16 should succeed and the container's new name should be present in ps, inspect and govc vm.info output.
+* Step 17 should show that both the container's display name and datastore folder name are containerName-containerID
+* Step 18 should show that (1) on a non-vsan setup, the container's display name is containerName-containerShortID while the datastore folder name is containerID, or (2) on a vsan setup, both the container's display name and datastore folder name are containerName-containerShortID
 * All other steps should result in success
 
 # Possible Problems:


### PR DESCRIPTION
This change stores container create timestamps in nanoseconds in the
portlayer instead of seconds like we did previously. This allows us to
store and sort container list output more granularly for the docker
personality.

Before this change, we were seeing failures where the 'docker ps -l'
command showed a container that wasn't the last one created. A possible
reason is that multiple containers can have the same second in their
create timestamps, and Go's sort.Sort is unstable w.r.t. the order of
equal values in a slice.

This commit includes:

  * using nsec instead of sec for create timestamps,
  * converting the stored timestamps to seconds in the docker persona
    for 'docker ps' and 'docker inspect', and
  * defining a new container data version so containers from older VCHs
    that don't use nsec timestamps still show valid ps and inspect
    output by multiplying sec timestamps by 1e9.

Fixes #6676