### PR TITLE
[specific ci=1-11-Docker-RM] Use retries in docker rm

### DIFF
--- a/lib/apiservers/engine/backends/container.go
+++ b/lib/apiservers/engine/backends/container.go
@@ -793,11 +793,14 @@ func (c *Container) ContainerRm(name string, config *types.ContainerRmConfig) er
 		return NotFoundError(name)
 	}
 	id := vc.ContainerID
+	secs := 0
+	running := false
 
 	// Use the force and stop the container first
-	secs := 0
 	if config.ForceRemove {
-		c.ContainerStop(name, &secs)
+		if err := c.ContainerStop(name, &secs); err != nil {
+			return err
+		}
 	} else {
 		state, err := c.containerProxy.State(vc)
 		if err != nil {
@@ -808,13 +811,16 @@ func (c *Container) ContainerRm(name string, config *types.ContainerRmConfig) er
 			}
 			return InternalServerError(err.Error())
 		}
-		// force stop if container state is error to make sure container is deletable later
-		if state.Status == ContainerError {
+
+		switch state.Status {
+		case ContainerError:
+			// force stop if container state is error to make sure container is deletable later
 			c.containerProxy.Stop(vc, name, &secs, true)
-		}
-		// if we are starting let the user know they must use the force
-		if state.Status == "Starting" {
+		case "Starting":
+			// if we are starting let the user know they must use the force
 			return derr.NewRequestConflictError(fmt.Errorf("The container is starting.  To remove use -f"))
+		case ContainerRunning:
+			running = true
 		}
 
 		handle, err := c.Handle(id, name)
@@ -828,11 +834,17 @@ func (c *Container) ContainerRm(name string, config *types.ContainerRmConfig) er
 		}
 	}
 
-	operation := func() error {
-		return c.containerProxy.Remove(vc, config)
+	// Retry remove operation if container is not in running state.  If in running state, we only try
+	// once to prevent retries from degrading performance.
+	if !running {
+		operation := func() error {
+			return c.containerProxy.Remove(vc, config)
+		}
+
+		return retry.Do(operation, IsConflictError)
 	}
 
-	return retry.Do(operation, IsConflictError)
+	return c.containerProxy.Remove(vc, config)
 }
 
 // cleanupPortBindings gets port bindings for the container and

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-4-High-Availability.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-4-High-Availability.robot
@@ -227,6 +227,7 @@ Test
     \     Should Be Equal As Integers  ${rc}  0
     \     Should Be Equal  ${output}  running
     \     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} rm -f ${c}
+    \     Log To Console  ${output}
     \     Should Be Equal As Integers  ${rc}  0
 
     # check stopped containers are still stopped
@@ -235,6 +236,7 @@ Test
     \     Should Be Equal As Integers  ${rc}  0
     \     Should Be Equal  ${output}  exited
     \     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} rm -f ${c}
+    \     Log To Console  ${output}
     \     Should Be Equal As Integers  ${rc}  0
 
 Run Regression Tests


### PR DESCRIPTION
We retry operations to the portlayer nearly everywhere in the persona.
For ContainerRm, we do not.  Added retries for the container remove
part of the function and switched to using ContainerStop for the stop
part since ContainerStop has retries built in.  This should fix the
issues with 'docker rm -f' issues that keep popping up.  Initially,
we tried fixing this at the source in the portlayer but decided the
eventual state consistency nature of the portlayer would make that very
difficult.  We were able to fix the stop operation in the portlayer
working, but the state consistency on the delete became a problem.
Retries in the persona is the end result.

Modified the HA test suite to be more clear about failures.  It may
still fail if docker rm -f fails; however, if it failed because the
host temporarily disconnected from the VC cluster, the test output
should indicate that.

Fixes #6252 and #6263 and #6580
