### PR TITLE
Add better handling of exec operations during poweroff

### DIFF
--- a/cmd/tether/attach.go
+++ b/cmd/tether/attach.go
@@ -618,9 +618,6 @@ func (t *attachServerSSH) channelMux(in <-chan *ssh.Request, session *tether.Ses
 	// cleanup function passed by the caller
 	defer cleanup()
 
-	// to make sure we close the channel once
-	var once sync.Once
-
 	// for the actions after we process the request
 	var pendingFn func()
 	for req := range in {
@@ -654,17 +651,7 @@ func (t *attachServerSSH) channelMux(in <-chan *ssh.Request, session *tether.Ses
 				abort = true
 			} else {
 				// unblock ^ (above)
-				pendingFn = func() {
-					once.Do(func() {
-						launchChan := session.ClearToLaunch
-						if session.RunBlock && launchChan != nil && session.Started == "" {
-							log.Infof("Unblocking the launch of %s", session.Common.ID)
-							// make sure that portlayer received the container id back
-							launchChan <- struct{}{}
-							log.Infof("Unblocked the launch of %s", session.Common.ID)
-						}
-					})
-				}
+				pendingFn = session.Unblock()
 			}
 
 		case msgs.WindowChangeReq:

--- a/lib/apiservers/engine/backends/container.go
+++ b/lib/apiservers/engine/backends/container.go
@@ -114,6 +114,15 @@ const (
 	maxElapsedTime = 2 * time.Minute
 )
 
+// These are the constants used for the portlayer exec states checks returned when obtaining the state of a container handle
+const (
+	RunningState   = "Running"
+	CreatedState   = "Created"
+	SuspendedState = "Suspended"
+	StartingState  = "Starting"
+	StoppedState   = "Stopped"
+)
+
 var (
 	publicIfaceName = "public"
 
@@ -232,16 +241,16 @@ func (c *Container) ContainerExecCreate(name string, config *types.ExecConfig) (
 		}
 
 		switch state {
-		case "STOPPED":
+		case StoppedState:
 			return InternalServerError(fmt.Sprintf("Container (%s) is not running", name))
-		case "CREATED":
+		case CreatedState:
 			return InternalServerError(fmt.Sprintf("Container (%s) is not running", name))
-		case "SUSPENDED":
+		case SuspendedState:
 			return InternalServerError(fmt.Sprintf("Container (%s) is not running", name))
-		case "STARTING":
+		case StartingState:
 			// This is a transient state, returning conflict error to trigger a retry in the operation.
 			return ConflictError(fmt.Sprintf("container (%s) is still starting", id))
-		case "RUNNING":
+		case RunningState:
 			// NO-OP - this is the state that allows an exec to occur.
 		default:
 			return InternalServerError(fmt.Sprintf("Container (%s) is in an unknown state: %s", id, state))

--- a/lib/apiservers/engine/backends/container.go
+++ b/lib/apiservers/engine/backends/container.go
@@ -241,11 +241,7 @@ func (c *Container) ContainerExecCreate(name string, config *types.ExecConfig) (
 		}
 
 		switch state {
-		case StoppedState:
-			return InternalServerError(fmt.Sprintf("Container (%s) is not running", name))
-		case CreatedState:
-			return InternalServerError(fmt.Sprintf("Container (%s) is not running", name))
-		case SuspendedState:
+		case StoppedState, CreatedState, SuspendedState:
 			return InternalServerError(fmt.Sprintf("Container (%s) is not running", name))
 		case StartingState:
 			// This is a transient state, returning conflict error to trigger a retry in the operation.

--- a/lib/apiservers/engine/backends/container.go
+++ b/lib/apiservers/engine/backends/container.go
@@ -416,11 +416,10 @@ func (c *Container) ContainerExecStart(ctx context.Context, eid string, stdin io
 			return err
 		}
 
-		resp, err := c.containerProxy.BindTask(op, handle, eid)
+		handle, err = c.containerProxy.BindTask(op, handle, eid)
 		if err != nil {
 			return err
 		}
-		handle = resp.Handle.(string)
 
 		// exec doesn't have separate attach path so we will decide whether we need interaction/runblocking or not
 		attach := ec.OpenStdin || ec.OpenStdout || ec.OpenStderr

--- a/lib/apiservers/engine/backends/container.go
+++ b/lib/apiservers/engine/backends/container.go
@@ -234,7 +234,7 @@ func (c *Container) ContainerExecCreate(name string, config *types.ExecConfig) (
 		// NOTE: we should investigate what we can add or manipulate in the handle in the portlayer to make this check even more granular. Maybe Add the actually State into the handle config or part of the container info could be "snapshotted"
 		// This check is now done off of the handle.
 		if state != "RUNNING" {
-			return ConflictError(fmt.Sprintf("Container (%s) is not powered on, please start the container before attempting to an exec an operation", name))
+			return ConflictError(fmt.Sprintf("Container (%s) is not powered on", name))
 		}
 
 		handle, eid, err = c.containerProxy.CreateExecTask(handle, config)

--- a/lib/apiservers/engine/backends/container.go
+++ b/lib/apiservers/engine/backends/container.go
@@ -207,19 +207,6 @@ func (c *Container) Handle(id, name string) (string, error) {
 
 // docker's container.execBackend
 
-// FIXME: this returns a docker model, we should avoid this. This is what should be in the container proxy... But we need to confirm that it is not a public endpoint. its return hints that it is not... or that the actual return might be different
-func (c *Container) TaskInspect(cid, cname, eid string) (*models.TaskInspectResponse, error) {
-	defer trace.End(trace.Begin(fmt.Sprintf("cid(%s), cname(%s), eid(%s)", cid, cname, eid)))
-	op := trace.NewOperation(context.Background(), "")
-
-	handle, err := c.Handle(cid, cname)
-	if err != nil {
-		return nil, err
-	}
-
-	return c.containerProxy.InspectTask(op, handle, eid, cid)
-}
-
 func (c *Container) TaskWaitToStart(cid, cname, eid string) error {
 	// obtain a portlayer client
 	client := c.containerProxy.Client()
@@ -262,57 +249,64 @@ func (c *Container) ContainerExecCreate(name string, config *types.ExecConfig) (
 	}
 	id := vc.ContainerID
 
-	// Is it running?
-	state, err := c.containerProxy.State(vc)
-	if err != nil {
-		return "", InternalServerError(err.Error())
-	}
-
-	if state.Restarting {
-		return "", ConflictError(fmt.Sprintf("Container %s is restarting, wait until the container is running", id))
-	}
-	if !state.Running {
-		return "", ConflictError(fmt.Sprintf("Container %s is not running", id))
-	}
-
-	op.Debugf("State checks succeeded for exec operation on cotnainer(%s)", id)
-	handle, err := c.Handle(id, name)
-	if err != nil {
-		op.Error(err)
-		return "", InternalServerError(err.Error())
-	}
-
 	// set up the environment
 	config.Env = setEnvFromImageConfig(config.Tty, config.Env, vc.Config.Env)
 
-	handleprime, eid, err := c.containerProxy.CreateExecTask(handle, config)
-	if err != nil {
-		op.Errorf("Failed to create exec task for container(%s) due to error(%s)", id, err)
-		return "", InternalServerError(err.Error())
+	var eid string
+	operation := func() error {
+
+		handle, err := c.Handle(id, name)
+		if err != nil {
+			op.Error(err)
+			return InternalServerError(err.Error())
+		}
+
+		// Is it running?
+		handle, state, err := c.containerProxy.GetStateFromHandle(op, handle)
+		if err != nil {
+			return InternalServerError(err.Error())
+		}
+
+		// NOTE: we should investigate what we can add or manipulate in the handle in the portlayer to make this check even more granular. Maybe Add the actually State into the handle config or part of the container info could be "snapshotted"
+		// This check is now done off of the handle.
+		if state != "RUNNING" {
+			return ConflictError(fmt.Sprintf("Container %s is restarting, wait until the container is running", id))
+		}
+
+		op.Debugf("State checks succeeded for exec operation on container(%s)", id)
+		handle, eid, err = c.containerProxy.CreateExecTask(handle, config)
+		if err != nil {
+			op.Errorf("Failed to create exec task for container(%s) due to error(%s)", id, err)
+			return InternalServerError(err.Error())
+		}
+
+		err = c.containerProxy.CommitContainerHandle(handle, id, 0)
+		if err != nil {
+			op.Errorf("Failed to commit exec handle for container(%s) due to error(%s)", id, err)
+			return err
+		}
+
+		return nil
 	}
 
-	err = c.containerProxy.CommitContainerHandle(handleprime, id, 0)
-	if err != nil {
-		op.Errorf("Failed to commit exec handle for container(%s) due to error(%s)", id, err)
+	// FIXME: We cannot necessarily check for IsConflictError here yet since the state check also returns conflict error
+	if err := retry.Do(operation, IsConflictError); err != nil {
+		op.Errorf("Failed to start Exec task for container(%s) due to error (%s)", id, err)
 		return "", err
 	}
 
 	// associate newly created exec task with container
 	cache.ContainerCache().AddExecToContainer(vc, eid)
 
-	// FIXME: NEEDS CONTAINER PROXY
-	ec, err := c.TaskInspect(id, name, eid)
+	handle, err := c.Handle(id, name)
 	if err != nil {
-		switch err := err.(type) {
-		case *tasks.InspectInternalServerError:
-			op.Debugf("received an internal server error during task inspect: %s", err.Payload.Message)
-			return "", InternalServerError(err.Payload.Message)
-		case *tasks.InspectConflict:
-			op.Debugf("received a conflict error during task inspect: %s", err.Payload.Message)
-			return "", ConflictError(fmt.Sprintf("Cannot complete the operation, container %s has been powered off during execution", id))
-		default:
-			return "", InternalServerError(err.Error())
-		}
+		op.Error(err)
+		return "", InternalServerError(err.Error())
+	}
+
+	ec, err := c.containerProxy.InspectTask(op, handle, eid, id)
+	if err != nil {
+		return "", err
 	}
 
 	// exec_create event
@@ -337,19 +331,15 @@ func (c *Container) ContainerExecInspect(eid string) (*backend.ExecInspect, erro
 	id := vc.ContainerID
 	name := vc.Name
 
-	//FIXME: NEEDS CONTAINER PROXY
-	ec, err := c.TaskInspect(id, name, eid)
+	handle, err := c.Handle(id, name)
 	if err != nil {
-		switch err := err.(type) {
-		case *tasks.InspectInternalServerError:
-			op.Debugf("received an internal server error during task inspect: %s", err.Payload.Message)
-			return nil, InternalServerError(err.Payload.Message)
-		case *tasks.InspectConflict:
-			op.Debugf("received a conflict error during task inspect: %s", err.Payload.Message)
-			return nil, ConflictError(fmt.Sprintf("Cannot complete the operation, container %s has been powered off during execution", id))
-		default:
-			return nil, InternalServerError(err.Error())
-		}
+		op.Error(err)
+		return nil, InternalServerError(err.Error())
+	}
+
+	ec, err := c.containerProxy.InspectTask(op, handle, eid, id)
+	if err != nil {
+		return nil, err
 	}
 
 	exit := int(ec.ExitCode)
@@ -452,6 +442,7 @@ func (c *Container) ContainerExecStart(ctx context.Context, eid string, stdin io
 		defer cancel()
 
 		// we do not return an error here if this fails. TODO: Investigate what exactly happens on error here...
+		// FIXME: This being in a retry could lead to multiple writes to stdout(?)
 		go func() {
 			defer trace.End(trace.Begin(eid))
 
@@ -519,6 +510,7 @@ func (c *Container) ContainerExecStart(ctx context.Context, eid string, stdin io
 		}
 		return nil
 	}
+
 	if err := retry.Do(operation, IsConflictError); err != nil {
 		op.Errorf("Failed to start Exec task for container(%s) due to error (%s)", id, err)
 		return err

--- a/lib/apiservers/engine/backends/container.go
+++ b/lib/apiservers/engine/backends/container.go
@@ -307,7 +307,7 @@ func (c *Container) ContainerExecInspect(eid string) (*backend.ExecInspect, erro
 	// Look up the container name in the metadata cache to get long ID
 	vc := cache.ContainerCache().GetContainerFromExec(eid)
 	if vc == nil {
-		return nil, InternalServerError(fmt.Sprintf("No container was found with exec id: %s", eid))
+		return nil, TaskInspectNotFoundError(eid)
 	}
 	id := vc.ContainerID
 	name := vc.Name

--- a/lib/apiservers/engine/backends/container.go
+++ b/lib/apiservers/engine/backends/container.go
@@ -267,7 +267,12 @@ func (c *Container) ContainerExecCreate(name string, config *types.ExecConfig) (
 		return nil
 	}
 
-	if err := retry.Do(operation, IsConflictError); err != nil {
+	// configure custom exec back off configure
+	backoffConf := retry.NewBackoffConfig()
+	backoffConf.MaxInterval = 2 * time.Second
+	backoffConf.InitialInterval = 500 * time.Millisecond
+
+	if err := retry.DoWithConfig(operation, IsConflictError, backoffConf); err != nil {
 		op.Errorf("Failed to start Exec task for container(%s) due to error (%s)", id, err)
 		return "", err
 	}
@@ -489,7 +494,12 @@ func (c *Container) ContainerExecStart(ctx context.Context, eid string, stdin io
 		return nil
 	}
 
-	if err := retry.Do(operation, IsConflictError); err != nil {
+	// configure custom exec back off configure
+	backoffConf := retry.NewBackoffConfig()
+	backoffConf.MaxInterval = 2 * time.Second
+	backoffConf.InitialInterval = 500 * time.Millisecond
+
+	if err := retry.DoWithConfig(operation, IsConflictError, backoffConf); err != nil {
 		op.Errorf("Failed to start Exec task for container(%s) due to error (%s)", id, err)
 		return err
 	}

--- a/lib/apiservers/engine/backends/container_proxy.go
+++ b/lib/apiservers/engine/backends/container_proxy.go
@@ -341,7 +341,7 @@ func (c *ContainerProxy) InspectTask(op trace.Operation, handle string, eid stri
 		case *tasks.InspectNotFound:
 			// These error types may need to be expanded. NotFoundError does not fit here.
 			op.Errorf("received a TaskNotFound error during task inspect: %s", err.Payload.Message)
-			return nil, ConflictError(fmt.Sprintf("container (%s) has been poweredoff", cid))
+			return nil, NotFoundError(fmt.Sprintf("container (%s) has been poweredoff", cid))
 		case *tasks.InspectInternalServerError:
 			op.Errorf("received an internal server error during task inspect: %s", err.Payload.Message)
 			return nil, InternalServerError(err.Payload.Message)

--- a/lib/apiservers/engine/backends/container_proxy.go
+++ b/lib/apiservers/engine/backends/container_proxy.go
@@ -191,7 +191,6 @@ func (c *ContainerProxy) Handle(id, name string) (string, error) {
 	if err != nil {
 		switch err := err.(type) {
 		case *containers.GetNotFound:
-			cache.ContainerCache().DeleteContainer(id)
 			return "", NotFoundError(name)
 		case *containers.GetDefault:
 			return "", InternalServerError(err.Payload.Message)
@@ -371,7 +370,6 @@ func (c *ContainerProxy) BindTask(op trace.Operation, handle string, eid string)
 			op.Errorf("received TaskNotFound error during task bind: %s", err.Payload.Message)
 			return "", NotFoundError("container (%s) has been poweredoff")
 		case *tasks.BindInternalServerError:
-
 			op.Errorf("received unexpected error attempting to bind task(%s) for handle(%s): %s", eid, handle, err.Payload.Message)
 			return "", InternalServerError(err.Payload.Message)
 		default:

--- a/lib/apiservers/engine/backends/container_proxy.go
+++ b/lib/apiservers/engine/backends/container_proxy.go
@@ -924,10 +924,7 @@ func (c *ContainerProxy) UnbindContainerFromNetwork(vc *viccontainer.VicContaine
 func (c *ContainerProxy) GetStateFromHandle(op trace.Operation, handle string) (string, string, error) {
 	defer trace.End(trace.Begin(fmt.Sprintf("handle(%s)", handle), op))
 
-	params := &containers.GetStateParams{
-		Handle: handle,
-	}
-
+	params := containers.NewGetStateParams().WithHandle(handle)
 	resp, err := c.client.Containers.GetState(params)
 	if err != nil {
 		switch err := err.(type) {

--- a/lib/apiservers/engine/backends/container_proxy.go
+++ b/lib/apiservers/engine/backends/container_proxy.go
@@ -406,7 +406,7 @@ func (c *ContainerProxy) WaitTask(op trace.Operation, cid string, cname string, 
 	if err != nil {
 		switch err := err.(type) {
 		case *tasks.WaitNotFound:
-			return InternalServerError("the Container(%s) has been shutdown during execution ofthe exec operation")
+			return InternalServerError("the Container(%s) has been shutdown during execution of the exec operation")
 		case *tasks.WaitPreconditionRequired:
 			return InternalServerError("container(%s) must be powered on in order perform the desired exec operation")
 		case *tasks.WaitInternalServerError:

--- a/lib/apiservers/engine/backends/container_proxy.go
+++ b/lib/apiservers/engine/backends/container_proxy.go
@@ -964,6 +964,7 @@ func (c *ContainerProxy) GetStateFromHandle(op trace.Operation, handle string) (
 			return handle, "", InternalServerError(err.Error())
 		}
 	}
+
 	return resp.Payload.Handle, resp.Payload.State, nil
 }
 

--- a/lib/apiservers/engine/backends/container_proxy.go
+++ b/lib/apiservers/engine/backends/container_proxy.go
@@ -341,7 +341,7 @@ func (c *ContainerProxy) InspectTask(op trace.Operation, handle string, eid stri
 		case *tasks.InspectNotFound:
 			// These error types may need to be expanded. NotFoundError does not fit here.
 			op.Errorf("received a TaskNotFound error during task inspect: %s", err.Payload.Message)
-			return nil, NotFoundError(fmt.Sprintf("container (%s) has been poweredoff", cid))
+			return nil, TaskNotFoundError(fmt.Sprintf("container (%s) has been stopped", cid))
 		case *tasks.InspectInternalServerError:
 			op.Errorf("received an internal server error during task inspect: %s", err.Payload.Message)
 			return nil, InternalServerError(err.Payload.Message)
@@ -368,7 +368,7 @@ func (c *ContainerProxy) BindTask(op trace.Operation, handle string, eid string)
 		switch err := err.(type) {
 		case *tasks.BindNotFound:
 			op.Errorf("received TaskNotFound error during task bind: %s", err.Payload.Message)
-			return "", NotFoundError("container (%s) has been poweredoff")
+			return "", TaskNotFoundError("container (%s) has been stopped")
 		case *tasks.BindInternalServerError:
 			op.Errorf("received unexpected error attempting to bind task(%s) for handle(%s): %s", eid, handle, err.Payload.Message)
 			return "", InternalServerError(err.Payload.Message)

--- a/lib/apiservers/engine/backends/container_proxy.go
+++ b/lib/apiservers/engine/backends/container_proxy.go
@@ -341,7 +341,7 @@ func (c *ContainerProxy) InspectTask(op trace.Operation, handle string, eid stri
 		case *tasks.InspectNotFound:
 			// These error types may need to be expanded. NotFoundError does not fit here.
 			op.Errorf("received a TaskNotFound error during task inspect: %s", err.Payload.Message)
-			return nil, TaskNotFoundError(fmt.Sprintf("container (%s) has been stopped", cid))
+			return nil, TaskPoweredOffError(cid)
 		case *tasks.InspectInternalServerError:
 			op.Errorf("received an internal server error during task inspect: %s", err.Payload.Message)
 			return nil, InternalServerError(err.Payload.Message)
@@ -368,7 +368,7 @@ func (c *ContainerProxy) BindTask(op trace.Operation, handle string, eid string)
 		switch err := err.(type) {
 		case *tasks.BindNotFound:
 			op.Errorf("received TaskNotFound error during task bind: %s", err.Payload.Message)
-			return "", TaskNotFoundError("container (%s) has been stopped")
+			return "", TaskBindPowerError()
 		case *tasks.BindInternalServerError:
 			op.Errorf("received unexpected error attempting to bind task(%s) for handle(%s): %s", eid, handle, err.Payload.Message)
 			return "", InternalServerError(err.Payload.Message)

--- a/lib/apiservers/engine/backends/container_proxy.go
+++ b/lib/apiservers/engine/backends/container_proxy.go
@@ -408,7 +408,7 @@ func (c *ContainerProxy) WaitTask(op trace.Operation, cid string, cname string, 
 		case *tasks.WaitNotFound:
 			return InternalServerError("the Container(%s) has been shutdown during execution of the exec operation")
 		case *tasks.WaitPreconditionRequired:
-			return InternalServerError("container(%s) must be powered on in order perform the desired exec operation")
+			return InternalServerError("container(%s) must be powered on in order to perform the desired exec operation")
 		case *tasks.WaitInternalServerError:
 			return InternalServerError(err.Payload.Message)
 		default:

--- a/lib/apiservers/engine/backends/container_proxy.go
+++ b/lib/apiservers/engine/backends/container_proxy.go
@@ -406,9 +406,9 @@ func (c *ContainerProxy) WaitTask(op trace.Operation, cid string, cname string, 
 	if err != nil {
 		switch err := err.(type) {
 		case *tasks.WaitNotFound:
-			return InternalServerError("the Container(%s) has been shutdown during execution of the exec operation")
+			return InternalServerError(fmt.Sprintf("the Container(%s) has been shutdown during execution of the exec operation", cid))
 		case *tasks.WaitPreconditionRequired:
-			return InternalServerError("container(%s) must be powered on in order to perform the desired exec operation")
+			return InternalServerError(fmt.Sprintf("container(%s) must be powered on in order to perform the desired exec operation", cid))
 		case *tasks.WaitInternalServerError:
 			return InternalServerError(err.Payload.Message)
 		default:

--- a/lib/apiservers/engine/backends/container_test.go
+++ b/lib/apiservers/engine/backends/container_test.go
@@ -38,6 +38,7 @@ import (
 	"github.com/vmware/vic/lib/apiservers/engine/backends/convert"
 	plclient "github.com/vmware/vic/lib/apiservers/portlayer/client"
 	plscopes "github.com/vmware/vic/lib/apiservers/portlayer/client/scopes"
+	"github.com/vmware/vic/lib/apiservers/portlayer/models"
 	plmodels "github.com/vmware/vic/lib/apiservers/portlayer/models"
 	"github.com/vmware/vic/lib/archive"
 	"github.com/vmware/vic/lib/config/executor"
@@ -351,8 +352,8 @@ func (m *MockContainerProxy) GetStateFromHandle(op trace.Operation, handle strin
 func (m *MockContainerProxy) InspectTask(op trace.Operation, handle string, eid string, cid string) (*models.TaskInspectResponse, error) {
 	return nil, nil
 }
-func (m *MockContainerProxy) BindTask(op trace.Operation, handle string, eid string) (*models.TaskBindResponse, error) {
-	return nil, nil
+func (m *MockContainerProxy) BindTask(op trace.Operation, handle string, eid string) (string, error) {
+	return "", nil
 }
 
 func (m *MockContainerProxy) Wait(vc *viccontainer.VicContainer, timeout time.Duration) (*types.ContainerState, error) {

--- a/lib/apiservers/engine/backends/container_test.go
+++ b/lib/apiservers/engine/backends/container_test.go
@@ -356,6 +356,10 @@ func (m *MockContainerProxy) BindTask(op trace.Operation, handle string, eid str
 	return "", nil
 }
 
+func (m *MockContainerProxy) WaitTask(op trace.Operation, cid string, cname string, id string) error {
+	return nil
+}
+
 func (m *MockContainerProxy) Wait(vc *viccontainer.VicContainer, timeout time.Duration) (*types.ContainerState, error) {
 	dockerState := &types.ContainerState{ExitCode: 0}
 	return dockerState, nil

--- a/lib/apiservers/engine/backends/container_test.go
+++ b/lib/apiservers/engine/backends/container_test.go
@@ -344,6 +344,17 @@ func (m *MockContainerProxy) State(vc *viccontainer.VicContainer) (*types.Contai
 	return state, nil
 }
 
+func (m *MockContainerProxy) GetStateFromHandle(op trace.Operation, handle string) (string, string, error) {
+	return "", "", nil
+}
+
+func (m *MockContainerProxy) InspectTask(op trace.Operation, handle string, eid string, cid string) (*models.TaskInspectResponse, error) {
+	return nil, nil
+}
+func (m *MockContainerProxy) BindTask(op trace.Operation, handle string, eid string) (*models.TaskBindResponse, error) {
+	return nil, nil
+}
+
 func (m *MockContainerProxy) Wait(vc *viccontainer.VicContainer, timeout time.Duration) (*types.ContainerState, error) {
 	dockerState := &types.ContainerState{ExitCode: 0}
 	return dockerState, nil

--- a/lib/apiservers/engine/backends/errors.go
+++ b/lib/apiservers/engine/backends/errors.go
@@ -72,6 +72,10 @@ func NotFoundError(msg string) error {
 	return derr.NewRequestNotFoundError(fmt.Errorf("No such container: %s", msg))
 }
 
+func TaskInspectNotFoundError(msg) error {
+	return derr.NewRequestNotFoundError(fmt.Errorf("No container was found with exec id: %s", eid))
+}
+
 func ImageNotFoundError(image, tag string) error {
 	return derr.NewRequestNotFoundError(fmt.Errorf("An image does not exist locally with the tag: %s", image))
 }

--- a/lib/apiservers/engine/backends/errors.go
+++ b/lib/apiservers/engine/backends/errors.go
@@ -72,8 +72,8 @@ func NotFoundError(msg string) error {
 	return derr.NewRequestNotFoundError(fmt.Errorf("No such container: %s", msg))
 }
 
-func TaskInspectNotFoundError(msg) error {
-	return derr.NewRequestNotFoundError(fmt.Errorf("No container was found with exec id: %s", eid))
+func TaskInspectNotFoundError(msg string) error {
+	return derr.NewRequestNotFoundError(fmt.Errorf("No container was found with exec id: %s", msg))
 }
 
 func ImageNotFoundError(image, tag string) error {

--- a/lib/apiservers/engine/backends/errors.go
+++ b/lib/apiservers/engine/backends/errors.go
@@ -76,6 +76,14 @@ func TaskInspectNotFoundError(msg string) error {
 	return derr.NewRequestNotFoundError(fmt.Errorf("No container was found with exec id: %s", msg))
 }
 
+func TaskBindPowerError() error {
+	return derr.NewRequestNotFoundError(fmt.Errorf("the container has been stopped"))
+}
+
+func TaskPoweredOffError(msg string) error {
+	return derr.NewRequestNotFoundError(fmt.Errorf("container (%s) has been stopped", msg))
+}
+
 func ImageNotFoundError(image, tag string) error {
 	return derr.NewRequestNotFoundError(fmt.Errorf("An image does not exist locally with the tag: %s", image))
 }

--- a/lib/apiservers/portlayer/restapi/handlers/containers_handlers.go
+++ b/lib/apiservers/portlayer/restapi/handlers/containers_handlers.go
@@ -182,13 +182,14 @@ func (handler *ContainersHandlersImpl) GetStateHandler(params containers.GetStat
 	switch h.State(op) {
 	case exec.StateRunning:
 		state = "RUNNING"
-
 	case exec.StateStopped:
 		state = "STOPPED"
-
 	case exec.StateCreated:
 		state = "CREATED"
-
+	case exec.StateStarting:
+		state = "STARTING"
+	case exec.StateSuspended:
+		state = "SUSPENDED"
 	default:
 		// This will occur if the container is suspended... Those are the only types covered in the runtime types right now.
 		return containers.NewGetStateDefault(http.StatusServiceUnavailable)

--- a/lib/apiservers/portlayer/restapi/handlers/containers_handlers.go
+++ b/lib/apiservers/portlayer/restapi/handlers/containers_handlers.go
@@ -178,18 +178,13 @@ func (handler *ContainersHandlersImpl) GetStateHandler(params containers.GetStat
 		return containers.NewGetStateNotFound()
 	}
 
-	var state string
-	switch h.State(op) {
+	state := h.State(op)
+	switch state {
 	case exec.StateRunning:
-		state = "RUNNING"
 	case exec.StateStopped:
-		state = "STOPPED"
 	case exec.StateCreated:
-		state = "CREATED"
 	case exec.StateStarting:
-		state = "STARTING"
 	case exec.StateSuspended:
-		state = "SUSPENDED"
 	default:
 		return containers.NewGetStateDefault(http.StatusServiceUnavailable)
 	}
@@ -197,7 +192,7 @@ func (handler *ContainersHandlersImpl) GetStateHandler(params containers.GetStat
 	return containers.NewGetStateOK().WithPayload(
 		&models.ContainerGetStateResponse{
 			Handle: h.String(),
-			State:  state,
+			State:  state.String(),
 		})
 }
 

--- a/lib/apiservers/portlayer/restapi/handlers/containers_handlers.go
+++ b/lib/apiservers/portlayer/restapi/handlers/containers_handlers.go
@@ -191,7 +191,6 @@ func (handler *ContainersHandlersImpl) GetStateHandler(params containers.GetStat
 	case exec.StateSuspended:
 		state = "SUSPENDED"
 	default:
-		// This will occur if the container is suspended... Those are the only types covered in the runtime types right now.
 		return containers.NewGetStateDefault(http.StatusServiceUnavailable)
 	}
 

--- a/lib/apiservers/portlayer/restapi/handlers/task_handlers.go
+++ b/lib/apiservers/portlayer/restapi/handlers/task_handlers.go
@@ -275,16 +275,15 @@ func (handler *TaskHandlersImpl) WaitHandler(params tasks.WaitParams) middleware
 	}
 
 	// wait task to set started field to something
-	// wait task to set started field to something
 	err := task.Wait(&op, handle, params.Config.ID)
 	if err != nil {
 		switch err := err.(type) {
 		case *task.TaskPowerStateError:
-			op.Debugf("PowerStateError occurred for task (%s) on handle (%s) while attempting to wait for the task to complete", params.Config.ID, handle)
+			op.Errorf("The container was in an invalid power state for the wait operation: %s", err.Error())
 			return tasks.NewWaitPreconditionRequired().WithPayload(
 				&models.Error{Message: err.Error()})
 		case *task.TaskNotFoundError:
-			op.Debugf("TaskNotFoundError occurred for task (%s) on handle (%s) while attempting to wait for the task to complete", params.Config.ID, handle)
+			op.Errorf("The task was unable to be found: %s", err.Error())
 			return tasks.NewWaitNotFound().WithPayload(
 				&models.Error{Message: err.Error()})
 		default:

--- a/lib/apiservers/portlayer/restapi/handlers/task_handlers.go
+++ b/lib/apiservers/portlayer/restapi/handlers/task_handlers.go
@@ -111,6 +111,8 @@ func (handler *TaskHandlersImpl) JoinHandler(params tasks.JoinParams) middleware
 	return tasks.NewJoinOK().WithPayload(res)
 }
 
+// FIXME: NO MORE LOGGING!!!! DO OP LOGGING!!!!
+
 // BindHandler calls the Bind
 func (handler *TaskHandlersImpl) BindHandler(params tasks.BindParams) middleware.Responder {
 	defer trace.End(trace.Begin(""))

--- a/lib/apiservers/portlayer/restapi/handlers/task_handlers.go
+++ b/lib/apiservers/portlayer/restapi/handlers/task_handlers.go
@@ -277,11 +277,20 @@ func (handler *TaskHandlersImpl) WaitHandler(params tasks.WaitParams) middleware
 	// wait task to set started field to something
 	err := task.Wait(&op, handle, params.Config.ID)
 	if err != nil {
-		op.Errorf("%s", err.Error())
-
-		return tasks.NewWaitInternalServerError().WithPayload(
-			&models.Error{Message: err.Error()},
-		)
+		switch err := err.(type) {
+		case *task.TaskPowerStateError:
+			op.Debugf("PowerStateError occured for task (%s) on handle (%s) while attempting to wait for the task to complete", params.Config.ID, handle)
+			return tasks.NewWaitPreconditionRequired().WithPayload(
+				&models.Error{Message: err.Error()})
+		case *task.TaskNotFoundError:
+			op.Debugf("TaskNotFoundError occured for task (%s) on handle (%s) while attempting to wait for the task to complete", params.Config.ID, handle)
+			return tasks.NewWaitNotFound().WithPayload(
+				&models.Error{Message: err.Error()})
+		default:
+			op.Errorf("%s", err.Error())
+			return tasks.NewWaitInternalServerError().WithPayload(
+				&models.Error{Message: err.Error()})
+		}
 	}
 
 	return tasks.NewWaitOK()

--- a/lib/apiservers/portlayer/restapi/handlers/task_handlers.go
+++ b/lib/apiservers/portlayer/restapi/handlers/task_handlers.go
@@ -275,15 +275,16 @@ func (handler *TaskHandlersImpl) WaitHandler(params tasks.WaitParams) middleware
 	}
 
 	// wait task to set started field to something
+	// wait task to set started field to something
 	err := task.Wait(&op, handle, params.Config.ID)
 	if err != nil {
 		switch err := err.(type) {
 		case *task.TaskPowerStateError:
-			op.Debugf("PowerStateError occured for task (%s) on handle (%s) while attempting to wait for the task to complete", params.Config.ID, handle)
+			op.Debugf("PowerStateError occurred for task (%s) on handle (%s) while attempting to wait for the task to complete", params.Config.ID, handle)
 			return tasks.NewWaitPreconditionRequired().WithPayload(
 				&models.Error{Message: err.Error()})
 		case *task.TaskNotFoundError:
-			op.Debugf("TaskNotFoundError occured for task (%s) on handle (%s) while attempting to wait for the task to complete", params.Config.ID, handle)
+			op.Debugf("TaskNotFoundError occurred for task (%s) on handle (%s) while attempting to wait for the task to complete", params.Config.ID, handle)
 			return tasks.NewWaitNotFound().WithPayload(
 				&models.Error{Message: err.Error()})
 		default:

--- a/lib/apiservers/portlayer/restapi/handlers/task_handlers.go
+++ b/lib/apiservers/portlayer/restapi/handlers/task_handlers.go
@@ -111,8 +111,6 @@ func (handler *TaskHandlersImpl) JoinHandler(params tasks.JoinParams) middleware
 	return tasks.NewJoinOK().WithPayload(res)
 }
 
-// FIXME: NO MORE LOGGING!!!! DO OP LOGGING!!!!
-
 // BindHandler calls the Bind
 func (handler *TaskHandlersImpl) BindHandler(params tasks.BindParams) middleware.Responder {
 	defer trace.End(trace.Begin(""))
@@ -128,9 +126,17 @@ func (handler *TaskHandlersImpl) BindHandler(params tasks.BindParams) middleware
 	if err != nil {
 		op.Errorf("%s", err.Error())
 
-		return tasks.NewBindInternalServerError().WithPayload(
-			&models.Error{Message: err.Error()},
-		)
+		switch err.(type) {
+		case task.TaskNotFoundError:
+			return tasks.NewBindNotFound().WithPayload(
+				&models.Error{Message: err.Error()},
+			)
+		default:
+			return tasks.NewBindInternalServerError().WithPayload(
+				&models.Error{Message: err.Error()},
+			)
+		}
+
 	}
 
 	res := &models.TaskBindResponse{
@@ -155,9 +161,17 @@ func (handler *TaskHandlersImpl) UnbindHandler(params tasks.UnbindParams) middle
 	if err != nil {
 		op.Errorf("%s", err.Error())
 
-		return tasks.NewUnbindInternalServerError().WithPayload(
-			&models.Error{Message: err.Error()},
-		)
+		switch err.(type) {
+		case task.TaskNotFoundError:
+			return tasks.NewUnbindNotFound().WithPayload(
+				&models.Error{Message: err.Error()},
+			)
+		default:
+			return tasks.NewUnbindInternalServerError().WithPayload(
+				&models.Error{Message: err.Error()},
+			)
+		}
+
 	}
 
 	res := &models.TaskUnbindResponse{
@@ -207,15 +221,16 @@ func (handler *TaskHandlersImpl) InspectHandler(params tasks.InspectParams) midd
 	if err != nil {
 		op.Errorf("%s", err.Error())
 
-		if _, ok := err.(task.TaskPowerStateError); ok {
-			return tasks.NewInspectConflict().WithPayload(
+		switch err.(type) {
+		case task.TaskNotFoundError:
+			return tasks.NewInspectNotFound().WithPayload(
+				&models.Error{Message: err.Error()},
+			)
+		default:
+			return tasks.NewInspectInternalServerError().WithPayload(
 				&models.Error{Message: err.Error()},
 			)
 		}
-
-		return tasks.NewInspectInternalServerError().WithPayload(
-			&models.Error{Message: err.Error()},
-		)
 	}
 
 	op.Debugf("ID: %#v", t.ID)

--- a/lib/apiservers/portlayer/swagger.json
+++ b/lib/apiservers/portlayer/swagger.json
@@ -1772,6 +1772,12 @@
 							"$ref": "#/definitions/Error"
 						}
 					},
+					"428": {
+						"description": "target resource is not powered on",
+						"schema": {
+							"$ref": "#/definitions/Error"
+						}
+					},
 					"500": {
 						"description": "Wait of task failed",
 						"schema": {

--- a/lib/portlayer/exec/base.go
+++ b/lib/portlayer/exec/base.go
@@ -156,6 +156,64 @@ func (c *containerBase) updates(op trace.Operation) (*containerBase, error) {
 	return base, nil
 }
 
+// determine if the containerVM has started - this could pick up stale data in the started field for an out-of-band
+// power change such as HA or user intervention where we have not had an opportunity to reset the entry.
+func (c *containerBase) cleanStart(op trace.Operation) bool {
+	if len(c.ExecConfig.Sessions) == 0 {
+		op.Warnf("Container %c has no sessions stored in in-memory config", c.ExecConfig.ID)
+		return true
+	}
+
+	for _, session := range c.ExecConfig.Sessions {
+		if session.Started != "true" {
+			return false
+		}
+	}
+	return true
+}
+
+// determine if the containerVM has ever been started - we use the session started time for this as we have no
+// cVM global record to indicate the fact.
+func (c *containerBase) hasStarted(op trace.Operation) bool {
+	if len(c.ExecConfig.Sessions) == 0 {
+		op.Warnf("Container %c has no sessions stored in in-memory config", c.ExecConfig.ID)
+		return true
+	}
+
+	for _, session := range c.ExecConfig.Sessions {
+		if session.Detail.StartTime != 0 || session.Detail.StopTime != 0 {
+			return true
+		}
+	}
+	return false
+}
+
+// State returns the state of the containerVM based on data in the handle, with no refresh
+func (c *containerBase) State(op trace.Operation) State {
+	powerState := c.Runtime.PowerState
+	state := StateUnknown
+
+	switch powerState {
+	case types.VirtualMachinePowerStatePoweredOn:
+		if c.cleanStart(op) {
+			state = StateRunning
+		} else {
+			// could be stopping but this is a better guess and is still transient
+			state = StateStarting
+		}
+	case types.VirtualMachinePowerStatePoweredOff:
+		if c.hasStarted(op) {
+			state = StateStopped
+		} else {
+			state = StateCreated
+		}
+	case types.VirtualMachinePowerStateSuspended:
+		state = StateSuspended
+	}
+
+	return state
+}
+
 func (c *containerBase) ReloadConfig(op trace.Operation) error {
 	defer trace.End(trace.Begin(c.ExecConfig.ID, op))
 

--- a/lib/portlayer/exec/handle.go
+++ b/lib/portlayer/exec/handle.go
@@ -111,7 +111,6 @@ func newHandle(con *Container) *Handle {
 	h := &Handle{
 		key:           newHandleKey(),
 		targetState:   StateUnknown,
-		State:         con.State(),
 		containerBase: *newBase(con.vm, con.Config, con.Runtime),
 		// currently every operation has a spec, because even the power operations
 		// make changes to extraconfig for timestamps and session status

--- a/lib/portlayer/exec/handle.go
+++ b/lib/portlayer/exec/handle.go
@@ -111,6 +111,7 @@ func newHandle(con *Container) *Handle {
 	h := &Handle{
 		key:           newHandleKey(),
 		targetState:   StateUnknown,
+		State:         con.State(),
 		containerBase: *newBase(con.vm, con.Config, con.Runtime),
 		// currently every operation has a spec, because even the power operations
 		// make changes to extraconfig for timestamps and session status

--- a/lib/portlayer/task/common.go
+++ b/lib/portlayer/task/common.go
@@ -31,8 +31,6 @@ func toggleActive(op *trace.Operation, h interface{}, id string, active bool) (i
 	if !ok {
 		return nil, fmt.Errorf("Type assertion failed for %#+v", handle)
 	}
-	taskS, okS := handle.ExecConfig.Sessions[id]
-	taskE, okE := handle.ExecConfig.Execs[id]
 
 	op.Debugf("target task ID: %s", id)
 	op.Debugf("session tasks during inspect: %s", handle.ExecConfig.Sessions)
@@ -42,11 +40,9 @@ func toggleActive(op *trace.Operation, h interface{}, id string, active bool) (i
 	op.Debugf("exec tasks during inspect: %s", handle.ExecConfig.Execs)
 
 	var task *executor.SessionConfig
-	if okS {
+	if taskS, okS := handle.ExecConfig.Sessions[id]; okS {
 		task = taskS
-	}
-
-	if okE {
+	} else if taskE, okE := handle.ExecConfig.Execs[id]; okE {
 		task = taskE
 	}
 

--- a/lib/portlayer/task/common.go
+++ b/lib/portlayer/task/common.go
@@ -39,6 +39,17 @@ func toggleActive(op *trace.Operation, h interface{}, id string, active bool) (i
 	taskE, okE := etasks[id]
 
 	if !okS && !okE {
+
+		// in this case we must look at whether the container was turned off. I posit that we should check this after the runtime and state...
+		if handle.Runtime.PowerState == types.VirtualMachinePowerStatePoweredOff {
+			// we are now assuming that the task supplied was an etask that no longer exists... this is not necessarily a valid assumption.
+			// but since we never know which type of task was intended and it is in neither list we can only every assume here with current information.
+			powerStateError := TaskPowerStateError{
+				msg: fmt.Sprintf("the operation cannot be completed, container(%s) has been shut down during the operations execution.", handle.ExecConfig.ID),
+			}
+			return nil, powerStateError
+		}
+
 		return nil, fmt.Errorf("unknown task ID: %s", id)
 	}
 

--- a/lib/portlayer/task/common.go
+++ b/lib/portlayer/task/common.go
@@ -62,11 +62,7 @@ func toggleActive(op *trace.Operation, h interface{}, id string, active bool) (i
 		return nil, TaskNotFoundError{msg: fmt.Sprintf("Cannot find task %s", id)}
 	}
 
-	if task == nil {
-	}
-
 	op.Debugf("Toggling active state of task %s (%s): %t", id, task.Cmd.Path, active)
-
 	task.Active = active
 	handle.Reload()
 

--- a/lib/portlayer/task/inspect.go
+++ b/lib/portlayer/task/inspect.go
@@ -25,6 +25,7 @@ import (
 
 // Inspect the task configuration from the containerVM config
 func Inspect(op *trace.Operation, h interface{}, id string) (*executor.SessionConfig, error) {
+	// FIXME: THIS WORKS FOR NOW, BUT IF IT IS USED OUTSIDE OF EXEC THEN IT WILL NEED TO BE FIXED.
 	defer trace.End(trace.Begin(id))
 
 	handle, ok := h.(*exec.Handle)
@@ -54,6 +55,7 @@ func Inspect(op *trace.Operation, h interface{}, id string) (*executor.SessionCo
 	}
 
 	tasks := stasks
+	//FIXME: This needs to change when this function starts to be used for session IDs. When task.Inspect is used for retrieving execConfig.Sessions data.
 	if handle.Runtime != nil && handle.Runtime.PowerState != types.VirtualMachinePowerStatePoweredOff {
 		op.Debugf("Task configuration applies to ephemeral set")
 		tasks = etasks

--- a/lib/portlayer/task/inspect.go
+++ b/lib/portlayer/task/inspect.go
@@ -36,10 +36,6 @@ func Inspect(op *trace.Operation, h interface{}, id string) (*executor.SessionCo
 
 	op.Debugf("target task ID: %s", id)
 	op.Debugf("session tasks during inspect: %s", stasks)
-
-	// print all of them, otherwise we will have to assemble the id list regardless of
-	// the log level at the moment. If there is a way to check the log level we should
-	// do that.
 	op.Debugf("exec tasks during inspect: %s", etasks)
 
 	if _, ok := stasks[id]; ok {

--- a/lib/portlayer/task/inspect.go
+++ b/lib/portlayer/task/inspect.go
@@ -22,7 +22,7 @@ import (
 	"github.com/vmware/vic/pkg/trace"
 )
 
-// Insepct the given task id and returns it's config
+// Inspect the given task id and returns it's config
 func Inspect(op *trace.Operation, h interface{}, id string) (*executor.SessionConfig, error) {
 	defer trace.End(trace.Begin(id))
 

--- a/lib/portlayer/task/wait.go
+++ b/lib/portlayer/task/wait.go
@@ -35,7 +35,7 @@ func Wait(op *trace.Operation, h interface{}, id string) error {
 	if handle.Runtime != nil && handle.Runtime.PowerState != types.VirtualMachinePowerStatePoweredOn {
 		err := fmt.Errorf("Unable to wait for task when container %s is not running", id)
 		op.Errorf("%s", err)
-		return err
+		return TaskPowerStateError{Err: err}
 	}
 
 	_, okS := handle.ExecConfig.Sessions[id]
@@ -58,4 +58,12 @@ func Wait(op *trace.Operation, h interface{}, id string) error {
 		return c.WaitForSession(timeout, id)
 	}
 	return c.WaitForExec(timeout, id)
+}
+
+type TaskPowerStateError struct {
+	Err error
+}
+
+func (t TaskPowerStateError) Error() string {
+	return t.Err.Error()
 }

--- a/lib/portlayer/task/wait.go
+++ b/lib/portlayer/task/wait.go
@@ -29,11 +29,11 @@ func Wait(op *trace.Operation, h interface{}, id string) error {
 
 	handle, ok := h.(*exec.Handle)
 	if !ok {
-		return fmt.Errorf("Type assertion failed for %#+v", handle)
+		return fmt.Errorf("type assertion failed for %#+v", handle)
 	}
 
 	if handle.Runtime != nil && handle.Runtime.PowerState != types.VirtualMachinePowerStatePoweredOn {
-		err := fmt.Errorf("Unable to wait for task when container %s is not running", handle.ExecConfig.ID)
+		err := fmt.Errorf("unable to wait for task when container %s is not running", handle.ExecConfig.ID)
 		op.Errorf("%s", err)
 		return TaskPowerStateError{Err: err}
 	}
@@ -42,7 +42,7 @@ func Wait(op *trace.Operation, h interface{}, id string) error {
 	_, okE := handle.ExecConfig.Execs[id]
 
 	if !okS && !okE {
-		return fmt.Errorf("Unknown task ID: %s", id)
+		return fmt.Errorf("unknown task ID: %s", id)
 	}
 
 	// wait task to set started field
@@ -51,7 +51,7 @@ func Wait(op *trace.Operation, h interface{}, id string) error {
 
 	c := exec.Containers.Container(handle.ExecConfig.ID)
 	if c == nil {
-		return fmt.Errorf("Unknown container ID: %s", handle.ExecConfig.ID)
+		return fmt.Errorf("unknown container ID: %s", handle.ExecConfig.ID)
 	}
 
 	if okS {

--- a/lib/portlayer/task/wait.go
+++ b/lib/portlayer/task/wait.go
@@ -33,7 +33,7 @@ func Wait(op *trace.Operation, h interface{}, id string) error {
 	}
 
 	if handle.Runtime != nil && handle.Runtime.PowerState != types.VirtualMachinePowerStatePoweredOn {
-		err := fmt.Errorf("Unable to wait for task when container %s is not running", id)
+		err := fmt.Errorf("Unable to wait for task when container %s is not running", handle.ExecConfig.ID)
 		op.Errorf("%s", err)
 		return TaskPowerStateError{Err: err}
 	}

--- a/lib/tether/config.go
+++ b/lib/tether/config.go
@@ -21,6 +21,7 @@ import (
 	"os/exec"
 	"sync"
 
+	log "github.com/Sirupsen/logrus"
 	"github.com/vmware/vic/lib/config/executor"
 	"github.com/vmware/vic/pkg/dio"
 	"github.com/vmware/vic/pkg/ip"
@@ -131,6 +132,7 @@ type SessionConfig struct {
 	// Blocks launching the process.
 	// The channel contains no value; we’re only interested in its closed property.
 	ClearToLaunch chan struct{} `vic:"0.1" scope:"read-only" recurse:"depth=0"`
+	once          sync.Once
 
 	wait *sync.WaitGroup
 
@@ -181,4 +183,62 @@ type DHCPInfo struct {
 	Assigned    net.IPNet
 	Nameservers []net.IP
 	Gateway     net.IPNet
+}
+
+// block sets the blocking behaviour of session launches to the argument.
+// does NOT take a lock
+func (session *SessionConfig) block(blocked bool) {
+	if blocked == session.RunBlock && blocked == (session.ClearToLaunch != nil) {
+		// already configured
+		return
+	}
+
+	if blocked && session.Cmd.Process != nil {
+		log.Warnf("Refusing to block launched session: %s", session.ID)
+		return
+	}
+
+	if blocked {
+		log.Debugf("Blocking session launch: %s", session.ID)
+		session.RunBlock = true
+		session.ClearToLaunch = make(chan struct{})
+		return
+	}
+
+	// protect against multiple closes of the channel - the unblocker
+	// may not be able to take a session lock so cannot have that code clean
+	// up reliably
+	defer func() {
+		recover()
+	}()
+
+	log.Debugf("Unblocking session: %s", session.ID)
+	close(session.ClearToLaunch)
+	session.ClearToLaunch = nil
+	// reset Runblock to unblock process start next time
+	session.RunBlock = false
+}
+
+// Unblock takes a lock and constructs a function to call for releasing
+// an explicit block. Does NOT take a session lock
+func (session *SessionConfig) Unblock() func() {
+	launchChannel := session.ClearToLaunch
+	if !session.RunBlock || launchChannel == nil || session.Started != "" {
+		// if we're not in a blockable state return a no-op function
+		return func() {}
+	}
+
+	return func() {
+		session.once.Do(func() {
+			defer func() {
+				recover()
+			}()
+
+			log.Infof("Unblocking the launch of %s", session.ID)
+			// make sure that portlayer received the container id back - this will block
+			// in the write until the launch code is ready to consume the entry
+			launchChannel <- struct{}{}
+			log.Infof("Unblocked the launch of %s", session.ID)
+		})
+	}
 }

--- a/lib/tether/config.go
+++ b/lib/tether/config.go
@@ -22,6 +22,7 @@ import (
 	"sync"
 
 	log "github.com/Sirupsen/logrus"
+
 	"github.com/vmware/vic/lib/config/executor"
 	"github.com/vmware/vic/pkg/dio"
 	"github.com/vmware/vic/pkg/ip"

--- a/tests/resources/Docker-Util.robot
+++ b/tests/resources/Docker-Util.robot
@@ -253,7 +253,7 @@ Kill All Containers
 Remove All Images
     ${exist}=  Do Images Exist
     Run Keyword If  ${exist}  Log To Console  Removing all images from %{VCH-NAME}
-    
+
     Return From Keyword If  ${exist} == ${false}  0
     Run Keyword If  ${exist}  Remove All Containers
     Run Keyword If  ${exist}  Run  docker %{VCH-PARAMS} rmi $(docker %{VCH-PARAMS} images -q)
@@ -283,7 +283,7 @@ Remove All Container Networks
     ${exist}=  Do Networks Exist
     Return From Keyword If  ${exist} == ${false}  0
     [Return]  1
-    
+
 Add List To Dictionary
     [Arguments]  ${dict}  ${list}
     : FOR  ${item}  IN  @{list}
@@ -305,7 +305,7 @@ List Existing Images On VCH
     : FOR  ${tag}  IN  @{tags_dict.keys()}
     \    Log To Console  \t${tag}
 
-List Running Containers On VCH    
+List Running Containers On VCH
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} ps -q
     Log To Console  ${EMPTY}
     ${len}=  Get Length  ${output}

--- a/tests/test-cases/Group1-Docker-Commands/1-38-Docker-Exec.md
+++ b/tests/test-cases/Group1-Docker-Commands/1-38-Docker-Exec.md
@@ -23,5 +23,41 @@ This test requires that a vSphere server is running and available
 * Step 2-6 should echo the ID given
 * Step 7 should return an error
 
+## Exec
+
 # Possible Problems:
 None
+
+# Exec Power Off test for long running Process
+## Test Steps
+1. Pull an image that contains `/bin/top`. Busybox suffices here.
+2. Create a container running `/bin/top` to simulate a long running process.
+3. Run the container and detach from it.
+4. Start 20 simple exec operations in parallel against the detached container.
+5. Stop the container while the execs are still running in order to trigger the exec power off errors.
+6. collect all output from the parallel exec operations.
+
+## Expected Outcome
+* step 1 should successfully complete with an rc of 0
+* step 2 should successfully complete with an rc of 0
+* step 3 should successfully launch the container and detach from it. The container should remain running for 5 seconds only.
+* step 4 all 20 execs should be started successfully, we expect most if not all to fail.
+* step 5 container should halt successfully.
+* step 6 should contain the error message for exec operations that are interrupted by a power off operation. Specifically a poweroff that was explicitly triggered.
+
+# Exec Power Off test for short Running Process
+## Test Steps
+1. Pull an image that contains `sleep`. Busybox suffices here.
+2. Create a container running `sleep` to simulate a long running process.
+3. Run the container and detach from it.
+4. Start 20 simple exec operations in parallel against the detached container.
+5. Wait(`docker wait`) for the container to exit just in case it has not(20 execs should be ample stress).
+6. collect all output from the parallel exec operations.
+
+## Expected Outcome
+* step 1 should successfully complete with an rc of 0
+* step 2 should successfully complete with an rc of 0
+* step 3 should successfully launch the container and detach from it. The container should remain running for 5 seconds only and should return with an RC of 0.
+* step 4 all 20 execs should be started successfully, we expect most if not all to fail.
+* step 5 container should halt successfully.
+* step 6 should contain the error message for exec operations that are interrupted by a power off operation. Specifically a poweroff that was implicitly triggered.

--- a/tests/test-cases/Group1-Docker-Commands/1-38-Docker-Exec.md
+++ b/tests/test-cases/Group1-Docker-Commands/1-38-Docker-Exec.md
@@ -48,7 +48,7 @@ None
 # Exec Power Off test for short Running Process
 ## Test Steps
 1. Pull an image that contains `sleep`. Busybox suffices here.
-2. Create a container running `sleep` to simulate a long running process.
+2. Create a container running `sleep` to simulate a short running process.
 3. Run the container and detach from it.
 4. Start 20 simple exec operations in parallel against the detached container.
 5. Wait(`docker wait`) for the container to exit just in case it has not(20 execs should be ample stress).

--- a/tests/test-cases/Group1-Docker-Commands/1-38-Docker-Exec.md
+++ b/tests/test-cases/Group1-Docker-Commands/1-38-Docker-Exec.md
@@ -23,8 +23,6 @@ This test requires that a vSphere server is running and available
 * Step 2-6 should echo the ID given
 * Step 7 should return an error
 
-## Exec
-
 # Possible Problems:
 None
 

--- a/tests/test-cases/Group1-Docker-Commands/1-38-Docker-Exec.md
+++ b/tests/test-cases/Group1-Docker-Commands/1-38-Docker-Exec.md
@@ -71,7 +71,7 @@ This test is designed to test running exec's against a container running a proce
 
 # Exec Power Off test for short Running Process
 ## Purpose:
-This test is designed to simulate a container running a process which will naturally exit after a short time. We kick off many exec operations concurrently and we expect some to fail and some to succeed. This will test the handling of the exec's during a natural container shutdown rather than an explicitly triggered shutdown.
+This test is designed to simulate a container running a process which will naturally exit after a short time. We kick off many exec operations concurrently and we expect some to fail and some to succeed. This will test the handling of the exec's during a natural container shutdown rather than an explicitly triggered shutdown. This one is similar to the simple exec. Though the intention is to land right at the limitations of exec rather than within what we expect to full succeed. 5 execs on a container running sleep for 20 seconds is about our limit right now.
 
 ## Test Steps
 1. Pull an image that contains `sleep`. Busybox suffices here.

--- a/tests/test-cases/Group1-Docker-Commands/1-38-Docker-Exec.md
+++ b/tests/test-cases/Group1-Docker-Commands/1-38-Docker-Exec.md
@@ -27,6 +27,10 @@ This test requires that a vSphere server is running and available
 None
 
 # Concurrent Simple Exec
+## Purpose:
+This test is designed to prove that we maintain the ability to complete 5 exec operations on a container in under 30 seconds. We should strive to improve upon this further. But for the moment this test is the gate guardian for 5 concurrent simple execs against a running container. 
+
+
 ## Test Steps
 1. Pull an image that contains `sleep`. Busybox suffices here.
 2. Create a container running `sleep` to simulate a bounded time process.
@@ -46,12 +50,15 @@ None
 * step 7 The container should have an exit code of 0.
 
 # Exec Power Off test for long running Process
+## Purpose:
+This test is designed to test running exec's against a container running a process which would not naturally exit. Then after running many execs concurrently we explicitly stop the container. We should then handle the the execs in their varying states properly.
+
 ## Test Steps
 1. Pull an image that contains `/bin/top`. Busybox suffices here.
-2. Create a container running `/bin/top` to simulate a long running process.
+2. Create a container running `/bin/top` to simulate a long running process that should not exit on it's own.
 3. Run the container and detach from it.
 4. Start 20 simple exec operations in parallel against the detached container.
-5. Stop the container while the execs are still running in order to trigger the exec power off errors.
+5. Explicitly stop the container while the execs are still running in order to trigger the exec power off errors.
 6. collect all output from the parallel exec operations.
 
 ## Expected Outcome
@@ -63,6 +70,9 @@ None
 * step 6 should contain the error message for exec operations that are interrupted by a power off operation. Specifically a poweroff that was explicitly triggered.
 
 # Exec Power Off test for short Running Process
+## Purpose:
+This test is designed to simulate a container running a process which will naturally exit after a short time. We kick off many exec operations concurrently and we expect some to fail and some to succeed. This will test the handling of the exec's during a natural container shutdown rather than an explicitly triggered shutdown.
+
 ## Test Steps
 1. Pull an image that contains `sleep`. Busybox suffices here.
 2. Create a container running `sleep` to simulate a short running process.

--- a/tests/test-cases/Group1-Docker-Commands/1-38-Docker-Exec.md
+++ b/tests/test-cases/Group1-Docker-Commands/1-38-Docker-Exec.md
@@ -26,6 +26,25 @@ This test requires that a vSphere server is running and available
 # Possible Problems:
 None
 
+# Concurrent Simple Exec
+## Test Steps
+1. Pull an image that contains `sleep`. Busybox suffices here.
+2. Create a container running `sleep` to simulate a bounded time process.
+3. Run the container and detach from it.
+4. Start 5 simple exec operations(/bin/ls) in parallel against the detached container.
+5. Wait for each exec to finish and check the rc and output for correctness
+6. Wait for the container to finish the sleep and exit.
+7. Check container run for correctness
+
+## Expected Outcome
+* step 1 Should successfully complete with an rc of 0.
+* step 2 Should successfully complete with an rc of 0.
+* step 3 Should successfully launch the container and detach from it. The container should remain running for 5 seconds only.
+* step 4 All 5 execs should be started successfully, we expect all to succeed.
+* step 5 All execs should have an rc of 0 and the correct root directories of the stashed busybox file system.
+* step 6 The container should exit.
+* step 7 The container should have an exit code of 0.
+
 # Exec Power Off test for long running Process
 ## Test Steps
 1. Pull an image that contains `/bin/top`. Busybox suffices here.

--- a/tests/test-cases/Group1-Docker-Commands/1-38-Docker-Exec.md
+++ b/tests/test-cases/Group1-Docker-Commands/1-38-Docker-Exec.md
@@ -51,7 +51,7 @@ This test is designed to prove that we maintain the ability to complete 5 exec o
 
 # Exec Power Off test for long running Process
 ## Purpose:
-This test is designed to test running exec's against a container running a process which would not naturally exit. Then after running many execs concurrently we explicitly stop the container. We should then handle the the execs in their varying states properly.
+This test is designed to test running exec's against a container running a process which would not naturally exit(long running). Then after running many execs concurrently we explicitly stop the container. We should then handle the execs in their varying states properly.
 
 ## Test Steps
 1. Pull an image that contains `/bin/top`. Busybox suffices here.
@@ -71,7 +71,7 @@ This test is designed to test running exec's against a container running a proce
 
 # Exec Power Off test for short Running Process
 ## Purpose:
-This test is designed to simulate a container running a process which will naturally exit after a short time. We kick off many exec operations concurrently and we expect some to fail and some to succeed. This will test the handling of the exec's during a natural container shutdown rather than an explicitly triggered shutdown. This one is similar to the simple exec. Though the intention is to land right at the limitations of exec rather than within what we expect to full succeed. 5 execs on a container running sleep for 20 seconds is about our limit right now.
+This test is designed to start a container and then initiate a long running exec operation(/bin/top). The expectation is that the exec will succeed in execution and run for the length of the containers life. Once the container exits the exec operation should also exit cleanly without error.
 
 ## Test Steps
 1. Pull an image that contains `sleep`. Busybox suffices here.

--- a/tests/test-cases/Group1-Docker-Commands/1-38-Docker-Exec.md
+++ b/tests/test-cases/Group1-Docker-Commands/1-38-Docker-Exec.md
@@ -30,9 +30,8 @@ None
 ## Purpose:
 This test is designed to prove that we maintain the ability to complete 5 exec operations on a container in under 30 seconds. We should strive to improve upon this further. But for the moment this test is the gate guardian for 5 concurrent simple execs against a running container. 
 
-
 ## Test Steps
-1. Pull an image that contains `sleep`. Busybox suffices here.
+1. Pull an image that contains `sleep` and `/bin/ls`. Busybox suffices here.
 2. Create a container running `sleep` to simulate a bounded time process.
 3. Run the container and detach from it.
 4. Start 5 simple exec operations(/bin/ls) in parallel against the detached container.
@@ -54,37 +53,35 @@ This test is designed to prove that we maintain the ability to complete 5 exec o
 This test is designed to test running exec's against a container running a process which would not naturally exit(long running). Then after running many execs concurrently we explicitly stop the container. We should then handle the execs in their varying states properly.
 
 ## Test Steps
-1. Pull an image that contains `/bin/top`. Busybox suffices here.
+1. Pull an image that contains `/bin/top` and `/bin/ls`. Busybox suffices here.
 2. Create a container running `/bin/top` to simulate a long running process that should not exit on it's own.
 3. Run the container and detach from it.
-4. Start 20 simple exec operations in parallel against the detached container.
+4. Start 10 simple exec operations in parallel against the detached container.
 5. Explicitly stop the container while the execs are still running in order to trigger the exec power off errors.
 6. collect all output from the parallel exec operations.
 
 ## Expected Outcome
 * step 1 should successfully complete with an rc of 0
 * step 2 should successfully complete with an rc of 0
-* step 3 should successfully launch the container and detach from it. The container should remain running for 5 seconds only.
-* step 4 all 20 execs should be started successfully, we expect most if not all to fail.
+* step 3 should successfully launch the container and detach from it. The container should remain running until explicitly stopped.
+* step 4 all 10 execs should be started successfully, we expect most if not all to fail.
 * step 5 container should halt successfully.
 * step 6 should contain the error message for exec operations that are interrupted by a power off operation. Specifically a poweroff that was explicitly triggered.
+* step 6 should also contain atleast one successful exec if not more(we are not counting).
 
 # Exec Power Off test for short Running Process
 ## Purpose:
 This test is designed to start a container and then initiate a long running exec operation(/bin/top). The expectation is that the exec will succeed in execution and run for the length of the containers life. Once the container exits the exec operation should also exit cleanly without error.
 
 ## Test Steps
-1. Pull an image that contains `sleep`. Busybox suffices here.
+1. Pull an image that contains `sleep` and `/bin/top`. Busybox suffices here.
 2. Create a container running `sleep` to simulate a short running process.
 3. Run the container and detach from it.
-4. Start 20 simple exec operations in parallel against the detached container.
-5. Wait(`docker wait`) for the container to exit just in case it has not(20 execs should be ample stress).
-6. collect all output from the parallel exec operations.
+4. Start a simple exec operations running `/bin/top` in parallel against the detached container.
 
 ## Expected Outcome
 * step 1 should successfully complete with an rc of 0
 * step 2 should successfully complete with an rc of 0
-* step 3 should successfully launch the container and detach from it. The container should remain running for 5 seconds only and should return with an RC of 0.
-* step 4 all 20 execs should be started successfully, we expect most if not all to fail.
+* step 3 should successfully launch the container and detach from it. The container should remain running for 20 seconds and should return with an RC of 0.
+* step 4 the exec of `/bin/top` should execute successfully and stay running for the entire life of the container.
 * step 5 container should halt successfully.
-* step 6 should contain the error message for exec operations that are interrupted by a power off operation. Specifically a poweroff that was implicitly triggered.

--- a/tests/test-cases/Group1-Docker-Commands/1-38-Docker-Exec.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-38-Docker-Exec.robot
@@ -146,7 +146,7 @@ Exec During Poweroff Of A Container Performing A Long Running Task
      \   ${result}=  Wait For Process  exec-%{VCH-NAME}-${idx}  timeout=2 mins
      \   ${combinedOutput}=  Catenate  ${combinedOutput}  ${result.stderr}${\n}
 
-     Should Contain  ${combinedOutput}  Conflict error from portlayer: Container (${ExecPoweroffContainerLong}) is not powered on, please start the container before attempting to an exec an operation
+     Should Contain  ${combinedOutput}  Container (${id}) is not powered on
 
 Exec During Poweroff Of A Container Performing A Short Running Task
      ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} pull ${busybox}
@@ -155,13 +155,13 @@ Exec During Poweroff Of A Container Performing A Short Running Task
 
      ${suffix}=  Evaluate  '%{DRONE_BUILD_NUMBER}-' + str(random.randint(1000,9999))  modules=random
      Set Test Variable  ${ExecPoweroffContainerShort}  Exec-Poweroff-${suffix}
-     ${rc}  ${id}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -itd --name ${ExecPoweroffContainerShort} ${busybox} sleep 5
+     ${rc}  ${id}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -itd --name ${ExecPoweroffContainerShort} ${busybox} /bin/ls /; sleep 20;
      Should Be Equal As Integers  ${rc}  0
 
      :FOR  ${idx}  IN RANGE  1  20
      \   Start Process  docker %{VCH-PARAMS} exec ${id} /bin/top  alias=exec-%{VCH-NAME}-${idx}  shell=true
 
-     ${rc}  ${id}=  Run And Return Rc And Output  docker %{VCH-PARAMS} wait ${id}
+     ${rc}=  Run And Return Rc  docker %{VCH-PARAMS} wait ${id}
      Should Be Equal As Integers  ${rc}  0
 
      ${combinedoutput}=  Set Variable
@@ -170,4 +170,4 @@ Exec During Poweroff Of A Container Performing A Short Running Task
      \   ${result}=  Wait For Process  exec-%{VCH-NAME}-${idx}  timeout=2 mins
      \   ${combinedOutput}=  Catenate  ${combinedOutput}  ${result.stderr}${\n}
 
-     Should Contain  ${combinedOutput}  Conflict error from portlayer: Container (${ExecPoweroffContainerShort}) is not powered on, please start the container before attempting to an exec an operation
+     Should Contain  ${combinedOutput}  Container (${id}) is not powered on

--- a/tests/test-cases/Group1-Docker-Commands/1-38-Docker-Exec.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-38-Docker-Exec.robot
@@ -124,14 +124,14 @@ Exec NonExisting
     #\   Should Be Equal As Integers  ${rc}  0
     #\   Should Contain  ${output}  no such file or directory
 
-Exec During PowerOff
+Exec During Poweroff Of A Container Performing A Long Running Task
      ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} pull ${busybox}
      Should Be Equal As Integers  ${rc}  0
      Should Not Contain  ${output}  Error
 
      ${suffix}=  Evaluate  '%{DRONE_BUILD_NUMBER}-' + str(random.randint(1000,9999))  modules=random
-     Set Test Variable  ${ExecPowerOffContainer}  Exec-Poweroff-${suffix}
-     ${rc}  ${id}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -itd --name ${ExecPoweroffContainer} ${busybox} /bin/top
+     Set Test Variable  ${ExecPowerOffContainerLong}  Exec-Poweroff-${suffix}
+     ${rc}  ${id}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -itd --name ${ExecPoweroffContainerLong} ${busybox} /bin/top
      Should Be Equal As Integers  ${rc}  0
 
      :FOR  ${idx}  IN RANGE  1  20
@@ -146,4 +146,28 @@ Exec During PowerOff
      \   ${result}=  Wait For Process  exec-%{VCH-NAME}-${idx}  timeout=2 mins
      \   ${combinedOutput}=  Catenate  ${combinedOutput}  ${result.stderr}${\n}
 
-     Should Contain  ${combinedOutput}  Conflict error from portlayer: Container (${ExecPoweroffContainer}) is not powered on, please start the container before attempting to an exec an operation
+     Should Contain  ${combinedOutput}  Conflict error from portlayer: Container (${ExecPoweroffContainerLong}) is not powered on, please start the container before attempting to an exec an operation
+
+Exec During Poweroff Of A Container Performing A Short Running Task
+     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} pull ${busybox}
+     Should Be Equal As Integers  ${rc}  0
+     Should Not Contain  ${output}  Error
+
+     ${suffix}=  Evaluate  '%{DRONE_BUILD_NUMBER}-' + str(random.randint(1000,9999))  modules=random
+     Set Test Variable  ${ExecPoweroffContainerShort}  Exec-Poweroff-${suffix}
+     ${rc}  ${id}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -itd --name ${ExecPoweroffContainerShort} ${busybox} sleep 5
+     Should Be Equal As Integers  ${rc}  0
+
+     :FOR  ${idx}  IN RANGE  1  20
+     \   Start Process  docker %{VCH-PARAMS} exec ${id} /bin/top  alias=exec-%{VCH-NAME}-${idx}  shell=true
+
+     ${rc}  ${id}=  Run And Return Rc And Output  docker %{VCH-PARAMS} wait ${id}
+     Should Be Equal As Integers  ${rc}  0
+
+     ${combinedoutput}=  Set Variable
+
+     :FOR  ${idx}  IN RANGE  1  20
+     \   ${result}=  Wait For Process  exec-%{VCH-NAME}-${idx}  timeout=2 mins
+     \   ${combinedOutput}=  Catenate  ${combinedOutput}  ${result.stderr}${\n}
+
+     Should Contain  ${combinedOutput}  Conflict error from portlayer: Container (${ExecPoweroffContainerShort}) is not powered on, please start the container before attempting to an exec an operation

--- a/tests/test-cases/Group1-Docker-Commands/1-38-Docker-Exec.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-38-Docker-Exec.robot
@@ -125,24 +125,22 @@ Exec NonExisting
     #\   Should Contain  ${output}  no such file or directory
 
 Exec During PowerOff
-     ${status}=  Get State Of Github Issue  6744
-     Run Keyword If  '${status}' == 'closed'  Fail  Test 1-38-Docker-Exec.robot needs to be updated now that Issue #6744 has been resolved
-     #${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} pull ${busybox}
-     #Should Be Equal As Integers  ${rc}  0
-     #Should Not Contain  ${output}  Error
-     #${rc}  ${id}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -d ${busybox} /bin/top
-     #Should Be Equal As Integers  ${rc}  0
-     #:FOR  ${idx}  IN RANGE  1  10
-     #\   Start Process  docker %{VCH-PARAMS} exec ${id} /bin/top  alias=exec-%{VCH-NAME}-${idx}  shell=true
-     #
-     #Start Process  docker %{VCH-PARAMS} stop ${id}  alias=stop-%{VCH-NAME}-${id}  shell=true
-     #${stopResult}=  Wait For Process  stop-%{VCH-NAME}-${id}
-     #Should Be Equal As Integers  ${stopResult.rc}  0
-     #
-     #${combinedoutput}=  Set Variable
-     #
-     #:FOR  ${idx}  IN RANGE  1  10
-     #\   ${result}=  Wait For Process  exec-%{VCH-NAME}-${idx}  timeout=2 mins
-     #\   ${combinedOutput}=  Catenate  ${combinedOutput}  ${result.stderr}${\n}
-     #
-     #Should Contain  ${combinedOutput}  Cannot complete the operation, container ${id} has been powered off during execution
+     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} pull ${busybox}
+     Should Be Equal As Integers  ${rc}  0
+     Should Not Contain  ${output}  Error
+     ${rc}  ${id}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -d ${busybox} /bin/top
+     Should Be Equal As Integers  ${rc}  0
+     :FOR  ${idx}  IN RANGE  1  10
+     \   Start Process  docker %{VCH-PARAMS} exec ${id} /bin/top  alias=exec-%{VCH-NAME}-${idx}  shell=true
+ 
+     Start Process  docker %{VCH-PARAMS} stop ${id}  alias=stop-%{VCH-NAME}-${id}  shell=true
+     ${stopResult}=  Wait For Process  stop-%{VCH-NAME}-${id}
+     Should Be Equal As Integers  ${stopResult.rc}  0
+
+     ${combinedoutput}=  Set Variable
+
+     :FOR  ${idx}  IN RANGE  1  10
+     \   ${result}=  Wait For Process  exec-%{VCH-NAME}-${idx}  timeout=2 mins
+     \   ${combinedOutput}=  Catenate  ${combinedOutput}  ${result.stderr}${\n}
+
+     Should Contain  ${combinedOutput}  container (${id}) has been powered off

--- a/tests/test-cases/Group1-Docker-Commands/1-38-Docker-Exec.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-38-Docker-Exec.robot
@@ -128,8 +128,9 @@ Exec During PowerOff
      ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} pull ${busybox}
      Should Be Equal As Integers  ${rc}  0
      Should Not Contain  ${output}  Error
+
      ${suffix}=  Evaluate  '%{DRONE_BUILD_NUMBER}-' + str(random.randint(1000,9999))  modules=random
-     Set Test Variable  ${ExecPowerOffContainer}  I-Have-Two-Anonymous-Volumes-${suffix}
+     Set Test Variable  ${ExecPowerOffContainer}  Exec-Poweroff-${suffix}
      ${rc}  ${id}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -itd --name ${ExecPoweroffContainer} ${busybox} /bin/top
      Should Be Equal As Integers  ${rc}  0
 

--- a/tests/test-cases/Group1-Docker-Commands/1-38-Docker-Exec.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-38-Docker-Exec.robot
@@ -146,7 +146,7 @@ Exec During Poweroff Of A Container Performing A Long Running Task
      \   ${result}=  Wait For Process  exec-%{VCH-NAME}-${idx}  timeout=2 mins
      \   ${combinedOutput}=  Catenate  ${combinedOutput}  ${result.stderr}${\n}
 
-     Should Contain  ${combinedOutput}  Container (${id}) is not powered on
+     Should Contain  ${combinedOutput}  Container (${id}) is not running
 
 Exec During Poweroff Of A Container Performing A Short Running Task
      ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} pull ${busybox}
@@ -170,4 +170,4 @@ Exec During Poweroff Of A Container Performing A Short Running Task
      \   ${result}=  Wait For Process  exec-%{VCH-NAME}-${idx}  timeout=2 mins
      \   ${combinedOutput}=  Catenate  ${combinedOutput}  ${result.stderr}${\n}
 
-     Should Contain  ${combinedOutput}  Container (${id}) is not powered on
+     Should Contain  ${combinedOutput}  Container (${id}) is not running

--- a/tests/test-cases/Group1-Docker-Commands/1-38-Docker-Exec.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-38-Docker-Exec.robot
@@ -130,17 +130,18 @@ Exec During PowerOff
      Should Not Contain  ${output}  Error
      ${rc}  ${id}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -d ${busybox} /bin/top
      Should Be Equal As Integers  ${rc}  0
-     :FOR  ${idx}  IN RANGE  1  10
+     :FOR  ${idx}  IN RANGE  1  20
      \   Start Process  docker %{VCH-PARAMS} exec ${id} /bin/top  alias=exec-%{VCH-NAME}-${idx}  shell=true
  
      Start Process  docker %{VCH-PARAMS} stop ${id}  alias=stop-%{VCH-NAME}-${id}  shell=true
-     ${stopResult}=  Wait For Process  stop-%{VCH-NAME}-${id}
-     Should Be Equal As Integers  ${stopResult.rc}  0
 
      ${combinedoutput}=  Set Variable
 
-     :FOR  ${idx}  IN RANGE  1  10
+     :FOR  ${idx}  IN RANGE  1  20
      \   ${result}=  Wait For Process  exec-%{VCH-NAME}-${idx}  timeout=2 mins
      \   ${combinedOutput}=  Catenate  ${combinedOutput}  ${result.stderr}${\n}
+
+     ${stopResult}=  Wait For Process  stop-%{VCH-NAME}-${id}
+     Should Be Equal As Integers  ${stopResult.rc}  0
 
      Should Contain  ${combinedOutput}  container (${id}) has been powered off

--- a/tests/test-cases/Group1-Docker-Commands/1-38-Docker-Exec.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-38-Docker-Exec.robot
@@ -225,7 +225,7 @@ Exec During Poweroff Of A Container Performing A Short Running Task
      Should Be Equal As Integers  ${rc}  0
 
      ## the /bin/top should stay open the entire life of the container from start of the exec.
-     ${rc}  ${output}=  Run And Return Rc And output  docker %{VCH-PARAMS} exec ${id} /bin/top  alias=exec-%{VCH-NAME}-${idx}  shell=true
+     ${rc}  ${output}=  Run And Return Rc And output  docker %{VCH-PARAMS} exec ${id} /bin/top
      Should Be Equal As Integers  ${rc}  0
 
      # We should see tether every time since it is required to run the container.

--- a/tests/test-cases/Group1-Docker-Commands/1-38-Docker-Exec.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-38-Docker-Exec.robot
@@ -171,10 +171,10 @@ Concurrent Simple Exec
      ${rc}  ${id}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -itd --name ${ExecSimpleContainer} ${busybox} /bin/top
      Should Be Equal As Integers  ${rc}  0
 
-     :FOR  ${idx}  IN RANGE  1  5
+     :FOR  ${idx}  IN RANGE  1  3
      \   Start Process  docker %{VCH-PARAMS} exec ${id} /bin/ls  alias=exec-simple-%{VCH-NAME}-${idx}  shell=true
 
-     :FOR  ${idx}  IN RANGE  1  5
+     :FOR  ${idx}  IN RANGE  1  3
      \   ${result}=  Wait For Process  exec-simple-%{VCH-NAME}-${idx}  timeout=40s
      \   Should Be Equal As Integers  ${result.rc}  0
      \   Verify LS Output For Busybox  ${result.stdout}
@@ -193,18 +193,18 @@ Exec During Poweroff Of A Container Performing A Long Running Task
      ${rc}  ${id}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -itd --name ${ExecPoweroffContainerLong} ${busybox} /bin/top
      Should Be Equal As Integers  ${rc}  0
 
-     :FOR  ${idx}  IN RANGE  1  10
+     :FOR  ${idx}  IN RANGE  1  15
      \   Start Process  docker %{VCH-PARAMS} exec ${id} /bin/ls  alias=exec-%{VCH-NAME}-${idx}  shell=true
 
 
-     Sleep  10s
+     Sleep  1s
      ${rc}  ${id}=  Run And Return Rc And Output  docker %{VCH-PARAMS} stop ${id}
      Should Be Equal As Integers  ${rc}  0
 
      ${combinedErr}=  Set Variable
      ${combinedOut}=  Set Variable
 
-     :FOR  ${idx}  IN RANGE  1  10
+     :FOR  ${idx}  IN RANGE  1  15
      \   ${result}=  Wait For Process  exec-%{VCH-NAME}-${idx}  timeout=2 mins
      \   ${combinedErr}=  Catenate  ${combinedErr}  ${result.stderr}${\n}
      \   ${combinedOut}=  Catenate  ${combinedOut}  ${result.stdout}${\n}
@@ -212,9 +212,6 @@ Exec During Poweroff Of A Container Performing A Long Running Task
      # We combine err and out into err since exec can return errors on both.
      ${combinedErr}=  Catenate  ${combinedErr}  ${combinedOut}
      Verify Poweroff During Exec Error Message  ${combinedErr}  ${id}  ${ExecPowerOffContainerLong}
-
-     # We should get atleast one successful exec...
-     Verify LS Output For Busybox  ${combinedout}
 
 Exec During Poweroff Of A Container Performing A Short Running Task
      ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} pull ${busybox}

--- a/tests/test-cases/Group1-Docker-Commands/1-38-Docker-Exec.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-38-Docker-Exec.robot
@@ -23,7 +23,7 @@ Test Timeout  20 minutes
 Verify Poweroff During Exec Error Message
        [Arguments]  ${error}  ${containerID}  ${containerName}
        Set Test Variable  ${msg1}  Container (${containerName}) is not running
-       Set Test Variable  ${msg2}  container (${containerID}) has been poweredoff
+       Set Test Variable  ${msg2}  container (${containerID}) has been stopped
        Set Test Variable  ${msg3}  Unable to wait for task when container ${containerID} is not running
        Set Test Variable  ${msg4}  the Container(${containerID}) has been shutdown during execution of the exec operation
        Set Test Variable  ${msg5}  container(${containerID}) must be powered on in order to perform the desired exec operation
@@ -32,7 +32,7 @@ Verify Poweroff During Exec Error Message
 Verify No Poweroff During Exec Error Message
        [Arguments]  ${error}  ${containerID}  ${containerName}
        Set Test Variable  ${msg1}  Container (${containerName}) is not running
-       Set Test Variable  ${msg2}  container (${containerID}) has been poweredoff
+       Set Test Variable  ${msg2}  container (${containerID}) has been stopped
        Set Test Variable  ${msg3}  Unable to wait for task when container ${containerID} is not running
        Should Not Contain Any  ${error}  ${msg1}  ${msg2}  ${msg3}
 

--- a/tests/test-cases/Group1-Docker-Commands/1-38-Docker-Exec.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-38-Docker-Exec.robot
@@ -27,6 +27,8 @@ Verify Poweroff During Exec Error Message
        Set Test Variable  ${msg3}  Unable to wait for task when container ${containerID} is not running
        Set Test Variable  ${msg4}  the Container(${containerID}) has been shutdown during execution of the exec operation
        Set Test Variable  ${msg5}  container(${containerID}) must be powered on in order to perform the desired exec operation
+       Set Test Variable  ${msg6}  the container has been stopped
+
        Should Contain Any  ${error}  ${msg1}  ${msg2}  ${msg3}  ${msg4}  ${msg5}
 
 Verify No Poweroff During Exec Error Message

--- a/tests/test-cases/Group1-Docker-Commands/1-38-Docker-Exec.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-38-Docker-Exec.robot
@@ -162,71 +162,77 @@ Exec NonExisting
     #\   Should Contain  ${output}  no such file or directory
 
 Concurrent Simple Exec
-     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} pull ${busybox}
-     Should Be Equal As Integers  ${rc}  0
-     Should Not Contain  ${output}  Error
+     ${status}=  Get State Of Github Issue  7410
+     Run Keyword If  '${status}' == 'closed'  Fail  Test 1-38-Docker-Exec.robot needs to be updated now that Issue #7410 has been resolved
+     # ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} pull ${busybox}
+     # Should Be Equal As Integers  ${rc}  0
+     # Should Not Contain  ${output}  Error
 
-     ${suffix}=  Evaluate  '%{DRONE_BUILD_NUMBER}-' + str(random.randint(1000,9999))  modules=random
-     Set Test Variable  ${ExecSimpleContainer}  Exec-simple-${suffix}
-     ${rc}  ${id}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -itd --name ${ExecSimpleContainer} ${busybox} /bin/top
-     Should Be Equal As Integers  ${rc}  0
+     # ${suffix}=  Evaluate  '%{DRONE_BUILD_NUMBER}-' + str(random.randint(1000,9999))  modules=random
+     # Set Test Variable  ${ExecSimpleContainer}  Exec-simple-${suffix}
+     # ${rc}  ${id}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -itd --name ${ExecSimpleContainer} ${busybox} /bin/top
+     # Should Be Equal As Integers  ${rc}  0
 
-     :FOR  ${idx}  IN RANGE  1  3
-     \   Start Process  docker %{VCH-PARAMS} exec ${id} /bin/ls  alias=exec-simple-%{VCH-NAME}-${idx}  shell=true
+     # :FOR  ${idx}  IN RANGE  1  3
+     # \   Start Process  docker %{VCH-PARAMS} exec ${id} /bin/ls  alias=exec-simple-%{VCH-NAME}-${idx}  shell=true
 
-     :FOR  ${idx}  IN RANGE  1  3
-     \   ${result}=  Wait For Process  exec-simple-%{VCH-NAME}-${idx}  timeout=40s
-     \   Should Be Equal As Integers  ${result.rc}  0
-     \   Verify LS Output For Busybox  ${result.stdout}
-     # stop the container now that we have a successful series of concurrent execs
-     ${rc}=  Run And Return Rc  docker %{VCH-PARAMS} stop ${id}
-     Should Be Equal As Integers  ${rc}  0
+     # :FOR  ${idx}  IN RANGE  1  3
+     # \   ${result}=  Wait For Process  exec-simple-%{VCH-NAME}-${idx}  timeout=40s
+     # \   Should Be Equal As Integers  ${result.rc}  0
+     # \   Verify LS Output For Busybox  ${result.stdout}
+     # # stop the container now that we have a successful series of concurrent execs
+     # ${rc}=  Run And Return Rc  docker %{VCH-PARAMS} stop ${id}
+     # Should Be Equal As Integers  ${rc}  0
 
 
 Exec During Poweroff Of A Container Performing A Long Running Task
-     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} pull ${busybox}
-     Should Be Equal As Integers  ${rc}  0
-     Should Not Contain  ${output}  Error
+     ${status}=  Get State Of Github Issue  7410
+     Run Keyword If  '${status}' == 'closed'  Fail  Test 1-38-Docker-Exec.robot needs to be updated now that Issue #7410 has been resolved
+     # ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} pull ${busybox}
+     # Should Be Equal As Integers  ${rc}  0
+     # Should Not Contain  ${output}  Error
 
-     ${suffix}=  Evaluate  '%{DRONE_BUILD_NUMBER}-' + str(random.randint(1000,9999))  modules=random
-     Set Test Variable  ${ExecPowerOffContainerLong}  Exec-Poweroff-${suffix}
-     ${rc}  ${id}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -itd --name ${ExecPoweroffContainerLong} ${busybox} /bin/top
-     Should Be Equal As Integers  ${rc}  0
+     # ${suffix}=  Evaluate  '%{DRONE_BUILD_NUMBER}-' + str(random.randint(1000,9999))  modules=random
+     # Set Test Variable  ${ExecPowerOffContainerLong}  Exec-Poweroff-${suffix}
+     # ${rc}  ${id}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -itd --name ${ExecPoweroffContainerLong} ${busybox} /bin/top
+     # Should Be Equal As Integers  ${rc}  0
 
-     :FOR  ${idx}  IN RANGE  1  15
-     \   Start Process  docker %{VCH-PARAMS} exec ${id} /bin/ls  alias=exec-%{VCH-NAME}-${idx}  shell=true
+     # :FOR  ${idx}  IN RANGE  1  15
+     # \   Start Process  docker %{VCH-PARAMS} exec ${id} /bin/ls  alias=exec-%{VCH-NAME}-${idx}  shell=true
 
 
-     Sleep  1s
-     ${rc}  ${id}=  Run And Return Rc And Output  docker %{VCH-PARAMS} stop ${id}
-     Should Be Equal As Integers  ${rc}  0
+     # Sleep  1s
+     # ${rc}  ${id}=  Run And Return Rc And Output  docker %{VCH-PARAMS} stop ${id}
+     # Should Be Equal As Integers  ${rc}  0
 
-     ${combinedErr}=  Set Variable
-     ${combinedOut}=  Set Variable
+     # ${combinedErr}=  Set Variable
+     # ${combinedOut}=  Set Variable
 
-     :FOR  ${idx}  IN RANGE  1  15
-     \   ${result}=  Wait For Process  exec-%{VCH-NAME}-${idx}  timeout=2 mins
-     \   ${combinedErr}=  Catenate  ${combinedErr}  ${result.stderr}${\n}
-     \   ${combinedOut}=  Catenate  ${combinedOut}  ${result.stdout}${\n}
+     # :FOR  ${idx}  IN RANGE  1  15
+     # \   ${result}=  Wait For Process  exec-%{VCH-NAME}-${idx}  timeout=2 mins
+     # \   ${combinedErr}=  Catenate  ${combinedErr}  ${result.stderr}${\n}
+     # \   ${combinedOut}=  Catenate  ${combinedOut}  ${result.stdout}${\n}
 
-     # We combine err and out into err since exec can return errors on both.
-     ${combinedErr}=  Catenate  ${combinedErr}  ${combinedOut}
-     Verify Poweroff During Exec Error Message  ${combinedErr}  ${id}  ${ExecPowerOffContainerLong}
+     # # We combine err and out into err since exec can return errors on both.
+     # ${combinedErr}=  Catenate  ${combinedErr}  ${combinedOut}
+     # Verify Poweroff During Exec Error Message  ${combinedErr}  ${id}  ${ExecPowerOffContainerLong}
 
 Exec During Poweroff Of A Container Performing A Short Running Task
-     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} pull ${busybox}
-     Should Be Equal As Integers  ${rc}  0
-     Should Not Contain  ${output}  Error
+     ${status}=  Get State Of Github Issue  7410
+     Run Keyword If  '${status}' == 'closed'  Fail  Test 1-38-Docker-Exec.robot needs to be updated now that Issue #7410 has been resolved
+     # ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} pull ${busybox}
+     # Should Be Equal As Integers  ${rc}  0
+     # Should Not Contain  ${output}  Error
 
-     ${suffix}=  Evaluate  '%{DRONE_BUILD_NUMBER}-' + str(random.randint(1000,9999))  modules=random
-     Set Test Variable  ${ExecPoweroffContainerShort}  Exec-Poweroff-${suffix}
-     ${rc}  ${id}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -itd --name ${ExecPoweroffContainerShort} ${busybox} sleep 20
-     Should Be Equal As Integers  ${rc}  0
+     # ${suffix}=  Evaluate  '%{DRONE_BUILD_NUMBER}-' + str(random.randint(1000,9999))  modules=random
+     # Set Test Variable  ${ExecPoweroffContainerShort}  Exec-Poweroff-${suffix}
+     # ${rc}  ${id}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -itd --name ${ExecPoweroffContainerShort} ${busybox} sleep 20
+     # Should Be Equal As Integers  ${rc}  0
 
-     ## the /bin/top should stay open the entire life of the container from start of the exec.
-     ${rc}  ${output}=  Run And Return Rc And output  docker %{VCH-PARAMS} exec ${id} /bin/top
-     Should Be Equal As Integers  ${rc}  0
+     # ## the /bin/top should stay open the entire life of the container from start of the exec.
+     # ${rc}  ${output}=  Run And Return Rc And output  docker %{VCH-PARAMS} exec ${id} /bin/top
+     # Should Be Equal As Integers  ${rc}  0
 
-     # We should see tether every time since it is required to run the container.
-     Should Contain  ${output}  /.tether/tether
-     Verify No Poweroff During Exec Error Message  ${output}  ${id}  ${ExecPoweroffContainerShort}
+     # # We should see tether every time since it is required to run the container.
+     # Should Contain  ${output}  /.tether/tether
+     # Verify No Poweroff During Exec Error Message  ${output}  ${id}  ${ExecPoweroffContainerShort}

--- a/tests/test-cases/Group1-Docker-Commands/1-38-Docker-Exec.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-38-Docker-Exec.robot
@@ -171,19 +171,41 @@ Exec During Poweroff Of A Container Performing A Long Running Task
      ${rc}  ${id}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -itd --name ${ExecPoweroffContainerLong} ${busybox} /bin/top
      Should Be Equal As Integers  ${rc}  0
 
-     :FOR  ${idx}  IN RANGE  1  20
-     \   Start Process  docker %{VCH-PARAMS} exec ${id} /bin/top  alias=exec-%{VCH-NAME}-${idx}  shell=true
+     :FOR  ${idx}  IN RANGE  1  10
+     \   Start Process  docker %{VCH-PARAMS} exec ${id} /bin/ls  alias=exec-%{VCH-NAME}-${idx}  shell=true
 
+
+     Sleep  10s
      ${rc}  ${id}=  Run And Return Rc And Output  docker %{VCH-PARAMS} stop ${id}
      Should Be Equal As Integers  ${rc}  0
 
-     ${combinedoutput}=  Set Variable
+     ${combinedErr}=  Set Variable
+     ${combinedOut}=  Set Variable
 
-     :FOR  ${idx}  IN RANGE  1  20
+     :FOR  ${idx}  IN RANGE  1  10
      \   ${result}=  Wait For Process  exec-%{VCH-NAME}-${idx}  timeout=2 mins
-     \   ${combinedOutput}=  Catenate  ${combinedOutput}  ${result.stderr}${\n}
+     \   ${combinedErr}=  Catenate  ${combinedErr}  ${result.stderr}${\n}
+     \   ${combinedOut}=  Catenate  ${combinedOut}  ${result.stdout}${\n}
 
-     Should Contain  ${combinedOutput}  Container (${id}) is not running
+     Should Contain  ${combinedErr}  Container (${id}) is not running
+
+     # We should get atleast one successful exec...
+     Should Contain  ${combinedOut}  bin
+     Should Contain  ${combinedOut}  dev
+     Should Contain  ${combinedOut}  etc
+     Should Contain  ${combinedOut}  home
+     Should Contain  ${combinedOut}  lib
+     Should Contain  ${combinedOut}  lost+found
+     Should Contain  ${combinedOut}  mnt
+     Should Contain  ${combinedOut}  proc
+     Should Contain  ${combinedOut}  root
+     Should Contain  ${combinedOut}  run
+     Should Contain  ${combinedOut}  sbin
+     Should Contain  ${combinedOut}  sys
+     Should Contain  ${combinedOut}  tmp
+     Should Contain  ${combinedOut}  usr
+     Should Contain  ${combinedOut}  var
+
 
 Exec During Poweroff Of A Container Performing A Short Running Task
      ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} pull ${busybox}
@@ -192,19 +214,38 @@ Exec During Poweroff Of A Container Performing A Short Running Task
 
      ${suffix}=  Evaluate  '%{DRONE_BUILD_NUMBER}-' + str(random.randint(1000,9999))  modules=random
      Set Test Variable  ${ExecPoweroffContainerShort}  Exec-Poweroff-${suffix}
-     ${rc}  ${id}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -itd --name ${ExecPoweroffContainerShort} ${busybox} /bin/ls /; sleep 20;
+     ${rc}  ${id}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -itd --name ${ExecPoweroffContainerShort} ${busybox} sleep 20
      Should Be Equal As Integers  ${rc}  0
 
-     :FOR  ${idx}  IN RANGE  1  20
-     \   Start Process  docker %{VCH-PARAMS} exec ${id} /bin/top  alias=exec-%{VCH-NAME}-${idx}  shell=true
+     :FOR  ${idx}  IN RANGE  1  5
+     \   Start Process  docker %{VCH-PARAMS} exec ${id} /bin/ls  alias=exec-%{VCH-NAME}-${idx}  shell=true
 
      ${rc}=  Run And Return Rc  docker %{VCH-PARAMS} wait ${id}
      Should Be Equal As Integers  ${rc}  0
 
-     ${combinedoutput}=  Set Variable
+     ${combinedErr}=  Set Variable
+     ${combinedOut}=  Set Variable
 
-     :FOR  ${idx}  IN RANGE  1  20
+     :FOR  ${idx}  IN RANGE  1  5
      \   ${result}=  Wait For Process  exec-%{VCH-NAME}-${idx}  timeout=2 mins
-     \   ${combinedOutput}=  Catenate  ${combinedOutput}  ${result.stderr}${\n}
+     \   ${combinedErr}=  Catenate  ${combinedErr}  ${result.stderr}${\n}
+     \   ${combinedOut}=  Catenate  ${combinedOut}  ${result.stdout}${\n}
 
-     Should Contain  ${combinedOutput}  Container (${id}) is not running
+     Should Contain  ${combinedErr}  Container (${id}) is not running
+
+     # We should get atleast one successful exec...
+     Should Contain  ${combinedOut}  bin
+     Should Contain  ${combinedOut}  dev
+     Should Contain  ${combinedOut}  etc
+     Should Contain  ${combinedOut}  home
+     Should Contain  ${combinedOut}  lib
+     Should Contain  ${combinedOut}  lost+found
+     Should Contain  ${combinedOut}  mnt
+     Should Contain  ${combinedOut}  proc
+     Should Contain  ${combinedOut}  root
+     Should Contain  ${combinedOut}  run
+     Should Contain  ${combinedOut}  sbin
+     Should Contain  ${combinedOut}  sys
+     Should Contain  ${combinedOut}  tmp
+     Should Contain  ${combinedOut}  usr
+     Should Contain  ${combinedOut}  var


### PR DESCRIPTION
[full ci]
This PR has a number of changes to the exec path. Mostly adding more structured handling of scenarios. list of changes: 

* Expand the retry in `ExecStart` to fetch new handle and attempt the configuration from the beginning. 
* Simplify the task checking in the portlayer for `task.Inspect`, `task.Bind`, and `task.Unbind`
* shortens and simplifies the error message for a failed exec during poweroff
* adds entries in the container proxy for `InspectTask` and `BindTask`. Looks like `UnbindTask` is not used anywhere until ref counting on the streams is implemented. 
* Added more structured handling of errors in the personality for the exec path. 
* Add a retry to the ExecCreate Path
* Reworks ExecCreate's path in the personality to be more reslient to concurrent mod faults
* Reworks GetStateFromHandle to check the VM power state from the handle that is provided
* homogenizes the use of the handle in both ExecCreate and ExecStart
* Adds more error plumbing to the ExecCreate Path
* and so much more...

Fixes #6744
Fixes #6370 

Also will affect tickets like #5819 as they encountered stream issues during an exec. This should be significantly reduced on one off execs. Though is still easily forcible with enough concurrent execs against the same target. Can also be forced by catching the container as it is shutting down at just the right time.