### PR TITLE
Configure managedBy info for plugin and OVA

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -417,15 +417,15 @@ $(vic-machine-darwin): $$(call godeps,cmd/vic-machine/*.go)
 	@echo building vic-machine darwin...
 	@GOARCH=amd64 GOOS=darwin $(TIME) $(GO) build $(RACE) -ldflags "$(LDFLAGS)" -o ./$@ ./$(dir $<)
 
-$(vic-ui-linux): $$(call godeps,cmd/vic-ui/*.go)
+$(vic-ui-linux): $$(call godeps,cmd/vic-ui/*.go) $(admiralapi-client)
 	@echo building vic-ui linux...
 	@GOARCH=amd64 GOOS=linux $(TIME) $(GO) build $(RACE) -ldflags "-X main.BuildID=${BUILD_NUMBER} -X main.CommitID=${COMMIT}" -o ./$@ ./$(dir $<)
 
-$(vic-ui-windows): $$(call godeps,cmd/vic-ui/*.go)
+$(vic-ui-windows): $$(call godeps,cmd/vic-ui/*.go) $(admiralapi-client)
 	@echo building vic-ui windows...
 	@GOARCH=amd64 GOOS=windows $(TIME) $(GO) build $(RACE) -ldflags "-X main.BuildID=${BUILD_NUMBER} -X main.CommitID=${COMMIT}" -o ./$@ ./$(dir $<)
 
-$(vic-ui-darwin): $$(call godeps,cmd/vic-ui/*.go)
+$(vic-ui-darwin): $$(call godeps,cmd/vic-ui/*.go) $(admiralapi-client)
 	@echo building vic-ui darwin...
 	@GOARCH=amd64 GOOS=darwin $(TIME) $(GO) build $(RACE) -ldflags "-X main.BuildID=${BUILD_NUMBER} -X main.CommitID=${COMMIT}" -o ./$@ ./$(dir $<)
 

--- a/lib/install/ova/configure.go
+++ b/lib/install/ova/configure.go
@@ -1,0 +1,135 @@
+// Copyright 2016 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ova
+
+import (
+	"context"
+	"net"
+	"net/url"
+
+	log "github.com/Sirupsen/logrus"
+
+	"github.com/vmware/govmomi/vim25/types"
+	"github.com/vmware/vic/lib/config/dynamic/admiral"
+	"github.com/vmware/vic/pkg/errors"
+	"github.com/vmware/vic/pkg/vsphere/session"
+	"github.com/vmware/vic/pkg/vsphere/tasks"
+	"github.com/vmware/vic/pkg/vsphere/vm"
+)
+
+const (
+	// ManagedByKey defines the extension key to use in the ManagedByInfo of the OVA
+	ManagedByKey = "com.vmware.vic"
+	// ManagedByType defines the type to use in the ManagedByInfo of the OVA
+	ManagedByType = "VicApplianceVM"
+)
+
+// ConfigureManagedByInfo takes sets the ManagedBy field for the VM specified by ovaURL
+func ConfigureManagedByInfo(ctx context.Context, config *session.Config, ovaURL string) error {
+	sess := session.NewSession(config)
+	sess, err := sess.Connect(ctx)
+	if err != nil {
+		return err
+	}
+
+	v, err := getOvaVMByTag(ctx, sess, ovaURL)
+	if err != nil {
+		return err
+	}
+
+	log.Infof("Attempting to configure ManagedByInfo")
+	err = configureManagedByInfo(ctx, sess, v)
+	if err != nil {
+		return err
+	}
+
+	log.Infof("Successfully configured ManagedByInfo")
+	return nil
+}
+
+func configureManagedByInfo(ctx context.Context, sess *session.Session, v *vm.VirtualMachine) error {
+	spec := types.VirtualMachineConfigSpec{
+		ManagedBy: &types.ManagedByInfo{
+			ExtensionKey: ManagedByKey,
+			Type:         ManagedByType,
+		},
+	}
+
+	info, err := v.WaitForResult(ctx, func(ctx context.Context) (tasks.Task, error) {
+		return v.Reconfigure(ctx, spec)
+	})
+
+	if err != nil {
+		log.Errorf("Error while setting ManagedByInfo: %s", err)
+		return err
+	}
+
+	if info.State != types.TaskInfoStateSuccess {
+		log.Errorf("Setting ManagedByInfo reported: %s", info.Error.LocalizedMessage)
+		return err
+	}
+
+	return nil
+}
+
+func getOvaVMByTag(ctx context.Context, sess *session.Session, u string) (*vm.VirtualMachine, error) {
+	ovaURL, err := url.Parse(u)
+	if err != nil {
+		return nil, err
+	}
+
+	host := ovaURL.Hostname()
+
+	log.Debugf("Looking up host %s", host)
+	ips, err := net.LookupIP(host)
+	if err != nil {
+		return nil, errors.Errorf("IP lookup failed: %s", err)
+	}
+
+	log.Debugf("found %d IP(s) from hostname lookup on %s:", len(ips), host)
+	var ip string
+	for _, i := range ips {
+		log.Debugf(i.String())
+		if i.To4() != nil {
+			ip = i.String()
+		}
+	}
+
+	if ip == "" {
+		return nil, errors.Errorf("IPV6 support not yet implemented")
+	}
+
+	vms, err := admiral.DefaultDiscovery.Discover(ctx, sess)
+	if err != nil {
+		return nil, errors.Errorf("failed to discover OVA vm(s): %s", err)
+	}
+
+	log.Infof("Found %d VM(s) tagged as OVA", len(vms))
+	for i, v := range vms {
+		log.Debugf("Checking IP for %s", v.Reference().Value)
+		vmIP, err := v.WaitForIP(ctx)
+		if err != nil && i == len(vms)-1 {
+			return nil, errors.Errorf("failed to get VM IP: %s", err)
+		}
+
+		// verify the tagged vm has the IP we expect
+		if vmIP == ip {
+			log.Debugf("Found OVA with matching IP: %s", ip)
+			return v, nil
+		}
+	}
+
+	return nil, errors.Errorf("no VM(s) found with OVA tag")
+}

--- a/lib/install/ova/configure_test.go
+++ b/lib/install/ova/configure_test.go
@@ -1,0 +1,106 @@
+// Copyright 2016 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ova
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"net/url"
+	"os"
+	"testing"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/vic/pkg/vsphere/session"
+)
+
+func TestGetOvaVMByTagBadURL(t *testing.T) {
+	ctx := context.Background()
+	bogusURL := "foo/bar.url://what-is-this"
+	vm, err := getOvaVMByTag(ctx, nil, bogusURL)
+	assert.Nil(t, vm)
+	assert.Error(t, err)
+}
+
+func TestGetOvaVMByTag(t *testing.T) {
+	username := os.Getenv("TEST_VC_USERNAME")
+	password := os.Getenv("TEST_VC_PASSWORD")
+	vcURL := os.Getenv("TEST_VC_URL")
+	ovaURL := os.Getenv("TEST_OVA_URL")
+
+	if vcURL == "" || ovaURL == "" {
+		log.Infof("Skipping TestGetOvaVMByTag")
+		t.Skipf("This test should only run against a VC with a deployed OVA")
+	}
+
+	ctx := context.Background()
+
+	vc, err := url.Parse(vcURL)
+	if err != nil {
+		fmt.Printf("Failed to parse VC url: %s", err)
+		t.FailNow()
+	}
+
+	vc.User = url.UserPassword(username, password)
+
+	var cert object.HostCertificateInfo
+	if err = cert.FromURL(vc, new(tls.Config)); err != nil {
+		log.Error(err.Error())
+		t.FailNow()
+	}
+
+	if cert.Err != nil {
+		log.Errorf("Failed to verify certificate for target=%s (thumbprint=%s)", vc.Host, cert.ThumbprintSHA1)
+		log.Error(cert.Err.Error())
+	}
+
+	tp := cert.ThumbprintSHA1
+	log.Infof("Accepting host %q thumbprint %s", vc.Host, tp)
+
+	sessionConfig := &session.Config{
+		Thumbprint:     tp,
+		Service:        vc.String(),
+		DatacenterPath: "/ha-datacenter",
+		DatastorePath:  "datastore1",
+		User:           vc.User,
+		Insecure:       true,
+	}
+
+	s := session.NewSession(sessionConfig)
+	sess, err := s.Connect(ctx)
+	if err != nil {
+		log.Errorf("Error connecting: %s", err.Error())
+	}
+	defer sess.Logout(ctx)
+
+	sess, err = sess.Populate(ctx)
+	if err != nil {
+		log.Errorf("Error populating: %s", err.Error())
+	}
+
+	vm, err := getOvaVMByTag(ctx, sess, ovaURL)
+	if err != nil {
+		log.Errorf("Error getting OVA by tag: %s", err.Error())
+	}
+	if vm == nil {
+		log.Errorf("No VM found")
+		t.FailNow()
+	}
+
+	log.Infof("%s", vm.String())
+}

--- a/lib/install/plugin/register.go
+++ b/lib/install/plugin/register.go
@@ -33,6 +33,8 @@ import (
 )
 
 type Info struct {
+	*ManagedEntityInfo
+
 	Company               string
 	Key                   string
 	Name                  string
@@ -42,6 +44,13 @@ type Info struct {
 	Type                  string
 	URL                   string
 	Version               string
+}
+
+type ManagedEntityInfo struct {
+	Description  string
+	IconURL      string
+	SmallIconURL string
+	EntityType   string
 }
 
 type Pluginator struct {
@@ -150,6 +159,10 @@ func (p *Pluginator) Register() error {
 		Description: &desc,
 	}
 
+	if p.info.ManagedEntityInfo != nil {
+		e.Type = p.info.EntityType
+	}
+
 	eci := types.ExtensionClientInfo{
 		Version:     p.info.Version,
 		Company:     p.info.Company,
@@ -167,6 +180,14 @@ func (p *Pluginator) Register() error {
 	eri := types.ExtensionResourceInfo{
 		Locale: "en_US",
 		Module: "name",
+	}
+
+	if p.info.ManagedEntityInfo != nil {
+		mei := types.ExtManagedEntityInfo{
+			Description: p.info.ManagedEntityInfo.Description,
+			Type:        p.info.ManagedEntityInfo.EntityType,
+		}
+		e.ManagedEntityInfo = append(e.ManagedEntityInfo, mei)
 	}
 
 	eri.Data = append(eri.Data, d)


### PR DESCRIPTION
This change adds functionality to the VIC ui installer that allows it to configure both the extension and the OVA that the extension manages. This gets us away from having the asynchronous dependency on having the fileserver waiting to configure the OVA until the user decides to install the plugin.

Fixes https://github.com/vmware/vic-ui/issues/26
Fixes https://github.com/vmware/vic-ui/issues/26.