### PR TITLE
High-availability test reliability

### DIFF
--- a/lib/apiservers/engine/backends/container.go
+++ b/lib/apiservers/engine/backends/container.go
@@ -797,7 +797,7 @@ func (c *Container) ContainerRm(name string, config *types.ContainerRmConfig) er
 	// Use the force and stop the container first
 	secs := 0
 	if config.ForceRemove {
-		c.containerProxy.Stop(vc, name, &secs, true)
+		c.ContainerStop(name, &secs)
 	} else {
 		state, err := c.containerProxy.State(vc)
 		if err != nil {
@@ -828,11 +828,11 @@ func (c *Container) ContainerRm(name string, config *types.ContainerRmConfig) er
 		}
 	}
 
-	if err := c.containerProxy.Remove(vc, config); err != nil {
-		return err
+	operation := func() error {
+		return c.containerProxy.Remove(vc, config)
 	}
 
-	return nil
+	return retry.Do(operation, IsConflictError)
 }
 
 // cleanupPortBindings gets port bindings for the container and

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-4-High-Availability.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-4-High-Availability.robot
@@ -180,6 +180,8 @@ Test
     \     Should Be Equal As Integers  ${rc}  0
     \     Append To List  ${stopped}  ${c}
 
+    # Speculating that this is here to add some stability if VMs vmotion immediately after power on
+    # If so it should be replaced with a check for active tasks running against the VM or a DRS rule to avoid it completely
     Sleep  2 minutes
 
     ${output}=  Run  govc vm.info %{VCH-NAME}
@@ -204,17 +206,15 @@ Test
 
     # Abruptly power off the host
     Open Connection  ${curHost}  prompt=:~]
-    Login  root  e2eFunctionalTest
+    Login  root  ${NIMBUS_ESX_PASSWORD}
     ${out}=  Execute Command  poweroff -d 0 -f
     Close connection
 
     ${info}=  Run  govc vm.info \\*
     Log  ${info}
 
-    # Really not sure what better to do here?  Otherwise, vic-machine-inspect returns the old IP address... maybe some sort of power monitoring? Can I pull uptime of the system?
-    Sleep  4 minutes
-    Run VIC Machine Inspect Command
-    Wait Until Keyword Succeeds  20x  5 seconds  Run Docker Info  %{VCH-PARAMS}
+    # Wait for the VCH to come back up fully - if it's not completely reinitialized it will still report the old IP address 
+    Wait For VCH Initialization
 
     ${info}=  Run  govc vm.info \\*
     Log  ${info}

--- a/tests/resources/Nimbus-Util.robot
+++ b/tests/resources/Nimbus-Util.robot
@@ -422,3 +422,11 @@ Check License Features
     ${out}=  Run  govc object.collect -json $(govc object.collect -s - content.licenseManager) licenses | jq '.[].Val.LicenseManagerLicenseInfo[].Properties[] | select(.Key == "feature") | .Value'
     Should Contain  ${out}  serialuri
     Should Contain  ${out}  dvs
+
+# Abruptly power off the host
+Power Off Host
+    [Arguments]  ${host}
+    Open Connection  ${host}  prompt=:~]
+    Login  root  ${NIMBUS_ESX_PASSWORD}
+    ${out}=  Execute Command  poweroff -d 0 -f
+    Close connection

--- a/tests/resources/VCH-Util.robot
+++ b/tests/resources/VCH-Util.robot
@@ -338,6 +338,15 @@ Inspect VCH
     Should Be Equal As Integers  ${rc}  0
     Should Contain  ${output}  ${expected}
 
+Wait For VCH Initialization
+    [Arguments]  ${attempts}=12x  ${interval}=10 seconds
+    Wait Until Keyword Succeeds  ${attempts}  ${interval}  VCH Docker Info
+
+VCH Docker Info
+    Run VIC Machine Inspect Command
+    ${rc}=  Run And Return Rc  docker %{VCH-PARAMS} info
+    Should Be Equal As Integers  ${rc}  0
+
 Check UpdateInProgress
     [Arguments]  ${expected}
     ${rc}  ${output}=  Run And Return Rc And Output  govc vm.info -e %{VCH-NAME} | grep UpdateInProgress

--- a/tests/resources/Vsphere-Util.robot
+++ b/tests/resources/Vsphere-Util.robot
@@ -113,6 +113,19 @@ vMotion A VM
     Run Keyword If  ${status}  Run  govc vm.migrate -host cls/${esx2-ip} -pool cls/Resources ${vm}
     Run Keyword Unless  ${status}  Run  govc vm.migrate -host cls/${esx1-ip} -pool cls/Resources ${vm}
 
+vMotion A VM And Wait
+    [Arguments]  ${vm}  ${attempts}  ${interval}
+    ${host}=  Get VM Host Name  ${vm}
+    ${status}=  Run Keyword And Return Status  Should Contain  ${host}  ${esx1-ip}
+    Run Keyword If  ${status}  Run  govc vm.migrate -host cls/${esx2-ip} -pool cls/Resources ${vm}
+    Run Keyword Unless  ${status}  Run  govc vm.migrate -host cls/${esx1-ip} -pool cls/Resources ${vm}
+    Wait Until Keyword Succeeds  ${attempts}  ${interval}  VM Host Has Changed  ${host}  ${vm}
+
+VM Host Has Changed
+    [Arguments]  ${oldHost}  ${vm}
+    ${curHost}=  Get VM Host Name  ${vm}
+    Should Not Be Equal  ${oldHost}  ${curHost}
+
 Create Test Server Snapshot
     [Arguments]  ${vm}  ${snapshot}
     Set Environment Variable  GOVC_URL  %{BUILD_SERVER}


### PR DESCRIPTION
This adds tolerance to conflict error in ContainerRm (duplicates work
for #6252). Having looked at the ContainerRm logic we should have
a general pass over the personality code as the use of portlayer
Handles is not really as designed; these methods should almost all
be following the pattern below, however currently they are invoking
separate calls that are not batched within a single commit:
1. new handle
2. apply changes as necessary to handle
3. commit handle
4. if conflict error, redo from (1)

In the test side this explicitly checks for VCH initialization instead of
sleeping for set period.
This still requires logic to preserve the test environment if one of the
rare and non-reproducible errors occurs.

#6786 contains the same fix for ContainerRm but it's unclear what
the intent of the HA test change is - if we need an exception of that
kind it really should apply to all operations that could hit it, not a
single test. That may well require significant rework of the tests to
allow for common condition checking - the same requirement as
for preserving test envs for non-repo errors.

Towards #4666
