### PR TITLE
ops-grant-perms exposed on vic-machine create API [specific ci=Group23-VIC-Machine-Service]

### DIFF
--- a/lib/apiservers/service/restapi/handlers/vch_create.go
+++ b/lib/apiservers/service/restapi/handlers/vch_create.go
@@ -401,6 +401,7 @@ func buildCreate(op trace.Operation, d *data.Data, finder finder, vch *models.VC
 				c.OpsCredentials = common.OpsCredentials{
 					OpsUser:     &vch.Endpoint.OperationsCredentials.User,
 					OpsPassword: &opsPassword,
+					GrantPerms:  &vch.Endpoint.OperationsCredentials.GrantPermissions,
 				}
 			}
 		}

--- a/lib/apiservers/service/swagger.json
+++ b/lib/apiservers/service/swagger.json
@@ -759,6 +759,9 @@
                 },
                 "user": {
                   "type": "string"
+                },
+                "grant_permissions": {
+                  "type": "boolean"
                 }
               }
             }


### PR DESCRIPTION
Fixes #6632 

`grant_perms` is added to vic-machine create API as a write-only field
correspondent to the `--ops-grant-perms` flag in CLI #6774 