### PR TITLE
Put nfs nightly test infra deployment on the same pod

### DIFF
--- a/tests/manual-test-cases/Group5-Functional-Tests/5-22-NFS-Volume.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-22-NFS-Volume.robot
@@ -37,11 +37,14 @@ Setup ESX And NFS Suite
     Run Keyword And Ignore Error  Nimbus Cleanup  ${list}  ${false}
     Log To Console  \nStarting test...
 
-    ${esx1}  ${esx1_ip}=  Deploy Nimbus ESXi Server  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}
+    ${esx_name}=  Evaluate  'ESX-' + str(time.clock())  modules=time
+    ${esx1}  ${esx1_ip}=  Deploy Nimbus ESXi Server  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}  name=${esx_name}
+    ${esx1_name}=  Fetch From Right  ${esx_name}  -
+    ${POD}=  Fetch POD  ${esx_name}
 
-    ${nfs}  ${nfs_ip}=  Deploy Nimbus NFS Datastore  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}
+    ${nfs}  ${nfs_ip}=  Deploy Nimbus NFS Datastore  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}  additional-args=--nimbus ${POD}
 
-    ${nfs_readonly}  ${nfs_readonly_ip}=  Deploy Nimbus NFS Datastore  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}  additional-args=--disk 5000000 --disk 5000000 --mountOpt ro --nfsOpt ro --mountPoint=storage1 --mountPoint=storage2
+    ${nfs_readonly}  ${nfs_readonly_ip}=  Deploy Nimbus NFS Datastore  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}  additional-args=--disk 5000000 --disk 5000000 --mountOpt ro --nfsOpt ro --mountPoint=storage1 --mountPoint=storage2 --nimbus ${POD}
 
     Set Suite Variable  @{list}  ${esx1}  ${nfs}  ${nfs_readonly}
     Set Suite Variable  ${ESX1}  ${esx1}

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-22-NFS-Volume.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-22-NFS-Volume.robot
@@ -18,7 +18,6 @@ Resource  ../../resources/Util.robot
 Suite Setup  Wait Until Keyword Succeeds  10x  10m  Setup ESX And NFS Suite
 Suite Teardown  Run Keyword And Ignore Error  NFS Volume Cleanup
 
-
 *** Variables ***
 ${nfsVolumeStore}=  nfsVolumeStore
 ${nfsFakeVolumeStore}=  nfsFakeVolumeStore
@@ -41,7 +40,7 @@ Setup ESX And NFS Suite
     ${esx1}  ${esx1_ip}=  Deploy Nimbus ESXi Server  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}  name=${esx_name}
 
     Open Connection  %{NIMBUS_GW}
-    Wait Until Keyword Succeeds  2 min  30 sec  Login  ${user}  ${password}
+    Wait Until Keyword Succeeds  2 min  30 sec  Login  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}
     ${POD}=  Fetch POD  ${esx_name}
     Log To Console  ${POD}
 

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-22-NFS-Volume.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-22-NFS-Volume.robot
@@ -36,12 +36,10 @@ Setup ESX And NFS Suite
     Run Keyword And Ignore Error  Nimbus Cleanup  ${list}  ${false}
     Log To Console  \nStarting test...
 
-    ${esx_name}=  Evaluate  'ESX-' + str(time.clock())  modules=time
     ${esx1}  ${esx1_ip}=  Deploy Nimbus ESXi Server  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}
-
     Open Connection  %{NIMBUS_GW}
     Wait Until Keyword Succeeds  2 min  30 sec  Login  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}
-    ${POD}=  Fetch POD  ${esx_name}
+    ${POD}=  Fetch POD  ${esx1}
     Log To Console  ${POD}
 
     ${nfs}  ${nfs_ip}=  Deploy Nimbus NFS Datastore  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}  additional-args=--nimbus ${POD}

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-22-NFS-Volume.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-22-NFS-Volume.robot
@@ -41,6 +41,7 @@ Setup ESX And NFS Suite
     Wait Until Keyword Succeeds  2 min  30 sec  Login  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}
     ${POD}=  Fetch POD  ${esx1}
     Log To Console  ${POD}
+    Close Connection
 
     ${nfs}  ${nfs_ip}=  Deploy Nimbus NFS Datastore  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}  additional-args=--nimbus ${POD}
 

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-22-NFS-Volume.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-22-NFS-Volume.robot
@@ -39,8 +39,11 @@ Setup ESX And NFS Suite
 
     ${esx_name}=  Evaluate  'ESX-' + str(time.clock())  modules=time
     ${esx1}  ${esx1_ip}=  Deploy Nimbus ESXi Server  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}  name=${esx_name}
-    ${esx1_name}=  Fetch From Right  ${esx_name}  -
+
+    Open Connection  %{NIMBUS_GW}
+    Wait Until Keyword Succeeds  2 min  30 sec  Login  ${user}  ${password}
     ${POD}=  Fetch POD  ${esx_name}
+    Log To Console  ${POD}
 
     ${nfs}  ${nfs_ip}=  Deploy Nimbus NFS Datastore  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}  additional-args=--nimbus ${POD}
 

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-22-NFS-Volume.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-22-NFS-Volume.robot
@@ -37,7 +37,7 @@ Setup ESX And NFS Suite
     Log To Console  \nStarting test...
 
     ${esx_name}=  Evaluate  'ESX-' + str(time.clock())  modules=time
-    ${esx1}  ${esx1_ip}=  Deploy Nimbus ESXi Server  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}  name=${esx_name}
+    ${esx1}  ${esx1_ip}=  Deploy Nimbus ESXi Server  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}
 
     Open Connection  %{NIMBUS_GW}
     Wait Until Keyword Succeeds  2 min  30 sec  Login  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}

--- a/tests/resources/Nimbus-Util.robot
+++ b/tests/resources/Nimbus-Util.robot
@@ -44,11 +44,8 @@ Fetch POD
 
 Deploy Nimbus ESXi Server
     [Arguments]  ${user}  ${password}  ${name}=  ${version}=${ESX_VERSION}  ${tls_disabled}=True
-    Log To Console  ${name}
     ${default_name}=  Evaluate  'ESX-' + str(random.randint(1000,9999)) + str(time.clock())  modules=random,time
-    Log To Console  ${default_name}
     Run Keyword Unless  '${name}'  Set Variable  ${name}  ${default_name}
-    Log To Console  I MADE IT
     Log To Console  \nDeploying Nimbus ESXi server: ${name}
     Open Connection  %{NIMBUS_GW}
     Wait Until Keyword Succeeds  2 min  30 sec  Login  ${user}  ${password}

--- a/tests/resources/Nimbus-Util.robot
+++ b/tests/resources/Nimbus-Util.robot
@@ -37,15 +37,16 @@ Get IP
 
 Fetch POD
       [Arguments]  ${name}
-      ${out}=  Wait Until Keyword Succeeds  10x  1 minute  Fetch IP  ${name}
+      ${out}=  Execute Command  nimbus-ctl list | grep ${name}
+      Should Not Be Empty  ${out}
+      ${len}=  Get Line Count  ${out}
+      Should Be Equal As Integers  ${len}  1
       ${pod}=  Fetch From Left  ${out}  :
       [return]  ${pod}
 
-
 Deploy Nimbus ESXi Server
-    [Arguments]  ${user}  ${password}  ${name}=  ${version}=${ESX_VERSION}  ${tls_disabled}=True
-    ${default_name}=  Evaluate  'ESX-' + str(random.randint(1000,9999)) + str(time.clock())  modules=random,time
-    Run Keyword Unless  '${name}'  Set Variable  ${name}  ${default_name}
+    [Arguments]  ${user}  ${password}  ${version}=${ESX_VERSION}  ${tls_disabled}=True
+    ${name}=  Evaluate  'ESX-' + str(random.randint(1000,9999)) + str(time.clock())  modules=random,time
     Log To Console  \nDeploying Nimbus ESXi server: ${name}
     Open Connection  %{NIMBUS_GW}
     Wait Until Keyword Succeeds  2 min  30 sec  Login  ${user}  ${password}

--- a/tests/resources/Nimbus-Util.robot
+++ b/tests/resources/Nimbus-Util.robot
@@ -35,9 +35,20 @@ Get IP
     ${ip}=  Fetch From Right  ${out}  ${SPACE}
     [Return]  ${ip}
 
+Fetch POD
+      [Arguments]  ${name}
+      ${out}=  Wait Until Keyword Succeeds  10x  1 minute  Fetch IP  ${name}
+      ${pod}=  Fetch From Left  ${out}  :
+      [return]  ${out}
+
+
 Deploy Nimbus ESXi Server
-    [Arguments]  ${user}  ${password}  ${version}=${ESX_VERSION}  ${tls_disabled}=True
-    ${name}=  Evaluate  'ESX-' + str(random.randint(1000,9999)) + str(time.clock())  modules=random,time
+    [Arguments]  ${user}  ${password}  ${name}=  ${version}=${ESX_VERSION}  ${tls_disabled}=True
+    Log To Console  ${name}
+    ${default_name}=  Evaluate  'ESX-' + str(random.randint(1000,9999)) + str(time.clock())  modules=random,time
+    Log To Console  ${default_name}
+    Run Keyword Unless  '${name}'  Set Variable  ${name}  ${default_name}
+    Log To Console  I MADE IT
     Log To Console  \nDeploying Nimbus ESXi server: ${name}
     Open Connection  %{NIMBUS_GW}
     Wait Until Keyword Succeeds  2 min  30 sec  Login  ${user}  ${password}
@@ -384,7 +395,7 @@ Get Vsphere Version
 
 Deploy Nimbus NFS Datastore
     [Arguments]  ${user}  ${password}  ${additional-args}=
-    ${name}=  Evaluate  'NFS-' + str(random.randint(1000,9999)) + str(time.clock())  modules=random,time
+    ${name}=  Evaluate  'NFS-' + str(random.randint(1000,9999)) + str(time.c  lock())  modules=random,time
     Log To Console  \nDeploying Nimbus NFS server: ${name}
     Open Connection  %{NIMBUS_GW}
     Wait Until Keyword Succeeds  2 min  30 sec  Login  ${user}  ${password}

--- a/tests/resources/Nimbus-Util.robot
+++ b/tests/resources/Nimbus-Util.robot
@@ -39,7 +39,7 @@ Fetch POD
       [Arguments]  ${name}
       ${out}=  Wait Until Keyword Succeeds  10x  1 minute  Fetch IP  ${name}
       ${pod}=  Fetch From Left  ${out}  :
-      [return]  ${out}
+      [return]  ${pod}
 
 
 Deploy Nimbus ESXi Server
@@ -392,7 +392,7 @@ Get Vsphere Version
 
 Deploy Nimbus NFS Datastore
     [Arguments]  ${user}  ${password}  ${additional-args}=
-    ${name}=  Evaluate  'NFS-' + str(random.randint(1000,9999)) + str(time.c  lock())  modules=random,time
+    ${name}=  Evaluate  'NFS-' + str(random.randint(1000,9999)) + str(time.clock())  modules=random,time
     Log To Console  \nDeploying Nimbus NFS server: ${name}
     Open Connection  %{NIMBUS_GW}
     Wait Until Keyword Succeeds  2 min  30 sec  Login  ${user}  ${password}


### PR DESCRIPTION
This is a PR that has been made in response to recent NFS test failures. Putting all of the Nimbus infra on the same POD eliminates another potential failure situation with the tests connectivity issues. It is not guaranteed to fix all of the problems we are seeing in the NFS nightly tests, but may go a long way toward fixing them and making other kinds of errors more predictable. 

this is in reference to: #6616 and #6677 