### PR TITLE
Always update software in vic-machine-server image

### DIFF
--- a/cmd/vic-machine-server/Dockerfile
+++ b/cmd/vic-machine-server/Dockerfile
@@ -7,7 +7,8 @@
 
 FROM vmware/photon:1.0
 
-RUN tdnf distro-sync --refresh -y && \
+RUN set -eux && \
+    tdnf distro-sync --refresh -y && \
     tdnf info installed && \
     tdnf clean all
 

--- a/cmd/vic-machine-server/Dockerfile
+++ b/cmd/vic-machine-server/Dockerfile
@@ -7,6 +7,10 @@
 
 FROM vmware/photon:1.0
 
+RUN tdnf distro-sync --refresh -y && \
+    tdnf info installed && \
+    tdnf clean all
+
 ENV HOST 0.0.0.0
 ENV PORT 80
 ENV TLS_PORT 443

--- a/cmd/vic-machine-server/Dockerfile
+++ b/cmd/vic-machine-server/Dockerfile
@@ -7,9 +7,9 @@
 
 FROM vmware/photon:1.0
 
-RUN set -eux && \
-    tdnf distro-sync --refresh -y && \
-    tdnf info installed && \
+RUN set -eux; \
+    tdnf distro-sync --refresh -y; \
+    tdnf info installed; \
     tdnf clean all
 
 ENV HOST 0.0.0.0


### PR DESCRIPTION
To ensure we always ship the most up-to-date version of packages with the vic-machine-server image, perform a distro-sync as a part of the image build.

To reduce bloat, clean up up temporary files, data, and metadata.

In between, print information about installed packages for tracking.