### PR TITLE
Treat BufferedPipe like a buffer in upload logic [specific ci=Group23-VIC-Machine-Service]

### DIFF
--- a/lib/install/vchlog/vchlogger.go
+++ b/lib/install/vchlog/vchlogger.go
@@ -15,9 +15,11 @@
 package vchlog
 
 import (
+	"io/ioutil"
 	"path"
 
 	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25/soap"
 	"github.com/vmware/vic/pkg/trace"
 )
 
@@ -60,7 +62,9 @@ func (l *VCHLogger) Run() {
 	sig := <-l.signalChan
 	// suffix the log file name with caller operation ID and timestamp
 	logFileName := "vic-machine" + "_" + sig.Timestamp + "_" + sig.Name + "_" + sig.Operation.ID() + ".log"
-	sig.Datastore.Upload(sig.Operation.Context, l.pipe, path.Join(sig.VMPathName, logFileName), nil)
+	param := soap.DefaultUpload
+	param.ContentLength = -1
+	sig.Datastore.Upload(sig.Operation.Context, ioutil.NopCloser(l.pipe), path.Join(sig.VMPathName, logFileName), &param)
 }
 
 // GetPipe returns the streaming pipe of the vch logger


### PR DESCRIPTION
Update the `VCHLogger`'s `Run` logic to treat the `BufferedPipe` like the underlying request would treat a buffer. If `http.NewRequest` is passed a body that is a `bytes.Buffer` it would use a `ioutil.NopCloser`, so we do the same. Additionally, explicitly indicate the `Content-Length` is unknown by specifying the documented value of `-1`.

With this change, the process seems to consistently upload the entire log without reporting errors to the user.

Fixes #6801
