### PR TITLE
Use the existing operation for log naming [specific ci=Group23-VIC-Machine-Service]

### DIFF
--- a/lib/install/management/create.go
+++ b/lib/install/management/create.go
@@ -64,7 +64,7 @@ func (d *Dispatcher) CreateVCH(conf *config.VirtualContainerHostConfigSpec, sett
 	datastoreReadySignal := vchlog.DatastoreReadySignal{
 		Datastore:  d.session.Datastore,
 		Name:       "create",
-		Operation:  trace.NewOperation(d.op, "create"),
+		Operation:  d.op,
 		VMPathName: d.vmPathName,
 		Timestamp:  time.Now().UTC().Format(timeFormat),
 	}


### PR DESCRIPTION
Avoid creating a new operation when naming the datastore log file, as that causes a mis-match between the operation ID in the log name and the operation ID used elsewhere (e.g., the log messages in that log
file).
