### PR TITLE
Centralize time formatting in datastore log naming [specific ci=Group23-VIC-Machine-Service]

### DIFF
--- a/lib/apiservers/service/restapi/handlers/vch_log_get.go
+++ b/lib/apiservers/service/restapi/handlers/vch_log_get.go
@@ -28,13 +28,9 @@ import (
 	"github.com/vmware/vic/lib/install/data"
 	"github.com/vmware/vic/lib/install/management"
 	"github.com/vmware/vic/lib/install/validate"
+	"github.com/vmware/vic/lib/install/vchlog"
 	"github.com/vmware/vic/pkg/trace"
 	"github.com/vmware/vic/pkg/vsphere/datastore"
-)
-
-const (
-	logFilePrefix = "vic-machine" // logFilePrefix is the prefix for file names of all vic-machine log files
-	logFileSuffix = ".log"        // logFileSuffix is the suffix for file names of all vic-machine log files
 )
 
 // VCHLogGet is the handler for getting the log messages for a VCH
@@ -161,7 +157,7 @@ func getAllLogFilePaths(op trace.Operation, helper *datastore.Helper) ([]string,
 	var paths []string
 	for _, f := range res.File {
 		path := f.GetFileInfo().Path
-		if strings.HasPrefix(path, logFilePrefix) && strings.HasSuffix(path, logFileSuffix) {
+		if strings.HasPrefix(path, vchlog.LogFilePrefix) && strings.HasSuffix(path, vchlog.LogFileSuffix) {
 			paths = append(paths, path)
 		}
 	}

--- a/lib/install/management/create.go
+++ b/lib/install/management/create.go
@@ -36,7 +36,6 @@ const (
 	uploadMaxElapsedTime  = 30 * time.Minute
 	uploadMaxInterval     = 1 * time.Minute
 	uploadInitialInterval = 10 * time.Second
-	timeFormat            = "2006-01-02T15:04:05-0700"
 )
 
 func (d *Dispatcher) CreateVCH(conf *config.VirtualContainerHostConfigSpec, settings *data.InstallerData, receiver vchlog.Receiver) error {
@@ -66,7 +65,7 @@ func (d *Dispatcher) CreateVCH(conf *config.VirtualContainerHostConfigSpec, sett
 		Name:       "create",
 		Operation:  d.op,
 		VMPathName: d.vmPathName,
-		Timestamp:  time.Now().UTC().Format(timeFormat),
+		Timestamp:  time.Now(),
 	}
 	receiver.Signal(datastoreReadySignal)
 

--- a/lib/install/vchlog/vchlogger.go
+++ b/lib/install/vchlog/vchlogger.go
@@ -17,10 +17,17 @@ package vchlog
 import (
 	"io/ioutil"
 	"path"
+	"time"
 
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/vim25/soap"
 	"github.com/vmware/vic/pkg/trace"
+)
+
+// Reminder: When changing these, consider the impact to backwards compatibility.
+const (
+	LogFilePrefix = "vic-machine" // logFilePrefix is the prefix for file names of all vic-machine log files
+	LogFileSuffix = ".log"        // logFileSuffix is the suffix for file names of all vic-machine log files
 )
 
 // DatastoreReadySignal serves as a signal struct indicating datastore folder path is available
@@ -34,7 +41,7 @@ type DatastoreReadySignal struct {
 	Name       string
 	Operation  trace.Operation
 	VMPathName string
-	Timestamp  string
+	Timestamp  time.Time
 }
 
 type VCHLogger struct {
@@ -61,7 +68,7 @@ func New() *VCHLogger {
 func (l *VCHLogger) Run() {
 	sig := <-l.signalChan
 	// suffix the log file name with caller operation ID and timestamp
-	logFileName := "vic-machine" + "_" + sig.Timestamp + "_" + sig.Name + "_" + sig.Operation.ID() + ".log"
+	logFileName := LogFilePrefix + "_" + sig.Timestamp.UTC().Format(time.RFC3339) + "_" + sig.Name + "_" + sig.Operation.ID() + LogFileSuffix
 	param := soap.DefaultUpload
 	param.ContentLength = -1
 	sig.Datastore.Upload(sig.Operation.Context, ioutil.NopCloser(l.pipe), path.Join(sig.VMPathName, logFileName), &param)


### PR DESCRIPTION
Refactor `VCHLogger` to ensure that time formatting is handled in a single location, for consistency.

Additionally, replace the time format string with a reference to the pre-defined constant.

Lastly, de-duplicate other information about log file naming.

(See also: https://github.com/vmware/vic/pull/6665#discussion_r149548721)