### PR TITLE
Log vic-machine-server version [specific ci=Group23-VIC-Machine-Service]

### DIFF
--- a/lib/apiservers/service/restapi/configure_vic_machine.go
+++ b/lib/apiservers/service/restapi/configure_vic_machine.go
@@ -32,6 +32,7 @@ import (
 	"github.com/vmware/vic/lib/apiservers/service/restapi/handlers"
 	"github.com/vmware/vic/lib/apiservers/service/restapi/operations"
 	"github.com/vmware/vic/pkg/trace"
+	"github.com/vmware/vic/pkg/version"
 )
 
 // This file is safe to edit. Once it exists it will not be overwritten
@@ -63,6 +64,7 @@ func configureAPI(api *operations.VicMachineAPI) http.Handler {
 	// configure logging to user specified directory
 	logger = configureLogger()
 	api.Logger = logger.Infof
+	api.Logger("Starting Service. Version: %q", version.GetBuild())
 
 	api.JSONConsumer = runtime.JSONConsumer()
 

--- a/lib/apiservers/service/restapi/handlers/vch_create.go
+++ b/lib/apiservers/service/restapi/handlers/vch_create.go
@@ -144,6 +144,8 @@ func setUpLogger(op *trace.Operation) *vchlog.VCHLogger {
 	op.Logger.Level = logrus.DebugLevel
 	op.Logger.Formatter = viclog.NewTextFormatter()
 
+	op.Logger.Infof("Starting API-based VCH Creation. Version: %q", version.GetBuild())
+
 	go log.Run()
 
 	return log


### PR DESCRIPTION
When a customer reports an issue, it may not be obvious what version of the `vic-machine-server` was in use at the time.
 * When starting the server, log the server's full version number to the server-side log file.
 * When create a VCH via the API, log the server's full version number to the datastore.