### PR TITLE
[specific ci=1-02-Docker-Pull] Fix docker pull on artifactory

### DIFF
--- a/lib/imagec/imagec.go
+++ b/lib/imagec/imagec.go
@@ -583,7 +583,7 @@ func (ic *ImageC) prepareTransfer(ctx context.Context) error {
 	// Get the URL of the OAuth endpoint
 	url, err := LearnAuthURL(ic.Options)
 	if err != nil {
-		log.Infof(err.Error())
+		log.Warnf("LearnAuthURL returned %s", err.Error())
 		switch err := err.(type) {
 		case urlfetcher.ImageNotFoundError:
 			return fmt.Errorf("Error: image %s not found", ic.Reference)

--- a/pkg/fetcher/fetcher.go
+++ b/pkg/fetcher/fetcher.go
@@ -453,7 +453,12 @@ func (u *URLFetcher) buildRegistryErrMsg(url *url.URL, respBody io.ReadCloser) s
 		return errMsg
 	}
 
-	errMsg += fmt.Sprintf(", Message: %s", errDetail)
+	if strings.Contains(errDetail, "does not have permission") {
+		errMsg = fmt.Sprintf("unauthorized: %s", errDetail)
+	} else {
+		errMsg += fmt.Sprintf("Message: %s", errDetail)
+	}
+
 	return errMsg
 }
 


### PR DESCRIPTION
Artifactory responds with HTTP 403 when attempting initial query
to look up bearer realm.  We use an URL that includes manifest and
repo.  That works on most registries, and appears to be correct
according to the docker OAuth spec.

Now, if the URL we use does not work, we attempt another query
with just the registry URL.  This works well with Artifactory.  It
is also the same URL we use for docker login.

Fixes #6738