### PR TITLE
Clean up the VCH Management API swagger definition

### DIFF
--- a/lib/apiservers/service/restapi/configure_vic_machine.go
+++ b/lib/apiservers/service/restapi/configure_vic_machine.go
@@ -35,6 +35,7 @@ import (
 	"github.com/vmware/vic/lib/apiservers/service/restapi/handlers"
 	"github.com/vmware/vic/lib/apiservers/service/restapi/handlers/target"
 	"github.com/vmware/vic/lib/apiservers/service/restapi/operations"
+	"github.com/vmware/vic/lib/apiservers/service/restapi/operations/not_yet_implemented"
 	"github.com/vmware/vic/pkg/trace"
 	"github.com/vmware/vic/pkg/version"
 )
@@ -82,92 +83,92 @@ func configureAPI(api *operations.VicMachineAPI) http.Handler {
 
 	api.SessionAuth = target.SessionAuth
 
-	// GET /container
-	api.GetHandler = operations.GetHandlerFunc(func(params operations.GetParams) middleware.Responder {
+	// GET    /container
+	api.NotYetImplementedGetHandler = not_yet_implemented.GetHandlerFunc(func(params not_yet_implemented.GetParams) middleware.Responder {
 		return middleware.NotImplemented("operation .Get has not yet been implemented")
 	})
 
-	// GET /container/hello
+	// GET    /container/hello
 	api.GetHelloHandler = &handlers.HelloGet{}
 
-	// GET /container/version
+	// GET    /container/version
 	api.GetVersionHandler = &handlers.VersionGet{}
 
-	// POST /container/target/{target}
-	api.PostTargetTargetHandler = operations.PostTargetTargetHandlerFunc(func(params operations.PostTargetTargetParams, principal interface{}) middleware.Responder {
+	// POST   /container/target/{target}
+	api.NotYetImplementedPostTargetTargetHandler = not_yet_implemented.PostTargetTargetHandlerFunc(func(params not_yet_implemented.PostTargetTargetParams, principal interface{}) middleware.Responder {
 		return middleware.NotImplemented("operation .PostTargetTarget has not yet been implemented")
 	})
 
-	// GET /container/target/{target}/vch
+	// GET    /container/target/{target}/vch
 	api.GetTargetTargetVchHandler = &handlers.VCHListGet{}
 
-	// POST /container/target/{target}/vch
+	// POST   /container/target/{target}/vch
 	api.PostTargetTargetVchHandler = &handlers.VCHCreate{}
 
-	// GET /container/target/{target}/vch/{vch-id}
+	// GET    /container/target/{target}/vch/{vch-id}
 	api.GetTargetTargetVchVchIDHandler = &handlers.VCHGet{}
 
-	// GET /container/target/{target}/vch/{vch-id}/certificate
-	api.GetTargetTargetVchVchIDCertificateHandler = &handlers.VCHCertGet{}
-
-	// GET /container/target/{target}/vch/{vch-id}/log
-	api.GetTargetTargetVchVchIDLogHandler = &handlers.VCHLogGet{}
-
-	// GET /container/target/{target}/datacenter/{datacenter}/vch/{vch-id}/certificate
-	api.GetTargetTargetDatacenterDatacenterVchVchIDCertificateHandler = &handlers.VCHDatacenterCertGet{}
-
-	// GET /container/target/{target}/datacenter/{datacenter}/vch/{vch-id}/log
-	api.GetTargetTargetDatacenterDatacenterVchVchIDLogHandler = &handlers.VCHDatacenterLogGet{}
-
-	// PUT /container/target/{target}/vch/{vch-id}
-	api.PutTargetTargetVchVchIDHandler = operations.PutTargetTargetVchVchIDHandlerFunc(func(params operations.PutTargetTargetVchVchIDParams, principal interface{}) middleware.Responder {
+	// PUT    /container/target/{target}/vch/{vch-id}
+	api.NotYetImplementedPutTargetTargetVchVchIDHandler = not_yet_implemented.PutTargetTargetVchVchIDHandlerFunc(func(params not_yet_implemented.PutTargetTargetVchVchIDParams, principal interface{}) middleware.Responder {
 		return middleware.NotImplemented("operation .PutTargetTargetVchVchID has not yet been implemented")
 	})
 
-	// PATCH /container/target/{target}/vch/{vch-id}
-	api.PatchTargetTargetVchVchIDHandler = operations.PatchTargetTargetVchVchIDHandlerFunc(func(params operations.PatchTargetTargetVchVchIDParams, principal interface{}) middleware.Responder {
+	// PATCH  /container/target/{target}/vch/{vch-id}
+	api.NotYetImplementedPatchTargetTargetVchVchIDHandler = not_yet_implemented.PatchTargetTargetVchVchIDHandlerFunc(func(params not_yet_implemented.PatchTargetTargetVchVchIDParams, principal interface{}) middleware.Responder {
 		return middleware.NotImplemented("operation .PatchTargetTargetVchVchID has not yet been implemented")
 	})
 
-	// POST /container/target/{target}/vch/{vch-id}
-	api.PostTargetTargetVchVchIDHandler = operations.PostTargetTargetVchVchIDHandlerFunc(func(params operations.PostTargetTargetVchVchIDParams, principal interface{}) middleware.Responder {
+	// POST   /container/target/{target}/vch/{vch-id}
+	api.NotYetImplementedPostTargetTargetVchVchIDHandler = not_yet_implemented.PostTargetTargetVchVchIDHandlerFunc(func(params not_yet_implemented.PostTargetTargetVchVchIDParams, principal interface{}) middleware.Responder {
 		return middleware.NotImplemented("operation .PostTargetTargetVchVchID has not yet been implemented")
 	})
 
 	// DELETE /container/target/{target}/vch/{vch-id}
 	api.DeleteTargetTargetVchVchIDHandler = &handlers.VCHDelete{}
 
-	// POST /container/target/{target}/datacenter/{datacenter}
-	api.PostTargetTargetDatacenterDatacenterHandler = operations.PostTargetTargetDatacenterDatacenterHandlerFunc(func(params operations.PostTargetTargetDatacenterDatacenterParams, principal interface{}) middleware.Responder {
+	// GET    /container/target/{target}/vch/{vch-id}/certificate
+	api.GetTargetTargetVchVchIDCertificateHandler = &handlers.VCHCertGet{}
+
+	// GET    /container/target/{target}/vch/{vch-id}/log
+	api.GetTargetTargetVchVchIDLogHandler = &handlers.VCHLogGet{}
+
+	// POST   /container/target/{target}/datacenter/{datacenter}
+	api.NotYetImplementedPostTargetTargetDatacenterDatacenterHandler = not_yet_implemented.PostTargetTargetDatacenterDatacenterHandlerFunc(func(params not_yet_implemented.PostTargetTargetDatacenterDatacenterParams, principal interface{}) middleware.Responder {
 		return middleware.NotImplemented("operation .PostTargetTargetDatacenterDatacenter has not yet been implemented")
 	})
 
-	// GET /container/target/{target}/datacenter/{datacenter}/vch
+	// GET    /container/target/{target}/datacenter/{datacenter}/vch
 	api.GetTargetTargetDatacenterDatacenterVchHandler = &handlers.VCHDatacenterListGet{}
 
-	// POST /container/target/{target}/datacenter/{datacenter}/vch
+	// POST   /container/target/{target}/datacenter/{datacenter}/vch
 	api.PostTargetTargetDatacenterDatacenterVchHandler = &handlers.VCHDatacenterCreate{}
 
-	// GET /container/target/{target}/datacenter/{datacenter}/vch/{vch-id}
+	// GET    /container/target/{target}/datacenter/{datacenter}/vch/{vch-id}
 	api.GetTargetTargetDatacenterDatacenterVchVchIDHandler = &handlers.VCHDatacenterGet{}
 
-	// PUT /container/target/{target}/datacenter/{datacenter}/vch/{vch-id}
-	api.PutTargetTargetDatacenterDatacenterVchVchIDHandler = operations.PutTargetTargetDatacenterDatacenterVchVchIDHandlerFunc(func(params operations.PutTargetTargetDatacenterDatacenterVchVchIDParams, principal interface{}) middleware.Responder {
+	// PUT    /container/target/{target}/datacenter/{datacenter}/vch/{vch-id}
+	api.NotYetImplementedPutTargetTargetDatacenterDatacenterVchVchIDHandler = not_yet_implemented.PutTargetTargetDatacenterDatacenterVchVchIDHandlerFunc(func(params not_yet_implemented.PutTargetTargetDatacenterDatacenterVchVchIDParams, principal interface{}) middleware.Responder {
 		return middleware.NotImplemented("operation .PutTargetTargetDatacenterDatacenterVchVchID has not yet been implemented")
 	})
 
 	// PATCH /container/target/{target}/datacenter/{datacenter}/vch/{vch-id}
-	api.PatchTargetTargetDatacenterDatacenterVchVchIDHandler = operations.PatchTargetTargetDatacenterDatacenterVchVchIDHandlerFunc(func(params operations.PatchTargetTargetDatacenterDatacenterVchVchIDParams, principal interface{}) middleware.Responder {
+	api.NotYetImplementedPatchTargetTargetDatacenterDatacenterVchVchIDHandler = not_yet_implemented.PatchTargetTargetDatacenterDatacenterVchVchIDHandlerFunc(func(params not_yet_implemented.PatchTargetTargetDatacenterDatacenterVchVchIDParams, principal interface{}) middleware.Responder {
 		return middleware.NotImplemented("operation .PatchTargetTargetDatacenterDatacenterVchVchID has not yet been implemented")
 	})
 
 	// POST /container/target/{target}/datacenter/{datacenter}/vch/{vch-id}
-	api.PostTargetTargetDatacenterDatacenterVchVchIDHandler = operations.PostTargetTargetDatacenterDatacenterVchVchIDHandlerFunc(func(params operations.PostTargetTargetDatacenterDatacenterVchVchIDParams, principal interface{}) middleware.Responder {
+	api.NotYetImplementedPostTargetTargetDatacenterDatacenterVchVchIDHandler = not_yet_implemented.PostTargetTargetDatacenterDatacenterVchVchIDHandlerFunc(func(params not_yet_implemented.PostTargetTargetDatacenterDatacenterVchVchIDParams, principal interface{}) middleware.Responder {
 		return middleware.NotImplemented("operation .PostTargetTargetDatacenterDatacenterVchVchID has not yet been implemented")
 	})
 
 	// DELETE /container/target/{target}/datacenter/{datacenter}/vch/{vch-id}
 	api.DeleteTargetTargetDatacenterDatacenterVchVchIDHandler = &handlers.VCHDatacenterDelete{}
+
+	// GET /container/target/{target}/datacenter/{datacenter}/vch/{vch-id}/certificate
+	api.GetTargetTargetDatacenterDatacenterVchVchIDCertificateHandler = &handlers.VCHDatacenterCertGet{}
+
+	// GET /container/target/{target}/datacenter/{datacenter}/vch/{vch-id}/log
+	api.GetTargetTargetDatacenterDatacenterVchVchIDLogHandler = &handlers.VCHDatacenterLogGet{}
 
 	api.ServerShutdown = func() {}
 

--- a/lib/apiservers/service/swagger.json
+++ b/lib/apiservers/service/swagger.json
@@ -2,7 +2,7 @@
   "swagger": "2.0",
   "info": {
     "title": "vic-machine API",
-    "description": "An API for interacting with vic-machine as a RESTful web service.",
+    "description": "An API for performing administrative operations on Virtual Container Hosts. Provides functionality similar to the vic-machine CLI.",
     "license": {
       "name": "Apache 2.0",
       "url": "https://raw.githubusercontent.com/vmware/vic/master/LICENSE"
@@ -24,10 +24,11 @@
     "/": {
       "get": {
         "summary": "Show VIC metadata",
-        "description": "A `GET` request on the base resource will return a JSON object containing metadata including the version number of the service software and a list of known appliance ISOs.",
+        "description": "A `GET` request on the base resource will return a JSON object containing metadata including the version number of the server software and a list of available appliance ISOs.",
         "responses": {
           "200": { "$ref": "#/responses/metadata" }
         },
+        "tags": ["not-yet-implemented"],
         "security": []
       }
     },
@@ -47,7 +48,7 @@
     "/version": {
       "get": {
         "summary": "Show VIC version information",
-        "description": "A `GET` request on the `version` sub-resource will return the version number of the service software.",
+        "description": "A `GET` request on the `version` sub-resource will return the version number of the server software.",
         "produces": [
           "text/plain"
         ],
@@ -60,7 +61,7 @@
     "/target/{target}": {
       "get": {
         "summary": "Show information about the specified vSphere resources",
-        "description": "Making a `GET` request on a vSphere target will return information about the state of the host firewall on those resources.",
+        "description": "A `GET` request on a vSphere target will return information about the state of the host firewall on those resources.",
         "parameters": [
           { "$ref": "#/parameters/target" },
           { "$ref": "#/parameters/computeResource" },
@@ -69,11 +70,12 @@
         "responses": {
           "200": { "$ref": "#/responses/target" },
           "default": { "$ref": "#/responses/error" }
-        }
+        },
+        "tags": ["not-yet-implemented"]
       },
       "post": {
         "summary": "Perform an action on the specified vSphere resources",
-        "description": "Making a `POST` request on a vSphere target with an action of `firewall:allow` or `firewall:deny` will update the host firewall on those resources.",
+        "description": "A `POST` request on a vSphere target with an action of `firewall:allow` or `firewall:deny` will update the host firewall on those resources.",
         "parameters": [
           { "$ref": "#/parameters/target" },
           { "$ref": "#/parameters/computeResource" },
@@ -83,13 +85,14 @@
         "responses": {
           "204": { "$ref": "#/responses/success" },
           "default": { "$ref": "#/responses/error" }
-        }
+        },
+        "tags": ["not-yet-implemented"]
       }
     },
     "/target/{target}/vch": {
       "get": {
         "summary": "List VCHs on the target system",
-        "description": "Making a `GET` request on `/vch` under a target will return information about the VCHs on that target.",
+        "description": "A `GET` request on `/vch` under a target will return information about the VCHs on that target.",
         "parameters": [
           { "$ref": "#/parameters/target" },
           { "$ref": "#/parameters/computeResource" },
@@ -102,7 +105,7 @@
       },
       "post": {
         "summary": "Create a VCH on the target system",
-        "description": "Making a `POST` request on `/vch` under a target will create a VCH on that target. Information about the VCH will be provided in the body of the request. Note that validation of the request will occur synchronously, with any errors being returned using an appropriate response code and status. The rest of creation will proceed asynchronously, with errors being reported via a vSphere task that is returned once the synchronous validation is complete.",
+        "description": "A `POST` request on `/vch` under a target will create a VCH on that target. Information about the VCH will be provided in the body of the request. A portion of the request, including validation, will occur synchronously, with any errors being returned using an appropriate response code and status. The rest of the operation will proceed asynchronously. If present, the returned task can be used to track the progress and status of that asynchronous work.",
         "parameters": [
           { "$ref": "#/parameters/target" },
           { "$ref": "#/parameters/vch" },
@@ -117,7 +120,7 @@
     "/target/{target}/vch/{vchId}": {
       "get": {
         "summary": "Get information about the target VCH",
-        "description": "Making a `GET` request on a VCH resource will return information about the VCH. Information about the VCH will be provided in the body of the response in the same format as create.",
+        "description": "A `GET` request on a VCH resource will return information about the VCH. Information about the VCH will be provided in the body of the response in the same format as the `POST` request to create a VCH.",
         "parameters": [
           { "$ref": "#/parameters/target" },
           { "$ref": "#/parameters/vch-id" },
@@ -130,7 +133,7 @@
       },
       "put": {
         "summary": "Reconfigure the target VCH",
-        "description": "Making a `PUT` request on a VCH resource will update that VCH's configuration. Information about the VCH will be provided in the body of the request in the same format as create. Fields which cannot be modified may appear in the body of a `PUT` as long as the value of those fields match the current state of the object. When the value of a field which cannot be modified does not match the current state, a `409 Conflict` will be returned.",
+        "description": "A `PUT` request on a VCH resource will update that VCH's configuration. Information about the VCH will be provided in the body of the request in the same format as the `POST` request to create a VCH. Fields which cannot be modified may appear in the body of a `PUT` as long as the value of those fields match the current state of the object. When the value of a field which cannot be modified does not match the current state, a `409 Conflict` will be returned.",
         "parameters": [
           { "$ref": "#/parameters/target" },
           { "$ref": "#/parameters/vch-id" },
@@ -140,11 +143,12 @@
         "responses": {
           "202": { "$ref": "#/responses/vsphere-task" },
           "default": { "$ref": "#/responses/error" }
-        }
+        },
+        "tags": ["not-yet-implemented"]
       },
       "patch": {
         "summary": "Reconfigure the target VCH",
-        "description": "Making a `PATCH` request on a VCH resource (with a body as described in RFC 7396) will update a subset of that VCH's configuration. As `PATCH` is an explicit request to update a set of fields, fields which cannot be modified must not appear in the body of the `PATCH` request, even if the modification would be a no-op.",
+        "description": "A `PATCH` request on a VCH resource (with a body as described in RFC 7396) will update a subset of that VCH's configuration. As `PATCH` is an explicit request to update a set of fields, fields which cannot be modified must not appear in the body of the `PATCH` request, even if the modification would be a no-op.",
         "consumes": [
           "application/merge-patch+json"
         ],
@@ -157,11 +161,12 @@
         "responses": {
           "202": { "$ref": "#/responses/vsphere-task" },
           "default": { "$ref": "#/responses/error" }
-        }
+        },
+        "tags": ["not-yet-implemented"]
       },
       "post": {
         "summary": "Perform an action on the target VCH",
-        "description": "Making a `POST` request on a VCH resource with an action of `upgrade` will initiate an upgrade of the VCH. The body of the request will be a JSON object containing the following optional properties: `bootstrap-iso` (a reference to a known bootstrap ISO on the OVA) and `rollback` (a boolean value).",
+        "description": "A `POST` request on a VCH resource with an action of `upgrade` will initiate an upgrade of the VCH. The body of the request will be a JSON object containing the following optional properties: `bootstrap-iso` (a reference to a known bootstrap ISO on the OVA) and `rollback` (a boolean value).",
         "parameters": [
           { "$ref": "#/parameters/target" },
           { "$ref": "#/parameters/vch-id" },
@@ -171,11 +176,12 @@
         "responses": {
           "202": { "$ref": "#/responses/vsphere-task" },
           "default": { "$ref": "#/responses/error" }
-        }
+        },
+        "tags": ["not-yet-implemented"]
       },
       "delete": {
         "summary": "Delete the target VCH",
-        "description": "Making a `DELETE` request on a VCH resource will delete that VCH.",
+        "description": "A `DELETE` request on a VCH resource will delete that VCH. By default, the request will fail if the VCH contains powered on Container VMs. By default, volume stores will not be deleted.",
         "parameters": [
           { "$ref": "#/parameters/target" },
           { "$ref": "#/parameters/vch-id" },
@@ -191,7 +197,7 @@
     "/target/{target}/vch/{vchId}/certificate": {
       "get": {
         "summary": "Access the host certificate for a VCH",
-        "description": "Making a GET request on /certificate under a VCH resource will return the certificate the VCH uses when acting as a server, which clients may wish to access to download and add to a trust store.",
+        "description": "A GET request on `/certificate` under a VCH resource will return the certificate the VCH uses when acting as a server, which clients may wish to download and add to a trust store.",
         "produces": [
             "application/x-pem-file"
         ],
@@ -211,7 +217,7 @@
     "/target/{target}/vch/{vchId}/log": {
       "get": {
         "summary": "Access log messages for a VCH",
-        "description": "Making a `GET` request on /log under a VCH resource will return the log messages for vic-machine processes on a VCH",
+        "description": "A `GET` request on `/log` under a VCH resource will return the log messages for the creation process of that VCH.",
         "produces": [ "text/plain" ],
         "parameters": [
           { "$ref": "#/parameters/target" },
@@ -237,7 +243,8 @@
         "responses": {
           "200": { "$ref": "#/responses/target" },
           "default": { "$ref": "#/responses/error" }
-        }
+        },
+        "tags": ["not-yet-implemented"]
       },
       "post": {
         "summary": "Perform an action on the specified vSphere resources",
@@ -252,13 +259,14 @@
         "responses": {
           "204": { "$ref": "#/responses/success" },
           "default": { "$ref": "#/responses/error" }
-        }
+        },
+        "tags": ["not-yet-implemented"]
       }
     },
     "/target/{target}/datacenter/{datacenter}/vch": {
       "get": {
         "summary": "List VCHs in the specified datacenter of the target system",
-        "description": "Making a `GET` request on `/vch` under a datacenter will return information about the VCHs in that datacenter.",
+        "description": "A `GET` request on `/vch` under a datacenter will return information about the VCHs in that datacenter.",
         "parameters": [
           { "$ref": "#/parameters/target" },
           { "$ref": "#/parameters/datacenter" },
@@ -272,7 +280,7 @@
       },
       "post": {
         "summary": "Create a VCH on the target system",
-        "description": "Making a `POST` request on `/vch` under a datacenter will create a VCH in that datacenter. Information about the VCH will be provided in the body of the request. Note that validation of the request will occur synchronously, with any errors being returned using an appropriate response code and status. The rest of creation will proceed asynchronously, with errors being reported via a vSphere task that is returned once the synchronous validation is complete.",
+        "description": "A `POST` request on `/vch` under a datacenter will create a VCH in that datacenter. Information about the VCH will be provided in the body of the request. A portion of the request, including validation, will occur synchronously, with any errors being returned using an appropriate response code and status. The rest of the operation will proceed asynchronously. If present, the returned task can be used to track the progress and status of that asynchronous work.",
         "parameters": [
           { "$ref": "#/parameters/target" },
           { "$ref": "#/parameters/datacenter" },
@@ -288,7 +296,7 @@
     "/target/{target}/datacenter/{datacenter}/vch/{vchId}": {
       "get": {
         "summary": "Get information about the target VCH",
-        "description": "Making a `GET` request on a VCH resource will return information about the VCH. Information about the VCH will be provided in the body of the response in the same format as create.",
+        "description": "A `GET` request on a VCH resource will return information about the VCH. Information about the VCH will be provided in the body of the response in the same format as the `POST` request to create a VCH.",
         "parameters": [
           { "$ref": "#/parameters/target" },
           { "$ref": "#/parameters/datacenter" },
@@ -302,7 +310,7 @@
       },
       "put": {
         "summary": "Reconfigure the target VCH",
-        "description": "Making a `PUT` request on a VCH resource will update that VCH's configuration. Information about the VCH will be provided in the body of the request in the same format as create. Fields which cannot be modified may appear in the body of a `PUT` as long as the value of those fields match the current state of the object. When the value of a field which cannot be modified does not match the current state, a `409 Conflict` will be returned.",
+        "description": "A `PUT` request on a VCH resource will update that VCH's configuration. Information about the VCH will be provided in the body of the request in the same format as the `POST` request to create a VCH. Fields which cannot be modified may appear in the body of a `PUT` as long as the value of those fields match the current state of the object. When the value of a field which cannot be modified does not match the current state, a `409 Conflict` will be returned.",
         "parameters": [
           { "$ref": "#/parameters/target" },
           { "$ref": "#/parameters/datacenter" },
@@ -313,11 +321,12 @@
         "responses": {
           "202": { "$ref": "#/responses/vsphere-task" },
           "default": { "$ref": "#/responses/error" }
-        }
+        },
+        "tags": ["not-yet-implemented"]
       },
       "patch": {
         "summary": "Reconfigure the target VCH",
-        "description": "Making a `PATCH` request on a VCH resource (with a body as described in RFC 7396) will update a subset of that VCH's configuration. As `PATCH` is an explicit request to update a set of fields, fields which cannot be modified must not appear in the body of the `PATCH` request, even if the modification would be a no-op.",
+        "description": "A `PATCH` request on a VCH resource (with a body as described in RFC 7396) will update a subset of that VCH's configuration. As `PATCH` is an explicit request to update a set of fields, fields which cannot be modified must not appear in the body of the `PATCH` request, even if the modification would be a no-op.",
         "consumes": [
           "application/merge-patch+json"
         ],
@@ -331,11 +340,12 @@
         "responses": {
           "202": { "$ref": "#/responses/vsphere-task" },
           "default": { "$ref": "#/responses/error" }
-        }
+        },
+        "tags": ["not-yet-implemented"]
       },
       "post": {
         "summary": "Perform an action on the target VCH",
-        "description": "Making a `POST` request on a VCH resource with an action of `upgrade` will initiate an upgrade of the VCH. The body of the request will be a JSON object containing the following optional properties: `bootstrap-iso` (a reference to a known bootstrap ISO on the OVA) and `rollback` (a boolean value).",
+        "description": "A `POST` request on a VCH resource with an action of `upgrade` will initiate an upgrade of the VCH. The body of the request will be a JSON object containing the following optional properties: `bootstrap-iso` (a reference to a known bootstrap ISO on the OVA) and `rollback` (a boolean value).",
         "parameters": [
           { "$ref": "#/parameters/target" },
           { "$ref": "#/parameters/datacenter" },
@@ -346,11 +356,12 @@
         "responses": {
           "202": { "$ref": "#/responses/vsphere-task" },
           "default": { "$ref": "#/responses/error" }
-        }
+        },
+        "tags": ["not-yet-implemented"]
       },
       "delete": {
         "summary": "Delete the target VCH",
-        "description": "Making a `DELETE` request on a VCH resource will delete that VCH.",
+        "description": "A `DELETE` request on a VCH resource will delete that VCH. By default, the request will fail if the VCH contains powered on Container VMs. By default, volume stores will not be deleted.",
         "parameters": [
           { "$ref": "#/parameters/target" },
           { "$ref": "#/parameters/datacenter" },
@@ -366,8 +377,8 @@
     },
     "/target/{target}/datacenter/{datacenter}/vch/{vchId}/certificate": {
       "get": {
-        "summary": "Access the host certificate for a VCH in a particular datacenter",
-        "description": "Making a GET request on /certificate under a VCH resource will return the certificate the VCH uses when acting as a server, which clients may wish to access to download and add to a trust store.",
+        "summary": "Access the host certificate for a VCH",
+        "description": "A GET request on `/certificate` under a VCH resource will return the certificate the VCH uses when acting as a server, which clients may wish to download and add to a trust store.",
         "produces": [
             "application/x-pem-file"
         ],
@@ -387,8 +398,8 @@
     },
     "/target/{target}/datacenter/{datacenter}/vch/{vchId}/log": {
       "get": {
-        "summary": "Access log messages for a VCH in a particular datacenter",
-        "description": "Making a `GET` request on /log under a VCH resource will return the log messages for vic-machine processes on a VCH.",
+        "summary": "Access log messages for a VCH",
+        "description": "A `GET` request on `/log` under a VCH resource will return the log messages for the creation process of that VCH.",
         "produces": [ "text/plain" ],
         "parameters": [
           { "$ref": "#/parameters/target" },
@@ -1054,7 +1065,7 @@
         "type": "string"
       },
       "examples": {
-        "text/plain": "v1.1.0-xxx-0-000000"
+        "text/plain": "v1.3.0-xxx-0-000000"
       }
     }
   },


### PR DESCRIPTION
Correct various minor issues and inconsistencies in the swagger definition for the VCH Management API so that it accurately communicates what has been implemented.

`[specific ci=Group23-VIC-Machine-Service]`