### PR TITLE
[specific ci=12-01-Delete] Use VIC 1.1.1 instead of 0.6 in 12-01-Delete test

### DIFF
--- a/tests/test-cases/Group12-VCH-BC/12-01-Delete.md
+++ b/tests/test-cases/Group12-VCH-BC/12-01-Delete.md
@@ -2,14 +2,14 @@ Test 12-01 - Delete
 =======
 
 # Purpose:
-To verify vic-machine delete can delete VCH created by vic 0.6.0
+To verify vic-machine delete can delete VCH and its containers created by vic 1.1.1
 
 # Environment:
 This test requires that a vSphere server is running and available
 
 # Test Steps:
-1. Download vic_0.6.0.tar.gz from gcp
-2. Deploy VIC 0.6.0 to vsphere server
+1. Download vic_1.1.1.tar.gz from gcp
+2. Deploy VIC 1.1.1 to vSphere server
 3. Create container
 3. Using latest version vic-machine to delete this VCH
 


### PR DESCRIPTION
This commit fixes a regression failure seen in the 12-01-Delete
integration test. Commit 42fbe58 added functionality to prevent
non-containerVMs from being deleted by vic-machine. However, there was
a regression in the 12-01-Delete test where a container created by a
0.6.0 vic-machine binary was not removed by a forced vic-machine delete
using the latest binary.

The failure was because the vic-machine delete logic was unable to find
the resource pool that the 0.6.0 VCH belonged to. This was due to a VCH
configuration field that wasn't used in 0.6.0. Therefore, the forced
vic-machine delete operation proceeded without deleting the container
and completed successfully.

This change uses VIC 1.1.1 to install the VCH in the test instead of
0.6.0, since 1.1.1 is an acceptable backwards-compatible scenario and
0.6.0 is outdated.