### PR TITLE
Additional retry case for image store creation

### DIFF
--- a/pkg/vsphere/tasks/waiter.go
+++ b/pkg/vsphere/tasks/waiter.go
@@ -166,6 +166,9 @@ func IsRetryError(op trace.Operation, err error) bool {
 		case *types.InvalidArgument:
 			logExpectedFault(op, taskFault, f)
 			return true
+		case *types.HostCommunication:
+			logExpectedFault(op, taskFault, f)
+			return true
 		default:
 			logFault(op, err.Fault())
 			return false


### PR DESCRIPTION
Adds an additional retry when a task error is
encountered during image store creation.

Fixes #4858
