### PR TITLE
Allow API to delete VCHs of other versions [specific ci=Group23-VIC-Machine-Service]

### DIFF
--- a/lib/apiservers/service/restapi/handlers/vch_delete.go
+++ b/lib/apiservers/service/restapi/handlers/vch_delete.go
@@ -103,8 +103,7 @@ func deleteVCH(op trace.Operation, d *data.Data, validator *validate.Validator, 
 	// compare vch version and vic-machine version
 	installerBuild := version.GetBuild()
 	if vchConfig.Version == nil || !installerBuild.Equal(vchConfig.Version) {
-		err = fmt.Errorf("VCH version %q is different than API version %s", vchConfig.Version.ShortVersion(), installerBuild.ShortVersion())
-		return util.WrapError(http.StatusBadRequest, err)
+		op.Debugf("VCH version %q is different than API version %s", vchConfig.Version.ShortVersion(), installerBuild.ShortVersion())
 	}
 
 	deleteContainers, deleteVolumeStores := fromDeletionSpecification(specification)


### PR DESCRIPTION
The default (i.e., non-force) behavior for the CLI is to fail to delete a VCH if the version does not match the `vic-machine` version.

The API mimicked that behavior, but should instead attempt deletion.

Fixes #6862 