### PR TITLE
Specify host parameter to datastore download command

### DIFF
--- a/tests/resources/VCH-Util.robot
+++ b/tests/resources/VCH-Util.robot
@@ -371,9 +371,9 @@ Gather Logs From Test Server
     ${out}=  Run  curl -k -b vic-admin-cookies %{VIC-ADMIN}/container-logs.zip -o ${SUITE NAME}-%{VCH-NAME}-container-logs${name-suffix}.zip
     Log  ${out}
     Remove File  vic-admin-cookies
-    ${out}=  Run  govc datastore.download %{VCH-NAME}/vmware.log %{VCH-NAME}-vmware${name-suffix}.log
+    ${out}=  Run  govc datastore.download -host $(govc vm.info %{VCH-NAME} | grep Host: | awk '{print $2}') %{VCH-NAME}/vmware.log %{VCH-NAME}-vmware${name-suffix}.log
     Should Contain  ${out}  OK
-    ${out}=  Run  govc datastore.download %{VCH-NAME}/tether.debug %{VCH-NAME}-tether${name-suffix}.debug
+    ${out}=  Run  govc datastore.download -host $(govc vm.info %{VCH-NAME} | grep Host: | awk '{print $2}') %{VCH-NAME}/tether.debug %{VCH-NAME}-tether${name-suffix}.debug
     Should Contain  ${out}  OK
     Run Keyword If  '%{HOST_TYPE}' == 'ESXi'  Run  govc logs -log=vmkernel -n=10000 > vmkernel${name-suffix}.log
 

--- a/tests/resources/VCH-Util.robot
+++ b/tests/resources/VCH-Util.robot
@@ -371,9 +371,10 @@ Gather Logs From Test Server
     ${out}=  Run  curl -k -b vic-admin-cookies %{VIC-ADMIN}/container-logs.zip -o ${SUITE NAME}-%{VCH-NAME}-container-logs${name-suffix}.zip
     Log  ${out}
     Remove File  vic-admin-cookies
-    ${out}=  Run  govc datastore.download -host $(govc vm.info %{VCH-NAME} | grep Host: | awk '{print $2}') %{VCH-NAME}/vmware.log %{VCH-NAME}-vmware${name-suffix}.log
+    ${host}=  Get VM Host Name  %{VCH-NAME}
+    ${out}=  Run  govc datastore.download -host ${host} %{VCH-NAME}/vmware.log %{VCH-NAME}-vmware${name-suffix}.log
     Should Contain  ${out}  OK
-    ${out}=  Run  govc datastore.download -host $(govc vm.info %{VCH-NAME} | grep Host: | awk '{print $2}') %{VCH-NAME}/tether.debug %{VCH-NAME}-tether${name-suffix}.debug
+    ${out}=  Run  govc datastore.download -host ${host} %{VCH-NAME}/tether.debug %{VCH-NAME}-tether${name-suffix}.debug
     Should Contain  ${out}  OK
     Run Keyword If  '%{HOST_TYPE}' == 'ESXi'  Run  govc logs -log=vmkernel -n=10000 > vmkernel${name-suffix}.log
 


### PR DESCRIPTION
If we combine the jenkins logs from both 6.0 longevity with 6.5 longevity, we see that the the problem began on Nov 20th between 9:50AM and 1:27PM and affects both systems seemingly equally. Which leads me to believe that something changed in our software at the same time as that is the common denominator.  I went back to the VIC 1.2.1 build and continue to see the problem, which narrows it down to something outside of the engine code itself and we find this commit which happened on Nov 20th 1:10PM:
https://github.com/vmware/vic/pull/6788
Reverting to govc 0.15 immediately seemed to fix the problem on longevity 6.5, the upgrade from govc 0.15 to 0.16 included what looks like close to 100 commits over the course of almost 6 months.