### PR TITLE
cherry-pick: Exclude vic-machine-server from the engine tarball (#6871)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -446,7 +446,7 @@ $(gandalf):  $$(call godeps,cmd/gandalf/*.go)
 	@GOARCH=amd64 GOOS=linux $(TIME) $(GO) build $(RACE) -ldflags "$(LDFLAGS)" -o ./$@ ./$(dir $<)
 
 distro: all
-	@tar czvf $(REV).tar.gz bin/*.iso bin/vic-machine-*
+	@tar czvf $(REV).tar.gz bin/*.iso bin/vic-machine-* --exclude=bin/vic-machine-server
 
 mrrobot:
 	@rm -rf *.xml *.html *.log *.zip VCH-0-*


### PR DESCRIPTION
A wildcard pattern in old code which packaged up all platform-specific variants of `vic-machine` matched `vic-machine-server` as well.

Add an explicit exclusion for `vic-machine-server` so that it is not included in engine tar downloaded by users via the fileserver.

Fixes #6864