### PR TITLE
Fix version string in log output

### DIFF
--- a/lib/apiservers/service/restapi/configure_vic_machine.go
+++ b/lib/apiservers/service/restapi/configure_vic_machine.go
@@ -67,7 +67,7 @@ func configureAPI(api *operations.VicMachineAPI) http.Handler {
 	// configure logging to user specified directory
 	logger = configureLogger()
 	api.Logger = logger.Infof
-	api.Logger("Starting Service. Version: %q", version.GetBuild())
+	api.Logger("Starting Service. Version: %q", version.GetBuild().ShortVersion())
 
 	api.JSONConsumer = runtime.JSONConsumer()
 

--- a/lib/apiservers/service/restapi/handlers/vch_create.go
+++ b/lib/apiservers/service/restapi/handlers/vch_create.go
@@ -145,7 +145,7 @@ func setUpLogger(op *trace.Operation) *vchlog.VCHLogger {
 	op.Logger.Level = logrus.DebugLevel
 	op.Logger.Formatter = viclog.NewTextFormatter()
 
-	op.Logger.Infof("Starting API-based VCH Creation. Version: %q", version.GetBuild())
+	op.Logger.Infof("Starting API-based VCH Creation. Version: %q", version.GetBuild().ShortVersion())
 
 	go log.Run()
 


### PR DESCRIPTION
This change fixes the version string shown in the `vic-machine-server` logs during startup.

Partially fixes https://github.com/vmware/vic-product/issues/1170