### PR TITLE
Improve NFS nightly test to reliably get the IP of the VCH after reboot

### DIFF
--- a/tests/manual-test-cases/Group5-Functional-Tests/5-22-NFS-Volume.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-22-NFS-Volume.robot
@@ -98,15 +98,7 @@ Reboot VM and Verify Basic VCH Info
     Log To Console  Rebooting VCH\n - %{VCH-NAME}
     Reboot VM  %{VCH-NAME}
 
-    Log To Console  Getting VCH IP ...
-    ${new_vch_ip}=  Get VM IP  %{VCH-NAME}
-    Log To Console  New VCH IP is ${new_vch_ip}
-    ${updated_vch_ip}=  Replace String  %{VCH-PARAMS}  %{VCH-IP}  ${new_vch_ip}
-    Should Contain  %{VCH-PARAMS}  ${new_vch_ip}
-    Should Be Equal  ${updated_vch_ip}  %{VCH-PARAMS}
-
-    # wait for docker info to succeed
-    Wait Until Keyword Succeeds  20x  5 seconds  Run Docker Info  %{VCH-PARAMS}
+    Wait For VCH Initialization
 
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} images
     Should Be Equal As Integers  ${rc}  0


### PR DESCRIPTION
This will address the changing IP address of the VCH upon reboot(if it does change). Previously we looked once and then retried with that IP a bunch. with the change to using `Wait For VCH Initialization` the parameter `VCH-PARAMS` should get updated repeatedly until the VCH presents with a viable IP address. This is a patch provided by @hickeng I am just the messenger and applier, all praise goes to him.  

this behavior was seen in this run of the nightlies ----> [5-22-NFS-Volume.zip](https://github.com/vmware/vic/files/1522816/5-22-NFS-Volume.zip)

No official issue was filed for this since it was previously suspected as part of another failure. @andrewtchin is the current triage master, I will ask further about a ticket. 
