### PR TITLE
Cherry Pick: CreateImageStore returns vSphere error allowing retry

### DIFF
--- a/lib/apiservers/portlayer/restapi/handlers/storage_handlers.go
+++ b/lib/apiservers/portlayer/restapi/handlers/storage_handlers.go
@@ -57,8 +57,7 @@ const (
 func (h *StorageHandlersImpl) Configure(api *operations.PortLayerAPI, handlerCtx *HandlerContext) {
 	var err error
 
-	ctx := context.Background()
-	op := trace.NewOperation(ctx, "configure")
+	op := trace.NewOperation(context.Background(), "configure storage layer")
 
 	if len(spl.Config.ImageStores) == 0 {
 		op.Panicf("No image stores provided; unable to instantiate storage layer")
@@ -165,6 +164,7 @@ func (h *StorageHandlersImpl) configureVolumeStores(op trace.Operation, handlerC
 func (h *StorageHandlersImpl) CreateImageStore(params storage.CreateImageStoreParams) middleware.Responder {
 	op := trace.NewOperation(context.Background(), fmt.Sprintf("CreateImageStore(%s)", params.Body.Name))
 	name := params.Body.Name
+	defer trace.End(trace.Begin(fmt.Sprintf("CreateImageStore: %s", name), op))
 
 	registerImageStore := func(h *StorageHandlersImpl, name string) {
 		// register image store importer/export

--- a/lib/portlayer/storage/vsphere/image.go
+++ b/lib/portlayer/storage/vsphere/image.go
@@ -640,7 +640,7 @@ func (v *ImageStore) deleteImage(op trace.Operation, storeName, ID string) error
 
 // Find any image directories without the manifest file and remove them.
 func (v *ImageStore) cleanup(op trace.Operation, store *url.URL) error {
-	op.Infof("Checking for inconsistent images on %s", store.String())
+	defer trace.End(trace.Begin(fmt.Sprintf("Checking for inconsistent images on %s", store.String()), op))
 
 	storeName, err := util.ImageStoreName(store)
 	if err != nil {

--- a/pkg/trace/operation.go
+++ b/pkg/trace/operation.go
@@ -226,7 +226,11 @@ func opID(opNum uint64) string {
 
 // NewOperation will return a new operation with operationID added as a value to the context
 func NewOperation(ctx context.Context, format string, args ...interface{}) Operation {
-	return newOperation(ctx, opID(atomic.AddUint64(&opCount, 1)), 3, fmt.Sprintf(format, args...))
+	o := newOperation(ctx, opID(atomic.AddUint64(&opCount, 1)), 3, fmt.Sprintf(format, args...))
+
+	frame := o.t[0]
+	o.Debugf("[NewOperation] %s [%s:%d]", o.header(), frame.funcName, frame.lineNo)
+	return o
 }
 
 // NewOperationWithLoggerFrom will return a new operation with operationID added as a value to the


### PR DESCRIPTION

- Propagate vSphere error allowing retry
- Log when a new operation is created
- Additional logging during ImageStore creation

Fixes #4858

