### PR TITLE
Use correct invocation of docker network ls

### DIFF
--- a/tests/resources/Docker-Util.robot
+++ b/tests/resources/Docker-Util.robot
@@ -226,7 +226,7 @@ Do Volumes Exist
     [Return]  ${true}
 
 Do Networks Exist
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} networks ls -q
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} network ls -q
     ${len}=  Get Length  ${output}
     Return From Keyword If  ${len} == 0  ${false}
     [Return]  ${true}


### PR DESCRIPTION
Found this while investigating a failed merge to master here. 

logs: 
[Test-Cases.Group1-Docker-Commands.1-18-Docker-Network-RM-VCH-15223-5080-container-logs.zip](https://github.com/vmware/vic/files/1536768/Test-Cases.Group1-Docker-Commands.1-18-Docker-Network-RM-VCH-15223-5080-container-logs.zip)
[log.html.zip](https://github.com/vmware/vic/files/1536770/log.html.zip)


