### PR TITLE
 [skip ci] Wait longer for portlayer to come up

### DIFF
--- a/tests/manual-test-cases/Group5-Functional-Tests/5-4-High-Availability.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-4-High-Availability.robot
@@ -16,7 +16,7 @@
 Documentation  Test 5-4 - High Availability
 Resource  ../../resources/Util.robot
 Suite Setup  Wait Until Keyword Succeeds  10x  10m  High Availability Setup
-#Suite Teardown  Nimbus Cleanup  ${list}
+Suite Teardown  Nimbus Cleanup  ${list}
 Test Teardown  Run Keyword If Test Failed  Gather Logs From Test Server
 
 *** Variables ***

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-4-High-Availability.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-4-High-Availability.robot
@@ -16,7 +16,7 @@
 Documentation  Test 5-4 - High Availability
 Resource  ../../resources/Util.robot
 Suite Setup  Wait Until Keyword Succeeds  10x  10m  High Availability Setup
-Suite Teardown  Nimbus Cleanup  ${list}
+#Suite Teardown  Nimbus Cleanup  ${list}
 Test Teardown  Run Keyword If Test Failed  Gather Logs From Test Server
 
 *** Variables ***
@@ -209,7 +209,7 @@ Test
     Wait Until Keyword Succeeds  24x  10s  VM Host Has Changed  ${curHost}  %{VCH-NAME}
 
     # Wait for the VCH to come back up fully - if it's not completely reinitialized it will still report the old IP address 
-    Wait For VCH Initialization
+    Wait For VCH Initialization  12x  20 seconds
 
     ${info}=  Run  govc vm.info \\*
     Log  ${info}


### PR DESCRIPTION
Manually executing the HA testplan I saw port layer take longer than initial waiting period to come up:
```
Dec  7 2017 21:50:40.544Z INFO  Waiting for portlayer to come up
Dec  7 2017 21:54:28.594Z INFO  Portlayer is up and responding to pings
```