### PR TITLE
Guest shutdown support in endpointVM

### DIFF
--- a/cmd/port-layer-server/main.go
+++ b/cmd/port-layer-server/main.go
@@ -149,6 +149,9 @@ func main() {
 	go func() {
 		<-sig
 
+		// if vspc server fails to shut down in a timely manner then the clean endpointVM shutdown will fail
+		// this failure to shut down cleanly can be observed in the "/var/log/vic/init.log" or
+		// "[datastore] endpointVM/tether.debug" log files as vic-init will report that it's waiting for the portlayer to exit.
 		vspc.Stop()
 		dnsserver.Stop()
 		restapi.StopAPIServers()

--- a/cmd/tether/main_test.go
+++ b/cmd/tether/main_test.go
@@ -135,6 +135,10 @@ func (m *mockery) Stop() error {
 	return nil
 }
 
+func (m *mockery) Wait(ctx context.Context) error {
+	return nil
+}
+
 func (m *mockery) Register(name string, config tether.Extension) {
 }
 

--- a/cmd/vic-init/main_linux.go
+++ b/cmd/vic-init/main_linux.go
@@ -15,7 +15,10 @@
 package main
 
 import (
+	"context"
+	"errors"
 	"os"
+	"os/signal"
 	"runtime/debug"
 	"syscall"
 	"time"
@@ -25,6 +28,7 @@ import (
 
 	"github.com/vmware/govmomi/toolbox"
 	"github.com/vmware/vic/lib/tether"
+	"github.com/vmware/vic/lib/tether/shared"
 	viclog "github.com/vmware/vic/pkg/log"
 	"github.com/vmware/vic/pkg/log/syslog"
 	"github.com/vmware/vic/pkg/logmgr"
@@ -78,6 +82,8 @@ func main() {
 
 	extraconfig.Decode(src, &config)
 	debugLevel = config.Diagnostics.DebugLevel
+
+	startSignalHandler()
 
 	logcfg := viclog.NewLoggingConfig()
 	if debugLevel > 0 {
@@ -136,32 +142,79 @@ func main() {
 	log.Info("Clean exit from init")
 }
 
-// exit cleanly shuts down the system
-func halt() {
-	log.Infof("Powering off the system")
-	if debugLevel > 0 {
-		log.Info("Squashing power off for debug init")
-		return
+// exitTether signals the current process, which triggers tether.Stop and the killing of its children.
+// NOTE: I don't like having this here and it really needs to be moved into an interface that
+// can be provided to toolbox for system callbacks. While this could be part of the Operations
+// interface I think I'd rather have a separate one specifically for the possible toolbox interactions.
+func exitTether() error {
+	defer trace.End(trace.Begin(""))
+
+	p, err := os.FindProcess(os.Getpid())
+	if err != nil {
+		return err
 	}
+
+	if err = p.Signal(syscall.SIGUSR2); err != nil {
+		return err
+	}
+
+	return err
+}
+
+// exit cleanly shuts down the system
+func halt() error {
+	log.Infof("Powering off the system")
+
+	err := exitTether()
+	if err != nil {
+		log.Warn(err)
+	}
+
+	if debugLevel > 2 {
+		log.Info("Squashing power off for debug init")
+		return errors.New("debug config suppresses shutdown")
+	}
+
+	timeout, cancel := context.WithTimeout(context.Background(), shared.GuestShutdownTimeout)
+	err = tthr.Wait(timeout)
+	cancel()
 
 	syscall.Sync()
 	syscall.Reboot(syscall.LINUX_REBOOT_CMD_POWER_OFF)
+
+	return err
 }
 
-func reboot() {
+func reboot() error {
 	log.Infof("Rebooting the system")
-	if debugLevel > 0 {
-		log.Info("Squashing reboot for debug init")
-		return
+
+	err := exitTether()
+	if err != nil {
+		log.Warn(err)
 	}
+
+	if debugLevel > 2 {
+		log.Info("Squashing reboot for debug init")
+		return errors.New("debug config suppresses reboot")
+	}
+
+	timeout, cancel := context.WithTimeout(context.Background(), shared.GuestRebootTimeout)
+	err = tthr.Wait(timeout)
+	cancel()
 
 	syscall.Sync()
 	syscall.Reboot(syscall.LINUX_REBOOT_CMD_RESTART)
+
+	return err
 }
 
 func configureToolbox(t *tether.Toolbox) *tether.Toolbox {
 	cmd := t.Service.Command
 	cmd.ProcessStartCommand = startCommand
+
+	t.Power.Halt.Handler = halt
+	t.Power.Reboot.Handler = reboot
+	t.Power.Suspend.Handler = exitTether
 
 	return t
 }
@@ -200,4 +253,32 @@ func defaultIP() string {
 	}
 
 	return toolbox.DefaultIP()
+}
+
+// This code is mirrored in cmd/tether/main_linux.go and should be de-duped
+func startSignalHandler() {
+	sigs := make(chan os.Signal, 1)
+	signal.Notify(sigs, syscall.SIGHUP, syscall.SIGUSR1, syscall.SIGUSR2, syscall.SIGPWR, syscall.SIGTERM, syscall.SIGINT)
+
+	go func() {
+		for s := range sigs {
+			switch s {
+			case syscall.SIGHUP:
+				log.Infof("Reloading tether configuration")
+				tthr.Reload()
+			case syscall.SIGUSR1, syscall.SIGUSR2, syscall.SIGPWR:
+				log.Infof("Stopping tether via signal %s", s.String())
+				tthr.Stop()
+				return
+			case syscall.SIGTERM, syscall.SIGINT:
+				log.Infof("Stopping system in lieu of restart handling via signal %s", s.String())
+				// TODO: update this to adjust power off handling for reboot
+				// this should be in guest reboot rather than power cycle
+				tthr.Stop()
+				return
+			default:
+				log.Infof("%s signal not defined", s.String())
+			}
+		}
+	}()
 }

--- a/cmd/vicadmin/server.go
+++ b/cmd/vicadmin/server.go
@@ -519,6 +519,8 @@ func (s *server) serve() error {
 func (s *server) stop() error {
 	defer trace.End(trace.Begin(""))
 
+	s.uss.Destroy()
+
 	if s.l != nil {
 		err := s.l.Close()
 		s.l = nil

--- a/cmd/vicadmin/usersession.go
+++ b/cmd/vicadmin/usersession.go
@@ -69,6 +69,13 @@ func (u *UserSessionStore) Add(id string, config *session.Config, vs *session.Se
 func (u *UserSessionStore) Delete(id string) {
 	u.mutex.Lock()
 	defer u.mutex.Unlock()
+
+	us := u.sessions[id]
+	if us != nil && us.vsphere != nil {
+		log.Infof("Logging out vSphere session for %s", id)
+		us.vsphere.Logout(context.Background())
+	}
+
 	delete(u.sessions, id)
 }
 
@@ -109,6 +116,13 @@ func (u *UserSessionStore) reaper() {
 				u.Delete(id)
 			}
 		}
+	}
+}
+
+// Destroy will logout and delete all sessions in the store, irrespective of expiration
+func (u *UserSessionStore) Destroy() {
+	for id := range u.sessions {
+		u.Delete(id)
 	}
 }
 

--- a/cmd/vicadmin/vicadm.go
+++ b/cmd/vicadmin/vicadm.go
@@ -613,15 +613,9 @@ func main() {
 	}
 
 	log.Infof("listening on %s", s.addr)
-	signals := []syscall.Signal{
-		syscall.SIGTERM,
-		syscall.SIGINT,
-	}
 
 	sigchan := make(chan os.Signal, 1)
-	for _, signum := range signals {
-		signal.Notify(sigchan, signum)
-	}
+	signal.Notify(sigchan, syscall.SIGTERM, syscall.SIGINT)
 
 	go func() {
 		signal := <-sigchan

--- a/infra/scripts/replace-running-components.sh
+++ b/infra/scripts/replace-running-components.sh
@@ -152,7 +152,7 @@ function replace-component() {
     if [[ $1 == "vic-init" ]]; then
         on-vch systemctl restart vic-init
     else
-        on-vch kill -9 $pid
+        on-vch kill -TERM $pid
     fi
 }
 

--- a/lib/apiservers/engine/backends/backends.go
+++ b/lib/apiservers/engine/backends/backends.go
@@ -154,6 +154,18 @@ func Init(portLayerAddr, product string, port uint, config *config.VirtualContai
 	return nil
 }
 
+// Finalize performs cleanup before a graceful exit of the API server.
+// In this case that means logging out the dynamic config session if any.
+func Finalize(ctx context.Context) error {
+	log.Info("Shutting down docker API server backend")
+
+	if vchConfig != nil && vchConfig.sess != nil {
+		vchConfig.sess.Logout(ctx)
+	}
+
+	return nil
+}
+
 func hydrateCaches(op trace.Operation) error {
 	const waiters = 3
 

--- a/lib/apiservers/engine/backends/backends.go
+++ b/lib/apiservers/engine/backends/backends.go
@@ -532,7 +532,7 @@ func newSession(ctx context.Context, config *config.VirtualContainerHostConfigSp
 		User:       url.UserPassword(config.Username, config.Token),
 		Thumbprint: config.TargetThumbprint,
 		Keepalive:  defaultSessionKeepAlive,
-		UserAgent:  version.UserAgent("vic-engine"),
+		UserAgent:  version.UserAgent("vic-dynamic-config"),
 	}
 
 	sess := session.NewSession(sessCfg)

--- a/lib/install/management/configure.go
+++ b/lib/install/management/configure.go
@@ -285,18 +285,10 @@ func (d *Dispatcher) deleteISOs(ds *object.Datastore, settings *data.InstallerDa
 func (d *Dispatcher) update(conf *config.VirtualContainerHostConfigSpec, settings *data.InstallerData) error {
 	defer trace.End(trace.Begin(conf.Name, d.op))
 
-	power, err := d.appliance.PowerState(d.op)
+	err := d.powerOffVM(d.appliance)
 	if err != nil {
-		d.op.Errorf("Failed to get vm power status %q: %s", d.appliance.Reference(), err)
+		d.op.Errorf("Failed to power off appliance: %s", err)
 		return err
-	}
-	if power != types.VirtualMachinePowerStatePoweredOff {
-		if _, err = d.appliance.WaitForResult(d.op, func(ctx context.Context) (tasks.Task, error) {
-			return d.appliance.PowerOff(ctx)
-		}); err != nil {
-			d.op.Errorf("Failed to power off appliance: %s", err)
-			return err
-		}
 	}
 
 	isoFile := ""

--- a/lib/install/management/delete.go
+++ b/lib/install/management/delete.go
@@ -350,19 +350,10 @@ func (d *Dispatcher) deleteNetworkDevices(vmm *vm.VirtualMachine, conf *config.V
 
 	d.op.Info("Removing appliance VM network devices")
 
-	power, err := vmm.PowerState(d.op)
+	err := d.powerOffVM(vmm)
 	if err != nil {
-		d.op.Errorf("Failed to get vm power status %q: %s", vmm.Reference(), err)
+		d.op.Errorf("Failed to power off existing appliance for %s", err)
 		return err
-
-	}
-	if power != types.VirtualMachinePowerStatePoweredOff {
-		if _, err = vmm.WaitForResult(d.op, func(ctx context.Context) (tasks.Task, error) {
-			return vmm.PowerOff(ctx)
-		}); err != nil {
-			d.op.Errorf("Failed to power off existing appliance for %s", err)
-			return err
-		}
 	}
 
 	devices, err := d.networkDevices(vmm)

--- a/lib/install/management/resource_pool.go
+++ b/lib/install/management/resource_pool.go
@@ -99,22 +99,24 @@ func (d *Dispatcher) destroyResourcePoolIfEmpty(conf *config.VirtualContainerHos
 		d.op.Warn("Did not find parent VCH resource pool")
 		return nil
 	}
+
 	var vms []*vm.VirtualMachine
 	var err error
 	if vms, err = d.parentResourcepool.GetChildrenVMs(d.op); err != nil {
 		err = errors.Errorf("Unable to get children vm of resource pool %q: %s", d.parentResourcepool.Name(), err)
 		return err
 	}
+
 	if len(vms) != 0 {
-		err = errors.Errorf("Resource pool is not empty: found %d vms under %q", len(vms), d.parentResourcepool.Name())
+		err = errors.Errorf("resource pool %s is not empty (has %d VMs)", d.parentResourcepool.Name(), len(vms))
 		return err
 	}
-	if _, err := tasks.WaitForResult(d.op, func(ctx context.Context) (tasks.Task, error) {
+
+	_, err = tasks.WaitForResult(d.op, func(ctx context.Context) (tasks.Task, error) {
 		return d.parentResourcepool.Destroy(ctx)
-	}); err != nil {
-		return err
-	}
-	return nil
+	})
+
+	return err
 }
 
 func (d *Dispatcher) findResourcePool(path string) (*object.ResourcePool, error) {

--- a/lib/portlayer/exec/base.go
+++ b/lib/portlayer/exec/base.go
@@ -325,11 +325,11 @@ func (c *containerBase) kill(op trace.Operation) error {
 		timeout.Warnf("timeout (%s) waiting for %s to power off via SIG%s", wait, c, sig)
 	}
 	if err != nil {
-		timeout.Warnf("killing %s attempt resulted in: %s", c, err.Error())
-
-		if tasks.IsInvalidPowerStateError(err) {
+		if tasks.IsAlreadyPoweredOffError(err) {
 			return nil
 		}
+
+		timeout.Warnf("killing %s attempt resulted in: %s", c, err.Error())
 	}
 
 	// Even if startGuestProgram failed above, it may actually have executed.  If the container came up and then
@@ -393,7 +393,7 @@ func (c *containerBase) shutdown(op trace.Operation, waitTime *int32) error {
 			// If the error tells us "The attempted operation cannot be performed in the current state (Powered off)" (InvalidPowerState),
 			// we can avoid hard poweroff (issues #6236 and #6252). Here we wait for the power state changes instead of return
 			// immediately to avoid excess vSphere queries
-			if tasks.IsInvalidPowerStateError(err) {
+			if tasks.IsAlreadyPoweredOffError(err) {
 				killed = true
 			}
 		}

--- a/lib/portlayer/exec/container.go
+++ b/lib/portlayer/exec/container.go
@@ -34,6 +34,7 @@ import (
 	"github.com/vmware/vic/lib/iolog"
 	"github.com/vmware/vic/lib/portlayer/event/events"
 	stateevents "github.com/vmware/vic/lib/portlayer/event/events/vsphere"
+	"github.com/vmware/vic/lib/tether/shared"
 	"github.com/vmware/vic/pkg/errors"
 	"github.com/vmware/vic/pkg/trace"
 	"github.com/vmware/vic/pkg/uid"
@@ -475,7 +476,7 @@ func (c *Container) Signal(op trace.Operation, num int64) error {
 		return c.containerBase.kill(op)
 	}
 
-	return c.startGuestProgram(op, "kill", fmt.Sprintf("%d", num))
+	return c.startGuestProgram(op, shared.GuestActionKill, fmt.Sprintf("%d", num))
 }
 
 func (c *Container) onStop() {

--- a/lib/portlayer/exec/exec.go
+++ b/lib/portlayer/exec/exec.go
@@ -179,6 +179,16 @@ func Init(ctx context.Context, sess *session.Session, source extraconfig.DataSou
 	return initializer.err
 }
 
+func Finalize(ctx context.Context) error {
+	collectors := Config.EventManager.Collectors()
+	for name, collector := range collectors {
+		log.Infof("Shutting down event collector %s", name)
+		collector.Stop()
+	}
+
+	return nil
+}
+
 // publishContainerEvent will publish a ContainerEvent to the vic event stream
 func publishContainerEvent(op trace.Operation, id string, created time.Time, eventType string) {
 	if Config.EventManager == nil || eventType == "" {

--- a/lib/portlayer/logging/logging.go
+++ b/lib/portlayer/logging/logging.go
@@ -47,6 +47,12 @@ func Init(ctx context.Context) error {
 	return nil
 }
 
+// TODO: figure out why the Init calls are wrapped in once.Do - implies it can be called
+// multiple times, but once Finalize is called things will not be functional.
+func Finalize(ctx context.Context) error {
+	return nil
+}
+
 // listens migrated events and connects the file backed serial ports
 func eventCallback(ie events.Event) {
 	defer trace.End(trace.Begin(""))

--- a/lib/portlayer/metrics/metrics.go
+++ b/lib/portlayer/metrics/metrics.go
@@ -69,6 +69,14 @@ func Init(ctx context.Context, session *session.Session) error {
 
 }
 
+func Finalize(ctx context.Context) error {
+	if Supervisor != nil && Supervisor.vms != nil {
+		Supervisor.vms.Destroy(ctx)
+	}
+
+	return nil
+}
+
 func newSupervisor(session *session.Session) *super {
 	defer trace.End(trace.Begin(""))
 	// create the vm metric collector

--- a/lib/portlayer/network/network.go
+++ b/lib/portlayer/network/network.go
@@ -116,6 +116,12 @@ func Init(ctx context.Context, sess *session.Session, source extraconfig.DataSou
 	return initializer.err
 }
 
+// TODO: figure out why the Init calls are wrapped in once.Do - implies it can be called
+// multiple times, but once Finalize is called things will not be functional.
+func Finalize(ctx context.Context) error {
+	return nil
+}
+
 // handleEvent processes events
 func handleEvent(netctx *Context, ie events.Event) {
 	switch ie.String() {
@@ -134,7 +140,7 @@ func handleEvent(netctx *Context, ie events.Event) {
 		defer handle.Close()
 
 		if handle.Runtime.PowerState != types.VirtualMachinePowerStatePoweredOff {
-			op.Warnf("Live power state check on power off event shows %s: not unbinding network", ie.Reference(), handle.Runtime.PowerState)
+			op.Warnf("Live power state check on power off event for %s shows %s, therefore not unbinding network", ie.Reference(), handle.Runtime.PowerState)
 			return
 		}
 

--- a/lib/portlayer/portlayer.go
+++ b/lib/portlayer/portlayer.go
@@ -110,6 +110,20 @@ func Init(ctx context.Context, sess *session.Session) error {
 	return nil
 }
 
+func Finalize(ctx context.Context) error {
+	op := trace.NewOperation(context.Background(), "Shutdown")
+	defer trace.End(trace.Begin("", op))
+
+	storage.Finalize(op)
+	store.Finalize(ctx)
+	exec.Finalize(op)
+	network.Finalize(ctx)
+	logging.Finalize(ctx)
+	metrics.Finalize(op)
+
+	return nil
+}
+
 // TakeCareOfSerialPorts disconnects serial ports backed by network on the VCH's old IP and connects serial ports backed by file.
 // This is useful when the appliance or the portlayer restarts and the VCH has a new IP or container vms gets migrated
 // Any errors are logged and portlayer init proceeds as usual.

--- a/lib/portlayer/storage/config.go
+++ b/lib/portlayer/storage/config.go
@@ -17,6 +17,7 @@ package storage
 import (
 	"github.com/vmware/govmomi/view"
 	"github.com/vmware/vic/lib/config"
+	"github.com/vmware/vic/pkg/vsphere/disk"
 )
 
 var Config Configuration
@@ -32,4 +33,7 @@ type Configuration struct {
 	// ContainerView
 	// https://pubs.vmware.com/vsphere-6-0/index.jsp#com.vmware.wssdk.apiref.doc/vim.view.ContainerView.html
 	ContainerView *view.ContainerView
+
+	// Disk Manager for local VM
+	DiskManager *disk.Manager
 }

--- a/lib/portlayer/storage/storage.go
+++ b/lib/portlayer/storage/storage.go
@@ -91,6 +91,14 @@ func Init(ctx context.Context, session *session.Session, pool *object.ResourcePo
 	return err
 }
 
+// TODO: figure out why the Init calls are wrapped in once.Do - implies it can be called
+// multiple times, but once Finalize is called things will not be functional.
+func Finalize(ctx context.Context) error {
+	Config.ContainerView.Destroy(ctx)
+
+	return nil
+}
+
 // RegisterImporter registers the specified importer against the provided store for later retrieval.
 func RegisterImporter(op trace.Operation, store string, i Importer) {
 	op.Infof("Registering importer: %s => %T", store, i)

--- a/lib/portlayer/storage/vsphere/container.go
+++ b/lib/portlayer/storage/vsphere/container.go
@@ -49,14 +49,9 @@ type ContainerStore struct {
 
 // NewContainerStore creates and returns a new container store
 func NewContainerStore(op trace.Operation, s *session.Session, imageResolver storage.Resolver) (*ContainerStore, error) {
-	dm, err := disk.NewDiskManager(op, s, storage.Config.ContainerView)
-	if err != nil {
-		return nil, err
-	}
-
 	cs := &ContainerStore{
 		Vmdk: disk.Vmdk{
-			Manager: dm,
+			Manager: storage.Config.DiskManager,
 			//ds: ds,
 			Session: s,
 		},

--- a/lib/portlayer/storage/vsphere/image.go
+++ b/lib/portlayer/storage/vsphere/image.go
@@ -79,13 +79,9 @@ type ImageStore struct {
 }
 
 func NewImageStore(op trace.Operation, s *session.Session, u *url.URL) (*ImageStore, error) {
-	dm, err := disk.NewDiskManager(op, s, portlayer.Config.ContainerView)
-	if err != nil {
-		return nil, err
-	}
-
 	if DetachAll {
-		if err = dm.DetachAll(op); err != nil {
+		// we can and should assume that Config objects are fully initialized
+		if err := portlayer.Config.DiskManager.DetachAll(op); err != nil {
 			return nil, err
 		}
 	}
@@ -106,7 +102,7 @@ func NewImageStore(op trace.Operation, s *session.Session, u *url.URL) (*ImageSt
 
 	vis := &ImageStore{
 		Vmdk: disk.Vmdk{
-			Manager: dm,
+			Manager: portlayer.Config.DiskManager,
 			Helper:  ds,
 			Session: s,
 		},

--- a/lib/portlayer/storage/vsphere/volume.go
+++ b/lib/portlayer/storage/vsphere/volume.go
@@ -46,13 +46,8 @@ func NewVolumeStore(op trace.Operation, storeName string, s *session.Session, ds
 		return nil, err
 	}
 
-	dm, err := disk.NewDiskManager(op, s, storage.Config.ContainerView)
-	if err != nil {
-		return nil, err
-	}
-
 	if DetachAll {
-		if err = dm.DetachAll(op); err != nil {
+		if err := storage.Config.DiskManager.DetachAll(op); err != nil {
 			return nil, err
 		}
 	}
@@ -64,7 +59,7 @@ func NewVolumeStore(op trace.Operation, storeName string, s *session.Session, ds
 
 	v := &VolumeStore{
 		Vmdk: disk.Vmdk{
-			Manager: dm,
+			Manager: storage.Config.DiskManager,
 			Helper:  ds,
 			Session: s,
 		},

--- a/lib/portlayer/store/store.go
+++ b/lib/portlayer/store/store.go
@@ -81,6 +81,12 @@ func Init(ctx context.Context, session *session.Session, imgStoreURL *url.URL) e
 	return initializer.err
 }
 
+// TODO: figure out why the Init calls are wrapped in once.Do - implies it can be called
+// multiple times, but once Finalize is called things will not be functional.
+func Finalize(ctx context.Context) error {
+	return nil
+}
+
 // Store will return the requested store
 func Store(name string) (kvstore.KeyValueStore, error) {
 	mgr.m.RLock()

--- a/lib/tether/interfaces.go
+++ b/lib/tether/interfaces.go
@@ -77,6 +77,7 @@ type System interface {
 type Tether interface {
 	Start() error
 	Stop() error
+	Wait(ctx context.Context) error
 	Reload()
 	Register(name string, ext Extension)
 }

--- a/lib/tether/shared/constants.go
+++ b/lib/tether/shared/constants.go
@@ -16,13 +16,21 @@
 // to be consistent across packages so as to avoid transitive package includes
 package shared
 
+import "time"
+
 /* Constants used by tether for exchange outside of tether */
 const (
 	DiskLabelQueryName   = "disk-label"
 	FilterSpecQueryName  = "filter-spec"
 	SkipRecurseQueryName = "skip-recurse"
 	SkipDataQueryName    = "skip-data"
+
 	GuestActionReload    = "reload"
 	GuestActionKill      = "kill"
 	GuestActionGroupKill = "group-kill"
+
+	GuestShutdownTimeout = 20 * time.Second
+	GuestRebootTimeout   = 20 * time.Second
+
+	WaitForSessionExitTimeout = 20 * time.Second
 )

--- a/lib/tether/shared/func_linux.go
+++ b/lib/tether/shared/func_linux.go
@@ -22,6 +22,10 @@ import (
 
 var Sys = system.New()
 
-func PIDFileDir() string {
-	return path.Join(Sys.Root, pidFilePath)
+func PIDFileDir(sys *system.System) string {
+	if sys == nil {
+		sys = &Sys
+	}
+
+	return path.Join(sys.Root, pidFilePath)
 }

--- a/lib/tether/tether.go
+++ b/lib/tether/tether.go
@@ -84,6 +84,11 @@ type tether struct {
 	ctx    context.Context
 	cancel context.CancelFunc
 
+	// Cancelable context and its cancel func specifically for Reload loop.
+	// This allows us to trigger a staged shutdown
+	reloadCtx    context.Context
+	reloadCancel context.CancelFunc
+
 	incoming chan os.Signal
 
 	// syslog writer shared by all sessions
@@ -95,18 +100,21 @@ type tether struct {
 
 func New(src extraconfig.DataSource, sink extraconfig.DataSink, ops Operations) Tether {
 	ctx, cancel := context.WithCancel(context.Background())
+	rCtx, rCancel := context.WithCancel(ctx)
 	return &tether{
 		ops:    ops,
 		reload: make(chan struct{}, 1),
 		config: &ExecutorConfig{
 			pids: make(map[int]*SessionConfig),
 		},
-		extensions: make(map[string]Extension),
-		src:        src,
-		sink:       sink,
-		ctx:        ctx,
-		cancel:     cancel,
-		incoming:   make(chan os.Signal, 32),
+		extensions:   make(map[string]Extension),
+		src:          src,
+		sink:         sink,
+		ctx:          ctx,
+		cancel:       cancel,
+		reloadCtx:    rCtx,
+		reloadCancel: rCancel,
+		incoming:     make(chan os.Signal, 32),
 	}
 }
 
@@ -190,7 +198,18 @@ func (t *tether) setup() error {
 func (t *tether) cleanup() {
 	defer trace.End(trace.Begin("main tether cleanup"))
 
-	// stop child reaping
+	// clean up child processes
+	// cancel in case we've ended up here on a path that hasn't already
+	t.reloadCancel()
+	// this will deactivate child processes
+	t.processSessions()
+
+	// wait for sessions to exit
+	timeout, cancel := context.WithTimeout(t.ctx, shared.WaitForSessionExitTimeout)
+	t.Wait(timeout)
+	cancel()
+
+	// stop child reaping - we depend on this for tether.Wait so must come after
 	t.stopReaper()
 
 	// stop the extensions first as they may use the config
@@ -433,13 +452,19 @@ func (t *tether) processSessions() error {
 				// check if session is alive and well
 				if proc != nil && proc.Signal(syscall.Signal(0)) == nil {
 					log.Debugf("Process for session %s is running (pid: %d)", id, proc.Pid)
-					if !session.Active {
+
+					if !session.Active || t.reloadCtx.Err() != nil {
 						// stop process - for now this doesn't do any staged levels of aggression
-						log.Infof("Running session %s has been deactivated (pid: %d)", id, proc.Pid)
+						log.Infof("Running session %s has been deactivated (pid: %d, system status: %s)", id, proc.Pid, t.reloadCtx.Err())
 
 						killHelper(session)
 					}
 
+					return
+				}
+
+				if t.reloadCtx.Err() != nil {
+					log.Debugf("No action needed during shutdown for session: %s", id)
 					return
 				}
 
@@ -529,8 +554,8 @@ func (t *tether) Start() error {
 		var err error
 
 		select {
-		case <-t.ctx.Done():
-			log.Warnf("Someone called shutdown, returning from start")
+		case <-t.reloadCtx.Done():
+			log.Warnf("Someone called shutdown, exiting reload loop")
 			return nil
 		default:
 		}
@@ -600,11 +625,44 @@ func (t *tether) Start() error {
 func (t *tether) Stop() error {
 	defer trace.End(trace.Begin(""))
 
-	// cancel the context to signal waiters
+	// cancel the context to signal waiters and indicate shutdown
+	t.reloadCancel()
+
+	// trigger a reload - this should deliver the stopsignal to the children
+	t.reload <- struct{}{}
+
+	close(t.reload)
+
+	// this gets called from inside HandleSessionExit so cannot take session locks
+	// TODO: add a mechanism to block for clean shutdown of:
+	//   session processes
+	//   extensions
+	// probably should wait for the long overdue tether rewrite
+	// instead we're going to rely on the outstanding pid count via tether.Wait
+	timeout, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	err := t.Wait(timeout)
+	cancel()
+
 	t.cancel()
 
-	// TODO: kill all the children
-	close(t.reload)
+	return err
+}
+
+func (t *tether) Wait(ctx context.Context) error {
+	tick := time.Tick(500 * time.Millisecond)
+
+	pids := t.lenChildPid()
+	for pids > 0 && ctx.Err() == nil {
+		log.Infof("Waiting for %d processes to exit", pids)
+		pids = t.lenChildPid()
+		<-tick
+	}
+
+	if pids > 0 {
+		detail := fmt.Sprintf("Timed out waiting for processes to exit, %d processes remaining", pids)
+		log.Warn(detail)
+		return errors.New(detail)
+	}
 
 	return nil
 }
@@ -613,7 +671,7 @@ func (t *tether) Reload() {
 	defer trace.End(trace.Begin(""))
 
 	select {
-	case <-t.ctx.Done():
+	case <-t.reloadCtx.Done():
 		log.Warnf("Someone called shutdown, dropping the reload request")
 		return
 	default:

--- a/lib/tether/tether.go
+++ b/lib/tether/tether.go
@@ -165,7 +165,7 @@ func (t *tether) setup() error {
 		}
 	}
 
-	pidDir := shared.PIDFileDir()
+	pidDir := shared.PIDFileDir(&Sys)
 
 	// #nosec: Expect directory permissions to be 0700 or less
 	if err = os.MkdirAll(pidDir, 0755); err != nil {
@@ -688,7 +688,7 @@ func (t *tether) handleSessionExit(session *SessionConfig) {
 	// Remove associated PID file
 	cmdname := path.Base(session.Cmd.Path)
 
-	_ = os.Remove(fmt.Sprintf("%s.pid", path.Join(shared.PIDFileDir(), cmdname)))
+	_ = os.Remove(fmt.Sprintf("%s.pid", path.Join(shared.PIDFileDir(&Sys), cmdname)))
 
 	// set the stop time
 	session.StopTime = time.Now().UTC().Unix()
@@ -853,7 +853,7 @@ func (t *tether) launch(session *SessionConfig) error {
 
 	// Write the PID to the associated PID file
 	cmdname := path.Base(session.Cmd.Path)
-	err = ioutil.WriteFile(fmt.Sprintf("%s.pid", path.Join(shared.PIDFileDir(), cmdname)),
+	err = ioutil.WriteFile(fmt.Sprintf("%s.pid", path.Join(shared.PIDFileDir(&Sys), cmdname)),
 		[]byte(fmt.Sprintf("%d", pid)),
 		0644)
 	if err != nil {

--- a/lib/vicadmin/validate.go
+++ b/lib/vicadmin/validate.go
@@ -379,7 +379,7 @@ func (v *Validator) QueryVCHStatus(ctx context.Context, vch *config.VirtualConta
 
 	for service, proc := range procs {
 		log.Infof("Checking status of %s", proc)
-		pid, err := ioutil.ReadFile(fmt.Sprintf("%s.pid", path.Join(shared.PIDFileDir(), proc)))
+		pid, err := ioutil.ReadFile(fmt.Sprintf("%s.pid", path.Join(shared.PIDFileDir(nil), proc)))
 		if err != nil {
 			// #nosec: this method will not auto-escape HTML. Verify data is well formed.
 			v.VCHIssues = template.HTML(fmt.Sprintf("%s<span class=\"error-message\">%s service is not running</span>\n",

--- a/lib/vspc/vspc.go
+++ b/lib/vspc/vspc.go
@@ -164,10 +164,18 @@ func (vspc *Vspc) Start() {
 
 	go func() {
 		for {
+
+			select {
+			case <-vspc.doneCh:
+				log.Infof("vSPC exiting...")
+				return
+			default:
+			}
+
 			_, err := vspc.Accept()
 			if err != nil {
 				log.Errorf("vSPC cannot accept connections: %v", err)
-				log.Errorf("vSPC exiting...")
+				log.Infof("vSPC exiting...")
 				return
 			}
 		}
@@ -179,7 +187,8 @@ func (vspc *Vspc) Start() {
 func (vspc *Vspc) Stop() {
 	defer trace.End(trace.Begin("stop vspc"))
 
-	vspc.doneCh <- true
+	close(vspc.doneCh)
+	vspc.Server.Close()
 }
 
 // cVM returns the VM struct from its uuid

--- a/pkg/telnet/server.go
+++ b/pkg/telnet/server.go
@@ -99,7 +99,11 @@ func NewServer(opts ServerOpts) *Server {
 // Accept accepts a connection and returns the Telnet connection
 func (ts *Server) Accept() (*Conn, error) {
 	// #nosec: Errors unhandled.
-	conn, _ := ts.ln.Accept()
+	conn, err := ts.ln.Accept()
+	if err != nil {
+		return nil, err
+	}
+
 	log.Info("connection received")
 	opts := connOpts{
 		conn:       conn,
@@ -113,4 +117,14 @@ func (ts *Server) Accept() (*Conn, error) {
 	go tc.fsm.start()
 	go tc.startNegotiation()
 	return tc, nil
+}
+
+// Close call close on the underlying net.Listener and ensures
+// go routines are stopped
+func (ts *Server) Close() error {
+	err := ts.ln.Close()
+
+	// so far I have not identified any routines that need to be
+	// explicitly stopped after the underlying connection is closed.
+	return err
 }

--- a/pkg/vsphere/tasks/waiter_test.go
+++ b/pkg/vsphere/tasks/waiter_test.go
@@ -513,3 +513,37 @@ func TestSoapFaults(t *testing.T) {
 		t.Errorf("called=%d", called)
 	}
 }
+
+// Added to validate the following, received from VC
+//&types.InvalidPowerState{
+//	InvalidState:types.InvalidState{
+//		VimFault:types.VimFault{
+//			MethodFault:types.MethodFault{
+//				FaultCause:(*types.LocalizedMethodFault)(nil),
+//				FaultMessage:[]types.LocalizableMessage(nil)
+//			}
+//		}
+//	},
+//	RequestedState:\"poweredOn\", ExistingState:\"poweredOff\"
+//}"
+func TestIsAlreadyPoweredOff(t *testing.T) {
+	fault := task.Error{
+		LocalizedMethodFault: &types.LocalizedMethodFault{
+			Fault: &types.InvalidPowerState{
+				InvalidState: types.InvalidState{
+					VimFault: types.VimFault{
+						MethodFault: types.MethodFault{
+							FaultCause:   (*types.LocalizedMethodFault)(nil),
+							FaultMessage: []types.LocalizableMessage(nil),
+						},
+					},
+				},
+				RequestedState: "poweredOn",
+				ExistingState:  "poweredOff",
+			},
+			LocalizedMessage: "test message",
+		},
+	}
+
+	assert.True(t, IsAlreadyPoweredOffError(fault), "expected to correctly detect already powered off from fault")
+}

--- a/pkg/vsphere/vm/vm.go
+++ b/pkg/vsphere/vm/vm.go
@@ -1000,3 +1000,9 @@ func (vm *VirtualMachine) InCluster(op trace.Operation) bool {
 	op.Debugf("vm compute resource: %s", vm.Cluster.Name())
 	return cls
 }
+
+// IsAlreadyPoweredOffError is an accessor method because of the number of times package name and
+// variable name tend to collide for VMs.
+func (vm *VirtualMachine) IsAlreadyPoweredOffError(err error) bool {
+	return tasks.IsAlreadyPoweredOffError(err)
+}


### PR DESCRIPTION
This adds neat shutdown support in the endpointVM:
* cleans up Views, Managers and sessions in portlayer
* cleans up session in personality
* cleans up vicadmin sessions on shutdown

Unifies diskmanager usage on a single instance for the storage
component. This is unrelated to the rest of the PR but is the correct usage
given locking assumptions and will reduce retries of vmomi operations.

Updates vic-machine to use guest shutdown for polite shutdown first.

Fixes tether unit tests to run as non-root (again).

Notes:
Need to find an effective way to test this. I was planning on adding the name of the VCH to the client but that ran into the immovable object that is `session.Session` usage. I still think this would be a useful UX enhancement for both us and customers, and `session.Session` _definitely_ needs attention.

Currently there is still occasional dangling sessions from the personality admiral client. In this case client.Logout gets called but it does not occur. In the last full-ci run this happened twice:
```
Deleting the VCH appliance VCH-17937-4337
[ WARN ] Dangling sessions found: 52558178-8cbb-2dd6-fe91-75f1f64a7128  VSPHERE.LOCAL\Administrator                                        2018-04-02 23:01  3m34s  10.158.214.80   vic-dynamic-config/1.4.0-dev  
```

This is ~~**not ready to merge**~~ until the hardcoded filtering for 1.4.0-dev sessions is improved.
 - updated to filter for `-dev`, skipping the upgrade leaked sessions. This can be removed once old versions are not expected to leak sessions.

```
[parallel jobs=4]
```
Todo:
- [x] remove hardcoded version filtering
  - now filters for `-dev` to omit sessions from GA code. This means it will not currently match RC builds but given we're only using it for warning currently I'm ok with that.
- [x] perform neat exit on `could not initialize port layer` errors rather than log.Fatal