### PR TITLE
Make vic-machine-server log level configurable and default to DEBUG 

### DIFF
--- a/lib/apiservers/service/restapi/configure_vic_machine.go
+++ b/lib/apiservers/service/restapi/configure_vic_machine.go
@@ -44,6 +44,7 @@ import (
 
 var loggingOption = struct {
 	Directory string `long:"log-directory" description:"the directory where vic-machine-server log is stored" default:"/var/log/vic-machine-server" env:"LOG_DIRECTORY"`
+	Level     string `long:"log-level" description:"the minimum log level for vic-machine-server log messages" default:"info" env:"LOG_LEVEL" choice:"debug" choice:"info" choice:"warning" choice:"error"`
 }{}
 
 // logger is a workaround used to pass the logger instance from configureAPI to setupGlobalMiddleware
@@ -241,6 +242,13 @@ func configureLogger() *logrus.Logger {
 	}
 
 	l.Out = file
+
+	level, err := logrus.ParseLevel(loggingOption.Level)
+	if err != nil {
+		log.Printf("Error parsing log level %s: %s", loggingOption.Level, err)
+		level = logrus.InfoLevel
+	}
+	l.Level = level
 
 	// In case code uses the global logrus logger (it shouldn't):
 	logrus.SetOutput(file)

--- a/lib/apiservers/service/restapi/configure_vic_machine.go
+++ b/lib/apiservers/service/restapi/configure_vic_machine.go
@@ -44,7 +44,7 @@ import (
 
 var loggingOption = struct {
 	Directory string `long:"log-directory" description:"the directory where vic-machine-server log is stored" default:"/var/log/vic-machine-server" env:"LOG_DIRECTORY"`
-	Level     string `long:"log-level" description:"the minimum log level for vic-machine-server log messages" default:"info" env:"LOG_LEVEL" choice:"debug" choice:"info" choice:"warning" choice:"error"`
+	Level     string `long:"log-level" description:"the minimum log level for vic-machine-server log messages" default:"debug" env:"LOG_LEVEL" choice:"debug" choice:"info" choice:"warning" choice:"error"`
 }{}
 
 // logger is a workaround used to pass the logger instance from configureAPI to setupGlobalMiddleware
@@ -246,7 +246,7 @@ func configureLogger() *logrus.Logger {
 	level, err := logrus.ParseLevel(loggingOption.Level)
 	if err != nil {
 		log.Printf("Error parsing log level %s: %s", loggingOption.Level, err)
-		level = logrus.InfoLevel
+		level = logrus.DebugLevel
 	}
 	l.Level = level
 


### PR DESCRIPTION
It if often hard to debug `vic-machine-server` using only `INFO`-level log messages. Allow the log level for `vic-machine-server` to be configured. Adjust the default log level to `DEBUG`.

This will increase the volume of logs generated by the server, but the resources saved troubleshooting outweighs the cost of disk space.

Resolves #6942.

Notes:
 * VCH creation logs written to the datastore by the API are already written at `DEBUG` level.
 * This is not exposed to end-users (the setting would need to be passed into the container via the appliance). I think allowing it to be configured is the right _design_, but it's not clear that this is a case where more end-user-visible "knobs" are valuable.