### PR TITLE
Write all vic-machine log files at debug log level

### DIFF
--- a/cmd/vic-machine/create/create.go
+++ b/cmd/vic-machine/create/create.go
@@ -25,7 +25,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/Sirupsen/logrus"
 	"gopkg.in/urfave/cli.v1"
 
 	"github.com/vmware/vic/cmd/vic-machine/common"
@@ -680,12 +679,6 @@ func (c *Create) Run(clic *cli.Context) (err error) {
 	// These operations will be executed without timeout
 	op := common.NewOperation(clic, c.Debug.Debug)
 	op.Infof("### Installing VCH ####")
-
-	// When writing creation log files (vic-machine.log and the datastore log), always log at debug.
-	defer func(old logrus.Level) {
-		trace.Logger.Level = old
-	}(trace.Logger.Level)
-	trace.Logger.Level = logrus.DebugLevel
 
 	defer func() {
 		// urfave/cli will print out exit in error handling, so no more information in main method can be printed out.

--- a/cmd/vic-machine/create/create.go
+++ b/cmd/vic-machine/create/create.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Sirupsen/logrus"
 	"gopkg.in/urfave/cli.v1"
 
 	"github.com/vmware/vic/cmd/vic-machine/common"
@@ -679,6 +680,12 @@ func (c *Create) Run(clic *cli.Context) (err error) {
 	// These operations will be executed without timeout
 	op := common.NewOperation(clic, c.Debug.Debug)
 	op.Infof("### Installing VCH ####")
+
+	// When writing creation log files (vic-machine.log and the datastore log), always log at debug.
+	defer func(old logrus.Level) {
+		trace.Logger.Level = old
+	}(trace.Logger.Level)
+	trace.Logger.Level = logrus.DebugLevel
 
 	defer func() {
 		// urfave/cli will print out exit in error handling, so no more information in main method can be printed out.

--- a/cmd/vic-machine/main.go
+++ b/cmd/vic-machine/main.go
@@ -161,6 +161,12 @@ func main() {
 		}
 	}()
 
+	// When writing log files (vic-machine.log and the datastore log), always log at debug.
+	defer func(old log.Level) {
+		trace.Logger.Level = old
+	}(trace.Logger.Level)
+	trace.Logger.Level = log.DebugLevel
+
 	// #nosec: Errors unhandled.
 	app.Run(os.Args)
 }


### PR DESCRIPTION
Historically, the log level of output written to the TTY has been tied to the log level of messages written to the `vic-machine.log` file.

This tight coupling no longer exists. Now, separate loggers are used for writing to files (`vic-machine.log` and the datastore log file) and standard out, allowing for separate log level configuration.

Leverage this separation of concerns to always write log files at the debug log level. This may simplify debugging of VCH creation issues; we will no longer ever have to ask a user to re-try the operation at
a more verbose log level.

If useful, this pattern could be applied to other CLI operations; perhaps all log files should be written at the debug log level.