### PR TITLE
WIP improve nfs test by attempting mount before running test

### DIFF
--- a/tests/manual-test-cases/Group5-Functional-Tests/5-22-NFS-Volume.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-22-NFS-Volume.robot
@@ -111,6 +111,14 @@ Gather NFS Logs
     ${out}=  Run Keyword And Continue On Failure  Run  sshpass -p %{DEPLOYED_PASSWORD} ssh -o StrictHostKeyChecking\=no root@${NFS_READONLY_IP} dmesg
     Log  ${out}
 
+Check NFS Connection
+    ${tmpdir1}= Run And Return Output  "mktemp -d"
+    ${rc}=  Run And Return Rc mount ${NFS_IP}:/exports/storage1 $tmpdir1
+    Should Be Equal  ${rc}  0
+    ${tmpdir2}= Run And Return Output  "mktemp -d"
+    ${rc}=  Run And Return Rc mount ${NFS_READONLY_IP}:/exports/storage1 $tmpdir2
+    Should Be Equal  ${rc}  0
+
 NFS Volume Cleanup
     Gather NFS Logs
     Nimbus Cleanup  ${list}
@@ -295,6 +303,8 @@ Docker Inspect Mount Data after Reboot
 
 
 Kill NFS Server
+     Wait Until Keyword Succeeeds  10 min  Check NFS Connection
+
     ${rc}  ${runningContainer}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -d -v ${nfsNamedVolume}:/mydata ${busybox} sh -c "while true; do echo 'Still here...\n' >> /mydata/test_nfs_kill.txt; sleep 2; done"
     Should Be Equal As Integers  ${rc}  0
 


### PR DESCRIPTION
This PR is meant to help with tickets https://github.com/vmware/vic/issues/6616 and #6910 

The added keyword should mount the sharepoint of both of the NFS servers involved showing that the connection is active and able to be used. It will wait for this behavior to succeed for a certain amount of time before failing the operation. 