### PR TITLE
[skip ci] Sleep to allow the NFS server to recover

### DIFF
--- a/tests/manual-test-cases/Group5-Functional-Tests/5-22-NFS-Volume.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-22-NFS-Volume.robot
@@ -295,6 +295,7 @@ Docker Inspect Mount Data after Reboot
 
 
 Kill NFS Server
+    Sleep  5 minutes
     ${rc}  ${runningContainer}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -d -v ${nfsNamedVolume}:/mydata ${busybox} sh -c "while true; do echo 'Still here...\n' >> /mydata/test_nfs_kill.txt; sleep 2; done"
     Should Be Equal As Integers  ${rc}  0
 


### PR DESCRIPTION
fixes #6616 

From testing, it appears that the NFS server is overwhelmed by the previous test and does not recover for a few minutes. Prior to this change I could reproduce this failure >50% of the time. After this change it passed 100% for me.