### PR TITLE
Ensure that only a single session is constructed for each VCH Management API request [specific ci=Group23-VIC-Machine-Service] 

### DIFF
--- a/lib/apiservers/service/restapi/handlers/common.go
+++ b/lib/apiservers/service/restapi/handlers/common.go
@@ -40,71 +40,88 @@ type buildDataParams struct {
 	thumbprint      *string
 	datacenter      *string
 	computeResource *string
+	vchID           *string
 }
 
-func buildData(op trace.Operation, params buildDataParams, principal interface{}) (*data.Data, error) {
-	d := data.Data{
+func buildDataAndValidateTarget(op trace.Operation, params buildDataParams, principal interface{}) (*data.Data, *validate.Validator, error) {
+	data := &data.Data{
 		Target: &common.Target{
 			URL: &url.URL{Host: params.target},
 		},
 	}
 
 	if c, ok := principal.(Credentials); ok {
-		d.Target.User = c.user
-		d.Target.Password = &c.pass
+		data.Target.User = c.user
+		data.Target.Password = &c.pass
 	} else {
-		d.Target.CloneTicket = principal.(Session).ticket
+		data.Target.CloneTicket = principal.(Session).ticket
+	}
+
+	if err := data.HasCredentials(op); err != nil {
+		return data, nil, util.NewError(http.StatusUnauthorized, "Invalid Credentials: %s", err)
 	}
 
 	if params.thumbprint != nil {
-		d.Thumbprint = *params.thumbprint
+		data.Thumbprint = *params.thumbprint
 	}
 
+	if params.computeResource != nil {
+		data.ComputeResourcePath = *params.computeResource
+	}
+
+	if params.vchID != nil {
+		data.ID = *params.vchID
+	}
+
+	// TODO (#6032): clean this up
+	var validator *validate.Validator
 	if params.datacenter != nil {
-		validator, err := validateTarget(op, &d)
+		v, err := validate.NewValidator(op, data)
 		if err != nil {
-			return nil, util.WrapError(http.StatusInternalServerError, err)
+			return data, nil, util.NewError(http.StatusBadRequest, "Validation Error: %s", err)
 		}
 
 		datacenterManagedObjectReference := types.ManagedObjectReference{Type: "Datacenter", Value: *params.datacenter}
 
-		datacenterObject, err := validator.Session.Finder.ObjectReference(op, datacenterManagedObjectReference)
+		datacenterObject, err := v.Session.Finder.ObjectReference(op, datacenterManagedObjectReference)
 		if err != nil {
-			return nil, util.WrapError(http.StatusNotFound, err)
+			return nil, nil, util.WrapError(http.StatusNotFound, err)
 		}
 
-		d.Target.URL.Path = datacenterObject.(*object.Datacenter).InventoryPath
+		dc, ok := datacenterObject.(*object.Datacenter)
+		if !ok {
+			return data, nil, util.NewError(http.StatusBadRequest, "Validation Error: datacenter parameter is not a datacenter moref")
+		}
+
+		data.Target.URL.Path = dc.InventoryPath
+
+		// Do what NewValidator would have done if a Datacenter had been set
+		v.DatacenterPath = dc.Name()
+		v.Session.DatastorePath = v.DatacenterPath
+		v.Session.Finder.SetDatacenter(dc)
+
+		validator = v
+	} else {
+		v, err := validate.NewValidator(op, data)
+		if err != nil {
+			return data, nil, util.NewError(http.StatusBadRequest, "Validation Error: %s", err)
+		}
+
+		// If dc is not set, and multiple datacenters are available, operate on all datacenters.
+		v.AllowEmptyDC()
+
+		validator = v
 	}
 
-	if params.computeResource != nil {
-		d.ComputeResourcePath = *params.computeResource
+	if _, err := validator.ValidateTarget(op, data); err != nil {
+		return data, nil, util.NewError(http.StatusBadRequest, "Target validation failed: %s", err)
 	}
 
-	return &d, nil
-}
-
-func validateTarget(op trace.Operation, d *data.Data) (*validate.Validator, error) {
-	if err := d.HasCredentials(op); err != nil {
-		return nil, fmt.Errorf("Invalid Credentials: %s", err)
+	if _, err := validator.ValidateCompute(op, data, false); err != nil {
+		return data, nil, util.NewError(http.StatusBadRequest, "Compute resource validation failed: %s", err)
 	}
 
-	validator, err := validate.NewValidator(op, d)
-	if err != nil {
-		return nil, fmt.Errorf("Validation Error: %s", err)
-	}
-
-	// If dc is not set, and multiple datacenters are available, operate on all datacenters.
-	validator.AllowEmptyDC()
-
-	if _, err = validator.ValidateTarget(op, d); err != nil {
-		return nil, fmt.Errorf("Target validation failed: %s", err)
-	}
-
-	if _, err = validator.ValidateCompute(op, d, false); err != nil {
-		return nil, fmt.Errorf("Compute resource validation failed: %s", err)
-	}
-
-	return validator, nil
+	return data, validator, nil
 }
 
 // Copied from list.go, and appears to be present other places. TODO (#6032): deduplicate
@@ -141,13 +158,7 @@ func upgradeStatusMessage(op trace.Operation, vch *vm.VirtualMachine, installerV
 	return "Invalid upgrade status"
 }
 
-func getVCHConfig(op trace.Operation, d *data.Data) (*config.VirtualContainerHostConfigSpec, error) {
-	// TODO (#6032): abstract some of this boilerplate into helpers
-	validator, err := validateTarget(op, d)
-	if err != nil {
-		return nil, util.WrapError(http.StatusBadRequest, err)
-	}
-
+func getVCHConfig(op trace.Operation, d *data.Data, validator *validate.Validator) (*config.VirtualContainerHostConfigSpec, error) {
 	executor := management.NewDispatcher(validator.Context, validator.Session, nil, false)
 	vch, err := executor.NewVCHFromID(d.ID)
 	if err != nil {

--- a/lib/apiservers/service/restapi/handlers/util/error.go
+++ b/lib/apiservers/service/restapi/handlers/util/error.go
@@ -14,7 +14,10 @@
 
 package util
 
-import "net/http"
+import (
+	"fmt"
+	"net/http"
+)
 
 func StatusCode(err error) int {
 	e, ok := err.(statusCode)
@@ -25,7 +28,10 @@ func StatusCode(err error) int {
 	return e.Code()
 }
 
-func NewError(code int, message string) error {
+func NewError(code int, message string, a ...interface{}) error {
+	if a != nil {
+		return httpError{code: code, message: fmt.Sprintf(message, a...)}
+	}
 	return httpError{code: code, message: message}
 }
 

--- a/lib/apiservers/service/restapi/handlers/util/error_test.go
+++ b/lib/apiservers/service/restapi/handlers/util/error_test.go
@@ -21,14 +21,27 @@ import (
 )
 
 func TestNewError(t *testing.T) {
-	e := NewError(123, "new error")
+	e := NewError(123, "new error %d %s %q")
 	c := StatusCode(e)
 
 	if c != 123 {
 		t.Errorf("Status code was %d, not 123.", c)
 	}
 
-	if e.Error() != "new error" {
+	if e.Error() != "new error %d %s %q" {
+		t.Error("NewError did not preserve message.")
+	}
+}
+
+func TestNewErrorWithArgs(t *testing.T) {
+	e := NewError(123, "new error %d %s %q", 1, "a", "foo")
+	c := StatusCode(e)
+
+	if c != 123 {
+		t.Errorf("Status code was %d, not 123.", c)
+	}
+
+	if e.Error() != "new error 1 a \"foo\"" {
 		t.Error("NewError did not preserve message.")
 	}
 }

--- a/lib/apiservers/service/restapi/handlers/vch_cert_get.go
+++ b/lib/apiservers/service/restapi/handlers/vch_cert_get.go
@@ -26,6 +26,7 @@ import (
 	"github.com/vmware/vic/lib/apiservers/service/restapi/operations"
 	"github.com/vmware/vic/lib/config"
 	"github.com/vmware/vic/lib/install/data"
+	"github.com/vmware/vic/lib/install/validate"
 	"github.com/vmware/vic/pkg/trace"
 )
 
@@ -39,17 +40,16 @@ func (h *VCHCertGet) Handle(params operations.GetTargetTargetVchVchIDCertificate
 	b := buildDataParams{
 		target:     params.Target,
 		thumbprint: params.Thumbprint,
+		vchID:      &params.VchID,
 	}
 
-	d, err := buildData(op, b, principal)
+	d, validator, err := buildDataAndValidateTarget(op, b, principal)
 	if err != nil {
 		return operations.NewGetTargetTargetVchVchIDCertificateDefault(
 			util.StatusCode(err)).WithPayload(&models.Error{Message: err.Error()})
 	}
 
-	d.ID = params.VchID
-
-	c, err := getVCHCert(op, d)
+	c, err := getVCHCert(op, d, validator)
 	if err != nil {
 		return operations.NewGetTargetTargetVchVchIDCertificateDefault(
 			util.StatusCode(err)).WithPayload(&models.Error{Message: err.Error()})
@@ -66,17 +66,16 @@ func (h *VCHDatacenterCertGet) Handle(params operations.GetTargetTargetDatacente
 		target:     params.Target,
 		thumbprint: params.Thumbprint,
 		datacenter: &params.Datacenter,
+		vchID:      &params.VchID,
 	}
 
-	d, err := buildData(op, b, principal)
+	d, validator, err := buildDataAndValidateTarget(op, b, principal)
 	if err != nil {
 		return operations.NewGetTargetTargetDatacenterDatacenterVchVchIDCertificateDefault(
 			util.StatusCode(err)).WithPayload(&models.Error{Message: err.Error()})
 	}
 
-	d.ID = params.VchID
-
-	c, err := getVCHCert(op, d)
+	c, err := getVCHCert(op, d, validator)
 	if err != nil {
 		return operations.NewGetTargetTargetDatacenterDatacenterVchVchIDCertificateDefault(
 			util.StatusCode(err)).WithPayload(&models.Error{Message: err.Error()})
@@ -86,8 +85,8 @@ func (h *VCHDatacenterCertGet) Handle(params operations.GetTargetTargetDatacente
 	return NewGetTargetTargetDatacenterDatacenterVchVchIDCertificateOK(cert.Pem)
 }
 
-func getVCHCert(op trace.Operation, d *data.Data) (*config.RawCertificate, error) {
-	vchConfig, err := getVCHConfig(op, d)
+func getVCHCert(op trace.Operation, d *data.Data, validator *validate.Validator) (*config.RawCertificate, error) {
+	vchConfig, err := getVCHConfig(op, d, validator)
 	if err != nil {
 		return nil, err
 	}

--- a/lib/apiservers/service/restapi/handlers/vch_create.go
+++ b/lib/apiservers/service/restapi/handlers/vch_create.go
@@ -78,14 +78,9 @@ func (h *VCHCreate) Handle(params operations.PostTargetTargetVchParams, principa
 		thumbprint: params.Thumbprint,
 	}
 
-	d, err := buildData(op, b, principal)
+	d, validator, err := buildDataAndValidateTarget(op, b, principal)
 	if err != nil {
 		return operations.NewPostTargetTargetVchDefault(util.StatusCode(err)).WithPayload(&models.Error{Message: err.Error()})
-	}
-
-	validator, err := validateTarget(op, d)
-	if err != nil {
-		return operations.NewPostTargetTargetVchDefault(http.StatusBadRequest).WithPayload(&models.Error{Message: err.Error()})
 	}
 
 	c, err := buildCreate(op, d, finder(validator.Session.Finder), params.Vch)
@@ -114,14 +109,9 @@ func (h *VCHDatacenterCreate) Handle(params operations.PostTargetTargetDatacente
 		datacenter: &params.Datacenter,
 	}
 
-	d, err := buildData(op, b, principal)
+	d, validator, err := buildDataAndValidateTarget(op, b, principal)
 	if err != nil {
 		return operations.NewPostTargetTargetDatacenterDatacenterVchDefault(util.StatusCode(err)).WithPayload(&models.Error{Message: err.Error()})
-	}
-
-	validator, err := validateTarget(op, d)
-	if err != nil {
-		return operations.NewPostTargetTargetDatacenterDatacenterVchDefault(http.StatusBadRequest).WithPayload(&models.Error{Message: err.Error()})
 	}
 
 	c, err := buildCreate(op, d, validator.Session.Finder, params.Vch)

--- a/lib/apiservers/service/restapi/handlers/vch_create_test.go
+++ b/lib/apiservers/service/restapi/handlers/vch_create_test.go
@@ -17,6 +17,7 @@ package handlers
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"os"
 	"reflect"
 	"sort"
@@ -30,6 +31,7 @@ import (
 	"github.com/vmware/vic/cmd/vic-machine/common"
 	"github.com/vmware/vic/cmd/vic-machine/create"
 	"github.com/vmware/vic/lib/apiservers/service/models"
+	"github.com/vmware/vic/lib/install/data"
 	"github.com/vmware/vic/pkg/trace"
 )
 
@@ -179,24 +181,19 @@ func TestCreateVCH(t *testing.T) {
 		assert.NoError(t, err, "Error removing temp directory: %s", err)
 	}()
 
-	principal := Credentials{
-		user: "testuser",
-		pass: "testpass",
+	pass := "testpass"
+	data := &data.Data{
+		Target: &common.Target{
+			URL:      &url.URL{Host: "10.10.1.2"},
+			User:     "testuser",
+			Password: &pass,
+		},
 	}
-
-	tp := "thumbprint"
-	params := buildDataParams{
-		target:     "10.10.1.2",
-		thumbprint: &tp,
-	}
-	data, err := buildData(op, params, principal)
-	assert.NoError(t, err, "Expected no error")
-	// TODO(jzt): assert data struct is as expected
 
 	ca := newCreate()
 	ca.Data = data
 	ca.DisplayName = "test-vch"
-	err = ca.ProcessParams(op)
+	err := ca.ProcessParams(op)
 	assert.NoError(t, err, "Error while processing params: %s", err)
 	op.Infof("ca EnvFile: %s", ca.Certs.EnvFile)
 

--- a/lib/apiservers/service/restapi/handlers/vch_get.go
+++ b/lib/apiservers/service/restapi/handlers/vch_get.go
@@ -55,16 +55,15 @@ func (h *VCHGet) Handle(params operations.GetTargetTargetVchVchIDParams, princip
 	b := buildDataParams{
 		target:     params.Target,
 		thumbprint: params.Thumbprint,
+		vchID:      &params.VchID,
 	}
 
-	d, err := buildData(op, b, principal)
+	d, validator, err := buildDataAndValidateTarget(op, b, principal)
 	if err != nil {
 		return operations.NewGetTargetTargetVchVchIDDefault(util.StatusCode(err)).WithPayload(&models.Error{Message: err.Error()})
 	}
 
-	d.ID = params.VchID
-
-	vch, err := getVCH(op, d)
+	vch, err := getVCH(op, d, validator)
 	if err != nil {
 		return operations.NewGetTargetTargetVchVchIDDefault(util.StatusCode(err)).WithPayload(&models.Error{Message: err.Error()})
 	}
@@ -79,16 +78,15 @@ func (h *VCHDatacenterGet) Handle(params operations.GetTargetTargetDatacenterDat
 		target:     params.Target,
 		thumbprint: params.Thumbprint,
 		datacenter: &params.Datacenter,
+		vchID:      &params.VchID,
 	}
 
-	d, err := buildData(op, b, principal)
+	d, validator, err := buildDataAndValidateTarget(op, b, principal)
 	if err != nil {
 		return operations.NewGetTargetTargetDatacenterDatacenterVchVchIDDefault(util.StatusCode(err)).WithPayload(&models.Error{Message: err.Error()})
 	}
 
-	d.ID = params.VchID
-
-	vch, err := getVCH(op, d)
+	vch, err := getVCH(op, d, validator)
 	if err != nil {
 		return operations.NewGetTargetTargetDatacenterDatacenterVchVchIDDefault(util.StatusCode(err)).WithPayload(&models.Error{Message: err.Error()})
 	}
@@ -96,12 +94,7 @@ func (h *VCHDatacenterGet) Handle(params operations.GetTargetTargetDatacenterDat
 	return operations.NewGetTargetTargetDatacenterDatacenterVchVchIDOK().WithPayload(vch)
 }
 
-func getVCH(op trace.Operation, d *data.Data) (*models.VCH, error) {
-	validator, err := validateTarget(op, d)
-	if err != nil {
-		return nil, util.WrapError(http.StatusBadRequest, err)
-	}
-
+func getVCH(op trace.Operation, d *data.Data, validator *validate.Validator) (*models.VCH, error) {
 	executor := management.NewDispatcher(validator.Context, validator.Session, nil, false)
 	vch, err := executor.NewVCHFromID(d.ID)
 	if err != nil {

--- a/tests/resources/Group23-VIC-Machine-Service-Util.robot
+++ b/tests/resources/Group23-VIC-Machine-Service-Util.robot
@@ -48,6 +48,16 @@ Get Path Under Target
     Set Test Variable    ${OUTPUT}
     Set Test Variable    ${STATUS}
 
+Get Path Under Target Using Session
+    [Arguments]    ${path}    @{query}
+    ${fullQuery}=    Catenate    SEPARATOR=&    thumbprint=%{TEST_THUMBPRINT}    @{query}
+    ${ticket}=    Run    govc vm.console %{VCH-NAME} | awk -F'[:@]' '{print $3}'
+    ${RC}  ${OUTPUT}=    Run And Return Rc And Output    curl -s -w "\n\%{http_code}\n" -X GET "http://127.0.0.1:${HTTP_PORT}/container/target/%{TEST_URL}/${path}?${fullQuery}" -H "Accept: application/json" -H "X-VMWARE-TICKET: ${ticket}"
+    ${OUTPUT}    ${STATUS}=    Split String From Right    ${OUTPUT}    \n    1
+    Set Test Variable    ${RC}
+    Set Test Variable    ${OUTPUT}
+    Set Test Variable    ${STATUS}
+
 Post Path Under Target
     [Arguments]    ${path}    ${data}    @{query}
     ${fullQuery}=    Catenate    SEPARATOR=&    thumbprint=%{TEST_THUMBPRINT}    @{query}

--- a/tests/test-cases/Group23-VIC-Machine-Service/23-02-VCH-List.robot
+++ b/tests/test-cases/Group23-VIC-Machine-Service/23-02-VCH-List.robot
@@ -52,6 +52,14 @@ Verify VCH List
     Property Should Not Be Empty    .vchs[] | select(.name=="%{VCH-NAME}").version
 
 
+Get VCH List Using Session
+    Get Path Under Target Using Session    vch
+
+Get VCH List Within Datacenter Using Session
+    ${dcID}=    Get Datacenter ID
+    Get Path Under Target Using Session    datacenter/${dcID}/vch
+
+
 *** Test Cases ***
 Get VCH List
     Get VCH List
@@ -60,9 +68,22 @@ Get VCH List
     Verify Status Ok
     Verify VCH List
 
+Get VCH List Using Session
+    Get VCH List Using Session
+
+    Verify Return Code
+    Verify Status Ok
+    Verify VCH List
 
 Get VCH List Within Datacenter
     Get VCH List Within Datacenter
+
+    Verify Return Code
+    Verify Status Ok
+    Verify VCH List
+
+Get VCH List Within Datacenter Using Session
+    Get VCH List Within Datacenter Using Session
 
     Verify Return Code
     Verify Status Ok


### PR DESCRIPTION
The VCH Management API supports two authentication mechanisms:
1. Basic authentication with a username and password.
2. Ticket-based authentication using a session ticket.

One limitation of ticket-based authentication, which is used by the
vSphere H5 Client Plugin, is that a session ticket may only be used
once.

Previously, we created two sessions as a part of handling datacenter-
scoped API requests: one un-scoped session to resolve and validate
the supplied datacenter, and one datacenter-scoped session to actually
handle the request.

This pattern worked fine for basic authentication, but not for ticket-
based authentication.

To fix this, refactor the common buildData and validateTarget methods
to eliminate the creation of a second Validator. The approach taken is
to combine the two methods, which requires refactoring of call sites.

By constructing a single Validator, we construct a single Session,
which ensures we do not attempt to re-use a session ticket.

Additionally:
 * Enhance the error utility used by the VCH API handlers to support
   formatting errors with arguments. This makes its signature more
   like standard error construction code, which in turn makes it
   easier to refactor existing code to use these errors.
 * Refactor validation logic to set appropriate http status codes on
   errors it constructs, instead of leaving that to the handler. This
   fixes a bug where 400 Bad Request was being used instead of 401
   Unauthorized when invalid credentials were supplied.
 * Fix a bug where the datacenter list handler was using the same
   [non-datacenter] structs as the non-datacenter list handler.
 * Include the VCH ID as a part of the buildDataParams.
 * Introduce two test cases for session-based authentication to un-
   scoped and datacenter-scoped requests. (Previously, all automated
   tests used basic authentication.)

Fixes #6947

---

Note: This is the same as #6949, but on `master`. It will be pushed first, in accordance with our branching process (https://github.com/vmware/vic/pull/6949#issuecomment-351515926).