### PR TITLE
Add per container API locking for ContainerStart and improve logging

### DIFF
--- a/lib/apiservers/engine/backends/backends.go
+++ b/lib/apiservers/engine/backends/backends.go
@@ -57,6 +57,7 @@ const (
 	// RetryTimeSeconds defines how many seconds to wait between retries
 	RetryTimeSeconds        = 2
 	defaultSessionKeepAlive = 20 * time.Second
+	APITimeout              = constants.PropertyCollectorTimeout + 3*time.Second
 )
 
 var (

--- a/lib/apiservers/engine/backends/cache/repo_cache.go
+++ b/lib/apiservers/engine/backends/cache/repo_cache.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/vmware/vic/lib/apiservers/engine/backends/kv"
 	"github.com/vmware/vic/lib/apiservers/portlayer/client"
-	"github.com/vmware/vic/pkg/trace"
 
 	"github.com/docker/distribution/digest"
 	"github.com/docker/docker/reference"
@@ -128,8 +127,6 @@ func init() {
 // NewRespositoryCache will create a new repoCache or rehydrate
 // an existing repoCache from the portlayer k/v store
 func NewRepositoryCache(client *client.PortLayer) error {
-	defer trace.End(trace.Begin(""))
-
 	rCache.client = client
 
 	val, err := kv.Get(client, repoKey)
@@ -165,8 +162,6 @@ func NewRepositoryCache(client *client.PortLayer) error {
 // Save will persist the repository cache to the
 // portlayer k/v
 func (store *repoCache) Save() error {
-	defer trace.End(trace.Begin(""))
-
 	b, err := json.Marshal(store)
 	if err != nil {
 		log.Errorf("Unable to marshal repository cache: %s", err.Error())
@@ -183,7 +178,6 @@ func (store *repoCache) Save() error {
 }
 
 func (store *repoCache) AddReference(ref reference.Named, imageID string, force bool, layerID string, save bool) error {
-	defer trace.End(trace.Begin(""))
 	if ref.Name() == string(digest.Canonical) {
 		return errors.New("refusing to create an ambiguous tag using digest algorithm as name")
 	}
@@ -253,7 +247,6 @@ func (store *repoCache) AddReference(ref reference.Named, imageID string, force 
 // Tags: busybox:1.25.1
 // Digest: nginx@sha256:7281cf7c854b0dfc7c68a6a4de9a785a973a14f1481bc028e2022bcd6a8d9f64
 func (store *repoCache) Remove(ref string, save bool) (string, error) {
-	defer trace.End(trace.Begin(""))
 	n, err := reference.ParseNamed(ref)
 	if err != nil {
 		return "", err
@@ -270,7 +263,6 @@ func (store *repoCache) Remove(ref string, save bool) (string, error) {
 // Delete deletes a reference from the store. It returns true if a deletion
 // happened, or false otherwise.
 func (store *repoCache) Delete(ref reference.Named, save bool) (bool, error) {
-	defer trace.End(trace.Begin(""))
 	ref = reference.WithDefaultTag(ref)
 
 	store.mu.Lock()
@@ -315,7 +307,6 @@ func (store *repoCache) Delete(ref reference.Named, save bool) (bool, error) {
 // GetImageID will return the imageID associated with the
 // specified layerID
 func (store *repoCache) GetImageID(layerID string) string {
-	defer trace.End(trace.Begin(layerID))
 	var imageID string
 	store.mu.RLock()
 	defer store.mu.RUnlock()
@@ -327,7 +318,6 @@ func (store *repoCache) GetImageID(layerID string) string {
 
 // Get returns the imageID for a parsed reference
 func (store *repoCache) Get(ref reference.Named) (string, error) {
-	defer trace.End(trace.Begin(""))
 	ref = reference.WithDefaultTag(ref)
 
 	store.mu.RLock()
@@ -347,8 +337,6 @@ func (store *repoCache) Get(ref reference.Named) (string, error) {
 
 // Tags returns a slice of tags for the specified imageID
 func (store *repoCache) Tags(imageID string) []string {
-	defer trace.End(trace.Begin(""))
-
 	store.mu.RLock()
 	defer store.mu.RUnlock()
 	var tags []string
@@ -362,8 +350,6 @@ func (store *repoCache) Tags(imageID string) []string {
 
 // Digests returns a slice of digests for the specified imageID
 func (store *repoCache) Digests(imageID string) []string {
-	defer trace.End(trace.Begin(""))
-
 	store.mu.RLock()
 	defer store.mu.RUnlock()
 	var digests []string
@@ -378,8 +364,6 @@ func (store *repoCache) Digests(imageID string) []string {
 // References returns a slice of references to the given imageID. The slice
 // will be nil if there are no references to this imageID.
 func (store *repoCache) References(imageID string) []reference.Named {
-	defer trace.End(trace.Begin(""))
-
 	store.mu.RLock()
 	defer store.mu.RUnlock()
 
@@ -401,8 +385,6 @@ func (store *repoCache) References(imageID string) []reference.Named {
 // If there are no references known for this repository name,
 // ReferencesByName returns nil.
 func (store *repoCache) ReferencesByName(ref reference.Named) []Association {
-	defer trace.End(trace.Begin(""))
-
 	store.mu.RLock()
 	defer store.mu.RUnlock()
 

--- a/lib/apiservers/engine/backends/convert/state.go
+++ b/lib/apiservers/engine/backends/convert/state.go
@@ -23,14 +23,11 @@ import (
 	"github.com/docker/go-units"
 
 	"github.com/vmware/vic/lib/apiservers/portlayer/models"
-	"github.com/vmware/vic/pkg/trace"
 )
 
 // State will create and return a docker ContainerState object
 // from the passed vic ContainerInfo object
 func State(info *models.ContainerInfo) *types.ContainerState {
-	defer trace.End(trace.Begin(""))
-
 	// ensure we have the data we need
 	if info == nil || info.ProcessConfig == nil || info.ContainerConfig == nil {
 		return nil

--- a/lib/apiservers/engine/backends/errors.go
+++ b/lib/apiservers/engine/backends/errors.go
@@ -111,6 +111,10 @@ func StreamFormatNotRecognized() error {
 	return derr.NewRequestConflictError(fmt.Errorf("Stream format not recognized"))
 }
 
+func ConcurrentAPIError(name, request string) error {
+	return derr.NewRequestConflictError(fmt.Errorf("%s request is already in progress for container '%s'.", request, name))
+}
+
 // Error type check
 
 func IsNotFoundError(err error) bool {

--- a/lib/apiservers/portlayer/restapi/handlers/containers_handlers.go
+++ b/lib/apiservers/portlayer/restapi/handlers/containers_handlers.go
@@ -515,7 +515,6 @@ func (handler *ContainersHandlersImpl) RenameContainerHandler(params containers.
 // utility function to convert from a Container type to the API Model ContainerInfo (which should prob be called ContainerDetail)
 func convertContainerToContainerInfo(c *exec.Container) *models.ContainerInfo {
 	container := c.Info()
-	defer trace.End(trace.Begin(container.ExecConfig.ID))
 
 	// ensure we have probably up-to-date info
 	for _, endpoint := range container.ExecConfig.Networks {

--- a/lib/apiservers/portlayer/restapi/handlers/scopes_handlers.go
+++ b/lib/apiservers/portlayer/restapi/handlers/scopes_handlers.go
@@ -270,7 +270,8 @@ func (handler *ScopesHandlersImpl) ScopesRemoveContainer(params scopes.RemoveCon
 }
 
 func (handler *ScopesHandlersImpl) ScopesBindContainer(params scopes.BindContainerParams) middleware.Responder {
-	defer trace.End(trace.Begin(fmt.Sprintf("handle(%s)", params.Handle)))
+	op := trace.NewOperation(context.Background(), params.Handle)
+	defer trace.End(trace.Begin(fmt.Sprintf("handle(%s)", params.Handle), op))
 
 	h := exec.GetHandle(params.Handle)
 	if h == nil {
@@ -279,7 +280,7 @@ func (handler *ScopesHandlersImpl) ScopesBindContainer(params scopes.BindContain
 
 	var endpoints []*network.Endpoint
 	var err error
-	if endpoints, err = handler.netCtx.BindContainer(h); err != nil {
+	if endpoints, err = handler.netCtx.BindContainer(op, h); err != nil {
 		switch err := err.(type) {
 		case network.ResourceNotFoundError:
 			return scopes.NewBindContainerNotFound().WithPayload(errorPayload(err))

--- a/lib/dns/dns_test.go
+++ b/lib/dns/dns_test.go
@@ -27,6 +27,9 @@ import (
 	"github.com/vmware/vic/lib/constants"
 	"github.com/vmware/vic/lib/portlayer/exec"
 	"github.com/vmware/vic/lib/portlayer/network"
+	"github.com/vmware/vic/pkg/trace"
+
+	"context"
 
 	mdns "github.com/miekg/dns"
 )
@@ -86,6 +89,7 @@ func TestForwarding(t *testing.T) {
 
 func TestVIC(t *testing.T) {
 	t.Skipf("Failing with CI")
+	op := trace.NewOperation(context.Background(), "TestVIC")
 
 	log.SetLevel(log.PanicLevel)
 
@@ -137,7 +141,7 @@ func TestVIC(t *testing.T) {
 	}
 
 	// bind it
-	_, err = ctx.BindContainer(con)
+	_, err = ctx.BindContainer(op, con)
 	if err != nil {
 		t.Fatalf("%s", err)
 	}

--- a/lib/portlayer/exec/container.go
+++ b/lib/portlayer/exec/container.go
@@ -766,12 +766,13 @@ func (c *Container) OnEvent(e events.Event) {
 			return
 		}
 
+		log.Debugf("Container (%s) publishing event %s from event %s", c, newState, e.String())
 		// regardless of state update success or failure publish the container event
 		publishContainerEvent(op, c.ExecConfig.ID, e.Created(), e.String())
 		return
 	}
 
-	op.Debugf("Container(%s) state(%s) didn't change", c, newState)
+	op.Debugf("Container(%s) state(%s) didn't change after event %s", c, newState, e.String())
 
 	switch e.String() {
 	case events.ContainerRelocated:

--- a/lib/portlayer/network/context.go
+++ b/lib/portlayer/network/context.go
@@ -654,15 +654,15 @@ func (c *Context) DefaultScope() *Scope {
 	return c.defaultScope
 }
 
-func (c *Context) BindContainer(h *exec.Handle) ([]*Endpoint, error) {
-	defer trace.End(trace.Begin(""))
+func (c *Context) BindContainer(op trace.Operation, h *exec.Handle) ([]*Endpoint, error) {
+	defer trace.End(trace.Begin("", op))
 	c.Lock()
 	defer c.Unlock()
 
-	return c.bindContainer(h)
+	return c.bindContainer(op, h)
 }
 
-func (c *Context) bindContainer(h *exec.Handle) ([]*Endpoint, error) {
+func (c *Context) bindContainer(op trace.Operation, h *exec.Handle) ([]*Endpoint, error) {
 	con, err := c.container(h)
 	if con != nil {
 		return con.Endpoints(), nil // already bound
@@ -698,14 +698,20 @@ func (c *Context) bindContainer(h *exec.Handle) ([]*Endpoint, error) {
 		var eip *net.IP
 		if ne.Static {
 			eip = &ne.IP.IP
-		} else if !ip.IsUnspecifiedIP(ne.Assigned.IP) {
-			// for VCH restart, we need to reserve
-			// the IP of the running container
-			//
-			// this may be a DHCP assigned IP, however, the
-			// addContainer call below will ignore reserving
-			// an IP if the scope is "dynamic"
-			eip = &ne.Assigned.IP
+			op.Debugf("BindContainer found container %s with static endpoint and IP %s", con.ID(), eip.String())
+		} else {
+			if !ip.IsUnspecifiedIP(ne.Assigned.IP) {
+				// for VCH restart, we need to reserve
+				// the IP of the running container
+				//
+				// this may be a DHCP assigned IP, however, the
+				// addContainer call below will ignore reserving
+				// an IP if the scope is "dynamic"
+				op.Debugf("BindContainer found container %s with dynamic endpoint and assigned IP %s", con.ID(), ne.Assigned.IP.String())
+				eip = &ne.Assigned.IP
+			} else {
+				op.Debugf("BindContainer found container %s with dynamic endpoint and unassigned IP", con.ID())
+			}
 		}
 
 		e := newEndpoint(con, s, eip, nil)
@@ -757,7 +763,7 @@ func (c *Context) bindContainer(h *exec.Handle) ([]*Endpoint, error) {
 
 		// container specific aliases
 		for _, a := range ne.Network.Aliases {
-			log.Debugf("parsing alias %s", a)
+			op.Debugf("parsing alias %s", a)
 			l := strings.Split(a, ":")
 			if len(l) != 2 {
 				err = fmt.Errorf("Parsing network alias %s failed", a)
@@ -782,7 +788,7 @@ func (c *Context) bindContainer(h *exec.Handle) ([]*Endpoint, error) {
 				if whoc != nil {
 					aliases[a.scopedName()] = whoc
 				} else {
-					log.Debugf("skipping alias %s since %s is not bound yet", a, who)
+					op.Debugf("skipping alias %s since %s is not bound yet", a, who)
 				}
 			}
 		}
@@ -794,7 +800,6 @@ func (c *Context) bindContainer(h *exec.Handle) ([]*Endpoint, error) {
 				continue
 			}
 
-			log.Debugf("getting aliases for %s from %s", con.name, e.Container().Name())
 			for _, a := range e.getAliases(con.name) {
 				aliases[a.scopedName()] = con
 			}
@@ -964,6 +969,8 @@ func (c *Context) UnbindContainer(op trace.Operation, h *exec.Handle) ([]*Endpoi
 
 		return nil, err
 	}
+
+	op.Debugf("Removing endpoints from container %s", con.ID())
 
 	// aliases to remove
 	var aliases []string

--- a/lib/portlayer/network/context_test.go
+++ b/lib/portlayer/network/context_test.go
@@ -717,6 +717,7 @@ func TestContextBindUnbindContainer(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewContext() => (nil, %s), want (ctx, nil)", err)
 	}
+	op := trace.NewOperation(context.Background(), "TestContextBindUnbindContainer")
 
 	scopeData := &ScopeData{
 		ScopeType: constants.BridgeScopeType,
@@ -789,7 +790,7 @@ func TestContextBindUnbindContainer(t *testing.T) {
 	}
 
 	for i, te := range tests {
-		eps, err := ctx.BindContainer(te.h)
+		eps, err := ctx.BindContainer(op, te.h)
 		if te.err != nil {
 			// expect an error
 			if err == nil || eps != nil {
@@ -928,6 +929,7 @@ func TestContextBindUnbindContainer(t *testing.T) {
 
 func TestContextRemoveContainer(t *testing.T) {
 
+	op := trace.NewOperation(context.Background(), "TestContextRemoveContainer")
 	hFoo := newContainer("foo")
 
 	ctx, err := NewContext(testConfig(), nil)
@@ -948,7 +950,7 @@ func TestContextRemoveContainer(t *testing.T) {
 		Scope: scope.Name(),
 	}
 	ctx.AddContainer(hFoo, options)
-	ctx.BindContainer(hFoo)
+	ctx.BindContainer(op, hFoo)
 
 	// container that is added to multiple bridge scopes
 	hBar := newContainer("bar")
@@ -1046,6 +1048,7 @@ func TestDeleteScope(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewContext() => (nil, %s), want (ctx, nil)", err)
 	}
+	op := trace.NewOperation(context.Background(), "TestDeleteScope")
 
 	scopeData := &ScopeData{
 		ScopeType: constants.BridgeScopeType,
@@ -1074,7 +1077,7 @@ func TestDeleteScope(t *testing.T) {
 	h = newContainer("container2")
 	options.Scope = bar.Name()
 	ctx.AddContainer(h, options)
-	ctx.BindContainer(h)
+	ctx.BindContainer(op, h)
 
 	scopeData = &ScopeData{
 		ScopeType: constants.BridgeScopeType,
@@ -1139,6 +1142,7 @@ func TestAliases(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, ctx)
 
+	op := trace.NewOperation(context.Background(), "TestAliases")
 	scope := ctx.DefaultScope()
 
 	var tests = []struct {
@@ -1169,7 +1173,7 @@ func TestAliases(t *testing.T) {
 		assert.NoError(t, err)
 		assert.EqualValues(t, opts.Aliases, c.ExecConfig.Networks[scope.Name()].Network.Aliases)
 
-		eps, err := ctx.BindContainer(c)
+		eps, err := ctx.BindContainer(op, c)
 		if te.err != nil {
 			assert.Error(t, err)
 			assert.Empty(t, eps)
@@ -1226,7 +1230,6 @@ func TestAliases(t *testing.T) {
 	t.Logf("containers: %#v", ctx.containers)
 
 	c := containers["c2"]
-	op := trace.NewOperation(context.Background(), "unbind")
 	_, err = ctx.UnbindContainer(op, c)
 	assert.NoError(t, err)
 	// verify aliases are gone

--- a/lib/portlayer/network/network.go
+++ b/lib/portlayer/network/network.go
@@ -177,6 +177,7 @@ func engageContext(ctx context.Context, netctx *Context, em event.EventManager) 
 		}
 	}()
 
+	op := trace.NewOperation(context.Background(), "engageContext")
 	s.Suspend(true)
 	defer s.Resume()
 	for _, c := range exec.Containers.Containers(nil) {
@@ -219,7 +220,7 @@ func engageContext(ctx context.Context, netctx *Context, em event.EventManager) 
 		}
 
 		if c.CurrentState() == exec.StateRunning {
-			if _, err = netctx.bindContainer(h); err != nil {
+			if _, err = netctx.bindContainer(op, h); err != nil {
 				return err
 			}
 		}

--- a/lib/portlayer/network/scope_test.go
+++ b/lib/portlayer/network/scope_test.go
@@ -15,6 +15,7 @@
 package network
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"reflect"
@@ -22,6 +23,7 @@ import (
 
 	"github.com/vmware/govmomi/vim25/types"
 	"github.com/vmware/vic/lib/portlayer/exec"
+	"github.com/vmware/vic/pkg/trace"
 	"github.com/vmware/vic/pkg/uid"
 )
 
@@ -42,6 +44,7 @@ func TestScopeAddRemoveContainer(t *testing.T) {
 		t.Errorf("NewContext() => (nil, %s), want (ctx, nil)", err)
 		return
 	}
+	op := trace.NewOperation(context.Background(), "TestScopeAddRemoveContainer")
 
 	s := ctx.defaultScope
 
@@ -146,7 +149,7 @@ func TestScopeAddRemoveContainer(t *testing.T) {
 	}
 	bound := exec.TestHandle("bound")
 	ctx.AddContainer(bound, options)
-	ctx.BindContainer(bound)
+	ctx.BindContainer(op, bound)
 
 	// test RemoveContainer
 	var tests2 = []struct {


### PR DESCRIPTION
In load testing, we've found overlapping request to ContainerStart
for the same container, causing IP reservation issues.  We are
adding back the per container locking we had before to prevent this.
Currently, this locking is being utilized for operations around
ContainerStart.  We need to add this back in for other docker API
access in the future.

Also, we removed useless logging and added more logging around
ContainerStart in the persona and around IP reservation/release in
the portlayer.

Resolves #6851