### PR TITLE
[WIP] Add concurrent access error to network

### DIFF
--- a/lib/apiservers/engine/backends/cache/image_cache.go
+++ b/lib/apiservers/engine/backends/cache/image_cache.go
@@ -117,7 +117,6 @@ func InitializeImageCache(client *client.PortLayer) error {
 
 // GetImages returns a slice containing metadata for all cached images
 func (ic *ICache) GetImages() []*metadata.ImageConfig {
-	defer trace.End(trace.Begin(""))
 	ic.m.RLock()
 	defer ic.m.RUnlock()
 
@@ -143,7 +142,6 @@ func (ic *ICache) IsImageID(id string) bool {
 
 // Get parses input to retrieve a cached image
 func (ic *ICache) Get(idOrRef string) (*metadata.ImageConfig, error) {
-	defer trace.End(trace.Begin(idOrRef))
 	ic.m.RLock()
 	defer ic.m.RUnlock()
 
@@ -183,7 +181,6 @@ func (ic *ICache) Get(idOrRef string) (*metadata.ImageConfig, error) {
 }
 
 func (ic *ICache) getImageByDigest(digest digest.Digest) *metadata.ImageConfig {
-	defer trace.End(trace.Begin(digest.String()))
 	var config *metadata.ImageConfig
 	config, ok := ic.cacheByID[string(digest)]
 	if !ok {
@@ -194,7 +191,6 @@ func (ic *ICache) getImageByDigest(digest digest.Digest) *metadata.ImageConfig {
 
 // Looks up image by reference.Named
 func (ic *ICache) getImageByNamed(named reference.Named) *metadata.ImageConfig {
-	defer trace.End(trace.Begin(""))
 	// get the imageID from the repoCache
 	// #nosec: Errors unhandled.
 	id, _ := RepositoryCache().Get(named)
@@ -213,8 +209,6 @@ func prefixImageID(imageID string) string {
 
 // Add adds an image to the image cache
 func (ic *ICache) Add(imageConfig *metadata.ImageConfig) error {
-	defer trace.End(trace.Begin(""))
-
 	ic.m.Lock()
 	defer ic.m.Unlock()
 
@@ -257,8 +251,6 @@ func (ic *ICache) Add(imageConfig *metadata.ImageConfig) error {
 
 // RemoveImageByConfig removes image from the cache.
 func (ic *ICache) RemoveImageByConfig(imageConfig *metadata.ImageConfig) {
-	defer trace.End(trace.Begin(""))
-
 	ic.m.Lock()
 	defer ic.m.Unlock()
 

--- a/lib/apiservers/engine/backends/container_proxy.go
+++ b/lib/apiservers/engine/backends/container_proxy.go
@@ -1470,13 +1470,11 @@ func processVolumeFields(volumes []string) (map[string]volumeFields, error) {
 }
 
 func finalizeVolumeList(specifiedVolumes, anonymousVolumes []string) ([]volumeFields, error) {
-	log.Infof("Specified Volumes : %#v", specifiedVolumes)
 	processedVolumes, err := processVolumeFields(specifiedVolumes)
 	if err != nil {
 		return nil, err
 	}
 
-	log.Infof("anonymous Volumes : %#v", anonymousVolumes)
 	processedAnonVolumes, err := processVolumeFields(anonymousVolumes)
 	if err != nil {
 		return nil, err

--- a/lib/apiservers/portlayer/restapi/handlers/scopes_handlers.go
+++ b/lib/apiservers/portlayer/restapi/handlers/scopes_handlers.go
@@ -284,7 +284,8 @@ func (handler *ScopesHandlersImpl) ScopesBindContainer(params scopes.BindContain
 		switch err := err.(type) {
 		case network.ResourceNotFoundError:
 			return scopes.NewBindContainerNotFound().WithPayload(errorPayload(err))
-
+		case network.ConcurrentResourceError:
+			return scopes.NewBindContainerConflict().WithPayload(&models.Error{Message: err.Error()})
 		default:
 			return scopes.NewBindContainerInternalServerError().WithPayload(errorPayload(err))
 		}

--- a/lib/apiservers/portlayer/swagger.json
+++ b/lib/apiservers/portlayer/swagger.json
@@ -1273,6 +1273,12 @@
 							"$ref": "#/definitions/Error"
 						}
 					},
+					"409": {
+						"description": "conflict",
+						"schema": {
+							"$ref": "#/definitions/Error"
+						}
+					},
 					"500": {
 						"description": "error",
 						"schema": {

--- a/lib/portlayer/network/ipam.go
+++ b/lib/portlayer/network/ipam.go
@@ -293,7 +293,7 @@ func (s *AddressSpace) ReserveIP4Range(firstIP net.IP, lastIP net.IP) (*AddressS
 	var err error
 	if compareIP4(firstIP, s.Pool.FirstIP) > 0 && compareIP4(lastIP, s.Pool.LastIP) < 0 {
 		// IP range is within the pool but not found available
-		err = fmt.Errorf("Cannot reserve IP range %s - %s.  Already in use", firstIP.String(), lastIP.String())
+		err = ConcurrentResourceError{fmt.Errorf("Cannot reserve IP range %s - %s.  Already in use", firstIP.String(), lastIP.String())}
 	} else {
 		err = fmt.Errorf("Cannot reserve IP range %s - %s.  Not within pool's range %s - %s",
 			firstIP.String(), lastIP.String(), s.Pool.FirstIP, s.Pool.LastIP)

--- a/lib/portlayer/network/scope.go
+++ b/lib/portlayer/network/scope.go
@@ -150,6 +150,7 @@ func (s *Scope) reserveEndpointIP(e *Endpoint) error {
 	var err error
 	for _, p := range s.spaces {
 		if !ip.IsUnspecifiedIP(e.ip) {
+			//If an IP was specified, try to reserve it
 			if err = p.ReserveIP4(e.ip); err == nil {
 				return nil
 			}


### PR DESCRIPTION
Add concurrent access error as a return result from
network reservation.  This should allow the persona
to retry on 'IP already in use' error instead of
just returning the error to the API caller.

Also removed more useless logging clogging up the logs.

Towards #6581