### PR TITLE
[specific ci=Group23-VIC-Machine-Service] Remove path from target URL in vic-machine-service API

### DIFF
--- a/lib/apiservers/service/restapi/handlers/common.go
+++ b/lib/apiservers/service/restapi/handlers/common.go
@@ -93,11 +93,10 @@ func buildDataAndValidateTarget(op trace.Operation, params buildDataParams, prin
 			return data, nil, util.NewError(http.StatusBadRequest, "Validation Error: datacenter parameter is not a datacenter moref")
 		}
 
-		data.Target.URL.Path = dc.InventoryPath
-
 		// Do what NewValidator would have done if a Datacenter had been set
 		v.DatacenterPath = dc.Name()
-		v.Session.DatastorePath = v.DatacenterPath
+		v.Session.DatacenterPath = v.DatacenterPath
+		v.Session.Datacenter = dc
 		v.Session.Finder.SetDatacenter(dc)
 
 		validator = v

--- a/lib/apiservers/service/restapi/handlers/common.go
+++ b/lib/apiservers/service/restapi/handlers/common.go
@@ -93,7 +93,7 @@ func buildDataAndValidateTarget(op trace.Operation, params buildDataParams, prin
 			return data, nil, util.NewError(http.StatusBadRequest, "Validation Error: datacenter parameter is not a datacenter moref")
 		}
 
-		// Do what NewValidator would have done if a Datacenter had been set
+		// Set validator datacenter path and correspondent validator session config
 		v.DatacenterPath = dc.Name()
 		v.Session.DatacenterPath = v.DatacenterPath
 		v.Session.Datacenter = dc

--- a/tests/resources/VCH-Util.robot
+++ b/tests/resources/VCH-Util.robot
@@ -316,7 +316,7 @@ Run Secret VIC Machine Delete Command
 Run Secret VIC Machine Inspect Command
     [Tags]  secret
     [Arguments]  ${name}
-    ${rc}  ${output}=  Run And Return Rc And Output  bin/vic-machine-linux inspect --name=${name} --target=%{TEST_URL}%{TEST_DATACENTER} --user=%{TEST_USERNAME} --password=%{TEST_PASSWORD} --thumbprint=%{TEST_THUMBPRINT}
+    ${rc}  ${output}=  Run And Return Rc And Output  bin/vic-machine-linux inspect --name=${name} --target=%{TEST_URL}%{TEST_DATACENTER} --user=%{TEST_USERNAME} --password=%{TEST_PASSWORD} --thumbprint=%{TEST_THUMBPRINT} --compute-resource=%{TEST_RESOURCE}
 
     [Return]  ${rc}  ${output}
 
@@ -329,7 +329,8 @@ Run VIC Machine Delete Command
     [Return]  ${output}
 
 Run VIC Machine Inspect Command
-    ${rc}  ${output}=  Run Secret VIC Machine Inspect Command  %{VCH-NAME}
+    [Arguments]  ${name}=%{VCH-NAME}
+    ${rc}  ${output}=  Run Secret VIC Machine Inspect Command  ${name}
     Get Docker Params  ${output}  ${true}
 
 Inspect VCH
@@ -339,11 +340,12 @@ Inspect VCH
     Should Contain  ${output}  ${expected}
 
 Wait For VCH Initialization
-    [Arguments]  ${attempts}=12x  ${interval}=10 seconds
-    Wait Until Keyword Succeeds  ${attempts}  ${interval}  VCH Docker Info
+    [Arguments]  ${attempts}=12x  ${interval}=10 seconds  ${name}=%{VCH-NAME}
+    Wait Until Keyword Succeeds  ${attempts}  ${interval}  VCH Docker Info  ${name}
 
 VCH Docker Info
-    Run VIC Machine Inspect Command
+    [Arguments]  ${name}=%{VCH-NAME}
+    Run VIC Machine Inspect Command  ${name}
     ${rc}=  Run And Return Rc  docker %{VCH-PARAMS} info
     Should Be Equal As Integers  ${rc}  0
 

--- a/tests/test-cases/Group23-VIC-Machine-Service/23-03-VCH-Create.md
+++ b/tests/test-cases/Group23-VIC-Machine-Service/23-03-VCH-Create.md
@@ -14,7 +14,7 @@ This test requires a vSphere system where VCHs can be deployed
 1. Create a VCH with as minimal a configuration as possible
 2. Inspect that VCH using the CLI
 3. Verify that the VCH appliance created has been successfully initialized
-4. Create a VCH with a more complex configuration
+4. Create a VCH with a more complex configuration (some input params for creation have placeholder values)
 5. Inspect that VCH using the CLI
 
 # Expected Outcome:

--- a/tests/test-cases/Group23-VIC-Machine-Service/23-03-VCH-Create.md
+++ b/tests/test-cases/Group23-VIC-Machine-Service/23-03-VCH-Create.md
@@ -13,12 +13,14 @@ This test requires a vSphere system where VCHs can be deployed
 # Test Steps:
 1. Create a VCH with as minimal a configuration as possible
 2. Inspect that VCH using the CLI
-3. Create a VCH with a more complex configuration
-4. Inspect that VCH using the CLI
+3. Verify that the VCH appliance created has been successfully initialized
+4. Create a VCH with a more complex configuration
+5. Inspect that VCH using the CLI
 
 # Expected Outcome:
 * The results of 2 should contain the same information as was supplied when the VCH was created in 1.
-* The results of 4 should contain the same information as was supplied when the VCH was created in 3.
+* The results of 3 should show that the VCH appliance is initialized and docker endpoint is able to connect.
+* The results of 5 should contain the same information as was supplied when the VCH was created in 4.
 
 # Possible Problems:
 None known

--- a/tests/test-cases/Group23-VIC-Machine-Service/23-03-VCH-Create.robot
+++ b/tests/test-cases/Group23-VIC-Machine-Service/23-03-VCH-Create.robot
@@ -280,3 +280,11 @@ Fail to create VCH without network
 
     Output Should Contain    network
 
+
+Fail to create VCH with gateway without static address
+    Create VCH    '{"name":"%{VCH-NAME}-api-bad-gateway","compute":{"resource":{"name":"%{TEST_RESOURCE}"}},"storage":{"image_stores":["ds://%{TEST_DATASTORE}"]},"network":{"bridge":{"ip_range":"172.16.0.0/12","port_group":{"name":"%{BRIDGE_NETWORK}"}},"public":{"port_group":{"name":"${PUBLIC_NETWORK}"},"gateway":{"address":"127.0.0.1","routing_destinations":[]}}},"auth":{"server":{"generate":{"cname":"vch.example.com","organization":["VMware, Inc."],"size":{"value":2048,"units":"bits"}}},"client":{"no_tls_verify": true}}}'
+
+    Verify Return Code
+    Verify Status Bad Request
+
+    Output Should Contain    static

--- a/tests/test-cases/Group23-VIC-Machine-Service/23-03-VCH-Create.robot
+++ b/tests/test-cases/Group23-VIC-Machine-Service/23-03-VCH-Create.robot
@@ -78,7 +78,6 @@ Verify VCH Initialization ${name}
     Wait Until Keyword Succeeds  12x  10 seconds  Get VCH Docker Info  ${name}
 
 
-
 *** Test Cases ***
 Create minimal VCH
     Create VCH    '{"name":"%{VCH-NAME}-api-test-minimal","compute":{"resource":{"name":"%{TEST_RESOURCE}"}},"storage":{"image_stores":["ds://%{TEST_DATASTORE}"]},"network":{"bridge":{"ip_range":"172.16.0.0/12","port_group":{"name":"%{BRIDGE_NETWORK}"}},"public":{"port_group":{"name":"${PUBLIC_NETWORK}"}}},"auth":{"server":{"generate":{"cname":"vch.example.com","organization":["VMware, Inc."],"size":{"value":2048,"units":"bits"}}},"client":{"no_tls_verify": true}}}'

--- a/tests/test-cases/Group23-VIC-Machine-Service/23-03-VCH-Create.robot
+++ b/tests/test-cases/Group23-VIC-Machine-Service/23-03-VCH-Create.robot
@@ -51,31 +51,11 @@ Inspect VCH Config ${name}
     Set Test Variable    ${OUTPUT}
 
 
-Inspect VCH
-    [Arguments]  ${name}  ${expected}
-    ${rc}    ${output}=    Run And Return Rc And Output  bin/vic-machine-linux inspect --name=${name} --target=%{TEST_URL} --thumbprint=%{TEST_THUMBPRINT} --user=%{TEST_USERNAME} --password=%{TEST_PASSWORD} --compute-resource=%{TEST_RESOURCE}
-    Should Be Equal As Integers  ${rc}  0
-    Should Contain  ${output}  ${expected}
-    [Return]  ${output}
-
-
 Get VCH ${name}
     Get Path Under Target    vch
     ${id}=    Run    echo '${OUTPUT}' | jq -r '.vchs[] | select(.name=="${name}").id'
 
     Get Path Under Target    vch/${id}
-
-
-Get VCH Docker Info
-    [Arguments]  ${name}
-    ${output}=  Inspect VCH  ${name}  Completed successfully
-    Get Docker Params  ${output}  ${true}
-    ${rc}=  Run And Return Rc  docker %{VCH-PARAMS} info
-    Should Be Equal As Integers  ${rc}  0
-
-
-Verify VCH Initialization ${name}
-    Wait Until Keyword Succeeds  12x  10 seconds  Get VCH Docker Info  ${name}
 
 
 *** Test Cases ***

--- a/tests/test-cases/Group23-VIC-Machine-Service/23-03-VCH-Create.robot
+++ b/tests/test-cases/Group23-VIC-Machine-Service/23-03-VCH-Create.robot
@@ -110,7 +110,7 @@ Create minimal VCH
     Property Should Contain         .runtime.power_state                 poweredOn
     Property Should Contain         .runtime.upgrade_status              Up to date
 
-    Verify VCH Initialization %{VCH-NAME}-api-test-minimal
+    Wait For VCH Initialization  name=%{VCH-NAME}-api-test-minimal
 
     [Teardown]    Run Secret VIC Machine Delete Command    %{VCH-NAME}-api-test-minimal
 
@@ -146,7 +146,7 @@ Create minimal VCH within datacenter
     Property Should Contain         .runtime.power_state                 poweredOn
     Property Should Contain         .runtime.upgrade_status              Up to date
 
-    Verify VCH Initialization %{VCH-NAME}-api-test-dc
+    Wait For VCH Initialization  name=%{VCH-NAME}-api-test-dc
 
     [Teardown]    Run Secret VIC Machine Delete Command    %{VCH-NAME}-api-test-dc
 

--- a/tests/test-cases/Group23-VIC-Machine-Service/23-03-VCH-Create.robot
+++ b/tests/test-cases/Group23-VIC-Machine-Service/23-03-VCH-Create.robot
@@ -288,3 +288,4 @@ Fail to create VCH with gateway without static address
     Verify Status Bad Request
 
     Output Should Contain    static
+    

--- a/tests/test-cases/Group23-VIC-Machine-Service/23-03-VCH-Create.robot
+++ b/tests/test-cases/Group23-VIC-Machine-Service/23-03-VCH-Create.robot
@@ -288,4 +288,3 @@ Fail to create VCH with gateway without static address
     Verify Status Bad Request
 
     Output Should Contain    static
-    


### PR DESCRIPTION
Fixes #6978 , also hopefully fixes https://github.com/vmware/vic-ui/issues/257

The root causes of the issues are:
1. path is not stripped from the target URL when creating a VCH
2. datacenter in validator session config is never set
3. typo on assigning datacenter path to datastore path

So the fixes are: 
1. remove the path from target URL
2. set datacenter in validator session to the management object
3. fix the typo

Also a simple VCH initialization check (docker connectivity check) is added to the API create robot test