### PR TITLE
Fix hostd resource exhaustion in high load CI (#6998)

### DIFF
--- a/lib/portlayer/event/collector/vsphere/collector.go
+++ b/lib/portlayer/event/collector/vsphere/collector.go
@@ -124,9 +124,9 @@ func (ec *EventCollector) Start() error {
 
 	// pageSize is the number of events on the last page of the eventCollector
 	// as new events are added the oldest are removed.  Originally this value
-	// was 1 and then 25, both led to missed events.  Setting to the default
-	// size of 1000 to help avoid more misses
-	pageSize := int32(1000)
+	// was 1 and we encountered missed events due to them being evicted
+	// before being processed.  A setting of 25 should provide ample buffer.
+	pageSize := int32(25)
 	// bool to follow the stream
 	followStream := true
 	// don't exceed the govmomi object limit

--- a/tests/test-cases/Group23-VIC-Machine-Service/23-08-VCH-Delete.robot
+++ b/tests/test-cases/Group23-VIC-Machine-Service/23-08-VCH-Delete.robot
@@ -19,6 +19,7 @@ Resource          ../../resources/Group23-VIC-Machine-Service-Util.robot
 Suite Setup       Start VIC Machine Server
 Suite Teardown    Terminate All Processes    kill=True
 Test Setup        Install And Prepare VIC Appliance
+
 Default Tags
 
 
@@ -197,30 +198,60 @@ Verify VCH Not Exists
 Verify Volume Exists
     [Arguments]    ${volume}    ${name}
 
-    ${ds}=    Run    govc datastore.ls ${volume}/volumes/${name}
-
+    ${ds}=  Run                       govc datastore.ls ${volume}/volumes/${name}
     Should Not Contain                ${ds}    was not found
+
+
+Verify Volume Exists Docker
+    [Arguments]    ${volume}    ${name}
+
+    ${ds}=  Run                       govc datastore.ls ${volume}/volumes/${name}
+    Should Not Contain                ${ds}    was not found
+
+    Run Docker Command                volume ls -q -f name=${name}
+    Verify Return Code
+    Output Should Contain             ${name}
+
 
 Verify Volume Not Exists
     [Arguments]    ${volume}    ${name}
 
-    ${ds}=    Run    govc datastore.ls ${volume}/volumes/${name}
-
+    ${ds}=  Run                       govc datastore.ls ${volume}/volumes/${name}
     Should Contain                    ${ds}    was not found
+
+
+Verify Volume Not Exists Docker
+    [Arguments]    ${volume}    ${name}
+
+    ${ds}=  Run                       govc datastore.ls ${volume}/volumes/${name}
+    Should Contain                    ${ds}    was not found
+
+    Run Docker Command                volume ls -q -f name=${name}
+    Verify Return Code
+    Output Should Not Contain         ${name}
+
 
 Verify Volume Store Exists
     [Arguments]    ${name}
 
-    ${ds}=    Run    govc datastore.ls ${name}
-
+    ${ds}=  Run                       govc datastore.ls ${name}
     Should Not Contain                ${ds}    was not found
+
+# don't currently have the pretty volume store name
+#    Run Docker Command                info
+#    Verify Return Code
+#    Output Should Match Regexp        ^VolumeStores:\s[^$]*${name}
 
 Verify Volume Store Not Exists
     [Arguments]    ${name}
 
-    ${ds}=    Run    govc datastore.ls ${name}
-
+    ${ds}=  Run                       govc datastore.ls ${name}
     Should Contain                    ${ds}    was not found
+
+# don't currently have the pretty volume store name
+#    Run Docker Command                info
+#    Verify Return Code
+#    Output Should Not Match Regexp    ^VolumeStores:\s[^$]*${name}
 
 
 *** Test Cases ***
@@ -235,6 +266,8 @@ Delete VCH
 
     Verify VCH Not Exists             vch/${id}
 
+    # No VCH to delete
+    [Teardown]                        NONE
 
 Delete VCH within datacenter
     ${dc}=    Get Datacenter ID
@@ -248,6 +281,8 @@ Delete VCH within datacenter
 
     Verify VCH Not Exists             datacenter/${dc}/vch/${id}
 
+    # No VCH to delete
+    [Teardown]                        NONE
 
 Delete the correct VCH
     ${one}=    Get VCH ID %{VCH-NAME}
@@ -259,6 +294,8 @@ Delete the correct VCH
 
     Should Not Be Equal As Integers    ${one}    ${two}
 
+    # This will fail when run outside of drone because "Install VIC Appliance To Test Server"
+    # will delete "dangling" VCHs - which means any associated with a drone job id that isn't running
     Verify VCH Exists                 vch/${one}    ${old}
     Verify VCH Exists                 vch/${two}
 
@@ -268,6 +305,8 @@ Delete the correct VCH
 
     Verify VCH Not Exists             vch/${one}    ${old}
     Verify VCH Exists                 vch/${two}
+
+    [Teardown]                        Cleanup VIC Appliance On Test Server
 
 
 Delete invalid VCH
@@ -279,7 +318,7 @@ Delete invalid VCH
 
     Verify VCH Exists                  vch/${id}
 
-    [Teardown]    Cleanup VIC Appliance On Test Server
+    [Teardown]                        Cleanup VIC Appliance On Test Server
 
 
 Delete VCH in invalid datacenter
@@ -291,7 +330,7 @@ Delete VCH in invalid datacenter
 
     Verify VCH Exists                  vch/${id}
 
-    [Teardown]    Cleanup VIC Appliance On Test Server
+    [Teardown]                        Cleanup VIC Appliance On Test Server
 
 
 Delete with invalid bodies
@@ -323,7 +362,7 @@ Delete with invalid bodies
 
     Verify VCH Exists                  vch/${id}
 
-    [Teardown]    Cleanup VIC Appliance On Test Server
+    [Teardown]                         Cleanup VIC Appliance On Test Server
 
 
 Delete VCH with powered off container
@@ -341,6 +380,8 @@ Delete VCH with powered off container
     Verify VCH Not Exists             vch/${id}
     Verify Container Not Exists       ${POWERED_OFF_CONTAINER_NAME}
 
+    # No VCH to delete
+    [Teardown]                        NONE
 
 Delete VCH with powered off container deletes files
     ${id}=    Get VCH ID %{VCH-NAME}
@@ -363,6 +404,8 @@ Delete VCH with powered off container deletes files
 
     Verify VCH Not Exists             vch/${id}
 
+    # No VCH to delete
+    [Teardown]                        NONE
 
 Delete VCH without deleting powered on container
     ${id}=    Get VCH ID %{VCH-NAME}
@@ -382,7 +425,7 @@ Delete VCH without deleting powered on container
     Verify Container Exists           ${POWERED_ON_CONTAINER_NAME}
     Verify Container Not Exists       ${POWERED_OFF_CONTAINER_NAME}
 
-    [Teardown]    Cleanup VIC Appliance On Test Server
+    [Teardown]                        Cleanup VIC Appliance On Test Server
 
 
 Delete VCH explicitly without deleting powered on container
@@ -403,7 +446,7 @@ Delete VCH explicitly without deleting powered on container
     Verify Container Exists           ${POWERED_ON_CONTAINER_NAME}
     Verify Container Not Exists       ${POWERED_OFF_CONTAINER_NAME}
 
-    [Teardown]    Cleanup VIC Appliance On Test Server
+    [Teardown]                        Cleanup VIC Appliance On Test Server
 
 
 Delete VCH and delete powered on container
@@ -424,6 +467,12 @@ Delete VCH and delete powered on container
     Verify Container Not Exists       ${POWERED_ON_CONTAINER_NAME}
     Verify Container Not Exists       ${POWERED_OFF_CONTAINER_NAME}
 
+    # should this delete volume stores?
+    # if it should then we should check they're gone, if it shouldn't we should check they're not
+    # if not then we should clean up volume stores in teardown
+
+    # No VCH to delete
+    [Teardown]                        NONE
 
 Delete VCH and powered off containers and volumes
     [Setup]    Install And Prepare VIC Appliance With Volume Stores
@@ -457,6 +506,8 @@ Delete VCH and powered off containers and volumes
     Verify Volume Store Not Exists    ${VOLUME_STORE_PATH}
     Verify Volume Not Exists          ${VOLUME_STORE_PATH}           ${OFF_NV_NVS_VOLUME_NAME}
 
+    # No VCH to delete
+    [Teardown]                        NONE
 
 Delete VCH and powered on containers and volumes
     [Setup]    Install And Prepare VIC Appliance With Volume Stores
@@ -490,6 +541,8 @@ Delete VCH and powered on containers and volumes
     Verify Volume Store Not Exists    ${VOLUME_STORE_PATH}
     Verify Volume Not Exists          ${VOLUME_STORE_PATH}           ${ON_NV_NVS_VOLUME_NAME}
 
+    # No VCH to delete
+    [Teardown]                        NONE
 
 Delete VCH and powered off container and preserve volumes
     [Setup]    Install And Prepare VIC Appliance With Volume Stores
@@ -529,25 +582,30 @@ Delete VCH and powered off container and preserve volumes
 
     Verify VCH Exists                 vch/${id}
 
-    Run Docker Command    create --name ${OFF_NV_DVS_CONTAINER_NAME} -v ${OFF_NV_DVS_VOLUME_NAME}:/volume ${busybox} /bin/top
-    Verify Return Code
-    Output Should Not Contain    Error
-
-    Verify Container Exists           ${OFF_NV_DVS_CONTAINER_NAME}
+    # volume should already exist even before use - default volume store
     Verify Volume Store Exists        %{VCH-NAME}-VOL
-    Verify Volume Exists              %{VCH-NAME}-VOL                ${OFF_NV_DVS_VOLUME_NAME}
+    Verify Volume Exists Docker       %{VCH-NAME}-VOL                ${OFF_NV_DVS_VOLUME_NAME}
 
-    Run Docker Command    create --name ${OFF_NV_NVS_CONTAINER_NAME} -v ${OFF_NV_NVS_VOLUME_NAME}:/volume ${busybox} /bin/top
+    # confirm volume can be referenced
+    Run Docker Command                create --name ${OFF_NV_DVS_CONTAINER_NAME} -v ${OFF_NV_DVS_VOLUME_NAME}:/volume ${busybox} /bin/top
     Verify Return Code
-    Output Should Not Contain    Error
+    Output Should Not Contain         Error
+    Verify Container Exists           ${OFF_NV_DVS_CONTAINER_NAME}
 
-    Verify Container Exists           ${OFF_NV_NVS_CONTAINER_NAME}
+    # volume should already exist even before use - named volume store
     Verify Volume Store Exists        ${VOLUME_STORE_PATH}
-    Verify Volume Exists              ${VOLUME_STORE_PATH}           ${OFF_NV_NVS_VOLUME_NAME}
+    Verify Volume Exists Docker       ${VOLUME_STORE_PATH}           ${OFF_NV_NVS_VOLUME_NAME}
+
+    # confirm volume can be referenced
+    Run Docker Command                create --name ${OFF_NV_NVS_CONTAINER_NAME} -v ${OFF_NV_NVS_VOLUME_NAME}:/volume ${busybox} /bin/top
+    Verify Return Code
+    Output Should Not Contain         Error
+    Verify Container Exists           ${OFF_NV_NVS_CONTAINER_NAME}
+
+    [Teardown]                        Cleanup VIC Appliance On Test Server
 
 
 Delete VCH and powered on container but preserve volume
-    [Setup]    Install And Prepare VIC Appliance With Volume Stores
     ${id}=    Get VCH ID %{VCH-NAME}
 
     Verify VCH Exists                 vch/${id}
@@ -574,13 +632,18 @@ Delete VCH and powered on container but preserve volume
 
     Verify VCH Exists                 vch/${id}
 
-    Run Docker Command    create --name ${ON_NV_DVS_CONTAINER_NAME} -v ${ON_NV_DVS_VOLUME_NAME}:/volume ${busybox} /bin/top
+    # volume should already exist even before use
+    Verify Volume Store Exists        %{VCH-NAME}-VOL
+    Verify Volume Exists Docker       %{VCH-NAME}-VOL                ${ON_NV_DVS_VOLUME_NAME}
+
+    # confirm volume can be referenced AND USED - confirms the disk is healthy
+    Run Docker Command                run --name ${ON_NV_DVS_CONTAINER_NAME} -v ${ON_NV_DVS_VOLUME_NAME}:/volume ${busybox} /bin/touch /volume/hello
     Verify Return Code
-    Output Should Not Contain    Error
+    Output Should Not Contain         Error
 
     Verify Container Exists           ${ON_NV_DVS_CONTAINER_NAME}
-    Verify Volume Store Exists        %{VCH-NAME}-VOL
-    Verify Volume Exists              %{VCH-NAME}-VOL                ${ON_NV_DVS_VOLUME_NAME}
+
+    [Teardown]                        Cleanup VIC Appliance On Test Server
 
 
 Delete VCH and preserve powered on container and volumes
@@ -605,6 +668,8 @@ Delete VCH and preserve powered on container and volumes
     Verify Volume Store Exists        %{VCH-NAME}-VOL
     Verify Volume Exists              %{VCH-NAME}-VOL                ${ON_NV_DVS_VOLUME_NAME}
 
+    [Teardown]                        Cleanup VIC Appliance On Test Server
+
 
 Delete VCH and preserve powered on container and fail to delete volumes
     [Setup]    Install And Prepare VIC Appliance With Volume Stores
@@ -627,3 +692,5 @@ Delete VCH and preserve powered on container and fail to delete volumes
     Verify Container Exists           ${ON_NV_DVS_CONTAINER_NAME}
     Verify Volume Store Exists        %{VCH-NAME}-VOL
     Verify Volume Exists              %{VCH-NAME}-VOL                ${ON_NV_DVS_VOLUME_NAME}
+
+    [Teardown]                        Cleanup VIC Appliance On Test Server

--- a/tests/test-cases/Group6-VIC-Machine/6-03-Delete.robot
+++ b/tests/test-cases/Group6-VIC-Machine/6-03-Delete.robot
@@ -142,7 +142,13 @@ Delete VCH with non-cVM in same RP
 
 
 Delete VCH moved from its RP
+    # Don't perform unconditional setup as we skip the test on ESX
+    [Setup]     NONE
+
     Run Keyword If  '%{HOST_TYPE}' == 'ESXi'  Pass Execution  Test skipped on ESX due to unable to move into RP
+
+    Install VIC Appliance To Test Server
+
     ${rand}=  Generate Random String  15
     ${dummyvm}=  Set Variable  anothervm-${rand}
     Set Suite Variable  ${tempvm}  ${dummyvm}
@@ -191,6 +197,13 @@ Delete VCH moved from its RP
 
 
 Delete VCH moved to root RP and original RP deleted
+    # Don't perform unconditional setup as we skip the test on ESX
+    [Setup]     NONE
+
+    Run Keyword If  '%{HOST_TYPE}' == 'ESXi'  Pass Execution  Test skipped on ESX due to unable to move into RP
+
+    Install VIC Appliance To Test Server
+
     Run Keyword If  '%{HOST_TYPE}' == 'ESXi'  Pass Execution  Test skipped on ESX due to unable to move into RP
     ${rand}=  Generate Random String  15
     ${dummyvm}=  Set Variable  anothervm-${rand}


### PR DESCRIPTION
* Fix leak of VCHs after test runs

The delete tests for vic-machine and vic-machine-service leaks VCHs.
For the service it's because the tests deploy VCHs directly that are not
cleaned up.
For vic-machine base it's because we render the VCH invalid by moving the
endpointVM in such a manner that the deletion fails without explicit
cleanup after.

* Revert "Increase event page size to 1000 (#6937)"

This reverts commit 7796336f068a27357cf7920ffe482adb868ed162 because it's
apparent that increasing the page size to this extent can cause hostd to
both hit its resource limits and drastically fragment its heap.
