### PR TITLE
Add basic vic-machine inspect integration tests

### DIFF
--- a/tests/test-cases/Group6-VIC-Machine/6-01-Help.md
+++ b/tests/test-cases/Group6-VIC-Machine/6-01-Help.md
@@ -12,11 +12,18 @@ Standalone test requires nothing but vic-machine to be built
 
 # Test Cases
 
+## Inspect help basic
+1. Issue the `vic-machine-linux inspect -h` command
+
 ## Delete help basic
-1. Issue the following command:
-```
-* vic-machine-linux delete -h
-```
+1. Issue the `vic-machine-linux delete -h` command
 
 ### Expected Outcome:
-* Command should output Usage of vic-machine delete -h:
+* Command should output the usage of vic-machine inspect -h:
+```
+vic-machine-linux inspect - Inspect VCH
+```
+* Command should output the usage of vic-machine delete -h:
+```
+vic-machine-linux delete - Delete VCH
+```

--- a/tests/test-cases/Group6-VIC-Machine/6-01-Help.robot
+++ b/tests/test-cases/Group6-VIC-Machine/6-01-Help.robot
@@ -18,6 +18,10 @@ Resource  ../../resources/Util.robot
 Test Timeout  20 minutes
 
 *** Test Cases ***
+Inspect help basic
+    ${ret}=  Run  bin/vic-machine-linux inspect -h
+    Should Contain  ${ret}  vic-machine-linux inspect - Inspect VCH
+
 Delete help basic
     ${ret}=  Run  bin/vic-machine-linux delete -h
     Should Contain  ${ret}  vic-machine-linux delete - Delete VCH

--- a/tests/test-cases/Group6-VIC-Machine/6-09-Inspect.md
+++ b/tests/test-cases/Group6-VIC-Machine/6-09-Inspect.md
@@ -12,29 +12,44 @@ This test requires that a vSphere server is running and available
 
 # Test Steps:
 1. Install VCH
-2. Issue vic-machine inspect config command
-3. Issue vic-machine inspect config --format raw command
-4. Create a VCH with tlsverify
-5. Inspect the VCH without specifying --tls-cert-path
-6. Inspect the VCH with a valid --tls-cert-path
-7. Inspect the VCH with an invalid --tls-cert-path
-8. Create a VCH with --no-tls
-9. Inspect the VCH without specifying --tls-cert-path
-10. Create a VCH with --no-tlsverify
+2. Issue a basic vic-machine inspect command
+3. Issue vic-machine inspect config command
+4. Issue vic-machine inspect config --format raw command
+5. Create a VCH with custom resource settings
+6. Issue vic-machine inspect config command
+7. Issue vic-machine inspect config --format raw command
+8. Create a VCH with some container-network options
+9. Issue vic-machine inspect config --format raw command
+10. Create a VCH with tlsverify
 11. Inspect the VCH without specifying --tls-cert-path
-12. Create a VCH with some container-network options
-13. Verify the `inspect config` contains the correct options
+12. Inspect the VCH with a valid --tls-cert-path
+13. Inspect the VCH with an invalid --tls-cert-path
+14. Create a VCH with --no-tls
+15. Inspect the VCH without specifying --tls-cert-path
+16. Create a VCH with --no-tlsverify
+17. Inspect the VCH without specifying --tls-cert-path
+18. Create a VCH with some container-network options
 
 # Expected Outcome:
-* Steps 1 should succeed, and output from step 2 and 3 should contain expected flags & values
-* Steps 4-13 should complete successfully, however, step 6 should show a warning in the output (see below)
-* The output of steps 5 and 6 should contain the correct `DOCKER_CERT_PATH`.
-* The output of step 7 should not contain a `DOCKER_CERT_PATH` and should contain:
+* Step 1 should succeed 
+* Step 2 should succeed and the output should contain the following:
+  * VCH ID
+  * VCH upgrade information
+  * VCH Admin address
+  * Address of published ports
+  * The docker info command for the VCH
+* Steps 3-9 should succeed
+* Output from steps 3 and 4 should contain expected flags & values
+* Output from steps 6 and 7 should contain the expected resource flags and values
+* Output from step 9 should contain the expected container network flags and values
+* Steps 10-18 should complete successfully, however, step 12 should show a warning in the output (see below)
+* The output of steps 11 and 12 should contain the correct `DOCKER_CERT_PATH`
+* The output of step 13 should not contain a `DOCKER_CERT_PATH` and should contain:
 ```
 Unable to find valid client certs
 DOCKER_CERT_PATH must be provided in environment or certificates specified individually via CLI arguments
 ```
-* The outputs of steps 9 and 11 should not contain a `DOCKER_CERT_PATH` and should not contain:
+* The outputs of steps 15 and 17 should not contain a `DOCKER_CERT_PATH` and should not contain:
 ```
 Unable to find valid client certs
 DOCKER_CERT_PATH must be provided in environment or certificates specified individually via CLI arguments

--- a/tests/test-cases/Group6-VIC-Machine/6-09-Inspect.robot
+++ b/tests/test-cases/Group6-VIC-Machine/6-09-Inspect.robot
@@ -30,9 +30,22 @@ Cleanup Container Network Test
     Cleanup Container Network Test Networks
 
 *** Test Cases ***
-Inspect VCH Configuration
+Inspect VCH Basic
     Install VIC Appliance To Test Server
 
+    ${rc}  ${output}=  Run And Return Rc And Output  bin/vic-machine-linux inspect --target=%{TEST_URL} --thumbprint=%{TEST_THUMBPRINT} --user %{TEST_USERNAME} --password=%{TEST_PASSWORD} --name=%{VCH-NAME}
+    Should Be Equal As Integers  0  ${rc}
+    Should Contain  ${output}  VCH ID
+    Should Contain  ${output}  Installer version
+    Should Contain  ${output}  VCH version
+    Should Contain  ${output}  VCH upgrade status
+    Should Contain  ${output}  Installer has same version as VCH
+    Should Contain  ${output}  No upgrade available with this installer version
+    Should Contain  ${output}  VCH Admin Portal
+    Should Contain  ${output}  Published ports can be reached at
+    Should Contain  ${output}  Connect to docker
+
+Inspect VCH Configuration
     ${rc}  ${output}=  Run And Return Rc And Output  bin/vic-machine-linux inspect config --target=%{TEST_URL} --thumbprint=%{TEST_THUMBPRINT} --user %{TEST_USERNAME} --password=%{TEST_PASSWORD} --name=%{VCH-NAME}
     Should Contain  ${output}  --debug=1
     Should Contain  ${output}  --name=%{VCH-NAME}


### PR DESCRIPTION
This commit adds two vic-machine inspect tests for verifying usage
help output and output from a basic command execution. These test
cases were previously not present in the integration test suite.

Fixes #5045