### PR TITLE
Cherry-pick: Remove path from target URL in vic-machine-service API [specific ci=Group23-VIC-Machine-Service]

### DIFF
--- a/lib/apiservers/service/restapi/handlers/common.go
+++ b/lib/apiservers/service/restapi/handlers/common.go
@@ -93,11 +93,10 @@ func buildDataAndValidateTarget(op trace.Operation, params buildDataParams, prin
 			return data, nil, util.NewError(http.StatusBadRequest, "Validation Error: datacenter parameter is not a datacenter moref")
 		}
 
-		data.Target.URL.Path = dc.InventoryPath
-
-		// Do what NewValidator would have done if a Datacenter had been set
+		// Set validator datacenter path and correspondent validator session config
 		v.DatacenterPath = dc.Name()
-		v.Session.DatastorePath = v.DatacenterPath
+		v.Session.DatacenterPath = v.DatacenterPath
+		v.Session.Datacenter = dc
 		v.Session.Finder.SetDatacenter(dc)
 
 		validator = v

--- a/tests/resources/VCH-Util.robot
+++ b/tests/resources/VCH-Util.robot
@@ -316,7 +316,7 @@ Run Secret VIC Machine Delete Command
 Run Secret VIC Machine Inspect Command
     [Tags]  secret
     [Arguments]  ${name}
-    ${rc}  ${output}=  Run And Return Rc And Output  bin/vic-machine-linux inspect --name=${name} --target=%{TEST_URL}%{TEST_DATACENTER} --user=%{TEST_USERNAME} --password=%{TEST_PASSWORD} --thumbprint=%{TEST_THUMBPRINT}
+    ${rc}  ${output}=  Run And Return Rc And Output  bin/vic-machine-linux inspect --name=${name} --target=%{TEST_URL}%{TEST_DATACENTER} --user=%{TEST_USERNAME} --password=%{TEST_PASSWORD} --thumbprint=%{TEST_THUMBPRINT} --compute-resource=%{TEST_RESOURCE}
 
     [Return]  ${rc}  ${output}
 
@@ -329,7 +329,8 @@ Run VIC Machine Delete Command
     [Return]  ${output}
 
 Run VIC Machine Inspect Command
-    ${rc}  ${output}=  Run Secret VIC Machine Inspect Command  %{VCH-NAME}
+    [Arguments]  ${name}=%{VCH-NAME}
+    ${rc}  ${output}=  Run Secret VIC Machine Inspect Command  ${name}
     Get Docker Params  ${output}  ${true}
 
 Inspect VCH
@@ -339,11 +340,12 @@ Inspect VCH
     Should Contain  ${output}  ${expected}
 
 Wait For VCH Initialization
-    [Arguments]  ${attempts}=12x  ${interval}=10 seconds
-    Wait Until Keyword Succeeds  ${attempts}  ${interval}  VCH Docker Info
+    [Arguments]  ${attempts}=12x  ${interval}=10 seconds  ${name}=%{VCH-NAME}
+    Wait Until Keyword Succeeds  ${attempts}  ${interval}  VCH Docker Info  ${name}
 
 VCH Docker Info
-    Run VIC Machine Inspect Command
+    [Arguments]  ${name}=%{VCH-NAME}
+    Run VIC Machine Inspect Command  ${name}
     ${rc}=  Run And Return Rc  docker %{VCH-PARAMS} info
     Should Be Equal As Integers  ${rc}  0
 

--- a/tests/test-cases/Group23-VIC-Machine-Service/23-03-VCH-Create.md
+++ b/tests/test-cases/Group23-VIC-Machine-Service/23-03-VCH-Create.md
@@ -13,12 +13,14 @@ This test requires a vSphere system where VCHs can be deployed
 # Test Steps:
 1. Create a VCH with as minimal a configuration as possible
 2. Inspect that VCH using the CLI
-3. Create a VCH with a more complex configuration
-4. Inspect that VCH using the CLI
+3. Verify that the VCH appliance created has been successfully initialized
+4. Create a VCH with a more complex configuration (some input params for creation have placeholder values)
+5. Inspect that VCH using the CLI
 
 # Expected Outcome:
 * The results of 2 should contain the same information as was supplied when the VCH was created in 1.
-* The results of 4 should contain the same information as was supplied when the VCH was created in 3.
+* The results of 3 should show that the VCH appliance is initialized and docker endpoint is able to connect.
+* The results of 5 should contain the same information as was supplied when the VCH was created in 4.
 
 # Possible Problems:
 None known

--- a/tests/test-cases/Group23-VIC-Machine-Service/23-03-VCH-Create.robot
+++ b/tests/test-cases/Group23-VIC-Machine-Service/23-03-VCH-Create.robot
@@ -45,8 +45,8 @@ Create VCH Within Datacenter
     Post Path Under Target    datacenter/${dcID}/vch    ${data}
 
 
-Inspect VCH ${name}
-    ${RC}    ${OUTPUT}=    Run And Return Rc And Output    bin/vic-machine-linux inspect config --target=%{TEST_URL} --thumbprint=%{TEST_THUMBPRINT} --user %{TEST_USERNAME} --password=%{TEST_PASSWORD} --name=${name} --format raw
+Inspect VCH Config ${name}
+    ${RC}    ${OUTPUT}=    Run And Return Rc And Output    bin/vic-machine-linux inspect config --target=%{TEST_URL} --thumbprint=%{TEST_THUMBPRINT} --user %{TEST_USERNAME} --password=%{TEST_PASSWORD} --compute-resource=%{TEST_RESOURCE} --name=${name} --format raw
     Should Be Equal As Integers    ${RC}    0
     Set Test Variable    ${OUTPUT}
 
@@ -66,7 +66,7 @@ Create minimal VCH
     Verify Status Created
 
 
-    Inspect VCH %{VCH-NAME}-api-test-minimal
+    Inspect VCH Config %{VCH-NAME}-api-test-minimal
 
     Output Should Contain    --image-store=ds://%{TEST_DATASTORE}
     Output Should Contain    --bridge-network=%{BRIDGE_NETWORK}
@@ -90,6 +90,8 @@ Create minimal VCH
     Property Should Contain         .runtime.power_state                 poweredOn
     Property Should Contain         .runtime.upgrade_status              Up to date
 
+    Wait For VCH Initialization  name=%{VCH-NAME}-api-test-minimal
+
     [Teardown]    Run Secret VIC Machine Delete Command    %{VCH-NAME}-api-test-minimal
 
 
@@ -100,7 +102,7 @@ Create minimal VCH within datacenter
     Verify Status Created
 
 
-    Inspect VCH %{VCH-NAME}-api-test-dc
+    Inspect VCH Config %{VCH-NAME}-api-test-dc
 
     Output Should Contain    --image-store=ds://%{TEST_DATASTORE}
     Output Should Contain    --bridge-network=%{BRIDGE_NETWORK}
@@ -124,6 +126,8 @@ Create minimal VCH within datacenter
     Property Should Contain         .runtime.power_state                 poweredOn
     Property Should Contain         .runtime.upgrade_status              Up to date
 
+    Wait For VCH Initialization  name=%{VCH-NAME}-api-test-dc
+
     [Teardown]    Run Secret VIC Machine Delete Command    %{VCH-NAME}-api-test-dc
 
 
@@ -134,7 +138,7 @@ Create complex VCH
     Verify Status Created
 
 
-    Inspect VCH %{VCH-NAME}-api-test-complex
+    Inspect VCH Config %{VCH-NAME}-api-test-complex
 
     Output Should Contain    --debug=3
 


### PR DESCRIPTION
original ticket: https://github.com/vmware/vic/issues/6978
PR: https://github.com/vmware/vic/pull/6994
cherry-pick commit: https://github.com/vmware/vic/commit/1eebc19bdaf84336b1da67d0077154fdabd6a811

Changes:
1. Remove path from target URL in vch create API
2. Set validator datacenter path and related session config fields in vch create API
3. Added docker info connectivity check in vch create API robot tests
