### PR TITLE
[specific ci=Group23-VIC-Machine-Service] Manually set validator session VMFolder for vic-machine-service API handlers

### DIFF
--- a/lib/apiservers/service/restapi/handlers/common.go
+++ b/lib/apiservers/service/restapi/handlers/common.go
@@ -99,6 +99,15 @@ func buildDataAndValidateTarget(op trace.Operation, params buildDataParams, prin
 		v.Session.Datacenter = dc
 		v.Session.Finder.SetDatacenter(dc)
 
+		// Do what validator.session.Populate would have done if datacenterPath is set
+		if v.Session.Datacenter != nil {
+			folders, err := v.Session.Datacenter.Folders(op)
+			if err != nil {
+				return data, nil, util.NewError(http.StatusBadRequest, "Validator Error: error finding datacenter folders: %s", err)
+			}
+			v.Session.VMFolder = folders.VmFolder
+		}
+
 		validator = v
 	} else {
 		v, err := validate.NewValidator(op, data)

--- a/lib/apiservers/service/restapi/handlers/common.go
+++ b/lib/apiservers/service/restapi/handlers/common.go
@@ -103,7 +103,7 @@ func buildDataAndValidateTarget(op trace.Operation, params buildDataParams, prin
 		if v.Session.Datacenter != nil {
 			folders, err := v.Session.Datacenter.Folders(op)
 			if err != nil {
-				return data, nil, util.NewError(http.StatusBadRequest, "Validator Error: error finding datacenter folders: %s", err)
+				return data, nil, util.NewError(http.StatusBadRequest, "Validation Error: error finding datacenter folders: %s", err)
 			}
 			v.Session.VMFolder = folders.VmFolder
 		}


### PR DESCRIPTION
Fixes #7011 

We never set the `validator.session.VMFolder` field and it caused a runtime panic in appliance.go during VCH create:
```
return d.session.VMFolder.CreateVM(ctx, *spec, d.vchPool, d.session.Host)
```
https://github.com/vmware/vic/blob/master/lib/install/management/appliance.go#L506

So this PR includes a fix that manually sets the `VMFolder` field.

This fix is a no-op for single-dc env, because the datacenter will default to the only dc. However under multi-dc, since there're multiple dc, the session.Populate will get confused and return error, leaving the dc in validator session never set. 

@hickeng @zjs Do we think if it's good to add a multi-dc robot test to API create?
Also TBH this fix looks a bit brutal to me but it's the only way to go...normally, the validator is responsible for populating all session vars, but we don't have the dc path in the URL anymore, we only have the moref (is that right?), and we have to wait for session populate to finish so we can have the govmomi finder to grab the dc mo.
Do we have a plan of refactoring this post 1.3?