### PR TITLE
Cherry-pick: Manually set validator session VMFolder for vic-machine-service API handlers

### DIFF
--- a/lib/apiservers/service/restapi/handlers/common.go
+++ b/lib/apiservers/service/restapi/handlers/common.go
@@ -99,6 +99,15 @@ func buildDataAndValidateTarget(op trace.Operation, params buildDataParams, prin
 		v.Session.Datacenter = dc
 		v.Session.Finder.SetDatacenter(dc)
 
+		// Do what validator.session.Populate would have done if datacenterPath is set
+		if v.Session.Datacenter != nil {
+			folders, err := v.Session.Datacenter.Folders(op)
+			if err != nil {
+				return data, nil, util.NewError(http.StatusBadRequest, "Validation Error: error finding datacenter folders: %s", err)
+			}
+			v.Session.VMFolder = folders.VmFolder
+		}
+
 		validator = v
 	} else {
 		v, err := validate.NewValidator(op, data)


### PR DESCRIPTION
Original ticket: #7011 
Cherry-pick commit: https://github.com/vmware/vic/commit/86fa5f0e4d30b241a49488f01bc8eaa9c9bcfeed

Manually set VMFolder outside of validator in API handlers