### PR TITLE
Include vic-machine server log file in integration test log bundle [specific ci=Group23-VIC-Machine-Service]

### DIFF
--- a/tests/integration-test.sh
+++ b/tests/integration-test.sh
@@ -47,12 +47,7 @@ rc="$?"
 timestamp=$(date +%s)
 outfile="integration_logs_"$DRONE_BUILD_NUMBER"_"$DRONE_COMMIT".zip"
 
-if [ -f "/var/log/vic-machine-server/vic-machine-server.log" ]
-then
-  zip -9 $outfile output.xml log.html report.html package.list *container-logs.zip *.log /var/log/vic-machine-server/vic-machine-server.log 
-else
-  zip -9 $outfile output.xml log.html report.html package.list *container-logs.zip *.log
-fi
+zip -9 $outfile output.xml log.html report.html package.list *container-logs.zip *.log /var/log/vic-machine-server/vic-machine-server.log 
 
 # GC credentials
 keyfile="/root/vic-ci-logs.key"

--- a/tests/integration-test.sh
+++ b/tests/integration-test.sh
@@ -47,7 +47,12 @@ rc="$?"
 timestamp=$(date +%s)
 outfile="integration_logs_"$DRONE_BUILD_NUMBER"_"$DRONE_COMMIT".zip"
 
-zip -9 $outfile output.xml log.html report.html package.list *container-logs.zip *.log
+if [ -f "/var/log/vic-machine-server/vic-machine-server.log" ]
+then
+  zip -9 $outfile output.xml log.html report.html package.list *container-logs.zip *.log /var/log/vic-machine-server/vic-machine-server.log 
+else
+  zip -9 $outfile output.xml log.html report.html package.list *container-logs.zip *.log
+fi
 
 # GC credentials
 keyfile="/root/vic-ci-logs.key"

--- a/tests/integration-test.sh
+++ b/tests/integration-test.sh
@@ -47,7 +47,7 @@ rc="$?"
 timestamp=$(date +%s)
 outfile="integration_logs_"$DRONE_BUILD_NUMBER"_"$DRONE_COMMIT".zip"
 
-zip -9 $outfile output.xml log.html report.html package.list *container-logs.zip *.log /var/log/vic-machine-server/vic-machine-server.log 
+zip -9 -j $outfile output.xml log.html report.html package.list *container-logs.zip *.log /var/log/vic-machine-server/vic-machine-server.log 
 
 # GC credentials
 keyfile="/root/vic-ci-logs.key"

--- a/tests/test-cases/Group23-VIC-Machine-Service/23-01-Metadata.md
+++ b/tests/test-cases/Group23-VIC-Machine-Service/23-01-Metadata.md
@@ -12,12 +12,13 @@ This test has no environmental requirements
 
 # Test Steps:
 1. Start the vic-machine-server
-2. Wait 1 second
-3. Use curl to issue a GET request for the version
+2. Retry 5 times using curl to issue a GET request for the version endpoint
+3. Use curl to issue a GET request for the gretting hello message endpoint
 
 # Expected Outcome:
-* Step 3 should succeed with a 200 OK response containing a version number
+* Step 2 should succeed with a 200 OK response containing a version number
+* Step 3 should succeed with a 200 OK response containing a greeting message
 
 # Possible Problems:
-* Step 1 could take more than 1 second to complete causing step 3 to fail with a return code of 7. (Other tests in this suite may wait on a response from the version endpoint to determine whether the service is available, but this test should not as it is the endpoint under test.)
+* Step 1 could take more than the expected retry time for the service to become available, causing the GET request sent in step 2 to fail with a return code of 7. (Other tests in this suite may wait on a response from the version endpoint to determine whether the service is available, but this test should not as it is the endpoint under test.)
 

--- a/tests/test-cases/Group23-VIC-Machine-Service/23-01-Metadata.robot
+++ b/tests/test-cases/Group23-VIC-Machine-Service/23-01-Metadata.robot
@@ -24,6 +24,7 @@ Default Tags
 *** Keywords ***
 Get Version
     Get Path    version
+    Verify Return Code
 
 Get Hello
     Get Path    hello
@@ -40,11 +41,8 @@ Verify Hello
 
 *** Test Cases ***
 Get Version
-    Sleep    1s    for service to start
+    Wait Until Keyword Succeeds  5x  1s  Get Version 
 
-    Get Version
-
-    Verify Return Code
     Verify Status Ok
     Verify Version
 


### PR DESCRIPTION
Fixes #7052 
Fixes #7051 

Changes:
1. Include the vic-machine-server log file in the integration log bundle
2. Add retries in checking version endpoint in 23-01-Metadata integration test
  
  