### PR TITLE
[specific ci=6-04-Create-Basic] Enable debug on custom base disk test

### DIFF
--- a/tests/test-cases/Group6-VIC-Machine/6-04-Create-Basic.robot
+++ b/tests/test-cases/Group6-VIC-Machine/6-04-Create-Basic.robot
@@ -48,7 +48,8 @@ Create VCH - custom base disk
     Run Keyword And Ignore Error  Cleanup Dangling VMs On Test Server
     Run Keyword And Ignore Error  Cleanup Datastore On Test Server
 
-    ${output}=  Run  bin/vic-machine-linux create --name=%{VCH-NAME} --target=%{TEST_URL} --thumbprint=%{TEST_THUMBPRINT} --user=%{TEST_USERNAME} --bridge-network=%{BRIDGE_NETWORK} --public-network=%{PUBLIC_NETWORK} --image-store=%{TEST_DATASTORE} --password=%{TEST_PASSWORD} --base-image-size=6GB ${vicmachinetls} --insecure-registry harbor.ci.drone.local
+    # Deploy vic-machine with debug enabled to attempt to cache #7047
+    ${output}=  Run  bin/vic-machine-linux create --name=%{VCH-NAME} --debug=1 --target=%{TEST_URL} --thumbprint=%{TEST_THUMBPRINT} --user=%{TEST_USERNAME} --bridge-network=%{BRIDGE_NETWORK} --public-network=%{PUBLIC_NETWORK} --image-store=%{TEST_DATASTORE} --password=%{TEST_PASSWORD} --base-image-size=6GB ${vicmachinetls} --insecure-registry harbor.ci.drone.local
     Should Contain  ${output}  Installer completed successfully
     Get Docker Params  ${output}  ${true}
     Log To Console  Installer completed successfully: %{VCH-NAME}


### PR DESCRIPTION
Enable debug on this test to help reproduce issue 7047.
In this issue, the container process starts up and ends
so quickly, the portlayer doesn't catch the container
start event and returns an error indicating the container
unexpectedly shutdown.

Helps debug #7047