### PR TITLE
[specific ci=23-01-Metadata]Make rcX group optional in the version

### DIFF
--- a/tests/test-cases/Group23-VIC-Machine-Service/23-01-Metadata.robot
+++ b/tests/test-cases/Group23-VIC-Machine-Service/23-01-Metadata.robot
@@ -29,7 +29,6 @@ Get Version
 Get Hello
     Get Path    hello
 
-
 Verify Version
     Output Should Match Regexp    v\\d+\\.\\d+\\.\\d+-(\\w+-)?\\d+-[a-f0-9]+
     Output Should Not Contain     "

--- a/tests/test-cases/Group23-VIC-Machine-Service/23-01-Metadata.robot
+++ b/tests/test-cases/Group23-VIC-Machine-Service/23-01-Metadata.robot
@@ -31,7 +31,7 @@ Get Hello
 
 
 Verify Version
-    Output Should Match Regexp    v\\d+\\.\\d+\\.\\d+-\\w+-\\d+-[a-f0-9]+
+    Output Should Match Regexp    v\\d+\\.\\d+\\.\\d+-(\\w+-)?\\d+-[a-f0-9]+
     Output Should Not Contain     "
 
 Verify Hello


### PR DESCRIPTION
There are times when an RC candidate is not tagged, so we need this regex to support that.