### PR TITLE
Collect vmx and vmsd files in log bundle

### DIFF
--- a/cmd/vicadmin/vicadm.go
+++ b/cmd/vicadmin/vicadm.go
@@ -472,6 +472,26 @@ func findDatastoreLogs(c *session.Session) (map[string]entryReader, error) {
 
 			log.Debugf("Added log file for collection: %s", logfile.URL.String())
 		}
+
+		f := logfile.VMName
+		if !c.IsVC() {
+			f = logfile.URL.Path
+		}
+
+		// get the vmx and vmsd files
+		for _, ext := range []string{"vmx", "vmsd"} {
+			rpath := fmt.Sprintf("%s/%s.%s", logfile.URL.Path, f, ext)
+			wpath := fmt.Sprintf("%s/%s.%s", logfile.VMName, f, ext)
+			log.Infof("Processed File read Path : %s", rpath)
+			log.Infof("Processed File write Path : %s", wpath)
+			readers[wpath] = datastoreReader{
+				ds:   ds,
+				path: rpath,
+				ctx:  hCtx,
+			}
+
+			log.Debugf("Added log file for collection: %s", logfile.URL.String())
+		}
 	}
 
 	return readers, nil

--- a/cmd/vicadmin/vicadm_test.go
+++ b/cmd/vicadmin/vicadm_test.go
@@ -253,6 +253,7 @@ func testSeek(t *testing.T, st seekTest, td string) {
 	log.Printf("Successfully seeked to position %d", st.output)
 	os.Remove(f.Name())
 }
+
 func TestFindSeekPos(t *testing.T) {
 	if runtime.GOOS != "linux" {
 		t.SkipNow()


### PR DESCRIPTION
This change will enable the vicadmin log bundler to also collect the `vmx` and `vmsd` files for VMs associated with the VCH. Useful for debugging.