### PR TITLE
Do not force logout on validation failure

### DIFF
--- a/lib/vicadmin/validate.go
+++ b/lib/vicadmin/validate.go
@@ -250,11 +250,6 @@ func NewValidator(ctx context.Context, vch *config.VirtualContainerHostConfigSpe
 		log.Errorf("Had a problem querying the datastores: %s", err.Error())
 	}
 	v.QueryVCHStatus(vch, sess)
-	defer func() {
-		if sess != nil && len(nwErrors) > 0 {
-			sess.Logout(ctx)
-		}
-	}()
 	return v
 }
 


### PR DESCRIPTION
Removes an explicit logout on vicadmin validation failure. This was causing the vicadmin session to be invalidated immediately which prevents collection of log bundles.
This was of particular annoyance when in an environment that does not have internet access as 
docker hub is always unavailable which results in a completely useless vicadmin.

This does not have an explicit test as we do not have an existing test environment defined without internet access and I'm unwilling to write a test that actually breaks the environment in order to test the other validated elements. I have opened #7102 for expansion of testing to include isolated environments.

This was part of #6943 but has been pulled out for 1.3.1 inclusion.