### PR TITLE
Add integration test on open container upon VCH reboot [specific ci=Group10-VCH-Restart]

### DIFF
--- a/tests/test-cases/Group10-VCH-Restart/10-01-VCH-Restart.md
+++ b/tests/test-cases/Group10-VCH-Restart/10-01-VCH-Restart.md
@@ -17,15 +17,21 @@ This test requires that a vSphere server is running and available
 7. Issue docker stop, start and ls
 8. Check container service in specified port
 9. Start container with same port
-10. Create container with volume and then reboot VCH
-11. Inspect container to check volume info
+10. Deploy VIC appliance with open container network
+11. Create container on the open network, and create contaienr with port mapping
+12. Reboot VCH
+13. Check container service in specified port
+14. Create container with volume and then reboot VCH
+15. Inspect container to check volume info
 
 # Expected Outcome:
 * VCH should reboot within a reasonable amount of time
 * After VCH restart, network ls should have the previously created network listed
 * Step 6, 7 and 8 should result in success
 * Step 9 should result in false
-* Step 10-11 should result in success
+* Step 12 (VCH reboot with open container network) should succeed within a reasonable amount of time
+* Step 13 would result in success
+* Step 14-15 should result in success
 
 #Possible Problems:
 None

--- a/tests/test-cases/Group10-VCH-Restart/10-01-VCH-Restart.robot
+++ b/tests/test-cases/Group10-VCH-Restart/10-01-VCH-Restart.robot
@@ -74,14 +74,6 @@ Created Network And Images Persists As Well As Containers Are Discovered With Co
     ${rc}=  Run And Return Rc  docker %{VCH-PARAMS} exec bar-c2 ping -c3 bar-c1
     Should Be Equal As Integers  ${rc}  0
 
-    # ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} create -it -p 10000:80 -p 10001:80 --name webserver ${nginx}
-    # Should Be Equal As Integers  ${rc}  0
-    # Should Not Contain  ${output}  Error
-    # ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} start webserver
-    # Should Be Equal As Integers  ${rc}  0
-    # Should Not Contain  ${output}  Error
-    # Wait Until Keyword Succeeds  20x  5 seconds  Hit Nginx Endpoint  %{VCH-IP}  10000
-    # Wait Until Keyword Succeeds  20x  5 seconds  Hit Nginx Endpoint  %{VCH-IP}  10001
     Launch Container With Port Forwarding  ${name}=webserver  ${port1}=10000  ${port2}=10001
 
     Reboot VM  %{VCH-NAME}

--- a/tests/test-cases/Group10-VCH-Restart/10-01-VCH-Restart.robot
+++ b/tests/test-cases/Group10-VCH-Restart/10-01-VCH-Restart.robot
@@ -14,8 +14,8 @@
 
 *** Settings ***
 Documentation  Test 10-01 - VCH Restart
-Test Setup  Install VIC Appliance To Test Server
-Test Teardown  Cleanup VIC Appliance On Test Server
+Suite Setup  Install VIC Appliance To Test Server
+Suite Teardown  Cleanup VIC Appliance On Test Server
 Resource  ../../resources/Util.robot
 Default Tags
 

--- a/tests/test-cases/Group10-VCH-Restart/10-01-VCH-Restart.robot
+++ b/tests/test-cases/Group10-VCH-Restart/10-01-VCH-Restart.robot
@@ -17,7 +17,6 @@ Documentation  Test 10-01 - VCH Restart
 Resource  ../../resources/Util.robot
 Suite Setup  Install VIC Appliance To Test Server
 Suite Teardown  Cleanup VIC Appliance On Test Server
-
 Default Tags
 
 *** Keywords ***

--- a/tests/test-cases/Group10-VCH-Restart/10-01-VCH-Restart.robot
+++ b/tests/test-cases/Group10-VCH-Restart/10-01-VCH-Restart.robot
@@ -14,9 +14,10 @@
 
 *** Settings ***
 Documentation  Test 10-01 - VCH Restart
+Resource  ../../resources/Util.robot
 Suite Setup  Install VIC Appliance To Test Server
 Suite Teardown  Cleanup VIC Appliance On Test Server
-Resource  ../../resources/Util.robot
+
 Default Tags
 
 *** Keywords ***

--- a/tests/test-cases/Group10-VCH-Restart/10-01-VCH-Restart.robot
+++ b/tests/test-cases/Group10-VCH-Restart/10-01-VCH-Restart.robot
@@ -15,8 +15,8 @@
 *** Settings ***
 Documentation  Test 10-01 - VCH Restart
 Resource  ../../resources/Util.robot
-Suite Setup  Install VIC Appliance To Test Server
-Suite Teardown  Cleanup VIC Appliance On Test Server
+Test Setup  Install VIC Appliance To Test Server
+Test Teardown  Cleanup VIC Appliance On Test Server
 Default Tags
 
 *** Keywords ***

--- a/tests/test-cases/Group10-VCH-Restart/10-01-VCH-Restart.robot
+++ b/tests/test-cases/Group10-VCH-Restart/10-01-VCH-Restart.robot
@@ -159,99 +159,99 @@ Created Network And Images Persists As Well As Containers Are Discovered With Co
 
     Cleanup VIC Appliance On Test Server
 
-# Container on Open Network And Port Forwarding Persist After Reboot
-#     Set Test Environment Variables
+Container on Open Network And Port Forwarding Persist After Reboot
+    Set Test Environment Variables
 
-#     Log To Console  Create Port Groups For Container network
-#     ${out}=  Run Keyword If  '%{HOST_TYPE}' == 'ESXi'  Run  govc host.portgroup.add -vswitch vSwitchLAN open-net
+    Log To Console  Create Port Groups For Container network
+    ${out}=  Run Keyword If  '%{HOST_TYPE}' == 'ESXi'  Run  govc host.portgroup.add -vswitch vSwitchLAN open-net
 
-#     ${createcommand}=  catenate  SEPARATOR=\ \
-#     ...  bin/vic-machine-linux create --debug 1 --name=%{VCH-NAME}
-#     ...  --target=%{TEST_URL}%{TEST_DATACENTER} --thumbprint=%{TEST_THUMBPRINT}
-#     ...  --user=%{TEST_USERNAME} --image-store=%{TEST_DATASTORE} --password=%{TEST_PASSWORD}
-#     ...  --force=true --bridge-network=bridge --compute-resource=%{TEST_RESOURCE} --no-tlsverify --no-tls
-#     ...  --container-network=open-net --container-network-firewall=open-net:open
+    ${createcommand}=  catenate  SEPARATOR=\ \
+    ...  bin/vic-machine-linux create --debug 1 --name=%{VCH-NAME}
+    ...  --target=%{TEST_URL}%{TEST_DATACENTER} --thumbprint=%{TEST_THUMBPRINT}
+    ...  --user=%{TEST_USERNAME} --image-store=%{TEST_DATASTORE} --password=%{TEST_PASSWORD}
+    ...  --force=true --bridge-network=bridge --compute-resource=%{TEST_RESOURCE} --no-tlsverify --no-tls
+    ...  --container-network=open-net --container-network-firewall=open-net:open
 
-#     ${output}=  Run  ${createcommand}
+    ${output}=  Run  ${createcommand}
 
-#     # Create a container on the open network
-#     ${open-running}=  Launch Container  vch-restart-open-running  open-net
-#     ${open-exited}=  Launch Container  vch-restart-open-exited  open-net  ls
+    # Create a container on the open network
+    ${open-running}=  Launch Container  vch-restart-open-running  open-net
+    ${open-exited}=  Launch Container  vch-restart-open-exited  open-net  ls
 
-#     # Create nginx on the open network and check port forwarding
-#     Launch Container With Port Forwarding  ${name}=webserver  ${port1}=10000  ${port2}=10001  ${network}=open-net
+    # Create nginx on the open network and check port forwarding
+    Launch Container With Port Forwarding  ${name}=webserver  ${port1}=10000  ${port2}=10001  ${network}=open-net
 
-#     # Reboot VCH
-#     Reboot VM  %{VCH-NAME}
-#     Log To Console  Getting VCH IP ...
-#     ${new-vch-ip}=  Get VM IP  %{VCH-NAME}
-#     Log To Console  New VCH IP is ${new-vch-ip}
-#     Replace String  %{VCH-PARAMS}  %{VCH-IP}  ${new-vch-ip}
+    # Reboot VCH
+    Reboot VM  %{VCH-NAME}
+    Log To Console  Getting VCH IP ...
+    ${new-vch-ip}=  Get VM IP  %{VCH-NAME}
+    Log To Console  New VCH IP is ${new-vch-ip}
+    Replace String  %{VCH-PARAMS}  %{VCH-IP}  ${new-vch-ip}
 
-#     # wait for docker info to succeed
-#     Wait Until Keyword Succeeds  20x  5 seconds  Run Docker Info  %{VCH-PARAMS}
+    # wait for docker info to succeed
+    Wait Until Keyword Succeeds  20x  5 seconds  Run Docker Info  %{VCH-PARAMS}
 
-#     # Check if the open container is persisted
-#     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} inspect ${open-running} | jq '.[0].State.Status'
-#     Should Be Equal As Integers  ${rc}  0
-#     Should Be Equal  ${output}  \"running\"
-#     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} inspect ${open-exited} | jq '.[0].State.Status'
-#     Should Be Equal As Integers  ${rc}  0
-#     Should Be Equal  ${output}  \"exited\"
-#     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} start ${open-exited}
-#     Should Be Equal As Integers  ${rc}  0
+    # Check if the open container is persisted
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} inspect ${open-running} | jq '.[0].State.Status'
+    Should Be Equal As Integers  ${rc}  0
+    Should Be Equal  ${output}  \"running\"
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} inspect ${open-exited} | jq '.[0].State.Status'
+    Should Be Equal As Integers  ${rc}  0
+    Should Be Equal  ${output}  \"exited\"
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} start ${open-exited}
+    Should Be Equal As Integers  ${rc}  0
 
-#     # Check port forwarding after reboot
-#     Wait Until Keyword Succeeds  20x  5 seconds  Hit Nginx Endpoint  %{VCH-IP}  10000
-#     Wait Until Keyword Succeeds  20x  5 seconds  Hit Nginx Endpoint  %{VCH-IP}  10001
+    # Check port forwarding after reboot
+    Wait Until Keyword Succeeds  20x  5 seconds  Hit Nginx Endpoint  %{VCH-IP}  10000
+    Wait Until Keyword Succeeds  20x  5 seconds  Hit Nginx Endpoint  %{VCH-IP}  10001
 
 
-# Create VCH attach disk and reboot
-#     Install VIC Appliance To Test Server
+Create VCH attach disk and reboot
+    Install VIC Appliance To Test Server
 
-#     ${rc}=  Run And Return Rc  govc vm.disk.create -vm=%{VCH-NAME} -name=%{VCH-NAME}/deleteme -size "16M"
-#     Should Be Equal As Integers  ${rc}  0
+    ${rc}=  Run And Return Rc  govc vm.disk.create -vm=%{VCH-NAME} -name=%{VCH-NAME}/deleteme -size "16M"
+    Should Be Equal As Integers  ${rc}  0
 
-#     Reboot VM  %{VCH-NAME}
+    Reboot VM  %{VCH-NAME}
 
-#     # wait for docker info to succeed
-#     Wait Until Keyword Succeeds  20x  5 seconds  Run Docker Info  %{VCH-PARAMS}
-#     ${rc}=  Run And Return Rc  govc device.ls -vm=%{VCH-NAME} | grep disk
-#     Should Be Equal As Integers  ${rc}  1
+    # wait for docker info to succeed
+    Wait Until Keyword Succeeds  20x  5 seconds  Run Docker Info  %{VCH-PARAMS}
+    ${rc}=  Run And Return Rc  govc device.ls -vm=%{VCH-NAME} | grep disk
+    Should Be Equal As Integers  ${rc}  1
 
-#     Cleanup VIC Appliance On Test Server
+    Cleanup VIC Appliance On Test Server
 
-# Docker inspect mount and cmd data after reboot
-#     Install VIC Appliance To Test Server
+Docker inspect mount and cmd data after reboot
+    Install VIC Appliance To Test Server
 
-#     ${rc}  ${container}=  Run And Return Rc And Output  docker %{VCH-PARAMS} volume create --name=named-volume
-#     Should Be Equal As Integers  ${rc}  0
-#     ${rc}  ${container}=  Run And Return Rc And Output  docker %{VCH-PARAMS} create --name=mount-data-test -v /mnt/test -v named-volume:/mnt/named busybox /bin/ls -la /
-#     Should Be Equal As Integers  ${rc}  0
-#     ${rc}  ${out}=  Run And Return Rc And Output  docker %{VCH-PARAMS} inspect -f '{{.Mounts}}' mount-data-test
-#     Should Be Equal As Integers  ${rc}  0
-#     Should Contain  ${out}  /mnt/test
-#     Should Contain  ${out}  /mnt/named
+    ${rc}  ${container}=  Run And Return Rc And Output  docker %{VCH-PARAMS} volume create --name=named-volume
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${container}=  Run And Return Rc And Output  docker %{VCH-PARAMS} create --name=mount-data-test -v /mnt/test -v named-volume:/mnt/named busybox /bin/ls -la /
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${out}=  Run And Return Rc And Output  docker %{VCH-PARAMS} inspect -f '{{.Mounts}}' mount-data-test
+    Should Be Equal As Integers  ${rc}  0
+    Should Contain  ${out}  /mnt/test
+    Should Contain  ${out}  /mnt/named
 
-#     ${rc}  ${out}=  Run And Return Rc And Output  docker %{VCH-PARAMS} inspect -f '{{.Config.Cmd}}' mount-data-test
-#     Should Be Equal As Integers  ${rc}  0
-#     Should Contain X Times  ${out}  /bin/ls  1
-#     Should Contain X Times  ${out}  -la  1
-#     Should Contain X Times  ${out}  ${SPACE}/  1
+    ${rc}  ${out}=  Run And Return Rc And Output  docker %{VCH-PARAMS} inspect -f '{{.Config.Cmd}}' mount-data-test
+    Should Be Equal As Integers  ${rc}  0
+    Should Contain X Times  ${out}  /bin/ls  1
+    Should Contain X Times  ${out}  -la  1
+    Should Contain X Times  ${out}  ${SPACE}/  1
 
-#     Reboot VM  %{VCH-NAME}
+    Reboot VM  %{VCH-NAME}
 
-#     # wait for docker info to succeed
-#     Wait Until Keyword Succeeds  20x  5 seconds  Run Docker Info  %{VCH-PARAMS}
-#     ${rc}  ${out}=  Run And Return Rc And Output  docker %{VCH-PARAMS} inspect -f '{{.Mounts}}' mount-data-test
-#     Should Be Equal As Integers  ${rc}  0
-#     Should Contain  ${out}  /mnt/test
-#     Should Contain  ${out}  /mnt/named
+    # wait for docker info to succeed
+    Wait Until Keyword Succeeds  20x  5 seconds  Run Docker Info  %{VCH-PARAMS}
+    ${rc}  ${out}=  Run And Return Rc And Output  docker %{VCH-PARAMS} inspect -f '{{.Mounts}}' mount-data-test
+    Should Be Equal As Integers  ${rc}  0
+    Should Contain  ${out}  /mnt/test
+    Should Contain  ${out}  /mnt/named
 
-#     ${rc}  ${out}=  Run And Return Rc And Output  docker %{VCH-PARAMS} inspect -f '{{.Config.Cmd}}' mount-data-test
-#     Should Be Equal As Integers  ${rc}  0
-#     Should Contain X Times  ${out}  /bin/ls  1
-#     Should Contain X Times  ${out}  -la  1
-#     Should Contain X Times  ${out}  ${SPACE}/  1
+    ${rc}  ${out}=  Run And Return Rc And Output  docker %{VCH-PARAMS} inspect -f '{{.Config.Cmd}}' mount-data-test
+    Should Be Equal As Integers  ${rc}  0
+    Should Contain X Times  ${out}  /bin/ls  1
+    Should Contain X Times  ${out}  -la  1
+    Should Contain X Times  ${out}  ${SPACE}/  1
 
-#     Cleanup VIC Appliance On Test Server
+    Cleanup VIC Appliance On Test Server


### PR DESCRIPTION
Currently we have a bug that if we configure container network with open firewall policy, after VCH reboot, all ports are being forwarded. docker persona takes a long time to start, `docker ps` and `docker inspect` gives huge list of all ports. 
A test is needed on VCH reboot with open container network. 

Related to: https://github.com/vmware/vic/issues/7084

Cc: @hickeng 