### PR TITLE
[specific ci=Group1-Docker-Commands] Fix persona image cache init upon VCH restart

### DIFF
--- a/lib/apiservers/engine/backends/image.go
+++ b/lib/apiservers/engine/backends/image.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2017 VMware, Inc. All Rights Reserved.
+// Copyright 2016-2018 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -475,9 +475,9 @@ func imageConfigToDockerImageInspect(imageConfig *metadata.ImageConfig, productN
 
 	inspectData.GraphDriver.Name = productName + " " + PortlayerName
 
-	//imageid is currently stored within VIC without "sha256:" so we add it to
-	//match Docker
-	inspectData.ID = "sha256:" + imageConfig.ImageID
+	// ImageID is currently stored within VIC without the "sha256:" prefix
+	// so we add it here to match Docker output.
+	inspectData.ID = digest.Canonical.String() + ":" + imageConfig.ImageID
 
 	return inspectData
 }

--- a/tests/test-cases/Group1-Docker-Commands/1-12-Docker-RMI.md
+++ b/tests/test-cases/Group1-Docker-Commands/1-12-Docker-RMI.md
@@ -25,6 +25,12 @@ This test requires that a vSphere server is running and available
 12. Issue docker rmi fakeImage to the VIC appliance
 13. Issue a docker pull by digest
 14. Issue a docker rmi by digest
+15. Issue docker pull for busybox and alpine
+16. Reboot the VCH and wait for it to initialize
+17. Obtain the image short ID for busybox
+18. Issue docker rmi using the short ID for busybox
+19. Obtain the image long ID for alpine
+20. Issue docker rmi using the long ID for alpine
 
 # Expected Outcome:
 * Step 3 and 7 should result in success and the image should be removed from inventory
@@ -38,6 +44,7 @@ Failed to remove image (busybox): Error response from daemon: conflict: unable t
 Failed to remove image (fakeImage): Error response from daemon: No such image: fakeImage:latest
 ```
 * Steps 13-14 should result in success and the output of step 14 should contain the digest of the rmi'd image
+* Steps 15-20 should succeed
 
 # Possible Problems:
 None

--- a/tests/test-cases/Group1-Docker-Commands/1-12-Docker-RMI.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-12-Docker-RMI.robot
@@ -1,4 +1,4 @@
-# Copyright 2016-2017 VMware, Inc. All Rights Reserved.
+# Copyright 2016-2018 VMware, Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -26,15 +26,10 @@ Basic docker pull, restart, and remove image
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} pull ${alpine}
     Should Be Equal As Integers  ${rc}  0
 
+    # Gather logs before rebooting
+    Run Keyword And Continue On Failure  Gather Logs From Test Server  -before-reboot-1
     Reboot VM  %{VCH-NAME}
-
-    Log To Console  Getting VCH IP ...
-    ${new-vch-ip}=  Get VM IP  %{VCH-NAME}
-    Log To Console  New VCH IP is ${new-vch-ip}
-    Replace String  %{VCH-PARAMS}  %{VCH-IP}  ${new-vch-ip}
-
-    # wait for docker info to succeed
-    Wait Until Keyword Succeeds  20x  5 seconds  Run Docker Info  %{VCH-PARAMS}
+    Wait For VCH Initialization  20x  5 seconds
 
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} images
     Should Be Equal As Integers  ${rc}  0
@@ -64,7 +59,7 @@ Remove image with a removed container
 Remove image with a container
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} pull ${busybox}
     Should Be Equal As Integers  ${rc}  0
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} create ${busybox} /bin/top
+    ${rc}  ${container}=  Run And Return Rc And Output  docker %{VCH-PARAMS} create ${busybox} /bin/top
     Should Be Equal As Integers  ${rc}  0
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} rmi ${busybox}
     Should Be Equal As Integers  ${rc}  1
@@ -72,6 +67,10 @@ Remove image with a container
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} images
     Should Be Equal As Integers  ${rc}  0
     Should Contain  ${output}  ${busybox}
+
+    # Cleanup container for future test-cases that use ${busybox}
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} rm -f ${container}
+    Should Be Equal As Integers  ${rc}  0
 
 Remove a fake image
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} rmi fakeImage
@@ -84,3 +83,37 @@ Remove an image pulled by digest
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} rmi ubuntu@sha256:45b23dee08af5e43a7fea6c4cf9c25ccf269ee113168c19722f87876677c5cb2
     Should Be Equal As Integers  ${rc}  0
     Should Contain  ${output}  ubuntu@sha256:45b23dee08af5e43a7fea6c4cf9c25ccf269ee113168c19722f87876677c5cb2
+
+Remove images by short and long ID after VCH restart
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} pull ${busybox}
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} pull ${alpine}
+    Should Be Equal As Integers  ${rc}  0
+
+    # Gather logs before rebooting
+    Run Keyword And Continue On Failure  Gather Logs From Test Server  -before-reboot-2
+    Reboot VM  %{VCH-NAME}
+    Wait For VCH Initialization  20x  5 seconds
+
+    # Remove image by short ID
+    ${rc}  ${busybox-shortID}=  Run And Return Rc And Output  docker %{VCH-PARAMS} images -q ${busybox}
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} rmi ${busybox-shortID}
+    Should Be Equal As Integers  ${rc}  0
+    Should Not Contain  ${output}  Error
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} images -q ${busybox}
+    Should Be Equal As Integers  ${rc}  0
+    Should Not Contain  ${output}  ${busybox-shortID}
+
+    # Remove image by long ID
+    ${rc}  ${alpine-shortID}=  Run And Return Rc And Output  docker %{VCH-PARAMS} images -q ${alpine}
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${alpineID}=  Run And Return Rc And Output  docker %{VCH-PARAMS} inspect ${alpine} | jq -r '.[0].Id'
+    Should Be Equal As Integers  ${rc}  0
+    ${alpine-longID}=  Fetch From Right  ${alpineID}  sha256:
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} rmi ${alpine-longID}
+    Should Be Equal As Integers  ${rc}  0
+    Should Not Contain  ${output}  Error
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} images -q ${alpine}
+    Should Be Equal As Integers  ${rc}  0
+    Should Not Contain  ${output}  ${alpine-shortID}


### PR DESCRIPTION
This commit fixes the initialization logic of the docker personality's
image cache. Before this change, images pulled before a VCH restart
would fail to be removed later by their short ID (their long ID would
work). This was because when the personality server was restarted, the
ID index in the image cache was populated with the incorrect key format.

When an image is pulled, the ID index in the image cache is keyed by the
full ID of the image, while the name cache is keyed by the full ID
prefixed with "sha256:". In the cache init logic, the ID index was
previously populated with the name cache's keys, and this would cause
image lookups (docker rmi, inspect) to fail when the image's short ID
was used.

To fix this issue, this change trims the "sha256:" prefix from the name
cache's keys before using them as keys for the ID index.

Fixes: #6076 #7118