### PR TITLE
[specific ci=11-02-Upgrade-Exec] Fix Get Container IP Robot util keyword

### DIFF
--- a/tests/resources/Docker-Util.robot
+++ b/tests/resources/Docker-Util.robot
@@ -1,4 +1,4 @@
-# Copyright 2016-2017 VMware, Inc. All Rights Reserved.
+# Copyright 2016-2018 VMware, Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -48,7 +48,7 @@ Hit Nginx Endpoint
     Should Be Equal As Integers  ${rc}  0
 
 Get Container IP
-    [Arguments]  ${docker-params}  ${id}  ${network}=default  ${dockercmd}=docker
+    [Arguments]  ${docker-params}  ${id}  ${network}=bridge  ${dockercmd}=docker
     ${rc}  ${ip}=  Run And Return Rc And Output  ${dockercmd} ${docker-params} inspect --format='{{(index .NetworkSettings.Networks "${network}").IPAddress}}' ${id}
     Should Be Equal As Integers  ${rc}  0
     [Return]  ${ip}

--- a/tests/test-cases/Group11-Upgrade/11-02-Upgrade-Exec.robot
+++ b/tests/test-cases/Group11-Upgrade/11-02-Upgrade-Exec.robot
@@ -1,4 +1,4 @@
-# Copyright 2016-2017 VMware, Inc. All Rights Reserved.
+# Copyright 2016-2018 VMware, Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@ Default Tags
 
 *** Test Cases ***
 Exec Not Allowed On Older Containers
-    Launch Container  exec-test
+    Launch Container  exec-test  bridge
 
     Upgrade
     Check Upgraded Version
@@ -30,6 +30,6 @@ Exec Not Allowed On Older Containers
     Should Not Be Equal As Integers  ${rc}  0
     Should Contain  ${output}  running tasks not supported for this container
 
-    Launch Container  exec-test2
+    Launch Container  exec-test2  bridge
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} exec -d exec-test2 ls
     Should Be Equal As Integers  ${rc}  0


### PR DESCRIPTION
This commit changes the 'Get Container IP' keyword's default value for
the network parameter to "bridge" instead of "default" as the keyword
was updated in commit 29eeb81 (#6641) to use container inspect instead
of network inspect.