### PR TITLE
[specific ci=23-08-VCH-Delete] Remove each leaked volume from the delete tests

### DIFF
--- a/tests/test-cases/Group23-VIC-Machine-Service/23-08-VCH-Delete.robot
+++ b/tests/test-cases/Group23-VIC-Machine-Service/23-08-VCH-Delete.robot
@@ -19,7 +19,7 @@ Resource          ../../resources/Group23-VIC-Machine-Service-Util.robot
 Suite Setup       Start VIC Machine Server
 Suite Teardown    Terminate All Processes    kill=True
 Test Setup        Install And Prepare VIC Appliance
-Test Teardown     Run keyword  govc datastore.rm  %{VCH-NAME}-VOL
+Test Teardown     Run  govc datastore.rm  %{VCH-NAME}-VOL
 
 Default Tags
 

--- a/tests/test-cases/Group23-VIC-Machine-Service/23-08-VCH-Delete.robot
+++ b/tests/test-cases/Group23-VIC-Machine-Service/23-08-VCH-Delete.robot
@@ -19,7 +19,7 @@ Resource          ../../resources/Group23-VIC-Machine-Service-Util.robot
 Suite Setup       Start VIC Machine Server
 Suite Teardown    Terminate All Processes    kill=True
 Test Setup        Install And Prepare VIC Appliance
-Test Teardown     Run  govc datastore.rm  %{VCH-NAME}-VOL
+Test Teardown     Run  govc datastore.rm %{VCH-NAME}-VOL
 
 Default Tags
 

--- a/tests/test-cases/Group23-VIC-Machine-Service/23-08-VCH-Delete.robot
+++ b/tests/test-cases/Group23-VIC-Machine-Service/23-08-VCH-Delete.robot
@@ -19,6 +19,7 @@ Resource          ../../resources/Group23-VIC-Machine-Service-Util.robot
 Suite Setup       Start VIC Machine Server
 Suite Teardown    Terminate All Processes    kill=True
 Test Setup        Install And Prepare VIC Appliance
+Test Teardown     Run keyword  govc datastore.rm  %{VCH-NAME}-VOL
 
 Default Tags
 


### PR DESCRIPTION
fixes #7151 

This test group uses the default install keyword, which creates a volume.  But the API does not delete associated volumes unless explicitly requested.