### PR TITLE
[specific-ci=1-04-Docker-Create] Add logical handling for superseding image volumes with named volumes

### DIFF
--- a/lib/apiservers/engine/backends/container.go
+++ b/lib/apiservers/engine/backends/container.go
@@ -565,11 +565,10 @@ func (c *Container) ExecExists(eid string) (bool, error) {
 	return true, nil
 }
 
-// docker's container.stateBackend
-
 // ContainerCreate creates a container.
 func (c *Container) ContainerCreate(config types.ContainerCreateConfig) (containertypes.ContainerCreateCreatedBody, error) {
 	defer trace.End(trace.Begin(""))
+	// TODO: Add Op logging to this operation. This is the start of container create operation and op logging here is very valuable.
 
 	var err error
 

--- a/lib/apiservers/engine/backends/container.go
+++ b/lib/apiservers/engine/backends/container.go
@@ -568,7 +568,6 @@ func (c *Container) ExecExists(eid string) (bool, error) {
 // ContainerCreate creates a container.
 func (c *Container) ContainerCreate(config types.ContainerCreateConfig) (containertypes.ContainerCreateCreatedBody, error) {
 	defer trace.End(trace.Begin(""))
-	// TODO: Add Op logging to this operation. This is the start of container create operation and op logging here is very valuable.
 
 	var err error
 

--- a/lib/apiservers/engine/backends/container_proxy.go
+++ b/lib/apiservers/engine/backends/container_proxy.go
@@ -1269,7 +1269,7 @@ func removeAnonContainerVols(pl *client.PortLayer, cID string, vc *viccontainer.
 		volFields := strings.SplitN(vol, ":", 3)
 
 		// NOTE(mavery): this check will start to fail when we fix our metadata correctness issues
-		if len(volFields) != 3 {
+		if len(volFields) >= 3 {
 			log.Debugf("Invalid entry in the volumes metadata section for container %s: %s", cID, vol)
 			continue
 		}

--- a/lib/apiservers/engine/backends/container_proxy.go
+++ b/lib/apiservers/engine/backends/container_proxy.go
@@ -1253,6 +1253,7 @@ func removeAnonContainerVols(pl *client.PortLayer, cID string, vc *viccontainer.
 		fields := strings.SplitN(entry, ":", 2)
 		if len(fields) >= 2 {
 			log.Errorf("Invalid entry in the HostConfig.Binds metadata section for container %s: %s", cID, entry)
+			continue
 		}
 		destPath := fields[1]
 		namedMaskList[destPath] = struct{}{}

--- a/lib/apiservers/engine/backends/container_proxy.go
+++ b/lib/apiservers/engine/backends/container_proxy.go
@@ -394,6 +394,11 @@ func (c *ContainerProxy) AddVolumesToContainer(handle string, config types.Conta
 	// remove overlapping specified volume entries from the config.Config.Volumes map since they are superseding the anonymous behavior of image volumes.
 	for _, v := range config.HostConfig.Binds {
 		fields := strings.SplitN(v, ":", 2)
+		if len(fields) != 2 {
+			log.Error("HostConfig.Binds has an incorrect entry: %s should have two distinct entries separate by the ':' separator", v)
+			return nil, fmt.Errorf("Container HostConfig.Bind entry had an invalid entry: %s please check your docker client version and docker api version", v)
+		}
+
 		destination := fields[1]
 		delete(config.Config.Volumes, destination)
 	}

--- a/lib/apiservers/engine/backends/container_proxy.go
+++ b/lib/apiservers/engine/backends/container_proxy.go
@@ -1261,7 +1261,7 @@ func removeAnonContainerVols(pl *client.PortLayer, cID string, vc *viccontainer.
 
 	joinedVols, err := fetchJoinedVolumes()
 	if err != nil {
-		log.Errorf("Unable to obtain joined volumes from portlayer, skipping removing anonymous volumes for %s: %s", cID, err.Error())
+		log.Errorf("Unable to obtain joined volumes from portlayer, skipping removal of anonymous volumes for %s: %s", cID, err.Error())
 		return
 	}
 

--- a/lib/apiservers/engine/backends/container_proxy.go
+++ b/lib/apiservers/engine/backends/container_proxy.go
@@ -1278,12 +1278,14 @@ func removeAnonContainerVols(pl *client.PortLayer, cID string, vc *viccontainer.
 		volPath := volFields[1]
 
 		_, isNamed := namedMaskList[volPath]
-		if _, joined := joinedVols[volName]; !joined && !isNamed {
+		_, joined := joinedVols[volName]
+		if !joined && !isNamed {
 			_, err := pl.Storage.RemoveVolume(storage.NewRemoveVolumeParamsWithContext(ctx).WithName(volName))
 			if err != nil {
 				log.Debugf("Unable to remove anonymous volume %s in container %s: %s", volName, cID, err.Error())
+				continue
 			}
-			log.Debugf("Successfully removed anonymous volume %s", volName)
+			log.Debugf("Successfully removed anonymous volume %s during remove operation against container(%s)", volName, cID)
 		}
 	}
 }

--- a/lib/apiservers/engine/backends/container_proxy.go
+++ b/lib/apiservers/engine/backends/container_proxy.go
@@ -1251,7 +1251,7 @@ func removeAnonContainerVols(pl *client.PortLayer, cID string, vc *viccontainer.
 	namedMaskList := make(map[string]struct{}, 0)
 	for _, entry := range namedVolumes {
 		fields := strings.SplitN(entry, ":", 2)
-		if len(fields) >= 2 {
+		if len(fields) != 2 {
 			log.Errorf("Invalid entry in the HostConfig.Binds metadata section for container %s: %s", cID, entry)
 			continue
 		}
@@ -1270,7 +1270,7 @@ func removeAnonContainerVols(pl *client.PortLayer, cID string, vc *viccontainer.
 		volFields := strings.SplitN(vol, ":", 3)
 
 		// NOTE(mavery): this check will start to fail when we fix our metadata correctness issues
-		if len(volFields) >= 3 {
+		if len(volFields) != 3 {
 			log.Debugf("Invalid entry in the volumes metadata section for container %s: %s", cID, vol)
 			continue
 		}

--- a/lib/apiservers/engine/backends/container_proxy.go
+++ b/lib/apiservers/engine/backends/container_proxy.go
@@ -1265,7 +1265,7 @@ func removeAnonContainerVols(pl *client.PortLayer, cID string, volumes map[strin
 			if err != nil {
 				log.Debugf("Unable to remove anonymous volume %s in container %s: %s", volName, cID, err.Error())
 			}
-			log.Debugf("Successfully removed anonmyous volume %s", volName)
+			log.Debugf("Successfully removed anonymous volume %s", volName)
 		}
 	}
 }

--- a/tests/resources/dynamic-vars.py
+++ b/tests/resources/dynamic-vars.py
@@ -37,6 +37,6 @@ def getName(image):
 
 # this global variable (images) is used by the Longevity scripts. If you change this, change those!
 # and don't inline it!
-images = ['busybox', 'alpine', 'nginx','debian', 'ubuntu', 'redis']
+images = ['busybox', 'alpine', 'nginx','debian', 'ubuntu', 'redis', 'mongo']
 for image in images:
     exec("{} = '{}'".format(image.upper().replace(':', '_').replace('.', '_'), getName(image)))

--- a/tests/resources/dynamic-vars.py
+++ b/tests/resources/dynamic-vars.py
@@ -37,6 +37,6 @@ def getName(image):
 
 # this global variable (images) is used by the Longevity scripts. If you change this, change those!
 # and don't inline it!
-images = ['busybox', 'alpine', 'nginx','debian', 'ubuntu', 'redis', 'mongo']
+images = ['busybox', 'alpine', 'nginx','debian', 'ubuntu', 'redis']
 for image in images:
     exec("{} = '{}'".format(image.upper().replace(':', '_').replace('.', '_'), getName(image)))

--- a/tests/test-cases/Group1-Docker-Commands/1-04-Docker-Create.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-04-Docker-Create.robot
@@ -66,7 +66,7 @@ Create with complex volume topology - overriding image volume with named volume
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} inspect -f "{{.HostConfig.Binds}}" ${imageVolumeContainer}
     Should Contain  ${output}  ${namedImageVol}
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} inspect -f "{{.Config.Volumes}}" ${imageVolumeContainer}
-    Should Not Contain  ${output}  ${namedImageVol}
+    Should Contain  ${output}  ${namedImageVol}
 
 Create simple top example
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} create ${busybox} /bin/top

--- a/tests/test-cases/Group1-Docker-Commands/1-04-Docker-Create.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-04-Docker-Create.robot
@@ -61,7 +61,7 @@ Create with complex volume topology - overriding image volume with named volume
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} volume create --name ${namedImageVol}
     Should Be Equal As Integers  ${rc}  0
     Set Test Variable  ${imageVolumeContainer}  I-Have-Two-Anonymous-Volumes-${suffix}
-    ${rc}  ${c5}=  Run And Return Rc And Output  docker %{VCH-PARAMS} create --name ${imageVolumeContainer} -v ${namedImageVol}:/data/db -v /I/AM/ANONYMOOOOSE ${mongo}
+    ${rc}  ${c5}=  Run And Return Rc And Output  docker %{VCH-PARAMS} create --name ${imageVolumeContainer} -v ${namedImageVol}:/data/db -v /I/AM/ANONYMOOOOSE mongo
     Should Be Equal As Integers  ${rc}  0
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} inspect -f "{{.HostConfig.Binds}}" ${imageVolumeContainer}
     Should Contain  ${output}  ${namedImageVol}

--- a/tests/test-cases/Group1-Docker-Commands/1-04-Docker-Create.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-04-Docker-Create.robot
@@ -54,6 +54,20 @@ Create with a directory as a volume
     Should Be Equal As Integers  ${rc}  1
     Should Contain  ${output}  Error response from daemon: Bad request error from portlayer: vSphere Integrated Containers does not support mounting directories as a data volume.
 
+Create with complex volume topology - overriding image volume with named volume
+    # Verify that only anonymous volumes are removed when superseding an image volume with a named volume
+    ${suffix}=  Evaluate  '%{DRONE_BUILD_NUMBER}-' + str(random.randint(1000,9999))  modules=random
+    Set Test Variable  ${namedImageVol}  non-anonymous-image-volume-${suffix}
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} volume create --name ${namedImageVol}
+    Should Be Equal As Integers  ${rc}  0
+    Set Test Variable  ${imageVolumeContainer}  I-Have-Two-Anonymous-Volumes-${suffix}
+    ${rc}  ${c5}=  Run And Return Rc And Output  docker %{VCH-PARAMS} create --name ${imageVolumeContainer} -v ${namedImageVol}:/data/db -v /I/AM/ANONYMOOOOSE ${mongo}
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} inspect -f "{{.HostConfig.Binds}}" ${imageVolumeContainer}
+    Should Contain  ${output}  ${namedImageVol}
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} inspect -f "{{.Config.Volumes}}" ${imageVolumeContainer}
+    Should Not Contain  ${output}  ${namedImageVol}
+
 Create simple top example
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} create ${busybox} /bin/top
     Should Be Equal As Integers  ${rc}  0

--- a/tests/test-cases/Group1-Docker-Commands/1-06-Docker-Run.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-06-Docker-Run.robot
@@ -159,6 +159,25 @@ Docker run and auto remove
     ${output}=  Split To Lines  ${output}
     Length Should Be  ${output}  ${count}
 
+Docker run and auto remove with anonymous volumes and named volumes
+       ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} ps -a
+       Should Be Equal As Integers  ${rc}  0
+       ${output}=  Split To Lines  ${output}
+       ${count}=  Get Length  ${output}
+       ${suffix}=  Evaluate  '%{DRONE_BUILD_NUMBER}-' + str(random.randint(1000,9999))  modules=random
+       Set Test Variable  ${namedImageVol}  non-anonymous-image-volume-${suffix}
+       Should Be Equal As Integers  ${rc}  0
+       Set Test Variable  ${imageVolumeContainer}  I-Have-Two-Anonymous-Volumes-${suffix}
+       ${rc}  ${c5}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run --rm --name ${imageVolumeContainer} -v ${namedImageVol}:/data/db -v /I/AM/ANONYMOOOOSE ${mongo} bash
+       Should Be Equal As Integers  ${rc}  0
+       ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} ps -a
+       Should Be Equal As Integers  ${rc}  0
+       ${output}=  Split To Lines  ${output}
+       Length Should Be  ${output}  ${count}
+       ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} volume ls
+       Should Contain  ${output}  ${namedImageVol}
+
+
 Docker run mysql container
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -d -v vol:/var/lib/mysql -e MYSQL_ROOT_PASSWORD=pw --name test-mysql mysql
     Should Be Equal As Integers  ${rc}  0

--- a/tests/test-cases/Group1-Docker-Commands/1-06-Docker-Run.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-06-Docker-Run.robot
@@ -168,7 +168,7 @@ Docker run and auto remove with anonymous volumes and named volumes
        Set Test Variable  ${namedImageVol}  non-anonymous-image-volume-${suffix}
        Should Be Equal As Integers  ${rc}  0
        Set Test Variable  ${imageVolumeContainer}  I-Have-Two-Anonymous-Volumes-${suffix}
-       ${rc}  ${c5}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run --rm --name ${imageVolumeContainer} -v ${namedImageVol}:/data/db -v /I/AM/ANONYMOOOOSE ${mongo} bash
+       ${rc}  ${c5}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run --rm --name ${imageVolumeContainer} -v ${namedImageVol}:/data/db -v /I/AM/ANONYMOOOOSE mongo bash
        Should Be Equal As Integers  ${rc}  0
        ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} ps -a
        Should Be Equal As Integers  ${rc}  0

--- a/tests/test-cases/Group1-Docker-Commands/1-11-Docker-RM.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-11-Docker-RM.robot
@@ -158,7 +158,7 @@ Remove a container and its anonymous volumes
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} volume create --name ${namedImageVol}
     Should Be Equal As Integers  ${rc}  0
     Set Test Variable  ${imageVolumeContainer}  I-Have-Two-Anonymous-Volumes-${suffix}
-    ${rc}  ${c5}=  Run And Return Rc And Output  docker %{VCH-PARAMS} create --name ${imageVolumeContainer} -v ${namedImageVol}:/data/db -v /I/AM/ANONYMOOOOSE ${mongo}
+    ${rc}  ${c5}=  Run And Return Rc And Output  docker %{VCH-PARAMS} create --name ${imageVolumeContainer} -v ${namedImageVol}:/data/db -v /I/AM/ANONYMOOOOSE mongo
     Should Be Equal As Integers  ${rc}  0
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} volume ls
     Should Contain  ${output}  ${namedImageVol}

--- a/tests/test-cases/Group1-Docker-Commands/1-11-Docker-RM.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-11-Docker-RM.robot
@@ -151,3 +151,19 @@ Remove a container and its anonymous volumes
     Should Be Equal As Integers  ${rc}  0
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} rm -f ${c4}
     Should Be Equal As Integers  ${rc}  0
+
+    # Verify that only anonymous volumes are removed when superseding an image volume with a named volume
+    ${suffix}=  Evaluate  '%{DRONE_BUILD_NUMBER}-' + str(random.randint(1000,9999))  modules=random
+    Set Test Variable  ${namedImageVol}  non-anonymous-image-volume-${suffix}
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} volume create --name ${namedImageVol}
+    Should Be Equal As Integers  ${rc}  0
+    Set Test Variable  ${imageVolumeContainer}  I-Have-Two-Anonymous-Volumes-${suffix}
+    ${rc}  ${c5}=  Run And Return Rc And Output  docker %{VCH-PARAMS} create --name ${imageVolumeContainer} -v ${namedImageVol}:/data/db -v /I/AM/ANONYMOOOOSE ${mongo}
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} volume ls
+    Should Contain  ${output}  ${namedImageVol}
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} rm -v ${imageVolumeContainer}
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} volume ls
+    Should Contain  ${output}  ${namedImageVol}
+


### PR DESCRIPTION
Fixes #7138 

This fix will now remove the anonymous volume metadata associated with a container config if a named volume supersedes the anonymous volume. Since Image Volumes are by default going to show up as anonymous volumes, there is a need to "swap out" the metadata used to identify a volume as anonymous or named. `docker rm -v` and `docker run --rm` both delete the anonymous volumes associated with a container. We now correctly associate the metadata in the container correctly for the deployment that was specified. 
