### PR TITLE
Add unit tests to archives util_test.go

### DIFF
--- a/lib/archive/util_test.go
+++ b/lib/archive/util_test.go
@@ -21,6 +21,25 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// INPUT VALIDATION TESTS
+
+func TestNilSpecForAddInclusionExclusion(t *testing.T) {
+	var emptyMounts []string
+	err := AddMountInclusionsExclusions("", nil, emptyMounts, "")
+	assert.Error(t, err)
+
+	emptySpec := FilterSpec{
+		RebasePath: "",
+		StripPath:  "",
+		Exclusions: nil,
+		Inclusions: nil,
+	}
+
+	err = AddMountInclusionsExclusions("", &emptySpec, emptyMounts, "")
+	assert.Error(t, err)
+
+}
+
 // COPY TO TESTS
 
 func TestComplexWriteSpec(t *testing.T) {

--- a/lib/archive/util_test.go
+++ b/lib/archive/util_test.go
@@ -37,7 +37,6 @@ func TestNilSpecForAddInclusionExclusion(t *testing.T) {
 
 	err = AddMountInclusionsExclusions("", &emptySpec, emptyMounts, "")
 	assert.Error(t, err)
-
 }
 
 // COPY TO TESTS


### PR DESCRIPTION
This is a starter change to improve a small hole in testing for `/lib/archive/util.go`
