### PR TITLE
Added local ci testing target to makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ endif
 # Caches dependencies to speed repeated calls
 define godeps
 	$(call assert,$(call gmsl_compatible,1 1 7), Wrong GMSL version) \
-	$(if $(filter-out push push-portlayer push-docker push-vic-init push-vicadmin focused-test test check clean distclean mrrobot mark sincemark .DEFAULT,$(MAKECMDGOALS)), \
+	$(if $(filter-out push push-portlayer push-docker push-vic-init push-vicadmin focused-test test check clean distclean mrrobot mark sincemark local-ci-test .DEFAULT,$(MAKECMDGOALS)), \
 		$(if $(call defined,dep_cache,$(dir $1)),,$(info Generating dependency set for $(dir $1))) \
 		$(or \
 			$(if $(call defined,dep_cache,$(dir $1)), $(debug Using cached Go dependencies) $(wildcard $1) $(call get,dep_cache,$(dir $1))),
@@ -287,6 +287,10 @@ push-vic-init:
 push-vicadmin:
 	$(BASE_DIR)/infra/scripts/replace-running-components.sh vicadmin
 
+local-ci-test:
+	@echo running CI tests locally...
+	infra/scripts/local-ci.sh
+
 focused-test:
 # test only those packages that have changes
 	infra/scripts/focused-test.sh $(REMOTE)
@@ -336,7 +340,7 @@ $(imagec): $(call godeps,cmd/imagec/*.go) $(portlayerapi-client)
 
 $(docker-engine-api): $(portlayerapi-client) $(admiralapi-client) $$(call godeps,cmd/docker/*.go)
 ifeq ($(OS),linux)
-	@echo Building docker-engine-api server...
+	@echo building docker-engine-api server...
 	@$(TIME) $(GO) build $(RACE) -ldflags "$(LDFLAGS)" -o $@ ./cmd/docker
 else
 	@echo skipping docker-engine-api server, cannot build on non-linux
@@ -344,11 +348,12 @@ endif
 
 $(docker-engine-api-test): $$(call godeps,cmd/docker/*.go) $(portlayerapi-client)
 ifeq ($(OS),linux)
-	@echo Building docker-engine-api server for test...
+	@echo building docker-engine-api server for test...
 	@$(TIME) $(GO) test -c -coverpkg github.com/vmware/vic/lib/...,github.com/vmware/vic/pkg/... -outputdir /tmp -coverprofile docker-engine-api.cov -o $@ ./cmd/docker
 else
 	@echo skipping docker-engine-api server for test, cannot build on non-linux
 endif
+
 
 # Common portlayer dependencies between client and server
 PORTLAYER_DEPS ?= lib/apiservers/portlayer/swagger.json \

--- a/infra/scripts/local-ci.sh
+++ b/infra/scripts/local-ci.sh
@@ -1,0 +1,215 @@
+#!/bin/bash
+# Copyright 2018 VMware, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+##### defaults
+secretsfile=""
+docker_test="Group1-Docker-Commands"
+target_vch=""
+odir="ci-results"
+ci_container="gcr.io/eminent-nation-87317/vic-integration-test:1.39"
+github_api_key=""
+test_url=""
+test_datastore=""
+test_username=""
+test_password=""
+BASE_DIR=$(dirname $(readlink -f "$BASH_SOURCE"))
+vic_dir=${BASE_DIR}/../../
+
+##### utility functions
+function usage() {
+  echo "Usage: $0 [options]" 1>&2
+  echo
+  echo "  Options can be provided by commandline argument, environment variable, or a secrets yaml file containing the"
+  echo "  variables.  If a secrets file is not provided, this script will attempt to retrieve some info from govc, such as"
+  echo "  TEST_URL, TEST_USERNAME, and TEST_PASSWORD."
+  echo
+  echo "  options:"
+  echo "    -t DOCKER_TEST (or env var)"
+  echo "    -v TARGET_VCH (or env var) name of VCH"
+  echo "    -f SECRETS_FILE (or env var)"
+  echo "    -g GITHUB_API_KEY (or env var)"
+  echo "    -u TEST_URL (or env var or in secretsfile)"
+  echo "    -s TEST_DATASTORE (or env var or in secretsfile)"
+  echo "    -n TEST_USERNAME (or env var or in secretsfile)"
+  echo "    -p TEST_PASSWORD (or env var or in secretsfile)"
+  echo "    -d debug dumps out all the inputs and results of the resulting options"
+  echo
+  echo "  example:"
+  echo "    $0 -t Group1-Docker-Commands -v my_vch -s test.secrets.nested -g xxxxxx"
+  echo "    $0 -t 1-01-Docker-Info.robot -v my_vch -s test.secrets.nested -g xxxxxx"
+  echo 
+  echo "    DOCKER_TEST=Group1-Docker-Commands/1-01-Docker-Info.robot TARGET_VCH=my_vch SECRETS_FILE=test.secrets.nested $0"
+  echo
+  echo "    $0 -s test.secrets.nested (all params defined in secrets file)"
+  exit 1
+}
+
+function GetGovcParamsFromEnv() {
+  echo "Getting params from GOVC var"
+  test_username=$(govc env | grep GOVC_USERNAME | cut -d= -f2)
+  test_password=$(govc env | grep GOVC_PASSWORD | cut -d= -f2)
+  test_url=$(govc env | grep GOVC_URL | cut -d= -f2)
+}
+
+function GetParamsFromSecrets() {
+  echo "Getting params from the secrets file"
+  secrets_api_key="$(grep 'GITHUB_AUTOMATION_API_KEY' ${secretsfile} | awk '{ print $2 }')"
+  secrets_url="$(grep 'TEST_URL_ARRAY' ${secretsfile} | awk '{ print $2 }')"
+  secrets_datastore="$(grep -E '\s+TEST_DATASTORE' ${secretsfile} | awk '{ print $2 }')"
+  secrets_username="$(grep 'TEST_USERNAME' ${secretsfile} | awk '{ print $2 }')"
+  secrets_password="$(grep 'TEST_PASSWORD' ${secretsfile} | awk '{ print $2 }')"
+  secrets_docker_test="$(grep 'DOCKER_TEST' ${secretsfile} | awk '{ print $2 }')"
+  secrets_target_vch="$(grep 'TARGET_VCH' ${secretsfile} | awk '{ print $2 }')"
+}
+
+function DoWork() {
+  mkdir -p $odir
+
+  testsContainer=$(docker create -it \
+                        -w /vic \
+                        -v "$vic_dir:/vic" \
+                        -e GOVC_URL="$ip" \
+                        -e GOVC_INSECURE=1 \
+                        -e GITHUB_AUTOMATION_API_KEY=${github_api_key}\
+                        -e TEST_URL_ARRAY=${test_url}\
+                        -e TEST_DATASTORE=${test_datastore}\
+                        -e TEST_USERNAME=${test_username}\
+                        -e TEST_PASSWORD=${test_password}\
+                        -e TARGET_VCH=${target_vch}\
+                        -e DEBUG_VCH=1\
+                        ${ci_container}\
+                        bash -c "pybot -d /vic/${odir} /vic/tests/test-cases/"$docker_test"")
+
+  docker start -ai $testsContainer
+}
+
+function DebugInputDump() {
+  echo "Environment Variables"
+  echo "---------------------"
+  echo "SECRETS_FILE="${SECRETS_FILE}
+  echo "TARGET_VCH="${TARGET_VCH}
+  echo "DOCKER_TEST="${DOCKER_TEST}
+  echo "GITHUB_API_KEY="${GITHUB_API_KEY}
+  echo "TEST_URL="${TEST_URL}
+  echo "TEST_DATASTORE"=${TEST_DATASTORE}
+  echo "TEST_USERNAME"=${TEST_USERNAME}
+  echo "TEST_PASSWORD"=${TEST_PASSWORD}
+  echo
+  echo "Arguments"
+  echo "---------------------"
+  echo "SECRETS_FILE="$secretsfile
+  echo "TARGET_VCH="$target_vch
+  echo "DOCKER_TEST="$docker_Test
+  echo "GITHUB_API_KEY="$github_api_key
+  echo "TEST_URL="$test_url
+  echo "TEST_DATASTORE"=$test_datastore
+  echo "TEST_USERNAME"=$test_username
+  echo "TEST_PASSWORD"=$test_password
+  echo
+  echo "Secrets file"
+  echo "---------------------"
+  echo "TARGET_VCH="$secrets_target_vch
+  echo "DOCKER_TEST="$secrets_docker_test
+  echo "GITHUB_API_KEY="$secrets_api_key
+  echo "TEST_URL="$secrets_url
+  echo "TEST_DATASTORE"=$secrets_datastore
+  echo "TEST_USERNAME"=$secrets_username
+  echo "TEST_PASSWORD"=$secrets_password
+}
+
+function DebugDump() {
+  echo
+  echo "====================="
+  echo "SECRETS_FILE="$secretsfile
+  echo "TARGET_VCH="$target_vch
+  echo "DOCKER_TEST="$docker_test
+  echo "GITHUB_API_KEY="$github_api_key
+  echo "TEST_URL="$test_url
+  echo "TEST_DATASTORE"=$test_datastore
+  echo "TEST_USERNAME"=$test_username
+  echo "TEST_PASSWORD"=$test_password
+  echo "vic-dir"=$vic_dir
+}
+
+##### Get command line arguments
+while getopts f:t:v:g:u:s:n:p:d flag
+do
+  case $flag in
+    f)
+      secretsfile=$OPTARG
+      ;;
+    t)
+      docker_test="$OPTARG"
+      ;;
+    v)
+      target_vch=$OPTARG
+      ;;
+    g)
+      github_api_key=$OPTARG
+      ;;
+    u)
+     test_url=$OPTARG
+      ;;
+    s)
+      test_datastore=$OPTARG
+      ;;
+    n)
+      test_username=$OPTARG
+      ;;
+    p)
+      test_password=$OPTARG
+      ;;
+    d)
+      debug_enabled=1
+      ;;
+    *)
+      usage
+      ;;
+  esac
+done
+
+##### Preconditions...
+
+# There is a priority in the preconditions.  First, environment variable.  Second, secrets file.  Third, command line argument.
+
+secretsfile=${SECRETS_FILE:-$secretsfile}
+if [[ -z $secretsfile ]] ; then
+  GetGovcParamsFromEnv
+else
+  GetParamsFromSecrets
+fi
+
+if [[ ! -z ${debug_enabled} ]] ; then
+    DebugInputDump
+fi
+
+target_vch=${TARGET_VCH:-$secrets_target_vch}
+docker_test=${DOCKER_TEST:-$secrets_docker_test}
+github_api_key=${GITHUB_API_KEY:-$secrets_api_key}
+test_url=${TEST_URL:-$secrets_url}
+test_datastore=${TEST_DATASTORE:-$secrets_datastore}
+test_username=${TEST_USERNAME:-$secrets_username}
+test_password=${TEST_PASSWORD:-$secrets_password}
+if [[ -z ${target_vch} ]] || [[ -z "${docker_test}" ]] || [[ -z $github_api_key ]] || [[ -z $test_url ]] || [[ -z $test_datastore ]] || [[ -z $test_password ]] ; then
+  usage
+fi
+
+if [[ ! -z ${debug_enabled} ]] ; then
+  DebugDump
+fi
+
+##### The actual work
+DoWork

--- a/tests/README.md
+++ b/tests/README.md
@@ -78,6 +78,33 @@ Use ./local-integration-test.sh
   ./tests/robot.sh tests/test-cases/Group6-VIC-Machine/6-04-Create-Basic.robot
   ```
 
+## Run Docker command tests via makefile target
+
+There exists a makefile target for developers to run the docker command tests locally (not in CI environment) against a pre-deployed VCH. This is a fast way for contributors to test their potential code chages, against the CI tests locally, before pushing the commit. There is another benefit gained from using the makefile target, the way it is setup, logs from the run are written out to vic/ci-results, even if the tests fail. The method described above, to run the tests locally with drone, has the weakness that a failure in the test can sometimes result in no written logs to help debug the failure.
+
+There are a few requirements before using this makefile target.
+
+1. A VCH must be pre-deployed before calling this makefile target
+2. The makefile target relies on a script that looks for a few more secrets variable.  When running the script directly, these secrets variables may be passed into the script via commandline arguments, environment variables, or via a secrets file.  When running the makefile target via make, the secrets must be defined in environment variables.
+
+To run these tests using the makefile target,
+
+```
+make local-ci-test
+
+SECRETS_FILE=test.secrets.esx make local-ci-test
+
+DOCKER_TEST=Group1-Docker-Commands/1-01-Docker-Info.robot make local-ci-test
+```
+In the above example, the first command assumes all environment variables are defined.  The second command defines one environment variable, SECRETS_FILE, before calling the make target.  This allows calling the make target with all the necessary secrets variable defined in the secrets file instead of in environment variables.  The third command defines a specific test to run using the environment variable, DOCKER_TEST.
+
+Currently, only the Group1 tests are setup to use an existing VCH so this makefile target only works on the group 1 tests.
+
+It is also possible to run the docker command tests, without using make, by calling the internal script itself.  The script is located at "infra/scripts/local-ci.sh".  As stated above, the scripts also allows command line arguments to be passed directly into the script.
+
+A helpful tip is to create different secrets files for different environments.  For instance, test.secrets.esx and test.secrets.vc for an ESX host and VC cluster, respectively.
+
+
 ## Find the documentation for each of the tests here:
 
 * [Automated Test Suite Documentation](test-cases/TestGroups.md)


### PR DESCRIPTION
Make testing locally as friction-free as possible by

1. Adding a makefile target 'local-ci-test'
2. Using TARGET_VCH added in VIC 1.3 to use an existing VCH
3. Using a custom script that doesn't utilize drone so that if
   the test fails and craters, we can still access the logs

Resolves #7162
