### PR TITLE
Enforce container naming convention on all paths [specific ci=6-18-Container-Name-Convention]

### DIFF
--- a/lib/apiservers/portlayer/restapi/handlers/containers_handlers.go
+++ b/lib/apiservers/portlayer/restapi/handlers/containers_handlers.go
@@ -396,7 +396,7 @@ func (handler *ContainersHandlersImpl) GetContainerStatsHandler(params container
 }
 
 func (handler *ContainersHandlersImpl) GetContainerLogsHandler(params containers.GetContainerLogsParams) middleware.Responder {
-	op := trace.NewOperation(context.Background(), params.ID)
+	op := trace.NewOperation(context.Background(), "Getting logs for %s", params.ID)
 	defer trace.End(trace.Begin(params.ID, op))
 
 	container := exec.Containers.Container(params.ID)
@@ -478,12 +478,14 @@ func (handler *ContainersHandlersImpl) ContainerWaitHandler(params containers.Co
 }
 
 func (handler *ContainersHandlersImpl) RenameContainerHandler(params containers.ContainerRenameParams) middleware.Responder {
-	defer trace.End(trace.Begin(fmt.Sprintf("Rename container to %s", params.Name)))
+	op := trace.NewOperation(context.Background(), "Rename container to %s", params.Name)
 
 	h := exec.GetHandle(params.Handle)
 	if h == nil || h.ExecConfig == nil {
 		return containers.NewContainerRenameNotFound()
 	}
+
+	defer trace.End(trace.Begin(h.ExecConfig.ID, op))
 
 	// get the indicated container for rename
 	container := exec.Containers.Container(h.ExecConfig.ID)
@@ -507,7 +509,7 @@ func (handler *ContainersHandlersImpl) RenameContainerHandler(params containers.
 		return containers.NewContainerRenameInternalServerError().WithPayload(err)
 	}
 
-	h = h.Rename(params.Name)
+	h = h.Rename(op, params.Name)
 
 	return containers.NewContainerRenameOK().WithPayload(h.String())
 }

--- a/lib/config/virtual_container_host.go
+++ b/lib/config/virtual_container_host.go
@@ -34,11 +34,14 @@ type PatternToken string
 
 const (
 	// VM is the VM name - i.e. [ds] {vm}/{vm}.vmx
-	VM PatternToken = "{vm}"
+	VMToken PatternToken = "{vm}"
 	// ID is the container ID for the VM
-	ID PatternToken = "{id}"
+	IDToken PatternToken = "{id}"
 	// Name is the container name of the VM
-	Name PatternToken = "{name}"
+	NameToken PatternToken = "{name}"
+
+	// The default naming pattern that gets applied if no convention is supplied
+	DefaultNamePattern = "{name}-{id}"
 
 	// ID represents the VCH in creating status, which helps to identify VCH VM which still does not have a valid VM moref set
 	CreatingVCH = "CreatingVCH"
@@ -58,6 +61,10 @@ const (
 
 	AddPerms = "ADD"
 )
+
+func (p PatternToken) String() string {
+	return string(p)
+}
 
 // Can we just treat the VCH appliance as a containerVM booting off a specific bootstrap image
 // It has many of the same requirements (around networks being attached, version recorded,

--- a/lib/install/validate/validator.go
+++ b/lib/install/validate/validator.go
@@ -377,12 +377,12 @@ func (v *Validator) basics(op trace.Operation, input *data.Data, conf *config.Vi
 
 	if input.ContainerNameConvention != "" {
 		// ensure token is present
-		if !strings.Contains(input.ContainerNameConvention, string(config.ID)) && !strings.Contains(input.ContainerNameConvention, string(config.Name)) {
-			v.NoteIssue(errors.Errorf("Container name convention must include %s or %s token", config.ID, config.Name))
+		if !strings.Contains(input.ContainerNameConvention, string(config.IDToken)) && !strings.Contains(input.ContainerNameConvention, string(config.NameToken)) {
+			v.NoteIssue(errors.Errorf("Container name convention must include %s or %s token", config.IDToken, config.NameToken))
 		}
 		// guard against both -- possibly we want to allow, but for now only allow one
-		if strings.Contains(input.ContainerNameConvention, string(config.ID)) && strings.Contains(input.ContainerNameConvention, string(config.Name)) {
-			v.NoteIssue(errors.Errorf("Container name convention only allows one token, either %s or %s", config.ID, config.Name))
+		if strings.Contains(input.ContainerNameConvention, string(config.IDToken)) && strings.Contains(input.ContainerNameConvention, string(config.NameToken)) {
+			v.NoteIssue(errors.Errorf("Container name convention only allows one token, either %s or %s", config.IDToken, config.NameToken))
 		}
 	}
 

--- a/lib/install/validate/validator.go
+++ b/lib/install/validate/validator.go
@@ -1,4 +1,4 @@
-// Copyright 2016 VMware, Inc. All Rights Reserved.
+// Copyright 2016-2018 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -39,6 +39,7 @@ import (
 	"github.com/vmware/vic/lib/config"
 	"github.com/vmware/vic/lib/config/dynamic"
 	"github.com/vmware/vic/lib/config/executor"
+	"github.com/vmware/vic/lib/constants"
 	"github.com/vmware/vic/lib/install/data"
 	"github.com/vmware/vic/lib/install/opsuser"
 	"github.com/vmware/vic/pkg/errors"
@@ -380,9 +381,11 @@ func (v *Validator) basics(op trace.Operation, input *data.Data, conf *config.Vi
 		if !strings.Contains(input.ContainerNameConvention, string(config.IDToken)) && !strings.Contains(input.ContainerNameConvention, string(config.NameToken)) {
 			v.NoteIssue(errors.Errorf("Container name convention must include %s or %s token", config.IDToken, config.NameToken))
 		}
-		// guard against both -- possibly we want to allow, but for now only allow one
-		if strings.Contains(input.ContainerNameConvention, string(config.IDToken)) && strings.Contains(input.ContainerNameConvention, string(config.NameToken)) {
-			v.NoteIssue(errors.Errorf("Container name convention only allows one token, either %s or %s", config.IDToken, config.NameToken))
+
+		// coarse check - only enforce that there's enough capcity for a shortID
+		// name lengths are many and vary significantly so much harder to provide sanity checks for - they will truncate when convention is applied.
+		if len(input.ContainerNameConvention)-len(config.IDToken) >= constants.MaxVMNameLength-constants.ShortIDLen {
+			v.NoteIssue(errors.Errorf("Container name convetion exceeds maximum length (%d, discounting tokens)", constants.MaxVMNameLength-constants.ShortIDLen))
 		}
 	}
 

--- a/lib/portlayer/exec/handle.go
+++ b/lib/portlayer/exec/handle.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"io"
 	"net"
-	"strings"
 	"sync"
 	"time"
 
@@ -150,13 +149,8 @@ func (h *Handle) Rename(newName string) *Handle {
 		ID:   h.ExecConfig.ID,
 		Name: newName,
 	}
-	// Only rename on vSphere when the containerNameConvention is name
-	var convention string
-	if strings.Contains(Config.ContainerNameConvention, "{name}") {
-		convention = Config.ContainerNameConvention
-	}
 
-	h.Spec.Spec().Name = util.DisplayName(s, convention)
+	h.Spec.Spec().Name = util.DisplayName(s, Config.ContainerNameConvention)
 
 	return h
 }

--- a/lib/portlayer/exec/handle.go
+++ b/lib/portlayer/exec/handle.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2017 VMware, Inc. All Rights Reserved.
+// Copyright 2016-2018 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -140,7 +140,7 @@ func (h *Handle) Reload() {
 }
 
 // Rename updates the container name in ExecConfig as well as the vSphere display name
-func (h *Handle) Rename(newName string) *Handle {
+func (h *Handle) Rename(op trace.Operation, newName string) *Handle {
 	defer trace.End(trace.Begin(newName))
 
 	h.ExecConfig.Name = newName
@@ -150,7 +150,7 @@ func (h *Handle) Rename(newName string) *Handle {
 		Name: newName,
 	}
 
-	h.Spec.Spec().Name = util.DisplayName(s, Config.ContainerNameConvention)
+	h.Spec.Spec().Name = util.DisplayName(op, s, Config.ContainerNameConvention)
 
 	return h
 }
@@ -272,7 +272,8 @@ func (h *Handle) Close() {
 // TODO: either deep copy the configuration, or provide an alternative means of passing the data that
 // avoids the need for the caller to unpack/repack the parameters
 func Create(ctx context.Context, vmomiSession *session.Session, config *ContainerCreateConfig) (*Handle, error) {
-	defer trace.End(trace.Begin("Handle.Create"))
+	op := trace.FromContext(ctx, "Handle.Create")
+	defer trace.End(trace.Begin(config.Metadata.Name, op))
 
 	h := &Handle{
 		key:         newHandleKey(),
@@ -329,11 +330,11 @@ func Create(ctx context.Context, vmomiSession *session.Session, config *Containe
 	}
 
 	// if not vsan, set the datastore folder name to containerID
-	if !vmomiSession.IsVSAN(ctx) {
+	if !vmomiSession.IsVSAN(op) {
 		specconfig.VMPathName = fmt.Sprintf("[%s] %s/%s.vmx", vmomiSession.Datastore.Name(), specconfig.ID, specconfig.ID)
 	}
 
-	specconfig.VMFullName = util.DisplayName(specconfig, Config.ContainerNameConvention)
+	specconfig.VMFullName = util.DisplayName(op, specconfig, Config.ContainerNameConvention)
 
 	// log only core portions
 	s := specconfig
@@ -357,7 +358,7 @@ func Create(ctx context.Context, vmomiSession *session.Session, config *Containe
 	}
 
 	// Create a linux guest
-	linux, err := guest.NewLinuxGuest(ctx, vmomiSession, specconfig)
+	linux, err := guest.NewLinuxGuest(op, vmomiSession, specconfig)
 	if err != nil {
 		log.Errorf("Failed during linux specific spec generation during create of %s: %s", config.Metadata.ID, err)
 		return nil, err

--- a/lib/portlayer/util/util.go
+++ b/lib/portlayer/util/util.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2017 VMware, Inc. All Rights Reserved.
+// Copyright 2016-2018 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -20,12 +20,14 @@ import (
 	"net/url"
 	"os"
 	"strings"
+	"sync"
 
 	log "github.com/Sirupsen/logrus"
 
 	"github.com/vmware/vic/lib/config"
 	"github.com/vmware/vic/lib/constants"
 	"github.com/vmware/vic/lib/spec"
+	"github.com/vmware/vic/pkg/trace"
 )
 
 const (
@@ -34,7 +36,11 @@ const (
 )
 
 var (
-	DefaultHost = Host()
+	DefaultHost           = Host()
+	nameTemplateOnce      sync.Once
+	nameTemplateInitial   string
+	nameTemplate          string
+	nameAvailableCapacity int
 )
 
 func Host() *url.URL {
@@ -61,50 +67,85 @@ func ServiceURL(serviceName string) *url.URL {
 	return s
 }
 
+// prepTemplate takes a template string, determines it's suitability for use and adjusts it if necessary
+// returns:
+//   adjusted template
+//   available length for insertions
+func prepTemplate(op trace.Operation, template string) (string, int) {
+	if template == "" {
+		template = config.DefaultNamePattern
+	}
+
+	withoutName := strings.Replace(template, config.NameToken.String(), "", 1)
+	withoutEither := strings.Replace(withoutName, config.IDToken.String(), "", 1)
+	availableLen := constants.MaxVMNameLength - len(withoutEither)
+
+	// TODO: initialization time check that template actually contains a token or we have a static string
+
+	// TODO: initialization time check that template is of usable length
+
+	// if there's zero space for replacement then there is no room for parameterization to avoid collisons
+	if availableLen > 0 {
+		return template, availableLen
+	}
+
+	op.Error("Falling back to default name convention as custom convention overflows name capacity")
+
+	template, availableLen = prepTemplate(op, config.DefaultNamePattern)
+	if availableLen > 0 {
+		return template, availableLen
+	}
+
+	// return sane fallback - has bounded length and probably few collisions
+	op.Error("Falling back to raw ID name convention as default convention overflows name capacity")
+	return config.IDToken.String(), constants.MaxVMNameLength
+}
+
+// cachedPrepTemplate provides basic single value memoization caching wrapping prepTemplate
+func cachedPrepTemplate(op trace.Operation, template string) (string, int) {
+	// cache these values for the first template
+	// can move to full memoization if/when we allow dynamic choice or dynamic config
+	nameTemplateOnce.Do(func() {
+		nameTemplateInitial = template
+		nameTemplate, nameAvailableCapacity = prepTemplate(op, template)
+		op.Infof("Cached processed name convention template %q with insertion capacity of %d", nameTemplate, nameAvailableCapacity)
+	})
+
+	if template == nameTemplateInitial {
+		return nameTemplate, nameAvailableCapacity
+	}
+
+	return prepTemplate(op, template)
+}
+
+// replaceToken will replace the first occurrence only of the specific PatternToken in the template.
+// Returns:
+//	 updated template with value inserted
+//   renaming available capacity for insertions
+func replaceToken(template string, token config.PatternToken, value string, availableLen int) (string, int) {
+	if strings.Contains(template, token.String()) {
+		trunc := value
+		if len(value) > availableLen {
+			trunc = value[:availableLen]
+		}
+
+		return strings.Replace(template, token.String(), trunc, 1), availableLen - len(trunc)
+	}
+
+	return template, availableLen
+}
+
 // Update the VM display name on vSphere UI
-func DisplayName(cfg *spec.VirtualMachineConfigSpecConfig, namingConvention string) string {
+func DisplayName(op trace.Operation, cfg *spec.VirtualMachineConfigSpecConfig, namingConvention string) string {
 	shortID := cfg.ID[:constants.ShortIDLen]
 	prettyName := cfg.Name
 
-	if namingConvention == "" {
-		namingConvention = config.DefaultNamePattern
-	}
-	name := namingConvention
-
 	// determine length of template without tokens
-	templateLen := len(strings.Replace(strings.Replace(namingConvention, config.NameToken.String(), "", -1), config.IDToken.String(), "", -1))
-	availableLen := constants.MaxVMNameLength - templateLen
+	name, availableLen := cachedPrepTemplate(op, namingConvention)
+	name, availableLen = replaceToken(name, config.IDToken, shortID, availableLen)
+	name, availableLen = replaceToken(name, config.NameToken, prettyName, availableLen)
 
-	if availableLen < 0 {
-		// revert to default
-		namingConvention = config.DefaultNamePattern
-		name = config.DefaultNamePattern
-		templateLen = len(strings.Replace(strings.Replace(namingConvention, config.NameToken.String(), "", -1), config.IDToken.String(), "", -1))
-		availableLen = constants.MaxVMNameLength - templateLen
-	}
-
-	if strings.Contains(namingConvention, config.IDToken.String()) {
-		trunc := shortID
-		if len(shortID) > availableLen {
-			trunc = shortID[:availableLen]
-		}
-
-		name = strings.Replace(name, config.IDToken.String(), trunc, -1)
-		availableLen -= len(trunc)
-	}
-
-	// check for presence in template not working result so we don't have issues with recursive templates
-	if strings.Contains(namingConvention, config.NameToken.String()) {
-		trunc := prettyName
-		if len(prettyName) > availableLen {
-			trunc = prettyName[:availableLen]
-		}
-
-		name = strings.Replace(name, config.NameToken.String(), trunc, -1)
-		availableLen -= len(trunc)
-	}
-
-	log.Infof("Applied naming convention: %s resulting %s", namingConvention, name)
+	op.Infof("Applied naming convention: %s resulting %s", namingConvention, name)
 	return name
 }
 

--- a/lib/portlayer/util/util_test.go
+++ b/lib/portlayer/util/util_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"github.com/vmware/vic/lib/config"
 	"github.com/vmware/vic/lib/constants"
 	"github.com/vmware/vic/lib/spec"

--- a/lib/portlayer/util/util_test.go
+++ b/lib/portlayer/util/util_test.go
@@ -1,4 +1,4 @@
-// Copyright 2016 VMware, Inc. All Rights Reserved.
+// Copyright 2016-2018 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
 package util
 
 import (
+	"context"
 	"fmt"
 	"net/url"
 	"path"
@@ -28,8 +29,10 @@ import (
 	"github.com/vmware/vic/lib/config"
 	"github.com/vmware/vic/lib/constants"
 	"github.com/vmware/vic/lib/spec"
+	"github.com/vmware/vic/pkg/trace"
 )
 
+// testName allows easy embedding of the test function name in the test body as string data
 func testName(t *testing.T) string {
 	pc, _, _, ok := runtime.Caller(1)
 	require.True(t, ok, "unable to determine test name")
@@ -52,6 +55,8 @@ func TestServiceUrl(t *testing.T) {
 }
 
 func TestNameConventionDefault(t *testing.T) {
+	op := trace.NewOperation(context.Background(), testName(t))
+
 	formatString := "%s-%s"
 	template := fmt.Sprintf(formatString, config.NameToken.String(), config.IDToken.String())
 
@@ -62,11 +67,16 @@ func TestNameConventionDefault(t *testing.T) {
 
 	shortID := cfg.ID[:constants.ShortIDLen]
 
-	formatted := DisplayName(cfg, template)
+	formatted := DisplayName(op, cfg, template)
 	assert.Equal(t, fmt.Sprintf(formatString, cfg.Name, shortID), formatted, "display name not as expected")
+
+	second := DisplayName(op, cfg, template)
+	assert.Equal(t, formatted, second, "second call should return the same output")
 }
 
 func TestNameConventionUnspecified(t *testing.T) {
+	op := trace.NewOperation(context.Background(), testName(t))
+
 	formatString := "%s-%s"
 	template := ""
 
@@ -77,11 +87,13 @@ func TestNameConventionUnspecified(t *testing.T) {
 
 	shortID := cfg.ID[:constants.ShortIDLen]
 
-	formatted := DisplayName(cfg, template)
+	formatted := DisplayName(op, cfg, template)
 	assert.Equal(t, fmt.Sprintf(formatString, cfg.Name, shortID), formatted, "display name not as expected")
 }
 
 func TestNameConventionNameInsertOnly(t *testing.T) {
+	op := trace.NewOperation(context.Background(), testName(t))
+
 	formatString := "%s"
 	template := fmt.Sprintf(formatString, config.NameToken.String())
 
@@ -92,11 +104,13 @@ func TestNameConventionNameInsertOnly(t *testing.T) {
 
 	_ = cfg.ID[:constants.ShortIDLen]
 
-	formatted := DisplayName(cfg, template)
+	formatted := DisplayName(op, cfg, template)
 	assert.Equal(t, fmt.Sprintf(formatString, cfg.Name), formatted, "display name not as expected")
 }
 
 func TestNameConventionIdInsertOnly(t *testing.T) {
+	op := trace.NewOperation(context.Background(), testName(t))
+
 	formatString := "%s"
 	template := fmt.Sprintf(formatString, config.IDToken.String())
 
@@ -107,11 +121,13 @@ func TestNameConventionIdInsertOnly(t *testing.T) {
 
 	shortID := cfg.ID[:constants.ShortIDLen]
 
-	formatted := DisplayName(cfg, template)
+	formatted := DisplayName(op, cfg, template)
 	assert.Equal(t, fmt.Sprintf(formatString, shortID), formatted, "display name not as expected")
 }
 
 func TestNameConventionNamePre(t *testing.T) {
+	op := trace.NewOperation(context.Background(), testName(t))
+
 	formatString := "pre-%s"
 	template := fmt.Sprintf(formatString, config.NameToken.String())
 
@@ -122,11 +138,13 @@ func TestNameConventionNamePre(t *testing.T) {
 
 	_ = cfg.ID[:constants.ShortIDLen]
 
-	formatted := DisplayName(cfg, template)
+	formatted := DisplayName(op, cfg, template)
 	assert.Equal(t, fmt.Sprintf(formatString, cfg.Name), formatted, "display name not as expected")
 }
 
 func TestNameConventionNamePost(t *testing.T) {
+	op := trace.NewOperation(context.Background(), testName(t))
+
 	formatString := "%s-post"
 	template := fmt.Sprintf(formatString, config.NameToken.String())
 
@@ -137,11 +155,13 @@ func TestNameConventionNamePost(t *testing.T) {
 
 	_ = cfg.ID[:constants.ShortIDLen]
 
-	formatted := DisplayName(cfg, template)
+	formatted := DisplayName(op, cfg, template)
 	assert.Equal(t, fmt.Sprintf(formatString, cfg.Name), formatted, "display name not as expected")
 }
 
 func TestNameConventionIDPre(t *testing.T) {
+	op := trace.NewOperation(context.Background(), testName(t))
+
 	formatString := "pre-%s"
 	template := fmt.Sprintf(formatString, config.IDToken.String())
 
@@ -152,12 +172,14 @@ func TestNameConventionIDPre(t *testing.T) {
 
 	shortID := cfg.ID[:constants.ShortIDLen]
 
-	formatted := DisplayName(cfg, template)
+	formatted := DisplayName(op, cfg, template)
 	assert.Equal(t, fmt.Sprintf(formatString, shortID), formatted, "display name not as expected")
 
 }
 
 func TestNameConventionIDPost(t *testing.T) {
+	op := trace.NewOperation(context.Background(), testName(t))
+
 	formatString := "%s-post"
 	template := fmt.Sprintf(formatString, config.IDToken.String())
 
@@ -168,11 +190,13 @@ func TestNameConventionIDPost(t *testing.T) {
 
 	shortID := cfg.ID[:constants.ShortIDLen]
 
-	formatted := DisplayName(cfg, template)
+	formatted := DisplayName(op, cfg, template)
 	assert.Equal(t, fmt.Sprintf(formatString, shortID), formatted, "display name not as expected")
 }
 
 func TestNameConventionNameBoth(t *testing.T) {
+	op := trace.NewOperation(context.Background(), testName(t))
+
 	formatString := "pre-%s-post"
 	template := fmt.Sprintf(formatString, config.NameToken.String())
 
@@ -183,11 +207,13 @@ func TestNameConventionNameBoth(t *testing.T) {
 
 	_ = cfg.ID[:constants.ShortIDLen]
 
-	formatted := DisplayName(cfg, template)
+	formatted := DisplayName(op, cfg, template)
 	assert.Equal(t, fmt.Sprintf(formatString, cfg.Name), formatted, "display name not as expected")
 }
 
 func TestNameConventionIDBoth(t *testing.T) {
+	op := trace.NewOperation(context.Background(), testName(t))
+
 	formatString := "pre-%s-post"
 	template := fmt.Sprintf(formatString, config.IDToken.String())
 
@@ -198,11 +224,13 @@ func TestNameConventionIDBoth(t *testing.T) {
 
 	shortID := cfg.ID[:constants.ShortIDLen]
 
-	formatted := DisplayName(cfg, template)
+	formatted := DisplayName(op, cfg, template)
 	assert.Equal(t, fmt.Sprintf(formatString, shortID), formatted, "display name not as expected")
 }
 
 func TestNameConventionNameAndIDWithPrePost(t *testing.T) {
+	op := trace.NewOperation(context.Background(), testName(t))
+
 	formatString := "pre-%s-%s-post"
 	template := fmt.Sprintf(formatString, config.NameToken.String(), config.IDToken.String())
 
@@ -213,11 +241,13 @@ func TestNameConventionNameAndIDWithPrePost(t *testing.T) {
 
 	shortID := cfg.ID[:constants.ShortIDLen]
 
-	formatted := DisplayName(cfg, template)
+	formatted := DisplayName(op, cfg, template)
 	assert.Equal(t, fmt.Sprintf(formatString, cfg.Name, shortID), formatted, "display name not as expected")
 }
 
 func TestNameConventionIDAndNameWithPrePost(t *testing.T) {
+	op := trace.NewOperation(context.Background(), testName(t))
+
 	formatString := "pre-%s-%s-post"
 	template := fmt.Sprintf(formatString, config.IDToken.String(), config.NameToken.String())
 
@@ -228,11 +258,13 @@ func TestNameConventionIDAndNameWithPrePost(t *testing.T) {
 
 	shortID := cfg.ID[:constants.ShortIDLen]
 
-	formatted := DisplayName(cfg, template)
+	formatted := DisplayName(op, cfg, template)
 	assert.Equal(t, fmt.Sprintf(formatString, shortID, cfg.Name), formatted, "display name not as expected")
 }
 
 func TestNameConventionNameOverflowWithPrePost(t *testing.T) {
+	op := trace.NewOperation(context.Background(), testName(t))
+
 	formatString := "this-is-a-really-long-pre-segment-in-order-to-test-name-truncation-%s-post"
 	template := fmt.Sprintf(formatString, config.NameToken.String())
 
@@ -243,11 +275,13 @@ func TestNameConventionNameOverflowWithPrePost(t *testing.T) {
 
 	_ = cfg.ID[:constants.ShortIDLen]
 
-	formatted := DisplayName(cfg, template)
+	formatted := DisplayName(op, cfg, template)
 	assert.Equal(t, constants.MaxVMNameLength, len(formatted), "name was expected to be the max vm name length")
 }
 
 func TestNameConventionIDOverflowWithPrePost(t *testing.T) {
+	op := trace.NewOperation(context.Background(), testName(t))
+
 	formatString := "this-is-a-really-long-pre-segment-in-order-to-test-name-truncation-%s-post"
 	template := fmt.Sprintf(formatString, config.IDToken.String())
 
@@ -258,11 +292,13 @@ func TestNameConventionIDOverflowWithPrePost(t *testing.T) {
 
 	_ = cfg.ID[:constants.ShortIDLen]
 
-	formatted := DisplayName(cfg, template)
+	formatted := DisplayName(op, cfg, template)
 	assert.Equal(t, constants.MaxVMNameLength, len(formatted), "name was expected to be the max vm name length")
 }
 
 func TestNameConventionBothOverflowWithPrePost(t *testing.T) {
+	op := trace.NewOperation(context.Background(), testName(t))
+
 	formatString := "this-is-a-really-long-pre-segment-in-order-to-test-name-truncation-%s-%s-post"
 	template := fmt.Sprintf(formatString, config.IDToken.String(), config.NameToken.String())
 
@@ -273,11 +309,13 @@ func TestNameConventionBothOverflowWithPrePost(t *testing.T) {
 
 	_ = cfg.ID[:constants.ShortIDLen]
 
-	formatted := DisplayName(cfg, template)
+	formatted := DisplayName(op, cfg, template)
 	assert.Equal(t, constants.MaxVMNameLength, len(formatted), "name was expected to be the max vm name length")
 }
 
 func TestTemplateOverflow(t *testing.T) {
+	op := trace.NewOperation(context.Background(), testName(t))
+
 	formatString := "this-is-a-really-long-pre-segment-in-order-to-test-name-truncation-that-overflows-without-any-%s-post"
 	template := fmt.Sprintf(formatString, config.IDToken.String(), config.NameToken.String())
 
@@ -288,7 +326,7 @@ func TestTemplateOverflow(t *testing.T) {
 
 	shortID := cfg.ID[:constants.ShortIDLen]
 
-	formatted := DisplayName(cfg, template)
+	formatted := DisplayName(op, cfg, template)
 	// behaviour of template overflow is to revert to default template
 	assert.Equal(t, fmt.Sprintf("%s-%s", cfg.Name, shortID), formatted, "display name not as expected")
 }

--- a/lib/portlayer/util/util_test.go
+++ b/lib/portlayer/util/util_test.go
@@ -15,11 +15,31 @@
 package util
 
 import (
+	"fmt"
 	"net/url"
+	"path"
+	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/vmware/vic/lib/config"
+	"github.com/vmware/vic/lib/constants"
+	"github.com/vmware/vic/lib/spec"
 )
+
+func testName(t *testing.T) string {
+	pc, _, _, ok := runtime.Caller(1)
+	require.True(t, ok, "unable to determine test name")
+
+	// lets only return the func name from the repo (vic)
+	// down - i.e. vic/lib/etc vs. github.com/vmware/vic/lib/etc
+	// if github.com/vmware doesn't match then the original is returned
+	pkgAndFunc := path.Base(runtime.FuncForPC(pc).Name())
+	parts := strings.Split(pkgAndFunc, ".")
+	return parts[len(parts)-1]
+}
 
 func TestServiceUrl(t *testing.T) {
 	DefaultHost, _ = url.Parse("http://foo.com/")
@@ -28,4 +48,246 @@ func TestServiceUrl(t *testing.T) {
 	if !assert.Equal(t, "http://foo.com/storage", u.String()) {
 		return
 	}
+}
+
+func TestNameConventionDefault(t *testing.T) {
+	formatString := "%s-%s"
+	template := fmt.Sprintf(formatString, config.NameToken.String(), config.IDToken.String())
+
+	cfg := &spec.VirtualMachineConfigSpecConfig{
+		ID:   "abcdefg0123456789hijklmnopqrstu",
+		Name: testName(t),
+	}
+
+	shortID := cfg.ID[:constants.ShortIDLen]
+
+	formatted := DisplayName(cfg, template)
+	assert.Equal(t, fmt.Sprintf(formatString, cfg.Name, shortID), formatted, "display name not as expected")
+}
+
+func TestNameConventionUnspecified(t *testing.T) {
+	formatString := "%s-%s"
+	template := ""
+
+	cfg := &spec.VirtualMachineConfigSpecConfig{
+		ID:   "abcdefg0123456789hijklmnopqrstu",
+		Name: testName(t),
+	}
+
+	shortID := cfg.ID[:constants.ShortIDLen]
+
+	formatted := DisplayName(cfg, template)
+	assert.Equal(t, fmt.Sprintf(formatString, cfg.Name, shortID), formatted, "display name not as expected")
+}
+
+func TestNameConventionNameInsertOnly(t *testing.T) {
+	formatString := "%s"
+	template := fmt.Sprintf(formatString, config.NameToken.String())
+
+	cfg := &spec.VirtualMachineConfigSpecConfig{
+		ID:   "abcdefg0123456789hijklmnopqrstu",
+		Name: testName(t),
+	}
+
+	_ = cfg.ID[:constants.ShortIDLen]
+
+	formatted := DisplayName(cfg, template)
+	assert.Equal(t, fmt.Sprintf(formatString, cfg.Name), formatted, "display name not as expected")
+}
+
+func TestNameConventionIdInsertOnly(t *testing.T) {
+	formatString := "%s"
+	template := fmt.Sprintf(formatString, config.IDToken.String())
+
+	cfg := &spec.VirtualMachineConfigSpecConfig{
+		ID:   "abcdefg0123456789hijklmnopqrstu",
+		Name: testName(t),
+	}
+
+	shortID := cfg.ID[:constants.ShortIDLen]
+
+	formatted := DisplayName(cfg, template)
+	assert.Equal(t, fmt.Sprintf(formatString, shortID), formatted, "display name not as expected")
+}
+
+func TestNameConventionNamePre(t *testing.T) {
+	formatString := "pre-%s"
+	template := fmt.Sprintf(formatString, config.NameToken.String())
+
+	cfg := &spec.VirtualMachineConfigSpecConfig{
+		ID:   "abcdefg0123456789hijklmnopqrstu",
+		Name: testName(t),
+	}
+
+	_ = cfg.ID[:constants.ShortIDLen]
+
+	formatted := DisplayName(cfg, template)
+	assert.Equal(t, fmt.Sprintf(formatString, cfg.Name), formatted, "display name not as expected")
+}
+
+func TestNameConventionNamePost(t *testing.T) {
+	formatString := "%s-post"
+	template := fmt.Sprintf(formatString, config.NameToken.String())
+
+	cfg := &spec.VirtualMachineConfigSpecConfig{
+		ID:   "abcdefg0123456789hijklmnopqrstu",
+		Name: testName(t),
+	}
+
+	_ = cfg.ID[:constants.ShortIDLen]
+
+	formatted := DisplayName(cfg, template)
+	assert.Equal(t, fmt.Sprintf(formatString, cfg.Name), formatted, "display name not as expected")
+}
+
+func TestNameConventionIDPre(t *testing.T) {
+	formatString := "pre-%s"
+	template := fmt.Sprintf(formatString, config.IDToken.String())
+
+	cfg := &spec.VirtualMachineConfigSpecConfig{
+		ID:   "abcdefg0123456789hijklmnopqrstu",
+		Name: testName(t),
+	}
+
+	shortID := cfg.ID[:constants.ShortIDLen]
+
+	formatted := DisplayName(cfg, template)
+	assert.Equal(t, fmt.Sprintf(formatString, shortID), formatted, "display name not as expected")
+
+}
+
+func TestNameConventionIDPost(t *testing.T) {
+	formatString := "%s-post"
+	template := fmt.Sprintf(formatString, config.IDToken.String())
+
+	cfg := &spec.VirtualMachineConfigSpecConfig{
+		ID:   "abcdefg0123456789hijklmnopqrstu",
+		Name: testName(t),
+	}
+
+	shortID := cfg.ID[:constants.ShortIDLen]
+
+	formatted := DisplayName(cfg, template)
+	assert.Equal(t, fmt.Sprintf(formatString, shortID), formatted, "display name not as expected")
+}
+
+func TestNameConventionNameBoth(t *testing.T) {
+	formatString := "pre-%s-post"
+	template := fmt.Sprintf(formatString, config.NameToken.String())
+
+	cfg := &spec.VirtualMachineConfigSpecConfig{
+		ID:   "abcdefg0123456789hijklmnopqrstu",
+		Name: testName(t),
+	}
+
+	_ = cfg.ID[:constants.ShortIDLen]
+
+	formatted := DisplayName(cfg, template)
+	assert.Equal(t, fmt.Sprintf(formatString, cfg.Name), formatted, "display name not as expected")
+}
+
+func TestNameConventionIDBoth(t *testing.T) {
+	formatString := "pre-%s-post"
+	template := fmt.Sprintf(formatString, config.IDToken.String())
+
+	cfg := &spec.VirtualMachineConfigSpecConfig{
+		ID:   "abcdefg0123456789hijklmnopqrstu",
+		Name: testName(t),
+	}
+
+	shortID := cfg.ID[:constants.ShortIDLen]
+
+	formatted := DisplayName(cfg, template)
+	assert.Equal(t, fmt.Sprintf(formatString, shortID), formatted, "display name not as expected")
+}
+
+func TestNameConventionNameAndIDWithPrePost(t *testing.T) {
+	formatString := "pre-%s-%s-post"
+	template := fmt.Sprintf(formatString, config.NameToken.String(), config.IDToken.String())
+
+	cfg := &spec.VirtualMachineConfigSpecConfig{
+		ID:   "abcdefg0123456789hijklmnopqrstu",
+		Name: testName(t),
+	}
+
+	shortID := cfg.ID[:constants.ShortIDLen]
+
+	formatted := DisplayName(cfg, template)
+	assert.Equal(t, fmt.Sprintf(formatString, cfg.Name, shortID), formatted, "display name not as expected")
+}
+
+func TestNameConventionIDAndNameWithPrePost(t *testing.T) {
+	formatString := "pre-%s-%s-post"
+	template := fmt.Sprintf(formatString, config.IDToken.String(), config.NameToken.String())
+
+	cfg := &spec.VirtualMachineConfigSpecConfig{
+		ID:   "abcdefg0123456789hijklmnopqrstu",
+		Name: testName(t),
+	}
+
+	shortID := cfg.ID[:constants.ShortIDLen]
+
+	formatted := DisplayName(cfg, template)
+	assert.Equal(t, fmt.Sprintf(formatString, shortID, cfg.Name), formatted, "display name not as expected")
+}
+
+func TestNameConventionNameOverflowWithPrePost(t *testing.T) {
+	formatString := "this-is-a-really-long-pre-segment-in-order-to-test-name-truncation-%s-post"
+	template := fmt.Sprintf(formatString, config.NameToken.String())
+
+	cfg := &spec.VirtualMachineConfigSpecConfig{
+		ID:   "abcdefg0123456789hijklmnopqrstu",
+		Name: testName(t),
+	}
+
+	_ = cfg.ID[:constants.ShortIDLen]
+
+	formatted := DisplayName(cfg, template)
+	assert.Equal(t, constants.MaxVMNameLength, len(formatted), "name was expected to be the max vm name length")
+}
+
+func TestNameConventionIDOverflowWithPrePost(t *testing.T) {
+	formatString := "this-is-a-really-long-pre-segment-in-order-to-test-name-truncation-%s-post"
+	template := fmt.Sprintf(formatString, config.IDToken.String())
+
+	cfg := &spec.VirtualMachineConfigSpecConfig{
+		ID:   "abcdefg0123456789hijklmnopqrstu",
+		Name: testName(t),
+	}
+
+	_ = cfg.ID[:constants.ShortIDLen]
+
+	formatted := DisplayName(cfg, template)
+	assert.Equal(t, constants.MaxVMNameLength, len(formatted), "name was expected to be the max vm name length")
+}
+
+func TestNameConventionBothOverflowWithPrePost(t *testing.T) {
+	formatString := "this-is-a-really-long-pre-segment-in-order-to-test-name-truncation-%s-%s-post"
+	template := fmt.Sprintf(formatString, config.IDToken.String(), config.NameToken.String())
+
+	cfg := &spec.VirtualMachineConfigSpecConfig{
+		ID:   "abcdefg0123456789hijklmnopqrstu",
+		Name: testName(t),
+	}
+
+	_ = cfg.ID[:constants.ShortIDLen]
+
+	formatted := DisplayName(cfg, template)
+	assert.Equal(t, constants.MaxVMNameLength, len(formatted), "name was expected to be the max vm name length")
+}
+
+func TestTemplateOverflow(t *testing.T) {
+	formatString := "this-is-a-really-long-pre-segment-in-order-to-test-name-truncation-that-overflows-without-any-%s-post"
+	template := fmt.Sprintf(formatString, config.IDToken.String(), config.NameToken.String())
+
+	cfg := &spec.VirtualMachineConfigSpecConfig{
+		ID:   "abcdefg0123456789hijklmnopqrstu",
+		Name: testName(t),
+	}
+
+	shortID := cfg.ID[:constants.ShortIDLen]
+
+	formatted := DisplayName(cfg, template)
+	// behaviour of template overflow is to revert to default template
+	assert.Equal(t, fmt.Sprintf("%s-%s", cfg.Name, shortID), formatted, "display name not as expected")
 }

--- a/tests/test-cases/Group6-VIC-Machine/6-18-Container-Name-Convention.robot
+++ b/tests/test-cases/Group6-VIC-Machine/6-18-Container-Name-Convention.robot
@@ -20,22 +20,36 @@ Test Timeout  20 minutes
 
 *** Test Cases ***
 Container name convention with id
-    Install VIC Appliance To Test Server  additional-args=--container-name-convention 192.168.1.1-{id}
+    Set Test Environment Variables
+    Install VIC Appliance To Test Server With Current Environment Variables  additional-args=--container-name-convention %{VCH-NAME}-{id}
     Run  docker %{VCH-PARAMS} pull ${busybox}
     ${containerID}=  Run  docker %{VCH-PARAMS} run -d ${busybox}
     ${shortId}=  Get container shortID  ${containerID}
     ${output}=  Run  govc ls vm
-    Should Contain  ${output}  192.168.1.1-${shortID}
+    Should Contain  ${output}  %{VCH-NAME}-${shortID}
+
+    Run  docker %{VCH-PARAMS} rename ${containerID} renamed-container
+    ${output}=  Run  govc ls vm
+    # confirm that the cnc is still in force
+    Should Contain  ${output}  %{VCH-NAME}-${shortID}
+
     Run  docker %{VCH-PARAMS} rm -f ${containerID}
     Run Regression Tests
     
 Container name convention with name
-    Install VIC Appliance To Test Server  additional-args=--container-name-convention 192.168.1.1-{name}
+    Set Test Environment Variables
+    Install VIC Appliance To Test Server With Current Environment Variables  additional-args=--container-name-convention %{VCH-NAME}-{name}
     Run  docker %{VCH-PARAMS} pull ${busybox}
     ${containerID}=  Run  docker %{VCH-PARAMS} run -d ${busybox}
     ${name}=  Get container name  ${containerID}
     ${output}=  Run  govc ls vm
-    Should Contain  ${output}  192.168.1.1-${name}
+    Should Contain  ${output}  %{VCH-NAME}-${name}
+
+    Run  docker %{VCH-PARAMS} rename ${containerID} renamed-container
+    ${output}=  Run  govc ls vm
+    # confirm that the cnc is still in force but updated for new container name
+    Should Contain  ${output}  %{VCH-NAME}-renamed-container
+
     Run  docker %{VCH-PARAMS} rm -f ${containerID}
     Run Regression Tests
 


### PR DESCRIPTION
This ensures we always call the name convention logic during rename paths.
Additionally this enforces maximum VM name length limits on the resulting names.
If the convention template as a whole somehow exceeds the maximum length we will revert to using default.
ID is replaced first, then Name. If truncation occurs it will be applied to the ID or Name insertions and not the template.

Adds:
* rename assertions to robot tests
* unit tests for convention transformations

Fixes #7159
