### PR TITLE
[skip ci] Add Robot markdown updates for commit d5cd74f

### DIFF
--- a/tests/test-cases/Group1-Docker-Commands/1-04-Docker-Create.md
+++ b/tests/test-cases/Group1-Docker-Commands/1-04-Docker-Create.md
@@ -23,46 +23,52 @@ This test requires that a vSphere server is running and available
 10. Issue docker start <containerID>
 11. Issue docker logs <containerID> to grab the disk size of the volume
 12. Issue docker create -v /dir:/dir busybox
-13. Issue docker create busybox /bin/top to the new VIC appliance
-14. Issue docker create fakeimage to the new VIC appliance
-15. Issue docker create fakeImage to the new VIC appliance
-16. Issue docker create --name busy1 busybox /bin/top to the new VIC appliance
-17. Issue docker start busy1 to the new VIC appliance
-18. Issue docker create --link busy1:busy1 --name busy2 busybox ping -c2 busy1 to the new VIC appliance
-19. Issue docker start busy2 to the new VIC appliance
-20. Issue docker logs busy2 to the new VIC appliance
-21. Create a container, rm the container, then create another container
-22. Create a container directly without pulling the image first for an image that hasn't been pulled yet
-23. Create a container without specifying a command
-24. Create a container with a custom amount of CPUs
-25. Create a container with a custom amount of Memory in GB
-26. Create a container with a custom amount of Memory in MB
-27. Create a container with a custom amount of Memory in KB
-28. Create a container with a custom amount of Memory in Bytes
-29. Create a container using a rest api call without HostConfig in the form data
-30. Create a container, then check the vm display name in vsphere through govc
-31. Create a container, then check the vm Destroy_Task method is disabled in VC through govc
-32. Create two containers with the same name in parallel, then check that only one attempt is successful
-33. Remove the container from Step 32 by name and create another container with the same name
+13. Create a named volume
+14. Create a mongo container with the above named volume (mapped to an image volume path) and an anonymous volume
+15. Inspect the above container and obtain the HostConfig.Binds field
+16. Inspect the above container and obtain the Config.Volumes field
+17. Issue docker create busybox /bin/top to the new VIC appliance
+18. Issue docker create fakeimage to the new VIC appliance
+19. Issue docker create fakeImage to the new VIC appliance
+20. Issue docker create --name busy1 busybox /bin/top to the new VIC appliance
+21. Issue docker start busy1 to the new VIC appliance
+22. Issue docker create --link busy1:busy1 --name busy2 busybox ping -c2 busy1 to the new VIC appliance
+23. Issue docker start busy2 to the new VIC appliance
+24. Issue docker logs busy2 to the new VIC appliance
+25. Create a container, rm the container, then create another container
+26. Create a container directly without pulling the image first for an image that hasn't been pulled yet
+27. Create a container without specifying a command
+28. Create a container with a custom amount of CPUs
+29. Create a container with a custom amount of Memory in GB
+30. Create a container with a custom amount of Memory in MB
+31. Create a container with a custom amount of Memory in KB
+32. Create a container with a custom amount of Memory in Bytes
+33. Create a container using a rest api call without HostConfig in the form data
+34. Create a container, then check the vm display name in vsphere through govc
+35. Create a container, then check the vm Destroy_Task method is disabled in VC through govc
+36. Create two containers with the same name in parallel, then check that only one attempt is successful
+37. Remove the container from Step 32 by name and create another container with the same name
 
 # Expected Outcome:
 * Steps 3-7 should all return without error and printing the container ID on return
 * Step 8 should show that the contents of the containers /var/log matches the contents of the hosts /var/log
 * Steps 9, 10 and 11 should return without errors and should successfully create a new volume called `test-named-vol` with disk size 975.9M
 * Step 12 should return with the error message - Error response from daemon: vSphere Integrated Containers does not support mounting directories as a data volume.
-* Step 14 should return with the error message - Error: image library/fakeimage not found
-* Step 15 should return with the error message - Error parsing reference: "fakeImage" is not a valid repository/tag
-* Step 18 should result in success and the busy2 container should exist
-* Step 20 should show that busy2 was able to successfully ping busy1 just using the linked name
-* Step 21 should result in success for all three parts
-* Step 22 should return without error
-* Step 23 should return with the following error message - Error response from daemon: No command specified
-* Steps 24-28 should return without error.
-* Step 29 should return without error.
-* Step 30 should show that the VM display name equals to containerName-containerShortID and datastore folder name equal to containerID
-* Step 31 should show that the VM Destroy_Task method is disabled in VC
-* Step 32 should have one container create process succeed and the other fail with an error
-* Step 33 should succeed
+* Steps 13 and 14 should succeed
+* Step 15's and 16's output should contain the named volume created in Step 13
+* Step 18 should return with the error message - Error: image library/fakeimage not found
+* Step 19 should return with the error message - Error parsing reference: "fakeImage" is not a valid repository/tag
+* Step 22 should result in success and the busy2 container should exist
+* Step 24 should show that busy2 was able to successfully ping busy1 just using the linked name
+* Step 25 should result in success for all three parts
+* Step 26 should return without error
+* Step 27 should return with the following error message - Error response from daemon: No command specified
+* Steps 28-32 should return without error.
+* Step 33 should return without error.
+* Step 34 should show that the VM display name equals to containerName-containerShortID and datastore folder name equal to containerID
+* Step 35 should show that the VM Destroy_Task method is disabled in VC
+* Step 36 should have one container create process succeed and the other fail with an error
+* Step 37 should succeed
 
 # Possible Problems:
 None

--- a/tests/test-cases/Group1-Docker-Commands/1-06-Docker-Run.md
+++ b/tests/test-cases/Group1-Docker-Commands/1-06-Docker-Run.md
@@ -29,12 +29,16 @@ This test requires that a vSphere server is running and available
 16. Issue docker run busybox date
 17. Create container1 with id1 and then create container2 with name = id1
 18. Run a short lived container with autoremove specified
-19. Issue docker run -d -v vol:/var/lib/mysql -e MYSQL_ROOT_PASSWORD=pw --name test-mysql mysql to the VIC appliance
-20. Issue docker ps to the VIC appliance to verify that test-mysql is running and clean up afterward
-21. Issue docker run -d -e MYSQL_ROOT_PASSWORD=pw --name test-mariadb mariadb to the VIC appliance
-22. Issue docker ps to the VIC appliance to verify that test-mariadb is running and clean up afterward
-23. Issue docker run -d --name test-postgres postgres to the VIC appliance
-24. Issue docker ps to the VIC appliance to verify that test-postgres is running and clean up afterward
+19. Check the number of containers with docker ps -a
+20. Run a short-lived auto-remove mongo container with a named volume (mapped to an image volume path) and an anonymous volume
+21. Check the number of containers with docker ps -a
+22. Run docker volume ls
+23. Issue docker run -d -v vol:/var/lib/mysql -e MYSQL_ROOT_PASSWORD=pw --name test-mysql mysql to the VIC appliance
+24. Issue docker ps to the VIC appliance to verify that test-mysql is running and clean up afterward
+25. Issue docker run -d -e MYSQL_ROOT_PASSWORD=pw --name test-mariadb mariadb to the VIC appliance
+26. Issue docker ps to the VIC appliance to verify that test-mariadb is running and clean up afterward
+27. Issue docker run -d --name test-postgres postgres to the VIC appliance
+28. Issue docker ps to the VIC appliance to verify that test-postgres is running and clean up afterward
 
 # Expected Outcome:
 * Step 2 and 3 should result in success and print the dmesg of the container
@@ -59,7 +63,10 @@ docker: Error parsing reference: "fakeImage" is not a valid repository/tag.
 * Step 16 should result in success and the output should contain the current date
 * Step 17 should result in no conflicts
 * Step 18 should result in the same container count at beginning and end
-* Step 19-24 should result in success with exit code 0
+* Steps 19 and 20 should succeed
+* Step 21's output should contain the same number of containers as Step 19's output
+* Step 22's output should contain the named volume used in Step 20
+* Step 23-28 should result in success with exit code 0
 
 # Possible Problems:
 None

--- a/tests/test-cases/Group1-Docker-Commands/1-11-Docker-RM.md
+++ b/tests/test-cases/Group1-Docker-Commands/1-11-Docker-RM.md
@@ -36,10 +36,15 @@ This test requires that a vSphere server is running and available
 23. Issue docker rm -v to the container from Step 20
 24. Issue volume ls to the VIC appliance
 25. Run a container with the volume from Step 19's volume
-26. Issue docker rm to the container from Step 25
+26. Issue docker rm -f to the container from Step 25
+27. Create a new named volume
+28. Create a mongo container with the above named volume (mapped to an image volume path) and an anonymous volume
+29. Run docker volume ls
+30. Run docker rm -v for the container created in Step 28
+31. Run docker volume ls
 
 # Expected Outcome:
-* Steps 2-8,12,15-26 should complete without error
+* Steps 2-8,12,15-31 should complete without error
 * Step 3,6,10 should result in the container being removed from the VIC appliance
 * Step 9 should result in the following error:  
 ```
@@ -60,6 +65,7 @@ Error response from daemon: No such container: test
 * Step 17's output should contain the named volume but not the anonymous volume from Step 16
 * Step 22's output should contain the volume used in steps 19 and 20
 * Step 24's output should contain the volume used in steps 19 and 20
+* Step 29's and 31's output should contain the named volume used in step 28
 
 # Possible Problems:
 None


### PR DESCRIPTION
This commit updates the markdown files for the Robot tests added in
commit d5cd74f (#7155), which fixes an issue wherein a named volume
whose mapped directory was the same as an image volume would
(incorrectly) get deleted if the container was run with the --rm
(auto-remove) option, since that option also removes anonymous volumes
associated with the container.

Towards #7138