### PR TITLE
Cherry-pick: Test container with open network upon VCH reboot (#6641) [specific ci=10-01-VCH-Restart]

### DIFF
--- a/tests/test-cases/Group10-VCH-Restart/10-01-VCH-Restart.md
+++ b/tests/test-cases/Group10-VCH-Restart/10-01-VCH-Restart.md
@@ -17,21 +17,21 @@ This test requires that a vSphere server is running and available
 7. Issue docker stop, start and ls
 8. Check container service in specified port
 9. Start container with same port
-10. Create container with volume and then reboot VCH
-11. Inspect container to check volume info
-12. Deploy VIC appliance with open container network
-13. Create container on the open network, and create container with port mapping
-14. Reboot VCH
-15. Check container service in specified port
-16. Create container with volume and then reboot VCH
-17. Inspect container to check volume info
+10. Deploy VIC appliance with open container network
+11. Create container on the open network, and create container with port mapping
+12. Reboot VCH
+13. Check container service in specified port
+14. Create container with volume and then reboot VCH
+15. Inspect container to check volume info
 
 # Expected Outcome:
 * VCH should reboot within a reasonable amount of time
 * After VCH restart, network ls should have the previously created network listed
 * Step 6, 7 and 8 should result in success
 * Step 9 should result in false
-* Step 10-11 should result in success
+* Step 12 (VCH reboot with open container network) should succeed within a reasonable amount of time
+* Step 13 would result in success
+* Step 14-15 should result in success
 
 #Possible Problems:
 None


### PR DESCRIPTION
This was supposed to be prior to 29eeb811 in the branch however was missed.
I do not have the ability to place this in the correct location in history so it's layered on top.