### PR TITLE
Cherry-pick: Fix Get Container IP Robot util keyword (#7152) [specific ci=Group11-Upgrade]

### DIFF
--- a/tests/resources/Docker-Util.robot
+++ b/tests/resources/Docker-Util.robot
@@ -1,4 +1,4 @@
-# Copyright 2016-2017 VMware, Inc. All Rights Reserved.
+# Copyright 2016-2018 VMware, Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -48,7 +48,7 @@ Hit Nginx Endpoint
     Should Be Equal As Integers  ${rc}  0
 
 Get Container IP
-    [Arguments]  ${docker-params}  ${id}  ${network}=default  ${dockercmd}=docker
+    [Arguments]  ${docker-params}  ${id}  ${network}=bridge  ${dockercmd}=docker
     ${rc}  ${ip}=  Run And Return Rc And Output  ${dockercmd} ${docker-params} inspect --format='{{(index .NetworkSettings.Networks "${network}").IPAddress}}' ${id}
     Should Be Equal As Integers  ${rc}  0
     [Return]  ${ip}

--- a/tests/test-cases/Group10-VCH-Restart/10-01-VCH-Restart.robot
+++ b/tests/test-cases/Group10-VCH-Restart/10-01-VCH-Restart.robot
@@ -133,12 +133,13 @@ Created Network And Images Persists As Well As Containers Are Discovered With Co
 
     Check Nginx Port Forwarding  10000  10001
 
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} create -it -p 10000:80 -p 10001:80 --name webserver1 ${nginx}
+    # one of the ports collides
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} create -it -p 10001:80 -p 10002:80 --name webserver1 ${nginx}
     Should Be Equal As Integers  ${rc}  0
     Should Not Contain  ${output}  Error
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} start webserver1
     Should Be Equal As Integers  ${rc}  1
-    Should Contain  ${output}  port 10000 is not available
+    Should Contain  ${output}  port 10001 is not available
 
     # docker pull should work
     # if this fails, very likely the default gateway on the VCH is not set

--- a/tests/test-cases/Group11-Upgrade/11-01-Upgrade.robot
+++ b/tests/test-cases/Group11-Upgrade/11-01-Upgrade.robot
@@ -104,12 +104,13 @@ Run Docker Checks
     Wait Until Keyword Succeeds  20x  5 seconds  Hit Nginx Endpoint  %{VCH-IP}  10000
     Wait Until Keyword Succeeds  20x  5 seconds  Hit Nginx Endpoint  %{VCH-IP}  10001
 
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} create -it -p 10000:80 -p 10001:80 --name webserver1 nginx
+    # one of the ports collides
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} create -it -p 10001:80 -p 10002:80 --name webserver1 ${nginx}
     Should Be Equal As Integers  ${rc}  0
     Should Not Contain  ${output}  Error
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} start webserver1
     Should Be Equal As Integers  ${rc}  1
-    Should Contain  ${output}  port 10000 is not available
+    Should Contain  ${output}  port 10001 is not available
 
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} ps -aq | xargs -n1 docker %{VCH-PARAMS} stop
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} ps -aq | xargs -n1 docker %{VCH-PARAMS} rm

--- a/tests/test-cases/Group11-Upgrade/11-02-Upgrade-Exec.robot
+++ b/tests/test-cases/Group11-Upgrade/11-02-Upgrade-Exec.robot
@@ -1,4 +1,4 @@
-# Copyright 2016-2017 VMware, Inc. All Rights Reserved.
+# Copyright 2016-2018 VMware, Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@ Default Tags
 
 *** Test Cases ***
 Exec Not Allowed On Older Containers
-    Launch Container  exec-test
+    Launch Container  exec-test  bridge
 
     Upgrade
     Check Upgraded Version
@@ -30,6 +30,6 @@ Exec Not Allowed On Older Containers
     Should Not Be Equal As Integers  ${rc}  0
     Should Contain  ${output}  running tasks not supported for this container
 
-    Launch Container  exec-test2
+    Launch Container  exec-test2  bridge
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} exec -d exec-test2 ls
     Should Be Equal As Integers  ${rc}  0


### PR DESCRIPTION
NOTE: this should have preceeded e3319b1

This commit changes the 'Get Container IP' keyword's default value for
the network parameter to "bridge" instead of "default" as the keyword
was updated in commit 29eeb81 (#6641) to use container inspect instead
of network inspect. It also changes the 11-02-Upgrade-Exec test to
launch containers on the bridge network explicitly so the bridge network
is propagated to the 'Get Container IP' keyword.

Additionally in the PR is a change to avoid issues with unstable map
iteration order when determining port collisions. Test change only.