### PR TITLE
Fix map iteration order issue in portmap tests

### DIFF
--- a/tests/test-cases/Group10-VCH-Restart/10-01-VCH-Restart.robot
+++ b/tests/test-cases/Group10-VCH-Restart/10-01-VCH-Restart.robot
@@ -136,12 +136,13 @@ Created Network And Images Persists As Well As Containers Are Discovered With Co
 
     Check Nginx Port Forwarding  10000  10001
 
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} create -it -p 10000:80 -p 10001:80 --name webserver1 ${nginx}
+    # one of the ports collides
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} create -it -p 10001:80 -p 10002:80 --name webserver1 ${nginx}
     Should Be Equal As Integers  ${rc}  0
     Should Not Contain  ${output}  Error
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} start webserver1
     Should Be Equal As Integers  ${rc}  1
-    Should Contain  ${output}  port 10000 is not available
+    Should Contain  ${output}  port 10001 is not available
 
     # docker pull should work
     # if this fails, very likely the default gateway on the VCH is not set

--- a/tests/test-cases/Group11-Upgrade/11-01-Upgrade.robot
+++ b/tests/test-cases/Group11-Upgrade/11-01-Upgrade.robot
@@ -104,12 +104,13 @@ Run Docker Checks
     Wait Until Keyword Succeeds  20x  5 seconds  Hit Nginx Endpoint  %{VCH-IP}  10000
     Wait Until Keyword Succeeds  20x  5 seconds  Hit Nginx Endpoint  %{VCH-IP}  10001
 
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} create -it -p 10000:80 -p 10001:80 --name webserver1 nginx
+    # one of the ports collides
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} create -it -p 10001:80 -p 10002:80 --name webserver1 ${nginx}
     Should Be Equal As Integers  ${rc}  0
     Should Not Contain  ${output}  Error
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} start webserver1
     Should Be Equal As Integers  ${rc}  1
-    Should Contain  ${output}  port 10000 is not available
+    Should Contain  ${output}  port 10001 is not available
 
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} ps -aq | xargs -n1 docker %{VCH-PARAMS} stop
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} ps -aq | xargs -n1 docker %{VCH-PARAMS} rm


### PR DESCRIPTION
This commit updates the 10-01-VCH-Restart and 11-01-Upgrade test suites
where tests creating a container with two occupied ports would often
fail. While the test always expected a particular port to be reported in
the error output, it's possible that the other port is processed first
and reported since the iteration order of Golang maps is not specified.

This change updates the tests so only one port is in conflict.

Fixes #7156