### PR TITLE
Enable passing log level to the Longevity script

### DIFF
--- a/cmd/docker/main.go
+++ b/cmd/docker/main.go
@@ -171,7 +171,12 @@ func initLogging() error {
 
 	tags.Logger = log.StandardLogger()
 
-	return viclog.Init(logcfg)
+	err := viclog.Init(logcfg)
+	if err != nil {
+		return err
+	}
+
+	return trace.InitLogger(logcfg)
 }
 
 func loadCAPool() *x509.CertPool {

--- a/cmd/port-layer-server/main.go
+++ b/cmd/port-layer-server/main.go
@@ -119,6 +119,7 @@ func main() {
 	log.Infof("%+v", *logcfg)
 	// #nosec: Errors unhandled.
 	viclog.Init(logcfg)
+	trace.InitLogger(logcfg)
 
 	server.ConfigureAPI()
 

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -70,22 +70,28 @@ func Init(cfg *LoggingConfig) error {
 
 			logrus.Debugf("log cfg: %+v", *cfg)
 
-			if cfg.Syslog != nil {
-				logrus.Debugf("syslog cfg: %+v", *cfg.Syslog)
-				hook, err := syslog.NewHook(
-					cfg.Syslog.Network,
-					cfg.Syslog.RAddr,
-					cfg.Syslog.Priority,
-					cfg.Syslog.Tag,
-				)
-				if err != nil {
-					// not a fatal error, so just log a warning
-					logrus.Warnf("error trying to initialize syslog: %s", err)
-				} else {
-					logrus.AddHook(hook)
-				}
+			hook, err := GetSyslogHook(cfg)
+			if err == nil && hook != nil {
+				logrus.AddHook(hook)
 			}
 		})
 
 	return initializer.err
+}
+
+func GetSyslogHook(cfg *LoggingConfig) (logrus.Hook, error) {
+	if cfg.Syslog == nil {
+		return nil, nil
+	}
+	hook, err := syslog.NewHook(
+		cfg.Syslog.Network,
+		cfg.Syslog.RAddr,
+		cfg.Syslog.Priority,
+		cfg.Syslog.Tag,
+	)
+	if err != nil {
+		// not a fatal error, so just log a warning
+		logrus.Warnf("error trying to initialize syslog: %s", err)
+	}
+	return hook, err
 }

--- a/pkg/trace/trace.go
+++ b/pkg/trace/trace.go
@@ -66,6 +66,15 @@ func (t *Message) delta() time.Duration {
 	return time.Now().Sub(t.startTime)
 }
 
+// Add Syslog hook
+func InitLogger(cfg *log.LoggingConfig) error {
+	hook, err := log.GetSyslogHook(cfg)
+	if err == nil && hook != nil {
+		Logger.Hooks.Add(hook)
+	}
+	return err
+}
+
 // begin a trace from this stack frame less the skip.
 func newTrace(msg string, skip int, opID string) *Message {
 	pc, _, line, ok := runtime.Caller(skip)

--- a/tests/manual-test-cases/Group14-Longevity/14-1-Longevity.robot
+++ b/tests/manual-test-cases/Group14-Longevity/14-1-Longevity.robot
@@ -29,11 +29,11 @@ Longevity
     :FOR  ${idx}  IN RANGE  0  48
     \   ${rand}=  Evaluate  random.randint(10, 50)  modules=random
     \   Log To Console  \nLoop: ${idx}
-    \   Install VIC Appliance To Test Server  debug=0  additional-args=%{STATIC_VCH_OPTIONS}
+    \   Install VIC Appliance To Test Server  debug=%{DEBUG_VCH_LEVEL}  additional-args=%{STATIC_VCH_OPTIONS} %{SYSLOG_VCH_OPTION}
     \   Repeat Keyword  ${rand} times  Run Regression Tests
     \   Cleanup VIC Appliance On Test Server
     \   ${rand}=  Evaluate  random.randint(10, 50)  modules=random
-    \   Install VIC Appliance To Test Server  debug=0  certs=${true}  additional-args=%{STATIC_VCH_OPTIONS} %{SYSLOG_VCH_OPTION}
+    \   Install VIC Appliance To Test Server  debug=%{DEBUG_VCH_LEVEL}  certs=${true}  additional-args=%{STATIC_VCH_OPTIONS} %{SYSLOG_VCH_OPTION}
     \   Repeat Keyword  ${rand} times  Run Regression Tests
     \   Cleanup VIC Appliance On Test Server
 

--- a/tests/test-cases/Group6-VIC-Machine/6-15-Syslog.robot
+++ b/tests/test-cases/Group6-VIC-Machine/6-15-Syslog.robot
@@ -91,6 +91,8 @@ Verify VCH remote syslog
     Should Match Regexp  ${out}  ${vch-ip} docker-engine-server\\[${pid}\\]: Calling DELETE /v\\d.\\d{2}/containers/\\w{64}
     Should Match Regexp  ${out}  ${vch-ip} docker-engine-server\\[${pid}\\]: Calling DELETE /v\\d.\\d{2}/images/(\\S+)*busybox
 
+    Should Match Regexp  ${out}  ${vch-ip} docker-engine-server\\[${pid}\\]: op=\\[${pid}\\].\\d: Commit container \\w{64}
+
     Should Match Regexp  ${out}  ${shortID} ${shortID}\\[1\\]: bin
     Should Match Regexp  ${out}  ${shortID} ${shortID}\\[1\\]: home
     Should Match Regexp  ${out}  ${shortID} ${shortID}\\[1\\]: var


### PR DESCRIPTION
This change allows the caller of the longevity top script to specify the desired log level. This in combination with the syslog parameter should provide a better debugging experience of the Longevity tests.