### PR TITLE
Checking for explicit string values instead of just a prefix

### DIFF
--- a/pkg/vsphere/vm/vm.go
+++ b/pkg/vsphere/vm/vm.go
@@ -520,7 +520,7 @@ func (vm *VirtualMachine) Properties(ctx context.Context, r types.ManagedObjectR
 
 	contains := false
 	for _, v := range ps {
-		if strings.HasPrefix(v, "summary") {
+		if v == "summary" || v == "summary.runtime" {
 			contains = true
 			break
 		}


### PR DESCRIPTION
Checking for explicit string values instead of just a prefix. Using prefix happened to be not a safe option since summary.config key is also can be present. This is basically a rollback if to a previous "if" condition.