### PR TITLE
Enable passing log level to the Longevity scripts

### DIFF
--- a/tests/manual-test-cases/Group14-Longevity/14-1-Longevity.robot
+++ b/tests/manual-test-cases/Group14-Longevity/14-1-Longevity.robot
@@ -29,11 +29,11 @@ Longevity
     :FOR  ${idx}  IN RANGE  0  48
     \   ${rand}=  Evaluate  random.randint(10, 50)  modules=random
     \   Log To Console  \nLoop: ${idx}
-    \   Install VIC Appliance To Test Server  debug=0  additional-args=%{STATIC_VCH_OPTIONS}
+    \   Install VIC Appliance To Test Server  debug=%{DEBUG_VCH_LEVEL}  additional-args=%{STATIC_VCH_OPTIONS} %{SYSLOG_VCH_OPTION}
     \   Repeat Keyword  ${rand} times  Run Regression Tests
     \   Cleanup VIC Appliance On Test Server
     \   ${rand}=  Evaluate  random.randint(10, 50)  modules=random
-    \   Install VIC Appliance To Test Server  debug=0  certs=${true}  additional-args=%{STATIC_VCH_OPTIONS} %{SYSLOG_VCH_OPTION}
+    \   Install VIC Appliance To Test Server  debug=%{DEBUG_VCH_LEVEL}  certs=${true}  additional-args=%{STATIC_VCH_OPTIONS} %{SYSLOG_VCH_OPTION}
     \   Repeat Keyword  ${rand} times  Run Regression Tests
     \   Cleanup VIC Appliance On Test Server
 


### PR DESCRIPTION
Fix Longevity bash script and robot script to allow specifying the log level as an argument.