### PR TITLE
Setup correct Syslog hooks for trace Logger

### DIFF
--- a/cmd/docker/main.go
+++ b/cmd/docker/main.go
@@ -171,7 +171,12 @@ func initLogging() error {
 
 	tags.Logger = log.StandardLogger()
 
-	return viclog.Init(logcfg)
+	err := viclog.Init(logcfg)
+	if err != nil {
+		return err
+	}
+
+	return trace.InitLogger(logcfg)
 }
 
 func loadCAPool() *x509.CertPool {

--- a/cmd/port-layer-server/main.go
+++ b/cmd/port-layer-server/main.go
@@ -119,6 +119,7 @@ func main() {
 	log.Infof("%+v", *logcfg)
 	// #nosec: Errors unhandled.
 	viclog.Init(logcfg)
+	trace.InitLogger(logcfg)
 
 	server.ConfigureAPI()
 

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -70,22 +70,28 @@ func Init(cfg *LoggingConfig) error {
 
 			logrus.Debugf("log cfg: %+v", *cfg)
 
-			if cfg.Syslog != nil {
-				logrus.Debugf("syslog cfg: %+v", *cfg.Syslog)
-				hook, err := syslog.NewHook(
-					cfg.Syslog.Network,
-					cfg.Syslog.RAddr,
-					cfg.Syslog.Priority,
-					cfg.Syslog.Tag,
-				)
-				if err != nil {
-					// not a fatal error, so just log a warning
-					logrus.Warnf("error trying to initialize syslog: %s", err)
-				} else {
-					logrus.AddHook(hook)
-				}
+			hook, err := CreateSyslogHook(cfg)
+			if err == nil && hook != nil {
+				logrus.AddHook(hook)
 			}
 		})
 
 	return initializer.err
+}
+
+func CreateSyslogHook(cfg *LoggingConfig) (logrus.Hook, error) {
+	if cfg.Syslog == nil {
+		return nil, nil
+	}
+	hook, err := syslog.NewHook(
+		cfg.Syslog.Network,
+		cfg.Syslog.RAddr,
+		cfg.Syslog.Priority,
+		cfg.Syslog.Tag,
+	)
+	if err != nil {
+		// not a fatal error, so just log a warning
+		logrus.Warnf("error trying to initialize syslog: %s", err)
+	}
+	return hook, err
 }

--- a/pkg/trace/trace.go
+++ b/pkg/trace/trace.go
@@ -66,6 +66,17 @@ func (t *Message) delta() time.Duration {
 	return time.Now().Sub(t.startTime)
 }
 
+// Add Syslog hook
+// This method is not thread safe, this is currently
+// not a problem because it is only called once from main
+func InitLogger(cfg *log.LoggingConfig) error {
+	hook, err := log.CreateSyslogHook(cfg)
+	if err == nil && hook != nil {
+		Logger.Hooks.Add(hook)
+	}
+	return err
+}
+
 // begin a trace from this stack frame less the skip.
 func newTrace(msg string, skip int, opID string) *Message {
 	pc, _, line, ok := runtime.Caller(skip)

--- a/tests/test-cases/Group6-VIC-Machine/6-15-Syslog.robot
+++ b/tests/test-cases/Group6-VIC-Machine/6-15-Syslog.robot
@@ -77,6 +77,7 @@ Verify VCH remote syslog
     \     Should Contain  ${out}  ${host} ${proc}[${pid}]:
 
     ${pid}=  Get From Dictionary  ${proc-pids}  docker-engine-server
+    ${port-layer-pid}=  Get From Dictionary  ${proc-pids}  port-layer-server
     Should Match Regexp  ${out}  ${vch-ip} docker-engine-server\\[${pid}\\]: Calling GET /v\\d.\\d{2}/containers/json\\?all\\=1
 
     Should Match Regexp  ${out}  ${vch-ip} docker-engine-server\\[${pid}\\]: Calling POST /v\\d.\\d{2}/containers/create
@@ -90,6 +91,10 @@ Verify VCH remote syslog
 
     Should Match Regexp  ${out}  ${vch-ip} docker-engine-server\\[${pid}\\]: Calling DELETE /v\\d.\\d{2}/containers/\\w{64}
     Should Match Regexp  ${out}  ${vch-ip} docker-engine-server\\[${pid}\\]: Calling DELETE /v\\d.\\d{2}/images/(\\S+)*busybox
+
+    # Check trace logger for docker-engine and port-layer
+    Should Match Regexp  ${out}  ${vch-ip} docker-engine-server\\[${pid}\\]: op=${pid}.\\d+: Commit container \\w{64}
+    Should Match Regexp  ${out}  ${vch-ip} port-layer-server\\[${port-layer-pid}\\]: op=${port-layer-pid}.\\d+: Creating base file structure on disk
 
     Should Match Regexp  ${out}  ${shortID} ${shortID}\\[1\\]: bin
     Should Match Regexp  ${out}  ${shortID} ${shortID}\\[1\\]: home


### PR DESCRIPTION
Syslog hooks are currently not properly setup for the trace Logger. That causes the operation syslog messages to go lost.

Fixes 7169