### PR TITLE
[specific ci=Group10-VCH-Restart] Optimize portlayer volume cache rebuild on startup

### DIFF
--- a/lib/portlayer/storage/volume_cache.go
+++ b/lib/portlayer/storage/volume_cache.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2017 VMware, Inc. All Rights Reserved.
+// Copyright 2016-2018 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -59,7 +59,7 @@ func (v *VolumeLookupCache) GetVolumeStore(op trace.Operation, storeName string)
 	return u, nil
 }
 
-// AddStore adds a volumestore by name.  The url returned is the service url to the volume store.
+// AddStore adds a volumestore by name. The url returned is the service url to the volume store.
 func (v *VolumeLookupCache) AddStore(op trace.Operation, storeName string, vs VolumeStorer) (*url.URL, error) {
 	v.vlcLock.Lock()
 	defer v.vlcLock.Unlock()
@@ -70,12 +70,13 @@ func (v *VolumeLookupCache) AddStore(op trace.Operation, storeName string, vs Vo
 		return nil, err
 	}
 
-	if _, ok := v.volumeStores[u.String()]; ok {
-		return nil, fmt.Errorf("volumestore (%s) already added", u.String())
+	storeURLStr := u.String()
+	if _, ok := v.volumeStores[storeURLStr]; ok {
+		return nil, fmt.Errorf("volumestore (%s) already added", storeURLStr)
 	}
 
-	v.volumeStores[u.String()] = vs
-	return u, v.rebuildCache(op)
+	v.volumeStores[storeURLStr] = vs
+	return u, v.addVolumesToCache(op, storeURLStr, vs)
 }
 
 func (v *VolumeLookupCache) volumeStore(store *url.URL) (VolumeStorer, error) {
@@ -94,7 +95,6 @@ func (v *VolumeLookupCache) volumeStore(store *url.URL) (VolumeStorer, error) {
 
 // VolumeStoresList returns a list of volume store names
 func (v *VolumeLookupCache) VolumeStoresList(op trace.Operation) ([]string, error) {
-
 	v.vlcLock.RLock()
 	defer v.vlcLock.RUnlock()
 
@@ -201,21 +201,19 @@ func (v *VolumeLookupCache) VolumesList(op trace.Operation) ([]*Volume, error) {
 	return l, nil
 }
 
-// goto the volume store and repopulate the cache.
-func (v *VolumeLookupCache) rebuildCache(op trace.Operation) error {
-	op.Infof("Refreshing volume cache.")
+// addVolumesToCache finds the volumes in the input volume store and adds them to the cache.
+func (v *VolumeLookupCache) addVolumesToCache(op trace.Operation, storeURLStr string, vs VolumeStorer) error {
+	op.Infof("Adding volumes in volume store %s to volume cache", storeURLStr)
 
-	for _, vs := range v.volumeStores {
-		vols, err := vs.VolumesList(op)
-		if err != nil {
-			return err
-		}
+	vols, err := vs.VolumesList(op)
+	if err != nil {
+		return err
+	}
 
-		for _, vol := range vols {
-			log.Infof("Volumestore: Found vol %s on store %s.", vol.ID, vol.Store)
-			// Add it to the cache.
-			v.vlc[vol.ID] = *vol
-		}
+	for _, vol := range vols {
+		log.Infof("Volumestore: Found vol %s on store %s", vol.ID, vol.Store)
+		// Add it to the cache.
+		v.vlc[vol.ID] = *vol
 	}
 
 	return nil


### PR DESCRIPTION
This commit modifies the portlayer volume cache's rebuildCache func to
only process the volumes from the volume store that is currently being
added to the cache. rebuildCache is invoked for every volume store
during portlayer startup.

Before this change, rebuildCache would process volumes from all volume
stores in the cache every time a volume store was added. This led to
unneeded duplicate computation which could slow down portlayer startup
and overwhelm NFS endpoints if NFS volume stores are being used.

Fixes #6991