### PR TITLE
Break dependencies for Scratch.ID constant.

### DIFF
--- a/cmd/imagec/main.go
+++ b/cmd/imagec/main.go
@@ -37,6 +37,7 @@ import (
 	"github.com/vmware/vic/lib/apiservers/engine/proxy"
 	apiclient "github.com/vmware/vic/lib/apiservers/portlayer/client"
 	vicarchive "github.com/vmware/vic/lib/archive"
+	"github.com/vmware/vic/lib/constants"
 	"github.com/vmware/vic/lib/imagec"
 	optrace "github.com/vmware/vic/pkg/trace"
 	"github.com/vmware/vic/pkg/version"
@@ -232,7 +233,7 @@ func saveImage(ap proxy.VicArchiveProxy, ic *imagec.ImageC) error {
 	errChan := make(chan error, len(layers))
 
 	for i := len(layers) - 1; i >= 0; i-- {
-		if layers[i].ID == imagec.ScratchLayerID {
+		if layers[i].ID == constants.ScratchLayerID {
 			continue
 		}
 		wg.Add(1)

--- a/lib/apiservers/engine/backends/commit.go
+++ b/lib/apiservers/engine/backends/commit.go
@@ -46,6 +46,7 @@ import (
 
 	"github.com/vmware/vic/lib/apiservers/engine/backends/cache"
 	"github.com/vmware/vic/lib/apiservers/portlayer/models"
+	"github.com/vmware/vic/lib/constants"
 	"github.com/vmware/vic/lib/imagec"
 	"github.com/vmware/vic/pkg/trace"
 	"github.com/vmware/vic/pkg/version"
@@ -118,7 +119,7 @@ func (i *Image) Commit(name string, config *backend.ContainerCommitConfig) (imag
 
 	layers = append(layers, layer)
 	lm := layer
-	for pl := lm.Parent; pl != imagec.ScratchLayerID; pl = lm.Parent {
+	for pl := lm.Parent; pl != constants.ScratchLayerID; pl = lm.Parent {
 		// populate manifest layer with existing cached data
 		if lm, err = imagec.LayerCache().Get(pl); err != nil {
 			return "", InternalServerError(fmt.Sprintf("Failed to get parent image layer %s: %s", pl, err))

--- a/lib/apiservers/portlayer/restapi/handlers/storage_handlers_test.go
+++ b/lib/apiservers/portlayer/restapi/handlers/storage_handlers_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/vmware/vic/lib/apiservers/portlayer/models"
 	"github.com/vmware/vic/lib/apiservers/portlayer/restapi/operations/storage"
 	"github.com/vmware/vic/lib/archive"
+	"github.com/vmware/vic/lib/constants"
 	spl "github.com/vmware/vic/lib/portlayer/storage"
 	"github.com/vmware/vic/lib/portlayer/util"
 	"github.com/vmware/vic/pkg/trace"
@@ -226,7 +227,7 @@ func (c *MockDataStore) WriteMetadata(op trace.Operation, storeName string, ID s
 
 // GetImage gets the specified image from the given store by retreiving it from the cache.
 func (c *MockDataStore) GetImage(op trace.Operation, store *url.URL, ID string) (*spl.Image, error) {
-	if ID == spl.Scratch.ID {
+	if ID == constants.ScratchLayerID {
 		return &spl.Image{Store: store}, nil
 	}
 
@@ -389,7 +390,9 @@ func TestListImages(t *testing.T) {
 
 	// create a set of images
 	images := make(map[string]*spl.Image)
-	parent := spl.Scratch
+	parent := spl.Image{
+		ID: constants.ScratchLayerID,
+	}
 	parent.Store = &testStoreURL
 	for i := 1; i < 50; i++ {
 		id := fmt.Sprintf("id-%d", i)

--- a/lib/constants/constants.go
+++ b/lib/constants/constants.go
@@ -72,6 +72,9 @@ const (
 
 	// All volumes are stored in this directory.
 	VolumesDir = "volumes"
+
+	// Scratch layer ID
+	ScratchLayerID = "scratch"
 )
 
 func DefaultAltVCHGuestName() string {

--- a/lib/imagec/imagec.go
+++ b/lib/imagec/imagec.go
@@ -40,8 +40,8 @@ import (
 
 	"github.com/vmware/vic/lib/apiservers/engine/backends/cache"
 	"github.com/vmware/vic/lib/apiservers/portlayer/models"
+	"github.com/vmware/vic/lib/constants"
 	"github.com/vmware/vic/lib/metadata"
-	"github.com/vmware/vic/lib/portlayer/storage"
 	urlfetcher "github.com/vmware/vic/pkg/fetcher"
 	"github.com/vmware/vic/pkg/trace"
 	"github.com/vmware/vic/pkg/vsphere/sys"
@@ -152,9 +152,6 @@ const (
 	// DefaultHTTPTimeout specifies the default HTTP timeout
 	DefaultHTTPTimeout = 3600 * time.Second
 
-	// Scratch layer ID
-	ScratchLayerID = "scratch"
-
 	// attribute update actions
 	Add = iota + 1
 )
@@ -246,7 +243,7 @@ func (ic *ImageC) LayersToDownload() ([]*ImageWithMeta, error) {
 		}
 
 		// if parent is empty set it to scratch
-		parent := ScratchLayerID
+		parent := constants.ScratchLayerID
 		if v1.Parent != "" {
 			parent = v1.Parent
 		}
@@ -529,7 +526,7 @@ func (ic *ImageC) ListLayers() error {
 		return err
 	}
 
-	progress.Message(ic.progressOutput, "", storage.Scratch.ID)
+	progress.Message(ic.progressOutput, "", constants.ScratchLayerID)
 	for i := len(layers) - 1; i >= 0; i-- {
 		progress.Message(ic.progressOutput, "", layers[i].ID)
 	}

--- a/lib/portlayer/storage/image_cache_test.go
+++ b/lib/portlayer/storage/image_cache_test.go
@@ -15,6 +15,7 @@
 package storage
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"net/url"
@@ -22,14 +23,12 @@ import (
 	"strconv"
 	"testing"
 
-	"context"
-
 	"github.com/Sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
-	"github.com/vmware/vic/lib/constants"
 
 	"github.com/vmware/govmomi/vim25/mo"
 	"github.com/vmware/vic/lib/archive"
+	"github.com/vmware/vic/lib/constants"
 	"github.com/vmware/vic/lib/portlayer/util"
 	"github.com/vmware/vic/pkg/trace"
 	"github.com/vmware/vic/pkg/vsphere/vm"

--- a/lib/portlayer/storage/image_cache_test.go
+++ b/lib/portlayer/storage/image_cache_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/Sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
+	"github.com/vmware/vic/lib/constants"
 
 	"github.com/vmware/govmomi/vim25/mo"
 	"github.com/vmware/vic/lib/archive"
@@ -192,7 +193,9 @@ func TestListImages(t *testing.T) {
 
 	// Create a set of images
 	images := make(map[string]*Image)
-	parent := Scratch
+	parent := Image{
+		ID: constants.ScratchLayerID,
+	}
 	parent.Store = storeURL
 	testSum := "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
 	for i := 1; i < 50; i++ {
@@ -261,7 +264,9 @@ func TestOutsideCacheWriteImage(t *testing.T) {
 
 	// Create a set of images
 	images := make(map[string]*Image)
-	parent := Scratch
+	parent := Image{
+		ID: constants.ScratchLayerID,
+	}
 	parent.Store = storeURL
 	for i := 1; i < 50; i++ {
 		id := fmt.Sprintf("ID-%d", i)
@@ -321,7 +326,7 @@ func TestImageStoreRestart(t *testing.T) {
 	// Create a set of images
 	expectedImages := make(map[string]*Image)
 
-	parent, err := firstCache.GetImage(op, storeURL, Scratch.ID)
+	parent, err := firstCache.GetImage(op, storeURL, constants.ScratchLayerID)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -388,7 +393,7 @@ func TestDeleteImage(t *testing.T) {
 		return
 	}
 
-	scratch, err := imageCache.GetImage(op, storeURL, Scratch.ID)
+	scratch, err := imageCache.GetImage(op, storeURL, constants.ScratchLayerID)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -476,7 +481,7 @@ func TestDeleteBranch(t *testing.T) {
 		return
 	}
 
-	scratch, err := imageCache.GetImage(op, storeURL, Scratch.ID)
+	scratch, err := imageCache.GetImage(op, storeURL, constants.ScratchLayerID)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -649,14 +654,14 @@ func TestPopulateCacheInExpectedOrder(t *testing.T) {
 	url2, _ := url.Parse(storageURLStr + "/id2")
 	url3, _ := url.Parse(storageURLStr + "/id3")
 	url4, _ := url.Parse(storageURLStr + "/id4")
-	scratchURL, _ := url.Parse(storageURLStr + Scratch.ID)
+	scratchURL, _ := url.Parse(storageURLStr + constants.ScratchLayerID)
 
 	img1 := &Image{ID: "id1", SelfLink: url1, ParentLink: scratchURL, Store: storeURL}
 	img2 := &Image{ID: "id2", SelfLink: url2, ParentLink: url1, Store: storeURL}
 	img3 := &Image{ID: "id3", SelfLink: url3, ParentLink: url2, Store: storeURL}
 	img4 := &Image{ID: "id4", SelfLink: url4, ParentLink: url3, Store: storeURL}
 	scratchImg := &Image{
-		ID:         Scratch.ID,
+		ID:         constants.ScratchLayerID,
 		SelfLink:   scratchURL,
 		ParentLink: scratchURL,
 		Store:      storeURL,

--- a/lib/portlayer/storage/image_test.go
+++ b/lib/portlayer/storage/image_test.go
@@ -18,8 +18,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/vmware/vic/lib/constants"
 
+	"github.com/vmware/vic/lib/constants"
 	"github.com/vmware/vic/lib/portlayer/util"
 )
 

--- a/lib/portlayer/storage/image_test.go
+++ b/lib/portlayer/storage/image_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/vmware/vic/lib/constants"
 
 	"github.com/vmware/vic/lib/portlayer/util"
 )
@@ -31,7 +32,7 @@ func TestImageCopy(t *testing.T) {
 		return
 	}
 
-	parentURL, err := util.ImageURL(storeName, Scratch.ID)
+	parentURL, err := util.ImageURL(storeName, constants.ScratchLayerID)
 	if !assert.NoError(t, err) {
 		return
 	}

--- a/lib/portlayer/storage/vsphere/image.go
+++ b/lib/portlayer/storage/vsphere/image.go
@@ -252,7 +252,7 @@ func (v *ImageStore) WriteImage(op trace.Operation, parent *portlayer.Image, ID 
 	var dsk *disk.VirtualDisk
 	// If this is scratch, then it's the root of the image store.  All images
 	// will be descended from this created and prepared fs.
-	if ID == portlayer.Scratch.ID {
+	if ID == constants.ScratchLayerID {
 		// Create the scratch layer
 		if err := v.scratch(op, storeName); err != nil {
 			return nil, err
@@ -439,19 +439,19 @@ func (v *ImageStore) scratch(op trace.Operation, storeName string) error {
 	)
 
 	// Create the image directory in the store.
-	imageDir := v.imageDirPath(storeName, portlayer.Scratch.ID)
+	imageDir := v.imageDirPath(storeName, constants.ScratchLayerID)
 	if _, err := v.Mkdir(op, false, imageDir); err != nil {
 		return err
 	}
 
 	// Write the metadata to the datastore
-	metaDataDir := v.imageMetadataDirPath(storeName, portlayer.Scratch.ID)
+	metaDataDir := v.imageMetadataDirPath(storeName, constants.ScratchLayerID)
 	if err := writeMetadata(op, v.Helper, metaDataDir, nil); err != nil {
 		return err
 	}
 
-	imageDiskDsURI := v.imageDiskDSPath(storeName, portlayer.Scratch.ID)
-	op.Infof("Creating image %s (%s)", portlayer.Scratch.ID, imageDiskDsURI)
+	imageDiskDsURI := v.imageDiskDSPath(storeName, constants.ScratchLayerID)
+	op.Infof("Creating image %s (%s)", constants.ScratchLayerID, imageDiskDsURI)
 
 	size = defaultDiskSizeInKB
 	if portlayer.Config.ScratchSize != 0 {
@@ -462,7 +462,7 @@ func (v *ImageStore) scratch(op trace.Operation, storeName string) error {
 		if err == nil {
 			return
 		}
-		v.cleanupDisk(op, portlayer.Scratch.ID, storeName, vmdisk)
+		v.cleanupDisk(op, constants.ScratchLayerID, storeName, vmdisk)
 	}()
 
 	config := disk.NewPersistentDisk(imageDiskDsURI).WithCapacity(size)
@@ -491,7 +491,7 @@ func (v *ImageStore) scratch(op trace.Operation, storeName string) error {
 		return err
 	}
 
-	if err = v.writeManifest(op, storeName, portlayer.Scratch.ID, nil); err != nil {
+	if err = v.writeManifest(op, storeName, constants.ScratchLayerID, nil); err != nil {
 		op.Errorf("Failed to create manifest for scratch image: %s", err)
 		return err
 	}
@@ -576,7 +576,7 @@ func (v *ImageStore) ListImages(op trace.Operation, store *url.URL, IDs []string
 		ID := file.Path
 
 		// filter out scratch
-		if ID == portlayer.Scratch.ID {
+		if ID == constants.ScratchLayerID {
 			continue
 		}
 
@@ -661,7 +661,7 @@ func (v *ImageStore) cleanup(op trace.Operation, store *url.URL) error {
 		ID := file.Path
 
 		if err := v.verifyImage(op, storeName, ID); err != nil {
-			if ID == portlayer.Scratch.ID {
+			if ID == constants.ScratchLayerID {
 				op.Errorf("Failed to verify scratch image - skipping deletion so as not to invalidate image chain but this is probably non-functional")
 				continue
 			}

--- a/lib/portlayer/storage/vsphere/image_test.go
+++ b/lib/portlayer/storage/vsphere/image_test.go
@@ -203,7 +203,7 @@ func TestCreateImageLayers(t *testing.T) {
 	}
 
 	// base this image off scratch
-	parent, err := cacheStore.GetImage(op, storeURL, portlayer.Scratch.ID)
+	parent, err := cacheStore.GetImage(op, storeURL, constants.ScratchLayerID)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -371,7 +371,7 @@ func TestBrokenPull(t *testing.T) {
 	}
 
 	// base this image off scratch
-	parent, err := cacheStore.GetImage(op, storeURL, portlayer.Scratch.ID)
+	parent, err := cacheStore.GetImage(op, storeURL, constants.ScratchLayerID)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -435,7 +435,7 @@ func TestParallel(t *testing.T) {
 	}
 
 	// base this image off scratch
-	parent, err := cacheStore.GetImage(op, storeURL, portlayer.Scratch.ID)
+	parent, err := cacheStore.GetImage(op, storeURL, constants.ScratchLayerID)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -479,7 +479,7 @@ func TestInProgressCleanup(t *testing.T) {
 	}
 
 	// base this image off scratch
-	parent, err := cacheStore.GetImage(op, storeURL, portlayer.Scratch.ID)
+	parent, err := cacheStore.GetImage(op, storeURL, constants.ScratchLayerID)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -522,7 +522,7 @@ func TestInProgressCleanup(t *testing.T) {
 
 	// Make sure list is now empty.
 	listedImages, err := vsStore.ListImages(op, parent.Store, nil)
-	if !assert.NoError(t, err) || !assert.Equal(t, len(listedImages), 1) || !assert.Equal(t, listedImages[0].ID, portlayer.Scratch.ID) {
+	if !assert.NoError(t, err) || !assert.Equal(t, len(listedImages), 1) || !assert.Equal(t, listedImages[0].ID, constants.ScratchLayerID) {
 		return
 	}
 }


### PR DESCRIPTION
Breaking unnecessary dependency.

Fixes #7288
[vicgraph_before_after.zip](https://github.com/vmware/vic/files/1708158/vicgraph_before_after.zip)
