### PR TITLE
Remove superfluous calls to Set Test VCH Name [specific ci=Group6-VIC-Machine] 

### DIFF
--- a/tests/test-cases/Group6-VIC-Machine/6-05-Create-Validation.robot
+++ b/tests/test-cases/Group6-VIC-Machine/6-05-Create-Validation.robot
@@ -25,7 +25,6 @@ Suggest resources - Invalid datacenter
     # Attempt to cleanup old/canceled tests
     Run Keyword And Ignore Error  Cleanup Dangling VMs On Test Server
     Run Keyword And Ignore Error  Cleanup Datastore On Test Server
-    Set Test VCH Name
 
     Log To Console  \nInstalling VCH to test server...
     ${output}=  Run  bin/vic-machine-linux create --name=%{VCH-NAME} --target=%{TEST_URL}/WOW --thumbprint=%{TEST_THUMBPRINT} --user=%{TEST_USERNAME} --image-store=%{TEST_DATASTORE} --password=%{TEST_PASSWORD} ${vicmachinetls}
@@ -38,7 +37,6 @@ Suggest resources - Invalid target path
     # Attempt to cleanup old/canceled tests
     Run Keyword And Ignore Error  Cleanup Dangling VMs On Test Server
     Run Keyword And Ignore Error  Cleanup Datastore On Test Server
-    Set Test VCH Name
 
     Log To Console  \nInstalling VCH to test server...
     ${output}=  Run  bin/vic-machine-linux create --name=%{VCH-NAME} --target=%{TEST_URL}/MUCH/DATACENTER --thumbprint=%{TEST_THUMBPRINT} --user=%{TEST_USERNAME} --image-store=%{TEST_DATASTORE} --password=%{TEST_PASSWORD} ${vicmachinetls}
@@ -51,7 +49,6 @@ Create VCH - target thumbprint verification
     # Attempt to cleanup old/canceled tests
     Run Keyword And Ignore Error  Cleanup Dangling VMs On Test Server
     Run Keyword And Ignore Error  Cleanup Datastore On Test Server
-    Set Test VCH Name
 
     ${output}=  Run  bin/vic-machine-linux create --thumbprint=NOPE --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --image-store=ENOENT ${vicmachinetls}
     Should Contain  ${output}  thumbprint does not match
@@ -63,7 +60,6 @@ Default image datastore
     # Attempt to cleanup old/canceled tests
     Run Keyword And Ignore Error  Cleanup Dangling VMs On Test Server
     Run Keyword And Ignore Error  Cleanup Datastore On Test Server
-    Set Test VCH Name
 
     Log To Console  \nInstalling VCH to test server...
     ${output}=  Run  bin/vic-machine-linux create --name=%{VCH-NAME} --target=%{TEST_URL} --thumbprint=%{TEST_THUMBPRINT} --user=%{TEST_USERNAME} --password=%{TEST_PASSWORD} ${vicmachinetls} --insecure-registry harbor.ci.drone.local
@@ -88,7 +84,6 @@ Custom image datastore
     # Attempt to cleanup old/canceled tests
     Run Keyword And Ignore Error  Cleanup Dangling VMs On Test Server
     Run Keyword And Ignore Error  Cleanup Datastore On Test Server
-    Set Test VCH Name
 
     Log To Console  \nInstalling VCH to test server...
     ${output-esx}=  Run Keyword If  '%{HOST_TYPE}' == 'ESXi'  Run  bin/vic-machine-linux create --name=%{VCH-NAME} --target=%{TEST_URL} --thumbprint=%{TEST_THUMBPRINT} --user=%{TEST_USERNAME} --password=%{TEST_PASSWORD} --image-store=%{TEST_DATASTORE}/long/weird/path ${vicmachinetls} --insecure-registry harbor.ci.drone.local

--- a/tests/test-cases/Group6-VIC-Machine/6-06-Create-Datastore.robot
+++ b/tests/test-cases/Group6-VIC-Machine/6-06-Create-Datastore.robot
@@ -25,8 +25,6 @@ Image Store Delete - Image store not found
     # Attempt to cleanup old/canceled tests
     Run Keyword And Ignore Error  Cleanup Dangling VMs On Test Server
     Run Keyword And Ignore Error  Cleanup Datastore On Test Server
-    Set Test VCH Name
-    ${output}=  Run  rm -rf %{VCH-NAME}
 
     Log To Console  \nInstalling VCH to test server...
     ${output}=  Run  bin/vic-machine-linux create --name=%{VCH-NAME} --target=%{TEST_URL} --user=%{TEST_USERNAME} --bridge-network=%{BRIDGE_NETWORK} --public-network=%{PUBLIC_NETWORK} --image-store=%{TEST_DATASTORE}/images --password=%{TEST_PASSWORD} --force --kv


### PR DESCRIPTION
Several tests explicitly call the `Set Test VCH Name` keyword shortly after calling `Set Test Environment Variables`.

This can lead to test failures when a VCH name collision occurs; subsequent tests which re-use the VCH name fail because there may be leftover certificates from the first VCH with that name.

`Set Test Environment Variables` itself calls `Set Test VCH Name` and then cleans up old certificate directories. Therefore, the explicit calls to `Set Test VCH Name` are both superfluous and problematic.

Towards #7302
