### PR TITLE
Avoid exposing test credentials in 12-01-Delete [specific ci=Group12-VCH-BC]

### DIFF
--- a/tests/test-cases/Group12-VCH-BC/12-01-Delete.robot
+++ b/tests/test-cases/Group12-VCH-BC/12-01-Delete.robot
@@ -55,9 +55,7 @@ Delete VCH with new vic-machine
     Should Contain  ${ret}  is different than installer version
 
     # Delete with force
-    ${ret}=  Run  bin/vic-machine-linux delete --target %{TEST_URL} --user %{TEST_USERNAME} --password=%{TEST_PASSWORD} --compute-resource=%{TEST_RESOURCE} --name %{VCH-NAME} --force
-    Should Contain  ${ret}  Completed successfully
-    Should Not Contain  ${ret}  delete failed
+    Run VIC Machine Delete Command
 
     # Check VM is removed
     ${ret}=  Run  govc vm.info -json=true ${containerName}-*


### PR DESCRIPTION
To avoid exposing test credentials, use the established `Run VIC
Machine Delete Command` keyword, which in turn calls a secret keyword.

This changes the behavior of the test slightly:
 - It no longer checks for the absence of "delete failed" in output.
 - It will wait up to 30 seconds for the deletion to succeed.
 - It will clean up cert files at the end of the deletion.

Towards #7302 