### PR TITLE
[skip ci] Ensure that static ip worker is on the same nimbus pod as VC otherwise network connectivity not guaranteed

### DIFF
--- a/cmd/vic-machine-server/Dockerfile
+++ b/cmd/vic-machine-server/Dockerfile
@@ -18,8 +18,8 @@ ENV TLS_PORT 443
 
 # Default location for TLS - Specify `-v /host/cert/path:/certs` to use defaults
 # Override by providing a volume and values for `-e TLS_CERTIFICATE` and `-e TLS_PRIVATE_KEY`
-ENV TLS_CERTIFICATE=/certs/server.cert.pem
-ENV TLS_PRIVATE_KEY=/certs/server.key.pem
+ENV TLS_CERTIFICATE=/certs/server.crt
+ENV TLS_PRIVATE_KEY=/certs/server.key
 
 EXPOSE $PORT
 EXPOSE $TLS_PORT

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-26-Static-IP-Address.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-26-Static-IP-Address.robot
@@ -29,12 +29,15 @@ Static IP Address Create
     Log To Console  Finished Creating Cluster ${vc}
     Set Suite Variable  @{list}  ${esx1}  ${esx2}  ${esx3}  %{NIMBUS_USER}-${vc}
 
-    ${pod}=  Fetch POD  %{NIMBUS_USER}-${vc}
-    Set Suite Variable  ${NIMBUS_POD}  NIMBUS_POD=${pod}
+    Open Connection  %{NIMBUS_GW}
+    Wait Until Keyword Succeeds  2 min  30 sec  Login  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}
+    ${pod}=  Fetch POD  ${vc}
+    Set Suite Variable  ${NIMBUS_POD}  ${pod}
+    Close Connection
 
     ${out}=  Get Static IP Address
     Set Suite Variable  ${static}  ${out}
-    Append To List  ${list}  %{STATIC_WORKER_NAME} 
+    Append To List  ${list}  %{STATIC_WORKER_NAME}
 
 *** Test Cases ***
 Test

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-26-Static-IP-Address.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-26-Static-IP-Address.robot
@@ -29,7 +29,10 @@ Static IP Address Create
     Log To Console  Finished Creating Cluster ${vc}
     Set Suite Variable  @{list}  ${esx1}  ${esx2}  ${esx3}  %{NIMBUS_USER}-${vc}
 
-    ${out}=  Get Static IP Address
+    #  Need to suggest which subnet/gateway to install the static IP address worker into
+    ${pre}  ${post}=  Split String From Right  ${vc-ip}  .  1
+
+    ${out}=  Get Static IP Address  --gateway ${pre}.253
     Set Suite Variable  ${static}  ${out}
     Append To List  ${list}  %{STATIC_WORKER_NAME} 
 

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-26-Static-IP-Address.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-26-Static-IP-Address.robot
@@ -30,12 +30,25 @@ Static IP Address Create
     Open Connection  %{NIMBUS_GW}
     Wait Until Keyword Succeeds  10 min  30 sec  Login  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}
     ${vc-ip}=  Get IP  ${name}.vc.0
+    ${esx1-ip}=  Get IP  ${name}.esx.0
+    ${esx2-ip}=  Get IP  ${name}.esx.1
+    ${esx3-ip}=  Get IP  ${name}.esx.2
     ${pod}=  Fetch POD  ${name}.vc.0
     Set Suite Variable  ${NIMBUS_POD}  ${pod}
     Close Connection
 
     Set Suite Variable  @{list}  %{NIMBUS_USER}-${name}.esx.0  %{NIMBUS_USER}-${name}.esx.1  %{NIMBUS_USER}-${name}.esx.2  %{NIMBUS_USER}-${name}.nfs.0  %{NIMBUS_USER}-${name}.vc.0
     Log To Console  Finished Creating Cluster ${name}
+
+    Log To Console  Disable firewall for the ESX servers...
+    Set Environment Variable  GOVC_USERNAME  root
+    Set Environment Variable  GOVC_PASSWORD  e2eFunctionalTest
+    Set Environment Variable  GOVC_URL  ${esx1-ip}
+    Run  govc host.esxcli network firewall set -e false
+    Set Environment Variable  GOVC_URL  ${esx2-ip}
+    Run  govc host.esxcli network firewall set -e false
+    Set Environment Variable  GOVC_URL  ${esx3-ip}
+    Run  govc host.esxcli network firewall set -e false
 
     ${out}=  Get Static IP Address
     Set Suite Variable  ${static}  ${out}
@@ -62,5 +75,7 @@ Static IP Address Create
 *** Test Cases ***
 Test
     Log To Console  \nStarting test...
+    Custom Testbed Keepalive  /dbc/pa-dbc1111/mhagen
+
     Install VIC Appliance To Test Server  additional-args=--public-network-ip &{static}[ip]/&{static}[netmask] --public-network-gateway &{static}[gateway] --dns-server 10.170.16.48
     Run Regression Tests

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-26-Static-IP-Address.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-26-Static-IP-Address.robot
@@ -21,19 +21,21 @@ Suite Teardown  Run Keyword And Ignore Error  Nimbus Cleanup  ${list}
 *** Keywords ***
 Static IP Address Create
     [Timeout]    110 minutes
+    Log To Console  Starting Static IP Address test...
     Set Suite Variable  ${NIMBUS_LOCATION}  NIMBUS_LOCATION=wdc
     Run Keyword And Ignore Error  Nimbus Cleanup  ${list}  ${false}
-    Open Connection  %{NIMBUS_GW}
-    Wait Until Keyword Succeeds  10 min  30 sec  Login  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}
-    ${esx1}  ${esx2}  ${esx3}  ${vc}  ${esx1-ip}  ${esx2-ip}  ${esx3-ip}  ${vc-ip}=  Create a Simple VC Cluster  dc1  cls
-    Log To Console  Finished Creating Cluster ${vc}
-    Set Suite Variable  @{list}  ${esx1}  ${esx2}  ${esx3}  %{NIMBUS_USER}-${vc}
+    ${name}=  Evaluate  'vic-5-26-' + str(random.randint(1000,9999))  modules=random
+    ${out}=  Deploy Nimbus Testbed  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}  --noSupportBundles --plugin testng --vcvaBuild ${VC_VERSION} --esxBuild ${ESX_VERSION} --testbedName vic-simple-cluster --testbedSpecRubyFile /dbc/pa-dbc1111/mhagen/nimbus-testbeds/testbeds/vic-simple-cluster.rb --runName ${name}
 
     Open Connection  %{NIMBUS_GW}
-    Wait Until Keyword Succeeds  2 min  30 sec  Login  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}
-    ${pod}=  Fetch POD  ${vc}
+    Wait Until Keyword Succeeds  10 min  30 sec  Login  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}
+    ${vc-ip}=  Get IP  ${name}.vc.0
+    ${pod}=  Fetch POD  ${name}.vc.0
     Set Suite Variable  ${NIMBUS_POD}  ${pod}
     Close Connection
+
+    Set Suite Variable  @{list}  %{NIMBUS_USER}-${name}.esx.0  %{NIMBUS_USER}-${name}.esx.1  %{NIMBUS_USER}-${name}.esx.2  %{NIMBUS_USER}-${name}.nfs.0  %{NIMBUS_USER}-${name}.vc.0
+    Log To Console  Finished Creating Cluster ${name}
 
     ${out}=  Get Static IP Address
     Set Suite Variable  ${static}  ${out}

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-26-Static-IP-Address.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-26-Static-IP-Address.robot
@@ -29,10 +29,10 @@ Static IP Address Create
     Log To Console  Finished Creating Cluster ${vc}
     Set Suite Variable  @{list}  ${esx1}  ${esx2}  ${esx3}  %{NIMBUS_USER}-${vc}
 
-    #  Need to suggest which subnet/gateway to install the static IP address worker into
-    ${pre}  ${post}=  Split String From Right  ${vc-ip}  .  1
+    ${pod}=  Fetch POD  %{NIMBUS_USER}-${vc}
+    Set Suite Variable  ${NIMBUS_POD}  NIMBUS_POD=${pod}
 
-    ${out}=  Get Static IP Address  --gateway ${pre}.253
+    ${out}=  Get Static IP Address
     Set Suite Variable  ${static}  ${out}
     Append To List  ${list}  %{STATIC_WORKER_NAME} 
 

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-26-Static-IP-Address.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-26-Static-IP-Address.robot
@@ -40,6 +40,24 @@ Static IP Address Create
     ${out}=  Get Static IP Address
     Set Suite Variable  ${static}  ${out}
     Append To List  ${list}  %{STATIC_WORKER_NAME}
+    
+    Log To Console  Set environment variables up for GOVC
+    Set Environment Variable  GOVC_URL  ${vc-ip}
+    Set Environment Variable  GOVC_USERNAME  Administrator@vsphere.local
+    Set Environment Variable  GOVC_PASSWORD  Admin\!23
+
+    Add Host To Distributed Switch  /dc1/host/cls
+
+    Log To Console  Deploy VIC to the VC cluster
+    Set Environment Variable  TEST_URL_ARRAY  ${vc-ip}
+    Set Environment Variable  TEST_USERNAME  Administrator@vsphere.local
+    Set Environment Variable  TEST_PASSWORD  Admin\!23
+    Set Environment Variable  BRIDGE_NETWORK  bridge
+    Set Environment Variable  PUBLIC_NETWORK  vm-network
+    Remove Environment Variable  TEST_DATACENTER
+    Set Environment Variable  TEST_DATASTORE  nfs0-1
+    Set Environment Variable  TEST_RESOURCE  cls
+    Set Environment Variable  TEST_TIMEOUT  15m
 
 *** Test Cases ***
 Test

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-26-Static-IP-Address.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-26-Static-IP-Address.robot
@@ -30,25 +30,12 @@ Static IP Address Create
     Open Connection  %{NIMBUS_GW}
     Wait Until Keyword Succeeds  10 min  30 sec  Login  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}
     ${vc-ip}=  Get IP  ${name}.vc.0
-    ${esx1-ip}=  Get IP  ${name}.esx.0
-    ${esx2-ip}=  Get IP  ${name}.esx.1
-    ${esx3-ip}=  Get IP  ${name}.esx.2
     ${pod}=  Fetch POD  ${name}.vc.0
     Set Suite Variable  ${NIMBUS_POD}  ${pod}
     Close Connection
 
     Set Suite Variable  @{list}  %{NIMBUS_USER}-${name}.esx.0  %{NIMBUS_USER}-${name}.esx.1  %{NIMBUS_USER}-${name}.esx.2  %{NIMBUS_USER}-${name}.nfs.0  %{NIMBUS_USER}-${name}.vc.0
     Log To Console  Finished Creating Cluster ${name}
-
-    Log To Console  Disable firewall for the ESX servers...
-    Set Environment Variable  GOVC_USERNAME  root
-    Set Environment Variable  GOVC_PASSWORD  e2eFunctionalTest
-    Set Environment Variable  GOVC_URL  ${esx1-ip}
-    Run  govc host.esxcli network firewall set -e false
-    Set Environment Variable  GOVC_URL  ${esx2-ip}
-    Run  govc host.esxcli network firewall set -e false
-    Set Environment Variable  GOVC_URL  ${esx3-ip}
-    Run  govc host.esxcli network firewall set -e false
 
     ${out}=  Get Static IP Address
     Set Suite Variable  ${static}  ${out}

--- a/tests/resources/Nimbus-Util.robot
+++ b/tests/resources/Nimbus-Util.robot
@@ -440,11 +440,10 @@ Power Off Host
     Close connection
 
 Create Static IP Worker
-    [Arguments]  ${suggested-gateway}=${EMPTY}
     Open Connection  %{NIMBUS_GW}
     Wait Until Keyword Succeeds  10 min  30 sec  Login  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}
     Log To Console  Create a new static ip address worker...
-    ${out}=  Execute Command  ${NIMBUS_LOCATION} nimbus-ctl --silentObjectNotFoundError kill '%{NIMBUS_USER}-static-worker' && ${NIMBUS_LOCATION} nimbus-worker-deploy --enableStaticIpService static-worker ${suggested-gateway}
+    ${out}=  Execute Command  ${NIMBUS_LOCATION} nimbus-ctl --silentObjectNotFoundError kill '%{NIMBUS_USER}-static-worker' && ${NIMBUS_POD} ${NIMBUS_LOCATION} nimbus-worker-deploy --enableStaticIpService static-worker
     Should Contain  ${out}  "deploy_status": "success"
     Set Environment Variable  STATIC_WORKER_NAME  %{NIMBUS_USER}-static-worker
     ${ip}=  Get IP  static-worker
@@ -452,9 +451,8 @@ Create Static IP Worker
     Close Connection
 
 Get Static IP Address
-    [Arguments]  ${suggested-gateway}=${EMPTY}
     ${status}  ${message}=  Run Keyword And Ignore Error  Environment Variable Should Be Set  STATIC_WORKER_IP
-    Run Keyword If  '${status}' == 'FAIL'  Create Static IP Worker  ${suggested-gateway}
+    Run Keyword If  '${status}' == 'FAIL'  Create Static IP Worker
     Log To Console  Curl a new static ip address from the created worker...
     ${out}=  Run  curl -s http://%{STATIC_WORKER_IP}:4827/nsips
 

--- a/tests/resources/Nimbus-Util.robot
+++ b/tests/resources/Nimbus-Util.robot
@@ -440,10 +440,11 @@ Power Off Host
     Close connection
 
 Create Static IP Worker
+    [Arguments]  ${suggested-gateway}=${EMPTY}
     Open Connection  %{NIMBUS_GW}
     Wait Until Keyword Succeeds  10 min  30 sec  Login  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}
     Log To Console  Create a new static ip address worker...
-    ${out}=  Execute Command  ${NIMBUS_LOCATION} nimbus-ctl --silentObjectNotFoundError kill '%{NIMBUS_USER}-static-worker' && ${NIMBUS_LOCATION} nimbus-worker-deploy --enableStaticIpService static-worker
+    ${out}=  Execute Command  ${NIMBUS_LOCATION} nimbus-ctl --silentObjectNotFoundError kill '%{NIMBUS_USER}-static-worker' && ${NIMBUS_LOCATION} nimbus-worker-deploy --enableStaticIpService static-worker ${suggested-gateway}
     Should Contain  ${out}  "deploy_status": "success"
     Set Environment Variable  STATIC_WORKER_NAME  %{NIMBUS_USER}-static-worker
     ${ip}=  Get IP  static-worker
@@ -451,8 +452,9 @@ Create Static IP Worker
     Close Connection
 
 Get Static IP Address
+    [Arguments]  ${suggested-gateway}=${EMPTY}
     ${status}  ${message}=  Run Keyword And Ignore Error  Environment Variable Should Be Set  STATIC_WORKER_IP
-    Run Keyword If  '${status}' == 'FAIL'  Create Static IP Worker
+    Run Keyword If  '${status}' == 'FAIL'  Create Static IP Worker  ${suggested-gateway}
     Log To Console  Curl a new static ip address from the created worker...
     ${out}=  Run  curl -s http://%{STATIC_WORKER_IP}:4827/nsips
 

--- a/tests/resources/nimbus-testbeds/vic-simple-cluster.rb
+++ b/tests/resources/nimbus-testbeds/vic-simple-cluster.rb
@@ -1,0 +1,92 @@
+oneGB = 1 * 1000 * 1000 # in KB
+ 
+$testbed = Proc.new do
+  {
+    "name" => "vic-simple-cluster",
+    "version" => 3,
+    "esx" => (0..2).map do | idx |
+      {
+        "name" => "esx.#{idx}",
+        "vc" => "vc.0",
+        "style" => "fullInstall",
+        "desiredPassword" => "e2eFunctionalTest",
+        "disks" => [ 30 * oneGB, 30 * oneGB, 30 * oneGB],
+        "nics" => 2,
+        "mountNfs" => ["nfs.0"],
+        "clusterName" => "cls",
+      }
+    end,
+
+    "nfs" => [
+      {
+        "name" => "nfs.0",
+        "type" => "NFS41"
+      }
+    ],
+ 
+    "vcs" => [
+      {
+        "name" => "vc.0",
+        "type" => "vcva",
+        "dcName" => "dc1",
+        "clusters" => [{"name" => "cls", "vsan" => false, "enableDrs" => true, "enableHA" => true}],
+        "addHosts" => "allInSameCluster",
+      }
+    ],
+
+    "postBoot" => Proc.new do |runId, testbedSpec, vmList, catApi, logDir|
+      vc = vmList['vc'][0]
+      vim = VIM.connect vc.rbvmomiConnectSpec
+      datacenters = vim.serviceInstance.content.rootFolder.childEntity.grep(RbVmomi::VIM::Datacenter)
+      raise "Couldn't find a Datacenter precreated"  if datacenters.length == 0
+      datacenter = datacenters.first
+      Log.info "Found a datacenter successfully in the system, name: #{datacenter.name}"
+      clusters = datacenter.hostFolder.children
+      raise "Couldn't find a cluster precreated"  if clusters.length == 0
+      cluster = clusters.first
+      Log.info "Found a cluster successfully in the system, name: #{cluster.name}"
+
+      dvs = datacenter.networkFolder.CreateDVS_Task(
+        :spec => {
+          :configSpec => {
+            :name => "test-ds"
+          },
+	    }
+      ).wait_for_completion
+      Log.info "Vds DSwitch created"
+
+      dvpg1 = dvs.AddDVPortgroup_Task(
+        :spec => [
+          {
+            :name => "management",
+            :type => :earlyBinding,
+            :numPorts => 12,
+          }
+        ]
+      ).wait_for_completion
+      Log.info "management DPG created"
+
+      dvpg2 = dvs.AddDVPortgroup_Task(
+        :spec => [
+          {
+            :name => "vm-network",
+            :type => :earlyBinding,
+            :numPorts => 12,
+          }
+        ]
+      ).wait_for_completion
+      Log.info "vm-network DPG created"
+
+      dvpg3 = dvs.AddDVPortgroup_Task(
+        :spec => [
+          {
+            :name => "bridge",
+            :type => :earlyBinding,
+            :numPorts => 12,
+          }
+        ]
+      ).wait_for_completion
+      Log.info "bridge DPG created"
+    end
+  }
+end

--- a/tests/resources/nimbus-testbeds/vic-simple-cluster.rb
+++ b/tests/resources/nimbus-testbeds/vic-simple-cluster.rb
@@ -35,6 +35,12 @@ $testbed = Proc.new do
     ],
 
     "postBoot" => Proc.new do |runId, testbedSpec, vmList, catApi, logDir|
+      esxList = vmList['esx']
+        esxList.each do |host|
+          host.ssh do |ssh|
+            ssh.exec!("esxcli network firewall set -e false")
+          end
+      end
       vc = vmList['vc'][0]
       vim = VIM.connect vc.rbvmomiConnectSpec
       datacenters = vim.serviceInstance.content.rootFolder.childEntity.grep(RbVmomi::VIM::Datacenter)
@@ -90,3 +96,4 @@ $testbed = Proc.new do
     end
   }
 end
+


### PR DESCRIPTION
fixes #7300 
official response from nimbus - need to be on the same pod to guarantee network connectivity.  This now does that.