### PR TITLE
Ignore not-supported result from RetrieveUserGroups in VC 6.0

### DIFF
--- a/tests/manual-test-cases/Group5-Functional-Tests/5-25-OPS-User-Grant.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-25-OPS-User-Grant.robot
@@ -17,8 +17,15 @@ Documentation  Test 5-25 - OPS-User-Grant
 Resource  ../../resources/Util.robot
 Suite Setup  Wait Until Keyword Succeeds  10x  10m  Ops User Create
 Suite Teardown  Run Keyword And Ignore Error  Nimbus Cleanup  ${list}
+Test Teardown  Run Keyword If Test Failed  Gather VC Logs
 
 *** Keywords ***
+
+Gather VC Logs
+    Log To Console  Collecting VC logs ..
+    Run Keyword And Ignore Error  Gather Logs From ESX Server
+    Log To Console  VC logs collected
+
 Ops User Create
     [Timeout]    110 minutes
     Run Keyword And Ignore Error  Nimbus Cleanup  ${list}  ${false}

--- a/tests/nightly/upload-logs.sh
+++ b/tests/nightly/upload-logs.sh
@@ -24,9 +24,9 @@ outfile="vic_nightly_logs_"$1".zip"
 echo $outfile
 
 if [ -d "60" ]; then
-    /usr/bin/zip -9 -r $outfile 60 *.zip *.log *.debug
+    /usr/bin/zip -9 -r $outfile 60 *.zip *.log *.debug *.tgz
 elif [ -d "65" ]; then
-    /usr/bin/zip -9 -r $outfile 65 *.zip *.log *.debug
+    /usr/bin/zip -9 -r $outfile 65 *.zip *.log *.debug *.tgz
 else
     echo "No output directories to upload!"
     exit 1


### PR DESCRIPTION
On VC 6.0, the API RetrieveUserGroups is not implemented. Return success and print warning message when running against 6.0. This PR also add the collection of the VC logs when the test 5-25-OPS-User-Grant test fails.

Fixes: #7251 