### PR TITLE
Update ROBO SKU test to use vSAN testbed

### DIFF
--- a/tests/manual-test-cases/Group19-ROBO/19-1-ROBO-SKU.md
+++ b/tests/manual-test-cases/Group19-ROBO/19-1-ROBO-SKU.md
@@ -2,23 +2,23 @@ Test 19-1 - ROBO SKU
 =======
 
 # Purpose:
-To verify that VIC works properly when a VCH is installed in a remote office branch office (ROBO) version of vSphere.
+To verify that VIC works properly when a VCH is installed in a remote office branch office (ROBO) version of vSphere
 
 # References:
-1. [vSphere Remote Office and Branch Office](http://www.vmware.com/products/vsphere/remote-office-branch-office.html)
+1 - [vSphere Remote Office and Branch Office](http://www.vmware.com/products/vsphere/remote-office-branch-office.html)
 
 # Environment:
 This test requires access to VMware Nimbus cluster for dynamic ESXi and vCenter creation
 
 # Test Steps:
-1. Deploy a new vCenter with stand alone hosts
-2. Add the Enterprise license to the vCenter appliance
+1. Deploy a simple vSAN cluster
+2. Add the ROBO SKU license to the vCenter appliance
 3. Assign the ROBO SKU license to each of the hosts within the vCenter
 4. Install a VCH onto a particular multi-host cluster in the vCenter
 5. Run a variety of docker operations on the VCH, including the regression test suite
 
 # Expected Outcome:
-* All test steps should complete without error
+All test steps should complete without error
 
 # Possible Problems:
 None

--- a/tests/resources/Nimbus-Util.robot
+++ b/tests/resources/Nimbus-Util.robot
@@ -178,7 +178,7 @@ Run Secret SSHPASS command
     [Tags]  secret
     [Arguments]  ${user}  ${password}  ${cmd}
 
-    ${out}=  Start Process  sshpass -p ${password} ssh -o StrictHostKeyChecking\=no ${user}@%{NIMBUS_GW} ${cmd}  shell=True
+    ${out}=  Start Process  sshpass -p ${password} ssh -o StrictHostKeyChecking\=no -o ServerAliveInterval\=60 -o ServerAliveCountMax\=10 ${user}@%{NIMBUS_GW} ${cmd}  shell=True
     [Return]  ${out}
 
 Deploy Nimbus vCenter Server Async

--- a/tests/resources/nimbus-testbeds/vic-robo.rb
+++ b/tests/resources/nimbus-testbeds/vic-robo.rb
@@ -1,0 +1,72 @@
+#usage: nimbus-testbeddeploy --testbedSpecRubyFile ~/vcan-vc-5esx-allflash.rb \
+# --testbedName vcan-vc-5esx-allflash-iscsi-fullInstall-vcva --vcvaBuild ob-4602587 \
+# --esxBuild ob-3620759 --runName NAME --esxPxeDir ob-3620759
+#
+# This file is needed because there are 3 functions in it which are used in this testbed.
+require '/mts/git/nimbus/lib/testframeworks/testng/testng.rb'
+oneGB = 1 * 1000 * 1000
+$testbed = Proc.new do |sharedStorageStyle, esxStyle, vcStyle|
+  esxStyle ||= 'fullInstall'
+  vcStyle ||= 'vcva'
+  esxStyle = esxStyle.to_s
+  vcStyle = vcStyle.to_s
+  sharedStorageStyle = sharedStorageStyle.to_s
+
+  testbed = {
+    'version' => 3,
+    'name' => "vcan-vc-3esx-allflash-#{sharedStorageStyle}-#{esxStyle}-#{vcStyle}",
+    'esx' => (0..2).map do |i|
+      {
+        'name' => "esx.#{i}",
+        'style' => esxStyle,
+        'numMem' => 64 * 1024,
+        'numCPUs' => 6,
+        'disks' => [ 250 * oneGB ],
+        'disableNfsMounts' => true,
+        'ssds' => [ 200 * oneGB, 250 * oneGB ],
+        'nics' => 2,
+        'staf' => false,
+        'desiredPassword' => 'ca$hc0w',
+        'vmotionNics' => ['vmk0'],
+        'clusterName' => '001',
+        'post_postboot_commands' => [
+            'esxcli system settings kernel set -s autoPartition -v "TRUE"', \
+            'esxcli system settings kernel set -s skipPartitioningSsds -v "TRUE"', \
+            'services.sh restart', \
+            'esxcli vsan storage tag add -d mpx.vmhba1:C0:T1:L0 -t capacityFlash', \
+            'esxcli storage core adapter rescan --all', \
+            'esxcli network firewall set --enabled false', \
+            'echo \'vhv.enable = "TRUE"\' >> /etc/vmware/config'
+            ],
+      }
+    end,
+    'vcs' => [{
+      'name' => 'vc',
+      'type' => vcStyle,
+      'numMem' => 32 * 1024,
+      'addHosts' => 'allInSameCluster',
+      'clusters' => [{'name' => '001', 'dc' => 'vcqaDC', 'vsan' => true, 'enableDrs' => false, 'enableHA' => true}],
+      'linuxCertFile' => TestngLauncher.vcvaCertFile,
+#     'addHosts' => 'multiple-clusters',
+#      'esxsPerCluster' => '3',
+#      'numOfClusters' => '2',
+#      'clusterName' => ['001', '002'],
+             }],
+      'vsan' => true,
+    'postBoot' => Proc.new do |runId, testbedSpec, vmList|
+      vc = vmList['vc'].first
+      puts "======#{vc.ip}======"
+    end,
+  }
+
+  testbed
+end
+
+[:pxeBoot, :fullInstall].each do |esxStyle|
+  [:vpxInstall, :vcva].each do |vcStyle|
+    [:iscsi, :fc].each do |sharedStorageStyle|
+      testbedSpec = $testbed.call(sharedStorageStyle, esxStyle, vcStyle)
+      Nimbus::TestbedRegistry.registerTestbed testbedSpec
+    end
+  end
+end


### PR DESCRIPTION
This change updates the ROBO SKU robot test to use the vSAN simple testbed. Manually deploying the same testbed in Nimbus can be done in the same fashion by running the `nimbus-testbeddeploy` command directly, passing the same arguments that the test would pass during a CI run, as well as any subsequent `govc` commands.

I've also added a vic-robo testbed file that deploys an all-SSD vSAN testbed without NFS or DRS enabled. It will eventually replace the vSAN simple testbed with the long-term goal being to update this testbed to also include ELM support, multiple clusters and more ESX hosts. It will likely need some tweaking from its current state in order to enable HA, explicitly disable DRS, etc.

Fixes #7227.