### PR TITLE
[skip ci] Terminate gracefully to gather logs

### DIFF
--- a/tests/manual-test-cases/Group5-Functional-Tests/5-24-Non-vSphere-Local-Cluster.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-24-Non-vSphere-Local-Cluster.robot
@@ -34,7 +34,9 @@ Non vSphere Local Cluster Install Setup
     Set Suite Variable  @{list}  @{esx_names}[0]  @{esx_names}[1]  @{esx_names}[2]  %{NIMBUS_USER}-${vc}
 
     # Finish vCenter deploy
-    ${output}=  Wait For Process  ${pid}
+    ${output}=  Wait For Process  ${pid}  timeout=40 minutes  on_timeout=terminate
+    Log  ${output.stdout}
+    Log  ${output.stderr}
     Should Contain  ${output.stdout}  Overall Status: Succeeded
 
     Open Connection  %{NIMBUS_GW}

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-24-Non-vSphere-Local-Cluster.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-24-Non-vSphere-Local-Cluster.robot
@@ -34,7 +34,7 @@ Non vSphere Local Cluster Install Setup
     Set Suite Variable  @{list}  @{esx_names}[0]  @{esx_names}[1]  @{esx_names}[2]  %{NIMBUS_USER}-${vc}
 
     # Finish vCenter deploy
-    ${output}=  Wait For Process  ${pid}  timeout=40 minutes  on_timeout=terminate
+    ${output}=  Wait For Process  ${pid}  timeout=70 minutes  on_timeout=terminate
     Log  ${output.stdout}
     Log  ${output.stderr}
     Should Contain  ${output.stdout}  Overall Status: Succeeded

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-3-Enhanced-Linked-Mode.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-3-Enhanced-Linked-Mode.robot
@@ -62,7 +62,7 @@ Enhanced Link Mode Setup
     ${esx6-ip}=  Get From List  ${esx-ips}  2
 
     # Finish test bed deploy
-    ${output}=  Wait For Process  ${pid}  timeout=40 minutes  on_timeout=terminate
+    ${output}=  Wait For Process  ${pid}  timeout=70 minutes  on_timeout=terminate
     Log  ${output.stdout}
     Log  ${output.stderr}
     Should Be Equal As Integers  ${output.rc}  0

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-3-Enhanced-Linked-Mode.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-3-Enhanced-Linked-Mode.robot
@@ -99,7 +99,6 @@ Enhanced Link Mode Setup
     Set Environment Variable  GOVC_URL  ${vc1-ip}
     Set Environment Variable  GOVC_USERNAME  administrator@vsphere.local
     Set Environment Variable  GOVC_PASSWORD  Admin!23
-
     ${license}=  Run  govc license.ls
 
     # First VC cluster

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-3-Enhanced-Linked-Mode.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-3-Enhanced-Linked-Mode.robot
@@ -62,7 +62,7 @@ Enhanced Link Mode Setup
     ${esx6-ip}=  Get From List  ${esx-ips}  2
 
     # Finish test bed deploy
-    ${output}=  Wait For Process  ${pid}
+    ${output}=  Wait For Process  ${pid}  timeout=40 minutes  on_timeout=terminate
     Log  ${output.stdout}
     Log  ${output.stderr}
     Should Be Equal As Integers  ${output.rc}  0
@@ -99,7 +99,7 @@ Enhanced Link Mode Setup
     Set Environment Variable  GOVC_URL  ${vc1-ip}
     Set Environment Variable  GOVC_USERNAME  administrator@vsphere.local
     Set Environment Variable  GOVC_PASSWORD  Admin!23
-    
+
     ${license}=  Run  govc license.ls
 
     # First VC cluster


### PR DESCRIPTION
Fixes #7250 

These tests won't have the opportunity to hit the big 110 minute timeout anymore. Instead they will terminate ahead of time and provide logs. 