### PR TITLE
Refactor Install Harbor To Test Server keyword

### DIFF
--- a/tests/resources/Harbor-Util.robot
+++ b/tests/resources/Harbor-Util.robot
@@ -48,6 +48,7 @@ Install Harbor To Test Server
 
     Log To Console  \nDeploying ova...
     ${out}=  Secret Install Harbor To Test Server  ${name}  ${protocol}  ${verify}  ${host}  ${datastore}  ${network}
+    Log  ${out}
     Should Contain  ${out}  Received IP address:
     Should Not Contain  ${out}  None
 


### PR DESCRIPTION
The secret tag on the `Install Harbor To Test Server` makes it difficult to investigate failures when they occur.

Only one out of 30+ lines actually uses secret information.

Refactor the keyword to extract the secret information into its own keyword, allowing the tag to be applied in a more focused way. This is similar to the pattern used by keywords in `VCH-Util`.

Towards #7249