### PR TITLE
Add ability to cache generated dependency.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -488,7 +488,7 @@ distro: all
 mrrobot:
 	@rm -rf *.xml *.html *.log *.zip VCH-0-*
 
-clean:
+clean: cleandeps
 	@echo removing binaries
 	@rm -rf $(BIN)/*
 	@echo removing Go object files
@@ -520,3 +520,7 @@ clean:
 distclean: clean
 	@echo removing binaries
 	@rm -rf $(BIN)
+
+cleandeps:
+	@echo removing dependency cache
+	@rm -rf .godeps_cache

--- a/README.md
+++ b/README.md
@@ -86,6 +86,22 @@ To run unit tests after a successful build, issue the following:
 make test
 ```
 
+Running "make" every time causes Go dependency regeneration for each component, so that "make" can rebuild only those components that are changed.  However, such regeneration may take significant amount of time when it is not really needed. To fight that developers can use cached dependencies that can be enabled by defining the environment variable VIC_CACHE_DEPS. As soon as it is set, infra/scripts/go-deps.sh will read cached version of dependencies if those exist.
+
+```shell
+export VIC_CACHE_DEPS=1
+```
+
+This is important to note that as soon as you add a new package or an internal project dependency that didn't exist before, those dependencies
+should be regenerated to reflect latest changes. It can be done just by running:
+
+```shell
+make cleandeps
+```
+
+After that next "make" run will regenerate dependencies from scratch.
+
+
 ## Managing vendor/ directory
 
 To build the VIC Engine dependencies, ensure `GOPATH` is set, then issue the following.

--- a/infra/scripts/go-deps.sh
+++ b/infra/scripts/go-deps.sh
@@ -21,19 +21,32 @@
 #     pkg       This is github.com/vmware/vic/cmd/imagec for example
 #
 
+cache_dir=.godeps_cache
+
 pkg=$1
 flags=$2
+cachedname=`echo .$1.godeps_cache | sed 's/\//_/g'`
 
 if [ -d "$pkg" ]; then
-    if [[ "$flags" == *d* ]]
-    then
+
+    if [[ "$flags" == *d* ]]; then
         # Only output if make is given the '-d' flag
         echo "Generating deps for $pkg" >&2
     fi
 
-    go list -f '{{join .Deps "\n"}}' github.com/vmware/vic/"$pkg" 2>/dev/null | \
-        xargs go list -f '{{if not .Standard}}{{.ImportPath}}{{end}}' 2>/dev/null | \
-        sed -e 's:github.com/vmware/vic/\(.*\)$:\1/*:'
+    if [ -n "$VIC_CACHE_DEPS" ]; then
+        mkdir -p $cache_dir
+        if [ ! -f $cache_dir/$cachedname ]; then
+            go list -f '{{join .Deps "\n"}}' github.com/vmware/vic/"$pkg" 2>/dev/null | \
+                xargs go list -f '{{if not .Standard}}{{.ImportPath}}{{end}}' 2>/dev/null | \
+                sed -e 's:github.com/vmware/vic/\(.*\)$:\1/*:' > "$cache_dir/$cachedname"
+        fi
+        cat "$cache_dir/$cachedname"
+    else
+        go list -f '{{join .Deps "\n"}}' github.com/vmware/vic/"$pkg" 2>/dev/null | \
+            xargs go list -f '{{if not .Standard}}{{.ImportPath}}{{end}}' 2>/dev/null | \
+            sed -e 's:github.com/vmware/vic/\(.*\)$:\1/*:'
+    fi
 else
     if [[ "$flags" == *d* ]]
     then

--- a/infra/scripts/go-deps.sh
+++ b/infra/scripts/go-deps.sh
@@ -20,6 +20,9 @@
 #
 #     pkg       This is github.com/vmware/vic/cmd/imagec for example
 #
+# If VIC_CACHE_DEPS environment variable is defined, this script will attempt to read
+# cached dependencies from disk if those exist. If they are not cached, dependencies will be
+# regenerated and cached.
 
 cache_dir=.godeps_cache
 


### PR DESCRIPTION
This PR adds ability to cache discovered Go dependencies that are used by 'make' tool to build changed targets. So that, if you are not changing project structure and only working withing existing set of packages regeneration such dependencies is redundant and adds 7-30 seconds (depends on IO speed) each time you are trying to run 'make <target>'.

With this PR you can cut 7-30 seconds for each 'make <target>' call. To make that possible just define an environment variable as the following:
```
export VIC_CACHE_DEPS=1
```

At some point if you add an additional package and need to regenerate dependencies, just run "make cleandeps", so next "make" run will regenerate all dependencies from scratch.

Fixes #7339 

<!--
To trigger a custom build with this PR, include one of these in the PR's title or commit messages:
- To skip running tests (e.g. for a work-in-progress PR), add `[ci skip]` or `[skip ci]`
to the commit message or the PR title.
- To run the full test suite, use `[full ci]`.
- To run _one_ integration test or group, use `[specific ci=$test]`. Examples:
  - To run the `1-01-Docker-Info` suite: `[specific ci=1-01-Docker-Info]`
  - To run all suites under the `Group1-Docker-Commands` group: `[specific ci=Group1-Docker-Commands]`
-->
