### PR TITLE
Skip non vSphere managed datastores when granting perms

### DIFF
--- a/lib/install/opsuser/opsuser.go
+++ b/lib/install/opsuser/opsuser.go
@@ -217,6 +217,10 @@ func (mgr *RBACManager) collectDatastores(ctx context.Context, finder *find.Find
 	}
 	volumeLocations := make([]url.URL, 0, len(mgr.configSpec.Storage.VolumeLocations))
 	for _, volumeLocation := range mgr.configSpec.Storage.VolumeLocations {
+		// Only apply changes to datastores managed by vSphere
+		if volumeLocation.Scheme != "ds" {
+			continue
+		}
 		volumeLocations = append(volumeLocations, *volumeLocation)
 	}
 	if err = mgr.findDatastores(ctx, finder, volumeLocations, dsNameToRef); err != nil {

--- a/lib/install/validate/validator_test_sim_util.go
+++ b/lib/install/validate/validator_test_sim_util.go
@@ -91,6 +91,17 @@ var testInputConfigVPX = data.Data{
 			RawQuery:   "",
 			Fragment:   "",
 		},
+		"nfs": {
+			Scheme:     "nfs",
+			Opaque:     "",
+			User:       (*url.Userinfo)(nil),
+			Host:       "nfs-host",
+			Path:       "vic-volumes:nas",
+			RawPath:    "",
+			ForceQuery: false,
+			RawQuery:   "",
+			Fragment:   "",
+		},
 	},
 	BridgeNetworkName: "DC0_DVPG0",
 	ClientNetwork: data.NetworkConfig{


### PR DESCRIPTION
Fix: #7337

Avoid locating datastores when they are not managed by vSphere.