### PR TITLE
Start virtual-kubelet inside the VCH

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,6 +107,7 @@ vic-ui-windows := $(BIN)/vic-ui-windows.exe
 vic-ui-darwin := $(BIN)/vic-ui-darwin
 vic-init := $(BIN)/vic-init
 vic-init-test := $(BIN)/vic-init-test
+kubelet-starter := $(BIN)/kubelet-starter
 # NOT BUILT WITH make all TARGET
 # vic-dns variants to create standalone DNS service.
 vic-dns-linux := $(BIN)/vic-dns-linux
@@ -142,6 +143,7 @@ vicadmin: $(vicadmin)
 rpctool: $(rpctool)
 vic-init: $(vic-init)
 vic-init-test: $(vic-init-test)
+kubelet-starter: $(kubelet-starter)
 
 tether-linux: $(tether-linux)
 
@@ -318,6 +320,10 @@ $(vic-init-test): $$(call godeps,cmd/vic-init/*.go)
 	@echo building vic-init-test
 	@CGO_ENABLED=1 GOOS=linux GOARCH=amd64 $(GO) test -c -coverpkg github.com/vmware/vic/lib/...,github.com/vmware/vic/pkg/... -outputdir /tmp -coverprofile init.cov -o ./$@ ./$(dir $<)
 
+$(kubelet-starter): $$(call godeps,cmd/kubelet-starter/*.go)
+	@echo building kubelet-starter
+	@CGO_ENABLED=1 GOOS=linux GOARCH=amd64 $(GO) build $(RACE) -ldflags "$(LDFLAGS)" -tags netgo -installsuffix netgo -o ./$@ ./$(dir $<)
+
 $(tether-linux): $$(call godeps,cmd/tether/*.go)
 	@echo building tether-linux
 	@CGO_ENABLED=1 GOOS=linux GOARCH=amd64 $(TIME) $(GO) build $(RACE) -tags netgo -installsuffix netgo -ldflags '$(LDFLAGS) -extldflags "-static"' -o ./$@ ./$(dir $<)
@@ -430,7 +436,7 @@ $(appliance): isos/appliance.sh isos/appliance/* isos/vicadmin/** $(vicadmin) $(
 
 .PHONY: $(appliance-vkubelet)
 # main appliance target + virtual kubelet - depends on all top level component targets
-$(appliance-vkubelet): isos/appliance-extra.sh isos/appliance/* isos/vicadmin/** $(vicadmin) $(vic-init) $(portlayerapi) $(docker-engine-api) $(appliance-staging) $(archive)
+$(appliance-vkubelet): isos/appliance-virtual-kubelet.sh isos/appliance/* isos/vicadmin/** $(vicadmin) $(vic-init) $(kubelet-starter) $(portlayerapi) $(docker-engine-api) $(appliance-staging) $(archive)
 	@echo building VCH appliance ISO
 	@$(TIME) $< -p $(appliance-staging) -b $(BIN) -x $(VIRTUAL_KUBELET) -f virtual-kubelet -o $@
 

--- a/cmd/kubelet-starter/main.go
+++ b/cmd/kubelet-starter/main.go
@@ -1,0 +1,105 @@
+// Copyright 2016-2018 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"strconv"
+
+	log "github.com/Sirupsen/logrus"
+
+	"github.com/vmware/vic/lib/config"
+	"github.com/vmware/vic/lib/constants"
+	viclog "github.com/vmware/vic/pkg/log"
+	"github.com/vmware/vic/pkg/log/syslog"
+	"github.com/vmware/vic/pkg/trace"
+	"github.com/vmware/vic/pkg/vsphere/extraconfig"
+)
+
+var (
+	vchConfig config.VirtualContainerHostConfigSpec
+)
+
+const (
+	KubeletConfigFile = "/etc/kubelet.conf"
+	KubeletPath       = "/sbin/virtual-kubelet"
+)
+
+func main() {
+	op := trace.NewOperation(context.Background(), "kubelet-starter")
+
+	// load the vch config
+	src, err := extraconfig.GuestInfoSource()
+	if err != nil {
+		op.Fatalf("Unable to load configuration from guestinfo: %s", err)
+	}
+	extraconfig.Decode(src, &vchConfig)
+
+	logcfg := viclog.NewLoggingConfig()
+	if vchConfig.Diagnostics.DebugLevel > 0 {
+		logcfg.Level = log.DebugLevel
+		trace.Logger.Level = log.DebugLevel
+		syslog.Logger.Level = log.DebugLevel
+	}
+
+	if vchConfig.Diagnostics.DebugLevel > 3 {
+		// extraconfig is very, very verbose
+		extraconfig.SetLogLevel(log.DebugLevel)
+	}
+
+	if vchConfig.Diagnostics.SysLogConfig != nil {
+		logcfg.Syslog = &viclog.SyslogConfig{
+			Network:  vchConfig.Diagnostics.SysLogConfig.Network,
+			RAddr:    vchConfig.Diagnostics.SysLogConfig.RAddr,
+			Priority: syslog.Info | syslog.Daemon,
+		}
+	}
+
+	op.Infof("%+v", *logcfg)
+	// #nosec: Errors unhandled.
+	viclog.Init(logcfg)
+	trace.InitLogger(logcfg)
+
+	if vchConfig.Diagnostics.DebugLevel > 2 {
+		// expose portlayer service on client interface
+		plPort := constants.DebugPortLayerPort
+		os.Setenv("PORTLAYER_ADDR", strconv.Itoa(plPort))
+	}
+
+	op.Infof("KUBELET_NAME = %s", os.Getenv("KUBELET_NAME"))
+	op.Infof("KUBERNETES_SERVICE_HOST = %s", os.Getenv("KUBERNETES_SERVICE_HOST"))
+	op.Infof("KUBERNETES_SERVICE_PORT = %s", os.Getenv("KUBERNETES_SERVICE_PORT"))
+	op.Infof("PERSONA_ADDR = %s", os.Getenv("PERSONA_ADDR"))
+	op.Infof("PORTLAYER_ADDR = %s", os.Getenv("PORTLAYER_ADDR"))
+
+	// Create Kubelet config file
+	content := []byte(vchConfig.Kubelet.KubeletConfigContent)
+	err = ioutil.WriteFile(KubeletConfigFile, content, 0644)
+
+	if err != nil {
+		op.Fatalf("Cannot write Kubelet config file to: %s, err: %s", KubeletConfigFile, err)
+	}
+
+	kubeletName := os.Getenv("KUBELET_NAME")
+
+	op.Infof("Executing kubelet: %s %s %s %s %s %s %s", KubeletPath, "--provider", "mock", "--kubeconfig", KubeletConfigFile, "--nodename", kubeletName)
+	/* #nosec */
+	kubeletCmd := exec.Command(KubeletPath, "--provider", "mock", "--kubeconfig", KubeletConfigFile, "--nodename", kubeletName)
+	output, err := kubeletCmd.CombinedOutput()
+	op.Infof("Output: %s, Error: %s", string(output), err)
+}

--- a/cmd/kubelet-starter/main_test.go
+++ b/cmd/kubelet-starter/main_test.go
@@ -1,0 +1,15 @@
+// Copyright 2016-2018 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main

--- a/cmd/vic-machine/common/kubelet.go
+++ b/cmd/vic-machine/common/kubelet.go
@@ -1,0 +1,59 @@
+// Copyright 2018 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"gopkg.in/urfave/cli.v1"
+
+	"github.com/vmware/vic/pkg/errors"
+	"github.com/vmware/vic/pkg/flags"
+	"github.com/vmware/vic/pkg/trace"
+)
+
+// Kubelet holds credentials for the VCH operations user
+type Kubelet struct {
+	ServerAddress *string `cmd:"kubelet"`
+	ConfigFile    *string
+}
+
+func (v *Kubelet) Flags(hidden bool) []cli.Flag {
+	return []cli.Flag{
+		cli.GenericFlag{
+			Name:   "k8s-server-address",
+			Value:  flags.NewOptionalString(&v.ServerAddress),
+			Usage:  "The Kubernetes Server URL, <hostname/ip>:<port>",
+			Hidden: hidden,
+		},
+		cli.GenericFlag{
+			Name:   "k8s-config",
+			Value:  flags.NewOptionalString(&v.ConfigFile),
+			Usage:  "Kubernetes client config file",
+			Hidden: hidden,
+		},
+	}
+}
+
+func (v *Kubelet) ProcessKubelet(op trace.Operation, isCreateOp bool) error {
+	if isCreateOp {
+		if v.ServerAddress != nil && v.ConfigFile == nil {
+			return errors.Errorf("A Kubernetes Config File must be specified when specifying a Kubernetes Server Address")
+		}
+		if v.ServerAddress == nil && v.ConfigFile != nil {
+			return errors.Errorf("A Kubernetes Server Address must be specified when specifying a Kubernetes Config File")
+		}
+	}
+
+	return nil
+}

--- a/cmd/vic-machine/common/kubelet_test.go
+++ b/cmd/vic-machine/common/kubelet_test.go
@@ -1,0 +1,15 @@
+// Copyright 2018 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common

--- a/cmd/vic-machine/create/create.go
+++ b/cmd/vic-machine/create/create.go
@@ -308,11 +308,12 @@ func (c *Create) Flags() []cli.Flag {
 	cNetwork := c.containerNetworks.CNetworkFlags(true)
 	dns := c.Nameservers.DNSFlags(true)
 	proxies := c.Proxies.ProxyFlags(true)
+	kubelet := c.Kubelet.Flags(true)
 	debug := c.DebugFlags(true)
 
 	// flag arrays are declared, now combined
 	var flags []cli.Flag
-	for _, f := range [][]cli.Flag{target, compute, ops, create, container, volume, dns, networks, cNetwork, memory, cpu, tls, registries, proxies, syslog, iso, util, debug, help} {
+	for _, f := range [][]cli.Flag{target, compute, ops, create, container, volume, dns, networks, cNetwork, memory, cpu, tls, registries, proxies, syslog, iso, util, kubelet, debug, help} {
 		flags = append(flags, f...)
 	}
 
@@ -341,6 +342,10 @@ func (c *Create) ProcessParams(op trace.Operation) error {
 
 	// Pass admin credentials for use as ops credentials if ops credentials are not supplied.
 	if err := c.OpsCredentials.ProcessOpsCredentials(op, true, c.Target.User, c.Target.Password); err != nil {
+		return err
+	}
+
+	if err := c.Kubelet.ProcessKubelet(op, true); err != nil {
 		return err
 	}
 

--- a/cmd/vic-machine/create/create_test.go
+++ b/cmd/vic-machine/create/create_test.go
@@ -72,7 +72,7 @@ func TestParseGatewaySpec(t *testing.T) {
 func TestFlags(t *testing.T) {
 	c := NewCreate()
 	flags := c.Flags()
-	numberOfFlags := 60
+	numberOfFlags := 62
 	assert.Equal(t, numberOfFlags, len(flags), "Missing flags during Create.")
 }
 

--- a/isos/appliance-virtual-kubelet.sh
+++ b/isos/appliance-virtual-kubelet.sh
@@ -149,6 +149,9 @@ cp ${BIN}/vic-init $(rootfs_dir $PKGDIR)/sbin/vic-init
 cp ${BIN}/{docker-engine-server,port-layer-server,vicadmin} $(rootfs_dir $PKGDIR)/sbin/
 cp ${BIN}/unpack $(rootfs_dir $PKGDIR)/bin/
 
+# Kubelet-starter
+cp ${BIN}/kubelet-starter $(rootfs_dir $PKGDIR)/sbin/kubelet-starter
+
 # Extra binaries
 APPLIANCE_NAME=$(basename ${APPLIANCE_OUTNAME})
 GS=$(echo ${EXTRABIN} | grep '^gs://' | cat)

--- a/lib/config/virtual_container_host.go
+++ b/lib/config/virtual_container_host.go
@@ -53,6 +53,7 @@ const (
 	PersonaService   = "docker-personality"
 	PortLayerService = "port-layer"
 	VicAdminService  = "vicadmin"
+	KubeletService   = "virtual-kubelet"
 
 	GeneralHTTPProxy   = "HTTP_PROXY"
 	GeneralHTTPSProxy  = "HTTPS_PROXY"
@@ -102,6 +103,9 @@ type VirtualContainerHostConfigSpec struct {
 	// Registry configuration for Imagec
 	Registry `vic:"0.1" scope:"read-only" key:"registry"`
 
+	// virtual kubelet specific options
+	Kubelet `vic:"0.1" scope:"read-only" key:"virtual_kubelet"`
+
 	// configuration for vic-machine
 	CreateBridgeNetwork bool `vic:"0.1" scope:"read-only" key:"create_bridge_network"`
 
@@ -134,6 +138,13 @@ type Registry struct {
 	RegistryBlacklist []string `vic:"0.1" scope:"read-only" recurse:"depth=0"`
 	// Insecure registries
 	InsecureRegistries []string `vic:"0.1" scope:"read-only" key:"insecure_registries"`
+}
+
+// Virtual Kubelet
+type Kubelet struct {
+	KubernetesServerAddress string
+	KubeletConfigFile       string
+	KubeletConfigContent    string
 }
 
 // NetworkConfig defines the network configuration of virtual container host

--- a/lib/install/data/data.go
+++ b/lib/install/data/data.go
@@ -41,6 +41,7 @@ type Data struct {
 	common.ContainerConfig
 
 	OpsCredentials common.OpsCredentials
+	Kubelet        common.Kubelet
 
 	CertPEM     []byte
 	KeyPEM      []byte

--- a/lib/install/kubelet/kubelet.go
+++ b/lib/install/kubelet/kubelet.go
@@ -1,0 +1,34 @@
+// Copyright 2016-2018 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kubelet
+
+import (
+	"context"
+	"io/ioutil"
+
+	"github.com/vmware/vic/lib/config"
+)
+
+func ReadKubeletConfigFile(ctx context.Context, configSpec *config.VirtualContainerHostConfigSpec) error {
+	// TODO: this function should perform full validation of the config file
+	pathName := configSpec.KubeletConfigFile
+	data, err := ioutil.ReadFile(pathName)
+	if err != nil {
+		return err
+	}
+
+	configSpec.KubeletConfigContent = string(data)
+	return nil
+}

--- a/lib/install/validate/validator.go
+++ b/lib/install/validate/validator.go
@@ -41,6 +41,7 @@ import (
 	"github.com/vmware/vic/lib/config/executor"
 	"github.com/vmware/vic/lib/constants"
 	"github.com/vmware/vic/lib/install/data"
+	"github.com/vmware/vic/lib/install/kubelet"
 	"github.com/vmware/vic/lib/install/opsuser"
 	"github.com/vmware/vic/pkg/errors"
 	"github.com/vmware/vic/pkg/registry"
@@ -335,6 +336,9 @@ func (v *Validator) Validate(ctx context.Context, input *data.Data) (*config.Vir
 	v.compatibility(op, conf)
 
 	v.syslog(op, conf, input)
+
+	// Kubelet
+	v.kubelet(op, conf, input)
 
 	// TODO: determine if this is where we should turn the noted issues into message
 	return conf, v.ListIssues(op)
@@ -933,6 +937,22 @@ func (v *Validator) syslog(op trace.Operation, conf *config.VirtualContainerHost
 	conf.Diagnostics.SysLogConfig = &executor.SysLogConfig{
 		Network: network,
 		RAddr:   host,
+	}
+}
+
+func (v *Validator) kubelet(op trace.Operation, conf *config.VirtualContainerHostConfigSpec, input *data.Data) {
+	defer trace.End(trace.Begin("", op))
+
+	if input.Kubelet.ServerAddress == nil || input.Kubelet.ConfigFile == nil {
+		return
+	}
+
+	conf.KubernetesServerAddress = *input.Kubelet.ServerAddress
+	conf.KubeletConfigFile = *input.Kubelet.ConfigFile
+
+	err := kubelet.ReadKubeletConfigFile(op, conf)
+	if err != nil {
+		v.NoteIssue(fmt.Errorf("Failed to load K8s config file: %s", err.Error()))
 	}
 }
 


### PR DESCRIPTION
To build this image you must have a binary image of virtual-kubelet to be included in the iso.
The path to that image should be saved into this environment variable: **VIRTUAL_KUBELET_PATH**.
for instance: 
```
export VIRTUAL_KUBELET_PATH=/home/username/golang/src/github.com/virtual-kubelet/virtual-kubelet/bin/virtual-kubelet
```
then build vic with the target:
```
make appliance-vkubelet
```
the ISO is named: **appliance-vkubelet.iso**

Use the **--ai** option when running vic-machine create

This covers creation only (no upgrade or configure), unit tests to come.