### PR TITLE
WIP: Log and indent on Operation inheritence

### DIFF
--- a/lib/portlayer/exec/container.go
+++ b/lib/portlayer/exec/container.go
@@ -317,7 +317,7 @@ func (c *Container) WaitForState(s State) <-chan struct{} {
 func (c *Container) NewHandle(ctx context.Context) *Handle {
 	// Call property collector to fill the data
 	if c.vm != nil {
-		op := trace.FromContext(ctx, "NewHandle")
+		op := trace.FromContext(ctx, "")
 		// FIXME: this should be calling the cache to decide if a refresh is needed
 		if err := c.Refresh(op); err != nil {
 			op.Errorf("refreshing container %s failed: %s", c, err)
@@ -517,7 +517,7 @@ func (c *Container) LogReader(op trace.Operation, tail int, follow bool, since i
 
 				// revert the govmomi returned context to the previous op
 				// the op was preserved as a value in the context
-				op = trace.FromContext(ctx, "LogReader")
+				op = trace.FromContext(ctx, "")
 				via = fmt.Sprintf(" via %s", h.Reference())
 			}
 		}
@@ -570,7 +570,6 @@ func (c *Container) LogReader(op trace.Operation, tail int, follow bool, since i
 
 // Remove removes a containerVM after detaching the disks
 func (c *Container) Remove(op trace.Operation, sess *session.Session) error {
-	// op := trace.FromContext(ctx, "Remove")
 	defer trace.End(trace.Begin(c.ExecConfig.ID, op))
 	c.m.Lock()
 	defer c.m.Unlock()

--- a/lib/portlayer/exec/handle.go
+++ b/lib/portlayer/exec/handle.go
@@ -272,7 +272,7 @@ func (h *Handle) Close() {
 // TODO: either deep copy the configuration, or provide an alternative means of passing the data that
 // avoids the need for the caller to unpack/repack the parameters
 func Create(ctx context.Context, vmomiSession *session.Session, config *ContainerCreateConfig) (*Handle, error) {
-	op := trace.FromContext(ctx, "Handle.Create")
+	op := trace.ChildFromContext(ctx, "Handle.Create")
 	defer trace.End(trace.Begin(config.Metadata.Name, op))
 
 	h := &Handle{

--- a/lib/portlayer/network/config.go
+++ b/lib/portlayer/network/config.go
@@ -17,6 +17,7 @@ package network
 import (
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/vic/lib/config"
+	"github.com/vmware/vic/pkg/trace"
 	"github.com/vmware/vic/pkg/vsphere/extraconfig"
 )
 
@@ -37,10 +38,10 @@ type Configuration struct {
 	PortGroups map[string]object.NetworkReference `vic:"0.1" scope:"read-only" recurse:"depth=0"`
 }
 
-func (c *Configuration) Encode() {
+func (c *Configuration) Encode(op trace.Operation) {
 	extraconfig.Encode(c.sink, c)
 }
 
-func (c *Configuration) Decode() {
+func (c *Configuration) Decode(op trace.Operation) {
 	extraconfig.Decode(c.source, c)
 }

--- a/pkg/vsphere/datastore/datastore.go
+++ b/pkg/vsphere/datastore/datastore.go
@@ -155,7 +155,7 @@ func mkdir(op trace.Operation, sess *session.Session, fm *object.FileManager, cr
 
 // Mkdir creates directories.
 func (d *Helper) Mkdir(ctx context.Context, createParentDirectories bool, dirs ...string) (string, error) {
-	op := trace.FromContext(ctx, "Mkdir")
+	op := trace.FromContext(ctx, "")
 
 	return mkdir(op, d.s, d.fm, createParentDirectories, path.Join(d.RootURL.String(), path.Join(dirs...)))
 }
@@ -260,7 +260,7 @@ func (d *Helper) Stat(ctx context.Context, pth string) (types.BaseFileInfo, erro
 }
 
 func (d *Helper) Mv(ctx context.Context, fromPath, toPath string) error {
-	op := trace.FromContext(ctx, "Mv")
+	op := trace.FromContext(ctx, "")
 
 	from := path.Join(d.RootURL.String(), fromPath)
 	to := path.Join(d.RootURL.String(), toPath)
@@ -273,7 +273,7 @@ func (d *Helper) Mv(ctx context.Context, fromPath, toPath string) error {
 }
 
 func (d *Helper) Rm(ctx context.Context, pth string) error {
-	op := trace.FromContext(ctx, "Rm")
+	op := trace.FromContext(ctx, "")
 
 	f := path.Join(d.RootURL.String(), pth)
 	op.Infof("Removing %s", pth)

--- a/pkg/vsphere/session/session.go
+++ b/pkg/vsphere/session/session.go
@@ -249,10 +249,9 @@ func (s *Session) Connect(ctx context.Context) (*Session, error) {
 	}
 
 	if s.Keepalive != 0 {
+		cop := trace.NewOperation(op, "vmomi keep alive")
 		vimClient.RoundTripper = session.KeepAliveHandler(soapClient, s.Keepalive,
 			func(roundTripper soap.RoundTripper) error {
-				cop := trace.FromOperation(op, "KeepAlive")
-
 				_, err := methods.GetCurrentTime(cop, roundTripper)
 				if err == nil {
 					return nil


### PR DESCRIPTION
This adds explicit logging when a child operation is created, adds a new
call of ChildFromContext to differentiate from just retrieving an
Operation from a context.
Includes various modifications to Operation construction calls and
positioning to make logging sane with the revision

Moved this back to WIP while discussing child operations/indent. If no solid conclusion can be reached there then I will drop that portion of it but will keep the logging improvements to the wider code.
