### PR TITLE
Add ESX host metrics library

### DIFF
--- a/pkg/vsphere/performance/host_metrics.go
+++ b/pkg/vsphere/performance/host_metrics.go
@@ -1,0 +1,179 @@
+// Copyright 2018 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package performance
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/performance"
+	"github.com/vmware/govmomi/vim25/types"
+	"github.com/vmware/vic/pkg/trace"
+	"github.com/vmware/vic/pkg/vsphere/session"
+)
+
+const (
+	// cpuUsage measures the actively used CPU of the host, as a percentage of the total available CPU.
+	cpuUsage = "cpu.usage.average"
+
+	// memActive measures the sum of all active metrics for all powered-on VMs plus vSphere services on the host.
+	memActive = "mem.active.average"
+
+	// memConsumed measures the amount of machine memory used on the host, including vSphere services, VMkernel,
+	// the service console and the total consumed memory metrics for all running VMs.
+	memConsumed = "mem.consumed.average"
+
+	// memTotalCapacity measures the total amount of memory reservation used by and available for powered-on VMs
+	// and vSphere services on the host.
+	memTotalCapacity = "mem.totalCapacity.average"
+
+	// memOverhead measures the total of all overhead metrics for powered-on VMs, plus the overhead of running
+	// vSphere services on the host.
+	memOverhead = "mem.overhead.average"
+)
+
+// HostMemory stores an ESXi host's memory metrics.
+type HostMemory struct {
+	ActiveKB   int64
+	ConsumedKB int64
+	OverheadKB int64
+	TotalKB    int64
+}
+
+// HostCPU stores an ESXi host's CPU metrics.
+type HostCPU struct {
+	UsagePercent float64
+}
+
+// HostMetricsInfo stores an ESXi host's memory and CPU metrics.
+type HostMetricsInfo struct {
+	Memory HostMemory
+	CPU    HostCPU
+}
+
+// HostMetrics returns CPU and memory metrics for all ESXi hosts in the input session's cluster.
+func HostMetrics(op trace.Operation, session *session.Session) (map[*object.HostSystem]*HostMetricsInfo, error) {
+	if session == nil {
+		return nil, fmt.Errorf("session not set")
+	}
+
+	// Gather hosts from the session cluster and then obtain their morefs.
+	hosts, err := gatherHosts(op.Context, session)
+	if err != nil {
+		return nil, fmt.Errorf("unable to obtain host morefs from session: %s", err)
+	}
+	morefToHost := make(map[types.ManagedObjectReference]*object.HostSystem)
+	morefs := make([]types.ManagedObjectReference, len(hosts))
+	for i, host := range hosts {
+		moref := host.Reference()
+		morefToHost[moref] = host
+		morefs[i] = moref
+	}
+
+	// Query CPU and memory metrics for the morefs.
+	spec := types.PerfQuerySpec{
+		Format:     string(types.PerfFormatNormal),
+		IntervalId: sampleInterval,
+	}
+
+	counters := []string{cpuUsage, memActive, memConsumed, memTotalCapacity, memOverhead}
+	perfMgr := performance.NewManager(session.Vim25())
+	sample, err := perfMgr.SampleByName(op.Context, spec, counters, morefs)
+	if err != nil {
+		errStr := "unable to get metric sample: %s"
+		op.Errorf(errStr, err)
+		return nil, fmt.Errorf(errStr, err)
+	}
+
+	results, err := perfMgr.ToMetricSeries(op.Context, sample)
+	if err != nil {
+		errStr := "unable to convert metric sample to metric series: %s"
+		op.Errorf(errStr, err)
+		return nil, fmt.Errorf(errStr, err)
+	}
+
+	metrics := assembleMetrics(op, morefToHost, results)
+	return metrics, nil
+}
+
+// assembleMetrics processes the metric samples received from govmomi and returns a finalized metrics map
+// keyed by the hosts.
+func assembleMetrics(op trace.Operation, morefToHost map[types.ManagedObjectReference]*object.HostSystem,
+	results []performance.EntityMetric) map[*object.HostSystem]*HostMetricsInfo {
+	metrics := make(map[*object.HostSystem]*HostMetricsInfo)
+
+	for _, host := range morefToHost {
+		metrics[host] = &HostMetricsInfo{}
+	}
+
+	for i := range results {
+		res := results[i]
+		host, exists := morefToHost[res.Entity]
+		if !exists {
+			op.Warnf("moref %s does not exist in requested morefs, skipping", res.Entity.String())
+			continue
+		}
+
+		// Process each value and assign it directly to the corresponding metric field
+		// since there is only one sample.
+		for _, v := range res.Value {
+
+			// We don't need to collect non-aggregate (non-empty Instance) metrics.
+			if v.Instance != "" {
+				continue
+			}
+
+			if len(v.Value) == 0 {
+				op.Warnf("metric %s for moref %s has no value, skipping", v.Name, res.Entity.String())
+				continue
+			}
+
+			switch v.Name {
+			case cpuUsage:
+				// Convert percent units from 1/100th of a percent (100 = 1%) to a human-readable percentage.
+				metrics[host].CPU.UsagePercent = float64(v.Value[0]) / 100.0
+			case memActive:
+				metrics[host].Memory.ActiveKB = v.Value[0]
+			case memConsumed:
+				metrics[host].Memory.ConsumedKB = v.Value[0]
+			case memOverhead:
+				metrics[host].Memory.OverheadKB = v.Value[0]
+			case memTotalCapacity:
+				// Total capacity is in MB, convert to KB so as to have all memory values in KB.
+				metrics[host].Memory.TotalKB = v.Value[0] * 1024
+			}
+		}
+	}
+
+	return metrics
+}
+
+// gatherHosts gathers ESXi host(s) from the input session's cluster.
+func gatherHosts(ctx context.Context, session *session.Session) ([]*object.HostSystem, error) {
+	if session.Cluster == nil {
+		return nil, fmt.Errorf("session cluster not set")
+	}
+
+	hosts, err := session.Cluster.Hosts(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("unable to obtain hosts from session cluster: %s", err)
+	}
+	if hosts == nil {
+		return nil, fmt.Errorf("no hosts found from session cluster")
+	}
+
+	return hosts, nil
+}

--- a/pkg/vsphere/performance/host_metrics_test.go
+++ b/pkg/vsphere/performance/host_metrics_test.go
@@ -1,0 +1,185 @@
+// Copyright 2018 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package performance
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/performance"
+	"github.com/vmware/govmomi/simulator"
+	"github.com/vmware/govmomi/vim25/types"
+	"github.com/vmware/vic/pkg/trace"
+	"github.com/vmware/vic/pkg/vsphere/session"
+	"github.com/vmware/vic/pkg/vsphere/test"
+)
+
+// vpxModelSetup creates a VPX model, starts its server and populates the session. The caller must
+// clean up the model and the server once it is done using them.
+func vpxModelSetup(ctx context.Context, t *testing.T) (*simulator.Model, *simulator.Server, *session.Session) {
+	model := simulator.VPX()
+	if err := model.Create(); err != nil {
+		t.Fatal(err)
+	}
+
+	server := model.Service.NewServer()
+	sess, err := test.SessionWithVPX(ctx, server.URL.String())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return model, server, sess
+}
+
+func TestAssembleMetrics(t *testing.T) {
+	ctx := context.Background()
+	op := trace.NewOperation(ctx, "TestAssembleMetrics")
+
+	model, server, sess := vpxModelSetup(ctx, t)
+	defer func() {
+		model.Remove()
+		server.Close()
+	}()
+
+	hosts, err := sess.Cluster.Hosts(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	morefToHost := make(map[types.ManagedObjectReference]*object.HostSystem)
+	for i := range hosts {
+		moref := hosts[i].Reference()
+		morefToHost[moref] = hosts[i]
+	}
+
+	var results []performance.EntityMetric
+	counters := []string{cpuUsage, memActive, memConsumed, memTotalCapacity, memOverhead}
+
+	// Create a fake host and then populate metric results for it. This tests that assembleMetrics
+	// rejects and does not assemble metrics for a host whose metrics were not requested
+	// (i.e. part of morefToHost) but were still present in the metrics from govmomi.
+	fakeHostMoref := types.ManagedObjectReference{
+		Type:  "foo",
+		Value: "bar",
+	}
+	fakeHost := object.NewHostSystem(nil, fakeHostMoref)
+	hosts = append(hosts, fakeHost)
+
+	// Populate metric results for all hosts, including fakeHost.
+	for i := range hosts {
+		var values []performance.MetricSeries
+		for j := range counters {
+			val := performance.MetricSeries{
+				Name:  counters[j],
+				Value: []int64{int64(i)},
+			}
+			values = append(values, val)
+		}
+
+		results = append(results, performance.EntityMetric{
+			Entity: hosts[i].Reference(),
+			Value:  values,
+		})
+	}
+
+	// Insert a non-aggregrate CPU usage value for the first host in metrics results
+	// to check that non-aggregrate values aren't processed in assembleMetrics.
+	instanceValue := []performance.MetricSeries{{
+		Name:     counters[0],
+		Instance: "1",
+		Value:    []int64{int64(9999)},
+	}}
+	results = append(results, performance.EntityMetric{
+		Entity: hosts[0].Reference(),
+		Value:  instanceValue,
+	})
+
+	// Insert a metric with no value to test that assembleMetrics skips it.
+	emptyValue := []performance.MetricSeries{{
+		Name:  counters[0],
+		Value: []int64{},
+	}}
+	results = append(results, performance.EntityMetric{
+		Entity: hosts[0].Reference(),
+		Value:  emptyValue,
+	})
+
+	// Once fakeHost's metrics have been added, remove it from the hosts slice for upcoming checks.
+	hosts = hosts[:len(hosts)-1]
+
+	metrics := assembleMetrics(op, morefToHost, results)
+
+	// Assembled metrics should not have an entry for fakeHost.
+	assert.Equal(t, len(metrics), len(hosts))
+	_, exists := metrics[fakeHost]
+	assert.False(t, exists, "fakeHost %s should not be present in result metrics", fakeHost.String())
+
+	for i, host := range hosts {
+		hostMetric, exists := metrics[host]
+		assert.True(t, exists, "host %s should be present in result metrics", host.String())
+
+		i := int64(i)
+		assert.Equal(t, hostMetric.CPU.UsagePercent, float64(i)/100.0)
+		assert.Equal(t, hostMetric.Memory.ActiveKB, i)
+		assert.Equal(t, hostMetric.Memory.ConsumedKB, i)
+		assert.Equal(t, hostMetric.Memory.OverheadKB, i)
+		// Test that the total memory value is converted from MB to KB.
+		assert.Equal(t, hostMetric.Memory.TotalKB, i*1024)
+	}
+
+	// Test that when a host moref is present in the govmomi metrics request but its metric
+	// results are missing, assembleMetrics creates an empty entry for the said host.
+	morefToHost[fakeHost.Reference()] = fakeHost
+
+	// Remove fakeHost's metrics from the results slice to feed into assembleMetrics.
+	var fakeResults []performance.EntityMetric
+	for i := range results {
+		if results[i].Entity != fakeHost.Reference() {
+			fakeResults = append(fakeResults, results[i])
+		}
+	}
+
+	metrics = assembleMetrics(op, morefToHost, fakeResults)
+	// Assembled metrics should now have an (empty) entry for fakeHost.
+	assert.Equal(t, len(metrics), len(hosts)+1)
+	fakeHostMetrics, exists := metrics[fakeHost]
+	assert.True(t, exists, "fakeHost %s should now be present in result metrics", fakeHost.String())
+	expectedFakeMetrics := HostMetricsInfo{}
+	assert.Equal(t, expectedFakeMetrics, *fakeHostMetrics)
+}
+
+func TestGatherHosts(t *testing.T) {
+	ctx := context.Background()
+
+	model, server, sess := vpxModelSetup(ctx, t)
+	defer func() {
+		model.Remove()
+		server.Close()
+	}()
+
+	// gatherHosts should return a valid slice of hosts for a populated session.
+	hosts, err := gatherHosts(ctx, sess)
+	assert.NoError(t, err)
+	assert.NotNil(t, hosts)
+
+	// Test for an error when the session cluster is nil.
+	sess.Cluster = nil
+	hosts, err = gatherHosts(ctx, sess)
+	assert.Error(t, err)
+	assert.Nil(t, hosts)
+}


### PR DESCRIPTION
This change adds the HostMetrics() library to pkg/vsphere/performance.
HostMetrics takes a populated session as input, collects all hosts in
the cluster and feeds them to the govmomi metrics helpers. The returned
artifact is a map of HostSystem objects to their assembled metric value.

We currently collect CPU - active usage percentage - and memory -
active, consumed, overhead and total (all in KB). Non-aggregate metric
values returned by govmomi are not processed.

Fixes #7327 

---

Sample usage:

```diff
--- a/lib/portlayer/exec/commit.go
+++ b/lib/portlayer/exec/commit.go
@@ -24,6 +24,7 @@ import (
        "github.com/vmware/vic/lib/portlayer/event/events"
        "github.com/vmware/vic/pkg/retry"
        "github.com/vmware/vic/pkg/trace"
+       "github.com/vmware/vic/pkg/vsphere/performance"
        "github.com/vmware/vic/pkg/vsphere/session"
        "github.com/vmware/vic/pkg/vsphere/tasks"
        "github.com/vmware/vic/pkg/vsphere/vm"
@@ -56,6 +57,24 @@ func Commit(op trace.Operation, sess *session.Session, h *Handle, waitTime *int3
 
                var res *types.TaskInfo
                var err error
+
+               op.Infof("checking host metrics")
+               metrics, err := performance.HostMetrics(op, sess)
+               if err != nil {
+                       op.Errorf("error: %s", err)
+               } else {
+                       for host, metric := range metrics {
+                               op.Infof("host: %s", host.String())
+                               op.Infof("cpu usage: %f", metric.CPU.UsagePercent)
+                               op.Infof("mem active: %d", metric.Memory.ActiveKB)
+                               op.Infof("mem consumed: %d", metric.Memory.ConsumedKB)
+                               op.Infof("mem overhead: %d", metric.Memory.OverheadKB)
+                               op.Infof("mem total: %d", metric.Memory.TotalKB)
+                       }
+               }
```