### PR TITLE
Add tether.debug in integration test log bundle

### DIFF
--- a/tests/integration-test.sh
+++ b/tests/integration-test.sh
@@ -56,7 +56,7 @@ rc="$?"
 timestamp=$(date +%s)
 outfile="integration_logs_"$DRONE_BUILD_NUMBER"_"$DRONE_COMMIT".zip"
 
-zip -9 -j $outfile output.xml log.html report.html package.list *container-logs*.zip *.log /var/log/vic-machine-server/vic-machine-server.log
+zip -9 -j $outfile output.xml log.html report.html package.list *container-logs*.zip *.log /var/log/vic-machine-server/vic-machine-server.log *.debug
 
 # GC credentials
 keyfile="/root/vic-ci-logs.key"


### PR DESCRIPTION
Attempting to determine the timeout cause of https://ci-vic.vmware.com/vmware/vic/17082/8
I found that we are not saving the one log file necessary to root cause the problem.