### PR TITLE
Delete datastore files recursively for all datastore types

### DIFF
--- a/lib/install/management/store_files.go
+++ b/lib/install/management/store_files.go
@@ -43,6 +43,7 @@ func (d *Dispatcher) deleteImages(conf *config.VirtualContainerHostConfigSpec) e
 	d.op.Info("Removing image stores")
 
 	for _, imageDir := range conf.ImageStores {
+
 		imageDSes, err := d.session.Finder.DatastoreList(d.op, imageDir.Host)
 		if err != nil {
 			errs = append(errs, err.Error())
@@ -158,23 +159,22 @@ func (d *Dispatcher) isVSAN(ds *object.Datastore) bool {
 func (d *Dispatcher) deleteFilesIteratively(m *object.DatastoreFileManager, ds *object.Datastore, dsPath string) error {
 	defer trace.End(trace.Begin(dsPath, d.op))
 
-	if d.isVSAN(ds) {
-		// Get sorted result to make sure child files are listed ahead of their parent folder so we empty the folder before deleting it.
-		// This behaviour is specifically for vSan, as vSan sometimes throws an error when deleting a folder that is not empty.
-		res, err := d.getSortedChildren(ds, dsPath)
-		if err != nil {
-			if !types.IsFileNotFound(err) {
-				err = errors.Errorf("Failed to browse sub folders %q: %s", dsPath, err)
-				return err
-			}
-			d.op.Debugf("Folder %q is not found", dsPath)
-			return nil
+	// Get sorted result to make sure child files are listed ahead of their parent folder so we empty the folder before deleting it.
+	// This behaviour was specifically for vSan, as vSan sometimes throws an error when deleting a folder that is not empty.
+	// Sometimes for non-vSAN type datastores, deleting non-empty directories would throw error as well
+	res, err := d.getSortedChildren(ds, dsPath)
+	if err != nil {
+		if !types.IsFileNotFound(err) {
+			err = errors.Errorf("Failed to browse sub folders %q: %s", dsPath, err)
+			return err
 		}
+		d.op.Debugf("Folder %q is not found", dsPath)
+		return nil
+	}
 
-		for _, path := range res {
-			if err = d.deleteVMFSFiles(m, ds, path); err != nil {
-				return err
-			}
+	for _, path := range res {
+		if err = d.deleteVMFSFiles(m, ds, path); err != nil {
+			return err
 		}
 	}
 

--- a/lib/install/management/store_files.go
+++ b/lib/install/management/store_files.go
@@ -43,7 +43,6 @@ func (d *Dispatcher) deleteImages(conf *config.VirtualContainerHostConfigSpec) e
 	d.op.Info("Removing image stores")
 
 	for _, imageDir := range conf.ImageStores {
-
 		imageDSes, err := d.session.Finder.DatastoreList(d.op, imageDir.Host)
 		if err != nil {
 			errs = append(errs, err.Error())


### PR DESCRIPTION
`[specific ci=6-03-Delete --suite 1-02-Docker-Pull]`

Fixes #7359 

For non-vSAN type datastores, sometimes it complains when we try to delete non-empty datastore folders with child image files, causing trailing VCH datastore folders after vic-machine delete finishes.

Revert of PR: https://github.com/vmware/vic/pull/6951