### PR TITLE
Build non-stripped binaries when env VIC_DEBUG_BUILD is set

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,11 @@ define godeps
 endef
 endif
 
-LDFLAGS := $(shell BUILD_NUMBER=${BUILD_NUMBER} $(BASE_DIR)/infra/scripts/version-linker-flags.sh)
+ifeq ($(VIC_DEBUG_BUILD),)
+	LDFLAGS := $(shell BUILD_NUMBER=${BUILD_NUMBER} $(BASE_DIR)/infra/scripts/version-linker-flags.sh)
+else
+	LDFLAGS := $(shell BUILD_NUMBER=${BUILD_NUMBER} $(BASE_DIR)/infra/scripts/version-debug-linker-flags.sh)
+endif
 
 # target aliases - environment variable definition
 docker-engine-api := $(BIN)/docker-engine-server

--- a/infra/scripts/version-debug-linker-flags.sh
+++ b/infra/scripts/version-debug-linker-flags.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# Copyright 2016 VMware, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+echo " \
+    -X github.com/vmware/vic/pkg/version.Version=`git describe --abbrev=0 --tags` \
+    -X github.com/vmware/vic/pkg/version.BuildNumber=\"${BUILD_NUMBER}\" \
+    -X github.com/vmware/vic/pkg/version.BuildDate=`date -u +%Y/%m/%d@%H:%M:%S` \
+    -X github.com/vmware/vic/pkg/version.GitCommit=`git rev-parse --short HEAD` \
+    -X github.com/vmware/vic/pkg/version.State=` \
+      if [[ -n $(git ls-files --others --exclude-standard) || \
+            ! $(git diff-files --no-ext-diff --quiet) || \
+            ! $(git diff-index --no-ext-diff --quiet --cached HEAD) \
+     ]]; then echo 'dirty'; fi`"
+


### PR DESCRIPTION
When VIC_DEBUG_BUILD is set, the generated binaries are non-stripped and contain DWARF debug information. 