### PR TITLE
Basic vic-machine ROBO support

### DIFF
--- a/lib/install/management/appliance.go
+++ b/lib/install/management/appliance.go
@@ -113,7 +113,6 @@ func (d *Dispatcher) checkExistence(conf *config.VirtualContainerHostConfigSpec,
 	defer trace.End(trace.Begin(""))
 
 	var err error
-	d.vchPoolPath = path.Join(settings.ResourcePoolPath, conf.Name)
 	var orp *object.ResourcePool
 	if orp, err = d.findResourcePool(d.vchPoolPath); err != nil {
 		return err

--- a/lib/install/management/create.go
+++ b/lib/install/management/create.go
@@ -45,6 +45,15 @@ func (d *Dispatcher) CreateVCH(conf *config.VirtualContainerHostConfigSpec, sett
 
 	var err error
 
+	// resource pool path determined based on DRS setting.  If enabled then
+	// append the appliance name to the path and a pool will be created.
+	// disabled then no resource pools are supported, so use the provided compute path.
+	if d.session.DRSEnabled != nil && *d.session.DRSEnabled {
+		d.vchPoolPath = path.Join(settings.ResourcePoolPath, conf.Name)
+	} else {
+		d.vchPoolPath = settings.ResourcePoolPath
+	}
+
 	if err = d.checkExistence(conf, settings); err != nil {
 		return err
 	}

--- a/lib/install/management/finder.go
+++ b/lib/install/management/finder.go
@@ -111,11 +111,18 @@ func (d *Dispatcher) NewVCHFromComputePath(computePath string, name string, v *v
 	if vchPool == nil {
 		vchPool, err = d.session.Finder.ResourcePool(d.op, d.vchPoolPath)
 		if err != nil {
-			d.op.Errorf("Failed to get VCH resource pool %q: %s", d.vchPoolPath, err)
-			return nil, err
+			// we didn't find the ResourcePool with a name matching the appliance, so
+			// lets look for just the resource pool -- this could be at the cluster level
+			d.vchPoolPath = parent.InventoryPath
+			vchPool, err = d.session.Finder.ResourcePool(d.op, d.vchPoolPath)
+			if err != nil {
+				d.op.Errorf("Failed to find VCH resource pool %q: %s", d.vchPoolPath, err)
+				return nil, err
+			}
 		}
 	}
 
+	// creating a pkg/vsphere resource pool for use of convenience method
 	rp := compute.NewResourcePool(d.op, d.session, vchPool.Reference())
 
 	if d.session.Cluster, err = rp.GetCluster(d.op); err != nil {

--- a/lib/install/management/resource_pool.go
+++ b/lib/install/management/resource_pool.go
@@ -17,7 +17,6 @@ package management
 import (
 	"context"
 	"fmt"
-	"path"
 
 	"github.com/vmware/govmomi/find"
 	"github.com/vmware/govmomi/object"
@@ -33,8 +32,6 @@ import (
 
 func (d *Dispatcher) createResourcePool(conf *config.VirtualContainerHostConfigSpec, settings *data.InstallerData) (*object.ResourcePool, error) {
 	defer trace.End(trace.Begin("", d.op))
-
-	d.vchPoolPath = path.Join(settings.ResourcePoolPath, conf.Name)
 
 	rp, err := d.session.Finder.ResourcePool(d.op, d.vchPoolPath)
 	if err != nil {

--- a/lib/install/validate/compute.go
+++ b/lib/install/validate/compute.go
@@ -39,7 +39,6 @@ func (v *Validator) compute(op trace.Operation, input *data.Data, conf *config.V
 		return
 	}
 
-	// TODO: for vApp creation assert that the name doesn't exist
 	// TODO: for RP creation assert whatever we decide about the pool - most likely that it's empty
 }
 
@@ -56,7 +55,7 @@ func (v *Validator) inventoryPath(op trace.Operation, obj object.Reference) stri
 // ResourcePoolHelper finds a resource pool from the input compute path and shows
 // suggestions if unable to do so when the path is ambiguous.
 func (v *Validator) ResourcePoolHelper(ctx context.Context, path string) (*object.ResourcePool, error) {
-	op := trace.FromContext(ctx, "DatastoreHelper")
+	op := trace.FromContext(ctx, "ResourcePoolHelper")
 	defer trace.End(trace.Begin(path, op))
 
 	// if compute-resource is unspecified is there a default

--- a/lib/install/validate/validator.go
+++ b/lib/install/validate/validator.go
@@ -69,8 +69,7 @@ type Validator struct {
 	isVC   bool
 	issues []error
 
-	DisableDRSCheck bool
-	allowEmptyDC    bool
+	allowEmptyDC bool
 }
 
 func CreateFromVCHConfig(ctx context.Context, vch *config.VirtualContainerHostConfigSpec, sess *session.Session) (*Validator, error) {
@@ -141,6 +140,7 @@ func NewValidator(ctx context.Context, input *data.Data) (*Validator, error) {
 		tURL.Path = ""
 	}
 
+	sessionconfig.ClusterPath = input.ComputeResourcePath
 	sessionconfig.Service = tURL.String()
 
 	sessionconfig.CloneTicket = input.CloneTicket
@@ -325,7 +325,7 @@ func (v *Validator) Validate(ctx context.Context, input *data.Data) (*config.Vir
 	v.CheckFirewall(op, conf)
 	v.CheckPersistNetworkBacking(op, false)
 	v.CheckLicense(op)
-	v.CheckDrs(op)
+	v.CheckDRS(op)
 
 	v.certificate(op, input, conf)
 	v.certificateAuthorities(op, input, conf)

--- a/lib/install/validate/validator_test_sim_util.go
+++ b/lib/install/validate/validator_test_sim_util.go
@@ -188,7 +188,7 @@ func (v *Validator) VcsimValidate(ctx context.Context, localInputConfig *data.Da
 	v.storage(op, localInputConfig, conf)
 	v.network(op, localInputConfig, conf)
 	v.CheckLicense(op)
-	v.CheckDrs(op)
+	v.CheckDRS(op)
 
 	// fmt.Printf("Config: %# v\n", pretty.Formatter(conf))
 

--- a/pkg/vsphere/compute/cluster.go
+++ b/pkg/vsphere/compute/cluster.go
@@ -1,0 +1,46 @@
+// Copyright 2018 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package compute
+
+import (
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/vic/pkg/trace"
+)
+
+type Cluster struct {
+	*object.ClusterComputeResource
+}
+
+func NewCluster(compute object.ComputeResource) *Cluster {
+	// ensure we have a cluster
+	if compute.Reference().Type != "ClusterComputeResource" {
+		return nil
+	}
+
+	return &Cluster{
+		&object.ClusterComputeResource{
+			ComputeResource: compute,
+		},
+	}
+}
+
+// DRSEnabled returns a bool indicating if DRS is enabled
+func (c *Cluster) DRSEnabled(op trace.Operation) (bool, error) {
+	config, err := c.Configuration(op)
+	if err != nil {
+		return false, err
+	}
+	return *config.DrsConfig.Enabled, nil
+}

--- a/tests/test-cases/Group6-VIC-Machine/6-11-Debug.robot
+++ b/tests/test-cases/Group6-VIC-Machine/6-11-Debug.robot
@@ -48,7 +48,7 @@ Check Password Change When Expired
     ${rc}=  Run And Return Rc  bin/vic-machine-linux debug --target %{TEST_URL} --thumbprint=%{TEST_THUMBPRINT} --user %{TEST_USERNAME} --password=%{TEST_PASSWORD} --compute-resource=%{TEST_RESOURCE} --name %{VCH-NAME} --enable-ssh --authorized-key=%{VCH-NAME}.key.pub
     Should Be Equal As Integers  ${rc}  0
 
-    # push the date forward, past the suport duration
+    # push the date forward, past the support duration
     ${rc}  ${output}=  Run And Return Rc And Output  ssh -o StrictHostKeyChecking=no -i %{VCH-NAME}.key root@%{VCH-IP} 'date -s " +6 year"'
     Should Be Equal As Integers  ${rc}  0
 
@@ -70,6 +70,6 @@ Check Password Change When Expired
 Check Error From Incorrect ID
     ${rc}  ${output}=  Run And Return Rc And Output  bin/vic-machine-linux debug --target %{TEST_URL} --thumbprint=%{TEST_THUMBPRINT} --user %{TEST_USERNAME} --password=%{TEST_PASSWORD} --id=wrong
     Should Be Equal As Integers  ${rc}  1
-    Should Contain  ${output}  Failed to get Virtual Container Host 
+    Should Contain  ${output}  Failed to get Virtual Container Host
     Should Contain  ${output}  id \\"wrong\\" could not be found
-    
+


### PR DESCRIPTION
Provides vic-machine create/delete functionality for clusters that have DRS disabled.  In a future refinement support will be limited to robo advanced licenses.  This unblocks other work dependent on ROBO support.  Changes will be required for inventory folder support and to complete the license and feature check.   

Toward #7275 