### PR TITLE
Stop blowing away our vm-network

### DIFF
--- a/lib/apiservers/engine/backends/eventmonitor.go
+++ b/lib/apiservers/engine/backends/eventmonitor.go
@@ -120,8 +120,20 @@ func (m *PortlayerEventMonitor) Start() error {
 	}
 
 	m.stop = make(chan struct{})
-	go m.monitor()
-
+	go func() {
+		var err error
+		for {
+			select {
+			case <-m.stop:
+				log.Infof("Portlayer Event Monitor stopped normally")
+				break
+			default:
+				if err = m.monitor(); err != nil {
+					log.Errorf("Restarting Portlayer event monitor due to error: %s", err)
+				}
+			}
+		}
+	}()
 	return nil
 }
 

--- a/tests/test-cases/Group6-VIC-Machine/6-07-Create-Network.robot
+++ b/tests/test-cases/Group6-VIC-Machine/6-07-Create-Network.robot
@@ -463,11 +463,13 @@ Container Firewalls
     ${out}=  Run Keyword If  '%{HOST_TYPE}' == 'ESXi'  Run  govc host.portgroup.add -vswitch vSwitchLAN outbound-net
     ${out}=  Run Keyword If  '%{HOST_TYPE}' == 'ESXi'  Run  govc host.portgroup.add -vswitch vSwitchLAN peers-net-1
     ${out}=  Run Keyword If  '%{HOST_TYPE}' == 'ESXi'  Run  govc host.portgroup.add -vswitch vSwitchLAN peers-net-2
-    ${out}=  Run Keyword If  '%{HOST_TYPE}' == 'VC'  Add VC Distributed Portgroup  test-ds  bridge
-    ${out}=  Run Keyword If  '%{HOST_TYPE}' == 'VC'  Add VC Distributed Portgroup  test-ds  open-net
-    ${out}=  Run Keyword If  '%{HOST_TYPE}' == 'VC'  Add VC Distributed Portgroup  test-ds  closed-net
-    ${out}=  Run Keyword If  '%{HOST_TYPE}' == 'VC'  Add VC Distributed Portgroup  test-ds  published-net
-    ${out}=  Run Keyword If  '%{HOST_TYPE}' == 'VC'  Add VC Distributed Portgroup  test-ds  outbound-net
+
+    ${vlan}=  Evaluate  str(random.randint(1, 4093))  modules=random
+    ${rc}  ${output}=  Run Keyword If  '%{HOST_TYPE}' == 'VC'  Run And Return Rc And Output  govc dvs.portgroup.add -vlan=${vlan} -dvs test-ds bridge
+    ${rc}  ${output}=  Run Keyword If  '%{HOST_TYPE}' == 'VC'  Run And Return Rc And Output  govc dvs.portgroup.add -vlan=196 -dvs test-ds open-net
+    ${rc}  ${output}=  Run Keyword If  '%{HOST_TYPE}' == 'VC'  Run And Return Rc And Output  govc dvs.portgroup.add -vlan=196 -dvs test-ds closed-net
+    ${rc}  ${output}=  Run Keyword If  '%{HOST_TYPE}' == 'VC'  Run And Return Rc And Output  govc dvs.portgroup.add -vlan=196 -dvs test-ds published-net
+    ${rc}  ${output}=  Run Keyword If  '%{HOST_TYPE}' == 'VC'  Run And Return Rc And Output  govc dvs.portgroup.add -vlan=196 -dvs test-ds outbound-net
     ${out}=  Run Keyword If  '%{HOST_TYPE}' == 'VC'  Add VC Distributed Portgroup  test-ds  peers-net-1
     ${out}=  Run Keyword If  '%{HOST_TYPE}' == 'VC'  Add VC Distributed Portgroup  test-ds  peers-net-2
 


### PR DESCRIPTION
[specific ci=6-07-Create-Network]
This test was both leaking and blowing away our public portgroup that has a specific VLAN id in order to work with the network.