### PR TITLE
Reduce number of iterations

### DIFF
--- a/tests/test-cases/Group1-Docker-Commands/1-40-Docker-Restart.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-40-Docker-Restart.robot
@@ -94,7 +94,7 @@ Restart with start-stop stress
     ${restart-pid}=  Start Process  while true; do docker %{VCH-PARAMS} restart -t 5 ${container}; done  shell=${true}
     ${restart-pid2}=  Start Process  while true; do docker %{VCH-PARAMS} restart -t 5 ${container}; done  shell=${true}
     ${loopOutput}=  Create List
-    :FOR  ${idx}  IN RANGE  0  150
+    :FOR  ${idx}  IN RANGE  0  10
     \   ${out}=  Run  (docker %{VCH-PARAMS} start ${container} && docker %{VCH-PARAMS} stop -t1 ${container})
     \   Append To List  ${loopOutput}  ${out}
     Terminate Process  ${restart-pid}


### PR DESCRIPTION
[specific ci=1-40-Docker-Restart]

Talked with @hickeng about this test, he believes that significantly reducing the number of iterations will still allow us to see the expected purposed of this test.  We will be maintaining this issue to investigate why we are seeing such poor performance, but it is not a critical issue at this point:
https://github.com/vmware/vic/issues/7437