### PR TITLE
Implement RankedHostPolicy and host filtering 

### DIFF
--- a/lib/install/management/create.go
+++ b/lib/install/management/create.go
@@ -132,28 +132,20 @@ func (d *Dispatcher) relocateAppliance() error {
 		return errors.Errorf("Unable to obtain VCH's host system before relocation: %s", err)
 	}
 
-	// TODO(anchal): Use this form when #7459 is merged.
 	// Collect a ranked slice of hosts and pick the first one to relocate the VCH VM to.
 	// Pass a nil slice of hosts to use all hosts in the cluster as candidate hosts.
-	// hosts, err := randomPolicy.RecommendHost(d.op, d.appliance, nil)
-	// if err != nil {
-	// 	msg := "Unable to obtain recommended host: %s"
-	// 	d.op.Warnf(msg, err)
-	// 	return errors.Errorf(msg, err)
-	// }
-	// if len(hosts) == 0 {
-	// 	msg := "No hosts returned by placement library, skipping relocation"
-	// 	d.op.Warnf(msg)
-	// 	return errors.New(msg)
-	// }
-	// hMoref := hosts[0].Reference()
-
-	host, err := randomPolicy.RecommendHost(d.op, d.appliance.Session, []*object.HostSystem{d.appliance.Host})
+	hosts, err := randomPolicy.RecommendHost(d.op, d.appliance.Session, nil)
 	if err != nil {
-		return errors.Errorf("Unable to obtain recommended host: %s", err)
+		msg := "Unable to obtain recommended host: %s"
+		d.op.Warnf(msg, err)
+		return errors.Errorf(msg, err)
 	}
-
-	hMoref := host.Reference()
+	if len(hosts) == 0 {
+		msg := "No hosts returned by placement library, skipping relocation"
+		d.op.Warnf(msg)
+		return errors.New(msg)
+	}
+	hMoref := hosts[0].Reference()
 
 	// Skip relocation if the recommended host is the same as the old host.
 	if hMoref == oldHost.Reference() {

--- a/lib/install/management/create.go
+++ b/lib/install/management/create.go
@@ -121,7 +121,11 @@ func (d *Dispatcher) relocateAppliance() error {
 	// provider := performance.NewHostMetricsProvider(d.session)
 	// rankedPolicy := placement.NewRankedHostPolicy()
 
-	randomPolicy := placement.NewRandomHostPolicy(d.session)
+	randomPolicy, err := placement.NewRandomHostPolicy(d.op, d.session)
+	if err != nil {
+		return err
+	}
+
 	if randomPolicy.CheckHost(d.op, d.appliance.Host) {
 		// The current host of the appliance is suitable; no migration needed.
 		return nil

--- a/lib/install/management/create.go
+++ b/lib/install/management/create.go
@@ -121,8 +121,8 @@ func (d *Dispatcher) relocateAppliance() error {
 	// provider := performance.NewHostMetricsProvider(d.session)
 	// rankedPolicy := placement.NewRankedHostPolicy()
 
-	randomPolicy := placement.NewRandomHostPolicy()
-	if randomPolicy.CheckHost(d.op, d.appliance.Session) {
+	randomPolicy := placement.NewRandomHostPolicy(d.session)
+	if randomPolicy.CheckHost(d.op, d.appliance.Host) {
 		// The current host of the appliance is suitable; no migration needed.
 		return nil
 	}
@@ -134,7 +134,7 @@ func (d *Dispatcher) relocateAppliance() error {
 
 	// Collect a ranked slice of hosts and pick the first one to relocate the VCH VM to.
 	// Pass a nil slice of hosts to use all hosts in the cluster as candidate hosts.
-	hosts, err := randomPolicy.RecommendHost(d.op, d.appliance.Session, nil)
+	hosts, err := randomPolicy.RecommendHost(d.op, nil)
 	if err != nil {
 		msg := "Unable to obtain recommended host: %s"
 		d.op.Warnf(msg, err)

--- a/lib/install/management/create.go
+++ b/lib/install/management/create.go
@@ -122,7 +122,7 @@ func (d *Dispatcher) relocateAppliance() error {
 	// rankedPolicy := placement.NewRankedHostPolicy()
 
 	randomPolicy := placement.NewRandomHostPolicy()
-	if randomPolicy.CheckHost(d.op, d.appliance) {
+	if randomPolicy.CheckHost(d.op, d.appliance.Session) {
 		// The current host of the appliance is suitable; no migration needed.
 		return nil
 	}
@@ -148,7 +148,7 @@ func (d *Dispatcher) relocateAppliance() error {
 	// }
 	// hMoref := hosts[0].Reference()
 
-	host, err := randomPolicy.RecommendHost(d.op, d.appliance)
+	host, err := randomPolicy.RecommendHost(d.op, d.appliance.Session, []*object.HostSystem{d.appliance.Host})
 	if err != nil {
 		return errors.Errorf("Unable to obtain recommended host: %s", err)
 	}

--- a/pkg/vsphere/compute/placement/placement.go
+++ b/pkg/vsphere/compute/placement/placement.go
@@ -26,6 +26,7 @@ type HostPlacementPolicy interface {
 	// CheckHost checks whether or not the host a VM was created on is adequate for power-on.
 	CheckHost(trace.Operation, *vm.VirtualMachine) bool
 
-	// RecommendHost recommends an adequate host for the supplied VM power-on.
-	RecommendHost(trace.Operation, *vm.VirtualMachine) (*object.HostSystem, error)
+	// RecommendHost recommends an adequate host for the supplied VM power-on. If a nil set of hosts is
+	// specified, it will choose from the hosts contained in the cluster in which the VM is located.
+	RecommendHost(trace.Operation, *vm.VirtualMachine, []*object.HostSystem) ([]*object.HostSystem, error)
 }

--- a/pkg/vsphere/compute/placement/placement.go
+++ b/pkg/vsphere/compute/placement/placement.go
@@ -23,9 +23,10 @@ import (
 // for a VM based on host metrics and VM provisioned resources.
 type HostPlacementPolicy interface {
 	// CheckHost checks whether or not the host a VM was created on is adequate for power-on.
-	CheckHost(trace.Operation, *object.HostSystem) bool
+	CheckHost(trace.Operation, *object.VirtualMachine) bool
 
-	// RecommendHost recommends an adequate host for the supplied VM power-on. If a nil set of hosts is
-	// specified, it will choose from the hosts contained in the cluster in which the VM is located.
+	// RecommendHost recommends an adequate host for the supplied VM power-on. If a nil or empty
+	// set of hosts is specified, it will choose from the hosts contained in the cluster in which
+	// the VM is located.
 	RecommendHost(trace.Operation, []*object.HostSystem) ([]*object.HostSystem, error)
 }

--- a/pkg/vsphere/compute/placement/placement.go
+++ b/pkg/vsphere/compute/placement/placement.go
@@ -17,16 +17,16 @@ package placement
 import (
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/vic/pkg/trace"
-	"github.com/vmware/vic/pkg/vsphere/vm"
+	"github.com/vmware/vic/pkg/vsphere/session"
 )
 
 // HostPlacementPolicy defines the interface for using metrics to decide the appropriate host
 // for a VM based on host metrics and VM provisioned resources.
 type HostPlacementPolicy interface {
 	// CheckHost checks whether or not the host a VM was created on is adequate for power-on.
-	CheckHost(trace.Operation, *vm.VirtualMachine) bool
+	CheckHost(trace.Operation, *session.Session) bool
 
 	// RecommendHost recommends an adequate host for the supplied VM power-on. If a nil set of hosts is
 	// specified, it will choose from the hosts contained in the cluster in which the VM is located.
-	RecommendHost(trace.Operation, *vm.VirtualMachine, []*object.HostSystem) ([]*object.HostSystem, error)
+	RecommendHost(trace.Operation, *session.Session, []*object.HostSystem) ([]*object.HostSystem, error)
 }

--- a/pkg/vsphere/compute/placement/placement.go
+++ b/pkg/vsphere/compute/placement/placement.go
@@ -17,16 +17,15 @@ package placement
 import (
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/vic/pkg/trace"
-	"github.com/vmware/vic/pkg/vsphere/session"
 )
 
 // HostPlacementPolicy defines the interface for using metrics to decide the appropriate host
 // for a VM based on host metrics and VM provisioned resources.
 type HostPlacementPolicy interface {
 	// CheckHost checks whether or not the host a VM was created on is adequate for power-on.
-	CheckHost(trace.Operation, *session.Session) bool
+	CheckHost(trace.Operation, *object.HostSystem) bool
 
 	// RecommendHost recommends an adequate host for the supplied VM power-on. If a nil set of hosts is
 	// specified, it will choose from the hosts contained in the cluster in which the VM is located.
-	RecommendHost(trace.Operation, *session.Session, []*object.HostSystem) ([]*object.HostSystem, error)
+	RecommendHost(trace.Operation, []*object.HostSystem) ([]*object.HostSystem, error)
 }

--- a/pkg/vsphere/compute/placement/random.go
+++ b/pkg/vsphere/compute/placement/random.go
@@ -20,7 +20,7 @@ import (
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/vic/pkg/trace"
 	"github.com/vmware/vic/pkg/vsphere/compute"
-	"github.com/vmware/vic/pkg/vsphere/vm"
+	"github.com/vmware/vic/pkg/vsphere/session"
 )
 
 // RandomHostPolicy chooses a random host on which to power-on a VM.
@@ -32,19 +32,14 @@ func NewRandomHostPolicy() *RandomHostPolicy {
 }
 
 // CheckHost always returns false in a RandomHostPolicy.
-func (p *RandomHostPolicy) CheckHost(op trace.Operation, vm *vm.VirtualMachine) bool {
+func (p *RandomHostPolicy) CheckHost(op trace.Operation, sess *session.Session) bool {
 	return false
 }
 
 // RecommendHost recommends a random host on which to place a newly created VM.
-func (p *RandomHostPolicy) RecommendHost(op trace.Operation, vm *vm.VirtualMachine, hosts []*object.HostSystem) ([]*object.HostSystem, error) {
+func (p *RandomHostPolicy) RecommendHost(op trace.Operation, sess *session.Session, hosts []*object.HostSystem) ([]*object.HostSystem, error) {
 	if hosts == nil {
-		r, err := vm.ResourcePool(op)
-		if err != nil {
-			return nil, err
-		}
-
-		rp := compute.NewResourcePool(op, vm.Session, r.Reference())
+		rp := compute.NewResourcePool(op, sess, sess.Pool.Reference())
 
 		cls, err := rp.GetCluster(op)
 		if err != nil {

--- a/pkg/vsphere/compute/placement/random.go
+++ b/pkg/vsphere/compute/placement/random.go
@@ -19,8 +19,6 @@ import (
 
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/vic/pkg/trace"
-	"github.com/vmware/vic/pkg/vsphere/compute"
-	"github.com/vmware/vic/pkg/vsphere/session"
 )
 
 // RandomHostPolicy chooses a random host on which to power-on a VM.
@@ -29,17 +27,12 @@ type RandomHostPolicy struct {
 }
 
 // NewRandomHostPolicy returns a RandomHostPolicy instance.
-func NewRandomHostPolicy(op trace.Operation, s *session.Session) (*RandomHostPolicy, error) {
-	rp := compute.NewResourcePool(op, s, s.Pool.Reference())
-	cls, err := rp.GetCluster(op)
-	if err != nil {
-		return nil, err
-	}
+func NewRandomHostPolicy(op trace.Operation, cls *object.ComputeResource) (*RandomHostPolicy, error) {
 	return &RandomHostPolicy{cluster: cls}, nil
 }
 
 // CheckHost always returns false in a RandomHostPolicy.
-func (p *RandomHostPolicy) CheckHost(op trace.Operation, host *object.HostSystem) bool {
+func (p *RandomHostPolicy) CheckHost(op trace.Operation, vm *object.VirtualMachine) bool {
 	return false
 }
 

--- a/pkg/vsphere/compute/placement/random.go
+++ b/pkg/vsphere/compute/placement/random.go
@@ -24,22 +24,24 @@ import (
 )
 
 // RandomHostPolicy chooses a random host on which to power-on a VM.
-type RandomHostPolicy struct{}
+type RandomHostPolicy struct {
+	*session.Session
+}
 
 // NewRandomHostPolicy returns a RandomHostPolicy instance.
-func NewRandomHostPolicy() *RandomHostPolicy {
-	return &RandomHostPolicy{}
+func NewRandomHostPolicy(s *session.Session) *RandomHostPolicy {
+	return &RandomHostPolicy{Session: s}
 }
 
 // CheckHost always returns false in a RandomHostPolicy.
-func (p *RandomHostPolicy) CheckHost(op trace.Operation, sess *session.Session) bool {
+func (p *RandomHostPolicy) CheckHost(op trace.Operation, host *object.HostSystem) bool {
 	return false
 }
 
 // RecommendHost recommends a random host on which to place a newly created VM.
-func (p *RandomHostPolicy) RecommendHost(op trace.Operation, sess *session.Session, hosts []*object.HostSystem) ([]*object.HostSystem, error) {
+func (p *RandomHostPolicy) RecommendHost(op trace.Operation, hosts []*object.HostSystem) ([]*object.HostSystem, error) {
 	if hosts == nil {
-		rp := compute.NewResourcePool(op, sess, sess.Pool.Reference())
+		rp := compute.NewResourcePool(op, p.Session, p.Pool.Reference())
 
 		cls, err := rp.GetCluster(op)
 		if err != nil {

--- a/pkg/vsphere/compute/placement/random_test.go
+++ b/pkg/vsphere/compute/placement/random_test.go
@@ -46,15 +46,27 @@ func TestRandomRecommendHost(t *testing.T) {
 
 	rhp := NewRandomHostPolicy()
 	assert.False(t, rhp.CheckHost(op, v))
-	h, err := rhp.RecommendHost(op, v)
+	h, err := rhp.RecommendHost(op, v, nil)
 	assert.NoError(t, err)
 
+	top := h[0].Reference().String()
 	found := false
 	for _, host := range hosts {
-		if h.Reference().String() == host.Reference().String() {
+		if h[0].Reference().String() == host.Reference().String() {
 			found = true
+
+			// remove this host for the next test
+			h = append(h[:0], h[1:]...)
 			break
 		}
 	}
 	assert.True(t, found)
+
+	// try with a subset
+	x, err := rhp.RecommendHost(op, v, h)
+	assert.NoError(t, err)
+	assert.Len(t, x, len(hosts)-1)
+	for _, host := range x {
+		assert.NotEqual(t, top, host.Reference().String())
+	}
 }

--- a/pkg/vsphere/compute/placement/random_test.go
+++ b/pkg/vsphere/compute/placement/random_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/vmware/vic/pkg/trace"
 	"github.com/vmware/vic/pkg/vsphere/test"
+	"github.com/vmware/vic/pkg/vsphere/vm"
 )
 
 func TestRandomRecommendHost(t *testing.T) {
@@ -38,8 +39,10 @@ func TestRandomRecommendHost(t *testing.T) {
 	hosts, err := cls.Hosts(op)
 	assert.NoError(t, err)
 
-	v, err := test.CreateVM(op, sess, "test-vm")
+	moref, err := test.CreateVM(op, sess, "test-vm")
 	assert.NoError(t, err)
+
+	v := vm.NewVirtualMachine(op, sess, moref)
 
 	rhp := NewRandomHostPolicy()
 	assert.False(t, rhp.CheckHost(op, v))

--- a/pkg/vsphere/compute/placement/random_test.go
+++ b/pkg/vsphere/compute/placement/random_test.go
@@ -16,42 +16,18 @@ package placement
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/vmware/govmomi/simulator"
-	"github.com/vmware/govmomi/vim25/types"
 	"github.com/vmware/vic/pkg/trace"
-	"github.com/vmware/vic/pkg/vsphere/extraconfig"
-	"github.com/vmware/vic/pkg/vsphere/session"
-	"github.com/vmware/vic/pkg/vsphere/tasks"
 	"github.com/vmware/vic/pkg/vsphere/test"
-	"github.com/vmware/vic/pkg/vsphere/vm"
 )
-
-// vpxModelSetup creates a VPX model, starts its server and populates the session. The caller must
-// clean up the model and the server once it is done using them.
-func vpxModelSetup(ctx context.Context, t *testing.T) (*simulator.Model, *simulator.Server, *session.Session) {
-	model := simulator.VPX()
-	if err := model.Create(); err != nil {
-		t.Fatal(err)
-	}
-
-	server := model.Service.NewServer()
-	sess, err := test.SessionWithVPX(ctx, server.URL.String())
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	return model, server, sess
-}
 
 func TestRandomRecommendHost(t *testing.T) {
 	op := trace.NewOperation(context.Background(), "TestRandomRecommendHost")
 
-	model, server, sess := vpxModelSetup(op, t)
+	model, server, sess := test.VpxModelSetup(op, t)
 	defer func() {
 		model.Remove()
 		server.Close()
@@ -62,41 +38,14 @@ func TestRandomRecommendHost(t *testing.T) {
 	hosts, err := cls.Hosts(op)
 	assert.NoError(t, err)
 
-	name := "test-vm"
-	vmx := fmt.Sprintf("%s/%s.vmx", name, name)
-	ds := sess.Datastore
-	secretKey, err := extraconfig.NewSecretKey()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	spec := types.VirtualMachineConfigSpec{
-		Name:    name,
-		GuestId: string(types.VirtualMachineGuestOsIdentifierOtherGuest),
-		Files: &types.VirtualMachineFileInfo{
-			VmPathName: fmt.Sprintf("[%s] %s", ds.Name(), vmx),
-		},
-		ExtraConfig: []types.BaseOptionValue{
-			&types.OptionValue{
-				Key:   extraconfig.GuestInfoSecretKey,
-				Value: secretKey.String(),
-			},
-		},
-	}
-
-	res, err := tasks.WaitForResult(op, func(op context.Context) (tasks.Task, error) {
-		return sess.VMFolder.CreateVM(op, spec, sess.Pool, nil)
-	})
+	v, err := test.CreateVM(op, sess, "test-vm")
 	assert.NoError(t, err)
-
-	v := vm.NewVirtualMachine(op, sess, res.Result.(types.ManagedObjectReference))
 
 	rhp := NewRandomHostPolicy()
 	assert.False(t, rhp.CheckHost(op, v))
 	h, err := rhp.RecommendHost(op, v)
 	assert.NoError(t, err)
 
-	// TODO(jzt): come up with a better way to verify this than using a loop/moref comparison
 	found := false
 	for _, host := range hosts {
 		if h.Reference().String() == host.Reference().String() {

--- a/pkg/vsphere/compute/placement/random_test.go
+++ b/pkg/vsphere/compute/placement/random_test.go
@@ -45,8 +45,8 @@ func TestRandomRecommendHost(t *testing.T) {
 	v := vm.NewVirtualMachine(op, sess, moref)
 
 	rhp := NewRandomHostPolicy()
-	assert.False(t, rhp.CheckHost(op, v))
-	h, err := rhp.RecommendHost(op, v, nil)
+	assert.False(t, rhp.CheckHost(op, v.Session))
+	h, err := rhp.RecommendHost(op, v.Session, nil)
 	assert.NoError(t, err)
 
 	top := h[0].Reference().String()
@@ -63,7 +63,7 @@ func TestRandomRecommendHost(t *testing.T) {
 	assert.True(t, found)
 
 	// try with a subset
-	x, err := rhp.RecommendHost(op, v, h)
+	x, err := rhp.RecommendHost(op, v.Session, h)
 	assert.NoError(t, err)
 	assert.Len(t, x, len(hosts)-1)
 	for _, host := range x {

--- a/pkg/vsphere/compute/placement/random_test.go
+++ b/pkg/vsphere/compute/placement/random_test.go
@@ -44,9 +44,9 @@ func TestRandomRecommendHost(t *testing.T) {
 
 	v := vm.NewVirtualMachine(op, sess, moref)
 
-	rhp := NewRandomHostPolicy()
-	assert.False(t, rhp.CheckHost(op, v.Session))
-	h, err := rhp.RecommendHost(op, v.Session, nil)
+	rhp := NewRandomHostPolicy(v.Session)
+	assert.False(t, rhp.CheckHost(op, nil))
+	h, err := rhp.RecommendHost(op, nil)
 	assert.NoError(t, err)
 
 	top := h[0].Reference().String()
@@ -63,7 +63,7 @@ func TestRandomRecommendHost(t *testing.T) {
 	assert.True(t, found)
 
 	// try with a subset
-	x, err := rhp.RecommendHost(op, v.Session, h)
+	x, err := rhp.RecommendHost(op, h)
 	assert.NoError(t, err)
 	assert.Len(t, x, len(hosts)-1)
 	for _, host := range x {

--- a/pkg/vsphere/compute/placement/random_test.go
+++ b/pkg/vsphere/compute/placement/random_test.go
@@ -44,7 +44,7 @@ func TestRandomRecommendHost(t *testing.T) {
 
 	v := vm.NewVirtualMachine(op, sess, moref)
 
-	rhp, err := NewRandomHostPolicy(op, v.Session)
+	rhp, err := NewRandomHostPolicy(op, v.Cluster)
 	assert.NoError(t, err)
 
 	assert.False(t, rhp.CheckHost(op, nil))
@@ -58,7 +58,7 @@ func TestRandomRecommendHost(t *testing.T) {
 			found = true
 
 			// remove this host for the next test
-			h = append(h[:0], h[1:]...)
+			h = h[1:]
 			break
 		}
 	}

--- a/pkg/vsphere/compute/placement/random_test.go
+++ b/pkg/vsphere/compute/placement/random_test.go
@@ -44,7 +44,9 @@ func TestRandomRecommendHost(t *testing.T) {
 
 	v := vm.NewVirtualMachine(op, sess, moref)
 
-	rhp := NewRandomHostPolicy(v.Session)
+	rhp, err := NewRandomHostPolicy(op, v.Session)
+	assert.NoError(t, err)
+
 	assert.False(t, rhp.CheckHost(op, nil))
 	h, err := rhp.RecommendHost(op, nil)
 	assert.NoError(t, err)

--- a/pkg/vsphere/compute/placement/ranked.go
+++ b/pkg/vsphere/compute/placement/ranked.go
@@ -81,7 +81,7 @@ func (r *RankedHostPolicy) RecommendHost(op trace.Operation, sess *session.Sessi
 		hm  map[string]*performance.HostMetricsInfo
 	)
 
-	if hosts == nil || len(hosts) == 0 {
+	if len(hosts) == 0 {
 		op.Debugf("no hosts specified - gathering metrics on cluster")
 		hm, err = r.source.GetMetricsForComputeResource(op, sess.Cluster)
 	} else {

--- a/pkg/vsphere/compute/placement/ranked.go
+++ b/pkg/vsphere/compute/placement/ranked.go
@@ -81,6 +81,10 @@ func (r *RankedHostPolicy) RecommendHost(op trace.Operation, v *vm.VirtualMachin
 		return nil, err
 	}
 
+	if len(hm) == 0 {
+		return nil, fmt.Errorf("no candidate hosts to rank")
+	}
+
 	ranked := r.rankHosts(op, hm)
 	ref := types.ManagedObjectReference{}
 	if ok := ref.FromString(ranked[0].HostReference); !ok {

--- a/pkg/vsphere/compute/placement/ranked.go
+++ b/pkg/vsphere/compute/placement/ranked.go
@@ -54,8 +54,8 @@ type RankedHostPolicy struct {
 // the default weighting configuration.
 func NewRankedHostPolicy(s performance.MetricsProvider) *RankedHostPolicy {
 	return NewRankedHostPolicyWithConfig(s, WeightConfiguration{
-		memInactiveWeight:   MemDefaultInactiveWeight,
-		memUnconsumedWeight: MemDefaultUnconsumedWeight,
+		memInactiveWeight:   memDefaultInactiveWeight,
+		memUnconsumedWeight: memDefaultUnconsumedWeight,
 	})
 }
 

--- a/pkg/vsphere/compute/placement/ranked.go
+++ b/pkg/vsphere/compute/placement/ranked.go
@@ -70,7 +70,7 @@ func NewRankedHostPolicyWithConfig(op trace.Operation, cls *object.ComputeResour
 }
 
 // CheckHost returns true if the host has adequate capacity to power on the VM, false otherwise.
-func (r *RankedHostPolicy) CheckHost(op trace.Operation, host *object.HostSystem) bool {
+func (r *RankedHostPolicy) CheckHost(op trace.Operation, vm *object.VirtualMachine) bool {
 	// TODO(jzt): return false until we have host checking logic decided
 	return false
 }

--- a/pkg/vsphere/compute/placement/ranked.go
+++ b/pkg/vsphere/compute/placement/ranked.go
@@ -91,7 +91,7 @@ func (r *RankedHostPolicy) RecommendHost(op trace.Operation, v *vm.VirtualMachin
 		return nil, fmt.Errorf("could not restore serialized managed object reference: %s", ranked[0].HostReference)
 	}
 
-	result := object.NewHostSystem(v.Session.Client.Client, ref)
+	result := object.NewHostSystem(v.Session.Vim25(), ref)
 
 	return result, nil
 }

--- a/pkg/vsphere/compute/placement/ranked_defaults.go
+++ b/pkg/vsphere/compute/placement/ranked_defaults.go
@@ -15,8 +15,8 @@
 package placement
 
 const (
-	// MemDefaultInactiveWeight defines the default value used to weight inactive memory when ranking hosts by metric.
-	MemDefaultInactiveWeight = 0.3
-	// MemDefaultUnconsumedWeight defines the default value used to weight unconsumed memory when ranking hosts by metric.
-	MemDefaultUnconsumedWeight = 0.7
+	// memDefaultInactiveWeight defines the default value used to weight inactive memory when ranking hosts by metric.
+	memDefaultInactiveWeight = 0.3
+	// memDefaultUnconsumedWeight defines the default value used to weight unconsumed memory when ranking hosts by metric.
+	memDefaultUnconsumedWeight = 0.7
 )

--- a/pkg/vsphere/compute/placement/ranked_defaults.go
+++ b/pkg/vsphere/compute/placement/ranked_defaults.go
@@ -1,0 +1,22 @@
+// Copyright 2018 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package placement
+
+const (
+	// MemDefaultInactiveWeight defines the default value used to weight inactive memory when ranking hosts by metric.
+	MemDefaultInactiveWeight = 0.3
+	// MemDefaultUnconsumedWeight defines the default value used to weight unconsumed memory when ranking hosts by metric.
+	MemDefaultUnconsumedWeight = 0.7
+)

--- a/pkg/vsphere/compute/placement/ranked_test.go
+++ b/pkg/vsphere/compute/placement/ranked_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/vmware/vic/pkg/trace"
 	"github.com/vmware/vic/pkg/vsphere/performance"
 	"github.com/vmware/vic/pkg/vsphere/test"
+	"github.com/vmware/vic/pkg/vsphere/vm"
 )
 
 var (
@@ -121,8 +122,10 @@ func TestRankedRecommendHost(t *testing.T) {
 		server.Close()
 	}()
 
-	v, err := test.CreateVM(op, sess, "test-vm")
+	moref, err := test.CreateVM(op, sess, "test-vm")
 	assert.NoError(t, err)
+
+	v := vm.NewVirtualMachine(op, sess, moref)
 
 	m := MockMetricsProvider{}
 

--- a/pkg/vsphere/compute/placement/ranked_test.go
+++ b/pkg/vsphere/compute/placement/ranked_test.go
@@ -138,7 +138,7 @@ func TestRankedRecommendHost(t *testing.T) {
 	m := MockMetricsProvider{}
 
 	rhp := NewRankedHostPolicy(m)
-	result, err := rhp.RecommendHost(op, v, nil)
+	result, err := rhp.RecommendHost(op, v.Session, nil)
 	assert.NoError(t, err)
 
 	expected := hh.Reference().String()
@@ -162,7 +162,7 @@ func TestRankedRecommendHostWithHosts(t *testing.T) {
 
 	m := MockMetricsProvider{}
 	rhp := NewRankedHostPolicy(m)
-	hosts, err := rhp.RecommendHost(op, v, nil)
+	hosts, err := rhp.RecommendHost(op, v.Session, nil)
 	assert.NoError(t, err)
 
 	expected := hh.Reference().String()
@@ -171,7 +171,7 @@ func TestRankedRecommendHostWithHosts(t *testing.T) {
 
 	subset := hosts[1:]
 
-	result, err := rhp.RecommendHost(op, v, subset)
+	result, err := rhp.RecommendHost(op, v.Session, subset)
 	assert.NoError(t, err)
 
 	expected = mh.Reference().String()

--- a/pkg/vsphere/compute/placement/ranked_test.go
+++ b/pkg/vsphere/compute/placement/ranked_test.go
@@ -137,8 +137,8 @@ func TestRankedRecommendHost(t *testing.T) {
 
 	m := MockMetricsProvider{}
 
-	rhp := NewRankedHostPolicy(m)
-	result, err := rhp.RecommendHost(op, v.Session, nil)
+	rhp := NewRankedHostPolicy(v.Session, m)
+	result, err := rhp.RecommendHost(op, nil)
 	assert.NoError(t, err)
 
 	expected := hh.Reference().String()
@@ -161,8 +161,8 @@ func TestRankedRecommendHostWithHosts(t *testing.T) {
 	v := vm.NewVirtualMachine(op, sess, moref)
 
 	m := MockMetricsProvider{}
-	rhp := NewRankedHostPolicy(m)
-	hosts, err := rhp.RecommendHost(op, v.Session, nil)
+	rhp := NewRankedHostPolicy(v.Session, m)
+	hosts, err := rhp.RecommendHost(op, nil)
 	assert.NoError(t, err)
 
 	expected := hh.Reference().String()
@@ -171,7 +171,7 @@ func TestRankedRecommendHostWithHosts(t *testing.T) {
 
 	subset := hosts[1:]
 
-	result, err := rhp.RecommendHost(op, v.Session, subset)
+	result, err := rhp.RecommendHost(op, subset)
 	assert.NoError(t, err)
 
 	expected = mh.Reference().String()

--- a/pkg/vsphere/compute/placement/ranked_test.go
+++ b/pkg/vsphere/compute/placement/ranked_test.go
@@ -137,7 +137,7 @@ func TestRankedRecommendHost(t *testing.T) {
 
 	m := MockMetricsProvider{}
 
-	rhp, err := NewRankedHostPolicy(op, v.Session, m)
+	rhp, err := NewRankedHostPolicy(op, v.Cluster, m)
 	assert.NoError(t, err)
 
 	result, err := rhp.RecommendHost(op, nil)
@@ -163,7 +163,7 @@ func TestRankedRecommendHostWithHosts(t *testing.T) {
 	v := vm.NewVirtualMachine(op, sess, moref)
 
 	m := MockMetricsProvider{}
-	rhp, err := NewRankedHostPolicy(op, v.Session, m)
+	rhp, err := NewRankedHostPolicy(op, v.Cluster, m)
 	assert.NoError(t, err)
 
 	hosts, err := rhp.RecommendHost(op, nil)

--- a/pkg/vsphere/compute/placement/ranked_test.go
+++ b/pkg/vsphere/compute/placement/ranked_test.go
@@ -137,7 +137,9 @@ func TestRankedRecommendHost(t *testing.T) {
 
 	m := MockMetricsProvider{}
 
-	rhp := NewRankedHostPolicy(v.Session, m)
+	rhp, err := NewRankedHostPolicy(op, v.Session, m)
+	assert.NoError(t, err)
+
 	result, err := rhp.RecommendHost(op, nil)
 	assert.NoError(t, err)
 
@@ -161,7 +163,9 @@ func TestRankedRecommendHostWithHosts(t *testing.T) {
 	v := vm.NewVirtualMachine(op, sess, moref)
 
 	m := MockMetricsProvider{}
-	rhp := NewRankedHostPolicy(v.Session, m)
+	rhp, err := NewRankedHostPolicy(op, v.Session, m)
+	assert.NoError(t, err)
+
 	hosts, err := rhp.RecommendHost(op, nil)
 	assert.NoError(t, err)
 

--- a/pkg/vsphere/compute/placement/ranked_test.go
+++ b/pkg/vsphere/compute/placement/ranked_test.go
@@ -140,7 +140,11 @@ func TestRankedRecommendHost(t *testing.T) {
 	rhp, err := NewRankedHostPolicy(op, v.Cluster, m)
 	assert.NoError(t, err)
 
-	result, err := rhp.RecommendHost(op, nil)
+	testRankedRecommendHostInterface(t, op, rhp)
+}
+
+func testRankedRecommendHostInterface(t *testing.T, op trace.Operation, p HostPlacementPolicy) {
+	result, err := p.RecommendHost(op, nil)
 	assert.NoError(t, err)
 
 	expected := hh.Reference().String()
@@ -165,8 +169,11 @@ func TestRankedRecommendHostWithHosts(t *testing.T) {
 	m := MockMetricsProvider{}
 	rhp, err := NewRankedHostPolicy(op, v.Cluster, m)
 	assert.NoError(t, err)
+	testRankedRecommendHostInterfaceWithHosts(t, op, rhp)
+}
 
-	hosts, err := rhp.RecommendHost(op, nil)
+func testRankedRecommendHostInterfaceWithHosts(t *testing.T, op trace.Operation, p HostPlacementPolicy) {
+	hosts, err := p.RecommendHost(op, nil)
 	assert.NoError(t, err)
 
 	expected := hh.Reference().String()
@@ -175,7 +182,7 @@ func TestRankedRecommendHostWithHosts(t *testing.T) {
 
 	subset := hosts[1:]
 
-	result, err := rhp.RecommendHost(op, subset)
+	result, err := p.RecommendHost(op, subset)
 	assert.NoError(t, err)
 
 	expected = mh.Reference().String()

--- a/pkg/vsphere/compute/rp.go
+++ b/pkg/vsphere/compute/rp.go
@@ -68,7 +68,7 @@ func (rp *ResourcePool) GetChildrenVMs(ctx context.Context, s *session.Session) 
 func (rp *ResourcePool) GetChildVM(ctx context.Context, s *session.Session, name string) (*vm.VirtualMachine, error) {
 	op := trace.FromContext(ctx, "GetChildVM")
 
-	searchIndex := object.NewSearchIndex(s.Client.Client)
+	searchIndex := object.NewSearchIndex(s.Vim25())
 	child, err := searchIndex.FindChild(op, rp.Reference(), name)
 	if err != nil {
 		return nil, errors.Errorf("Unable to find VM(%s): %s", name, err.Error())
@@ -91,7 +91,7 @@ func (rp *ResourcePool) GetCluster(ctx context.Context) (*object.ComputeResource
 		return nil, err
 	}
 
-	return object.NewComputeResource(rp.Client.Client, mrp.Owner), nil
+	return object.NewComputeResource(rp.Vim25(), mrp.Owner), nil
 }
 
 func (rp *ResourcePool) GetDatacenter(ctx context.Context) (*object.Datacenter, error) {
@@ -103,7 +103,7 @@ func (rp *ResourcePool) GetDatacenter(ctx context.Context) (*object.Datacenter, 
 		return nil, errors.Errorf("Unable to get datacenter ancestor of rp %s: %s", rp.Name(), err)
 	}
 
-	return object.NewDatacenter(rp.Client.Client, *dcRef), nil
+	return object.NewDatacenter(rp.Vim25(), *dcRef), nil
 }
 
 func (rp *ResourcePool) getAncestors(op trace.Operation, inType string) ([]types.ManagedObjectReference, error) {

--- a/pkg/vsphere/performance/host_metrics.go
+++ b/pkg/vsphere/performance/host_metrics.go
@@ -20,6 +20,7 @@ import (
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/performance"
 	"github.com/vmware/govmomi/property"
+	"github.com/vmware/govmomi/vim25"
 	"github.com/vmware/govmomi/vim25/mo"
 	"github.com/vmware/govmomi/vim25/types"
 	"github.com/vmware/vic/pkg/trace"
@@ -68,21 +69,17 @@ type HostMetricsInfo struct {
 // HostMetricsProvider returns CPU and memory metrics for all ESXi hosts in a cluster
 // via implementation of the MetricsProvider interface.
 type HostMetricsProvider struct {
-	*session.Session
+	*vim25.Client
 }
 
 // NewHostMetricsProvider returns a new instance of HostMetricsProvider.
-func NewHostMetricsProvider(s *session.Session) *HostMetricsProvider {
-	return &HostMetricsProvider{Session: s}
+func NewHostMetricsProvider(c *vim25.Client) *HostMetricsProvider {
+	return &HostMetricsProvider{Client: c}
 }
 
 // GetMetricsForComputeResource gathers host metrics from the supplied compute resource.
 // Returned map is keyed on the host ManagedObjectReference in string form.
 func (h *HostMetricsProvider) GetMetricsForComputeResource(op trace.Operation, cr *object.ComputeResource) (map[string]*HostMetricsInfo, error) {
-	if h.Session == nil {
-		return nil, fmt.Errorf("session not set")
-	}
-
 	// Gather hosts from the session cluster and then obtain their morefs.
 	hosts, err := cr.Hosts(op)
 	if err != nil {
@@ -103,8 +100,8 @@ func (h *HostMetricsProvider) GetMetricsForHosts(op trace.Operation, hosts []*ob
 		return nil, fmt.Errorf("no hosts provided")
 	}
 
-	if h.Session == nil {
-		return nil, fmt.Errorf("session not set")
+	if h.Client == nil {
+		return nil, fmt.Errorf("client not set")
 	}
 
 	morefToHost := make(map[string]*object.HostSystem)
@@ -122,7 +119,7 @@ func (h *HostMetricsProvider) GetMetricsForHosts(op trace.Operation, hosts []*ob
 	}
 
 	counters := []string{cpuUsage, memActive, memConsumed, memTotalCapacity, memOverhead}
-	perfMgr := performance.NewManager(h.Vim25())
+	perfMgr := performance.NewManager(h.Client)
 	sample, err := perfMgr.SampleByName(op.Context, spec, counters, morefs)
 	if err != nil {
 		errStr := "unable to get metric sample: %s"

--- a/pkg/vsphere/performance/host_metrics.go
+++ b/pkg/vsphere/performance/host_metrics.go
@@ -68,18 +68,18 @@ type HostMetricsInfo struct {
 // HostMetricsProvider returns CPU and memory metrics for all ESXi hosts in a cluster
 // via implementation of the MetricsProvider interface.
 type HostMetricsProvider struct {
-	session *session.Session
+	*session.Session
 }
 
 // NewHostMetricsProvider returns a new instance of HostMetricsProvider.
 func NewHostMetricsProvider(s *session.Session) *HostMetricsProvider {
-	return &HostMetricsProvider{session: s}
+	return &HostMetricsProvider{Session: s}
 }
 
 // GetMetricsForComputeResource gathers host metrics from the supplied compute resource.
 // Returned map is keyed on the host ManagedObjectReference in string form.
 func (h *HostMetricsProvider) GetMetricsForComputeResource(op trace.Operation, cr *object.ComputeResource) (map[string]*HostMetricsInfo, error) {
-	if h.session == nil {
+	if h.Session == nil {
 		return nil, fmt.Errorf("session not set")
 	}
 
@@ -103,7 +103,7 @@ func (h *HostMetricsProvider) GetMetricsForHosts(op trace.Operation, hosts []*ob
 		return nil, fmt.Errorf("no hosts provided")
 	}
 
-	if h.session == nil {
+	if h.Session == nil {
 		return nil, fmt.Errorf("session not set")
 	}
 
@@ -122,7 +122,7 @@ func (h *HostMetricsProvider) GetMetricsForHosts(op trace.Operation, hosts []*ob
 	}
 
 	counters := []string{cpuUsage, memActive, memConsumed, memTotalCapacity, memOverhead}
-	perfMgr := performance.NewManager(h.session.Vim25())
+	perfMgr := performance.NewManager(h.Vim25())
 	sample, err := perfMgr.SampleByName(op.Context, spec, counters, morefs)
 	if err != nil {
 		errStr := "unable to get metric sample: %s"

--- a/pkg/vsphere/performance/host_metrics.go
+++ b/pkg/vsphere/performance/host_metrics.go
@@ -200,9 +200,7 @@ func filterHosts(op trace.Operation, s *session.Session, hosts []*object.HostSys
 		return nil, fmt.Errorf("no candidate hosts to filter check")
 	}
 
-	// TODO(jzt): figure out how to hone in on connection state and maintenance mode keywords to make the result
-	// more sparse
-	props := []string{"summary"}
+	props := []string{"summary.runtime"}
 	refs := make([]types.ManagedObjectReference, 0, len(hosts))
 	for _, h := range hosts {
 		refs = append(refs, h.Reference())

--- a/pkg/vsphere/performance/host_metrics.go
+++ b/pkg/vsphere/performance/host_metrics.go
@@ -209,7 +209,7 @@ func filterHosts(op trace.Operation, s *session.Session, hosts []*object.HostSys
 	}
 
 	hs := make([]mo.HostSystem, 0, len(hosts))
-	pc := property.DefaultCollector(s.Client.Client)
+	pc := property.DefaultCollector(s.Vim25())
 	err := pc.Retrieve(op, refs, props, &hs)
 	if err != nil {
 		return nil, err

--- a/pkg/vsphere/performance/host_metrics_test.go
+++ b/pkg/vsphere/performance/host_metrics_test.go
@@ -162,6 +162,7 @@ func TestFilterHosts(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Len(t, filteredHosts, len(hosts))
 
+	h0 := hosts[0]
 	spec := &types.HostMaintenanceSpec{}
 
 	_, err = tasks.WaitForResult(op, func(op context.Context) (tasks.Task, error) {
@@ -172,6 +173,7 @@ func TestFilterHosts(t *testing.T) {
 	filteredHosts, err = filterHosts(op, sess, hosts)
 	assert.NoError(t, err)
 	assert.Len(t, filteredHosts, len(hosts)-1)
+	assert.NotContains(t, filteredHosts, h0)
 
 	// TODO(jzt): uncomment this when vcsim host_system.go supports DisconnectHost_Task
 	// _, err = tasks.WaitForResult(op, func(op context.Context) (tasks.Task, error) {

--- a/pkg/vsphere/test/test.go
+++ b/pkg/vsphere/test/test.go
@@ -15,6 +15,7 @@
 package test
 
 import (
+	"context"
 	"fmt"
 	"math/rand"
 	"strings"
@@ -22,11 +23,15 @@ import (
 	"time"
 
 	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/simulator"
+	"github.com/vmware/govmomi/vim25/types"
 	"github.com/vmware/vic/lib/spec"
+	"github.com/vmware/vic/pkg/trace"
+	"github.com/vmware/vic/pkg/vsphere/extraconfig"
 	"github.com/vmware/vic/pkg/vsphere/session"
+	"github.com/vmware/vic/pkg/vsphere/tasks"
 	"github.com/vmware/vic/pkg/vsphere/test/env"
-
-	"context"
+	"github.com/vmware/vic/pkg/vsphere/vm"
 )
 
 // Session returns a session.Session struct
@@ -122,4 +127,56 @@ func PickRandomHost(ctx context.Context, session *session.Session, t *testing.T)
 		t.SkipNow()
 	}
 	return hosts[rand.Intn(len(hosts))]
+}
+
+// VpxModelSetup creates a VPX model, starts its server and populates the session. The caller must
+// clean up the model and the server once it is done using them.
+func VpxModelSetup(ctx context.Context, t *testing.T) (*simulator.Model, *simulator.Server, *session.Session) {
+	model := simulator.VPX()
+	if err := model.Create(); err != nil {
+		t.Fatal(err)
+	}
+
+	server := model.Service.NewServer()
+	sess, err := SessionWithVPX(ctx, server.URL.String())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return model, server, sess
+}
+
+// CreateVM creates a VM using a VPX session.
+func CreateVM(op trace.Operation, sess *session.Session, name string) (*vm.VirtualMachine, error) {
+
+	vmx := fmt.Sprintf("%s/%s.vmx", name, name)
+	ds := sess.Datastore
+	secretKey, err := extraconfig.NewSecretKey()
+	if err != nil {
+		return nil, err
+	}
+
+	spec := types.VirtualMachineConfigSpec{
+		Name:    name,
+		GuestId: string(types.VirtualMachineGuestOsIdentifierOtherGuest),
+		Files: &types.VirtualMachineFileInfo{
+			VmPathName: fmt.Sprintf("[%s] %s", ds.Name(), vmx),
+		},
+		ExtraConfig: []types.BaseOptionValue{
+			&types.OptionValue{
+				Key:   extraconfig.GuestInfoSecretKey,
+				Value: secretKey.String(),
+			},
+		},
+	}
+
+	res, err := tasks.WaitForResult(op, func(op context.Context) (tasks.Task, error) {
+		return sess.VMFolder.CreateVM(op, spec, sess.Pool, nil)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	v := vm.NewVirtualMachine(op, sess, res.Result.(types.ManagedObjectReference))
+	return v, nil
 }

--- a/pkg/vsphere/test/test.go
+++ b/pkg/vsphere/test/test.go
@@ -31,7 +31,6 @@ import (
 	"github.com/vmware/vic/pkg/vsphere/session"
 	"github.com/vmware/vic/pkg/vsphere/tasks"
 	"github.com/vmware/vic/pkg/vsphere/test/env"
-	"github.com/vmware/vic/pkg/vsphere/vm"
 )
 
 // Session returns a session.Session struct
@@ -146,13 +145,13 @@ func VpxModelSetup(ctx context.Context, t *testing.T) (*simulator.Model, *simula
 	return model, server, sess
 }
 
-// CreateVM creates a VM using a VPX session.
-func CreateVM(op trace.Operation, sess *session.Session, name string) (*vm.VirtualMachine, error) {
+// CreateVM provides a moref to a created VM
+func CreateVM(op trace.Operation, sess *session.Session, name string) (types.ManagedObjectReference, error) {
 	vmx := fmt.Sprintf("%s/%s.vmx", name, name)
 	ds := sess.Datastore
 	secretKey, err := extraconfig.NewSecretKey()
 	if err != nil {
-		return nil, err
+		return types.ManagedObjectReference{}, err
 	}
 
 	spec := types.VirtualMachineConfigSpec{
@@ -173,9 +172,8 @@ func CreateVM(op trace.Operation, sess *session.Session, name string) (*vm.Virtu
 		return sess.VMFolder.CreateVM(op, spec, sess.Pool, nil)
 	})
 	if err != nil {
-		return nil, err
+		return types.ManagedObjectReference{}, err
 	}
 
-	v := vm.NewVirtualMachine(op, sess, res.Result.(types.ManagedObjectReference))
-	return v, nil
+	return res.Result.(types.ManagedObjectReference), nil
 }

--- a/pkg/vsphere/test/test.go
+++ b/pkg/vsphere/test/test.go
@@ -148,7 +148,6 @@ func VpxModelSetup(ctx context.Context, t *testing.T) (*simulator.Model, *simula
 
 // CreateVM creates a VM using a VPX session.
 func CreateVM(op trace.Operation, sess *session.Session, name string) (*vm.VirtualMachine, error) {
-
 	vmx := fmt.Sprintf("%s/%s.vmx", name, name)
 	ds := sess.Datastore
 	secretKey, err := extraconfig.NewSecretKey()

--- a/pkg/vsphere/vm/vm_test.go
+++ b/pkg/vsphere/vm/vm_test.go
@@ -113,7 +113,7 @@ func TestDeleteExceptDisk(t *testing.T) {
 	}
 
 	// clean up
-	dm := object.NewVirtualDiskManager(session.Client.Client)
+	dm := object.NewVirtualDiskManager(session.Vim25())
 
 	task, err := dm.DeleteVirtualDisk(context.TODO(), diskName, nil)
 	if err != nil {


### PR DESCRIPTION
This change implements a very rudimentary first stab at the `RankedHostPolicy` behavior. It also enables custom weight values, as well as filtering out hosts who are either disconnected or who are in maintenance mode.

Note: I placed the filtering logic in `host_metrics.go` for a couple of reasons:  One is to remove the need for the `HostMetricsProvider` to do any error handling on hosts that are in this state - we also error on attempt to gather metrics on an empty list of hosts, so if by chance all hosts are either disconnected or are in maintenance mode, we can catch it at gathering time.  The other reason is that all `HostPlacementPolicy` implementations need to be able to filter as well (neither `Random` nor `Ranked` policies should attempt to place a vm on one of these hosts). This makes me think it may be able to go into it's own place and become a general purpose filter for host systems based on a caller-supplied filter `func()` (this way, any implementation of the `MetricsProvider` or `HostPlacementPolicy` interfaces can have the capability of filtering hosts on whatever criteria they like). Thoughts?

Fixes #7279, though I expect more iteration in the future when we start using it.