### PR TITLE
Add VC log collection to Group13 vMotion nightly tests

### DIFF
--- a/tests/manual-test-cases/Group13-vMotion/13-1-vMotion-VCH-Appliance.robot
+++ b/tests/manual-test-cases/Group13-vMotion/13-1-vMotion-VCH-Appliance.robot
@@ -17,7 +17,12 @@ Documentation  Test 13-1 - vMotion VCH Appliance
 Resource  ../../resources/Util.robot
 Suite Setup  Wait Until Keyword Succeeds  10x  10m  Create a VSAN Cluster  vic-vmotion-13-1
 Suite Teardown  Run Keyword And Ignore Error  Nimbus Cleanup  ${list}
-Test Teardown  Gather Logs From Test Server 
+Test Teardown  Cleanup VIC Appliance And Gather VC Log
+
+*** Keywords ***
+Cleanup VIC Appliance And Gather VC Logs
+    Cleanup VIC Appliance On Test Server
+    Run Keyword If Test Failed  Gather VC Logs
 
 *** Test Cases ***
 #Step 1-5

--- a/tests/manual-test-cases/Group13-vMotion/13-2-vMotion-Container.robot
+++ b/tests/manual-test-cases/Group13-vMotion/13-2-vMotion-Container.robot
@@ -17,7 +17,12 @@ Documentation  Test 13-2 - vMotion Container
 Resource  ../../resources/Util.robot
 Suite Setup  Wait Until Keyword Succeeds  10x  10m  Create a VSAN Cluster  vic-vmotion-13-2
 Suite Teardown  Run Keyword And Ignore Error  Nimbus Cleanup  ${list}
-Test Teardown  Cleanup VIC Appliance On Test Server
+Test Teardown  Cleanup VIC Appliance And Gather VC Logs
+
+*** Keywords ***
+Cleanup VIC Appliance And Gather VC Logs
+    Cleanup VIC Appliance On Test Server
+    Run Keyword If Test Failed  Gather VC Logs
 
 *** Test Cases ***
 Test

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-25-OPS-User-Grant.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-25-OPS-User-Grant.robot
@@ -20,12 +20,6 @@ Suite Teardown  Run Keyword And Ignore Error  Nimbus Cleanup  ${list}
 Test Teardown  Run Keyword If Test Failed  Gather VC Logs
 
 *** Keywords ***
-
-Gather VC Logs
-    Log To Console  Collecting VC logs ..
-    Run Keyword And Ignore Error  Gather Logs From ESX Server
-    Log To Console  VC logs collected
-
 Ops User Create
     [Timeout]    110 minutes
     Run Keyword And Ignore Error  Nimbus Cleanup  ${list}  ${false}

--- a/tests/resources/Vsphere-Util.robot
+++ b/tests/resources/Vsphere-Util.robot
@@ -194,6 +194,11 @@ Gather Logs From ESX Server
     Environment Variable Should Be Set  TEST_URL
     ${out}=  Run  govc logs.download
 
+Gather VC Logs
+    Log To Console  Collecting VC logs ..
+    Run Keyword And Ignore Error  Gather Logs From ESX Server
+    Log To Console  VC logs collected
+
 Change Log Level On Server
     [Arguments]  ${level}
     ${out}=  Run  govc host.option.set Config.HostAgent.log.level ${level}


### PR DESCRIPTION
Fixes #6701 

Added VC log collection upon failure for Group 13 vMotion tests