### PR TITLE
WIP: Validate full set after delta property match fail

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -14,8 +14,6 @@ pipeline:
   clone-pr:
     image: wdc-harbor-ci.eng.vmware.com/default-project/git-clone:1.0
     pull: true
-    environment:
-      DRONE_PULL_REQUEST: ${DRONE_PULL_REQUEST}
     when:
       event: [ pull_request ]
 

--- a/.drone.yml
+++ b/.drone.yml
@@ -15,7 +15,7 @@ pipeline:
     image: wdc-harbor-ci.eng.vmware.com/default-project/git-clone:1.0
     pull: true
     environment:
-      DRONE_PULL_REQUEST:  ${DRONE_PULL_REQUEST}
+      DRONE_PULL_REQUEST: ${DRONE_PULL_REQUEST}
     when:
       event: [ pull_request ]
 

--- a/.drone.yml
+++ b/.drone.yml
@@ -11,6 +11,14 @@ pipeline:
     tags: true
     recursive: false
 
+  clone-pr:
+    image: wdc-harbor-ci.eng.vmware.com/default-project/git-clone:1.0
+    pull: true
+    environment:
+      DRONE_PULL_REQUEST:  ${DRONE_PULL_REQUEST}
+    when:
+      event: [ pull_request ]
+
   display-status:
     image: 'wdc-harbor-ci.eng.vmware.com/default-project/vic-integration-test:1.44'
     pull: true

--- a/pkg/vsphere/vm/vm.go
+++ b/pkg/vsphere/vm/vm.go
@@ -240,12 +240,12 @@ func (vm *VirtualMachine) WaitForKeyInExtraConfig(ctx context.Context, key strin
 			if err == nil && checkOptionValueFunc(ovs) {
 				return true
 			}
-		}
 
-		if firstFail {
-			op.Debug("Resetting power state for first fail")
-			firstFail = false
-			poweredOff = nil
+			if firstFail {
+				op.Debug("Resetting power state for first fail")
+				firstFail = false
+				poweredOff = nil
+			}
 		}
 
 		return poweredOff != nil

--- a/pkg/vsphere/vm/vm.go
+++ b/pkg/vsphere/vm/vm.go
@@ -189,6 +189,7 @@ func (vm *VirtualMachine) WaitForKeyInExtraConfig(ctx context.Context, key strin
 
 	var detail string
 	var poweredOff error
+	firstFail := true
 
 	checkOptionValueFunc := func(ovs []types.BaseOptionValue) bool {
 		for _, value := range ovs {
@@ -239,6 +240,11 @@ func (vm *VirtualMachine) WaitForKeyInExtraConfig(ctx context.Context, key strin
 			if err == nil && checkOptionValueFunc(ovs) {
 				return true
 			}
+		}
+
+		if firstFail {
+			firstFail = false
+			poweredOff = nil
 		}
 
 		return poweredOff != nil

--- a/pkg/vsphere/vm/vm.go
+++ b/pkg/vsphere/vm/vm.go
@@ -243,6 +243,7 @@ func (vm *VirtualMachine) WaitForKeyInExtraConfig(ctx context.Context, key strin
 		}
 
 		if firstFail {
+			op.Debug("Resetting power state for first fail")
 			firstFail = false
 			poweredOff = nil
 		}

--- a/pkg/vsphere/vm/vm.go
+++ b/pkg/vsphere/vm/vm.go
@@ -190,6 +190,24 @@ func (vm *VirtualMachine) WaitForKeyInExtraConfig(ctx context.Context, key strin
 	var detail string
 	var poweredOff error
 
+	checkOptionValueFunc := func(ovs []types.BaseOptionValue) bool {
+		for _, value := range ovs {
+			// check the status of the key and return true if it's been set to non-nil
+			if key == value.GetOptionValue().Key {
+				detail = value.GetOptionValue().Value.(string)
+				if detail != "" && detail != "<nil>" {
+					// ensure we clear any tentative error
+					poweredOff = nil
+
+					return true
+				}
+				break // continue the outer loop as we may have a powerState change too
+			}
+		}
+
+		return false
+	}
+
 	waitFunc := func(pc []types.PropertyChange) bool {
 		for _, c := range pc {
 			if c.Op != types.PropertyChangeOpAssign {
@@ -198,18 +216,8 @@ func (vm *VirtualMachine) WaitForKeyInExtraConfig(ctx context.Context, key strin
 
 			switch v := c.Val.(type) {
 			case types.ArrayOfOptionValue:
-				for _, value := range v.OptionValue {
-					// check the status of the key and return true if it's been set to non-nil
-					if key == value.GetOptionValue().Key {
-						detail = value.GetOptionValue().Value.(string)
-						if detail != "" && detail != "<nil>" {
-							// ensure we clear any tentative error
-							poweredOff = nil
-
-							return true
-						}
-						break // continue the outer loop as we may have a powerState change too
-					}
+				if checkOptionValueFunc(v.OptionValue) {
+					return true
 				}
 			case types.VirtualMachinePowerState:
 				// Give up if the vm has powered off
@@ -221,6 +229,15 @@ func (vm *VirtualMachine) WaitForKeyInExtraConfig(ctx context.Context, key strin
 					}
 					poweredOff = fmt.Errorf("container VM has unexpectedly %s", msg)
 				}
+			}
+		}
+
+		if poweredOff != nil {
+			// SPECULATIVE: directly getting the properties to see if a change was missed
+			// #6700 is showing up very frequently in CI
+			ovs, err := vm.FetchExtraConfigBaseOptions(op)
+			if err == nil && checkOptionValueFunc(ovs) {
+				return true
 			}
 		}
 


### PR DESCRIPTION
We currently rely on the delta logic for property changes to wait on
certain keys in extraconfig. However we see occasional invalid state from
an application perspective - namely we have state being powered off but
without a key being true that we can see being set in vmware.log

This change grabs the entire extraconfig property set, not just deltas, if
we detect that error condition and does a final attempt to extract the
key.

If this is effective then we should open a vSphere bug about the dropped
property change.

Speculative: #6700 

[skip unit]
[specific ci=1-07-Docker-Stop]
