### PR TITLE
Explicitly clone PR to avoid merge master

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -11,6 +11,12 @@ pipeline:
     tags: true
     recursive: false
 
+  clone-pr:
+    image: wdc-harbor-ci.eng.vmware.com/default-project/git-clone:1.0
+    pull: true
+    when:
+      event: [ pull_request ]
+
   display-status:
     image: 'wdc-harbor-ci.eng.vmware.com/default-project/vic-integration-test:1.44'
     pull: true


### PR DESCRIPTION
Drone has starting doing a silent merge with master as part of the clone
plugin. It's possible that setting DRONE_GITHUB_MERGE_REF=false for the
server will make this behaviour sane, but this PR explicitly ensures we've
got what we expected from the PR.

There are some more details [in this thread](https://discourse.drone.io/t/github-claims-that-merge-refs-are-undocumented-feature/1100/10?u=hickeng) 