### PR TITLE
Retry during upgrade test sensitive to time-skew

### DIFF
--- a/tests/test-cases/Group11-Upgrade/11-01-Upgrade.robot
+++ b/tests/test-cases/Group11-Upgrade/11-01-Upgrade.robot
@@ -173,6 +173,11 @@ Check Container Create Timestamps
 
     # Pause for 2 seconds to allow for the time check below
     Sleep  2
+    # Wait up to a minute extra to allow for time skew between machines
+    Wait Until Keyword Succeeds  30x  2s  Atempt Check Container Create Timestamps  ${newc}
+
+Atempt Check Container Create Timestamps
+    [Arguments]    ${newc}
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} ps -a
     Should Be Equal As Integers  ${rc}  0
     ${oldcshortID}=  Get container shortID  ${TestContainerVolume}
@@ -181,6 +186,7 @@ Check Container Create Timestamps
     ${newcshortID}=  Get container shortID  ${newc}
     ${lines}=  Get Lines Containing String  ${output}  ${newcshortID}
     Should Not Contain  ${lines}  Less than a second ago
+
 
 *** Test Cases ***
 Upgrade Present in vic-machine

--- a/tests/test-cases/Group11-Upgrade/11-01-Upgrade.robot
+++ b/tests/test-cases/Group11-Upgrade/11-01-Upgrade.robot
@@ -174,9 +174,9 @@ Check Container Create Timestamps
     # Pause for 2 seconds to allow for the time check below
     Sleep  2
     # Wait up to a minute extra to allow for time skew between machines
-    Wait Until Keyword Succeeds  30x  2s  Atempt Check Container Create Timestamps  ${newc}
+    Wait Until Keyword Succeeds  30x  2s  Attempt To Check Container Create Timestamps  ${newc}
 
-Atempt Check Container Create Timestamps
+Attempt To Check Container Create Timestamps
     [Arguments]    ${newc}
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} ps -a
     Should Be Equal As Integers  ${rc}  0


### PR DESCRIPTION
Up to one minute of time skew could occur between two VMs given our infrastructure configuration. Retry as necessary to account for possible skew.

Fixes #7012

[specific ci=11-01-Upgrade]