### PR TITLE
Don't fail if you can't delete other build datastore items

### DIFF
--- a/tests/resources/VCH-Util.robot
+++ b/tests/resources/VCH-Util.robot
@@ -489,7 +489,8 @@ Cleanup Datastore On Test Server
     \   ${state}=  Get State Of Drone Build  @{build}[1]
     \   Continue For Loop If  '${state}' == 'running'
     \   Log To Console  Removing the following item from datastore: ${item}
-    \   ${out}=  Run  govc datastore.rm ${item}
+    \   ${rc}  ${out}=    Run And Return Rc And Output  govc datastore.rm ${item}
+    \   Continue For Loop If  ${rc} != 0
     \   Wait Until Keyword Succeeds  6x  5s  Check Delete Success  ${item}
 
 Cleanup Dangling VMs On Test Server


### PR DESCRIPTION
govc datastore.rm can fail if a VM is still attached to the datastore item.  Change our behavior so that it:
1. doesn't waste 30 seconds every time trying to delete something that isn't going to be deleted
2. ignore when this happens because it is unrelated to the current test either way