### PR TITLE
Remove license check for vCenter in nightly

### DIFF
--- a/tests/manual-test-cases/Group5-Functional-Tests/5-3-Enhanced-Linked-Mode.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-3-Enhanced-Linked-Mode.robot
@@ -98,7 +98,7 @@ Enhanced Link Mode Setup
     Set Environment Variable  GOVC_URL  ${vc1-ip}
     Set Environment Variable  GOVC_USERNAME  administrator@vsphere.local
     Set Environment Variable  GOVC_PASSWORD  Admin!23
-    Wait Until Keyword Succeeds  6x   10 sec  Check License Features
+    Wait Until Keyword Succeeds  6x   10 sec  Check License Present
 
     # First VC cluster
     Log To Console  Create a datacenter on the VC

--- a/tests/resources/Nimbus-Util.robot
+++ b/tests/resources/Nimbus-Util.robot
@@ -426,12 +426,14 @@ Change ESXi Server Password
     ${out}=  Run  govc host.account.update -id root -password ${password}
     Should Be Empty  ${out}
 
-Check License Features
+Check License Present
     ${license}=  Run  govc license.ls
     Log  ${license}
     Should Contain      ${license}  Key
     Should Not Contain  ${license}  SecurityError
 
+Check License Features
+    Check License Present
     ${out}=  Run  govc object.collect -json $(govc object.collect -s - content.licenseManager) licenses | jq '.[].Val.LicenseManagerLicenseInfo[].Properties[] | select(.Key == "feature") | .Value'
     Log  ${out}
     Should Contain  ${out}  serialuri


### PR DESCRIPTION
[skip ci]
License features do not show up on vCenter with eval license installed. Features show up on ESX, so removing feature check on vCenter target.