### PR TITLE
vic-machine validator bail out if session populate doesn't find a vm folder

### DIFF
--- a/lib/install/validate/validator.go
+++ b/lib/install/validate/validator.go
@@ -163,6 +163,15 @@ func NewValidator(ctx context.Context, input *data.Data) (*Validator, error) {
 		op.Debugf("new validator Session.Populate: %s", err)
 	}
 
+	if v.Session.VMFolder == nil {
+		op.Debugf("Failed to set validator session VM folder")
+		// it's possible that VMFolder is not set, but session.Populate doesn't return any error
+		if err == nil {
+			err = errors.New("validator Session.Populate: no datacenter folder (nil) is found")
+		}
+		return nil, err
+	}
+
 	if strings.Contains(sessionconfig.DatacenterPath, "/") {
 		detail := "--target should only specify datacenter in the path (e.g. https://addr/datacenter) - specify cluster, resource pool, or folder with --compute-resource"
 		op.Error(detail)

--- a/pkg/vsphere/session/session.go
+++ b/pkg/vsphere/session/session.go
@@ -359,6 +359,13 @@ func (s *Session) Populate(ctx context.Context) (*Session, error) {
 		} else {
 			op.Debugf("Cached folders: %s", s.DatacenterPath)
 		}
+		// There could be cases where no error from Datacenter.Folders, but nil folder is returned. In this case we should bail out.
+		// It's also possible that there's an error, but a valid vm folder is returned
+		if folders == nil {
+			errs = append(errs, fmt.Sprintf("Nil folder returned when finding folders (%s)", s.DatacenterPath))
+			return nil, errors.New(strings.Join(errs, "\n"))
+		}
+
 		s.VMFolder = folders.VmFolder
 	}
 


### PR DESCRIPTION
`[specific ci=Group6-VIC-Machine]`

Fixes #7016 
(not necessarily fixes the root cause - just an improvement on a more reasonable behavior rather than core dump)

During validator session.Populate, under some extreme circumstances `session.Datacenter.Folders(op)` could return nil folder. In this case, we should terminate session populate, make validator return an error and quit vic-machine process. 
