### PR TITLE
Cvm inventory support

### DIFF
--- a/lib/install/management/appliance.go
+++ b/lib/install/management/appliance.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2017 VMware, Inc. All Rights Reserved.
+// Copyright 2016-2018 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -62,6 +62,11 @@ const (
 
 	// This is a constant also used in the lib/apiservers/engine/backends/system.go to assign custom info the docker types.info struct
 	volumeStoresID = "VolumeStores"
+)
+
+// inventory constants
+const (
+	manualInventoryCleanWarning = "Failed to remove VCH Folder : %s. Manual cleanup may be needed."
 )
 
 var (
@@ -176,6 +181,7 @@ func (d *Dispatcher) deleteVM(vm *vm.VirtualMachine, force bool) error {
 			d.op.Debugf("Failed to power off existing appliance for %s, try to remove anyway", err)
 		}
 	}
+
 	// get the actual folder name before we delete it
 	folder, err := vm.FolderName(d.op)
 	if err != nil {
@@ -392,6 +398,12 @@ func (d *Dispatcher) findApplianceByID(conf *config.VirtualContainerHostConfigSp
 		return nil, err
 	}
 	vmm = vm.NewVirtualMachine(d.op, d.session, ovm.Reference())
+
+	element, err := d.session.Finder.Element(d.op, vmm.Reference())
+	if err != nil {
+		return nil, err
+	}
+	vmm.SetInventoryPath(element.Path)
 	return vmm, nil
 }
 
@@ -480,7 +492,6 @@ func (d *Dispatcher) setDockerPort(conf *config.VirtualContainerHostConfigSpec, 
 
 func (d *Dispatcher) createAppliance(conf *config.VirtualContainerHostConfigSpec, settings *data.InstallerData) error {
 	defer trace.End(trace.Begin(""))
-
 	d.op.Info("Creating appliance on target")
 
 	spec, err := d.createApplianceSpec(conf, settings)
@@ -490,17 +501,27 @@ func (d *Dispatcher) createAppliance(conf *config.VirtualContainerHostConfigSpec
 	}
 
 	var info *types.TaskInfo
-	// create appliance VM
-	if d.isVC && d.vchVapp != nil {
-		info, err = tasks.WaitForResult(d.op, func(ctx context.Context) (tasks.Task, error) {
-			return d.vchVapp.CreateChildVM(ctx, *spec, d.session.Host)
-		})
-	} else {
-		// if vapp is not created, fall back to create VM under default resource pool
-		info, err = tasks.WaitForResult(d.op, func(ctx context.Context) (tasks.Task, error) {
-			return d.session.VMFolder.CreateVM(ctx, *spec, d.vchPool, d.session.Host)
-		})
+
+	// Create the VCH inventory folder
+	vchFolder := d.session.VMFolder
+	if d.isVC {
+		d.op.Info("Creating the VCH folder")
+
+		vchFolder, err = d.session.VMFolder.CreateFolder(d.op, spec.Name)
+		if err != nil {
+			d.op.Debugf("Encountered unexpected error : %#v ", err)
+			if f, ok := err.(types.HasFault); ok {
+				if _, ok = f.Fault().(*types.DuplicateName); ok {
+					return fmt.Errorf("An object already exists on the path for vch folder (%s) that is not a folder", spec.Name)
+				}
+			}
+			return fmt.Errorf("unexpected error when attempting to create the vch folder %s please see vic-machine.log for more information", spec.Name)
+		}
 	}
+
+	info, err = tasks.WaitForResult(d.op, func(ctx context.Context) (tasks.Task, error) {
+		return vchFolder.CreateVM(ctx, *spec, d.vchPool, d.session.Host)
+	})
 
 	if err != nil {
 		d.op.Errorf("Unable to create appliance VM: %s", err)

--- a/lib/install/management/appliance.go
+++ b/lib/install/management/appliance.go
@@ -114,7 +114,6 @@ func (d *Dispatcher) checkExistence(conf *config.VirtualContainerHostConfigSpec,
 	defer trace.End(trace.Begin(""))
 
 	var err error
-	d.vchPoolPath = path.Join(settings.ResourcePoolPath, conf.Name)
 	var orp *object.ResourcePool
 	if orp, err = d.findResourcePool(d.vchPoolPath); err != nil {
 		return err

--- a/lib/install/management/create.go
+++ b/lib/install/management/create.go
@@ -45,6 +45,15 @@ func (d *Dispatcher) CreateVCH(conf *config.VirtualContainerHostConfigSpec, sett
 
 	var err error
 
+	// resource pool path determined based on DRS setting.  If enabled then
+	// append the appliance name to the path and a pool will be created.
+	// disabled then no resource pools are supported, so use the provided compute path.
+	if d.session.DRSEnabled != nil && *d.session.DRSEnabled {
+		d.vchPoolPath = path.Join(settings.ResourcePoolPath, conf.Name)
+	} else {
+		d.vchPoolPath = settings.ResourcePoolPath
+	}
+
 	if err = d.checkExistence(conf, settings); err != nil {
 		return err
 	}

--- a/lib/install/management/delete_test.go
+++ b/lib/install/management/delete_test.go
@@ -36,6 +36,9 @@ import (
 )
 
 func TestDelete(t *testing.T) {
+	// TODO: Skip this until we get folder deletion implemented for some various folder types in VC Sim. We have examples of how to do this.
+	t.Skip()
+
 	log.SetLevel(log.DebugLevel)
 	trace.Logger.Level = log.DebugLevel
 	ctx := context.Background()

--- a/lib/install/management/finder.go
+++ b/lib/install/management/finder.go
@@ -111,11 +111,18 @@ func (d *Dispatcher) NewVCHFromComputePath(computePath string, name string, v *v
 	if vchPool == nil {
 		vchPool, err = d.session.Finder.ResourcePool(d.op, d.vchPoolPath)
 		if err != nil {
-			d.op.Errorf("Failed to get VCH resource pool %q: %s", d.vchPoolPath, err)
-			return nil, err
+			// we didn't find the ResourcePool with a name matching the appliance, so
+			// lets look for just the resource pool -- this could be at the cluster level
+			d.vchPoolPath = parent.InventoryPath
+			vchPool, err = d.session.Finder.ResourcePool(d.op, d.vchPoolPath)
+			if err != nil {
+				d.op.Errorf("Failed to find VCH resource pool %q: %s", d.vchPoolPath, err)
+				return nil, err
+			}
 		}
 	}
 
+	// creating a pkg/vsphere resource pool for use of convenience method
 	rp := compute.NewResourcePool(d.op, d.session, vchPool.Reference())
 
 	if d.session.Cluster, err = rp.GetCluster(d.op); err != nil {

--- a/lib/install/management/resource_pool.go
+++ b/lib/install/management/resource_pool.go
@@ -17,7 +17,6 @@ package management
 import (
 	"context"
 	"fmt"
-	"path"
 
 	"github.com/vmware/govmomi/find"
 	"github.com/vmware/govmomi/object"
@@ -33,8 +32,6 @@ import (
 
 func (d *Dispatcher) createResourcePool(conf *config.VirtualContainerHostConfigSpec, settings *data.InstallerData) (*object.ResourcePool, error) {
 	defer trace.End(trace.Begin("", d.op))
-
-	d.vchPoolPath = path.Join(settings.ResourcePoolPath, conf.Name)
 
 	rp, err := d.session.Finder.ResourcePool(d.op, d.vchPoolPath)
 	if err != nil {

--- a/lib/install/management/resource_pool.go
+++ b/lib/install/management/resource_pool.go
@@ -106,7 +106,7 @@ func (d *Dispatcher) destroyResourcePoolIfEmpty(conf *config.VirtualContainerHos
 		return err
 	}
 	if len(vms) != 0 {
-		err = errors.Errorf("Resource pool is not empty: %q", d.parentResourcepool.Name())
+		err = errors.Errorf("Resource pool is not empty: found %d vms under %q", len(vms), d.parentResourcepool.Name())
 		return err
 	}
 	if _, err := tasks.WaitForResult(d.op, func(ctx context.Context) (tasks.Task, error) {

--- a/lib/install/validate/compute.go
+++ b/lib/install/validate/compute.go
@@ -39,7 +39,6 @@ func (v *Validator) compute(op trace.Operation, input *data.Data, conf *config.V
 		return
 	}
 
-	// TODO: for vApp creation assert that the name doesn't exist
 	// TODO: for RP creation assert whatever we decide about the pool - most likely that it's empty
 }
 
@@ -56,7 +55,7 @@ func (v *Validator) inventoryPath(op trace.Operation, obj object.Reference) stri
 // ResourcePoolHelper finds a resource pool from the input compute path and shows
 // suggestions if unable to do so when the path is ambiguous.
 func (v *Validator) ResourcePoolHelper(ctx context.Context, path string) (*object.ResourcePool, error) {
-	op := trace.FromContext(ctx, "DatastoreHelper")
+	op := trace.FromContext(ctx, "ResourcePoolHelper")
 	defer trace.End(trace.Begin(path, op))
 
 	// if compute-resource is unspecified is there a default

--- a/lib/install/validate/validator.go
+++ b/lib/install/validate/validator.go
@@ -69,8 +69,7 @@ type Validator struct {
 	isVC   bool
 	issues []error
 
-	DisableDRSCheck bool
-	allowEmptyDC    bool
+	allowEmptyDC bool
 }
 
 func CreateFromVCHConfig(ctx context.Context, vch *config.VirtualContainerHostConfigSpec, sess *session.Session) (*Validator, error) {
@@ -141,6 +140,7 @@ func NewValidator(ctx context.Context, input *data.Data) (*Validator, error) {
 		tURL.Path = ""
 	}
 
+	sessionconfig.ClusterPath = input.ComputeResourcePath
 	sessionconfig.Service = tURL.String()
 
 	sessionconfig.CloneTicket = input.CloneTicket
@@ -325,7 +325,7 @@ func (v *Validator) Validate(ctx context.Context, input *data.Data) (*config.Vir
 	v.CheckFirewall(op, conf)
 	v.CheckPersistNetworkBacking(op, false)
 	v.CheckLicense(op)
-	v.CheckDrs(op)
+	v.CheckDRS(op)
 
 	v.certificate(op, input, conf)
 	v.certificateAuthorities(op, input, conf)

--- a/lib/install/validate/validator_test_sim_util.go
+++ b/lib/install/validate/validator_test_sim_util.go
@@ -188,7 +188,7 @@ func (v *Validator) VcsimValidate(ctx context.Context, localInputConfig *data.Da
 	v.storage(op, localInputConfig, conf)
 	v.network(op, localInputConfig, conf)
 	v.CheckLicense(op)
-	v.CheckDrs(op)
+	v.CheckDRS(op)
 
 	// fmt.Printf("Config: %# v\n", pretty.Formatter(conf))
 

--- a/lib/portlayer/exec/commit.go
+++ b/lib/portlayer/exec/commit.go
@@ -64,7 +64,7 @@ func Commit(op trace.Operation, sess *session.Session, h *Handle, waitTime *int3
 		} else {
 			// Create the vm
 			res, err = tasks.WaitForResult(op, func(op context.Context) (tasks.Task, error) {
-				return sess.VMFolder.CreateVM(op, *h.Spec.Spec(), Config.ResourcePool, nil)
+				return sess.VCHFolder.CreateVM(op, *h.Spec.Spec(), Config.ResourcePool, nil)
 			})
 		}
 

--- a/lib/portlayer/portlayer.go
+++ b/lib/portlayer/portlayer.go
@@ -72,6 +72,13 @@ func Init(ctx context.Context, sess *session.Session) error {
 		return err
 	}
 
+	// store the reference to the vch inventory folder before poertlayer init
+	vchFolder, err := vchvm.ParentInventoryFolder(ctx, sess)
+	if err != nil {
+		return err
+	}
+	sess.VCHFolder = vchFolder
+
 	if err = storage.Init(ctx, sess, vmParentPool, source, sink); err != nil {
 		return err
 	}

--- a/pkg/vsphere/compute/cluster.go
+++ b/pkg/vsphere/compute/cluster.go
@@ -1,0 +1,46 @@
+// Copyright 2018 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package compute
+
+import (
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/vic/pkg/trace"
+)
+
+type Cluster struct {
+	*object.ClusterComputeResource
+}
+
+func NewCluster(compute object.ComputeResource) *Cluster {
+	// ensure we have a cluster
+	if compute.Reference().Type != "ClusterComputeResource" {
+		return nil
+	}
+
+	return &Cluster{
+		&object.ClusterComputeResource{
+			ComputeResource: compute,
+		},
+	}
+}
+
+// DRSEnabled returns a bool indicating if DRS is enabled
+func (c *Cluster) DRSEnabled(op trace.Operation) (bool, error) {
+	config, err := c.Configuration(op)
+	if err != nil {
+		return false, err
+	}
+	return *config.DrsConfig.Enabled, nil
+}

--- a/pkg/vsphere/compute/placement/placement.go
+++ b/pkg/vsphere/compute/placement/placement.go
@@ -1,0 +1,31 @@
+// Copyright 2018 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package placement
+
+import (
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/vic/pkg/trace"
+	"github.com/vmware/vic/pkg/vsphere/vm"
+)
+
+// HostPlacementPolicy defines the interface for using metrics to decide the appropriate host
+// for a VM based on host metrics and VM provisioned resources.
+type HostPlacementPolicy interface {
+	// CheckHost checks whether or not the host a VM was created on is adequate for power-on.
+	CheckHost(trace.Operation, *vm.VirtualMachine) bool
+
+	// RecommendHost recommends an adequate host for the supplied VM power-on.
+	RecommendHost(trace.Operation, *vm.VirtualMachine) (*object.HostSystem, error)
+}

--- a/pkg/vsphere/compute/placement/random.go
+++ b/pkg/vsphere/compute/placement/random.go
@@ -1,0 +1,59 @@
+// Copyright 2018 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package placement
+
+import (
+	"math/rand"
+
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/vic/pkg/trace"
+	"github.com/vmware/vic/pkg/vsphere/compute"
+	"github.com/vmware/vic/pkg/vsphere/vm"
+)
+
+// RandomHostPolicy chooses a random host on which to power-on a VM.
+type RandomHostPolicy struct{}
+
+// NewRandomHostPolicy returns a RandomHostPolicy instance.
+func NewRandomHostPolicy() *RandomHostPolicy {
+	return &RandomHostPolicy{}
+}
+
+// CheckHost always returns false in a RandomHostPolicy.
+func (p *RandomHostPolicy) CheckHost(op trace.Operation, vm *vm.VirtualMachine) bool {
+	return false
+}
+
+// RecommendHost recommends a random host on which to place a newly created VM.
+func (p *RandomHostPolicy) RecommendHost(op trace.Operation, vm *vm.VirtualMachine) (*object.HostSystem, error) {
+	r, err := vm.ResourcePool(op)
+	if err != nil {
+		return nil, err
+	}
+
+	rp := compute.NewResourcePool(op, vm.Session, r.Reference())
+
+	cls, err := rp.GetCluster(op)
+	if err != nil {
+		return nil, err
+	}
+
+	hosts, err := cls.Hosts(op)
+	if err != nil {
+		return nil, err
+	}
+
+	return hosts[rand.Intn(len(hosts))], nil
+}

--- a/pkg/vsphere/compute/placement/random_test.go
+++ b/pkg/vsphere/compute/placement/random_test.go
@@ -1,0 +1,108 @@
+// Copyright 2018 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package placement
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/vmware/govmomi/simulator"
+	"github.com/vmware/govmomi/vim25/types"
+	"github.com/vmware/vic/pkg/trace"
+	"github.com/vmware/vic/pkg/vsphere/extraconfig"
+	"github.com/vmware/vic/pkg/vsphere/session"
+	"github.com/vmware/vic/pkg/vsphere/tasks"
+	"github.com/vmware/vic/pkg/vsphere/test"
+	"github.com/vmware/vic/pkg/vsphere/vm"
+)
+
+// vpxModelSetup creates a VPX model, starts its server and populates the session. The caller must
+// clean up the model and the server once it is done using them.
+func vpxModelSetup(ctx context.Context, t *testing.T) (*simulator.Model, *simulator.Server, *session.Session) {
+	model := simulator.VPX()
+	if err := model.Create(); err != nil {
+		t.Fatal(err)
+	}
+
+	server := model.Service.NewServer()
+	sess, err := test.SessionWithVPX(ctx, server.URL.String())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return model, server, sess
+}
+
+func TestRandomRecommendHost(t *testing.T) {
+	op := trace.NewOperation(context.Background(), "TestRandomRecommendHost")
+
+	model, server, sess := vpxModelSetup(op, t)
+	defer func() {
+		model.Remove()
+		server.Close()
+	}()
+
+	cls := sess.Cluster
+
+	hosts, err := cls.Hosts(op)
+	assert.NoError(t, err)
+
+	name := "test-vm"
+	vmx := fmt.Sprintf("%s/%s.vmx", name, name)
+	ds := sess.Datastore
+	secretKey, err := extraconfig.NewSecretKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	spec := types.VirtualMachineConfigSpec{
+		Name:    name,
+		GuestId: string(types.VirtualMachineGuestOsIdentifierOtherGuest),
+		Files: &types.VirtualMachineFileInfo{
+			VmPathName: fmt.Sprintf("[%s] %s", ds.Name(), vmx),
+		},
+		ExtraConfig: []types.BaseOptionValue{
+			&types.OptionValue{
+				Key:   extraconfig.GuestInfoSecretKey,
+				Value: secretKey.String(),
+			},
+		},
+	}
+
+	res, err := tasks.WaitForResult(op, func(op context.Context) (tasks.Task, error) {
+		return sess.VMFolder.CreateVM(op, spec, sess.Pool, nil)
+	})
+	assert.NoError(t, err)
+
+	v := vm.NewVirtualMachine(op, sess, res.Result.(types.ManagedObjectReference))
+
+	rhp := NewRandomHostPolicy()
+	assert.False(t, rhp.CheckHost(op, v))
+	h, err := rhp.RecommendHost(op, v)
+	assert.NoError(t, err)
+
+	// TODO(jzt): come up with a better way to verify this than using a loop/moref comparison
+	found := false
+	for _, host := range hosts {
+		if h.Reference().String() == host.Reference().String() {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found)
+}

--- a/pkg/vsphere/compute/placement/ranked.go
+++ b/pkg/vsphere/compute/placement/ranked.go
@@ -1,0 +1,83 @@
+// Copyright 2018 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package placement
+
+import (
+	"sort"
+
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/vic/pkg/trace"
+	"github.com/vmware/vic/pkg/vsphere/performance"
+	"github.com/vmware/vic/pkg/vsphere/vm"
+)
+
+const (
+	// TODO(jzt): move these values into a Configuration struct so that consumers can provide
+	// different weights.
+	memUnconsumedWeight = 0.7 // available memory (total - consumed)
+	memInactiveWeight   = 0.3 // active memory on the host
+)
+
+type rankedHost struct {
+	HostReference string
+	*performance.HostMetricsInfo
+	score float64
+}
+
+type rankedHosts []rankedHost
+
+func (r rankedHosts) Len() int           { return len(r) }
+func (r rankedHosts) Swap(i, j int)      { r[i], r[j] = r[j], r[i] }
+func (r rankedHosts) Less(i, j int) bool { return r[i].score > r[j].score }
+
+// RankedHostPolicy uses data from a MetricsProvider to decide on which host to power-on a VM.
+type RankedHostPolicy struct {
+	source performance.MetricsProvider
+}
+
+// NewRankedHostPolicy returns a RandomHostPolicy instance using the supplied MetricsProvider.
+func NewRankedHostPolicy(s performance.MetricsProvider) *RankedHostPolicy {
+	return &RankedHostPolicy{source: s}
+}
+
+// CheckHost returns true if the host has adequate capacity to power on the VM, false otherwise.
+func (r *RankedHostPolicy) CheckHost(op trace.Operation, vm *vm.VirtualMachine) bool {
+	// TODO(jzt): return false until we have host checking logic decided
+	return false
+}
+
+// RecommendHost recommends an ideal host on which to place a newly created VM.
+func (r *RankedHostPolicy) RecommendHost(op trace.Operation, vm *vm.VirtualMachine) (*object.HostSystem, error) {
+	return nil, nil
+}
+
+func (r *RankedHostPolicy) rankHosts(op trace.Operation, hm map[string]*performance.HostMetricsInfo) []rankedHost {
+	ranking := []rankedHost{}
+	for h, m := range hm {
+		rh := rankedHost{
+			HostReference:   h,
+			HostMetricsInfo: m,
+			score:           r.rankMemory(m) * (1 - m.CPU.UsagePercent),
+		}
+		ranking = append(ranking, rh)
+	}
+	sort.Sort(rankedHosts(ranking))
+	return ranking
+}
+
+func (r *RankedHostPolicy) rankMemory(hm *performance.HostMetricsInfo) float64 {
+	free := float64(hm.Memory.TotalKB-hm.Memory.ConsumedKB) / 1024.0
+	return free * memUnconsumedWeight
+}

--- a/pkg/vsphere/compute/placement/ranked_test.go
+++ b/pkg/vsphere/compute/placement/ranked_test.go
@@ -1,0 +1,140 @@
+// Copyright 2018 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package placement
+
+import (
+	"context"
+	"testing"
+
+	units "github.com/docker/go-units"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25/types"
+	"github.com/vmware/vic/pkg/trace"
+	"github.com/vmware/vic/pkg/vsphere/performance"
+)
+
+// MockMetricsProvider mocks the MetricsProvider interface.
+type MockMetricsProvider struct{}
+
+// GetMetricsForComputeResource not yet implemented.
+func (m MockMetricsProvider) GetMetricsForComputeResource(op trace.Operation, cr *object.ComputeResource) (map[string]*performance.HostMetricsInfo, error) {
+	return nil, nil
+}
+
+var (
+	low = &performance.HostMetricsInfo{
+		Memory: performance.HostMemory{
+			TotalKB:    1 * units.GiB,
+			ConsumedKB: 900 * units.MiB,
+		},
+		CPU: performance.HostCPU{
+			UsagePercent: 0.25,
+		},
+	}
+	// slightly higher CPU usage than medium
+	lowMedium = &performance.HostMetricsInfo{
+		Memory: performance.HostMemory{
+			TotalKB:    16 * units.GiB,
+			ConsumedKB: 9 * units.GiB,
+		},
+		CPU: performance.HostCPU{
+			UsagePercent: 0.50,
+		},
+	}
+	medium = &performance.HostMetricsInfo{
+		Memory: performance.HostMemory{
+			TotalKB:    16 * units.GiB,
+			ConsumedKB: 9 * units.GiB,
+		},
+		CPU: performance.HostCPU{
+			UsagePercent: 0.25,
+		},
+	}
+	high = &performance.HostMetricsInfo{
+		Memory: performance.HostMemory{
+			TotalKB:    32 * units.GiB,
+			ConsumedKB: 24 * units.GiB,
+		},
+		CPU: performance.HostCPU{
+			UsagePercent: 0.3,
+		},
+	}
+
+	lh = &object.HostSystem{
+		Common: object.NewCommon(nil, types.ManagedObjectReference{
+			Type:  "low_type",
+			Value: "low_value",
+		}),
+	}
+	lmh = &object.HostSystem{
+		Common: object.NewCommon(nil, types.ManagedObjectReference{
+			Type:  "lowmedium_type",
+			Value: "lowmedium_value",
+		}),
+	}
+	mh = &object.HostSystem{
+		Common: object.NewCommon(nil, types.ManagedObjectReference{
+			Type:  "medium_type",
+			Value: "medium_value",
+		}),
+	}
+	hh = &object.HostSystem{
+		Common: object.NewCommon(nil, types.ManagedObjectReference{
+			Type:  "high_type",
+			Value: "high_value",
+		}),
+	}
+)
+
+func (m MockMetricsProvider) GetMetricsForHosts(op trace.Operation, hosts []*object.HostSystem) (map[string]*performance.HostMetricsInfo, error) {
+	fakeHostMetrics := make(map[string]*performance.HostMetricsInfo)
+	fakeHostMetrics[lh.Reference().String()] = low
+	fakeHostMetrics[lmh.Reference().String()] = lowMedium
+	fakeHostMetrics[mh.Reference().String()] = medium
+	fakeHostMetrics[hh.Reference().String()] = high
+
+	return fakeHostMetrics, nil
+}
+
+func TestRankedRecommendHost(t *testing.T) {
+	op := trace.NewOperation(context.Background(), "TestRankedRecommendHost")
+
+	model, server, _ := vpxModelSetup(op, t)
+	defer func() {
+		model.Remove()
+		server.Close()
+	}()
+
+	m := MockMetricsProvider{}
+	hm, err := m.GetMetricsForHosts(op, []*object.HostSystem{})
+	assert.NoError(t, err)
+
+	rhp := NewRankedHostPolicy(m)
+	result := rhp.rankHosts(op, hm)
+
+	for _, r := range result {
+		op.Infof("%s: %f", r.HostReference, r.score)
+	}
+
+	expected := lh.Reference().String()
+	actual := result[0].HostReference
+	assert.NotEqual(t, expected, actual)
+
+	expected = hh.Reference().String()
+	actual = result[0].HostReference
+	assert.Equal(t, expected, actual)
+}

--- a/pkg/vsphere/performance/host_metrics.go
+++ b/pkg/vsphere/performance/host_metrics.go
@@ -1,0 +1,179 @@
+// Copyright 2018 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package performance
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/performance"
+	"github.com/vmware/govmomi/vim25/types"
+	"github.com/vmware/vic/pkg/trace"
+	"github.com/vmware/vic/pkg/vsphere/session"
+)
+
+const (
+	// cpuUsage measures the actively used CPU of the host, as a percentage of the total available CPU.
+	cpuUsage = "cpu.usage.average"
+
+	// memActive measures the sum of all active metrics for all powered-on VMs plus vSphere services on the host.
+	memActive = "mem.active.average"
+
+	// memConsumed measures the amount of machine memory used on the host, including vSphere services, VMkernel,
+	// the service console and the total consumed memory metrics for all running VMs.
+	memConsumed = "mem.consumed.average"
+
+	// memTotalCapacity measures the total amount of memory reservation used by and available for powered-on VMs
+	// and vSphere services on the host.
+	memTotalCapacity = "mem.totalCapacity.average"
+
+	// memOverhead measures the total of all overhead metrics for powered-on VMs, plus the overhead of running
+	// vSphere services on the host.
+	memOverhead = "mem.overhead.average"
+)
+
+// HostMemory stores an ESXi host's memory metrics.
+type HostMemory struct {
+	ActiveKB   int64
+	ConsumedKB int64
+	OverheadKB int64
+	TotalKB    int64
+}
+
+// HostCPU stores an ESXi host's CPU metrics.
+type HostCPU struct {
+	UsagePercent float64
+}
+
+// HostMetricsInfo stores an ESXi host's memory and CPU metrics.
+type HostMetricsInfo struct {
+	Memory HostMemory
+	CPU    HostCPU
+}
+
+// HostMetrics returns CPU and memory metrics for all ESXi hosts in the input session's cluster.
+func HostMetrics(op trace.Operation, session *session.Session) (map[*object.HostSystem]*HostMetricsInfo, error) {
+	if session == nil {
+		return nil, fmt.Errorf("session not set")
+	}
+
+	// Gather hosts from the session cluster and then obtain their morefs.
+	hosts, err := gatherHosts(op.Context, session)
+	if err != nil {
+		return nil, fmt.Errorf("unable to obtain host morefs from session: %s", err)
+	}
+	morefToHost := make(map[types.ManagedObjectReference]*object.HostSystem)
+	morefs := make([]types.ManagedObjectReference, len(hosts))
+	for i, host := range hosts {
+		moref := host.Reference()
+		morefToHost[moref] = host
+		morefs[i] = moref
+	}
+
+	// Query CPU and memory metrics for the morefs.
+	spec := types.PerfQuerySpec{
+		Format:     string(types.PerfFormatNormal),
+		IntervalId: sampleInterval,
+	}
+
+	counters := []string{cpuUsage, memActive, memConsumed, memTotalCapacity, memOverhead}
+	perfMgr := performance.NewManager(session.Vim25())
+	sample, err := perfMgr.SampleByName(op.Context, spec, counters, morefs)
+	if err != nil {
+		errStr := "unable to get metric sample: %s"
+		op.Errorf(errStr, err)
+		return nil, fmt.Errorf(errStr, err)
+	}
+
+	results, err := perfMgr.ToMetricSeries(op.Context, sample)
+	if err != nil {
+		errStr := "unable to convert metric sample to metric series: %s"
+		op.Errorf(errStr, err)
+		return nil, fmt.Errorf(errStr, err)
+	}
+
+	metrics := assembleMetrics(op, morefToHost, results)
+	return metrics, nil
+}
+
+// assembleMetrics processes the metric samples received from govmomi and returns a finalized metrics map
+// keyed by the hosts.
+func assembleMetrics(op trace.Operation, morefToHost map[types.ManagedObjectReference]*object.HostSystem,
+	results []performance.EntityMetric) map[*object.HostSystem]*HostMetricsInfo {
+	metrics := make(map[*object.HostSystem]*HostMetricsInfo)
+
+	for _, host := range morefToHost {
+		metrics[host] = &HostMetricsInfo{}
+	}
+
+	for i := range results {
+		res := results[i]
+		host, exists := morefToHost[res.Entity]
+		if !exists {
+			op.Warnf("moref %s does not exist in requested morefs, skipping", res.Entity.String())
+			continue
+		}
+
+		// Process each value and assign it directly to the corresponding metric field
+		// since there is only one sample.
+		for _, v := range res.Value {
+
+			// We don't need to collect non-aggregate (non-empty Instance) metrics.
+			if v.Instance != "" {
+				continue
+			}
+
+			if len(v.Value) == 0 {
+				op.Warnf("metric %s for moref %s has no value, skipping", v.Name, res.Entity.String())
+				continue
+			}
+
+			switch v.Name {
+			case cpuUsage:
+				// Convert percent units from 1/100th of a percent (100 = 1%) to a human-readable percentage.
+				metrics[host].CPU.UsagePercent = float64(v.Value[0]) / 100.0
+			case memActive:
+				metrics[host].Memory.ActiveKB = v.Value[0]
+			case memConsumed:
+				metrics[host].Memory.ConsumedKB = v.Value[0]
+			case memOverhead:
+				metrics[host].Memory.OverheadKB = v.Value[0]
+			case memTotalCapacity:
+				// Total capacity is in MB, convert to KB so as to have all memory values in KB.
+				metrics[host].Memory.TotalKB = v.Value[0] * 1024
+			}
+		}
+	}
+
+	return metrics
+}
+
+// gatherHosts gathers ESXi host(s) from the input session's cluster.
+func gatherHosts(ctx context.Context, session *session.Session) ([]*object.HostSystem, error) {
+	if session.Cluster == nil {
+		return nil, fmt.Errorf("session cluster not set")
+	}
+
+	hosts, err := session.Cluster.Hosts(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("unable to obtain hosts from session cluster: %s", err)
+	}
+	if hosts == nil {
+		return nil, fmt.Errorf("no hosts found from session cluster")
+	}
+
+	return hosts, nil
+}

--- a/pkg/vsphere/performance/host_metrics_test.go
+++ b/pkg/vsphere/performance/host_metrics_test.go
@@ -1,0 +1,185 @@
+// Copyright 2018 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package performance
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/performance"
+	"github.com/vmware/govmomi/simulator"
+	"github.com/vmware/govmomi/vim25/types"
+	"github.com/vmware/vic/pkg/trace"
+	"github.com/vmware/vic/pkg/vsphere/session"
+	"github.com/vmware/vic/pkg/vsphere/test"
+)
+
+// vpxModelSetup creates a VPX model, starts its server and populates the session. The caller must
+// clean up the model and the server once it is done using them.
+func vpxModelSetup(ctx context.Context, t *testing.T) (*simulator.Model, *simulator.Server, *session.Session) {
+	model := simulator.VPX()
+	if err := model.Create(); err != nil {
+		t.Fatal(err)
+	}
+
+	server := model.Service.NewServer()
+	sess, err := test.SessionWithVPX(ctx, server.URL.String())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return model, server, sess
+}
+
+func TestAssembleMetrics(t *testing.T) {
+	ctx := context.Background()
+	op := trace.NewOperation(ctx, "TestAssembleMetrics")
+
+	model, server, sess := vpxModelSetup(ctx, t)
+	defer func() {
+		model.Remove()
+		server.Close()
+	}()
+
+	hosts, err := sess.Cluster.Hosts(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	morefToHost := make(map[types.ManagedObjectReference]*object.HostSystem)
+	for i := range hosts {
+		moref := hosts[i].Reference()
+		morefToHost[moref] = hosts[i]
+	}
+
+	var results []performance.EntityMetric
+	counters := []string{cpuUsage, memActive, memConsumed, memTotalCapacity, memOverhead}
+
+	// Create a fake host and then populate metric results for it. This tests that assembleMetrics
+	// rejects and does not assemble metrics for a host whose metrics were not requested
+	// (i.e. part of morefToHost) but were still present in the metrics from govmomi.
+	fakeHostMoref := types.ManagedObjectReference{
+		Type:  "foo",
+		Value: "bar",
+	}
+	fakeHost := object.NewHostSystem(nil, fakeHostMoref)
+	hosts = append(hosts, fakeHost)
+
+	// Populate metric results for all hosts, including fakeHost.
+	for i := range hosts {
+		var values []performance.MetricSeries
+		for j := range counters {
+			val := performance.MetricSeries{
+				Name:  counters[j],
+				Value: []int64{int64(i)},
+			}
+			values = append(values, val)
+		}
+
+		results = append(results, performance.EntityMetric{
+			Entity: hosts[i].Reference(),
+			Value:  values,
+		})
+	}
+
+	// Insert a non-aggregrate CPU usage value for the first host in metrics results
+	// to check that non-aggregrate values aren't processed in assembleMetrics.
+	instanceValue := []performance.MetricSeries{{
+		Name:     counters[0],
+		Instance: "1",
+		Value:    []int64{int64(9999)},
+	}}
+	results = append(results, performance.EntityMetric{
+		Entity: hosts[0].Reference(),
+		Value:  instanceValue,
+	})
+
+	// Insert a metric with no value to test that assembleMetrics skips it.
+	emptyValue := []performance.MetricSeries{{
+		Name:  counters[0],
+		Value: []int64{},
+	}}
+	results = append(results, performance.EntityMetric{
+		Entity: hosts[0].Reference(),
+		Value:  emptyValue,
+	})
+
+	// Once fakeHost's metrics have been added, remove it from the hosts slice for upcoming checks.
+	hosts = hosts[:len(hosts)-1]
+
+	metrics := assembleMetrics(op, morefToHost, results)
+
+	// Assembled metrics should not have an entry for fakeHost.
+	assert.Equal(t, len(metrics), len(hosts))
+	_, exists := metrics[fakeHost]
+	assert.False(t, exists, "fakeHost %s should not be present in result metrics", fakeHost.String())
+
+	for i, host := range hosts {
+		hostMetric, exists := metrics[host]
+		assert.True(t, exists, "host %s should be present in result metrics", host.String())
+
+		i := int64(i)
+		assert.Equal(t, hostMetric.CPU.UsagePercent, float64(i)/100.0)
+		assert.Equal(t, hostMetric.Memory.ActiveKB, i)
+		assert.Equal(t, hostMetric.Memory.ConsumedKB, i)
+		assert.Equal(t, hostMetric.Memory.OverheadKB, i)
+		// Test that the total memory value is converted from MB to KB.
+		assert.Equal(t, hostMetric.Memory.TotalKB, i*1024)
+	}
+
+	// Test that when a host moref is present in the govmomi metrics request but its metric
+	// results are missing, assembleMetrics creates an empty entry for the said host.
+	morefToHost[fakeHost.Reference()] = fakeHost
+
+	// Remove fakeHost's metrics from the results slice to feed into assembleMetrics.
+	var fakeResults []performance.EntityMetric
+	for i := range results {
+		if results[i].Entity != fakeHost.Reference() {
+			fakeResults = append(fakeResults, results[i])
+		}
+	}
+
+	metrics = assembleMetrics(op, morefToHost, fakeResults)
+	// Assembled metrics should now have an (empty) entry for fakeHost.
+	assert.Equal(t, len(metrics), len(hosts)+1)
+	fakeHostMetrics, exists := metrics[fakeHost]
+	assert.True(t, exists, "fakeHost %s should now be present in result metrics", fakeHost.String())
+	expectedFakeMetrics := HostMetricsInfo{}
+	assert.Equal(t, expectedFakeMetrics, *fakeHostMetrics)
+}
+
+func TestGatherHosts(t *testing.T) {
+	ctx := context.Background()
+
+	model, server, sess := vpxModelSetup(ctx, t)
+	defer func() {
+		model.Remove()
+		server.Close()
+	}()
+
+	// gatherHosts should return a valid slice of hosts for a populated session.
+	hosts, err := gatherHosts(ctx, sess)
+	assert.NoError(t, err)
+	assert.NotNil(t, hosts)
+
+	// Test for an error when the session cluster is nil.
+	sess.Cluster = nil
+	hosts, err = gatherHosts(ctx, sess)
+	assert.Error(t, err)
+	assert.Nil(t, hosts)
+}

--- a/pkg/vsphere/performance/metrics_provider.go
+++ b/pkg/vsphere/performance/metrics_provider.go
@@ -1,0 +1,29 @@
+// Copyright 2018 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package performance
+
+import (
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/vic/pkg/trace"
+)
+
+// MetricsProvider defines the interface for providing metrics.
+type MetricsProvider interface {
+	// GetMetricsForComputeResource returns metrics for a particular compute resource
+	GetMetricsForComputeResource(trace.Operation, *object.ComputeResource) (map[string]*HostMetricsInfo, error)
+
+	// GetMetricsForHosts returns metrics pertaining to supplied ESX hosts.
+	GetMetricsForHosts(trace.Operation, []*object.HostSystem) (map[string]*HostMetricsInfo, error)
+}

--- a/pkg/vsphere/session/session.go
+++ b/pkg/vsphere/session/session.go
@@ -93,6 +93,9 @@ type Session struct {
 
 	VMFolder *object.Folder
 
+	// the parent inventory folder to the VCH
+	VCHFolder *object.Folder
+
 	Finder *find.Finder
 
 	DRSEnabled *bool
@@ -125,7 +128,12 @@ func LimitConcurrency(rt http.RoundTripper, limit int) http.RoundTripper {
 }
 
 // NewSession creates a new Session struct.
-func NewSession(config *Config) *Session {
+func NewSession(config *Config, vchMoref ...*types.ManagedObjectReference) *Session {
+	if len(vchMoref) > 0 {
+		// get the virtual machine reference for the VCH and assign it.
+
+	}
+
 	return &Session{Config: config}
 }
 
@@ -371,6 +379,7 @@ func (s *Session) Populate(ctx context.Context) (*Session, error) {
 			op.Debugf("Cached folders: %s", s.DatacenterPath)
 		}
 		s.VMFolder = folders.VmFolder
+		s.VCHFolder = folders.VmFolder
 	}
 
 	if len(errs) > 0 {

--- a/pkg/vsphere/vm/vm.go
+++ b/pkg/vsphere/vm/vm.go
@@ -121,6 +121,21 @@ func (vm *VirtualMachine) FolderName(ctx context.Context) (string, error) {
 	return path.Base(u.Path), nil
 }
 
+func (vm *VirtualMachine) ParentInventoryFolder(ctx context.Context, sess *session.Session) (*object.Folder, error) {
+	element, err := sess.Finder.Element(ctx, vm.Reference())
+	if err != nil {
+		return nil, err
+	}
+
+	parentPath := path.Dir(element.Path)
+	folderRef, err := sess.Finder.Folder(ctx, parentPath)
+	if err != nil {
+		return nil, err
+	}
+
+	return folderRef, nil
+}
+
 func (vm *VirtualMachine) getNetworkName(op trace.Operation, nic types.BaseVirtualEthernetCard) (string, error) {
 	if card, ok := nic.GetVirtualEthernetCard().Backing.(*types.VirtualEthernetCardDistributedVirtualPortBackingInfo); ok {
 		pg := card.Port.PortgroupKey
@@ -471,7 +486,7 @@ func (vm *VirtualMachine) fixVM(op trace.Operation) error {
 		return err
 	}
 
-	task, err := vm.registerVM(op, mvm.Summary.Config.VmPathName, name, mvm.ParentVApp, mvm.ResourcePool, mvm.Summary.Runtime.Host, vm.Session.VMFolder)
+	task, err := vm.registerVM(op, mvm.Summary.Config.VmPathName, name, mvm.ParentVApp, mvm.ResourcePool, mvm.Summary.Runtime.Host, vm.Session.VCHFolder)
 	if err != nil {
 		op.Errorf("Unable to register VM %q back: %s", name, err)
 		return err

--- a/tests/manual-test-cases/Group19-ROBO/19-3-ROBO-VM-Placement.md
+++ b/tests/manual-test-cases/Group19-ROBO/19-3-ROBO-VM-Placement.md
@@ -20,24 +20,26 @@ See https://confluence.eng.vmware.com/display/CNA/VIC+ROBO for more details.
 
 # Test Steps:
 1. Deploy a ROBO Advanced vCenter testbed for both environments above
-2. Install a VCH on a particular cluster on vCenter - see note in [Environment](#environment)
-3. Deploy containers that will consume resources predictably (e.g. the `progrium/stress` image)
-4. Measure cluster metrics and gather resource consumption
-5. Create and run regular containers such as `busybox`
-6. Create and run enough containers to consume all available cluster resources
-7. Attempt to create and run more containers
-8. Delete some containers
-9. Create and run a few containers
-10. Delete the VCH
+2. Run a few dummy VMs on the host(s) in the vCenter cluster meant for VCH installation. This ensures that the hosts have varying resource utilization.
+3. Install a VCH on a particular cluster on vCenter - see note in [Environment](#environment)
+4. Deploy containers that will consume resources predictably (e.g. the `progrium/stress` image)
+5. Measure cluster metrics and gather resource consumption
+6. Create and run regular containers such as `busybox`
+7. Create and run enough containers to consume all available cluster resources
+8. Attempt to create and run more containers
+9. Delete some containers
+10. Create and run a few containers
+11. Delete the VCH
 
 # Expected Outcome:
 * Step 1 should succeed
-* Step 2 should succeed and the VCH should be placed on a host that satisfies the license and other feature requirements
-* Steps 3-4 should succeed and containers should be placed on ESX hosts in the cluster according to the criteria defined in point 2 of [References](#references)
-* Step 5 should succeed and containers should be placed on ESX hosts in the cluster that have available resources according to the criteria defined in point 2 of [References](#references). In the multi-host cluster environment, the cluster resource utilization level should be as expected given containerVM sizes, cluster capacity and placement logic.
-* Step 6 should succeed
-* Step 7 should fail since the available resources are exhausted
-* Steps 8-10 should succeed
+* Step 2 should succeed
+* Step 3 should succeed and the VCH should be placed on a host that satisfies the license and feature checks. The VCH's host should also meet the criteria defined in point 2 of [References](#references)
+* Steps 4-5 should succeed and containers should be placed on ESX hosts in the cluster according to the criteria defined in point 2 of [References](#references)
+* Step 6 should succeed and containers should be placed on ESX hosts in the cluster that have available resources according to the criteria defined in point 2 of [References](#references). In the multi-host cluster environment, the cluster resource utilization level should be as expected given containerVM sizes, cluster capacity and placement logic.
+* Step 7 should succeed
+* Step 8 should fail since the available resources are exhausted
+* Steps 9-11 should succeed
 
 # Possible Problems:
 None

--- a/tests/test-cases/Group6-VIC-Machine/6-11-Debug.robot
+++ b/tests/test-cases/Group6-VIC-Machine/6-11-Debug.robot
@@ -48,7 +48,7 @@ Check Password Change When Expired
     ${rc}=  Run And Return Rc  bin/vic-machine-linux debug --target %{TEST_URL} --thumbprint=%{TEST_THUMBPRINT} --user %{TEST_USERNAME} --password=%{TEST_PASSWORD} --compute-resource=%{TEST_RESOURCE} --name %{VCH-NAME} --enable-ssh --authorized-key=%{VCH-NAME}.key.pub
     Should Be Equal As Integers  ${rc}  0
 
-    # push the date forward, past the suport duration
+    # push the date forward, past the support duration
     ${rc}  ${output}=  Run And Return Rc And Output  ssh -o StrictHostKeyChecking=no -i %{VCH-NAME}.key root@%{VCH-IP} 'date -s " +6 year"'
     Should Be Equal As Integers  ${rc}  0
 
@@ -70,6 +70,6 @@ Check Password Change When Expired
 Check Error From Incorrect ID
     ${rc}  ${output}=  Run And Return Rc And Output  bin/vic-machine-linux debug --target %{TEST_URL} --thumbprint=%{TEST_THUMBPRINT} --user %{TEST_USERNAME} --password=%{TEST_PASSWORD} --id=wrong
     Should Be Equal As Integers  ${rc}  1
-    Should Contain  ${output}  Failed to get Virtual Container Host 
+    Should Contain  ${output}  Failed to get Virtual Container Host
     Should Contain  ${output}  id \\"wrong\\" could not be found
-    
+

--- a/vendor/github.com/vmware/govmomi/govc/cluster/change.go
+++ b/vendor/github.com/vmware/govmomi/govc/cluster/change.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2015 VMware, Inc. All Rights Reserved.
+Copyright (c) 2015-2017 VMware, Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -26,6 +26,16 @@ import (
 	"github.com/vmware/govmomi/vim25/types"
 )
 
+func DrsBehaviorUsage() string {
+	drsModes := []string{
+		string(types.DrsBehaviorManual),
+		string(types.DrsBehaviorPartiallyAutomated),
+		string(types.DrsBehaviorFullyAutomated),
+	}
+
+	return "DRS behavior for virtual machines: " + strings.Join(drsModes, ", ")
+}
+
 type change struct {
 	*flags.DatacenterFlag
 
@@ -48,13 +58,7 @@ func (cmd *change) Register(ctx context.Context, f *flag.FlagSet) {
 	// DRS
 	f.Var(flags.NewOptionalBool(&cmd.DrsConfig.Enabled), "drs-enabled", "Enable DRS")
 
-	drsModes := []string{
-		string(types.DrsBehaviorManual),
-		string(types.DrsBehaviorPartiallyAutomated),
-		string(types.DrsBehaviorFullyAutomated),
-	}
-	f.StringVar((*string)(&cmd.DrsConfig.DefaultVmBehavior), "drs-mode", "",
-		"DRS behavior for virtual machines: "+strings.Join(drsModes, ", "))
+	f.StringVar((*string)(&cmd.DrsConfig.DefaultVmBehavior), "drs-mode", "", DrsBehaviorUsage())
 
 	// HA
 	f.Var(flags.NewOptionalBool(&cmd.DasConfig.Enabled), "ha-enabled", "Enable HA")

--- a/vendor/github.com/vmware/govmomi/govc/cluster/override/change.go
+++ b/vendor/github.com/vmware/govmomi/govc/cluster/override/change.go
@@ -1,0 +1,148 @@
+/*
+Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package override
+
+import (
+	"context"
+	"flag"
+	"strings"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/cluster"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type change struct {
+	*flags.ClusterFlag
+	*flags.VirtualMachineFlag
+
+	drs types.ClusterDrsVmConfigInfo
+	das types.ClusterDasVmConfigInfo
+}
+
+func init() {
+	cli.Register("cluster.override.change", &change{})
+}
+
+func (cmd *change) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.ClusterFlag, ctx = flags.NewClusterFlag(ctx)
+	cmd.ClusterFlag.Register(ctx, f)
+	cmd.VirtualMachineFlag, ctx = flags.NewVirtualMachineFlag(ctx)
+	cmd.VirtualMachineFlag.Register(ctx, f)
+
+	// DRS
+	f.Var(flags.NewOptionalBool(&cmd.drs.Enabled), "drs-enabled", "Enable DRS")
+
+	f.StringVar((*string)(&cmd.drs.Behavior), "drs-mode", "", cluster.DrsBehaviorUsage())
+
+	// HA
+	rp := []string{
+		string(types.DasVmPriorityDisabled),
+		string(types.DasVmPriorityLow),
+		string(types.DasVmPriorityMedium),
+		string(types.DasVmPriorityHigh),
+	}
+	cmd.das.DasSettings = new(types.ClusterDasVmSettings)
+
+	f.StringVar((*string)(&cmd.das.DasSettings.RestartPriority), "ha-restart-priority", "", "HA restart priority: "+strings.Join(rp, ", "))
+}
+
+func (cmd *change) Description() string {
+	return `Change cluster VM overrides.
+
+Examples:
+  govc cluster.override.change -cluster cluster_1 -vm vm_1 -ha-restart-priority high
+  govc cluster.override.change -cluster cluster_1 -vm vm_2 -drs-enabled=false
+  govc cluster.override.change -cluster cluster_1 -vm vm_3 -drs-enabled -drs-mode fullyAutomated`
+}
+
+func (cmd *change) Process(ctx context.Context) error {
+	if err := cmd.ClusterFlag.Process(ctx); err != nil {
+		return err
+	}
+	return cmd.VirtualMachineFlag.Process(ctx)
+}
+
+func (cmd *change) Run(ctx context.Context, f *flag.FlagSet) error {
+	vm, err := cmd.VirtualMachine()
+	if err != nil {
+		return err
+	}
+
+	if vm == nil {
+		return flag.ErrHelp
+	}
+
+	cluster, err := cmd.Cluster()
+	if err != nil {
+		return err
+	}
+
+	config, err := cluster.Configuration(ctx)
+	if err != nil {
+		return err
+	}
+
+	spec := &types.ClusterConfigSpecEx{}
+	cmd.drs.Key = vm.Reference()
+	cmd.das.Key = vm.Reference()
+
+	if cmd.drs.Behavior != "" || cmd.drs.Enabled != nil {
+		op := types.ArrayUpdateOperationAdd
+		for _, c := range config.DrsVmConfig {
+			if c.Key == cmd.drs.Key {
+				op = types.ArrayUpdateOperationEdit
+				break
+			}
+		}
+
+		spec.DrsVmConfigSpec = []types.ClusterDrsVmConfigSpec{
+			{
+				ArrayUpdateSpec: types.ArrayUpdateSpec{
+					Operation: op,
+				},
+				Info: &cmd.drs,
+			},
+		}
+	}
+
+	if cmd.das.DasSettings.RestartPriority != "" {
+		op := types.ArrayUpdateOperationAdd
+		for _, c := range config.DasVmConfig {
+			if c.Key == cmd.das.Key {
+				op = types.ArrayUpdateOperationEdit
+				break
+			}
+		}
+
+		spec.DasVmConfigSpec = []types.ClusterDasVmConfigSpec{
+			{
+				ArrayUpdateSpec: types.ArrayUpdateSpec{
+					Operation: op,
+				},
+				Info: &cmd.das,
+			},
+		}
+	}
+
+	if spec.DrsVmConfigSpec == nil && spec.DasVmConfigSpec == nil {
+		return flag.ErrHelp
+	}
+
+	return cmd.Reconfigure(ctx, spec)
+}

--- a/vendor/github.com/vmware/govmomi/govc/cluster/override/info.go
+++ b/vendor/github.com/vmware/govmomi/govc/cluster/override/info.go
@@ -1,0 +1,142 @@
+/*
+Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package override
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type info struct {
+	*flags.ClusterFlag
+}
+
+func init() {
+	cli.Register("cluster.override.info", &info{})
+}
+
+func (cmd *info) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.ClusterFlag, ctx = flags.NewClusterFlag(ctx)
+	cmd.ClusterFlag.Register(ctx, f)
+}
+
+func (cmd *info) Description() string {
+	return `Cluster VM overrides info.
+
+Examples:
+  govc cluster.override.info
+  govc cluster.override.info -json`
+}
+
+func (cmd *info) Process(ctx context.Context) error {
+	return cmd.ClusterFlag.Process(ctx)
+}
+
+type Override struct {
+	id   types.ManagedObjectReference
+	Name string
+	Host string                        `json:",omitempty"`
+	DRS  *types.ClusterDrsVmConfigInfo `json:",omitempty"`
+	DAS  *types.ClusterDasVmConfigInfo `json:",omitempty"`
+}
+
+type infoResult struct {
+	Overrides map[string]*Override
+}
+
+func (r *infoResult) Write(w io.Writer) error {
+	tw := tabwriter.NewWriter(w, 2, 0, 2, ' ', 0)
+
+	for _, entry := range r.Overrides {
+		behavior := fmt.Sprintf("Default (%s)", types.DrsBehaviorFullyAutomated)
+		if entry.DRS != nil {
+			if *entry.DRS.Enabled {
+				behavior = string(entry.DRS.Behavior)
+			}
+		}
+
+		priority := fmt.Sprintf("Default (%s)", types.DasVmPriorityMedium)
+		if entry.DAS != nil {
+			priority = entry.DAS.DasSettings.RestartPriority
+		}
+
+		fmt.Fprintf(tw, "Name:\t%s\n", entry.Name)
+		fmt.Fprintf(tw, "  DRS Automation Level:\t%s\n", strings.Title(behavior))
+		fmt.Fprintf(tw, "  HA Restart Priority:\t%s\n", strings.Title(priority))
+		fmt.Fprintf(tw, "  Host:\t%s\n", entry.Host)
+	}
+
+	return tw.Flush()
+}
+
+func (r *infoResult) entry(id types.ManagedObjectReference) *Override {
+	key := id.String()
+	vm, ok := r.Overrides[key]
+	if !ok {
+		r.Overrides[key] = &Override{id: id}
+		vm = r.Overrides[key]
+	}
+	return vm
+}
+
+func (cmd *info) Run(ctx context.Context, f *flag.FlagSet) error {
+	cluster, err := cmd.Cluster()
+	if err != nil {
+		return err
+	}
+
+	config, err := cluster.Configuration(ctx)
+	if err != nil {
+		return err
+	}
+
+	res := &infoResult{
+		Overrides: make(map[string]*Override),
+	}
+
+	for i := range config.DasVmConfig {
+		vm := res.entry(config.DasVmConfig[i].Key)
+
+		vm.DAS = &config.DasVmConfig[i]
+	}
+
+	for i := range config.DrsVmConfig {
+		vm := res.entry(config.DrsVmConfig[i].Key)
+
+		vm.DRS = &config.DrsVmConfig[i]
+	}
+
+	for _, o := range res.Overrides {
+		// TODO: can optimize to reduce round trips
+		vm := object.NewVirtualMachine(cluster.Client(), o.id)
+		o.Name, _ = vm.ObjectName(ctx)
+		if h, herr := vm.HostSystem(ctx); herr == nil {
+			o.Host, _ = h.ObjectName(ctx)
+		}
+	}
+
+	return cmd.WriteResult(res)
+}

--- a/vendor/github.com/vmware/govmomi/govc/cluster/override/remove.go
+++ b/vendor/github.com/vmware/govmomi/govc/cluster/override/remove.go
@@ -1,0 +1,110 @@
+/*
+Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package override
+
+import (
+	"context"
+	"flag"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type remove struct {
+	*flags.ClusterFlag
+	*flags.VirtualMachineFlag
+}
+
+func init() {
+	cli.Register("cluster.override.remove", &remove{})
+}
+
+func (cmd *remove) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.ClusterFlag, ctx = flags.NewClusterFlag(ctx)
+	cmd.ClusterFlag.Register(ctx, f)
+	cmd.VirtualMachineFlag, ctx = flags.NewVirtualMachineFlag(ctx)
+	cmd.VirtualMachineFlag.Register(ctx, f)
+}
+
+func (cmd *remove) Description() string {
+	return `Remove cluster VM overrides.
+
+Examples:
+  govc cluster.override.remove -cluster cluster_1 -vm vm_1`
+}
+
+func (cmd *remove) Process(ctx context.Context) error {
+	if err := cmd.ClusterFlag.Process(ctx); err != nil {
+		return err
+	}
+	return cmd.VirtualMachineFlag.Process(ctx)
+}
+
+func (cmd *remove) Run(ctx context.Context, f *flag.FlagSet) error {
+	vm, err := cmd.VirtualMachine()
+	if err != nil {
+		return err
+	}
+
+	if vm == nil {
+		return flag.ErrHelp
+	}
+
+	cluster, err := cmd.Cluster()
+	if err != nil {
+		return err
+	}
+
+	config, err := cluster.Configuration(ctx)
+	if err != nil {
+		return err
+	}
+
+	spec := &types.ClusterConfigSpecEx{}
+	ref := vm.Reference()
+
+	for _, c := range config.DrsVmConfig {
+		if c.Key == ref {
+			spec.DrsVmConfigSpec = []types.ClusterDrsVmConfigSpec{
+				{
+					ArrayUpdateSpec: types.ArrayUpdateSpec{
+						Operation: types.ArrayUpdateOperationRemove,
+						RemoveKey: ref,
+					},
+				},
+			}
+			break
+		}
+	}
+
+	for _, c := range config.DasVmConfig {
+		if c.Key == ref {
+			spec.DasVmConfigSpec = []types.ClusterDasVmConfigSpec{
+				{
+					ArrayUpdateSpec: types.ArrayUpdateSpec{
+						Operation: types.ArrayUpdateOperationRemove,
+						RemoveKey: ref,
+					},
+				},
+			}
+			break
+		}
+	}
+
+	return cmd.Reconfigure(ctx, spec)
+}

--- a/vendor/github.com/vmware/govmomi/govc/datastore/disk/create.go
+++ b/vendor/github.com/vmware/govmomi/govc/datastore/disk/create.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+Copyright (c) 2017-2018 VMware, Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ package disk
 import (
 	"context"
 	"flag"
+	"fmt"
 
 	"github.com/vmware/govmomi/govc/cli"
 	"github.com/vmware/govmomi/govc/flags"
@@ -27,10 +28,22 @@ import (
 	"github.com/vmware/govmomi/vim25/types"
 )
 
+type spec struct {
+	types.FileBackedVirtualDiskSpec
+	force bool
+}
+
+func (s *spec) Register(ctx context.Context, f *flag.FlagSet) {
+	f.StringVar(&s.AdapterType, "a", string(types.VirtualDiskAdapterTypeLsiLogic), "Disk adapter")
+	f.StringVar(&s.DiskType, "d", string(types.VirtualDiskTypeThin), "Disk format")
+	f.BoolVar(&s.force, "f", false, "Force")
+}
+
 type create struct {
 	*flags.DatastoreFlag
 
 	Bytes units.ByteSize
+	spec
 }
 
 func init() {
@@ -43,13 +56,8 @@ func (cmd *create) Register(ctx context.Context, f *flag.FlagSet) {
 
 	_ = cmd.Bytes.Set("10G")
 	f.Var(&cmd.Bytes, "size", "Size of new disk")
-}
 
-func (cmd *create) Process(ctx context.Context) error {
-	if err := cmd.DatastoreFlag.Process(ctx); err != nil {
-		return err
-	}
-	return nil
+	cmd.spec.Register(ctx, f)
 }
 
 func (cmd *create) Usage() string {
@@ -83,24 +91,24 @@ func (cmd *create) Run(ctx context.Context, f *flag.FlagSet) error {
 	m := object.NewVirtualDiskManager(ds.Client())
 
 	var task *object.Task
-
-	spec := &types.FileBackedVirtualDiskSpec{
-		VirtualDiskSpec: types.VirtualDiskSpec{
-			AdapterType: string(types.VirtualDiskAdapterTypeLsiLogic),
-			DiskType:    string(types.VirtualDiskTypeThin),
-		},
-		CapacityKb: int64(cmd.Bytes) / 1024,
-	}
+	var dst string
 
 	if f.NArg() == 1 {
-		task, err = m.CreateVirtualDisk(ctx, ds.Path(f.Arg(0)), dc, spec)
+		cmd.spec.CapacityKb = int64(cmd.Bytes) / 1024
+		dst = ds.Path(f.Arg(0))
+		task, err = m.CreateVirtualDisk(ctx, dst, dc, &cmd.spec.FileBackedVirtualDiskSpec)
 	} else {
-		task, err = m.CreateChildDisk(ctx, ds.Path(f.Arg(0)), dc, ds.Path(f.Arg(1)), dc, true)
+		dst = ds.Path(f.Arg(0))
+		task, err = m.CreateChildDisk(ctx, ds.Path(f.Arg(0)), dc, dst, dc, cmd.force)
 	}
 
 	if err != nil {
 		return err
 	}
 
-	return task.Wait(ctx)
+	logger := cmd.ProgressLogger(fmt.Sprintf("Creating %s...", dst))
+	defer logger.Wait()
+
+	_, err = task.WaitForResult(ctx, logger)
+	return err
 }

--- a/vendor/github.com/vmware/govmomi/govc/device/info.go
+++ b/vendor/github.com/vmware/govmomi/govc/device/info.go
@@ -154,7 +154,11 @@ func toInfoList(devices object.VirtualDeviceList) []infoDevice {
 	var res []infoDevice
 
 	for _, device := range devices {
-		res = append(res, infoDevice{devices.Name(device), device})
+		res = append(res, infoDevice{
+			Name:              devices.Name(device),
+			Type:              devices.TypeName(device),
+			BaseVirtualDevice: device,
+		})
 	}
 
 	return res
@@ -162,6 +166,7 @@ func toInfoList(devices object.VirtualDeviceList) []infoDevice {
 
 type infoDevice struct {
 	Name string
+	Type string
 	types.BaseVirtualDevice
 }
 
@@ -173,7 +178,7 @@ func (d *infoDevice) MarshalJSON() ([]byte, error) {
 
 	// TODO: make use of "inline" tag if it comes to be: https://github.com/golang/go/issues/6213
 
-	return append([]byte(fmt.Sprintf(`{"Name":"%s",`, d.Name)), b[1:]...), err
+	return append([]byte(fmt.Sprintf(`{"Name":"%s","Type":"%s",`, d.Name, d.Type)), b[1:]...), err
 }
 
 type infoResult struct {

--- a/vendor/github.com/vmware/govmomi/govc/flags/client.go
+++ b/vendor/github.com/vmware/govmomi/govc/flags/client.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2014-2015 VMware, Inc. All Rights Reserved.
+Copyright (c) 2014-2018 VMware, Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -73,6 +73,8 @@ type ClientFlag struct {
 	tlsCaCerts    string
 	tlsKnownHosts string
 	client        *vim25.Client
+
+	Login func(context.Context, *vim25.Client) error
 }
 
 var (
@@ -92,6 +94,7 @@ func NewClientFlag(ctx context.Context) (*ClientFlag, context.Context) {
 	}
 
 	v := &ClientFlag{}
+	v.Login = v.login
 	v.DebugFlag, ctx = NewDebugFlag(ctx)
 	ctx = context.WithValue(ctx, clientFlagKey, v)
 	return v, ctx
@@ -397,13 +400,42 @@ func (flag *ClientFlag) SetRootCAs(c *soap.Client) error {
 	return nil
 }
 
+func (flag *ClientFlag) login(ctx context.Context, c *vim25.Client) error {
+	m := session.NewManager(c)
+	u := flag.url.User
+
+	if u.Username() == "" {
+		if !c.IsVC() {
+			// If no username is provided, try to acquire a local ticket.
+			// When invoked remotely, ESX returns an InvalidRequestFault.
+			// So, rather than return an error here, fallthrough to Login() with the original User to
+			// to avoid what would be a confusing error message.
+			luser, lerr := flag.localTicket(ctx, m)
+			if lerr == nil {
+				// We are running directly on an ESX or Workstation host and can use the ticket with Login()
+				u = luser
+			} else {
+				flag.persist = true // Not persisting, but this avoids the call to Logout()
+				return nil          // Avoid SaveSession for non-authenticated session
+			}
+		}
+	}
+
+	if flag.cert != "" {
+		err := m.LoginExtensionByCertificate(ctx, u.Username(), "")
+		if err != nil {
+			return err
+		}
+	}
+
+	return m.Login(ctx, u)
+}
+
 func (flag *ClientFlag) newClient() (*vim25.Client, error) {
 	ctx := context.TODO()
 	sc := soap.NewClient(flag.url, flag.insecure)
-	isTunnel := false
 
 	if flag.cert != "" {
-		isTunnel = true
 		cert, err := tls.LoadX509KeyPair(flag.cert, flag.key)
 		if err != nil {
 			return nil, err
@@ -425,39 +457,11 @@ func (flag *ClientFlag) newClient() (*vim25.Client, error) {
 	// Set client, since we didn't pass it in the constructor
 	c.Client = sc
 
-	m := session.NewManager(c)
-	u := flag.url.User
-
-	if u.Username() == "" && !c.IsVC() {
-		// If no username is provided, try to acquire a local ticket.
-		// When invoked remotely, ESX returns an InvalidRequestFault.
-		// So, rather than return an error here, fallthrough to Login() with the original User to
-		// to avoid what would be a confusing error message.
-		luser, lerr := flag.localTicket(ctx, m)
-		if lerr == nil {
-			// We are running directly on an ESX or Workstation host and can use the ticket with Login()
-			u = luser
-		}
-	}
-
-	if isTunnel {
-		err = m.LoginExtensionByCertificate(ctx, u.Username(), "")
-		if err != nil {
-			return nil, err
-		}
-	} else {
-		err = m.Login(ctx, u)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	err = flag.saveClient(c)
-	if err != nil {
+	if err := flag.Login(ctx, c); err != nil {
 		return nil, err
 	}
 
-	return c, nil
+	return c, flag.saveClient(c)
 }
 
 func (flag *ClientFlag) localTicket(ctx context.Context, m *session.Manager) (*url.Userinfo, error) {

--- a/vendor/github.com/vmware/govmomi/govc/flags/cluster.go
+++ b/vendor/github.com/vmware/govmomi/govc/flags/cluster.go
@@ -92,6 +92,13 @@ func (f *ClusterFlag) Cluster() (*object.ClusterComputeResource, error) {
 	return f.cluster, nil
 }
 
+func (f *ClusterFlag) ClusterIfSpecified() (*object.ClusterComputeResource, error) {
+	if f.Name == "" {
+		return nil, nil
+	}
+	return f.Cluster()
+}
+
 func (f *ClusterFlag) Reconfigure(ctx context.Context, spec types.BaseComputeResourceConfigSpec) error {
 	cluster, err := f.Cluster()
 	if err != nil {

--- a/vendor/github.com/vmware/govmomi/govc/flags/datacenter.go
+++ b/vendor/github.com/vmware/govmomi/govc/flags/datacenter.go
@@ -33,7 +33,7 @@ type DatacenterFlag struct {
 	*ClientFlag
 	*OutputFlag
 
-	path   string
+	Name   string
 	dc     *object.Datacenter
 	finder *find.Finder
 	err    error
@@ -61,7 +61,7 @@ func (flag *DatacenterFlag) Register(ctx context.Context, f *flag.FlagSet) {
 		env := "GOVC_DATACENTER"
 		value := os.Getenv(env)
 		usage := fmt.Sprintf("Datacenter [%s]", env)
-		f.StringVar(&flag.path, "dc", value, usage)
+		f.StringVar(&flag.Name, "dc", value, usage)
 	})
 }
 
@@ -93,10 +93,10 @@ func (flag *DatacenterFlag) Finder() (*find.Finder, error) {
 	// Set for relative func if dc flag is given or
 	// if there is a single (default) Datacenter
 	ctx := context.TODO()
-	if flag.path == "" {
+	if flag.Name == "" {
 		flag.dc, flag.err = finder.DefaultDatacenter(ctx)
 	} else {
-		if flag.dc, err = finder.Datacenter(ctx, flag.path); err != nil {
+		if flag.dc, err = finder.Datacenter(ctx, flag.Name); err != nil {
 			return nil, err
 		}
 	}
@@ -127,7 +127,7 @@ func (flag *DatacenterFlag) Datacenter() (*object.Datacenter, error) {
 }
 
 func (flag *DatacenterFlag) DatacenterIfSpecified() (*object.Datacenter, error) {
-	if flag.path == "" {
+	if flag.Name == "" {
 		return nil, nil
 	}
 	return flag.Datacenter()

--- a/vendor/github.com/vmware/govmomi/govc/flags/network.go
+++ b/vendor/github.com/vmware/govmomi/govc/flags/network.go
@@ -129,3 +129,19 @@ func (flag *NetworkFlag) Device() (types.BaseVirtualDevice, error) {
 
 	return device, nil
 }
+
+// Change applies update backing and hardware address changes to the given network device.
+func (flag *NetworkFlag) Change(device types.BaseVirtualDevice, update types.BaseVirtualDevice) {
+	current := device.(types.BaseVirtualEthernetCard).GetVirtualEthernetCard()
+	changed := update.(types.BaseVirtualEthernetCard).GetVirtualEthernetCard()
+
+	current.Backing = changed.Backing
+
+	if changed.MacAddress != "" {
+		current.MacAddress = changed.MacAddress
+	}
+
+	if changed.AddressType != "" {
+		current.AddressType = changed.AddressType
+	}
+}

--- a/vendor/github.com/vmware/govmomi/govc/flags/version.go
+++ b/vendor/github.com/vmware/govmomi/govc/flags/version.go
@@ -21,7 +21,7 @@ import (
 	"strings"
 )
 
-const Version = "0.16.1"
+const Version = "0.17.0"
 
 type version []int
 

--- a/vendor/github.com/vmware/govmomi/govc/host/info.go
+++ b/vendor/github.com/vmware/govmomi/govc/host/info.go
@@ -139,7 +139,7 @@ func (r *infoResult) Write(w io.Writer) error {
 		s := host.Summary
 		h := s.Hardware
 		z := s.QuickStats
-		ncpu := int32(h.NumCpuPkgs * h.NumCpuCores)
+		ncpu := int32(h.NumCpuPkgs * h.NumCpuThreads)
 		cpuUsage := 100 * float64(z.OverallCpuUsage) / float64(ncpu*h.CpuMhz)
 		memUsage := 100 * float64(z.OverallMemoryUsage) / float64(h.MemorySize>>20)
 

--- a/vendor/github.com/vmware/govmomi/govc/importx/archive.go
+++ b/vendor/github.com/vmware/govmomi/govc/importx/archive.go
@@ -182,5 +182,5 @@ func (o Opener) OpenRemote(link string) (io.ReadCloser, int64, error) {
 		return nil, 0, err
 	}
 
-	return o.Download(u, &soap.DefaultDownload)
+	return o.Download(context.Background(), u, &soap.DefaultDownload)
 }

--- a/vendor/github.com/vmware/govmomi/govc/logs/download.go
+++ b/vendor/github.com/vmware/govmomi/govc/logs/download.go
@@ -84,7 +84,7 @@ func (cmd *download) DownloadFile(c *vim25.Client, b string) error {
 		p.Progress = logger
 	}
 
-	return c.Client.DownloadFile(dst, u, &p)
+	return c.Client.DownloadFile(context.Background(), dst, u, &p)
 }
 
 func (cmd *download) GenerateLogBundles(m *object.DiagnosticManager, host []*object.HostSystem) ([]types.DiagnosticManagerBundleInfo, error) {

--- a/vendor/github.com/vmware/govmomi/govc/ls/command.go
+++ b/vendor/github.com/vmware/govmomi/govc/ls/command.go
@@ -137,7 +137,7 @@ func (cmd *ls) Run(ctx context.Context, f *flag.FlagSet) error {
 }
 
 type listResult struct {
-	*ls
+	*ls      `json:"-"`
 	Elements []list.Element `json:"elements"`
 }
 

--- a/vendor/github.com/vmware/govmomi/govc/main.go
+++ b/vendor/github.com/vmware/govmomi/govc/main.go
@@ -24,6 +24,7 @@ import (
 	_ "github.com/vmware/govmomi/govc/about"
 	_ "github.com/vmware/govmomi/govc/cluster"
 	_ "github.com/vmware/govmomi/govc/cluster/group"
+	_ "github.com/vmware/govmomi/govc/cluster/override"
 	_ "github.com/vmware/govmomi/govc/cluster/rule"
 	_ "github.com/vmware/govmomi/govc/datacenter"
 	_ "github.com/vmware/govmomi/govc/datastore"

--- a/vendor/github.com/vmware/govmomi/govc/object/find.go
+++ b/vendor/github.com/vmware/govmomi/govc/object/find.go
@@ -136,6 +136,7 @@ ROOT can be an inventory path or ManagedObjectReference.
 ROOT defaults to '.', an alias for the root folder or DC if set.
 
 Optional KEY VAL pairs can be used to filter results against object instance properties.
+Use the govc 'object.collect' command to view possible object property keys.
 
 The '-type' flag value can be a managed entity type or one of the following aliases:
 
@@ -149,13 +150,6 @@ Examples:
   govc find . -type m -datastore $(govc find -i datastore -name vsanDatastore)
   govc find . -type s -summary.type vsan
   govc find . -type h -hardware.cpuInfo.numCpuCores 16`, atable)
-}
-
-func (cmd *find) Process(ctx context.Context) error {
-	if err := cmd.DatacenterFlag.Process(ctx); err != nil {
-		return err
-	}
-	return nil
 }
 
 // rootMatch returns true if the root object path should be printed

--- a/vendor/github.com/vmware/govmomi/govc/session/login.go
+++ b/vendor/github.com/vmware/govmomi/govc/session/login.go
@@ -1,0 +1,195 @@
+/*
+Copyright (c) 2018 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package session
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/session"
+	"github.com/vmware/govmomi/vim25"
+	"github.com/vmware/govmomi/vim25/methods"
+	"github.com/vmware/govmomi/vim25/soap"
+)
+
+type login struct {
+	*flags.ClientFlag
+	*flags.OutputFlag
+
+	clone  bool
+	long   bool
+	ticket string
+	cookie string
+}
+
+func init() {
+	cli.Register("session.login", &login{})
+}
+
+func (cmd *login) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.ClientFlag, ctx = flags.NewClientFlag(ctx)
+	cmd.ClientFlag.Register(ctx, f)
+	cmd.OutputFlag, ctx = flags.NewOutputFlag(ctx)
+	cmd.OutputFlag.Register(ctx, f)
+
+	f.BoolVar(&cmd.clone, "clone", false, "Acquire clone ticket")
+	f.BoolVar(&cmd.long, "l", false, "Output session cookie")
+	f.StringVar(&cmd.ticket, "ticket", "", "Clone ticket")
+	f.StringVar(&cmd.cookie, "cookie", "", "Set HTTP cookie for an existing session")
+}
+
+func (cmd *login) Process(ctx context.Context) error {
+	if err := cmd.OutputFlag.Process(ctx); err != nil {
+		return err
+	}
+	return cmd.ClientFlag.Process(ctx)
+}
+
+func (cmd *login) Description() string {
+	return `Session login.
+
+The session.login command is optional, all other govc commands will auto login when given credentials.
+The session.login command can be used to:
+- Persist a session without writing to disk via the '-cookie' flag
+- Acquire a clone ticket
+- Login using a clone ticket
+- Avoid passing credentials to other govc commands
+
+Examples:
+  govc session.login -u root:password@host
+  ticket=$(govc session.login -u root@host -clone)
+  govc session.login -u root@host -ticket $ticket`
+}
+
+type ticketResult struct {
+	cmd    *login
+	Ticket string `json:",omitempty"`
+	Cookie string `json:",omitempty"`
+}
+
+func (r *ticketResult) Write(w io.Writer) error {
+	var output []string
+
+	for _, val := range []string{r.Ticket, r.Cookie} {
+		if val != "" {
+			output = append(output, val)
+		}
+	}
+
+	if len(output) == 0 {
+		return nil
+	}
+
+	fmt.Fprintln(w, strings.Join(output, " "))
+
+	return nil
+}
+
+// Logout is called by cli.Run()
+// We override ClientFlag's Logout impl to avoid ending a session when -persist-session=false,
+// otherwise Logout would invalidate the cookie and/or ticket.
+func (cmd *login) Logout(ctx context.Context) error {
+	if cmd.long || cmd.clone {
+		return nil
+	}
+	return cmd.ClientFlag.Logout(ctx)
+}
+
+func (cmd *login) cloneSession(ctx context.Context, c *vim25.Client) error {
+	return session.NewManager(c).CloneSession(ctx, cmd.ticket)
+}
+
+func (cmd *login) setCookie(ctx context.Context, c *vim25.Client) error {
+	url := c.URL()
+	jar := c.Client.Jar
+	cookies := jar.Cookies(url)
+	add := true
+
+	cookie := &http.Cookie{
+		Name: soap.SessionCookieName,
+	}
+
+	for _, e := range cookies {
+		if e.Name == cookie.Name {
+			add = false
+			cookie = e
+			break
+		}
+	}
+
+	if cmd.cookie == "" {
+		// This is the cookie from Set-Cookie after a Login or CloneSession
+		cmd.cookie = cookie.Value
+	} else {
+		// The cookie flag is set, set the HTTP header and skip Login()
+		cookie.Value = cmd.cookie
+		if add {
+			cookies = append(cookies, cookie)
+		}
+		jar.SetCookies(url, cookies)
+
+		// Check the session is still valid
+		_, err := methods.GetCurrentTime(ctx, c)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (cmd *login) Run(ctx context.Context, f *flag.FlagSet) error {
+	if cmd.ticket != "" {
+		cmd.Login = cmd.cloneSession
+	} else if cmd.cookie != "" {
+		cmd.Login = cmd.setCookie
+	}
+
+	c, err := cmd.Client()
+	if err != nil {
+		return err
+	}
+
+	m := session.NewManager(c)
+	r := &ticketResult{cmd: cmd}
+
+	if cmd.clone {
+		r.Ticket, err = m.AcquireCloneTicket(ctx)
+		if err != nil {
+			return err
+		}
+	}
+
+	if cmd.cookie == "" {
+		_ = cmd.setCookie(ctx, c)
+		if cmd.cookie == "" {
+			return flag.ErrHelp
+		}
+	}
+
+	if cmd.long {
+		r.Cookie = cmd.cookie
+	}
+
+	return cmd.WriteResult(r)
+}

--- a/vendor/github.com/vmware/govmomi/govc/session/logout.go
+++ b/vendor/github.com/vmware/govmomi/govc/session/logout.go
@@ -1,0 +1,63 @@
+/*
+Copyright (c) 2018 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package session
+
+import (
+	"context"
+	"flag"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	"github.com/vmware/govmomi/session"
+)
+
+type logout struct {
+	*flags.ClientFlag
+}
+
+func init() {
+	cli.Register("session.logout", &logout{})
+}
+
+func (cmd *logout) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.ClientFlag, ctx = flags.NewClientFlag(ctx)
+	cmd.ClientFlag.Register(ctx, f)
+}
+
+func (cmd *logout) Process(ctx context.Context) error {
+	return cmd.ClientFlag.Process(ctx)
+}
+
+func (cmd *logout) Description() string {
+	return `Logout the current session.
+
+By default, govc commands persist sessions and do not logout unless '-persist-session=false' is set.
+The session.logout command can be used to end the current persisted session.
+The session.rm command can be used to remove sessions other than the current session.
+
+Examples:
+  govc session.logout`
+}
+
+func (cmd *logout) Run(ctx context.Context, f *flag.FlagSet) error {
+	c, err := cmd.Client()
+	if err != nil {
+		return err
+	}
+
+	return session.NewManager(c).Logout(ctx)
+}

--- a/vendor/github.com/vmware/govmomi/govc/vm/console.go
+++ b/vendor/github.com/vmware/govmomi/govc/vm/console.go
@@ -111,7 +111,7 @@ func (cmd *console) Run(ctx context.Context, f *flag.FlagSet) error {
 		param := soap.DefaultDownload
 
 		if cmd.capture == "-" {
-			w, _, derr := c.Download(u, &param)
+			w, _, derr := c.Download(ctx, u, &param)
 			if derr != nil {
 				return derr
 			}
@@ -124,7 +124,7 @@ func (cmd *console) Run(ctx context.Context, f *flag.FlagSet) error {
 			return w.Close()
 		}
 
-		return c.DownloadFile(cmd.capture, u, &param)
+		return c.DownloadFile(ctx, cmd.capture, u, &param)
 	}
 
 	m := session.NewManager(c)

--- a/vendor/github.com/vmware/govmomi/govc/vm/guest/download.go
+++ b/vendor/github.com/vmware/govmomi/govc/vm/guest/download.go
@@ -101,5 +101,5 @@ func (cmd *download) Run(ctx context.Context, f *flag.FlagSet) error {
 		defer logger.Wait()
 	}
 
-	return c.ProcessManager.Client().WriteFile(dst, s, n, p, nil)
+	return c.ProcessManager.Client().WriteFile(ctx, dst, s, n, p, nil)
 }

--- a/vendor/github.com/vmware/govmomi/govc/vm/guest/touch.go
+++ b/vendor/github.com/vmware/govmomi/govc/vm/guest/touch.go
@@ -115,7 +115,7 @@ func (cmd *touch) Run(ctx context.Context, f *flag.FlagSet) error {
 				return cerr
 			}
 
-			err = c.Client.Upload(new(bytes.Buffer), u, &soap.DefaultUpload)
+			err = c.Client.Upload(ctx, new(bytes.Buffer), u, &soap.DefaultUpload)
 			if err == nil && cmd.date != "" {
 				err = m.ChangeFileAttributes(ctx, cmd.Auth(), name, &attr)
 			}

--- a/vendor/github.com/vmware/govmomi/govc/vm/network/change.go
+++ b/vendor/github.com/vmware/govmomi/govc/vm/network/change.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/vmware/govmomi/govc/cli"
 	"github.com/vmware/govmomi/govc/flags"
-	"github.com/vmware/govmomi/vim25/types"
 )
 
 type change struct {
@@ -103,18 +102,7 @@ func (cmd *change) Run(ctx context.Context, f *flag.FlagSet) error {
 		return err
 	}
 
-	current := net.(types.BaseVirtualEthernetCard).GetVirtualEthernetCard()
-	changed := dev.(types.BaseVirtualEthernetCard).GetVirtualEthernetCard()
-
-	current.Backing = changed.Backing
-
-	if changed.MacAddress != "" {
-		current.MacAddress = changed.MacAddress
-	}
-
-	if changed.AddressType != "" {
-		current.AddressType = changed.AddressType
-	}
+	cmd.NetworkFlag.Change(net, dev)
 
 	return vm.EditDevice(ctx, net)
 }

--- a/vendor/github.com/vmware/govmomi/govc/vm/power.go
+++ b/vendor/github.com/vmware/govmomi/govc/vm/power.go
@@ -39,6 +39,7 @@ type power struct {
 	Shutdown bool
 	Suspend  bool
 	Force    bool
+	Multi    bool
 }
 
 func init() {
@@ -59,6 +60,7 @@ func (cmd *power) Register(ctx context.Context, f *flag.FlagSet) {
 	f.BoolVar(&cmd.Reboot, "r", false, "Reboot guest")
 	f.BoolVar(&cmd.Shutdown, "s", false, "Shutdown guest")
 	f.BoolVar(&cmd.Force, "force", false, "Force (ignore state error and hard shutdown/reboot if tools unavailable)")
+	f.BoolVar(&cmd.Multi, "M", false, "Use Datacenter.PowerOnMultiVM method instead of VirtualMachine.PowerOnVM")
 }
 
 func (cmd *power) Process(ctx context.Context) error {
@@ -98,9 +100,44 @@ func isToolsUnavailable(err error) bool {
 	return false
 }
 
+// this is annoying, but the likely use cases for Datacenter.PowerOnVM outside of this command would
+// use []types.ManagedObjectReference via ContainerView or field such as ResourcePool.Vm rather than the Finder.
+func vmReferences(vms []*object.VirtualMachine) []types.ManagedObjectReference {
+	refs := make([]types.ManagedObjectReference, len(vms))
+	for i, vm := range vms {
+		refs[i] = vm.Reference()
+	}
+	return refs
+}
+
 func (cmd *power) Run(ctx context.Context, f *flag.FlagSet) error {
 	vms, err := cmd.VirtualMachines(f.Args())
 	if err != nil {
+		return err
+	}
+
+	if cmd.On && cmd.Multi {
+		dc, derr := cmd.Datacenter()
+		if derr != nil {
+			return derr
+		}
+
+		task, derr := dc.PowerOnVM(ctx, vmReferences(vms))
+		if derr != nil {
+			return derr
+		}
+
+		msg := fmt.Sprintf("Powering on %d VMs...", len(vms))
+		if task == nil {
+			// running against ESX
+			fmt.Fprintf(cmd, "%s OK\n", msg)
+			return nil
+		}
+
+		logger := cmd.ProgressLogger(msg)
+		defer logger.Wait()
+
+		_, err = task.WaitForResult(ctx, logger)
 		return err
 	}
 

--- a/vendor/github.com/vmware/govmomi/govc/vm/rdm/attach.go
+++ b/vendor/github.com/vmware/govmomi/govc/vm/rdm/attach.go
@@ -59,7 +59,7 @@ func (cmd *attach) Process(ctx context.Context) error {
 	return nil
 }
 
-//This piece of code was developped mainly thanks to the project govmax on github.com
+//This piece of code was developed mainly thanks to the project govmax on github.com
 //This file in particular https://github.com/codedellemc/govmax/blob/master/api/v1/vmomi.go
 func (cmd *attach) Run(ctx context.Context, f *flag.FlagSet) error {
 	vm, err := cmd.VirtualMachine()

--- a/vendor/github.com/vmware/govmomi/guest/toolbox/client.go
+++ b/vendor/github.com/vmware/govmomi/guest/toolbox/client.go
@@ -114,7 +114,7 @@ func (c *Client) RoundTrip(req *http.Request) (*http.Response, error) {
 	p := soap.DefaultUpload
 	p.ContentLength = size
 
-	err = vc.Client.Upload(&buf, u, &p)
+	err = vc.Client.Upload(ctx, &buf, u, &p)
 	if err != nil {
 		return nil, err
 	}
@@ -129,7 +129,7 @@ func (c *Client) RoundTrip(req *http.Request) (*http.Response, error) {
 		return nil, err
 	}
 
-	f, _, err := vc.Client.Download(u, &soap.DefaultDownload)
+	f, _, err := vc.Client.Download(ctx, u, &soap.DefaultDownload)
 	if err != nil {
 		return nil, err
 	}
@@ -177,7 +177,7 @@ func (c *Client) Run(ctx context.Context, cmd *exec.Cmd) error {
 		p := soap.DefaultUpload
 		p.ContentLength = size
 
-		err = vc.Client.Upload(&buf, u, &p)
+		err = vc.Client.Upload(ctx, &buf, u, &p)
 		if err != nil {
 			return err
 		}
@@ -202,7 +202,7 @@ func (c *Client) Run(ctx context.Context, cmd *exec.Cmd) error {
 			return err
 		}
 
-		f, _, err := vc.Client.Download(u, &soap.DefaultDownload)
+		f, _, err := vc.Client.Download(ctx, u, &soap.DefaultDownload)
 		if err != nil {
 			return err
 		}
@@ -284,7 +284,7 @@ func (c *Client) Download(ctx context.Context, src string) (io.ReadCloser, int64
 
 	p := soap.DefaultDownload
 
-	f, n, err := vc.Download(u, &p)
+	f, n, err := vc.Download(ctx, u, &p)
 	if err != nil {
 		return nil, n, err
 	}
@@ -341,5 +341,5 @@ func (c *Client) Upload(ctx context.Context, src io.Reader, dst string, p soap.U
 		return err
 	}
 
-	return vc.Client.Upload(src, u, &p)
+	return vc.Client.Upload(ctx, src, u, &p)
 }

--- a/vendor/github.com/vmware/govmomi/nfc/lease.go
+++ b/vendor/github.com/vmware/govmomi/nfc/lease.go
@@ -224,7 +224,7 @@ func (l *Lease) Upload(ctx context.Context, item FileItem, f io.Reader, opts soa
 		opts.Type = "application/x-vnd.vmware-streamVmdk"
 	}
 
-	return l.c.Upload(f, item.URL, &opts)
+	return l.c.Upload(ctx, f, item.URL, &opts)
 }
 
 func (l *Lease) DownloadFile(ctx context.Context, file string, item FileItem, opts soap.Download) error {
@@ -234,5 +234,5 @@ func (l *Lease) DownloadFile(ctx context.Context, file string, item FileItem, op
 		opts.Progress = progress.Tee(item, opts.Progress)
 	}
 
-	return l.c.DownloadFile(file, item.URL, &opts)
+	return l.c.DownloadFile(ctx, file, item.URL, &opts)
 }

--- a/vendor/github.com/vmware/govmomi/object/datastore.go
+++ b/vendor/github.com/vmware/govmomi/object/datastore.go
@@ -284,7 +284,7 @@ func (d Datastore) Upload(ctx context.Context, f io.Reader, path string, param *
 	if err != nil {
 		return err
 	}
-	return d.Client().Upload(f, u, p)
+	return d.Client().Upload(ctx, f, u, p)
 }
 
 // UploadFile via soap.Upload with an http service ticket
@@ -293,7 +293,7 @@ func (d Datastore) UploadFile(ctx context.Context, file string, path string, par
 	if err != nil {
 		return err
 	}
-	return d.Client().UploadFile(file, u, p)
+	return d.Client().UploadFile(ctx, file, u, p)
 }
 
 // Download via soap.Download with an http service ticket
@@ -302,7 +302,7 @@ func (d Datastore) Download(ctx context.Context, path string, param *soap.Downlo
 	if err != nil {
 		return nil, 0, err
 	}
-	return d.Client().Download(u, p)
+	return d.Client().Download(ctx, u, p)
 }
 
 // DownloadFile via soap.Download with an http service ticket
@@ -311,7 +311,7 @@ func (d Datastore) DownloadFile(ctx context.Context, path string, file string, p
 	if err != nil {
 		return err
 	}
-	return d.Client().DownloadFile(file, u, p)
+	return d.Client().DownloadFile(ctx, file, u, p)
 }
 
 // AttachedHosts returns hosts that have this Datastore attached, accessible and writable.

--- a/vendor/github.com/vmware/govmomi/object/datastore_file.go
+++ b/vendor/github.com/vmware/govmomi/object/datastore_file.go
@@ -172,7 +172,7 @@ func (f *DatastoreFile) Stat() (os.FileInfo, error) {
 		return nil, err
 	}
 
-	res, err := f.d.Client().DownloadRequest(u, p)
+	res, err := f.d.Client().DownloadRequest(f.ctx, u, p)
 	if err != nil {
 		return nil, err
 	}
@@ -202,7 +202,7 @@ func (f *DatastoreFile) get() (io.Reader, error) {
 		}
 	}
 
-	res, err := f.d.Client().DownloadRequest(u, p)
+	res, err := f.d.Client().DownloadRequest(f.ctx, u, p)
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/github.com/vmware/govmomi/object/datastore_file_manager.go
+++ b/vendor/github.com/vmware/govmomi/object/datastore_file_manager.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+Copyright (c) 2017-2018 VMware, Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -26,6 +26,7 @@ import (
 	"path"
 	"strings"
 
+	"github.com/vmware/govmomi/vim25/progress"
 	"github.com/vmware/govmomi/vim25/soap"
 )
 
@@ -36,7 +37,8 @@ type DatastoreFileManager struct {
 	FileManager        *FileManager
 	VirtualDiskManager *VirtualDiskManager
 
-	Force bool
+	Force            bool
+	DatacenterTarget *Datacenter
 }
 
 // NewFileManager creates a new instance of DatastoreFileManager
@@ -49,9 +51,23 @@ func (d Datastore) NewFileManager(dc *Datacenter, force bool) *DatastoreFileMana
 		FileManager:        NewFileManager(c),
 		VirtualDiskManager: NewVirtualDiskManager(c),
 		Force:              force,
+		DatacenterTarget:   dc,
 	}
 
 	return m
+}
+
+func (m *DatastoreFileManager) WithProgress(ctx context.Context, s progress.Sinker) context.Context {
+	return context.WithValue(ctx, m, s)
+}
+
+func (m *DatastoreFileManager) wait(ctx context.Context, task *Task) error {
+	var logger progress.Sinker
+	if s, ok := ctx.Value(m).(progress.Sinker); ok {
+		logger = s
+	}
+	_, err := task.WaitForResult(ctx, logger)
+	return err
 }
 
 // Delete dispatches to the appropriate Delete method based on file name extension
@@ -73,7 +89,7 @@ func (m *DatastoreFileManager) DeleteFile(ctx context.Context, name string) erro
 		return err
 	}
 
-	return task.Wait(ctx)
+	return m.wait(ctx, task)
 }
 
 // DeleteVirtualDisk calls VirtualDiskManager.DeleteVirtualDisk
@@ -94,10 +110,58 @@ func (m *DatastoreFileManager) DeleteVirtualDisk(ctx context.Context, name strin
 		return err
 	}
 
-	return task.Wait(ctx)
+	return m.wait(ctx, task)
 }
 
-// Move dispatches to the appropriate Move method based on file name extension
+// CopyFile calls FileManager.CopyDatastoreFile
+func (m *DatastoreFileManager) CopyFile(ctx context.Context, src string, dst string) error {
+	srcp := m.Path(src)
+	dstp := m.Path(dst)
+
+	task, err := m.FileManager.CopyDatastoreFile(ctx, srcp.String(), m.Datacenter, dstp.String(), m.DatacenterTarget, m.Force)
+	if err != nil {
+		return err
+	}
+
+	return m.wait(ctx, task)
+}
+
+// Copy dispatches to the appropriate FileManager or VirtualDiskManager Copy method based on file name extension
+func (m *DatastoreFileManager) Copy(ctx context.Context, src string, dst string) error {
+	srcp := m.Path(src)
+	dstp := m.Path(dst)
+
+	f := m.FileManager.CopyDatastoreFile
+
+	if srcp.IsVMDK() {
+		// types.VirtualDiskSpec=nil as it is not implemented by vCenter
+		f = func(ctx context.Context, src string, srcDC *Datacenter, dst string, dstDC *Datacenter, force bool) (*Task, error) {
+			return m.VirtualDiskManager.CopyVirtualDisk(ctx, src, srcDC, dst, dstDC, nil, force)
+		}
+	}
+
+	task, err := f(ctx, srcp.String(), m.Datacenter, dstp.String(), m.DatacenterTarget, m.Force)
+	if err != nil {
+		return err
+	}
+
+	return m.wait(ctx, task)
+}
+
+// MoveFile calls FileManager.MoveDatastoreFile
+func (m *DatastoreFileManager) MoveFile(ctx context.Context, src string, dst string) error {
+	srcp := m.Path(src)
+	dstp := m.Path(dst)
+
+	task, err := m.FileManager.MoveDatastoreFile(ctx, srcp.String(), m.Datacenter, dstp.String(), m.DatacenterTarget, m.Force)
+	if err != nil {
+		return err
+	}
+
+	return m.wait(ctx, task)
+}
+
+// Move dispatches to the appropriate FileManager or VirtualDiskManager Move method based on file name extension
 func (m *DatastoreFileManager) Move(ctx context.Context, src string, dst string) error {
 	srcp := m.Path(src)
 	dstp := m.Path(dst)
@@ -108,12 +172,12 @@ func (m *DatastoreFileManager) Move(ctx context.Context, src string, dst string)
 		f = m.VirtualDiskManager.MoveVirtualDisk
 	}
 
-	task, err := f(ctx, srcp.String(), m.Datacenter, dstp.String(), m.Datacenter, m.Force)
+	task, err := f(ctx, srcp.String(), m.Datacenter, dstp.String(), m.DatacenterTarget, m.Force)
 	if err != nil {
 		return err
 	}
 
-	return task.Wait(ctx)
+	return m.wait(ctx, task)
 }
 
 // Path converts path name to a DatastorePath

--- a/vendor/github.com/vmware/govmomi/object/host_storage_system.go
+++ b/vendor/github.com/vmware/govmomi/object/host_storage_system.go
@@ -161,3 +161,14 @@ func (s HostStorageSystem) MarkAsNonLocal(ctx context.Context, uuid string) (*Ta
 
 	return NewTask(s.c, res.Returnval), nil
 }
+
+func (s HostStorageSystem) AttachScsiLun(ctx context.Context, uuid string) error {
+	req := types.AttachScsiLun{
+		This:    s.Reference(),
+		LunUuid: uuid,
+	}
+
+	_, err := methods.AttachScsiLun(ctx, s.c, &req)
+
+	return err
+}

--- a/vendor/github.com/vmware/govmomi/object/types.go
+++ b/vendor/github.com/vmware/govmomi/object/types.go
@@ -47,8 +47,10 @@ func NewReference(c *vim25.Client, e types.ManagedObjectReference) Reference {
 		return NewClusterComputeResource(c, e)
 	case "HostSystem":
 		return NewHostSystem(c, e)
-	case "Network", "OpaqueNetwork":
+	case "Network":
 		return NewNetwork(c, e)
+	case "OpaqueNetwork":
+		return NewOpaqueNetwork(c, e)
 	case "ResourcePool":
 		return NewResourcePool(c, e)
 	case "DistributedVirtualSwitch":

--- a/vendor/github.com/vmware/govmomi/simulator/cluster_compute_resource.go
+++ b/vendor/github.com/vmware/govmomi/simulator/cluster_compute_resource.go
@@ -49,18 +49,18 @@ func (add *addHost) Run(task *Task) (types.AnyType, types.BaseMethodFault) {
 	host := NewHostSystem(esx.HostSystem)
 	host.Summary.Config.Name = spec.HostName
 	host.Name = host.Summary.Config.Name
-	host.Runtime.ConnectionState = types.HostSystemConnectionStateDisconnected
+	if add.req.AsConnected {
+		host.Runtime.ConnectionState = types.HostSystemConnectionStateConnected
+	} else {
+		host.Runtime.ConnectionState = types.HostSystemConnectionStateDisconnected
+	}
 
 	cr := add.ClusterComputeResource
 	Map.PutEntity(cr, Map.NewEntity(host))
+	host.Summary.Host = &host.Self
 
 	cr.Host = append(cr.Host, host.Reference())
-
-	if add.req.AsConnected {
-		host.Runtime.ConnectionState = types.HostSystemConnectionStateConnected
-	}
-
-	addComputeResource(add.ClusterComputeResource.Summary.GetComputeResourceSummary(), host)
+	addComputeResource(cr.Summary.GetComputeResourceSummary(), host)
 
 	return host.Reference(), nil
 }
@@ -164,6 +164,103 @@ func (c *ClusterComputeResource) updateGroups(cfg *types.ClusterConfigInfoEx, cs
 	return nil
 }
 
+func (c *ClusterComputeResource) updateOverridesDAS(cfg *types.ClusterConfigInfoEx, cspec *types.ClusterConfigSpecEx) types.BaseMethodFault {
+	for _, spec := range cspec.DasVmConfigSpec {
+		var i int
+		var key types.ManagedObjectReference
+		exists := false
+
+		if spec.Operation == types.ArrayUpdateOperationRemove {
+			key = spec.RemoveKey.(types.ManagedObjectReference)
+		} else {
+			key = spec.Info.Key
+		}
+
+		for i = range cfg.DasVmConfig {
+			if cfg.DasVmConfig[i].Key == key {
+				exists = true
+				break
+			}
+		}
+
+		switch spec.Operation {
+		case types.ArrayUpdateOperationAdd:
+			if exists {
+				return new(types.InvalidArgument)
+			}
+			cfg.DasVmConfig = append(cfg.DasVmConfig, *spec.Info)
+		case types.ArrayUpdateOperationEdit:
+			if !exists {
+				return new(types.InvalidArgument)
+			}
+			src := spec.Info.DasSettings
+			if src == nil {
+				return new(types.InvalidArgument)
+			}
+			dst := cfg.DasVmConfig[i].DasSettings
+			if src.RestartPriority != "" {
+				dst.RestartPriority = src.RestartPriority
+			}
+			if src.RestartPriorityTimeout != 0 {
+				dst.RestartPriorityTimeout = src.RestartPriorityTimeout
+			}
+		case types.ArrayUpdateOperationRemove:
+			if !exists {
+				return new(types.InvalidArgument)
+			}
+			cfg.DasVmConfig = append(cfg.DasVmConfig[:i], cfg.DasVmConfig[i+1:]...)
+		}
+	}
+
+	return nil
+}
+
+func (c *ClusterComputeResource) updateOverridesDRS(cfg *types.ClusterConfigInfoEx, cspec *types.ClusterConfigSpecEx) types.BaseMethodFault {
+	for _, spec := range cspec.DrsVmConfigSpec {
+		var i int
+		var key types.ManagedObjectReference
+		exists := false
+
+		if spec.Operation == types.ArrayUpdateOperationRemove {
+			key = spec.RemoveKey.(types.ManagedObjectReference)
+		} else {
+			key = spec.Info.Key
+		}
+
+		for i = range cfg.DrsVmConfig {
+			if cfg.DrsVmConfig[i].Key == key {
+				exists = true
+				break
+			}
+		}
+
+		switch spec.Operation {
+		case types.ArrayUpdateOperationAdd:
+			if exists {
+				return new(types.InvalidArgument)
+			}
+			cfg.DrsVmConfig = append(cfg.DrsVmConfig, *spec.Info)
+		case types.ArrayUpdateOperationEdit:
+			if !exists {
+				return new(types.InvalidArgument)
+			}
+			if spec.Info.Enabled != nil {
+				cfg.DrsVmConfig[i].Enabled = spec.Info.Enabled
+			}
+			if spec.Info.Behavior != "" {
+				cfg.DrsVmConfig[i].Behavior = spec.Info.Behavior
+			}
+		case types.ArrayUpdateOperationRemove:
+			if !exists {
+				return new(types.InvalidArgument)
+			}
+			cfg.DrsVmConfig = append(cfg.DrsVmConfig[:i], cfg.DrsVmConfig[i+1:]...)
+		}
+	}
+
+	return nil
+}
+
 func (c *ClusterComputeResource) ReconfigureComputeResourceTask(req *types.ReconfigureComputeResource_Task) soap.HasFault {
 	task := CreateTask(c, "reconfigureCluster", func(*Task) (types.AnyType, types.BaseMethodFault) {
 		spec, ok := req.Spec.(*types.ClusterConfigSpecEx)
@@ -174,6 +271,8 @@ func (c *ClusterComputeResource) ReconfigureComputeResourceTask(req *types.Recon
 		updates := []func(*types.ClusterConfigInfoEx, *types.ClusterConfigSpecEx) types.BaseMethodFault{
 			c.updateRules,
 			c.updateGroups,
+			c.updateOverridesDAS,
+			c.updateOverridesDRS,
 		}
 
 		for _, update := range updates {

--- a/vendor/github.com/vmware/govmomi/simulator/custom_fields_manager.go
+++ b/vendor/github.com/vmware/govmomi/simulator/custom_fields_manager.go
@@ -101,9 +101,11 @@ func (c *CustomFieldsManager) SetField(req *types.SetField) soap.HasFault {
 	body := &methods.SetFieldBody{}
 
 	entity := Map.Get(req.Entity).(mo.Entity).Entity()
-	entity.CustomValue = append(entity.CustomValue, &types.CustomFieldStringValue{
-		CustomFieldValue: types.CustomFieldValue{Key: req.Key},
-		Value:            req.Value,
+	Map.WithLock(entity, func() {
+		entity.CustomValue = append(entity.CustomValue, &types.CustomFieldStringValue{
+			CustomFieldValue: types.CustomFieldValue{Key: req.Key},
+			Value:            req.Value,
+		})
 	})
 
 	body.Res = &types.SetFieldResponse{}

--- a/vendor/github.com/vmware/govmomi/simulator/datacenter.go
+++ b/vendor/github.com/vmware/govmomi/simulator/datacenter.go
@@ -20,15 +20,40 @@ import (
 	"strings"
 
 	"github.com/vmware/govmomi/simulator/esx"
+	"github.com/vmware/govmomi/vim25/methods"
 	"github.com/vmware/govmomi/vim25/mo"
+	"github.com/vmware/govmomi/vim25/soap"
 	"github.com/vmware/govmomi/vim25/types"
 )
+
+type Datacenter struct {
+	mo.Datacenter
+
+	isESX bool
+}
+
+// NewDatacenter creates a Datacenter and its child folders.
+func NewDatacenter(f *Folder) *Datacenter {
+	dc := &Datacenter{
+		isESX: f.Self == esx.RootFolder.Self,
+	}
+
+	if dc.isESX {
+		dc.Datacenter = esx.Datacenter
+	}
+
+	f.putChild(dc)
+
+	dc.createFolders()
+
+	return dc
+}
 
 // Create Datacenter Folders.
 // Every Datacenter has 4 inventory Folders: Vm, Host, Datastore and Network.
 // The ESX folder child types are limited to 1 type.
 // The VC folders have additional child types, including nested folders.
-func createDatacenterFolders(dc *mo.Datacenter, isVC bool) {
+func (dc *Datacenter) createFolders() {
 	folders := []struct {
 		ref   *types.ManagedObjectReference
 		name  string
@@ -44,7 +69,11 @@ func createDatacenterFolders(dc *mo.Datacenter, isVC bool) {
 		folder := &Folder{}
 		folder.Name = f.name
 
-		if isVC {
+		if dc.isESX {
+			folder.ChildType = f.types[:1]
+			folder.Self = *f.ref
+			Map.PutEntity(dc, folder)
+		} else {
 			folder.ChildType = f.types
 			e := Map.PutEntity(dc, folder)
 
@@ -52,10 +81,6 @@ func createDatacenterFolders(dc *mo.Datacenter, isVC bool) {
 			ref := e.Reference()
 			f.ref.Type = ref.Type
 			f.ref.Value = ref.Value
-		} else {
-			folder.ChildType = f.types[:1]
-			folder.Self = *f.ref
-			Map.PutEntity(dc, folder)
 		}
 	}
 
@@ -67,10 +92,69 @@ func createDatacenterFolders(dc *mo.Datacenter, isVC bool) {
 		network.Self = ref
 		network.Name = strings.Split(ref.Value, "-")[1]
 		network.Entity().Name = network.Name
-		if isVC {
+		if !dc.isESX {
 			network.Self.Value = "" // we want a different moid per-DC
 		}
 
 		net.putChild(network)
+	}
+}
+
+func datacenterEventArgument(obj mo.Entity) *types.DatacenterEventArgument {
+	dc, ok := obj.(*Datacenter)
+	if !ok {
+		dc = Map.getEntityDatacenter(obj)
+	}
+	return &types.DatacenterEventArgument{
+		Datacenter:          dc.Self,
+		EntityEventArgument: types.EntityEventArgument{Name: dc.Name},
+	}
+}
+
+func (dc *Datacenter) PowerOnMultiVMTask(ctx *Context, req *types.PowerOnMultiVM_Task) soap.HasFault {
+	task := CreateTask(dc, "powerOnMultiVM", func(_ *Task) (types.AnyType, types.BaseMethodFault) {
+		if dc.isESX {
+			return nil, new(types.NotImplemented)
+		}
+
+		for _, ref := range req.Vm {
+			vm := Map.Get(ref).(*VirtualMachine)
+			Map.WithLock(vm, func() {
+				vm.PowerOnVMTask(ctx, &types.PowerOnVM_Task{})
+			})
+		}
+
+		return nil, nil
+	})
+
+	return &methods.PowerOnMultiVM_TaskBody{
+		Res: &types.PowerOnMultiVM_TaskResponse{
+			Returnval: task.Run(),
+		},
+	}
+}
+
+func (d *Datacenter) DestroyTask(req *types.Destroy_Task) soap.HasFault {
+	task := CreateTask(d, "destroy", func(t *Task) (types.AnyType, types.BaseMethodFault) {
+		folders := []types.ManagedObjectReference{
+			d.VmFolder,
+			d.HostFolder,
+		}
+
+		for _, ref := range folders {
+			if len(Map.Get(ref).(*Folder).ChildEntity) != 0 {
+				return nil, &types.ResourceInUse{}
+			}
+		}
+
+		Map.Get(*d.Parent).(*Folder).removeChild(d.Self)
+
+		return nil, nil
+	})
+
+	return &methods.Destroy_TaskBody{
+		Res: &types.Destroy_TaskResponse{
+			Returnval: task.Run(),
+		},
 	}
 }

--- a/vendor/github.com/vmware/govmomi/simulator/dvs.go
+++ b/vendor/github.com/vmware/govmomi/simulator/dvs.go
@@ -63,13 +63,16 @@ func (s *DistributedVirtualSwitch) AddDVPortgroupTask(c *types.AddDVPortgroup_Ta
 				VmVnicNetworkResourcePoolKey: spec.VmVnicNetworkResourcePoolKey,
 			}
 
+			pg.PortKeys = []string{}
+
 			s.Portgroup = append(s.Portgroup, pg.Self)
 			s.Summary.PortgroupName = append(s.Summary.PortgroupName, pg.Name)
 
 			for _, h := range s.Summary.HostMember {
-				pg.Host = AddReference(h, pg.Host)
+				pg.Host = append(pg.Host, h)
+
 				host := Map.Get(h).(*HostSystem)
-				host.Network = append(host.Network, pg.Reference())
+				Map.AppendReference(host, &host.Network, pg.Reference())
 			}
 		}
 
@@ -101,13 +104,13 @@ func (s *DistributedVirtualSwitch) ReconfigureDvsTask(req *types.ReconfigureDvs_
 					return nil, &types.AlreadyExists{Name: host.Name}
 				}
 
-				host.Network = append(host.Network, s.Self)
-				host.Network = append(host.Network, s.Portgroup...)
+				Map.AppendReference(host, &host.Network, s.Self)
+				Map.AppendReference(host, &host.Network, s.Portgroup...)
 				s.Summary.HostMember = append(s.Summary.HostMember, member.Host)
 
 				for _, ref := range s.Portgroup {
 					pg := Map.Get(ref).(*DistributedVirtualPortgroup)
-					pg.Host = AddReference(member.Host, pg.Host)
+					Map.AddReference(pg, &pg.Host, member.Host)
 				}
 			case types.ConfigSpecOperationRemove:
 				if pg := FindReference(host.Network, s.Portgroup...); pg != nil {
@@ -117,8 +120,8 @@ func (s *DistributedVirtualSwitch) ReconfigureDvsTask(req *types.ReconfigureDvs_
 					}
 				}
 
-				host.Network = RemoveReference(s.Self, host.Network)
-				s.Summary.HostMember = RemoveReference(s.Self, s.Summary.HostMember)
+				Map.RemoveReference(host, &host.Network, s.Self)
+				RemoveReference(&s.Summary.HostMember, s.Self)
 			case types.ConfigSpecOperationEdit:
 				return nil, &types.NotSupported{}
 			}

--- a/vendor/github.com/vmware/govmomi/simulator/esx/event_manager.go
+++ b/vendor/github.com/vmware/govmomi/simulator/esx/event_manager.go
@@ -1,0 +1,236 @@
+/*
+Copyright (c) 2018 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package esx
+
+import "github.com/vmware/govmomi/vim25/types"
+
+// EventInfo is the default template for the EventManager description.eventInfo property.
+// Capture method:
+//   govc object.collect -s -dump EventManager:ha-eventmgr description.eventInfo
+// The captured list has been manually pruned and FullFormat fields changed to use Go's template variable syntax.
+var EventInfo = []types.EventDescriptionEventDetail{
+	{
+		Key:         "UserLoginSessionEvent",
+		Description: "User login",
+		Category:    "info",
+		FullFormat:  "User {{.UserName}}@{{.IpAddress}} logged in as {{.UserAgent}}",
+	},
+	{
+		Key:         "UserLogoutSessionEvent",
+		Description: "User logout",
+		Category:    "info",
+		FullFormat:  "User {{.UserName}}@{{.IpAddress}} logged out (login time: {{.LoginTime}}, number of API invocations: {{.CallCount}}, user agent: {{.UserAgent}})",
+	},
+	{
+		Key:         "DatacenterCreatedEvent",
+		Description: "Datacenter created",
+		Category:    "info",
+		FullFormat:  "Created datacenter {{.Datacenter.Name}} in folder {{.Parent.Name}}",
+	},
+	{
+		Key:         "DatastoreFileMovedEvent",
+		Description: "File or directory moved to datastore",
+		Category:    "info",
+		FullFormat:  "Move of file or directory {{.SourceFile}} from {{.SourceDatastore.Name}} to {{.Datastore.Name}} as {{.TargetFile}}",
+	},
+	{
+		Key:         "DatastoreFileCopiedEvent",
+		Description: "File or directory copied to datastore",
+		Category:    "info",
+		FullFormat:  "Copy of file or directory {{.SourceFile}} from {{.SourceDatastore.Name}} to {{.Datastore.Name}} as {{.TargetFile}}",
+	},
+	{
+		Key:         "DatastoreFileDeletedEvent",
+		Description: "File or directory deleted",
+		Category:    "info",
+		FullFormat:  "Deletion of file or directory {{.TargetFile}} from {{.Datastore.Name}} was initiated",
+	},
+	{
+		Key:         "EnteringMaintenanceModeEvent",
+		Description: "Entering maintenance mode",
+		Category:    "info",
+		FullFormat:  "Host {{.Host.Name}} in {{.Datacenter.Name}} has started to enter maintenance mode",
+	},
+	{
+		Key:         "EnteredMaintenanceModeEvent",
+		Description: "Entered maintenance mode",
+		Category:    "info",
+		FullFormat:  "Host {{.Host.Name}} in {{.Datacenter.Name}} has entered maintenance mode",
+	},
+	{
+		Key:         "ExitMaintenanceModeEvent",
+		Description: "Exit maintenance mode",
+		Category:    "info",
+		FullFormat:  "Host {{.Host.Name}} in {{.Datacenter.Name}} has exited maintenance mode",
+	},
+	{
+		Key:         "VmSuspendedEvent",
+		Description: "VM suspended",
+		Category:    "info",
+		FullFormat:  "{{.Vm.Name}} on {{.Host.Name}} in {{.Datacenter.Name}} is suspended",
+	},
+	{
+		Key:         "VmMigratedEvent",
+		Description: "VM migrated",
+		Category:    "info",
+		FullFormat:  "Migration of virtual machine {{.Vm.Name}} from {{.SourceHost.Name}, {{.SourceDatastore.Name}} to {{.Host.Name}, {{.Ds.Name}} completed",
+	},
+	{
+		Key:         "VmBeingMigratedEvent",
+		Description: "VM migrating",
+		Category:    "info",
+		FullFormat:  "Relocating {{.Vm.Name}} from {{.Host.Name}, {{.Ds.Name}} in {{.Datacenter.Name}} to {{.DestHost.Name}, {{.DestDatastore.Name}} in {{.DestDatacenter.Name}}",
+	},
+	{
+		Key:         "VmMacAssignedEvent",
+		Description: "VM MAC assigned",
+		Category:    "info",
+		FullFormat:  "New MAC address ({{.Mac}}) assigned to adapter {{.Adapter}} for {{.Vm.Name}}",
+	},
+	{
+		Key:         "VmRegisteredEvent",
+		Description: "VM registered",
+		Category:    "info",
+		FullFormat:  "Registered {{.Vm.Name}} on {{.Host.Name}} in {{.Datacenter.Name}}",
+	},
+	{
+		Key:         "VmReconfiguredEvent",
+		Description: "VM reconfigured",
+		Category:    "info",
+		FullFormat:  "Reconfigured {{.Vm.Name}} on {{.Host.Name}} in {{.Datacenter.Name}}",
+	},
+	{
+		Key:         "VmGuestRebootEvent",
+		Description: "Guest reboot",
+		Category:    "info",
+		FullFormat:  "Guest OS reboot for {{.Vm.Name}} on {{.Host.Name}} in {{.Datacenter.Name}}",
+	},
+	{
+		Key:         "VmBeingClonedEvent",
+		Description: "VM being cloned",
+		Category:    "info",
+		FullFormat:  "Cloning {{.Vm.Name}} on host {{.Host.Name}} in {{.Datacenter.Name}} to {{.DestName}} on host {{.DestHost.Name}}",
+	},
+	{
+		Key:         "VmClonedEvent",
+		Description: "VM cloned",
+		Category:    "info",
+		FullFormat:  "Clone of {{.SourceVm.Name}} completed",
+	},
+	{
+		Key:         "VmBeingDeployedEvent",
+		Description: "Deploying VM",
+		Category:    "info",
+		FullFormat:  "Deploying {{.Vm.Name}} on host {{.Host.Name}} in {{.Datacenter.Name}} from template {{.SrcTemplate.Name}}",
+	},
+	{
+		Key:         "VmDeployedEvent",
+		Description: "VM deployed",
+		Category:    "info",
+		FullFormat:  "Template {{.SrcTemplate.Name}} deployed on host {{.Host.Name}}",
+	},
+	{
+		Key:         "VmInstanceUuidAssignedEvent",
+		Description: "Assign a new instance UUID",
+		Category:    "info",
+		FullFormat:  "Assign a new instance UUID ({{.InstanceUuid}}) to {{.Vm.Name}}",
+	},
+	{
+		Key:         "VmPoweredOnEvent",
+		Description: "VM powered on",
+		Category:    "info",
+		FullFormat:  "{{.Vm.Name}} on {{.Host.Name}} in {{.Datacenter.Name}} is powered on",
+	},
+	{
+		Key:         "VmStartingEvent",
+		Description: "VM starting",
+		Category:    "info",
+		FullFormat:  "{{.Vm.Name}} on host {{.Host.Name}} in {{.Datacenter.Name}} is starting",
+	},
+	{
+		Key:         "VmSuspendingEvent",
+		Description: "VM being suspended",
+		Category:    "info",
+		FullFormat:  "{{.Vm.Name}} on {{.Host.Name}} in {{.Datacenter.Name}} is being suspended",
+	},
+	{
+		Key:         "VmResumingEvent",
+		Description: "VM resuming",
+		Category:    "info",
+		FullFormat:  "{{.Vm.Name}} on {{.Host.Name}} in {{.Datacenter.Name}} is resumed",
+	},
+	{
+		Key:         "VmBeingCreatedEvent",
+		Description: "Creating VM",
+		Category:    "info",
+		FullFormat:  "Creating {{.Vm.Name}} on host {{.Host.Name}} in {{.Datacenter.Name}}",
+	},
+	{
+		Key:         "VmCreatedEvent",
+		Description: "VM created",
+		Category:    "info",
+		FullFormat:  "Created virtual machine {{.Vm.Name}} on {{.Host.Name}} in {{.Datacenter.Name}}",
+	},
+	{
+		Key:         "VmRemovedEvent",
+		Description: "VM removed",
+		Category:    "info",
+		FullFormat:  "Removed {{.Vm.Name}} on {{.Host.Name}} from {{.Datacenter.Name}}",
+	},
+	{
+		Key:         "VmResettingEvent",
+		Description: "VM resetting",
+		Category:    "info",
+		FullFormat:  "{{.Vm.Name}} on {{.Host.Name}} in {{.Datacenter.Name}} is reset",
+	},
+	{
+		Key:         "VmGuestShutdownEvent",
+		Description: "Guest OS shut down",
+		Category:    "info",
+		FullFormat:  "Guest OS shut down for {{.Vm.Name}} on {{.Host.Name}} in {{.Datacenter.Name}}",
+	},
+	{
+		Key:         "VmUuidAssignedEvent",
+		Description: "VM UUID assigned",
+		Category:    "info",
+		FullFormat:  "Assigned new BIOS UUID ({{.Uuid}}) to {{.Vm.Name}} on {{.Host.Name}} in {{.Datacenter.Name}}",
+	},
+	{
+		Key:         "VmPoweredOffEvent",
+		Description: "VM powered off",
+		Category:    "info",
+		FullFormat:  "{{.Vm.Name}} on {{.Host.Name}} in {{.Datacenter.Name}} is powered off",
+	},
+	{
+		Key:         "VmRelocatedEvent",
+		Description: "VM relocated",
+		Category:    "info",
+		FullFormat:  "Completed the relocation of the virtual machine",
+	},
+	{
+		Key:         "DrsVmMigratedEvent",
+		Description: "DRS VM migrated",
+		Category:    "info",
+		FullFormat:  "DRS migrated {{.Vm.Name}} from {{.SourceHost.Name}} to {{.Host.Name}} in cluster {{.ComputeResource.Name}} in {{.Datacenter.Name}}",
+	},
+	{
+		Key:         "DrsVmPoweredOnEvent",
+		Description: "DRS VM powered on",
+		Category:    "info",
+		FullFormat:  "DRS powered On {{.Vm.Name}} on {{.Host.Name}} in {{.Datacenter.Name}}",
+	},
+}

--- a/vendor/github.com/vmware/govmomi/simulator/event_manager.go
+++ b/vendor/github.com/vmware/govmomi/simulator/event_manager.go
@@ -1,0 +1,423 @@
+/*
+Copyright (c) 2018 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package simulator
+
+import (
+	"bytes"
+	"container/ring"
+	"log"
+	"reflect"
+	"text/template"
+	"time"
+
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/simulator/esx"
+	"github.com/vmware/govmomi/vim25/methods"
+	"github.com/vmware/govmomi/vim25/mo"
+	"github.com/vmware/govmomi/vim25/soap"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+var (
+	maxPageSize = 1000
+	logEvents   = false
+)
+
+type EventManager struct {
+	mo.EventManager
+
+	root       types.ManagedObjectReference
+	page       *ring.Ring
+	key        int32
+	collectors map[types.ManagedObjectReference]*EventHistoryCollector
+	templates  map[string]*template.Template
+}
+
+func NewEventManager(ref types.ManagedObjectReference) object.Reference {
+	return &EventManager{
+		EventManager: mo.EventManager{
+			Self: ref,
+			Description: types.EventDescription{
+				EventInfo: esx.EventInfo,
+			},
+			MaxCollector: 1000,
+		},
+		root:       Map.content().RootFolder,
+		page:       ring.New(maxPageSize),
+		collectors: make(map[types.ManagedObjectReference]*EventHistoryCollector),
+		templates:  make(map[string]*template.Template),
+	}
+}
+
+func (m *EventManager) createCollector(ctx *Context, req *types.CreateCollectorForEvents) (*EventHistoryCollector, *soap.Fault) {
+	size, err := validatePageSize(req.Filter.MaxCount)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(m.collectors) >= int(m.MaxCollector) {
+		return nil, Fault("Too many event collectors to create", new(types.InvalidState))
+	}
+
+	collector := &EventHistoryCollector{
+		m:    m,
+		page: ring.New(size),
+	}
+	collector.Filter = req.Filter
+	collector.fillPage(size)
+
+	return collector, nil
+}
+
+func (m *EventManager) CreateCollectorForEvents(ctx *Context, req *types.CreateCollectorForEvents) soap.HasFault {
+	body := new(methods.CreateCollectorForEventsBody)
+	collector, err := m.createCollector(ctx, req)
+	if err != nil {
+		body.Fault_ = err
+		return body
+	}
+
+	ref := ctx.Session.Put(collector).Reference()
+	m.collectors[ref] = collector
+
+	body.Res = &types.CreateCollectorForEventsResponse{
+		Returnval: ref,
+	}
+
+	return body
+}
+
+func (m *EventManager) QueryEvents(ctx *Context, req *types.QueryEvents) soap.HasFault {
+	if Map.IsESX() {
+		return &methods.QueryEventsBody{
+			Fault_: Fault("", new(types.NotImplemented)),
+		}
+	}
+
+	body := new(methods.QueryEventsBody)
+	collector, err := m.createCollector(ctx, &types.CreateCollectorForEvents{Filter: req.Filter})
+	if err != nil {
+		body.Fault_ = err
+		return body
+	}
+
+	body.Res = &types.QueryEventsResponse{
+		Returnval: collector.GetLatestPage(),
+	}
+
+	return body
+}
+
+// formatMessage applies the EventDescriptionEventDetail.FullFormat template to the given event's FullFormattedMessage field.
+func (m *EventManager) formatMessage(event types.BaseEvent) {
+	id := reflect.ValueOf(event).Elem().Type().Name()
+	e := event.GetEvent()
+
+	t, ok := m.templates[id]
+	if !ok {
+		for _, info := range m.Description.EventInfo {
+			if info.Key == id {
+				t = template.Must(template.New(id).Parse(info.FullFormat))
+				m.templates[id] = t
+				break
+			}
+		}
+	}
+
+	var buf bytes.Buffer
+	if err := t.Execute(&buf, event); err != nil {
+		log.Print(err)
+	}
+	e.FullFormattedMessage = buf.String()
+
+	if logEvents {
+		log.Printf("[%s] %s", id, e.FullFormattedMessage)
+	}
+}
+
+func (m *EventManager) PostEvent(ctx *Context, req *types.PostEvent) soap.HasFault {
+	m.key++
+	event := req.EventToPost.GetEvent()
+	event.Key = m.key
+	event.ChainId = event.Key
+	event.CreatedTime = time.Now()
+	event.UserName = ctx.Session.UserName
+
+	m.page = m.page.Next()
+	m.page.Value = req.EventToPost
+	m.formatMessage(req.EventToPost)
+
+	for _, c := range m.collectors {
+		if c.eventMatches(req.EventToPost) {
+			c.page = c.page.Next()
+			c.page.Value = event
+		}
+	}
+
+	return &methods.PostEventBody{
+		Res: new(types.PostEventResponse),
+	}
+}
+
+type EventHistoryCollector struct {
+	mo.EventHistoryCollector
+
+	m    *EventManager
+	page *ring.Ring
+}
+
+// doEntityEventArgument calls f for each entity argument in the event.
+// If f returns true, the iteration stops.
+func doEntityEventArgument(event types.BaseEvent, f func(types.ManagedObjectReference, *types.EntityEventArgument) bool) bool {
+	e := event.GetEvent()
+
+	if arg := e.Vm; arg != nil {
+		if f(arg.Vm, &arg.EntityEventArgument) {
+			return true
+		}
+	}
+
+	if arg := e.Host; arg != nil {
+		if f(arg.Host, &arg.EntityEventArgument) {
+			return true
+		}
+	}
+
+	if arg := e.ComputeResource; arg != nil {
+		if f(arg.ComputeResource, &arg.EntityEventArgument) {
+			return true
+		}
+	}
+
+	if arg := e.Ds; arg != nil {
+		if f(arg.Datastore, &arg.EntityEventArgument) {
+			return true
+		}
+	}
+
+	if arg := e.Net; arg != nil {
+		if f(arg.Network, &arg.EntityEventArgument) {
+			return true
+		}
+	}
+
+	if arg := e.Dvs; arg != nil {
+		if f(arg.Dvs, &arg.EntityEventArgument) {
+			return true
+		}
+	}
+
+	if arg := e.Datacenter; arg != nil {
+		if f(arg.Datacenter, &arg.EntityEventArgument) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// eventFilterSelf returns true if self is one of the entity arguments in the event.
+func eventFilterSelf(event types.BaseEvent, self types.ManagedObjectReference) bool {
+	return doEntityEventArgument(event, func(ref types.ManagedObjectReference, _ *types.EntityEventArgument) bool {
+		return self == ref
+	})
+}
+
+// eventFilterChildren returns true if a child of self is one of the entity arguments in the event.
+func eventFilterChildren(event types.BaseEvent, self types.ManagedObjectReference) bool {
+	return doEntityEventArgument(event, func(ref types.ManagedObjectReference, _ *types.EntityEventArgument) bool {
+		seen := false
+
+		var match func(types.ManagedObjectReference)
+
+		match = func(child types.ManagedObjectReference) {
+			if child == self {
+				seen = true
+				return
+			}
+
+			walk(child, match)
+		}
+
+		walk(ref, match)
+
+		return seen
+	})
+}
+
+// entityMatches returns true if the spec Entity filter matches the event.
+func (c *EventHistoryCollector) entityMatches(event types.BaseEvent, spec *types.EventFilterSpec) bool {
+	e := spec.Entity
+	if e == nil {
+		return true
+	}
+
+	isRootFolder := c.m.root == e.Entity
+
+	switch e.Recursion {
+	case types.EventFilterSpecRecursionOptionSelf:
+		return isRootFolder || eventFilterSelf(event, e.Entity)
+	case types.EventFilterSpecRecursionOptionChildren:
+		return eventFilterChildren(event, e.Entity)
+	case types.EventFilterSpecRecursionOptionAll:
+		if isRootFolder || eventFilterSelf(event, e.Entity) {
+			return true
+		}
+		return eventFilterChildren(event, e.Entity)
+	}
+
+	return false
+}
+
+// typeMatches returns true if one of the spec EventTypeId types matches the event.
+func (c *EventHistoryCollector) typeMatches(event types.BaseEvent, spec *types.EventFilterSpec) bool {
+	if len(spec.EventTypeId) == 0 {
+		return true
+	}
+
+	matches := func(name string) bool {
+		for _, id := range spec.EventTypeId {
+			if id == name {
+				return true
+			}
+		}
+		return false
+	}
+	kind := reflect.ValueOf(event).Elem().Type()
+
+	if matches(kind.Name()) {
+		return true // concrete type
+	}
+
+	field, ok := kind.FieldByNameFunc(matches)
+	if ok {
+		return field.Anonymous // base type (embedded field)
+	}
+	return false
+}
+
+// eventMatches returns true one of the filters matches the event.
+func (c *EventHistoryCollector) eventMatches(event types.BaseEvent) bool {
+	spec := c.Filter.(types.EventFilterSpec)
+
+	if !c.typeMatches(event, &spec) {
+		return false
+	}
+
+	// TODO: spec.Time, spec.UserName, etc
+
+	return c.entityMatches(event, &spec)
+}
+
+// filePage copies the manager's latest events into the collector's page with Filter applied.
+func (c *EventHistoryCollector) fillPage(size int) {
+	l := c.page.Len()
+	delta := size - l
+
+	if delta < 0 {
+		// Shrink ring size
+		c.page = c.page.Unlink(-delta)
+		return
+	}
+
+	matches := 0
+	mpage := c.m.page
+	page := c.page
+
+	if delta != 0 {
+		// Grow ring size
+		c.page = c.page.Link(ring.New(delta))
+	}
+
+	for i := 0; i < maxPageSize; i++ {
+		event, ok := mpage.Value.(types.BaseEvent)
+		mpage = mpage.Prev()
+		if !ok {
+			continue
+		}
+
+		if c.eventMatches(event) {
+			page.Value = event
+			page = page.Prev()
+			matches++
+			if matches == size {
+				break
+			}
+		}
+	}
+}
+
+func validatePageSize(count int32) (int, *soap.Fault) {
+	size := int(count)
+
+	if size == 0 {
+		size = 10 // defaultPageSize
+	} else if size < 0 || size > maxPageSize {
+		return -1, Fault("", &types.InvalidArgument{InvalidProperty: "maxCount"})
+	}
+
+	return size, nil
+}
+
+func (c *EventHistoryCollector) SetCollectorPageSize(ctx *Context, req *types.SetCollectorPageSize) soap.HasFault {
+	body := new(methods.SetCollectorPageSizeBody)
+	size, err := validatePageSize(req.MaxCount)
+	if err != nil {
+		body.Fault_ = err
+		return body
+	}
+
+	ctx.WithLock(c.m, func() {
+		c.fillPage(size)
+	})
+
+	body.Res = new(types.SetCollectorPageSizeResponse)
+	return body
+}
+
+func (c *EventHistoryCollector) DestroyCollector(ctx *Context, req *types.DestroyCollector) soap.HasFault {
+	ctx.Session.Remove(req.This)
+
+	ctx.WithLock(c.m, func() {
+		delete(c.m.collectors, req.This)
+	})
+
+	return &methods.DestroyCollectorBody{
+		Res: new(types.DestroyCollectorResponse),
+	}
+}
+
+func (c *EventHistoryCollector) GetLatestPage() []types.BaseEvent {
+	var latestPage []types.BaseEvent
+
+	c.page.Do(func(val interface{}) {
+		if val == nil {
+			return
+		}
+		latestPage = append(latestPage, val.(types.BaseEvent))
+	})
+
+	return latestPage
+}
+
+func (c *EventHistoryCollector) Get() mo.Reference {
+	clone := *c
+
+	clone.LatestPage = clone.GetLatestPage()
+
+	return &clone
+}

--- a/vendor/github.com/vmware/govmomi/simulator/file_manager.go
+++ b/vendor/github.com/vmware/govmomi/simulator/file_manager.go
@@ -80,7 +80,7 @@ func (f *FileManager) resolve(dc *types.ManagedObjectReference, name string) (st
 		}
 	}
 
-	folder := Map.Get(*dc).(*mo.Datacenter).DatastoreFolder
+	folder := Map.Get(*dc).(*Datacenter).DatastoreFolder
 
 	ds, fault := f.findDatastore(Map.Get(folder), p.Datastore)
 	if fault != nil {

--- a/vendor/github.com/vmware/govmomi/simulator/folder.go
+++ b/vendor/github.com/vmware/govmomi/simulator/folder.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"math/rand"
 	"path"
-	"sync"
 
 	"github.com/google/uuid"
 
@@ -32,12 +31,17 @@ import (
 
 type Folder struct {
 	mo.Folder
+}
 
-	m sync.Mutex
+func (f *Folder) eventArgument() types.FolderEventArgument {
+	return types.FolderEventArgument{
+		Folder:              f.Self,
+		EntityEventArgument: types.EntityEventArgument{Name: f.Name},
+	}
 }
 
 // update references when objects are added/removed from a Folder
-func (f *Folder) update(o mo.Reference, u func(types.ManagedObjectReference, []types.ManagedObjectReference) []types.ManagedObjectReference) {
+func (f *Folder) update(o mo.Reference, u func(mo.Reference, *[]types.ManagedObjectReference, types.ManagedObjectReference)) {
 	ref := o.Reference()
 
 	if f.Parent == nil {
@@ -53,9 +57,9 @@ func (f *Folder) update(o mo.Reference, u func(types.ManagedObjectReference, []t
 
 	switch ref.Type {
 	case "Network", "DistributedVirtualSwitch", "DistributedVirtualPortgroup":
-		dc.Network = u(ref, dc.Network)
+		u(dc, &dc.Network, ref)
 	case "Datastore":
-		dc.Datastore = u(ref, dc.Datastore)
+		u(dc, &dc.Datastore, ref)
 	}
 }
 
@@ -70,12 +74,9 @@ func networkSummary(n *mo.Network) *types.NetworkSummary {
 func (f *Folder) putChild(o mo.Entity) {
 	Map.PutEntity(f, o)
 
-	f.m.Lock()
-	defer f.m.Unlock()
+	f.ChildEntity = append(f.ChildEntity, o.Reference())
 
-	f.ChildEntity = AddReference(o.Reference(), f.ChildEntity)
-
-	f.update(o, AddReference)
+	f.update(o, Map.AddReference)
 
 	switch e := o.(type) {
 	case *mo.Network:
@@ -90,12 +91,9 @@ func (f *Folder) putChild(o mo.Entity) {
 func (f *Folder) removeChild(o mo.Reference) {
 	Map.Remove(o.Reference())
 
-	f.m.Lock()
-	defer f.m.Unlock()
+	RemoveReference(&f.ChildEntity, o.Reference())
 
-	f.ChildEntity = RemoveReference(o.Reference(), f.ChildEntity)
-
-	f.update(o, RemoveReference)
+	f.update(o, Map.RemoveReference)
 }
 
 func (f *Folder) hasChildType(kind string) bool {
@@ -195,21 +193,26 @@ func (p *StoragePod) MoveIntoFolderTask(c *types.MoveIntoFolder_Task) soap.HasFa
 	return (&Folder{Folder: p.Folder}).MoveIntoFolderTask(c)
 }
 
-func (f *Folder) CreateDatacenter(c *types.CreateDatacenter) soap.HasFault {
+func (f *Folder) CreateDatacenter(ctx *Context, c *types.CreateDatacenter) soap.HasFault {
 	r := &methods.CreateDatacenterBody{}
 
 	if f.hasChildType("Datacenter") && f.hasChildType("Folder") {
-		dc := &mo.Datacenter{}
+		dc := NewDatacenter(f)
 
 		dc.Name = c.Name
-
-		f.putChild(dc)
-
-		createDatacenterFolders(dc, true)
 
 		r.Res = &types.CreateDatacenterResponse{
 			Returnval: dc.Self,
 		}
+
+		ctx.postEvent(&types.DatacenterCreatedEvent{
+			DatacenterEvent: types.DatacenterEvent{
+				Event: types.Event{
+					Datacenter: datacenterEventArgument(dc),
+				},
+			},
+			Parent: f.eventArgument(),
+		})
 	} else {
 		r.Fault_ = f.typeNotSupported()
 	}
@@ -240,6 +243,7 @@ func (f *Folder) CreateClusterEx(c *types.CreateClusterEx) soap.HasFault {
 type createVM struct {
 	*Folder
 
+	ctx *Context
 	req *types.CreateVM_Task
 
 	register bool
@@ -291,27 +295,50 @@ func (c *createVM) Run(task *Task) (types.AnyType, types.BaseMethodFault) {
 	c.Folder.putChild(vm)
 
 	host := Map.Get(*vm.Runtime.Host).(*HostSystem)
-	host.Vm = append(host.Vm, vm.Self)
+	Map.AppendReference(host, &host.Vm, vm.Self)
 
 	for i := range vm.Datastore {
 		ds := Map.Get(vm.Datastore[i]).(*Datastore)
-		ds.Vm = append(ds.Vm, vm.Self)
+		Map.AppendReference(ds, &ds.Vm, vm.Self)
 	}
 
-	switch rp := Map.Get(*vm.ResourcePool).(type) {
-	case *ResourcePool:
-		rp.Vm = append(rp.Vm, vm.Self)
-	case *VirtualApp:
-		rp.Vm = append(rp.Vm, vm.Self)
-	}
+	pool := Map.Get(*vm.ResourcePool)
+	// This can be an internal call from VirtualApp.CreateChildVMTask, where pool is already locked.
+	c.ctx.WithLock(pool, func() {
+		switch rp := pool.(type) {
+		case *ResourcePool:
+			rp.Vm = append(rp.Vm, vm.Self)
+		case *VirtualApp:
+			rp.Vm = append(rp.Vm, vm.Self)
+		}
+	})
+
+	event := vm.event()
+	c.ctx.postEvent(
+		&types.VmBeingCreatedEvent{
+			VmEvent:    event,
+			ConfigSpec: &c.req.Config,
+		},
+		&types.VmInstanceUuidAssignedEvent{
+			VmEvent:      event,
+			InstanceUuid: vm.Config.InstanceUuid,
+		},
+		&types.VmUuidAssignedEvent{
+			VmEvent: event,
+			Uuid:    vm.Config.Uuid,
+		},
+		&types.VmCreatedEvent{
+			VmEvent: event,
+		},
+	)
 
 	return vm.Reference(), nil
 }
 
-func (f *Folder) CreateVMTask(c *types.CreateVM_Task) soap.HasFault {
+func (f *Folder) CreateVMTask(ctx *Context, c *types.CreateVM_Task) soap.HasFault {
 	return &methods.CreateVM_TaskBody{
 		Res: &types.CreateVM_TaskResponse{
-			Returnval: NewTask(&createVM{f, c, false}).Run(),
+			Returnval: NewTask(&createVM{f, ctx, c, false}).Run(),
 		},
 	}
 }
@@ -319,6 +346,7 @@ func (f *Folder) CreateVMTask(c *types.CreateVM_Task) soap.HasFault {
 type registerVM struct {
 	*Folder
 
+	ctx *Context
 	req *types.RegisterVM_Task
 }
 
@@ -367,6 +395,7 @@ func (c *registerVM) Run(task *Task) (types.AnyType, types.BaseMethodFault) {
 	create := NewTask(&createVM{
 		Folder:   c.Folder,
 		register: true,
+		ctx:      c.ctx,
 		req: &types.CreateVM_Task{
 			This: c.Folder.Reference(),
 			Config: types.VirtualMachineConfigSpec{
@@ -389,10 +418,12 @@ func (c *registerVM) Run(task *Task) (types.AnyType, types.BaseMethodFault) {
 	return create.Info.Result, nil
 }
 
-func (f *Folder) RegisterVMTask(c *types.RegisterVM_Task) soap.HasFault {
+func (f *Folder) RegisterVMTask(ctx *Context, c *types.RegisterVM_Task) soap.HasFault {
+	ctx.Caller = &f.Self
+
 	return &methods.RegisterVM_TaskBody{
 		Res: &types.RegisterVM_TaskResponse{
-			Returnval: NewTask(&registerVM{f, c}).Run(),
+			Returnval: NewTask(&registerVM{f, ctx, c}).Run(),
 		},
 	}
 }
@@ -495,4 +526,46 @@ func (f *Folder) CreateDVSTask(req *types.CreateDVS_Task) soap.HasFault {
 
 func (f *Folder) RenameTask(r *types.Rename_Task) soap.HasFault {
 	return RenameTask(f, r)
+}
+
+func (f *Folder) DestroyTask(req *types.Destroy_Task) soap.HasFault {
+	type destroyer interface {
+		mo.Reference
+		DestroyTask(*types.Destroy_Task) soap.HasFault
+	}
+
+	task := CreateTask(f, "destroy", func(*Task) (types.AnyType, types.BaseMethodFault) {
+		// Attempt to destroy all children
+		for _, c := range f.ChildEntity {
+			obj, ok := Map.Get(c).(destroyer)
+			if !ok {
+				continue
+			}
+
+			var fault types.BaseMethodFault
+			Map.WithLock(obj, func() {
+				id := obj.DestroyTask(&types.Destroy_Task{
+					This: c,
+				}).(*methods.Destroy_TaskBody).Res.Returnval
+
+				t := Map.Get(id).(*Task)
+				if t.Info.Error != nil {
+					fault = t.Info.Error.Fault // For example, can't destroy a powered on VM
+				}
+			})
+			if fault != nil {
+				return nil, fault
+			}
+		}
+
+		// Remove the folder itself
+		Map.Get(*f.Parent).(*Folder).removeChild(f.Self)
+		return nil, nil
+	})
+
+	return &methods.Destroy_TaskBody{
+		Res: &types.Destroy_TaskResponse{
+			Returnval: task.Run(),
+		},
+	}
 }

--- a/vendor/github.com/vmware/govmomi/simulator/host_datastore_system.go
+++ b/vendor/github.com/vmware/govmomi/simulator/host_datastore_system.go
@@ -72,7 +72,7 @@ func (dss *HostDatastoreSystem) add(ds *Datastore) *soap.Fault {
 	dss.Datastore = append(dss.Datastore, ds.Self)
 	dss.Host.Datastore = dss.Datastore
 	parent := hostParent(dss.Host)
-	parent.Datastore = AddReference(ds.Self, parent.Datastore)
+	Map.AddReference(parent, &parent.Datastore, ds.Self)
 
 	browser := &HostDatastoreBrowser{}
 	browser.Datastore = dss.Datastore

--- a/vendor/github.com/vmware/govmomi/simulator/host_system.go
+++ b/vendor/github.com/vmware/govmomi/simulator/host_system.go
@@ -71,6 +71,22 @@ func NewHostSystem(host mo.HostSystem) *HostSystem {
 	return hs
 }
 
+func (h *HostSystem) eventArgument() *types.HostEventArgument {
+	return &types.HostEventArgument{
+		Host:                h.Self,
+		EntityEventArgument: types.EntityEventArgument{Name: h.Name},
+	}
+}
+
+func (h *HostSystem) eventArgumentParent() *types.ComputeResourceEventArgument {
+	parent := hostParent(&h.HostSystem)
+
+	return &types.ComputeResourceEventArgument{
+		ComputeResource:     parent.Self,
+		EntityEventArgument: types.EntityEventArgument{Name: parent.Name},
+	}
+}
+
 func hostParent(host *mo.HostSystem) *mo.ComputeResource {
 	switch parent := Map.Get(*host.Parent).(type) {
 	case *mo.ComputeResource:
@@ -97,9 +113,7 @@ func addComputeResource(s *types.ComputeResourceSummary, h *HostSystem) {
 // CreateDefaultESX creates a standalone ESX
 // Adds objects of type: Datacenter, Network, ComputeResource, ResourcePool and HostSystem
 func CreateDefaultESX(f *Folder) {
-	dc := &esx.Datacenter
-	f.putChild(dc)
-	createDatacenterFolders(dc, false)
+	dc := NewDatacenter(f)
 
 	host := NewHostSystem(esx.HostSystem)
 
@@ -145,6 +159,7 @@ func CreateStandaloneHost(f *Folder, spec types.HostConnectSpec) (*HostSystem, t
 	}
 
 	Map.PutEntity(cr, Map.NewEntity(host))
+	host.Summary.Host = &host.Self
 
 	Map.PutEntity(cr, Map.NewEntity(pool))
 
@@ -156,6 +171,25 @@ func CreateStandaloneHost(f *Folder, spec types.HostConnectSpec) (*HostSystem, t
 	pool.Owner = cr.Self
 
 	return host, nil
+}
+
+func (h *HostSystem) DestroyTask(req *types.Destroy_Task) soap.HasFault {
+	task := CreateTask(h, "destroy", func(t *Task) (types.AnyType, types.BaseMethodFault) {
+		if len(h.Vm) > 0 {
+			return nil, &types.ResourceInUse{}
+		}
+
+		f := Map.getEntityParent(h, "Folder").(*Folder)
+		f.removeChild(h.Reference())
+
+		return nil, nil
+	})
+
+	return &methods.Destroy_TaskBody{
+		Res: &types.Destroy_TaskResponse{
+			Returnval: task.Run(),
+		},
+	}
 }
 
 func (h *HostSystem) EnterMaintenanceModeTask(spec *types.EnterMaintenanceMode_Task) soap.HasFault {

--- a/vendor/github.com/vmware/govmomi/simulator/os_unix.go
+++ b/vendor/github.com/vmware/govmomi/simulator/os_unix.go
@@ -1,3 +1,5 @@
+//+build !windows
+
 /*
 Copyright (c) 2017 VMware, Inc. All Rights Reserved.
 

--- a/vendor/github.com/vmware/govmomi/simulator/portgroup.go
+++ b/vendor/github.com/vmware/govmomi/simulator/portgroup.go
@@ -53,22 +53,11 @@ func (s *DistributedVirtualPortgroup) ReconfigureDVPortgroupTask(req *types.Reco
 func (s *DistributedVirtualPortgroup) DestroyTask(req *types.Destroy_Task) soap.HasFault {
 	task := CreateTask(s, "destroy", func(t *Task) (types.AnyType, types.BaseMethodFault) {
 		vswitch := Map.Get(*s.Config.DistributedVirtualSwitch).(*DistributedVirtualSwitch)
-		for i, pg := range vswitch.Portgroup {
-			if pg.Reference() == s.Reference() {
-				vswitch.Portgroup = append(vswitch.Portgroup[:i], vswitch.Portgroup[i+1:]...)
-				break
-			}
-		}
+		Map.RemoveReference(vswitch, &vswitch.Portgroup, s.Reference())
+		Map.removeString(vswitch, &vswitch.Summary.PortgroupName, s.Name)
 
 		f := Map.getEntityParent(vswitch, "Folder").(*Folder)
 		f.removeChild(s.Reference())
-
-		for i, name := range vswitch.Summary.PortgroupName {
-			if name == s.Name {
-				vswitch.Summary.PortgroupName = append(vswitch.Summary.PortgroupName[:i],
-					vswitch.Summary.PortgroupName[i+1:]...)
-			}
-		}
 
 		return nil, nil
 	})

--- a/vendor/github.com/vmware/govmomi/simulator/property_filter.go
+++ b/vendor/github.com/vmware/govmomi/simulator/property_filter.go
@@ -32,7 +32,7 @@ type PropertyFilter struct {
 func (f *PropertyFilter) DestroyPropertyFilter(c *types.DestroyPropertyFilter) soap.HasFault {
 	body := &methods.DestroyPropertyFilterBody{}
 
-	f.pc.Filter = RemoveReference(c.This, f.pc.Filter)
+	RemoveReference(&f.pc.Filter, c.This)
 
 	Map.Remove(c.This)
 

--- a/vendor/github.com/vmware/govmomi/simulator/registry.go
+++ b/vendor/github.com/vmware/govmomi/simulator/registry.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+Copyright (c) 2017-2018 VMware, Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -17,7 +17,9 @@ limitations under the License.
 package simulator
 
 import (
+	"encoding/json"
 	"fmt"
+	"os"
 	"reflect"
 	"strings"
 	"sync"
@@ -55,6 +57,7 @@ type Registry struct {
 	m        sync.Mutex
 	objects  map[types.ManagedObjectReference]mo.Reference
 	handlers map[types.ManagedObjectReference]RegisterObject
+	locks    map[types.ManagedObjectReference]sync.Locker
 	counter  int
 }
 
@@ -63,6 +66,7 @@ func NewRegistry() *Registry {
 	r := &Registry{
 		objects:  make(map[types.ManagedObjectReference]mo.Reference),
 		handlers: make(map[types.ManagedObjectReference]RegisterObject),
+		locks:    make(map[types.ManagedObjectReference]sync.Locker),
 	}
 
 	return r
@@ -97,6 +101,11 @@ func (r *Registry) newReference(item mo.Reference) types.ManagedObjectReference 
 	}
 
 	return ref
+}
+
+func (r *Registry) setReference(item mo.Reference, ref types.ManagedObjectReference) {
+	// mo.Reference() returns a value, not a pointer so use reflect to set the Self field
+	reflect.ValueOf(item).Elem().FieldByName("Self").Set(reflect.ValueOf(ref))
 }
 
 // AddHandler adds a RegisterObject handler to the Registry.
@@ -156,8 +165,7 @@ func (r *Registry) Put(item mo.Reference) mo.Reference {
 	ref := item.Reference()
 	if ref.Type == "" || ref.Value == "" {
 		ref = r.newReference(item)
-		// mo.Reference() returns a value, not a pointer so use reflect to set the Self field
-		reflect.ValueOf(item).Elem().FieldByName("Self").Set(reflect.ValueOf(ref))
+		r.setReference(item, ref)
 	}
 
 	if me, ok := item.(mo.Entity); ok {
@@ -186,6 +194,7 @@ func (r *Registry) Remove(item types.ManagedObjectReference) {
 
 	delete(r.objects, item)
 	delete(r.handlers, item)
+	delete(r.locks, item)
 }
 
 // getEntityParent traverses up the inventory and returns the first object of type kind.
@@ -204,8 +213,8 @@ func (r *Registry) getEntityParent(item mo.Entity, kind string) mo.Entity {
 }
 
 // getEntityDatacenter returns the Datacenter containing the given item
-func (r *Registry) getEntityDatacenter(item mo.Entity) *mo.Datacenter {
-	return r.getEntityParent(item, "Datacenter").(*mo.Datacenter)
+func (r *Registry) getEntityDatacenter(item mo.Entity) *Datacenter {
+	return r.getEntityParent(item, "Datacenter").(*Datacenter)
 }
 
 func (r *Registry) getEntityFolder(item mo.Entity, kind string) *Folder {
@@ -278,29 +287,48 @@ func FindReference(refs []types.ManagedObjectReference, match ...types.ManagedOb
 	return nil
 }
 
-// RemoveReference returns a slice with ref removed from refs
-func RemoveReference(ref types.ManagedObjectReference, refs []types.ManagedObjectReference) []types.ManagedObjectReference {
-	var result []types.ManagedObjectReference
-
-	for i, r := range refs {
-		if r == ref {
-			result = append(result, refs[i+1:]...)
-			break
-		}
-
-		result = append(result, r)
-	}
-
-	return result
+// AppendReference appends the given refs to field.
+func (r *Registry) AppendReference(obj mo.Reference, field *[]types.ManagedObjectReference, ref ...types.ManagedObjectReference) {
+	r.WithLock(obj, func() {
+		*field = append(*field, ref...)
+	})
 }
 
-// AddReference returns a slice with ref appended if not already in refs.
-func AddReference(ref types.ManagedObjectReference, refs []types.ManagedObjectReference) []types.ManagedObjectReference {
-	if FindReference(refs, ref) == nil {
-		return append(refs, ref)
-	}
+// AddReference appends ref to field if not already in the given field.
+func (r *Registry) AddReference(obj mo.Reference, field *[]types.ManagedObjectReference, ref types.ManagedObjectReference) {
+	r.WithLock(obj, func() {
+		if FindReference(*field, ref) == nil {
+			*field = append(*field, ref)
+		}
+	})
+}
 
-	return refs
+// RemoveReference removes ref from the given field.
+func RemoveReference(field *[]types.ManagedObjectReference, ref types.ManagedObjectReference) {
+	for i, r := range *field {
+		if r == ref {
+			*field = append((*field)[:i], (*field)[i+1:]...)
+			break
+		}
+	}
+}
+
+// RemoveReference removes ref from the given field.
+func (r *Registry) RemoveReference(obj mo.Reference, field *[]types.ManagedObjectReference, ref types.ManagedObjectReference) {
+	r.WithLock(obj, func() {
+		RemoveReference(field, ref)
+	})
+}
+
+func (r *Registry) removeString(obj mo.Reference, field *[]string, val string) {
+	r.WithLock(obj, func() {
+		for i, name := range *field {
+			if name == val {
+				*field = append((*field)[:i], (*field)[i+1:]...)
+				break
+			}
+		}
+	})
 }
 
 func (r *Registry) content() types.ServiceContent {
@@ -322,6 +350,11 @@ func (r *Registry) SearchIndex() *SearchIndex {
 	return r.Get(r.content().SearchIndex.Reference()).(*SearchIndex)
 }
 
+// EventManager returns the EventManager singleton
+func (r *Registry) EventManager() *EventManager {
+	return r.Get(r.content().EventManager.Reference()).(*EventManager)
+}
+
 // FileManager returns the FileManager singleton
 func (r *Registry) FileManager() *FileManager {
 	return r.Get(r.content().FileManager.Reference()).(*FileManager)
@@ -340,4 +373,53 @@ func (r *Registry) ViewManager() *ViewManager {
 // UserDirectory returns the UserDirectory singleton
 func (r *Registry) UserDirectory() *UserDirectory {
 	return r.Get(r.content().UserDirectory.Reference()).(*UserDirectory)
+}
+
+// SessionManager returns the SessionManager singleton
+func (r *Registry) SessionManager() *SessionManager {
+	return r.Get(r.content().SessionManager.Reference()).(*SessionManager)
+}
+
+func (r *Registry) MarshalJSON() ([]byte, error) {
+	r.m.Lock()
+	defer r.m.Unlock()
+
+	vars := struct {
+		Objects int
+		Locks   int
+	}{
+		len(r.objects),
+		len(r.locks),
+	}
+
+	return json.Marshal(vars)
+}
+
+func (r *Registry) locker(obj mo.Reference) sync.Locker {
+	if mu, ok := obj.(sync.Locker); ok {
+		return mu
+	}
+
+	ref := obj.Reference()
+	r.m.Lock()
+	mu, ok := r.locks[ref]
+	if !ok {
+		mu = new(sync.Mutex)
+		r.locks[ref] = mu
+	}
+	r.m.Unlock()
+
+	return mu
+}
+
+var enableLocker = os.Getenv("VCSIM_LOCKER") != "false"
+
+// WithLock holds a lock for the given object while then given function is run.
+func (r *Registry) WithLock(obj mo.Reference, f func()) {
+	if enableLocker {
+		mu := r.locker(obj)
+		mu.Lock()
+		defer mu.Unlock()
+	}
+	f()
 }

--- a/vendor/github.com/vmware/govmomi/simulator/search_index.go
+++ b/vendor/github.com/vmware/govmomi/simulator/search_index.go
@@ -94,7 +94,7 @@ func (s *SearchIndex) FindChild(req *types.FindChild) soap.HasFault {
 	var children []types.ManagedObjectReference
 
 	switch e := obj.(type) {
-	case *mo.Datacenter:
+	case *Datacenter:
 		children = []types.ManagedObjectReference{e.VmFolder, e.HostFolder, e.DatastoreFolder, e.NetworkFolder}
 	case *Folder:
 		children = e.ChildEntity

--- a/vendor/github.com/vmware/govmomi/simulator/service_instance.go
+++ b/vendor/github.com/vmware/govmomi/simulator/service_instance.go
@@ -62,6 +62,7 @@ func NewServiceInstance(content types.ServiceContent, folder mo.Folder) *Service
 		NewLicenseManager(*s.Content.LicenseManager),
 		NewSearchIndex(*s.Content.SearchIndex),
 		NewViewManager(*s.Content.ViewManager),
+		NewEventManager(*s.Content.EventManager),
 		NewTaskManager(*s.Content.TaskManager),
 		NewUserDirectory(*s.Content.UserDirectory),
 		NewOptionManager(s.Content.Setting, setting),

--- a/vendor/github.com/vmware/govmomi/simulator/session_manager.go
+++ b/vendor/github.com/vmware/govmomi/simulator/session_manager.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+Copyright (c) 2017-2018 VMware, Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -17,6 +17,10 @@ limitations under the License.
 package simulator
 
 import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -33,26 +37,30 @@ type SessionManager struct {
 	mo.SessionManager
 
 	ServiceHostName string
+
+	sessions map[string]Session
 }
 
 func NewSessionManager(ref types.ManagedObjectReference) object.Reference {
-	s := &SessionManager{}
+	s := &SessionManager{
+		sessions: make(map[string]Session),
+	}
 	s.Self = ref
 	return s
 }
 
-func (s *SessionManager) Login(login *types.Login) soap.HasFault {
+func (s *SessionManager) Login(ctx *Context, login *types.Login) soap.HasFault {
 	body := &methods.LoginBody{}
 
 	if login.Locale == "" {
 		login.Locale = session.Locale
 	}
 
-	if login.UserName == "" || login.Password == "" {
-		body.Fault_ = Fault("Login failure", &types.InvalidLogin{})
+	if login.UserName == "" || login.Password == "" || ctx.Session != nil {
+		body.Fault_ = invalidLogin
 	} else {
-		body.Res = &types.LoginResponse{
-			Returnval: types.UserSession{
+		session := Session{
+			UserSession: types.UserSession{
 				Key:            uuid.New().String(),
 				UserName:       login.UserName,
 				FullName:       login.UserName,
@@ -61,14 +69,78 @@ func (s *SessionManager) Login(login *types.Login) soap.HasFault {
 				Locale:         login.Locale,
 				MessageLocale:  login.Locale,
 			},
+			Registry: NewRegistry(),
+		}
+
+		ctx.SetSession(session, true)
+
+		body.Res = &types.LoginResponse{
+			Returnval: session.UserSession,
 		}
 	}
 
 	return body
 }
 
-func (s *SessionManager) Logout(*types.Logout) soap.HasFault {
+func (s *SessionManager) Logout(ctx *Context, _ *types.Logout) soap.HasFault {
+	session := ctx.Session
+	delete(s.sessions, session.Key)
+
+	ctx.postEvent(&types.UserLogoutSessionEvent{
+		IpAddress: session.IpAddress,
+		UserAgent: session.UserAgent,
+		SessionId: session.Key,
+		LoginTime: &session.LoginTime,
+	})
+
 	return &methods.LogoutBody{Res: new(types.LogoutResponse)}
+}
+
+func (s *SessionManager) TerminateSession(ctx *Context, req *types.TerminateSession) soap.HasFault {
+	body := new(methods.TerminateSessionBody)
+
+	for _, id := range req.SessionId {
+		if id == ctx.Session.Key {
+			body.Fault_ = Fault("", new(types.InvalidArgument))
+			return body
+		}
+		delete(s.sessions, id)
+	}
+
+	body.Res = new(types.TerminateSessionResponse)
+	return body
+}
+
+func (s *SessionManager) AcquireCloneTicket(ctx *Context, _ *types.AcquireCloneTicket) soap.HasFault {
+	session := *ctx.Session
+	session.Key = uuid.New().String()
+	s.sessions[session.Key] = session
+
+	return &methods.AcquireCloneTicketBody{
+		Res: &types.AcquireCloneTicketResponse{
+			Returnval: session.Key,
+		},
+	}
+}
+
+func (s *SessionManager) CloneSession(ctx *Context, ticket *types.CloneSession) soap.HasFault {
+	body := new(methods.CloneSessionBody)
+
+	session, exists := s.sessions[ticket.CloneTicket]
+
+	if exists {
+		delete(s.sessions, ticket.CloneTicket) // A clone ticket can only be used once
+		session.Key = uuid.New().String()
+		ctx.SetSession(session, true)
+
+		body.Res = &types.CloneSessionResponse{
+			Returnval: session.UserSession,
+		}
+	} else {
+		body.Fault_ = invalidLogin
+	}
+
+	return body
 }
 
 func (s *SessionManager) AcquireGenericServiceTicket(ticket *types.AcquireGenericServiceTicket) soap.HasFault {
@@ -80,4 +152,126 @@ func (s *SessionManager) AcquireGenericServiceTicket(ticket *types.AcquireGeneri
 			},
 		},
 	}
+}
+
+// internalContext is the session for use by the in-memory client (Service.RoundTrip)
+var internalContext = &Context{
+	Context: context.Background(),
+	Session: &Session{
+		UserSession: types.UserSession{
+			Key: uuid.New().String(),
+		},
+		Registry: NewRegistry(),
+	},
+}
+
+var invalidLogin = Fault("Login failure", new(types.InvalidLogin))
+
+// Context provides per-request Session management.
+type Context struct {
+	req *http.Request
+	res http.ResponseWriter
+	m   *SessionManager
+
+	context.Context
+	Session *Session
+	Caller  *types.ManagedObjectReference
+}
+
+// mapSession maps an HTTP cookie to a Session.
+func (c *Context) mapSession() {
+	if cookie, err := c.req.Cookie(soap.SessionCookieName); err == nil {
+		if val, ok := c.m.sessions[cookie.Value]; ok {
+			c.SetSession(val, false)
+		}
+	}
+}
+
+// SetSession should be called after successful authentication.
+func (c *Context) SetSession(session Session, login bool) {
+	session.UserAgent = c.req.UserAgent()
+	session.IpAddress = strings.Split(c.req.RemoteAddr, ":")[0]
+	session.LastActiveTime = time.Now()
+
+	c.m.sessions[session.Key] = session
+	c.Session = &session
+
+	if login {
+		http.SetCookie(c.res, &http.Cookie{
+			Name:  soap.SessionCookieName,
+			Value: session.Key,
+		})
+
+		c.postEvent(&types.UserLoginSessionEvent{
+			SessionId: session.Key,
+			IpAddress: session.IpAddress,
+			UserAgent: session.UserAgent,
+			Locale:    session.Locale,
+		})
+	}
+}
+
+// WithLock holds a lock for the given object while then given function is run.
+func (c *Context) WithLock(obj mo.Reference, f func()) {
+	if c.Caller != nil && *c.Caller == obj.Reference() {
+		// Internal method invocation, obj is already locked
+		f()
+		return
+	}
+	Map.WithLock(obj, f)
+}
+
+// postEvent wraps EventManager.PostEvent for internal use, with a lock on the EventManager.
+func (c *Context) postEvent(events ...types.BaseEvent) {
+	m := Map.EventManager()
+	c.WithLock(m, func() {
+		for _, event := range events {
+			m.PostEvent(c, &types.PostEvent{EventToPost: event})
+		}
+	})
+}
+
+// Session combines a UserSession and a Registry for per-session managed objects.
+type Session struct {
+	types.UserSession
+	*Registry
+}
+
+// Put wraps Registry.Put, setting the moref value to include the session key.
+func (s *Session) Put(item mo.Reference) mo.Reference {
+	ref := item.Reference()
+	if ref.Value == "" {
+		ref.Value = fmt.Sprintf("session[%s]%s", s.Key, uuid.New())
+	}
+	s.Registry.setReference(item, ref)
+	return s.Registry.Put(item)
+}
+
+// Get wraps Registry.Get, session-izing singleton objects such as SessionManager and the root PropertyCollector.
+func (s *Session) Get(ref types.ManagedObjectReference) mo.Reference {
+	obj := s.Registry.Get(ref)
+	if obj != nil {
+		return obj
+	}
+
+	// Return a session "view" of certain singleton objects
+	switch ref.Type {
+	case "SessionManager":
+		// Clone SessionManager so the PropertyCollector can properly report CurrentSession
+		m := *Map.SessionManager()
+		m.CurrentSession = &s.UserSession
+
+		// TODO: we could maintain SessionList as part of the SessionManager singleton
+		for _, session := range m.sessions {
+			m.SessionList = append(m.SessionList, session.UserSession)
+		}
+
+		return &m
+	case "PropertyCollector":
+		if ref == Map.content().PropertyCollector {
+			return s.Put(NewPropertyCollector(ref))
+		}
+	}
+
+	return Map.Get(ref)
 }

--- a/vendor/github.com/vmware/govmomi/simulator/simulator.go
+++ b/vendor/github.com/vmware/govmomi/simulator/simulator.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+Copyright (c) 2017-2018 VMware, Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -59,10 +59,12 @@ type Method struct {
 // Service decodes incoming requests and dispatches to a Handler
 type Service struct {
 	client *vim25.Client
+	sm     *SessionManager
 
 	readAll func(io.Reader) ([]byte, error)
 
-	TLS *tls.Config
+	TLS      *tls.Config
+	ServeMux *http.ServeMux
 }
 
 // Server provides a simulator Service over HTTP
@@ -77,6 +79,7 @@ type Server struct {
 func New(instance *ServiceInstance) *Service {
 	s := &Service{
 		readAll: ioutil.ReadAll,
+		sm:      Map.SessionManager(),
 	}
 
 	s.client, _ = vim25.NewClient(context.Background(), s)
@@ -106,8 +109,29 @@ func Fault(msg string, fault types.BaseMethodFault) *soap.Fault {
 	return f
 }
 
-func (s *Service) call(method *Method) soap.HasFault {
+func (s *Service) call(ctx *Context, method *Method) soap.HasFault {
 	handler := Map.Get(method.This)
+	session := ctx.Session
+
+	if session == nil {
+		switch method.Name {
+		case "RetrieveServiceContent", "Login", "RetrieveProperties", "RetrievePropertiesEx", "CloneSession":
+			// ok for now, TODO: authz
+		default:
+			fault := &types.NotAuthenticated{
+				NoPermission: types.NoPermission{
+					Object:      method.This,
+					PrivilegeId: "System.View",
+				},
+			}
+			return &serverFaultBody{Reason: Fault("", fault)}
+		}
+	} else {
+		// Prefer the Session.Registry, ServiceContent.PropertyCollector filter field for example is per-session
+		if h := session.Get(method.This); h != nil {
+			handler = h
+		}
+	}
 
 	if handler == nil {
 		msg := fmt.Sprintf("managed object not found: %s", method.This)
@@ -141,7 +165,14 @@ func (s *Service) call(method *Method) soap.HasFault {
 		}
 	}
 
-	res := m.Call([]reflect.Value{reflect.ValueOf(method.Body)})
+	var args, res []reflect.Value
+	if m.Type().NumIn() == 2 {
+		args = append(args, reflect.ValueOf(ctx))
+	}
+	args = append(args, reflect.ValueOf(method.Body))
+	Map.WithLock(handler, func() {
+		res = m.Call(args)
+	})
 
 	return res[0].Interface().(soap.HasFault)
 }
@@ -165,7 +196,10 @@ func (s *Service) RoundTrip(ctx context.Context, request, response soap.HasFault
 		Body: req.Interface(),
 	}
 
-	res := s.call(method)
+	res := s.call(&Context{
+		Context: ctx,
+		Session: internalContext.Session,
+	}, method)
 
 	if err := res.Fault(); err != nil {
 		return soap.WrapSoapFault(err)
@@ -226,7 +260,11 @@ func (s *Service) About(w http.ResponseWriter, r *http.Request) {
 			}
 			seen[m.Name] = true
 
-			if m.Type.NumIn() != 2 || m.Type.NumOut() != 1 || m.Type.Out(0) != f {
+			in := m.Type.NumIn()
+			if in < 2 || in > 3 { // at least 2 params (receiver and request), optionally a 3rd param (context)
+				continue
+			}
+			if m.Type.NumOut() != 1 || m.Type.Out(0) != f { // all methods return soap.HasFault
 				continue
 			}
 
@@ -262,6 +300,15 @@ func (s *Service) ServeSDK(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintf(os.Stderr, "Request: %s\n", string(body))
 	}
 
+	ctx := &Context{
+		req: r,
+		res: w,
+		m:   s.sm,
+
+		Context: context.Background(),
+	}
+	Map.WithLock(s.sm, ctx.mapSession)
+
 	var res soap.HasFault
 	var soapBody interface{}
 
@@ -269,7 +316,7 @@ func (s *Service) ServeSDK(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		res = serverFault(err.Error())
 	} else {
-		res = s.call(method)
+		res = s.call(ctx, method)
 	}
 
 	if f := res.Fault(); f != nil {
@@ -349,20 +396,10 @@ func (s *Service) ServeDatastore(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	file := strings.TrimPrefix(r.URL.Path, folderPrefix)
-	p := path.Join(ds.Info.GetDatastoreInfo().Url, file)
+	r.URL.Path = strings.TrimPrefix(r.URL.Path, folderPrefix)
+	p := path.Join(ds.Info.GetDatastoreInfo().Url, r.URL.Path)
 
 	switch r.Method {
-	case "GET":
-		f, err := os.Open(p)
-		if err != nil {
-			log.Printf("failed to %s '%s': %s", r.Method, p, err)
-			w.WriteHeader(http.StatusNotFound)
-			return
-		}
-		defer f.Close()
-
-		_, _ = io.Copy(w, f)
 	case "POST":
 		_, err := os.Stat(p)
 		if err == nil {
@@ -384,7 +421,9 @@ func (s *Service) ServeDatastore(w http.ResponseWriter, r *http.Request) {
 
 		_, _ = io.Copy(f, r.Body)
 	default:
-		w.WriteHeader(http.StatusMethodNotAllowed)
+		fs := http.FileServer(http.Dir(ds.Info.GetDatastoreInfo().Url))
+
+		fs.ServeHTTP(w, r)
 	}
 }
 
@@ -408,7 +447,11 @@ func (*Service) ServiceVersions(w http.ResponseWriter, r *http.Request) {
 
 // NewServer returns an http Server instance for the given service
 func (s *Service) NewServer() *Server {
-	mux := http.NewServeMux()
+	mux := s.ServeMux
+	if mux == nil {
+		mux = http.NewServeMux()
+	}
+
 	path := "/sdk"
 
 	mux.HandleFunc(path, s.ServeSDK)
@@ -428,7 +471,7 @@ func (s *Service) NewServer() *Server {
 	}
 
 	// Redirect clients to this http server, rather than HostSystem.Name
-	Map.Get(*s.client.ServiceContent.SessionManager).(*SessionManager).ServiceHostName = u.Host
+	Map.SessionManager().ServiceHostName = u.Host
 
 	if f := flag.Lookup("httptest.serve"); f != nil {
 		// Avoid the blocking behaviour of httptest.Server.Start() when this flag is set

--- a/vendor/github.com/vmware/govmomi/simulator/snapshot.go
+++ b/vendor/github.com/vmware/govmomi/simulator/snapshot.go
@@ -32,13 +32,14 @@ func (v *VirtualMachineSnapshot) RemoveSnapshotTask(req *types.RemoveSnapshot_Ta
 		Map.Remove(req.This)
 
 		vm := Map.Get(v.Vm).(*VirtualMachine)
+		Map.WithLock(vm, func() {
+			if vm.Snapshot.CurrentSnapshot != nil && *vm.Snapshot.CurrentSnapshot == req.This {
+				parent := findParentSnapshotInTree(vm.Snapshot.RootSnapshotList, req.This)
+				vm.Snapshot.CurrentSnapshot = parent
+			}
 
-		if vm.Snapshot.CurrentSnapshot != nil && *vm.Snapshot.CurrentSnapshot == req.This {
-			parent := findParentSnapshotInTree(vm.Snapshot.RootSnapshotList, req.This)
-			vm.Snapshot.CurrentSnapshot = parent
-		}
-
-		vm.Snapshot.RootSnapshotList = removeSnapshotInTree(vm.Snapshot.RootSnapshotList, req.This, req.RemoveChildren)
+			vm.Snapshot.RootSnapshotList = removeSnapshotInTree(vm.Snapshot.RootSnapshotList, req.This, req.RemoveChildren)
+		})
 
 		return nil, nil
 	})
@@ -54,8 +55,7 @@ func (v *VirtualMachineSnapshot) RevertToSnapshotTask(req *types.RevertToSnapsho
 	task := CreateTask(v, "revertToSnapshot", func(t *Task) (types.AnyType, types.BaseMethodFault) {
 		vm := Map.Get(v.Vm).(*VirtualMachine)
 
-		ref := v.Reference()
-		vm.Snapshot.CurrentSnapshot = &ref
+		Map.WithLock(vm, func() { vm.Snapshot.CurrentSnapshot = &v.Self })
 
 		return nil, nil
 	})

--- a/vendor/github.com/vmware/govmomi/simulator/virtual_machine.go
+++ b/vendor/github.com/vmware/govmomi/simulator/virtual_machine.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+Copyright (c) 2017-2018 VMware, Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -18,7 +18,6 @@ package simulator
 
 import (
 	"fmt"
-	"io"
 	"log"
 	"net"
 	"os"
@@ -40,8 +39,7 @@ import (
 type VirtualMachine struct {
 	mo.VirtualMachine
 
-	log *log.Logger
-	out io.Closer
+	log string
 	sid int32
 }
 
@@ -91,6 +89,7 @@ func NewVirtualMachine(parent types.ManagedObjectReference, spec *types.VirtualM
 		NumCoresPerSocket: 1,
 		MemoryMB:          32,
 		Uuid:              uuid.New().String(),
+		InstanceUuid:      uuid.New().String(),
 		Version:           "vmx-11",
 		Files: &types.VirtualMachineFileInfo{
 			SnapshotDirectory: dsPath,
@@ -118,6 +117,22 @@ func NewVirtualMachine(parent types.ManagedObjectReference, spec *types.VirtualM
 	return vm, nil
 }
 
+func (vm *VirtualMachine) event() types.VmEvent {
+	host := Map.Get(*vm.Runtime.Host).(*HostSystem)
+
+	return types.VmEvent{
+		Event: types.Event{
+			Datacenter:      datacenterEventArgument(host),
+			ComputeResource: host.eventArgumentParent(),
+			Host:            host.eventArgument(),
+			Vm: &types.VmEventArgument{
+				EntityEventArgument: types.EntityEventArgument{Name: vm.Name},
+				Vm:                  vm.Self,
+			},
+		},
+	}
+}
+
 func (vm *VirtualMachine) apply(spec *types.VirtualMachineConfigSpec) {
 	if spec.Files == nil {
 		spec.Files = new(types.VirtualMachineFileInfo)
@@ -142,6 +157,9 @@ func (vm *VirtualMachine) apply(spec *types.VirtualMachineConfigSpec) {
 		{spec.GuestId, &vm.Summary.Config.GuestId},
 		{spec.GuestId, &vm.Summary.Config.GuestFullName},
 		{spec.Uuid, &vm.Config.Uuid},
+		{spec.Uuid, &vm.Summary.Config.Uuid},
+		{spec.InstanceUuid, &vm.Config.InstanceUuid},
+		{spec.InstanceUuid, &vm.Summary.Config.InstanceUuid},
 		{spec.Version, &vm.Config.Version},
 		{spec.Files.VmPathName, &vm.Config.Files.VmPathName},
 		{spec.Files.VmPathName, &vm.Summary.Config.VmPathName},
@@ -242,8 +260,6 @@ func (vm *VirtualMachine) apply(spec *types.VirtualMachineConfigSpec) {
 	vm.Config.ExtraConfig = append(vm.Config.ExtraConfig, spec.ExtraConfig...)
 
 	vm.Config.Modified = time.Now()
-
-	vm.Summary.Config.Uuid = vm.Config.Uuid
 }
 
 func validateGuestID(id string) types.BaseMethodFault {
@@ -285,14 +301,11 @@ func (vm *VirtualMachine) useDatastore(name string) *Datastore {
 
 	ds := Map.FindByName(name, host.Datastore).(*Datastore)
 
-	vm.Datastore = AddReference(ds.Self, vm.Datastore)
+	if FindReference(vm.Datastore, ds.Self) == nil {
+		vm.Datastore = append(vm.Datastore, ds.Self)
+	}
 
 	return ds
-}
-
-func (vm *VirtualMachine) setLog(w io.WriteCloser) {
-	vm.out = w
-	vm.log = log.New(w, "vmx ", log.Flags())
 }
 
 func (vm *VirtualMachine) createFile(spec string, name string, register bool) (*os.File, types.BaseMethodFault) {
@@ -350,17 +363,29 @@ func (vm *VirtualMachine) createFile(spec string, name string, register bool) (*
 	return f, nil
 }
 
+// Rather than keep an fd open for each VM, open/close the log for each messages.
+// This is ok for now as we do not do any heavy VM logging.
+func (vm *VirtualMachine) logPrintf(format string, v ...interface{}) {
+	f, err := os.OpenFile(vm.log, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0)
+	if err != nil {
+		log.Println(err)
+		return
+	}
+	log.New(f, "vmx ", log.Flags()).Printf(format, v...)
+	_ = f.Close()
+}
+
 func (vm *VirtualMachine) create(spec *types.VirtualMachineConfigSpec, register bool) types.BaseMethodFault {
 	vm.apply(spec)
 
 	files := []struct {
 		spec string
 		name string
-		use  func(w io.WriteCloser)
+		use  *string
 	}{
 		{vm.Config.Files.VmPathName, "", nil},
 		{vm.Config.Files.VmPathName, fmt.Sprintf("%s.nvram", vm.Name), nil},
-		{vm.Config.Files.LogDirectory, "vmware.log", vm.setLog},
+		{vm.Config.Files.LogDirectory, "vmware.log", &vm.log},
 	}
 
 	for _, file := range files {
@@ -368,15 +393,13 @@ func (vm *VirtualMachine) create(spec *types.VirtualMachineConfigSpec, register 
 		if err != nil {
 			return err
 		}
-
 		if file.use != nil {
-			file.use(f)
-		} else {
-			_ = f.Close()
+			*file.use = f.Name()
 		}
+		_ = f.Close()
 	}
 
-	vm.log.Print("created")
+	vm.logPrintf("created")
 
 	return vm.configureDevices(spec)
 }
@@ -397,7 +420,8 @@ func (vm *VirtualMachine) generateMAC() string {
 	return mac.String()
 }
 
-func (vm *VirtualMachine) configureDevice(devices object.VirtualDeviceList, device types.BaseVirtualDevice) types.BaseMethodFault {
+func (vm *VirtualMachine) configureDevice(devices object.VirtualDeviceList, spec *types.VirtualDeviceConfigSpec) types.BaseMethodFault {
+	device := spec.Device
 	d := device.GetVirtualDevice()
 	var controller types.BaseVirtualController
 
@@ -458,7 +482,7 @@ func (vm *VirtualMachine) configureDevice(devices object.VirtualDeviceList, devi
 				info.FileName = filename
 			}
 
-			err := dm.createVirtualDisk(&types.CreateVirtualDisk_Task{
+			err := dm.createVirtualDisk(spec.FileOperation, &types.CreateVirtualDisk_Task{
 				Datacenter: &dc.Self,
 				Name:       info.FileName,
 			})
@@ -468,10 +492,10 @@ func (vm *VirtualMachine) configureDevice(devices object.VirtualDeviceList, devi
 
 			p, _ := parseDatastorePath(info.FileName)
 
-			info.Datastore = &types.ManagedObjectReference{
-				Type:  "Datastore",
-				Value: p.Datastore,
-			}
+			host := Map.Get(*vm.Runtime.Host).(*HostSystem)
+			ds := Map.FindByName(p.Datastore, host.Datastore).Reference()
+
+			info.Datastore = &ds
 		}
 	}
 
@@ -489,19 +513,54 @@ func (vm *VirtualMachine) configureDevice(devices object.VirtualDeviceList, devi
 	return nil
 }
 
-func removeDevice(devices object.VirtualDeviceList, device types.BaseVirtualDevice) object.VirtualDeviceList {
-	var result object.VirtualDeviceList
+func (vm *VirtualMachine) removeDevice(devices object.VirtualDeviceList, spec *types.VirtualDeviceConfigSpec) object.VirtualDeviceList {
+	key := spec.Device.GetVirtualDevice().Key
 
 	for i, d := range devices {
-		if d.GetVirtualDevice().Key == device.GetVirtualDevice().Key {
-			result = append(result, devices[i+1:]...)
-			break
+		if d.GetVirtualDevice().Key != key {
+			continue
 		}
 
-		result = append(result, d)
+		devices = append(devices[:i], devices[i+1:]...)
+
+		switch device := spec.Device.(type) {
+		case *types.VirtualDisk:
+			if spec.FileOperation == types.VirtualDeviceConfigSpecFileOperationDestroy {
+				var file string
+
+				switch b := device.Backing.(type) {
+				case types.BaseVirtualDeviceFileBackingInfo:
+					file = b.GetVirtualDeviceFileBackingInfo().FileName
+				}
+
+				if file != "" {
+					dc := Map.getEntityDatacenter(Map.Get(*vm.Parent).(mo.Entity))
+					dm := Map.VirtualDiskManager()
+
+					dm.DeleteVirtualDiskTask(&types.DeleteVirtualDisk_Task{
+						Name:       file,
+						Datacenter: &dc.Self,
+					})
+				}
+			}
+		case types.BaseVirtualEthernetCard:
+			var net types.ManagedObjectReference
+
+			switch b := device.GetVirtualEthernetCard().Backing.(type) {
+			case *types.VirtualEthernetCardNetworkBackingInfo:
+				net = *b.Network
+			case *types.VirtualEthernetCardDistributedVirtualPortBackingInfo:
+				net.Type = "DistributedVirtualPortgroup"
+				net.Value = b.Port.PortgroupKey
+			}
+
+			RemoveReference(&vm.Network, net)
+		}
+
+		break
 	}
 
-	return result
+	return devices
 }
 
 func (vm *VirtualMachine) genVmdkPath() (string, types.BaseMethodFault) {
@@ -550,17 +609,32 @@ func (vm *VirtualMachine) configureDevices(spec *types.VirtualMachineConfigSpec)
 				}
 
 				// In this case, the CreateVM() spec included one of the default devices
-				devices = removeDevice(devices, device)
+				devices = vm.removeDevice(devices, dspec)
 			}
 
-			err := vm.configureDevice(devices, dspec.Device)
+			err := vm.configureDevice(devices, dspec)
+			if err != nil {
+				return err
+			}
+
+			devices = append(devices, dspec.Device)
+		case types.VirtualDeviceConfigSpecOperationEdit:
+			rspec := *dspec
+			rspec.Device = devices.FindByKey(device.Key)
+			if rspec.Device == nil {
+				return invalid
+			}
+			devices = vm.removeDevice(devices, &rspec)
+			device.DeviceInfo = nil // regenerate summary + label
+
+			err := vm.configureDevice(devices, dspec)
 			if err != nil {
 				return err
 			}
 
 			devices = append(devices, dspec.Device)
 		case types.VirtualDeviceConfigSpecOperationRemove:
-			devices = removeDevice(devices, dspec.Device)
+			devices = vm.removeDevice(devices, dspec)
 		}
 	}
 
@@ -573,10 +647,11 @@ type powerVMTask struct {
 	*VirtualMachine
 
 	state types.VirtualMachinePowerState
+	ctx   *Context
 }
 
 func (c *powerVMTask) Run(task *Task) (types.AnyType, types.BaseMethodFault) {
-	c.log.Printf("running power task: requesting %s, existing %s",
+	c.logPrintf("running power task: requesting %s, existing %s",
 		c.state, c.VirtualMachine.Runtime.PowerState)
 
 	if c.VirtualMachine.Runtime.PowerState == c.state {
@@ -597,11 +672,28 @@ func (c *powerVMTask) Run(task *Task) (types.AnyType, types.BaseMethodFault) {
 		*bt = nil
 	}
 
+	event := c.event()
+	switch c.state {
+	case types.VirtualMachinePowerStatePoweredOn:
+		c.ctx.postEvent(
+			&types.VmStartingEvent{VmEvent: event},
+			&types.VmPoweredOnEvent{VmEvent: event},
+		)
+	case types.VirtualMachinePowerStatePoweredOff:
+		c.ctx.postEvent(&types.VmPoweredOffEvent{VmEvent: event})
+	}
+
 	return nil, nil
 }
 
-func (vm *VirtualMachine) PowerOnVMTask(c *types.PowerOnVM_Task) soap.HasFault {
-	runner := &powerVMTask{vm, types.VirtualMachinePowerStatePoweredOn}
+func (vm *VirtualMachine) PowerOnVMTask(ctx *Context, c *types.PowerOnVM_Task) soap.HasFault {
+	if vm.Config.Template {
+		return &methods.PowerOnVM_TaskBody{
+			Fault_: Fault("cannot powerOn a template", &types.InvalidState{}),
+		}
+	}
+
+	runner := &powerVMTask{vm, types.VirtualMachinePowerStatePoweredOn, ctx}
 	task := CreateTask(runner.Reference(), "powerOn", runner.Run)
 
 	return &methods.PowerOnVM_TaskBody{
@@ -611,8 +703,8 @@ func (vm *VirtualMachine) PowerOnVMTask(c *types.PowerOnVM_Task) soap.HasFault {
 	}
 }
 
-func (vm *VirtualMachine) PowerOffVMTask(c *types.PowerOffVM_Task) soap.HasFault {
-	runner := &powerVMTask{vm, types.VirtualMachinePowerStatePoweredOff}
+func (vm *VirtualMachine) PowerOffVMTask(ctx *Context, c *types.PowerOffVM_Task) soap.HasFault {
+	runner := &powerVMTask{vm, types.VirtualMachinePowerStatePoweredOff, ctx}
 	task := CreateTask(runner.Reference(), "powerOff", runner.Run)
 
 	return &methods.PowerOffVM_TaskBody{
@@ -622,12 +714,17 @@ func (vm *VirtualMachine) PowerOffVMTask(c *types.PowerOffVM_Task) soap.HasFault
 	}
 }
 
-func (vm *VirtualMachine) ReconfigVMTask(req *types.ReconfigVM_Task) soap.HasFault {
+func (vm *VirtualMachine) ReconfigVMTask(ctx *Context, req *types.ReconfigVM_Task) soap.HasFault {
 	task := CreateTask(vm, "reconfigVm", func(t *Task) (types.AnyType, types.BaseMethodFault) {
 		err := vm.configure(&req.Spec)
 		if err != nil {
 			return nil, err
 		}
+
+		ctx.postEvent(&types.VmReconfiguredEvent{
+			VmEvent:    vm.event(),
+			ConfigSpec: req.Spec,
+		})
 
 		return nil, nil
 	})
@@ -639,9 +736,9 @@ func (vm *VirtualMachine) ReconfigVMTask(req *types.ReconfigVM_Task) soap.HasFau
 	}
 }
 
-func (vm *VirtualMachine) DestroyTask(req *types.Destroy_Task) soap.HasFault {
+func (vm *VirtualMachine) DestroyTask(ctx *Context, req *types.Destroy_Task) soap.HasFault {
 	task := CreateTask(vm, "destroy", func(t *Task) (types.AnyType, types.BaseMethodFault) {
-		r := vm.UnregisterVM(&types.UnregisterVM{
+		r := vm.UnregisterVM(ctx, &types.UnregisterVM{
 			This: req.This,
 		})
 
@@ -669,7 +766,7 @@ func (vm *VirtualMachine) DestroyTask(req *types.Destroy_Task) soap.HasFault {
 	}
 }
 
-func (vm *VirtualMachine) UnregisterVM(c *types.UnregisterVM) soap.HasFault {
+func (vm *VirtualMachine) UnregisterVM(ctx *Context, c *types.UnregisterVM) soap.HasFault {
 	r := &methods.UnregisterVMBody{}
 
 	if vm.Runtime.PowerState == types.VirtualMachinePowerStatePoweredOn {
@@ -681,34 +778,45 @@ func (vm *VirtualMachine) UnregisterVM(c *types.UnregisterVM) soap.HasFault {
 		return r
 	}
 
-	_ = vm.out.Close() // Close log fd
-
-	Map.getEntityParent(vm, "Folder").(*Folder).removeChild(c.This)
-
 	host := Map.Get(*vm.Runtime.Host).(*HostSystem)
-	host.Vm = RemoveReference(vm.Self, host.Vm)
+	Map.RemoveReference(host, &host.Vm, vm.Self)
 
 	switch pool := Map.Get(*vm.ResourcePool).(type) {
 	case *ResourcePool:
-		pool.Vm = RemoveReference(vm.Self, pool.Vm)
+		Map.RemoveReference(pool, &pool.Vm, vm.Self)
 	case *VirtualApp:
-		pool.Vm = RemoveReference(vm.Self, pool.Vm)
+		Map.RemoveReference(pool, &pool.Vm, vm.Self)
 	}
 
 	for i := range vm.Datastore {
 		ds := Map.Get(vm.Datastore[i]).(*Datastore)
-		ds.Vm = RemoveReference(vm.Self, ds.Vm)
+		Map.RemoveReference(ds, &ds.Vm, vm.Self)
 	}
+
+	ctx.postEvent(&types.VmRemovedEvent{VmEvent: vm.event()})
+	Map.getEntityParent(vm, "Folder").(*Folder).removeChild(c.This)
 
 	r.Res = new(types.UnregisterVMResponse)
 
 	return r
 }
 
-func (vm *VirtualMachine) CloneVMTask(req *types.CloneVM_Task) soap.HasFault {
-	task := CreateTask(vm, "cloneVm", func(t *Task) (types.AnyType, types.BaseMethodFault) {
-		folder := Map.Get(req.Folder).(*Folder)
+func (vm *VirtualMachine) CloneVMTask(ctx *Context, req *types.CloneVM_Task) soap.HasFault {
+	ctx.Caller = &vm.Self
+	folder := Map.Get(req.Folder).(*Folder)
+	host := Map.Get(*vm.Runtime.Host).(*HostSystem)
+	event := vm.event()
 
+	ctx.postEvent(&types.VmBeingClonedEvent{
+		VmCloneEvent: types.VmCloneEvent{
+			VmEvent: event,
+		},
+		DestFolder: folder.eventArgument(),
+		DestName:   req.Name,
+		DestHost:   *host.eventArgument(),
+	})
+
+	task := CreateTask(vm, "cloneVm", func(t *Task) (types.AnyType, types.BaseMethodFault) {
 		config := types.VirtualMachineConfigSpec{
 			Name:    req.Name,
 			GuestId: vm.Config.GuestId,
@@ -717,10 +825,35 @@ func (vm *VirtualMachine) CloneVMTask(req *types.CloneVM_Task) soap.HasFault {
 			},
 		}
 
-		res := folder.CreateVMTask(&types.CreateVM_Task{
+		for _, device := range vm.Config.Hardware.Device {
+			var fop types.VirtualDeviceConfigSpecFileOperation
+
+			switch device.(type) {
+			case *types.VirtualDisk:
+				// TODO: consider VirtualMachineCloneSpec.DiskMoveType
+				fop = types.VirtualDeviceConfigSpecFileOperationCreate
+				device = &types.VirtualDisk{
+					VirtualDevice: types.VirtualDevice{
+						Backing: &types.VirtualDiskFlatVer2BackingInfo{
+							DiskMode: string(types.VirtualDiskModePersistent),
+							// Leave FileName empty so CreateVM will just create a new one under VmPathName
+						},
+					},
+				}
+			}
+
+			config.DeviceChange = append(config.DeviceChange, &types.VirtualDeviceConfigSpec{
+				Operation:     types.VirtualDeviceConfigSpecOperationAdd,
+				Device:        device,
+				FileOperation: fop,
+			})
+		}
+
+		res := folder.CreateVMTask(ctx, &types.CreateVM_Task{
 			This:   folder.Self,
 			Config: config,
 			Pool:   *vm.ResourcePool,
+			Host:   vm.Runtime.Host,
 		})
 
 		ctask := Map.Get(res.(*methods.CreateVM_TaskBody).Res.Returnval).(*Task)
@@ -728,7 +861,16 @@ func (vm *VirtualMachine) CloneVMTask(req *types.CloneVM_Task) soap.HasFault {
 			return nil, ctask.Info.Error.Fault
 		}
 
-		return ctask.Info.Result.(types.ManagedObjectReference), nil
+		ref := ctask.Info.Result.(types.ManagedObjectReference)
+		clone := Map.Get(ref).(*VirtualMachine)
+		clone.configureDevices(&types.VirtualMachineConfigSpec{DeviceChange: req.Spec.Location.DeviceChange})
+
+		ctx.postEvent(&types.VmClonedEvent{
+			VmCloneEvent: types.VmCloneEvent{VmEvent: clone.event()},
+			SourceVm:     *event.Vm,
+		})
+
+		return ref, nil
 	})
 
 	return &methods.CloneVM_TaskBody{
@@ -742,7 +884,7 @@ func (vm *VirtualMachine) RelocateVMTask(req *types.RelocateVM_Task) soap.HasFau
 	task := CreateTask(vm, "relocateVm", func(t *Task) (types.AnyType, types.BaseMethodFault) {
 		if ref := req.Spec.Datastore; ref != nil {
 			ds := Map.Get(*ref).(*Datastore)
-			ds.Vm = RemoveReference(*ref, ds.Vm)
+			Map.RemoveReference(ds, &ds.Vm, *ref)
 
 			vm.Datastore = []types.ManagedObjectReference{*ref}
 
@@ -751,14 +893,14 @@ func (vm *VirtualMachine) RelocateVMTask(req *types.RelocateVM_Task) soap.HasFau
 
 		if ref := req.Spec.Pool; ref != nil {
 			pool := Map.Get(*ref).(*ResourcePool)
-			pool.Vm = RemoveReference(*ref, pool.Vm)
+			Map.RemoveReference(pool, &pool.Vm, *ref)
 
 			vm.ResourcePool = ref
 		}
 
 		if ref := req.Spec.Host; ref != nil {
 			host := Map.Get(*ref).(*HostSystem)
-			host.Vm = RemoveReference(*ref, host.Vm)
+			Map.RemoveReference(host, &host.Vm, *ref)
 
 			vm.Runtime.Host = ref
 		}
@@ -882,6 +1024,24 @@ func (vm *VirtualMachine) ShutdownGuest(c *types.ShutdownGuest) soap.HasFault {
 	vm.Summary.Runtime.PowerState = types.VirtualMachinePowerStatePoweredOff
 
 	r.Res = new(types.ShutdownGuestResponse)
+
+	return r
+}
+
+func (vm *VirtualMachine) MarkAsTemplate(req *types.MarkAsTemplate) soap.HasFault {
+	r := &methods.MarkAsTemplateBody{}
+
+	if vm.Runtime.PowerState != types.VirtualMachinePowerStatePoweredOff {
+		r.Fault_ = Fault("", &types.InvalidPowerState{
+			RequestedState: types.VirtualMachinePowerStatePoweredOff,
+			ExistingState:  vm.Runtime.PowerState,
+		})
+		return r
+	}
+
+	vm.Config.Template = true
+
+	r.Res = &types.MarkAsTemplateResponse{}
 
 	return r
 }

--- a/vendor/github.com/vmware/govmomi/simulator/vpx/setting.go
+++ b/vendor/github.com/vmware/govmomi/simulator/vpx/setting.go
@@ -57,4 +57,16 @@ var Setting = []types.BaseOptionValue{
 		Key:   "config.vpxd.sso.admin.uri",
 		Value: "https://127.0.0.1/sso-adminserver/sdk/vsphere.local",
 	},
+	&types.OptionValue{
+		Key:   "event.batchsize",
+		Value: int32(2000),
+	},
+	&types.OptionValue{
+		Key:   "event.maxAge",
+		Value: int32(30),
+	},
+	&types.OptionValue{
+		Key:   "event.maxAgeEnabled",
+		Value: bool(true),
+	},
 }

--- a/vendor/github.com/vmware/govmomi/vim25/types/helpers.go
+++ b/vendor/github.com/vmware/govmomi/vim25/types/helpers.go
@@ -17,6 +17,7 @@ limitations under the License.
 package types
 
 import (
+	"reflect"
 	"strings"
 	"time"
 )
@@ -85,4 +86,10 @@ func DefaultResourceConfigSpec() ResourceConfigSpec {
 		CpuAllocation:    defaultResourceAllocationInfo(),
 		MemoryAllocation: defaultResourceAllocationInfo(),
 	}
+}
+
+func init() {
+	// Known 6.5 issue where this event type is sent even though it is internal.
+	// This workaround allows us to unmarshal and avoid NPEs.
+	t["HostSubSpecificationUpdateEvent"] = reflect.TypeOf((*HostEvent)(nil)).Elem()
 }

--- a/vendor/github.com/vmware/govmomi/vim25/types/types.go
+++ b/vendor/github.com/vmware/govmomi/vim25/types/types.go
@@ -48188,7 +48188,7 @@ func init() {
 type VirtualMachineAffinityInfo struct {
 	DynamicData
 
-	AffinitySet []int32 `xml:"affinitySet,omitempty"`
+	AffinitySet []int32 `xml:"affinitySet"`
 }
 
 func init() {

--- a/vendor/manifest
+++ b/vendor/manifest
@@ -1143,7 +1143,7 @@
 			"importpath": "github.com/vmware/govmomi",
 			"repository": "https://github.com/vmware/govmomi",
 			"vcs": "git",
-			"revision": "91fbd1f705a64043039044b469b7fcf33d2e61d2",
+			"revision": "0c574f49f8b3832b45af4cfece376d792105865c",
 			"branch": "master",
 			"notests": true
 		},


### PR DESCRIPTION
This PR should ensure that cvm's are created in the parent folder to the VCH. It also provides the new way of determining cvm deletion candidates during an uninstall. The logic for candidate deletion is as such. If the vch parefnt folder is the vmfolder we go to the resource pool for the deletion candidates. if the folder is not we grab all the children of the folder and check them for cvm status before attempting to delete them. 

[full ci]
Fixes #7025 