### PR TITLE
Cvm inventory support

### DIFF
--- a/lib/install/management/appliance.go
+++ b/lib/install/management/appliance.go
@@ -520,7 +520,7 @@ func (d *Dispatcher) createAppliance(conf *config.VirtualContainerHostConfigSpec
 		}
 	}
 
-	d.op.Info("Creating the VCH vm")
+	d.op.Info("Creating the VCH VM")
 	info, err = tasks.WaitForResult(d.op, func(ctx context.Context) (tasks.Task, error) {
 		return vchFolder.CreateVM(ctx, *spec, d.vchPool, d.session.Host)
 	})
@@ -1204,9 +1204,9 @@ func (d *Dispatcher) CheckServiceReady(ctx context.Context, conf *config.Virtual
 }
 
 // vchFolder returns the namespaced folder for the vch or an error.
-func vchFolder(op trace.Operation, sess *session.Session, conf *config.VirtualContainerHostConfigSpec) (*object.Folder, error) {
+func VchFolder(op trace.Operation, sess *session.Session, conf *config.VirtualContainerHostConfigSpec) (*object.Folder, error) {
 	vchFolder := path.Join(sess.VMFolder.InventoryPath, conf.Name)
-	op.Debugf("Looking for vch folder: %s", vchFolder)
+	op.Debugf("Looking for VCH folder: %s", vchFolder)
 	folderRef, err := sess.Finder.Folder(op, vchFolder)
 
 	if err != nil {

--- a/lib/install/management/appliance.go
+++ b/lib/install/management/appliance.go
@@ -50,6 +50,7 @@ import (
 	"github.com/vmware/vic/pkg/vsphere/diag"
 	"github.com/vmware/vic/pkg/vsphere/extraconfig"
 	"github.com/vmware/vic/pkg/vsphere/extraconfig/vmomi"
+	"github.com/vmware/vic/pkg/vsphere/session"
 	"github.com/vmware/vic/pkg/vsphere/tasks"
 	"github.com/vmware/vic/pkg/vsphere/vm"
 )
@@ -509,7 +510,7 @@ func (d *Dispatcher) createAppliance(conf *config.VirtualContainerHostConfigSpec
 
 		vchFolder, err = d.session.VMFolder.CreateFolder(d.op, spec.Name)
 		if err != nil {
-			d.op.Debugf("Encountered unexpected error : %#v ", err)
+			d.op.Debugf("Encountered unexpected error : %s ", err)
 			if f, ok := err.(types.HasFault); ok {
 				if _, ok = f.Fault().(*types.DuplicateName); ok {
 					return fmt.Errorf("An object already exists on the path for vch folder (%s) that is not a folder", spec.Name)
@@ -519,6 +520,7 @@ func (d *Dispatcher) createAppliance(conf *config.VirtualContainerHostConfigSpec
 		}
 	}
 
+	d.op.Info("Creating the VCH vm")
 	info, err = tasks.WaitForResult(d.op, func(ctx context.Context) (tasks.Task, error) {
 		return vchFolder.CreateVM(ctx, *spec, d.vchPool, d.session.Host)
 	})
@@ -1199,4 +1201,16 @@ func (d *Dispatcher) CheckServiceReady(ctx context.Context, conf *config.Virtual
 		return err
 	}
 	return nil
+}
+
+// vchFolder returns the namespaced folder for the vch or an error.
+func vchFolder(op trace.Operation, sess *session.Session, conf *config.VirtualContainerHostConfigSpec) (*object.Folder, error) {
+	vchFolder := path.Join(sess.VMFolder.InventoryPath, conf.Name)
+	op.Debugf("Looking for vch folder: %s", vchFolder)
+	folderRef, err := sess.Finder.Folder(op, vchFolder)
+
+	if err != nil {
+		return nil, err
+	}
+	return folderRef, nil
 }

--- a/lib/install/management/create.go
+++ b/lib/install/management/create.go
@@ -334,7 +334,7 @@ func (d *Dispatcher) cleanupAfterCreationFailed(conf *config.VirtualContainerHos
 	if d.isVC {
 
 		// we don't know if the appliance or the folder was made. so recreate the folder path.
-		vchFolder := fmt.Sprintf("%s/%s", d.session.VMFolder, conf.Name)
+		vchFolder := fmt.Sprintf("%s/%s", d.session.VMFolder.InventoryPath, conf.Name)
 		folderRef, err := d.session.Finder.Folder(d.op, vchFolder)
 		if folderRef != nil {
 			children, err := folderRef.Children(d.op)

--- a/lib/install/management/create.go
+++ b/lib/install/management/create.go
@@ -332,9 +332,7 @@ func (d *Dispatcher) cleanupAfterCreationFailed(conf *config.VirtualContainerHos
 	// cleanup the vch inventory folder if it is empty. Can happen in some cases where the create is cancelled after successful creation.
 
 	if d.isVC {
-		// we don't know if the appliance or the folder was made. so recreate the folder path.
-		vchFolder := path.Join(d.session.VMFolder.InventoryPath, conf.Name)
-		folderRef, err := d.session.Finder.Folder(d.op, vchFolder)
+		folderRef, err := vchFolder(d.op, d.session, conf)
 		if folderRef != nil {
 			children, err := folderRef.Children(d.op)
 			if err != nil {

--- a/lib/install/management/create.go
+++ b/lib/install/management/create.go
@@ -332,9 +332,8 @@ func (d *Dispatcher) cleanupAfterCreationFailed(conf *config.VirtualContainerHos
 	// cleanup the vch inventory folder if it is empty. Can happen in some cases where the create is cancelled after successful creation.
 
 	if d.isVC {
-
 		// we don't know if the appliance or the folder was made. so recreate the folder path.
-		vchFolder := fmt.Sprintf("%s/%s", d.session.VMFolder.InventoryPath, conf.Name)
+		vchFolder := path.Join(d.session.VMFolder.InventoryPath, conf.Name)
 		folderRef, err := d.session.Finder.Folder(d.op, vchFolder)
 		if folderRef != nil {
 			children, err := folderRef.Children(d.op)

--- a/lib/install/management/create.go
+++ b/lib/install/management/create.go
@@ -332,21 +332,21 @@ func (d *Dispatcher) cleanupAfterCreationFailed(conf *config.VirtualContainerHos
 	// cleanup the vch inventory folder if it is empty. Can happen in some cases where the create is cancelled after successful creation.
 
 	if d.isVC {
-		folderRef, err := vchFolder(d.op, d.session, conf)
+		folderRef, err := VchFolder(d.op, d.session, conf)
 		if folderRef != nil {
 			children, err := folderRef.Children(d.op)
 			if err != nil {
 				d.op.Debugf("encountered error during vch folder cleanup : %s", err)
-				d.op.Warnf(manualInventoryCleanWarning, vchFolder)
+				d.op.Warnf(manualInventoryCleanWarning, folderRef.InventoryPath)
 			}
 
 			if len(children) != 0 {
-				d.op.Warnf(manualInventoryCleanWarning, vchFolder)
+				d.op.Warnf(manualInventoryCleanWarning, folderRef.InventoryPath)
 			}
 
 			d.removeFolder(folderRef)
 			if err != nil {
-				d.op.Warnf(manualInventoryCleanWarning, vchFolder)
+				d.op.Warnf(manualInventoryCleanWarning, folderRef.InventoryPath)
 			}
 		}
 		if err != nil {

--- a/lib/install/management/delete.go
+++ b/lib/install/management/delete.go
@@ -16,7 +16,7 @@ package management
 
 import (
 	"context"
-	"path"
+	"fmt"
 	"strings"
 	"sync"
 
@@ -110,7 +110,7 @@ func (d *Dispatcher) DeleteVCH(conf *config.VirtualContainerHostConfigSpec, cont
 	}
 
 	// delete the VCH inventory folder
-	d.deleteFolder()
+	d.deleteFolder(conf)
 
 	defaultrp, err := d.session.Cluster.ResourcePool(d.op)
 	if err != nil {
@@ -238,12 +238,9 @@ func (d *Dispatcher) DeleteVCHInstances(vmm *vm.VirtualMachine, conf *config.Vir
 	var err error
 	var children []*vm.VirtualMachine
 
-	parentFolder, err := vmm.Folder(d.op)
-	if err != nil {
-		return err
-	}
+	folderRef, err := vchFolder(d.op, d.session, conf)
 
-	if parentFolder.Reference() == d.session.VMFolder.Reference() {
+	if err != nil || folderRef == nil {
 		// use the resource pool to cut down on the number of candidates
 		d.op.Debugf("Looking in the resource pool for delete targets")
 		if children, err = d.parentResourcepool.GetChildrenVMs(d.op, d.session); err != nil {
@@ -251,7 +248,8 @@ func (d *Dispatcher) DeleteVCHInstances(vmm *vm.VirtualMachine, conf *config.Vir
 		}
 	} else {
 		// vch parent inventory folder exists, get the children from it.
-		folderChildren, err := parentFolder.Children(d.op)
+		d.op.Debugf("Found VCH Parent Folder: %s", folderRef.InventoryPath)
+		folderChildren, err := folderRef.Children(d.op)
 		if err != nil {
 			return err
 		}
@@ -379,7 +377,7 @@ func (d *Dispatcher) networkDevices(vmm *vm.VirtualMachine) ([]types.BaseVirtual
 	return devices, nil
 }
 
-func (d *Dispatcher) deleteFolder() {
+func (d *Dispatcher) deleteFolder(conf *config.VirtualContainerHostConfigSpec) {
 	var err error
 
 	// no inventory folders if we are targeting ESX
@@ -388,19 +386,20 @@ func (d *Dispatcher) deleteFolder() {
 	}
 
 	d.op.Info("Removing VCH Inventory Folder")
-	vchFolderPath := path.Dir(d.appliance.InventoryPath)
+	folderRef, err := vchFolder(d.op, d.session, conf)
+	if err != nil {
+		folderPath := fmt.Sprintf("%s/%s", d.session.VMFolder.InventoryPath, conf.Name)
+		d.op.Debugf("failed to find vch folder(%s): %s", folderPath, err)
+		d.op.Warnf("Could not find a vch folder(%s), continuing with vch deletion", folderPath)
+		return
+	}
+
 	defer func() {
 		if err != nil {
-			d.op.Warnf(manualInventoryCleanWarning, vchFolderPath)
+			d.op.Warnf(manualInventoryCleanWarning, folderRef.InventoryPath)
 			return
 		}
 	}()
-
-	folderRef, err := d.session.Finder.Folder(d.op, vchFolderPath)
-	if err != nil {
-		d.op.Debugf("failed to find folder: %s for the VCH target", vchFolderPath)
-		return
-	}
 
 	// protections against old vch's since they are directly in the VMFolder
 	dcFolder, err := d.session.Datacenter.Folders(d.op)
@@ -417,7 +416,7 @@ func (d *Dispatcher) deleteFolder() {
 	// NOTE: Destroy on Inventory Folders is RECURSIVE
 	folderContents, err := folderRef.Children(d.op)
 	if err != nil || len(folderContents) != 0 {
-		d.op.Debugf("Could not remove VCH folder, %s has existing contents in it. Manual cleanup required.", vchFolderPath)
+		d.op.Debugf("Could not remove VCH folder, %s has existing contents in it. Manual cleanup required.", folderRef.InventoryPath)
 		return
 	}
 

--- a/lib/install/management/delete.go
+++ b/lib/install/management/delete.go
@@ -238,7 +238,7 @@ func (d *Dispatcher) DeleteVCHInstances(vmm *vm.VirtualMachine, conf *config.Vir
 	var err error
 	var children []*vm.VirtualMachine
 
-	parentFolder, err := vmm.Folder(d.op, d.session)
+	parentFolder, err := vmm.Folder(d.op)
 	if err != nil {
 		return err
 	}

--- a/lib/install/management/delete.go
+++ b/lib/install/management/delete.go
@@ -386,11 +386,11 @@ func (d *Dispatcher) deleteFolder(conf *config.VirtualContainerHostConfigSpec) {
 	}
 
 	d.op.Info("Removing VCH Inventory Folder")
-	folderRef, err := vchFolder(d.op, d.session, conf)
+	folderRef, err := VchFolder(d.op, d.session, conf)
 	if err != nil {
 		folderPath := fmt.Sprintf("%s/%s", d.session.VMFolder.InventoryPath, conf.Name)
-		d.op.Debugf("failed to find vch folder(%s): %s", folderPath, err)
-		d.op.Warnf("Could not find a vch folder(%s), continuing with vch deletion", folderPath)
+		d.op.Debugf("failed to find VCH folder(%s): %s", folderPath, err)
+		d.op.Warnf("Could not find a VCH folder(%s), continuing with vch deletion", folderPath)
 		return
 	}
 

--- a/lib/install/management/delete.go
+++ b/lib/install/management/delete.go
@@ -260,6 +260,10 @@ func (d *Dispatcher) DeleteVCHInstances(vmm *vm.VirtualMachine, conf *config.Vir
 			vmObj, ok := child.(*object.VirtualMachine)
 			if ok {
 				childVM := vm.NewVirtualMachine(d.op, d.session, vmObj.Reference())
+				cerr := childVM.EnableDestroy(d.op)
+				if cerr != nil {
+					d.op.Debugf("unable to enable the destroy task on container (%s): due to %s", childVM.InventoryPath, cerr)
+				}
 				children = append(children, childVM)
 			}
 		}

--- a/lib/install/management/delete.go
+++ b/lib/install/management/delete.go
@@ -245,7 +245,7 @@ func (d *Dispatcher) DeleteVCHInstances(vmm *vm.VirtualMachine, conf *config.Vir
 
 	if parentFolder.Reference() == d.session.VMFolder.Reference() {
 		// use the resource pool to cut down on the number of candidates
-		d.op.Debugf("looking in the resource pool for delete targets")
+		d.op.Debugf("Looking in the resource pool for delete targets")
 		if children, err = d.parentResourcepool.GetChildrenVMs(d.op, d.session); err != nil {
 			return err
 		}
@@ -260,9 +260,9 @@ func (d *Dispatcher) DeleteVCHInstances(vmm *vm.VirtualMachine, conf *config.Vir
 			vmObj, ok := child.(*object.VirtualMachine)
 			if ok {
 				childVM := vm.NewVirtualMachine(d.op, d.session, vmObj.Reference())
-				cerr := childVM.EnableDestroy(d.op)
-				if cerr != nil {
-					d.op.Debugf("unable to enable the destroy task on container (%s): due to %s", childVM.InventoryPath, cerr)
+				cErr := childVM.EnableDestroy(d.op)
+				if cErr != nil {
+					d.op.Debugf("unable to enable the destroy task on container (%s): due to %s", childVM.InventoryPath, cErr)
 				}
 				children = append(children, childVM)
 			}
@@ -314,7 +314,7 @@ func (d *Dispatcher) DeleteVCHInstances(vmm *vm.VirtualMachine, conf *config.Vir
 				errs = append(errs, err.Error())
 				mu.Unlock()
 			}
-			d.op.Debugf("Successfully deleted container vm: %s", child.InventoryPath)
+			d.op.Debugf("Successfully deleted container: %s", child.InventoryPath)
 		}(child)
 	}
 	wg.Wait()

--- a/lib/install/management/delete.go
+++ b/lib/install/management/delete.go
@@ -388,6 +388,7 @@ func (d *Dispatcher) deleteFolder() {
 	defer func() {
 		if err != nil {
 			d.op.Warnf(manualInventoryCleanWarning, vchFolderPath)
+			return
 		}
 	}()
 

--- a/lib/portlayer/exec/commit.go
+++ b/lib/portlayer/exec/commit.go
@@ -64,7 +64,7 @@ func Commit(op trace.Operation, sess *session.Session, h *Handle, waitTime *int3
 		} else {
 			// Create the vm
 			res, err = tasks.WaitForResult(op, func(op context.Context) (tasks.Task, error) {
-				return sess.VMFolder.CreateVM(op, *h.Spec.Spec(), Config.ResourcePool, nil)
+				return sess.VCHFolder.CreateVM(op, *h.Spec.Spec(), Config.ResourcePool, nil)
 			})
 		}
 

--- a/lib/portlayer/exec/container.go
+++ b/lib/portlayer/exec/container.go
@@ -817,7 +817,7 @@ func infraContainers(ctx context.Context, sess *session.Session) ([]*Container, 
 	// Does the VCH have it's own folder?
 	if sess.VCHFolder.Reference() == sess.VMFolder.Reference() {
 		var rp mo.ResourcePool
-		// popluate the vm property of the vch resource pool
+		// populate the vm property of the vch resource pool
 		if err := Config.ResourcePool.Properties(ctx, Config.ResourcePool.Reference(), []string{"vm"}, &rp); err != nil {
 			name := Config.ResourcePool.Name()
 			log.Errorf("List failed to get %s resource pool child vms: %s", name, err)

--- a/lib/portlayer/exec/container.go
+++ b/lib/portlayer/exec/container.go
@@ -25,6 +25,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/vim25/mo"
 	"github.com/vmware/govmomi/vim25/soap"
 	"github.com/vmware/govmomi/vim25/types"
@@ -43,7 +44,6 @@ import (
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/google/uuid"
-	"github.com/vmware/govmomi/object"
 )
 
 type State int
@@ -808,7 +808,7 @@ func (c *Container) onEvent(op trace.Operation, newState State, e events.Event) 
 	}
 }
 
-// get the containerVMs from infrastructure for this resource pool
+// get the containerVMs from infrastructure for this resource pool or the VCH Folder
 func infraContainers(ctx context.Context, sess *session.Session) ([]*Container, error) {
 	defer trace.End(trace.Begin(""))
 	var vms []mo.VirtualMachine
@@ -840,7 +840,6 @@ func infraContainers(ctx context.Context, sess *session.Session) ([]*Container, 
 		for _, child := range children {
 			vmObj, ok := child.(*object.VirtualMachine)
 			if ok {
-				// check that we are not looking at the VCH.
 				childVms = append(childVms, vmObj.Reference())
 			}
 		}

--- a/lib/portlayer/portlayer.go
+++ b/lib/portlayer/portlayer.go
@@ -73,6 +73,7 @@ func Init(ctx context.Context, sess *session.Session) error {
 	}
 
 	// store the reference to the vch inventory folder before portlayer init
+	// NOTE: This will cause problems if an upgrade has been done on a 1.1-1.2.1 vapp based deployment. due to the vApp's effects on getting a vm's inventory path.
 	vchFolder, err := vchvm.Folder(ctx)
 	if err != nil {
 		return err

--- a/lib/portlayer/portlayer.go
+++ b/lib/portlayer/portlayer.go
@@ -72,6 +72,13 @@ func Init(ctx context.Context, sess *session.Session) error {
 		return err
 	}
 
+	// store the reference to the vch inventory folder before poertlayer init
+	vchFolder, err := vchvm.ParentInventoryFolder(ctx, sess)
+	if err != nil {
+		return err
+	}
+	sess.VCHFolder = vchFolder
+
 	if err = storage.Init(ctx, sess, vmParentPool, source, sink); err != nil {
 		return err
 	}

--- a/lib/portlayer/portlayer.go
+++ b/lib/portlayer/portlayer.go
@@ -73,7 +73,7 @@ func Init(ctx context.Context, sess *session.Session) error {
 	}
 
 	// store the reference to the vch inventory folder before portlayer init
-	vchFolder, err := vchvm.Folder(ctx, sess)
+	vchFolder, err := vchvm.Folder(ctx)
 	if err != nil {
 		return err
 	}

--- a/lib/portlayer/portlayer.go
+++ b/lib/portlayer/portlayer.go
@@ -72,12 +72,12 @@ func Init(ctx context.Context, sess *session.Session) error {
 		return err
 	}
 
-	// store the reference to the vch inventory folder before poertlayer init
-	vchFolder, err := vchvm.ParentInventoryFolder(ctx, sess)
+	// store the reference to the vch inventory folder before portlayer init
+	vchFolder, err := vchvm.Folder(ctx, sess)
 	if err != nil {
 		return err
 	}
-	sess.VCHFolder = vchFolder
+	sess.Config.VCHFolder = vchFolder
 
 	if err = storage.Init(ctx, sess, vmParentPool, source, sink); err != nil {
 		return err

--- a/pkg/vsphere/session/session.go
+++ b/pkg/vsphere/session/session.go
@@ -77,6 +77,8 @@ type Config struct {
 	DatastorePath  string
 	HostPath       string
 	PoolPath       string
+
+	VCHFolder *object.Folder
 }
 
 // Session caches vSphere objects obtained by querying the SDK.
@@ -92,9 +94,6 @@ type Session struct {
 	Pool       *object.ResourcePool
 
 	VMFolder *object.Folder
-
-	// the parent inventory folder to the VCH
-	VCHFolder *object.Folder
 
 	Finder *find.Finder
 
@@ -128,12 +127,7 @@ func LimitConcurrency(rt http.RoundTripper, limit int) http.RoundTripper {
 }
 
 // NewSession creates a new Session struct.
-func NewSession(config *Config, vchMoref ...*types.ManagedObjectReference) *Session {
-	if len(vchMoref) > 0 {
-		// get the virtual machine reference for the VCH and assign it.
-
-	}
-
+func NewSession(config *Config) *Session {
 	return &Session{Config: config}
 }
 
@@ -379,7 +373,10 @@ func (s *Session) Populate(ctx context.Context) (*Session, error) {
 			op.Debugf("Cached folders: %s", s.DatacenterPath)
 		}
 		s.VMFolder = folders.VmFolder
-		s.VCHFolder = folders.VmFolder
+
+		if s.VCHFolder == nil {
+			s.VCHFolder = folders.VmFolder
+		}
 	}
 
 	if len(errs) > 0 {

--- a/pkg/vsphere/session/session.go
+++ b/pkg/vsphere/session/session.go
@@ -78,6 +78,7 @@ type Config struct {
 	HostPath       string
 	PoolPath       string
 
+	// VCH appliance folder location, this could be the VMFolder or a custom folder location(currently <VMFolder>/<VCHNAME>/<VCH>.vm)
 	VCHFolder *object.Folder
 }
 

--- a/pkg/vsphere/session/session.go
+++ b/pkg/vsphere/session/session.go
@@ -93,6 +93,9 @@ type Session struct {
 
 	VMFolder *object.Folder
 
+	// the parent inventory folder to the VCH
+	VCHFolder *object.Folder
+
 	Finder *find.Finder
 
 	DRSEnabled *bool
@@ -125,7 +128,12 @@ func LimitConcurrency(rt http.RoundTripper, limit int) http.RoundTripper {
 }
 
 // NewSession creates a new Session struct.
-func NewSession(config *Config) *Session {
+func NewSession(config *Config, vchMoref ...*types.ManagedObjectReference) *Session {
+	if len(vchMoref) > 0 {
+		// get the virtual machine reference for the VCH and assign it.
+
+	}
+
 	return &Session{Config: config}
 }
 
@@ -371,6 +379,7 @@ func (s *Session) Populate(ctx context.Context) (*Session, error) {
 			op.Debugf("Cached folders: %s", s.DatacenterPath)
 		}
 		s.VMFolder = folders.VmFolder
+		s.VCHFolder = folders.VmFolder
 	}
 
 	if len(errs) > 0 {

--- a/pkg/vsphere/vm/vm.go
+++ b/pkg/vsphere/vm/vm.go
@@ -122,8 +122,8 @@ func (vm *VirtualMachine) FolderName(ctx context.Context) (string, error) {
 }
 
 // Folder returns a reference to the parent folder that owns the vm
-func (vm *VirtualMachine) Folder(ctx context.Context, sess *session.Session) (*object.Folder, error) {
-	element, err := sess.Finder.Element(ctx, vm.Reference())
+func (vm *VirtualMachine) Folder(ctx context.Context) (*object.Folder, error) {
+	element, err := vm.Session.Finder.Element(ctx, vm.Reference())
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/vsphere/vm/vm.go
+++ b/pkg/vsphere/vm/vm.go
@@ -121,6 +121,21 @@ func (vm *VirtualMachine) FolderName(ctx context.Context) (string, error) {
 	return path.Base(u.Path), nil
 }
 
+func (vm *VirtualMachine) ParentInventoryFolder(ctx context.Context, sess *session.Session) (*object.Folder, error) {
+	element, err := sess.Finder.Element(ctx, vm.Reference())
+	if err != nil {
+		return nil, err
+	}
+
+	parentPath := path.Dir(element.Path)
+	folderRef, err := sess.Finder.Folder(ctx, parentPath)
+	if err != nil {
+		return nil, err
+	}
+
+	return folderRef, nil
+}
+
 func (vm *VirtualMachine) getNetworkName(op trace.Operation, nic types.BaseVirtualEthernetCard) (string, error) {
 	if card, ok := nic.GetVirtualEthernetCard().Backing.(*types.VirtualEthernetCardDistributedVirtualPortBackingInfo); ok {
 		pg := card.Port.PortgroupKey
@@ -471,7 +486,7 @@ func (vm *VirtualMachine) fixVM(op trace.Operation) error {
 		return err
 	}
 
-	task, err := vm.registerVM(op, mvm.Summary.Config.VmPathName, name, mvm.ParentVApp, mvm.ResourcePool, mvm.Summary.Runtime.Host, vm.Session.VMFolder)
+	task, err := vm.registerVM(op, mvm.Summary.Config.VmPathName, name, mvm.ParentVApp, mvm.ResourcePool, mvm.Summary.Runtime.Host, vm.Session.VCHFolder)
 	if err != nil {
 		op.Errorf("Unable to register VM %q back: %s", name, err)
 		return err

--- a/pkg/vsphere/vm/vm.go
+++ b/pkg/vsphere/vm/vm.go
@@ -121,7 +121,7 @@ func (vm *VirtualMachine) FolderName(ctx context.Context) (string, error) {
 	return path.Base(u.Path), nil
 }
 
-// Folder returns a reference to the parent folder that owns the vch
+// Folder returns a reference to the parent folder that owns the vm
 func (vm *VirtualMachine) Folder(ctx context.Context, sess *session.Session) (*object.Folder, error) {
 	element, err := sess.Finder.Element(ctx, vm.Reference())
 	if err != nil {

--- a/pkg/vsphere/vm/vm.go
+++ b/pkg/vsphere/vm/vm.go
@@ -121,7 +121,8 @@ func (vm *VirtualMachine) FolderName(ctx context.Context) (string, error) {
 	return path.Base(u.Path), nil
 }
 
-func (vm *VirtualMachine) ParentInventoryFolder(ctx context.Context, sess *session.Session) (*object.Folder, error) {
+// Folder returns a reference to the parent folder that owns the vch
+func (vm *VirtualMachine) Folder(ctx context.Context, sess *session.Session) (*object.Folder, error) {
 	element, err := sess.Finder.Element(ctx, vm.Reference())
 	if err != nil {
 		return nil, err

--- a/pkg/vsphere/vm/vm.go
+++ b/pkg/vsphere/vm/vm.go
@@ -129,7 +129,7 @@ func (vm *VirtualMachine) Folder(ctx context.Context) (*object.Folder, error) {
 	}
 
 	parentPath := path.Dir(element.Path)
-	folderRef, err := sess.Finder.Folder(ctx, parentPath)
+	folderRef, err := vm.Session.Finder.Folder(ctx, parentPath)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/vsphere/vm/vm.go
+++ b/pkg/vsphere/vm/vm.go
@@ -123,6 +123,9 @@ func (vm *VirtualMachine) FolderName(ctx context.Context) (string, error) {
 
 // Folder returns a reference to the parent folder that owns the vm
 func (vm *VirtualMachine) Folder(ctx context.Context) (*object.Folder, error) {
+	// NOTE: We must retrieve the folder by assembling the path. If the vm is in a vApp the inventory path will be the compute folder path of the vApp.
+	// right now this will likely not work with upgrade 1.1.1-1.2.1 vapp based deployments.
+
 	element, err := vm.Session.Finder.Element(ctx, vm.Reference())
 	if err != nil {
 		return nil, err

--- a/tests/test-cases/Group1-Docker-Commands/1-39-Docker-Stats.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-39-Docker-Stats.robot
@@ -42,7 +42,7 @@ Create test containers
     Should Be Equal As Integers  ${rc}  0
     Set Environment Variable  STOPPER  ${output}
     ${stress}=  Get Container ShortID  %{STRESSED}
-    Set Environment Variable  VM-PATH  vm/*${stress}
+    Set Environment Variable  VM-PATH  vm/%{VCH-NAME}/*${stress}
 
 Check Memory Usage
     ${vmomiMemory}=  Get Average Active Memory  %{VM-PATH}

--- a/tests/test-cases/Group12-VCH-BC/12-01-Delete.robot
+++ b/tests/test-cases/Group12-VCH-BC/12-01-Delete.robot
@@ -15,7 +15,7 @@
 *** Settings ***
 Documentation  Test 12-01 - Delete
 Resource  ../../resources/Util.robot
-Suite Setup  Install VIC 0.6.0 to Test Server
+Suite Setup  Install VIC 1.1.1 to Test Server
 Test Teardown  Run Keyword If Test Failed  Clean up VIC Appliance And Local Binary
 
 *** Keywords ***
@@ -23,7 +23,7 @@ Clean up VIC Appliance And Local Binary
     Cleanup VIC Appliance On Test Server
     Run  rm -rf vic.tar.gz vic
 
-Install VIC 0.6.0 to Test Server
+Install VIC 1.1.1 to Test Server
     Log To Console  \nDownloading VIC 1.1.1 from gcp...
     ${rc}  ${output}=  Run And Return Rc And Output  wget https://storage.googleapis.com/vic-engine-releases/vic_1.1.1.tar.gz -O vic.tar.gz
     ${rc}  ${output}=  Run And Return Rc And Output  tar zxvf vic.tar.gz

--- a/tests/test-cases/Group6-VIC-Machine/6-18-Container-Name-Convention.robot
+++ b/tests/test-cases/Group6-VIC-Machine/6-18-Container-Name-Convention.robot
@@ -25,28 +25,28 @@ Container name convention with id
     Run  docker %{VCH-PARAMS} pull ${busybox}
     ${containerID}=  Run  docker %{VCH-PARAMS} run -d ${busybox}
     ${shortId}=  Get container shortID  ${containerID}
-    ${output}=  Run  govc ls vm
+    ${output}=  Run  govc ls vm/%{VCH-NAME}
     Should Contain  ${output}  %{VCH-NAME}-${shortID}
 
     Run  docker %{VCH-PARAMS} rename ${containerID} renamed-container
-    ${output}=  Run  govc ls vm
+    ${output}=  Run  govc ls vm/%{VCH-NAME}
     # confirm that the cnc is still in force
     Should Contain  ${output}  %{VCH-NAME}-${shortID}
 
     Run  docker %{VCH-PARAMS} rm -f ${containerID}
     Run Regression Tests
-    
+ 
 Container name convention with name
     Set Test Environment Variables
     Install VIC Appliance To Test Server With Current Environment Variables  additional-args=--container-name-convention %{VCH-NAME}-{name}
     Run  docker %{VCH-PARAMS} pull ${busybox}
     ${containerID}=  Run  docker %{VCH-PARAMS} run -d ${busybox}
     ${name}=  Get container name  ${containerID}
-    ${output}=  Run  govc ls vm
+    ${output}=  Run  govc ls vm/%{VCH-NAME}
     Should Contain  ${output}  %{VCH-NAME}-${name}
 
     Run  docker %{VCH-PARAMS} rename ${containerID} renamed-container
-    ${output}=  Run  govc ls vm
+    ${output}=  Run  govc ls vm/%{VCH-NAME}
     # confirm that the cnc is still in force but updated for new container name
     Should Contain  ${output}  %{VCH-NAME}-renamed-container
 

--- a/tests/test-cases/Group8-vSphere-Integration/8-02-OOB-VM-Register.robot
+++ b/tests/test-cases/Group8-vSphere-Integration/8-02-OOB-VM-Register.robot
@@ -42,7 +42,7 @@ Verify VIC Still Works When Different VM Is Registered
     ${out}=  Run  govc vm.unregister ${old-vm}
     Should Be Empty  ${out}
 
-    # At this point the vm is unregsitered and we will need to reregister this vm...
+    # At this point the vm is unregistered and we will need to reregister this vm...
     # we need to put it into the original inventory folder. so we need to fetch that
     # path. We also want to be explicit about the resource pool.
     ${old-vm-folder}=  Run  govc find / -name ${old-vm} -type f


### PR DESCRIPTION
This PR should ensure that cvm's are created in the parent folder to the VCH. It also provides the new way of determining cvm deletion candidates during an uninstall. The logic for candidate deletion is as such. If the vch parent folder is the vmfolder we go to the resource pool for the deletion candidates. if the folder is not we grab all the children of the folder and check them for cvm status before attempting to delete them.

[specific ci=Group10-VCH-Restart --suite 8-02-OOB-VM-Register --suite 1-24-Docker-Link --suite 1-25-Docker-Port-Map --suite 1-27-Docker-Login]
Fixes #7025 #7032