### PR TITLE
Pull the correct image for the bundle step

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -182,7 +182,7 @@ pipeline:
      branch: ['releases/*', 'refs/tags/*']
 
   bundle:
-    image: 'gcr.io/eminent-nation-87317/golang:1.8'
+    image: 'wdc-harbor-ci.eng.vmware.com/default-project/golang:1.8'
     pull: true
     environment:
       BIN: bin


### PR DESCRIPTION
for some reason the bundle step would just exit 0, even though that image is clearly not correct.  But either way resulted in the bundle step never doing anything, so any publish would fail because the dir was empty.