### PR TITLE
Disable and tag upgrade-related CI tests

### DIFF
--- a/tests/test-cases/Group1-Docker-Commands/1-08-Docker-Logs.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-08-Docker-Logs.robot
@@ -15,8 +15,8 @@
 *** Settings ***
 Documentation  Test 1-08 - Docker Logs
 Resource  ../../resources/Util.robot
-Suite Setup  Install VIC with version to Test Server  version=7315
-Suite Teardown  Cleanup VIC Appliance On Test Server
+#Suite Setup  Install VIC with version to Test Server  version=7315
+#Suite Teardown  Cleanup VIC Appliance On Test Server
 Test Timeout  20 minutes
 
 *** Keywords ***
@@ -48,82 +48,90 @@ Check Upgraded Version
 *** Test Cases ***
 # This test happens first because the rest of the tests need the latest VCH after the upgrade step
 Docker logs backward compatibility
-    ${rc}  ${output}=  Run And Return Rc And Output  docker1.11 %{VCH-PARAMS} pull busybox
-    Should Be Equal As Integers  ${rc}  0
-    ${rc}  ${id1}=  Run And Return Rc And Output  docker1.11 %{VCH-PARAMS} run -d busybox sh -c "echo These pretzels are making me thirsty"
-    Should Be Equal As Integers  ${rc}  0
-    ${rc}  ${output}=  Run And Return Rc And Output  docker1.11 %{VCH-PARAMS} logs ${id1}
-    Should Be Equal As Integers  ${rc}  0
-    Should Contain  ${output}  These pretzels are making me thirsty
-    ${rc}  ${output}=  Run And Return Rc And Output  docker1.11 %{VCH-PARAMS} logs --timestamps ${id1}
-    Should Be Equal As Integers  ${rc}  1
-    Should Contain  ${output}  vSphere Integrated Containers does not yet support '--timestamps'
-    Upgrade
-    Check Upgraded Version
-    ${rc}  ${id2}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -d busybox sh -c "echo Whats the deeeal with Ovaltine?"
-    Should Be Equal As Integers  ${rc}  0
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} logs --timestamps ${id2}
-    Should Be Equal As Integers  ${rc}  0
-    Should Contain  ${output}  Whats the deeeal with Ovaltine?
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} logs --timestamps ${id1}
-    Should Be Equal As Integers  ${rc}  1
-    Should Contain  ${output}  container ${id1} does not support '--timestamps'
+    ${status}=  Get State Of Github Issue  7497
+    Run Keyword If  '${status}' == 'closed'  Fail  Test 1-08-Docker-Logs.robot needs to be updated now that Issue #7497 has been resolved
+    # ${rc}  ${output}=  Run And Return Rc And Output  docker1.11 %{VCH-PARAMS} pull busybox
+    # Should Be Equal As Integers  ${rc}  0
+    # ${rc}  ${id1}=  Run And Return Rc And Output  docker1.11 %{VCH-PARAMS} run -d busybox sh -c "echo These pretzels are making me thirsty"
+    # Should Be Equal As Integers  ${rc}  0
+    # ${rc}  ${output}=  Run And Return Rc And Output  docker1.11 %{VCH-PARAMS} logs ${id1}
+    # Should Be Equal As Integers  ${rc}  0
+    # Should Contain  ${output}  These pretzels are making me thirsty
+    # ${rc}  ${output}=  Run And Return Rc And Output  docker1.11 %{VCH-PARAMS} logs --timestamps ${id1}
+    # Should Be Equal As Integers  ${rc}  1
+    # Should Contain  ${output}  vSphere Integrated Containers does not yet support '--timestamps'
+    # Upgrade
+    # Check Upgraded Version
+    # ${rc}  ${id2}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -d busybox sh -c "echo Whats the deeeal with Ovaltine?"
+    # Should Be Equal As Integers  ${rc}  0
+    # ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} logs --timestamps ${id2}
+    # Should Be Equal As Integers  ${rc}  0
+    # Should Contain  ${output}  Whats the deeeal with Ovaltine?
+    # ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} logs --timestamps ${id1}
+    # Should Be Equal As Integers  ${rc}  1
+    # Should Contain  ${output}  container ${id1} does not support '--timestamps'
 
 Docker logs with tail
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} pull ${busybox}
-    Should Be Equal As Integers  ${rc}  0
-    ${rc}  ${id}=  Run And Return Rc And Output  docker %{VCH-PARAMS} create ${busybox} sh -c 'seq 1 5000'
-    Should Be Equal As Integers  ${rc}  0
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} start ${id}
-    Should Be Equal As Integers  ${rc}  0
-    Wait Until Keyword Succeeds  20x  200 milliseconds  Grep Logs And Count Lines  ${id}  2500  5000
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} logs --tail=all ${id}
-    ${linecount}=  Get Line Count  ${output}
-    Should Be Equal As Integers  ${rc}  0
-    Should Be Equal As Integers  ${linecount}  5000
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} logs --tail=200 ${id}
-    ${linecount}=  Get Line Count  ${output}
-    Should Be Equal As Integers  ${rc}  0
-    Should Be Equal As Integers  ${linecount}  200
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} logs --tail=0 ${id}
-    Should Be Equal As Integers  ${rc}  0
-    ${linecount}=  Get Line Count  ${output}
-    Should Be Equal As Integers  ${linecount}  0
+    ${status}=  Get State Of Github Issue  7497
+    Run Keyword If  '${status}' == 'closed'  Fail  Test 1-08-Docker-Logs.robot needs to be updated now that Issue #7497 has been resolved
+    # ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} pull ${busybox}
+    # Should Be Equal As Integers  ${rc}  0
+    # ${rc}  ${id}=  Run And Return Rc And Output  docker %{VCH-PARAMS} create ${busybox} sh -c 'seq 1 5000'
+    # Should Be Equal As Integers  ${rc}  0
+    # ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} start ${id}
+    # Should Be Equal As Integers  ${rc}  0
+    # Wait Until Keyword Succeeds  20x  200 milliseconds  Grep Logs And Count Lines  ${id}  2500  5000
+    # ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} logs --tail=all ${id}
+    # ${linecount}=  Get Line Count  ${output}
+    # Should Be Equal As Integers  ${rc}  0
+    # Should Be Equal As Integers  ${linecount}  5000
+    # ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} logs --tail=200 ${id}
+    # ${linecount}=  Get Line Count  ${output}
+    # Should Be Equal As Integers  ${rc}  0
+    # Should Be Equal As Integers  ${linecount}  200
+    # ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} logs --tail=0 ${id}
+    # Should Be Equal As Integers  ${rc}  0
+    # ${linecount}=  Get Line Count  ${output}
+    # Should Be Equal As Integers  ${linecount}  0
 
 Docker logs with follow
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} pull ${busybox}
-    Should Be Equal As Integers  ${rc}  0
-    ${rc}  ${id}=  Run And Return Rc And Output  docker %{VCH-PARAMS} create ${busybox} sh -c 'for i in $(seq 1 5) ; do sleep 1 && echo line $i; done'
-    Should Be Equal As Integers  ${rc}  0
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} start ${id}
-    Should Be Equal As Integers  ${rc}  0
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} logs --follow ${id}
-    Should Be Equal As Integers  ${rc}  0
-    ${linecount}=  Get Line Count  ${output}
-    Should Be Equal As Integers  ${linecount}  5
-    ${lastline}=  Get Line  ${output}  4
-    Should Contain  ${lastline}  line 5
-    # Container is stopped at this point, verify that --follow does not block.
-    ${rc}  ${output2}=  Run And Return Rc And Output  docker %{VCH-PARAMS} logs --follow ${id}
-    Should Be Equal  ${output}  ${output2}
+    ${status}=  Get State Of Github Issue  7497
+    Run Keyword If  '${status}' == 'closed'  Fail  Test 1-08-Docker-Logs.robot needs to be updated now that Issue #7497 has been resolved
+    # ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} pull ${busybox}
+    # Should Be Equal As Integers  ${rc}  0
+    # ${rc}  ${id}=  Run And Return Rc And Output  docker %{VCH-PARAMS} create ${busybox} sh -c 'for i in $(seq 1 5) ; do sleep 1 && echo line $i; done'
+    # Should Be Equal As Integers  ${rc}  0
+    # ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} start ${id}
+    # Should Be Equal As Integers  ${rc}  0
+    # ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} logs --follow ${id}
+    # Should Be Equal As Integers  ${rc}  0
+    # ${linecount}=  Get Line Count  ${output}
+    # Should Be Equal As Integers  ${linecount}  5
+    # ${lastline}=  Get Line  ${output}  4
+    # Should Contain  ${lastline}  line 5
+    # # Container is stopped at this point, verify that --follow does not block.
+    # ${rc}  ${output2}=  Run And Return Rc And Output  docker %{VCH-PARAMS} logs --follow ${id}
+    # Should Be Equal  ${output}  ${output2}
 
 Docker logs with follow and tail
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} pull ${busybox}
-    Should Be Equal As Integers  ${rc}  0
-    ${rc}  ${id}=  Run And Return Rc And Output  docker %{VCH-PARAMS} create ${busybox} sh -c 'trap "seq 11 20; exit" HUP; seq 1 10; while true; do sleep 1; done'
-    Should Be Equal As Integers  ${rc}  0
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} start ${id}
-    Should Be Equal As Integers  ${rc}  0
-    # Wait for the first 10 lines to be logged
-    Wait Until Keyword Succeeds  20x  200 milliseconds  Grep Logs And Count Lines  ${id}  5  10
-    # kill -HUP will create another 5 lines of log output
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} kill -s HUP ${id}
-    Should Be Equal As Integers  ${rc}  0
-    # --tail=5 to skip the first 5 lines and --follow to wait for the rest
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} logs --tail 5 --follow ${id}
-    Should Be Equal As Integers  ${rc}  0
-    ${linecount}=  Get Line Count  ${output}
-    Should Be True  ${linecount} >= 5
+    ${status}=  Get State Of Github Issue  7497
+    Run Keyword If  '${status}' == 'closed'  Fail  Test 1-08-Docker-Logs.robot needs to be updated now that Issue #7497 has been resolved
+    # ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} pull ${busybox}
+    # Should Be Equal As Integers  ${rc}  0
+    # ${rc}  ${id}=  Run And Return Rc And Output  docker %{VCH-PARAMS} create ${busybox} sh -c 'trap "seq 11 20; exit" HUP; seq 1 10; while true; do sleep 1; done'
+    # Should Be Equal As Integers  ${rc}  0
+    # ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} start ${id}
+    # Should Be Equal As Integers  ${rc}  0
+    # # Wait for the first 10 lines to be logged
+    # Wait Until Keyword Succeeds  20x  200 milliseconds  Grep Logs And Count Lines  ${id}  5  10
+    # # kill -HUP will create another 5 lines of log output
+    # ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} kill -s HUP ${id}
+    # Should Be Equal As Integers  ${rc}  0
+    # # --tail=5 to skip the first 5 lines and --follow to wait for the rest
+    # ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} logs --tail 5 --follow ${id}
+    # Should Be Equal As Integers  ${rc}  0
+    # ${linecount}=  Get Line Count  ${output}
+    # Should Be True  ${linecount} >= 5
 
 Docker logs follow shutdown
     # Test that logs --follow reads all data following a close (shutdown) event.
@@ -131,77 +139,89 @@ Docker logs follow shutdown
     # - The container VM shutdown event happens while the (HTTP) log follow poller is asleep.
     # - The container VM log accumulates > interaction layer buffer size data while log follow poller was alseep.
     # Note that the interaction layer currently uses an extra super tiny buffer size of 64 bytes.
-    ${rc}  ${buffer}=  Run And Return Rc And Output  bash -c "printf '=%.0s' {1..65}"
-    Should Be Equal As Integers  ${rc}  0
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} pull ${busybox}
-    Should Be Equal As Integers  ${rc}  0
-    ${rc}  ${id}=  Run And Return Rc And Output  docker %{VCH-PARAMS} create ${busybox} sh -c 'echo ${buffer}; sleep .5; echo ${buffer}'
-    Should Be Equal As Integers  ${rc}  0
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} start ${id}
-    Should Be Equal As Integers  ${rc}  0
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} logs --follow ${id}
-    Should Be Equal As Integers  ${rc}  0
-    Should Be Equal  ${output}  ${buffer}\n${buffer}
+    ${status}=  Get State Of Github Issue  7497
+    Run Keyword If  '${status}' == 'closed'  Fail  Test 1-08-Docker-Logs.robot needs to be updated now that Issue #7497 has been resolved
+    # ${rc}  ${buffer}=  Run And Return Rc And Output  bash -c "printf '=%.0s' {1..65}"
+    # Should Be Equal As Integers  ${rc}  0
+    # ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} pull ${busybox}
+    # Should Be Equal As Integers  ${rc}  0
+    # ${rc}  ${id}=  Run And Return Rc And Output  docker %{VCH-PARAMS} create ${busybox} sh -c 'echo ${buffer}; sleep .5; echo ${buffer}'
+    # Should Be Equal As Integers  ${rc}  0
+    # ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} start ${id}
+    # Should Be Equal As Integers  ${rc}  0
+    # ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} logs --follow ${id}
+    # Should Be Equal As Integers  ${rc}  0
+    # Should Be Equal  ${output}  ${buffer}\n${buffer}
 
 Docker binary logs
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} pull ${ubuntu}
-    Should Be Equal As Integers  ${rc}  0
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run ${ubuntu} /bin/cat /bin/hostname >/tmp/hostname
-    Should Be Equal As Integers  ${rc}  0
-    ${rc}  ${id}=  Run And Return Rc And Output  docker %{VCH-PARAMS} ps -a |grep ${ubuntu} |awk '{print $1}'
-    Should Be Equal As Integers  ${rc}  0
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} logs ${id} >/tmp/hostname-log
-    Should Be Equal As Integers  ${rc}  0
-    ${rc}  ${h1}=  Run And Return Rc And Output  sha256sum /tmp/hostname |awk '{print $1}'
-    Should Be Equal As Integers  ${rc}  0
-    ${rc}  ${h2}=  Run And Return Rc And Output  sha256sum /tmp/hostname-log |awk '{print $1}'
-    Should Be Equal As Integers  ${rc}  0
-    Should Be Equal  ${h1}  ${h2}
-    ${rc}  ${output}=  Run And Return Rc And Output  rm /tmp/hostname*
-    Should Be Equal As Integers  ${rc}  0
+    ${status}=  Get State Of Github Issue  7497
+    Run Keyword If  '${status}' == 'closed'  Fail  Test 1-08-Docker-Logs.robot needs to be updated now that Issue #7497 has been resolved
+    # ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} pull ${ubuntu}
+    # Should Be Equal As Integers  ${rc}  0
+    # ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run ${ubuntu} /bin/cat /bin/hostname >/tmp/hostname
+    # Should Be Equal As Integers  ${rc}  0
+    # ${rc}  ${id}=  Run And Return Rc And Output  docker %{VCH-PARAMS} ps -a |grep ${ubuntu} |awk '{print $1}'
+    # Should Be Equal As Integers  ${rc}  0
+    # ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} logs ${id} >/tmp/hostname-log
+    # Should Be Equal As Integers  ${rc}  0
+    # ${rc}  ${h1}=  Run And Return Rc And Output  sha256sum /tmp/hostname |awk '{print $1}'
+    # Should Be Equal As Integers  ${rc}  0
+    # ${rc}  ${h2}=  Run And Return Rc And Output  sha256sum /tmp/hostname-log |awk '{print $1}'
+    # Should Be Equal As Integers  ${rc}  0
+    # Should Be Equal  ${h1}  ${h2}
+    # ${rc}  ${output}=  Run And Return Rc And Output  rm /tmp/hostname*
+    # Should Be Equal As Integers  ${rc}  0
 
 Docker text logs
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run ${ubuntu} /bin/ls >/tmp/ls
-    Should Be Equal As Integers  ${rc}  0
-    ${rc}  ${id}=  Run And Return Rc And Output  docker %{VCH-PARAMS} ps -a |grep /bin/ls |awk '{print $1}'
-    Should Be Equal As Integers  ${rc}  0
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} logs ${id} >/tmp/ls-log
-    Should Be Equal As Integers  ${rc}  0
-    ${rc}  ${h1}=  Run And Return Rc And Output  sha256sum /tmp/ls |awk '{print $1}'
-    Should Be Equal As Integers  ${rc}  0
-    ${rc}  ${h2}=  Run And Return Rc And Output  sha256sum /tmp/ls-log |awk '{print $1}'
-    Should Be Equal As Integers  ${rc}  0
-    Should Be Equal  ${h1}  ${h2}
-    ${rc}  ${output}=  Run And Return Rc And Output  rm /tmp/ls*
-    Should Be Equal As Integers  ${rc}  0
+    ${status}=  Get State Of Github Issue  7497
+    Run Keyword If  '${status}' == 'closed'  Fail  Test 1-08-Docker-Logs.robot needs to be updated now that Issue #7497 has been resolved
+    # ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run ${ubuntu} /bin/ls >/tmp/ls
+    # Should Be Equal As Integers  ${rc}  0
+    # ${rc}  ${id}=  Run And Return Rc And Output  docker %{VCH-PARAMS} ps -a |grep /bin/ls |awk '{print $1}'
+    # Should Be Equal As Integers  ${rc}  0
+    # ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} logs ${id} >/tmp/ls-log
+    # Should Be Equal As Integers  ${rc}  0
+    # ${rc}  ${h1}=  Run And Return Rc And Output  sha256sum /tmp/ls |awk '{print $1}'
+    # Should Be Equal As Integers  ${rc}  0
+    # ${rc}  ${h2}=  Run And Return Rc And Output  sha256sum /tmp/ls-log |awk '{print $1}'
+    # Should Be Equal As Integers  ${rc}  0
+    # Should Be Equal  ${h1}  ${h2}
+    # ${rc}  ${output}=  Run And Return Rc And Output  rm /tmp/ls*
+    # Should Be Equal As Integers  ${rc}  0
 
 Docker logs with timestamps and since certain time
-    ${rc}=  Run And Return Rc  docker %{VCH-PARAMS} run ${busybox} sh -c 'for i in $(seq 0 9) ; do sleep 1 && echo line $i; done'
-    Should Be Equal As Integers  ${rc}  0
-    ${rc}  ${containerID}=  Run And Return Rc And Output  docker %{VCH-PARAMS} ps -a -q |head --lines=1
-    Should Be Equal As Integers  ${rc}  0
-    ${rc}  ${lines}=  Run And Return Rc And Output  docker %{VCH-PARAMS} logs --since=5s ${containerID} |wc -l
-    Should Be Equal As Integers  ${rc}  0
-    Should Not Be Equal As Integers  ${lines}  10
-    ${rc}  ${lines}=  Run And Return Rc And Output  docker %{VCH-PARAMS} logs --since=1h ${containerID} |wc -l
-    Should Be Equal As Integers  ${rc}  0
-    Should Be Equal As Integers  ${lines}  10
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} logs ${containerID} |wc -l
-    Should Be Equal As Integers  ${rc}  0
-    Should Be Equal As Integers  ${output}  10
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} logs --timestamps ${containerID}
-    Should Be Equal As Integers  ${rc}  0
-    ${date}=  Fetch From Left  ${output}  ${SPACE}
-    Should Match Regexp  ${date}  \\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d{9}Z
+    ${status}=  Get State Of Github Issue  7497
+    Run Keyword If  '${status}' == 'closed'  Fail  Test 1-08-Docker-Logs.robot needs to be updated now that Issue #7497 has been resolved
+    # ${rc}=  Run And Return Rc  docker %{VCH-PARAMS} run ${busybox} sh -c 'for i in $(seq 0 9) ; do sleep 1 && echo line $i; done'
+    # Should Be Equal As Integers  ${rc}  0
+    # ${rc}  ${containerID}=  Run And Return Rc And Output  docker %{VCH-PARAMS} ps -a -q |head --lines=1
+    # Should Be Equal As Integers  ${rc}  0
+    # ${rc}  ${lines}=  Run And Return Rc And Output  docker %{VCH-PARAMS} logs --since=5s ${containerID} |wc -l
+    # Should Be Equal As Integers  ${rc}  0
+    # Should Not Be Equal As Integers  ${lines}  10
+    # ${rc}  ${lines}=  Run And Return Rc And Output  docker %{VCH-PARAMS} logs --since=1h ${containerID} |wc -l
+    # Should Be Equal As Integers  ${rc}  0
+    # Should Be Equal As Integers  ${lines}  10
+    # ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} logs ${containerID} |wc -l
+    # Should Be Equal As Integers  ${rc}  0
+    # Should Be Equal As Integers  ${output}  10
+    # ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} logs --timestamps ${containerID}
+    # Should Be Equal As Integers  ${rc}  0
+    # ${date}=  Fetch From Left  ${output}  ${SPACE}
+    # Should Match Regexp  ${date}  \\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d{9}Z
 
 Docker logs with no flags
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} pull ${busybox}
-    Should Be Equal As Integers  ${rc}  0
-    ${rc}  ${id}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -d ${busybox} sh -c "seq 1 128 | xargs -n1 echo"
-    Should Be Equal As Integers  ${rc}  0
-    Wait Until Keyword Succeeds  20x  200 milliseconds  Grep Logs And Count Lines  ${id}  42  128
+    ${status}=  Get State Of Github Issue  7497
+    Run Keyword If  '${status}' == 'closed'  Fail  Test 1-08-Docker-Logs.robot needs to be updated now that Issue #7497 has been resolved
+    # ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} pull ${busybox}
+    # Should Be Equal As Integers  ${rc}  0
+    # ${rc}  ${id}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -d ${busybox} sh -c "seq 1 128 | xargs -n1 echo"
+    # Should Be Equal As Integers  ${rc}  0
+    # Wait Until Keyword Succeeds  20x  200 milliseconds  Grep Logs And Count Lines  ${id}  42  128
 
 Docker logs non-existent container
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} logs fakeContainer
-    Should Be Equal As Integers  ${rc}  1
-    Should Contain  ${output}  Error: No such container: fakeContainer
+    ${status}=  Get State Of Github Issue  7497
+    Run Keyword If  '${status}' == 'closed'  Fail  Test 1-08-Docker-Logs.robot needs to be updated now that Issue #7497 has been resolved
+    # ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} logs fakeContainer
+    # Should Be Equal As Integers  ${rc}  1
+    # Should Contain  ${output}  Error: No such container: fakeContainer

--- a/tests/test-cases/Group11-Upgrade/11-01-Upgrade.robot
+++ b/tests/test-cases/Group11-Upgrade/11-01-Upgrade.robot
@@ -15,8 +15,8 @@
 *** Settings ***
 Documentation  Test 11-01 - Upgrade
 Resource  ../../resources/Util.robot
-Suite Setup  Install VIC with version to Test Server  7315
-Suite Teardown  Clean up VIC Appliance And Local Binary
+# Suite Setup  Install VIC with version to Test Server  7315
+# Suite Teardown  Clean up VIC Appliance And Local Binary
 Default Tags
 
 *** Variables ***
@@ -184,44 +184,50 @@ Check Container Create Timestamps
 
 *** Test Cases ***
 Upgrade Present in vic-machine
-    ${rc}  ${output}=  Run And Return Rc And Output  bin/vic-machine-linux
-    Should Contain  ${output}  upgrade
+    ${status}=  Get State Of Github Issue  7497
+    Run Keyword If  '${status}' == 'closed'  Fail  Test 11-01-Upgrade.robot needs to be updated now that Issue #7497 has been resolved
+    # ${rc}  ${output}=  Run And Return Rc And Output  bin/vic-machine-linux
+    # Should Contain  ${output}  upgrade
 
 Upgrade VCH with unreasonably short timeout and automatic rollback after failure
-    Log To Console  \nUpgrading VCH with 1s timeout ...
-    ${rc}  ${output}=  Run And Return Rc And Output  bin/vic-machine-linux upgrade --debug 1 --name=%{VCH-NAME} --target=%{TEST_URL}%{TEST_DATACENTER} --user=%{TEST_USERNAME} --password=%{TEST_PASSWORD} --force=true --compute-resource=%{TEST_RESOURCE} --timeout 1s
-    Should Contain  ${output}  Upgrading VCH exceeded time limit
-    Should Not Contain  ${output}  Completed successfully
-    ${rc}  ${output}=  Run And Return Rc And Output  govc snapshot.tree -vm=%{VCH-NAME}
-    Should Not Contain  ${output}  upgrade
+    ${status}=  Get State Of Github Issue  7497
+    Run Keyword If  '${status}' == 'closed'  Fail  Test 11-01-Upgrade.robot needs to be updated now that Issue #7497 has been resolved
+    # Log To Console  \nUpgrading VCH with 1s timeout ...
+    # ${rc}  ${output}=  Run And Return Rc And Output  bin/vic-machine-linux upgrade --debug 1 --name=%{VCH-NAME} --target=%{TEST_URL}%{TEST_DATACENTER} --user=%{TEST_USERNAME} --password=%{TEST_PASSWORD} --force=true --compute-resource=%{TEST_RESOURCE} --timeout 1s
+    # Should Contain  ${output}  Upgrading VCH exceeded time limit
+    # Should Not Contain  ${output}  Completed successfully
+    # ${rc}  ${output}=  Run And Return Rc And Output  govc snapshot.tree -vm=%{VCH-NAME}
+    # Should Not Contain  ${output}  upgrade
 
-    # confirm that the rollback took effect
-    Check Original Version
+    # # confirm that the rollback took effect
+    # Check Original Version
 
 Upgrade VCH
-    Create Docker Containers
+    ${status}=  Get State Of Github Issue  7497
+    Run Keyword If  '${status}' == 'closed'  Fail  Test 11-01-Upgrade.robot needs to be updated now that Issue #7497 has been resolved
+    # Create Docker Containers
 
-    Create Container with Named Volume
+    # Create Container with Named Volume
 
-    # Create check list for Volume Inspect
-    @{checkList}=  Create List  ${mntTest}  ${mntNamed}  ${namedVolume}
+    # # Create check list for Volume Inspect
+    # @{checkList}=  Create List  ${mntTest}  ${mntNamed}  ${namedVolume}
 
-    Upgrade
-    Check Upgraded Version
-    Check Container Create Timestamps
+    # Upgrade
+    # Check Upgraded Version
+    # Check Container Create Timestamps
 
-    Verify Volume Inspect Info  After Upgrade and Before Rollback  ${TestContainerVolume}  ${checkList}
+    # Verify Volume Inspect Info  After Upgrade and Before Rollback  ${TestContainerVolume}  ${checkList}
 
-    Rollback
-    Check Original Version
+    # Rollback
+    # Check Original Version
 
-    Upgrade with ID
-    Check Upgraded Version
+    # Upgrade with ID
+    # Check Upgraded Version
 
-    Verify Volume Inspect Info  After Upgrade with ID  ${TestContainerVolume}  ${checkList}
+    # Verify Volume Inspect Info  After Upgrade with ID  ${TestContainerVolume}  ${checkList}
 
-    Run Docker Checks
+    # Run Docker Checks
 
 
-    Log To Console  Regression Tests...
-    Run Regression Tests
+    # Log To Console  Regression Tests...
+    # Run Regression Tests

--- a/tests/test-cases/Group11-Upgrade/11-02-Upgrade-Exec.robot
+++ b/tests/test-cases/Group11-Upgrade/11-02-Upgrade-Exec.robot
@@ -15,21 +15,23 @@
 *** Settings ***
 Documentation  Test 11-02 - Upgrade Exec
 Resource  ../../resources/Util.robot
-Suite Setup  Install VIC with version to Test Server  8351
-Suite Teardown  Clean up VIC Appliance And Local Binary
+# Suite Setup  Install VIC with version to Test Server  8351
+# Suite Teardown  Clean up VIC Appliance And Local Binary
 Default Tags
 
 *** Test Cases ***
 Exec Not Allowed On Older Containers
-    Launch Container  exec-test  bridge
+    ${status}=  Get State Of Github Issue  7497
+    Run Keyword If  '${status}' == 'closed'  Fail  Test 11-02-Upgrade-Exec.robot needs to be updated now that Issue #7497 has been resolved
+    # Launch Container  exec-test  bridge
 
-    Upgrade
-    Check Upgraded Version
+    # Upgrade
+    # Check Upgraded Version
 
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} exec -d exec-test ls
-    Should Not Be Equal As Integers  ${rc}  0
-    Should Contain  ${output}  running tasks not supported for this container
+    # ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} exec -d exec-test ls
+    # Should Not Be Equal As Integers  ${rc}  0
+    # Should Contain  ${output}  running tasks not supported for this container
 
-    Launch Container  exec-test2  bridge
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} exec -d exec-test2 ls
-    Should Be Equal As Integers  ${rc}  0
+    # Launch Container  exec-test2  bridge
+    # ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} exec -d exec-test2 ls
+    # Should Be Equal As Integers  ${rc}  0

--- a/tests/test-cases/Group11-Upgrade/11-04-Upgrade-UpdateInProgress.robot
+++ b/tests/test-cases/Group11-Upgrade/11-04-Upgrade-UpdateInProgress.robot
@@ -14,23 +14,27 @@
 
 *** Settings ***
 Documentation  Test 11-04 - Upgrade-UpdateInProgress
-Suite Setup  Install VIC with version to Test Server  7315
-Suite Teardown  Clean up VIC Appliance And Local Binary
+# Suite Setup  Install VIC with version to Test Server  7315
+# Suite Teardown  Clean up VIC Appliance And Local Binary
 Resource  ../../resources/Util.robot
 
 *** Test Cases ***
 Upgrade VCH with UpdateInProgress
-    Run  govc vm.change -vm=%{VCH-NAME} -e=UpdateInProgress=true
-    Check UpdateInProgress  true
-    ${rc}  ${output}=  Run And Return Rc And Output  bin/vic-machine-linux upgrade --debug 1 --name=%{VCH-NAME} --target=%{TEST_URL} --user=%{TEST_USERNAME} --password=%{TEST_PASSWORD} --force=true --compute-resource=%{TEST_RESOURCE} --timeout %{TEST_TIMEOUT}
-    Should Contain  ${output}  Upgrade failed: another upgrade/configure operation is in progress
-    ${rc}  ${output}=  Run And Return Rc And Output  bin/vic-machine-linux upgrade --reset-progress --name=%{VCH-NAME} --target=%{TEST_URL} --user=%{TEST_USERNAME} --password=%{TEST_PASSWORD} --force=true --compute-resource=%{TEST_RESOURCE} --timeout %{TEST_TIMEOUT}
-    Should Contain  ${output}  Reset UpdateInProgress flag successfully
-    Check UpdateInProgress  false
+    ${status}=  Get State Of Github Issue  7497
+    Run Keyword If  '${status}' == 'closed'  Fail  Test 11-04-Upgrade-UpdateInProgress.robot needs to be updated now that Issue #7497 has been resolved
+    # Run  govc vm.change -vm=%{VCH-NAME} -e=UpdateInProgress=true
+    # Check UpdateInProgress  true
+    # ${rc}  ${output}=  Run And Return Rc And Output  bin/vic-machine-linux upgrade --debug 1 --name=%{VCH-NAME} --target=%{TEST_URL} --user=%{TEST_USERNAME} --password=%{TEST_PASSWORD} --force=true --compute-resource=%{TEST_RESOURCE} --timeout %{TEST_TIMEOUT}
+    # Should Contain  ${output}  Upgrade failed: another upgrade/configure operation is in progress
+    # ${rc}  ${output}=  Run And Return Rc And Output  bin/vic-machine-linux upgrade --reset-progress --name=%{VCH-NAME} --target=%{TEST_URL} --user=%{TEST_USERNAME} --password=%{TEST_PASSWORD} --force=true --compute-resource=%{TEST_RESOURCE} --timeout %{TEST_TIMEOUT}
+    # Should Contain  ${output}  Reset UpdateInProgress flag successfully
+    # Check UpdateInProgress  false
 
 Upgrade and inspect VCH
-    Start Process  bin/vic-machine-linux upgrade --debug 1 --name %{VCH-NAME} --target %{TEST_URL} --user %{TEST_USERNAME} --password %{TEST_PASSWORD} --force --compute-resource %{TEST_RESOURCE} --timeout %{TEST_TIMEOUT}  shell=True  alias=UpgradeVCH
-    Wait Until Keyword Succeeds  20x  5s  Inspect VCH   Upgrade/configure in progress
-    Wait For Process  UpgradeVCH
-    Inspect VCH  Completed successfully
-    Check UpdateInProgress  false
+    ${status}=  Get State Of Github Issue  7497
+    Run Keyword If  '${status}' == 'closed'  Fail  Test 11-04-Upgrade-UpdateInProgress.robot needs to be updated now that Issue #7497 has been resolved
+    # Start Process  bin/vic-machine-linux upgrade --debug 1 --name %{VCH-NAME} --target %{TEST_URL} --user %{TEST_USERNAME} --password %{TEST_PASSWORD} --force --compute-resource %{TEST_RESOURCE} --timeout %{TEST_TIMEOUT}  shell=True  alias=UpgradeVCH
+    # Wait Until Keyword Succeeds  20x  5s  Inspect VCH   Upgrade/configure in progress
+    # Wait For Process  UpgradeVCH
+    # Inspect VCH  Completed successfully
+    # Check UpdateInProgress  false

--- a/tests/test-cases/Group11-Upgrade/11-05-Configure.robot
+++ b/tests/test-cases/Group11-Upgrade/11-05-Configure.robot
@@ -15,11 +15,13 @@
 *** Settings ***
 Documentation  Test 11-05 - Configure
 Resource  ../../resources/Util.robot
-Suite Setup  Install VIC with version to Test Server  7315
-Suite Teardown  Clean up VIC Appliance And Local Binary
+# Suite Setup  Install VIC with version to Test Server  7315
+# Suite Teardown  Clean up VIC Appliance And Local Binary
 
 *** Test Cases ***
 Configure VCH with new vic-machine
-    ${ret}=  Run  bin/vic-machine-linux configure --target %{TEST_URL} --user %{TEST_USERNAME} --password=%{TEST_PASSWORD} --compute-resource=%{TEST_RESOURCE} --name %{VCH-NAME} --http-proxy http://proxy.vmware.com:3128
-    Should Not Contain  ${ret}  Completed successfully
-    Should Contain  ${ret}  configure failed
+    ${status}=  Get State Of Github Issue  7497
+    Run Keyword If  '${status}' == 'closed'  Fail  Test 11-05-Configure.robot needs to be updated now that Issue #7497 has been resolved
+    # ${ret}=  Run  bin/vic-machine-linux configure --target %{TEST_URL} --user %{TEST_USERNAME} --password=%{TEST_PASSWORD} --compute-resource=%{TEST_RESOURCE} --name %{VCH-NAME} --http-proxy http://proxy.vmware.com:3128
+    # Should Not Contain  ${ret}  Completed successfully
+    # Should Contain  ${ret}  configure failed


### PR DESCRIPTION
This commit disables the tests that rely on upgrade support with
inventory folders (#7497). The tests are tagged against that issue.