### PR TITLE
Fix folder deletion function

### DIFF
--- a/lib/install/management/delete.go
+++ b/lib/install/management/delete.go
@@ -371,12 +371,14 @@ func (d *Dispatcher) deleteFolder() {
 	folderRef, err := d.session.Finder.Folder(d.op, vchFolderPath)
 	if err != nil {
 		d.op.Debugf("failed to find folder: %s for the VCH target", vchFolderPath)
+		return
 	}
 
 	// protections against old vch's since they are directly in the VMFolder
 	dcFolder, err := d.session.Datacenter.Folders(d.op)
 	if err != nil {
 		d.op.Debugf("failed to find the datacenter folders: %s ", err)
+		return
 	}
 	VMFolder := dcFolder.VmFolder
 	if folderRef.Reference() == VMFolder.Reference() {
@@ -388,11 +390,13 @@ func (d *Dispatcher) deleteFolder() {
 	folderContents, err := folderRef.Children(d.op)
 	if err != nil || len(folderContents) != 0 {
 		d.op.Debugf("Could not remove VCH folder, %s has existing contents in it. Manual cleanup required.", vchFolderPath)
+		return
 	}
 
 	err = d.removeFolder(folderRef)
 	if err != nil {
 		d.op.Warnf(manualInventoryCleanWarning, folderRef.InventoryPath)
+		return
 	}
 }
 

--- a/tests/test-cases/Group6-VIC-Machine/6-02-Default.robot
+++ b/tests/test-cases/Group6-VIC-Machine/6-02-Default.robot
@@ -38,7 +38,7 @@ Delete with defaults
 
     ${ret}=  Run  bin/vic-machine-linux delete --target %{TEST_URL} --thumbprint=%{TEST_THUMBPRINT} --user %{TEST_USERNAME} --password=%{TEST_PASSWORD}
     Should Contain  ${ret}  vic-machine-linux delete failed:  resource pool
-    Should Contain  ${ret}  /Resources/virtual-container-host' not found
+    Should Contain  ${ret}  Didn't find VM \\"virtual-container-host\\" in resource pool
 
 Wrong Password No Panic
     Set Test Environment Variables


### PR DESCRIPTION
Some error cases were not fully exercised during the folder deltion phase of an uninstall. These changes should fix that. 