### PR TITLE
Disable and tag Create VCH - Existing VM name test

### DIFF
--- a/tests/test-cases/Group6-VIC-Machine/6-04-Create-Basic.robot
+++ b/tests/test-cases/Group6-VIC-Machine/6-04-Create-Basic.robot
@@ -211,29 +211,31 @@ Create VCH - Existing VCH name
     Cleanup VIC Appliance On Test Server
 
 Create VCH - Existing VM name
-    Set Test Environment Variables
-    Run Keyword And Ignore Error  Cleanup Dangling VMs On Test Server
-    Run Keyword And Ignore Error  Cleanup Datastore On Test Server
+    ${status}=  Get State Of Github Issue  7499
+    Run Keyword If  '${status}' == 'closed'  Fail  Test 6-04-Create-Basic.robot needs to be updated now that Issue #7499 has been resolved
+    # Set Test Environment Variables
+    # Run Keyword And Ignore Error  Cleanup Dangling VMs On Test Server
+    # Run Keyword And Ignore Error  Cleanup Datastore On Test Server
 
-    # Create dummy VM
-    ${rc}  ${output}=  Run And Return Rc And Output  govc vm.create -net=%{PUBLIC_NETWORK} %{VCH-NAME}
-    Should Be Equal As Integers  ${rc}  0
+    # # Create dummy VM
+    # ${rc}  ${output}=  Run And Return Rc And Output  govc vm.create -net=%{PUBLIC_NETWORK} %{VCH-NAME}
+    # Should Be Equal As Integers  ${rc}  0
 
-    ${output}=  Run  bin/vic-machine-linux create --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --image-store=%{TEST_DATASTORE} --bridge-network=%{BRIDGE_NETWORK} --public-network=%{PUBLIC_NETWORK} ${vicmachinetls}
-    Log  ${output}
+    # ${output}=  Run  bin/vic-machine-linux create --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --image-store=%{TEST_DATASTORE} --bridge-network=%{BRIDGE_NETWORK} --public-network=%{PUBLIC_NETWORK} ${vicmachinetls}
+    # Log  ${output}
 
-    # VCH creation should succeed on ESXi
-    Run Keyword If  '%{HOST_TYPE}' == 'ESXi'  Get Docker Params  ${output}  ${true}
-    Run Keyword If  '%{HOST_TYPE}' == 'ESXi'  Should Contain  ${output}  Installer completed successfully
-    Run Keyword If  '%{HOST_TYPE}' == 'ESXi'  Log To Console  Installer completed successfully: %{VCH-NAME}
-    Run Keyword If  '%{HOST_TYPE}' == 'ESXi'  Run Keyword And Ignore Error  Cleanup VIC Appliance On Test Server
+    # # VCH creation should succeed on ESXi
+    # Run Keyword If  '%{HOST_TYPE}' == 'ESXi'  Get Docker Params  ${output}  ${true}
+    # Run Keyword If  '%{HOST_TYPE}' == 'ESXi'  Should Contain  ${output}  Installer completed successfully
+    # Run Keyword If  '%{HOST_TYPE}' == 'ESXi'  Log To Console  Installer completed successfully: %{VCH-NAME}
+    # Run Keyword If  '%{HOST_TYPE}' == 'ESXi'  Run Keyword And Ignore Error  Cleanup VIC Appliance On Test Server
 
-    # VCH creation should fail on VC
-    Run Keyword If  '%{HOST_TYPE}' == 'VC'  Should Contain  ${output}  The name '%{VCH-NAME}' already exists.
+    # # VCH creation should fail on VC
+    # Run Keyword If  '%{HOST_TYPE}' == 'VC'  Should Contain  ${output}  The name '%{VCH-NAME}' already exists.
 
-    ${rc}  ${output}=  Run And Return Rc And Output  govc vm.destroy %{VCH-NAME}
-    Should Be Equal As Integers  ${rc}  0
-    Cleanup VCH Bridge Network  %{BRIDGE_NETWORK}
+    # ${rc}  ${output}=  Run And Return Rc And Output  govc vm.destroy %{VCH-NAME}
+    # Should Be Equal As Integers  ${rc}  0
+    # Cleanup VCH Bridge Network  %{BRIDGE_NETWORK}
 
 Create VCH - Existing RP on ESX
     Run Keyword If  '%{HOST_TYPE}' == 'VC'  Pass Execution  Test skipped on VC


### PR DESCRIPTION
This commit disables the Create VCH - Existing VM name test in
6-04-Create-Basic and tags it with #7499, since that issue covers
updating CI tests for inventory folder support.