### PR TITLE
Improve logging for nightly debugging

### DIFF
--- a/cmd/vic-machine/create/create.go
+++ b/cmd/vic-machine/create/create.go
@@ -35,6 +35,7 @@ import (
 	"github.com/vmware/vic/lib/install/vchlog"
 	"github.com/vmware/vic/pkg/errors"
 	"github.com/vmware/vic/pkg/trace"
+	"github.com/vmware/vic/pkg/version"
 )
 
 const (
@@ -679,6 +680,8 @@ func (c *Create) Run(clic *cli.Context) (err error) {
 	// These operations will be executed without timeout
 	op := common.NewOperation(clic, c.Debug.Debug)
 	op.Infof("### Installing VCH ####")
+	ver := version.GetBuild().ShortVersion()
+	op.Debugf("Version %s", ver)
 
 	defer func() {
 		// urfave/cli will print out exit in error handling, so no more information in main method can be printed out.

--- a/tests/resources/Nimbus-Util.robot
+++ b/tests/resources/Nimbus-Util.robot
@@ -407,6 +407,7 @@ Deploy Nimbus NFS Datastore
     Wait Until Keyword Succeeds  2 min  30 sec  Login  ${user}  ${password}
 
     ${out}=  Execute Command  ${NIMBUS_LOCATION} nimbus-nfsdeploy ${name} ${additional-args}
+    Log  ${out}
     # Make sure the deploy actually worked
     Should Contain  ${out}  To manage this VM use
     # Now grab the IP address and return the name and ip for later use


### PR DESCRIPTION
Adds version line to debug, logs nimbus deploy output
```
⇒  ./bin/vic-machine-linux create --debug 1
INFO[0000] ### Installing VCH ####                      
DEBU[0000] Version v1.4.0-dev-0-375f45e                 
ERRO[0000] --------------------                         
ERRO[0000] vic-machine-linux create failed: --target argument must be specified
```