### PR TITLE
Enable host recommendation in vm power-on

### DIFF
--- a/lib/install/management/configure.go
+++ b/lib/install/management/configure.go
@@ -329,7 +329,7 @@ func (d *Dispatcher) update(conf *config.VirtualContainerHostConfigSpec, setting
 		return err
 	}
 
-	if err = d.startAppliance(conf); err != nil {
+	if err = d.appliance.PowerOn(d.op); err != nil {
 		return err
 	}
 
@@ -372,7 +372,7 @@ func (d *Dispatcher) ensureRollbackReady(conf *config.VirtualContainerHostConfig
 		d.op.Info("Roll back finished - Appliance is kept in powered off status")
 		return nil
 	}
-	if err = d.startAppliance(conf); err != nil {
+	if err = d.appliance.PowerOn(d.op); err != nil {
 		return err
 	}
 

--- a/lib/install/management/create_test.go
+++ b/lib/install/management/create_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/vmware/vic/lib/install/validate"
 	"github.com/vmware/vic/pkg/trace"
 	"github.com/vmware/vic/pkg/vsphere/session"
-	"github.com/vmware/vic/pkg/vsphere/vm"
 )
 
 func TestMain(t *testing.T) {
@@ -91,16 +90,13 @@ func TestMain(t *testing.T) {
 		// The other way around, if we test positive case first, the VCH data and session data are modified, so we are not able to test the negative case
 		conf2, err := validator.Validate(op, input)
 		conf2.ImageStores[0].Host = "http://non-exist"
-		_ = testCreateAppliance(op, validator.Session, conf2, installSettings, true, t)
+		testCreateAppliance(op, validator.Session, conf2, installSettings, true, t)
 		testCleanup(op, validator.Session, conf2, t)
 
-		appliance := testCreateAppliance(op, validator.Session, conf, installSettings, false, t)
+		testCreateAppliance(op, validator.Session, conf, installSettings, false, t)
 
 		// cannot run test for func not implemented in vcsim: ResourcePool:resourcepool-24 does not implement: UpdateConfig
 		// testUpdateResources(ctx, validator.Session, conf, installSettings, false, t)
-
-		// Test that the applianceVM can be relocated after it is created.
-		testRelocateAppliance(op, appliance, validator.Session, conf, installSettings, t)
 	}
 }
 
@@ -224,7 +220,7 @@ func testCleanup(op trace.Operation, sess *session.Session, conf *config.Virtual
 	}
 }
 
-func testCreateAppliance(op trace.Operation, sess *session.Session, conf *config.VirtualContainerHostConfigSpec, vConf *data.InstallerData, hasErr bool, t *testing.T) *vm.VirtualMachine {
+func testCreateAppliance(op trace.Operation, sess *session.Session, conf *config.VirtualContainerHostConfigSpec, vConf *data.InstallerData, hasErr bool, t *testing.T) {
 	d := &Dispatcher{
 		session: sess,
 		op:      op,
@@ -239,7 +235,7 @@ func testCreateAppliance(op trace.Operation, sess *session.Session, conf *config
 		} else {
 			t.Fatal(err)
 		}
-		return nil
+		return
 	}
 
 	err = d.createAppliance(conf, vConf)
@@ -249,27 +245,10 @@ func testCreateAppliance(op trace.Operation, sess *session.Session, conf *config
 		} else {
 			t.Fatal(err)
 		}
-		return nil
+		return
 	}
 
 	if hasErr {
 		t.Errorf("No error when error is expected.")
-	}
-
-	return d.appliance
-}
-
-func testRelocateAppliance(op trace.Operation, appliance *vm.VirtualMachine, sess *session.Session, conf *config.VirtualContainerHostConfigSpec, vConf *data.InstallerData, t *testing.T) {
-	d := &Dispatcher{
-		session:   sess,
-		op:        op,
-		isVC:      sess.IsVC(),
-		appliance: appliance,
-		force:     false,
-	}
-
-	err := d.relocateAppliance()
-	if err != nil {
-		t.Fatalf("Failed to relocate appliance: %s", err)
 	}
 }

--- a/lib/portlayer/exec/base.go
+++ b/lib/portlayer/exec/base.go
@@ -269,12 +269,7 @@ func (c *containerBase) start(op trace.Operation) error {
 		return NotYetExistError{c.ExecConfig.ID}
 	}
 
-	// Power on
-	_, err := c.vm.WaitForResult(op, func(op context.Context) (tasks.Task, error) {
-		return c.vm.PowerOn(op)
-	})
-
-	return err
+	return c.vm.PowerOn(op)
 }
 
 func (c *containerBase) stop(op trace.Operation, waitTime *int32) error {

--- a/lib/portlayer/exec/container_cache.go
+++ b/lib/portlayer/exec/container_cache.go
@@ -36,6 +36,7 @@ type containerCache struct {
 	cache map[string]*Container
 }
 
+// Containers is an in-memory cache of containerVMs.
 var Containers *containerCache
 
 func NewContainerCache() {

--- a/pkg/retry/retry.go
+++ b/pkg/retry/retry.go
@@ -57,15 +57,8 @@ func NewBackoffConfig() *BackoffConfig {
 // Do retries the given function until defaultMaxInterval time passes, while sleeping some time between unsuccessful attempts
 // if retryOnError returns true, continue retry, otherwise, return error
 func Do(operation func() error, retryOnError func(err error) bool) error {
-	bConf := &BackoffConfig{
-		InitialInterval:     defaultInitialInterval,
-		RandomizationFactor: defaultRandomizationFactor,
-		Multiplier:          defaultMultiplier,
-		MaxInterval:         defaultMaxInterval,
-		MaxElapsedTime:      defaultMaxElapsedTime,
-	}
-
-	return DoWithConfig(operation, retryOnError, bConf)
+	conf := NewBackoffConfig()
+	return DoWithConfig(operation, retryOnError, conf)
 }
 
 // DoWithConfig will attempt an operation while retrying using an exponential back off based on the config supplied by the caller. The retry decider is the supplied function retryOnError

--- a/pkg/vsphere/compute/placement/placement.go
+++ b/pkg/vsphere/compute/placement/placement.go
@@ -22,6 +22,7 @@ import (
 // HostPlacementPolicy defines the interface for using metrics to decide the appropriate host
 // for a VM based on host metrics and VM provisioned resources.
 type HostPlacementPolicy interface {
+	// TODO(jzt): refactor to consider vm resource needs in the future
 	// CheckHost checks whether or not the host a VM was created on is adequate for power-on.
 	CheckHost(trace.Operation, *object.VirtualMachine) bool
 

--- a/pkg/vsphere/compute/placement/random_test.go
+++ b/pkg/vsphere/compute/placement/random_test.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/vmware/vic/pkg/trace"
 	"github.com/vmware/vic/pkg/vsphere/test"
-	"github.com/vmware/vic/pkg/vsphere/vm"
 )
 
 func TestRandomRecommendHost(t *testing.T) {
@@ -39,12 +38,7 @@ func TestRandomRecommendHost(t *testing.T) {
 	hosts, err := cls.Hosts(op)
 	assert.NoError(t, err)
 
-	moref, err := test.CreateVM(op, sess, "test-vm")
-	assert.NoError(t, err)
-
-	v := vm.NewVirtualMachine(op, sess, moref)
-
-	rhp, err := NewRandomHostPolicy(op, v.Cluster)
+	rhp, err := NewRandomHostPolicy(op, cls)
 	assert.NoError(t, err)
 
 	assert.False(t, rhp.CheckHost(op, nil))

--- a/pkg/vsphere/compute/placement/ranked.go
+++ b/pkg/vsphere/compute/placement/ranked.go
@@ -120,7 +120,7 @@ func (r *RankedHostPolicy) rankHosts(op trace.Operation, hm map[string]*performa
 		rh := rankedHost{
 			HostReference:   h,
 			HostMetricsInfo: m,
-			score:           r.rankMemory(m) * (1 - m.CPU.UsagePercent),
+			score:           r.rankMemory(m) * (1.0 - (m.CPU.UsagePercent / 100.0)),
 		}
 		ranking = append(ranking, rh)
 	}
@@ -130,5 +130,6 @@ func (r *RankedHostPolicy) rankHosts(op trace.Operation, hm map[string]*performa
 
 func (r *RankedHostPolicy) rankMemory(hm *performance.HostMetricsInfo) float64 {
 	free := float64(hm.Memory.TotalKB-hm.Memory.ConsumedKB) / 1024.0
-	return free * r.config.memUnconsumedWeight
+	inactive := float64(hm.Memory.TotalKB-hm.Memory.ActiveKB) / 1024.0
+	return free*r.config.memUnconsumedWeight + inactive*r.config.memInactiveWeight
 }

--- a/pkg/vsphere/compute/placement/ranked_test.go
+++ b/pkg/vsphere/compute/placement/ranked_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/vmware/vic/pkg/trace"
 	"github.com/vmware/vic/pkg/vsphere/performance"
 	"github.com/vmware/vic/pkg/vsphere/test"
-	"github.com/vmware/vic/pkg/vsphere/vm"
 )
 
 var (
@@ -130,14 +129,11 @@ func TestRankedRecommendHost(t *testing.T) {
 		server.Close()
 	}()
 
-	moref, err := test.CreateVM(op, sess, "test-vm")
-	assert.NoError(t, err)
-
-	v := vm.NewVirtualMachine(op, sess, moref)
+	cls := sess.Cluster
 
 	m := MockMetricsProvider{}
 
-	rhp, err := NewRankedHostPolicy(op, v.Cluster, m)
+	rhp, err := NewRankedHostPolicy(op, cls, m)
 	assert.NoError(t, err)
 
 	testRankedRecommendHostInterface(t, op, rhp)
@@ -161,13 +157,11 @@ func TestRankedRecommendHostWithHosts(t *testing.T) {
 		server.Close()
 	}()
 
-	moref, err := test.CreateVM(op, sess, "test-vm")
-	assert.NoError(t, err)
-
-	v := vm.NewVirtualMachine(op, sess, moref)
+	cls := sess.Cluster
 
 	m := MockMetricsProvider{}
-	rhp, err := NewRankedHostPolicy(op, v.Cluster, m)
+
+	rhp, err := NewRankedHostPolicy(op, cls, m)
 	assert.NoError(t, err)
 	testRankedRecommendHostInterfaceWithHosts(t, op, rhp)
 }

--- a/pkg/vsphere/performance/vm_subscription.go
+++ b/pkg/vsphere/performance/vm_subscription.go
@@ -26,13 +26,12 @@ import (
 
 	"github.com/vmware/vic/pkg/trace"
 	"github.com/vmware/vic/pkg/vsphere/session"
-	"github.com/vmware/vic/pkg/vsphere/vm"
 )
 
 // vmSubscription is a 1:1 relationship to a Virtual Machine and a
 // 1:M relationship to subscribers
 type vmSubscription struct {
-	vm *vm.VirtualMachine
+	vm *object.VirtualMachine
 	id string
 
 	pub                 *pubsub.Publisher
@@ -171,7 +170,7 @@ func newVMSubscription(op trace.Operation, session *session.Session, moref types
 	}
 
 	sub := &vmSubscription{
-		vm:                  vm.NewVirtualMachine(op.Context, session, moref),
+		vm:                  object.NewVirtualMachine(session.Vim25(), moref),
 		deviceInstanceToKey: make(map[string]string),
 	}
 

--- a/pkg/vsphere/vm/vm.go
+++ b/pkg/vsphere/vm/vm.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2017 VMware, Inc. All Rights Reserved.
+// Copyright 2016-2018 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@ import (
 	"strconv"
 	"strings"
 	"sync/atomic"
+	"time"
 
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/property"
@@ -33,7 +34,9 @@ import (
 
 	"github.com/vmware/vic/pkg/retry"
 	"github.com/vmware/vic/pkg/trace"
+	"github.com/vmware/vic/pkg/vsphere/compute/placement"
 	"github.com/vmware/vic/pkg/vsphere/extraconfig/vmomi"
+	"github.com/vmware/vic/pkg/vsphere/performance"
 	"github.com/vmware/vic/pkg/vsphere/session"
 	"github.com/vmware/vic/pkg/vsphere/tasks"
 )
@@ -730,4 +733,150 @@ func (vm *VirtualMachine) RemoveSnapshotByRef(ctx context.Context, snapshot *typ
 	}
 
 	return object.NewTask(vm.Vim25(), res.Returnval), nil
+}
+
+// CheckHostCompatibility checks that a host is compatible for VM placement.
+func (vm *VirtualMachine) CheckHostCompatibility(ctx context.Context, host *types.ManagedObjectReference) (*object.Task, error) {
+	req := types.CheckCompatibility_Task{
+		This: vm.ServiceContent.VmCompatibilityChecker.Reference(),
+		Vm:   vm.Reference(),
+		Host: host,
+	}
+
+	res, err := methods.CheckCompatibility_Task(ctx, vm.Vim25(), &req)
+	if err != nil {
+		return nil, err
+	}
+	return object.NewTask(vm.Vim25(), res.Returnval), nil
+}
+
+// PowerOn powers on a VM. If the environment is VC without DRS enabled, it will attempt to relocate  the VM
+// to the most suitable host in the cluster. If relocation or subsequent power-on fail, it will attempt the next
+// best host, and repeat this process until a successful power-on is achieved or there are no more hosts to try.
+func (vm *VirtualMachine) PowerOn(op trace.Operation) error {
+	drs := vm.Session.DRSEnabled != nil && *vm.Session.DRSEnabled
+	cls := vm.InCluster(op)
+
+	op.Debugf("DRS: %t", drs)
+	op.Debugf("In cluster: %t", cls)
+
+	// otherwise place the VM before powering it on
+	hmp := performance.NewHostMetricsProvider(vm.Session.Vim25())
+	rhp, err := placement.NewRankedHostPolicy(op, vm.Cluster, hmp)
+	if err != nil {
+		return err
+	}
+
+	// any of the following conditions are sufficient to power-on the VM:
+	// - environment is not VC
+	// - DRS is enabled
+	// - the VM does not belong to a cluster
+	// - the current host is adequate for power-on
+	if !vm.IsVC() || drs || !cls || rhp.CheckHost(op, vm.VirtualMachine) {
+		return vm.powerOn(op)
+	}
+
+	op.Warnf("Host is not adequate for power-on, getting placement recommendation")
+
+	var hosts, subset []*object.HostSystem
+
+	f := func() error {
+		hosts, err = rhp.RecommendHost(op, subset)
+		if err != nil {
+			return fmt.Errorf("error recommending host: %s", err.Error())
+		}
+		return nil
+	}
+
+	conf := retry.NewBackoffConfig()
+	conf.MaxInterval = 1 * time.Second
+	conf.MaxElapsedTime = 20 * time.Second
+
+	err = retry.DoWithConfig(f, retry.OnError, conf)
+	if err != nil {
+		return err
+	}
+
+	for len(hosts) > 0 {
+		op.Debugf("hosts: %s", hosts)
+		op.Infof("Placement recommended %s", hosts[0].Reference().String())
+
+		if vm.relocate(op, hosts[0]) != nil {
+			op.Warnf("VM relocation failed: %s", err.Error())
+		} else if vm.powerOn(op) != nil {
+			op.Warnf("VM power-on failed: %s", err.Error())
+		} else {
+			return nil
+		}
+
+		// if relocation or powerOn fails, something has changed and we need a new recommendation
+		subset = hosts[1:]
+
+		if err = retry.DoWithConfig(f, retry.OnError, conf); err != nil {
+			return err
+		}
+
+	}
+	return fmt.Errorf("vm placement failed: no available hosts")
+}
+
+func (vm *VirtualMachine) relocate(op trace.Operation, host *object.HostSystem) error {
+	h, err := vm.HostSystem(op)
+	if err != nil {
+		return err
+	}
+	src := h.Reference()
+	dst := host.Reference()
+
+	// NOP if dest host and src host are the same
+	if src.String() == dst.String() {
+		op.Debugf("Skipping relocate - source and destination hosts are the same")
+		return nil
+	}
+
+	op.Debugf("Attempting to relocate %s from host %s to host %s", vm.Reference().String(), src.String(), dst.String())
+
+	spec := types.VirtualMachineRelocateSpec{Host: &dst}
+	_, err = vm.WaitForResult(op, func(op context.Context) (tasks.Task, error) {
+		return vm.Relocate(op, spec, types.VirtualMachineMovePriorityDefaultPriority)
+	})
+	if err != nil {
+		return err
+	}
+
+	op.Infof("VM %s successfully relocated", vm.Reference().String())
+
+	return nil
+}
+
+func (vm *VirtualMachine) powerOn(op trace.Operation) error {
+	// TODO(jzt): use DRS aware power-on
+	// see https://github.com/vmware/vic/issues/7237
+
+	// dc := vm.Session.Datacenter
+	// task, err := dc.PowerOnVM(op, []types.ManagedObjectReference{vm.Reference()})
+
+	// if task == nil {
+	// 	op.Infof("powering on %s", vm.Reference().String())
+	// 	return nil
+	// }
+
+	// _, err = task.WaitForResult(op, nil)
+	// if err != nil {
+	// 	op.Warnf("error attempting to power on vm: %s", err.Error())
+	// } else {
+	// 	op.Infof("VM %s successfully powered on", vm.Reference().String())
+	// }
+	// return err
+
+	_, err := vm.WaitForResult(op, func(op context.Context) (tasks.Task, error) {
+		return vm.VirtualMachine.PowerOn(op)
+	})
+	return err
+}
+
+func (vm *VirtualMachine) InCluster(op trace.Operation) bool {
+	cls := vm.Cluster.Reference().Type == "ClusterComputeResource"
+	op.Debugf("vm compute resource: %s", vm.Cluster.Name())
+	return cls
 }

--- a/pkg/vsphere/vm/vm.go
+++ b/pkg/vsphere/vm/vm.go
@@ -757,8 +757,8 @@ func (vm *VirtualMachine) PowerOn(op trace.Operation) error {
 	drs := vm.Session.DRSEnabled != nil && *vm.Session.DRSEnabled
 	cls := vm.InCluster(op)
 
-	op.Debugf("DRS: %t", drs)
-	op.Debugf("In cluster: %t", cls)
+	op.Debugf("DRS enabled: %t", drs)
+	op.Debugf("%s resides in a cluster: %t", vm.Reference.String(), cls)
 
 	// otherwise place the VM before powering it on
 	hmp := performance.NewHostMetricsProvider(vm.Session.Vim25())

--- a/pkg/vsphere/vm/vm.go
+++ b/pkg/vsphere/vm/vm.go
@@ -818,7 +818,8 @@ func (vm *VirtualMachine) PowerOn(op trace.Operation) error {
 		}
 
 	}
-	return fmt.Errorf("vm placement failed: no available hosts")
+	op.Warnf("vm placement failed: no available hosts. Attempting power-on.")
+	return vm.powerOn(op)
 }
 
 func (vm *VirtualMachine) relocate(op trace.Operation, host *object.HostSystem) error {

--- a/pkg/vsphere/vm/vm.go
+++ b/pkg/vsphere/vm/vm.go
@@ -758,7 +758,7 @@ func (vm *VirtualMachine) PowerOn(op trace.Operation) error {
 	cls := vm.InCluster(op)
 
 	op.Debugf("DRS enabled: %t", drs)
-	op.Debugf("%s resides in a cluster: %t", vm.Reference.String(), cls)
+	op.Debugf("%s resides in a cluster: %t", vm.Reference().String(), cls)
 
 	// otherwise place the VM before powering it on
 	hmp := performance.NewHostMetricsProvider(vm.Session.Vim25())

--- a/pkg/vsphere/vm/vm.go
+++ b/pkg/vsphere/vm/vm.go
@@ -801,9 +801,10 @@ func (vm *VirtualMachine) PowerOn(op trace.Operation) error {
 		op.Debugf("hosts: %s", hosts)
 		op.Infof("Placement recommended %s", hosts[0].Reference().String())
 
-		if vm.relocate(op, hosts[0]) != nil {
+		var err error
+		if err = vm.relocate(op, hosts[0]); err != nil {
 			op.Warnf("VM relocation failed: %s", err.Error())
-		} else if vm.powerOn(op) != nil {
+		} else if err = vm.powerOn(op); err != nil {
 			op.Warnf("VM power-on failed: %s", err.Error())
 		} else {
 			return nil
@@ -850,25 +851,6 @@ func (vm *VirtualMachine) relocate(op trace.Operation, host *object.HostSystem) 
 }
 
 func (vm *VirtualMachine) powerOn(op trace.Operation) error {
-	// TODO(jzt): use DRS aware power-on
-	// see https://github.com/vmware/vic/issues/7237
-
-	// dc := vm.Session.Datacenter
-	// task, err := dc.PowerOnVM(op, []types.ManagedObjectReference{vm.Reference()})
-
-	// if task == nil {
-	// 	op.Infof("powering on %s", vm.Reference().String())
-	// 	return nil
-	// }
-
-	// _, err = task.WaitForResult(op, nil)
-	// if err != nil {
-	// 	op.Warnf("error attempting to power on vm: %s", err.Error())
-	// } else {
-	// 	op.Infof("VM %s successfully powered on", vm.Reference().String())
-	// }
-	// return err
-
 	_, err := vm.WaitForResult(op, func(op context.Context) (tasks.Task, error) {
 		return vm.VirtualMachine.PowerOn(op)
 	})

--- a/pkg/vsphere/vm/vm_test.go
+++ b/pkg/vsphere/vm/vm_test.go
@@ -259,7 +259,7 @@ func TestVMAttributes(t *testing.T) {
 		t.Fatalf("ERROR: %s", err)
 	}
 	assert.Equal(t, name, folder)
-	task, err := vm.PowerOn(ctx)
+	task, err := vm.VirtualMachine.PowerOn(ctx)
 	if err != nil {
 		t.Fatalf("ERROR: %s", err)
 	}
@@ -560,7 +560,7 @@ func TestWaitForResult(t *testing.T) {
 	vmm := NewVirtualMachine(ctx, s, vmo.Reference())
 	// Test the success path
 	_, err = vmm.WaitForResult(ctx, func(ctx context.Context) (tasks.Task, error) {
-		return vmm.PowerOn(ctx)
+		return vmm.VirtualMachine.PowerOn(ctx)
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/tests/manual-test-cases/Group19-DRS-Disabled/19-3-DRS-Disabled-Placement.md
+++ b/tests/manual-test-cases/Group19-DRS-Disabled/19-3-DRS-Disabled-Placement.md
@@ -11,35 +11,29 @@ The current placement strategy is to avoid bad host selection, instead of select
 
 # Environment:
 This test requires access to VMware Nimbus cluster for dynamic ESXi and vCenter creation. This test should be executed in the following topologies and should have vSAN enabled.
-* 1 vCenter host with 3 clusters, where 1 cluster has 1 ESXi host and the other 2 clusters have 3 ESXi hosts each
-* 2 vCenter hosts connected with ELM, where each vCenter host has a cluster/host/datacenter topology that emulates a customer environment (exact topology TBD)
+* 1 vCenter host with 1 cluster containing 4 ESX hosts with DRS disabled.
 
 In addition, this test should be run in multi-ESX-host and single-ESX-host cluster topologies.
 
 See https://confluence.eng.vmware.com/display/CNA/VIC+ROBO for more details.
 
 # Test Steps:
-1. Deploy a ROBO Advanced vCenter testbed for both environments above
-2. Run a few dummy VMs on the host(s) in the vCenter cluster meant for VCH installation. This ensures that the hosts have varying resource utilization.
-3. Install a VCH on a particular cluster on vCenter - see note in [Environment](#environment)
-4. Deploy containers that will consume resources predictably (e.g. the `progrium/stress` image)
-5. Measure cluster metrics and gather resource consumption
-6. Create and run regular containers such as `busybox`
-7. Create and run enough containers to consume all available cluster resources
-8. Attempt to create and run more containers
-9. Delete some containers
-10. Create and run a few containers
-11. Delete the VCH
+1. Deploy a vCenter testbed with DRS disabled
+2. Install the VIC VCH appliance with compute resource set to the cluster
+3. Deploy 2 containers that will consume resources predictably (e.g. the `progrium/stress` image)
+4. Measure cluster metrics and gather resource consumption
+5. Create a normal container using the `busybox` image
+6. Relocate the `busybox` container to the same host as the VCH
+7. Start the `busybox` container
+8. Delete the VCH
 
 # Expected Outcome:
 * Step 1 should succeed
-* Step 2 should succeed
-* Step 3 should succeed and the VCH should be placed on a host that satisfies the license and feature checks. The VCH's host should also meet the criteria defined in point 2 of [References](#references)
+* Step 2 should succeed and the VCH should be placed on a host that satisfies the license and feature checks. The VCH's host should also meet the criteria defined in point 2 of [References](#references)
+* Step 3 should succeed, with each stress container being relocated to its own host by the placement logic, separate from one another, and separate from the host containing the VCH
 * Steps 4-5 should succeed and containers should be placed on ESX hosts in the cluster according to the criteria defined in point 2 of [References](#references)
-* Step 6 should succeed and containers should be placed on ESX hosts in the cluster that have available resources according to the criteria defined in point 2 of [References](#references). In the multi-host cluster environment, the cluster resource utilization level should be as expected given containerVM sizes, cluster capacity and placement logic.
-* Step 7 should succeed
-* Step 8 should fail since the available resources are exhausted
-* Steps 9-11 should succeed
+* Steps 5 and 6 should succeed
+* Step 7 should succeed, with the `busybox` container having been relocated from the ESX host containing the VCH to an ESX host that is does not contain the VCH or either of the stress containers
 
 # Possible Problems:
 None

--- a/tests/manual-test-cases/Group19-DRS-Disabled/19-3-DRS-Disabled-Placement.robot
+++ b/tests/manual-test-cases/Group19-DRS-Disabled/19-3-DRS-Disabled-Placement.robot
@@ -1,0 +1,94 @@
+# Copyright 2016-2018 VMware, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#	http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License
+
+*** Settings ***
+Documentation  Test 19-3 - DRS-Disabled-Placement
+Resource  ../../resources/Util.robot
+Suite Setup  Wait Until Keyword Succeeds  10x  10m  ROBO SKU Setup
+Suite Teardown  Run Keyword And Ignore Error  Nimbus Cleanup  ${list}
+
+*** Keywords ***
+Get Host IP
+    [Arguments]  ${name}
+    Log To Console  Getting host IP for ${name}
+    ${rc}  ${ip}=  Run And Return Rc And Output  govc vm.info ${name} |grep Host |awk '{print $2}'
+    Should Be Equal As Integers  ${rc}  0
+    [Return]  ${ip}
+
+Deploy Stress Container And Return Host IP
+    [Arguments]  ${name}
+    Log To Console  Deploying stress container ${name}...
+    ${rc}  ${id}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -d --name ${name} progrium/stress --vm 5 --vm-bytes 256M --vm-hang 0
+    Should Be Equal As Integers  ${rc}  0
+
+    ${vm_name}=  Get VM display name  ${id}
+    ${host_ip}=  Get Host IP  ${vm_name}
+    [Return]  ${host_ip}
+
+Create Busybox Container VM And Return ID
+    [Arguments]
+    Log To Console  Deploying busybox container VM..
+    Pull Image  busybox
+    ${rc}  ${id}=  Run And Return Rc And Output  docker %{VCH-PARAMS} create busybox /bin/top
+    Should Be Equal As Integers  ${rc}  0
+    [Return]  ${id}
+
+Relocate VM To Host
+    [Arguments]  ${host}  ${vm_name}
+    Log To Console  Relocating VM ${vm_name} to host ${host}...
+    ${rc}  ${output}=  Run And Return Rc And Output  govc vm.migrate -host ${host} ${vm_name}
+    Should Be Equal As Integers  ${rc}  0
+    Should Contain  ${output}  OK
+
+Power On VM
+    [Arguments]  ${id}
+    ${rc}  ${id}=  Run And Return Rc And Output  docker %{VCH-PARAMS} start ${id}
+    Should Be Equal As Integers  ${rc}  0
+
+*** Test Cases ***
+
+# TODO(jzt): we need to test against a single ESX host
+
+Simple Placement
+    Install VIC Appliance To Test Server
+    ${vch_host}=  Get Host IP  %{VCH-NAME}
+
+    Pull Image  progrium/stress
+
+    ${stressed_hosts}=  Create List  ${vch_host}
+    :FOR  ${i}  IN RANGE  2
+    \   ${ip}=  Deploy Stress Container And Return Host IP  stresser${i}
+    \   Should Not Contain  ${stressed_hosts}  ${ip}
+    \   Append To List  ${stressed_hosts}  ${ip}
+
+    # 1 VCH host + 2 stressed hosts out of 4 total, leaving one
+    # clean host to which a new container should relocate
+    ${len}=  Get Length  ${stressed_hosts}
+    Should Be Equal As Integers  ${len}  3
+
+    ${id}=  Create Busybox Container VM And Return ID
+    ${vm_name}=  Get VM display name  ${id}
+
+    # Move it onto the same host as the VC
+    Relocate VM To Host  ${vch_host}  ${vm_name}
+
+    ${host_ip}=  Get Host IP  ${vm_name}
+    Should Be Equal  ${host_ip}  ${vch_host}
+
+    # power on the busybox container - it should relocate to a non-stressed host
+    Power On VM  ${id}
+    ${host_ip}=  Get Host IP  ${vm_name}
+
+    Should Not Contain  ${stressed_hosts}  ${host_ip}
+    Cleanup VIC Appliance On Test Server

--- a/tests/manual-test-cases/Group19-DRS-Disabled/19-3-DRS-Disabled-Placement.robot
+++ b/tests/manual-test-cases/Group19-DRS-Disabled/19-3-DRS-Disabled-Placement.robot
@@ -16,11 +16,12 @@
 Documentation  Test 19-3 - DRS-Disabled-Placement
 Resource  ../../resources/Util.robot
 Suite Setup  Wait Until Keyword Succeeds  10x  10m  ROBO SKU Setup
-Suite Teardown  Run Keyword And Ignore Error  Nimbus Cleanup  ${list}
+Suite Teardown  Teardown VCH And Cleanup Nimbus
 
 *** Keywords ***
 Deploy Stress Container And Return Host IP
     [Arguments]  ${name}
+    Pull Image  progrium/stress
     Log To Console  Deploying stress container ${name}...
     ${rc}  ${id}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -d --name ${name} progrium/stress --vm 5 --vm-bytes 256M --vm-hang 0
     Should Be Equal As Integers  ${rc}  0
@@ -44,6 +45,10 @@ Relocate VM To Host
     Should Be Equal As Integers  ${rc}  0
     Should Contain  ${output}  OK
 
+Teardown VCH And Cleanup Nimbus
+    Cleanup VIC Appliance On Test Server
+    Run Keyword And Ignore Error  Nimbus Cleanup  ${list}
+
 *** Test Cases ***
 
 # TODO(jzt): we need to test against a single ESX host
@@ -51,8 +56,6 @@ Relocate VM To Host
 Simple Placement
     Install VIC Appliance To Test Server
     ${vch_host}=  Get VM Host Name  %{VCH-NAME}
-
-    Pull Image  progrium/stress
 
     ${stressed_hosts}=  Create List  ${vch_host}
     :FOR  ${i}  IN RANGE  2
@@ -80,4 +83,3 @@ Simple Placement
     ${host_ip}=  Get VM Host Name  ${vm_name}
 
     Should Not Contain  ${stressed_hosts}  ${host_ip}
-    Cleanup VIC Appliance On Test Server


### PR DESCRIPTION
This change moves host checking & relocation into the vm PowerOn call.

If the environment is VC, the VM resides in a cluster, and DRS is disabled, a recommendation/relocation is attempted.
If relocation or power-on fails on the recommended host, the host is discarded and a new recommendation/relocation
attempt is made against the rest, until there are no more hosts. In this case, we warn that placement failed, but we attempt to power-on anyway.

If the environment is ESX, the VM is not in a cluster, or DRS is enabled, we simply power-on.

Fixes #7281.