### PR TITLE
Vic machine configure tlsverify

### DIFF
--- a/cmd/vic-machine/configure/configure.go
+++ b/cmd/vic-machine/configure/configure.go
@@ -252,7 +252,7 @@ func updateSessionEnv(sess *executor.SessionConfig, envName, envValue string) {
 
 func (c *Configure) processCertificates(op trace.Operation, client, public, management data.NetworkConfig) error {
 
-	if !c.certificates.NoTLSverify && (c.certificates.Skey == "" || c.certificates.Scert == "") {
+	if len(c.certificates.Cname) == 0 && !c.certificates.NoTLSverify && (c.certificates.Skey == "" || c.certificates.Scert == "") {
 		op.Info("No certificate regeneration requested. No new certificates provided. Certificates left unchanged.")
 		return nil
 	}

--- a/cmd/vic-machine/configure/configure.go
+++ b/cmd/vic-machine/configure/configure.go
@@ -252,7 +252,7 @@ func updateSessionEnv(sess *executor.SessionConfig, envName, envValue string) {
 
 func (c *Configure) processCertificates(op trace.Operation, client, public, management data.NetworkConfig) error {
 
-	if len(c.certificates.Cname) == 0 && !c.certificates.NoTLSverify && (c.certificates.Skey == "" || c.certificates.Scert == "") {
+	if c.certificates.Cname == "" && !c.certificates.NoTLSverify && (c.certificates.Skey == "" || c.certificates.Scert == "") {
 		op.Info("No certificate regeneration requested. No new certificates provided. Certificates left unchanged.")
 		return nil
 	}

--- a/tests/test-cases/Group6-VIC-Machine/6-17-Configure-TLS.robot
+++ b/tests/test-cases/Group6-VIC-Machine/6-17-Configure-TLS.robot
@@ -162,10 +162,10 @@ Configure VCH - Replace certificates with self-signed certificate using --tls-cn
 
     ${output}=  Run  bin/vic-machine-linux configure --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} ${vicmachinetls} --tls-cert-path "new-bar-certs" --debug 1 --tls-cname="*.eng.vmware.com"
 
-    Should Contain  ${output}  Generating self-signed server certificate/key pair - private key in new-bar-certs/server-key.pem
-    Should Contain  ${output}  Generating self-signed client certificate/key pair - private key in new-bar-certs/server-key.pem
-    Should Contain  ${output}  Generated browser friendly PFX client certificate - certificate in
-
+    Should Contain  ${output}  Generating CA certificate/key pair - private key in new-bar-certs/ca-key.pem
+    Should Contain  ${output}  Generating server certificate/key pair - private key in new-bar-certs/server-key.pem
+    Should Contain  ${output}  Generating client certificate/key pair - private key in new-bar-certs/key.pem
+    Should Contain  ${output}  Generated browser friendly PFX client certificate - certificate in new-bar-certs/cert.pfx
     Should Contain  ${output}  Completed successfully
 
     ${output}=  Run  openssl s_client -showcerts -connect %{VCH-IP}:2378

--- a/tests/test-cases/Group6-VIC-Machine/6-17-Configure-TLS.robot
+++ b/tests/test-cases/Group6-VIC-Machine/6-17-Configure-TLS.robot
@@ -108,7 +108,7 @@ Configure VCH - Run Configure Without Cert Options & Ensure Certs Are Unchanged
 
     Run  rm -rf foo-bar-certs
     # Run vic-machine configure, supply server cert and key
-    ${output}=  Run  bin/vic-machine-linux configure --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --tls-server-key "bundle/*.%{DOMAIN}.key.pem" --tls-server-cert "bundle/*.%{DOMAIN}.cert.pem" ${vicmachinetls} --tls-cert-path=foo-bar-certs --debug 1
+    ${output}=  Run  bin/vic-machine-linux configure --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --tls-server-key "bundle/*.%{DOMAIN}.key.pem" --tls-server-cert "bundle/*.%{DOMAIN}.cert.pem" --tls-cert-path=foo-bar-certs --debug 1
     Log  ${output}
     Should Contain  ${output}  Loaded server certificate bundle
     Should Contain  ${output}  Unable to locate existing CA in cert path
@@ -126,7 +126,7 @@ Configure VCH - Run Configure Without Cert Options & Ensure Certs Are Unchanged
     Reload Default Certificate Authorities
 
     # Run vic-machine configure, supply server cert and key
-    ${output}=  Run  bin/vic-machine-linux configure --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} ${vicmachinetls} --debug 1
+    ${output}=  Run  bin/vic-machine-linux configure --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --debug 1
 
     Log  ${output}
     Should Contain  ${output}  No certificate regeneration requested. No new certificates provided. Certificates left unchanged

--- a/tests/test-cases/Group6-VIC-Machine/6-17-Configure-TLS.robot
+++ b/tests/test-cases/Group6-VIC-Machine/6-17-Configure-TLS.robot
@@ -160,11 +160,10 @@ Configure VCH - Replace certificates with self-signed certificate using --tls-cn
     ${domain}=  Get Environment Variable  DOMAIN  ''
     Run Keyword If  '${domain}' == ''  Pass Execution  Skipping test - domain not set, won't generate keys
 
-    Run  rm -rf foo-bar-certs
     ${output}=  Run  bin/vic-machine-linux configure --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} ${vicmachinetls} --tls-cert-path "new-bar-certs" --debug 1 --tls-cname="*.eng.vmware.com"
 
-    Should Contain  ${output}  Generating self-signed server certificate/key pair - private key in foo-bar-certs/server-key.pem
-    Should Contain  ${output}  Generating self-signed client certificate/key pair - private key in foo-bar-certs/server-key.pem
+    Should Contain  ${output}  Generating self-signed server certificate/key pair - private key in new-bar-certs/server-key.pem
+    Should Contain  ${output}  Generating self-signed client certificate/key pair - private key in new-bar-certs/server-key.pem
     Should Contain  ${output}  Generated browser friendly PFX client certificate - certificate in
 
     Should Contain  ${output}  Completed successfully

--- a/tests/test-cases/Group6-VIC-Machine/6-17-Configure-TLS.robot
+++ b/tests/test-cases/Group6-VIC-Machine/6-17-Configure-TLS.robot
@@ -155,3 +155,24 @@ Configure VCH - Replace certificates with self-signed certificate using --no-tls
     Should Contain  ${output}  Verify return code: 21 (unable to verify the first certificate)
     Should Contain  ${output}  verify error:num=20:unable to get local issuer certificate
     Should Not Contain  ${output}  issuer=/C=US/ST=California/L=Los Angeles/O=Stark Enterprises/OU=Stark Enterprises Certificate Authority/CN=Stark Enterprises Global CA
+
+Configure VCH - Replace certificates with self-signed certificate using --tls-cname
+    ${domain}=  Get Environment Variable  DOMAIN  ''
+    Run Keyword If  '${domain}' == ''  Pass Execution  Skipping test - domain not set, won't generate keys
+
+    Run  rm -rf foo-bar-certs
+    ${output}=  Run  bin/vic-machine-linux configure --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} ${vicmachinetls} --tls-cert-path "new-bar-certs" --debug 1 --tls-cname="*.eng.vmware.com"
+
+    Should Contain  ${output}  Generating self-signed server certificate/key pair - private key in foo-bar-certs/server-key.pem
+    Should Contain  ${output}  Generating self-signed client certificate/key pair - private key in foo-bar-certs/server-key.pem
+    Should Contain  ${output}  Generated browser friendly PFX client certificate - certificate in
+
+    Should Contain  ${output}  Completed successfully
+
+    ${output}=  Run  openssl s_client -showcerts -connect %{VCH-IP}:2378
+    Log  ${output}
+
+    Should Contain  ${output}  Verify return code: 21 (unable to verify the first certificate)
+    Should Contain  ${output}  verify error:num=20:unable to get local issuer certificate
+    Should Not Contain  ${output}  issuer=/C=US/ST=California/L=Los Angeles/O=Stark Enterprises/OU=Stark Enterprises Certificate Authority/CN=Stark Enterprises Global CA
+    Should Contain  ${output}  CN = *.eng.vmware.com


### PR DESCRIPTION
Very small change to fix an oversight in `vic-machine configure`
Manual test passed; automated test WIP.

`[specific ci=6-17-Configure-TLS]`
Resolves #7378