### PR TITLE
vic-machine create validation allows disabled DRS

### DIFF
--- a/lib/install/validate/config_to_data.go
+++ b/lib/install/validate/config_to_data.go
@@ -72,13 +72,19 @@ func SetDataFromVM(ctx context.Context, finder Finder, vm *vm.VirtualMachine, d 
 	if err != nil {
 		return err
 	}
-	rp, ok := or.(*object.ResourcePool)
-	if !ok {
-		return fmt.Errorf("parent resource %s is not resource pool", mrp.Parent)
-	}
-	d.ComputeResourcePath = rp.InventoryPath
 
-	// Set VCH resource limits and VCH endpoint VM resource limits
+	// we are attempting to present the resource pool inventory path
+	// in a DRS disabled environment that inventory path could point to a
+	// cluster, so we need to evaluate the type and set the path accordingly
+	switch r := or.(type) {
+	case *object.ResourcePool:
+		d.ComputeResourcePath = r.InventoryPath
+	case *object.ClusterComputeResource:
+		d.ComputeResourcePath = r.InventoryPath
+	default:
+		fmt.Errorf("parent resource %s is not resource pool", mrp.Parent)
+	}
+
 	setVCHResources(op, parent, d)
 	setApplianceResources(op, vm, d)
 	return nil

--- a/lib/install/validate/validator.go
+++ b/lib/install/validate/validator.go
@@ -306,7 +306,6 @@ func (v *Validator) Validate(ctx context.Context, input *data.Data) (*config.Vir
 	}
 
 	v.basics(op, input, conf)
-
 	v.target(op, input, conf)
 	v.credentials(op, input, conf)
 	v.compute(op, input, conf)
@@ -325,7 +324,7 @@ func (v *Validator) Validate(ctx context.Context, input *data.Data) (*config.Vir
 	v.CheckFirewall(op, conf)
 	v.CheckPersistNetworkBacking(op, false)
 	v.CheckLicense(op)
-	v.CheckDRS(op)
+	v.CheckDRS(op, input)
 
 	v.certificate(op, input, conf)
 	v.certificateAuthorities(op, input, conf)

--- a/lib/install/validate/validator_test_sim_util.go
+++ b/lib/install/validate/validator_test_sim_util.go
@@ -188,7 +188,7 @@ func (v *Validator) VcsimValidate(ctx context.Context, localInputConfig *data.Da
 	v.storage(op, localInputConfig, conf)
 	v.network(op, localInputConfig, conf)
 	v.CheckLicense(op)
-	v.CheckDRS(op)
+	v.CheckDRS(op, localInputConfig)
 
 	// fmt.Printf("Config: %# v\n", pretty.Formatter(conf))
 


### PR DESCRIPTION
License and feature check will allow install to cluster
with DRS disabled.  Additionally, the following items have
changed:
- Warn that resource pool specific flags ignored when
  DRS is disabled
- Removed specific check for evaluation license
- Set session variable with DRS status during VCH boot

Fixes #7275

