### PR TITLE
[skip ci] Double the default memory of our default testbed

### DIFF
--- a/tests/resources/nimbus-testbeds/vic-simple-cluster.rb
+++ b/tests/resources/nimbus-testbeds/vic-simple-cluster.rb
@@ -10,6 +10,7 @@ $testbed = Proc.new do
         "vc" => "vc.0",
         "style" => "fullInstall",
         "desiredPassword" => "e2eFunctionalTest",
+        "memory" => 8192, # 2x default
         "disks" => [ 30 * oneGB, 30 * oneGB, 30 * oneGB],
         "nics" => 2,
         "mountNfs" => ["nfs.0"],


### PR DESCRIPTION
fixes #7552 

once this is merged, we need to copy it to nimbus and redeploy our CI test beds with it