### PR TITLE
Add containerVM to VMgroup on creation [skip ci]

### DIFF
--- a/lib/portlayer/exec/commit.go
+++ b/lib/portlayer/exec/commit.go
@@ -56,27 +56,61 @@ func Commit(op trace.Operation, sess *session.Session, h *Handle, waitTime *int3
 
 		var res *types.TaskInfo
 		var err error
-		if sess.IsVC() && Config.VirtualApp.ResourcePool != nil {
-			// Create the vm
-			res, err = tasks.WaitForResult(op, func(op context.Context) (tasks.Task, error) {
-				return Config.VirtualApp.CreateChildVM(op, *h.Spec.Spec(), nil)
-			})
-		} else {
-			// Create the vm
-			res, err = tasks.WaitForResult(op, func(op context.Context) (tasks.Task, error) {
-				return sess.VMFolder.CreateVM(op, *h.Spec.Spec(), Config.ResourcePool, nil)
-			})
-		}
+
+		// Create the vm
+		res, err = tasks.WaitForResult(op, func(op context.Context) (tasks.Task, error) {
+			return sess.VMFolder.CreateVM(op, *h.Spec.Spec(), Config.ResourcePool, nil)
+		})
 
 		if err != nil {
 			op.Errorf("An error occurred while waiting for a creation operation to complete. Spec was %+v", *h.Spec.Spec())
 			return err
 		}
-
 		h.vm = vm.NewVirtualMachine(op, sess, res.Result.(types.ManagedObjectReference))
+
 		h.vm.DisableDestroy(op)
 		c = newContainer(&h.containerBase)
 		Containers.Put(c)
+
+		if sess.IsVC() {
+			affinity := func(ctx context.Context) (tasks.Task, error) {
+				op2 := trace.FromContext(ctx, "vm group membership")
+
+				containers := Containers.References()
+
+				group := &types.ClusterVmGroup{
+					ClusterGroupInfo: types.ClusterGroupInfo{
+						Name: Config.VMGroupName,
+					},
+					Vm: append(containers, Config.SelfReference),
+				}
+
+				spec := &types.ClusterConfigSpecEx{
+					GroupSpec: []types.ClusterGroupSpec{
+						types.ClusterGroupSpec{
+							ArrayUpdateSpec: types.ArrayUpdateSpec{
+								Operation: types.ArrayUpdateOperationEdit,
+							},
+							Info: group,
+						},
+					},
+				}
+
+				op.Debugf("Attempting to update vm group: %+v", group)
+				return Config.Cluster.Reconfigure(op2, spec, true)
+			}
+
+			// TODO: change tasks package so InvalidArgument does not trigger a retry - or allow for more specific filtering
+			// if it turns out that specifying a deleted VM triggers this. Basically we do not want to end in a loop if the group doesn't
+			// exist - it's not something that's going to fix itself.
+			res, err = tasks.WaitForResult(op, affinity)
+			if err != nil {
+				op.Errorf("Failed to add VM to VMgroup: %s", err)
+				return err
+			}
+			op.Debugf("VM to group result: %+v", res)
+		}
+
 		// inform of creation irrespective of remaining operations
 		publishContainerEvent(op, c.ExecConfig.ID, time.Now().UTC(), events.ContainerCreated)
 

--- a/lib/portlayer/exec/config.go
+++ b/lib/portlayer/exec/config.go
@@ -18,6 +18,7 @@ import (
 	"net/url"
 
 	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25/types"
 	"github.com/vmware/vic/lib/config"
 	"github.com/vmware/vic/lib/config/executor"
 	"github.com/vmware/vic/lib/portlayer/event"
@@ -37,6 +38,16 @@ type Configuration struct {
 
 	// Resource pool is the working version of the compute resource config
 	ResourcePool *object.ResourcePool
+
+	// Cluster is the working reference to the cluster the VCH is present in
+	Cluster *object.ComputeResource
+
+	// VMGroupName is the name of the group all cVMs belong to for this VCH
+	VMGroupName string
+
+	// SelfReference is a reference to the endpointVM, added for VM group membership
+	SelfReference types.ManagedObjectReference
+
 	// Parent resource will be a VirtualApp on VC
 	VirtualApp *object.VirtualApp
 

--- a/lib/portlayer/exec/container_cache.go
+++ b/lib/portlayer/exec/container_cache.go
@@ -19,6 +19,7 @@ import (
 
 	"context"
 
+	"github.com/vmware/govmomi/vim25/types"
 	"github.com/vmware/vic/pkg/uid"
 	"github.com/vmware/vic/pkg/vsphere/session"
 )
@@ -83,6 +84,26 @@ func (conCache *containerCache) Containers(states []State) []*Container {
 	}
 
 	return containers
+}
+
+// TODO: rework this and Containers above to remove duplication of iteration and filtering logic.
+func (conCache *containerCache) References() []types.ManagedObjectReference {
+	conCache.m.RLock()
+	defer conCache.m.RUnlock()
+	// cache contains 2 items for each container
+	capacity := len(conCache.cache) / 2
+	references := make([]types.ManagedObjectReference, 0, capacity)
+
+	for id, con := range conCache.cache {
+		// is the key a proper ID?
+		if !isContainerID(id) {
+			continue
+		}
+
+		references = append(references, con.VMReference())
+	}
+
+	return references
 }
 
 // puts a container in the cache and will overwrite an existing container

--- a/lib/portlayer/portlayer.go
+++ b/lib/portlayer/portlayer.go
@@ -80,7 +80,7 @@ func Init(ctx context.Context, sess *session.Session) error {
 		return err
 	}
 
-	if err := exec.Init(ctx, sess, source, sink); err != nil {
+	if err := exec.Init(ctx, sess, source, sink, vchvm.Reference()); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
This will create a group named as per the resource pool for the VCH if one
doesn't exist when the portlayer initializes. It will add the endpointVM to
that group and any existing container VMs. It adds new containerVMs as
they are created.

There is a race condition around simultaneously created cVMs given the
nature of the VMgroup modification. The current races are:
1. between two create operations on the same VCH and an order inversion of container being added to the exec layer container cache and the VM group being updated. With current implementation this will be corrected on the next container create of restart of the endpointVM.
2. out-of-band creation/re-registration - this isn't a supported operation at this time so not a concern for product correctness. This is an issue if we look towards any multi-master style setup in the future.

This has not been tested against ESX.

Configuring to skip ci as there's no VM group cleanup logic so do not
want to pollute CI environment with large numbers of VMgroups

Fixes #7557 
