### PR TITLE
vic-machine return error when parent resource pool not found

### DIFF
--- a/lib/install/validate/config_to_data.go
+++ b/lib/install/validate/config_to_data.go
@@ -82,7 +82,7 @@ func SetDataFromVM(ctx context.Context, finder Finder, vm *vm.VirtualMachine, d 
 	case *object.ClusterComputeResource:
 		d.ComputeResourcePath = r.InventoryPath
 	default:
-		fmt.Errorf("parent resource %s is not resource pool", mrp.Parent)
+		return fmt.Errorf("parent resource %s is not resource pool", mrp.Parent)
 	}
 
 	setVCHResources(op, parent, d)


### PR DESCRIPTION
Correcting a missed error return when validating configuration
data within vic-machine.

Thanks @vburenin !
