### PR TITLE
vic-machine upgrade ignores version check with force flag

### DIFF
--- a/cmd/vic-machine/upgrade/upgrade.go
+++ b/cmd/vic-machine/upgrade/upgrade.go
@@ -47,8 +47,11 @@ func NewUpgrade() *Upgrade {
 func (u *Upgrade) Flags() []cli.Flag {
 	util := []cli.Flag{
 		cli.BoolFlag{
-			Name:        "force, f",
-			Usage:       "Force the upgrade (ignores version checks)",
+			Name: "force, f",
+			// TODO: having a single force to facilitate multiple things has been problematic
+			// updated description clarifies the intent, but still open to issue
+			// https://github.com/vmware/vic/issues/3118
+			Usage:       "Force the upgrade (ignores version check & thumbprint)",
 			Destination: &u.Force,
 		},
 		cli.DurationFlag{
@@ -197,7 +200,7 @@ func (u *Upgrade) Run(clic *cli.Context) (err error) {
 	vConfig.Timeout = u.Timeout
 
 	// only care about versions if we're not doing a manual rollback
-	if !u.Data.Rollback {
+	if !u.Data.Rollback && !u.Data.Force {
 		if err := validator.AssertVersion(op, vchConfig); err != nil {
 			op.Error(err)
 			return errors.New("upgrade failed")

--- a/tests/test-cases/Group6-VIC-Machine/6-11-Debug.robot
+++ b/tests/test-cases/Group6-VIC-Machine/6-11-Debug.robot
@@ -48,7 +48,7 @@ Check Password Change When Expired
     ${rc}=  Run And Return Rc  bin/vic-machine-linux debug --target %{TEST_URL} --thumbprint=%{TEST_THUMBPRINT} --user %{TEST_USERNAME} --password=%{TEST_PASSWORD} --compute-resource=%{TEST_RESOURCE} --name %{VCH-NAME} --enable-ssh --authorized-key=%{VCH-NAME}.key.pub
     Should Be Equal As Integers  ${rc}  0
 
-    # push the date forward, past the suport duration
+    # push the date forward, past the support duration
     ${rc}  ${output}=  Run And Return Rc And Output  ssh -o StrictHostKeyChecking=no -i %{VCH-NAME}.key root@%{VCH-IP} 'date -s " +6 year"'
     Should Be Equal As Integers  ${rc}  0
 


### PR DESCRIPTION
vic-machine upgrade will ignore the version check when the
force flag is supplied.

[specific ci=Group11-Upgrade]

Fixes #6344
