### PR TITLE
vic-machine will not include VCH memory with snapshot

### DIFF
--- a/tests/test-cases/Group11-Upgrade/11-01-Upgrade.robot
+++ b/tests/test-cases/Group11-Upgrade/11-01-Upgrade.robot
@@ -195,9 +195,11 @@ Upgrade VCH with unreasonably short timeout and automatic rollback after failure
     ${rc}  ${output}=  Run And Return Rc And Output  bin/vic-machine-linux upgrade --debug 1 --name=%{VCH-NAME} --target=%{TEST_URL}%{TEST_DATACENTER} --user=%{TEST_USERNAME} --password=%{TEST_PASSWORD} --force=true --compute-resource=%{TEST_RESOURCE} --timeout 1s
     Should Contain  ${output}  Upgrading VCH exceeded time limit
     Should Not Contain  ${output}  Completed successfully
+    # we should have no snapshots
     ${rc}  ${output}=  Run And Return Rc And Output  govc snapshot.tree -vm=%{VCH-NAME}
-    Should Not Contain  ${output}  upgrade
-
+    Should Be Empty  ${output}
+    # the appliance is restarting - attempt to wait until it's ready
+    Sleep  90
     # confirm that the rollback took effect
     Check Original Version
 


### PR DESCRIPTION
vic-machine takes a snapshot of the current appliance when facilitating
a configure or upgrade.  It does not need to snap the current appliance
memory.  This change will increase the performance of configure and
upgrade.

[specific ci=Group11-Upgrade --suite 6-16-Config]

Fixes: #6264, Fixes #7083 