### PR TITLE
Do not retrieve port for containers not found in cache.

### DIFF
--- a/lib/apiservers/engine/backends/container.go
+++ b/lib/apiservers/engine/backends/container.go
@@ -1402,7 +1402,11 @@ payloadLoop:
 				ips = []string{""}
 			}
 			c := cache.ContainerCache().GetContainer(t.ContainerConfig.ContainerID)
-			ports = append(ports, network.PortForwardingInformation(c, ips)...)
+			if c != nil {
+				ports = append(ports, network.PortForwardingInformation(c, ips)...)
+			} else {
+				log.Warningf("Container is not found in cache: %s", t.ContainerConfig.ContainerID)
+			}
 		}
 
 		// verify that the repo:tag exists for the container -- if it doesn't then we should present the

--- a/lib/apiservers/engine/backends/container_test.go
+++ b/lib/apiservers/engine/backends/container_test.go
@@ -787,7 +787,11 @@ func TestPortInformation(t *testing.T) {
 	cache.ContainerCache().AddContainer(co)
 
 	// unless there are entries in vicnetwork.ContainerByPort we won't report them as bound
-	ports := network.PortForwardingInformation(co, ips)
+	ports := network.PortForwardingInformation(nil, ips)
+	assert.Empty(t, ports, "No ports should be returned for nil container")
+
+	// unless there are entries in vicnetwork.ContainerByPort we won't report them as bound
+	ports = network.PortForwardingInformation(co, ips)
 	assert.Empty(t, ports, "There should be no bound IPs at this point for forwarding")
 
 	// the current port binding should show up as a direct port

--- a/lib/apiservers/engine/network/utils.go
+++ b/lib/apiservers/engine/network/utils.go
@@ -564,7 +564,7 @@ func PortForwardingInformation(vc *viccontainer.VicContainer, ips []string) []ty
 	//c := cache.ContainerCache().GetContainer(cid)
 
 	if vc == nil {
-		log.Errorf("Could not find container with ID %s", vc.ContainerID)
+		log.Errorf("No container provided")
 		return nil
 	}
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[  ] There is an associated issue that is labelled
[  ] Code is up-to-date with the `master` branch
[  ] You've successfully run `make test` locally
[  ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/vmware/vic/blob/master/.github/CONTRIBUTING.md
-->

Fixes #7576 

<!--
To trigger a custom build with this PR, include one of these in the PR's body:
- To skip running tests (e.g. for a work-in-progress PR), add `[ci skip]` or `[skip ci]`
to the commit message or the PR title.
- To run the full test suite, use `[full ci]`.
- To run _one_ integration test or group, use `[specific ci=$test]`. Examples:
  - To run the `1-01-Docker-Info` suite: `[specific ci=1-01-Docker-Info]`
  - To run all suites under the `Group1-Docker-Commands` group: `[specific ci=Group1-Docker-Commands]`
- To skip running the unit tests, use `[skip unit]`.
- To fail fast (make normal failures fatal) during the integration testing, use `[fast fail]`.
-->
