### PR TITLE
Define initial test cases for host affinity

### DIFF
--- a/tests/test-cases/Group24-Host-Affinity/24-01-Basic.md
+++ b/tests/test-cases/Group24-Host-Affinity/24-01-Basic.md
@@ -1,0 +1,40 @@
+Suite 24-01 - Basic
+===================
+
+# Purpose:
+To verify basic VM-Host Affinity functionality
+
+# References:
+1. [The design document](../../../doc/design/host-affinity.md)
+
+# Environment:
+This test requires a vCenter Server environment where VCHs can be deployed and container VMs created.
+
+
+Positive Testing
+----------------
+
+### 1. Creating a VCH creates a VM group and container VMs get added to it
+
+#### Test Steps:
+1. Verify that no DRS VM Group exists by the expected name.
+2. Create a VCH.
+3. Verify that a DRS VM Group was created and that the endpoint VM was added to it.
+4. Create a variety of containers.
+5. Verify that the container VMs were added to the DRS VM Group.
+
+#### Expected Outcome:
+* The DRS VM Group is created and the VCH endpoint VM and all container VMs are added to it.
+
+
+### 2. Deleting a VCH deletes its VM group
+
+#### Test Steps:
+1. Verify that no DRS VM Group exists by the expected name.
+2. Create a VCH.
+3. Verify that a DRS VM Group was created and that the endpoint VM was added to it.
+4. Delete the VCH.
+5. Verify that the DRS VM Group no longer exists.
+
+#### Expected Outcome:
+* The DRS VM Group is deleted when the VCH is deleted.

--- a/tests/test-cases/Group24-Host-Affinity/24-01-Basic.md
+++ b/tests/test-cases/Group24-Host-Affinity/24-01-Basic.md
@@ -8,7 +8,10 @@ To verify basic VM-Host Affinity functionality
 1. [The design document](../../../doc/design/host-affinity.md)
 
 # Environment:
-This test requires a vCenter Server environment where VCHs can be deployed and container VMs created.
+This suite requires a vCenter Server environment where VCHs can be deployed and container VMs created.
+
+Note that because these basic tests do not test the behavior of DRS in the presence of rules, but just the management of
+VM groups, these tests do not require an environment where DRS is enabled.
 
 
 Positive Testing
@@ -38,3 +41,17 @@ Positive Testing
 
 #### Expected Outcome:
 * The DRS VM Group is deleted when the VCH is deleted.
+
+
+### 3. Removing containers cleans up the VM group
+
+#### Test Steps:
+1. Verify that no DRS VM Group exists by the expected name.
+2. Create a VCH.
+3. Create a variety of containers.
+4. Verify that a DRS VM Group was created and that the endpoint VM and containers were added to it.
+5. Delete the containers.
+6. Verify that the DRS VM Group still exists, but does not include the removed containers.
+
+#### Expected Outcome:
+* Containers are removed from the DRS VM Group when they are deleted.

--- a/tests/test-cases/Group24-Host-Affinity/24-01-Basic.robot
+++ b/tests/test-cases/Group24-Host-Affinity/24-01-Basic.robot
@@ -1,0 +1,87 @@
+# Copyright 2018 VMware, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#	http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License
+
+*** Settings ***
+Documentation     Suite 24-01 - Basic
+Resource          ../../resources/Util.robot
+Test Teardown     Cleanup
+Default Tags
+
+
+*** Keywords ***
+Cleanup
+    Remove Group     %{VCH-NAME}
+
+    Cleanup VIC Appliance On Test Server
+
+Remove Group
+    [Arguments]    ${name}
+
+    ${rc}  ${out}=    Run And Return Rc And Output     govc cluster.group.remove -name ${name} --json 2>&1
+    Should Be Equal As Integers    ${rc}    0
+
+
+Verify Group Not Found
+    [Arguments]    ${name}
+
+    ${out}=    Run     govc cluster.group.ls -name ${name} --json 2>&1
+    Should Be Equal As Strings    ${out}    govc: group "${name}" not found
+
+Verify Group Contains VMs
+    [Arguments]    ${name}    ${count}
+
+    ${out}=    Run    govc cluster.group.ls -name ${name} --json | jq 'length'
+    Should Be Equal As Integers    ${out}    ${count}
+
+
+Create Three Containers
+    ${POWERED_OFF_CONTAINER_NAME}=  Generate Random String  15
+    ${rc}  ${out}=    Run And Return Rc And Output    docker %{VCH-PARAMS} create --name ${POWERED_OFF_CONTAINER_NAME} ${busybox} /bin/top
+
+    ${POWERED_ON_CONTAINER_NAME}=  Generate Random String  15
+    ${rc}  ${out}=    Run And Return Rc And Output    docker %{VCH-PARAMS} create --name ${POWERED_ON_CONTAINER_NAME} ${busybox} /bin/top
+    ${rc}  ${out}=    Run And Return Rc And Output    docker %{VCH-PARAMS} start ${out}
+
+    ${RUN_CONTAINER_NAME}=  Generate Random String  15
+    ${rc}  ${out}=    Run And Return Rc And Output    docker %{VCH-PARAMS} run --name ${RUN_CONTAINER_NAME} ${busybox} /bin/top
+
+
+
+*** Test Cases ***
+Creating a VCH creates a VM group and container VMs get added to it
+    Set Test Environment Variables
+
+    Verify Group Not Found       %{VCH-NAME}
+
+    Install VIC Appliance To Test Server With Current Environment Variables
+
+    Verify Group Contains VMs    %{VCH-NAME}    1
+
+    Create Three Containers
+
+    Verify Group Contains VMs    %{VCH-NAME}    4
+
+
+Deleting a VCH deletes its VM group
+    Set Test Environment Variables
+
+    Verify Group Not Found         %{VCH-NAME}
+
+    Install VIC Appliance To Test Server With Current Environment Variables
+
+    Verify Group Contains VMs    %{VCH-NAME}    1
+
+    Cleanup VIC Appliance On Test Server
+
+    Verify Group Not Found         %{VCH-NAME}

--- a/tests/test-cases/Group24-Host-Affinity/24-01-Basic.robot
+++ b/tests/test-cases/Group24-Host-Affinity/24-01-Basic.robot
@@ -46,16 +46,26 @@ Verify Group Contains VMs
 
 
 Create Three Containers
-    ${POWERED_OFF_CONTAINER_NAME}=  Generate Random String  15
+    ${POWERED_OFF_CONTAINER_NAME}=    Generate Random String  15
     ${rc}  ${out}=    Run And Return Rc And Output    docker %{VCH-PARAMS} create --name ${POWERED_OFF_CONTAINER_NAME} ${busybox} /bin/top
 
-    ${POWERED_ON_CONTAINER_NAME}=  Generate Random String  15
+    Set Test Variable    ${POWERED_OFF_CONTAINER_NAME}
+
+    ${POWERED_ON_CONTAINER_NAME}=    Generate Random String  15
     ${rc}  ${out}=    Run And Return Rc And Output    docker %{VCH-PARAMS} create --name ${POWERED_ON_CONTAINER_NAME} ${busybox} /bin/top
     ${rc}  ${out}=    Run And Return Rc And Output    docker %{VCH-PARAMS} start ${out}
 
-    ${RUN_CONTAINER_NAME}=  Generate Random String  15
+    Set Test Variable    ${POWERED_ON_CONTAINER_NAME}
+
+    ${RUN_CONTAINER_NAME}=    Generate Random String  15
     ${rc}  ${out}=    Run And Return Rc And Output    docker %{VCH-PARAMS} run --name ${RUN_CONTAINER_NAME} ${busybox} /bin/top
 
+    Set Test Variable    ${RUN_CONTAINER_NAME}
+
+Delete Containers
+    ${rc}  ${out}=    Run And Return Rc And Output    docker %{VCH-PARAMS} rm --name ${POWERED_OFF_CONTAINER_NAME} ${busybox} /bin/top
+    ${rc}  ${out}=    Run And Return Rc And Output    docker %{VCH-PARAMS} rm --name ${POWERED_ON_CONTAINER_NAME} ${busybox} /bin/top
+    ${rc}  ${out}=    Run And Return Rc And Output    docker %{VCH-PARAMS} rm --name ${RUN_CONTAINER_NAME} ${busybox} /bin/top
 
 
 *** Test Cases ***
@@ -85,3 +95,19 @@ Deleting a VCH deletes its VM group
     Cleanup VIC Appliance On Test Server
 
     Verify Group Not Found         %{VCH-NAME}
+
+
+Deleting a container cleans up its VM group
+    Set Test Environment Variables
+
+    Verify Group Not Found       %{VCH-NAME}
+
+    Install VIC Appliance To Test Server With Current Environment Variables
+
+    Create Three Containers
+
+    Verify Group Contains VMs    %{VCH-NAME}    4
+
+    Delete Containers
+
+    Verify Group Contains VMs    %{VCH-NAME}    1

--- a/tests/test-cases/Group24-Host-Affinity/TestCases.md
+++ b/tests/test-cases/Group24-Host-Affinity/TestCases.md
@@ -1,0 +1,4 @@
+Group 24 - Host Affinity
+========================
+
+[Suite 24-01 - Basic Testing](24-01-Basic.md)

--- a/tests/test-cases/TestGroups.md
+++ b/tests/test-cases/TestGroups.md
@@ -26,3 +26,5 @@ VIC Integration Test Suite
 -
 [Group 23 - VIC Machine Service](Group23-VIC-Machine-Service/TestCases.md)
 -
+[Group 24 - Host Affinity](Group24-Host-Affinity/TestCases.md)
+-


### PR DESCRIPTION
This change introduces two basic test cases for host affinity: one to verify that the DRS VM Group is created and that both the endpoint VM and all container VMs are added to it (regardless of power state) and a second to verify that the DRS VM Group is deleted when the VCH is.

The cleanup step will explicitly remove a leftover DRS VM Group, which is important because we have not implemented deletion and do not wish to leave empty orphaned groups in CI. (Note: running other test groups on this branch against a shared system is still unwise, as those tests do not include the logic to clean up DRS VM Groups!)

These test cases will need to evolve with the implementation; when use of Host-Affinity becomes configurable, that configuration option will need to be added to the creation operations in these tests.

This PR is expected to fail CI; it's adding tests for incomplete functionality.

[specific ci=Group24-Host-Affinity]