### PR TITLE
Grant ops-user minimum privileges on entities

### DIFF
--- a/cmd/vic-machine/common/ops_credentials.go
+++ b/cmd/vic-machine/common/ops_credentials.go
@@ -1,4 +1,4 @@
-// Copyright 2017 VMware, Inc. All Rights Reserved.
+// Copyright 2017-2018 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -51,7 +51,7 @@ func (o *OpsCredentials) Flags(hidden bool) []cli.Flag {
 		cli.GenericFlag{
 			Name:   "ops-grant-perms",
 			Value:  flags.NewOptionalBool(&o.GrantPerms),
-			Usage:  "Create roles and grant required permissions to the specified ops-use",
+			Usage:  "Create roles and grant required permissions to the specified ops-user",
 			Hidden: hidden,
 		},
 	}

--- a/lib/install/management/configure.go
+++ b/lib/install/management/configure.go
@@ -1,4 +1,4 @@
-// Copyright 2017 VMware, Inc. All Rights Reserved.
+// Copyright 2017-2018 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -113,7 +113,7 @@ func (d *Dispatcher) Configure(vch *vm.VirtualMachine, conf *config.VirtualConta
 
 	// If successful try to grant permissions to the ops-user
 	if err == nil && conf.ShouldGrantPerms() {
-		err = opsuser.GrantOpsUserPerms(d.op, d.session.Vim25(), conf)
+		err = opsuser.GrantOpsUserPerms(d.op, d.session, conf)
 		if err != nil {
 			// Update error message and fall through to roll back
 			err = errors.Errorf("Failed to grant permissions to ops-user, failure: %s", err)

--- a/lib/install/management/create.go
+++ b/lib/install/management/create.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2017 VMware, Inc. All Rights Reserved.
+// Copyright 2016-2018 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -85,7 +85,7 @@ func (d *Dispatcher) CreateVCH(conf *config.VirtualContainerHostConfigSpec, sett
 	}
 
 	if conf.ShouldGrantPerms() {
-		err = opsuser.GrantOpsUserPerms(d.op, d.session.Vim25(), conf)
+		err = opsuser.GrantOpsUserPerms(d.op, d.session, conf)
 		if err != nil {
 			return errors.Errorf("Cannot init ops-user permissions, failure: %s. Exiting...", err)
 		}
@@ -224,7 +224,7 @@ func (d *Dispatcher) cleanupAfterCreationFailed(conf *config.VirtualContainerHos
 	// cleanup the vch inventory folder if it is empty. Can happen in some cases where the create is cancelled after successful creation.
 
 	if d.isVC {
-		folderRef, err := VchFolder(d.op, d.session, conf)
+		folderRef, err := vchFolder(d.op, d.session, conf)
 		if folderRef != nil {
 			children, err := folderRef.Children(d.op)
 			if err != nil {

--- a/lib/install/management/delete.go
+++ b/lib/install/management/delete.go
@@ -238,7 +238,7 @@ func (d *Dispatcher) DeleteVCHInstances(vmm *vm.VirtualMachine, conf *config.Vir
 	var err error
 	var children []*vm.VirtualMachine
 
-	folderRef, err := VchFolder(d.op, d.session, conf)
+	folderRef, err := vchFolder(d.op, d.session, conf)
 
 	if err != nil || folderRef == nil {
 
@@ -393,7 +393,7 @@ func (d *Dispatcher) deleteFolder(conf *config.VirtualContainerHostConfigSpec) {
 	}
 
 	d.op.Info("Removing VCH Inventory Folder")
-	folderRef, err := VchFolder(d.op, d.session, conf)
+	folderRef, err := vchFolder(d.op, d.session, conf)
 	if err != nil {
 		folderPath := fmt.Sprintf("%s/%s", d.session.VMFolder.InventoryPath, conf.Name)
 		d.op.Debugf("failed to find VCH folder(%s): %s", folderPath, err)

--- a/lib/install/opsuser/opsuser_conf.go
+++ b/lib/install/opsuser/opsuser_conf.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2017 VMware, Inc. All Rights Reserved.
+// Copyright 2016-2018 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -39,11 +39,6 @@ var RoleDataCenter = types.AuthorizationRole{
 	Privilege: []string{
 		"Datastore.Config",
 		"Datastore.FileManagement",
-		"VirtualMachine.Config.AddNewDisk",
-		"VirtualMachine.Config.AdvancedConfig",
-		"VirtualMachine.Config.RemoveDisk",
-		"VirtualMachine.Inventory.Create",
-		"VirtualMachine.Inventory.Delete",
 	},
 }
 

--- a/lib/install/opsuser/opsuser_test.go
+++ b/lib/install/opsuser/opsuser_test.go
@@ -128,7 +128,8 @@ func TestOpsUserPermsSimulatorVPX(t *testing.T) {
 		},
 	}
 
-	mgr := NewRBACManager(ctx, sess.Vim25(), nil, &OpsuserRBACConf, configSpec)
+	mgr, err := NewRBACManager(ctx, sess, &OpsuserRBACConf, configSpec)
+	require.NoError(t, err)
 	am := mgr.AuthzManager
 
 	var roleCount = len(am.TargetRoles)

--- a/lib/install/validate/validator_test.go
+++ b/lib/install/validate/validator_test.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2017 VMware, Inc. All Rights Reserved.
+// Copyright 2016-2018 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -23,12 +23,10 @@ import (
 	"os"
 	"strings"
 	"testing"
-	"time"
 
 	log "github.com/Sirupsen/logrus"
-	"github.com/stretchr/testify/require"
-
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/vmware/govmomi/find"
 	"github.com/vmware/govmomi/simulator"
@@ -43,6 +41,7 @@ import (
 	"github.com/vmware/vic/pkg/trace"
 	"github.com/vmware/vic/pkg/vsphere/rbac"
 	"github.com/vmware/vic/pkg/vsphere/session"
+	"github.com/vmware/vic/pkg/vsphere/test"
 )
 
 func init() {
@@ -957,7 +956,8 @@ func TestDCReadOnlyPermsFromConfigSimulatorVPX(t *testing.T) {
 	require.NotNil(t, configSpec)
 
 	// Set up the Authz Manager
-	mgr := opsuser.NewRBACManager(ctx, v.Session.Vim25(), v.Session, &opsuser.DCReadOnlyConf, configSpec)
+	mgr, err := opsuser.NewRBACManager(ctx, v.Session, &opsuser.DCReadOnlyConf, configSpec)
+	require.NoError(t, err)
 
 	resourcePermission, err := mgr.SetupDCReadOnlyPermissions(ctx)
 	require.NoError(t, err)
@@ -988,12 +988,7 @@ func TestOpsUserPermsFromConfigSimulatorVPX(t *testing.T) {
 
 	fmt.Println(s.URL.String())
 
-	config := &session.Config{
-		Service:   s.URL.String(),
-		Insecure:  true,
-		Keepalive: time.Duration(5) * time.Minute,
-	}
-	sess, err := session.NewSession(config).Connect(ctx)
+	sess, err := test.SessionWithVPX(ctx, s.URL.String())
 	require.NoError(t, err)
 
 	input := GetVcsimInputConfig(ctx, s.URL)
@@ -1005,8 +1000,14 @@ func TestOpsUserPermsFromConfigSimulatorVPX(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, configSpec)
 
+	// Create the folder the VCH is supposed to be in, for testing that the endpoint
+	// role is applied to the folder.
+	_, err = sess.VMFolder.CreateFolder(ctx, configSpec.Name)
+	require.NoError(t, err)
+
 	// Set up the Authz Manager
-	mgr := opsuser.NewRBACManager(ctx, sess.Vim25(), nil, &opsuser.OpsuserRBACConf, configSpec)
+	mgr, err := opsuser.NewRBACManager(ctx, sess, &opsuser.OpsuserRBACConf, configSpec)
+	require.NoError(t, err)
 
 	resourcePermissions, err := mgr.SetupRolesAndPermissions(ctx)
 	require.NoError(t, err)

--- a/lib/install/validate/validator_test_sim_util.go
+++ b/lib/install/validate/validator_test_sim_util.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2017 VMware, Inc. All Rights Reserved.
+// Copyright 2016-2018 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -189,8 +189,6 @@ func (v *Validator) VcsimValidate(ctx context.Context, localInputConfig *data.Da
 	v.network(op, localInputConfig, conf)
 	v.CheckLicense(op)
 	v.CheckDRS(op, localInputConfig)
-
-	// fmt.Printf("Config: %# v\n", pretty.Formatter(conf))
 
 	// Perform the higher level compatibility and consistency checks
 	v.compatibility(op, conf)

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-25-OPS-User-Grant.md
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-25-OPS-User-Grant.md
@@ -10,12 +10,14 @@ This test requires access to VMware Nimbus cluster for dynamic ESXi and vCenter 
 # Test Steps:
 1. Deploy a new vCenter with a simple cluster
 2. Create Local OPS User on VC
-3. Give the Local OPS User ReadOnly Role on /
 3. Install the VIC appliance into the cluster with the --ops-grant-perms option
-4. Run a variety of docker operation on the VCH
+4. With the ops-user, use govc to attempt to change the DRS settings on the cluster
+5. Run a variety of docker operations on the VCH
 
 # Expected Outcome:
-All test steps should complete without error
+* Steps 1-3 should succeed
+* Step 4 should fail since the ops-user does not have enough permissions for the operation
+* Step 5 should succeed
 
 # Possible Problems:
 None

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-25-OPS-User-Grant.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-25-OPS-User-Grant.robot
@@ -1,4 +1,4 @@
-# Copyright 2016-2017 VMware, Inc. All Rights Reserved.
+# Copyright 2016-2018 VMware, Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -20,7 +20,6 @@ Suite Teardown  Run Keyword And Ignore Error  Nimbus Cleanup  ${list}
 Test Teardown  Run Keyword If Test Failed  Gather VC Logs
 
 *** Keywords ***
-
 Gather VC Logs
     Log To Console  Collecting VC logs ..
     Run Keyword And Ignore Error  Gather Logs From ESX Server
@@ -58,8 +57,7 @@ Ops User Create
     Log  Output, govc role.usage: ${out}
 
 *** Test Cases ***
-Test
-    Log To Console  \nStarting test...
+vic-machine create grants ops-user perms
     Install VIC Appliance To Test Server  additional-args=--ops-user ${ops_user_name} --ops-password ${ops_user_password} --ops-grant-perms
 
     # Run a govc test to check that access is denied on some resources
@@ -69,7 +67,19 @@ Test
     Should Be Equal As Integers  ${rc}  1
     Should Contain  ${output}  Permission to perform this operation was denied
 
-
     Run Regression Tests
+
+    # Run containers with volumes and container networks to test scenarios requiring containerVMs
+    # to have the highest privileges.
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} pull ${busybox}
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${c1}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -d --net public ${busybox}
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${c2}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -d -v fooVol:/dir ${busybox}
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${c3}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -d --net public -v barVol:/dir ${busybox}
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} rm -f ${c1} ${c2} ${c3}
+    Should Be Equal As Integers  ${rc}  0
 
     Cleanup VIC Appliance On Test Server


### PR DESCRIPTION
This commit includes several changes to restrict the permissions
granted to the vSphere operations user when the ops-grant-perms
option is used in vic-machine create.

Changes include:

  * The Endpoint role is also applied to the VCH inventory folder
    (only on vCenter). This allows us to reduce the privileges in
    the Datacenter role that is applied to the datacenter object.

  * Previously while granting the ops-user read-only access to the
    datacenter, we only checked if the ops-user was an Admin or in
    the Administrators group and didn't grant read-only access if so.
    This commit also adds a check to see if the ops-user already has
    enough permissions on the datacenter to satisfy the read-only role.

Fixes #7053