### PR TITLE
Remove superfluous type declaration [skip ci]

### DIFF
--- a/lib/portlayer/exec/commit.go
+++ b/lib/portlayer/exec/commit.go
@@ -87,7 +87,7 @@ func Commit(op trace.Operation, sess *session.Session, h *Handle, waitTime *int3
 
 				spec := &types.ClusterConfigSpecEx{
 					GroupSpec: []types.ClusterGroupSpec{
-						types.ClusterGroupSpec{
+						{
 							ArrayUpdateSpec: types.ArrayUpdateSpec{
 								Operation: types.ArrayUpdateOperationEdit,
 							},

--- a/lib/portlayer/exec/exec.go
+++ b/lib/portlayer/exec/exec.go
@@ -184,7 +184,7 @@ func Init(ctx context.Context, sess *session.Session, source extraconfig.DataSou
 		log.Info("Updating VM group membership for existing VCH members")
 		spec := &types.ClusterConfigSpecEx{
 			GroupSpec: []types.ClusterGroupSpec{
-				types.ClusterGroupSpec{
+				{
 					ArrayUpdateSpec: types.ArrayUpdateSpec{
 						Operation: vmGroupOpType,
 					},

--- a/lib/portlayer/exec/exec.go
+++ b/lib/portlayer/exec/exec.go
@@ -101,7 +101,7 @@ func Init(ctx context.Context, sess *session.Session, source extraconfig.DataSou
 			return
 		}
 
-		// TODO: see if we can find a different way of supplying this element. While in product it's a legitmate assumption
+		// TODO: see if we can find a different way of supplying this element. While in product it's a legitimate assumption
 		// for this code to run in a VM that's locatable in the infrastructure it may make testing more awkward.
 		// Alternatively, if committing to only testing via vcsim then we need a vcsim mechanism for "guest.GetSelf" so that
 		// we can pretend that the code runs in a VM in the simulated infra.


### PR DESCRIPTION
Make gofmt happy by removing a superfluous type declaration for a struct instance within a slice.

This has caused CI failures in #7586 and #7585.

Skipping CI for this change because it does not include the changes from #7586, but this has been tested by running `make check` locally.