### PR TITLE
Configure VM Group usage via vic-machine

### DIFF
--- a/cmd/vic-machine/common/compute.go
+++ b/cmd/vic-machine/common/compute.go
@@ -19,6 +19,7 @@ import "gopkg.in/urfave/cli.v1"
 type Compute struct {
 	ComputeResourcePath string `cmd:"compute-resource"`
 	DisplayName         string `cmd:"name"`
+	UseVMGroup          bool   `cmd:"affinity-vm-group"`
 }
 
 func (c *Compute) ComputeFlags() []cli.Flag {
@@ -41,6 +42,12 @@ func (c *Compute) ComputeFlagsNoName() []cli.Flag {
 			Value:       "",
 			Usage:       "Compute resource path, e.g. myCluster",
 			Destination: &c.ComputeResourcePath,
+		},
+		cli.BoolFlag{
+			Name:        "affinity-vm-group",
+			Usage:       "Use a DRS VM Group to allow VM-Host affinity rules to be defined for the VCH",
+			Destination: &c.UseVMGroup,
+			Hidden:      true,
 		},
 	}
 }

--- a/cmd/vic-machine/common/compute.go
+++ b/cmd/vic-machine/common/compute.go
@@ -1,4 +1,4 @@
-// Copyright 2016 VMware, Inc. All Rights Reserved.
+// Copyright 2016-2018 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cmd/vic-machine/create/create_test.go
+++ b/cmd/vic-machine/create/create_test.go
@@ -72,7 +72,7 @@ func TestParseGatewaySpec(t *testing.T) {
 func TestFlags(t *testing.T) {
 	c := NewCreate()
 	flags := c.Flags()
-	numberOfFlags := 60
+	numberOfFlags := 61
 	assert.Equal(t, numberOfFlags, len(flags), "Missing flags during Create.")
 }
 

--- a/lib/apiservers/service/restapi/handlers/vch_create.go
+++ b/lib/apiservers/service/restapi/handlers/vch_create.go
@@ -1,4 +1,4 @@
-// Copyright 2017 VMware, Inc. All Rights Reserved.
+// Copyright 2017-2018 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/apiservers/service/restapi/handlers/vch_create.go
+++ b/lib/apiservers/service/restapi/handlers/vch_create.go
@@ -186,6 +186,10 @@ func buildCreate(op trace.Operation, d *data.Data, finder finder, vch *models.VC
 				return nil, util.NewError(http.StatusBadRequest, "Resource pool must be specified (by name or id)")
 			}
 			c.ComputeResourcePath = resourcePath
+
+			if vch.Compute.Affinity != nil {
+				c.UseVMGroup = vch.Compute.Affinity.UseVMGroup
+			}
 		}
 
 		if vch.Network != nil {

--- a/lib/apiservers/service/restapi/handlers/vch_get.go
+++ b/lib/apiservers/service/restapi/handlers/vch_get.go
@@ -1,4 +1,4 @@
-// Copyright 2017 VMware, Inc. All Rights Reserved.
+// Copyright 2017-2018 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/apiservers/service/restapi/handlers/vch_get.go
+++ b/lib/apiservers/service/restapi/handlers/vch_get.go
@@ -127,6 +127,9 @@ func vchToModel(op trace.Operation, vch *vm.VirtualMachine, d *data.Data, execut
 
 	// compute
 	model.Compute = &models.VCHCompute{
+		Affinity: &models.VCHComputeAffinity{
+			UseVMGroup: vchConfig.UseVMGroup,
+		},
 		CPU: &models.VCHComputeCPU{
 			Limit:       asMHz(d.ResourceLimits.VCHCPULimitsMHz),
 			Reservation: asMHz(d.ResourceLimits.VCHCPUReservationsMHz),

--- a/lib/apiservers/service/swagger.json
+++ b/lib/apiservers/service/swagger.json
@@ -661,7 +661,15 @@
                 "shares": { "$ref": "#/definitions/Shares" }
               }
             },
-            "resource": { "$ref": "#/definitions/Managed_Object" }
+            "resource": { "$ref": "#/definitions/Managed_Object" },
+            "affinity": {
+              "type": "object",
+              "properties": {
+                "use_vm_group": {
+                  "type": "boolean"
+                }
+              }
+            }
           }
         },
         "network": {

--- a/lib/config/virtual_container_host.go
+++ b/lib/config/virtual_container_host.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2017 VMware, Inc. All Rights Reserved.
+// Copyright 2016-2018 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/config/virtual_container_host.go
+++ b/lib/config/virtual_container_host.go
@@ -122,6 +122,10 @@ type Container struct {
 	BootstrapImagePath string `vic:"0.1" scope:"read-only" key:"bootstrap_image_path"`
 	// Allow custom naming convention for containerVMs
 	ContainerNameConvention string
+	// Whether to create and manage a DRS VM Group for the VCH and its containerVMs
+	UseVMGroup bool
+	// Name to use for the DRS VM Group
+	VMGroupName string
 	// Permitted datastore URLs for container storage for this virtual container host
 	ContainerStores []url.URL `vic:"0.1" scope:"read-only" recurse:"depth=0"`
 }

--- a/lib/install/management/create.go
+++ b/lib/install/management/create.go
@@ -22,7 +22,6 @@ import (
 	"time"
 
 	"github.com/vmware/govmomi/object"
-	"github.com/vmware/govmomi/vim25/types"
 	"github.com/vmware/vic/lib/config"
 	"github.com/vmware/vic/lib/install/data"
 	"github.com/vmware/vic/lib/install/opsuser"
@@ -103,38 +102,6 @@ func (d *Dispatcher) createPool(conf *config.VirtualContainerHostConfigSpec, set
 	}
 
 	return nil
-}
-
-func (d *Dispatcher) createVMGroup(conf *config.VirtualContainerHostConfigSpec) error {
-	defer trace.End(trace.Begin("", d.op))
-
-	if !conf.UseVMGroup {
-		return nil
-	}
-
-	d.op.Debugf("Creating DRS VM Group %q on %q", conf.VMGroupName, d.appliance.Cluster)
-
-	spec := &types.ClusterConfigSpecEx{
-		GroupSpec: []types.ClusterGroupSpec{
-			{
-				ArrayUpdateSpec: types.ArrayUpdateSpec{
-					Operation: types.ArrayUpdateOperationAdd,
-				},
-				Info: &types.ClusterVmGroup{
-					ClusterGroupInfo: types.ClusterGroupInfo{
-						Name: conf.VMGroupName,
-					},
-					Vm: []types.ManagedObjectReference{d.appliance.Reference()},
-				},
-			},
-		},
-	}
-
-	_, err := tasks.WaitForResultAndRetryIf(d.op, func(op context.Context) (tasks.Task, error) {
-		return d.appliance.Cluster.Reconfigure(op, spec, true)
-	}, tasks.IsTransientError)
-
-	return err
 }
 
 func (d *Dispatcher) startAppliance(conf *config.VirtualContainerHostConfigSpec) error {

--- a/lib/install/management/create.go
+++ b/lib/install/management/create.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2017 VMware, Inc. All Rights Reserved.
+// Copyright 2016-2018 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/install/management/delete.go
+++ b/lib/install/management/delete.go
@@ -118,6 +118,11 @@ func (d *Dispatcher) DeleteVCH(conf *config.VirtualContainerHostConfigSpec, cont
 	if err = d.destroyResourcePoolIfEmpty(conf); err != nil {
 		d.op.Warnf("VCH resource pool is not removed: %s", err)
 	}
+
+	if err = d.destroyVMGroup(conf); err != nil {
+		d.op.Warnf("VCH DRS VM group is not removed: %s", err)
+	}
+
 	return nil
 }
 

--- a/lib/install/management/delete.go
+++ b/lib/install/management/delete.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2017 VMware, Inc. All Rights Reserved.
+// Copyright 2016-2018 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/install/management/resource_pool.go
+++ b/lib/install/management/resource_pool.go
@@ -111,9 +111,8 @@ func (d *Dispatcher) destroyVMGroup(conf *config.VirtualContainerHostConfigSpec)
 
 	groupExists := false
 	clusterConfigEx := clusterConfig.ConfigurationEx.(*types.ClusterConfigInfoEx)
-	for i := range clusterConfigEx.Group {
-		info := clusterConfigEx.Group[i].GetClusterGroupInfo()
-		if info.Name == conf.VMGroupName {
+	for _, g := range clusterConfigEx.Group {
+		if g.GetClusterGroupInfo().Name == conf.VMGroupName {
 			groupExists = true
 			break
 		}

--- a/lib/install/management/vmgroup.go
+++ b/lib/install/management/vmgroup.go
@@ -18,10 +18,11 @@ import (
 	"context"
 
 	"github.com/vmware/govmomi/vim25/types"
+
 	"github.com/vmware/vic/lib/config"
+	"github.com/vmware/vic/lib/install/validate"
 	"github.com/vmware/vic/pkg/trace"
 	"github.com/vmware/vic/pkg/vsphere/tasks"
-	"github.com/vmware/vic/lib/install/validate"
 )
 
 func (d *Dispatcher) createVMGroup(conf *config.VirtualContainerHostConfigSpec) error {

--- a/lib/install/management/vmgroup.go
+++ b/lib/install/management/vmgroup.go
@@ -76,7 +76,6 @@ func (d *Dispatcher) destroyVMGroup(conf *config.VirtualContainerHostConfigSpec)
 
 	d.op.Infof("Removing VM Group %q", conf.VMGroupName)
 
-
 	spec := &types.ClusterConfigSpecEx{
 		GroupSpec: []types.ClusterGroupSpec{
 			{

--- a/lib/install/management/vmgroup.go
+++ b/lib/install/management/vmgroup.go
@@ -1,0 +1,108 @@
+// Copyright 2018 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package management
+
+import (
+	"context"
+
+	"github.com/vmware/vic/lib/config"
+	"github.com/vmware/vic/pkg/trace"
+	"github.com/vmware/vic/pkg/vsphere/tasks"
+	"github.com/vmware/govmomi/vim25/types"
+	"github.com/vmware/govmomi/vim25/mo"
+)
+
+func (d *Dispatcher) createVMGroup(conf *config.VirtualContainerHostConfigSpec) error {
+	defer trace.End(trace.Begin("", d.op))
+
+	if !conf.UseVMGroup {
+		return nil
+	}
+
+	d.op.Debugf("Creating DRS VM Group %q on %q", conf.VMGroupName, d.appliance.Cluster)
+
+	spec := &types.ClusterConfigSpecEx{
+		GroupSpec: []types.ClusterGroupSpec{
+			{
+				ArrayUpdateSpec: types.ArrayUpdateSpec{
+					Operation: types.ArrayUpdateOperationAdd,
+				},
+				Info: &types.ClusterVmGroup{
+					ClusterGroupInfo: types.ClusterGroupInfo{
+						Name: conf.VMGroupName,
+					},
+					Vm: []types.ManagedObjectReference{d.appliance.Reference()},
+				},
+			},
+		},
+	}
+
+	_, err := tasks.WaitForResultAndRetryIf(d.op, func(op context.Context) (tasks.Task, error) {
+		return d.appliance.Cluster.Reconfigure(op, spec, true)
+	}, tasks.IsTransientError)
+
+	return err
+}
+
+func (d *Dispatcher) destroyVMGroup(conf *config.VirtualContainerHostConfigSpec) error {
+	defer trace.End(trace.Begin("", d.op))
+
+	if !conf.UseVMGroup {
+		return nil
+	}
+
+	d.op.Debugf("Checking for existence of DRS VM Group %s on %s", conf.VMGroupName, d.session.Cluster)
+
+	var clusterConfig mo.ClusterComputeResource
+	err := d.session.Cluster.Properties(d.op, d.session.Cluster.Reference(), []string{"configurationEx"}, &clusterConfig)
+	if err != nil {
+		d.op.Warnf("Unable to obtain cluster config: %s", err)
+		return nil
+	}
+
+	groupExists := false
+	clusterConfigEx := clusterConfig.ConfigurationEx.(*types.ClusterConfigInfoEx)
+	for _, g := range clusterConfigEx.Group {
+		if g.GetClusterGroupInfo().Name == conf.VMGroupName {
+			groupExists = true
+			break
+		}
+	}
+
+	if !groupExists {
+		d.op.Debugf("Expected VM Group cannot be found; skipping removal.")
+		return nil
+	}
+
+	d.op.Infof("Removing VM Group %q", conf.VMGroupName)
+
+
+	spec := &types.ClusterConfigSpecEx{
+		GroupSpec: []types.ClusterGroupSpec{
+			{
+				ArrayUpdateSpec: types.ArrayUpdateSpec{
+					Operation: types.ArrayUpdateOperationRemove,
+					RemoveKey: conf.VMGroupName,
+				},
+			},
+		},
+	}
+
+	_, err = tasks.WaitForResultAndRetryIf(d.op, func(op context.Context) (tasks.Task, error) {
+		return d.appliance.Cluster.Reconfigure(op, spec, true)
+	}, tasks.IsTransientError)
+
+	return err
+}

--- a/lib/install/validate/compute.go
+++ b/lib/install/validate/compute.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2017 VMware, Inc. All Rights Reserved.
+// Copyright 2016-2018 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/install/validate/config_to_data.go
+++ b/lib/install/validate/config_to_data.go
@@ -1,4 +1,4 @@
-// Copyright 2017 VMware, Inc. All Rights Reserved.
+// Copyright 2017-2018 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/install/validate/config_to_data.go
+++ b/lib/install/validate/config_to_data.go
@@ -219,6 +219,7 @@ func NewDataFromConfig(ctx context.Context, finder Finder, conf *config.VirtualC
 	}
 
 	d.ContainerNameConvention = conf.ContainerNameConvention
+	d.UseVMGroup = conf.UseVMGroup
 	return
 }
 

--- a/lib/install/validate/vmgroup.go
+++ b/lib/install/validate/vmgroup.go
@@ -1,0 +1,45 @@
+// Copyright 2018 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validate
+
+import (
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25/mo"
+	"github.com/vmware/govmomi/vim25/types"
+	"github.com/vmware/vic/pkg/errors"
+	"github.com/vmware/vic/pkg/trace"
+)
+
+func VMGroupExists(op trace.Operation, cluster *object.ComputeResource, group string) (bool, error) {
+	op.Debugf("Checking for existence of DRS VM Group %q on %s", group, cluster)
+
+	var clusterConfig mo.ClusterComputeResource
+	err := cluster.Properties(op, cluster.Reference(), []string{"configurationEx"}, &clusterConfig)
+	if err != nil {
+		return false, errors.Errorf("Unable to obtain cluster config: %s", err)
+	}
+
+	clusterConfigEx := clusterConfig.ConfigurationEx.(*types.ClusterConfigInfoEx)
+	for _, g := range clusterConfigEx.Group {
+		info := g.GetClusterGroupInfo()
+		if info.Name == group {
+			op.Debugf("DRS VM Group named %q exists", group)
+			return true, nil
+		}
+	}
+
+	op.Debugf("DRS VM Group named %q does not exist", group)
+	return false, nil
+}

--- a/lib/install/validate/vmgroup.go
+++ b/lib/install/validate/vmgroup.go
@@ -18,6 +18,7 @@ import (
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/vim25/mo"
 	"github.com/vmware/govmomi/vim25/types"
+
 	"github.com/vmware/vic/pkg/errors"
 	"github.com/vmware/vic/pkg/trace"
 )

--- a/lib/portlayer/exec/commit.go
+++ b/lib/portlayer/exec/commit.go
@@ -100,10 +100,7 @@ func Commit(op trace.Operation, sess *session.Session, h *Handle, waitTime *int3
 				return Config.Cluster.Reconfigure(op2, spec, true)
 			}
 
-			// TODO: change tasks package so InvalidArgument does not trigger a retry - or allow for more specific filtering
-			// if it turns out that specifying a deleted VM triggers this. Basically we do not want to end in a loop if the group doesn't
-			// exist - it's not something that's going to fix itself.
-			res, err = tasks.WaitForResult(op, affinity)
+			res, err = tasks.WaitForResultAndRetryIf(op, affinity, tasks.IsTransientError)
 			if err != nil {
 				op.Errorf("Failed to add VM to VMgroup: %s", err)
 				return err

--- a/lib/portlayer/exec/commit.go
+++ b/lib/portlayer/exec/commit.go
@@ -72,7 +72,7 @@ func Commit(op trace.Operation, sess *session.Session, h *Handle, waitTime *int3
 		c = newContainer(&h.containerBase)
 		Containers.Put(c)
 
-		if sess.IsVC() {
+		if Config.Container.UseVMGroup {
 			affinity := func(ctx context.Context) (tasks.Task, error) {
 				op2 := trace.FromContext(ctx, "vm group membership")
 
@@ -80,7 +80,7 @@ func Commit(op trace.Operation, sess *session.Session, h *Handle, waitTime *int3
 
 				group := &types.ClusterVmGroup{
 					ClusterGroupInfo: types.ClusterGroupInfo{
-						Name: Config.VMGroupName,
+						Name: Config.Container.VMGroupName,
 					},
 					Vm: append(containers, Config.SelfReference),
 				}

--- a/lib/portlayer/exec/commit.go
+++ b/lib/portlayer/exec/commit.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2017 VMware, Inc. All Rights Reserved.
+// Copyright 2016-2018 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/portlayer/exec/config.go
+++ b/lib/portlayer/exec/config.go
@@ -42,9 +42,6 @@ type Configuration struct {
 	// Cluster is the working reference to the cluster the VCH is present in
 	Cluster *object.ComputeResource
 
-	// VMGroupName is the name of the group all cVMs belong to for this VCH
-	VMGroupName string
-
 	// SelfReference is a reference to the endpointVM, added for VM group membership
 	SelfReference types.ManagedObjectReference
 

--- a/lib/portlayer/exec/config.go
+++ b/lib/portlayer/exec/config.go
@@ -1,4 +1,4 @@
-// Copyright 2016 VMware, Inc. All Rights Reserved.
+// Copyright 2016-2018 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/portlayer/exec/exec.go
+++ b/lib/portlayer/exec/exec.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/vmware/govmomi/find"
 	"github.com/vmware/govmomi/object"
-	"github.com/vmware/govmomi/vim25/mo"
 	"github.com/vmware/govmomi/vim25/types"
 
 	"github.com/vmware/vic/lib/portlayer/event"
@@ -35,7 +34,6 @@ import (
 	"github.com/vmware/vic/pkg/vsphere/compute"
 	"github.com/vmware/vic/pkg/vsphere/extraconfig"
 	"github.com/vmware/vic/pkg/vsphere/session"
-	"github.com/vmware/vic/pkg/vsphere/tasks"
 )
 
 var (
@@ -85,8 +83,6 @@ func Init(ctx context.Context, sess *session.Session, source extraconfig.DataSou
 			Config.ResourcePool = o.ResourcePool
 		case *object.ResourcePool:
 			Config.ResourcePool = o
-			// TODO: need to check vmgroup name constraints vs resource pool constraints
-			Config.VMGroupName = o.Name()
 			rp := compute.NewResourcePool(ctx, sess, cr)
 			Config.Cluster, err = rp.GetCluster(ctx)
 			if err != nil {
@@ -94,7 +90,6 @@ func Init(ctx context.Context, sess *session.Session, source extraconfig.DataSou
 				log.Error(err)
 				return
 			}
-
 		default:
 			err = fmt.Errorf("could not get resource pool or virtual app from reference %q: object type is wrong", cr.String())
 			log.Error(err)
@@ -108,30 +103,6 @@ func Init(ctx context.Context, sess *session.Session, source extraconfig.DataSou
 		//
 		// stash this aside for future use in vm group manipulation
 		Config.SelfReference = self
-
-		// create the VM group for DRS rule use
-		var clusterConfig mo.ClusterComputeResource
-		vmGroupOpType := types.ArrayUpdateOperationAdd
-
-		err = Config.Cluster.Properties(ctx, Config.Cluster.Reference(), []string{"configurationEx"}, &clusterConfig)
-		if err != nil {
-			log.Errorf("Unable to obtain cluster config: %s", err)
-			return
-		}
-
-		clusterConfigEx := clusterConfig.ConfigurationEx.(*types.ClusterConfigInfoEx)
-
-		for i := range clusterConfigEx.Group {
-			info := clusterConfigEx.Group[i].GetClusterGroupInfo()
-			if info.Name != Config.VMGroupName {
-				continue
-			}
-
-			if _, ok := clusterConfigEx.Group[i].(*types.ClusterVmGroup); ok {
-				vmGroupOpType = types.ArrayUpdateOperationEdit
-				break
-			}
-		}
 
 		// we want to monitor the cluster, so create a vSphere Event Collector
 		// The cluster managed object will either be a proper vSphere Cluster or
@@ -180,31 +151,6 @@ func Init(ctx context.Context, sess *session.Session, source extraconfig.DataSou
 			log.Errorf("Error encountered during container cache sync during init process: %s", err)
 			return
 		}
-
-		log.Info("Updating VM group membership for existing VCH members")
-		spec := &types.ClusterConfigSpecEx{
-			GroupSpec: []types.ClusterGroupSpec{
-				{
-					ArrayUpdateSpec: types.ArrayUpdateSpec{
-						Operation: vmGroupOpType,
-					},
-					Info: &types.ClusterVmGroup{
-						ClusterGroupInfo: types.ClusterGroupInfo{
-							Name: Config.VMGroupName,
-						},
-						Vm: append(Containers.References(), Config.SelfReference),
-					},
-				},
-			},
-		}
-
-		res, err := tasks.WaitForResult(ctx, func(op context.Context) (tasks.Task, error) {
-			log.Debugf("Attempting to add existing container VMs to group")
-			return Config.Cluster.Reconfigure(op, spec, true)
-		})
-
-		log.Debugf("Result of adding VM to group: %+v", res)
-
 	})
 
 	return initializer.err

--- a/lib/portlayer/exec/exec.go
+++ b/lib/portlayer/exec/exec.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2017 VMware, Inc. All Rights Reserved.
+// Copyright 2016-2018 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/vsphere/tasks/waiter.go
+++ b/pkg/vsphere/tasks/waiter.go
@@ -60,6 +60,16 @@ func Wait(ctx context.Context, f func(context.Context) (Task, error)) error {
 //       return vm, vm.Reconfigure(ctx, config)
 //    })
 func WaitForResult(ctx context.Context, f func(context.Context) (Task, error)) (*types.TaskInfo, error) {
+	return WaitForResultAndRetryIf(ctx, f, IsRetryError)
+}
+
+// WaitForResult wraps govmomi operations and wait the operation to complete, retrying under specified conditions.
+// Return the operation result
+// Sample usage:
+//    info, err := WaitForResult(ctx, func(ctx) (*TaskInfo, error) {
+//       return vm, vm.Reconfigure(ctx, config)
+//    })
+func WaitForResultAndRetryIf(ctx context.Context, f func(context.Context) (Task, error), shouldRetry func(op trace.Operation, err error) bool) (*types.TaskInfo, error) {
 	var err error
 	var backoffFactor int64 = 1
 
@@ -75,7 +85,7 @@ func WaitForResult(ctx context.Context, f func(context.Context) (Task, error)) (
 			}
 		}
 
-		if !IsRetryError(op, err) {
+		if !shouldRetry(op, err) {
 			return info, err
 		}
 

--- a/pkg/vsphere/tasks/waiter.go
+++ b/pkg/vsphere/tasks/waiter.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2017 VMware, Inc. All Rights Reserved.
+// Copyright 2016-2018 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/test-cases/Group23-VIC-Machine-Service/23-03-VCH-Create.robot
+++ b/tests/test-cases/Group23-VIC-Machine-Service/23-03-VCH-Create.robot
@@ -132,7 +132,7 @@ Create minimal VCH within datacenter
 
 
 Create complex VCH
-    Create VCH    '{"name":"%{VCH-NAME}-api-test-complex","debug":3,"compute":{"cpu":{"limit":{"units":"MHz","value":2345},"reservation":{"units":"GHz","value":2},"shares":{"level":"high"}},"memory":{"limit":{"units":"MiB","value":1200},"reservation":{"units":"MiB","value":501},"shares":{"number":81910}},"resource":{"name":"%{TEST_RESOURCE}"}},"endpoint":{"cpu":{"sockets":2},"memory":{"units":"MiB","value":3072}},"storage":{"image_stores":["ds://%{TEST_DATASTORE}"],"volume_stores":[{"datastore":"ds://%{TEST_DATASTORE}/test-volumes/foo","label":"foo"}],"base_image_size":{"units":"B","value":16000000}},"network":{"bridge":{"ip_range":"172.16.0.0/12","port_group":{"name":"%{BRIDGE_NETWORK}"}},"container":[{"alias":"vic-containers","firewall":"outbound","nameservers":["8.8.8.8","8.8.4.4"],"port_group":{"name":"${PUBLIC_NETWORK}"},"gateway":{"address":"203.0.113.1","routing_destinations":["203.0.113.1/24"]},"ip_ranges":["203.0.113.8/31"]}],"public":{"port_group":{"name":"${PUBLIC_NETWORK}"},"static":"192.168.100.22/24","gateway":{"address":"192.168.100.1"},"nameservers":["192.168.110.10","192.168.1.1"]}},"registry":{"image_fetch_proxy":{"http":"http://example.com","https":"https://example.com"},"insecure":["https://insecure.example.com"],"whitelist":["10.0.0.0/8"]},"auth":{"server":{"generate":{"cname":"vch.example.com","organization":["VMware, Inc."],"size":{"value":2048,"units":"bits"}}},"client":{"no_tls_verify": true}},"syslog_addr":"tcp://syslog.example.com:4444", "container": {"name_convention": "container-{id}"}}'
+    Create VCH    '{"name":"%{VCH-NAME}-api-test-complex","debug":3,"compute":{"cpu":{"limit":{"units":"MHz","value":2345},"reservation":{"units":"GHz","value":2},"shares":{"level":"high"}},"memory":{"limit":{"units":"MiB","value":1200},"reservation":{"units":"MiB","value":501},"shares":{"number":81910}},"resource":{"name":"%{TEST_RESOURCE}"},"affinity":{"use_vm_group":true}},"endpoint":{"cpu":{"sockets":2},"memory":{"units":"MiB","value":3072}},"storage":{"image_stores":["ds://%{TEST_DATASTORE}"],"volume_stores":[{"datastore":"ds://%{TEST_DATASTORE}/test-volumes/foo","label":"foo"}],"base_image_size":{"units":"B","value":16000000}},"network":{"bridge":{"ip_range":"172.16.0.0/12","port_group":{"name":"%{BRIDGE_NETWORK}"}},"container":[{"alias":"vic-containers","firewall":"outbound","nameservers":["8.8.8.8","8.8.4.4"],"port_group":{"name":"${PUBLIC_NETWORK}"},"gateway":{"address":"203.0.113.1","routing_destinations":["203.0.113.1/24"]},"ip_ranges":["203.0.113.8/31"]}],"public":{"port_group":{"name":"${PUBLIC_NETWORK}"},"static":"192.168.100.22/24","gateway":{"address":"192.168.100.1"},"nameservers":["192.168.110.10","192.168.1.1"]}},"registry":{"image_fetch_proxy":{"http":"http://example.com","https":"https://example.com"},"insecure":["https://insecure.example.com"],"whitelist":["10.0.0.0/8"]},"auth":{"server":{"generate":{"cname":"vch.example.com","organization":["VMware, Inc."],"size":{"value":2048,"units":"bits"}}},"client":{"no_tls_verify": true}},"syslog_addr":"tcp://syslog.example.com:4444", "container": {"name_convention": "container-{id}"}}'
 
     Verify Return Code
     Verify Status Created
@@ -148,6 +148,8 @@ Create complex VCH
     Output Should Contain    --memory=1200
     Output Should Contain    --memory-reservation=501
     Output Should Contain    --memory-shares=81910
+
+    Output Should Contain    --affinity-vm-group=true
 
     Output Should Contain    --endpoint-cpu=2
     Output Should Contain    --endpoint-memory=3072
@@ -191,6 +193,7 @@ Create complex VCH
     Property Should Be Equal        .compute.memory.reservation.value    501
     Property Should Be Equal        .compute.memory.reservation.units    MiB
     Property Should Be Equal        .compute.memory.shares.number        81910
+    Property Should Be Equal        .compute.affinity.use_vm_group       true
 
     Property Should Be Equal        .endpoint.cpu.sockets                2
     Property Should Be Equal        .endpoint.memory.value               3072

--- a/tests/test-cases/Group24-Host-Affinity/24-01-Basic.md
+++ b/tests/test-cases/Group24-Host-Affinity/24-01-Basic.md
@@ -43,7 +43,7 @@ Positive Testing
 * The DRS VM Group is deleted when the VCH is deleted.
 
 
-### 3. Removing containers cleans up the VM group
+### 3. Deleting a container cleans up its VM group
 
 #### Test Steps:
 1. Verify that no DRS VM Group exists by the expected name.
@@ -54,4 +54,47 @@ Positive Testing
 6. Verify that the DRS VM Group still exists, but does not include the removed containers.
 
 #### Expected Outcome:
-* Containers are removed from the DRS VM Group when they are deleted.
+* Container VMs are removed from the DRS VM Group when they are deleted.
+
+
+### 4. Create a VCH without a VM group
+
+#### Test Steps:
+1. Verify that no DRS VM Group exists by the expected name.
+2. Create a DRS VM Group with the expected name.
+3. Verify that the DRS VM Group is empty.
+4. Create a VCH which does not use a DRS VM Group.
+5. Verify that the DRS VM Group is empty.
+6. Create a variety of containers.
+7. Verify that the DRS VM Group is empty.
+
+#### Expected Outcome:
+* Neither the VCH Endpoint VM nor the Container VMs are added to the DRS VM Group the VCH is not configured to use.
+* VCH creation succeeds even though a DRS VM Group with the same name exists, as use of a group is not configured.
+
+
+### 5. Attempt to create a VCH when a VM group with the same name already exists
+
+#### Test Steps:
+1. Verify that no DRS VM Group exists by the expected name.
+2. Create a DRS VM Group with the expected name.
+3. Verify that the DRS VM Group is empty.
+4. Attempt to create a VCH which would use a DRS VM Group and expect an error.
+5. Verify that the DRS VM Group is empty.
+
+#### Expected Outcome:
+* VCH creation fails if a DRS VM Group with the same name already exists, instead of silently using the existing group.
+
+
+### 6. Deleting a VCH gracefully handles missing VM group
+
+#### Test Steps:
+1. Verify that no DRS VM Group exists by the expected name.
+2. Create a VCH.
+3. Verify that a DRS VM Group was created and that the endpoint VM was added to it.
+4. Remove the DRS VM Group with an out-of-band operation.
+5. Verify that the DRS VM Group no longer exists.
+6. Delete the VCH.
+
+#### Expected Outcome:
+* The overall deletion operation succeeds even though the DRS VM Group has already been deleted.

--- a/tests/test-cases/Group24-Host-Affinity/24-01-Basic.robot
+++ b/tests/test-cases/Group24-Host-Affinity/24-01-Basic.robot
@@ -15,6 +15,7 @@
 *** Settings ***
 Documentation     Suite 24-01 - Basic
 Resource          ../../resources/Util.robot
+Test Setup        Set Test Environment Variables
 Test Teardown     Cleanup
 Default Tags
 
@@ -25,23 +26,36 @@ Cleanup
 
     Cleanup VIC Appliance On Test Server
 
+
+Create Group
+    [Arguments]    ${name}
+
+    ${rc}  ${out}=    Run And Return Rc And Output     govc cluster.group.create -name "${name}" -vm --json 2>&1
+    Should Be Equal As Integers    ${rc}    0
+
 Remove Group
     [Arguments]    ${name}
 
-    ${rc}  ${out}=    Run And Return Rc And Output     govc cluster.group.remove -name ${name} --json 2>&1
+    ${rc}  ${out}=    Run And Return Rc And Output     govc cluster.group.remove -name "${name}" --json 2>&1
     Should Be Equal As Integers    ${rc}    0
 
 
 Verify Group Not Found
     [Arguments]    ${name}
 
-    ${out}=    Run     govc cluster.group.ls -name ${name} --json 2>&1
+    ${out}=    Run     govc cluster.group.ls -name "${name}" --json 2>&1
     Should Be Equal As Strings    ${out}    govc: group "${name}" not found
+
+Verify Group Empty
+    [Arguments]    ${name}
+
+    ${out}=    Run     govc cluster.group.ls -name "${name}" --json 2>&1
+    Should Be Equal As Strings    ${out}    null
 
 Verify Group Contains VMs
     [Arguments]    ${name}    ${count}
 
-    ${out}=    Run    govc cluster.group.ls -name ${name} --json | jq 'length'
+    ${out}=    Run    govc cluster.group.ls -name "${name}" --json | jq 'length'
     Should Be Equal As Integers    ${out}    ${count}
 
 
@@ -58,23 +72,23 @@ Create Three Containers
     Set Test Variable    ${POWERED_ON_CONTAINER_NAME}
 
     ${RUN_CONTAINER_NAME}=    Generate Random String  15
-    ${rc}  ${out}=    Run And Return Rc And Output    docker %{VCH-PARAMS} run --name ${RUN_CONTAINER_NAME} ${busybox} /bin/top
+    ${rc}  ${out}=    Run And Return Rc And Output    docker %{VCH-PARAMS} run -d --name ${RUN_CONTAINER_NAME} ${busybox} /bin/top
 
     Set Test Variable    ${RUN_CONTAINER_NAME}
 
 Delete Containers
-    ${rc}  ${out}=    Run And Return Rc And Output    docker %{VCH-PARAMS} rm --name ${POWERED_OFF_CONTAINER_NAME} ${busybox} /bin/top
-    ${rc}  ${out}=    Run And Return Rc And Output    docker %{VCH-PARAMS} rm --name ${POWERED_ON_CONTAINER_NAME} ${busybox} /bin/top
-    ${rc}  ${out}=    Run And Return Rc And Output    docker %{VCH-PARAMS} rm --name ${RUN_CONTAINER_NAME} ${busybox} /bin/top
+    ${rc}  ${out}=    Run And Return Rc And Output    docker %{VCH-PARAMS} rm ${POWERED_OFF_CONTAINER_NAME}
+    ${rc}  ${out}=    Run And Return Rc And Output    docker %{VCH-PARAMS} rm -f ${POWERED_ON_CONTAINER_NAME}
+    ${rc}  ${out}=    Run And Return Rc And Output    docker %{VCH-PARAMS} rm -f ${RUN_CONTAINER_NAME}
 
 
 *** Test Cases ***
 Creating a VCH creates a VM group and container VMs get added to it
-    Set Test Environment Variables
-
     Verify Group Not Found       %{VCH-NAME}
 
-    Install VIC Appliance To Test Server With Current Environment Variables
+    Install VIC Appliance To Test Server With Current Environment Variables    additional-args=--affinity-vm-group
+
+    Log To Console  %{VCH-NAME} created
 
     Verify Group Contains VMs    %{VCH-NAME}    1
 
@@ -84,25 +98,23 @@ Creating a VCH creates a VM group and container VMs get added to it
 
 
 Deleting a VCH deletes its VM group
-    Set Test Environment Variables
-
-    Verify Group Not Found         %{VCH-NAME}
-
-    Install VIC Appliance To Test Server With Current Environment Variables
-
-    Verify Group Contains VMs    %{VCH-NAME}    1
-
-    Cleanup VIC Appliance On Test Server
-
-    Verify Group Not Found         %{VCH-NAME}
-
-
-Deleting a container cleans up its VM group
-    Set Test Environment Variables
+    [Teardown]    Run Keyword If Test Failed    Cleanup VIC Appliance On Test Server
 
     Verify Group Not Found       %{VCH-NAME}
 
-    Install VIC Appliance To Test Server With Current Environment Variables
+    Install VIC Appliance To Test Server With Current Environment Variables    additional-args=--affinity-vm-group
+
+    Verify Group Contains VMs    %{VCH-NAME}    1
+
+    Run VIC Machine Delete Command
+
+    Verify Group Not Found       %{VCH-NAME}
+
+
+Deleting a container cleans up its VM group
+    Verify Group Not Found       %{VCH-NAME}
+
+    Install VIC Appliance To Test Server With Current Environment Variables    additional-args=--affinity-vm-group
 
     Create Three Containers
 
@@ -111,3 +123,49 @@ Deleting a container cleans up its VM group
     Delete Containers
 
     Verify Group Contains VMs    %{VCH-NAME}    1
+
+
+Create a VCH without a VM group
+    Verify Group Not Found       %{VCH-NAME}
+
+    Create Group                 %{VCH-NAME}
+
+    Verify Group Empty           %{VCH-NAME}
+
+    Install VIC Appliance To Test Server With Current Environment Variables    cleanup=${false}
+
+    Verify Group Empty           %{VCH-NAME}
+
+    Create Three Containers
+
+    Verify Group Empty           %{VCH-NAME}
+
+
+Attempt to create a VCH when a VM group with the same name already exists
+    [Teardown]    Remove Group   %{VCH-NAME}
+
+    Verify Group Not Found       %{VCH-NAME}
+
+    Create Group                 %{VCH-NAME}
+
+    Verify Group Empty           %{VCH-NAME}
+
+    Run Keyword and Expect Error    *    Install VIC Appliance To Test Server With Current Environment Variables    additional-args=--affinity-vm-group    cleanup=${false}
+
+    Verify Group Empty           %{VCH-NAME}
+
+
+Deleting a VCH gracefully handles missing VM group
+    [Teardown]    Run Keyword If Test Failed    Cleanup VIC Appliance On Test Server
+
+    Verify Group Not Found       %{VCH-NAME}
+
+    Install VIC Appliance To Test Server With Current Environment Variables    additional-args=--affinity-vm-group
+
+    Verify Group Contains VMs    %{VCH-NAME}    1
+
+    Remove Group                 %{VCH-NAME}
+
+    Verify Group Not Found       %{VCH-NAME}
+
+    Run VIC Machine Delete Command


### PR DESCRIPTION
Introduce a flag for `vic-machine create` to allow users to opt-in to use of a DRS VM Group with the same name as the VCH. Include this property when inspecting a VCH. Delete the group, if present, when deleting the VCH. Make analogous changes to the API. Fail fast if a user attempts to configure this functionality when interacting directly with ESX.

Expand test robot test coverage for this functionality.

Fixes #7559, #7560, #7568 

[specific ci=24-01-Basic]