### PR TITLE
Fix bridge network cleanup in 6-04-Create-Basic

### DIFF
--- a/tests/test-cases/Group6-VIC-Machine/6-04-Create-Basic.robot
+++ b/tests/test-cases/Group6-VIC-Machine/6-04-Create-Basic.robot
@@ -72,7 +72,7 @@ Create VCH - URL without user and password
     Should Contain  ${output}  vSphere user must be specified
 
     # Delete the portgroup added by env vars keyword
-    Cleanup VCH Bridge Network  %{BRIDGE_NETWORK}
+    Run Keyword If  %{DRONE_BUILD_NUMBER} != 0  Cleanup VCH Bridge Network
 
 Create VCH - target URL
     Set Test Environment Variables
@@ -193,7 +193,7 @@ Create VCH - long VCH name
     Should Contain  ${output}  exceeds the permitted 31 characters limit
 
     # Delete the portgroup added by env vars keyword
-    Cleanup VCH Bridge Network  %{BRIDGE_NETWORK}
+    Run Keyword If  %{DRONE_BUILD_NUMBER} != 0  Cleanup VCH Bridge Network
 
 Create VCH - Existing VCH name
     Set Test Environment Variables
@@ -235,7 +235,7 @@ Create VCH - Existing VM name
 
     # ${rc}  ${output}=  Run And Return Rc And Output  govc vm.destroy %{VCH-NAME}
     # Should Be Equal As Integers  ${rc}  0
-    # Cleanup VCH Bridge Network  %{BRIDGE_NETWORK}
+    # Run Keyword If  %{DRONE_BUILD_NUMBER} != 0  Cleanup VCH Bridge Network
 
 Create VCH - Existing RP on ESX
     Run Keyword If  '%{HOST_TYPE}' == 'VC'  Pass Execution  Test skipped on VC
@@ -286,7 +286,7 @@ Basic timeout
     Should Contain  ${ret}  Completed successfully
     ${out}=  Run  govc ls vm
     Should Not Contain  ${out}  %{VCH-NAME}
-    Run Keyword And Ignore Error  Cleanup VCH Bridge Network  %{BRIDGE_NETWORK}
+    Run Keyword If  %{DRONE_BUILD_NUMBER} != 0  Run Keyword And Ignore Error  Cleanup VCH Bridge Network
 
 Basic VCH resource config
     Pass execution  Test not implemented


### PR DESCRIPTION
[skip unit]
[specific ci=6-04-Create-Basic]

This commit fixes the usage of the 'Cleanup VCH Bridge Network' keyword
in four 6-04-Create-Basic test cases. The keyword was modified as part
of #7505 (merged to master). While rebasing the feature/robo branch,
the changes made to 6-04-Create-Basic by #7505 were dropped, causing
test failures in 6-04-Create-Basic.