### PR TITLE
Set HOME from /etc/passwd if set

### DIFF
--- a/cmd/tether/tether_test.go
+++ b/cmd/tether/tether_test.go
@@ -126,8 +126,8 @@ func (t *Mocker) HandleSessionExit(config *tether.ExecutorConfig, session *tethe
 	}
 }
 
-func (t *Mocker) ProcessEnv(env []string) []string {
-	return t.Base.ProcessEnv(env)
+func (t *Mocker) ProcessEnv(session *tether.SessionConfig) []string {
+	return t.Base.ProcessEnv(session)
 }
 
 // SetHostname sets both the kernel hostname and /etc/hostname to the specified string

--- a/cmd/vic-init/tether_test.go
+++ b/cmd/vic-init/tether_test.go
@@ -114,8 +114,8 @@ func (t *Mocker) HandleSessionExit(config *tether.ExecutorConfig, session *tethe
 	}
 }
 
-func (t *Mocker) ProcessEnv(env []string) []string {
-	return t.Base.ProcessEnv(env)
+func (t *Mocker) ProcessEnv(session *tether.SessionConfig) []string {
+	return t.Base.ProcessEnv(session)
 }
 
 // SetHostname sets both the kernel hostname and /etc/hostname to the specified string

--- a/lib/tether/interfaces.go
+++ b/lib/tether/interfaces.go
@@ -47,7 +47,7 @@ type Operations interface {
 	SessionLog(session *SessionConfig) (dio.DynamicMultiWriter, dio.DynamicMultiWriter, error)
 	// Returns a function to invoke after the session state has been persisted
 	HandleSessionExit(config *ExecutorConfig, session *SessionConfig) func()
-	ProcessEnv(env []string) []string
+	ProcessEnv(session *SessionConfig) []string
 	// LaunchUtility starts a process and provides a way to block on completion and retrieve
 	// it's exit code. This is needed to co-exist with a childreaper.
 	LaunchUtility(UtilityFn) (<-chan int, error)

--- a/lib/tether/tether.go
+++ b/lib/tether/tether.go
@@ -782,7 +782,7 @@ func (t *tether) launch(session *SessionConfig) error {
 		}
 	}
 
-	session.Cmd.Env = t.ops.ProcessEnv(session.Cmd.Env)
+	session.Cmd.Env = t.ops.ProcessEnv(session)
 	// Set Std{in|out|err} to nil, we will control pipes
 	session.Cmd.Stdin = nil
 	session.Cmd.Stdout = nil

--- a/lib/tether/tether_test.go
+++ b/lib/tether/tether_test.go
@@ -139,8 +139,8 @@ func (t *Mocker) HandleSessionExit(config *ExecutorConfig, session *SessionConfi
 	}
 }
 
-func (t *Mocker) ProcessEnv(env []string) []string {
-	return t.Base.ProcessEnv(env)
+func (t *Mocker) ProcessEnv(session *SessionConfig) []string {
+	return t.Base.ProcessEnv(session)
 }
 
 // SetHostname sets both the kernel hostname and /etc/hostname to the specified string

--- a/tests/test-cases/Group1-Docker-Commands/1-37-Docker-USER.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-37-Docker-USER.robot
@@ -59,3 +59,23 @@ Run as uid 0 group 0 With -u
     ${rc}    ${output}=    Run And Return Rc And Output    docker %{VCH-PARAMS} run -u 0:0 busybox whoami
     Should Be Equal As Integers    ${rc}       0
     Should Contain                 ${output}   root
+
+Run as user from dockerfile with specific home directory
+    ${rc}    ${cid}=       Run And Return Rc And Output    docker %{VCH-PARAMS} pull ${alpine}
+    Should Be Equal As Integers    ${rc}       0
+    ${rc}    ${cid}=       Run And Return Rc And Output    docker %{VCH-PARAMS} run -d ${alpine} adduser -h /home/testuser -s /bin/ash -D testuser
+    Should Be Equal As Integers    ${rc}       0
+    ${rc}=                 Run And Return Rc               docker %{VCH-PARAMS} wait ${cid}
+    Should Be Equal As Integers    ${rc}       0
+    ${rc}  ${imgid}=       Run And Return Rc And Output    docker %{VCH-PARAMS} commit ${cid} testuserimg
+    Should Be Equal As Integers    ${rc}       0
+    ${rc}    ${home}=       Run And Return Rc And Output   docker %{VCH-PARAMS} run -i -u testuser testuserimg /bin/ash -c 'echo $HOME'
+    Should Be Equal As Integers    ${rc}       0
+    Should Be Equal As Strings     ${home}     /home/testuser
+
+Root user home directory set correctly
+    ${rc}    ${cid}=       Run And Return Rc And Output    docker %{VCH-PARAMS} pull ${alpine}
+    Should Be Equal As Integers    ${rc}       0
+    ${rc}    ${home}=       Run And Return Rc And Output   docker %{VCH-PARAMS} run -i -u root ${alpine} /bin/ash -c 'echo $HOME'
+    Should Be Equal As Integers    ${rc}       0
+    Should Be Equal As Strings     ${home}     /root


### PR DESCRIPTION
This pulls the HOME environment variable from /etc/passwd if set.
If not set, defaults to /

```
[skip unit]
[specific ci=1-37-Docker-USER]
```

Fixes #7536
