### PR TITLE
Fail vic-machine delete if VCH Folder can't be determined

### DIFF
--- a/cmd/vicadmin/vicadm.go
+++ b/cmd/vicadmin/vicadm.go
@@ -346,7 +346,7 @@ func listVMPaths(ctx context.Context, s *session.Session) ([]logfile, error) {
 			continue
 		}
 
-		logname, err := child.Name(ctx)
+		logname, err := child.ObjectName(ctx)
 		if err != nil {
 			log.Errorf("Unable to get the vm name for %s: %s", child.Reference(), err)
 			continue

--- a/lib/install/management/configure.go
+++ b/lib/install/management/configure.go
@@ -103,7 +103,7 @@ func (d *Dispatcher) Configure(vch *vm.VirtualMachine, conf *config.VirtualConta
 	// #nosec: Errors unhandled.
 	oldSnapshot, _ := d.appliance.GetCurrentSnapshotTree(d.op)
 
-	newSnapshotRef, err := d.tryCreateSnapshot(snapshotName, "configure snapshot")
+	newSnapshotRef, err := d.createSnapshot(snapshotName, "configure snapshot")
 	if err != nil {
 		d.deleteUpgradeImages(ds, settings)
 		return err
@@ -258,21 +258,25 @@ func (d *Dispatcher) deleteSnapshotByRef(snapshot *types.ManagedObjectReference,
 	return nil
 }
 
-// tryCreateSnapshot try to create upgrade snapshot. It will check if upgrade snapshot already exists. If exists, return error.
-// if succeed, return snapshot refID
-func (d *Dispatcher) tryCreateSnapshot(name, desc string) (*types.ManagedObjectReference, error) {
+// createSnapshot will create a snapshot of the VCH Appliance
+func (d *Dispatcher) createSnapshot(name, desc string) (*types.ManagedObjectReference, error) {
 	defer trace.End(trace.Begin(name, d.op))
 
 	// TODO detect whether another upgrade is in progress & bail if it is.
 	// Use solution from https://github.com/vmware/vic/issues/4069 to do this either as part of 4069 or once it's closed
 
 	info, err := d.appliance.WaitForResult(d.op, func(ctx context.Context) (tasks.Task, error) {
-		return d.appliance.CreateSnapshot(ctx, name, desc, true, false)
+		return d.appliance.CreateSnapshot(ctx, name, desc, false, false)
 	})
 	if err != nil {
-		return nil, errors.Errorf("Failed to create upgrade snapshot %q: %s.", name, err)
+		return nil, errors.Errorf("Failed to create snapshot %q: %s.", name, err)
 	}
-	return info.Entity, nil
+	// must cast to the specific type as the result is the any type
+	snap, ok := info.Result.(types.ManagedObjectReference)
+	if !ok {
+		return nil, errors.Errorf("Failed to create snapshot %q: cast failure(%#v)", name, info.Result)
+	}
+	return &snap, nil
 }
 
 func (d *Dispatcher) deleteUpgradeImages(ds *object.Datastore, settings *data.InstallerData) {
@@ -363,25 +367,19 @@ func (d *Dispatcher) rollback(conf *config.VirtualContainerHostConfigSpec, snaps
 func (d *Dispatcher) ensureRollbackReady(conf *config.VirtualContainerHostConfigSpec, settings *data.InstallerData) error {
 	defer trace.End(trace.Begin(conf.Name, d.op))
 
-	power, err := d.appliance.PowerState(d.op)
-	if err != nil {
-		d.op.Errorf("Failed to get vm power status %q after rollback: %s", d.appliance.Reference(), err)
-		return err
-	}
-	if power == types.VirtualMachinePowerStatePoweredOff {
-		d.op.Info("Roll back finished - Appliance is kept in powered off status")
-		return nil
-	}
-	if err = d.appliance.PowerOn(d.op); err != nil {
+	// we've rolled back to the previous snap which didn't include
+	// memory, so we need to powerOn the VM
+	if err := d.appliance.PowerOn(d.op); err != nil {
 		return err
 	}
 
 	op, cancel := trace.WithTimeout(&d.op, settings.Timeout, "CheckServiceReady during rollback")
 	defer cancel()
-	if err = d.CheckServiceReady(op, conf, nil); err != nil {
+	if err := d.CheckServiceReady(op, conf, nil); err != nil {
 		// do not return error in this case, to make sure clean up continues
 		d.op.Info("\tAPI may be slow to start - try to connect to API after a few minutes")
 	}
+
 	return nil
 }
 

--- a/lib/install/management/create.go
+++ b/lib/install/management/create.go
@@ -221,30 +221,8 @@ func (d *Dispatcher) cleanupAfterCreationFailed(conf *config.VirtualContainerHos
 		}
 	}
 
-	// cleanup the vch inventory folder if it is empty. Can happen in some cases where the create is cancelled after successful creation.
-
-	if d.isVC {
-		folderRef, err := vchFolder(d.op, d.session, conf)
-		if folderRef != nil {
-			children, err := folderRef.Children(d.op)
-			if err != nil {
-				d.op.Debugf("encountered error during vch folder cleanup : %s", err)
-				d.op.Warnf(manualInventoryCleanWarning, folderRef.InventoryPath)
-			}
-
-			if len(children) != 0 {
-				d.op.Warnf(manualInventoryCleanWarning, folderRef.InventoryPath)
-			}
-
-			d.removeFolder(folderRef)
-			if err != nil {
-				d.op.Warnf(manualInventoryCleanWarning, folderRef.InventoryPath)
-			}
-		}
-		if err != nil {
-			d.op.Debugf("encountered error during vch folder cleanup : %s", err)
-		}
-	}
+	// delete the folder -- this will ONLY delete a folder if vic created it
+	d.deleteVCHFolder()
 }
 
 // cleanupEmptyPool cleans up any dangling empty VCH resource pool when creating this VCH. no-op when VCH pool is nonempty.

--- a/lib/install/validate/config_to_data.go
+++ b/lib/install/validate/config_to_data.go
@@ -48,7 +48,7 @@ func SetDataFromVM(ctx context.Context, finder Finder, vm *vm.VirtualMachine, d 
 	op := trace.FromContext(ctx, "SetDataFromVM")
 
 	// display name
-	name, err := vm.Name(op)
+	name, err := vm.ObjectName(op)
 	if err != nil {
 		return err
 	}

--- a/lib/portlayer/portlayer.go
+++ b/lib/portlayer/portlayer.go
@@ -38,7 +38,7 @@ import (
 // Init initializes portlayer components at startup
 func Init(ctx context.Context, sess *session.Session) error {
 	defer trace.End(trace.Begin(""))
-
+	op := trace.FromContext(ctx, "portLayer Init")
 	source, err := extraconfig.GuestInfoSource()
 	if err != nil {
 		return err
@@ -73,12 +73,11 @@ func Init(ctx context.Context, sess *session.Session) error {
 	}
 
 	// store the reference to the vch inventory folder before portlayer init
-	// NOTE: This will cause problems if an upgrade has been done on a 1.1-1.2.1 vapp based deployment. due to the vApp's effects on getting a vm's inventory path.
-	vchFolder, err := vchvm.Folder(ctx)
+	vchFolder, err := vchvm.Folder(op)
 	if err != nil {
 		return err
 	}
-	sess.Config.VCHFolder = vchFolder
+	sess.VCHFolder = vchFolder
 
 	if err = storage.Init(ctx, sess, vmParentPool, source, sink); err != nil {
 		return err

--- a/lib/vicadmin/validate.go
+++ b/lib/vicadmin/validate.go
@@ -277,7 +277,7 @@ func (v *Validator) GetVCHName(ctx context.Context, sess *session.Session) error
 	}
 
 	newVM := vm.NewVirtualMachineFromVM(ctx, sess, self)
-	vchName, err := newVM.Name(ctx)
+	vchName, err := newVM.ObjectName(ctx)
 	if err != nil {
 		v.Hostname = DefaultVCHName
 		return err

--- a/pkg/vsphere/session/session.go
+++ b/pkg/vsphere/session/session.go
@@ -1,4 +1,4 @@
-// Copyright 2016 VMware, Inc. All Rights Reserved.
+// Copyright 2016-2018 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -77,9 +77,6 @@ type Config struct {
 	DatastorePath  string
 	HostPath       string
 	PoolPath       string
-
-	// VCH appliance folder location, this could be the VMFolder or a custom folder location(currently <VMFolder>/<VCHNAME>/<VCH>.vm)
-	VCHFolder *object.Folder
 }
 
 // Session caches vSphere objects obtained by querying the SDK.
@@ -94,7 +91,10 @@ type Session struct {
 	Host       *object.HostSystem
 	Pool       *object.ResourcePool
 
+	// Default vSphere VMFolder
 	VMFolder *object.Folder
+	// Folder where appliance is located
+	VCHFolder *object.Folder
 
 	Finder *find.Finder
 
@@ -374,10 +374,15 @@ func (s *Session) Populate(ctx context.Context) (*Session, error) {
 			op.Debugf("Cached folders: %s", s.DatacenterPath)
 		}
 		s.VMFolder = folders.VmFolder
+		// We don't persist the VCH folder location so set
+		// the VCH folder to the default VM folder.
+		// The actual location of the VCH will be determined later
+		// and this folder ref will be updated accordingly.
+		//
+		// This will provide standalone ESXi and backwards
+		// compatibility to non-folder versions.
+		s.VCHFolder = folders.VmFolder
 
-		if s.VCHFolder == nil {
-			s.VCHFolder = folders.VmFolder
-		}
 	}
 
 	if len(errs) > 0 {

--- a/pkg/vsphere/vm/vm_test.go
+++ b/pkg/vsphere/vm/vm_test.go
@@ -162,7 +162,7 @@ func TestVM(t *testing.T) {
 	assert.Equal(t, types.VirtualMachinePowerStatePoweredOff, state)
 
 	// Check VM name
-	rname, err := vm.Name(ctx)
+	rname, err := vm.ObjectName(ctx)
 	if err != nil {
 		t.Errorf("Failed to load VM name: %s", err)
 	}
@@ -254,7 +254,7 @@ func TestVMAttributes(t *testing.T) {
 		t.Fatalf("ERROR: %s", err)
 	}
 
-	name, err := vm.Name(ctx)
+	name, err := vm.ObjectName(ctx)
 	if err != nil {
 		t.Fatalf("ERROR: %s", err)
 	}

--- a/tests/test-cases/Group11-Upgrade/11-01-Upgrade.robot
+++ b/tests/test-cases/Group11-Upgrade/11-01-Upgrade.robot
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#	http://www.apache.org/licenses/LICENSE-2.0
+#   http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,8 +15,8 @@
 *** Settings ***
 Documentation  Test 11-01 - Upgrade
 Resource  ../../resources/Util.robot
-# Suite Setup  Install VIC with version to Test Server  7315
-# Suite Teardown  Clean up VIC Appliance And Local Binary
+Suite Setup  Install VIC with version to Test Server  7315
+Suite Teardown  Clean up VIC Appliance And Local Binary
 Default Tags
 
 *** Variables ***
@@ -187,50 +187,49 @@ Check Container Create Timestamps
 
 *** Test Cases ***
 Upgrade Present in vic-machine
-    ${status}=  Get State Of Github Issue  7497
-    Run Keyword If  '${status}' == 'closed'  Fail  Test 11-01-Upgrade.robot needs to be updated now that Issue #7497 has been resolved
-    # ${rc}  ${output}=  Run And Return Rc And Output  bin/vic-machine-linux
-    # Should Contain  ${output}  upgrade
+    ${rc}  ${output}=  Run And Return Rc And Output  bin/vic-machine-linux
+    Should Contain  ${output}  upgrade
 
 Upgrade VCH with unreasonably short timeout and automatic rollback after failure
-    ${status}=  Get State Of Github Issue  7497
-    Run Keyword If  '${status}' == 'closed'  Fail  Test 11-01-Upgrade.robot needs to be updated now that Issue #7497 has been resolved
-    # Log To Console  \nUpgrading VCH with 1s timeout ...
-    # ${rc}  ${output}=  Run And Return Rc And Output  bin/vic-machine-linux upgrade --debug 1 --name=%{VCH-NAME} --target=%{TEST_URL}%{TEST_DATACENTER} --user=%{TEST_USERNAME} --password=%{TEST_PASSWORD} --force=true --compute-resource=%{TEST_RESOURCE} --timeout 1s
-    # Should Contain  ${output}  Upgrading VCH exceeded time limit
-    # Should Not Contain  ${output}  Completed successfully
-    # ${rc}  ${output}=  Run And Return Rc And Output  govc snapshot.tree -vm=%{VCH-NAME}
-    # Should Not Contain  ${output}  upgrade
-
-    # # confirm that the rollback took effect
-    # Check Original Version
+    Log To Console  \nUpgrading VCH with 1s timeout ...
+    ${rc}  ${output}=  Run And Return Rc And Output  bin/vic-machine-linux upgrade --debug 1 --name=%{VCH-NAME} --target=%{TEST_URL}%{TEST_DATACENTER} --user=%{TEST_USERNAME} --password=%{TEST_PASSWORD} --force=true --compute-resource=%{TEST_RESOURCE} --timeout 1s
+    Should Contain  ${output}  Upgrading VCH exceeded time limit
+    Should Not Contain  ${output}  Completed successfully
+    # we should have no snapshots
+    ${rc}  ${output}=  Run And Return Rc And Output  govc snapshot.tree -vm=%{VCH-NAME}
+    Should Be Empty  ${output}
+    # the appliance is restarting - attempt to wait until it's ready
+    # version of appliance we rolled back to is old, so we have to set DOCKER_API_VERSION
+    Set Environment Variable  DOCKER_API_VERSION  1.23
+    # keyword will call docker info until response or timeout
+    Wait For VCH Initialization  30x
+    # confirm that the rollback took effect
+    Check Original Version
 
 Upgrade VCH
-    ${status}=  Get State Of Github Issue  7497
-    Run Keyword If  '${status}' == 'closed'  Fail  Test 11-01-Upgrade.robot needs to be updated now that Issue #7497 has been resolved
-    # Create Docker Containers
+    Create Docker Containers
 
-    # Create Container with Named Volume
+    Create Container with Named Volume
 
-    # # Create check list for Volume Inspect
-    # @{checkList}=  Create List  ${mntTest}  ${mntNamed}  ${namedVolume}
+    # Create check list for Volume Inspect
+    @{checkList}=  Create List  ${mntTest}  ${mntNamed}  ${namedVolume}
 
-    # Upgrade
-    # Check Upgraded Version
-    # Check Container Create Timestamps
+    Upgrade
+    Check Upgraded Version
+    Check Container Create Timestamps
 
-    # Verify Volume Inspect Info  After Upgrade and Before Rollback  ${TestContainerVolume}  ${checkList}
+    Verify Volume Inspect Info  After Upgrade and Before Rollback  ${TestContainerVolume}  ${checkList}
 
-    # Rollback
-    # Check Original Version
+    Rollback
+    Check Original Version
 
-    # Upgrade with ID
-    # Check Upgraded Version
+    Upgrade with ID
+    Check Upgraded Version
 
-    # Verify Volume Inspect Info  After Upgrade with ID  ${TestContainerVolume}  ${checkList}
+    Verify Volume Inspect Info  After Upgrade with ID  ${TestContainerVolume}  ${checkList}
 
-    # Run Docker Checks
+    Run Docker Checks
 
 
-    # Log To Console  Regression Tests...
-    # Run Regression Tests
+    Log To Console  Regression Tests...
+    Run Regression Tests


### PR DESCRIPTION
This will provide consistent behavior across DRS and DRS disabled
environments.

Additionally, the vm.Folder code was refactored providing consistent results 
for VM or vApp.

[specific ci=Group11-Upgrade]