### PR TITLE
Log children that block imagestore delete

### DIFF
--- a/lib/install/management/store_files.go
+++ b/lib/install/management/store_files.go
@@ -89,7 +89,7 @@ func (d *Dispatcher) deleteImages(conf *config.VirtualContainerHostConfigSpec) e
 				errs = append(errs, err.Error())
 			}
 		} else {
-			d.op.Debug("Image store parent directory not empty, leaving in place.")
+			d.op.Debug("Image store parent directory not empty, leaving in place. Still contains the following entries: %q", strings.Join(children, ", "))
 		}
 	}
 


### PR DESCRIPTION
List the children that have not been deleted. We can see from the logs that it's
the image store that wasn't cleaned up fully, but not what was preventing deletion.

[skip unit]

Towards #7540 