### PR TITLE
Fix attach test race

### DIFF
--- a/tests/test-cases/Group1-Docker-Commands/1-09-Docker-Attach.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-09-Docker-Attach.robot
@@ -32,7 +32,6 @@ Basic attach
     Run  echo q > /tmp/fifo
     ${ret}=  Wait For Process  custom
     Should Be Equal As Integers  ${ret.rc}  0
-    Should Be Empty  ${ret.stdout}
     Should Be Empty  ${ret.stderr}
 
 Attach to stopped container


### PR DESCRIPTION
This test is essentially racing with whether we get valid attach output from bin/top or not.  ret.stdout can either be empty or contain the valid output from bin/top.

[specific ci=1-09-Docker-Attach]