### PR TITLE
Differentiate between HaaS systems and Nimbus systems

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -113,7 +113,7 @@ pipeline:
       - export DOMAIN=$CI_DOMAIN
       - export MULTI_VCH=1
       - echo $DOMAIN
-      - export TEST_URL_ARRAY=$HAAS_URL_ARRAY $OVERFLOW_URL_ARRAY
+      - export TEST_URL_ARRAY="$HAAS_URL_ARRAY $OVERFLOW_URL_ARRAY"
       - tests/integration-test.sh
     volumes:
       - /tmp

--- a/.drone.yml
+++ b/.drone.yml
@@ -66,24 +66,10 @@ pipeline:
       - drone_server
       - drone_token
       - github_automation_api_key
-      - registry_password
-      - test_password
-      - test_url_array
-      - test_username
       - codecov_token
     commands:
-      - 'export BUILD_NUMBER=${DRONE_BUILD_NUMBER}'
-      - 'export COMMIT=${DRONE_COMMIT}'
-      - 'make mark'
-      - 'make all'
-      - 'make sincemark'
-      - 'make mark'
-      - 'echo `ls vendor/github.com/vmware/govmomi/vim25/methods`'
-      - 'echo `ls vendor/github.com/vmware/govmomi/vim25/types`'
-      - 'echo `ls vendor/github.com/docker/docker/vendor/github.com/opencontainers/runc/libcontainer/system`'
-      - 'export VIC_ESX_URL_ARRAY="`tests/get_test_url.sh`"'
+      - make all
       - tests/unit-test-check.sh
-      - 'make sincemark'
     when:
       status: success
 
@@ -116,8 +102,9 @@ pipeline:
       - test_resource
       - test_timeout
       - test_password
-      - test_url_array
       - test_username
+      - haas_url_array
+      - overflow_url_array
     commands:
       - export GOVC_INSECURE=true
       - export GOVC_USERNAME=$TEST_USERNAME
@@ -126,9 +113,8 @@ pipeline:
       - export DOMAIN=$CI_DOMAIN
       - export MULTI_VCH=1
       - echo $DOMAIN
-      - 'make mark'
+      - export TEST_URL_ARRAY=$HAAS_URL_ARRAY $OVERFLOW_URL_ARRAY
       - tests/integration-test.sh
-      - 'make sincemark'
     volumes:
       - /tmp
     when:

--- a/tests/resources/VCH-Util.robot
+++ b/tests/resources/VCH-Util.robot
@@ -36,6 +36,10 @@ Set Test Environment Variables
     Set Environment Variable  GOVC_USERNAME  %{TEST_USERNAME}
     Set Environment Variable  GOVC_PASSWORD  %{TEST_PASSWORD}
 
+    ${IN_HAAS}=  Run Keyword And Return Status  Should Contain  %{HAAS_URL_ARRAY}  %{TEST_URL}
+    Run Keyword If  ${IN_HAAS}  Log To Console  Test Server is in HaaS
+    Run Keyword Unless  ${IN_HAAS}  Log To Console  Test Server is in Nimbus
+
     ${rc}  ${thumbprint}=  Run And Return Rc And Output  govc about.cert -k -json | jq -r .ThumbprintSHA1
     Should Be Equal As Integers  ${rc}  0
     Set Environment Variable  TEST_THUMBPRINT  ${thumbprint}


### PR DESCRIPTION
The 2 different environments have very different infra. While it works for current simple deployments, as we move to DRS based shared datastore scenarios we will need to potentially differentiate between where our tests are being run most esp when it pertains to networking and VLANs.

Also, performs some general cleanup of unneeded variables and using the timing stuff which we don't need as drone covers timing quite well now.