### PR TITLE
Switch to DRS-aware VM power-on

### DIFF
--- a/pkg/vsphere/compute/placement/ranked.go
+++ b/pkg/vsphere/compute/placement/ranked.go
@@ -72,6 +72,7 @@ func NewRankedHostPolicyWithConfig(op trace.Operation, cls *object.ComputeResour
 // CheckHost returns true if the host has adequate capacity to power on the VM, false otherwise.
 func (r *RankedHostPolicy) CheckHost(op trace.Operation, vm *object.VirtualMachine) bool {
 	// TODO(jzt): return false until we have host checking logic decided
+	// see https://github.com/vmware/vic/issues/7654
 	return false
 }
 

--- a/pkg/vsphere/vm/vm.go
+++ b/pkg/vsphere/vm/vm.go
@@ -785,7 +785,9 @@ func (vm *VirtualMachine) PowerOn(op trace.Operation) error {
 		return vm.powerOn(op)
 	}
 
-	op.Warnf("Host is not adequate for power-on, getting placement recommendation")
+	// TODO(jzt): uncomment this once we have CheckHost implemented.
+	// see https://github.com/vmware/vic/issues/7654
+	// op.Warnf("Host is not adequate for power-on, getting placement recommendation")
 
 	var hosts, subset []*object.HostSystem
 
@@ -861,10 +863,34 @@ func (vm *VirtualMachine) relocate(op trace.Operation, host *object.HostSystem) 
 }
 
 func (vm *VirtualMachine) powerOn(op trace.Operation) error {
-	_, err := vm.WaitForResult(op, func(op context.Context) (tasks.Task, error) {
-		return vm.VirtualMachine.PowerOn(op)
+	dc := vm.Datacenter
+
+	option := &types.OptionValue{
+		Key:   string(types.ClusterPowerOnVmOptionOverrideAutomationLevel),
+		Value: string(types.DrsBehaviorFullyAutomated),
+	}
+
+	t, err := vm.WaitForResult(op, func(op context.Context) (tasks.Task, error) {
+		return dc.PowerOnVM(op, []types.ManagedObjectReference{vm.Reference()}, option)
 	})
-	return err
+	if err != nil {
+		return err
+	}
+
+	switch r := t.Result.(type) {
+	case types.ClusterPowerOnVmResult:
+		attempts := len(r.Attempted)
+		if attempts != 1 {
+			return fmt.Errorf("Attempted to power on the wrong number of VMs. Expected 1, attempted %d", attempts)
+		}
+
+		info := r.Attempted[0]
+		task := object.NewTask(vm.Session.Vim25(), *info.Task)
+		_, err := task.WaitForResult(op, nil)
+		return err
+	default:
+		return fmt.Errorf("Unexpected return type when attempting to power on VM: %T", r)
+	}
 }
 
 func (vm *VirtualMachine) InCluster(op trace.Operation) bool {

--- a/tests/resources/VCH-Util.robot
+++ b/tests/resources/VCH-Util.robot
@@ -405,12 +405,13 @@ Check UpdateInProgress
     Should Be Equal As Integers  ${rc}  0
     Should Contain  ${output}  ${expected}
 
+# This keyword is used to match two patterns on the same line occurring in any order
 Portlayer Log Should Match Regexp
     [Tags]  secret
-    [Arguments]  ${pattern}
+    [Arguments]  ${pattern1}  ${pattern2}
     ${out}=  Run  curl -k -D /tmp/cookies-%{VCH-NAME} -Fusername=%{TEST_USERNAME} -Fpassword=%{TEST_PASSWORD} %{VIC-ADMIN}/authentication
     Log  ${out}
-    ${rc}=  Run And Return Rc  curl -sk %{VIC-ADMIN}/logs/port-layer.log -b /tmp/cookies-%{VCH-NAME} | grep -q -e \'${pattern}\'
+    ${rc}=  Run And Return Rc  curl -sk %{VIC-ADMIN}/logs/port-layer.log -b /tmp/cookies-%{VCH-NAME} | grep -ie \'${pattern1}\' | grep -iqe \'${pattern2}\'
     Should Be Equal As Integers  ${rc}  0
 
 Gather Logs From Test Server

--- a/tests/test-cases/Group0-Bugs/5343.robot
+++ b/tests/test-cases/Group0-Bugs/5343.robot
@@ -37,7 +37,7 @@ Check vsphere event stream
     # ensure that portlayer log contains the powered on event - this string comes in the e.Message portion of the vSphere event
     # and may be prone to Localization which would cause this test to fail.
     # for efficiency We assume that if we saw powered on then "${id} Created" would also have matched
-    Portlayer Log Should Match Regexp  ${name}-${shortid} on \\s\\S* in \\S* is powered on
+    Portlayer Log Should Match Regexp  ${name}-${shortid}  powered on
 
     # delete the session to suppress reception of events
     ${rc}  ${out}=  Run And Return Rc And Output  govc session.ls
@@ -59,4 +59,4 @@ Check vsphere event stream
 
     # Assert that the power off event is present
     # Would prefer to do this as a tail on the live log but no idea how to do stream processing in robot
-    Wait Until Keyword Succeeds  1m  10s  Portlayer Log Should Match Regexp  ${name}-${shortid} on \\s*\\S* in \\S* is powered off
+    Wait Until Keyword Succeeds  1m  10s  Portlayer Log Should Match Regexp  ${name}-${shortid}  powered off


### PR DESCRIPTION
This change switches over to using the DRS-aware `PowerOnMultiVM` call when powering on VMs in vSphere. If attempting to power-on a VM in ESX, it will use the standard power-on call.

Fixes #7237.

[specific ci=Group0-Bugs]