### PR TITLE
Fix VCH create unit test failure

### DIFF
--- a/lib/install/management/create_test.go
+++ b/lib/install/management/create_test.go
@@ -223,7 +223,8 @@ func testCleanup(op trace.Operation, sess *session.Session, conf *config.Virtual
 		return
 	}
 
-	d.deleteFolder(conf)
+	d.deleteVCHFolder()
+
 	// in this case we should expect the folder to be gone.
 	folder, err := d.session.Finder.Folder(d.op, path.Join(d.session.VMFolder.InventoryPath, conf.Name))
 	require.Error(t, err)


### PR DESCRIPTION
This commit fixes an erroneous call in the VCH create unit test. The
call was added in #7622 and detected in a CI build.

See https://ci-vic.vmware.com/vmware/vic/18101 and https://ci-vic.vmware.com/vmware/vic/18108