### PR TITLE
Check expected NFS volumes exist after endpoint restart

### DIFF
--- a/tests/manual-test-cases/Group5-Functional-Tests/5-22-NFS-Volume.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-22-NFS-Volume.robot
@@ -123,6 +123,11 @@ Reboot VM and Verify Basic VCH Info
     Should Be Equal As Integers  ${rc}  0
     Should Contain  ${output}  ${busybox}
 
+    # ensure that the volumes we expect to exist are still available
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} volumes
+    Should Be Equal As Integers  ${rc}  0
+    Should Contain  ${output}  ${nfsNamedVolume}
+
 Gather NFS Logs
     ${strippedPW}=  Remove String  %{DEPLOYED_PASSWORD}  \\
     ${strippedPW}=  Remove String  ${strippedPW}  '


### PR DESCRIPTION
This does nothing to address the actual failure observed, but will clarify the
cause so we don't have an involved triage when this issue happens again.

The problem here is that the failure to mount the NFS volume store is considered
a soft error (presumably because it may be corrected externally) and references
to volumes that are assumed to exist in that missing volume store result in
creation of new volumes with the same name in the VMFS volume store, and those
cannot be shared.

[skip ci]
Towards #7621 
