### PR TITLE
Retry infrastructure call to find host VM is on

### DIFF
--- a/tests/resources/VCH-Util.robot
+++ b/tests/resources/VCH-Util.robot
@@ -411,7 +411,7 @@ Gather Logs From Test Server
     [Arguments]  ${name-suffix}=${EMPTY}
     Run Keyword And Continue On Failure  Run  zip %{VCH-NAME}-certs -r %{VCH-NAME}
     Curl Container Logs  ${name-suffix}
-    ${host}=  Get VM Host Name  %{VCH-NAME}
+    ${host}=  Wait Until Keyword Succeeds  12x  10s  Get VM Host Name  %{VCH-NAME}
     Log  ${host}
     ${out}=  Run  govc datastore.download -host ${host} %{VCH-NAME}/vmware.log %{VCH-NAME}-vmware${name-suffix}.log
     Log  ${out}

--- a/tests/resources/Vsphere-Util.robot
+++ b/tests/resources/Vsphere-Util.robot
@@ -90,7 +90,8 @@ Get VM IP
 
 Get VM Host Name
     [Arguments]  ${vm}
-    ${out}=  Run  govc vm.info ${vm}
+    ${rc}  ${out}=  Run And Return Rc And Output  govc vm.info ${vm}
+    Should Be Equal As Integers  ${rc}  0
     ${out}=  Split To Lines  ${out}
     ${host}=  Fetch From Right  @{out}[-1]  ${SPACE}
     [Return]  ${host}


### PR DESCRIPTION
At least one of the builds over the weekend failed on this call. We don't need to fail builds on this call, as it has nothing to do with our product, so go ahead and retry it for up to 2 minutes.