### PR TITLE
Check that requests to docker endpoint are against rdns-valid hostname

### DIFF
--- a/cmd/docker/main.go
+++ b/cmd/docker/main.go
@@ -258,6 +258,8 @@ func startServer() *apiserver.Server {
 			tlsConfig.ClientCAs = loadCAPool()
 			tlsConfig.InsecureSkipVerify = false
 		}
+	} else {
+		log.Warnf("Docker endpoint running in plain HTTP mode")
 	}
 
 	addr := "0.0.0.0"
@@ -283,7 +285,6 @@ func startServer() *apiserver.Server {
 
 	if vchConfig.HostCertificate.IsNil() && vchConfig.Diagnostics.DebugLevel <= 2 {
 		// only enforce host header check in non-debug http-only mode
-		log.Warnf("Docker endpoint running in plain HTTP mode")
 		enforceHostHeaderCheck(addr, api)
 	}
 

--- a/cmd/docker/main.go
+++ b/cmd/docker/main.go
@@ -41,8 +41,10 @@ import (
 
 	vicbackends "github.com/vmware/vic/lib/apiservers/engine/backends"
 	"github.com/vmware/vic/lib/apiservers/engine/backends/executor"
+	vicmiddleware "github.com/vmware/vic/lib/apiservers/engine/backends/middleware"
 	"github.com/vmware/vic/lib/config"
 	"github.com/vmware/vic/lib/constants"
+	vicdns "github.com/vmware/vic/lib/dns"
 	"github.com/vmware/vic/lib/portlayer/util"
 	"github.com/vmware/vic/lib/pprof"
 	viclog "github.com/vmware/vic/pkg/log"
@@ -267,7 +269,19 @@ func startServer() *apiserver.Server {
 	mw := middleware.NewVersionMiddleware(version.DockerAPIVersion,
 		version.DockerDefaultVersion,
 		version.DockerMinimumVersion)
+
 	api.UseMiddleware(mw)
+	if vchConfig.HostCertificate.IsNil() {
+		log.Warnf("Docker endpoint running in plain HTTP mode")
+		rdnsNames := vicdns.ReverseLookup(addr)
+		if len(rdnsNames) == 0 {
+			log.Warnf("Could not resolve domain names for %s. Docker endpoint will only be accessible via the IP", addr)
+		}
+
+		rdnsNames[addr] = true // add the IP because that's always allowed
+		hostCheckMW := vicmiddleware.HostCheckMiddleware{ValidDomains: rdnsNames}
+		api.UseMiddleware(hostCheckMW)
+	}
 	fullserver := fmt.Sprintf("%s:%d", addr, *cli.serverPort)
 	l, err := listeners.Init(cli.proto, fullserver, "", serverConfig.TLSConfig)
 	if err != nil {

--- a/lib/apiservers/engine/backends/backends.go
+++ b/lib/apiservers/engine/backends/backends.go
@@ -50,7 +50,6 @@ import (
 	"github.com/vmware/vic/pkg/registry"
 	"github.com/vmware/vic/pkg/vsphere/session"
 	"github.com/vmware/vic/pkg/vsphere/sys"
-	//"github.com/vishvananda/netlink"
 )
 
 const (

--- a/lib/apiservers/engine/backends/middleware/middleware.go
+++ b/lib/apiservers/engine/backends/middleware/middleware.go
@@ -1,0 +1,43 @@
+// Copyright 2018 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package middleware
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	vicdns "github.com/vmware/vic/lib/dns"
+
+	context "golang.org/x/net/context"
+)
+
+// HostCheckMiddleware provides middleware for Host: field checking
+type HostCheckMiddleware struct {
+	ValidDomains vicdns.FQDNs
+}
+
+// WrapHandler satisfies the Docker middleware interface for HostCheckMiddleware
+func (h HostCheckMiddleware) WrapHandler(f func(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error) func(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
+	return func(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
+
+		hostname := strings.Split(r.Host, ":")[0] // trim port if it's there. r.Host should never contain a scheme so this should be fine
+		if h.ValidDomains[hostname] {
+			return f(ctx, w, r, vars)
+		}
+
+		return fmt.Errorf("request from %s with HTTP Host header \"%s\" rejected because %s is an invalid hostname for this endpoint", r.RemoteAddr, r.Host, r.Host)
+	}
+}

--- a/lib/apiservers/engine/backends/middleware/middleware.go
+++ b/lib/apiservers/engine/backends/middleware/middleware.go
@@ -17,7 +17,6 @@ package middleware
 import (
 	"fmt"
 	"net/http"
-	"net/url"
 	"strings"
 
 	"golang.org/x/net/context"
@@ -38,10 +37,6 @@ func validateHostname(r *http.Request) (hostname string, err error) {
 		return "", fmt.Errorf("empty host header from %s", r.RemoteAddr)
 	}
 
-	parsedURL, err := url.Parse(hostname)
-	if parsedURL.Hostname() != "<nil>" && err != nil && parsedURL.Hostname() != "" {
-		return parsedURL.Hostname(), nil
-	}
 	// trim port if it's there. r.Host should never contain a scheme
 	hostnameSplit := strings.Split(r.Host, ":")
 

--- a/lib/apiservers/engine/backends/middleware/middleware_test.go
+++ b/lib/apiservers/engine/backends/middleware/middleware_test.go
@@ -1,0 +1,75 @@
+// Copyright 2018 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package middleware
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidateHostname(t *testing.T) {
+	r := &http.Request{}
+	hostname, err := validateHostname(r)
+	assert.Error(t, err)
+	assert.EqualValues(t, "", hostname)
+
+	r.Host = ""
+	hostname, err = validateHostname(r)
+	assert.Error(t, err)
+	assert.EqualValues(t, "", hostname)
+
+	r.Host = "localname"
+	hostname, err = validateHostname(r)
+	assert.NoError(t, err)
+	assert.EqualValues(t, "localname", hostname)
+
+	r.Host = "localname:4567"
+	hostname, err = validateHostname(r)
+	assert.NoError(t, err)
+	assert.EqualValues(t, "localname", hostname)
+
+	r.Host = "[2605:a601:1119:6800:c69b:b2ec:eefa:ef4b]"
+	hostname, err = validateHostname(r)
+	assert.NoError(t, err)
+	assert.EqualValues(t, "[2605:a601:1119:6800:c69b:b2ec:eefa:ef4b]", hostname)
+
+	r.Host = "[2605:a601:1119:6800:c69b:b2ec:eefa:ef4b]:8080"
+	hostname, err = validateHostname(r)
+	assert.NoError(t, err)
+	assert.EqualValues(t, "[2605:a601:1119:6800:c69b:b2ec:eefa:ef4b]", hostname)
+
+	r.Host = "127.0.0.1:8080"
+	hostname, err = validateHostname(r)
+	assert.NoError(t, err)
+	assert.EqualValues(t, "127.0.0.1", hostname)
+
+	r.Host = "127.0.0.1"
+	hostname, err = validateHostname(r)
+	assert.NoError(t, err)
+	assert.EqualValues(t, "127.0.0.1", hostname)
+
+	r.Host = "foo.com:80"
+	hostname, err = validateHostname(r)
+	assert.NoError(t, err)
+	assert.EqualValues(t, "foo.com", hostname)
+
+	r.Host = "foo.com"
+	hostname, err = validateHostname(r)
+	assert.NoError(t, err)
+	assert.EqualValues(t, "foo.com", hostname)
+
+}

--- a/tests/test-cases/Group6-VIC-Machine/6-13-TLS.robot
+++ b/tests/test-cases/Group6-VIC-Machine/6-13-TLS.robot
@@ -57,213 +57,213 @@ Create VCH - defaults with --no-tls
     Run Regression Tests
     Cleanup VIC Appliance On Test Server
 
-# Create VCH - defaults custom cert path
-#     ${domain}=  Get Environment Variable  DOMAIN  ''
-#     Run Keyword If  '${domain}' == ''  Pass Execution  Skipping test - domain not set, won't generate keys
+Create VCH - defaults custom cert path
+    ${domain}=  Get Environment Variable  DOMAIN  ''
+    Run Keyword If  '${domain}' == ''  Pass Execution  Skipping test - domain not set, won't generate keys
 
-#     Set Test Environment Variables
-#     Run Keyword And Ignore Error  Cleanup Dangling VMs On Test Server
-#     Run Keyword And Ignore Error  Cleanup Datastore On Test Server
+    Set Test Environment Variables
+    Run Keyword And Ignore Error  Cleanup Dangling VMs On Test Server
+    Run Keyword And Ignore Error  Cleanup Datastore On Test Server
 
-#     ${output}=  Run  bin/vic-machine-linux create ${vicmachinetls} --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --image-store=%{TEST_DATASTORE} --bridge-network=%{BRIDGE_NETWORK} --public-network=%{PUBLIC_NETWORK} --tls-cert-path=${EXECDIR}/foo-bar-certs/ --insecure-registry wdc-harbor-ci.eng.vmware.com
-#     Should Contain  ${output}  --tlscacert=\\"${EXECDIR}/foo-bar-certs/ca.pem\\" --tlscert=\\"${EXECDIR}/foo-bar-certs/cert.pem\\" --tlskey=\\"${EXECDIR}/foo-bar-certs/key.pem\\"
-#     Should Contain  ${output}  Generating CA certificate/key pair - private key in ${EXECDIR}/foo-bar-certs/ca-key.pem
-#     Should Contain  ${output}  Generating server certificate/key pair - private key in ${EXECDIR}/foo-bar-certs/server-key.pem
-#     Should Contain  ${output}  Generating client certificate/key pair - private key in ${EXECDIR}/foo-bar-certs/key.pem
-#     Should Contain  ${output}  Generated browser friendly PFX client certificate - certificate in ${EXECDIR}/foo-bar-certs/cert.pfx
+    ${output}=  Run  bin/vic-machine-linux create ${vicmachinetls} --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --image-store=%{TEST_DATASTORE} --bridge-network=%{BRIDGE_NETWORK} --public-network=%{PUBLIC_NETWORK} --tls-cert-path=${EXECDIR}/foo-bar-certs/ --insecure-registry wdc-harbor-ci.eng.vmware.com
+    Should Contain  ${output}  --tlscacert=\\"${EXECDIR}/foo-bar-certs/ca.pem\\" --tlscert=\\"${EXECDIR}/foo-bar-certs/cert.pem\\" --tlskey=\\"${EXECDIR}/foo-bar-certs/key.pem\\"
+    Should Contain  ${output}  Generating CA certificate/key pair - private key in ${EXECDIR}/foo-bar-certs/ca-key.pem
+    Should Contain  ${output}  Generating server certificate/key pair - private key in ${EXECDIR}/foo-bar-certs/server-key.pem
+    Should Contain  ${output}  Generating client certificate/key pair - private key in ${EXECDIR}/foo-bar-certs/key.pem
+    Should Contain  ${output}  Generated browser friendly PFX client certificate - certificate in ${EXECDIR}/foo-bar-certs/cert.pfx
 
-#     Should Contain  ${output}  Installer completed successfully
-#     Get Docker Params  ${output}  ${true}
+    Should Contain  ${output}  Installer completed successfully
+    Get Docker Params  ${output}  ${true}
 
-#     ${save_env}=  Run  cat ${EXECDIR}/foo-bar-certs/%{VCH-NAME}.env
-#     Should Contain  ${save_env}  DOCKER_CERT_PATH=${EXECDIR}/foo-bar-certs
-#     Log To Console  Installer completed successfully: %{VCH-NAME}
+    ${save_env}=  Run  cat ${EXECDIR}/foo-bar-certs/%{VCH-NAME}.env
+    Should Contain  ${save_env}  DOCKER_CERT_PATH=${EXECDIR}/foo-bar-certs
+    Log To Console  Installer completed successfully: %{VCH-NAME}
 
-#     Run Regression Tests
-#     Cleanup VIC Appliance On Test Server
+    Run Regression Tests
+    Cleanup VIC Appliance On Test Server
 
-# Create VCH - force accept target thumbprint
-#     Set Test Environment Variables
-#     Run Keyword And Ignore Error  Cleanup Dangling VMs On Test Server
-#     Run Keyword And Ignore Error  Cleanup Datastore On Test Server
+Create VCH - force accept target thumbprint
+    Set Test Environment Variables
+    Run Keyword And Ignore Error  Cleanup Dangling VMs On Test Server
+    Run Keyword And Ignore Error  Cleanup Datastore On Test Server
 
-#     # Test that --force without --thumbprint accepts the --target thumbprint
-#     ${output}=  Run  bin/vic-machine-linux create --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --force --image-store=%{TEST_DATASTORE} --bridge-network=%{BRIDGE_NETWORK} --public-network=%{PUBLIC_NETWORK} ${vicmachinetls} --insecure-registry wdc-harbor-ci.eng.vmware.com
-#     Log  ${output}
-#     Should Contain  ${output}  Installer completed successfully
-#     Get Docker Params  ${output}  ${true}
-#     Log To Console  Installer completed successfully: %{VCH-NAME}
+    # Test that --force without --thumbprint accepts the --target thumbprint
+    ${output}=  Run  bin/vic-machine-linux create --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --force --image-store=%{TEST_DATASTORE} --bridge-network=%{BRIDGE_NETWORK} --public-network=%{PUBLIC_NETWORK} ${vicmachinetls} --insecure-registry wdc-harbor-ci.eng.vmware.com
+    Log  ${output}
+    Should Contain  ${output}  Installer completed successfully
+    Get Docker Params  ${output}  ${true}
+    Log To Console  Installer completed successfully: %{VCH-NAME}
 
-#     Run Regression Tests
-#     Cleanup VIC Appliance On Test Server
-
-
-
-# Create VCH - Specified keys
-#     Pass execution  Test not implemented until vic-machine can poll status correctly
+    Run Regression Tests
+    Cleanup VIC Appliance On Test Server
 
 
 
-# Create VCH - Server certificate with multiple blocks
-#     Set Test Environment Variables
-#     Run Keyword And Ignore Error  Cleanup Dangling VMs On Test Server
-#     Run Keyword And Ignore Error  Cleanup Datastore On Test Server
-
-#     # Install first to generate certificates
-#     ${output}=  Run  bin/vic-machine-linux create --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --image-store=%{TEST_DATASTORE} --bridge-network=%{BRIDGE_NETWORK} --public-network=%{PUBLIC_NETWORK} ${vicmachinetls}
-#     Should Contain  ${output}  Installer completed successfully
-#     Get Docker Params  ${output}  ${true}
-#     Log To Console  Installer completed successfully: %{VCH-NAME}
-
-#     # Remove the installed VCH
-#     ${ret}=  Run  bin/vic-machine-linux delete --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --name=%{VCH-NAME} --force
-#     Should Contain  ${ret}  Completed successfully
-
-#     # Update server-cert.pem with a junk block in the beginning
-#     Run  echo "-----BEGIN RSA PRIVATE KEY-----\nJUNK\n-----END RSA PRIVATE KEY-----" | cat - ./%{VCH-NAME}/server-cert.pem > /tmp/%{VCH-NAME}-server-cert.pem && mv /tmp/%{VCH-NAME}-server-cert.pem ./%{VCH-NAME}/server-cert.pem
-
-#     # Install VCH
-#     ${output}=  Run  bin/vic-machine-linux create --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --image-store=%{TEST_DATASTORE} --bridge-network=%{BRIDGE_NETWORK} --public-network=%{PUBLIC_NETWORK} --no-tlsverify
-#     Should Contain  ${output}  Failed to load x509 leaf
-#     Should Contain  ${output}  Loaded server certificate
-#     Should Contain  ${output}  Installer completed successfully
-
-#     Cleanup VIC Appliance On Test Server
+Create VCH - Specified keys
+    Pass execution  Test not implemented until vic-machine can poll status correctly
 
 
 
-# Create VCH - Invalid keys
-#     ${domain}=  Get Environment Variable  DOMAIN  ''
-#     Run Keyword If  '${domain}' == ''  Pass Execution  Skipping test - domain not set, won't generate keys
+Create VCH - Server certificate with multiple blocks
+    Set Test Environment Variables
+    Run Keyword And Ignore Error  Cleanup Dangling VMs On Test Server
+    Run Keyword And Ignore Error  Cleanup Datastore On Test Server
 
-#     Set Test Environment Variables
-#     Run Keyword And Ignore Error  Cleanup Dangling VMs On Test Server
-#     Run Keyword And Ignore Error  Cleanup Datastore On Test Server
+    # Install first to generate certificates
+    ${output}=  Run  bin/vic-machine-linux create --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --image-store=%{TEST_DATASTORE} --bridge-network=%{BRIDGE_NETWORK} --public-network=%{PUBLIC_NETWORK} ${vicmachinetls}
+    Should Contain  ${output}  Installer completed successfully
+    Get Docker Params  ${output}  ${true}
+    Log To Console  Installer completed successfully: %{VCH-NAME}
 
-#     ${output}=  Run  bin/vic-machine-linux create --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --image-store=%{TEST_DATASTORE} --bridge-network=%{BRIDGE_NETWORK} --public-network=%{PUBLIC_NETWORK} ${vicmachinetls}
+    # Remove the installed VCH
+    ${ret}=  Run  bin/vic-machine-linux delete --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --name=%{VCH-NAME} --force
+    Should Contain  ${ret}  Completed successfully
 
-#     # Invalid server key
-#     ${output}=  Run  bin/vic-machine-linux create --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --image-store=%{TEST_DATASTORE} --bridge-network=%{BRIDGE_NETWORK} --public-network=%{PUBLIC_NETWORK} ${vicmachinetls} --tls-ca="./%{VCH-NAME}/ca.pem" --tls-server-cert="./%{VCH-NAME}/server-cert.pem" --tls-server-key="./%{VCH-NAME}/ca.pem"
-#     Should Contain  ${output}  found a certificate rather than a key in the PEM for the private key
+    # Update server-cert.pem with a junk block in the beginning
+    Run  echo "-----BEGIN RSA PRIVATE KEY-----\nJUNK\n-----END RSA PRIVATE KEY-----" | cat - ./%{VCH-NAME}/server-cert.pem > /tmp/%{VCH-NAME}-server-cert.pem && mv /tmp/%{VCH-NAME}-server-cert.pem ./%{VCH-NAME}/server-cert.pem
 
-#     # Invalid server cert
-#     ${output}=  Run  bin/vic-machine-linux create --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --image-store=%{TEST_DATASTORE} --bridge-network=%{BRIDGE_NETWORK} --public-network=%{PUBLIC_NETWORK} ${vicmachinetls} --tls-ca="./%{VCH-NAME}/ca.pem" --tls-server-cert="./%{VCH-NAME}/server-key.pem" --tls-server-key="./%{VCH-NAME}/server-key.pem"
-#     Should Contain  ${output}  did find a private key; PEM inputs may have been switched
+    # Install VCH
+    ${output}=  Run  bin/vic-machine-linux create --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --image-store=%{TEST_DATASTORE} --bridge-network=%{BRIDGE_NETWORK} --public-network=%{PUBLIC_NETWORK} --no-tlsverify
+    Should Contain  ${output}  Failed to load x509 leaf
+    Should Contain  ${output}  Loaded server certificate
+    Should Contain  ${output}  Installer completed successfully
 
-#     # Invalid CA
-#     ${output}=  Run  bin/vic-machine-linux create --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --image-store=%{TEST_DATASTORE} --bridge-network=%{BRIDGE_NETWORK} --public-network=%{PUBLIC_NETWORK} ${vicmachinetls} --tls-ca="./%{VCH-NAME}/key.pem" --tls-server-cert="./%{VCH-NAME}/server-cert.pem" --tls-server-key="./%{VCH-NAME}/server-key.pem"
-#     Should Contain  ${output}  Unable to load certificate authority data
-
-#     Cleanup VIC Appliance On Test Server
-
-
-
-# Create VCH - Reuse keys
-#     ${domain}=  Get Environment Variable  DOMAIN  ''
-#     Run Keyword If  '${domain}' == ''  Pass Execution  Skipping test - domain not set, won't generate keys
-
-#     Set Test Environment Variables
-
-#     # use one install to generate certificates
-#     ${output}=  Run  bin/vic-machine-linux create --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --image-store=%{TEST_DATASTORE} --bridge-network=%{BRIDGE_NETWORK} --public-network=%{PUBLIC_NETWORK} ${vicmachinetls}
-#     Should Contain  ${output}  Installer completed successfully
-#     Get Docker Params  ${output}  ${true}
-#     Log To Console  Installer completed successfully: %{VCH-NAME}
-
-#     # remove the initial deployment
-#     ${ret}=  Run  bin/vic-machine-linux delete --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --name=%{VCH-NAME} --force
-#     Should Contain  ${ret}  Completed successfully
-
-#     # deploy using the same name - should reuse certificates
-#     ${output}=  Run  bin/vic-machine-linux create --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --image-store=%{TEST_DATASTORE} --bridge-network=%{BRIDGE_NETWORK} --public-network=%{PUBLIC_NETWORK} ${vicmachinetls}
-#     Should Contain  ${output}  Installer completed successfully
-
-#     Should Contain  ${output}  Loaded server certificate
-#     Should Contain  ${output}  Loaded CA with default name from certificate path
-#     Should Contain  ${output}  Loaded client certificate with default name from certificate path
-
-#     Cleanup VIC Appliance On Test Server
+    Cleanup VIC Appliance On Test Server
 
 
 
-# Create VCH - Server cert with untrusted CA
-#     ${domain}=  Get Environment Variable  DOMAIN  ''
-#     Run Keyword If  '${domain}' == ''  Pass Execution  Skipping test - domain not set, won't generate keys
+Create VCH - Invalid keys
+    ${domain}=  Get Environment Variable  DOMAIN  ''
+    Run Keyword If  '${domain}' == ''  Pass Execution  Skipping test - domain not set, won't generate keys
 
-#     Set Test Environment Variables
-#     Run Keyword And Ignore Error  Cleanup Dangling VMs On Test Server
-#     Run Keyword And Ignore Error  Cleanup Datastore On Test Server
+    Set Test Environment Variables
+    Run Keyword And Ignore Error  Cleanup Dangling VMs On Test Server
+    Run Keyword And Ignore Error  Cleanup Datastore On Test Server
 
-#     # Generate CA and wildcard cert for *.<DOMAIN>
-#     Generate Certificate Authority
-#     Generate Wildcard Server Certificate
+    ${output}=  Run  bin/vic-machine-linux create --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --image-store=%{TEST_DATASTORE} --bridge-network=%{BRIDGE_NETWORK} --public-network=%{PUBLIC_NETWORK} ${vicmachinetls}
 
-#     ${out}=  Run  cp /root/ca/cert-bundle.tgz .; tar xvf cert-bundle.tgz
-#     Log  ${out}
+    # Invalid server key
+    ${output}=  Run  bin/vic-machine-linux create --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --image-store=%{TEST_DATASTORE} --bridge-network=%{BRIDGE_NETWORK} --public-network=%{PUBLIC_NETWORK} ${vicmachinetls} --tls-ca="./%{VCH-NAME}/ca.pem" --tls-server-cert="./%{VCH-NAME}/server-cert.pem" --tls-server-key="./%{VCH-NAME}/ca.pem"
+    Should Contain  ${output}  found a certificate rather than a key in the PEM for the private key
 
-#     # Run vic-machine install, supply server cert and key
-#     ${output}=  Run  bin/vic-machine-linux create --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --tls-server-key "bundle/*.${domain}.key.pem" --tls-server-cert "bundle/*.${domain}.cert.pem" --image-store=%{TEST_DATASTORE} --bridge-network=%{BRIDGE_NETWORK} --public-network=%{PUBLIC_NETWORK} ${vicmachinetls} --debug 1
-#     Log  ${output}
-#     Should Contain  ${output}  Loaded server certificate bundle
-#     Should Contain  ${output}  Unable to locate existing CA in cert path
-#     Should Contain  ${output}  Failed to find a viable address for Docker API from certificates
-#     Should Contain  ${output}  Server certificate hostname doesn't match
-#     Should Contain  ${output}  Installer completed successfully
+    # Invalid server cert
+    ${output}=  Run  bin/vic-machine-linux create --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --image-store=%{TEST_DATASTORE} --bridge-network=%{BRIDGE_NETWORK} --public-network=%{PUBLIC_NETWORK} ${vicmachinetls} --tls-ca="./%{VCH-NAME}/ca.pem" --tls-server-cert="./%{VCH-NAME}/server-key.pem" --tls-server-key="./%{VCH-NAME}/server-key.pem"
+    Should Contain  ${output}  did find a private key; PEM inputs may have been switched
 
-#     # Verify that the supplied certificate is presented on web interface
-#     Get Docker Params  ${output}  ${true}
-#     ${output}=  Run  openssl s_client -showcerts -connect %{VCH-IP}:2378
-#     Log  ${output}
-#     Should Contain  ${output}  issuer=/C=US/ST=California/L=Los Angeles/O=Stark Enterprises/OU=Stark Enterprises Certificate Authority/CN=Stark Enterprises Global CA
+    # Invalid CA
+    ${output}=  Run  bin/vic-machine-linux create --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --image-store=%{TEST_DATASTORE} --bridge-network=%{BRIDGE_NETWORK} --public-network=%{PUBLIC_NETWORK} ${vicmachinetls} --tls-ca="./%{VCH-NAME}/key.pem" --tls-server-cert="./%{VCH-NAME}/server-cert.pem" --tls-server-key="./%{VCH-NAME}/server-key.pem"
+    Should Contain  ${output}  Unable to load certificate authority data
 
-#     Run  rm -rf bundle
-#     Run  rm -f cert-bundle.tgz
-#     Run  rm -rf /root/ca
-#     Run Keyword And Ignore Error  Cleanup VIC Appliance On Test Server
+    Cleanup VIC Appliance On Test Server
 
 
 
-# Create VCH - Server cert with trusted CA
-#     ${domain}=  Get Environment Variable  DOMAIN  ''
-#     Run Keyword If  '${domain}' == ''  Pass Execution  Skipping test - domain not set, won't generate keys
+Create VCH - Reuse keys
+    ${domain}=  Get Environment Variable  DOMAIN  ''
+    Run Keyword If  '${domain}' == ''  Pass Execution  Skipping test - domain not set, won't generate keys
 
-#     Set Test Environment Variables
-#     Run Keyword And Ignore Error  Cleanup Dangling VMs On Test Server
-#     Run Keyword And Ignore Error  Cleanup Datastore On Test Server
+    Set Test Environment Variables
 
-#     # Generate CA and wildcard cert for *.<DOMAIN>, install CA into root store
-#     Generate Certificate Authority
-#     Generate Wildcard Server Certificate
-#     Trust Certificate Authority
+    # use one install to generate certificates
+    ${output}=  Run  bin/vic-machine-linux create --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --image-store=%{TEST_DATASTORE} --bridge-network=%{BRIDGE_NETWORK} --public-network=%{PUBLIC_NETWORK} ${vicmachinetls}
+    Should Contain  ${output}  Installer completed successfully
+    Get Docker Params  ${output}  ${true}
+    Log To Console  Installer completed successfully: %{VCH-NAME}
 
-#     ${out}=  Run  cp /root/ca/cert-bundle.tgz .; tar xvf cert-bundle.tgz
-#     Log  ${out}
+    # remove the initial deployment
+    ${ret}=  Run  bin/vic-machine-linux delete --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --name=%{VCH-NAME} --force
+    Should Contain  ${ret}  Completed successfully
 
-#     # Run vic-machine install, supply server cert and key
-#     ${output}=  Run  bin/vic-machine-linux create --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --tls-server-key "bundle/*.%{DOMAIN}.key.pem" --tls-server-cert "bundle/*.%{DOMAIN}.cert.pem" --image-store=%{TEST_DATASTORE} --bridge-network=%{BRIDGE_NETWORK} --public-network=%{PUBLIC_NETWORK} ${vicmachinetls} --debug 1
-#     Log  ${output}
-#     Should Contain  ${output}  Loaded server certificate bundle
-#     Should Contain  ${output}  Unable to locate existing CA in cert path
-#     Should Contain  ${output}  Installer completed successfully
+    # deploy using the same name - should reuse certificates
+    ${output}=  Run  bin/vic-machine-linux create --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --image-store=%{TEST_DATASTORE} --bridge-network=%{BRIDGE_NETWORK} --public-network=%{PUBLIC_NETWORK} ${vicmachinetls}
+    Should Contain  ${output}  Installer completed successfully
 
+    Should Contain  ${output}  Loaded server certificate
+    Should Contain  ${output}  Loaded CA with default name from certificate path
+    Should Contain  ${output}  Loaded client certificate with default name from certificate path
 
-#     # Verify that the supplied certificate is presented on web interface
-#     Get Docker Params  ${output}  ${true}
-#     ${output}=  Run  openssl s_client -showcerts -connect %{VCH-IP}:2378
-#     Log  ${output}
-#     Should Contain  ${output}  issuer=/C=US/ST=California/L=Los Angeles/O=Stark Enterprises/OU=Stark Enterprises Certificate Authority/CN=Stark Enterprises Global CA
-
-#     Run  rm -rf bundle
-#     Run  rm -f cert-bundle.tgz
-#     Run  rm -rf /root/ca
-
-#     Reload Default Certificate Authorities
-
-#     Run Keyword And Ignore Error  Cleanup VIC Appliance On Test Server
+    Cleanup VIC Appliance On Test Server
 
 
 
-# Create VCH - Server cert with intermediate CA
-#     ${domain}=  Get Environment Variable  DOMAIN  ''
-#     Run Keyword If  '${domain}' == ''  Pass Execution  Skipping test - domain not set, won't generate keys
-#     Pass execution  Test not implemented
+Create VCH - Server cert with untrusted CA
+    ${domain}=  Get Environment Variable  DOMAIN  ''
+    Run Keyword If  '${domain}' == ''  Pass Execution  Skipping test - domain not set, won't generate keys
+
+    Set Test Environment Variables
+    Run Keyword And Ignore Error  Cleanup Dangling VMs On Test Server
+    Run Keyword And Ignore Error  Cleanup Datastore On Test Server
+
+    # Generate CA and wildcard cert for *.<DOMAIN>
+    Generate Certificate Authority
+    Generate Wildcard Server Certificate
+
+    ${out}=  Run  cp /root/ca/cert-bundle.tgz .; tar xvf cert-bundle.tgz
+    Log  ${out}
+
+    # Run vic-machine install, supply server cert and key
+    ${output}=  Run  bin/vic-machine-linux create --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --tls-server-key "bundle/*.${domain}.key.pem" --tls-server-cert "bundle/*.${domain}.cert.pem" --image-store=%{TEST_DATASTORE} --bridge-network=%{BRIDGE_NETWORK} --public-network=%{PUBLIC_NETWORK} ${vicmachinetls} --debug 1
+    Log  ${output}
+    Should Contain  ${output}  Loaded server certificate bundle
+    Should Contain  ${output}  Unable to locate existing CA in cert path
+    Should Contain  ${output}  Failed to find a viable address for Docker API from certificates
+    Should Contain  ${output}  Server certificate hostname doesn't match
+    Should Contain  ${output}  Installer completed successfully
+
+    # Verify that the supplied certificate is presented on web interface
+    Get Docker Params  ${output}  ${true}
+    ${output}=  Run  openssl s_client -showcerts -connect %{VCH-IP}:2378
+    Log  ${output}
+    Should Contain  ${output}  issuer=/C=US/ST=California/L=Los Angeles/O=Stark Enterprises/OU=Stark Enterprises Certificate Authority/CN=Stark Enterprises Global CA
+
+    Run  rm -rf bundle
+    Run  rm -f cert-bundle.tgz
+    Run  rm -rf /root/ca
+    Run Keyword And Ignore Error  Cleanup VIC Appliance On Test Server
+
+
+
+Create VCH - Server cert with trusted CA
+    ${domain}=  Get Environment Variable  DOMAIN  ''
+    Run Keyword If  '${domain}' == ''  Pass Execution  Skipping test - domain not set, won't generate keys
+
+    Set Test Environment Variables
+    Run Keyword And Ignore Error  Cleanup Dangling VMs On Test Server
+    Run Keyword And Ignore Error  Cleanup Datastore On Test Server
+
+    # Generate CA and wildcard cert for *.<DOMAIN>, install CA into root store
+    Generate Certificate Authority
+    Generate Wildcard Server Certificate
+    Trust Certificate Authority
+
+    ${out}=  Run  cp /root/ca/cert-bundle.tgz .; tar xvf cert-bundle.tgz
+    Log  ${out}
+
+    # Run vic-machine install, supply server cert and key
+    ${output}=  Run  bin/vic-machine-linux create --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --tls-server-key "bundle/*.%{DOMAIN}.key.pem" --tls-server-cert "bundle/*.%{DOMAIN}.cert.pem" --image-store=%{TEST_DATASTORE} --bridge-network=%{BRIDGE_NETWORK} --public-network=%{PUBLIC_NETWORK} ${vicmachinetls} --debug 1
+    Log  ${output}
+    Should Contain  ${output}  Loaded server certificate bundle
+    Should Contain  ${output}  Unable to locate existing CA in cert path
+    Should Contain  ${output}  Installer completed successfully
+
+
+    # Verify that the supplied certificate is presented on web interface
+    Get Docker Params  ${output}  ${true}
+    ${output}=  Run  openssl s_client -showcerts -connect %{VCH-IP}:2378
+    Log  ${output}
+    Should Contain  ${output}  issuer=/C=US/ST=California/L=Los Angeles/O=Stark Enterprises/OU=Stark Enterprises Certificate Authority/CN=Stark Enterprises Global CA
+
+    Run  rm -rf bundle
+    Run  rm -f cert-bundle.tgz
+    Run  rm -rf /root/ca
+
+    Reload Default Certificate Authorities
+
+    Run Keyword And Ignore Error  Cleanup VIC Appliance On Test Server
+
+
+
+Create VCH - Server cert with intermediate CA
+    ${domain}=  Get Environment Variable  DOMAIN  ''
+    Run Keyword If  '${domain}' == ''  Pass Execution  Skipping test - domain not set, won't generate keys
+    Pass execution  Test not implemented

--- a/tests/test-cases/Group6-VIC-Machine/6-13-TLS.robot
+++ b/tests/test-cases/Group6-VIC-Machine/6-13-TLS.robot
@@ -31,6 +31,14 @@ Check that normal requests are accepted
     Should Contain  ${output}  200 OK
     Should Not Contain  ${output}  500 Internal Server Error
 
+    # also make sure it works if the port isn't part of the host header
+    ${dockerHost}=  Get Environment Variable  DOCKER_HOST
+    @{hostParts}=  Split String  ${dockerHost}  :
+    ${ip}=  Strip String  @{hostParts}[0]
+
+    ${rc}  ${output}=  Run And Return Rc And Output  curl -vvv -H"Host: ${ip}" %{DOCKER_HOST}/_ping
+    Should Contain  ${output}  200 OK
+    Should Not Contain  ${output}  500 Internal Server Error
 
 *** Test Cases ***
 Create VCH - defaults with --no-tls
@@ -49,213 +57,213 @@ Create VCH - defaults with --no-tls
     Run Regression Tests
     Cleanup VIC Appliance On Test Server
 
-Create VCH - defaults custom cert path
-    ${domain}=  Get Environment Variable  DOMAIN  ''
-    Run Keyword If  '${domain}' == ''  Pass Execution  Skipping test - domain not set, won't generate keys
+# Create VCH - defaults custom cert path
+#     ${domain}=  Get Environment Variable  DOMAIN  ''
+#     Run Keyword If  '${domain}' == ''  Pass Execution  Skipping test - domain not set, won't generate keys
 
-    Set Test Environment Variables
-    Run Keyword And Ignore Error  Cleanup Dangling VMs On Test Server
-    Run Keyword And Ignore Error  Cleanup Datastore On Test Server
+#     Set Test Environment Variables
+#     Run Keyword And Ignore Error  Cleanup Dangling VMs On Test Server
+#     Run Keyword And Ignore Error  Cleanup Datastore On Test Server
 
-    ${output}=  Run  bin/vic-machine-linux create ${vicmachinetls} --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --image-store=%{TEST_DATASTORE} --bridge-network=%{BRIDGE_NETWORK} --public-network=%{PUBLIC_NETWORK} --tls-cert-path=${EXECDIR}/foo-bar-certs/ --insecure-registry wdc-harbor-ci.eng.vmware.com
-    Should Contain  ${output}  --tlscacert=\\"${EXECDIR}/foo-bar-certs/ca.pem\\" --tlscert=\\"${EXECDIR}/foo-bar-certs/cert.pem\\" --tlskey=\\"${EXECDIR}/foo-bar-certs/key.pem\\"
-    Should Contain  ${output}  Generating CA certificate/key pair - private key in ${EXECDIR}/foo-bar-certs/ca-key.pem
-    Should Contain  ${output}  Generating server certificate/key pair - private key in ${EXECDIR}/foo-bar-certs/server-key.pem
-    Should Contain  ${output}  Generating client certificate/key pair - private key in ${EXECDIR}/foo-bar-certs/key.pem
-    Should Contain  ${output}  Generated browser friendly PFX client certificate - certificate in ${EXECDIR}/foo-bar-certs/cert.pfx
+#     ${output}=  Run  bin/vic-machine-linux create ${vicmachinetls} --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --image-store=%{TEST_DATASTORE} --bridge-network=%{BRIDGE_NETWORK} --public-network=%{PUBLIC_NETWORK} --tls-cert-path=${EXECDIR}/foo-bar-certs/ --insecure-registry wdc-harbor-ci.eng.vmware.com
+#     Should Contain  ${output}  --tlscacert=\\"${EXECDIR}/foo-bar-certs/ca.pem\\" --tlscert=\\"${EXECDIR}/foo-bar-certs/cert.pem\\" --tlskey=\\"${EXECDIR}/foo-bar-certs/key.pem\\"
+#     Should Contain  ${output}  Generating CA certificate/key pair - private key in ${EXECDIR}/foo-bar-certs/ca-key.pem
+#     Should Contain  ${output}  Generating server certificate/key pair - private key in ${EXECDIR}/foo-bar-certs/server-key.pem
+#     Should Contain  ${output}  Generating client certificate/key pair - private key in ${EXECDIR}/foo-bar-certs/key.pem
+#     Should Contain  ${output}  Generated browser friendly PFX client certificate - certificate in ${EXECDIR}/foo-bar-certs/cert.pfx
 
-    Should Contain  ${output}  Installer completed successfully
-    Get Docker Params  ${output}  ${true}
+#     Should Contain  ${output}  Installer completed successfully
+#     Get Docker Params  ${output}  ${true}
 
-    ${save_env}=  Run  cat ${EXECDIR}/foo-bar-certs/%{VCH-NAME}.env
-    Should Contain  ${save_env}  DOCKER_CERT_PATH=${EXECDIR}/foo-bar-certs
-    Log To Console  Installer completed successfully: %{VCH-NAME}
+#     ${save_env}=  Run  cat ${EXECDIR}/foo-bar-certs/%{VCH-NAME}.env
+#     Should Contain  ${save_env}  DOCKER_CERT_PATH=${EXECDIR}/foo-bar-certs
+#     Log To Console  Installer completed successfully: %{VCH-NAME}
 
-    Run Regression Tests
-    Cleanup VIC Appliance On Test Server
+#     Run Regression Tests
+#     Cleanup VIC Appliance On Test Server
 
-Create VCH - force accept target thumbprint
-    Set Test Environment Variables
-    Run Keyword And Ignore Error  Cleanup Dangling VMs On Test Server
-    Run Keyword And Ignore Error  Cleanup Datastore On Test Server
+# Create VCH - force accept target thumbprint
+#     Set Test Environment Variables
+#     Run Keyword And Ignore Error  Cleanup Dangling VMs On Test Server
+#     Run Keyword And Ignore Error  Cleanup Datastore On Test Server
 
-    # Test that --force without --thumbprint accepts the --target thumbprint
-    ${output}=  Run  bin/vic-machine-linux create --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --force --image-store=%{TEST_DATASTORE} --bridge-network=%{BRIDGE_NETWORK} --public-network=%{PUBLIC_NETWORK} ${vicmachinetls} --insecure-registry wdc-harbor-ci.eng.vmware.com
-    Log  ${output}
-    Should Contain  ${output}  Installer completed successfully
-    Get Docker Params  ${output}  ${true}
-    Log To Console  Installer completed successfully: %{VCH-NAME}
+#     # Test that --force without --thumbprint accepts the --target thumbprint
+#     ${output}=  Run  bin/vic-machine-linux create --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --force --image-store=%{TEST_DATASTORE} --bridge-network=%{BRIDGE_NETWORK} --public-network=%{PUBLIC_NETWORK} ${vicmachinetls} --insecure-registry wdc-harbor-ci.eng.vmware.com
+#     Log  ${output}
+#     Should Contain  ${output}  Installer completed successfully
+#     Get Docker Params  ${output}  ${true}
+#     Log To Console  Installer completed successfully: %{VCH-NAME}
 
-    Run Regression Tests
-    Cleanup VIC Appliance On Test Server
-
-
-
-Create VCH - Specified keys
-    Pass execution  Test not implemented until vic-machine can poll status correctly
+#     Run Regression Tests
+#     Cleanup VIC Appliance On Test Server
 
 
 
-Create VCH - Server certificate with multiple blocks
-    Set Test Environment Variables
-    Run Keyword And Ignore Error  Cleanup Dangling VMs On Test Server
-    Run Keyword And Ignore Error  Cleanup Datastore On Test Server
-
-    # Install first to generate certificates
-    ${output}=  Run  bin/vic-machine-linux create --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --image-store=%{TEST_DATASTORE} --bridge-network=%{BRIDGE_NETWORK} --public-network=%{PUBLIC_NETWORK} ${vicmachinetls}
-    Should Contain  ${output}  Installer completed successfully
-    Get Docker Params  ${output}  ${true}
-    Log To Console  Installer completed successfully: %{VCH-NAME}
-
-    # Remove the installed VCH
-    ${ret}=  Run  bin/vic-machine-linux delete --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --name=%{VCH-NAME} --force
-    Should Contain  ${ret}  Completed successfully
-
-    # Update server-cert.pem with a junk block in the beginning
-    Run  echo "-----BEGIN RSA PRIVATE KEY-----\nJUNK\n-----END RSA PRIVATE KEY-----" | cat - ./%{VCH-NAME}/server-cert.pem > /tmp/%{VCH-NAME}-server-cert.pem && mv /tmp/%{VCH-NAME}-server-cert.pem ./%{VCH-NAME}/server-cert.pem
-
-    # Install VCH
-    ${output}=  Run  bin/vic-machine-linux create --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --image-store=%{TEST_DATASTORE} --bridge-network=%{BRIDGE_NETWORK} --public-network=%{PUBLIC_NETWORK} --no-tlsverify
-    Should Contain  ${output}  Failed to load x509 leaf
-    Should Contain  ${output}  Loaded server certificate
-    Should Contain  ${output}  Installer completed successfully
-
-    Cleanup VIC Appliance On Test Server
+# Create VCH - Specified keys
+#     Pass execution  Test not implemented until vic-machine can poll status correctly
 
 
 
-Create VCH - Invalid keys
-    ${domain}=  Get Environment Variable  DOMAIN  ''
-    Run Keyword If  '${domain}' == ''  Pass Execution  Skipping test - domain not set, won't generate keys
+# Create VCH - Server certificate with multiple blocks
+#     Set Test Environment Variables
+#     Run Keyword And Ignore Error  Cleanup Dangling VMs On Test Server
+#     Run Keyword And Ignore Error  Cleanup Datastore On Test Server
 
-    Set Test Environment Variables
-    Run Keyword And Ignore Error  Cleanup Dangling VMs On Test Server
-    Run Keyword And Ignore Error  Cleanup Datastore On Test Server
+#     # Install first to generate certificates
+#     ${output}=  Run  bin/vic-machine-linux create --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --image-store=%{TEST_DATASTORE} --bridge-network=%{BRIDGE_NETWORK} --public-network=%{PUBLIC_NETWORK} ${vicmachinetls}
+#     Should Contain  ${output}  Installer completed successfully
+#     Get Docker Params  ${output}  ${true}
+#     Log To Console  Installer completed successfully: %{VCH-NAME}
 
-    ${output}=  Run  bin/vic-machine-linux create --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --image-store=%{TEST_DATASTORE} --bridge-network=%{BRIDGE_NETWORK} --public-network=%{PUBLIC_NETWORK} ${vicmachinetls}
+#     # Remove the installed VCH
+#     ${ret}=  Run  bin/vic-machine-linux delete --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --name=%{VCH-NAME} --force
+#     Should Contain  ${ret}  Completed successfully
 
-    # Invalid server key
-    ${output}=  Run  bin/vic-machine-linux create --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --image-store=%{TEST_DATASTORE} --bridge-network=%{BRIDGE_NETWORK} --public-network=%{PUBLIC_NETWORK} ${vicmachinetls} --tls-ca="./%{VCH-NAME}/ca.pem" --tls-server-cert="./%{VCH-NAME}/server-cert.pem" --tls-server-key="./%{VCH-NAME}/ca.pem"
-    Should Contain  ${output}  found a certificate rather than a key in the PEM for the private key
+#     # Update server-cert.pem with a junk block in the beginning
+#     Run  echo "-----BEGIN RSA PRIVATE KEY-----\nJUNK\n-----END RSA PRIVATE KEY-----" | cat - ./%{VCH-NAME}/server-cert.pem > /tmp/%{VCH-NAME}-server-cert.pem && mv /tmp/%{VCH-NAME}-server-cert.pem ./%{VCH-NAME}/server-cert.pem
 
-    # Invalid server cert
-    ${output}=  Run  bin/vic-machine-linux create --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --image-store=%{TEST_DATASTORE} --bridge-network=%{BRIDGE_NETWORK} --public-network=%{PUBLIC_NETWORK} ${vicmachinetls} --tls-ca="./%{VCH-NAME}/ca.pem" --tls-server-cert="./%{VCH-NAME}/server-key.pem" --tls-server-key="./%{VCH-NAME}/server-key.pem"
-    Should Contain  ${output}  did find a private key; PEM inputs may have been switched
+#     # Install VCH
+#     ${output}=  Run  bin/vic-machine-linux create --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --image-store=%{TEST_DATASTORE} --bridge-network=%{BRIDGE_NETWORK} --public-network=%{PUBLIC_NETWORK} --no-tlsverify
+#     Should Contain  ${output}  Failed to load x509 leaf
+#     Should Contain  ${output}  Loaded server certificate
+#     Should Contain  ${output}  Installer completed successfully
 
-    # Invalid CA
-    ${output}=  Run  bin/vic-machine-linux create --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --image-store=%{TEST_DATASTORE} --bridge-network=%{BRIDGE_NETWORK} --public-network=%{PUBLIC_NETWORK} ${vicmachinetls} --tls-ca="./%{VCH-NAME}/key.pem" --tls-server-cert="./%{VCH-NAME}/server-cert.pem" --tls-server-key="./%{VCH-NAME}/server-key.pem"
-    Should Contain  ${output}  Unable to load certificate authority data
-
-    Cleanup VIC Appliance On Test Server
-
-
-
-Create VCH - Reuse keys
-    ${domain}=  Get Environment Variable  DOMAIN  ''
-    Run Keyword If  '${domain}' == ''  Pass Execution  Skipping test - domain not set, won't generate keys
-
-    Set Test Environment Variables
-
-    # use one install to generate certificates
-    ${output}=  Run  bin/vic-machine-linux create --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --image-store=%{TEST_DATASTORE} --bridge-network=%{BRIDGE_NETWORK} --public-network=%{PUBLIC_NETWORK} ${vicmachinetls}
-    Should Contain  ${output}  Installer completed successfully
-    Get Docker Params  ${output}  ${true}
-    Log To Console  Installer completed successfully: %{VCH-NAME}
-
-    # remove the initial deployment
-    ${ret}=  Run  bin/vic-machine-linux delete --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --name=%{VCH-NAME} --force
-    Should Contain  ${ret}  Completed successfully
-
-    # deploy using the same name - should reuse certificates
-    ${output}=  Run  bin/vic-machine-linux create --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --image-store=%{TEST_DATASTORE} --bridge-network=%{BRIDGE_NETWORK} --public-network=%{PUBLIC_NETWORK} ${vicmachinetls}
-    Should Contain  ${output}  Installer completed successfully
-
-    Should Contain  ${output}  Loaded server certificate
-    Should Contain  ${output}  Loaded CA with default name from certificate path
-    Should Contain  ${output}  Loaded client certificate with default name from certificate path
-
-    Cleanup VIC Appliance On Test Server
+#     Cleanup VIC Appliance On Test Server
 
 
 
-Create VCH - Server cert with untrusted CA
-    ${domain}=  Get Environment Variable  DOMAIN  ''
-    Run Keyword If  '${domain}' == ''  Pass Execution  Skipping test - domain not set, won't generate keys
+# Create VCH - Invalid keys
+#     ${domain}=  Get Environment Variable  DOMAIN  ''
+#     Run Keyword If  '${domain}' == ''  Pass Execution  Skipping test - domain not set, won't generate keys
 
-    Set Test Environment Variables
-    Run Keyword And Ignore Error  Cleanup Dangling VMs On Test Server
-    Run Keyword And Ignore Error  Cleanup Datastore On Test Server
+#     Set Test Environment Variables
+#     Run Keyword And Ignore Error  Cleanup Dangling VMs On Test Server
+#     Run Keyword And Ignore Error  Cleanup Datastore On Test Server
 
-    # Generate CA and wildcard cert for *.<DOMAIN>
-    Generate Certificate Authority
-    Generate Wildcard Server Certificate
+#     ${output}=  Run  bin/vic-machine-linux create --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --image-store=%{TEST_DATASTORE} --bridge-network=%{BRIDGE_NETWORK} --public-network=%{PUBLIC_NETWORK} ${vicmachinetls}
 
-    ${out}=  Run  cp /root/ca/cert-bundle.tgz .; tar xvf cert-bundle.tgz
-    Log  ${out}
+#     # Invalid server key
+#     ${output}=  Run  bin/vic-machine-linux create --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --image-store=%{TEST_DATASTORE} --bridge-network=%{BRIDGE_NETWORK} --public-network=%{PUBLIC_NETWORK} ${vicmachinetls} --tls-ca="./%{VCH-NAME}/ca.pem" --tls-server-cert="./%{VCH-NAME}/server-cert.pem" --tls-server-key="./%{VCH-NAME}/ca.pem"
+#     Should Contain  ${output}  found a certificate rather than a key in the PEM for the private key
 
-    # Run vic-machine install, supply server cert and key
-    ${output}=  Run  bin/vic-machine-linux create --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --tls-server-key "bundle/*.${domain}.key.pem" --tls-server-cert "bundle/*.${domain}.cert.pem" --image-store=%{TEST_DATASTORE} --bridge-network=%{BRIDGE_NETWORK} --public-network=%{PUBLIC_NETWORK} ${vicmachinetls} --debug 1
-    Log  ${output}
-    Should Contain  ${output}  Loaded server certificate bundle
-    Should Contain  ${output}  Unable to locate existing CA in cert path
-    Should Contain  ${output}  Failed to find a viable address for Docker API from certificates
-    Should Contain  ${output}  Server certificate hostname doesn't match
-    Should Contain  ${output}  Installer completed successfully
+#     # Invalid server cert
+#     ${output}=  Run  bin/vic-machine-linux create --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --image-store=%{TEST_DATASTORE} --bridge-network=%{BRIDGE_NETWORK} --public-network=%{PUBLIC_NETWORK} ${vicmachinetls} --tls-ca="./%{VCH-NAME}/ca.pem" --tls-server-cert="./%{VCH-NAME}/server-key.pem" --tls-server-key="./%{VCH-NAME}/server-key.pem"
+#     Should Contain  ${output}  did find a private key; PEM inputs may have been switched
 
-    # Verify that the supplied certificate is presented on web interface
-    Get Docker Params  ${output}  ${true}
-    ${output}=  Run  openssl s_client -showcerts -connect %{VCH-IP}:2378
-    Log  ${output}
-    Should Contain  ${output}  issuer=/C=US/ST=California/L=Los Angeles/O=Stark Enterprises/OU=Stark Enterprises Certificate Authority/CN=Stark Enterprises Global CA
+#     # Invalid CA
+#     ${output}=  Run  bin/vic-machine-linux create --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --image-store=%{TEST_DATASTORE} --bridge-network=%{BRIDGE_NETWORK} --public-network=%{PUBLIC_NETWORK} ${vicmachinetls} --tls-ca="./%{VCH-NAME}/key.pem" --tls-server-cert="./%{VCH-NAME}/server-cert.pem" --tls-server-key="./%{VCH-NAME}/server-key.pem"
+#     Should Contain  ${output}  Unable to load certificate authority data
 
-    Run  rm -rf bundle
-    Run  rm -f cert-bundle.tgz
-    Run  rm -rf /root/ca
-    Run Keyword And Ignore Error  Cleanup VIC Appliance On Test Server
+#     Cleanup VIC Appliance On Test Server
 
 
 
-Create VCH - Server cert with trusted CA
-    ${domain}=  Get Environment Variable  DOMAIN  ''
-    Run Keyword If  '${domain}' == ''  Pass Execution  Skipping test - domain not set, won't generate keys
+# Create VCH - Reuse keys
+#     ${domain}=  Get Environment Variable  DOMAIN  ''
+#     Run Keyword If  '${domain}' == ''  Pass Execution  Skipping test - domain not set, won't generate keys
 
-    Set Test Environment Variables
-    Run Keyword And Ignore Error  Cleanup Dangling VMs On Test Server
-    Run Keyword And Ignore Error  Cleanup Datastore On Test Server
+#     Set Test Environment Variables
 
-    # Generate CA and wildcard cert for *.<DOMAIN>, install CA into root store
-    Generate Certificate Authority
-    Generate Wildcard Server Certificate
-    Trust Certificate Authority
+#     # use one install to generate certificates
+#     ${output}=  Run  bin/vic-machine-linux create --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --image-store=%{TEST_DATASTORE} --bridge-network=%{BRIDGE_NETWORK} --public-network=%{PUBLIC_NETWORK} ${vicmachinetls}
+#     Should Contain  ${output}  Installer completed successfully
+#     Get Docker Params  ${output}  ${true}
+#     Log To Console  Installer completed successfully: %{VCH-NAME}
 
-    ${out}=  Run  cp /root/ca/cert-bundle.tgz .; tar xvf cert-bundle.tgz
-    Log  ${out}
+#     # remove the initial deployment
+#     ${ret}=  Run  bin/vic-machine-linux delete --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --name=%{VCH-NAME} --force
+#     Should Contain  ${ret}  Completed successfully
 
-    # Run vic-machine install, supply server cert and key
-    ${output}=  Run  bin/vic-machine-linux create --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --tls-server-key "bundle/*.%{DOMAIN}.key.pem" --tls-server-cert "bundle/*.%{DOMAIN}.cert.pem" --image-store=%{TEST_DATASTORE} --bridge-network=%{BRIDGE_NETWORK} --public-network=%{PUBLIC_NETWORK} ${vicmachinetls} --debug 1
-    Log  ${output}
-    Should Contain  ${output}  Loaded server certificate bundle
-    Should Contain  ${output}  Unable to locate existing CA in cert path
-    Should Contain  ${output}  Installer completed successfully
+#     # deploy using the same name - should reuse certificates
+#     ${output}=  Run  bin/vic-machine-linux create --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --image-store=%{TEST_DATASTORE} --bridge-network=%{BRIDGE_NETWORK} --public-network=%{PUBLIC_NETWORK} ${vicmachinetls}
+#     Should Contain  ${output}  Installer completed successfully
 
+#     Should Contain  ${output}  Loaded server certificate
+#     Should Contain  ${output}  Loaded CA with default name from certificate path
+#     Should Contain  ${output}  Loaded client certificate with default name from certificate path
 
-    # Verify that the supplied certificate is presented on web interface
-    Get Docker Params  ${output}  ${true}
-    ${output}=  Run  openssl s_client -showcerts -connect %{VCH-IP}:2378
-    Log  ${output}
-    Should Contain  ${output}  issuer=/C=US/ST=California/L=Los Angeles/O=Stark Enterprises/OU=Stark Enterprises Certificate Authority/CN=Stark Enterprises Global CA
-
-    Run  rm -rf bundle
-    Run  rm -f cert-bundle.tgz
-    Run  rm -rf /root/ca
-
-    Reload Default Certificate Authorities
-
-    Run Keyword And Ignore Error  Cleanup VIC Appliance On Test Server
+#     Cleanup VIC Appliance On Test Server
 
 
 
-Create VCH - Server cert with intermediate CA
-    ${domain}=  Get Environment Variable  DOMAIN  ''
-    Run Keyword If  '${domain}' == ''  Pass Execution  Skipping test - domain not set, won't generate keys
-    Pass execution  Test not implemented
+# Create VCH - Server cert with untrusted CA
+#     ${domain}=  Get Environment Variable  DOMAIN  ''
+#     Run Keyword If  '${domain}' == ''  Pass Execution  Skipping test - domain not set, won't generate keys
+
+#     Set Test Environment Variables
+#     Run Keyword And Ignore Error  Cleanup Dangling VMs On Test Server
+#     Run Keyword And Ignore Error  Cleanup Datastore On Test Server
+
+#     # Generate CA and wildcard cert for *.<DOMAIN>
+#     Generate Certificate Authority
+#     Generate Wildcard Server Certificate
+
+#     ${out}=  Run  cp /root/ca/cert-bundle.tgz .; tar xvf cert-bundle.tgz
+#     Log  ${out}
+
+#     # Run vic-machine install, supply server cert and key
+#     ${output}=  Run  bin/vic-machine-linux create --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --tls-server-key "bundle/*.${domain}.key.pem" --tls-server-cert "bundle/*.${domain}.cert.pem" --image-store=%{TEST_DATASTORE} --bridge-network=%{BRIDGE_NETWORK} --public-network=%{PUBLIC_NETWORK} ${vicmachinetls} --debug 1
+#     Log  ${output}
+#     Should Contain  ${output}  Loaded server certificate bundle
+#     Should Contain  ${output}  Unable to locate existing CA in cert path
+#     Should Contain  ${output}  Failed to find a viable address for Docker API from certificates
+#     Should Contain  ${output}  Server certificate hostname doesn't match
+#     Should Contain  ${output}  Installer completed successfully
+
+#     # Verify that the supplied certificate is presented on web interface
+#     Get Docker Params  ${output}  ${true}
+#     ${output}=  Run  openssl s_client -showcerts -connect %{VCH-IP}:2378
+#     Log  ${output}
+#     Should Contain  ${output}  issuer=/C=US/ST=California/L=Los Angeles/O=Stark Enterprises/OU=Stark Enterprises Certificate Authority/CN=Stark Enterprises Global CA
+
+#     Run  rm -rf bundle
+#     Run  rm -f cert-bundle.tgz
+#     Run  rm -rf /root/ca
+#     Run Keyword And Ignore Error  Cleanup VIC Appliance On Test Server
+
+
+
+# Create VCH - Server cert with trusted CA
+#     ${domain}=  Get Environment Variable  DOMAIN  ''
+#     Run Keyword If  '${domain}' == ''  Pass Execution  Skipping test - domain not set, won't generate keys
+
+#     Set Test Environment Variables
+#     Run Keyword And Ignore Error  Cleanup Dangling VMs On Test Server
+#     Run Keyword And Ignore Error  Cleanup Datastore On Test Server
+
+#     # Generate CA and wildcard cert for *.<DOMAIN>, install CA into root store
+#     Generate Certificate Authority
+#     Generate Wildcard Server Certificate
+#     Trust Certificate Authority
+
+#     ${out}=  Run  cp /root/ca/cert-bundle.tgz .; tar xvf cert-bundle.tgz
+#     Log  ${out}
+
+#     # Run vic-machine install, supply server cert and key
+#     ${output}=  Run  bin/vic-machine-linux create --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --tls-server-key "bundle/*.%{DOMAIN}.key.pem" --tls-server-cert "bundle/*.%{DOMAIN}.cert.pem" --image-store=%{TEST_DATASTORE} --bridge-network=%{BRIDGE_NETWORK} --public-network=%{PUBLIC_NETWORK} ${vicmachinetls} --debug 1
+#     Log  ${output}
+#     Should Contain  ${output}  Loaded server certificate bundle
+#     Should Contain  ${output}  Unable to locate existing CA in cert path
+#     Should Contain  ${output}  Installer completed successfully
+
+
+#     # Verify that the supplied certificate is presented on web interface
+#     Get Docker Params  ${output}  ${true}
+#     ${output}=  Run  openssl s_client -showcerts -connect %{VCH-IP}:2378
+#     Log  ${output}
+#     Should Contain  ${output}  issuer=/C=US/ST=California/L=Los Angeles/O=Stark Enterprises/OU=Stark Enterprises Certificate Authority/CN=Stark Enterprises Global CA
+
+#     Run  rm -rf bundle
+#     Run  rm -f cert-bundle.tgz
+#     Run  rm -rf /root/ca
+
+#     Reload Default Certificate Authorities
+
+#     Run Keyword And Ignore Error  Cleanup VIC Appliance On Test Server
+
+
+
+# Create VCH - Server cert with intermediate CA
+#     ${domain}=  Get Environment Variable  DOMAIN  ''
+#     Run Keyword If  '${domain}' == ''  Pass Execution  Skipping test - domain not set, won't generate keys
+#     Pass execution  Test not implemented

--- a/tests/test-cases/Group6-VIC-Machine/6-13-TLS.robot
+++ b/tests/test-cases/Group6-VIC-Machine/6-13-TLS.robot
@@ -32,11 +32,7 @@ Check that normal requests are accepted
     Should Not Contain  ${output}  500 Internal Server Error
 
     # also make sure it works if the port isn't part of the host header
-    ${dockerHost}=  Get Environment Variable  DOCKER_HOST
-    @{hostParts}=  Split String  ${dockerHost}  :
-    ${ip}=  Strip String  @{hostParts}[0]
-
-    ${rc}  ${output}=  Run And Return Rc And Output  curl -vvv -H"Host: ${ip}" %{DOCKER_HOST}/_ping
+    ${rc}  ${output}=  Run And Return Rc And Output  curl -vvv -H"Host: %{VCH-IP}" %{DOCKER_HOST}/_ping
     Should Contain  ${output}  200 OK
     Should Not Contain  ${output}  500 Internal Server Error
 

--- a/tests/test-cases/Group6-VIC-Machine/6-13-TLS.robot
+++ b/tests/test-cases/Group6-VIC-Machine/6-13-TLS.robot
@@ -18,6 +18,20 @@ Resource  ../../resources/Util.robot
 Test Teardown  Run Keyword If Test Failed  Cleanup VIC Appliance On Test Server
 Test Timeout  20 minutes
 
+*** Keywords ***
+Check that requests with invalid host field are rejected
+    ${rc}  ${output}=  Run And Return Rc And Output  curl -vvv -H"Host: please.ddos" %{DOCKER_HOST}/_ping
+    Should Contain  ${output}  invalid host header
+    Should Contain  ${output}  500 Internal Server Error
+    Should Contain  ${output}  to requested host please.ddos
+    Should Not Contain  ${output}  200 OK
+
+Check that normal requests are accepted
+    ${rc}  ${output}=  Run And Return Rc And Output  curl -vvv %{DOCKER_HOST}/_ping
+    Should Contain  ${output}  200 OK
+    Should Not Contain  ${output}  500 Internal Server Error
+
+
 *** Test Cases ***
 Create VCH - defaults with --no-tls
     Set Test Environment Variables
@@ -29,6 +43,8 @@ Create VCH - defaults with --no-tls
     Get Docker Params  ${output}  ${true}
     Log To Console  Installer completed successfully: %{VCH-NAME}
 
+    Check that requests with invalid host field are rejected
+    Check that normal requests are accepted
 
     Run Regression Tests
     Cleanup VIC Appliance On Test Server


### PR DESCRIPTION
Adds a helper tool to the `lib/dns` package that allows us to perform rDNS queries bypassing /etc/hosts for resolution of "real" domain names that point to given IP addresses according to nameservers in /etc/resolv.conf

Adds a check to HTTP-only Docker requests such that the Host in the request is validated against the rDNS-discovered names in a set created at startup-time in the Docker personality.

As usual I'm posting this for initial comment w/o tests so that I can address comments & write tests in parallel, but this PR is not a WIP as far as actual functionality goes.

`[specific ci=Group6-VIC-Machine/6-13-TLS]`
Resolves #7175 