### PR TITLE
Upgrade and configure support folders

### DIFF
--- a/cmd/vic-machine/common/limits.go
+++ b/cmd/vic-machine/common/limits.go
@@ -71,7 +71,7 @@ func (r *ResourceLimits) VCHCPULimitFlags(hidden bool) []cli.Flag {
 		cli.GenericFlag{
 			Name:   "cpu-shares, cpus",
 			Value:  flags.NewSharesFlag(&r.VCHCPUShares),
-			Usage:  "VCH VCH resource pool vCPUs shares, in level or share number, e.g. high, normal, low, or 4000",
+			Usage:  "VCH resource pool vCPUs shares, in level or share number, e.g. high, normal, low, or 4000",
 			Hidden: hidden,
 		},
 	}

--- a/cmd/vic-machine/create/create.go
+++ b/cmd/vic-machine/create/create.go
@@ -742,7 +742,8 @@ func (c *Create) Run(clic *cli.Context) (err error) {
 	// separate initial validation from dispatch of creation task
 	op.Info("")
 
-	executor := management.NewDispatcher(op, validator.Session, vchConfig, c.Force)
+	executor := management.NewDispatcher(op, validator.Session, management.CreateAction, c.Force)
+	executor.InitDiagnosticLogsFromConf(vchConfig)
 	if err = executor.CreateVCH(vchConfig, vConfig, datastoreLog); err != nil {
 		executor.CollectDiagnosticLogs()
 		op.Error(err)

--- a/cmd/vic-machine/debug/debug.go
+++ b/cmd/vic-machine/debug/debug.go
@@ -146,7 +146,7 @@ func (d *Debug) Run(clic *cli.Context) (err error) {
 		return errors.New("debug failed")
 	}
 
-	executor := management.NewDispatcher(validator.Context, validator.Session, nil, d.Force)
+	executor := management.NewDispatcher(validator.Context, validator.Session, management.DebugAction, d.Force)
 
 	var vch *vm.VirtualMachine
 	if d.Data.ID != "" {

--- a/cmd/vic-machine/delete/delete.go
+++ b/cmd/vic-machine/delete/delete.go
@@ -121,7 +121,7 @@ func (d *Uninstall) Run(clic *cli.Context) (err error) {
 		return errors.New("delete failed")
 	}
 
-	executor := management.NewDispatcher(validator.Context, validator.Session, nil, d.Force)
+	executor := management.NewDispatcher(validator.Context, validator.Session, management.DeleteAction, d.Force)
 
 	var vch *vm.VirtualMachine
 	if d.Data.ID != "" {

--- a/cmd/vic-machine/inspect/inspect.go
+++ b/cmd/vic-machine/inspect/inspect.go
@@ -158,7 +158,7 @@ func (i *Inspect) run(clic *cli.Context, op trace.Operation, cmd command) (err e
 		return errors.New("inspect failed")
 	}
 
-	executor := management.NewDispatcher(validator.Context, validator.Session, nil, i.Force)
+	executor := management.NewDispatcher(validator.Context, validator.Session, management.InspectAction, i.Force)
 
 	var vch *vm.VirtualMachine
 	if i.Data.ID != "" {

--- a/cmd/vic-machine/list/list.go
+++ b/cmd/vic-machine/list/list.go
@@ -176,8 +176,9 @@ func (l *List) Run(clic *cli.Context) (err error) {
 		op.Errorf("List cannot continue - compute resource validation failed: %s", err)
 		return errors.New("list failed")
 	}
-	executor := management.NewDispatcher(validator.Context, validator.Session, nil, false)
-	vchs, err := executor.SearchVCHs(validator.Session.ClusterPath)
+
+	executor := management.NewDispatcher(validator.Context, validator.Session, management.ListAction, false)
+	vchs, err := executor.SearchVCHs(validator.ClusterPath)
 	if err != nil {
 		op.Errorf("List cannot continue - failed to search VCHs in %s: %s", validator.ResourcePoolPath, err)
 	}

--- a/cmd/vic-machine/update/firewall.go
+++ b/cmd/vic-machine/update/firewall.go
@@ -140,7 +140,7 @@ func (i *UpdateFw) Run(clic *cli.Context) (err error) {
 		return errors.New("update firewall failed")
 	}
 
-	executor := management.NewDispatcher(validator.Context, validator.Session, nil, false)
+	executor := management.NewDispatcher(validator.Context, validator.Session, management.UpdateAction, false)
 
 	if i.enableFw {
 		op.Info("")

--- a/cmd/vic-machine/upgrade/upgrade.go
+++ b/cmd/vic-machine/upgrade/upgrade.go
@@ -76,7 +76,7 @@ func (u *Upgrade) Flags() []cli.Flag {
 	id := u.IDFlags()
 	compute := u.ComputeFlags()
 	iso := u.ImageFlags(false)
-	debug := u.DebugFlags(true)
+	debug := u.DebugFlags(false)
 
 	// flag arrays are declared, now combined
 	var flags []cli.Flag
@@ -134,7 +134,8 @@ func (u *Upgrade) Run(clic *cli.Context) (err error) {
 		op.Errorf("Upgrade cannot continue - target validation failed: %s", err)
 		return errors.New("upgrade failed")
 	}
-	executor := management.NewDispatcher(validator.Context, validator.Session, nil, u.Force)
+
+	executor := management.NewDispatcher(validator.Context, validator.Session, management.UpgradeAction, u.Force)
 
 	var vch *vm.VirtualMachine
 	if u.Data.ID != "" {
@@ -214,9 +215,10 @@ func (u *Upgrade) Run(clic *cli.Context) (err error) {
 	}
 
 	if !u.Data.Rollback {
-		err = executor.Configure(vch, vchConfig, vConfig, false)
+		err = executor.Configure(vchConfig, vConfig)
 	} else {
-		err = executor.Rollback(vch, vchConfig, vConfig)
+		executor.Action = management.RollbackAction
+		err = executor.Rollback(vchConfig, vConfig)
 	}
 
 	if err != nil {

--- a/cmd/vicadmin/vicadm.go
+++ b/cmd/vicadmin/vicadm.go
@@ -325,7 +325,8 @@ func listVMPaths(ctx context.Context, s *session.Session) ([]logfile, error) {
 
 	ref := vchConfig.ComputeResources[0]
 	rp := compute.NewResourcePool(ctx, s, ref)
-	if children, err = rp.GetChildrenVMs(ctx, s); err != nil {
+	op := trace.NewOperation(ctx, "GetChildren")
+	if children, err = rp.GetChildrenVMs(op); err != nil {
 		return nil, err
 	}
 

--- a/lib/apiservers/service/restapi/handlers/common.go
+++ b/lib/apiservers/service/restapi/handlers/common.go
@@ -168,7 +168,7 @@ func upgradeStatusMessage(op trace.Operation, vch *vm.VirtualMachine, installerV
 }
 
 func getVCHConfig(op trace.Operation, d *data.Data, validator *validate.Validator) (*config.VirtualContainerHostConfigSpec, error) {
-	executor := management.NewDispatcher(validator.Context, validator.Session, nil, false)
+	executor := management.NewDispatcher(validator.Context, validator.Session, management.NoAction, false)
 	vch, err := executor.NewVCHFromID(d.ID)
 	if err != nil {
 		return nil, util.NewError(http.StatusNotFound, fmt.Sprintf("Unable to find VCH %s: %s", d.ID, err))

--- a/lib/apiservers/service/restapi/handlers/vch_create.go
+++ b/lib/apiservers/service/restapi/handlers/vch_create.go
@@ -475,7 +475,7 @@ func handleCreate(op trace.Operation, c *create.Create, validator *validate.Vali
 	vConfig.HTTPProxy = c.HTTPProxy
 	vConfig.HTTPSProxy = c.HTTPSProxy
 
-	executor := management.NewDispatcher(op, validator.Session, nil, false)
+	executor := management.NewDispatcher(op, validator.Session, management.CreateAction, false)
 	err = executor.CreateVCH(vchConfig, vConfig, receiver)
 	if err != nil {
 		return nil, util.NewError(http.StatusInternalServerError, fmt.Sprintf("Failed to create VCH: %s", err))

--- a/lib/apiservers/service/restapi/handlers/vch_delete.go
+++ b/lib/apiservers/service/restapi/handlers/vch_delete.go
@@ -84,7 +84,7 @@ func (h *VCHDatacenterDelete) Handle(params operations.DeleteTargetTargetDatacen
 }
 
 func deleteVCH(op trace.Operation, d *data.Data, validator *validate.Validator, specification *models.DeletionSpecification) error {
-	executor := management.NewDispatcher(validator.Context, validator.Session, nil, false)
+	executor := management.NewDispatcher(validator.Context, validator.Session, management.DeleteAction, false)
 	vch, err := executor.NewVCHFromID(d.ID)
 	if err != nil {
 		return util.NewError(http.StatusNotFound, fmt.Sprintf("Failed to find VCH: %s", err))

--- a/lib/apiservers/service/restapi/handlers/vch_get.go
+++ b/lib/apiservers/service/restapi/handlers/vch_get.go
@@ -95,7 +95,7 @@ func (h *VCHDatacenterGet) Handle(params operations.GetTargetTargetDatacenterDat
 }
 
 func getVCH(op trace.Operation, d *data.Data, validator *validate.Validator) (*models.VCH, error) {
-	executor := management.NewDispatcher(validator.Context, validator.Session, nil, false)
+	executor := management.NewDispatcher(validator.Context, validator.Session, management.NoAction, false)
 	vch, err := executor.NewVCHFromID(d.ID)
 	if err != nil {
 		return nil, util.NewError(http.StatusNotFound, fmt.Sprintf("Failed to inspect VCH: %s", err))

--- a/lib/apiservers/service/restapi/handlers/vch_list_get.go
+++ b/lib/apiservers/service/restapi/handlers/vch_list_get.go
@@ -85,8 +85,9 @@ func (h *VCHDatacenterListGet) Handle(params operations.GetTargetTargetDatacente
 }
 
 func listVCHs(op trace.Operation, d *data.Data, validator *validate.Validator) ([]*models.VCHListItem, error) {
-	executor := management.NewDispatcher(validator.Context, validator.Session, nil, false)
-	vchs, err := executor.SearchVCHs(validator.Session.ClusterPath)
+
+	executor := management.NewDispatcher(validator.Context, validator.Session, management.NoAction, false)
+	vchs, err := executor.SearchVCHs(validator.ClusterPath)
 	if err != nil {
 		return nil, util.NewError(http.StatusInternalServerError, fmt.Sprintf("Failed to search VCHs in %s: %s", validator.ResourcePoolPath, err))
 	}

--- a/lib/apiservers/service/restapi/handlers/vch_log_get.go
+++ b/lib/apiservers/service/restapi/handlers/vch_log_get.go
@@ -97,7 +97,7 @@ func (h *VCHDatacenterLogGet) Handle(params operations.GetTargetTargetDatacenter
 
 // getDatastoreHelper validates the VCH and returns the datastore helper for the VCH. It errors when validation fails or when datastore is not ready
 func getDatastoreHelper(op trace.Operation, d *data.Data, validator *validate.Validator) (*datastore.Helper, error) {
-	executor := management.NewDispatcher(validator.Context, validator.Session, nil, false)
+	executor := management.NewDispatcher(validator.Context, validator.Session, management.NoAction, false)
 	vch, err := executor.NewVCHFromID(d.ID)
 	if err != nil {
 		return nil, util.NewError(http.StatusNotFound, fmt.Sprintf("Unable to find VCH %s: %s", d.ID, err))

--- a/lib/install/management/configure.go
+++ b/lib/install/management/configure.go
@@ -24,14 +24,12 @@ import (
 	"strings"
 
 	"github.com/vmware/govmomi/object"
-	"github.com/vmware/govmomi/task"
-	"github.com/vmware/govmomi/vim25/soap"
 	"github.com/vmware/govmomi/vim25/types"
+
 	"github.com/vmware/vic/lib/config"
 	"github.com/vmware/vic/lib/install/data"
 	"github.com/vmware/vic/lib/install/opsuser"
 	"github.com/vmware/vic/pkg/errors"
-	"github.com/vmware/vic/pkg/retry"
 	"github.com/vmware/vic/pkg/trace"
 	"github.com/vmware/vic/pkg/vsphere/datastore"
 	"github.com/vmware/vic/pkg/vsphere/extraconfig"
@@ -53,20 +51,18 @@ var (
 )
 
 // Configure will try to reconfigure vch appliance. If failed will try to roll back to original status.
-func (d *Dispatcher) Configure(vch *vm.VirtualMachine, conf *config.VirtualContainerHostConfigSpec, settings *data.InstallerData, isConfigureOp bool) (err error) {
+func (d *Dispatcher) Configure(conf *config.VirtualContainerHostConfigSpec, settings *data.InstallerData) (err error) {
 	defer trace.End(trace.Begin(conf.Name, d.op))
 
-	d.appliance = vch
-
-	// update the displayname to the actual folder name used
-	if d.vmPathName, err = d.appliance.FolderName(d.op); err != nil {
-		d.op.Errorf("Failed to get canonical name for appliance: %s", err)
+	// set the folerName for ISO uploads
+	if d.vmPathName, err = d.appliance.DatastoreFolderName(d.op); err != nil {
+		d.op.Errorf("Failed to get the datastore folder name for the appliance: %s", err)
 		return err
 	}
 
 	ds, err := d.session.Finder.Datastore(d.op, conf.ImageStores[0].Host)
 	if err != nil {
-		err = errors.Errorf("Failed to find image datastore %q", conf.ImageStores[0].Host)
+		err = errors.Errorf("Failed to find the image datastore %q", conf.ImageStores[0].Host)
 		return err
 	}
 	d.session.Datastore = ds
@@ -74,22 +70,26 @@ func (d *Dispatcher) Configure(vch *vm.VirtualMachine, conf *config.VirtualConta
 
 	if len(settings.ImageFiles) > 0 {
 		// Need to update iso files
-		if err = d.uploadImages(settings.ImageFiles); err != nil {
-			return errors.Errorf("Uploading images failed with %s. Exiting...", err)
+		if err = d.uploadISOs(settings.ImageFiles); err != nil {
+			return errors.Errorf("Uploading ISOs failed with %s. Exiting...", err)
 		}
 		conf.BootstrapImagePath = fmt.Sprintf("[%s] %s/%s", conf.ImageStores[0].Host, d.vmPathName, settings.BootstrapISO)
 	}
 
-	if err = d.updateResourceSettings(conf.Name, settings); err != nil {
-		err = errors.Errorf("Failed to reconfigure resources: %s", err)
-		return err
-	}
-
-	defer func() {
-		if err != nil {
-			d.rollbackResourceSettings(conf.Name, settings)
+	// Resource Pools not available in a DRS Disabled environment, so only attempt an update
+	// if DRS is Enabled and this is a configure action.
+	if d.session.DRSEnabled != nil && *d.session.DRSEnabled && d.Action == ConfigureAction {
+		if err = d.updateResourceSettings(conf.Name, settings); err != nil {
+			err = errors.Errorf("Failed to reconfigure resources: %s", err)
+			return err
 		}
-	}()
+
+		defer func() {
+			if err != nil {
+				d.rollbackResourceSettings(conf.Name, settings)
+			}
+		}()
+	}
 
 	// ensure that we wait for components to come up
 	for _, s := range conf.ExecutorConfig.Sessions {
@@ -98,50 +98,65 @@ func (d *Dispatcher) Configure(vch *vm.VirtualMachine, conf *config.VirtualConta
 
 	snapshotName := fmt.Sprintf("%s %s", ConfigurePrefix, conf.Version.BuildNumber)
 	snapshotName = strings.TrimSpace(snapshotName)
-
 	// check for old snapshot
-	// #nosec: Errors unhandled.
-	oldSnapshot, _ := d.appliance.GetCurrentSnapshotTree(d.op)
+	oldSnapshot, err := d.appliance.GetCurrentSnapshotTree(d.op)
+	if err != nil {
+		// log the error but continue
+		d.op.Debugf("Error checking appliance snapshot tree during %s: %s", d.Action.String(), err.Error())
+	}
 
 	newSnapshotRef, err := d.createSnapshot(snapshotName, "configure snapshot")
 	if err != nil {
-		d.deleteUpgradeImages(ds, settings)
+		d.deleteISOs(ds, settings)
 		return err
 	}
 
-	err = d.update(conf, settings, isConfigureOp)
-
-	// If successful try to grant permissions to the ops-user
-	if err == nil && conf.ShouldGrantPerms() {
-		err = opsuser.GrantOpsUserPerms(d.op, d.session, conf)
-		if err != nil {
-			// Update error message and fall through to roll back
-			err = errors.Errorf("Failed to grant permissions to ops-user, failure: %s", err)
-		}
-	}
-
-	if err != nil {
+	// rollback function
+	rollback := func() {
 		// Roll back
-		d.op.Errorf("Failed to upgrade: %s", err)
-		d.op.Infof("Rolling back upgrade")
+		d.op.Errorf("Failed to %s: %s", d.Action.String(), err)
+		d.op.Infof("Rolling back %s", d.Action.String())
 
 		if rerr := d.rollback(conf, snapshotName, settings); rerr != nil {
 			d.op.Errorf("Failed to revert appliance to snapshot: %s", rerr)
+			return
+		}
+		d.op.Infof("Appliance is rolled back to previous version")
+		d.deleteISOs(ds, settings)
+		d.deleteSnapshot(newSnapshotRef, snapshotName, conf.Name)
+	}
+
+	err = d.update(conf, settings)
+	if err != nil {
+		rollback()
+		return err
+	}
+
+	// if we are upgrading evaluate need for inventory upgrade
+	// vApp support planned: https://github.com/vmware/vic/issues/7670
+	if d.Action == UpgradeAction && d.session.IsVC() && d.vchPool.Reference().Type != "VirtualApp" {
+		err := d.inventoryUpdate(conf.Name)
+		if err != nil {
+			rollback()
 			return err
 		}
-		d.op.Infof("Appliance is rolled back to old version")
+	}
 
-		d.deleteUpgradeImages(ds, settings)
-		d.retryDeleteSnapshotByRef(newSnapshotRef, snapshotName, conf.Name)
-
-		// return the error message for upgrade
-		return err
+	// If successful try to grant permissions to the ops-user
+	if conf.ShouldGrantPerms() {
+		err := opsuser.GrantOpsUserPerms(d.op, d.session, conf)
+		if err != nil {
+			err = errors.Errorf("Failed to grant permissions to ops-user, failure: %s", err)
+			rollback()
+			return err
+		}
 	}
 
 	// compatible with old version's upgrade snapshot name
 	if oldSnapshot != nil && (vm.IsConfigureSnapshot(oldSnapshot, ConfigurePrefix) || vm.IsConfigureSnapshot(oldSnapshot, UpgradePrefix)) {
-		d.retryDeleteSnapshotByRef(&oldSnapshot.Snapshot, oldSnapshot.Name, conf.Name)
+		d.deleteSnapshot(&oldSnapshot.Snapshot, oldSnapshot.Name, conf.Name)
 	}
+
 	return nil
 }
 
@@ -159,29 +174,30 @@ func (d *Dispatcher) updateResourceSettings(poolName string, settings *data.Inst
 		return nil
 	}
 	var err error
-	// compute resource
+
 	d.vchPool, err = d.appliance.ResourcePool(d.op)
 	if err != nil {
 		err = errors.Errorf("Failed to get parent resource pool %q: %s", poolName, err)
 		return err
 	}
-	oldSettings, err := d.getPoolResourceSettings(d.vchPool)
+	current, err := d.getPoolResourceSettings(d.vchPool)
 	if err != nil {
 		err = errors.Errorf("Failed to get parent resource settings %q: %s", poolName, err)
 		return err
 	}
-	if reflect.DeepEqual(oldSettings, &settings.VCHSize) {
-		d.op.Debug("VCH resource settings are same as old value")
+
+	if reflect.DeepEqual(current, &settings.VCHSize) {
+		d.op.Info("VCH resource settings are same as old value")
 		return nil
 	}
-	d.oldVCHResources = oldSettings
+
+	d.oldVCHResources = current
 	return updateResourcePoolConfig(d.op, d.vchPool, poolName, &settings.VCHSize)
 }
 
-func (d *Dispatcher) Rollback(vch *vm.VirtualMachine, conf *config.VirtualContainerHostConfigSpec, settings *data.InstallerData) error {
-
+func (d *Dispatcher) Rollback(conf *config.VirtualContainerHostConfigSpec, settings *data.InstallerData) error {
+	d.op.Infof("Attempting rollback of VCH")
 	// some setup that is only necessary because we didn't just create a VCH in this case
-	d.appliance = vch
 	d.setDockerPort(conf, settings)
 
 	// ensure that we wait for components to come up
@@ -205,57 +221,18 @@ func (d *Dispatcher) Rollback(vch *vm.VirtualMachine, conf *config.VirtualContai
 		return errors.Errorf("could not complete manual rollback: %s", err)
 	}
 
-	return d.retryDeleteSnapshotByRef(&snapshot.Snapshot, snapshot.Name, conf.Name)
+	return d.deleteSnapshot(&snapshot.Snapshot, snapshot.Name, conf.Name)
 }
 
-// retryDeleteSnapshotByRef will retry to delete snapshot by its reference if there is GenericVmConfigFault returned. This is a workaround for vSAN delete snapshot
-func (d *Dispatcher) retryDeleteSnapshotByRef(snapshot *types.ManagedObjectReference, snapshotName, applianceName string) error {
-	// delete snapshot immediately after snapshot rollback usually fail in vSAN, so have to retry several times
-	operation := func() error {
-		return d.deleteSnapshotByRef(snapshot, snapshotName, applianceName)
-	}
-	var err error
-	if err = retry.Do(operation, isSystemError); err != nil {
-		d.op.Errorf("Failed to clean up appliance upgrade snapshot %q: %s.", snapshotName, err)
-		d.op.Errorf("Snapshot %q of appliance virtual machine %q MUST be removed manually before upgrade again", snapshotName, applianceName)
-	}
-	return err
-}
-
-func isSystemError(err error) bool {
-	if soap.IsSoapFault(err) {
-		if _, ok := soap.ToSoapFault(err).VimFault().(*types.SystemError); ok {
-			return true
-		}
-	}
-
-	if soap.IsVimFault(err) {
-		if _, ok := soap.ToVimFault(err).(*types.SystemError); ok {
-			return true
-		}
-	}
-
-	if terr, ok := err.(task.Error); ok {
-		if _, ok := terr.Fault().(*types.SystemError); ok {
-			return true
-		}
-	}
-
-	return false
-}
-
-func (d *Dispatcher) deleteSnapshotByRef(snapshot *types.ManagedObjectReference, snapshotName, applianceName string) error {
-	defer trace.End(trace.Begin(snapshotName, d.op))
-	d.op.Infof("Deleting upgrade snapshot %q", snapshotName)
-	// do clean up aggressively, even the previous operation failed with context deadline exceeded.
-	op := trace.NewOperationWithLoggerFrom(context.Background(), d.op, "deleteSnapshotByRef cleanup")
-	if _, err := d.appliance.WaitForResult(op, func(ctx context.Context) (tasks.Task, error) {
+// deleteSnapshot deletes the provided snapshot.  It retries on SystemError (GenericVmConfigFault) seen in vSAN
+func (d *Dispatcher) deleteSnapshot(snapshot *types.ManagedObjectReference, snapshotName, applianceName string) error {
+	defer trace.End(trace.Begin(fmt.Sprintf("Deleteing snaphost(%s) for %s", snapshotName, applianceName), d.op))
+	_, err := tasks.WaitForResultAndRetryIf(d.op, func(op context.Context) (tasks.Task, error) {
 		consolidate := true
-		return d.appliance.RemoveSnapshotByRef(ctx, snapshot, false, &consolidate)
-	}); err != nil {
-		return err
-	}
-	return nil
+		return d.appliance.RemoveSnapshot(d.op, snapshot, false, &consolidate)
+	}, tasks.IsTransientError)
+
+	return err
 }
 
 // createSnapshot will create a snapshot of the VCH Appliance
@@ -264,10 +241,9 @@ func (d *Dispatcher) createSnapshot(name, desc string) (*types.ManagedObjectRefe
 
 	// TODO detect whether another upgrade is in progress & bail if it is.
 	// Use solution from https://github.com/vmware/vic/issues/4069 to do this either as part of 4069 or once it's closed
-
-	info, err := d.appliance.WaitForResult(d.op, func(ctx context.Context) (tasks.Task, error) {
-		return d.appliance.CreateSnapshot(ctx, name, desc, false, false)
-	})
+	info, err := tasks.WaitForResultAndRetryIf(d.op, func(op context.Context) (tasks.Task, error) {
+		return d.appliance.CreateSnapshot(d.op, name, desc, false, false)
+	}, tasks.IsTransientError)
 	if err != nil {
 		return nil, errors.Errorf("Failed to create snapshot %q: %s.", name, err)
 	}
@@ -279,28 +255,28 @@ func (d *Dispatcher) createSnapshot(name, desc string) (*types.ManagedObjectRefe
 	return &snap, nil
 }
 
-func (d *Dispatcher) deleteUpgradeImages(ds *object.Datastore, settings *data.InstallerData) {
+func (d *Dispatcher) deleteISOs(ds *object.Datastore, settings *data.InstallerData) {
 	defer trace.End(trace.Begin("", d.op))
 
-	d.op.Info("Deleting upgrade images")
+	d.op.Infof("Deleting %s isos", d.Action.String())
 
 	// do clean up aggressively, even the previous operation failed with context deadline exceeded.
-	d.op = trace.NewOperation(context.Background(), "deleteUpgradeImages cleanup")
+	d.op = trace.NewOperation(context.Background(), "deleteISOs")
 
 	m := ds.NewFileManager(d.session.Datacenter, true)
 
 	file := ds.Path(path.Join(d.vmPathName, settings.ApplianceISO))
 	if err := d.deleteVMFSFiles(m, ds, file); err != nil {
-		d.op.Warnf("Image file %q is not removed for %s. Use the vSphere UI to delete content", file, err)
+		d.op.Warnf("VCH iso file %q is not removed for %s. Use the vSphere UI to delete content", file, err)
 	}
 
 	file = ds.Path(path.Join(d.vmPathName, settings.BootstrapISO))
 	if err := d.deleteVMFSFiles(m, ds, file); err != nil {
-		d.op.Warnf("Image file %q is not removed for %s. Use the vSphere UI to delete content", file, err)
+		d.op.Warnf("VCH iso file %q is not removed for %s. Use the vSphere UI to delete content", file, err)
 	}
 }
 
-func (d *Dispatcher) update(conf *config.VirtualContainerHostConfigSpec, settings *data.InstallerData, isConfigureOp bool) error {
+func (d *Dispatcher) update(conf *config.VirtualContainerHostConfigSpec, settings *data.InstallerData) error {
 	defer trace.End(trace.Begin(conf.Name, d.op))
 
 	power, err := d.appliance.PowerState(d.op)
@@ -323,7 +299,7 @@ func (d *Dispatcher) update(conf *config.VirtualContainerHostConfigSpec, setting
 	}
 
 	// Create volume stores only for a configure operation, where conf has its storage fields validated.
-	if isConfigureOp {
+	if d.Action == ConfigureAction {
 		if err := d.createVolumeStores(conf); err != nil {
 			return err
 		}

--- a/lib/install/management/create.go
+++ b/lib/install/management/create.go
@@ -88,8 +88,8 @@ func (d *Dispatcher) CreateVCH(conf *config.VirtualContainerHostConfigSpec, sett
 	}
 	receiver.Signal(datastoreReadySignal)
 
-	if err = d.uploadImages(settings.ImageFiles); err != nil {
-		return errors.Errorf("Uploading images failed with %s. Exiting...", err)
+	if err = d.uploadISOs(settings.ImageFiles); err != nil {
+		return errors.Errorf("Uploading vic isos failed with %s. Exiting...", err)
 	}
 
 	if conf.ShouldGrantPerms() {
@@ -119,11 +119,11 @@ func (d *Dispatcher) createPool(conf *config.VirtualContainerHostConfigSpec, set
 	return nil
 }
 
-func (d *Dispatcher) uploadImages(files map[string]string) error {
+func (d *Dispatcher) uploadISOs(files map[string]string) error {
 	defer trace.End(trace.Begin("", d.op))
 
 	// upload the images
-	d.op.Info("Uploading images for container")
+	d.op.Info("Uploading ISO images")
 
 	// Build retry config
 	backoffConf := retry.NewBackoffConfig()
@@ -137,7 +137,7 @@ func (d *Dispatcher) uploadImages(files map[string]string) error {
 		isoTargetPath := path.Join(d.vmPathName, key)
 
 		operationForRetry := func() error {
-			op, cancel := trace.WithCancel(&d.op, "uploadImages")
+			op, cancel := trace.WithCancel(&d.op, "uploadISOs")
 			defer cancel()
 
 			// attempt to delete the iso image first in case of failed upload
@@ -230,7 +230,7 @@ func (d *Dispatcher) cleanupAfterCreationFailed(conf *config.VirtualContainerHos
 	}
 
 	// Delete the VCH Folder
-	d.deleteVCHFolder()
+	d.deleteFolder(d.session.VCHFolder)
 }
 
 // cleanupEmptyPool cleans up any dangling empty VCH resource pool when creating this VCH. no-op when VCH pool is nonempty.

--- a/lib/install/management/create_test.go
+++ b/lib/install/management/create_test.go
@@ -223,7 +223,7 @@ func testCleanup(op trace.Operation, sess *session.Session, conf *config.Virtual
 		return
 	}
 
-	d.deleteVCHFolder()
+	d.deleteVCHFolder(d.session.VCHFolder)
 
 	// in this case we should expect the folder to be gone.
 	folder, err := d.session.Finder.Folder(d.op, path.Join(d.session.VMFolder.InventoryPath, conf.Name))

--- a/lib/install/management/delete.go
+++ b/lib/install/management/delete.go
@@ -110,7 +110,7 @@ func (d *Dispatcher) DeleteVCH(conf *config.VirtualContainerHostConfigSpec, cont
 	}
 
 	// delete the VCH folder
-	d.deleteVCHFolder()
+	d.deleteFolder(d.session.VCHFolder)
 
 	defaultrp, err := d.session.Cluster.ResourcePool(d.op)
 	if err != nil {
@@ -276,7 +276,7 @@ func (d *Dispatcher) DeleteVCHInstances(conf *config.VirtualContainerHostConfigS
 	} else {
 		// Find the children in the RP
 		d.op.Debugf("Finding children in VCH resource pool")
-		if children, err = d.parentResourcepool.GetChildrenVMs(d.op, d.session); err != nil {
+		if children, err = d.parentResourcepool.GetChildrenVMs(d.op); err != nil {
 			return err
 		}
 	}

--- a/lib/install/management/delete_test.go
+++ b/lib/install/management/delete_test.go
@@ -113,7 +113,7 @@ func testUpgrade(computePath string, name string, v *validate.Validator, setting
 
 		t.Errorf("Failed to get vch configuration: %s", err)
 	}
-	if err := d.Configure(vch, conf, settings, false); err != nil {
+	if err := d.Configure(conf, settings); err != nil {
 		t.Errorf("Failed to upgrade: %s", err)
 	}
 }

--- a/lib/install/management/dispatcher.go
+++ b/lib/install/management/dispatcher.go
@@ -37,7 +37,52 @@ import (
 	"github.com/vmware/vic/pkg/vsphere/vm"
 )
 
+// Action is the current action being performed
+type Action int
+
+// Action definitions
+const (
+	NoAction        Action = iota // 0
+	CreateAction                  // 1
+	ConfigureAction               // 2
+	UpgradeAction                 // 3
+	RollbackAction                // 4
+	DeleteAction                  // 5
+	InspectAction                 // 6
+	ListAction                    // 7
+	UpdateAction                  // 8
+	DebugAction                   // 9
+)
+
+// stringer for action
+func (a Action) String() string {
+	var act string
+	switch a {
+	case CreateAction:
+		act = "create"
+	case ConfigureAction:
+		act = "configure"
+	case UpgradeAction:
+		act = "upgrade"
+	case DeleteAction:
+		act = "delete"
+	case InspectAction:
+		act = "inspect"
+	case ListAction:
+		act = "list"
+	case DebugAction:
+		act = "debug"
+	case UpdateAction:
+		act = "update"
+	case RollbackAction:
+		act = "rollback"
+	}
+	return act
+}
+
 type Dispatcher struct {
+	Action
+
 	session *session.Session
 	op      trace.Operation
 	force   bool
@@ -75,17 +120,15 @@ var diagnosticLogs = make(map[string]*diagnosticLog)
 // NewDispatcher creates a dispatcher that can act upon VIC management operations.
 // clientCert is an optional client certificate to allow interaction with the Docker API for verification
 // force will ignore some errors
-func NewDispatcher(ctx context.Context, s *session.Session, conf *config.VirtualContainerHostConfigSpec, force bool) *Dispatcher {
+func NewDispatcher(ctx context.Context, s *session.Session, action Action, force bool) *Dispatcher {
 	defer trace.End(trace.Begin(""))
 	isVC := s.IsVC()
 	e := &Dispatcher{
+		Action:  action,
 		session: s,
 		op:      trace.FromContext(ctx, "Dispatcher"),
 		isVC:    isVC,
 		force:   force,
-	}
-	if conf != nil {
-		e.InitDiagnosticLogsFromConf(conf)
 	}
 	return e
 }

--- a/lib/install/management/inventory.go
+++ b/lib/install/management/inventory.go
@@ -1,0 +1,217 @@
+// Copyright 2018 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package management
+
+import (
+	"context"
+	"fmt"
+	"path"
+	"strings"
+
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25/mo"
+	"github.com/vmware/govmomi/vim25/types"
+
+	"github.com/vmware/vic/lib/config"
+	"github.com/vmware/vic/lib/config/executor"
+	"github.com/vmware/vic/lib/portlayer/util"
+	"github.com/vmware/vic/lib/spec"
+	"github.com/vmware/vic/pkg/trace"
+	"github.com/vmware/vic/pkg/uid"
+	"github.com/vmware/vic/pkg/vsphere/compute"
+	"github.com/vmware/vic/pkg/vsphere/extraconfig"
+	"github.com/vmware/vic/pkg/vsphere/extraconfig/vmomi"
+	"github.com/vmware/vic/pkg/vsphere/tasks"
+	"github.com/vmware/vic/pkg/vsphere/vm"
+)
+
+// inventoryUpdate updates the vSphere inventory structure
+// for the VCH and containerVMs
+//
+// If the VCH resides in the VMFolder then a new folder will
+// be created and the VCH and all Containers will be moved into the
+// new folder.  If the VCH already resides in a folder other than
+// the VMFolder, then no action will be taken.
+func (d *Dispatcher) inventoryUpdate(name string) error {
+	defer trace.End(trace.Begin(name, d.op))
+
+	d.op.Debugf("Updating VCH Inventory: %s", name)
+	var err error
+
+	// get the current appliance folder
+	currentFolder, err := d.appliance.Folder(d.op)
+	if err != nil {
+		d.op.Errorf("Unable to get current folder:  %s", err)
+		return err
+	}
+
+	if currentFolder.Reference() != d.session.VMFolder.Reference() {
+		// slight chance this could be an upgrade retry and the only
+		// thing that failed was renaming the VCH folder.  If the currentFolder
+		// is the same name then noop
+		d.renameFolder(currentFolder, name)
+		d.op.Debugf("No inventory update completed for %s", name)
+		return nil
+	}
+
+	// Get a slice of MoRefs that are the VCHs containers
+	refs, err := d.containerRefs(d.vchPool)
+	if err != nil {
+		d.op.Errorf("Error getting containers for Inventory Update: %s", err)
+		return err
+	}
+
+	// To avoid a Folder & VCH Name collison we need to create a temp folder name.
+	// Utilizing the portlayer naming convention to ensure the max length isn't exceeded
+	template := fmt.Sprintf("%s-%s", config.NameToken.String(), config.IDToken.String())
+	cfg := &spec.VirtualMachineConfigSpecConfig{
+		ID:   uid.New().Truncate().String(),
+		Name: name,
+	}
+	tempName := util.DisplayName(d.op, cfg, template)
+	target, err := d.session.VMFolder.CreateFolder(d.op, tempName)
+	if err != nil {
+		d.op.Errorf("Unable to create target folder during inventory update: %s", err)
+		return err
+	}
+	// best effort a cleaning up any orphaned temp folders
+	defer d.folderCleanup(name, fmt.Sprintf("%s-", name))
+
+	// if we have containers move them into the new VCH Folder
+	if len(refs) > 0 {
+		// Move containers into folder
+		d.op.Debugf("Moving %d container(s) into the folder", len(refs))
+		_, err = tasks.WaitForResultAndRetryIf(d.op, func(op context.Context) (tasks.Task, error) {
+			return target.MoveInto(d.op, refs)
+		}, tasks.IsTransientError)
+		if err != nil {
+			d.op.Errorf("Failure moving containers into folder(%s): %s", tempName, err)
+			return err
+		}
+		d.op.Debugf("%d container(s) moved into folder", len(refs))
+	}
+
+	// we must move the appliance after the containers due to the following factors:
+	//
+	// The transaction boundary for folder.MoveInto is at the object level.  A failure
+	// would potentially leave containers outside of the folder, which has consequences once
+	// the appliance is in the folder.
+	//
+	// On startup a VCH determines where to find it's containers based on it's current folder.
+	// If that folder is the VMFolder it will find them via resource pools, but if it's
+	// any other folder it will only look in that folder.  Thus we only move the VCH appliance
+	// when the containers have been relocated.  If the appliance move fails we can recover on
+	// the next attempted upgrade or if no further upgrades are attempted vic will continue to
+	// function without issue
+	d.op.Debugf("Moving %s into the folder", name)
+	_, err = tasks.WaitForResultAndRetryIf(d.op, func(op context.Context) (tasks.Task, error) {
+		return target.MoveInto(d.op, []types.ManagedObjectReference{d.appliance.Reference()})
+	}, tasks.IsTransientError)
+	if err != nil {
+		d.op.Errorf("Failure moving VCH(%s) into folder(%s): %s", name, tempName, err)
+		return err
+	}
+	d.op.Debugf("%s moved into folder", name)
+	//now rename the temp folder
+	d.renameFolder(target, name)
+	return nil
+}
+
+// renameFolder renames the the provided folder to the specified name
+func (d *Dispatcher) renameFolder(target *object.Folder, name string) error {
+	targetOriginal := target.Name()
+	if targetOriginal == name {
+		//noop
+		return nil
+	}
+
+	_, err := tasks.WaitForResultAndRetryIf(d.op, func(op context.Context) (tasks.Task, error) {
+		return target.Rename(d.op, name)
+	}, tasks.IsTransientError)
+	if err != nil {
+		d.op.Errorf("Unable to rename folder(%s) to %s during inventory update: %s", targetOriginal, name, err)
+		return err
+	}
+	d.op.Debugf("Folder renamed from %s to %s", targetOriginal, name)
+	return nil
+}
+
+// folderCleanup searches for folders with a name resembling a temporary folder during
+// inventoryUpdate.  This will remove empty folders that were not deleted during a failed upgrade.
+func (d *Dispatcher) folderCleanup(name string, tempPattern string) {
+	// check for any orphaned upgrade folders
+	folders, err := d.session.Finder.FolderList(d.op, path.Join(d.session.VMFolder.InventoryPath, "*"))
+	if err != nil {
+		d.op.Debugf("Error searching for orphaned upgrade folders: %s", err)
+		return
+	}
+	d.op.Debugf("Searching %d folders for partial name(%s) match", len(folders), tempPattern)
+	for _, f := range folders {
+		if strings.Contains(f.Name(), tempPattern) {
+			d.op.Debugf("Found Orphaned Folder: %s", f.Name())
+			// delete if it's not empty
+			d.deleteFolder(f)
+		}
+	}
+}
+
+// containerRefs returns an array of ManagedObjectRefrences that are the containerVMs for the pool
+func (d *Dispatcher) containerRefs(pool *object.ResourcePool) ([]types.ManagedObjectReference, error) {
+	defer trace.End(trace.Begin(pool.InventoryPath, d.op))
+	// slice for validated containers
+	var containers []types.ManagedObjectReference
+	// find the vms for this resource pool
+	vms, err := d.children(pool)
+	if err != nil {
+		return nil, err
+	}
+	// determine which are containers
+	for _, vm := range vms {
+		if d.isContainer(vm) {
+			d.op.Debugf("Found Container: %s", vm.Summary.Config.Name)
+			containers = append(containers, vm.Reference())
+		}
+	}
+	d.op.Debugf("Found %d containers", len(containers))
+	return containers, nil
+}
+
+// children returns an array of VirtualMachines with properties populated
+func (d *Dispatcher) children(pool *object.ResourcePool) ([]mo.VirtualMachine, error) {
+	defer trace.End(trace.Begin(pool.InventoryPath, d.op))
+
+	// Get the vmRefs for this resource pool
+	refs, err := compute.VM(d.op, d.session, pool)
+	if err != nil {
+		err = fmt.Errorf("Error retrieving vms: %s", err)
+		return nil, err
+	}
+
+	return vm.Attributes(d.op, d.session, refs)
+}
+
+func (d *Dispatcher) isContainer(vm mo.VirtualMachine) bool {
+	var cfg executor.ExecutorConfig
+	// convert extraconfig to map
+	info := vmomi.OptionValueMap(vm.Config.ExtraConfig)
+	// decode to the executorConfig
+	extraconfig.Decode(extraconfig.MapSource(info), &cfg)
+	id := uid.Parse(cfg.ID)
+	if id == uid.NilUID {
+		d.op.Debugf("skipping VM %s: could not parse id", vm.Summary.Config.Name)
+		return false
+	}
+	return true
+}

--- a/lib/install/management/resource_pool.go
+++ b/lib/install/management/resource_pool.go
@@ -101,7 +101,7 @@ func (d *Dispatcher) destroyResourcePoolIfEmpty(conf *config.VirtualContainerHos
 	}
 	var vms []*vm.VirtualMachine
 	var err error
-	if vms, err = d.parentResourcepool.GetChildrenVMs(d.op, d.session); err != nil {
+	if vms, err = d.parentResourcepool.GetChildrenVMs(d.op); err != nil {
 		err = errors.Errorf("Unable to get children vm of resource pool %q: %s", d.parentResourcepool.Name(), err)
 		return err
 	}

--- a/lib/install/validate/config_to_data.go
+++ b/lib/install/validate/config_to_data.go
@@ -80,14 +80,12 @@ func SetDataFromVM(ctx context.Context, finder Finder, vm *vm.VirtualMachine, d 
 	// in a DRS disabled environment that inventory path could point to a
 	// cluster, so we need to evaluate the type and set the path accordingly
 	switch r := or.(type) {
-	case *object.ResourcePool:
-		d.ComputeResourcePath = r.InventoryPath
-	case *object.ClusterComputeResource:
+	case *object.Common:
 		d.ComputeResourcePath = r.InventoryPath
 	default:
 		return fmt.Errorf("parent resource %s is not resource pool", mrp.Parent)
 	}
-
+	op.Infof("Common: %s", d.ComputeResourcePath)
 	setVCHResources(op, parent, d)
 	setApplianceResources(op, vm, d)
 	return nil
@@ -110,7 +108,7 @@ func setApplianceResources(op trace.Operation, vm *vm.VirtualMachine, d *data.Da
 // setVCHResources will populate the configuration data based on the deployed VCH config
 func setVCHResources(op trace.Operation, vch *object.ResourcePool, d *data.Data) error {
 	var p mo.ResourcePool
-	ps := []string{"config.cpuAllocation", "config.memoryAllocation"}
+	ps := []string{"config"}
 
 	if err := vch.Properties(op, vch.Reference(), ps, &p); err != nil {
 		return err

--- a/lib/portlayer/exec/container.go
+++ b/lib/portlayer/exec/container.go
@@ -841,7 +841,8 @@ func infraContainers(ctx context.Context, sess *session.Session) ([]*Container, 
 		}
 	}
 
-	vms, err = populateVMAttributes(ctx, sess, vmRefs)
+	// Retrieve slice of mo.VirtualMachine with default attributes populated
+	vms, err = vm.Attributes(ctx, sess, vmRefs)
 	if err != nil {
 		return nil, err
 	}
@@ -860,19 +861,6 @@ func instanceUUID(id string) (string, error) {
 		return "", errors.Errorf("unable to parse VCH uuid: %s", err)
 	}
 	return uuid.NewSHA1(namespace, []byte(id)).String(), nil
-}
-
-// populate the vm attributes for the specified morefs
-func populateVMAttributes(ctx context.Context, sess *session.Session, refs []types.ManagedObjectReference) ([]mo.VirtualMachine, error) {
-	defer trace.End(trace.Begin(fmt.Sprintf("populating %d refs", len(refs))))
-	var vms []mo.VirtualMachine
-
-	// current attributes we care about
-	attrib := []string{"config", "runtime.powerState", "summary"}
-
-	// populate the vm properties
-	err := sess.Retrieve(ctx, refs, attrib, &vms)
-	return vms, err
 }
 
 // convert the infra containers to a container object

--- a/pkg/vsphere/compute/rp.go
+++ b/pkg/vsphere/compute/rp.go
@@ -46,29 +46,36 @@ func NewResourcePool(ctx context.Context, session *session.Session, moref types.
 	}
 }
 
-func (rp *ResourcePool) GetChildrenVMs(ctx context.Context, s *session.Session) ([]*vm.VirtualMachine, error) {
-	op := trace.FromContext(ctx, "GetChildrenVMs")
-
-	var err error
+// VM returns a slice of MoRefs that are the virtual machines of the provided resource pool
+func VM(op trace.Operation, session *session.Session, pool *object.ResourcePool) ([]types.ManagedObjectReference, error) {
 	var mrp mo.ResourcePool
-	var vms []*vm.VirtualMachine
-
-	if err = rp.Properties(op, rp.Reference(), []string{"vm"}, &mrp); err != nil {
-		op.Errorf("Unable to get children vm of resource pool %s: %s", rp.Name(), err)
-		return vms, err
+	err := session.Retrieve(op, []types.ManagedObjectReference{pool.Reference()}, []string{"vm"}, &mrp)
+	if err != nil {
+		op.Errorf("Error retrieving VMs for resource pool %s: %s", pool.Name(), err)
+		return nil, err
 	}
+	return mrp.Vm, nil
+}
 
-	for _, o := range mrp.Vm {
-		v := vm.NewVirtualMachine(op, s, o)
+// GetChildrenVMs returns a slice of VirtualMachines that are the pools VMs
+func (rp *ResourcePool) GetChildrenVMs(op trace.Operation) ([]*vm.VirtualMachine, error) {
+	var vms []*vm.VirtualMachine
+	refs, err := VM(op, rp.Session, rp.ResourcePool)
+	if err != nil {
+		return nil, err
+	}
+	for _, o := range refs {
+		v := vm.NewVirtualMachine(op, rp.Session, o)
 		vms = append(vms, v)
 	}
 	return vms, nil
 }
 
-func (rp *ResourcePool) GetChildVM(ctx context.Context, s *session.Session, name string) (*vm.VirtualMachine, error) {
-	op := trace.FromContext(ctx, "GetChildVM")
+// GetChildVM searches the pool for a VM by name and returns a VirtualMachine
+func (rp *ResourcePool) GetChildVM(ctx context.Context, name string) (*vm.VirtualMachine, error) {
+	op := trace.FromContext(ctx, name)
 
-	searchIndex := object.NewSearchIndex(s.Vim25())
+	searchIndex := object.NewSearchIndex(rp.Vim25())
 	child, err := searchIndex.FindChild(op, rp.Reference(), name)
 	if err != nil {
 		return nil, errors.Errorf("Unable to find VM(%s): %s", name, err.Error())
@@ -77,11 +84,11 @@ func (rp *ResourcePool) GetChildVM(ctx context.Context, s *session.Session, name
 		return nil, nil
 	}
 	// instantiate the vm object
-	return vm.NewVirtualMachine(op, s, child.Reference()), nil
+	return vm.NewVirtualMachine(op, rp.Session, child.Reference()), nil
 }
 
 func (rp *ResourcePool) GetCluster(ctx context.Context) (*object.ComputeResource, error) {
-	op := trace.FromContext(ctx, "GetCluster")
+	op := trace.FromContext(ctx, rp.Name())
 
 	var err error
 	var mrp mo.ResourcePool
@@ -95,7 +102,7 @@ func (rp *ResourcePool) GetCluster(ctx context.Context) (*object.ComputeResource
 }
 
 func (rp *ResourcePool) GetDatacenter(ctx context.Context) (*object.Datacenter, error) {
-	op := trace.FromContext(ctx, "GetDatacenter")
+	op := trace.FromContext(ctx, rp.Name())
 
 	dcRef, err := rp.getLowestAncestor(op, "Datacenter")
 	if err != nil || dcRef == nil {

--- a/pkg/vsphere/compute/rp_test.go
+++ b/pkg/vsphere/compute/rp_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/vmware/govmomi/simulator"
+	"github.com/vmware/vic/pkg/trace"
 	"github.com/vmware/vic/pkg/vsphere/session"
 	"github.com/vmware/vic/pkg/vsphere/test"
 )
@@ -61,13 +62,11 @@ func TestRp(t *testing.T) {
 
 func testGetChildrenVMs(ctx context.Context, sess *session.Session, t *testing.T) {
 	rp := NewResourcePool(ctx, sess, sess.Pool.Reference())
-	vms, err := rp.GetChildrenVMs(ctx, sess)
+	op := trace.NewOperation(ctx, "children")
+	vms, err := rp.GetChildrenVMs(op)
 	if err != nil {
 		t.Errorf("Failed to get children vm of resource pool %s, %s", rp.Name(), err)
 	}
-	//	if vms == nil || len(vms) == 0 {
-	//		t.Error("Didn't get children VM")
-	//	}
 	for _, vm := range vms {
 		t.Logf("vm: %s", vm)
 	}
@@ -75,7 +74,7 @@ func testGetChildrenVMs(ctx context.Context, sess *session.Session, t *testing.T
 
 func testGetChildVM(ctx context.Context, sess *session.Session, t *testing.T) {
 	rp := NewResourcePool(ctx, sess, sess.Pool.Reference())
-	vm, err := rp.GetChildVM(ctx, sess, "random")
+	vm, err := rp.GetChildVM(ctx, "random")
 	if err == nil && vm != nil {
 		t.Logf("vm: %s", vm.Reference())
 		t.Errorf("Should not find VM random")

--- a/pkg/vsphere/vm/vm_test.go
+++ b/pkg/vsphere/vm/vm_test.go
@@ -92,7 +92,7 @@ func TestDeleteExceptDisk(t *testing.T) {
 	// Wrap the result with our version of VirtualMachine
 	vm := NewVirtualMachine(ctx, session, *moref)
 
-	folder, err := vm.FolderName(ctx)
+	folder, err := vm.DatastoreFolderName(ctx)
 	if err != nil {
 		t.Fatalf("ERROR: %s", err)
 	}
@@ -249,7 +249,7 @@ func TestVMAttributes(t *testing.T) {
 	// Wrap the result with our version of VirtualMachine
 	vm := NewVirtualMachine(ctx, session, *moref)
 
-	folder, err := vm.FolderName(ctx)
+	folder, err := vm.DatastoreFolderName(ctx)
 	if err != nil {
 		t.Fatalf("ERROR: %s", err)
 	}

--- a/tests/test-cases/Group6-VIC-Machine/6-16-Config.md
+++ b/tests/test-cases/Group6-VIC-Machine/6-16-Config.md
@@ -19,33 +19,32 @@ This test requires that a vSphere server is running and available
 6. Check the debug state of the VCH
 7. Check the debug state of the existing containerVM
 8. Create a new container and check the debug state of it
-9. Configure the debug state of the VCH again and check whether there is only a single snapshot left
-10. check whether the output of vic-machine inspect contains the desired debug state
-11. Configure the VCH by adding a container network
-12. Run docker network ls
-13. Run vic-machine inspect config
-14. Run a container with the new container network
-15. Configure the VCH by adding a new container network without specifying the previous network
-16. Configure the VCH by adding a new container network while specifying the previous network
-17. Run docker network ls
-18. Run vic-machine inspect config
-19. Run a container with the new container network
-20. Configure the VCH by attempting to change an existing container network
-21. Configure VCH http proxy
-22. Verify http proxy is set correctly through govc
-23. Configure the VCH's operations user credentials
-24. Run vic-machine inspect config
-26. Reset VCH http proxy using VCH ID
-26. Verify http proxy is reset correctly through govc
-27. Run vic-machine inspect config
-28. Configure VCH dns server to 10.118.81.1 and 10.118.81.2
-29. Run vic-machine inspect config
-30. Reset VCH dns server to default
-31. Run vic-machine inspect config
-32. Configure VCH resources
-33. Verify VCH configuration through vic-machine inspect
-34. Configure VCH resources with too small values
-35. Verify VCH configuration is rollback to old value
+9. check whether the output of vic-machine inspect contains the desired debug state
+10. Configure the VCH by adding a container network
+11. Run docker network ls
+12. Run vic-machine inspect config
+13. Run a container with the new container network
+14. Configure the VCH by adding a new container network without specifying the previous network
+15. Configure the VCH by adding a new container network while specifying the previous network
+16. Run docker network ls
+17. Run vic-machine inspect config
+18. Run a container with the new container network
+19. Configure the VCH by attempting to change an existing container network
+20. Configure VCH http proxy
+21. Verify http proxy is set correctly through govc
+22. Configure the VCH's operations user credentials
+23. Run vic-machine inspect config
+24. Reset VCH http proxy using VCH ID
+25. Verify http proxy is reset correctly through govc
+26. Run vic-machine inspect config
+27. Configure VCH dns server to 10.118.81.1 and 10.118.81.2
+28. Run vic-machine inspect config
+29. Reset VCH dns server to default
+30. Run vic-machine inspect config
+31. Configure VCH resources
+32. Verify VCH configuration through vic-machine inspect
+33. Configure VCH resources with too small values
+34. Verify VCH configuration is rollback to old value
 35. Configure the VCH by adding a new volume store
 36. Run vic-machine inspect config
 37. Run docker info

--- a/tests/test-cases/Group6-VIC-Machine/6-16-Config.robot
+++ b/tests/test-cases/Group6-VIC-Machine/6-16-Config.robot
@@ -56,10 +56,6 @@ Configure VCH debug state
     Should Contain  ${output}  0
     ${output}=  Run  bin/vic-machine-linux configure --debug 1 --name=%{VCH-NAME} --target=%{TEST_URL}%{TEST_DATACENTER} --thumbprint=%{TEST_THUMBPRINT} --user=%{TEST_USERNAME} --password=%{TEST_PASSWORD} --timeout %{TEST_TIMEOUT}
     Should Contain  ${output}  Completed successfully
-    ${rc}  ${output}=  Run And Return Rc And Output  govc snapshot.tree -vm %{VCH-NAME} | grep reconfigure
-    Should Be Equal As Integers  ${rc}  0
-    ${output}=  Split To Lines  ${output}
-    Length Should Be  ${output}  1
     ${rc}  ${output}=  Run And Return Rc And Output  bin/vic-machine-linux inspect config --name=%{VCH-NAME} --target=%{TEST_URL}%{TEST_DATACENTER} --thumbprint=%{TEST_THUMBPRINT} --user=%{TEST_USERNAME} --password=%{TEST_PASSWORD} --timeout %{TEST_TIMEOUT}
     Should Be Equal As Integers  0  ${rc}
     Should Contain  ${output}  --debug=1
@@ -95,7 +91,7 @@ Configure VCH Container Networks
     Run Keyword If  '%{HOST_TYPE}' == 'VC'  Remove VC Distributed Portgroup  management
     ${dvs}=  Run Keyword If  '%{HOST_TYPE}' == 'VC'  Run  govc find -type DistributedVirtualSwitch | head -n1
     ${rc}  ${output}=  Run Keyword If  '%{HOST_TYPE}' == 'VC'  Run And Return Rc And Output  govc dvs.portgroup.add -dvs ${dvs} management
-    
+
     ${output}=  Run  bin/vic-machine-linux configure --name=%{VCH-NAME} --target=%{TEST_URL}%{TEST_DATACENTER} --thumbprint=%{TEST_THUMBPRINT} --user=%{TEST_USERNAME} --password=%{TEST_PASSWORD} --timeout %{TEST_TIMEOUT} --container-network=%{PUBLIC_NETWORK}:public --container-network management:mgmt --container-network-ip-range=management:10.10.10.0/24 --container-network-gateway=management:10.10.10.1/24
     Should Contain  ${output}  all existing container networks must also be specified
     Should Not Contain  ${output}  Completed successfully


### PR DESCRIPTION
Upgrade will now update the inventory for the VCH by
moving the VCH and containerVMs into a folder with the
same name as the VCH.  This will match the functionality
provided in create.

Upgrade also has a debug flag allowing for more verbose
output from the cli.

Configure will not make any inventory changes.

Fixes #7497