### PR TITLE
Improved VM power-on readability

### DIFF
--- a/pkg/vsphere/vm/vm.go
+++ b/pkg/vsphere/vm/vm.go
@@ -728,7 +728,7 @@ func (vm *VirtualMachine) EnableDestroy(ctx context.Context) error {
 	return nil
 }
 
-// RemoveSnapshot removes a snapshot by reference
+// RemoveSnapshotByRef removes a snapshot by reference
 func (vm *VirtualMachine) RemoveSnapshotByRef(ctx context.Context, snapshot *types.ManagedObjectReference, removeChildren bool, consolidate *bool) (*object.Task, error) {
 	req := types.RemoveSnapshot_Task{
 		This:           snapshot.Reference(),
@@ -763,11 +763,32 @@ func (vm *VirtualMachine) CheckHostCompatibility(ctx context.Context, host *type
 // to the most suitable host in the cluster. If relocation or subsequent power-on fail, it will attempt the next
 // best host, and repeat this process until a successful power-on is achieved or there are no more hosts to try.
 func (vm *VirtualMachine) PowerOn(op trace.Operation) error {
-	drs := vm.Session.DRSEnabled != nil && *vm.Session.DRSEnabled
-	cls := vm.InCluster(op)
+	// if we aren't in VC, we don't need to recommend or use DRS-aware power-on
+	if !vm.IsVC() {
+		_, err := vm.WaitForResult(op, func(op context.Context) (tasks.Task, error) {
+			return vm.VirtualMachine.PowerOn(op)
+		})
+		return err
+	}
 
+	h, err := vm.Cluster.Hosts(op)
+	if err != nil {
+		return err
+	}
+
+	// we only recommend if the VM is in a cluster with more than one host
+	cls := vm.InCluster(op) && len(h) > 1
+	op.Debugf("%s resides in a multi-host cluster: %t", vm.Reference().String(), cls)
+
+	// or if DRS is disabled
+	drs := vm.Session.DRSEnabled != nil && *vm.Session.DRSEnabled
 	op.Debugf("DRS enabled: %t", drs)
-	op.Debugf("%s resides in a cluster: %t", vm.Reference().String(), cls)
+
+	if !cls || drs {
+		// if we aren't in a multi-host cluster or if we are and DRS is enabled,
+		// there is no reason to recommend a host, so bail early and power-on.
+		return vm.powerOnDRS(op)
+	}
 
 	// otherwise place the VM before powering it on
 	hmp := performance.NewHostMetricsProvider(vm.Session.Vim25())
@@ -776,13 +797,10 @@ func (vm *VirtualMachine) PowerOn(op trace.Operation) error {
 		return err
 	}
 
-	// any of the following conditions are sufficient to power-on the VM:
-	// - environment is not VC
-	// - DRS is enabled
-	// - the VM does not belong to a cluster
-	// - the current host is adequate for power-on
-	if !vm.IsVC() || drs || !cls || rhp.CheckHost(op, vm.VirtualMachine) {
-		return vm.powerOn(op)
+	// first we check if the host on which the VM was created is adequate for power-on
+	if rhp.CheckHost(op, vm.VirtualMachine) {
+		// if so, just power-on, don't bother recommending a better host
+		return vm.powerOnDRS(op)
 	}
 
 	// TODO(jzt): uncomment this once we have CheckHost implemented.
@@ -815,7 +833,7 @@ func (vm *VirtualMachine) PowerOn(op trace.Operation) error {
 		var err error
 		if err = vm.relocate(op, hosts[0]); err != nil {
 			op.Warnf("VM relocation failed: %s", err.Error())
-		} else if err = vm.powerOn(op); err != nil {
+		} else if err = vm.powerOnDRS(op); err != nil {
 			op.Warnf("VM power-on failed: %s", err.Error())
 		} else {
 			return nil
@@ -830,7 +848,35 @@ func (vm *VirtualMachine) PowerOn(op trace.Operation) error {
 
 	}
 	op.Warnf("vm placement failed: no available hosts. Attempting power-on.")
-	return vm.powerOn(op)
+	return vm.powerOnDRS(op)
+}
+
+func (vm *VirtualMachine) powerOnDRS(op trace.Operation) error {
+	option := &types.OptionValue{
+		Key:   string(types.ClusterPowerOnVmOptionOverrideAutomationLevel),
+		Value: string(types.DrsBehaviorFullyAutomated),
+	}
+
+	t, err := vm.WaitForResult(op, func(op context.Context) (tasks.Task, error) {
+		return vm.Datacenter.PowerOnVM(op, []types.ManagedObjectReference{vm.Reference()}, option)
+	})
+	if err != nil {
+		return err
+	}
+
+	switch r := t.Result.(type) {
+	case types.ClusterPowerOnVmResult:
+		attempts := len(r.Attempted)
+		if attempts != 1 {
+			return fmt.Errorf("Attempted to power on the wrong number of VMs. Expected 1, attempted %d", attempts)
+		}
+		info := r.Attempted[0]
+		task := object.NewTask(vm.Session.Vim25(), *info.Task)
+		_, err := task.WaitForResult(op, nil)
+		return err
+	default:
+		return fmt.Errorf("Unexpected return type when attempting to power on VM: %T", r)
+	}
 }
 
 func (vm *VirtualMachine) relocate(op trace.Operation, host *object.HostSystem) error {
@@ -862,52 +908,7 @@ func (vm *VirtualMachine) relocate(op trace.Operation, host *object.HostSystem) 
 	return nil
 }
 
-func (vm *VirtualMachine) powerOn(op trace.Operation) error {
-	var f func(context.Context) (tasks.Task, error)
-
-	if vm.IsVC() {
-		dc := vm.Datacenter
-
-		option := &types.OptionValue{
-			Key:   string(types.ClusterPowerOnVmOptionOverrideAutomationLevel),
-			Value: string(types.DrsBehaviorFullyAutomated),
-		}
-
-		f = func(op context.Context) (tasks.Task, error) {
-			return dc.PowerOnVM(op, []types.ManagedObjectReference{vm.Reference()}, option)
-
-		}
-	} else {
-		f = func(op context.Context) (tasks.Task, error) {
-			return vm.VirtualMachine.PowerOn(op)
-		}
-	}
-
-	t, err := vm.WaitForResult(op, f)
-	if err != nil {
-		return err
-	}
-
-	if vm.IsVC() {
-		switch r := t.Result.(type) {
-		case types.ClusterPowerOnVmResult:
-			attempts := len(r.Attempted)
-			if attempts != 1 {
-				return fmt.Errorf("Attempted to power on the wrong number of VMs. Expected 1, attempted %d", attempts)
-			}
-
-			info := r.Attempted[0]
-			task := object.NewTask(vm.Session.Vim25(), *info.Task)
-			_, err := task.WaitForResult(op, nil)
-			return err
-		default:
-			return fmt.Errorf("Unexpected return type when attempting to power on VM: %T", r)
-		}
-	}
-
-	return nil
-}
-
+// InCluster returns true if the VM belongs to a cluster
 func (vm *VirtualMachine) InCluster(op trace.Operation) bool {
 	cls := vm.Cluster.Reference().Type == "ClusterComputeResource"
 	op.Debugf("vm compute resource: %s", vm.Cluster.Name())


### PR DESCRIPTION
This reduces complexity in the VM power-on path as per review comments by @hickeng:  https://github.com/vmware/vic/pull/7667#pullrequestreview-110628312

Tested in ESX standalone, VC + DRS, and VC + DRS disabled.

Note: this commit will be squashed along with other commits that are addressing review comments.