### PR TITLE
Make VCH delete integration tests more robust

### DIFF
--- a/tests/test-cases/Group24-Multi-VCH/24-02-Multi-VCH-Delete.md
+++ b/tests/test-cases/Group24-Multi-VCH/24-02-Multi-VCH-Delete.md
@@ -13,6 +13,7 @@ This test requires a running and available vSphere server.
 4. Create a busybox container on the VCH from Step 3
 5. Clean up the VCH from Step 3
 6. Use govc to look for the first VCH's containerVM
+7. Clean up the VCH from Step 1
 
 ## Expected Outcome
 * All steps should succeed

--- a/tests/test-cases/Group24-Multi-VCH/24-02-Multi-VCH-Delete.robot
+++ b/tests/test-cases/Group24-Multi-VCH/24-02-Multi-VCH-Delete.robot
@@ -15,14 +15,14 @@
 *** Settings ***
 Documentation  Test 24-02 - Verify vic-machine delete only removes own cVMs
 Resource  ../../resources/Util.robot
-Suite Teardown  Cleanup VCHs
+Test Teardown  Run Keyword If Test Failed  Cleanup VCHs
 
 *** Keywords ***
 Cleanup VCHs
-    Run Keyword And Ignore Error  Cleanup VIC Appliance On Test Server
-    Set Environment Variable  VCH-NAME  ${old-vch}
-    Set Environment Variable  BRIDGE_NETWORK  ${old-vch-bridge}
-    Set Environment Variable  VCH-PARAMS  ${old-vch-params}
+    Run Keyword And Continue On Failure  Cleanup VIC Appliance On Test Server
+    Run Keyword If  '${old-vch}' != '${EMPTY}'  Set Environment Variable  VCH-NAME  ${old-vch}
+    Run Keyword If  '${old-vch-bridge}' != '${EMPTY}'  Set Environment Variable  BRIDGE_NETWORK  ${old-vch-bridge}
+    Run Keyword If  '${old-vch-params}' != '${EMPTY}'  Set Environment Variable  VCH-PARAMS  ${old-vch-params}
     Run Keyword And Continue On Failure  Cleanup VIC Appliance On Test Server
 
 *** Test Cases ***
@@ -52,6 +52,7 @@ VCH delete only removes its own containers
     ${rc}=  Run And Return Rc  docker %{VCH-PARAMS} create ${busybox}
     Should Be Equal As Integers  ${rc}  0
 
+    # Clean up the second VCH
     Cleanup VIC Appliance On Test Server
 
     # The old VCH's cVM should still exist
@@ -59,3 +60,8 @@ VCH delete only removes its own containers
     Should Be Equal As Integers  ${rc}  0
     Should Contain  ${output}  ${c1}
 
+    # Clean up the first VCH
+    Set Environment Variable  VCH-NAME  ${old-vch}
+    Set Environment Variable  BRIDGE_NETWORK  ${old-vch-bridge}
+    Set Environment Variable  VCH-PARAMS  ${old-vch-params}
+    Cleanup VIC Appliance On Test Server

--- a/tests/test-cases/Group6-VIC-Machine/6-03-Delete.robot
+++ b/tests/test-cases/Group6-VIC-Machine/6-03-Delete.robot
@@ -48,17 +48,14 @@ Cleanup Delete VCH with non-cVM in VCH folder test
     Set Environment Variable  TEST_DATACENTER  ${orig-dc}
 
     # Delete VCH folder and the non-cVM under it
-    ${rc}  ${output}=  Run And Return Rc And Output  govc object.destroy %{VCH-NAME}
+    ${output}=  Run  govc object.destroy %{VCH-NAME}
     Log  ${output}
-    Should Be Equal As Integers  ${rc}  0
 
     # Delete resource pool
-    ${rc}  ${output}=  Run And Return Rc And Output  govc pool.destroy "%{TEST_RESOURCE}/Resources/%{VCH-NAME}"
+    ${output}=  Run  govc pool.destroy "%{TEST_RESOURCE}/Resources/%{VCH-NAME}"
     Log  ${output}
-    Should Be Equal As Integers  ${rc}  0
-    ${rc}  ${output}=  Run And Return Rc And Output  govc pool.destroy "%{TEST_RESOURCE}/%{VCH-NAME}"
+    ${output}=  Run  govc pool.destroy "%{TEST_RESOURCE}/%{VCH-NAME}"
     Log  ${output}
-    Should Be Equal As Integers  ${rc}  0
 
 *** Test Cases ***
 Delete VCH and verify
@@ -166,9 +163,7 @@ Delete VCH with non-cVM in same RP
     Log  ${output}
     Should Be Equal As Integers  ${rc}  0
 
-    ${rc}  ${output}=  Run And Return Rc And Output  govc pool.destroy "%{TEST_RESOURCE}/Resources/%{VCH-NAME}"
-    Log  ${output}
-    Should Be Equal As Integers  ${rc}  0
+    Run Keyword And Continue On Failure  Run  govc pool.destroy "%{TEST_RESOURCE}/Resources/%{VCH-NAME}"
     ${rc}  ${output}=  Run And Return Rc And Output  govc pool.destroy "%{TEST_RESOURCE}/%{VCH-NAME}"
     Log  ${output}
     Should Be Equal As Integers  ${rc}  0


### PR DESCRIPTION
[specific ci=6-03-Delete --suite 24-02-Multi-VCH-Delete]

This commit addresses review comments in the feature/robo merge PR
(#7667) for the 6-03-Delete and 24-02-Multi-VCH-Delete Robot tests.
This change restructures some test commands and keywords to prevent
leaks after test failures.

Note: this commit will be squashed along with other commits that are addressing review comments.