### PR TITLE
Update VM placement test to use ELM

### DIFF
--- a/tests/manual-test-cases/Group19-DRS-Disabled/19-3-DRS-Disabled-Placement.md
+++ b/tests/manual-test-cases/Group19-DRS-Disabled/19-3-DRS-Disabled-Placement.md
@@ -11,9 +11,7 @@ The current placement strategy is to avoid bad host selection, instead of select
 
 # Environment:
 This test requires access to VMware Nimbus cluster for dynamic ESXi and vCenter creation. This test should be executed in the following topologies and should have vSAN enabled.
-* 1 vCenter host with 1 cluster containing 4 ESX hosts with DRS disabled.
-
-In addition, this test should be run in multi-ESX-host and single-ESX-host cluster topologies.
+* 1 PSC linking 2 VCs, each containing a 3-host cluster with VSAN enabled and DRS disabled, and a single host cluster.
 
 See https://confluence.eng.vmware.com/display/CNA/VIC+ROBO for more details.
 

--- a/tests/manual-test-cases/Group19-DRS-Disabled/19-3-DRS-Disabled-Placement.robot
+++ b/tests/manual-test-cases/Group19-DRS-Disabled/19-3-DRS-Disabled-Placement.robot
@@ -15,8 +15,7 @@
 *** Settings ***
 Documentation  Test 19-3 - DRS-Disabled-Placement
 Resource  ../../resources/Util.robot
-Suite Setup  Wait Until Keyword Succeeds  10x  10m  ROBO SKU Setup
-Suite Teardown  Teardown VCH And Cleanup Nimbus
+Suite Teardown  Cleanup VIC Appliance On Test Server
 
 *** Keywords ***
 Deploy Stress Container And Return Host IP
@@ -55,23 +54,28 @@ Teardown VCH And Cleanup Nimbus
 
 Simple Placement
     Install VIC Appliance To Test Server
+    Log To Console  Deploy VIC to the VC cluster
+    Set Environment Variable  GOVC_URL  ${vc1-ip}
+    Set Environment Variable  TEST_URL_ARRAY  ${vc1-ip}
+    Set Environment Variable  TEST_RESOURCE  cls3
+    Set Environment Variable  TEST_TIMEOUT  30m
+
     ${vch_host}=  Get VM Host Name  %{VCH-NAME}
 
     ${stressed_hosts}=  Create List  ${vch_host}
-    :FOR  ${i}  IN RANGE  2
-    \   ${ip}=  Deploy Stress Container And Return Host IP  stresser${i}
-    \   Should Not Contain  ${stressed_hosts}  ${ip}
-    \   Append To List  ${stressed_hosts}  ${ip}
+    ${ip}=  Deploy Stress Container And Return Host IP  stresser
+    Should Not Contain  ${stressed_hosts}  ${ip}
+    Append To List  ${stressed_hosts}  ${ip}
 
-    # 1 VCH host + 2 stressed hosts out of 4 total, leaving one
+    # 1 VCH host + 1 stressed hosts out of 3 hosts total, leaving one
     # clean host to which a new container should relocate
     ${len}=  Get Length  ${stressed_hosts}
-    Should Be Equal As Integers  ${len}  3
+    Should Be Equal As Integers  ${len}  2
 
     ${id}=  Create Busybox Container VM And Return ID
     ${vm_name}=  Get VM display name  ${id}
 
-    # Move it onto the same host as the VC
+    # Move it onto the same host as the VCH
     Relocate VM To Host  ${vch_host}  ${vm_name}
 
     ${host_ip}=  Get VM Host Name  ${vm_name}

--- a/tests/resources/Util.robot
+++ b/tests/resources/Util.robot
@@ -32,5 +32,6 @@ Resource  Admiral-Util.robot
 Resource  OVA-Util.robot
 Resource  Cert-Util.robot
 Resource  Slack-Util.robot
+Resource  nimbus-testbeds/ELM-DRS-Disabled.robot
 
 Variables  dynamic-vars.py


### PR DESCRIPTION
This updates the placement integration tests per review comments by @mhagen-vmware: https://github.com/vmware/vic/pull/7667#pullrequestreview-110866712

The testbed setup and teardown steps have been removed as this test will use an already existing testbed that will be torn down after the entire group is run.

Note: this commit will be squashed along with other commits that are addressing review comments.