### PR TITLE
Remove feature/robo from full ci group

### DIFF
--- a/tests/integration-test.sh
+++ b/tests/integration-test.sh
@@ -44,7 +44,7 @@ if (echo $prBody | grep -q "\[parallel jobs="); then
     jobs=$(echo $parallel | awk -F"\[parallel jobs=" '{sub(/\].*/,"",$2);print $2}')
 fi
 
-if [[ $DRONE_BRANCH == "master" || $DRONE_BRANCH == "releases/"* || $DRONE_BRANCH == "feature/robo" ]] && [[ $DRONE_REPO == "vmware/vic" ]] && [[ $DRONE_BUILD_EVENT == "push" ]]; then
+if [[ $DRONE_BRANCH == "master" || $DRONE_BRANCH == "releases/"* ]] && [[ $DRONE_REPO == "vmware/vic" ]] && [[ $DRONE_BUILD_EVENT == "push" ]]; then
     echo "Running full CI for $DRONE_BUILD_EVENT on $DRONE_BRANCH"
     pabot --verbose --processes $jobs --removekeywords TAG:secret --exclude skip tests/test-cases
 elif [[ $DRONE_BRANCH == *"refs/tags"* ]] && [[ $DRONE_REPO == "vmware/vic" ]] && [[ $DRONE_BUILD_EVENT == "tag" ]]; then


### PR DESCRIPTION
This removes the `feature/robo` branch from the full CI group as per review comments by @zjs : https://github.com/vmware/vic/pull/7667#discussion_r180243354

Going forward, we are now in the review comment addressing phase and can run a full CI manually if necessary.

Note: this commit will be squashed along with other commits that are addressing review comments.