### PR TITLE
Upgrade test sets API version local to test

### DIFF
--- a/tests/test-cases/Group11-Upgrade/11-01-Upgrade.robot
+++ b/tests/test-cases/Group11-Upgrade/11-01-Upgrade.robot
@@ -205,6 +205,7 @@ Upgrade VCH with unreasonably short timeout and automatic rollback after failure
     Wait For VCH Initialization  30x
     # confirm that the rollback took effect
     Check Original Version
+    Remove Environment Variable  DOCKER_API_VERSION  1.23
 
 Upgrade VCH
     Create Docker Containers


### PR DESCRIPTION
Change limits the DOCKER_API_VERSION variable to the specific
upgrade test vs environment variable that might impact other
tests.

[specific ci=11-01-Upgrade]