### PR TITLE
Update ops-grant-perms for VM-Host Affinity

### DIFF
--- a/lib/install/opsuser/opsuser.go
+++ b/lib/install/opsuser/opsuser.go
@@ -80,7 +80,11 @@ func GrantOpsUserPerms(ctx context.Context, session *session.Session, configSpec
 
 	// Use a separate RBAC configuration depending on whether DRS is enabled.
 	if session.DRSEnabled != nil && *session.DRSEnabled {
-		rbacConfig = &DRSConf
+		if configSpec.UseVMGroup {
+			rbacConfig = &ClusterConf
+		} else {
+			rbacConfig = &DRSConf
+		}
 	} else {
 		rbacConfig = &NoDRSConf
 	}

--- a/lib/install/opsuser/opsuser_conf.go
+++ b/lib/install/opsuser/opsuser_conf.go
@@ -51,6 +51,7 @@ var RoleCluster = types.AuthorizationRole{
 		"Datastore.DeleteFile",
 		"Datastore.FileManagement",
 		"Host.Config.SystemManagement",
+		"Host.Inventory.EditCluster",
 	},
 }
 
@@ -116,97 +117,61 @@ var DCReadOnlyConf = rbac.Config{
 	},
 }
 
-// DRSConf stores the RBAC configuration for the ops-user's roles in a DRS environment.
-var DRSConf = rbac.Config{
-	Resources: []rbac.Resource{
-		{
-			Type:      rbac.VCenter,
-			Propagate: false,
-			Role:      RoleVCenter,
+func buildConfig(clusterRole types.AuthorizationRole) rbac.Config {
+	return rbac.Config{
+		Resources: []rbac.Resource{
+			{
+				Type:      rbac.VCenter,
+				Propagate: false,
+				Role:      RoleVCenter,
+			},
+			{
+				Type:      rbac.Datacenter,
+				Propagate: true,
+				Role:      RoleDataCenter,
+			},
+			{
+				Type:      rbac.Cluster,
+				Propagate: true,
+				Role:      clusterRole,
+			},
+			{
+				Type:      rbac.DatastoreFolder,
+				Propagate: true,
+				Role:      RoleDataStore,
+			},
+			{
+				Type:      rbac.Datastore,
+				Propagate: false,
+				Role:      RoleDataStore,
+			},
+			{
+				Type:      rbac.VSANDatastore,
+				Propagate: false,
+				Role:      RoleDataStore,
+			},
+			{
+				Type:      rbac.Network,
+				Propagate: true,
+				Role:      RoleNetwork,
+			},
+			{
+				Type:      rbac.Endpoint,
+				Propagate: true,
+				Role:      RoleEndpoint,
+			},
 		},
-		{
-			Type:      rbac.Datacenter,
-			Propagate: true,
-			Role:      RoleDataCenter,
-		},
-		{
-			Type:      rbac.Cluster,
-			Propagate: true,
-			Role:      RoleDataStore,
-		},
-		{
-			Type:      rbac.DatastoreFolder,
-			Propagate: true,
-			Role:      RoleDataStore,
-		},
-		{
-			Type:      rbac.Datastore,
-			Propagate: false,
-			Role:      RoleDataStore,
-		},
-		{
-			Type:      rbac.VSANDatastore,
-			Propagate: false,
-			Role:      RoleDataStore,
-		},
-		{
-			Type:      rbac.Network,
-			Propagate: true,
-			Role:      RoleNetwork,
-		},
-		{
-			Type:      rbac.Endpoint,
-			Propagate: true,
-			Role:      RoleEndpoint,
-		},
-	},
+	}
 }
+
+// DRSConf stores the RBAC configuration for the ops-user's roles in a DRS environment.
+var DRSConf = buildConfig(RoleDataStore)
 
 // NoDRSConf stores the configuration for the ops-user's roles in a non-DRS environment.
 // It is different from DRSConf in that RoleEndpointDatastore is used for the cluster
 // instead of RoleDataStore. In a non-DRS environment, we need to apply the Endpoint and
 // Datastore roles at the cluster level since there are no resource pools.
-var NoDRSConf = rbac.Config{
-	Resources: []rbac.Resource{
-		{
-			Type:      rbac.VCenter,
-			Propagate: false,
-			Role:      RoleVCenter,
-		},
-		{
-			Type:      rbac.Datacenter,
-			Propagate: true,
-			Role:      RoleDataCenter,
-		},
-		{
-			Type:      rbac.Cluster,
-			Propagate: true,
-			Role:      RoleEndpointDatastore,
-		},
-		{
-			Type:      rbac.DatastoreFolder,
-			Propagate: true,
-			Role:      RoleDataStore,
-		},
-		{
-			Type:      rbac.Datastore,
-			Propagate: false,
-			Role:      RoleDataStore,
-		},
-		{
-			Type:      rbac.VSANDatastore,
-			Propagate: false,
-			Role:      RoleDataStore,
-		},
-		{
-			Type:      rbac.Network,
-			Propagate: true,
-			Role:      RoleNetwork,
-		},
-		{
-			Type:      rbac.Endpoint,
-			Propagate: true,
-			Role:      RoleEndpoint,
-		},
-	},
-}
+var NoDRSConf = buildConfig(RoleEndpointDatastore)
+
+// Configuration for the ops-user with increased cluster-level permissions, required for managing DRS VM Groups
+var ClusterConf = buildConfig(RoleCluster)

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-25-OPS-User-Grant.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-25-OPS-User-Grant.robot
@@ -84,3 +84,19 @@ vic-machine create grants ops-user perms
     Should Be Equal As Integers  ${rc}  0
 
     Cleanup VIC Appliance On Test Server
+
+Test with VM-Host Affinity
+    Log To Console  \nStarting test...
+    Install VIC Appliance To Test Server  additional-args=--ops-user ${ops_user_name} --ops-password ${ops_user_password} --ops-grant-perms --affinity-vm-group
+
+    # Run a govc test to check that access is denied on some resources
+    Log To Console  Running govc to create a resource pool named "5-25-OPS-User-Grant-%{DRONE_BUILD_NUMBER}", it should fail
+    ${rc}  ${output}=  Run And Return Rc And Output  GOVC_USERNAME=${ops_user_name} GOVC_PASSWORD=${ops_user_password} govc pool.create */Resources/5-25-OPS-User-Grant-%{DRONE_BUILD_NUMBER}
+    Log  Govc output: ${output}
+    Should Be Equal As Integers  ${rc}  1
+    Should Contain  ${output}  Permission to perform this operation was denied
+
+
+    Run Regression Tests
+
+    Cleanup VIC Appliance On Test Server


### PR DESCRIPTION
Managing DRS VM Groups requires the `Host.Inventory.EditCluster` privilege. Assign a role with this permission to the operations user when granting permissions if the VCH is using a DRS VM Group. This is not added for all VCHs as the `Host.Inventory.EditCluster` privilege is very broad.

Note: `RoleCluster` was previously unused.

Fixes #7562 

[specific ci=5-25-OPS-User-Grant]

---

Manually tested on vCenter 6.0 and 6.5
