### PR TITLE
Remove unnecessary robot keyword argument from upgrade test

### DIFF
--- a/tests/test-cases/Group11-Upgrade/11-01-Upgrade.robot
+++ b/tests/test-cases/Group11-Upgrade/11-01-Upgrade.robot
@@ -205,7 +205,7 @@ Upgrade VCH with unreasonably short timeout and automatic rollback after failure
     Wait For VCH Initialization  30x
     # confirm that the rollback took effect
     Check Original Version
-    Remove Environment Variable  DOCKER_API_VERSION  1.23
+    Remove Environment Variable  DOCKER_API_VERSION
 
 Upgrade VCH
     Create Docker Containers


### PR DESCRIPTION
This will be squashed into the final feature commit addressing
merge comments.