### PR TITLE
Correct docker command usage in nfs nightly test

### DIFF
--- a/tests/manual-test-cases/Group5-Functional-Tests/5-22-NFS-Volume.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-22-NFS-Volume.robot
@@ -124,7 +124,7 @@ Reboot VM and Verify Basic VCH Info
     Should Contain  ${output}  ${busybox}
 
     # ensure that the volumes we expect to exist are still available
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} volumes
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} volume ls
     Should Be Equal As Integers  ${rc}  0
     Should Contain  ${output}  ${nfsNamedVolume}
 


### PR DESCRIPTION
Embarrassing, but two errors compounded here. First I mangled the docker command in the test change, then I managed to push without having committed the local fix for that and none of us caught it in the PR (13111cc).

Change corrects the docker volume usage.

[skip ci]
Towards #7621 
