### PR TITLE
Add privilege to allow VM relocate with ops-user

### DIFF
--- a/lib/install/opsuser/opsuser_conf.go
+++ b/lib/install/opsuser/opsuser_conf.go
@@ -80,6 +80,7 @@ var RoleEndpoint = types.AuthorizationRole{
 		"DVPortgroup.PolicyOp",
 		"DVPortgroup.ScopeOp",
 		"Resource.AssignVMToPool",
+		"Resource.ColdMigrate",
 		"VirtualMachine.Config.AddExistingDisk",
 		"VirtualMachine.Config.AddNewDisk",
 		"VirtualMachine.Config.AddRemoveDevice",


### PR DESCRIPTION
This commit adds the 'Resource.ColdMigrate' privilege to the Endpoint
role for the ops-user. We found that attempts to relocate a containerVM
in a non-DRS env would fail due to this missing privilege when the VCH
was set up with an ops-user and --ops-grant-perms was used.

Fixes #7713