### PR TITLE
Fix vic-machine-server build drone plugin pull command

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -254,6 +254,7 @@ pipeline:
     pull: true
     repo: eminent-nation-87317/vic-machine-server
     dockerfile: cmd/vic-machine-server/Dockerfile
+    custom_dns: 10.142.7.21, 10.142.7.22, 10.166.17.90
     secrets: [ token ]
     tags:
       - dev
@@ -268,6 +269,7 @@ pipeline:
     pull: true
     repo: eminent-nation-87317/vic-machine-server
     dockerfile: cmd/vic-machine-server/Dockerfile
+    custom_dns: 10.142.7.21, 10.142.7.22, 10.166.17.90
     secrets: [ token ]
     tags:
       - latest

--- a/cmd/vic-machine-server/Dockerfile
+++ b/cmd/vic-machine-server/Dockerfile
@@ -5,20 +5,12 @@
 # gcloud auth login
 # gcloud docker -- push gcr.io/eminent-nation-87317/vic-machine-server:1.x
 
-FROM gcr.io/eminent-nation-87317/photon:1.0
-
-# Use local repo
-RUN mv /etc/yum.repos.d/{photon,photon-updates}.repo /tmp
-ADD isos/base/photon-local.repo /etc/yum.repos.d
-ADD isos/base/photon-updates-local.repo /etc/yum.repos.d
+FROM vmware/photon:1.0
 
 RUN set -eux; \
      tdnf distro-sync --refresh -y; \
      tdnf info installed; \
      tdnf clean all
-
-RUN rm /etc/yum.repos.d/{photon-local,photon-updates-local}.repo
-RUN mv /tmp/{photon,photon-updates}.repo /etc/yum.repos.d/
 
 ENV HOST 0.0.0.0
 ENV PORT 80

--- a/cmd/vic-machine-server/Dockerfile
+++ b/cmd/vic-machine-server/Dockerfile
@@ -5,7 +5,7 @@
 # gcloud auth login
 # gcloud docker -- push gcr.io/eminent-nation-87317/vic-machine-server:1.x
 
-FROM wdc-harbor-ci.eng.vmware.com/default-project/photon:1.0
+FROM gcr.io/eminent-nation-87317/photon:1.0
 
 # Use local repo
 RUN mv /etc/yum.repos.d/{photon,photon-updates}.repo /tmp


### PR DESCRIPTION
~The drone plugin that builds this image uses dind, which only works with insecure registries without some significant changes to the plugin itself.~

see comment below