### PR TITLE
Fixed wolfpack's build requirement for runc binary

### DIFF
--- a/isos/appliance-virtual-kubelet.sh
+++ b/isos/appliance-virtual-kubelet.sh
@@ -153,8 +153,6 @@ cp ${BIN}/unpack $(rootfs_dir $PKGDIR)/bin/
 cp ${BIN}/kubelet-starter $(rootfs_dir $PKGDIR)/sbin/kubelet-starter
 
 echo "pkgdir = " $PKGDIR
-# runc
-cp /usr/sbin/runc $(rootfs_dir $PKGDIR)/sbin/runc
 
 # Extra binaries
 APPLIANCE_NAME=$(basename ${APPLIANCE_OUTNAME})

--- a/isos/bootstrap-staging.sh
+++ b/isos/bootstrap-staging.sh
@@ -105,6 +105,7 @@ yum_cached -c $cache -u -p $PKGDIR install \
     haveged \
     systemd \
     iptables \
+    runc \
     -y --nogpgcheck
 
 # https://www.freedesktop.org/wiki/Software/systemd/InitrdInterface/

--- a/isos/bootstrap.sh
+++ b/isos/bootstrap.sh
@@ -82,7 +82,6 @@ fi
 
 # copy in our components
 cp ${BIN}/tether-linux $(rootfs_dir $PKGDIR)/bin/tether
-cp /usr/sbin/runc $(rootfs_dir $PKGDIR)/bin/runc
 
 # kick off our components at boot time
 mkdir -p $(rootfs_dir $PKGDIR)/etc/systemd/system/vic.target.wants

--- a/lib/tether/tether.go
+++ b/lib/tether/tether.go
@@ -69,7 +69,7 @@ var (
 
 const (
 	useRunc  = true
-	runcPath = "/bin/runc"
+	runcPath = "/sbin/runc"
 )
 
 type tether struct {


### PR DESCRIPTION
Use photon's runc package instead of copying local binary into bootstrap iso.

Resolves #7649
