### PR TITLE
Fix ops-user cluster permissions in non-DRS envs

### DIFF
--- a/lib/install/opsuser/opsuser_conf.go
+++ b/lib/install/opsuser/opsuser_conf.go
@@ -99,6 +99,13 @@ var RoleEndpoint = types.AuthorizationRole{
 	},
 }
 
+// RoleEndpointDatastore combines the privileges of RoleDataStore and RoleEndpoint
+// and is applied to the cluster in a non-DRS environment.
+var RoleEndpointDatastore = types.AuthorizationRole{
+	Name:      "endpoint-datastore",
+	Privilege: append(RoleDataStore.Privilege, RoleEndpoint.Privilege...),
+}
+
 var DCReadOnlyConf = rbac.Config{
 	Resources: []rbac.Resource{
 		{
@@ -109,8 +116,8 @@ var DCReadOnlyConf = rbac.Config{
 	},
 }
 
-// Configuration for the ops-user
-var OpsuserRBACConf = rbac.Config{
+// DRSConf stores the RBAC configuration for the ops-user's roles in a DRS environment.
+var DRSConf = rbac.Config{
 	Resources: []rbac.Resource{
 		{
 			Type:      rbac.VCenter,
@@ -126,6 +133,55 @@ var OpsuserRBACConf = rbac.Config{
 			Type:      rbac.Cluster,
 			Propagate: true,
 			Role:      RoleDataStore,
+		},
+		{
+			Type:      rbac.DatastoreFolder,
+			Propagate: true,
+			Role:      RoleDataStore,
+		},
+		{
+			Type:      rbac.Datastore,
+			Propagate: false,
+			Role:      RoleDataStore,
+		},
+		{
+			Type:      rbac.VSANDatastore,
+			Propagate: false,
+			Role:      RoleDataStore,
+		},
+		{
+			Type:      rbac.Network,
+			Propagate: true,
+			Role:      RoleNetwork,
+		},
+		{
+			Type:      rbac.Endpoint,
+			Propagate: true,
+			Role:      RoleEndpoint,
+		},
+	},
+}
+
+// NoDRSConf stores the configuration for the ops-user's roles in a non-DRS environment.
+// It is different from DRSConf in that RoleEndpointDatastore is used for the cluster
+// instead of RoleDataStore. In a non-DRS environment, we need to apply the Endpoint and
+// Datastore roles at the cluster level since there are no resource pools.
+var NoDRSConf = rbac.Config{
+	Resources: []rbac.Resource{
+		{
+			Type:      rbac.VCenter,
+			Propagate: false,
+			Role:      RoleVCenter,
+		},
+		{
+			Type:      rbac.Datacenter,
+			Propagate: true,
+			Role:      RoleDataCenter,
+		},
+		{
+			Type:      rbac.Cluster,
+			Propagate: true,
+			Role:      RoleEndpointDatastore,
 		},
 		{
 			Type:      rbac.DatastoreFolder,

--- a/lib/install/opsuser/opsuser_test.go
+++ b/lib/install/opsuser/opsuser_test.go
@@ -54,7 +54,7 @@ func TestOpsUserRolesSimulatorVPX(t *testing.T) {
 	require.NoError(t, err, "Cannot connect to VPX Simulator")
 
 	am := rbac.NewAuthzManager(ctx, sess.Vim25())
-	am.InitConfig(opsuser, rolePrefix, &OpsuserRBACConf)
+	am.InitConfig(opsuser, rolePrefix, &DRSConf)
 
 	var testRoleNames = []string{
 		"datastore",
@@ -84,7 +84,7 @@ func TestOpsUserRolesVCenter(t *testing.T) {
 	}
 
 	am := rbac.NewAuthzManager(ctx, sess.Vim25())
-	am.InitConfig(opsuser, rolePrefix, &OpsuserRBACConf)
+	am.InitConfig(opsuser, rolePrefix, &DRSConf)
 
 	var testRoleNames = []string{
 		"datastore",
@@ -128,7 +128,7 @@ func TestOpsUserPermsSimulatorVPX(t *testing.T) {
 		},
 	}
 
-	mgr, err := NewRBACManager(ctx, sess, &OpsuserRBACConf, configSpec)
+	mgr, err := NewRBACManager(ctx, sess, &DRSConf, configSpec)
 	require.NoError(t, err)
 	am := mgr.AuthzManager
 

--- a/lib/install/validate/validator_test.go
+++ b/lib/install/validate/validator_test.go
@@ -1006,7 +1006,7 @@ func TestOpsUserPermsFromConfigSimulatorVPX(t *testing.T) {
 	require.NoError(t, err)
 
 	// Set up the Authz Manager
-	mgr, err := opsuser.NewRBACManager(ctx, sess, &opsuser.OpsuserRBACConf, configSpec)
+	mgr, err := opsuser.NewRBACManager(ctx, sess, &opsuser.DRSConf, configSpec)
 	require.NoError(t, err)
 
 	resourcePermissions, err := mgr.SetupRolesAndPermissions(ctx)

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-25-OPS-User-Grant.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-25-OPS-User-Grant.robot
@@ -74,7 +74,13 @@ vic-machine create grants ops-user perms
     Should Be Equal As Integers  ${rc}  0
     ${rc}  ${c3}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -d --net public -v barVol:/dir ${busybox}
     Should Be Equal As Integers  ${rc}  0
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} rm -f ${c1} ${c2} ${c3}
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} volume create existingvol
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${c4}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -d -v existingvol:/dir ${busybox}
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} rm -f ${c1} ${c2} ${c3} ${c4}
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} volume rm existingvol
     Should Be Equal As Integers  ${rc}  0
 
     Cleanup VIC Appliance On Test Server


### PR DESCRIPTION
This commit fixes an issue in the ops-user logic for non-DRS
environments where we were applying two roles at the cluster-level.
Since vSphere only allows one role per entity per user, the first
role would be overwritten by the second.

This change combines the privileges of the Endpoint and Datastore
roles into a single role which is then assigned to the cluster in a
non-DRS env. We now have a separate ops-user RBAC config for DRS and
no-DRS environments.

Fixes #7721