### PR TITLE
Temporarily remove upload progress feature causing slowness

### DIFF
--- a/lib/install/management/create.go
+++ b/lib/install/management/create.go
@@ -25,7 +25,6 @@ import (
 	"github.com/vmware/vic/lib/install/data"
 	"github.com/vmware/vic/lib/install/opsuser"
 	"github.com/vmware/vic/lib/install/vchlog"
-	"github.com/vmware/vic/lib/progresslog"
 	"github.com/vmware/vic/pkg/errors"
 	"github.com/vmware/vic/pkg/retry"
 	"github.com/vmware/vic/pkg/trace"
@@ -163,12 +162,8 @@ func (d *Dispatcher) uploadImages(files map[string]string) error {
 
 			op.Infof("Uploading %s as %s", baseName, key)
 
-			ul := progresslog.NewUploadLogger(op.Infof, baseName, time.Second*3)
-			// need to wait since UploadLogger is asynchronous.
-			defer ul.Wait()
-
 			return d.session.Datastore.UploadFile(op, image, path.Join(d.vmPathName, key),
-				progresslog.UploadParams(ul))
+				nil)
 		}
 
 		// counter for retry decider


### PR DESCRIPTION
Minimal revert of the upload progress feature which is causing slowness when `vic-machine create` is called in parallel.

Fixes #1577

<!--
To trigger a custom build with this PR, include one of these in the PR's body:
- To skip running tests (e.g. for a work-in-progress PR), add `[ci skip]` or `[skip ci]`
to the commit message or the PR title.
- To run the full test suite, use `[full ci]`.
- To run _one_ integration test or group, use `[specific ci=$test]`. Examples:
  - To run the `1-01-Docker-Info` suite: `[specific ci=1-01-Docker-Info]`
  - To run all suites under the `Group1-Docker-Commands` group: `[specific ci=Group1-Docker-Commands]`
- To skip running the unit tests, use `[skip unit]`.
- To fail fast (make normal failures fatal) during the integration testing, use `[fast fail]`.
-->
