### PR TITLE
[skip ci] Remove ui group from pullapprove

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -220,15 +220,6 @@ groups:
       files:
         include:
           - "vendor/*"
-  ui:
-    users:
-      - jooskim
-      - cristianfalcone
-      - jak-atx
-    conditions:
-      files:
-        include:
-          - "ui/*"
 
   ui-cmd:
     users:


### PR DESCRIPTION
`[skip ci]`

Removes the UI group from the pullapprove.yml since we're not including those things in this repository any longer and in order to unblock merges from faulty pullapprove.yml