### PR TITLE
Add method privileges to ops-user's vCenter role

### DIFF
--- a/lib/install/opsuser/opsuser_conf.go
+++ b/lib/install/opsuser/opsuser_conf.go
@@ -31,6 +31,8 @@ var RoleVCenter = types.AuthorizationRole{
 	Name: "vcenter",
 	Privilege: []string{
 		"Datastore.Config",
+		"Global.EnableMethods",
+		"Global.DisableMethods",
 	},
 }
 

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-25-OPS-User-Grant.md
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-25-OPS-User-Grant.md
@@ -13,11 +13,16 @@ This test requires access to VMware Nimbus cluster for dynamic ESXi and vCenter 
 3. Install the VIC appliance into the cluster with the --ops-grant-perms option
 4. With the ops-user, use govc to attempt to change the DRS settings on the cluster
 5. Run a variety of docker operations on the VCH
+6. Create a container
+7. Use govc to attempt to out-of-band destroy the container from Step 6
+8. Clean up the VCH
 
 # Expected Outcome:
 * Steps 1-3 should succeed
 * Step 4 should fail since the ops-user does not have enough permissions for the operation
-* Step 5 should succeed
+* Step 5 and 6 should succeed
+* Step 7 should fail since the destroy method should be disabled by VIC
+* Step 8 should succeed
 
 # Possible Problems:
 None

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-25-OPS-User-Grant.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-25-OPS-User-Grant.robot
@@ -83,4 +83,15 @@ vic-machine create grants ops-user perms
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} volume rm existingvol
     Should Be Equal As Integers  ${rc}  0
 
+    # Verify that containers cannot be destroyed out-of-band, i.e., the Destroy_VM task is
+    # successfully disabled with an ops-user.
+    ${c5}=  Evaluate  'cvm-' + str(random.randint(1000,9999))  modules=random
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} create --name ${c5} ${busybox}
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${output}=  Run And Return Rc And Output  govc vm.destroy "${c5}*"
+    Should Not Be Equal As Integers  ${rc}  0
+    Should Contain  ${output}  The method is disabled by 'VIC'
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} rm -f ${c5}
+    Should Be Equal As Integers  ${rc}  0
+
     Cleanup VIC Appliance On Test Server


### PR DESCRIPTION
This commit adds the 'Global.EnableMethods' and 'Global.DisableMethods'
privileges to the vic-vch-vcenter role for the ops-user. These
privileges were missing from our ops-user configuration and are needed
to enable/disable out-of-band destroy operations through the vSphere
client for containerVMs.

These privileges were found to be ineffective when applied at the
endpoint or datacenter roles.

Fixes #7714