### PR TITLE
Fix drone yml events

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -141,8 +141,7 @@ pipeline:
       - 'ls -la ./$BIN && ./$BIN/ui/sync-vic-ui-version.sh -p bin/ 2>&1'
       - 'rm $BIN/vic_ui_*.tar.gz'
     when:
-      status: [success, failure]
-      branch: [master]
+      event: push
 
   vic-ui-release:
     image: 'wdc-harbor-ci.eng.vmware.com/default-project/vic-integration-test:1.48'
@@ -163,8 +162,7 @@ pipeline:
       - 'ls -la ./$BIN && ./$BIN/ui/sync-vic-ui-version.sh -p bin/ 2>&1'
       - 'rm $BIN/vic_ui_*.tar.gz'
     when:
-     status: success
-     branch: ['releases/*', 'refs/tags/*']
+      event: tag
 
   bundle:
     image: 'wdc-harbor-ci.eng.vmware.com/default-project/golang:1.8'
@@ -175,7 +173,6 @@ pipeline:
       GOPATH: /go
       SHELL: /bin/bash
     commands:
-      - 'make mark'
       - 'rm -rf $BIN_TEMP_DIR'
       - 'mkdir -p $BIN_TEMP_DIR'
       - 'mv $BIN/ui $BIN_TEMP_DIR'
@@ -194,12 +191,6 @@ pipeline:
       - 'mkdir bundle-release'
       - 'cp $BIN/vic_${DRONE_BUILD_NUMBER}.tar.gz bundle'
       - 'cp $BIN/vic_${DRONE_BUILD_NUMBER}.tar.gz bundle-release/vic_`git describe --tags $(git rev-list --tags --max-count=1)`.tar.gz'
-      - 'make sincemark'
-    when:
-      repo: vmware/vic
-      event: [push, tag]
-      branch: [master, 'releases/*', 'refs/tags/*']
-      status: [success, failure]
 
   publish-gcs-builds-on-pass:
     image: 'victest/drone-gcs:1'
@@ -213,7 +204,7 @@ pipeline:
     cache_control: 'public,max-age=3600'
     when:
       repo: vmware/vic
-      event: [push]
+      event: push
       branch: [master, 'releases/*']
       status: success
 
@@ -229,7 +220,7 @@ pipeline:
     cache_control: 'public,max-age=3600'
     when:
       repo: vmware/vic
-      event: [push]
+      event: [push, tag]
       branch: [master, 'releases/*']
       status: failure
 
@@ -245,8 +236,7 @@ pipeline:
     cache_control: 'public,max-age=3600'
     when:
       repo: vmware/vic
-      event: [push, tag]
-      branch: ['refs/tags/*']
+      event: tag
       status: success
 
   publish-vic-machine-server-dev:
@@ -260,8 +250,8 @@ pipeline:
       - dev
     when:
       repo: vmware/vic
-      event: [push]
-      branch: [master]
+      event: push
+      branch: [master, 'releases/*']
       status: success
 
   publish-vic-machine-server-releases:
@@ -275,8 +265,7 @@ pipeline:
       - latest
     when:
       repo: vmware/vic
-      event: [push, tag]
-      branch: ['refs/tags/*', 'releases/*']
+      event: tag
       status: success
 
   trigger-downstream:
@@ -289,7 +278,7 @@ pipeline:
     when:
       repo: vmware/vic
       event: [push, tag]
-      branch: [master, 'releases/*', 'refs/tags/*']
+      branch: [master, 'releases/*']
       status: success
 
   notify-slack-on-fail:
@@ -301,8 +290,8 @@ pipeline:
     template: "Build https://ci-vic.vmware.com/vmware/vic/{{ build.number }} by {{ build.author }} finished with a {{ build.status }} status. Logs: https://console.cloud.google.com/m/cloudstorage/b/vic-ci-logs/o/integration_logs_{{ build.number }}_{{ build.commit }}.zip?authuser=1\n"
     when:
       repo: vmware/vic
-      event: [push, tag, deployment]
-      branch: [master, 'releases/*', 'refs/tags/*']
+      event: [push, tag]
+      branch: [master, 'releases/*']
       status: failure
 
   notify-slack-on-pass:
@@ -314,7 +303,7 @@ pipeline:
     template: "Build https://ci-vic.vmware.com/vmware/vic/{{ build.number }} by {{ build.author }} finished with a {{ build.status }} status, find the build at: https://storage.googleapis.com/vic-engine-builds/vic_{{ build.number }}.tar.gz\n"
     when:
       repo: vmware/vic
-      event: [push, tag, deployment]
+      event: push
       branch: [master, 'releases/*']
       status: success
 
@@ -327,8 +316,8 @@ pipeline:
     template: "The latest version of VIC engine has been released, find the build here: https://console.cloud.google.com/storage/browser/vic-engine-releases\n"
     when:
       repo: vmware/vic
-      event: [push, tag, deployment]
-      branch: ['refs/tags/*']
+      event: tag
+      status: success
 
   pass-rate:
     image: 'wdc-harbor-ci.eng.vmware.com/default-project/vic-integration-test:1.48'

--- a/.drone.yml
+++ b/.drone.yml
@@ -191,6 +191,9 @@ pipeline:
       - 'mkdir bundle-release'
       - 'cp $BIN/vic_${DRONE_BUILD_NUMBER}.tar.gz bundle'
       - 'cp $BIN/vic_${DRONE_BUILD_NUMBER}.tar.gz bundle-release/vic_`git describe --tags $(git rev-list --tags --max-count=1)`.tar.gz'
+    when:
+      repo: vmware/vic
+      event: [push, tag]
 
   publish-gcs-builds-on-pass:
     image: 'victest/drone-gcs:1'


### PR DESCRIPTION
1. vic-ui steps should only care what the event is, because we want a functional build either way
2. bundle step should ~always~ happen *on PRs* because we publish failed or successful builds and we need a functioning bundle
3. branch: refs/tags/* does not exist anymore, it needs to be either referenced via ref: refs/tags/* or simplified to just event: tag
4. tag steps don't really need to care about branch at all in most cases, so simplify the logic to just look for that