### PR TITLE
Clean up VM Group validation logic following rebase

### DIFF
--- a/lib/install/validate/validator.go
+++ b/lib/install/validate/validator.go
@@ -325,6 +325,7 @@ func (v *Validator) Validate(ctx context.Context, input *data.Data) (*config.Vir
 	v.CheckPersistNetworkBacking(op, false)
 	v.CheckLicense(op)
 	v.CheckDRS(op, input)
+	v.checkVMGroup(op, input, conf) // Depends on a side-effect of the CheckDRS method.
 
 	v.certificate(op, input, conf)
 	v.certificateAuthorities(op, input, conf)


### PR DESCRIPTION
Following a rebase to pick up the latest ROBO changes, it is necessary to adjust VM Group validation logic to ensure validation steps are performed in the correct order for prerequisites to be met.

Additionally, simplify logic to avoid duplication with other steps.

[specific ci=24-01-Basic]