### PR TITLE
Fix reconfiguration of VCH using DRS VM Group

### DIFF
--- a/lib/install/validate/compute.go
+++ b/lib/install/validate/compute.go
@@ -56,6 +56,11 @@ func (v *Validator) checkVMGroup(op trace.Operation, input *data.Data, conf *con
 			return
 		}
 
+		if input.ID != "" {
+			op.Debug("Skipping DRS VM Group existence check as VCH has already been created")
+			return
+		}
+
 		conf.UseVMGroup = input.UseVMGroup
 		// For now, we always name the VM Group based on the name of the VCH
 		conf.VMGroupName = conf.Name

--- a/lib/install/validate/config_to_data.go
+++ b/lib/install/validate/config_to_data.go
@@ -54,6 +54,9 @@ func SetDataFromVM(ctx context.Context, finder Finder, vm *vm.VirtualMachine, d 
 	}
 	d.DisplayName = name
 
+	// id
+	d.ID = vm.Reference().Value
+
 	// compute resource
 	parent, err := vm.ResourcePool(op)
 	if err != nil {

--- a/tests/test-cases/Group24-Host-Affinity/24-01-Basic.md
+++ b/tests/test-cases/Group24-Host-Affinity/24-01-Basic.md
@@ -98,3 +98,18 @@ Positive Testing
 
 #### Expected Outcome:
 * The overall deletion operation succeeds even though the DRS VM Group has already been deleted.
+
+
+### 7. Configuring VCH does not affect affinity
+
+#### Test Steps:
+1. Verify that no DRS VM Group exists by the expected name.
+2. Create a VCH.
+3. Verify that a DRS VM Group was created and that the endpoint VM was added to it.
+4. Reconfigure the VCH to make a minor change unrelated to VM-Host affinity.
+5. Verify that the DRS VM Group still exists and the endpoint VM is still a member of it.
+6. Create a variety of containers.
+7. Verify that the container VMs were added to the DRS VM Group.
+
+#### Expected Outcome:
+* The VCH can be safely reconfigured without affecting the use of a DRS VM Group.

--- a/tests/test-cases/Group24-Host-Affinity/24-01-Basic.robot
+++ b/tests/test-cases/Group24-Host-Affinity/24-01-Basic.robot
@@ -82,13 +82,22 @@ Delete Containers
     ${rc}  ${out}=    Run And Return Rc And Output    docker %{VCH-PARAMS} rm -f ${RUN_CONTAINER_NAME}
 
 
+Configure VCH without modifying affinity
+    ${rc}  ${out}=    Secret configure VCH without modifying affinity
+    Log    ${out}
+    Should Be Equal As Integers    ${RC}    0
+
+Secret configure VCH without modifying affinity
+    [Tags]    secret
+    ${rc}  ${out}=    Run And Return Rc And Output    bin/vic-machine-linux configure --name=%{VCH-NAME} --target=%{TEST_URL} --thumbprint=%{TEST_THUMBPRINT} --user=%{TEST_USERNAME} --password=%{TEST_PASSWORD} --timeout %{TEST_TIMEOUT} --volume-store=%{TEST_DATASTORE}/%{VCH-NAME}-VOL:default --volume-store=%{TEST_DATASTORE}/%{VCH-NAME}-conf:configure
+    [Return]    ${rc}  ${out}
+
+
 *** Test Cases ***
 Creating a VCH creates a VM group and container VMs get added to it
     Verify Group Not Found       %{VCH-NAME}
 
     Install VIC Appliance To Test Server With Current Environment Variables    additional-args=--affinity-vm-group
-
-    Log To Console  %{VCH-NAME} created
 
     Verify Group Contains VMs    %{VCH-NAME}    1
 
@@ -169,3 +178,19 @@ Deleting a VCH gracefully handles missing VM group
     Verify Group Not Found       %{VCH-NAME}
 
     Run VIC Machine Delete Command
+
+
+Configuring VCH does not affect affinity
+    Verify Group Not Found       %{VCH-NAME}
+
+    Install VIC Appliance To Test Server With Current Environment Variables    additional-args=--affinity-vm-group
+
+    Verify Group Contains VMs    %{VCH-NAME}    1
+
+    Configure VCH without modifying affinity
+
+    Verify Group Contains VMs    %{VCH-NAME}    1
+
+    Create Three Containers
+
+    Verify Group Contains VMs    %{VCH-NAME}    4


### PR DESCRIPTION
Introduce a test to ensure that a VCH which uses a DRS VM Group can be safely reconfigured. This testing is important because we have not yet added support for VM-Host affinity to the VCH configuration workflow.
    
Update the validation logic to fix issues with the reconfiguration of any VCH using the DRS VM Group functionality; once the VCH has been created, we no longer want to validate that the DRS VM Group does not exist.

[specific ci=24-01-Basic]