### PR TITLE
Ensure focused test works for more git remotes

### DIFF
--- a/infra/scripts/focused-test.sh
+++ b/infra/scripts/focused-test.sh
@@ -20,7 +20,7 @@
 #
 
 if [ -z "$1" ]; then
-    export REMOTE=$(git remote -v | grep "github.com/vmware/vic.git (fetch)" | awk '{print$1;exit}')/master
+    export REMOTE=$(git remote -v | grep "github.com.vmware/vic.git (fetch)" | awk '{print$1;exit}')/master
     echo "Using ${REMOTE} as default remote"
 else
     echo "Using ${REMOTE} as specified remote"


### PR DESCRIPTION
Adjust the grep expression to match "`git@github.com:vmware/vic.git`" in addition to "`git://github.com/vmware/vic.git`" as both are valid.