### PR TITLE
Allow vic-machine configure to set appropriate roles for ops user

### DIFF
--- a/cmd/vic-machine/common/ops_credentials.go
+++ b/cmd/vic-machine/common/ops_credentials.go
@@ -63,7 +63,7 @@ func (o *OpsCredentials) Flags(hidden bool) []cli.Flag {
 // operation, adminUser and adminPassword are not needed.
 func (o *OpsCredentials) ProcessOpsCredentials(op trace.Operation, isCreateOp bool, adminUser string, adminPassword *string) error {
 	if o.OpsUser == nil && o.OpsPassword != nil {
-		return errors.New("Password for operations user specified without user having been specified")
+		return errors.New("Password for operations user specified without operations username")
 	}
 
 	if isCreateOp {

--- a/cmd/vic-machine/configure/configure.go
+++ b/cmd/vic-machine/configure/configure.go
@@ -158,7 +158,7 @@ func (c *Configure) processParams(op trace.Operation) error {
 // copyChangedConf takes the mostly-empty new config and copies it to the old one. NOTE: o gets installed on the VCH, not n
 // Currently we cannot automatically override old configuration with any difference in the new configuration, because some options are set during the VCH
 // Creation process, for example, image store path, volume store path, network slot id, etc. So we'll copy changes based on user input
-func (c *Configure) copyChangedConf(o *config.VirtualContainerHostConfigSpec, n *config.VirtualContainerHostConfigSpec) {
+func (c *Configure) copyChangedConf(o *config.VirtualContainerHostConfigSpec, n *config.VirtualContainerHostConfigSpec, clic *cli.Context) {
 	//TODO: copy changed data
 	personaSession := o.ExecutorConfig.Sessions[config.PersonaService]
 	vicAdminSession := o.ExecutorConfig.Sessions[config.VicAdminService]
@@ -197,6 +197,11 @@ func (c *Configure) copyChangedConf(o *config.VirtualContainerHostConfigSpec, n 
 	if c.OpsCredentials.IsSet {
 		o.Username = n.Username
 		o.Token = n.Token
+
+		// if the user explicitly set the `ops-grant-user` option, update the permissions level
+		if clic.IsSet("ops-grant-perms") {
+			o.GrantPermsLevel = n.GrantPermsLevel
+		}
 	}
 
 	// Copy the thumbprint directly since it has already been validated.
@@ -314,7 +319,7 @@ func (c *Configure) Run(clic *cli.Context) (err error) {
 
 	validator, err := validate.NewValidator(op, c.Data)
 	if err != nil {
-		op.Errorf("Configuring cannot continue - failed to create validator: %s", err)
+		op.Errorf("Configure cannot continue - failed to create validator: %s", err)
 		return errors.New("configure failed")
 	}
 	defer validator.Session.Logout(parentOp) // parentOp is used here to ensure the logout occurs, even in the event of timeout
@@ -417,7 +422,7 @@ func (c *Configure) Run(clic *cli.Context) (err error) {
 	c.Data.ResourceLimits = mergedResources
 
 	// TODO: copy changed configuration here. https://github.com/vmware/vic/issues/2911
-	c.copyChangedConf(vchConfig, newConfig)
+	c.copyChangedConf(vchConfig, newConfig, clic)
 
 	vConfig := validator.AddDeprecatedFields(op, vchConfig, c.Data)
 	vConfig.Timeout = c.Timeout

--- a/lib/migration/feature/feature.go
+++ b/lib/migration/feature/feature.go
@@ -28,6 +28,8 @@ const (
 	// create time is stored in nanoseconds (previously seconds) in the portlayer.
 	ContainerCreateTimestampVersion
 
+	VMFolderSupportVersion
+
 	// Add new feature flag here
 
 	// MaxPluginVersion must be the last

--- a/lib/migration/feature/feature.go
+++ b/lib/migration/feature/feature.go
@@ -28,7 +28,9 @@ const (
 	// create time is stored in nanoseconds (previously seconds) in the portlayer.
 	ContainerCreateTimestampVersion
 
-	VMFolderSupportVersion
+	// VCHFolderSupportVersion represents the VCH version that first introduced
+	// VM folder support for the VCH.
+	VCHFolderSupportVersion
 
 	// Add new feature flag here
 

--- a/pkg/vsphere/session/session.go
+++ b/pkg/vsphere/session/session.go
@@ -382,7 +382,6 @@ func (s *Session) Populate(ctx context.Context) (*Session, error) {
 		// This will provide standalone ESXi and backwards
 		// compatibility to non-folder versions.
 		s.VCHFolder = folders.VmFolder
-
 	}
 
 	if len(errs) > 0 {

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-25-OPS-User-Grant.md
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-25-OPS-User-Grant.md
@@ -13,16 +13,52 @@ This test requires access to VMware Nimbus cluster for dynamic ESXi and vCenter 
 3. Install the VIC appliance into the cluster with the --ops-grant-perms option
 4. With the ops-user, use govc to attempt to change the DRS settings on the cluster
 5. Run a variety of docker operations on the VCH
-6. Create a container
-7. Use govc to attempt to out-of-band destroy the container from Step 6
-8. Clean up the VCH
+6. Run privilege-dependent docker operations against the VCH
+7. Create a container
+8. Use govc to attempt to out-of-band destroy the container from Step 7
+9. Clean up the VCH
+10. Install version v1.3.0 of the VIC appliance into the cluster with the --ops-grant-perms option
+11. Perform a VCH upgrade to the current version
+12. With the ops-user, use govc to attempt to create a resource pool
+13. Run a variety of docker operations on the VCH
+14. Run privilege-dependent docker operations against the VCH
+15. Create a container
+16. Use govc to attempt to out-of-band destroy the container from Step 15
+17. Clean up the VCH
+18. Install the VIC appliance into the cluster with the --ops-grant-perms and --affinity-vm-group options
+19. With the ops-user, use govc to attempt to create a resource pool
+20. Run a variety of docker operations on the VCH
+21. Run privilege-dependent docker operations against the VCH
+22. Create a container
+23. Use govc to attempt to out-of-band destroy the container from Step 6
+24. Clean up the VCH
+25. Install the VIC appliance into the cluster without any ops user options
+26. Reconfigure the VCH with the --ops-user, --ops-password, --ops-grant-perms options
+27. With the ops-user, use govc to attempt to change the DRS settings on the cluster
+28. Run a variety of docker operations on the VCH
+29. Create a container
+30. Use govc to attempt to out-of-band destroy the container from Step 6
+31. Clean up the VCH
 
 # Expected Outcome:
 * Steps 1-3 should succeed
-* Step 4 should fail since the ops-user does not have enough permissions for the operation
-* Step 5 and 6 should succeed
-* Step 7 should fail since the destroy method should be disabled by VIC
-* Step 8 should succeed
+* Step 4 should fail since the ops-user does not have required permissions to execute the operation
+* Steps 5-7 should succeed
+* Step 8 should fail since the destroy method should be disabled by VIC
+* Steps 9-11 should succeed
+* Step 12 should fail since the ops-user does not have required permission to execute the operation
+* steps 13-15 should succeed
+* Step 16 should fail since the destroy method should be disabled by VIC
+* Steps 17 and 18 should succeed
+* Step 19 should fail since the ops-user does not have required permission to execute the operation
+* Step 20-22 should succeed
+* Step 23 should fail since the destroy method should be disabled by VIC
+* Step 24-26 should succeed
+* Step 27 should fail since the ops-user does not have required permission to execute the operation
+* Step 28 and 29 should succeed
+* Step 30 should fail since the destroy method should be disabled by VIC
+* Step 31 should succeed
+
 
 # Possible Problems:
 None


### PR DESCRIPTION
This change fixes a bug in `vic-machine configure` that was preventing a VCH installed without an ops user enabled to be reconfigured to do so. With this change, you can now run `vic-machine configure` against an existing VCH to configure the ops user credentials and permissions.

Fixes #7725, #7796