### PR TITLE
Fix oob shutdown on cvm during vic machine delete

### DIFF
--- a/lib/install/management/appliance.go
+++ b/lib/install/management/appliance.go
@@ -181,31 +181,39 @@ func (d *Dispatcher) deleteVM(vm *vm.VirtualMachine, force bool) error {
 		}
 	}
 
-	// Only retry VM destroy on CurrentAccess error
+	retryRemovalError := func(err error) bool {
+		return tasks.IsConcurrentAccessError(err) || tasks.IsInvalidPowerStateError(err)
+	}
+
+	// Only retry VM destroy on ConcurrentAccess error
+	var destroyFirstAttempt bool
 	err = retry.Do(func() error {
+		if !destroyFirstAttempt {
+			d.op.Debugf("detected an OOB powerOn for container (%s) attempting an additional shutdown before removal", vm.Reference().String())
+			vm.PowerOff(d.op)
+		}
+		destroyFirstAttempt = true
+
 		_, err := vm.DeleteExceptDisks(d.op)
 		return err
-	}, tasks.IsConcurrentAccessError)
+	}, retryRemovalError)
 
 	if err != nil {
 		d.op.Warnf("Destroy VM %s failed with %s, unregister the VM instead", vm.Reference(), err)
 
-		var firstAttempt bool
-		retryUnregister := func(err error) bool {
-			return tasks.IsConcurrentAccessError(err) || tasks.IsInvalidPowerStateError(err)
-		}
+		var unregisterFirstAttempt bool
 		// Only retry VM unregister on InvalidPowerState error, This will allow us to avoid OOB power ups of target vms.
 		err = retry.Do(func() error {
-			if !firstAttempt {
+			if !unregisterFirstAttempt {
 				d.op.Debugf("detected an OOB powerOn for container (%s) attempting an additional shutdown before unregister", vm.Reference().String())
 				// NOTE: ignore the error here. If it is a RuntimeFault then the following unregister will fail as well.
 				vm.PowerOff(d.op)
 			}
-			firstAttempt = true
+			unregisterFirstAttempt = true
 
 			return vm.Unregister(d.op)
 			// TODO: retry on InvalidPowerState. Unregister does not have the potential to return a ConcurrentAccess return
-		}, retryUnregister)
+		}, retryRemovalError)
 
 		if err != nil {
 			d.op.Errorf("Unregister the VM failed: %s", err)

--- a/lib/install/management/appliance.go
+++ b/lib/install/management/appliance.go
@@ -181,39 +181,33 @@ func (d *Dispatcher) deleteVM(vm *vm.VirtualMachine, force bool) error {
 		}
 	}
 
-	retryRemovalError := func(err error) bool {
-		return tasks.IsConcurrentAccessError(err) || tasks.IsInvalidPowerStateError(err)
+	// Power off the VM if necessary
+	retryErrHandler := func(err error) bool {
+		if vm.IsInvalidPowerStateError(err) {
+			_, terr := vm.WaitForResult(d.op, func(ctx context.Context) (tasks.Task, error) {
+				return vm.PowerOff(ctx)
+			})
+
+			if terr == nil || tasks.IsTransientError(d.op, terr) || vm.IsInvalidPowerStateError(terr) {
+				return true
+			}
+		}
+
+		return tasks.IsTransientError(d.op, err) || tasks.IsConcurrentAccessError(err)
 	}
 
 	// Only retry VM destroy on ConcurrentAccess error
-	var destroyFirstAttempt bool
 	err = retry.Do(func() error {
-		if !destroyFirstAttempt {
-			d.op.Debugf("detected an OOB powerOn for container (%s) attempting an additional shutdown before removal", vm.Reference().String())
-			vm.PowerOff(d.op)
-		}
-		destroyFirstAttempt = true
-
 		_, err := vm.DeleteExceptDisks(d.op)
 		return err
-	}, retryRemovalError)
+	}, retryErrHandler)
 
 	if err != nil {
 		d.op.Warnf("Destroy VM %s failed with %s, unregister the VM instead", vm.Reference(), err)
 
-		var unregisterFirstAttempt bool
-		// Only retry VM unregister on InvalidPowerState error, This will allow us to avoid OOB power ups of target vms.
 		err = retry.Do(func() error {
-			if !unregisterFirstAttempt {
-				d.op.Debugf("detected an OOB powerOn for container (%s) attempting an additional shutdown before unregister", vm.Reference().String())
-				// NOTE: ignore the error here. If it is a RuntimeFault then the following unregister will fail as well.
-				vm.PowerOff(d.op)
-			}
-			unregisterFirstAttempt = true
-
 			return vm.Unregister(d.op)
-			// TODO: retry on InvalidPowerState. Unregister does not have the potential to return a ConcurrentAccess return
-		}, retryRemovalError)
+		}, retryErrHandler)
 
 		if err != nil {
 			d.op.Errorf("Unregister the VM failed: %s", err)

--- a/lib/install/management/delete.go
+++ b/lib/install/management/delete.go
@@ -326,7 +326,7 @@ func (d *Dispatcher) DeleteVCHInstances(conf *config.VirtualContainerHostConfigS
 				errs = append(errs, err.Error())
 				mu.Unlock()
 			}
-			d.op.Debugf("Successfully deleted container: %s", child.InventoryPath)
+			d.op.Debugf("Successfully deleted container: %s", child.Reference().String())
 		}(child)
 	}
 	wg.Wait()

--- a/lib/install/management/delete.go
+++ b/lib/install/management/delete.go
@@ -320,13 +320,19 @@ func (d *Dispatcher) DeleteVCHInstances(conf *config.VirtualContainerHostConfigS
 
 		wg.Add(1)
 		go func(child *vm.VirtualMachine) {
+			name, err := child.ObjectName(d.op)
 			defer wg.Done()
 			if err = d.deleteVM(child, deletePoweredOnContainers); err != nil {
 				mu.Lock()
 				errs = append(errs, err.Error())
 				mu.Unlock()
 			}
-			d.op.Debugf("Successfully deleted container: %s", child.Reference().String())
+
+			if name != "" {
+				d.op.Debugf("Successfully deleted container: %s", name)
+			} else {
+				d.op.Debugf("Successfully deleted container: %q", child.Reference())
+			}
 		}(child)
 	}
 	wg.Wait()

--- a/pkg/vsphere/tasks/waiter.go
+++ b/pkg/vsphere/tasks/waiter.go
@@ -279,11 +279,18 @@ func IsNotFoundError(err error) bool {
 }
 
 func IsInvalidPowerStateError(err error) bool {
+	if soap.IsVimFault(err) {
+		_, ok1 := soap.ToVimFault(err).(*types.InvalidPowerState)
+		_, ok2 := soap.ToVimFault(err).(*types.InvalidPowerStateFault)
+		return ok1 || ok2
+	}
+
 	if soap.IsSoapFault(err) {
-		_, ok := soap.ToSoapFault(err).VimFault().(types.InvalidPowerState)
-		if ok {
-			return true
-		}
+		_, ok1 := soap.ToSoapFault(err).VimFault().(types.InvalidPowerState)
+		_, ok2 := soap.ToSoapFault(err).VimFault().(types.InvalidPowerStateFault)
+		// sometimes we get the correct fault but wrong type
+		return ok1 || ok2 || soap.ToSoapFault(err).String == "vim.fault.InvalidArgument" ||
+			soap.ToSoapFault(err).String == "vim.fault.InvalidArgumentFault"
 	}
 	return false
 }

--- a/pkg/vsphere/tasks/waiter.go
+++ b/pkg/vsphere/tasks/waiter.go
@@ -278,23 +278,6 @@ func IsNotFoundError(err error) bool {
 	return false
 }
 
-func IsInvalidPowerStateError(err error) bool {
-	if soap.IsVimFault(err) {
-		_, ok1 := soap.ToVimFault(err).(*types.InvalidPowerState)
-		_, ok2 := soap.ToVimFault(err).(*types.InvalidPowerStateFault)
-		return ok1 || ok2
-	}
-
-	if soap.IsSoapFault(err) {
-		_, ok1 := soap.ToSoapFault(err).VimFault().(types.InvalidPowerState)
-		_, ok2 := soap.ToSoapFault(err).VimFault().(types.InvalidPowerStateFault)
-		// sometimes we get the correct fault but wrong type
-		return ok1 || ok2 || soap.ToSoapFault(err).String == "vim.fault.InvalidArgument" ||
-			soap.ToSoapFault(err).String == "vim.fault.InvalidArgumentFault"
-	}
-	return false
-}
-
 // Helper Functions
 func logFault(op trace.Operation, fault types.BaseMethodFault) {
 	op.Errorf("unexpected fault on task retry: %#v", fault)

--- a/pkg/vsphere/tasks/waiter.go
+++ b/pkg/vsphere/tasks/waiter.go
@@ -278,6 +278,16 @@ func IsNotFoundError(err error) bool {
 	return false
 }
 
+func IsInvalidPowerStateError(err error) bool {
+	if soap.IsSoapFault(err) {
+		_, ok := soap.ToSoapFault(err).VimFault().(types.InvalidPowerState)
+		if ok {
+			return true
+		}
+	}
+	return false
+}
+
 // Helper Functions
 func logFault(op trace.Operation, fault types.BaseMethodFault) {
 	op.Errorf("unexpected fault on task retry: %#v", fault)

--- a/pkg/vsphere/vm/vm.go
+++ b/pkg/vsphere/vm/vm.go
@@ -577,7 +577,7 @@ func (vm *VirtualMachine) IsInvalidState(ctx context.Context) bool {
 	return false
 }
 
-// IsInvalidPowerStateError is a error certifier function for errors coming back from vsphere. It checks for an InvalidPowerStateFault
+// IsInvalidPowerStateError is an error certifier function for errors coming back from vsphere. It checks for an InvalidPowerStateFault
 func (vm *VirtualMachine) IsInvalidPowerStateError(err error) bool {
 	if soap.IsVimFault(err) {
 		_, ok1 := soap.ToVimFault(err).(*types.InvalidPowerState)

--- a/pkg/vsphere/vm/vm.go
+++ b/pkg/vsphere/vm/vm.go
@@ -30,6 +30,7 @@ import (
 	"github.com/vmware/govmomi/property"
 	"github.com/vmware/govmomi/vim25/methods"
 	"github.com/vmware/govmomi/vim25/mo"
+	"github.com/vmware/govmomi/vim25/soap"
 	"github.com/vmware/govmomi/vim25/types"
 
 	"github.com/vmware/vic/pkg/retry"
@@ -572,6 +573,24 @@ func (vm *VirtualMachine) IsInvalidState(ctx context.Context) bool {
 	}
 	if o.Summary.Runtime.ConnectionState == types.VirtualMachineConnectionStateInvalid {
 		return true
+	}
+	return false
+}
+
+// IsInvalidPowerStateError is a error certifier function for errors coming back from vsphere. It checks for an InvalidPowerStateFault
+func (vm *VirtualMachine) IsInvalidPowerStateError(err error) bool {
+	if soap.IsVimFault(err) {
+		_, ok1 := soap.ToVimFault(err).(*types.InvalidPowerState)
+		_, ok2 := soap.ToVimFault(err).(*types.InvalidPowerStateFault)
+		return ok1 || ok2
+	}
+
+	if soap.IsSoapFault(err) {
+		_, ok1 := soap.ToSoapFault(err).VimFault().(types.InvalidPowerState)
+		_, ok2 := soap.ToSoapFault(err).VimFault().(types.InvalidPowerStateFault)
+		// sometimes we get the correct fault but wrong type
+		return ok1 || ok2 || soap.ToSoapFault(err).String == "vim.fault.InvalidPowerState" ||
+			soap.ToSoapFault(err).String == "vim.fault.InvalidPowerState"
 	}
 	return false
 }

--- a/tests/test-cases/Group1-Docker-Commands/1-40-Docker-Restart.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-40-Docker-Restart.robot
@@ -15,8 +15,8 @@
 *** Settings ***
 Documentation   Test 1-40 - Docker Restart
 Resource        ../../resources/Util.robot
-#Suite Setup  Conditional Install VIC Appliance To Test Server
-#Suite Teardown  Cleanup VIC Appliance On Test Server
+Suite Setup  Conditional Install VIC Appliance To Test Server
+Suite Teardown  Cleanup VIC Appliance On Test Server
 Test Timeout  30 minutes
 
 *** Keywords ***
@@ -31,6 +31,8 @@ Create test containers
     Should Be Equal As Integers  ${rc}  0
     Set Environment Variable  CREATOR  ${output}
 
+
+*** Test Cases ***
 Restart Running Container
     Create test containers
     # grab the containerVM ip address - will compare after restart to ensure it remains the same
@@ -100,9 +102,3 @@ Restart with start-stop stress
     Terminate Process  ${restart-pid2}
     Log  ${loopOutput}
     Should Not Contain Match  ${loopOutput}  *EOF*
-
-*** Test Cases ***
-test
-    ${status}=  Get State Of Github Issue  7716
-    Run Keyword If  '${status}' == 'closed'  Fail  Test 1-40-Docker-Restart.robot needs to be updated now that Issue #7716 has been resolved
-    Log  Issue \#7716 is blocking implementation  WARN


### PR DESCRIPTION
fixes #7716 #6079 

Currently, part of the issue surrounding the bootstrap.iso not being removable was due to a container vm still being around that relied upon it. This was caused by an OOB poweron during the forced removal of the VM. Now we will retry the unregister action during a forced removal.

EDIT: 

I have added code to apply the `InvalidPowerState` retry to the destroy action as well. This means that we will try our hardest to power off the vm and then destroy it before attempting the unregister path.

[specific ci=1-40-Docker-Restart --suite Group6-Vic-Machine]