### PR TITLE
Cherry-pick: Merge branch 'feature/host-affinity' (#7735)

### DIFF
--- a/cmd/vic-machine/common/compute.go
+++ b/cmd/vic-machine/common/compute.go
@@ -1,4 +1,4 @@
-// Copyright 2016 VMware, Inc. All Rights Reserved.
+// Copyright 2016-2018 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ import "gopkg.in/urfave/cli.v1"
 type Compute struct {
 	ComputeResourcePath string `cmd:"compute-resource"`
 	DisplayName         string `cmd:"name"`
+	UseVMGroup          bool   `cmd:"affinity-vm-group"`
 }
 
 func (c *Compute) ComputeFlags() []cli.Flag {
@@ -41,6 +42,12 @@ func (c *Compute) ComputeFlagsNoName() []cli.Flag {
 			Value:       "",
 			Usage:       "Compute resource path, e.g. myCluster",
 			Destination: &c.ComputeResourcePath,
+		},
+		cli.BoolFlag{
+			Name:        "affinity-vm-group",
+			Usage:       "Use a DRS VM Group to allow VM-Host affinity rules to be defined for the VCH",
+			Destination: &c.UseVMGroup,
+			Hidden:      true,
 		},
 	}
 }

--- a/cmd/vic-machine/create/create_test.go
+++ b/cmd/vic-machine/create/create_test.go
@@ -72,7 +72,7 @@ func TestParseGatewaySpec(t *testing.T) {
 func TestFlags(t *testing.T) {
 	c := NewCreate()
 	flags := c.Flags()
-	numberOfFlags := 60
+	numberOfFlags := 61
 	assert.Equal(t, numberOfFlags, len(flags), "Missing flags during Create.")
 }
 

--- a/doc/design/host-affinity.md
+++ b/doc/design/host-affinity.md
@@ -1,0 +1,254 @@
+Background
+==========
+
+Customers may wish to restrict the set of hosts a set of VMs are executed on.
+
+This may be necessary for software licensing reasons (e.g., if they are billed
+based on the number of physical hosts, sockets, or cores running a piece of
+software), compliance reasons, or due to latency-sensitive workloads running in
+an environment with stretched clusters.
+
+Each of these use cases can be addressed by a similar pattern:
+1. Create a DRS Host Group for the set of hosts which may run the workloads.
+2. Create a DRS VM Group for the workloads themselves.
+3. Create a VM-Host Affinity Rule to express that the identified workloads may
+   only by run on the identified hosts.
+
+Notes:
+ * vSphere supports expressing the VM-Host Affinity Rule as either a requirement
+   ("must") or preference ("should") [1]. If "must" rules are used, DRS will not
+   allow the VMs to be run on other hosts, even in extreme circumstances (e.g.,
+   HA would not perform a failover to a host not in the DRS Host Group). If
+   "should" rules are used, violations will produce a log event and be reported
+   as Faults on the cluster's DRS tab [2].
+ * Because these rules are cluster-based, all hosts included in a DRS Host Group
+   must reside in the same cluster [1].
+
+
+Design
+======
+
+## Responsibility
+
+It seems undesirable to require administrators to manage DRS Host Groups through
+VIC, and it seems intractable for VIC to support such management without
+duplicating significant vSphere functionality. Similarly, it seems that VM-Host
+Affinity Rules should be managed directly in vSphere.
+
+However, vSphere does not support creation of an empty DRS VM Group (although
+empty groups may exist as the result of removing all VMs from a group). To avoid
+a "chicken and egg" problem, it will be necessary to support creation of a DRS
+VM Group as a part of the VCH creation process.
+
+Eventually, we may wish to support re-use of an existing DRS VM Group or allow
+administrators to supply a name to be used when creating the group. However,
+this functionality is not required for the first version; we can automatically
+name the DRS VM Group based on the supplied name for the VCH.
+
+This design provides significant flexibility: we can support both "must" and
+"should" rules as well as both Affinity and Anti-Affinity rules with no added
+implementation effort (testing may be desirable). (This is insufficient to
+support VM-VM Affinity, as those rules do not operate on DRS VM Groups [3].)
+
+Because the administrator creates the DRS Host Group and VM-Host Affinity Rule,
+it is reasonable to expect them to manage the rest of their lifecycle. However,
+deletion of any automatically-created DRS VM Group should be handled as a part
+of deletion of the corresponding VCH.
+
+Impacted areas: VCH create, configure, and inspect (via CLI, API, and UI); documentation
+
+
+## Permissions
+
+DRS VM Groups are expressed as a `ClusterVmGroup` [5]  in a cluster's
+configuration, which will need to be updated to include both the VCH Endpoint VM
+when it is created and the VCH's container VMs as they are created.
+
+To update this portion of the cluster's configuration, the user creating the VCH
+and the operations users will both require the `Host.Inventory.EditCluster` [6].
+
+Impacted areas: VCH create (validation and operations user grant); documentation
+
+
+## Execution
+
+To avoid placing each VM twice, it is desirable to associate each VM (including
+both the VCH Endpoint VM and container VMs) with the DRS VM Group between
+creation and initial power-on.
+
+Impacted areas: portlayer
+
+
+## Upgrade
+
+By default, we will not attempt association with a DRS VM Group. This ensures
+that existing VCHs can be safely upgraded without the need to grant existing
+operations users additional [permissions](#Permissions).
+
+Impacted areas: testing
+
+
+Decomposition
+=============
+
+
+## 1. Prototype portlayer work
+
+As an initial step to validate this design, we should prototype the portlayer
+changes using hard-coded rules and groups. This allows us to ensure that a VCH
+works as expected when configured as we intend.
+
+This should also be prioritized early, to ensure that effort isn't wasted on any
+user-facing changes that may need to be changed as a result of design changes.
+
+
+## 2. Finalize portlayer work
+
+This is likely to involve moving the hard-coded portions from the prototyping
+work above out of the portlayer and into the install code.
+
+This may also involve refactoring of `Commit`, as it is "getting excessively
+large and should be broken out into a separate subfunction with the addition of
+this logic" [7].
+
+Due to the read/update/put nature of the API, it will be necessary to ensure
+that concurrent operations to create container VMs are safe.
+
+Failure of the operation to update the `ClusterVmGroup` should be treated as a
+fatal error.
+
+No operations requiring `Host.Inventory.EditCluster` should be performed when no
+DRS VM Group has been specified.
+
+
+## 3. Update vic-machine create
+
+This is essentially using a DRS VM Group based on the VCH name supplied by the
+user instead of the hard-coded value used to enable the portlayer work to
+proceed. It does not include allowing the user to specify the DRS VM Group,
+which is discussed below.
+
+This includes both tagging the VCH Endpoint VM itself during creation as well as
+persisting the DRS VM Group so that container VMs are tagged as well.
+
+This includes changes to both the CLI (which will probably take a rule name) and
+API (which will probably accept either a rule name or identifier). 
+
+This requires validation that the DRS VM Group exists and that the operations
+user has the necessary `Host.Inventory.EditCluster` privilege.
+
+This should include end-to-end testing of both the CLI and API, which will
+require additional investigation to establish a pattern for configuring the
+prerequisites (DRS Host Group, DRS VM Group, VM-Host Affinity Rule) from robot.
+(The govc utility supports the necessary operations.)
+
+
+## 4. Update vic-machine delete
+
+When a DRS VM Group is created as a part of VCH creation or configuration, it
+should be deleted when that VCH is deleted.
+
+We should not delete a DRS VM Group associated with a VCH if it was not created
+by VIC as a part of that VCH's creation or configuration.
+
+We should not delete a DRS VM Group if it contains unexpected VMs (i.e., if it
+contains any VMs other than the VCH Endpoint VM and the container VMs associated
+with that VCH).
+
+This should include end-to-end testing of both the CLI and API, including tests
+which ensure that we do not delete DRS VM Groups in the above cases.
+
+
+## 5. Update vic-machine inspect
+
+The inspect CLI (including inspect config) and API should be updated to return
+the configured DRS VM Group.
+
+This work should include returning the name of the configured DRS VM Group, even
+when that name is automatically determined.
+
+This should include end-to-end testing of both the CLI and API, to ensure that
+the correct value is returned when a group is configured and a sane response
+is returned when no group is configured.
+
+
+## 6. Update vic-machine configure (deferred)
+
+Apply the changes from vic-machine create to configure as well, including
+retroactively associating or disassociating the VCH Endpoint VM and any existing
+container VMs. This includes creating or deleting the DRS VM Group (as would be
+done during VCH creation or VCH deletion) and does not include allowing the user
+to specify an existing DRS VM Group to use, or a name to be used when creating
+the group.
+
+This requires validation that the operations user has the necessary right when
+performing any configure which introduces a DRS VM Group.
+
+There may be complexity around ensuring the atomicity of this operation [8].
+
+
+## 7. Update VCH Management UI (deferred)
+
+As a part the VCH Creation Wizard, users should be able to indicate that they
+wish for a DRS VM Group to be created and used by this VCH.
+
+
+## 8. Operations user grant
+
+The operations user "grant permissions" logic will need to be updated to include
+granting `Host.Inventory.EditCluster` on the VCH's cluster.
+
+We should then leverage this grant functionality in some of the testing for the
+feature as a way of validating that it works as intended.
+
+
+## 9. Additional testing
+
+We should implement an additional end-to-end test case to ensure that an old
+VCH, created with an operations user that did not have this permission, can be
+upgraded to a version (i.e., one with the DRS VM Group functionality) and
+additional containers can be created without issue. 
+
+
+## 10. Detect and report a missing DRS VM Group
+
+`vicadmin` should detect when an expected DRS VM Group is missing and report
+an appropriate validation issue. This will help administrators understand what
+is broken if a DRS VM Group in use by a VCH is deleted out-of-band. 
+
+
+## 11. Allow users to supply a DRS VM Group to use (deferred)
+
+This work builds on the above by allowing the user to specify the name of the
+DRS VM Group to use, possibly re-using an existing group, instead of simply
+creating a new group for each VCH with an automatically determined name.
+
+This will involve updating the CLI and API for VCH creation, inspection,
+configuration, and deletion.
+
+This will involve writing additional end-to-end test cases for each of these
+operations.
+
+
+## 12. Allow users to supply a DRS VM Group to use via the UI (deferred)
+
+Once the API allows users to specify the name of the DRS VM Group to use, the
+UI could be updated to support this as well.
+
+
+## 13. Documentation
+
+Update documentation to reflect this work.
+
+
+References
+==========
+
+1. https://docs.vmware.com/en/VMware-vSphere/6.5/com.vmware.vsphere.resmgmt.doc/GUID-2FB90EF5-7733-4095-8B66-F10D6C57B820.html
+2. https://docs.vmware.com/en/VMware-vSphere/6.5/com.vmware.vsphere.resmgmt.doc/GUID-FF28F29C-8B67-4EFF-A2EF-63B3537E6934.html
+3. https://docs.vmware.com/en/VMware-vSphere/6.5/com.vmware.vsphere.resmgmt.doc/GUID-94FCC204-115A-4918-9533-BFC588338ECB.html
+4. https://docs.vmware.com/en/VMware-vSphere/6.5/com.vmware.vsphere.resmgmt.doc/GUID-56C0F68B-23D7-4CD3-A93A-BCF20EAA0C35.html
+5. http://pubs.vmware.com/vsphere-6-0/index.jsp?topic=%2Fcom.vmware.wssdk.apiref.doc%2Fvim.cluster.VmGroup.html
+6. http://pubs.vmware.com/vsphere-6-0/index.jsp#com.vmware.wssdk.apiref.doc/vim.ComputeResource.html?path=3_1_0_2_5_16_14#reconfigureEx
+7. https://github.com/vmware/vic/issues/6461#issuecomment-332584964
+8. https://github.com/vmware/vic/issues/6461#issuecomment-374366308

--- a/lib/apiservers/service/restapi/handlers/vch_create.go
+++ b/lib/apiservers/service/restapi/handlers/vch_create.go
@@ -1,4 +1,4 @@
-// Copyright 2017 VMware, Inc. All Rights Reserved.
+// Copyright 2017-2018 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -186,6 +186,10 @@ func buildCreate(op trace.Operation, d *data.Data, finder finder, vch *models.VC
 				return nil, util.NewError(http.StatusBadRequest, "Resource pool must be specified (by name or id)")
 			}
 			c.ComputeResourcePath = resourcePath
+
+			if vch.Compute.Affinity != nil {
+				c.UseVMGroup = vch.Compute.Affinity.UseVMGroup
+			}
 		}
 
 		if vch.Network != nil {

--- a/lib/apiservers/service/restapi/handlers/vch_get.go
+++ b/lib/apiservers/service/restapi/handlers/vch_get.go
@@ -1,4 +1,4 @@
-// Copyright 2017 VMware, Inc. All Rights Reserved.
+// Copyright 2017-2018 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -127,6 +127,9 @@ func vchToModel(op trace.Operation, vch *vm.VirtualMachine, d *data.Data, execut
 
 	// compute
 	model.Compute = &models.VCHCompute{
+		Affinity: &models.VCHComputeAffinity{
+			UseVMGroup: vchConfig.UseVMGroup,
+		},
 		CPU: &models.VCHComputeCPU{
 			Limit:       asMHz(d.ResourceLimits.VCHCPULimitsMHz),
 			Reservation: asMHz(d.ResourceLimits.VCHCPUReservationsMHz),

--- a/lib/apiservers/service/swagger.json
+++ b/lib/apiservers/service/swagger.json
@@ -661,7 +661,15 @@
                 "shares": { "$ref": "#/definitions/Shares" }
               }
             },
-            "resource": { "$ref": "#/definitions/Managed_Object" }
+            "resource": { "$ref": "#/definitions/Managed_Object" },
+            "affinity": {
+              "type": "object",
+              "properties": {
+                "use_vm_group": {
+                  "type": "boolean"
+                }
+              }
+            }
           }
         },
         "network": {

--- a/lib/config/virtual_container_host.go
+++ b/lib/config/virtual_container_host.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2017 VMware, Inc. All Rights Reserved.
+// Copyright 2016-2018 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -122,6 +122,10 @@ type Container struct {
 	BootstrapImagePath string `vic:"0.1" scope:"read-only" key:"bootstrap_image_path"`
 	// Allow custom naming convention for containerVMs
 	ContainerNameConvention string
+	// Whether to create and manage a DRS VM Group for the VCH and its containerVMs
+	UseVMGroup bool
+	// Name to use for the DRS VM Group
+	VMGroupName string
 	// Permitted datastore URLs for container storage for this virtual container host
 	ContainerStores []url.URL `vic:"0.1" scope:"read-only" recurse:"depth=0"`
 }

--- a/lib/install/management/create.go
+++ b/lib/install/management/create.go
@@ -99,6 +99,10 @@ func (d *Dispatcher) CreateVCH(conf *config.VirtualContainerHostConfigSpec, sett
 		}
 	}
 
+	if err = d.createVMGroup(conf); err != nil {
+		return err
+	}
+
 	return d.appliance.PowerOn(d.op)
 }
 

--- a/lib/install/management/delete.go
+++ b/lib/install/management/delete.go
@@ -125,6 +125,11 @@ func (d *Dispatcher) DeleteVCH(conf *config.VirtualContainerHostConfigSpec, cont
 	if err = d.destroyResourcePoolIfEmpty(conf); err != nil {
 		d.op.Warnf("VCH resource pool is not removed: %s", err)
 	}
+
+	if err = d.destroyVMGroup(conf); err != nil {
+		d.op.Warnf("VCH DRS VM group is not removed: %s", err)
+	}
+
 	return nil
 }
 

--- a/lib/install/management/vmgroup.go
+++ b/lib/install/management/vmgroup.go
@@ -1,0 +1,95 @@
+// Copyright 2018 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package management
+
+import (
+	"context"
+
+	"github.com/vmware/govmomi/vim25/types"
+
+	"github.com/vmware/vic/lib/config"
+	"github.com/vmware/vic/lib/install/validate"
+	"github.com/vmware/vic/pkg/trace"
+	"github.com/vmware/vic/pkg/vsphere/tasks"
+)
+
+func (d *Dispatcher) createVMGroup(conf *config.VirtualContainerHostConfigSpec) error {
+	defer trace.End(trace.Begin("", d.op))
+
+	if !conf.UseVMGroup {
+		return nil
+	}
+
+	d.op.Debugf("Creating DRS VM Group %q on %q", conf.VMGroupName, d.appliance.Cluster)
+
+	spec := &types.ClusterConfigSpecEx{
+		GroupSpec: []types.ClusterGroupSpec{
+			{
+				ArrayUpdateSpec: types.ArrayUpdateSpec{
+					Operation: types.ArrayUpdateOperationAdd,
+				},
+				Info: &types.ClusterVmGroup{
+					ClusterGroupInfo: types.ClusterGroupInfo{
+						Name: conf.VMGroupName,
+					},
+					Vm: []types.ManagedObjectReference{d.appliance.Reference()},
+				},
+			},
+		},
+	}
+
+	_, err := tasks.WaitForResultAndRetryIf(d.op, func(op context.Context) (tasks.Task, error) {
+		return d.appliance.Cluster.Reconfigure(op, spec, true)
+	}, tasks.IsTransientError)
+
+	return err
+}
+
+func (d *Dispatcher) destroyVMGroup(conf *config.VirtualContainerHostConfigSpec) error {
+	defer trace.End(trace.Begin("", d.op))
+
+	if !conf.UseVMGroup {
+		return nil
+	}
+
+	exists, err := validate.VMGroupExists(d.op, d.session.Cluster, conf.VMGroupName)
+	if err != nil {
+		d.op.Warn(err)
+		return nil
+	}
+	if !exists {
+		d.op.Debugf("Expected VM Group cannot be found; skipping removal.")
+		return nil
+	}
+
+	d.op.Infof("Removing VM Group %q", conf.VMGroupName)
+
+	spec := &types.ClusterConfigSpecEx{
+		GroupSpec: []types.ClusterGroupSpec{
+			{
+				ArrayUpdateSpec: types.ArrayUpdateSpec{
+					Operation: types.ArrayUpdateOperationRemove,
+					RemoveKey: conf.VMGroupName,
+				},
+			},
+		},
+	}
+
+	_, err = tasks.WaitForResultAndRetryIf(d.op, func(op context.Context) (tasks.Task, error) {
+		return d.appliance.Cluster.Reconfigure(op, spec, true)
+	}, tasks.IsTransientError)
+
+	return err
+}

--- a/lib/install/opsuser/opsuser.go
+++ b/lib/install/opsuser/opsuser.go
@@ -80,7 +80,11 @@ func GrantOpsUserPerms(ctx context.Context, session *session.Session, configSpec
 
 	// Use a separate RBAC configuration depending on whether DRS is enabled.
 	if session.DRSEnabled != nil && *session.DRSEnabled {
-		rbacConfig = &DRSConf
+		if configSpec.UseVMGroup {
+			rbacConfig = &ClusterConf
+		} else {
+			rbacConfig = &DRSConf
+		}
 	} else {
 		rbacConfig = &NoDRSConf
 	}

--- a/lib/install/opsuser/opsuser_conf.go
+++ b/lib/install/opsuser/opsuser_conf.go
@@ -53,6 +53,7 @@ var RoleCluster = types.AuthorizationRole{
 		"Datastore.DeleteFile",
 		"Datastore.FileManagement",
 		"Host.Config.SystemManagement",
+		"Host.Inventory.EditCluster",
 	},
 }
 
@@ -118,97 +119,61 @@ var DCReadOnlyConf = rbac.Config{
 	},
 }
 
-// DRSConf stores the RBAC configuration for the ops-user's roles in a DRS environment.
-var DRSConf = rbac.Config{
-	Resources: []rbac.Resource{
-		{
-			Type:      rbac.VCenter,
-			Propagate: false,
-			Role:      RoleVCenter,
+func buildConfig(clusterRole types.AuthorizationRole) rbac.Config {
+	return rbac.Config{
+		Resources: []rbac.Resource{
+			{
+				Type:      rbac.VCenter,
+				Propagate: false,
+				Role:      RoleVCenter,
+			},
+			{
+				Type:      rbac.Datacenter,
+				Propagate: true,
+				Role:      RoleDataCenter,
+			},
+			{
+				Type:      rbac.Cluster,
+				Propagate: true,
+				Role:      clusterRole,
+			},
+			{
+				Type:      rbac.DatastoreFolder,
+				Propagate: true,
+				Role:      RoleDataStore,
+			},
+			{
+				Type:      rbac.Datastore,
+				Propagate: false,
+				Role:      RoleDataStore,
+			},
+			{
+				Type:      rbac.VSANDatastore,
+				Propagate: false,
+				Role:      RoleDataStore,
+			},
+			{
+				Type:      rbac.Network,
+				Propagate: true,
+				Role:      RoleNetwork,
+			},
+			{
+				Type:      rbac.Endpoint,
+				Propagate: true,
+				Role:      RoleEndpoint,
+			},
 		},
-		{
-			Type:      rbac.Datacenter,
-			Propagate: true,
-			Role:      RoleDataCenter,
-		},
-		{
-			Type:      rbac.Cluster,
-			Propagate: true,
-			Role:      RoleDataStore,
-		},
-		{
-			Type:      rbac.DatastoreFolder,
-			Propagate: true,
-			Role:      RoleDataStore,
-		},
-		{
-			Type:      rbac.Datastore,
-			Propagate: false,
-			Role:      RoleDataStore,
-		},
-		{
-			Type:      rbac.VSANDatastore,
-			Propagate: false,
-			Role:      RoleDataStore,
-		},
-		{
-			Type:      rbac.Network,
-			Propagate: true,
-			Role:      RoleNetwork,
-		},
-		{
-			Type:      rbac.Endpoint,
-			Propagate: true,
-			Role:      RoleEndpoint,
-		},
-	},
+	}
 }
+
+// DRSConf stores the RBAC configuration for the ops-user's roles in a DRS environment.
+var DRSConf = buildConfig(RoleDataStore)
 
 // NoDRSConf stores the configuration for the ops-user's roles in a non-DRS environment.
 // It is different from DRSConf in that RoleEndpointDatastore is used for the cluster
 // instead of RoleDataStore. In a non-DRS environment, we need to apply the Endpoint and
 // Datastore roles at the cluster level since there are no resource pools.
-var NoDRSConf = rbac.Config{
-	Resources: []rbac.Resource{
-		{
-			Type:      rbac.VCenter,
-			Propagate: false,
-			Role:      RoleVCenter,
-		},
-		{
-			Type:      rbac.Datacenter,
-			Propagate: true,
-			Role:      RoleDataCenter,
-		},
-		{
-			Type:      rbac.Cluster,
-			Propagate: true,
-			Role:      RoleEndpointDatastore,
-		},
-		{
-			Type:      rbac.DatastoreFolder,
-			Propagate: true,
-			Role:      RoleDataStore,
-		},
-		{
-			Type:      rbac.Datastore,
-			Propagate: false,
-			Role:      RoleDataStore,
-		},
-		{
-			Type:      rbac.VSANDatastore,
-			Propagate: false,
-			Role:      RoleDataStore,
-		},
-		{
-			Type:      rbac.Network,
-			Propagate: true,
-			Role:      RoleNetwork,
-		},
-		{
-			Type:      rbac.Endpoint,
-			Propagate: true,
-			Role:      RoleEndpoint,
-		},
-	},
-}
+var NoDRSConf = buildConfig(RoleEndpointDatastore)
+
+// Configuration for the ops-user with increased cluster-level permissions, required for managing DRS VM Groups
+var ClusterConf = buildConfig(RoleCluster)

--- a/lib/install/validate/config_to_data.go
+++ b/lib/install/validate/config_to_data.go
@@ -1,4 +1,4 @@
-// Copyright 2017 VMware, Inc. All Rights Reserved.
+// Copyright 2017-2018 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -53,6 +53,9 @@ func SetDataFromVM(ctx context.Context, finder Finder, vm *vm.VirtualMachine, d 
 		return err
 	}
 	d.DisplayName = name
+
+	// id
+	d.ID = vm.Reference().Value
 
 	// compute resource
 	parent, err := vm.ResourcePool(op)
@@ -225,6 +228,7 @@ func NewDataFromConfig(ctx context.Context, finder Finder, conf *config.VirtualC
 	}
 
 	d.ContainerNameConvention = conf.ContainerNameConvention
+	d.UseVMGroup = conf.UseVMGroup
 	return
 }
 

--- a/lib/install/validate/validator.go
+++ b/lib/install/validate/validator.go
@@ -325,6 +325,7 @@ func (v *Validator) Validate(ctx context.Context, input *data.Data) (*config.Vir
 	v.CheckPersistNetworkBacking(op, false)
 	v.CheckLicense(op)
 	v.CheckDRS(op, input)
+	v.checkVMGroup(op, input, conf) // Depends on a side-effect of the CheckDRS method.
 
 	v.certificate(op, input, conf)
 	v.certificateAuthorities(op, input, conf)

--- a/lib/install/validate/vmgroup.go
+++ b/lib/install/validate/vmgroup.go
@@ -1,0 +1,46 @@
+// Copyright 2018 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validate
+
+import (
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25/mo"
+	"github.com/vmware/govmomi/vim25/types"
+
+	"github.com/vmware/vic/pkg/errors"
+	"github.com/vmware/vic/pkg/trace"
+)
+
+func VMGroupExists(op trace.Operation, cluster *object.ComputeResource, group string) (bool, error) {
+	op.Debugf("Checking for existence of DRS VM Group %q on %s", group, cluster)
+
+	var clusterConfig mo.ClusterComputeResource
+	err := cluster.Properties(op, cluster.Reference(), []string{"configurationEx"}, &clusterConfig)
+	if err != nil {
+		return false, errors.Errorf("Unable to obtain cluster config: %s", err)
+	}
+
+	clusterConfigEx := clusterConfig.ConfigurationEx.(*types.ClusterConfigInfoEx)
+	for _, g := range clusterConfigEx.Group {
+		info := g.GetClusterGroupInfo()
+		if info.Name == group {
+			op.Debugf("DRS VM Group named %q exists", group)
+			return true, nil
+		}
+	}
+
+	op.Debugf("DRS VM Group named %q does not exist", group)
+	return false, nil
+}

--- a/lib/portlayer/exec/commit.go
+++ b/lib/portlayer/exec/commit.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2017 VMware, Inc. All Rights Reserved.
+// Copyright 2016-2018 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -56,6 +56,7 @@ func Commit(op trace.Operation, sess *session.Session, h *Handle, waitTime *int3
 
 		var res *types.TaskInfo
 		var err error
+
 		if sess.IsVC() && Config.VirtualApp.ResourcePool != nil {
 			// Create the vm
 			res, err = tasks.WaitForResult(op, func(op context.Context) (tasks.Task, error) {
@@ -72,11 +73,18 @@ func Commit(op trace.Operation, sess *session.Session, h *Handle, waitTime *int3
 			op.Errorf("An error occurred while waiting for a creation operation to complete. Spec was %+v", *h.Spec.Spec())
 			return err
 		}
-
 		h.vm = vm.NewVirtualMachine(op, sess, res.Result.(types.ManagedObjectReference))
+
 		h.vm.DisableDestroy(op)
 		c = newContainer(&h.containerBase)
 		Containers.Put(c)
+
+		err = Config.addToVMGroup(op)
+		if err != nil {
+			op.Errorf("Failed to add VM to VMGroup: %s", err)
+			return err
+		}
+
 		// inform of creation irrespective of remaining operations
 		publishContainerEvent(op, c.ExecConfig.ID, time.Now().UTC(), events.ContainerCreated)
 
@@ -206,6 +214,85 @@ func Commit(op trace.Operation, sess *session.Session, h *Handle, waitTime *int3
 	}
 
 	return nil
+}
+
+// batchBlockOnFunc is a batching routine that batch processes incoming requests.
+// Incoming request signals the batching routine by throwing into a batch channel. When this routine is performing operation on
+// the previous requests, new requests will be batched in the channel, waiting for next iteration to process.
+func batchBlockOnFunc(ctx context.Context, batch chan chan error, operation func(operation trace.Operation) error) {
+	op := trace.FromContext(ctx, "Add container VM to VMGroup dispatch routine")
+
+	for {
+		members := make([]chan error, 0, 5) // batching queue
+		var req chan error
+		var ok bool
+
+		// block and wait for first request
+		select {
+		case req, ok = <-batch:
+			if !ok {
+				return // channel closed, quit
+			}
+			if req == nil {
+				continue
+			}
+			members = append(members, req)
+		case <-op.Done(): // when parent context is cancelled, quit
+			return
+		}
+
+		// fetch batched requests
+		for len(batch) > 0 {
+			req = <-batch
+			if req != nil {
+				members = append(members, req)
+			}
+		}
+
+		// process requests
+		err := operation(op)
+
+		// signal batched operations and throw back result
+		for _, member := range members {
+			member <- err
+			close(member)
+		}
+	}
+}
+
+// reconfigureVMGroup reconfigures the VM group associated with the endpoint VM on the cluster, by adding all containers in
+// cache and endpoint VM to the VM group
+func reconfigureVMGroup(op trace.Operation) error {
+	affinity := func(ctx context.Context) (tasks.Task, error) {
+		op2 := trace.FromContext(ctx, "vm group membership")
+
+		containers := Containers.References()
+
+		group := &types.ClusterVmGroup{
+			ClusterGroupInfo: types.ClusterGroupInfo{
+				Name: Config.Container.VMGroupName,
+			},
+			Vm: append(containers, Config.SelfReference),
+		}
+
+		spec := &types.ClusterConfigSpecEx{
+			GroupSpec: []types.ClusterGroupSpec{
+				{
+					ArrayUpdateSpec: types.ArrayUpdateSpec{
+						Operation: types.ArrayUpdateOperationEdit,
+					},
+					Info: group,
+				},
+			},
+		}
+
+		op.Debugf("Attempting to update vm group: %+v", group)
+		return Config.Cluster.Reconfigure(op2, spec, true)
+	}
+
+	_, err := tasks.WaitForResultAndRetryIf(op, affinity, tasks.IsTransientError)
+
+	return err
 }
 
 // HELPER FUNCTIONS BELOW

--- a/lib/portlayer/exec/commit_test.go
+++ b/lib/portlayer/exec/commit_test.go
@@ -1,0 +1,186 @@
+// Copyright 2018 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package exec
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/vmware/vic/pkg/errors"
+	"github.com/vmware/vic/pkg/trace"
+)
+
+func TestBatchBlockOnFuncSerialize(t *testing.T) {
+	ctx := context.Background()
+
+	var totalRequest int
+	var batchCount int
+	var reqInterval time.Duration
+	var waitTime time.Duration
+
+	countBatch := func(op trace.Operation, waitTime time.Duration) error {
+		time.Sleep(waitTime)
+		batchCount++
+		return nil
+	}
+
+	// serial test: only one request
+	batchCount = 0
+	testFetchOne(ctx, t, func(op trace.Operation) error {
+		return countBatch(op, 0)
+	})
+	assert.Equal(t, 1, batchCount)
+
+	// serial test: batch size 1, 5 requests
+	// batch size 1 means no batching
+	// total # of batches = total # of requests
+	batchCount = 0
+	totalRequest = 5
+	testMultipleBatch(ctx, t, 1, totalRequest, 0, func(op trace.Operation) error {
+		return countBatch(op, 0)
+	}, nil)
+	assert.Equal(t, totalRequest, batchCount)
+
+	// serial test: batch size 10, 20 requests
+	// requests come in slower than operation processing time, making all requests serialized
+	// total # of batches = total # of requests
+	batchCount = 0
+	totalRequest = 20
+	reqInterval = 15 * time.Millisecond
+	waitTime = 10 * time.Millisecond
+	testMultipleBatch(ctx, t, 10, totalRequest, reqInterval, func(op trace.Operation) error {
+		return countBatch(op, waitTime)
+	}, nil)
+	assert.Equal(t, totalRequest, batchCount)
+}
+
+func TestBatchBlockOnFuncConcurrent(t *testing.T) {
+	ctx := context.Background()
+
+	var batchCount int
+	var totalRequest int
+
+	operation := func(op trace.Operation) error {
+		time.Sleep(10 * time.Millisecond)
+		batchCount++
+		return nil
+	}
+
+	// batch size 10, 5 requests
+	// requests come in tight loop. All 5 should be processed in one single batch
+	// total time spent should be within: 1 * (operation wait time)
+	batchCount = 0
+	totalRequest = 5
+	testMultipleBatch(ctx, t, 10, totalRequest, 0, operation, nil)
+	assert.True(t, batchCount > 1 && batchCount < totalRequest)
+
+	// batch size 100, 50 requests
+	// the 50 requests should be processed in one batch
+	// total time spent should be within: 1 * (operation wait time)
+	batchCount = 0
+	totalRequest = 50
+	testMultipleBatch(ctx, t, 100, totalRequest, 0, operation, nil)
+	assert.True(t, batchCount > 1 && batchCount < totalRequest)
+
+	// stress test: batch size 100, 200 requests
+	// the 200 requests should be processed within 2 batches
+	// total time spent <= 2 * (operation wait time)
+	batchCount = 0
+	totalRequest = 200
+	testMultipleBatch(ctx, t, 100, totalRequest, 0, operation, nil)
+	assert.True(t, batchCount > 1 && batchCount < totalRequest)
+
+	// stress test: batch size 100, 500 requests
+	// the 500 requests should be processed within 5 batches
+	// total time spent <= 5 * (operation wait time)
+	batchCount = 0
+	totalRequest = 500
+	testMultipleBatch(ctx, t, 100, totalRequest, 0, operation, nil)
+	assert.True(t, batchCount > 1 && batchCount < totalRequest)
+}
+
+func TestBatchBlockOnFuncResultPropagate(t *testing.T) {
+	ctx := context.Background()
+
+	err := errors.New("test")
+	operation := func(op trace.Operation) error {
+		time.Sleep(10 * time.Millisecond)
+		return err
+	}
+
+	testMultipleBatch(ctx, t, 10, 5, 0, operation, err)
+}
+
+func testFetchOne(ctx context.Context, t *testing.T, operation func(op trace.Operation) error) {
+	batch := make(chan chan error, 5) // batch size 5
+
+	// fire background reader
+	go batchBlockOnFunc(ctx, batch, operation)
+
+	// send only 1 request
+	sendRequest(t, batch, nil, nil)
+	close(batch)
+}
+
+func testMultipleBatch(ctx context.Context, t *testing.T, batchSize int, totalRequest int, interval time.Duration, operation func(op trace.Operation) error, expected error) {
+	batch := make(chan chan error, batchSize)
+
+	// fire background request reader
+	go batchBlockOnFunc(ctx, batch, operation)
+
+	// send requests concurrently with a time interval between requests
+	done := sendMultiRequests(t, totalRequest, batch, interval, expected)
+
+	// wait until all requests are processed, close batch channel and quit background receiver
+	quitBatchUntilDone(t, done, batch)
+}
+
+func sendMultiRequests(t *testing.T, totalRequest int, batch chan chan error, interval time.Duration, expected error) []chan bool {
+	done := make([]chan bool, totalRequest)
+
+	for i := 0; i < totalRequest; i++ {
+		done[i] = make(chan bool, 1)
+		go sendRequest(t, batch, done[i], expected)
+		time.Sleep(interval)
+	}
+
+	return done
+}
+
+func sendRequest(t *testing.T, batch chan chan error, done chan bool, expected error) {
+	req := make(chan error)
+	batch <- req
+	err := <-req
+	assert.Equal(t, expected, err)
+	if done != nil {
+		done <- true
+	}
+}
+
+func quitBatchUntilDone(t *testing.T, done []chan bool, batch chan chan error) {
+	for _, c := range done {
+		select {
+		case _ = <-c:
+			close(c)
+			continue
+		case <-time.After(30 * time.Second):
+			t.Fail()
+		}
+	}
+	close(batch)
+}

--- a/lib/portlayer/exec/config.go
+++ b/lib/portlayer/exec/config.go
@@ -1,4 +1,4 @@
-// Copyright 2016 VMware, Inc. All Rights Reserved.
+// Copyright 2016-2018 VMware, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,9 +18,11 @@ import (
 	"net/url"
 
 	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25/types"
 	"github.com/vmware/vic/lib/config"
 	"github.com/vmware/vic/lib/config/executor"
 	"github.com/vmware/vic/lib/portlayer/event"
+	"github.com/vmware/vic/pkg/trace"
 )
 
 var Config Configuration
@@ -37,6 +39,13 @@ type Configuration struct {
 
 	// Resource pool is the working version of the compute resource config
 	ResourcePool *object.ResourcePool
+
+	// Cluster is the working reference to the cluster the VCH is present in
+	Cluster *object.ComputeResource
+
+	// SelfReference is a reference to the endpointVM, added for VM group membership
+	SelfReference types.ManagedObjectReference
+
 	// Parent resource will be a VirtualApp on VC
 	VirtualApp *object.VirtualApp
 
@@ -53,4 +62,7 @@ type Configuration struct {
 
 	// Datastore URLs for image stores - the top layer is [0], the bottom layer is [len-1]
 	ImageStores []url.URL `vic:"0.1" scope:"read-only" key:"storage/image_stores"`
+
+	// addToVMGroup sends signal for batching dispatcher to add container VM to VMGroup
+	addToVMGroup func(trace.Operation) error
 }

--- a/lib/portlayer/exec/container_cache.go
+++ b/lib/portlayer/exec/container_cache.go
@@ -19,6 +19,7 @@ import (
 
 	"context"
 
+	"github.com/vmware/govmomi/vim25/types"
 	"github.com/vmware/vic/pkg/uid"
 	"github.com/vmware/vic/pkg/vsphere/session"
 )
@@ -84,6 +85,26 @@ func (conCache *containerCache) Containers(states []State) []*Container {
 	}
 
 	return containers
+}
+
+// TODO: rework this and Containers above to remove duplication of iteration and filtering logic.
+func (conCache *containerCache) References() []types.ManagedObjectReference {
+	conCache.m.RLock()
+	defer conCache.m.RUnlock()
+	// cache contains 2 items for each container
+	capacity := len(conCache.cache) / 2
+	references := make([]types.ManagedObjectReference, 0, capacity)
+
+	for id, con := range conCache.cache {
+		// is the key a proper ID?
+		if !isContainerID(id) {
+			continue
+		}
+
+		references = append(references, con.VMReference())
+	}
+
+	return references
 }
 
 // puts a container in the cache and will overwrite an existing container

--- a/lib/portlayer/portlayer.go
+++ b/lib/portlayer/portlayer.go
@@ -87,7 +87,7 @@ func Init(ctx context.Context, sess *session.Session) error {
 		return err
 	}
 
-	if err := exec.Init(ctx, sess, source, sink); err != nil {
+	if err := exec.Init(ctx, sess, source, sink, vchvm.Reference()); err != nil {
 		return err
 	}
 

--- a/lib/vicadmin/validate.go
+++ b/lib/vicadmin/validate.go
@@ -17,6 +17,7 @@ package vicadmin
 import (
 	"context"
 	"fmt"
+	"html"
 	"html/template"
 	"io/ioutil"
 	"net"
@@ -249,7 +250,7 @@ func NewValidator(ctx context.Context, vch *config.VirtualContainerHostConfigSpe
 	if err != nil {
 		log.Errorf("Had a problem querying the datastores: %s", err.Error())
 	}
-	v.QueryVCHStatus(vch, sess)
+	v.QueryVCHStatus(ctx, vch, sess)
 	return v
 }
 
@@ -351,7 +352,7 @@ func (v *Validator) QueryDatastore(ctx context.Context, vch *config.VirtualConta
 	return nil
 }
 
-func (v *Validator) QueryVCHStatus(vch *config.VirtualContainerHostConfigSpec, sess *session.Session) {
+func (v *Validator) QueryVCHStatus(ctx context.Context, vch *config.VirtualContainerHostConfigSpec, sess *session.Session) {
 	defer trace.End(trace.Begin(""))
 
 	if sess == nil {
@@ -409,7 +410,31 @@ func (v *Validator) QueryVCHStatus(vch *config.VirtualContainerHostConfigSpec, s
 				v.VCHIssues, strings.Title(service)))
 		}
 	}
+
+	v.QueryVMGroupStatus(ctx, vch, sess)
+
 	if v.VCHIssues != template.HTML("") {
 		v.VCHStatus = BadStatus
 	}
+}
+
+func (v *Validator) QueryVMGroupStatus(ctx context.Context, vch *config.VirtualContainerHostConfigSpec, sess *session.Session) {
+	if !vch.UseVMGroup {
+		return
+	}
+
+	exists, err := validate.VMGroupExists(trace.FromContext(ctx, ""), sess.Cluster, vch.VMGroupName)
+
+	if err != nil {
+		// #nosec: this method will not auto-escape HTML. Verify data is well formed.
+		v.VCHIssues = template.HTML(fmt.Sprintf("%s<span class=\"error-message\">%s</span>\n", v.VCHIssues, html.EscapeString(err.Error())))
+		return
+	}
+
+	if !exists {
+		// #nosec: this method will not auto-escape HTML. Verify data is well formed.
+		v.VCHIssues = template.HTML(fmt.Sprintf("%s<span class=\"error-message\">VCH is configured to use DRS VM Group %q, which cannot be found</span>\n", v.VCHIssues, html.EscapeString(vch.VMGroupName)))
+	}
+
+	return
 }

--- a/tests/test-cases/Group23-VIC-Machine-Service/23-03-VCH-Create.robot
+++ b/tests/test-cases/Group23-VIC-Machine-Service/23-03-VCH-Create.robot
@@ -132,7 +132,7 @@ Create minimal VCH within datacenter
 
 
 Create complex VCH
-    Create VCH    '{"name":"%{VCH-NAME}-api-test-complex","debug":3,"compute":{"cpu":{"limit":{"units":"MHz","value":2345},"reservation":{"units":"GHz","value":2},"shares":{"level":"high"}},"memory":{"limit":{"units":"MiB","value":1200},"reservation":{"units":"MiB","value":501},"shares":{"number":81910}},"resource":{"name":"%{TEST_RESOURCE}"}},"endpoint":{"cpu":{"sockets":2},"memory":{"units":"MiB","value":3072}},"storage":{"image_stores":["ds://%{TEST_DATASTORE}"],"volume_stores":[{"datastore":"ds://%{TEST_DATASTORE}/test-volumes/foo","label":"foo"}],"base_image_size":{"units":"B","value":16000000}},"network":{"bridge":{"ip_range":"172.16.0.0/12","port_group":{"name":"%{BRIDGE_NETWORK}"}},"container":[{"alias":"vic-containers","firewall":"outbound","nameservers":["8.8.8.8","8.8.4.4"],"port_group":{"name":"${PUBLIC_NETWORK}"},"gateway":{"address":"203.0.113.1","routing_destinations":["203.0.113.1/24"]},"ip_ranges":["203.0.113.8/31"]}],"public":{"port_group":{"name":"${PUBLIC_NETWORK}"},"static":"192.168.100.22/24","gateway":{"address":"192.168.100.1"},"nameservers":["192.168.110.10","192.168.1.1"]}},"registry":{"image_fetch_proxy":{"http":"http://example.com","https":"https://example.com"},"insecure":["https://insecure.example.com"],"whitelist":["10.0.0.0/8"]},"auth":{"server":{"generate":{"cname":"vch.example.com","organization":["VMware, Inc."],"size":{"value":2048,"units":"bits"}}},"client":{"no_tls_verify": true}},"syslog_addr":"tcp://syslog.example.com:4444", "container": {"name_convention": "container-{id}"}}'
+    Create VCH    '{"name":"%{VCH-NAME}-api-test-complex","debug":3,"compute":{"cpu":{"limit":{"units":"MHz","value":2345},"reservation":{"units":"GHz","value":2},"shares":{"level":"high"}},"memory":{"limit":{"units":"MiB","value":1200},"reservation":{"units":"MiB","value":501},"shares":{"number":81910}},"resource":{"name":"%{TEST_RESOURCE}"},"affinity":{"use_vm_group":true}},"endpoint":{"cpu":{"sockets":2},"memory":{"units":"MiB","value":3072}},"storage":{"image_stores":["ds://%{TEST_DATASTORE}"],"volume_stores":[{"datastore":"ds://%{TEST_DATASTORE}/test-volumes/foo","label":"foo"}],"base_image_size":{"units":"B","value":16000000}},"network":{"bridge":{"ip_range":"172.16.0.0/12","port_group":{"name":"%{BRIDGE_NETWORK}"}},"container":[{"alias":"vic-containers","firewall":"outbound","nameservers":["8.8.8.8","8.8.4.4"],"port_group":{"name":"${PUBLIC_NETWORK}"},"gateway":{"address":"203.0.113.1","routing_destinations":["203.0.113.1/24"]},"ip_ranges":["203.0.113.8/31"]}],"public":{"port_group":{"name":"${PUBLIC_NETWORK}"},"static":"192.168.100.22/24","gateway":{"address":"192.168.100.1"},"nameservers":["192.168.110.10","192.168.1.1"]}},"registry":{"image_fetch_proxy":{"http":"http://example.com","https":"https://example.com"},"insecure":["https://insecure.example.com"],"whitelist":["10.0.0.0/8"]},"auth":{"server":{"generate":{"cname":"vch.example.com","organization":["VMware, Inc."],"size":{"value":2048,"units":"bits"}}},"client":{"no_tls_verify": true}},"syslog_addr":"tcp://syslog.example.com:4444", "container": {"name_convention": "container-{id}"}}'
 
     Verify Return Code
     Verify Status Created
@@ -148,6 +148,8 @@ Create complex VCH
     Output Should Contain    --memory=1200
     Output Should Contain    --memory-reservation=501
     Output Should Contain    --memory-shares=81910
+
+    Output Should Contain    --affinity-vm-group=true
 
     Output Should Contain    --endpoint-cpu=2
     Output Should Contain    --endpoint-memory=3072
@@ -191,6 +193,7 @@ Create complex VCH
     Property Should Be Equal        .compute.memory.reservation.value    501
     Property Should Be Equal        .compute.memory.reservation.units    MiB
     Property Should Be Equal        .compute.memory.shares.number        81910
+    Property Should Be Equal        .compute.affinity.use_vm_group       true
 
     Property Should Be Equal        .endpoint.cpu.sockets                2
     Property Should Be Equal        .endpoint.memory.value               3072

--- a/tests/test-cases/Group25-Host-Affinity/25-01-Basic.md
+++ b/tests/test-cases/Group25-Host-Affinity/25-01-Basic.md
@@ -1,0 +1,115 @@
+Suite 25-01 - Basic
+===================
+
+# Purpose:
+To verify basic VM-Host Affinity functionality
+
+# References:
+1. [The design document](../../../doc/design/host-affinity.md)
+
+# Environment:
+This suite requires a vCenter Server environment where VCHs can be deployed and container VMs created.
+
+Note that because these basic tests do not test the behavior of DRS in the presence of rules, but just the management of
+VM groups, these tests do not require an environment where DRS is enabled.
+
+
+Positive Testing
+----------------
+
+### 1. Creating a VCH creates a VM group and container VMs get added to it
+
+#### Test Steps:
+1. Verify that no DRS VM Group exists by the expected name.
+2. Create a VCH.
+3. Verify that a DRS VM Group was created and that the endpoint VM was added to it.
+4. Create a variety of containers.
+5. Verify that the container VMs were added to the DRS VM Group.
+
+#### Expected Outcome:
+* The DRS VM Group is created and the VCH endpoint VM and all container VMs are added to it.
+
+
+### 2. Deleting a VCH deletes its VM group
+
+#### Test Steps:
+1. Verify that no DRS VM Group exists by the expected name.
+2. Create a VCH.
+3. Verify that a DRS VM Group was created and that the endpoint VM was added to it.
+4. Delete the VCH.
+5. Verify that the DRS VM Group no longer exists.
+
+#### Expected Outcome:
+* The DRS VM Group is deleted when the VCH is deleted.
+
+
+### 3. Deleting a container cleans up its VM group
+
+#### Test Steps:
+1. Verify that no DRS VM Group exists by the expected name.
+2. Create a VCH.
+3. Create a variety of containers.
+4. Verify that a DRS VM Group was created and that the endpoint VM and containers were added to it.
+5. Delete the containers.
+6. Verify that the DRS VM Group still exists, but does not include the removed containers.
+
+#### Expected Outcome:
+* Container VMs are removed from the DRS VM Group when they are deleted.
+
+
+### 4. Create a VCH without a VM group
+
+#### Test Steps:
+1. Verify that no DRS VM Group exists by the expected name.
+2. Create a DRS VM Group with the expected name.
+3. Verify that the DRS VM Group is empty.
+4. Create a VCH which does not use a DRS VM Group.
+5. Verify that the DRS VM Group is empty.
+6. Create a variety of containers.
+7. Verify that the DRS VM Group is empty.
+
+#### Expected Outcome:
+* Neither the VCH Endpoint VM nor the Container VMs are added to the DRS VM Group the VCH is not configured to use.
+* VCH creation succeeds even though a DRS VM Group with the same name exists, as use of a group is not configured.
+
+
+### 5. Attempt to create a VCH when a VM group with the same name already exists
+
+#### Test Steps:
+1. Verify that no DRS VM Group exists by the expected name.
+2. Create a DRS VM Group with the expected name.
+3. Verify that the DRS VM Group is empty.
+4. Attempt to create a VCH which would use a DRS VM Group and expect an error.
+5. Verify that the DRS VM Group is empty.
+
+#### Expected Outcome:
+* VCH creation fails if a DRS VM Group with the same name already exists, instead of silently using the existing group.
+
+
+### 6. Deleting a VCH gracefully handles missing VM group
+
+#### Test Steps:
+1. Verify that no DRS VM Group exists by the expected name.
+2. Create a VCH.
+3. Verify that a DRS VM Group was created and that the endpoint VM was added to it.
+4. Remove the DRS VM Group with an out-of-band operation.
+5. Verify that the DRS VM Group no longer exists.
+6. Delete the VCH.
+
+#### Expected Outcome:
+* The overall deletion operation succeeds even though the DRS VM Group has already been deleted.
+
+
+### 7. Configuring VCH does not affect affinity
+
+#### Test Steps:
+1. Verify that no DRS VM Group exists by the expected name.
+2. Create a VCH.
+3. Verify that a DRS VM Group was created and that the endpoint VM was added to it.
+4. Reconfigure the VCH to make a minor change unrelated to VM-Host affinity.
+5. Verify that the DRS VM Group still exists and the endpoint VM is still a member of it.
+6. Create a variety of containers.
+7. Verify that the container VMs were added to the DRS VM Group.
+
+#### Expected Outcome:
+* The VCH can be safely reconfigured without affecting the use of a DRS VM Group.

--- a/tests/test-cases/Group25-Host-Affinity/25-01-Basic.robot
+++ b/tests/test-cases/Group25-Host-Affinity/25-01-Basic.robot
@@ -1,0 +1,196 @@
+# Copyright 2018 VMware, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#	http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License
+
+*** Settings ***
+Documentation     Suite 25-01 - Basic
+Resource          ../../resources/Util.robot
+Test Setup        Set Test Environment Variables
+Test Teardown     Cleanup
+Default Tags
+
+
+*** Keywords ***
+Cleanup
+    Run Keyword And Continue On Failure    Remove Group     %{VCH-NAME}
+
+    Cleanup VIC Appliance On Test Server
+
+
+Create Group
+    [Arguments]    ${name}
+
+    ${rc}  ${out}=    Run And Return Rc And Output     govc cluster.group.create -name "${name}" -vm --json 2>&1
+    Should Be Equal As Integers    ${rc}    0
+
+Remove Group
+    [Arguments]    ${name}
+
+    ${rc}  ${out}=    Run And Return Rc And Output     govc cluster.group.remove -name "${name}" --json 2>&1
+    Should Be Equal As Integers    ${rc}    0
+
+
+Verify Group Not Found
+    [Arguments]    ${name}
+
+    ${out}=    Run     govc cluster.group.ls -name "${name}" --json 2>&1
+    Should Be Equal As Strings    ${out}    govc: group "${name}" not found
+
+Verify Group Empty
+    [Arguments]    ${name}
+
+    ${out}=    Run     govc cluster.group.ls -name "${name}" --json 2>&1
+    Should Be Equal As Strings    ${out}    null
+
+Verify Group Contains VMs
+    [Arguments]    ${name}    ${count}
+
+    ${out}=    Run    govc cluster.group.ls -name "${name}" --json | jq 'length'
+    Should Be Equal As Integers    ${out}    ${count}
+
+
+Create Three Containers
+    ${POWERED_OFF_CONTAINER_NAME}=    Generate Random String  15
+    ${rc}  ${out}=    Run And Return Rc And Output    docker %{VCH-PARAMS} create --name ${POWERED_OFF_CONTAINER_NAME} ${busybox} /bin/top
+
+    Set Test Variable    ${POWERED_OFF_CONTAINER_NAME}
+
+    ${POWERED_ON_CONTAINER_NAME}=    Generate Random String  15
+    ${rc}  ${out}=    Run And Return Rc And Output    docker %{VCH-PARAMS} create --name ${POWERED_ON_CONTAINER_NAME} ${busybox} /bin/top
+    ${rc}  ${out}=    Run And Return Rc And Output    docker %{VCH-PARAMS} start ${out}
+
+    Set Test Variable    ${POWERED_ON_CONTAINER_NAME}
+
+    ${RUN_CONTAINER_NAME}=    Generate Random String  15
+    ${rc}  ${out}=    Run And Return Rc And Output    docker %{VCH-PARAMS} run -d --name ${RUN_CONTAINER_NAME} ${busybox} /bin/top
+
+    Set Test Variable    ${RUN_CONTAINER_NAME}
+
+Delete Containers
+    ${rc}  ${out}=    Run And Return Rc And Output    docker %{VCH-PARAMS} rm ${POWERED_OFF_CONTAINER_NAME}
+    ${rc}  ${out}=    Run And Return Rc And Output    docker %{VCH-PARAMS} rm -f ${POWERED_ON_CONTAINER_NAME}
+    ${rc}  ${out}=    Run And Return Rc And Output    docker %{VCH-PARAMS} rm -f ${RUN_CONTAINER_NAME}
+
+
+Configure VCH without modifying affinity
+    ${rc}  ${out}=    Secret configure VCH without modifying affinity
+    Log    ${out}
+    Should Be Equal As Integers    ${RC}    0
+
+Secret configure VCH without modifying affinity
+    [Tags]    secret
+    ${rc}  ${out}=    Run And Return Rc And Output    bin/vic-machine-linux configure --name=%{VCH-NAME} --target=%{TEST_URL} --thumbprint=%{TEST_THUMBPRINT} --user=%{TEST_USERNAME} --password=%{TEST_PASSWORD} --timeout %{TEST_TIMEOUT} --volume-store=%{TEST_DATASTORE}/%{VCH-NAME}-VOL:default --volume-store=%{TEST_DATASTORE}/%{VCH-NAME}-conf:configure
+    [Return]    ${rc}  ${out}
+
+
+*** Test Cases ***
+Creating a VCH creates a VM group and container VMs get added to it
+    Verify Group Not Found       %{VCH-NAME}
+
+    Install VIC Appliance To Test Server With Current Environment Variables    additional-args=--affinity-vm-group
+
+    Verify Group Contains VMs    %{VCH-NAME}    1
+
+    Create Three Containers
+
+    Verify Group Contains VMs    %{VCH-NAME}    4
+
+
+Deleting a VCH deletes its VM group
+    [Teardown]    Run Keyword If Test Failed    Cleanup VIC Appliance On Test Server
+
+    Verify Group Not Found       %{VCH-NAME}
+
+    Install VIC Appliance To Test Server With Current Environment Variables    additional-args=--affinity-vm-group
+
+    Verify Group Contains VMs    %{VCH-NAME}    1
+
+    Run VIC Machine Delete Command
+
+    Verify Group Not Found       %{VCH-NAME}
+
+
+Deleting a container cleans up its VM group
+    Verify Group Not Found       %{VCH-NAME}
+
+    Install VIC Appliance To Test Server With Current Environment Variables    additional-args=--affinity-vm-group
+
+    Create Three Containers
+
+    Verify Group Contains VMs    %{VCH-NAME}    4
+
+    Delete Containers
+
+    Verify Group Contains VMs    %{VCH-NAME}    1
+
+
+Create a VCH without a VM group
+    Verify Group Not Found       %{VCH-NAME}
+
+    Create Group                 %{VCH-NAME}
+
+    Verify Group Empty           %{VCH-NAME}
+
+    Install VIC Appliance To Test Server With Current Environment Variables    cleanup=${false}
+
+    Verify Group Empty           %{VCH-NAME}
+
+    Create Three Containers
+
+    Verify Group Empty           %{VCH-NAME}
+
+
+Attempt to create a VCH when a VM group with the same name already exists
+    [Teardown]    Remove Group   %{VCH-NAME}
+
+    Verify Group Not Found       %{VCH-NAME}
+
+    Create Group                 %{VCH-NAME}
+
+    Verify Group Empty           %{VCH-NAME}
+
+    Run Keyword and Expect Error    *    Install VIC Appliance To Test Server With Current Environment Variables    additional-args=--affinity-vm-group    cleanup=${false}
+
+    Verify Group Empty           %{VCH-NAME}
+
+
+Deleting a VCH gracefully handles missing VM group
+    [Teardown]    Run Keyword If Test Failed    Cleanup VIC Appliance On Test Server
+
+    Verify Group Not Found       %{VCH-NAME}
+
+    Install VIC Appliance To Test Server With Current Environment Variables    additional-args=--affinity-vm-group
+
+    Verify Group Contains VMs    %{VCH-NAME}    1
+
+    Remove Group                 %{VCH-NAME}
+
+    Verify Group Not Found       %{VCH-NAME}
+
+    Run VIC Machine Delete Command
+
+
+Configuring VCH does not affect affinity
+    Verify Group Not Found       %{VCH-NAME}
+
+    Install VIC Appliance To Test Server With Current Environment Variables    additional-args=--affinity-vm-group
+
+    Verify Group Contains VMs    %{VCH-NAME}    1
+
+    Configure VCH without modifying affinity
+
+    Verify Group Contains VMs    %{VCH-NAME}    1
+
+    Create Three Containers
+
+    Verify Group Contains VMs    %{VCH-NAME}    4

--- a/tests/test-cases/Group25-Host-Affinity/TestCases.md
+++ b/tests/test-cases/Group25-Host-Affinity/TestCases.md
@@ -1,0 +1,4 @@
+Group 25 - Host Affinity
+========================
+
+[Suite 25-01 - Basic Testing](25-01-Basic.md)

--- a/tests/test-cases/TestGroups.md
+++ b/tests/test-cases/TestGroups.md
@@ -26,3 +26,5 @@ VIC Integration Test Suite
 -
 [Group 23 - VIC Machine Service](Group23-VIC-Machine-Service/TestCases.md)
 -
+[Group 25 - Host Affinity](Group25-Host-Affinity/TestCases.md)
+-


### PR DESCRIPTION
Allow users to opt-in to use of a DRS VM Group for a VCH's Endpoint VM
and its Container VMs. This allows an administrator to define VM-Host
Affinity Rules for the VCH to restrict the set of hosts the VMs run on.

This may be useful for software licensing reasons (e.g., if they are
billed based on the number of physical hosts, sockets, or cores running
a piece of software), compliance reasons, or due to latency-sensitive
workloads running in an environment with stretched clusters.

This implementation integrates the functionality into VCH creation,
inspection, and deletion via the CLI and API; enhances the logic which
grants permissions to the operations user to support the necessary
operations; and provides error reporting via vicadmin.

This implementation includes a known issue around the fix VM workflow
during which the VM is unregistered and re-registered. This can cause
the VM being fixed to be removed from the DRS VM Group.

This implementation does not include support for reconfiguration of an
existing VCH to enable use of a DRS VM Group.