### PR TITLE
Move affinity-vm-group flag from compute to create

### DIFF
--- a/cmd/vic-machine/common/compute.go
+++ b/cmd/vic-machine/common/compute.go
@@ -43,11 +43,5 @@ func (c *Compute) ComputeFlagsNoName() []cli.Flag {
 			Usage:       "Compute resource path, e.g. myCluster",
 			Destination: &c.ComputeResourcePath,
 		},
-		cli.BoolFlag{
-			Name:        "affinity-vm-group",
-			Usage:       "Use a DRS VM Group to allow VM-Host affinity rules to be defined for the VCH",
-			Destination: &c.UseVMGroup,
-			Hidden:      true,
-		},
 	}
 }

--- a/cmd/vic-machine/create/create.go
+++ b/cmd/vic-machine/create/create.go
@@ -270,6 +270,15 @@ func (c *Create) Flags() []cli.Flag {
 		},
 	}
 
+	affinity := []cli.Flag{
+		cli.BoolFlag{
+			Name:        "affinity-vm-group",
+			Usage:       "Use a DRS VM Group to allow VM-Host affinity rules to be defined for the VCH",
+			Destination: &c.UseVMGroup,
+			Hidden:      true,
+		},
+	}
+
 	util := []cli.Flag{
 		// miscellaneous
 		cli.BoolFlag{
@@ -313,7 +322,7 @@ func (c *Create) Flags() []cli.Flag {
 
 	// flag arrays are declared, now combined
 	var flags []cli.Flag
-	for _, f := range [][]cli.Flag{target, compute, ops, create, container, volume, dns, networks, cNetwork, memory, cpu, tls, registries, proxies, syslog, iso, util, debug, help} {
+	for _, f := range [][]cli.Flag{target, compute, ops, create, affinity, container, volume, dns, networks, cNetwork, memory, cpu, tls, registries, proxies, syslog, iso, util, debug, help} {
 		flags = append(flags, f...)
 	}
 


### PR DESCRIPTION
While the affinity-vm-group flag controls compute-related behavior,
the common compute flags are shared across a variety of subcommands.

However, the affinity-vm-group flag is not used by other commands and
passing it to anything other than create should result in an error.

Because create is the only command that supports extended help, the
affinity-vm-group flag is not listed in other commands' help output,
making discovery of this bug difficult.

`[specific ci=25-01-Basic]`