### PR TITLE
Change default max_map_count in cVM

### DIFF
--- a/isos/bootstrap/bootstrap
+++ b/isos/bootstrap/bootstrap
@@ -99,6 +99,9 @@ if timeout --signal=KILL 2m mount -t ext4 /dev/disk/by-label/containerfs ${MOUNT
     echo 'tether tmpfs size after copying libraries: '
     df -k ${MOUNTPOINT}/.tether
 
+    # TEMP: https://github.com/vmware/vic/issues/6279
+    echo 262144 > /proc/sys/vm/max_map_count
+
     until [[ $(ls -1 /dev/disk/by-label | wc -l) -eq $(ls -1 /sys/block | wc -l) ]]; do sleep 0.1;done
 
     echo "switching to the new mount"


### PR DESCRIPTION
The correct approach for this issue is to allow specification of sysctl
options generally and then parse/apply them in the container. This
change is made because:
a. it's extremely quick to do
b. it impacts a common workload
c. after consultation with Photon kernel team there's no known
negative impact to changing the default given cVM model.

Towards #6279
