### PR TITLE
drone: Fix syntax error in check-org-membership

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -53,7 +53,7 @@ pipeline:
     commands:
       - echo ${DRONE_COMMIT_AUTHOR}
       - echo $SKIP_CHECK_MEMBERSHIP
-      - if "$SKIP_CHECK_MEMBERSHIP" == true; then echo 'check-org-membership step skipped'; else /bin/bash -c '[[ ! $(curl --silent "https://api.github.com/orgs/vmware/members/${DRONE_COMMIT_AUTHOR}?access_token=$GITHUB_AUTOMATION_API_KEY") ]]'; fi
+      - if [ "$SKIP_CHECK_MEMBERSHIP" = "true" ]; then echo 'check-org-membership step skipped'; else /bin/bash -c '[[ ! $(curl --silent "https://api.github.com/orgs/vmware/members/${DRONE_COMMIT_AUTHOR}?access_token=$GITHUB_AUTOMATION_API_KEY") ]]'; fi
     when:
       status: success
 


### PR DESCRIPTION
Currently, `check-org-membership` will result in a Permission denied
error from `/bin/sh` when `SKIP_CHECK_MEMBERSHIP` is not set to true
as a result of a syntax error.
