### PR TITLE
Use the most recent reachable tag during build

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -192,7 +192,7 @@ pipeline:
       - 'mkdir bundle'
       - 'mkdir bundle-release'
       - 'cp $BIN/vic_${DRONE_BUILD_NUMBER}.tar.gz bundle'
-      - 'cp $BIN/vic_${DRONE_BUILD_NUMBER}.tar.gz bundle-release/vic_`git describe --tags $(git rev-list --tags --max-count=1)`.tar.gz'
+      - 'cp $BIN/vic_${DRONE_BUILD_NUMBER}.tar.gz bundle-release/vic_`git describe --tags --abbrev=0)`.tar.gz'
     when:
       repo: vmware/vic
       branch: [master, 'releases/*']

--- a/Makefile
+++ b/Makefile
@@ -22,8 +22,8 @@ ifeq (vagrant, $(filter vagrant,$(USER) $(SUDO_USER)))
 	BIN_ARCH := -$(OS)
 endif
 REV :=$(shell git rev-parse --short=8 HEAD)
-TAG :=$(shell git for-each-ref --format="%(refname:short)" --sort=-authordate --count=1 refs/tags) # e.g. `v0.9.0`
-TAG_NUM :=$(shell git for-each-ref --format="%(refname:short)" --sort=-authordate --count=1 refs/tags | cut -c 2-) # e.g. `0.9.0`
+TAG :=$(shell git describe --tags --abbrev=0) # e.g. `v0.9.0`
+TAG_NUM :=$(shell git describe --tags --abbrev=0 | cut -c 2-) # e.g. `0.9.0`
 
 BASE_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 BASE_PKG := github.com/vmware/vic/


### PR DESCRIPTION
When determining which tag to use during the build process, use the most recent tag that is reachable from the current commit instead of the most recent tag in the repository.

Include `--tags` to enable matching on lightweight tags.

Include `--abbrev=0` to suppress the long format (which includes an offset and abbreviated hash) and show only the closest tag.

Towards: vmware/vic-product#1206
