### PR TITLE
Support add and remove VM Group via configure

### DIFF
--- a/cmd/vic-machine/common/compute.go
+++ b/cmd/vic-machine/common/compute.go
@@ -20,6 +20,8 @@ type Compute struct {
 	ComputeResourcePath string `cmd:"compute-resource"`
 	DisplayName         string `cmd:"name"`
 	UseVMGroup          bool   `cmd:"affinity-vm-group"`
+	CreateVMGroup       bool
+	DeleteVMGroup       bool
 }
 
 func (c *Compute) ComputeFlags() []cli.Flag {
@@ -42,6 +44,17 @@ func (c *Compute) ComputeFlagsNoName() []cli.Flag {
 			Value:       "",
 			Usage:       "Compute resource path, e.g. myCluster",
 			Destination: &c.ComputeResourcePath,
+		},
+	}
+}
+
+func (c *Compute) AffinityFlags(hidden bool) []cli.Flag {
+	return []cli.Flag{
+		cli.BoolFlag{
+			Name:        "affinity-vm-group",
+			Usage:       "Use a DRS VM Group to allow VM-Host affinity rules to be defined for the VCH",
+			Destination: &c.UseVMGroup,
+			Hidden:      hidden,
 		},
 	}
 }

--- a/cmd/vic-machine/create/create.go
+++ b/cmd/vic-machine/create/create.go
@@ -270,15 +270,6 @@ func (c *Create) Flags() []cli.Flag {
 		},
 	}
 
-	affinity := []cli.Flag{
-		cli.BoolFlag{
-			Name:        "affinity-vm-group",
-			Usage:       "Use a DRS VM Group to allow VM-Host affinity rules to be defined for the VCH",
-			Destination: &c.UseVMGroup,
-			Hidden:      true,
-		},
-	}
-
 	util := []cli.Flag{
 		// miscellaneous
 		cli.BoolFlag{
@@ -312,6 +303,7 @@ func (c *Create) Flags() []cli.Flag {
 	target := c.TargetFlags()
 	ops := c.OpsCredentials.Flags(true)
 	compute := c.ComputeFlags()
+	affinity := c.AffinityFlags(true)
 	container := c.ContainerFlags()
 	volume := c.volumeStores.Flags()
 	iso := c.ImageFlags(true)

--- a/lib/install/data/data.go
+++ b/lib/install/data/data.go
@@ -138,6 +138,10 @@ type InstallerData struct {
 
 	HTTPSProxy *url.URL
 	HTTPProxy  *url.URL
+
+	// Used only for configure, so that the current state can be validated relative to the requested changes
+	CreateVMGroup bool
+	DeleteVMGroup bool
 }
 
 func NewData() *Data {

--- a/lib/install/management/delete.go
+++ b/lib/install/management/delete.go
@@ -126,7 +126,7 @@ func (d *Dispatcher) DeleteVCH(conf *config.VirtualContainerHostConfigSpec, cont
 		d.op.Warnf("VCH resource pool is not removed: %s", err)
 	}
 
-	if err = d.destroyVMGroup(conf); err != nil {
+	if err = d.deleteVMGroupIfUsed(conf); err != nil {
 		d.op.Warnf("VCH DRS VM group is not removed: %s", err)
 	}
 

--- a/lib/install/validate/compute.go
+++ b/lib/install/validate/compute.go
@@ -56,14 +56,14 @@ func (v *Validator) checkVMGroup(op trace.Operation, input *data.Data, conf *con
 			return
 		}
 
-		if input.ID != "" {
-			op.Debug("Skipping DRS VM Group existence check as VCH has already been created")
-			return
-		}
-
 		conf.UseVMGroup = input.UseVMGroup
 		// For now, we always name the VM Group based on the name of the VCH
 		conf.VMGroupName = conf.Name
+
+		if input.ID != "" && !input.CreateVMGroup {
+			op.Debug("Skipping DRS VM Group existence check as VCH has already been created")
+			return
+		}
 
 		if v.Session.Cluster == nil {
 			// We already note a more helpful issue for this following the compute method's call to ResourcePoolHelper.

--- a/tests/resources/Group25-Host-Affinity-Util.robot
+++ b/tests/resources/Group25-Host-Affinity-Util.robot
@@ -1,0 +1,102 @@
+# Copyright 2018 VMware, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#	http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License
+
+*** Settings ***
+Documentation    This resource contains keywords which are helpful for testing DRS VM Groups.
+
+
+*** Keywords ***
+Cleanup
+    Run Keyword And Continue On Failure    Remove Group     %{VCH-NAME}
+
+    Cleanup VIC Appliance On Test Server
+
+
+Create Group
+    [Arguments]    ${name}
+
+    ${rc}  ${out}=    Run And Return Rc And Output     govc cluster.group.create -name "${name}" -vm --json 2>&1
+    Should Be Equal As Integers    ${rc}    0
+
+Remove Group
+    [Arguments]    ${name}
+
+    ${rc}  ${out}=    Run And Return Rc And Output     govc cluster.group.remove -name "${name}" --json 2>&1
+    Should Be Equal As Integers    ${rc}    0
+
+
+Verify Group Not Found
+    [Arguments]    ${name}
+
+    ${out}=    Run     govc cluster.group.ls -name "${name}" --json 2>&1
+    Should Be Equal As Strings    ${out}    govc: group "${name}" not found
+
+Verify Group Empty
+    [Arguments]    ${name}
+
+    ${out}=    Run     govc cluster.group.ls -name "${name}" --json 2>&1
+    Should Be Equal As Strings    ${out}    null
+
+Verify Group Contains VMs
+    [Arguments]    ${name}    ${count}
+
+    ${out}=    Run    govc cluster.group.ls -name "${name}" --json | jq 'length'
+    Should Be Equal As Integers    ${out}    ${count}
+
+
+Create Three Containers
+    ${POWERED_OFF_CONTAINER_NAME}=    Generate Random String  15
+    ${rc}  ${out}=    Run And Return Rc And Output    docker %{VCH-PARAMS} create --name ${POWERED_OFF_CONTAINER_NAME} ${busybox} /bin/top
+
+    Set Test Variable    ${POWERED_OFF_CONTAINER_NAME}
+
+    ${POWERED_ON_CONTAINER_NAME}=    Generate Random String  15
+    ${rc}  ${out}=    Run And Return Rc And Output    docker %{VCH-PARAMS} create --name ${POWERED_ON_CONTAINER_NAME} ${busybox} /bin/top
+    ${rc}  ${out}=    Run And Return Rc And Output    docker %{VCH-PARAMS} start ${out}
+
+    Set Test Variable    ${POWERED_ON_CONTAINER_NAME}
+
+    ${RUN_CONTAINER_NAME}=    Generate Random String  15
+    ${rc}  ${out}=    Run And Return Rc And Output    docker %{VCH-PARAMS} run -d --name ${RUN_CONTAINER_NAME} ${busybox} /bin/top
+
+    Set Test Variable    ${RUN_CONTAINER_NAME}
+
+Delete Containers
+    ${rc}  ${out}=    Run And Return Rc And Output    docker %{VCH-PARAMS} rm ${POWERED_OFF_CONTAINER_NAME}
+    ${rc}  ${out}=    Run And Return Rc And Output    docker %{VCH-PARAMS} rm -f ${POWERED_ON_CONTAINER_NAME}
+    ${rc}  ${out}=    Run And Return Rc And Output    docker %{VCH-PARAMS} rm -f ${RUN_CONTAINER_NAME}
+
+
+Configure VCH without modifying affinity
+    ${rc}  ${out}=    Secret configure VCH for affinity    --volume-store=%{TEST_DATASTORE}/%{VCH-NAME}-VOL:default --volume-store=%{TEST_DATASTORE}/%{VCH-NAME}-conf:configure
+    Log    ${out}
+    Should Be Equal As Integers    ${RC}    0
+
+Configure VCH to enable affinity
+    ${rc}  ${out}=    Secret configure VCH for affinity    --affinity-vm-group=true
+    Log    ${out}
+    Should Be Equal As Integers    ${RC}    0
+
+Configure VCH to disable affinity
+    ${rc}  ${out}=    Secret configure VCH for affinity    --affinity-vm-group=false
+    Log    ${out}
+    Should Be Equal As Integers    ${RC}    0
+
+Secret configure VCH for affinity
+    [Tags]    secret
+    [Arguments]    ${additional-args}=${EMPTY}
+    ${rc}  ${out}=    Run And Return Rc And Output    bin/vic-machine-linux configure --name=%{VCH-NAME} --target=%{TEST_URL} --thumbprint=%{TEST_THUMBPRINT} --user=%{TEST_USERNAME} --password=%{TEST_PASSWORD} --timeout %{TEST_TIMEOUT} ${additional-args}
+    [Return]    ${rc}  ${out}
+
+

--- a/tests/test-cases/Group25-Host-Affinity/25-01-Basic.md
+++ b/tests/test-cases/Group25-Host-Affinity/25-01-Basic.md
@@ -98,18 +98,3 @@ Positive Testing
 
 #### Expected Outcome:
 * The overall deletion operation succeeds even though the DRS VM Group has already been deleted.
-
-
-### 7. Configuring VCH does not affect affinity
-
-#### Test Steps:
-1. Verify that no DRS VM Group exists by the expected name.
-2. Create a VCH.
-3. Verify that a DRS VM Group was created and that the endpoint VM was added to it.
-4. Reconfigure the VCH to make a minor change unrelated to VM-Host affinity.
-5. Verify that the DRS VM Group still exists and the endpoint VM is still a member of it.
-6. Create a variety of containers.
-7. Verify that the container VMs were added to the DRS VM Group.
-
-#### Expected Outcome:
-* The VCH can be safely reconfigured without affecting the use of a DRS VM Group.

--- a/tests/test-cases/Group25-Host-Affinity/25-02-Reconfigure.md
+++ b/tests/test-cases/Group25-Host-Affinity/25-02-Reconfigure.md
@@ -1,0 +1,114 @@
+Suite 25-02 - Reconfigure
+=========================
+
+# Purpose:
+To verify VM-Host Affinity functionality when reconfiguring Virtual Container Hosts
+
+# References:
+1. [The design document](../../../doc/design/host-affinity.md)
+
+# Environment:
+This suite requires a vCenter Server environment where VCHs can be deployed and container VMs created.
+
+
+Positive Testing
+----------------
+
+### 1. Configuring a VCH does not affect affinity
+
+#### Test Steps:
+1. Verify that no DRS VM Group exists by the expected name.
+2. Create a VCH using a DRS VM Group.
+3. Verify that a DRS VM Group was created and that the endpoint VM was added to it.
+4. Reconfigure the VCH to make a minor change unrelated to VM-Host affinity.
+5. Verify that the DRS VM Group still exists and the endpoint VM is still a member of it.
+6. Create a variety of containers.
+7. Verify that the container VMs were added to the DRS VM Group.
+
+#### Expected Outcome:
+* The VCH can be safely reconfigured without unintentionally affecting the use of a DRS VM Group.
+
+
+### 2. Configuring a VCH without a VM group does not affect affinity
+
+#### Test Steps:
+1. Verify that no DRS VM Group exists by the expected name.
+2. Create a VCH without using a DRS VM Group.
+3. Verify that no DRS VM Group exists by the expected name.
+4. Reconfigure the VCH to make a minor change unrelated to VM-Host affinity.
+5. Verify that no DRS VM Group exists by the expected name.
+6. Create a variety of containers.
+7. Verify that no DRS VM Group exists by the expected name.
+
+#### Expected Outcome:
+* Reconfiguring a VCH without a DRS VM Group without specifying the --affinity-vm-group flag does not cause a group to be created.
+
+
+### 3. Enabling affinity affects existing container VMs
+
+#### Test Steps:
+1. Verify that no DRS VM Group exists by the expected name.
+2. Create a VCH without using a DRS VM Group.
+3. Verify that no DRS VM Group exists by the expected name.
+4. Create a variety of containers.
+5. Verify that no DRS VM Group exists by the expected name.
+6. Reconfigure the VCH to enable use of a DRS VM Group.
+7. Verify that a DRS VM Group was created and that the endpoint VM and container VMs were added to it.
+
+#### Expected Outcome:
+* Reconfiguring a VCH to enable use of a DRS VM Group creates the group and adds the endpoint VM and container VMs.
+
+
+### 4. Enabling affinity affects subsequent container VMs
+
+#### Test Steps:
+1. Verify that no DRS VM Group exists by the expected name.
+2. Create a VCH without using a DRS VM Group.
+3. Verify that no DRS VM Group exists by the expected name.
+4. Reconfigure the VCH to enable use of a DRS VM Group.
+5. Verify that a DRS VM Group was created and that the endpoint VM was added to it.
+6. Create a variety of containers.
+7. Verify that the container VMs were added to the DRS VM Group.
+
+#### Expected Outcome:
+* Reconfiguring a VCH to enable use of a DRS VM Group affects subsequent container VMs operations.
+
+
+### 5. Disabling affinity affects existing container VMs
+
+#### Test Steps:
+1. Verify that no DRS VM Group exists by the expected name.
+2. Create a VCH using a DRS VM Group.
+3. Verify that a DRS VM Group was created and that the endpoint VM was added to it.
+4. Create a variety of containers.
+5. Verify that the container VMs were added to the DRS VM Group.
+6. Reconfigure the VCH to disable use of a DRS VM Group.
+7. Verify that the DRS VM Group no longer exists.
+
+#### Expected Outcome:
+* Reconfiguring a VCH to disable use of a DRS VM Group affects existing container VMs.
+
+
+### 6. Disabling affinity affects subsequent container VMs
+
+#### Test Steps:
+1. Verify that no DRS VM Group exists by the expected name.
+2. Create a VCH using a DRS VM Group.
+3. Verify that a DRS VM Group was created and that the endpoint VM was added to it.
+4. Reconfigure the VCH to disable use of a DRS VM Group.
+5. Verify that the DRS VM Group no longer exists.
+6. Create a variety of containers.
+7. Verify that no DRS VM Group exists by the expected name.
+
+#### Expected Outcome:
+* Reconfiguring a VCH to disable use of a DRS VM Group affects subsequent container VM operations.
+
+
+### 7. With operations user, enabling affinity affects existing container VMs
+
+As 3, but with an operations user.
+
+
+### 8. With operations user, enabling affinity affects subsequent container VMs
+
+As 4, but with an operations user.

--- a/tests/test-cases/Group25-Host-Affinity/25-02-Reconfigure.robot
+++ b/tests/test-cases/Group25-Host-Affinity/25-02-Reconfigure.robot
@@ -1,0 +1,166 @@
+# Copyright 2018 VMware, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#	http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License
+
+*** Settings ***
+Documentation     Suite 25-02 - Reconfigure
+Resource          ../../resources/Util.robot
+Resource          ../../resources/Group25-Host-Affinity-Util.robot
+Test Setup        Set Test Environment Variables
+Test Teardown     Cleanup
+Default Tags
+
+
+*** Test Cases ***
+Configuring a VCH does not affect affinity
+    Verify Group Not Found       %{VCH-NAME}
+
+    Install VIC Appliance To Test Server With Current Environment Variables    additional-args=--affinity-vm-group
+
+    Verify Group Contains VMs    %{VCH-NAME}    1
+
+    Configure VCH without modifying affinity
+
+    Verify Group Contains VMs    %{VCH-NAME}    1
+
+    Create Three Containers
+
+    Verify Group Contains VMs    %{VCH-NAME}    4
+
+
+Configuring a VCH without a VM group does not affect affinity
+    [Teardown]    Cleanup VIC Appliance On Test Server
+
+    Verify Group Not Found       %{VCH-NAME}
+
+    Install VIC Appliance To Test Server With Current Environment Variables
+
+    Verify Group Not Found       %{VCH-NAME}
+
+    Configure VCH without modifying affinity
+
+    Verify Group Not Found       %{VCH-NAME}
+
+    Create Three Containers
+
+    Verify Group Not Found       %{VCH-NAME}
+
+
+Enabling affinity affects existing container VMs
+    Verify Group Not Found       %{VCH-NAME}
+
+    Install VIC Appliance To Test Server With Current Environment Variables
+
+    Verify Group Not Found       %{VCH-NAME}
+
+    Create Three Containers
+
+    Verify Group Not Found       %{VCH-NAME}
+
+    Configure VCH to enable affinity
+
+    Verify Group Contains VMs    %{VCH-NAME}    4
+
+
+Enabling affinity affects subsequent container VMs
+    Verify Group Not Found       %{VCH-NAME}
+
+    Install VIC Appliance To Test Server With Current Environment Variables
+
+    Verify Group Not Found       %{VCH-NAME}
+
+    Configure VCH to enable affinity
+
+    Verify Group Contains VMs    %{VCH-NAME}    1
+
+    Create Three Containers
+
+    Verify Group Contains VMs    %{VCH-NAME}    4
+
+
+Disabling affinity affects existing container VMs
+    [Teardown]    Cleanup VIC Appliance On Test Server
+
+    Verify Group Not Found       %{VCH-NAME}
+
+    Install VIC Appliance To Test Server With Current Environment Variables    additional-args=--affinity-vm-group
+
+    Verify Group Contains VMs    %{VCH-NAME}    1
+
+    Create Three Containers
+
+    Verify Group Contains VMs    %{VCH-NAME}    4
+
+    Configure VCH to disable affinity
+
+    Verify Group Not Found       %{VCH-NAME}
+
+
+Disabling affinity affects subsequent container VMs
+    [Teardown]    Cleanup VIC Appliance On Test Server
+
+    Verify Group Not Found       %{VCH-NAME}
+
+    Install VIC Appliance To Test Server With Current Environment Variables    additional-args=--affinity-vm-group
+
+    Verify Group Contains VMs    %{VCH-NAME}    1
+
+    Configure VCH to disable affinity
+
+    Verify Group Not Found       %{VCH-NAME}
+
+    Create Three Containers
+
+    Verify Group Not Found       %{VCH-NAME}
+
+
+With operations user, enabling affinity affects existing container VMs
+    ${status}=  Get State Of Github Issue  7722
+    Run Keyword If  '${status}' == 'closed'  Fail  Test 25-02-Upgrade.robot needs to be updated now that Issue #7722 has been resolved
+    Log  Issue \#7722 is blocking implementation  WARN
+    [Teardown]    No Operation
+
+    #Verify Group Not Found       %{VCH-NAME}
+    #
+    #Install VIC Appliance To Test Server With Current Environment Variables    additional-args=--ops-user=${ops_user_name} --ops-password=${ops_user_password} --ops-grant-perms
+    #
+    #Verify Group Not Found       %{VCH-NAME}
+    #
+    #Create Three Containers
+    #
+    #Verify Group Not Found       %{VCH-NAME}
+    #
+    #Configure VCH to enable affinity
+    #
+    #Verify Group Contains VMs    %{VCH-NAME}    4
+
+
+With operations user, enabling affinity affects subsequent container VMs
+    ${status}=  Get State Of Github Issue  7722
+    Run Keyword If  '${status}' == 'closed'  Fail  Test 25-02-Upgrade.robot needs to be updated now that Issue #7722 has been resolved
+    Log  Issue \#7722 is blocking implementation  WARN
+    [Teardown]    No Operation
+
+    #Verify Group Not Found       %{VCH-NAME}
+    #
+    #Install VIC Appliance To Test Server With Current Environment Variables    additional-args=--ops-user=${ops_user_name} --ops-password=${ops_user_password} --ops-grant-perms
+    #
+    #Verify Group Not Found       %{VCH-NAME}
+    #
+    #Configure VCH to enable affinity
+    #
+    #Verify Group Contains VMs    %{VCH-NAME}    1
+    #
+    #Create Three Containers
+    #
+    #Verify Group Contains VMs    %{VCH-NAME}    4

--- a/tests/test-cases/Group25-Host-Affinity/TestCases.md
+++ b/tests/test-cases/Group25-Host-Affinity/TestCases.md
@@ -2,3 +2,5 @@ Group 25 - Host Affinity
 ========================
 
 [Suite 25-01 - Basic Testing](25-01-Basic.md)
+-
+[Suite 25-02 - Reconfigure](25-02-Reconfigure.md)


### PR DESCRIPTION
(Note: currently has some duplication from #7777 to simplify the inevitable merge.)

Enhance configure to support the `--affinity-vm-group` flag supported
by create. Enable use of a DRS VM Group when a user specifies either
`--affinity-vm-group` or `--affinity-vm-group=true` and disable use when
a user specifies `--affinity-vm-group=false`.

Fixes: #7561

`[specific ci=Group25-Host-Affinity]`