### PR TITLE
Cherry pick: Create VCH in correct ESXi resource pool (#7783)

### DIFF
--- a/lib/install/management/create.go
+++ b/lib/install/management/create.go
@@ -54,10 +54,10 @@ func (d *Dispatcher) CreateVCH(conf *config.VirtualContainerHostConfigSpec, sett
 	// pool name match the appliance name.
 	// DRS Disabled:
 	// only use the compute path which will avoid a pool creation attempt.
-	if d.session.DRSEnabled != nil && *d.session.DRSEnabled {
-		d.vchPoolPath = path.Join(settings.ResourcePoolPath, conf.Name)
-	} else {
+	if d.session.DRSEnabled != nil && !*d.session.DRSEnabled {
 		d.vchPoolPath = settings.ResourcePoolPath
+	} else {
+		d.vchPoolPath = path.Join(settings.ResourcePoolPath, conf.Name)
 	}
 
 	if err = d.checkExistence(conf, settings); err != nil {

--- a/lib/install/opsuser/opsuser.go
+++ b/lib/install/opsuser/opsuser.go
@@ -79,14 +79,14 @@ func GrantOpsUserPerms(ctx context.Context, session *session.Session, configSpec
 	var rbacConfig *rbac.Config
 
 	// Use a separate RBAC configuration depending on whether DRS is enabled.
-	if session.DRSEnabled != nil && *session.DRSEnabled {
+	if session.DRSEnabled == nil || !*session.DRSEnabled {
+		rbacConfig = &NoDRSConf
+	} else {
 		if configSpec.UseVMGroup {
 			rbacConfig = &ClusterConf
 		} else {
 			rbacConfig = &DRSConf
 		}
-	} else {
-		rbacConfig = &NoDRSConf
 	}
 
 	mgr, err := NewRBACManager(ctx, session, rbacConfig, configSpec)


### PR DESCRIPTION
Fixes issue where the VCH was being created in the default
resource pool for standalone ESXi.  This would have cascading
effect on vic-machine and vic operations.