### PR TITLE
Search all resource pools when looking for a vic vApp

### DIFF
--- a/lib/install/management/finder.go
+++ b/lib/install/management/finder.go
@@ -341,25 +341,24 @@ func (d *Dispatcher) searchResourcePools(pools []*object.ResourcePool) []*vm.Vir
 		} else {
 			vchs = append(vchs, children...)
 		}
-		// if we have more than one resource pool we will search for vApps
-		// in each of the pools
-		if multiPool {
-			vappPath := path.Join(pool.InventoryPath, "*")
-			vapps, err := d.session.Finder.VirtualAppList(d.op, vappPath)
-			if err != nil {
-				if _, ok := err.(*find.NotFoundError); !ok {
-					d.op.Errorf("Failed to query vapp %q: %s", vappPath, err)
-				}
-			}
-			for _, vapp := range vapps {
-				children, err := d.findVCHs(vapp.ResourcePool, multiPool)
-				if err != nil {
-					d.op.Warnf("Failed to get VCH from vApp resource pool %q: %s", pool.InventoryPath, err)
-					continue
-				}
-				vchs = append(vchs, children...)
+
+		// search for a vApp
+		vappPath := path.Join(pool.InventoryPath, "*")
+		vapps, err := d.session.Finder.VirtualAppList(d.op, vappPath)
+		if err != nil {
+			if _, ok := err.(*find.NotFoundError); !ok {
+				d.op.Errorf("Failed to query vapp %q: %s", vappPath, err)
 			}
 		}
+		for _, vapp := range vapps {
+			children, err := d.findVCHs(vapp.ResourcePool, multiPool)
+			if err != nil {
+				d.op.Warnf("Failed to get VCH from vApp resource pool %q: %s", pool.InventoryPath, err)
+				continue
+			}
+			vchs = append(vchs, children...)
+		}
+
 	}
 	return vchs
 }

--- a/tests/test-cases/Group11-Upgrade/11-01-Upgrade.robot
+++ b/tests/test-cases/Group11-Upgrade/11-01-Upgrade.robot
@@ -204,32 +204,29 @@ Upgrade VCH with unreasonably short timeout and automatic rollback after failure
     Remove Environment Variable  DOCKER_API_VERSION
 
 Upgrade VCH
-    ${status}=  Get State Of Github Issue  7800
-    Run Keyword If  '${status}' == 'closed'  Fail  Test 11-01-Upgrade.robot needs to be updated now that Issue #7800 has been resolved
-    Log  Issue \#7800 is blocking implementation  WARN
-#    Create Docker Containers
+    Create Docker Containers
 
-#    Create Container with Named Volume
+    Create Container with Named Volume
 
     # Create check list for Volume Inspect
-#    @{checkList}=  Create List  ${mntTest}  ${mntNamed}  ${namedVolume}
+    @{checkList}=  Create List  ${mntTest}  ${mntNamed}  ${namedVolume}
 
-#    Upgrade
-#    Check Upgraded Version
-#    Check Container Create Timestamps
+    Upgrade
+    Check Upgraded Version
+    Check Container Create Timestamps
 
-#    Verify Volume Inspect Info  After Upgrade and Before Rollback  ${TestContainerVolume}  ${checkList}
+    Verify Volume Inspect Info  After Upgrade and Before Rollback  ${TestContainerVolume}  ${checkList}
 
-#    Rollback
-#    Check Original Version
+    Rollback
+    Check Original Version
 
-#    Upgrade with ID
-#    Check Upgraded Version
+    Upgrade with ID
+    Check Upgraded Version
 
-#    Verify Volume Inspect Info  After Upgrade with ID  ${TestContainerVolume}  ${checkList}
+    Verify Volume Inspect Info  After Upgrade with ID  ${TestContainerVolume}  ${checkList}
 
-#    Run Docker Checks
+    Run Docker Checks
 
 
-#    Log To Console  Regression Tests...
-#    Run Regression Tests
+    Log To Console  Regression Tests...
+    Run Regression Tests


### PR DESCRIPTION
If a cluster only has vApp(s) installed then there will only be
a single resource pool -- since there is only one pool vic-machine
ls assumes that DRS is disabled and doesn't look for a vApp.

This change will now search all resource pools for a vic
vApp.

[specific ci=11-01-Upgrade]

Fixes #7800

