### PR TITLE
Remove mention of container store from log

### DIFF
--- a/lib/install/validate/validator.go
+++ b/lib/install/validate/validator.go
@@ -826,7 +826,7 @@ func (v *Validator) checkDatastoresAreWriteable(op trace.Operation, conf *config
 	if len(clusterHosts) == 1 && v.Session.IsVC() && !justOneHost {
 		// if we have a cluster with >1 host to begin with, on VC, and only one host can talk to all the datastores, warn
 		// on ESX and clusters with only one host to begin with, this warning would be redundant/irrelevant
-		op.Warn("Only one host can access all of the image/container/volume datastores. This may be a point of contention/performance degradation and HA/DRS may not work as intended.")
+		op.Warn("Only one host can access all of the image/volume datastores. This may be a point of contention/performance degradation and HA/DRS may not work as intended.")
 	}
 }
 


### PR DESCRIPTION
The `--container-store` option was removed in 1.3. Remove a lingering mention of it from a log message.

Fixes #6683 
