### PR TITLE
Clarify rollback log output

### DIFF
--- a/cmd/vic-machine/upgrade/upgrade.go
+++ b/cmd/vic-machine/upgrade/upgrade.go
@@ -120,7 +120,14 @@ func (u *Upgrade) Run(clic *cli.Context) (err error) {
 		return err
 	}
 
-	op.Infof("### Upgrading VCH ####")
+	var action management.Action
+	if !u.Data.Rollback {
+		op.Infof("### Upgrading VCH ####")
+		action = management.UpgradeAction
+	} else {
+		op.Infof("### Rolling back VCH ####")
+		action = management.RollbackAction
+	}
 
 	validator, err := validate.NewValidator(op, u.Data)
 	if err != nil {
@@ -135,7 +142,7 @@ func (u *Upgrade) Run(clic *cli.Context) (err error) {
 		return errors.New("upgrade failed")
 	}
 
-	executor := management.NewDispatcher(validator.Context, validator.Session, management.UpgradeAction, u.Force)
+	executor := management.NewDispatcher(validator.Context, validator.Session, action, u.Force)
 
 	var vch *vm.VirtualMachine
 	if u.Data.ID != "" {
@@ -217,7 +224,6 @@ func (u *Upgrade) Run(clic *cli.Context) (err error) {
 	if !u.Data.Rollback {
 		err = executor.Configure(vchConfig, vConfig)
 	} else {
-		executor.Action = management.RollbackAction
 		err = executor.Rollback(vchConfig, vConfig)
 	}
 


### PR DESCRIPTION
When rolling back an upgrade, clearly log that we are doing so.

Fixes #6686
