### PR TITLE
Include VCH IP and management IP in create and inspect output

### DIFF
--- a/cmd/vic-machine/inspect/inspect.go
+++ b/cmd/vic-machine/inspect/inspect.go
@@ -209,9 +209,6 @@ func (i *Inspect) Run(clic *cli.Context) (err error) {
 	op := common.NewOperation(clic, i.Debug.Debug)
 
 	return i.run(clic, op, func(s state) error {
-		op.Infof("")
-		op.Infof("VCH ID: %s", s.vch.Reference().String())
-
 		installerVer := version.GetBuild()
 
 		op.Info("")

--- a/lib/install/management/inspect.go
+++ b/lib/install/management/inspect.go
@@ -164,6 +164,12 @@ func findCertPaths(op trace.Operation, vchName, certPath string) []string {
 }
 
 func (d *Dispatcher) ShowVCH(conf *config.VirtualContainerHostConfigSpec, key string, cert string, cacert string, envfile string, certpath string) {
+	moref := new(types.ManagedObjectReference)
+	if ok := moref.FromString(conf.ID); ok {
+		d.op.Info("")
+		d.op.Infof("VCH ID: %s", moref.Value)
+	}
+
 	if d.sshEnabled {
 		d.op.Info("")
 		d.op.Info("SSH to appliance:")

--- a/lib/install/management/inspect.go
+++ b/lib/install/management/inspect.go
@@ -185,6 +185,11 @@ func (d *Dispatcher) ShowVCH(conf *config.VirtualContainerHostConfigSpec, key st
 	d.op.Info("Published ports can be reached at:")
 	d.op.Infof("%s", publicIP.String())
 
+	d.op.Info("")
+	managementIP := conf.ExecutorConfig.Networks["management"].Assigned.IP
+	d.op.Info("Management traffic will use:")
+	d.op.Infof("%s", managementIP.String())
+
 	cmd, env := d.GetDockerAPICommand(conf, key, cert, cacert, certpath)
 
 	d.op.Info("")

--- a/lib/install/management/inspect.go
+++ b/lib/install/management/inspect.go
@@ -185,10 +185,12 @@ func (d *Dispatcher) ShowVCH(conf *config.VirtualContainerHostConfigSpec, key st
 	d.op.Info("Published ports can be reached at:")
 	d.op.Infof("%s", publicIP.String())
 
-	d.op.Info("")
-	managementIP := conf.ExecutorConfig.Networks["management"].Assigned.IP
-	d.op.Info("Management traffic will use:")
-	d.op.Infof("%s", managementIP.String())
+	if management := conf.ExecutorConfig.Networks["management"]; management != nil {
+		d.op.Info("")
+		managementIP := management.Assigned.IP
+		d.op.Info("Management traffic will use:")
+		d.op.Infof("%s", managementIP.String())
+	}
 
 	cmd, env := d.GetDockerAPICommand(conf, key, cert, cacert, certpath)
 


### PR DESCRIPTION
Allow users to take note of the VCH endpoint VM's ID for debugging or use with subsequent vic-machine commands.

The public and client IPs are already included. Output the management IP as well.

Fixes: #6517

---


Example `create` output:
```
$ bin/vic-machine-linux create --target=$TARGET --thumbprint=$THUMBPRINT --user=$USER --password=$PASSWORD --image-store=sharedVmfs-0 --bridge-network=network --compute-resource=cluster1 --no-tls --name=output-test
...
INFO[0058] Initialization of appliance successful       
INFO[0058]                                              
INFO[0058] VCH ID: vm-808                               
INFO[0058]                                              
INFO[0058] VCH Admin Portal:                            
INFO[0058] https://10.162.14.102:2378                   
INFO[0058]                                              
INFO[0058] Published ports can be reached at:           
INFO[0058] 10.162.14.102                                
INFO[0058]                                              
INFO[0058] Management traffic will use:                 
INFO[0058] 10.162.14.102                                
INFO[0058]                                              
INFO[0058] Docker environment variables:                
INFO[0058] DOCKER_HOST=10.162.14.102:2375               
INFO[0058]                                              
INFO[0058] Connect to docker:                           
INFO[0058] docker -H 10.162.14.102:2375 info            
INFO[0058] Installer completed successfully             
```

Example `inspect` output:
```
$ bin/vic-machine-linux inspect --target=$TARGET --thumbprint=$THUMBPRINT --user=$USER --password=$PASSWORD --name=output-test
INFO[0000] ### Inspecting VCH ####                      
INFO[0000] Validating target                            
INFO[0001]                                              
INFO[0001] Installer version: v1.5.0-dev-0-a619161      
INFO[0001] VCH version: v1.5.0-dev-0-ed2e4c3            
INFO[0001]                                              
INFO[0001] VCH upgrade status:                          
INFO[0001] Installer has same version as VCH            
INFO[0001] No upgrade available with this installer version 
INFO[0001]                                              
INFO[0001] VCH ID: vm-805                               
INFO[0001]                                              
INFO[0001] VCH Admin Portal:                            
INFO[0001] https://10.162.19.192:2378                   
INFO[0001]                                              
INFO[0001] Published ports can be reached at:           
INFO[0001] 10.162.19.192                                
INFO[0001]                                              
INFO[0001] Management traffic will use:                 
INFO[0001] 10.162.19.192                                
INFO[0001]                                              
INFO[0001] Docker environment variables:                
INFO[0001] DOCKER_HOST=10.162.19.192:2375               
INFO[0001]                                              
INFO[0001] Connect to docker:                           
INFO[0001] docker -H 10.162.19.192:2375 info            
INFO[0001] Completed successfully                       
```