### PR TITLE
Add ops-user privileges for docker cp operations

### DIFF
--- a/lib/install/opsuser/opsuser_conf.go
+++ b/lib/install/opsuser/opsuser_conf.go
@@ -92,6 +92,8 @@ var RoleEndpoint = types.AuthorizationRole{
 		"VirtualMachine.Config.RemoveDisk",
 		"VirtualMachine.Config.Rename",
 		"VirtualMachine.GuestOperations.Execute",
+		"VirtualMachine.GuestOperations.Modify",
+		"VirtualMachine.GuestOperations.Query",
 		"VirtualMachine.Interact.DeviceConnection",
 		"VirtualMachine.Interact.PowerOff",
 		"VirtualMachine.Interact.PowerOn",


### PR DESCRIPTION
Cherry-picks bef4420b956b08b0fadfa943a723bb34076ec8c7 from #7833

This commit adds the 'VirtualMachine.GuestOperations.Modify' and
'VirtualMachine.GuestOperations.Query' privileges to the Endpoint role
for the ops-user. The former is needed for docker cp operations to a
running container, while the latter is needed for docker cp operations
from a running container.

Fixes #7831