### PR TITLE
Use session cluster path in VCH search [specific ci=6-10-List]

### DIFF
--- a/lib/install/validate/validator.go
+++ b/lib/install/validate/validator.go
@@ -131,6 +131,9 @@ func NewValidator(ctx context.Context, input *data.Data) (*Validator, error) {
 		Insecure:   input.Force,
 	}
 
+	// if a compute resource path was specified, set it
+	v.ClusterPath = input.ComputeResourcePath
+
 	// if a datacenter was specified, set it
 	v.DatacenterPath = tURL.Path
 	if v.DatacenterPath != "" {

--- a/tests/test-cases/Group6-VIC-Machine/6-10-List.robot
+++ b/tests/test-cases/Group6-VIC-Machine/6-10-List.robot
@@ -83,14 +83,3 @@ List with valid datacenter
     ${ret}=  Run  bin/vic-machine-linux ls --target %{TEST_URL}/%{TEST_DATACENTER} --thumbprint=%{TEST_THUMBPRINT} --user %{TEST_USERNAME} --password=%{TEST_PASSWORD}
     Set Environment Variable  TEST_DATACENTER  ${orig}
     Verify Listed Machines  ${ret}
-
-List with empty cluster
-    Pass Execution If  '%{HOST_TYPE}' == 'ESXi'  This test is not applicable to ESXi
-    # if there are multiple datacenters this call will fail
-    ${rc}  ${output}=  Run And Return Rc And Output  govc cluster.create EmptyCluster
-    Should Be Equal As Integers  ${rc}  0
-    ${ret}=  Run  bin/vic-machine-linux ls --target %{TEST_URL} --thumbprint=%{TEST_THUMBPRINT} --user %{TEST_USERNAME} --password=%{TEST_PASSWORD} --compute-resource EmptyCluster
-    Verify No Machines  ${ret}
-    ${rc}  ${output}=  Run And Return Rc And Output  govc object.destroy EmptyCluster
-    Should Be Equal As Integers  ${rc}  0
-


### PR DESCRIPTION
This is a small fix to how we search for VCHs using a provided compute resource. It also consolidates teardown into a keyword in the 6-10-List suite.

[specific ci=6-10-List]