### PR TITLE
[WIP] Refactor "Configure VCH debug state" in 6-16-Config

### DIFF
--- a/tests/resources/OperatingSystem-Util.robot
+++ b/tests/resources/OperatingSystem-Util.robot
@@ -1,0 +1,28 @@
+# Copyright 2018 VMware, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#	http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License
+
+*** Settings ***
+Documentation    This resource extends functionality from the OperatingSystem library to simplify common patterns.
+Library          OperatingSystem
+
+
+*** Keywords ***
+
+Run And Verify Rc
+    [Arguments]    ${command}    ${expectedRC}=0
+
+    ${rc}    ${output}=    Run And Return Rc And Output    ${command}
+    Should Be Equal As Integers    ${rc}    ${expectedRC}
+
+    [Return]    ${output}

--- a/tests/resources/Util.robot
+++ b/tests/resources/Util.robot
@@ -32,6 +32,7 @@ Resource  Admiral-Util.robot
 Resource  OVA-Util.robot
 Resource  Cert-Util.robot
 Resource  Slack-Util.robot
+Resource  OperatingSystem-Util.robot
 Resource  nimbus-testbeds/ELM-DRS-Disabled.robot
 
 Variables  dynamic-vars.py

--- a/tests/test-cases/Group6-VIC-Machine/6-16-Config.robot
+++ b/tests/test-cases/Group6-VIC-Machine/6-16-Config.robot
@@ -31,35 +31,42 @@ Wait For DNS Update
     Run Keyword Unless    ${shouldContain}    Should Not Contain    ${output}    network/dns
 
 
+Guestinfo Should Contain
+    [Arguments]    ${vm}    ${key}    ${expected}
+
+    ${out}=    Check VM Guestinfo    ${vm}     ${key}
+               Should Contain        ${out}    ${expected}
+
+
 *** Test Cases ***
 Configure VCH debug state
-    ${output}=  Run  bin/vic-machine-linux configure --help
-    Should Contain  ${output}  --debug
-    ${output}=  Check VM Guestinfo  %{VCH-NAME}  guestinfo.vice./init/diagnostics/debug
-    Should Contain  ${output}  1
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} pull ${busybox}
-    Should Be Equal As Integers  ${rc}  0
-    ${rc}  ${id1}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -itd ${busybox}
-    Should Be Equal As Integers  ${rc}  0
-    ${vm1}=  Get VM display name  ${id1}
-    ${output}=  Check VM Guestinfo  ${vm1}  guestinfo.vice./diagnostics/debug
-    Should Contain  ${output}  1
-    ${output}=  Run  bin/vic-machine-linux configure --debug 0 --name=%{VCH-NAME} --target=%{TEST_URL}%{TEST_DATACENTER} --thumbprint=%{TEST_THUMBPRINT} --user=%{TEST_USERNAME} --password=%{TEST_PASSWORD} --timeout %{TEST_TIMEOUT}
-    Should Contain  ${output}  Completed successfully
-    ${output}=  Check VM Guestinfo  %{VCH-NAME}  guestinfo.vice./init/diagnostics/debug
-    Should Contain  ${output}  0
-    ${output}=  Check VM Guestinfo  ${vm1}  guestinfo.vice./diagnostics/debug
-    Should Contain  ${output}  1
-    ${rc}  ${id2}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -itd ${busybox}
-    Should Be Equal As Integers  ${rc}  0
-    ${vm2}=  Get VM display name  ${id2}
-    ${output}=  Check VM Guestinfo  ${vm2}  guestinfo.vice./diagnostics/debug
-    Should Contain  ${output}  0
-    ${output}=  Run  bin/vic-machine-linux configure --debug 1 --name=%{VCH-NAME} --target=%{TEST_URL}%{TEST_DATACENTER} --thumbprint=%{TEST_THUMBPRINT} --user=%{TEST_USERNAME} --password=%{TEST_PASSWORD} --timeout %{TEST_TIMEOUT}
-    Should Contain  ${output}  Completed successfully
-    ${rc}  ${output}=  Run And Return Rc And Output  bin/vic-machine-linux inspect config --name=%{VCH-NAME} --target=%{TEST_URL}%{TEST_DATACENTER} --thumbprint=%{TEST_THUMBPRINT} --user=%{TEST_USERNAME} --password=%{TEST_PASSWORD} --timeout %{TEST_TIMEOUT}
-    Should Be Equal As Integers  0  ${rc}
-    Should Contain  ${output}  --debug=1
+    ${out}=    Run                   bin/vic-machine-linux configure --help
+               Should Contain        ${out}    --debug
+
+               Guestinfo Should Contain    %{VCH-NAME}    guestinfo.vice./init/diagnostics/debug    1
+
+               Run And Verify Rc     docker %{VCH-PARAMS} pull ${busybox}
+    ${id1}=    Run And Verify Rc     docker %{VCH-PARAMS} run -itd ${busybox}
+    ${vm1}=    Get VM display name   ${id1}
+
+               Guestinfo Should Contain    ${vm1}         guestinfo.vice./diagnostics/debug         1
+
+    ${out}=    Run                   bin/vic-machine-linux configure --debug 0 --name=%{VCH-NAME} --target=%{TEST_URL}%{TEST_DATACENTER} --thumbprint=%{TEST_THUMBPRINT} --user=%{TEST_USERNAME} --password=%{TEST_PASSWORD} --timeout %{TEST_TIMEOUT}
+               Should Contain        ${out}    Completed successfully
+
+               Guestinfo Should Contain    %{VCH-NAME}    guestinfo.vice./init/diagnostics/debug    0
+               Guestinfo Should Contain    ${vm1}         guestinfo.vice./diagnostics/debug         1
+
+    ${id2}=    Run And Verify Rc     docker %{VCH-PARAMS} run -itd ${busybox}
+    ${vm2}=    Get VM display name   ${id2}
+
+               Guestinfo Should Contain    ${vm2}         guestinfo.vice./diagnostics/debug         0
+
+    ${out}=    Run                   bin/vic-machine-linux configure --debug 1 --name=%{VCH-NAME} --target=%{TEST_URL}%{TEST_DATACENTER} --thumbprint=%{TEST_THUMBPRINT} --user=%{TEST_USERNAME} --password=%{TEST_PASSWORD} --timeout %{TEST_TIMEOUT}
+               Should Contain        ${out}    Completed successfully
+
+    ${out}=    Run And Verify Rc      bin/vic-machine-linux inspect config --name=%{VCH-NAME} --target=%{TEST_URL}%{TEST_DATACENTER} --thumbprint=%{TEST_THUMBPRINT} --user=%{TEST_USERNAME} --password=%{TEST_PASSWORD} --timeout %{TEST_TIMEOUT}
+               Should Contain        ${out}    --debug=1
 
 Configure VCH Container Networks
     ${vlan}=  Get Public Network VLAN ID

--- a/tests/test-cases/Group6-VIC-Machine/6-16-Config.robot
+++ b/tests/test-cases/Group6-VIC-Machine/6-16-Config.robot
@@ -37,6 +37,19 @@ Guestinfo Should Contain
     ${out}=    Check VM Guestinfo    ${vm}     ${key}
                Should Contain        ${out}    ${expected}
 
+Inspect Should Contain
+    [Arguments]    ${expected}
+
+    ${out}=    Run And Verify Rc     bin/vic-machine-linux inspect config --name=%{VCH-NAME} --target=%{TEST_URL}%{TEST_DATACENTER} --thumbprint=%{TEST_THUMBPRINT} --user=%{TEST_USERNAME} --password=%{TEST_PASSWORD} --timeout=%{TEST_TIMEOUT}
+               Should Contain        ${out}    ${expected}
+
+Configure VCH
+    [Arguments]    ${additional-args}
+
+    ${out}=    Run And Verify Rc     bin/vic-machine-linux configure --name=%{VCH-NAME} --target=%{TEST_URL}%{TEST_DATACENTER} --thumbprint=%{TEST_THUMBPRINT} --user=%{TEST_USERNAME} --password=%{TEST_PASSWORD} --timeout=%{TEST_TIMEOUT} ${additional-args}
+               Should Contain        ${out}    Completed successfully
+
+
 
 *** Test Cases ***
 Configure VCH debug state
@@ -55,12 +68,10 @@ Configure VCH debug state
                Guestinfo Should Contain    ${vm1}         guestinfo.vice./diagnostics/debug         1
 
     # Use configure to change debug to 0
-    ${out}=    Run And Verify Rc     bin/vic-machine-linux configure --debug 0 --name=%{VCH-NAME} --target=%{TEST_URL}%{TEST_DATACENTER} --thumbprint=%{TEST_THUMBPRINT} --user=%{TEST_USERNAME} --password=%{TEST_PASSWORD} --timeout %{TEST_TIMEOUT}
-               Should Contain        ${out}    Completed successfully
+               Configure VCH    --debug 0
 
     # Verify that the inspect output is updated
-    ${out}=    Run And Verify Rc      bin/vic-machine-linux inspect config --name=%{VCH-NAME} --target=%{TEST_URL}%{TEST_DATACENTER} --thumbprint=%{TEST_THUMBPRINT} --user=%{TEST_USERNAME} --password=%{TEST_PASSWORD} --timeout %{TEST_TIMEOUT}
-               Should Contain        ${out}    --debug=0
+               Inspect Should Contain    --debug=0
 
     # Verify that the VCH was affected, but the existing container VM was not
                Guestinfo Should Contain    %{VCH-NAME}    guestinfo.vice./init/diagnostics/debug    0
@@ -72,13 +83,11 @@ Configure VCH debug state
 
                Guestinfo Should Contain    ${vm2}         guestinfo.vice./diagnostics/debug         0
 
-    # Use configure to change debug back to 1
-    ${out}=    Run And Verify Rc     bin/vic-machine-linux configure --debug 1 --name=%{VCH-NAME} --target=%{TEST_URL}%{TEST_DATACENTER} --thumbprint=%{TEST_THUMBPRINT} --user=%{TEST_USERNAME} --password=%{TEST_PASSWORD} --timeout %{TEST_TIMEOUT}
-               Should Contain        ${out}    Completed successfully
+    # Use configure to change debug to 1
+               Configure VCH    --debug 1
 
     # Verify that the inspect output is updated
-    ${out}=    Run And Verify Rc     bin/vic-machine-linux inspect config --name=%{VCH-NAME} --target=%{TEST_URL}%{TEST_DATACENTER} --thumbprint=%{TEST_THUMBPRINT} --user=%{TEST_USERNAME} --password=%{TEST_PASSWORD} --timeout %{TEST_TIMEOUT}
-               Should Contain        ${out}    --debug=1
+               Inspect Should Contain    --debug=1
 
     # Verify that the VCH was affected, but the existing container VM was not
                Guestinfo Should Contain    %{VCH-NAME}    guestinfo.vice./init/diagnostics/debug    1

--- a/tests/test-cases/Group6-VIC-Machine/6-16-Config.robot
+++ b/tests/test-cases/Group6-VIC-Machine/6-16-Config.robot
@@ -58,6 +58,10 @@ Configure VCH debug state
     ${out}=    Run                   bin/vic-machine-linux configure --debug 0 --name=%{VCH-NAME} --target=%{TEST_URL}%{TEST_DATACENTER} --thumbprint=%{TEST_THUMBPRINT} --user=%{TEST_USERNAME} --password=%{TEST_PASSWORD} --timeout %{TEST_TIMEOUT}
                Should Contain        ${out}    Completed successfully
 
+    # Verify that the inspect output is updated
+    ${out}=    Run And Verify Rc      bin/vic-machine-linux inspect config --name=%{VCH-NAME} --target=%{TEST_URL}%{TEST_DATACENTER} --thumbprint=%{TEST_THUMBPRINT} --user=%{TEST_USERNAME} --password=%{TEST_PASSWORD} --timeout %{TEST_TIMEOUT}
+               Should Contain        ${out}    --debug=0
+
     # Verify that the VCH was affected, but the existing container VM was not
                Guestinfo Should Contain    %{VCH-NAME}    guestinfo.vice./init/diagnostics/debug    0
                Guestinfo Should Contain    ${vm1}         guestinfo.vice./diagnostics/debug         1
@@ -75,6 +79,11 @@ Configure VCH debug state
     # Verify that the inspect output is updated
     ${out}=    Run And Verify Rc      bin/vic-machine-linux inspect config --name=%{VCH-NAME} --target=%{TEST_URL}%{TEST_DATACENTER} --thumbprint=%{TEST_THUMBPRINT} --user=%{TEST_USERNAME} --password=%{TEST_PASSWORD} --timeout %{TEST_TIMEOUT}
                Should Contain        ${out}    --debug=1
+
+    # Verify that the VCH was affected, but the existing container VM was not
+               Guestinfo Should Contain    %{VCH-NAME}    guestinfo.vice./init/diagnostics/debug    1
+               Guestinfo Should Contain    ${vm2}         guestinfo.vice./diagnostics/debug         0
+
 
 
 Configure VCH Container Networks

--- a/tests/test-cases/Group6-VIC-Machine/6-16-Config.robot
+++ b/tests/test-cases/Group6-VIC-Machine/6-16-Config.robot
@@ -41,7 +41,7 @@ Guestinfo Should Contain
 *** Test Cases ***
 Configure VCH debug state
     # Test whether the --debug flag is included in vic-machine configure's help output
-    ${out}=    Run                   bin/vic-machine-linux configure --help
+    ${out}=    Run And Verify Rc     bin/vic-machine-linux configure --help
                Should Contain        ${out}    --debug
 
     # Check that the VCH was created with a debug value of 1
@@ -55,7 +55,7 @@ Configure VCH debug state
                Guestinfo Should Contain    ${vm1}         guestinfo.vice./diagnostics/debug         1
 
     # Use configure to change debug to 0
-    ${out}=    Run                   bin/vic-machine-linux configure --debug 0 --name=%{VCH-NAME} --target=%{TEST_URL}%{TEST_DATACENTER} --thumbprint=%{TEST_THUMBPRINT} --user=%{TEST_USERNAME} --password=%{TEST_PASSWORD} --timeout %{TEST_TIMEOUT}
+    ${out}=    Run And Verify Rc     bin/vic-machine-linux configure --debug 0 --name=%{VCH-NAME} --target=%{TEST_URL}%{TEST_DATACENTER} --thumbprint=%{TEST_THUMBPRINT} --user=%{TEST_USERNAME} --password=%{TEST_PASSWORD} --timeout %{TEST_TIMEOUT}
                Should Contain        ${out}    Completed successfully
 
     # Verify that the inspect output is updated
@@ -73,17 +73,16 @@ Configure VCH debug state
                Guestinfo Should Contain    ${vm2}         guestinfo.vice./diagnostics/debug         0
 
     # Use configure to change debug back to 1
-    ${out}=    Run                   bin/vic-machine-linux configure --debug 1 --name=%{VCH-NAME} --target=%{TEST_URL}%{TEST_DATACENTER} --thumbprint=%{TEST_THUMBPRINT} --user=%{TEST_USERNAME} --password=%{TEST_PASSWORD} --timeout %{TEST_TIMEOUT}
+    ${out}=    Run And Verify Rc     bin/vic-machine-linux configure --debug 1 --name=%{VCH-NAME} --target=%{TEST_URL}%{TEST_DATACENTER} --thumbprint=%{TEST_THUMBPRINT} --user=%{TEST_USERNAME} --password=%{TEST_PASSWORD} --timeout %{TEST_TIMEOUT}
                Should Contain        ${out}    Completed successfully
 
     # Verify that the inspect output is updated
-    ${out}=    Run And Verify Rc      bin/vic-machine-linux inspect config --name=%{VCH-NAME} --target=%{TEST_URL}%{TEST_DATACENTER} --thumbprint=%{TEST_THUMBPRINT} --user=%{TEST_USERNAME} --password=%{TEST_PASSWORD} --timeout %{TEST_TIMEOUT}
+    ${out}=    Run And Verify Rc     bin/vic-machine-linux inspect config --name=%{VCH-NAME} --target=%{TEST_URL}%{TEST_DATACENTER} --thumbprint=%{TEST_THUMBPRINT} --user=%{TEST_USERNAME} --password=%{TEST_PASSWORD} --timeout %{TEST_TIMEOUT}
                Should Contain        ${out}    --debug=1
 
     # Verify that the VCH was affected, but the existing container VM was not
                Guestinfo Should Contain    %{VCH-NAME}    guestinfo.vice./init/diagnostics/debug    1
                Guestinfo Should Contain    ${vm2}         guestinfo.vice./diagnostics/debug         0
-
 
 
 Configure VCH Container Networks

--- a/tests/test-cases/Group6-VIC-Machine/6-16-Config.robot
+++ b/tests/test-cases/Group6-VIC-Machine/6-16-Config.robot
@@ -50,49 +50,35 @@ Configure VCH
                Should Contain        ${out}    Completed successfully
 
 
-
 *** Test Cases ***
 Configure VCH debug state
-    # Test whether the --debug flag is included in vic-machine configure's help output
     ${out}=    Run And Verify Rc     bin/vic-machine-linux configure --help
                Should Contain        ${out}    --debug
 
-    # Check that the VCH was created with a debug value of 1
-               Guestinfo Should Contain    %{VCH-NAME}    guestinfo.vice./init/diagnostics/debug    1
-
-    # Create a container VM and check that it also has a debug value of 1
                Run And Verify Rc     docker %{VCH-PARAMS} pull ${busybox}
     ${id1}=    Run And Verify Rc     docker %{VCH-PARAMS} run -itd ${busybox}
     ${vm1}=    Get VM display name   ${id1}
 
+               Inspect Should Contain      --debug=1
+               Guestinfo Should Contain    %{VCH-NAME}    guestinfo.vice./init/diagnostics/debug    1
                Guestinfo Should Contain    ${vm1}         guestinfo.vice./diagnostics/debug         1
 
-    # Use configure to change debug to 0
-               Configure VCH    --debug 0
+               Configure VCH               --debug=0
 
-    # Verify that the inspect output is updated
-               Inspect Should Contain    --debug=0
-
-    # Verify that the VCH was affected, but the existing container VM was not
+               Inspect Should Contain      --debug=0
                Guestinfo Should Contain    %{VCH-NAME}    guestinfo.vice./init/diagnostics/debug    0
                Guestinfo Should Contain    ${vm1}         guestinfo.vice./diagnostics/debug         1
 
-    # Create another container VM and verify that its debug value is affected
     ${id2}=    Run And Verify Rc     docker %{VCH-PARAMS} run -itd ${busybox}
     ${vm2}=    Get VM display name   ${id2}
 
                Guestinfo Should Contain    ${vm2}         guestinfo.vice./diagnostics/debug         0
 
-    # Use configure to change debug to 1
-               Configure VCH    --debug 1
+               Configure VCH               --debug=1
 
-    # Verify that the inspect output is updated
-               Inspect Should Contain    --debug=1
-
-    # Verify that the VCH was affected, but the existing container VM was not
+               Inspect Should Contain      --debug=1
                Guestinfo Should Contain    %{VCH-NAME}    guestinfo.vice./init/diagnostics/debug    1
                Guestinfo Should Contain    ${vm2}         guestinfo.vice./diagnostics/debug         0
-
 
 Configure VCH Container Networks
     ${vlan}=  Get Public Network VLAN ID

--- a/tests/test-cases/Group6-VIC-Machine/6-16-Config.robot
+++ b/tests/test-cases/Group6-VIC-Machine/6-16-Config.robot
@@ -13,11 +13,11 @@
 # limitations under the License
 
 *** Settings ***
-Documentation  Test 6-16 - Verify vic-machine configure
-Resource  ../../resources/Util.robot
-Suite Setup  Install VIC Appliance To Test Server
-Suite Teardown  Cleanup VIC Appliance On Test Server
-Test Timeout  20 minutes
+Documentation    Test 6-16 - Verify vic-machine configure
+Resource         ../../resources/Util.robot
+Suite Setup      Install VIC Appliance To Test Server
+Suite Teardown   Cleanup VIC Appliance On Test Server
+Test Timeout     20 minutes
 
 *** Keywords ***
 Wait For DNS Update

--- a/tests/test-cases/Group6-VIC-Machine/6-16-Config.robot
+++ b/tests/test-cases/Group6-VIC-Machine/6-16-Config.robot
@@ -21,14 +21,15 @@ Test Timeout     20 minutes
 
 *** Keywords ***
 Wait For DNS Update
-    [Arguments]  ${shouldContain}
-    ${rc}  ${output}=  Run And Return Rc And Output  govc vm.info -e %{VCH-NAME} | grep dns
-    Should Be Equal As Integers  ${rc}  0
-    Run Keyword If  ${shouldContain}  Should Contain  ${output}  network/dns
-    Run Keyword If  ${shouldContain}  Should Not Contain  ${output}  assigned.dns
+    [Arguments]    ${shouldContain}
+    ${output}=    Run And Verify RC    govc vm.info -e %{VCH-NAME} | grep dns
 
-    Run Keyword Unless  ${shouldContain}  Should Contain  ${output}  assigned.dns
-    Run Keyword Unless  ${shouldContain}  Should Not Contain  ${output}  network/dns
+    Run Keyword If        ${shouldContain}    Should Contain        ${output}    network/dns
+    Run Keyword If        ${shouldContain}    Should Not Contain    ${output}    assigned.dns
+
+    Run Keyword Unless    ${shouldContain}    Should Contain        ${output}    assigned.dns
+    Run Keyword Unless    ${shouldContain}    Should Not Contain    ${output}    network/dns
+
 
 *** Test Cases ***
 Configure VCH debug state


### PR DESCRIPTION
Introduce keywords and refactor 6-16-Config to improve readability and completeness of "Configure VCH debug state".

`[specific ci=6-16-Config]`
