### PR TITLE
Clarify usage string for vic-machine update

### DIFF
--- a/cmd/vic-machine/main.go
+++ b/cmd/vic-machine/main.go
@@ -114,7 +114,7 @@ func main() {
 		},
 		{
 			Name:  "update",
-			Usage: "Modify configuration",
+			Usage: "Modify infrastructure configuration",
 			Subcommands: []cli.Command{
 				{
 					Name:   "firewall",


### PR DESCRIPTION
To help users understand the difference between update and configure,
clarify that update is used to modify the infrastructure, not a VCH.

Fixes #5816