### PR TITLE
[skip ci] Publish vic-machine-server with git tags

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -256,34 +256,48 @@ pipeline:
       event: tag
       status: success
 
-  publish-vic-machine-server-dev:
-    image: plugins/gcr
+  vic-machine-server-tags-dev:
+    image: 'wdc-harbor-ci.eng.vmware.com/default-project/vic-integration-test:1.48'
     pull: true
-    repo: eminent-nation-87317/vic-machine-server
-    dockerfile: cmd/vic-machine-server/Dockerfile
-    custom_dns: 10.142.7.21, 10.142.7.22, 10.166.17.90
-    secrets: [ token ]
-    tags:
-      - dev
+    environment:
+      BIN: bin
+      SHELL: /bin/bash
+    commands:
+      - 'echo -n "$(git describe --tags --abbrev=0)-${DRONE_BUILD_NUMBER}-$(git rev-parse --short=8 HEAD)" > .tags;'
+      - 'if [ -n "$(echo "${DRONE_BRANCH}" | grep "master")" ]; then echo ",dev" >> .tags; fi'
+      - 'cat .tags'
     when:
       repo: vmware/vic
       event: push
       branch: [master, 'releases/*']
       status: success
 
-  publish-vic-machine-server-releases:
+  vic-machine-server-tags-release:
+    image: 'wdc-harbor-ci.eng.vmware.com/default-project/vic-integration-test:1.48'
+    pull: true
+    environment:
+      BIN: bin
+      SHELL: /bin/bash
+    commands:
+      - 'echo -n "$(git describe --tags --abbrev=0)-${DRONE_BUILD_NUMBER}-$(git rev-parse --short=8 HEAD),$(git describe --tags --abbrev=0),latest" > .tags;'
+      - 'cat .tags'
+    when:
+      repo: vmware/vic
+      event: tag
+      branch: 'releases/*'
+      status: success
+
+  vic-machine-server-publish:
     image: plugins/gcr
     pull: true
     repo: eminent-nation-87317/vic-machine-server
     dockerfile: cmd/vic-machine-server/Dockerfile
     custom_dns: 10.142.7.21, 10.142.7.22, 10.166.17.90
     secrets: [ token ]
-    tags:
-      - latest
     when:
       repo: vmware/vic
-      branch: ['releases/*']
-      event: tag
+      event: [push, tag]
+      branch: [master, 'releases/*']
       status: success
 
   trigger-downstream:


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[  ] There is an associated issue that is labelled
[  ] Code is up-to-date with the `master` branch
[  ] You've successfully run `make test` locally
[  ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/vmware/vic/blob/master/.github/CONTRIBUTING.md
-->

Fixes #1250.

This change preserves the current tagging functionality:
 - On a **push** to **master**, the image is tagged as **dev**
 - On a **tag** to **releases/**, the image is tagged as **latest**

It also adds the following new tagging scenarios:
 - On a **push** to **master** the image is tagged as **version-buildnumber-sha**
 - On a **push** to **releases/** the image is tagged as **version-buildnumber-sha**
 - On a **tag** to **master**, the image is tagged as **version-buildnumber-sha**
 - On a **tag** to **releases/**, the image is tagged as **version** and  **version-buildnumber-sha**

The above behavior is a precarious mix of how we tag components in the ova - using git tags - and how we upload binary components in vic - using drone build numbers. In the end, the resulting behavior is:
1) As a developer, I want to run the latest release of VMS: `pull vms:latest`
2) As a developer, I want to test my ci build: `pull vms:version-buildnumber-sha`
3) As an ova developer, I want to include the latest build components: `pull vms:dev`
4) As an ova release manager, I want to include a specific release version: `pull vms:1.4.0-rc1`

Where we might have trouble: If an rc1 commit is made to master and _then_ pulled into a release branch, drone sees that as a **push to releases/** and will subsequently tag VMS as `version-rc1-buildnumber-sha` instead of `version-rc1`. However, we've been tagging rc1 commits _after_ the release branch has been... branched, so this is not be a concern at the moment.

--- 

Example tagging based on branch/event:
```
$> export DRONE_BUILD_EVENT=push; export DRONE_BRANCH=master; drone exec --local .drone.local.yml
[vic-machine-server-tags:L0:0s] + echo -n "$(git describe --tags --abbrev=0)-0-$(git rev-parse --short=8 HEAD)" > .tags;
[vic-machine-server-tags:L1:0s] + if [ "push" = "push" -a "master" = "master" ];     then echo ",dev" >> .tags; fi
[vic-machine-server-tags:L2:0s] + if [ "push" = "tag"  -a "master" = "releases/"* ]; then echo ",$(git describe --tags --abbrev=0),latest" >> .tags; fi
[vic-machine-server-tags:L3:0s] + cat .tags
[vic-machine-server-tags:L4:0s] v1.4.0-dev-0-696cb97c,dev
[vic-machine-server-publish:L0:0s] + /usr/local/bin/dockerd -g /var/lib/docker --dns 10.142.7.21 --dns 10.142.7.22 --dns 10.166.17.90
[vic-machine-server-publish:L66:1s] + /usr/local/bin/docker build --rm=true -f cmd/vic-machine-server/Dockerfile -t 00000000 . --pull=true --label org.label-schema.build-date=2018-04-26T18:07:15Z --label org.label-schema.vcs-ref=00000000 --label org.label-schema.vcs-url=
[vic-machine-server-publish:L84:81s] + /usr/local/bin/docker tag 00000000 gcr.io/octocat/hello-world:v1.4.0-dev-0-696cb97c
[vic-machine-server-publish:L85:81s] + /usr/local/bin/docker tag 00000000 gcr.io/octocat/hello-world:dev
[vic-machine-server-publish:L86:81s] + /usr/local/bin/docker rmi 00000000

$> export DRONE_BUILD_EVENT=push; export DRONE_BRANCH="releases/1.4.0"; drone exec --local .drone.local.yml
[vic-machine-server-tags:L0:0s] + echo -n "$(git describe --tags --abbrev=0)-0-$(git rev-parse --short=8 HEAD)" > .tags;
[vic-machine-server-tags:L1:0s] + if [ "push" = "push" -a "releases/1.4.0" = "master" ];     then echo ",dev" >> .tags; fi
[vic-machine-server-tags:L2:0s] + if [ "push" = "tag"  -a "releases/1.4.0" = "releases/"* ]; then echo ",$(git describe --tags --abbrev=0),latest" >> .tags; fi
[vic-machine-server-tags:L3:0s] + cat .tags
[vic-machine-server-tags:L4:0s] v1.4.0-dev-0-696cb97c
[vic-machine-server-publish:L0:0s] + /usr/local/bin/dockerd -g /var/lib/docker --dns 10.142.7.21 --dns 10.142.7.22 --dns 10.166.17.90
[vic-machine-server-publish:L67:1s] + /usr/local/bin/docker build --rm=true -f cmd/vic-machine-server/Dockerfile -t 00000000 . --pull=true --label org.label-schema.build-date=2018-04-26T18:11:26Z --label org.label-schema.vcs-ref=00000000 --label org.label-schema.vcs-url=
[vic-machine-server-publish:L84:80s] + /usr/local/bin/docker tag 00000000 gcr.io/octocat/hello-world:v1.4.0-dev-0-696cb97c
[vic-machine-server-publish:L86:81s] + /usr/local/bin/docker rmi 00000000

$> export DRONE_BUILD_EVENT=tag; export DRONE_BRANCH="releases/1.4.0"; drone exec --local .drone.local.yml
[vic-machine-server-tags:L0:0s] + echo -n "$(git describe --tags --abbrev=0)-0-$(git rev-parse --short=8 HEAD)" > .tags;
[vic-machine-server-tags:L1:0s] + if [ "tag" = "push" -a "releases/1.4.0" = "master" ];     then echo ",dev" >> .tags; fi
[vic-machine-server-tags:L2:0s] + if [ "tag" = "tag"  -a -n "$(echo "releases/1.4.0" | grep "releases/")" ]; then echo ",$(git describe --tags --abbrev=0),latest" >> .tags; fi
[vic-machine-server-tags:L3:0s] + cat .tags
[vic-machine-server-tags:L4:0s] v1.4.0-dev-0-696cb97c,v1.4.0-dev,latest
[vic-machine-server-publish:L0:0s] + /usr/local/bin/dockerd -g /var/lib/docker --dns 10.142.7.21 --dns 10.142.7.22 --dns 10.166.17.90
[vic-machine-server-publish:L67:1s] + /usr/local/bin/docker build --rm=true -f cmd/vic-machine-server/Dockerfile -t 00000000 . --pull=true --label org.label-schema.build-date=2018-04-26T18:26:49Z --label org.label-schema.vcs-ref=00000000 --label org.label-schema.vcs-url=
[vic-machine-server-publish:L84:82s] + /usr/local/bin/docker tag 00000000 gcr.io/octocat/hello-world:v1.4.0-dev-0-696cb97c
[vic-machine-server-publish:L85:82s] + /usr/local/bin/docker tag 00000000 gcr.io/octocat/hello-world:v1.4.0-dev
[vic-machine-server-publish:L86:82s] + /usr/local/bin/docker tag 00000000 gcr.io/octocat/hello-world:latest
```

<!--
To trigger a custom build with this PR, include one of these in the PR's body:
- To skip running tests (e.g. for a work-in-progress PR), add `[ci skip]` or `[skip ci]`
to the commit message or the PR title.
- To run the full test suite, use `[full ci]`.
- To run _one_ integration test or group, use `[specific ci=$test]`. Examples:
  - To run the `1-01-Docker-Info` suite: `[specific ci=1-01-Docker-Info]`
  - To run all suites under the `Group1-Docker-Commands` group: `[specific ci=Group1-Docker-Commands]`
- To skip running the unit tests, use `[skip unit]`.
- To fail fast (make normal failures fatal) during the integration testing, use `[fast fail]`.
-->
