### PR TITLE
[skip ci] Nimbus testbed for nfs volume nightly test

### DIFF
--- a/tests/manual-test-cases/Group5-Functional-Tests/5-22-NFS-Volume.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-22-NFS-Volume.robot
@@ -38,23 +38,14 @@ Setup ESX And NFS Suite
     Run Keyword And Ignore Error  Nimbus Cleanup  ${list}  ${false}
     Log To Console  \nStarting test...
 
-    ${esx1}  ${esx1_ip}=  Deploy Nimbus ESXi Server  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}
-    Open Connection  %{NIMBUS_GW}
-    Wait Until Keyword Succeeds  2 min  30 sec  Login  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}
-    ${POD}=  Fetch POD  ${esx1}
-    Log To Console  ${POD}
-    Close Connection
+    ${nfs}  ${nfs_ro}  ${esx1}  ${nfs_ip}  ${nfs_ro_ip}  ${esx1_ip}=  Deploy Simple NFS Testbed  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}  additional-args=--testbedSpecRubyFile /dbc/w3-dbc302/rashok/vic-nfs.rb --esxBuild ${ESX_VERSION} --esxPxeDir ${ESX_VERSION} --plugin testng
 
-    ${nfs}  ${nfs_ip}=  Deploy Nimbus NFS Datastore  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}  additional-args=--nimbus ${POD}
-
-    ${nfs_readonly}  ${nfs_readonly_ip}=  Deploy Nimbus NFS Datastore  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}  additional-args=--disk 5000000 --disk 5000000 --mountOpt ro --nfsOpt ro --mountPoint=storage1 --mountPoint=storage2 --nimbus ${POD}
-
-    Set Suite Variable  @{list}  ${esx1}  ${nfs}  ${nfs_readonly}
+    Set Suite Variable  @{list}  ${esx1}  ${nfs}  ${nfs_ro}
     Set Suite Variable  ${ESX1}  ${esx1}
     Set Suite Variable  ${ESX1_IP}  ${esx1_ip}
     Set Suite Variable  ${NFS_IP}  ${nfs_ip}
     Set Suite Variable  ${NFS}  ${nfs}
-    Set Suite Variable  ${NFS_READONLY_IP}  ${nfs_readonly_ip}
+    Set Suite Variable  ${NFS_READONLY_IP}  ${nfs_ro_ip}
 
     # Add the NFS servers to SSH known host list
     ${out}=  Run Keyword And Ignore Error  Run  sshpass -p %{DEPLOYED_PASSWORD} ssh -o StrictHostKeyChecking\=no root@${NFS_IP} exit
@@ -84,7 +75,7 @@ Setup ENV Variables for VIC Appliance Install
     Set Environment Variable  TEST_URL  ${ESX1_IP}
     Set Environment Variable  TEST_USERNAME  root
     Set Environment Variable  TEST_PASSWORD  ${NIMBUS_ESX_PASSWORD}
-    Set Environment Variable  TEST_DATASTORE  datastore1
+    Set Environment Variable  TEST_DATASTORE  local-0
     Set Environment Variable  TEST_TIMEOUT  30m
     Set Environment Variable  HOST_TYPE  ESXi
     Remove Environment Variable  TEST_DATACENTER
@@ -328,7 +319,6 @@ Docker Inspect Mount Data after Reboot
     Reboot VM and Verify Basic VCH Info
 
     Verify Volume Inspect Info  After VM Reboot  ${mntDataTestContainer}  ${checkList}
-
 
 Kill NFS Server
     Sleep  5 minutes

--- a/tests/resources/nimbus-testbeds/vic-nfs.rb
+++ b/tests/resources/nimbus-testbeds/vic-nfs.rb
@@ -1,0 +1,43 @@
+require '/mts/git/nimbus/lib/testframeworks/testng/testng.rb'
+oneGB = 1 * 1000 * 1000
+$testbed = Proc.new do |sharedStorageStyle, esxStyle|
+  esxStyle ||= 'fullInstall'
+  esxStyle = esxStyle.to_s
+  sharedStorageStyle = sharedStorageStyle.to_s
+
+  testbed = {
+    'version' => 3,
+    'name' => "nfs-1esx-#{sharedStorageStyle}-#{esxStyle}",
+    'esx' => [
+      {
+        'name' => "esx.0",
+        'style' => esxStyle,
+        'numMem' => 16 * 1024,
+        'numCPUs' => 6,
+        "disks" => [ 30 * oneGB, 30 * oneGB, 30 * oneGB],
+        'disableNfsMounts' => true,
+        'nics' => 2,
+        'staf' => false,
+        'desiredPassword' => 'e2eFunctionalTest',
+    }],
+    'nfs' => [{
+    'name' => 'dev-nfs',
+    'type' => 'NFS',
+    'nfsOpt' => 'rw',
+    'numMem' => 16 * 1024,
+    },
+    'nfs' => {
+    'name' => 'dev-nfs',
+    'type' => 'NFS',
+    'nfsOpt' => 'ro',
+    'numMem' => 16 * 1024,
+    }],
+  }
+end
+
+[:pxeBoot, :fullInstall].each do |esxStyle|
+    [:iscsi, :fc].each do |sharedStorageStyle|
+      testbedSpec = $testbed.call(sharedStorageStyle, esxStyle)
+      Nimbus::TestbedRegistry.registerTestbed testbedSpec
+    end
+  end


### PR DESCRIPTION
Updated the NFS Volume nightlies to build a full NFS test bed instead of relying on the unsupported pod placement calls.

Fixes #7642