### PR TITLE
management: Fix testCleanup call to missing method

### DIFF
--- a/lib/install/management/create_test.go
+++ b/lib/install/management/create_test.go
@@ -223,7 +223,7 @@ func testCleanup(op trace.Operation, sess *session.Session, conf *config.Virtual
 		return
 	}
 
-	d.deleteVCHFolder(d.session.VCHFolder)
+	d.deleteFolder(d.session.VCHFolder)
 
 	// in this case we should expect the folder to be gone.
 	folder, err := d.session.Finder.Folder(d.op, path.Join(d.session.VMFolder.InventoryPath, conf.Name))


### PR DESCRIPTION
The `testCleanup` method failed because type `*Dispatcher` had no method `deleteVCHFolder`. Instead, call `deleteFolder`, which is defined.

---

A [GitHub search](https://github.com/vmware/vic/search?q=deleteVCHFolder) seems to confirm what my local system shows; the test is referencing a method that doesn't exist. I do not know why this was not caught by CI.