### PR TITLE
Refactor Validator to eliminate unnecessary state

### DIFF
--- a/cmd/vic-machine/configure/configure.go
+++ b/cmd/vic-machine/configure/configure.go
@@ -345,7 +345,7 @@ func (c *Configure) Run(clic *cli.Context) (err error) {
 		op.Errorf("Configuring cannot continue - target validation failed: %s", err)
 		return errors.New("configure failed")
 	}
-	executor := management.NewDispatcher(validator.Context, validator.Session, management.ConfigureAction, c.Force)
+	executor := management.NewDispatcher(op, validator.Session, management.ConfigureAction, c.Force)
 
 	var vch *vm.VirtualMachine
 	if c.Data.ID != "" {

--- a/cmd/vic-machine/configure/configure.go
+++ b/cmd/vic-machine/configure/configure.go
@@ -340,7 +340,7 @@ func (c *Configure) Run(clic *cli.Context) (err error) {
 	}
 	defer validator.Session().Logout(parentOp) // parentOp is used here to ensure the logout occurs, even in the event of timeout
 
-	_, err = validator.ValidateTarget(op, c.Data)
+	_, err = validator.ValidateTarget(op, c.Data, false)
 	if err != nil {
 		op.Errorf("Configuring cannot continue - target validation failed: %s", err)
 		return errors.New("configure failed")
@@ -444,7 +444,7 @@ func (c *Configure) Run(clic *cli.Context) (err error) {
 	}
 
 	// evaluate merged configuration
-	newConfig, err := validator.Validate(op, c.Data)
+	newConfig, err := validator.Validate(op, c.Data, false)
 	if err != nil {
 		op.Error("Configuring cannot continue: configuration validation failed")
 		return err

--- a/cmd/vic-machine/configure/configure.go
+++ b/cmd/vic-machine/configure/configure.go
@@ -338,14 +338,14 @@ func (c *Configure) Run(clic *cli.Context) (err error) {
 		op.Errorf("Configure cannot continue - failed to create validator: %s", err)
 		return errors.New("configure failed")
 	}
-	defer validator.Session.Logout(parentOp) // parentOp is used here to ensure the logout occurs, even in the event of timeout
+	defer validator.Session().Logout(parentOp) // parentOp is used here to ensure the logout occurs, even in the event of timeout
 
 	_, err = validator.ValidateTarget(op, c.Data)
 	if err != nil {
 		op.Errorf("Configuring cannot continue - target validation failed: %s", err)
 		return errors.New("configure failed")
 	}
-	executor := management.NewDispatcher(op, validator.Session, management.ConfigureAction, c.Force)
+	executor := management.NewDispatcher(op, validator.Session(), management.ConfigureAction, c.Force)
 
 	var vch *vm.VirtualMachine
 	if c.Data.ID != "" {
@@ -390,14 +390,14 @@ func (c *Configure) Run(clic *cli.Context) (err error) {
 	}
 
 	// Convert guestinfo *VirtualContainerHost back to *Data, decrypt secret data
-	oldData, err := validate.NewDataFromConfig(op, validator.Session.Finder, vchConfig)
+	oldData, err := validate.NewDataFromConfig(op, validator.Session().Finder, vchConfig)
 	if err != nil {
 		op.Error("Configuring cannot continue: configuration conversion failed")
 		op.Error(err)
 		return err
 	}
 
-	if err = validate.SetDataFromVM(op, validator.Session.Finder, vch, oldData); err != nil {
+	if err = validate.SetDataFromVM(op, validator.Session().Finder, vch, oldData); err != nil {
 		op.Error("Configuring cannot continue: querying configuration from VM failed")
 		op.Error(err)
 		return err

--- a/cmd/vic-machine/create/create.go
+++ b/cmd/vic-machine/create/create.go
@@ -684,7 +684,7 @@ func (c *Create) Run(clic *cli.Context) (err error) {
 		op.Error("Create cannot continue: failed to create validator")
 		return err
 	}
-	defer validator.Session.Logout(op)
+	defer validator.Session().Logout(op)
 
 	vchConfig, err := validator.Validate(op, c.Data)
 	if err != nil {
@@ -708,7 +708,7 @@ func (c *Create) Run(clic *cli.Context) (err error) {
 	// separate initial validation from dispatch of creation task
 	op.Info("")
 
-	executor := management.NewDispatcher(op, validator.Session, management.CreateAction, c.Force)
+	executor := management.NewDispatcher(op, validator.Session(), management.CreateAction, c.Force)
 	executor.InitDiagnosticLogsFromConf(vchConfig)
 	if err = executor.CreateVCH(vchConfig, vConfig, datastoreLog); err != nil {
 		executor.CollectDiagnosticLogs()

--- a/cmd/vic-machine/create/create.go
+++ b/cmd/vic-machine/create/create.go
@@ -686,7 +686,7 @@ func (c *Create) Run(clic *cli.Context) (err error) {
 	}
 	defer validator.Session().Logout(op)
 
-	vchConfig, err := validator.Validate(op, c.Data)
+	vchConfig, err := validator.Validate(op, c.Data, false)
 	if err != nil {
 		op.Error("Create cannot continue: configuration validation failed")
 		return err

--- a/cmd/vic-machine/debug/debug.go
+++ b/cmd/vic-machine/debug/debug.go
@@ -140,7 +140,7 @@ func (d *Debug) Run(clic *cli.Context) (err error) {
 	}
 	defer validator.Session().Logout(op)
 
-	_, err = validator.ValidateTarget(op, d.Data)
+	_, err = validator.ValidateTarget(op, d.Data, false)
 	if err != nil {
 		op.Errorf("Debug cannot continue - target validation failed: %s", err)
 		return errors.New("debug failed")

--- a/cmd/vic-machine/debug/debug.go
+++ b/cmd/vic-machine/debug/debug.go
@@ -146,7 +146,7 @@ func (d *Debug) Run(clic *cli.Context) (err error) {
 		return errors.New("debug failed")
 	}
 
-	executor := management.NewDispatcher(validator.Context, validator.Session, management.DebugAction, d.Force)
+	executor := management.NewDispatcher(op, validator.Session, management.DebugAction, d.Force)
 
 	var vch *vm.VirtualMachine
 	if d.Data.ID != "" {

--- a/cmd/vic-machine/debug/debug.go
+++ b/cmd/vic-machine/debug/debug.go
@@ -138,7 +138,7 @@ func (d *Debug) Run(clic *cli.Context) (err error) {
 		op.Errorf("Debug cannot continue - failed to create validator: %s", err)
 		return errors.New("debug failed")
 	}
-	defer validator.Session.Logout(op)
+	defer validator.Session().Logout(op)
 
 	_, err = validator.ValidateTarget(op, d.Data)
 	if err != nil {
@@ -146,7 +146,7 @@ func (d *Debug) Run(clic *cli.Context) (err error) {
 		return errors.New("debug failed")
 	}
 
-	executor := management.NewDispatcher(op, validator.Session, management.DebugAction, d.Force)
+	executor := management.NewDispatcher(op, validator.Session(), management.DebugAction, d.Force)
 
 	var vch *vm.VirtualMachine
 	if d.Data.ID != "" {

--- a/cmd/vic-machine/delete/delete.go
+++ b/cmd/vic-machine/delete/delete.go
@@ -121,7 +121,7 @@ func (d *Uninstall) Run(clic *cli.Context) (err error) {
 		return errors.New("delete failed")
 	}
 
-	executor := management.NewDispatcher(validator.Context, validator.Session, management.DeleteAction, d.Force)
+	executor := management.NewDispatcher(op, validator.Session, management.DeleteAction, d.Force)
 
 	var vch *vm.VirtualMachine
 	if d.Data.ID != "" {

--- a/cmd/vic-machine/delete/delete.go
+++ b/cmd/vic-machine/delete/delete.go
@@ -115,7 +115,7 @@ func (d *Uninstall) Run(clic *cli.Context) (err error) {
 		return errors.New("delete failed")
 	}
 	defer validator.Session().Logout(op)
-	_, err = validator.ValidateTarget(op, d.Data)
+	_, err = validator.ValidateTarget(op, d.Data, false)
 	if err != nil {
 		op.Errorf("Delete cannot continue - target validation failed: %s", err)
 		return errors.New("delete failed")

--- a/cmd/vic-machine/delete/delete.go
+++ b/cmd/vic-machine/delete/delete.go
@@ -114,14 +114,14 @@ func (d *Uninstall) Run(clic *cli.Context) (err error) {
 		op.Errorf("Delete cannot continue - failed to create validator: %s", err)
 		return errors.New("delete failed")
 	}
-	defer validator.Session.Logout(op)
+	defer validator.Session().Logout(op)
 	_, err = validator.ValidateTarget(op, d.Data)
 	if err != nil {
 		op.Errorf("Delete cannot continue - target validation failed: %s", err)
 		return errors.New("delete failed")
 	}
 
-	executor := management.NewDispatcher(op, validator.Session, management.DeleteAction, d.Force)
+	executor := management.NewDispatcher(op, validator.Session(), management.DeleteAction, d.Force)
 
 	var vch *vm.VirtualMachine
 	if d.Data.ID != "" {

--- a/cmd/vic-machine/inspect/inspect.go
+++ b/cmd/vic-machine/inspect/inspect.go
@@ -159,7 +159,7 @@ func (i *Inspect) run(clic *cli.Context, op trace.Operation, cmd command) (err e
 		return errors.New("inspect failed")
 	}
 
-	executor := management.NewDispatcher(validator.Context, validator.Session, management.InspectAction, i.Force)
+	executor := management.NewDispatcher(op, validator.Session, management.InspectAction, i.Force)
 
 	var vch *vm.VirtualMachine
 	if i.Data.ID != "" {

--- a/cmd/vic-machine/inspect/inspect.go
+++ b/cmd/vic-machine/inspect/inspect.go
@@ -153,7 +153,7 @@ func (i *Inspect) run(clic *cli.Context, op trace.Operation, cmd command) (err e
 	}
 	defer validator.Session().Logout(op)
 
-	_, err = validator.ValidateTarget(op, i.Data)
+	_, err = validator.ValidateTarget(op, i.Data, false)
 	if err != nil {
 		op.Errorf("Inspect cannot continue - target validation failed: %s", err)
 		return errors.New("inspect failed")

--- a/cmd/vic-machine/inspect/inspect.go
+++ b/cmd/vic-machine/inspect/inspect.go
@@ -151,7 +151,7 @@ func (i *Inspect) run(clic *cli.Context, op trace.Operation, cmd command) (err e
 		op.Errorf("Inspect cannot continue - failed to create validator: %s", err)
 		return errors.New("inspect failed")
 	}
-	defer validator.Session.Logout(op)
+	defer validator.Session().Logout(op)
 
 	_, err = validator.ValidateTarget(op, i.Data)
 	if err != nil {
@@ -159,7 +159,7 @@ func (i *Inspect) run(clic *cli.Context, op trace.Operation, cmd command) (err e
 		return errors.New("inspect failed")
 	}
 
-	executor := management.NewDispatcher(op, validator.Session, management.InspectAction, i.Force)
+	executor := management.NewDispatcher(op, validator.Session(), management.InspectAction, i.Force)
 
 	var vch *vm.VirtualMachine
 	if i.Data.ID != "" {
@@ -196,7 +196,7 @@ func (i *Inspect) RunConfig(clic *cli.Context) (err error) {
 	}
 
 	return i.run(clic, op, func(s state) error {
-		err = i.showConfiguration(s.op, s.validator.Session.Finder, s.vchConfig, s.vch)
+		err = i.showConfiguration(s.op, s.validator.Session().Finder, s.vchConfig, s.vch)
 		if err != nil {
 			op.Error("Failed to print Virtual Container Host configuration")
 			op.Error(err)

--- a/cmd/vic-machine/list/list.go
+++ b/cmd/vic-machine/list/list.go
@@ -178,7 +178,7 @@ func (l *List) Run(clic *cli.Context) (err error) {
 	}
 
 	executor := management.NewDispatcher(validator.Context, validator.Session, management.ListAction, false)
-	vchs, err := executor.SearchVCHs(validator.ClusterPath)
+	vchs, err := executor.SearchVCHs(validator.Session.ClusterPath)
 	if err != nil {
 		op.Errorf("List cannot continue - failed to search VCHs in %s: %s", validator.Session.PoolPath, err)
 	}

--- a/cmd/vic-machine/list/list.go
+++ b/cmd/vic-machine/list/list.go
@@ -180,7 +180,7 @@ func (l *List) Run(clic *cli.Context) (err error) {
 	executor := management.NewDispatcher(validator.Context, validator.Session, management.ListAction, false)
 	vchs, err := executor.SearchVCHs(validator.ClusterPath)
 	if err != nil {
-		op.Errorf("List cannot continue - failed to search VCHs in %s: %s", validator.ResourcePoolPath, err)
+		op.Errorf("List cannot continue - failed to search VCHs in %s: %s", validator.Session.PoolPath, err)
 	}
 	l.prettyPrint(op, clic, vchs, executor)
 	return nil

--- a/cmd/vic-machine/list/list.go
+++ b/cmd/vic-machine/list/list.go
@@ -163,10 +163,7 @@ func (l *List) Run(clic *cli.Context) (err error) {
 	}
 	defer validator.Session().Logout(op)
 
-	// If dc is not set, and multiple datacenter is available, vic-machine ls will list VCHs under all datacenters.
-	validator.AllowEmptyDC()
-
-	_, err = validator.ValidateTarget(op, l.Data)
+	_, err = validator.ValidateTarget(op, l.Data, true)
 	if err != nil {
 		op.Errorf("List cannot continue - target validation failed: %s", err)
 		return errors.New("list failed")

--- a/cmd/vic-machine/list/list.go
+++ b/cmd/vic-machine/list/list.go
@@ -177,7 +177,7 @@ func (l *List) Run(clic *cli.Context) (err error) {
 		return errors.New("list failed")
 	}
 
-	executor := management.NewDispatcher(validator.Context, validator.Session, management.ListAction, false)
+	executor := management.NewDispatcher(op, validator.Session, management.ListAction, false)
 	vchs, err := executor.SearchVCHs(validator.Session.ClusterPath)
 	if err != nil {
 		op.Errorf("List cannot continue - failed to search VCHs in %s: %s", validator.Session.PoolPath, err)

--- a/cmd/vic-machine/list/list.go
+++ b/cmd/vic-machine/list/list.go
@@ -161,7 +161,7 @@ func (l *List) Run(clic *cli.Context) (err error) {
 		op.Errorf("List cannot continue - failed to create validator: %s", err)
 		return errors.New("list failed")
 	}
-	defer validator.Session.Logout(op)
+	defer validator.Session().Logout(op)
 
 	// If dc is not set, and multiple datacenter is available, vic-machine ls will list VCHs under all datacenters.
 	validator.AllowEmptyDC()
@@ -177,10 +177,10 @@ func (l *List) Run(clic *cli.Context) (err error) {
 		return errors.New("list failed")
 	}
 
-	executor := management.NewDispatcher(op, validator.Session, management.ListAction, false)
-	vchs, err := executor.SearchVCHs(validator.Session.ClusterPath)
+	executor := management.NewDispatcher(op, validator.Session(), management.ListAction, false)
+	vchs, err := executor.SearchVCHs(validator.Session().ClusterPath)
 	if err != nil {
-		op.Errorf("List cannot continue - failed to search VCHs in %s: %s", validator.Session.PoolPath, err)
+		op.Errorf("List cannot continue - failed to search VCHs in %s: %s", validator.Session().PoolPath, err)
 	}
 	l.prettyPrint(op, clic, vchs, executor)
 	return nil

--- a/cmd/vic-machine/update/firewall.go
+++ b/cmd/vic-machine/update/firewall.go
@@ -140,7 +140,7 @@ func (i *UpdateFw) Run(clic *cli.Context) (err error) {
 		return errors.New("update firewall failed")
 	}
 
-	executor := management.NewDispatcher(validator.Context, validator.Session, management.UpdateAction, false)
+	executor := management.NewDispatcher(op, validator.Session, management.UpdateAction, false)
 
 	if i.enableFw {
 		op.Info("")

--- a/cmd/vic-machine/update/firewall.go
+++ b/cmd/vic-machine/update/firewall.go
@@ -129,7 +129,7 @@ func (i *UpdateFw) Run(clic *cli.Context) (err error) {
 	}
 	defer validator.Session().Logout(op)
 
-	_, err = validator.ValidateTarget(op, i.Data)
+	_, err = validator.ValidateTarget(op, i.Data, false)
 	if err != nil {
 		op.Errorf("Update cannot continue - target validation failed: %s", err)
 		return errors.New("update firewall failed")

--- a/cmd/vic-machine/update/firewall.go
+++ b/cmd/vic-machine/update/firewall.go
@@ -127,7 +127,7 @@ func (i *UpdateFw) Run(clic *cli.Context) (err error) {
 		op.Errorf("Update cannot continue - failed to create validator: %s", err)
 		return errors.New("update firewall failed")
 	}
-	defer validator.Session.Logout(op)
+	defer validator.Session().Logout(op)
 
 	_, err = validator.ValidateTarget(op, i.Data)
 	if err != nil {
@@ -140,7 +140,7 @@ func (i *UpdateFw) Run(clic *cli.Context) (err error) {
 		return errors.New("update firewall failed")
 	}
 
-	executor := management.NewDispatcher(op, validator.Session, management.UpdateAction, false)
+	executor := management.NewDispatcher(op, validator.Session(), management.UpdateAction, false)
 
 	if i.enableFw {
 		op.Info("")

--- a/cmd/vic-machine/upgrade/upgrade.go
+++ b/cmd/vic-machine/upgrade/upgrade.go
@@ -142,7 +142,7 @@ func (u *Upgrade) Run(clic *cli.Context) (err error) {
 		return errors.New("upgrade failed")
 	}
 
-	executor := management.NewDispatcher(validator.Context, validator.Session, action, u.Force)
+	executor := management.NewDispatcher(op, validator.Session, action, u.Force)
 
 	var vch *vm.VirtualMachine
 	if u.Data.ID != "" {

--- a/cmd/vic-machine/upgrade/upgrade.go
+++ b/cmd/vic-machine/upgrade/upgrade.go
@@ -134,7 +134,7 @@ func (u *Upgrade) Run(clic *cli.Context) (err error) {
 		op.Errorf("Upgrade cannot continue - failed to create validator: %s", err)
 		return errors.New("upgrade failed")
 	}
-	defer validator.Session.Logout(op)
+	defer validator.Session().Logout(op)
 
 	_, err = validator.ValidateTarget(op, u.Data)
 	if err != nil {
@@ -142,7 +142,7 @@ func (u *Upgrade) Run(clic *cli.Context) (err error) {
 		return errors.New("upgrade failed")
 	}
 
-	executor := management.NewDispatcher(op, validator.Session, action, u.Force)
+	executor := management.NewDispatcher(op, validator.Session(), action, u.Force)
 
 	var vch *vm.VirtualMachine
 	if u.Data.ID != "" {

--- a/cmd/vic-machine/upgrade/upgrade.go
+++ b/cmd/vic-machine/upgrade/upgrade.go
@@ -136,7 +136,7 @@ func (u *Upgrade) Run(clic *cli.Context) (err error) {
 	}
 	defer validator.Session().Logout(op)
 
-	_, err = validator.ValidateTarget(op, u.Data)
+	_, err = validator.ValidateTarget(op, u.Data, false)
 	if err != nil {
 		op.Errorf("Upgrade cannot continue - target validation failed: %s", err)
 		return errors.New("upgrade failed")

--- a/lib/apiservers/service/restapi/handlers/common.go
+++ b/lib/apiservers/service/restapi/handlers/common.go
@@ -95,9 +95,8 @@ func buildDataAndValidateTarget(op trace.Operation, params buildDataParams, prin
 			return data, nil, util.NewError(http.StatusBadRequest, "Validation Error: datacenter parameter is not a datacenter moref")
 		}
 
-		// Set validator datacenter path and correspondent validator session config
-		v.SetDatacenterPath(dc.Name())
-		v.Session().DatacenterPath = v.DatacenterPath()
+		// Set datacenter path and corresponding finder config
+		v.Session().DatacenterPath = dc.Name()
 		v.Session().Datacenter = dc
 		v.Session().Finder.SetDatacenter(dc)
 

--- a/lib/apiservers/service/restapi/handlers/common.go
+++ b/lib/apiservers/service/restapi/handlers/common.go
@@ -139,13 +139,13 @@ func upgradeStatusMessage(op trace.Operation, vch *vm.VirtualMachine, installerV
 }
 
 func getVCHConfig(op trace.Operation, d *data.Data, validator *validate.Validator) (*config.VirtualContainerHostConfigSpec, error) {
-	executor := management.NewDispatcher(validator.Context, validator.Session, management.NoAction, false)
+	executor := management.NewDispatcher(op, validator.Session, management.NoAction, false)
 	vch, err := executor.NewVCHFromID(d.ID)
 	if err != nil {
 		return nil, util.NewError(http.StatusNotFound, fmt.Sprintf("Unable to find VCH %s: %s", d.ID, err))
 	}
 
-	err = validate.SetDataFromVM(validator.Context, validator.Session.Finder, vch, d)
+	err = validate.SetDataFromVM(op, validator.Session.Finder, vch, d)
 	if err != nil {
 		return nil, util.NewError(http.StatusInternalServerError, fmt.Sprintf("Failed to load VCH data: %s", err))
 	}

--- a/lib/apiservers/service/restapi/handlers/common.go
+++ b/lib/apiservers/service/restapi/handlers/common.go
@@ -77,6 +77,7 @@ func buildDataAndValidateTarget(op trace.Operation, params buildDataParams, prin
 
 	// TODO (#6032): clean this up
 	var validator *validate.Validator
+	var allowEmptyDC bool
 	if params.datacenter != nil {
 		v, err := validate.NewValidator(op, data)
 		if err != nil {
@@ -117,12 +118,12 @@ func buildDataAndValidateTarget(op trace.Operation, params buildDataParams, prin
 		}
 
 		// If dc is not set, and multiple datacenters are available, operate on all datacenters.
-		v.AllowEmptyDC()
+		allowEmptyDC = true
 
 		validator = v
 	}
 
-	if _, err := validator.ValidateTarget(op, data); err != nil {
+	if _, err := validator.ValidateTarget(op, data, allowEmptyDC); err != nil {
 		return data, nil, util.NewError(http.StatusBadRequest, "Target validation failed: %s", err)
 	}
 

--- a/lib/apiservers/service/restapi/handlers/common.go
+++ b/lib/apiservers/service/restapi/handlers/common.go
@@ -96,8 +96,8 @@ func buildDataAndValidateTarget(op trace.Operation, params buildDataParams, prin
 		}
 
 		// Set validator datacenter path and correspondent validator session config
-		v.DatacenterPath = dc.Name()
-		v.Session.DatacenterPath = v.DatacenterPath
+		v.SetDatacenterPath(dc.Name())
+		v.Session.DatacenterPath = v.DatacenterPath()
 		v.Session.Datacenter = dc
 		v.Session.Finder.SetDatacenter(dc)
 

--- a/lib/apiservers/service/restapi/handlers/common.go
+++ b/lib/apiservers/service/restapi/handlers/common.go
@@ -85,7 +85,7 @@ func buildDataAndValidateTarget(op trace.Operation, params buildDataParams, prin
 
 		datacenterManagedObjectReference := types.ManagedObjectReference{Type: "Datacenter", Value: *params.datacenter}
 
-		datacenterObject, err := v.Session.Finder.ObjectReference(op, datacenterManagedObjectReference)
+		datacenterObject, err := v.Session().Finder.ObjectReference(op, datacenterManagedObjectReference)
 		if err != nil {
 			return nil, nil, util.WrapError(http.StatusNotFound, err)
 		}
@@ -97,17 +97,17 @@ func buildDataAndValidateTarget(op trace.Operation, params buildDataParams, prin
 
 		// Set validator datacenter path and correspondent validator session config
 		v.SetDatacenterPath(dc.Name())
-		v.Session.DatacenterPath = v.DatacenterPath()
-		v.Session.Datacenter = dc
-		v.Session.Finder.SetDatacenter(dc)
+		v.Session().DatacenterPath = v.DatacenterPath()
+		v.Session().Datacenter = dc
+		v.Session().Finder.SetDatacenter(dc)
 
-		// Do what validator.session.Populate would have done if datacenterPath is set
-		if v.Session.Datacenter != nil {
-			folders, err := v.Session.Datacenter.Folders(op)
+		// Do what validator.Session().Populate would have done if datacenterPath is set
+		if v.Session().Datacenter != nil {
+			folders, err := v.Session().Datacenter.Folders(op)
 			if err != nil {
 				return data, nil, util.NewError(http.StatusBadRequest, "Validation Error: error finding datacenter folders: %s", err)
 			}
-			v.Session.VMFolder = folders.VmFolder
+			v.Session().VMFolder = folders.VmFolder
 		}
 
 		validator = v
@@ -139,13 +139,13 @@ func upgradeStatusMessage(op trace.Operation, vch *vm.VirtualMachine, installerV
 }
 
 func getVCHConfig(op trace.Operation, d *data.Data, validator *validate.Validator) (*config.VirtualContainerHostConfigSpec, error) {
-	executor := management.NewDispatcher(op, validator.Session, management.NoAction, false)
+	executor := management.NewDispatcher(op, validator.Session(), management.NoAction, false)
 	vch, err := executor.NewVCHFromID(d.ID)
 	if err != nil {
 		return nil, util.NewError(http.StatusNotFound, fmt.Sprintf("Unable to find VCH %s: %s", d.ID, err))
 	}
 
-	err = validate.SetDataFromVM(op, validator.Session.Finder, vch, d)
+	err = validate.SetDataFromVM(op, validator.Session().Finder, vch, d)
 	if err != nil {
 		return nil, util.NewError(http.StatusInternalServerError, fmt.Sprintf("Failed to load VCH data: %s", err))
 	}

--- a/lib/apiservers/service/restapi/handlers/vch_create.go
+++ b/lib/apiservers/service/restapi/handlers/vch_create.go
@@ -83,7 +83,7 @@ func (h *VCHCreate) Handle(params operations.PostTargetTargetVchParams, principa
 		return operations.NewPostTargetTargetVchDefault(util.StatusCode(err)).WithPayload(&models.Error{Message: err.Error()})
 	}
 
-	c, err := buildCreate(op, d, finder(validator.Session.Finder), params.Vch)
+	c, err := buildCreate(op, d, finder(validator.Session().Finder), params.Vch)
 	if err != nil {
 		return operations.NewPostTargetTargetVchDefault(util.StatusCode(err)).WithPayload(&models.Error{Message: err.Error()})
 	}
@@ -114,7 +114,7 @@ func (h *VCHDatacenterCreate) Handle(params operations.PostTargetTargetDatacente
 		return operations.NewPostTargetTargetDatacenterDatacenterVchDefault(util.StatusCode(err)).WithPayload(&models.Error{Message: err.Error()})
 	}
 
-	c, err := buildCreate(op, d, validator.Session.Finder, params.Vch)
+	c, err := buildCreate(op, d, validator.Session().Finder, params.Vch)
 	if err != nil {
 		return operations.NewPostTargetTargetDatacenterDatacenterVchDefault(util.StatusCode(err)).WithPayload(&models.Error{Message: err.Error()})
 	}
@@ -475,7 +475,7 @@ func handleCreate(op trace.Operation, c *create.Create, validator *validate.Vali
 	vConfig.HTTPProxy = c.HTTPProxy
 	vConfig.HTTPSProxy = c.HTTPSProxy
 
-	executor := management.NewDispatcher(op, validator.Session, management.CreateAction, false)
+	executor := management.NewDispatcher(op, validator.Session(), management.CreateAction, false)
 	err = executor.CreateVCH(vchConfig, vConfig, receiver)
 	if err != nil {
 		return nil, util.NewError(http.StatusInternalServerError, fmt.Sprintf("Failed to create VCH: %s", err))

--- a/lib/apiservers/service/restapi/handlers/vch_create.go
+++ b/lib/apiservers/service/restapi/handlers/vch_create.go
@@ -453,7 +453,7 @@ func buildCreate(op trace.Operation, d *data.Data, finder finder, vch *models.VC
 }
 
 func handleCreate(op trace.Operation, c *create.Create, validator *validate.Validator, receiver vchlog.Receiver) (*strfmt.URI, error) {
-	vchConfig, err := validator.Validate(op, c.Data)
+	vchConfig, err := validator.Validate(op, c.Data, false)
 	if err != nil {
 		issues := validator.GetIssues()
 		messages := make([]string, 0, len(issues))

--- a/lib/apiservers/service/restapi/handlers/vch_delete.go
+++ b/lib/apiservers/service/restapi/handlers/vch_delete.go
@@ -84,13 +84,13 @@ func (h *VCHDatacenterDelete) Handle(params operations.DeleteTargetTargetDatacen
 }
 
 func deleteVCH(op trace.Operation, d *data.Data, validator *validate.Validator, specification *models.DeletionSpecification) error {
-	executor := management.NewDispatcher(validator.Context, validator.Session, management.DeleteAction, false)
+	executor := management.NewDispatcher(op, validator.Session, management.DeleteAction, false)
 	vch, err := executor.NewVCHFromID(d.ID)
 	if err != nil {
 		return util.NewError(http.StatusNotFound, fmt.Sprintf("Failed to find VCH: %s", err))
 	}
 
-	err = validate.SetDataFromVM(validator.Context, validator.Session.Finder, vch, d)
+	err = validate.SetDataFromVM(op, validator.Session.Finder, vch, d)
 	if err != nil {
 		return util.NewError(http.StatusInternalServerError, fmt.Sprintf("Failed to load VCH data: %s", err))
 	}

--- a/lib/apiservers/service/restapi/handlers/vch_delete.go
+++ b/lib/apiservers/service/restapi/handlers/vch_delete.go
@@ -84,13 +84,13 @@ func (h *VCHDatacenterDelete) Handle(params operations.DeleteTargetTargetDatacen
 }
 
 func deleteVCH(op trace.Operation, d *data.Data, validator *validate.Validator, specification *models.DeletionSpecification) error {
-	executor := management.NewDispatcher(op, validator.Session, management.DeleteAction, false)
+	executor := management.NewDispatcher(op, validator.Session(), management.DeleteAction, false)
 	vch, err := executor.NewVCHFromID(d.ID)
 	if err != nil {
 		return util.NewError(http.StatusNotFound, fmt.Sprintf("Failed to find VCH: %s", err))
 	}
 
-	err = validate.SetDataFromVM(op, validator.Session.Finder, vch, d)
+	err = validate.SetDataFromVM(op, validator.Session().Finder, vch, d)
 	if err != nil {
 		return util.NewError(http.StatusInternalServerError, fmt.Sprintf("Failed to load VCH data: %s", err))
 	}

--- a/lib/apiservers/service/restapi/handlers/vch_get.go
+++ b/lib/apiservers/service/restapi/handlers/vch_get.go
@@ -95,13 +95,13 @@ func (h *VCHDatacenterGet) Handle(params operations.GetTargetTargetDatacenterDat
 }
 
 func getVCH(op trace.Operation, d *data.Data, validator *validate.Validator) (*models.VCH, error) {
-	executor := management.NewDispatcher(op, validator.Session, management.NoAction, false)
+	executor := management.NewDispatcher(op, validator.Session(), management.NoAction, false)
 	vch, err := executor.NewVCHFromID(d.ID)
 	if err != nil {
 		return nil, util.NewError(http.StatusNotFound, fmt.Sprintf("Failed to inspect VCH: %s", err))
 	}
 
-	err = validate.SetDataFromVM(op, validator.Session.Finder, vch, d)
+	err = validate.SetDataFromVM(op, validator.Session().Finder, vch, d)
 	if err != nil {
 		return nil, util.NewError(http.StatusInternalServerError, fmt.Sprintf("Failed to load VCH data: %s", err))
 	}

--- a/lib/apiservers/service/restapi/handlers/vch_get.go
+++ b/lib/apiservers/service/restapi/handlers/vch_get.go
@@ -95,13 +95,13 @@ func (h *VCHDatacenterGet) Handle(params operations.GetTargetTargetDatacenterDat
 }
 
 func getVCH(op trace.Operation, d *data.Data, validator *validate.Validator) (*models.VCH, error) {
-	executor := management.NewDispatcher(validator.Context, validator.Session, management.NoAction, false)
+	executor := management.NewDispatcher(op, validator.Session, management.NoAction, false)
 	vch, err := executor.NewVCHFromID(d.ID)
 	if err != nil {
 		return nil, util.NewError(http.StatusNotFound, fmt.Sprintf("Failed to inspect VCH: %s", err))
 	}
 
-	err = validate.SetDataFromVM(validator.Context, validator.Session.Finder, vch, d)
+	err = validate.SetDataFromVM(op, validator.Session.Finder, vch, d)
 	if err != nil {
 		return nil, util.NewError(http.StatusInternalServerError, fmt.Sprintf("Failed to load VCH data: %s", err))
 	}

--- a/lib/apiservers/service/restapi/handlers/vch_list_get.go
+++ b/lib/apiservers/service/restapi/handlers/vch_list_get.go
@@ -87,7 +87,7 @@ func (h *VCHDatacenterListGet) Handle(params operations.GetTargetTargetDatacente
 func listVCHs(op trace.Operation, d *data.Data, validator *validate.Validator) ([]*models.VCHListItem, error) {
 
 	executor := management.NewDispatcher(validator.Context, validator.Session, management.NoAction, false)
-	vchs, err := executor.SearchVCHs(validator.ClusterPath)
+	vchs, err := executor.SearchVCHs(validator.Session.ClusterPath)
 	if err != nil {
 		return nil, util.NewError(http.StatusInternalServerError, fmt.Sprintf("Failed to search VCHs in %s: %s", validator.Session.PoolPath, err))
 	}

--- a/lib/apiservers/service/restapi/handlers/vch_list_get.go
+++ b/lib/apiservers/service/restapi/handlers/vch_list_get.go
@@ -86,7 +86,7 @@ func (h *VCHDatacenterListGet) Handle(params operations.GetTargetTargetDatacente
 
 func listVCHs(op trace.Operation, d *data.Data, validator *validate.Validator) ([]*models.VCHListItem, error) {
 
-	executor := management.NewDispatcher(validator.Context, validator.Session, management.NoAction, false)
+	executor := management.NewDispatcher(op, validator.Session, management.NoAction, false)
 	vchs, err := executor.SearchVCHs(validator.Session.ClusterPath)
 	if err != nil {
 		return nil, util.NewError(http.StatusInternalServerError, fmt.Sprintf("Failed to search VCHs in %s: %s", validator.Session.PoolPath, err))

--- a/lib/apiservers/service/restapi/handlers/vch_list_get.go
+++ b/lib/apiservers/service/restapi/handlers/vch_list_get.go
@@ -89,7 +89,7 @@ func listVCHs(op trace.Operation, d *data.Data, validator *validate.Validator) (
 	executor := management.NewDispatcher(validator.Context, validator.Session, management.NoAction, false)
 	vchs, err := executor.SearchVCHs(validator.ClusterPath)
 	if err != nil {
-		return nil, util.NewError(http.StatusInternalServerError, fmt.Sprintf("Failed to search VCHs in %s: %s", validator.ResourcePoolPath, err))
+		return nil, util.NewError(http.StatusInternalServerError, fmt.Sprintf("Failed to search VCHs in %s: %s", validator.Session.PoolPath, err))
 	}
 
 	return vchsToModels(op, vchs, executor), nil

--- a/lib/apiservers/service/restapi/handlers/vch_list_get.go
+++ b/lib/apiservers/service/restapi/handlers/vch_list_get.go
@@ -86,10 +86,10 @@ func (h *VCHDatacenterListGet) Handle(params operations.GetTargetTargetDatacente
 
 func listVCHs(op trace.Operation, d *data.Data, validator *validate.Validator) ([]*models.VCHListItem, error) {
 
-	executor := management.NewDispatcher(op, validator.Session, management.NoAction, false)
-	vchs, err := executor.SearchVCHs(validator.Session.ClusterPath)
+	executor := management.NewDispatcher(op, validator.Session(), management.NoAction, false)
+	vchs, err := executor.SearchVCHs(validator.Session().ClusterPath)
 	if err != nil {
-		return nil, util.NewError(http.StatusInternalServerError, fmt.Sprintf("Failed to search VCHs in %s: %s", validator.Session.PoolPath, err))
+		return nil, util.NewError(http.StatusInternalServerError, fmt.Sprintf("Failed to search VCHs in %s: %s", validator.Session().PoolPath, err))
 	}
 
 	return vchsToModels(op, vchs, executor), nil

--- a/lib/apiservers/service/restapi/handlers/vch_log_get.go
+++ b/lib/apiservers/service/restapi/handlers/vch_log_get.go
@@ -97,13 +97,13 @@ func (h *VCHDatacenterLogGet) Handle(params operations.GetTargetTargetDatacenter
 
 // getDatastoreHelper validates the VCH and returns the datastore helper for the VCH. It errors when validation fails or when datastore is not ready
 func getDatastoreHelper(op trace.Operation, d *data.Data, validator *validate.Validator) (*datastore.Helper, error) {
-	executor := management.NewDispatcher(op, validator.Session, management.NoAction, false)
+	executor := management.NewDispatcher(op, validator.Session(), management.NoAction, false)
 	vch, err := executor.NewVCHFromID(d.ID)
 	if err != nil {
 		return nil, util.NewError(http.StatusNotFound, fmt.Sprintf("Unable to find VCH %s: %s", d.ID, err))
 	}
 
-	if err := validate.SetDataFromVM(op, validator.Session.Finder, vch, d); err != nil {
+	if err := validate.SetDataFromVM(op, validator.Session().Finder, vch, d); err != nil {
 		return nil, util.NewError(http.StatusInternalServerError, fmt.Sprintf("Failed to load VCH data: %s", err))
 	}
 
@@ -114,13 +114,13 @@ func getDatastoreHelper(op trace.Operation, d *data.Data, validator *validate.Va
 	}
 
 	// Get VCH datastore object
-	ds, err := validator.Session.Finder.Datastore(op, vmPath.Host)
+	ds, err := validator.Session().Finder.Datastore(op, vmPath.Host)
 	if err != nil {
 		return nil, util.NewError(http.StatusNotFound, fmt.Sprintf("Datastore folder not found for VCH %s: %s", d.ID, err))
 	}
 
 	// Create a new datastore helper for file finding
-	helper, err := datastore.NewHelper(op, validator.Session, ds, vmPath.Path)
+	helper, err := datastore.NewHelper(op, validator.Session(), ds, vmPath.Path)
 	if err != nil {
 		return nil, fmt.Errorf("Unable to get datastore helper: %s", err)
 	}

--- a/lib/apiservers/service/restapi/handlers/vch_log_get.go
+++ b/lib/apiservers/service/restapi/handlers/vch_log_get.go
@@ -97,13 +97,13 @@ func (h *VCHDatacenterLogGet) Handle(params operations.GetTargetTargetDatacenter
 
 // getDatastoreHelper validates the VCH and returns the datastore helper for the VCH. It errors when validation fails or when datastore is not ready
 func getDatastoreHelper(op trace.Operation, d *data.Data, validator *validate.Validator) (*datastore.Helper, error) {
-	executor := management.NewDispatcher(validator.Context, validator.Session, management.NoAction, false)
+	executor := management.NewDispatcher(op, validator.Session, management.NoAction, false)
 	vch, err := executor.NewVCHFromID(d.ID)
 	if err != nil {
 		return nil, util.NewError(http.StatusNotFound, fmt.Sprintf("Unable to find VCH %s: %s", d.ID, err))
 	}
 
-	if err := validate.SetDataFromVM(validator.Context, validator.Session.Finder, vch, d); err != nil {
+	if err := validate.SetDataFromVM(op, validator.Session.Finder, vch, d); err != nil {
 		return nil, util.NewError(http.StatusInternalServerError, fmt.Sprintf("Failed to load VCH data: %s", err))
 	}
 
@@ -114,7 +114,7 @@ func getDatastoreHelper(op trace.Operation, d *data.Data, validator *validate.Va
 	}
 
 	// Get VCH datastore object
-	ds, err := validator.Session.Finder.Datastore(validator.Context, vmPath.Host)
+	ds, err := validator.Session.Finder.Datastore(op, vmPath.Host)
 	if err != nil {
 		return nil, util.NewError(http.StatusNotFound, fmt.Sprintf("Datastore folder not found for VCH %s: %s", d.ID, err))
 	}

--- a/lib/install/management/create_test.go
+++ b/lib/install/management/create_test.go
@@ -78,15 +78,15 @@ func TestCreate(t *testing.T) {
 			validator.ListIssues(op)
 		}
 
-		testCreateNetwork(op, validator.Session, conf, t)
+		testCreateNetwork(op, validator.Session(), conf, t)
 
-		testCreateVolumeStores(op, validator.Session, conf, false, t)
-		testDeleteVolumeStores(op, validator.Session, conf, 1, t)
+		testCreateVolumeStores(op, validator.Session(), conf, false, t)
+		testDeleteVolumeStores(op, validator.Session(), conf, 1, t)
 		errConf := &config.VirtualContainerHostConfigSpec{}
 		*errConf = *conf
 		errConf.VolumeLocations = make(map[string]*url.URL)
 		errConf.VolumeLocations["volume-store"], _ = url.Parse("ds://store_not_exist/volumes/test")
-		testCreateVolumeStores(op, validator.Session, errConf, true, t)
+		testCreateVolumeStores(op, validator.Session(), errConf, true, t)
 
 		// FIXME: (pull vic/7088) have to make another VCH config from validator for negative test case and cleanup test
 		// If we re-use the previous validator like we did in the earlier test (*errConf = *conf), it's not a deep copy of conf
@@ -94,10 +94,10 @@ func TestCreate(t *testing.T) {
 		// The other way around, if we test positive case first, the VCH data and session data are modified, so we are not able to test the negative case
 		conf2, err := validator.Validate(op, input)
 		conf2.ImageStores[0].Host = "http://non-exist"
-		testCreateAppliance(op, validator.Session, conf2, installSettings, true, t)
-		testCleanup(op, validator.Session, conf2, t)
+		testCreateAppliance(op, validator.Session(), conf2, installSettings, true, t)
+		testCleanup(op, validator.Session(), conf2, t)
 
-		testCreateAppliance(op, validator.Session, conf, installSettings, false, t)
+		testCreateAppliance(op, validator.Session(), conf, installSettings, false, t)
 
 		// cannot run test for func not implemented in vcsim: ResourcePool:resourcepool-24 does not implement: UpdateConfig
 		// testUpdateResources(ctx, validator.Session, conf, installSettings, false, t)

--- a/lib/install/management/create_test.go
+++ b/lib/install/management/create_test.go
@@ -72,7 +72,7 @@ func TestCreate(t *testing.T) {
 			t.Fatalf("Failed to validator: %s", err)
 		}
 
-		conf, err := validator.Validate(op, input)
+		conf, err := validator.Validate(op, input, false)
 		if err != nil {
 			log.Errorf("Failed to validate conf: %s", err)
 			validator.ListIssues(op)
@@ -92,7 +92,7 @@ func TestCreate(t *testing.T) {
 		// If we re-use the previous validator like we did in the earlier test (*errConf = *conf), it's not a deep copy of conf
 		// This conf will get modified by appliance creation and cleanup test, and we can't test create appliance in positive case
 		// The other way around, if we test positive case first, the VCH data and session data are modified, so we are not able to test the negative case
-		conf2, err := validator.Validate(op, input)
+		conf2, err := validator.Validate(op, input, false)
 		conf2.ImageStores[0].Host = "http://non-exist"
 		testCreateAppliance(op, validator.Session(), conf2, installSettings, true, t)
 		testCleanup(op, validator.Session(), conf2, t)

--- a/lib/install/management/delete_test.go
+++ b/lib/install/management/delete_test.go
@@ -86,19 +86,19 @@ func TestDelete(t *testing.T) {
 		testCreateNetwork(op, validator.Session, conf, t)
 		createAppliance(ctx, validator.Session, conf, installSettings, false, t)
 
-		testNewVCHFromCompute(input.ComputeResourcePath, input.DisplayName, validator, t)
+		testNewVCHFromCompute(op, input.ComputeResourcePath, input.DisplayName, validator, t)
 		//		testUpgrade(input.ComputeResourcePath, input.DisplayName, validator, installSettings, t) TODO: does not implement: CreateSnapshot_Task
-		testDeleteVCH(validator, conf, t)
+		testDeleteVCH(op, validator, conf, t)
 
-		testDeleteDatastoreFiles(validator, t)
+		testDeleteDatastoreFiles(op, validator, t)
 	}
 }
 
-func testUpgrade(computePath string, name string, v *validate.Validator, settings *data.InstallerData, t *testing.T) {
+func testUpgrade(op trace.Operation, computePath string, name string, v *validate.Validator, settings *data.InstallerData, t *testing.T) {
 	// TODO: add tests for rollback after snapshot func is added in vcsim
 	d := &Dispatcher{
 		session: v.Session,
-		op:      trace.FromContext(v.Context, "testUpgrade"),
+		op:      op,
 		isVC:    v.Session.IsVC(),
 		force:   false,
 	}
@@ -139,10 +139,10 @@ func createAppliance(ctx context.Context, sess *session.Session, conf *config.Vi
 	}
 }
 
-func testNewVCHFromCompute(computePath string, name string, v *validate.Validator, t *testing.T) {
+func testNewVCHFromCompute(op trace.Operation, computePath string, name string, v *validate.Validator, t *testing.T) {
 	d := &Dispatcher{
 		session: v.Session,
-		op:      trace.FromContext(v.Context, "testNewVCHFromCompute"),
+		op:      op,
 		isVC:    v.Session.IsVC(),
 		force:   false,
 	}
@@ -160,10 +160,10 @@ func testNewVCHFromCompute(computePath string, name string, v *validate.Validato
 	t.Logf("Got VCH %s, path %s", vch, path.Dir(vch.InventoryPath))
 }
 
-func testDeleteVCH(v *validate.Validator, conf *config.VirtualContainerHostConfigSpec, t *testing.T) {
+func testDeleteVCH(op trace.Operation, v *validate.Validator, conf *config.VirtualContainerHostConfigSpec, t *testing.T) {
 	d := &Dispatcher{
 		session: v.Session,
-		op:      trace.FromContext(v.Context, "testDeleteVCH"),
+		op:      op,
 		isVC:    v.Session.IsVC(),
 		force:   false,
 	}
@@ -202,27 +202,27 @@ func testDeleteVCH(v *validate.Validator, conf *config.VirtualContainerHostConfi
 	// delete VM does not clean up resource pool after VM is removed, so resource pool could not be removed
 }
 
-func testDeleteDatastoreFiles(v *validate.Validator, t *testing.T) {
+func testDeleteDatastoreFiles(op trace.Operation, v *validate.Validator, t *testing.T) {
 	d := &Dispatcher{
 		session: v.Session,
-		op:      trace.FromContext(v.Context, "testDeleteDatastoreFiles"),
+		op:      op,
 		isVC:    v.Session.IsVC(),
 		force:   false,
 	}
 
 	ds := v.Session.Datastore
 	m := object.NewFileManager(ds.Client())
-	err := m.MakeDirectory(v.Context, ds.Path("Test/folder/data"), v.Session.Datacenter, true)
+	err := m.MakeDirectory(op, ds.Path("Test/folder/data"), v.Session.Datacenter, true)
 	if err != nil {
 		t.Errorf("Failed to create datastore dir: %s", err)
 		return
 	}
-	err = m.MakeDirectory(v.Context, ds.Path("Test/folder/metadata"), v.Session.Datacenter, true)
+	err = m.MakeDirectory(op, ds.Path("Test/folder/metadata"), v.Session.Datacenter, true)
 	if err != nil {
 		t.Errorf("Failed to create datastore dir: %s", err)
 		return
 	}
-	err = m.MakeDirectory(v.Context, ds.Path("Test/folder/file"), v.Session.Datacenter, true)
+	err = m.MakeDirectory(op, ds.Path("Test/folder/file"), v.Session.Datacenter, true)
 	if err != nil {
 		t.Errorf("Failed to create datastore dir: %s", err)
 		return
@@ -241,7 +241,7 @@ func testDeleteDatastoreFiles(v *validate.Validator, t *testing.T) {
 		t.Errorf("Failed to delete recursively: %s", err)
 	}
 
-	err = m.MakeDirectory(v.Context, ds.Path("Test/folder/data"), v.Session.Datacenter, true)
+	err = m.MakeDirectory(op, ds.Path("Test/folder/data"), v.Session.Datacenter, true)
 	if err != nil {
 		t.Errorf("Failed to create datastore dir: %s", err)
 		return

--- a/lib/install/management/delete_test.go
+++ b/lib/install/management/delete_test.go
@@ -77,7 +77,7 @@ func TestDelete(t *testing.T) {
 			t.Errorf("Failed to validator: %s", err)
 		}
 
-		conf, err := validator.Validate(ctx, input)
+		conf, err := validator.Validate(ctx, input, false)
 		if err != nil {
 			log.Errorf("Failed to validate conf: %s", err)
 			validator.ListIssues(op)

--- a/lib/install/management/delete_test.go
+++ b/lib/install/management/delete_test.go
@@ -83,8 +83,8 @@ func TestDelete(t *testing.T) {
 			validator.ListIssues(op)
 		}
 
-		testCreateNetwork(op, validator.Session, conf, t)
-		createAppliance(ctx, validator.Session, conf, installSettings, false, t)
+		testCreateNetwork(op, validator.Session(), conf, t)
+		createAppliance(ctx, validator.Session(), conf, installSettings, false, t)
 
 		testNewVCHFromCompute(op, input.ComputeResourcePath, input.DisplayName, validator, t)
 		//		testUpgrade(input.ComputeResourcePath, input.DisplayName, validator, installSettings, t) TODO: does not implement: CreateSnapshot_Task
@@ -97,9 +97,9 @@ func TestDelete(t *testing.T) {
 func testUpgrade(op trace.Operation, computePath string, name string, v *validate.Validator, settings *data.InstallerData, t *testing.T) {
 	// TODO: add tests for rollback after snapshot func is added in vcsim
 	d := &Dispatcher{
-		session: v.Session,
+		session: v.Session(),
 		op:      op,
-		isVC:    v.Session.IsVC(),
+		isVC:    v.Session().IsVC(),
 		force:   false,
 	}
 	vch, err := d.NewVCHFromComputePath(computePath, name, v)
@@ -141,9 +141,9 @@ func createAppliance(ctx context.Context, sess *session.Session, conf *config.Vi
 
 func testNewVCHFromCompute(op trace.Operation, computePath string, name string, v *validate.Validator, t *testing.T) {
 	d := &Dispatcher{
-		session: v.Session,
+		session: v.Session(),
 		op:      op,
-		isVC:    v.Session.IsVC(),
+		isVC:    v.Session().IsVC(),
 		force:   false,
 	}
 	vch, err := d.NewVCHFromComputePath(computePath, name, v)
@@ -162,9 +162,9 @@ func testNewVCHFromCompute(op trace.Operation, computePath string, name string, 
 
 func testDeleteVCH(op trace.Operation, v *validate.Validator, conf *config.VirtualContainerHostConfigSpec, t *testing.T) {
 	d := &Dispatcher{
-		session: v.Session,
+		session: v.Session(),
 		op:      op,
-		isVC:    v.Session.IsVC(),
+		isVC:    v.Session().IsVC(),
 		force:   false,
 	}
 	// failed to get vm FolderName, that will eventually cause panic in simulator to delete empty datastore file
@@ -175,7 +175,7 @@ func testDeleteVCH(op trace.Operation, v *validate.Validator, conf *config.Virtu
 	t.Logf("Successfully deleted VCH")
 	// check images directory is removed
 	dsPath := "[LocalDS_0] VIC"
-	_, err := d.lsFolder(v.Session.Datastore, dsPath)
+	_, err := d.lsFolder(v.Session().Datastore, dsPath)
 	if err != nil {
 		if !types.IsFileNotFound(err) {
 			t.Errorf("Failed to browse folder %s: %s", dsPath, errors.ErrorStack(err))
@@ -204,25 +204,25 @@ func testDeleteVCH(op trace.Operation, v *validate.Validator, conf *config.Virtu
 
 func testDeleteDatastoreFiles(op trace.Operation, v *validate.Validator, t *testing.T) {
 	d := &Dispatcher{
-		session: v.Session,
+		session: v.Session(),
 		op:      op,
-		isVC:    v.Session.IsVC(),
+		isVC:    v.Session().IsVC(),
 		force:   false,
 	}
 
-	ds := v.Session.Datastore
+	ds := v.Session().Datastore
 	m := object.NewFileManager(ds.Client())
-	err := m.MakeDirectory(op, ds.Path("Test/folder/data"), v.Session.Datacenter, true)
+	err := m.MakeDirectory(op, ds.Path("Test/folder/data"), v.Session().Datacenter, true)
 	if err != nil {
 		t.Errorf("Failed to create datastore dir: %s", err)
 		return
 	}
-	err = m.MakeDirectory(op, ds.Path("Test/folder/metadata"), v.Session.Datacenter, true)
+	err = m.MakeDirectory(op, ds.Path("Test/folder/metadata"), v.Session().Datacenter, true)
 	if err != nil {
 		t.Errorf("Failed to create datastore dir: %s", err)
 		return
 	}
-	err = m.MakeDirectory(op, ds.Path("Test/folder/file"), v.Session.Datacenter, true)
+	err = m.MakeDirectory(op, ds.Path("Test/folder/file"), v.Session().Datacenter, true)
 	if err != nil {
 		t.Errorf("Failed to create datastore dir: %s", err)
 		return
@@ -241,7 +241,7 @@ func testDeleteDatastoreFiles(op trace.Operation, v *validate.Validator, t *test
 		t.Errorf("Failed to delete recursively: %s", err)
 	}
 
-	err = m.MakeDirectory(op, ds.Path("Test/folder/data"), v.Session.Datacenter, true)
+	err = m.MakeDirectory(op, ds.Path("Test/folder/data"), v.Session().Datacenter, true)
 	if err != nil {
 		t.Errorf("Failed to create datastore dir: %s", err)
 		return

--- a/lib/install/management/finder_test.go
+++ b/lib/install/management/finder_test.go
@@ -75,11 +75,10 @@ func TestFinder(t *testing.T) {
 		if err != nil {
 			t.Errorf("Failed to create validator: %s", err)
 		}
-		if _, err = validator.ValidateTarget(ctx, input); err != nil {
+		if _, err = validator.ValidateTarget(ctx, input, false); err != nil {
 			t.Logf("Got expected error to validate target: %s", err)
 		}
-		validator.AllowEmptyDC()
-		if _, err = validator.ValidateTarget(ctx, input); err != nil {
+		if _, err = validator.ValidateTarget(ctx, input, true); err != nil {
 			t.Errorf("Failed to valiate target: %s", err)
 		}
 		prefix := fmt.Sprintf("p%d-", i)

--- a/lib/install/management/finder_test.go
+++ b/lib/install/management/finder_test.go
@@ -83,7 +83,7 @@ func TestFinder(t *testing.T) {
 			t.Errorf("Failed to valiate target: %s", err)
 		}
 		prefix := fmt.Sprintf("p%d-", i)
-		if err = createTestData(ctx, validator.Session, prefix); err != nil {
+		if err = createTestData(ctx, validator.Session(), prefix); err != nil {
 			t.Errorf("Failed to create test data: %s", err)
 		}
 
@@ -105,9 +105,9 @@ func TestFinder(t *testing.T) {
 
 func testSearchVCHs(ctx context.Context, t *testing.T, v *validate.Validator, expect bool) int {
 	d := &Dispatcher{
-		session: v.Session,
+		session: v.Session(),
 		op:      trace.FromContext(ctx, "testSearchVCHs"),
-		isVC:    v.Session.IsVC(),
+		isVC:    v.Session().IsVC(),
 	}
 
 	if expect {

--- a/lib/install/management/finder_test.go
+++ b/lib/install/management/finder_test.go
@@ -87,12 +87,12 @@ func TestFinder(t *testing.T) {
 			t.Errorf("Failed to create test data: %s", err)
 		}
 
-		found := testSearchVCHs(t, validator, false)
+		found := testSearchVCHs(ctx, t, validator, false)
 		if found != 0 {
 			t.Errorf("found %d VCHs, expected %d", found, 0)
 		}
 
-		found = testSearchVCHs(t, validator, true)
+		found = testSearchVCHs(ctx, t, validator, true)
 		expect := 1 // 1 VCH per Resource pool
 		if model.Host != 0 {
 			expect *= (model.Host + model.Cluster) * 2
@@ -103,10 +103,10 @@ func TestFinder(t *testing.T) {
 	}
 }
 
-func testSearchVCHs(t *testing.T, v *validate.Validator, expect bool) int {
+func testSearchVCHs(ctx context.Context, t *testing.T, v *validate.Validator, expect bool) int {
 	d := &Dispatcher{
 		session: v.Session,
-		op:      trace.FromContext(v.Context, "testSearchVCHs"),
+		op:      trace.FromContext(ctx, "testSearchVCHs"),
 		isVC:    v.Session.IsVC(),
 	}
 

--- a/lib/install/validate/compute.go
+++ b/lib/install/validate/compute.go
@@ -227,7 +227,7 @@ func (v *Validator) suggestResourcePool(op trace.Operation, path string) {
 
 	op.Info("Suggested resource pool values for --compute-resource:")
 	for _, c := range pools {
-		p := strings.TrimPrefix(c, v.DatacenterPath+"/host/")
+		p := strings.TrimPrefix(c, v.datacenterPath+"/host/")
 		op.Infof("  %q", p)
 	}
 }

--- a/lib/install/validate/compute.go
+++ b/lib/install/validate/compute.go
@@ -167,8 +167,8 @@ func (v *Validator) ResourcePoolHelper(ctx context.Context, path string) (*objec
 	return pool, nil
 }
 
-func (v *Validator) ListComputeResource() ([]string, error) {
-	compute, err := v.Session.Finder.ComputeResourceList(v.Context, "*")
+func (v *Validator) listComputeResource(op trace.Operation) ([]string, error) {
+	compute, err := v.Session.Finder.ComputeResourceList(op, "*")
 	if err != nil {
 		return nil, fmt.Errorf("unable to list compute resource: %s", err)
 	}
@@ -187,7 +187,7 @@ func (v *Validator) ListComputeResource() ([]string, error) {
 func (v *Validator) suggestComputeResource(op trace.Operation) {
 	defer trace.End(trace.Begin("", op))
 
-	compute, err := v.ListComputeResource()
+	compute, err := v.listComputeResource(op)
 	if err != nil {
 		op.Error(err)
 		return
@@ -199,8 +199,8 @@ func (v *Validator) suggestComputeResource(op trace.Operation) {
 	}
 }
 
-func (v *Validator) ListResourcePool(path string) ([]string, error) {
-	pools, err := v.Session.Finder.ResourcePoolList(v.Context, path)
+func (v *Validator) listResourcePool(op trace.Operation, path string) ([]string, error) {
+	pools, err := v.Session.Finder.ResourcePoolList(op, path)
 	if err != nil {
 		return nil, fmt.Errorf("unable to list resource pool: %s", err)
 	}
@@ -219,7 +219,7 @@ func (v *Validator) ListResourcePool(path string) ([]string, error) {
 func (v *Validator) suggestResourcePool(op trace.Operation, path string) {
 	defer trace.End(trace.Begin("", op))
 
-	pools, err := v.ListResourcePool(path)
+	pools, err := v.listResourcePool(op, path)
 	if err != nil {
 		op.Error(err)
 		return

--- a/lib/install/validate/compute.go
+++ b/lib/install/validate/compute.go
@@ -158,10 +158,6 @@ func (v *Validator) ResourcePoolHelper(ctx context.Context, path string) (*objec
 		compute.InventoryPath = v.inventoryPath(op, compute.Reference())
 	}
 
-	// stash the pool for later use
-	v.ResourcePoolPath = pool.InventoryPath
-
-	// some hoops for while we're still using session package
 	v.Session.Pool = pool
 	v.Session.PoolPath = pool.InventoryPath
 

--- a/lib/install/validate/compute.go
+++ b/lib/install/validate/compute.go
@@ -51,7 +51,7 @@ func (v *Validator) checkVMGroup(op trace.Operation, input *data.Data, conf *con
 			return
 		}
 
-		if v.Session.DRSEnabled == nil || !*v.Session.DRSEnabled {
+		if v.session.DRSEnabled == nil || !*v.session.DRSEnabled {
 			v.NoteIssue(errors.New("DRS VM Groups may not be used without DRS"))
 			return
 		}
@@ -65,13 +65,13 @@ func (v *Validator) checkVMGroup(op trace.Operation, input *data.Data, conf *con
 			return
 		}
 
-		if v.Session.Cluster == nil {
+		if v.session.Cluster == nil {
 			// We already note a more helpful issue for this following the compute method's call to ResourcePoolHelper.
 			v.NoteIssue(errors.New("Unable to determine presence of DRS VM Groups due to previous errors"))
 			return
 		}
 
-		exists, err := VMGroupExists(op, v.Session.Cluster, conf.VMGroupName)
+		exists, err := VMGroupExists(op, v.session.Cluster, conf.VMGroupName)
 		if err != nil {
 			v.NoteIssue(err)
 			return
@@ -84,7 +84,7 @@ func (v *Validator) checkVMGroup(op trace.Operation, input *data.Data, conf *con
 }
 
 func (v *Validator) inventoryPath(op trace.Operation, obj object.Reference) string {
-	elt, err := v.Session.Finder.Element(op, obj.Reference())
+	elt, err := v.session.Finder.Element(op, obj.Reference())
 	if err != nil {
 		op.Warnf("failed to get inventory path for %s: %s", obj.Reference(), err)
 		return ""
@@ -101,17 +101,17 @@ func (v *Validator) ResourcePoolHelper(ctx context.Context, path string) (*objec
 
 	// if compute-resource is unspecified is there a default
 	if path == "" {
-		if v.Session.Pool == nil {
+		if v.session.Pool == nil {
 			// if no path specified and no default available the show all
 			v.suggestComputeResource(op)
 			return nil, errors.New("No unambiguous default compute resource available: --compute-resource must be specified")
 		}
 
-		path = v.Session.Pool.InventoryPath
-		op.Debugf("Using default resource pool for compute resource: %q", v.Session.Pool.InventoryPath)
+		path = v.session.Pool.InventoryPath
+		op.Debugf("Using default resource pool for compute resource: %q", v.session.Pool.InventoryPath)
 	}
 
-	pool, err := v.Session.Finder.ResourcePool(op, path)
+	pool, err := v.session.Finder.ResourcePool(op, path)
 	if err != nil {
 		switch err.(type) {
 		case *find.NotFoundError:
@@ -129,7 +129,7 @@ func (v *Validator) ResourcePoolHelper(ctx context.Context, path string) (*objec
 
 	if pool == nil {
 		// check if its a ComputeResource or ClusterComputeResource
-		compute, err = v.Session.Finder.ComputeResource(op, path)
+		compute, err = v.session.Finder.ComputeResource(op, path)
 		if err != nil {
 			switch err.(type) {
 			case *find.NotFoundError, *find.MultipleFoundError:
@@ -158,17 +158,17 @@ func (v *Validator) ResourcePoolHelper(ctx context.Context, path string) (*objec
 		compute.InventoryPath = v.inventoryPath(op, compute.Reference())
 	}
 
-	v.Session.Pool = pool
-	v.Session.PoolPath = pool.InventoryPath
+	v.session.Pool = pool
+	v.session.PoolPath = pool.InventoryPath
 
-	v.Session.Cluster = compute
-	v.Session.ClusterPath = compute.InventoryPath
+	v.session.Cluster = compute
+	v.session.ClusterPath = compute.InventoryPath
 
 	return pool, nil
 }
 
 func (v *Validator) listComputeResource(op trace.Operation) ([]string, error) {
-	compute, err := v.Session.Finder.ComputeResourceList(op, "*")
+	compute, err := v.session.Finder.ComputeResourceList(op, "*")
 	if err != nil {
 		return nil, fmt.Errorf("unable to list compute resource: %s", err)
 	}
@@ -200,7 +200,7 @@ func (v *Validator) suggestComputeResource(op trace.Operation) {
 }
 
 func (v *Validator) listResourcePool(op trace.Operation, path string) ([]string, error) {
-	pools, err := v.Session.Finder.ResourcePoolList(op, path)
+	pools, err := v.session.Finder.ResourcePoolList(op, path)
 	if err != nil {
 		return nil, fmt.Errorf("unable to list resource pool: %s", err)
 	}

--- a/lib/install/validate/compute.go
+++ b/lib/install/validate/compute.go
@@ -227,7 +227,7 @@ func (v *Validator) suggestResourcePool(op trace.Operation, path string) {
 
 	op.Info("Suggested resource pool values for --compute-resource:")
 	for _, c := range pools {
-		p := strings.TrimPrefix(c, v.datacenterPath+"/host/")
+		p := strings.TrimPrefix(c, v.session.DatacenterPath+"/host/")
 		op.Infof("  %q", p)
 	}
 }

--- a/lib/install/validate/compute.go
+++ b/lib/install/validate/compute.go
@@ -46,7 +46,7 @@ func (v *Validator) checkVMGroup(op trace.Operation, input *data.Data, conf *con
 	defer trace.End(trace.Begin("", op))
 
 	if input.UseVMGroup {
-		if !v.IsVC() {
+		if !v.isVC() {
 			v.NoteIssue(errors.New("DRS VM Groups may only be configured when using VC"))
 			return
 		}

--- a/lib/install/validate/config.go
+++ b/lib/install/validate/config.go
@@ -395,7 +395,7 @@ func (v *Validator) CheckLicense(ctx context.Context) {
 		return
 	}
 
-	if v.IsVC() {
+	if v.isVC() {
 		if err = v.checkAssignedLicenses(op); err != nil {
 			v.NoteIssue(err)
 			return
@@ -595,7 +595,7 @@ func (v *Validator) checkPersistNetworkBacking(ctx context.Context, quiet bool) 
 	if !v.sessionValid(op, errMsg) {
 		return false
 	}
-	if !v.IsVC() {
+	if !v.isVC() {
 		op.Debug(errMsg)
 		return true
 	}

--- a/lib/install/validate/network.go
+++ b/lib/install/validate/network.go
@@ -447,7 +447,7 @@ func (v *Validator) checkBridgeIPRange(bridgeIPRange *net.IPNet) error {
 func (v *Validator) getNetwork(op trace.Operation, name string) (object.NetworkReference, error) {
 	defer trace.End(trace.Begin(name, op))
 
-	nets, err := v.Session.Finder.NetworkList(op, name)
+	nets, err := v.session.Finder.NetworkList(op, name)
 	if err != nil {
 		op.Debugf("no such network %q", name)
 		// TODO: error message about no such match and how to get a network list
@@ -483,7 +483,7 @@ func (v *Validator) dpgMorefHelper(op trace.Operation, ref string) (string, erro
 		return "", errors.New("could not restore serialized managed object reference: " + ref)
 	}
 
-	net, err := v.Session.Finder.ObjectReference(op, *moref)
+	net, err := v.session.Finder.ObjectReference(op, *moref)
 	if err != nil {
 		// TODO: error message about no such match and how to get a network list
 		return "", errors.New("unable to locate network from moref: " + ref)
@@ -544,16 +544,16 @@ func (v *Validator) checkVDSMembership(op trace.Operation, network types.Managed
 		return nil
 	}
 
-	if v.Session.Cluster == nil {
+	if v.session.Cluster == nil {
 		return errors.New("Invalid cluster. Check --compute-resource")
 	}
 
-	clusterHosts, err := v.Session.Cluster.Hosts(op)
+	clusterHosts, err := v.session.Cluster.Hosts(op)
 	if err != nil {
 		return err
 	}
 
-	r := object.NewDistributedVirtualPortgroup(v.Session.Client.Client, network)
+	r := object.NewDistributedVirtualPortgroup(v.session.Client.Client, network)
 	if err := r.Properties(op, r.Reference(), []string{"name", "host"}, &dvp); err != nil {
 		return err
 	}
@@ -584,7 +584,7 @@ func (v *Validator) checkVDSMembership(op trace.Operation, network types.Managed
 func (v *Validator) listNetworks(op trace.Operation, incStdNets bool) ([]string, error) {
 	var selectedNets []string
 
-	nets, err := v.Session.Finder.NetworkList(op, "*")
+	nets, err := v.session.Finder.NetworkList(op, "*")
 	if err != nil {
 		return nil, fmt.Errorf("unable to list networks: %s", err)
 	}
@@ -640,7 +640,7 @@ func (v *Validator) isDVSUplink(op trace.Operation, ref types.ManagedObjectRefer
 
 	var dvp mo.DistributedVirtualPortgroup
 
-	r := object.NewDistributedVirtualPortgroup(v.Session.Client.Client, ref)
+	r := object.NewDistributedVirtualPortgroup(v.session.Client.Client, ref)
 	if err := r.Properties(op, r.Reference(), []string{"tag"}, &dvp); err != nil {
 		op.Errorf("Unable to check tags on %q: %s", ref, err)
 		return false

--- a/lib/install/validate/network.go
+++ b/lib/install/validate/network.go
@@ -584,7 +584,7 @@ func (v *Validator) checkVDSMembership(op trace.Operation, network types.Managed
 func (v *Validator) listNetworks(op trace.Operation, incStdNets bool) ([]string, error) {
 	var selectedNets []string
 
-	nets, err := v.Session.Finder.NetworkList(v.Context, "*")
+	nets, err := v.Session.Finder.NetworkList(op, "*")
 	if err != nil {
 		return nil, fmt.Errorf("unable to list networks: %s", err)
 	}
@@ -641,7 +641,7 @@ func (v *Validator) isDVSUplink(op trace.Operation, ref types.ManagedObjectRefer
 	var dvp mo.DistributedVirtualPortgroup
 
 	r := object.NewDistributedVirtualPortgroup(v.Session.Client.Client, ref)
-	if err := r.Properties(v.Context, r.Reference(), []string{"tag"}, &dvp); err != nil {
+	if err := r.Properties(op, r.Reference(), []string{"tag"}, &dvp); err != nil {
 		op.Errorf("Unable to check tags on %q: %s", ref, err)
 		return false
 	}

--- a/lib/install/validate/network.go
+++ b/lib/install/validate/network.go
@@ -286,7 +286,7 @@ func (v *Validator) network(op trace.Operation, input *data.Data, conf *config.V
 
 	checkBridgeVDS := true
 	if err != nil {
-		if _, ok := err.(*find.NotFoundError); !ok || v.IsVC() {
+		if _, ok := err.(*find.NotFoundError); !ok || v.isVC() {
 			v.NoteIssue(fmt.Errorf("An existing distributed port group must be specified for bridge network on vCenter: %s", err))
 			v.suggestNetwork(op, "--bridge-network", false)
 			checkBridgeVDS = false // prevent duplicate error output
@@ -491,7 +491,7 @@ func (v *Validator) dpgMorefHelper(op trace.Operation, ref string) (string, erro
 
 	// ensure that the type of the network is a Distributed Port Group if the target is a vCenter
 	// if it's not then any network suffices
-	if v.IsVC() {
+	if v.isVC() {
 		_, dpg := net.(*object.DistributedVirtualPortgroup)
 		if !dpg {
 			return "", fmt.Errorf("%q is not a Distributed Port Group", ref)
@@ -511,7 +511,7 @@ func (v *Validator) dpgHelper(op trace.Operation, path string) (types.ManagedObj
 
 	// ensure that the type of the network is a Distributed Port Group if the target is a vCenter
 	// if it's not then any network suffices
-	if v.IsVC() {
+	if v.isVC() {
 		_, dpg := net.(*object.DistributedVirtualPortgroup)
 		if !dpg {
 			return types.ManagedObjectReference{}, fmt.Errorf("%q is not a Distributed Port Group", path)
@@ -540,7 +540,7 @@ func (v *Validator) checkVDSMembership(op trace.Operation, network types.Managed
 	var dvp mo.DistributedVirtualPortgroup
 	var nonMembers []string
 
-	if !v.IsVC() {
+	if !v.isVC() {
 		return nil
 	}
 

--- a/lib/install/validate/storage.go
+++ b/lib/install/validate/storage.go
@@ -33,7 +33,7 @@ func (v *Validator) storage(op trace.Operation, input *data.Data, conf *config.V
 	defer trace.End(trace.Begin("", op))
 
 	// Image Store
-	imageDSpath, ds, err := v.DatastoreHelper(op, input.ImageDatastorePath, "", "--image-store")
+	imageDSpath, ds, err := v.datastoreHelper(op, input.ImageDatastorePath, "", "--image-store")
 
 	if err != nil {
 		v.NoteIssue(err)
@@ -46,7 +46,7 @@ func (v *Validator) storage(op trace.Operation, input *data.Data, conf *config.V
 	}
 
 	if ds != nil {
-		v.SetDatastore(ds, imageDSpath)
+		v.setDatastore(ds, imageDSpath)
 		conf.AddImageStore(imageDSpath)
 	}
 
@@ -61,12 +61,12 @@ func (v *Validator) storage(op trace.Operation, input *data.Data, conf *config.V
 			vsErr := validateNFSTarget(targetURL)
 			v.NoteIssue(vsErr)
 		case common.DsScheme:
-			// TODO: change v.DatastoreHelper to take url struct instead of string and modify tests.
-			targetURL, _, vsErr = v.DatastoreHelper(op, targetURL.Path, label, "--volume-store")
+			// TODO: change v.datastoreHelper to take url struct instead of string and modify tests.
+			targetURL, _, vsErr = v.datastoreHelper(op, targetURL.Path, label, "--volume-store")
 			v.NoteIssue(vsErr)
 		default:
 			// We should not reach here, if we do we will attempt to treat this as a vsphere datastore
-			targetURL, _, vsErr = v.DatastoreHelper(op, targetURL.String(), label, "--volume-store")
+			targetURL, _, vsErr = v.datastoreHelper(op, targetURL.String(), label, "--volume-store")
 			v.NoteIssue(vsErr)
 		}
 
@@ -91,8 +91,8 @@ func validateNFSTarget(nfsURL *url.URL) error {
 	return nil
 }
 
-func (v *Validator) DatastoreHelper(ctx context.Context, path string, label string, flag string) (*url.URL, *object.Datastore, error) {
-	op := trace.FromContext(ctx, "DatastoreHelper")
+func (v *Validator) datastoreHelper(ctx context.Context, path string, label string, flag string) (*url.URL, *object.Datastore, error) {
+	op := trace.FromContext(ctx, "datastoreHelper")
 	defer trace.End(trace.Begin(path, op))
 
 	stripRawTarget := path
@@ -167,7 +167,7 @@ func (v *Validator) DatastoreHelper(ctx context.Context, path string, label stri
 	return dsURL, stores[0], nil
 }
 
-func (v *Validator) SetDatastore(ds *object.Datastore, path *url.URL) {
+func (v *Validator) setDatastore(ds *object.Datastore, path *url.URL) {
 	v.Session.Datastore = ds
 	v.Session.DatastorePath = path.Host
 }

--- a/lib/install/validate/storage.go
+++ b/lib/install/validate/storage.go
@@ -131,7 +131,7 @@ func (v *Validator) datastoreHelper(ctx context.Context, path string, label stri
 
 	if dsURL.Host == "" {
 		// see if we can find a default datastore
-		store, err := v.Session.Finder.DatastoreOrDefault(op, "*")
+		store, err := v.session.Finder.DatastoreOrDefault(op, "*")
 		if err != nil {
 			v.suggestDatastore(op, "*", label, flag)
 			return nil, nil, errors.New("datastore empty")
@@ -141,7 +141,7 @@ func (v *Validator) datastoreHelper(ctx context.Context, path string, label stri
 		op.Infof("Using default datastore: %s", dsURL.Host)
 	}
 
-	stores, err := v.Session.Finder.DatastoreList(op, dsURL.Host)
+	stores, err := v.session.Finder.DatastoreList(op, dsURL.Host)
 	if err != nil {
 		op.Debugf("no such datastore %#v", dsURL)
 		v.suggestDatastore(op, path, label, flag)
@@ -168,12 +168,12 @@ func (v *Validator) datastoreHelper(ctx context.Context, path string, label stri
 }
 
 func (v *Validator) setDatastore(ds *object.Datastore, path *url.URL) {
-	v.Session.Datastore = ds
-	v.Session.DatastorePath = path.Host
+	v.session.Datastore = ds
+	v.session.DatastorePath = path.Host
 }
 
 func (v *Validator) listDatastores(op trace.Operation) ([]string, error) {
-	dss, err := v.Session.Finder.DatastoreList(op, "*")
+	dss, err := v.session.Finder.DatastoreList(op, "*")
 	if err != nil {
 		return nil, fmt.Errorf("Unable to list datastores: %s", err)
 	}

--- a/lib/install/validate/storage.go
+++ b/lib/install/validate/storage.go
@@ -172,8 +172,8 @@ func (v *Validator) SetDatastore(ds *object.Datastore, path *url.URL) {
 	v.Session.DatastorePath = path.Host
 }
 
-func (v *Validator) ListDatastores() ([]string, error) {
-	dss, err := v.Session.Finder.DatastoreList(v.Context, "*")
+func (v *Validator) listDatastores(op trace.Operation) ([]string, error) {
+	dss, err := v.Session.Finder.DatastoreList(op, "*")
 	if err != nil {
 		return nil, fmt.Errorf("Unable to list datastores: %s", err)
 	}
@@ -201,7 +201,7 @@ func (v *Validator) suggestDatastore(op trace.Operation, path string, label stri
 	}
 	op.Infof("Suggesting valid values for %s based on %q", flag, val)
 
-	dss, err := v.ListDatastores()
+	dss, err := v.listDatastores(op)
 	if err != nil {
 		op.Error(err)
 		return

--- a/lib/install/validate/validator.go
+++ b/lib/install/validate/validator.go
@@ -53,14 +53,9 @@ const defaultSyslogPort = 514
 const registryValidationTime = 10 * time.Second
 
 type Validator struct {
-	TargetPath        string
-	DatacenterPath    string
-	ClusterPath       string
-	ResourcePoolPath  string
-	ImageStorePath    string
-	PublicNetworkPath string
-	BridgeNetworkPath string
-	BridgeNetworkName string
+	DatacenterPath   string
+	ClusterPath      string
+	ResourcePoolPath string
 
 	Session *session.Session
 	Context context.Context

--- a/lib/install/validate/validator.go
+++ b/lib/install/validate/validator.go
@@ -278,19 +278,19 @@ func (v *Validator) Validate(ctx context.Context, input *data.Data) (*config.Vir
 	v.network(op, input, conf)
 	// FIXME ATC DEBT setting this value needs to be moved to Dispatcher
 	// https://github.com/vmware/vic/issues/6803
-	ok := v.CheckPersistNetworkBacking(op, true)
+	ok := v.checkPersistNetworkBacking(op, true)
 	if !ok {
-		err := v.ConfigureVCenter(op)
+		err := v.configureVCenter(op)
 		if err != nil {
 			op.Errorf("%s", err)
 			op.Errorf("vCenter settings update FAILED")
 		}
 	}
-	v.CheckFirewall(op, conf)
-	v.CheckPersistNetworkBacking(op, false)
+	v.checkFirewall(op, conf)
+	v.checkPersistNetworkBacking(op, false)
 	v.CheckLicense(op)
-	v.CheckDRS(op, input)
-	v.checkVMGroup(op, input, conf) // Depends on a side-effect of the CheckDRS method.
+	v.checkDRS(op, input)
+	v.checkVMGroup(op, input, conf) // Depends on a side-effect of the checkDRS method.
 
 	v.certificate(op, input, conf)
 	v.certificateAuthorities(op, input, conf)
@@ -904,7 +904,7 @@ func (v *Validator) syslog(op trace.Operation, conf *config.VirtualContainerHost
 // FIXME ATC DEBT setting this value needs to be moved to Dispatcher
 // https://github.com/vmware/vic/issues/6803
 // set PersistNetworkBacking key to "true"
-func (v *Validator) ConfigureVCenter(ctx context.Context) error {
+func (v *Validator) configureVCenter(ctx context.Context) error {
 	op := trace.FromContext(ctx, "Set vCenter serial port backing")
 	defer trace.End(trace.Begin("", op))
 

--- a/lib/install/validate/validator.go
+++ b/lib/install/validate/validator.go
@@ -53,9 +53,8 @@ const defaultSyslogPort = 514
 const registryValidationTime = 10 * time.Second
 
 type Validator struct {
-	DatacenterPath   string
-	ClusterPath      string
-	ResourcePoolPath string
+	DatacenterPath string
+	ClusterPath    string
 
 	Session *session.Session
 	Context context.Context
@@ -845,7 +844,7 @@ func (v *Validator) AddDeprecatedFields(ctx context.Context, conf *config.Virtua
 		op.Debug("session cluster is nil")
 	}
 
-	dconfig.ResourcePoolPath = v.ResourcePoolPath
+	dconfig.ResourcePoolPath = v.Session.PoolPath
 
 	op.Debugf("Datacenter: %q, Cluster: %q, Resource Pool: %q", dconfig.DatacenterName, dconfig.Cluster, dconfig.ResourcePoolPath)
 

--- a/lib/install/validate/validator.go
+++ b/lib/install/validate/validator.go
@@ -53,7 +53,7 @@ const defaultSyslogPort = 514
 const registryValidationTime = 10 * time.Second
 
 type Validator struct {
-	DatacenterPath string
+	datacenterPath string
 
 	Session *session.Session
 
@@ -61,6 +61,14 @@ type Validator struct {
 	issues []error
 
 	allowEmptyDC bool
+}
+
+func (v *Validator) DatacenterPath() string {
+	return v.datacenterPath
+}
+
+func (v *Validator) SetDatacenterPath(datacenterPath string) {
+	v.datacenterPath = datacenterPath
 }
 
 func CreateFromSession(ctx context.Context, sess *session.Session) (*Validator, error) {
@@ -121,10 +129,10 @@ func NewValidator(ctx context.Context, input *data.Data) (*Validator, error) {
 	}
 
 	// if a datacenter was specified, set it
-	v.DatacenterPath = tURL.Path
-	if v.DatacenterPath != "" {
-		v.DatacenterPath = strings.TrimPrefix(v.DatacenterPath, "/")
-		sessionconfig.DatacenterPath = v.DatacenterPath
+	v.datacenterPath = tURL.Path
+	if v.datacenterPath != "" {
+		v.datacenterPath = strings.TrimPrefix(v.datacenterPath, "/")
+		sessionconfig.DatacenterPath = v.datacenterPath
 		// path needs to be stripped before we can use it as a service url
 		tURL.Path = ""
 	}
@@ -167,16 +175,16 @@ func (v *Validator) AllowEmptyDC() {
 }
 
 func (v *Validator) datacenter(op trace.Operation) error {
-	if v.allowEmptyDC && v.DatacenterPath == "" {
+	if v.allowEmptyDC && v.datacenterPath == "" {
 		return nil
 	}
 	if v.Session.Datacenter != nil {
-		v.DatacenterPath = v.Session.Datacenter.InventoryPath
+		v.datacenterPath = v.Session.Datacenter.InventoryPath
 		return nil
 	}
 	var detail string
-	if v.DatacenterPath != "" {
-		detail = fmt.Sprintf("Datacenter %q in --target is not found", path.Base(v.DatacenterPath))
+	if v.datacenterPath != "" {
+		detail = fmt.Sprintf("Datacenter %q in --target is not found", path.Base(v.datacenterPath))
 	} else {
 		// this means multiple datacenter exists, but user did not specify it in --target
 		detail = "Datacenter must be specified in --target (e.g. https://addr/datacenter)"

--- a/lib/install/validate/validator.go
+++ b/lib/install/validate/validator.go
@@ -54,7 +54,6 @@ const registryValidationTime = 10 * time.Second
 
 type Validator struct {
 	DatacenterPath string
-	ClusterPath    string
 
 	Session *session.Session
 	Context context.Context
@@ -123,9 +122,6 @@ func NewValidator(ctx context.Context, input *data.Data) (*Validator, error) {
 		Thumbprint: input.Thumbprint,
 		Insecure:   input.Force,
 	}
-
-	// if a compute resource path was specified, set it
-	v.ClusterPath = input.ComputeResourcePath
 
 	// if a datacenter was specified, set it
 	v.DatacenterPath = tURL.Path

--- a/lib/install/validate/validator.go
+++ b/lib/install/validate/validator.go
@@ -53,22 +53,12 @@ const defaultSyslogPort = 514
 const registryValidationTime = 10 * time.Second
 
 type Validator struct {
-	datacenterPath string
-
 	session *session.Session
 
 	isVC   bool
 	issues []error
 
 	allowEmptyDC bool
-}
-
-func (v *Validator) DatacenterPath() string {
-	return v.datacenterPath
-}
-
-func (v *Validator) SetDatacenterPath(datacenterPath string) {
-	v.datacenterPath = datacenterPath
 }
 
 func (v *Validator) Session() *session.Session {
@@ -133,10 +123,10 @@ func NewValidator(ctx context.Context, input *data.Data) (*Validator, error) {
 	}
 
 	// if a datacenter was specified, set it
-	v.datacenterPath = tURL.Path
-	if v.datacenterPath != "" {
-		v.datacenterPath = strings.TrimPrefix(v.datacenterPath, "/")
-		sessionconfig.DatacenterPath = v.datacenterPath
+	datacenterPath := tURL.Path
+	if datacenterPath != "" {
+		datacenterPath = strings.TrimPrefix(datacenterPath, "/")
+		sessionconfig.DatacenterPath = datacenterPath
 		// path needs to be stripped before we can use it as a service url
 		tURL.Path = ""
 	}
@@ -179,16 +169,16 @@ func (v *Validator) AllowEmptyDC() {
 }
 
 func (v *Validator) datacenter(op trace.Operation) error {
-	if v.allowEmptyDC && v.datacenterPath == "" {
+	if v.allowEmptyDC && v.session.DatacenterPath == "" {
 		return nil
 	}
 	if v.session.Datacenter != nil {
-		v.datacenterPath = v.session.Datacenter.InventoryPath
+		v.session.DatacenterPath = v.session.Datacenter.InventoryPath
 		return nil
 	}
 	var detail string
-	if v.datacenterPath != "" {
-		detail = fmt.Sprintf("Datacenter %q in --target is not found", path.Base(v.datacenterPath))
+	if v.session.DatacenterPath != "" {
+		detail = fmt.Sprintf("Datacenter %q in --target is not found", path.Base(v.session.DatacenterPath))
 	} else {
 		// this means multiple datacenter exists, but user did not specify it in --target
 		detail = "Datacenter must be specified in --target (e.g. https://addr/datacenter)"

--- a/lib/install/validate/validator_test.go
+++ b/lib/install/validate/validator_test.go
@@ -356,7 +356,7 @@ func testStorage(ctx context.Context, v *Validator, input *data.Data, conf *conf
 	testURL3, _ := url.Parse("LocalDS_0/volumes/volume1")
 	testURL3.Scheme = "ds"
 
-	// These two should report errors due to bad characters in the url. These should test how DatastoreHelper handles a nil or malformed url.
+	// These two should report errors due to bad characters in the url. These should test how datastoreHelper handles a nil or malformed url.
 	testURL4, _ := url.Parse("😗/volumes/volume1")
 	testURL5, _ := url.Parse("ds://😗/volumes/volume2")
 

--- a/lib/install/validate/validator_test.go
+++ b/lib/install/validate/validator_test.go
@@ -874,12 +874,12 @@ func TestDCReadOnlyPermsFromConfigSimulatorVPX(t *testing.T) {
 
 	fmt.Println(s.URL.String())
 
-	input := GetVcsimInputConfig(ctx, s.URL)
+	input := getVcsimInputConfig(ctx, s.URL)
 	require.NotNil(t, input)
 	v, err := NewValidator(ctx, input)
 	require.NoError(t, err)
 	require.NotNil(t, v)
-	configSpec, err := v.VcsimValidate(ctx, input)
+	configSpec, err := v.vcsimValidate(ctx, input)
 	require.NoError(t, err)
 	require.NotNil(t, configSpec)
 
@@ -919,12 +919,12 @@ func TestOpsUserPermsFromConfigSimulatorVPX(t *testing.T) {
 	sess, err := test.SessionWithVPX(ctx, s.URL.String())
 	require.NoError(t, err)
 
-	input := GetVcsimInputConfig(ctx, s.URL)
+	input := getVcsimInputConfig(ctx, s.URL)
 	require.NotNil(t, input)
 	v, err := NewValidator(ctx, input)
 	require.NoError(t, err)
 	require.NotNil(t, v)
-	configSpec, err := v.VcsimValidate(ctx, input)
+	configSpec, err := v.vcsimValidate(ctx, input)
 	require.NoError(t, err)
 	require.NotNil(t, configSpec)
 

--- a/lib/install/validate/validator_test.go
+++ b/lib/install/validate/validator_test.go
@@ -89,10 +89,10 @@ func TestValidator(t *testing.T) {
 		if err != nil {
 			t.Errorf("Failed to new validator: %s", err)
 		}
-		ds, _ := validator.Session.Finder.Datastore(validator.Context, "LocalDS_1")
+		ds, _ := validator.Session.Finder.Datastore(ctx, "LocalDS_1")
 		simulator.Map.Get(ds.Reference()).(mo.Entity).Entity().Name = "Local DS_0"
 
-		ds, _ = validator.Session.Finder.Datastore(validator.Context, "LocalDS_2")
+		ds, _ = validator.Session.Finder.Datastore(ctx, "LocalDS_2")
 		simulator.Map.Get(ds.Reference()).(mo.Entity).Entity().Name = `😗`
 
 		t.Logf("session pool: %s", validator.Session.Pool)
@@ -100,9 +100,9 @@ func TestValidator(t *testing.T) {
 			t.Errorf("Unable to create resource pool: %s", err)
 		}
 
-		conf := testCompute(validator, input, t)
-		testTargets(validator, input, conf, t)
-		testStorage(validator, input, conf, t)
+		conf := testCompute(ctx, validator, input, t)
+		testTargets(ctx, validator, input, conf, t)
+		testStorage(ctx, validator, input, conf, t)
 	}
 }
 
@@ -285,8 +285,8 @@ func createPool(ctx context.Context, sess *session.Session, poolPath string, nam
 	return nil
 }
 
-func testCompute(v *Validator, input *data.Data, t *testing.T) *config.VirtualContainerHostConfigSpec {
-	op := trace.FromContext(v.Context, "testCompute")
+func testCompute(ctx context.Context, v *Validator, input *data.Data, t *testing.T) *config.VirtualContainerHostConfigSpec {
+	op := trace.FromContext(ctx, "testCompute")
 
 	tests := []struct {
 		path   string
@@ -332,8 +332,8 @@ func testCompute(v *Validator, input *data.Data, t *testing.T) *config.VirtualCo
 	return conf
 }
 
-func testTargets(v *Validator, input *data.Data, conf *config.VirtualContainerHostConfigSpec, t *testing.T) {
-	op := trace.FromContext(v.Context, "testTargets")
+func testTargets(ctx context.Context, v *Validator, input *data.Data, conf *config.VirtualContainerHostConfigSpec, t *testing.T) {
+	op := trace.FromContext(ctx, "testTargets")
 
 	v.target(op, input, conf)
 	v.credentials(op, input, conf)
@@ -346,8 +346,8 @@ func testTargets(v *Validator, input *data.Data, conf *config.VirtualContainerHo
 
 }
 
-func testStorage(v *Validator, input *data.Data, conf *config.VirtualContainerHostConfigSpec, t *testing.T) {
-	op := trace.FromContext(v.Context, "testStorage")
+func testStorage(ctx context.Context, v *Validator, input *data.Data, conf *config.VirtualContainerHostConfigSpec, t *testing.T) {
+	op := trace.FromContext(ctx, "testStorage")
 
 	// specifically ignoring err here because we do not care about the parse result.
 	testURL1, _ := url.Parse("LocalDS_0/volumes/volume1")

--- a/lib/install/validate/validator_test.go
+++ b/lib/install/validate/validator_test.go
@@ -89,14 +89,14 @@ func TestValidator(t *testing.T) {
 		if err != nil {
 			t.Errorf("Failed to new validator: %s", err)
 		}
-		ds, _ := validator.Session.Finder.Datastore(ctx, "LocalDS_1")
+		ds, _ := validator.session.Finder.Datastore(ctx, "LocalDS_1")
 		simulator.Map.Get(ds.Reference()).(mo.Entity).Entity().Name = "Local DS_0"
 
-		ds, _ = validator.Session.Finder.Datastore(ctx, "LocalDS_2")
+		ds, _ = validator.session.Finder.Datastore(ctx, "LocalDS_2")
 		simulator.Map.Get(ds.Reference()).(mo.Entity).Entity().Name = `😗`
 
-		t.Logf("session pool: %s", validator.Session.Pool)
-		if err = createPool(ctx, validator.Session, input.ComputeResourcePath, "validator", t); err != nil {
+		t.Logf("session pool: %s", validator.session.Pool)
+		if err = createPool(ctx, validator.session, input.ComputeResourcePath, "validator", t); err != nil {
 			t.Errorf("Unable to create resource pool: %s", err)
 		}
 
@@ -675,7 +675,7 @@ func TestValidateWithFolders(t *testing.T) {
 	}
 
 	// we have valid input at this point, test various compute-resource suggestions
-	vs := validator.Session
+	vs := validator.session
 	crs := []struct {
 		flag    string
 		pool    string
@@ -884,7 +884,7 @@ func TestDCReadOnlyPermsFromConfigSimulatorVPX(t *testing.T) {
 	require.NotNil(t, configSpec)
 
 	// Set up the Authz Manager
-	mgr, err := opsuser.NewRBACManager(ctx, v.Session, &opsuser.DCReadOnlyConf, configSpec)
+	mgr, err := opsuser.NewRBACManager(ctx, v.session, &opsuser.DCReadOnlyConf, configSpec)
 	require.NoError(t, err)
 
 	resourcePermission, err := mgr.SetupDCReadOnlyPermissions(ctx)

--- a/lib/install/validate/validator_test.go
+++ b/lib/install/validate/validator_test.go
@@ -657,7 +657,7 @@ func TestValidateWithFolders(t *testing.T) {
 			t.Fatalf("%d: expected error", i)
 		}
 
-		_, err = validator.Validate(op, input)
+		_, err = validator.Validate(op, input, true)
 		if i == len(steps)-1 {
 			if err != nil {
 				t.Fatal(err)
@@ -719,7 +719,7 @@ func TestValidateWithFolders(t *testing.T) {
 	}
 
 	// cover some other paths now that we have a valid config
-	spec, err := validator.ValidateTarget(op, input)
+	spec, err := validator.ValidateTarget(op, input, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -810,9 +810,7 @@ func TestValidateWithESX(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		validator.AllowEmptyDC()
-
-		_, err = validator.Validate(op, input)
+		_, err = validator.Validate(op, input, false)
 		if i == len(steps)-1 {
 			if err != nil {
 				t.Fatal(err)

--- a/lib/install/validate/validator_test.go
+++ b/lib/install/validate/validator_test.go
@@ -312,10 +312,10 @@ func testCompute(ctx context.Context, v *Validator, input *data.Data, t *testing
 	conf := &config.VirtualContainerHostConfigSpec{}
 
 	for _, test := range tests {
-		if v.isVC && !test.vc {
+		if v.isVC() && !test.vc {
 			continue
 		}
-		if !v.isVC && test.vc {
+		if !v.isVC() && test.vc {
 			continue
 		}
 		t.Logf("%+v", test)

--- a/lib/install/validate/validator_test_sim_util.go
+++ b/lib/install/validate/validator_test_sim_util.go
@@ -151,7 +151,7 @@ var testInputConfigVPX = data.Data{
 	SyslogConfig:        data.SyslogConfig{},
 }
 
-func GetVcsimInputConfig(ctx context.Context, URL *url.URL) *data.Data {
+func getVcsimInputConfig(ctx context.Context, URL *url.URL) *data.Data {
 	localInputConfig := testInputConfigVPX
 	// Fix the URL to point to vcsim
 	if URL != nil {
@@ -169,7 +169,7 @@ func GetVcsimInputConfig(ctx context.Context, URL *url.URL) *data.Data {
 // This method allows to perform validation of a configuration when
 // interacting with GO vmomi simulator, it skips some of the tests
 // that otherwise would fail (e.g. Firewall)
-func (v *Validator) VcsimValidate(ctx context.Context, localInputConfig *data.Data) (*config.VirtualContainerHostConfigSpec, error) {
+func (v *Validator) vcsimValidate(ctx context.Context, localInputConfig *data.Data) (*config.VirtualContainerHostConfigSpec, error) {
 	defer trace.End(trace.Begin(""))
 	op := trace.FromContext(ctx, "validateForSim")
 	log.Infof("Validating supplied configuration")

--- a/lib/install/validate/validator_test_sim_util.go
+++ b/lib/install/validate/validator_test_sim_util.go
@@ -206,7 +206,7 @@ func (v *Validator) vcsimValidate(ctx context.Context, localInputConfig *data.Da
 	conf.ComputeResources = append(conf.ComputeResources, pool.Reference())
 
 	// Add the VM
-	vm, err := v.Session.Finder.VirtualMachine(op, "/DC0/vm/DC0_C0_RP0_VM0")
+	vm, err := v.session.Finder.VirtualMachine(op, "/DC0/vm/DC0_C0_RP0_VM0")
 	v.NoteIssue(err)
 
 	if vm == nil {

--- a/lib/install/validate/validator_test_sim_util.go
+++ b/lib/install/validate/validator_test_sim_util.go
@@ -176,7 +176,7 @@ func (v *Validator) vcsimValidate(ctx context.Context, localInputConfig *data.Da
 
 	conf := &config.VirtualContainerHostConfigSpec{}
 
-	if err := v.datacenter(op); err != nil {
+	if err := v.datacenter(op, false); err != nil {
 		return conf, err
 	}
 

--- a/lib/install/validate/validator_test_sim_util.go
+++ b/lib/install/validate/validator_test_sim_util.go
@@ -188,7 +188,7 @@ func (v *Validator) VcsimValidate(ctx context.Context, localInputConfig *data.Da
 	v.storage(op, localInputConfig, conf)
 	v.network(op, localInputConfig, conf)
 	v.CheckLicense(op)
-	v.CheckDRS(op, localInputConfig)
+	v.checkDRS(op, localInputConfig)
 
 	// Perform the higher level compatibility and consistency checks
 	v.compatibility(op, conf)


### PR DESCRIPTION
Validator's broad public contract and duplication of state from Session have made it confusing to use. Eventually, we want to decouple Validator and Session (and clean up the associated abuses of Validator as a way to construct a Session found in the API code). As a first step, we simplify Validator by eliminating unnecessary state.

Towards: #6032, #7840

`[full ci]`

---

This is a large change, and the resulting diff may be hard to read. I suggest reviewing the "end state" for Validator and then looking at the commits one-by-one (as each should be accompanied by a useful commit message and be easy to understand on its own).