### PR TITLE
[skip ci] Configure ROBO nightlies with Group19-DRS-Disabled

### DIFF
--- a/tests/drs-disabled/jenkins-drs-disabled-run.sh
+++ b/tests/drs-disabled/jenkins-drs-disabled-run.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+# Copyright 2018 VMware, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+input=$(gsutil ls -l gs://vic-engine-builds/vic_* | grep -v TOTAL | sort -k2 -r | head -n1 | xargs | cut -d ' ' -f 3 | cut -d '/' -f 4)
+
+n=0
+   until [ $n -ge 5 ]
+   do
+      echo "Retry.. $n"
+      echo "Downloading gcp file $input"
+      wget https://storage.googleapis.com/vic-engine-builds/$input
+      if [ -f "$input" ]
+      then
+      echo "File found.."
+      break
+      else
+      echo "File NOT found"
+      fi
+      n=$[$n+1]
+      sleep 15
+   done
+
+n=0
+   until [ $n -ge 5 ]
+   do
+      mkdir bin
+      echo "Extracting .tar.gz"
+      tar xvzf $input -C bin/ --strip 1
+      if [ -f "bin/vic-machine-linux" ]
+      then
+      echo "tar extraction complete.."
+      canContinue="Yes"
+      break
+      else
+      echo "tar extraction failed"
+      canContinue="No"
+      rm -rf bin
+      fi
+      n=$[$n+1]
+      sleep 15
+   done
+
+if [[ $canContinue = "No" ]]; then
+    echo "Tarball extraction failed..quitting the run"
+    break
+else
+    echo "Tarball extraction passed, Running nightlies test.."
+fi
+
+# Run the Robot tests in a container
+envfile="vic-internal/drs-disabled-secrets.list"
+image="gcr.io/eminent-nation-87317/vic-integration-test:1.48"
+cmd="pabot --processes 1 --removekeywords TAG:secret -d drs-disabled tests/manual-test-cases/Group19-DRS-Disabled"
+docker run --rm -v $PWD/vic:/go --env-file $envfile $image $cmd
+
+# Remove the VIC binary tar file
+rm $input
+
+cat vic/drs-disabled/pabot_results/*/stdout.txt | grep -E '::|\.\.\.' | grep -E 'PASS|FAIL' > console.log
+
+# Format the email output for Jenkins
+sed -i -e 's/^/<br>/g' console.log
+sed -i -e 's|PASS|<font color="green">PASS</font>|g' console.log
+sed -i -e 's|FAIL|<font color="red">FAIL</font>|g' console.log
+
+# Run the log upload script in a container
+cmd="tests/drs-disabled/upload-logs.sh"
+docker run --rm -v $PWD/vic:/go --env-file $envfile $image $cmd
+

--- a/tests/drs-disabled/upload-logs.sh
+++ b/tests/drs-disabled/upload-logs.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+# Copyright 2016-2018 VMware, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+echo "Upload drs-disabled test logs"
+
+set -x
+gsutil version -l
+set +x
+
+outfile="vic_drs_disabled_logs_"$BUILD_TIMESTAMP".zip"
+echo $outfile
+
+/usr/bin/zip -9 -r $outfile drs-disabled *.zip *.log *.debug *.tgz
+
+# GC credentials
+keyfile=~/vic-drs-disabled-logs.key
+botofile=~/.boto
+if [ ! -f $keyfile ]; then
+    echo -en $GS_PRIVATE_KEY > $keyfile
+    chmod 400 $keyfile
+fi
+if [ ! -f $botofile ]; then
+    echo "[Credentials]" >> $botofile
+    echo "gs_service_key_file = $keyfile" >> $botofile
+    echo "gs_service_client_id = $GS_CLIENT_EMAIL" >> $botofile
+    echo "[GSUtil]" >> $botofile
+    echo "content_language = en" >> $botofile
+    echo "default_project_id = $GS_PROJECT_ID" >> $botofile
+fi
+
+if [ -f "$outfile" ]; then
+  gsutil cp $outfile gs://vic-drs-disabled-logs
+  echo "----------------------------------------------"
+  echo "Download test logs here:"
+  echo "https://console.cloud.google.com/m/cloudstorage/b/vic-drs-disabled-logs/o/$outfile?authuser=1"
+  echo "----------------------------------------------"
+else
+  echo "No log output file to upload"
+fi
+
+if [ -f "$keyfile" ]; then
+  rm -f $keyfile
+fi

--- a/tests/manual-test-cases/Group19-DRS-Disabled/19-3-DRS-Disabled-Placement.robot
+++ b/tests/manual-test-cases/Group19-DRS-Disabled/19-3-DRS-Disabled-Placement.robot
@@ -49,13 +49,14 @@ Teardown VCH And Cleanup Nimbus
     Run Keyword And Ignore Error  Nimbus Cleanup  ${list}
 
 *** Test Cases ***
-
 # TODO(jzt): we need to test against a single ESX host
 
 Simple Placement
-    Set Environment Variable  GOVC_URL  ${vc1-ip}
-    Set Environment Variable  TEST_URL_ARRAY  ${vc1-ip}
-    Set Environment Variable  TEST_RESOURCE  cls3
+    # TODO(anchal): these are currently set to the static testbed in the secrets file.
+    # Set Environment Variable  GOVC_URL  ${vc1-ip}
+    # Set Environment Variable  TEST_URL_ARRAY  ${vc1-ip}
+    # Set Environment Variable  TEST_RESOURCE  cls3
+
     Set Environment Variable  TEST_TIMEOUT  30m
 
     Log To Console  Deploy VIC to the VC cluster


### PR DESCRIPTION
This commit adds test scripts for running a nightly Jenkins job to
run tests in a non-DRS environment. This change runs the
Group19-DRS-Disabled suite against a pre-deployed, static vCenter
ELM testbed. The corresponding secrets file will be committed to
the internal repo.

Future changes will include adding more tests and using a testbed
deployed with a service account.

Fixes #7662