### PR TITLE
Fix several tests that did not appropriately use the vic-admin env var

### DIFF
--- a/tests/test-cases/Group23-VIC-Machine-Service/23-02-VCH-List.robot
+++ b/tests/test-cases/Group23-VIC-Machine-Service/23-02-VCH-List.robot
@@ -120,14 +120,3 @@ Get VCH List Within Invalid Datacenter and Compute Resource
 
     Verify Return Code
     Verify Status Not Found
-
-
-Get Empty VCH List When No VCH deployed
-    Cleanup VIC Appliance On Test Server
-
-    Get VCH List
-
-    Verify Return Code
-    Verify Status Ok
-
-    Verify VCH List Empty

--- a/tests/test-cases/Group24-Multi-VCH/24-01-Multi-VCH-PS.robot
+++ b/tests/test-cases/Group24-Multi-VCH/24-01-Multi-VCH-PS.robot
@@ -23,6 +23,7 @@ Clean Up VCHs
     Set Environment Variable  VCH-NAME  ${old-vm}
     Set Environment Variable  BRIDGE_NETWORK  ${old-vch-bridge}
     Set Environment Variable  VCH-PARAMS  ${old-vch-params}
+    Set Environment Variable  VIC-ADMIN  ${old-vic-admin}
     Run Keyword And Continue On Failure  Cleanup VIC Appliance On Test Server
 
 *** Test Cases ***
@@ -34,6 +35,7 @@ Create Multi VCH - Docker Ps Only Contains The Correct Containers
     Set Suite Variable  ${old-vm}  %{VCH-NAME}
     Set Suite Variable  ${old-vch-params}  %{VCH-PARAMS}
     Set Suite Variable  ${old-vch-bridge}  %{BRIDGE_NETWORK}
+    Set Suite Variable  ${old-vic-admin}  %{VIC-ADMIN}
 
     # make sure we create two different bridge networks
     Remove Environment Variable  BRIDGE_NETWORK

--- a/tests/test-cases/Group24-Multi-VCH/24-02-Multi-VCH-Delete.robot
+++ b/tests/test-cases/Group24-Multi-VCH/24-02-Multi-VCH-Delete.robot
@@ -23,6 +23,7 @@ Cleanup VCHs
     Run Keyword If  '${old-vch}' != '${EMPTY}'  Set Environment Variable  VCH-NAME  ${old-vch}
     Run Keyword If  '${old-vch-bridge}' != '${EMPTY}'  Set Environment Variable  BRIDGE_NETWORK  ${old-vch-bridge}
     Run Keyword If  '${old-vch-params}' != '${EMPTY}'  Set Environment Variable  VCH-PARAMS  ${old-vch-params}
+    Run Keyword If  '${old-vic-admin}' != '${EMPTY}'  Set Environment Variable  VIC-ADMIN  ${old-vic-admin}
     Run Keyword And Continue On Failure  Cleanup VIC Appliance On Test Server
 
 *** Test Cases ***
@@ -40,6 +41,7 @@ VCH delete only removes its own containers
     Set Suite Variable  ${old-vch}  %{VCH-NAME}
     Set Suite Variable  ${old-vch-params}  %{VCH-PARAMS}
     Set Suite Variable  ${old-vch-bridge}  %{BRIDGE_NETWORK}
+    Set Suite Variable  ${old-vic-admin}  %{VIC-ADMIN}
 
     # Unset BRIDGE_NETWORK so the new VCH uses a unique bridge network
     Remove Environment Variable  BRIDGE_NETWORK
@@ -64,4 +66,5 @@ VCH delete only removes its own containers
     Set Environment Variable  VCH-NAME  ${old-vch}
     Set Environment Variable  BRIDGE_NETWORK  ${old-vch-bridge}
     Set Environment Variable  VCH-PARAMS  ${old-vch-params}
+    Set Environment Variable  VIC-ADMIN  ${old-vic-admin}
     Cleanup VIC Appliance On Test Server

--- a/tests/test-cases/Group6-VIC-Machine/6-13-TLS.robot
+++ b/tests/test-cases/Group6-VIC-Machine/6-13-TLS.robot
@@ -123,6 +123,7 @@ Create VCH - Server certificate with multiple blocks
     Should Contain  ${output}  Failed to load x509 leaf
     Should Contain  ${output}  Loaded server certificate
     Should Contain  ${output}  Installer completed successfully
+    Get Docker Params  ${output}  ${true}
 
     Cleanup VIC Appliance On Test Server
 


### PR DESCRIPTION
1. remove the empty vch list test, that needs to be re-implemented in our nightlies otherwise we can never run parallel jobs
2. make sure to set VIC-ADMIN in the multi-vch tests so that gather logs will work
3. update the docker params with the newer VCH installed