### PR TITLE
[skip ci] Add test for no-DRS VCH create with RP options

### DIFF
--- a/tests/manual-test-cases/Group19-DRS-Disabled/19-4-DRS-Disabled-License-Features.md
+++ b/tests/manual-test-cases/Group19-DRS-Disabled/19-4-DRS-Disabled-License-Features.md
@@ -2,31 +2,26 @@ Test 19-4 - DRS Disabled License Features
 =======
 
 # Purpose:
-To verify that the license and feature checks required for a ROBO Advanced environment are displayed and updated on VCH Admin.
+To verify that vic-machine create checks for the DRS setting and command flags specific to resource pools in a vSphere environment without DRS, such as a ROBO deployment. If a VCH is being installed in a DRS-disabled environment, vic-machine create should warn that DRS is disabled and mention that any resource pool options supplied in the command will be ignored as they are not applicable in this environment.
 
 # References:
 1. [vSphere Remote Office and Branch Office](http://www.vmware.com/products/vsphere/remote-office-branch-office.html)
 2. [Provide License and Feature Check](https://github.com/vmware/vic/issues/7277)
-3. [vic-admin to report on license and feature compliance](https://github.com/vmware/vic/issues/7276)
+3. [vic-machine to provide license and feature check](https://github.com/vmware/vic/issues/7275)
 
 # Environment:
-This test requires access to VMware Nimbus cluster for dynamic ESXi and vCenter creation. This test should be executed in the following topologies and should have vSAN enabled.
-* 1 vCenter host with 3 clusters, where 1 cluster has 1 ESXi host and the other 2 clusters have 3 ESXi hosts each
-* 2 vCenter hosts connected with ELM, where each vCenter host has a cluster/host/datacenter topology that emulates a customer environment (exact topology TBD)
+This test requires access to VMware Nimbus cluster for dynamic ESXi and vCenter creation. This test should be executed in a vCenter environment with a cluster that has DRS turned off.
 
 See https://confluence.eng.vmware.com/display/CNA/VIC+ROBO for more details.
 
 # Test Steps:
-1. Deploy a ROBO Advanced vCenter testbed for both environments above
-2. Install a VCH on vCenter
-3. Visit the VCH Admin page and verify that the License and Feature Status sections show that required license and features are present
-4. Assign a more restrictive license such as ROBO Standard or Standard that does not have the required features (VDS, VSPC) to vCenter
-5. Assign the above license to each of the hosts within the vCenter cluster
-6. Refresh the VCH Admin page and verify that the License and Feature Status sections show that required license and features are not present
-7. Delete the VCH
+1. Deploy a vCenter testbed with DRS disabled
+2. Using vic-machine create, install a VCH with compute resource set to the cluster where DRS is off. Also supply options that are specific to resource pools: cpu, cpu-shares, cpu-reservation, memory, memory-shares and memory-reservation.
+3. Delete the VCH
 
 # Expected Outcome:
 * All test steps should complete without error
+* Step 2's output should contain a message stating that DRS is disabed and that the provided resource pool options will be ignored.
 
 # Possible Problems:
 None

--- a/tests/manual-test-cases/Group19-DRS-Disabled/19-4-DRS-Disabled-License-Features.robot
+++ b/tests/manual-test-cases/Group19-DRS-Disabled/19-4-DRS-Disabled-License-Features.robot
@@ -1,0 +1,31 @@
+# Copyright 2018 VMware, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#	http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License
+
+*** Settings ***
+Documentation  Test 19-4 - DRS-Disabled-License-Features
+Resource  ../../resources/Util.robot
+Suite Teardown  Cleanup VIC Appliance On Test Server
+
+*** Test Cases ***
+vic-machine create checks DRS setting and RP options
+    Set Environment Variable  TEST_TIMEOUT  30m
+
+    ${output}=  Install VIC Appliance To Test Server  additional-args=--memory 8000 --memory-reservation 512 --memory-shares 6000 --cpu 10000 --cpu-reservation 512 --cpu-shares high
+    Should Contain  ${output}  DRS is recommended, but is disabled
+    Should Contain  ${output}  Memory Limit
+    Should Contain  ${output}  Memory Reservation
+    Should Contain  ${output}  Memory Shares
+    Should Contain  ${output}  CPU Limit
+    Should Contain  ${output}  CPU Reservation
+    Should Contain  ${output}  CPU Shares


### PR DESCRIPTION
This commit adds an integration test in Group19-DRS-Disabled to
verify that during a VCH create, vic-machine checks for the DRS
setting in the targeted cluster and also warns if any command
options specific to resource pools are supplied, since they will
be ignored as they are not applicable in a DRS-disabled env.

Towards #7275