### PR TITLE
Add timeouts in case of hung operations

### DIFF
--- a/tests/manual-test-cases/Group5-Functional-Tests/5-25-OPS-User-Grant.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-25-OPS-User-Grant.robot
@@ -51,6 +51,7 @@ Ops User Create
     Log  Output, govc role.usage: ${out}
 
 Run privilege-dependent docker operations
+    [Timeout]  15 minutes
     # Run containers with volumes and container networks to test scenarios requiring containerVMs
     # to have the highest privileges.
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} pull ${busybox}

--- a/tests/resources/Docker-Util.robot
+++ b/tests/resources/Docker-Util.robot
@@ -123,6 +123,7 @@ Verify Container Rename
     Should Contain  ${output}  ${vmName}
 
 Run Regression Tests
+    [Timeout]  15 minutes
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} pull ${busybox}
     Log  ${output}
     Should Be Equal As Integers  ${rc}  0


### PR DESCRIPTION
[skip unit]
The most recent nightly hung on a docker pull within the ops user test, this adds a timeout to prevent it from hanging indefinitely again.