### PR TITLE
installer: deduplicate upgrade status code

### DIFF
--- a/cmd/vic-machine/inspect/inspect.go
+++ b/cmd/vic-machine/inspect/inspect.go
@@ -30,6 +30,7 @@ import (
 	"github.com/vmware/vic/cmd/vic-machine/create"
 	"github.com/vmware/vic/lib/config"
 	"github.com/vmware/vic/lib/install/data"
+	"github.com/vmware/vic/lib/install/interaction"
 	"github.com/vmware/vic/lib/install/management"
 	"github.com/vmware/vic/lib/install/validate"
 	"github.com/vmware/vic/pkg/errors"
@@ -296,44 +297,6 @@ func (i *Inspect) sortedOutput(mapOptions map[string][]string) (output []string)
 
 // upgradeStatusMessage generates a user facing status string about upgrade progress and status
 func (i *Inspect) upgradeStatusMessage(op trace.Operation, vch *vm.VirtualMachine, installerVer *version.Build, vchVer *version.Build) {
-	if sameVer := installerVer.Equal(vchVer); sameVer {
-		op.Info("Installer has same version as VCH")
-		op.Info("No upgrade available with this installer version")
-		return
-	}
-
-	upgrading, err := vch.VCHUpdateStatus(op)
-	if err != nil {
-		op.Errorf("Unable to determine if upgrade/configure is in progress: %s", err)
-		return
-	}
-	if upgrading {
-		op.Info("Upgrade/configure in progress")
-		return
-	}
-
-	canUpgrade, err := installerVer.IsNewer(vchVer)
-	if err != nil {
-		op.Errorf("Unable to determine if upgrade is available: %s", err)
-		return
-	}
-	if canUpgrade {
-		op.Info("Upgrade available")
-		return
-	}
-
-	oldInstaller, err := installerVer.IsOlder(vchVer)
-	if err != nil {
-		op.Errorf("Unable to determine if upgrade is available: %s", err)
-		return
-	}
-	if oldInstaller {
-		op.Info("Installer has older version than VCH")
-		op.Info("No upgrade available with this installer version")
-		return
-	}
-
-	// can't get here
-	op.Warn("Invalid upgrade status")
+	interaction.LogUpgradeStatusLongMessage(op, vch, installerVer, vchVer)
 	return
 }

--- a/cmd/vic-machine/list/list.go
+++ b/cmd/vic-machine/list/list.go
@@ -16,7 +16,6 @@ package list
 
 import (
 	"context"
-	"fmt"
 	"path"
 	"text/tabwriter"
 	"text/template"
@@ -26,6 +25,7 @@ import (
 
 	"github.com/vmware/vic/cmd/vic-machine/common"
 	"github.com/vmware/vic/lib/install/data"
+	"github.com/vmware/vic/lib/install/interaction"
 	"github.com/vmware/vic/lib/install/management"
 	"github.com/vmware/vic/lib/install/validate"
 	"github.com/vmware/vic/pkg/errors"
@@ -186,36 +186,6 @@ func (l *List) Run(clic *cli.Context) (err error) {
 	return nil
 }
 
-// upgradeStatusMessage generates a user facing status string about upgrade progress and status
 func (l *List) upgradeStatusMessage(op trace.Operation, vch *vm.VirtualMachine, installerVer *version.Build, vchVer *version.Build) string {
-	if sameVer := installerVer.Equal(vchVer); sameVer {
-		return "Up to date"
-	}
-
-	upgrading, err := vch.VCHUpdateStatus(op)
-	if err != nil {
-		return fmt.Sprintf("Unknown: %s", err)
-	}
-	if upgrading {
-		return "Upgrade in progress"
-	}
-
-	canUpgrade, err := installerVer.IsNewer(vchVer)
-	if err != nil {
-		return fmt.Sprintf("Unknown: %s", err)
-	}
-	if canUpgrade {
-		return fmt.Sprintf("Upgradeable to %s", installerVer.ShortVersion())
-	}
-
-	oldInstaller, err := installerVer.IsOlder(vchVer)
-	if err != nil {
-		return fmt.Sprintf("Unknown: %s", err)
-	}
-	if oldInstaller {
-		return fmt.Sprintf("VCH has newer version")
-	}
-
-	// can't get here
-	return "Invalid upgrade status"
+	return interaction.GetUpgradeStatusShortMessage(op, vch, installerVer, vchVer)
 }

--- a/lib/apiservers/service/restapi/handlers/common.go
+++ b/lib/apiservers/service/restapi/handlers/common.go
@@ -28,6 +28,7 @@ import (
 	"github.com/vmware/vic/lib/config"
 	"github.com/vmware/vic/lib/constants"
 	"github.com/vmware/vic/lib/install/data"
+	"github.com/vmware/vic/lib/install/interaction"
 	"github.com/vmware/vic/lib/install/management"
 	"github.com/vmware/vic/lib/install/validate"
 	"github.com/vmware/vic/pkg/ip"
@@ -133,38 +134,8 @@ func buildDataAndValidateTarget(op trace.Operation, params buildDataParams, prin
 	return data, validator, nil
 }
 
-// Copied from list.go, and appears to be present other places. TODO (#6032): deduplicate
 func upgradeStatusMessage(op trace.Operation, vch *vm.VirtualMachine, installerVer *version.Build, vchVer *version.Build) string {
-	if sameVer := installerVer.Equal(vchVer); sameVer {
-		return "Up to date"
-	}
-
-	upgrading, err := vch.VCHUpdateStatus(op)
-	if err != nil {
-		return fmt.Sprintf("Unknown: %s", err)
-	}
-	if upgrading {
-		return "Upgrade in progress"
-	}
-
-	canUpgrade, err := installerVer.IsNewer(vchVer)
-	if err != nil {
-		return fmt.Sprintf("Unknown: %s", err)
-	}
-	if canUpgrade {
-		return fmt.Sprintf("Upgradeable to %s", installerVer.ShortVersion())
-	}
-
-	oldInstaller, err := installerVer.IsOlder(vchVer)
-	if err != nil {
-		return fmt.Sprintf("Unknown: %s", err)
-	}
-	if oldInstaller {
-		return fmt.Sprintf("VCH has newer version")
-	}
-
-	// can't get here
-	return "Invalid upgrade status"
+	return interaction.GetUpgradeStatusShortMessage(op, vch, installerVer, vchVer)
 }
 
 func getVCHConfig(op trace.Operation, d *data.Data, validator *validate.Validator) (*config.VirtualContainerHostConfigSpec, error) {

--- a/lib/install/interaction/upgrade_status.go
+++ b/lib/install/interaction/upgrade_status.go
@@ -1,0 +1,109 @@
+// Copyright 2018 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package interaction
+
+import (
+	"fmt"
+
+	"github.com/vmware/vic/pkg/trace"
+	"github.com/vmware/vic/pkg/version"
+	"github.com/vmware/vic/pkg/vsphere/vm"
+)
+
+type upgradeStatus int
+
+const (
+	UpToDate upgradeStatus = iota
+	Unknown
+	InProgress
+	Upgradeable
+	Newer
+	Invalid
+)
+
+func determineUpgradeStatus(op trace.Operation, vch *vm.VirtualMachine, installerVer, vchVer *version.Build) (upgradeStatus, error) {
+	if sameVer := installerVer.Equal(vchVer); sameVer {
+		return UpToDate, nil
+	}
+
+	upgrading, err := vch.VCHUpdateStatus(op)
+	if err != nil {
+		return Unknown, err
+	}
+	if upgrading {
+		return InProgress, nil
+	}
+
+	canUpgrade, err := installerVer.IsNewer(vchVer)
+	if err != nil {
+		return Unknown, err
+	}
+	if canUpgrade {
+		return Upgradeable, nil
+	}
+
+	oldInstaller, err := installerVer.IsOlder(vchVer)
+	if err != nil {
+		return Unknown, err
+	}
+	if oldInstaller {
+		return Newer, nil
+	}
+
+	// can't get here
+	return Invalid, nil
+}
+
+// GetUpgradeStatusShortMessage returns a succinct message describing the upgrade state, suitable for use in a CLI command operating on multiple VCHs.
+func GetUpgradeStatusShortMessage(op trace.Operation, vch *vm.VirtualMachine, installerVer, vchVer *version.Build) string {
+	status, err := determineUpgradeStatus(op, vch, installerVer, vchVer)
+
+	switch status {
+	case UpToDate:
+		return "Up to date"
+	case Upgradeable:
+		return fmt.Sprintf("Upgradeable to %s", installerVer.ShortVersion())
+	case InProgress:
+		return "Upgrade in progress"
+	case Newer:
+		return "VCH has newer version"
+	case Unknown:
+		return fmt.Sprintf("Unknown: %s", err)
+	default:
+		return "Invalid upgrade status"
+	}
+}
+
+// LogUpgradeStatusLongMessage returns a verbose message describing the upgrade state, suitable for use in a CLI command operating on a single VCH.
+func LogUpgradeStatusLongMessage(op trace.Operation, vch *vm.VirtualMachine, installerVer, vchVer *version.Build) {
+	status, err := determineUpgradeStatus(op, vch, installerVer, vchVer)
+
+	switch status {
+	case UpToDate:
+		op.Info("Installer has same version as VCH")
+		op.Info("No upgrade available with this installer version")
+	case Upgradeable:
+		op.Info("Upgrade available")
+	case InProgress:
+		op.Info("Upgrade/configure in progress")
+	case Newer:
+		op.Info("Installer has older version than VCH")
+		op.Info("No upgrade available with this installer version")
+	case Unknown:
+		op.Errorf("Unable to determine upgrade status: %s", err)
+	default:
+		op.Warn("Invalid upgrade status")
+	}
+}


### PR DESCRIPTION
Previously, logic to determine upgrade status was duplicated between
the list and inspect CLI commands as well as the API.

Deduplicate aggressively, with as few user-facing changes as possible.

Exception:
 * Inspect will no longer differentiate where an error occurred.

Additionally, this change establishes a new pattern for the sharing of
interaction-related code between the API and CLI: an "interaction"
package under install (a sibling of data, management, and validate).

Towards: #6032 

`[specific ci=Group23-VIC-Machine-Service --suite 6-09-Inspect --suite 6-10-List]`