### PR TITLE
[skip ci]Select correct datastore for the test

### DIFF
--- a/tests/manual-test-cases/Group5-Functional-Tests/5-11-Multiple-Cluster.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-11-Multiple-Cluster.robot
@@ -16,7 +16,8 @@
 Documentation  Test 5-11 - Multiple Clusters
 Resource  ../../resources/Util.robot
 Suite Setup  Wait Until Keyword Succeeds  10x  10m  Multiple Cluster Setup
-Suite Teardown  Run Keyword And Ignore Error  Nimbus Cleanup Single VM  '*5-11-multiple-cluster*'
+Suite Teardown  Run Keyword And Ignore Error  Nimbus Cleanup Single VM  '*5-11-multiple-cluster*'  ${false}
+Test Teardown  Cleanup VIC Appliance On Test Server
 
 *** Keywords ***
 Multiple Cluster Setup
@@ -59,4 +60,3 @@ Test
 
     Install VIC Appliance To Test Server  certs=${false}  vol=default
     Run Regression Tests
-    Cleanup VIC Appliance On Test Server

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-11-Multiple-Cluster.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-11-Multiple-Cluster.robot
@@ -50,7 +50,7 @@ Multiple Cluster Setup
     ${hosts}=  Run  govc ls -t HostSystem host/cls
     @{hosts}=  Split To Lines  ${hosts}
     ${datastore}=  Get Name of First Local Storage For Host  @{hosts}[0]
-    Set Environment Variable  TEST_DATASTORE  '${datastore}'
+    Set Environment Variable  TEST_DATASTORE  "${datastore}"
 
 *** Test Cases ***
 Test

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-11-Multiple-Cluster.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-11-Multiple-Cluster.robot
@@ -16,7 +16,7 @@
 Documentation  Test 5-11 - Multiple Clusters
 Resource  ../../resources/Util.robot
 Suite Setup  Wait Until Keyword Succeeds  10x  10m  Multiple Cluster Setup
-#Suite Teardown  Run Keyword And Ignore Error  Nimbus Cleanup Single VM  '*5-11-multiple-cluster*'
+Suite Teardown  Run Keyword And Ignore Error  Nimbus Cleanup Single VM  '*5-11-multiple-cluster*'
 
 *** Keywords ***
 # Insert elements from dict2 into dict1, overwriting conflicts in dict1 & returning new dict

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-11-Multiple-Cluster.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-11-Multiple-Cluster.robot
@@ -19,15 +19,6 @@ Suite Setup  Wait Until Keyword Succeeds  10x  10m  Multiple Cluster Setup
 Suite Teardown  Run Keyword And Ignore Error  Nimbus Cleanup Single VM  '*5-11-multiple-cluster*'
 
 *** Keywords ***
-# Insert elements from dict2 into dict1, overwriting conflicts in dict1 & returning new dict
-Combine Dictionaries
-    [Arguments]  ${dict1}  ${dict2}
-    ${dict2keys}=  Get Dictionary Keys  ${dict2}
-    :FOR  ${key}  IN  @{dict2keys}
-    \    ${elem}=  Get From Dictionary  ${dict2}  ${key}
-    \    Set To Dictionary  ${dict1}  ${key}  ${elem}
-    [Return]  ${dict1}
-
 Multiple Cluster Setup
     [Timeout]    110 minutes
     Run Keyword And Ignore Error  Nimbus Cleanup Single VM  '*5-11-multiple-cluster*'  ${false}

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-11-Multiple-Cluster.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-11-Multiple-Cluster.robot
@@ -16,7 +16,7 @@
 Documentation  Test 5-11 - Multiple Clusters
 Resource  ../../resources/Util.robot
 Suite Setup  Wait Until Keyword Succeeds  10x  10m  Multiple Cluster Setup
-Suite Teardown  Run Keyword And Ignore Error  Nimbus Cleanup Single VM  '*5-11-multiple-cluster*'
+#Suite Teardown  Run Keyword And Ignore Error  Nimbus Cleanup Single VM  '*5-11-multiple-cluster*'
 
 *** Keywords ***
 # Insert elements from dict2 into dict1, overwriting conflicts in dict1 & returning new dict
@@ -52,9 +52,14 @@ Multiple Cluster Setup
     Set Environment Variable  BRIDGE_NETWORK  bridge
     Set Environment Variable  PUBLIC_NETWORK  vm-network
     Remove Environment Variable  TEST_DATACENTER
-    Set Environment Variable  TEST_DATASTORE  local-0
-    Set Environment Variable  TEST_RESOURCE  cls
     Set Environment Variable  TEST_TIMEOUT  15m
+    Set Environment Variable  TEST_RESOURCE  cls
+
+    # Get one of the hosts in the cluster we want and make sure we use the correct local datastore
+    ${hosts}=  Run  govc ls -t HostSystem host/cls
+    @{hosts}=  Split To Lines  ${hosts}
+    ${datastore}=  Get Name of First Local Storage For Host  @{hosts}[0]
+    Set Environment Variable  TEST_DATASTORE  '${datastore}'
 
 *** Test Cases ***
 Test

--- a/tests/resources/Nimbus-Util.robot
+++ b/tests/resources/Nimbus-Util.robot
@@ -562,3 +562,9 @@ Is Nimbus Location WDC
     ${status}=  Run Keyword And Return Status  Should Not Be Empty  ${out}
     Close Connection
     [Return]  ${status}
+
+Get Name of First Local Storage For Host
+    [Arguments]  ${host}
+    ${datastores}=  Run  govc host.info -host ${host} -json | jq -r '.HostSystems[].Config.FileSystemVolume.MountInfo[].Volume | select (.Type\=\="VMFS") | select (.Local\=\=true) | .Name'
+    @{datastores}=  Split To Lines  ${datastores}
+    [Return]  @{datastores}[0]


### PR DESCRIPTION
fix for the intermittent nightly failure in this test - hasn't been triaged yet, so no ticket for it.

Cleanup old keyword not needed anymore as well