### PR TITLE
inspect: Use lower case naming for arguments

### DIFF
--- a/lib/install/management/inspect.go
+++ b/lib/install/management/inspect.go
@@ -117,9 +117,9 @@ func (d *Dispatcher) InspectVCH(vch *vm.VirtualMachine, conf *config.VirtualCont
 	return nil
 }
 
-func (d *Dispatcher) GetTLSFriendlyHostIP(clientIP net.IP, cert *x509.Certificate, CertificateAuthorities []byte) string {
+func (d *Dispatcher) GetTLSFriendlyHostIP(clientIP net.IP, cert *x509.Certificate, certificateAuthorities []byte) string {
 	hostIP := clientIP.String()
-	name, _ := viableHostAddress(d.op, []net.IP{clientIP}, cert, CertificateAuthorities)
+	name, _ := viableHostAddress(d.op, []net.IP{clientIP}, cert, certificateAuthorities)
 
 	if name != "" {
 		d.op.Debugf("Retrieved proposed name from host certificate: %q", name)


### PR DESCRIPTION
For consistency and to reduce potential confusion, use an argument name which begins with a lower-case letter.

Towards #6032