### PR TITLE
validator: Make SetDataFromVM a validator method

### DIFF
--- a/cmd/vic-machine/configure/configure.go
+++ b/cmd/vic-machine/configure/configure.go
@@ -397,7 +397,7 @@ func (c *Configure) Run(clic *cli.Context) (err error) {
 		return err
 	}
 
-	if err = validate.SetDataFromVM(op, validator.Session().Finder, vch, oldData); err != nil {
+	if err = validator.SetDataFromVM(op, vch, oldData); err != nil {
 		op.Error("Configuring cannot continue: querying configuration from VM failed")
 		op.Error(err)
 		return err

--- a/cmd/vic-machine/inspect/inspect.go
+++ b/cmd/vic-machine/inspect/inspect.go
@@ -196,7 +196,7 @@ func (i *Inspect) RunConfig(clic *cli.Context) (err error) {
 	}
 
 	return i.run(clic, op, func(s state) error {
-		err = i.showConfiguration(s.op, s.validator.Session().Finder, s.vchConfig, s.vch)
+		err = i.showConfiguration(s.op, s.validator, s.vchConfig, s.vch)
 		if err != nil {
 			op.Error("Failed to print Virtual Container Host configuration")
 			op.Error(err)
@@ -231,20 +231,20 @@ func (i *Inspect) Run(clic *cli.Context) (err error) {
 	})
 }
 
-func retrieveMapOptions(op trace.Operation, finder validate.Finder,
+func retrieveMapOptions(op trace.Operation, validator *validate.Validator,
 	conf *config.VirtualContainerHostConfigSpec, vm *vm.VirtualMachine) (map[string][]string, error) {
-	data, err := validate.NewDataFromConfig(op, finder, conf)
+	data, err := validate.NewDataFromConfig(op, validator.Session().Finder, conf)
 	if err != nil {
 		return nil, err
 	}
-	if err = validate.SetDataFromVM(op, finder, vm, data); err != nil {
+	if err = validator.SetDataFromVM(op, vm, data); err != nil {
 		return nil, err
 	}
 	return converter.DataToOption(data)
 }
 
-func (i Inspect) showConfiguration(op trace.Operation, finder validate.Finder, conf *config.VirtualContainerHostConfigSpec, vm *vm.VirtualMachine) error {
-	mapOptions, err := retrieveMapOptions(op, finder, conf, vm)
+func (i Inspect) showConfiguration(op trace.Operation, validator *validate.Validator, conf *config.VirtualContainerHostConfigSpec, vm *vm.VirtualMachine) error {
+	mapOptions, err := retrieveMapOptions(op, validator, conf, vm)
 	if err != nil {
 		return err
 	}

--- a/lib/apiservers/service/restapi/handlers/common.go
+++ b/lib/apiservers/service/restapi/handlers/common.go
@@ -145,7 +145,7 @@ func getVCHConfig(op trace.Operation, d *data.Data, validator *validate.Validato
 		return nil, util.NewError(http.StatusNotFound, fmt.Sprintf("Unable to find VCH %s: %s", d.ID, err))
 	}
 
-	err = validate.SetDataFromVM(op, validator.Session().Finder, vch, d)
+	err = validator.SetDataFromVM(op, vch, d)
 	if err != nil {
 		return nil, util.NewError(http.StatusInternalServerError, fmt.Sprintf("Failed to load VCH data: %s", err))
 	}

--- a/lib/apiservers/service/restapi/handlers/vch_delete.go
+++ b/lib/apiservers/service/restapi/handlers/vch_delete.go
@@ -90,7 +90,7 @@ func deleteVCH(op trace.Operation, d *data.Data, validator *validate.Validator, 
 		return util.NewError(http.StatusNotFound, fmt.Sprintf("Failed to find VCH: %s", err))
 	}
 
-	err = validate.SetDataFromVM(op, validator.Session().Finder, vch, d)
+	err = validator.SetDataFromVM(op, vch, d)
 	if err != nil {
 		return util.NewError(http.StatusInternalServerError, fmt.Sprintf("Failed to load VCH data: %s", err))
 	}

--- a/lib/apiservers/service/restapi/handlers/vch_get.go
+++ b/lib/apiservers/service/restapi/handlers/vch_get.go
@@ -101,7 +101,7 @@ func getVCH(op trace.Operation, d *data.Data, validator *validate.Validator) (*m
 		return nil, util.NewError(http.StatusNotFound, fmt.Sprintf("Failed to inspect VCH: %s", err))
 	}
 
-	err = validate.SetDataFromVM(op, validator.Session().Finder, vch, d)
+	err = validator.SetDataFromVM(op, vch, d)
 	if err != nil {
 		return nil, util.NewError(http.StatusInternalServerError, fmt.Sprintf("Failed to load VCH data: %s", err))
 	}

--- a/lib/apiservers/service/restapi/handlers/vch_log_get.go
+++ b/lib/apiservers/service/restapi/handlers/vch_log_get.go
@@ -103,7 +103,7 @@ func getDatastoreHelper(op trace.Operation, d *data.Data, validator *validate.Va
 		return nil, util.NewError(http.StatusNotFound, fmt.Sprintf("Unable to find VCH %s: %s", d.ID, err))
 	}
 
-	if err := validate.SetDataFromVM(op, validator.Session().Finder, vch, d); err != nil {
+	if err := validator.SetDataFromVM(op, vch, d); err != nil {
 		return nil, util.NewError(http.StatusInternalServerError, fmt.Sprintf("Failed to load VCH data: %s", err))
 	}
 

--- a/lib/install/validate/config_to_data.go
+++ b/lib/install/validate/config_to_data.go
@@ -44,7 +44,7 @@ type Finder interface {
 }
 
 // SetDataFromVM set value based on VCH VM properties
-func SetDataFromVM(ctx context.Context, finder Finder, vm *vm.VirtualMachine, d *data.Data) error {
+func (v *Validator) SetDataFromVM(ctx context.Context, vm *vm.VirtualMachine, d *data.Data) error {
 	op := trace.FromContext(ctx, "SetDataFromVM")
 
 	// display name
@@ -71,7 +71,7 @@ func SetDataFromVM(ctx context.Context, finder Finder, vm *vm.VirtualMachine, d 
 	if mrp.Parent == nil {
 		return fmt.Errorf("Failed to get parent resource pool")
 	}
-	or, err := finder.ObjectReference(op, *mrp.Parent)
+	or, err := v.session.Finder.ObjectReference(op, *mrp.Parent)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Code which directly invokes complex functions in other packages makes writing unit tests difficult. Convert `SetDataFromVM` from a function to a method on `Validator` to allow code which invokes the method to be more easily tested in isolation.

Towards #6032
