### PR TITLE
management: Rename action iotas to share prefix and switch API to specific action iotas

### DIFF
--- a/cmd/vic-machine/configure/configure.go
+++ b/cmd/vic-machine/configure/configure.go
@@ -345,7 +345,7 @@ func (c *Configure) Run(clic *cli.Context) (err error) {
 		op.Errorf("Configuring cannot continue - target validation failed: %s", err)
 		return errors.New("configure failed")
 	}
-	executor := management.NewDispatcher(op, validator.Session(), management.ConfigureAction, c.Force)
+	executor := management.NewDispatcher(op, validator.Session(), management.ActionConfigure, c.Force)
 
 	var vch *vm.VirtualMachine
 	if c.Data.ID != "" {
@@ -490,7 +490,7 @@ func (c *Configure) Run(clic *cli.Context) (err error) {
 	if !c.Data.Rollback {
 		err = executor.Configure(vchConfig, vConfig)
 	} else {
-		executor.Action = management.RollbackAction
+		executor.Action = management.ActionRollback
 		err = executor.Rollback(vchConfig, vConfig)
 	}
 

--- a/cmd/vic-machine/create/create.go
+++ b/cmd/vic-machine/create/create.go
@@ -708,7 +708,7 @@ func (c *Create) Run(clic *cli.Context) (err error) {
 	// separate initial validation from dispatch of creation task
 	op.Info("")
 
-	executor := management.NewDispatcher(op, validator.Session(), management.CreateAction, c.Force)
+	executor := management.NewDispatcher(op, validator.Session(), management.ActionCreate, c.Force)
 	executor.InitDiagnosticLogsFromConf(vchConfig)
 	if err = executor.CreateVCH(vchConfig, vConfig, datastoreLog); err != nil {
 		executor.CollectDiagnosticLogs()

--- a/cmd/vic-machine/debug/debug.go
+++ b/cmd/vic-machine/debug/debug.go
@@ -146,7 +146,7 @@ func (d *Debug) Run(clic *cli.Context) (err error) {
 		return errors.New("debug failed")
 	}
 
-	executor := management.NewDispatcher(op, validator.Session(), management.DebugAction, d.Force)
+	executor := management.NewDispatcher(op, validator.Session(), management.ActionDebug, d.Force)
 
 	var vch *vm.VirtualMachine
 	if d.Data.ID != "" {

--- a/cmd/vic-machine/delete/delete.go
+++ b/cmd/vic-machine/delete/delete.go
@@ -121,7 +121,7 @@ func (d *Uninstall) Run(clic *cli.Context) (err error) {
 		return errors.New("delete failed")
 	}
 
-	executor := management.NewDispatcher(op, validator.Session(), management.DeleteAction, d.Force)
+	executor := management.NewDispatcher(op, validator.Session(), management.ActionDelete, d.Force)
 
 	var vch *vm.VirtualMachine
 	if d.Data.ID != "" {

--- a/cmd/vic-machine/inspect/inspect.go
+++ b/cmd/vic-machine/inspect/inspect.go
@@ -159,7 +159,7 @@ func (i *Inspect) run(clic *cli.Context, op trace.Operation, cmd command) (err e
 		return errors.New("inspect failed")
 	}
 
-	executor := management.NewDispatcher(op, validator.Session(), management.InspectAction, i.Force)
+	executor := management.NewDispatcher(op, validator.Session(), management.ActionInspect, i.Force)
 
 	var vch *vm.VirtualMachine
 	if i.Data.ID != "" {

--- a/cmd/vic-machine/list/list.go
+++ b/cmd/vic-machine/list/list.go
@@ -174,7 +174,7 @@ func (l *List) Run(clic *cli.Context) (err error) {
 		return errors.New("list failed")
 	}
 
-	executor := management.NewDispatcher(op, validator.Session(), management.ListAction, false)
+	executor := management.NewDispatcher(op, validator.Session(), management.ActionList, false)
 	vchs, err := executor.SearchVCHs(validator.Session().ClusterPath)
 	if err != nil {
 		op.Errorf("List cannot continue - failed to search VCHs in %s: %s", validator.Session().PoolPath, err)

--- a/cmd/vic-machine/update/firewall.go
+++ b/cmd/vic-machine/update/firewall.go
@@ -140,7 +140,7 @@ func (i *UpdateFw) Run(clic *cli.Context) (err error) {
 		return errors.New("update firewall failed")
 	}
 
-	executor := management.NewDispatcher(op, validator.Session(), management.UpdateAction, false)
+	executor := management.NewDispatcher(op, validator.Session(), management.ActionUpdate, false)
 
 	if i.enableFw {
 		op.Info("")

--- a/cmd/vic-machine/upgrade/upgrade.go
+++ b/cmd/vic-machine/upgrade/upgrade.go
@@ -123,10 +123,10 @@ func (u *Upgrade) Run(clic *cli.Context) (err error) {
 	var action management.Action
 	if !u.Data.Rollback {
 		op.Infof("### Upgrading VCH ####")
-		action = management.UpgradeAction
+		action = management.ActionUpgrade
 	} else {
 		op.Infof("### Rolling back VCH ####")
-		action = management.RollbackAction
+		action = management.ActionRollback
 	}
 
 	validator, err := validate.NewValidator(op, u.Data)

--- a/lib/apiservers/service/restapi/handlers/common.go
+++ b/lib/apiservers/service/restapi/handlers/common.go
@@ -139,7 +139,7 @@ func upgradeStatusMessage(op trace.Operation, vch *vm.VirtualMachine, installerV
 }
 
 func getVCHConfig(op trace.Operation, d *data.Data, validator *validate.Validator) (*config.VirtualContainerHostConfigSpec, error) {
-	executor := management.NewDispatcher(op, validator.Session(), management.NoAction, false)
+	executor := management.NewDispatcher(op, validator.Session(), management.ActionNone, false)
 	vch, err := executor.NewVCHFromID(d.ID)
 	if err != nil {
 		return nil, util.NewError(http.StatusNotFound, fmt.Sprintf("Unable to find VCH %s: %s", d.ID, err))

--- a/lib/apiservers/service/restapi/handlers/common.go
+++ b/lib/apiservers/service/restapi/handlers/common.go
@@ -139,7 +139,7 @@ func upgradeStatusMessage(op trace.Operation, vch *vm.VirtualMachine, installerV
 }
 
 func getVCHConfig(op trace.Operation, d *data.Data, validator *validate.Validator) (*config.VirtualContainerHostConfigSpec, error) {
-	executor := management.NewDispatcher(op, validator.Session(), management.ActionNone, false)
+	executor := management.NewDispatcher(op, validator.Session(), management.ActionInspectCertificates, false)
 	vch, err := executor.NewVCHFromID(d.ID)
 	if err != nil {
 		return nil, util.NewError(http.StatusNotFound, fmt.Sprintf("Unable to find VCH %s: %s", d.ID, err))

--- a/lib/apiservers/service/restapi/handlers/vch_create.go
+++ b/lib/apiservers/service/restapi/handlers/vch_create.go
@@ -475,7 +475,7 @@ func handleCreate(op trace.Operation, c *create.Create, validator *validate.Vali
 	vConfig.HTTPProxy = c.HTTPProxy
 	vConfig.HTTPSProxy = c.HTTPSProxy
 
-	executor := management.NewDispatcher(op, validator.Session(), management.CreateAction, false)
+	executor := management.NewDispatcher(op, validator.Session(), management.ActionCreate, false)
 	err = executor.CreateVCH(vchConfig, vConfig, receiver)
 	if err != nil {
 		return nil, util.NewError(http.StatusInternalServerError, fmt.Sprintf("Failed to create VCH: %s", err))

--- a/lib/apiservers/service/restapi/handlers/vch_delete.go
+++ b/lib/apiservers/service/restapi/handlers/vch_delete.go
@@ -84,7 +84,7 @@ func (h *VCHDatacenterDelete) Handle(params operations.DeleteTargetTargetDatacen
 }
 
 func deleteVCH(op trace.Operation, d *data.Data, validator *validate.Validator, specification *models.DeletionSpecification) error {
-	executor := management.NewDispatcher(op, validator.Session(), management.DeleteAction, false)
+	executor := management.NewDispatcher(op, validator.Session(), management.ActionDelete, false)
 	vch, err := executor.NewVCHFromID(d.ID)
 	if err != nil {
 		return util.NewError(http.StatusNotFound, fmt.Sprintf("Failed to find VCH: %s", err))

--- a/lib/apiservers/service/restapi/handlers/vch_get.go
+++ b/lib/apiservers/service/restapi/handlers/vch_get.go
@@ -95,7 +95,7 @@ func (h *VCHDatacenterGet) Handle(params operations.GetTargetTargetDatacenterDat
 }
 
 func getVCH(op trace.Operation, d *data.Data, validator *validate.Validator) (*models.VCH, error) {
-	executor := management.NewDispatcher(op, validator.Session(), management.ActionNone, false)
+	executor := management.NewDispatcher(op, validator.Session(), management.ActionInspect, false)
 	vch, err := executor.NewVCHFromID(d.ID)
 	if err != nil {
 		return nil, util.NewError(http.StatusNotFound, fmt.Sprintf("Failed to inspect VCH: %s", err))

--- a/lib/apiservers/service/restapi/handlers/vch_get.go
+++ b/lib/apiservers/service/restapi/handlers/vch_get.go
@@ -95,7 +95,7 @@ func (h *VCHDatacenterGet) Handle(params operations.GetTargetTargetDatacenterDat
 }
 
 func getVCH(op trace.Operation, d *data.Data, validator *validate.Validator) (*models.VCH, error) {
-	executor := management.NewDispatcher(op, validator.Session(), management.NoAction, false)
+	executor := management.NewDispatcher(op, validator.Session(), management.ActionNone, false)
 	vch, err := executor.NewVCHFromID(d.ID)
 	if err != nil {
 		return nil, util.NewError(http.StatusNotFound, fmt.Sprintf("Failed to inspect VCH: %s", err))

--- a/lib/apiservers/service/restapi/handlers/vch_list_get.go
+++ b/lib/apiservers/service/restapi/handlers/vch_list_get.go
@@ -86,7 +86,7 @@ func (h *VCHDatacenterListGet) Handle(params operations.GetTargetTargetDatacente
 
 func listVCHs(op trace.Operation, d *data.Data, validator *validate.Validator) ([]*models.VCHListItem, error) {
 
-	executor := management.NewDispatcher(op, validator.Session(), management.ActionNone, false)
+	executor := management.NewDispatcher(op, validator.Session(), management.ActionList, false)
 	vchs, err := executor.SearchVCHs(validator.Session().ClusterPath)
 	if err != nil {
 		return nil, util.NewError(http.StatusInternalServerError, fmt.Sprintf("Failed to search VCHs in %s: %s", validator.Session().PoolPath, err))

--- a/lib/apiservers/service/restapi/handlers/vch_list_get.go
+++ b/lib/apiservers/service/restapi/handlers/vch_list_get.go
@@ -86,7 +86,7 @@ func (h *VCHDatacenterListGet) Handle(params operations.GetTargetTargetDatacente
 
 func listVCHs(op trace.Operation, d *data.Data, validator *validate.Validator) ([]*models.VCHListItem, error) {
 
-	executor := management.NewDispatcher(op, validator.Session(), management.NoAction, false)
+	executor := management.NewDispatcher(op, validator.Session(), management.ActionNone, false)
 	vchs, err := executor.SearchVCHs(validator.Session().ClusterPath)
 	if err != nil {
 		return nil, util.NewError(http.StatusInternalServerError, fmt.Sprintf("Failed to search VCHs in %s: %s", validator.Session().PoolPath, err))

--- a/lib/apiservers/service/restapi/handlers/vch_log_get.go
+++ b/lib/apiservers/service/restapi/handlers/vch_log_get.go
@@ -97,7 +97,7 @@ func (h *VCHDatacenterLogGet) Handle(params operations.GetTargetTargetDatacenter
 
 // getDatastoreHelper validates the VCH and returns the datastore helper for the VCH. It errors when validation fails or when datastore is not ready
 func getDatastoreHelper(op trace.Operation, d *data.Data, validator *validate.Validator) (*datastore.Helper, error) {
-	executor := management.NewDispatcher(op, validator.Session(), management.NoAction, false)
+	executor := management.NewDispatcher(op, validator.Session(), management.ActionNone, false)
 	vch, err := executor.NewVCHFromID(d.ID)
 	if err != nil {
 		return nil, util.NewError(http.StatusNotFound, fmt.Sprintf("Unable to find VCH %s: %s", d.ID, err))

--- a/lib/apiservers/service/restapi/handlers/vch_log_get.go
+++ b/lib/apiservers/service/restapi/handlers/vch_log_get.go
@@ -97,7 +97,7 @@ func (h *VCHDatacenterLogGet) Handle(params operations.GetTargetTargetDatacenter
 
 // getDatastoreHelper validates the VCH and returns the datastore helper for the VCH. It errors when validation fails or when datastore is not ready
 func getDatastoreHelper(op trace.Operation, d *data.Data, validator *validate.Validator) (*datastore.Helper, error) {
-	executor := management.NewDispatcher(op, validator.Session(), management.ActionNone, false)
+	executor := management.NewDispatcher(op, validator.Session(), management.ActionInspectLogs, false)
 	vch, err := executor.NewVCHFromID(d.ID)
 	if err != nil {
 		return nil, util.NewError(http.StatusNotFound, fmt.Sprintf("Unable to find VCH %s: %s", d.ID, err))

--- a/lib/install/management/configure.go
+++ b/lib/install/management/configure.go
@@ -78,7 +78,7 @@ func (d *Dispatcher) Configure(conf *config.VirtualContainerHostConfigSpec, sett
 
 	// Resource Pools not available in a DRS Disabled environment, so only attempt an update
 	// if DRS is Enabled and this is a configure action.
-	if d.session.DRSEnabled != nil && *d.session.DRSEnabled && d.Action == ConfigureAction {
+	if d.session.DRSEnabled != nil && *d.session.DRSEnabled && d.Action == ActionConfigure {
 		if err = d.updateResourceSettings(conf.Name, settings); err != nil {
 			err = errors.Errorf("Failed to reconfigure resources: %s", err)
 			return err
@@ -305,7 +305,7 @@ func (d *Dispatcher) update(conf *config.VirtualContainerHostConfigSpec, setting
 	}
 
 	// Create volume stores only for a configure operation, where conf has its storage fields validated.
-	if d.Action == ConfigureAction {
+	if d.Action == ActionConfigure {
 		if err := d.createVolumeStores(conf); err != nil {
 			return err
 		}
@@ -317,7 +317,7 @@ func (d *Dispatcher) update(conf *config.VirtualContainerHostConfigSpec, setting
 
 	// if we are upgrading evaluate need for inventory upgrade
 	// vApp support planned: https://github.com/vmware/vic/issues/7670
-	if d.Action == UpgradeAction && d.session.IsVC() && d.vchPool.Reference().Type != "VirtualApp" {
+	if d.Action == ActionUpgrade && d.session.IsVC() && d.vchPool.Reference().Type != "VirtualApp" {
 		err = d.inventoryUpdate(conf.Name)
 		if err != nil {
 			return errors.Errorf("Failed to perform inventory update: %s", err)

--- a/lib/install/management/dispatcher.go
+++ b/lib/install/management/dispatcher.go
@@ -42,12 +42,13 @@ type Action int
 
 // Action definitions
 const (
-	ActionNone Action = iota
-	ActionConfigure
+	ActionConfigure Action = iota
 	ActionCreate
 	ActionDebug
 	ActionDelete
 	ActionInspect
+	ActionInspectCertificates
+	ActionInspectLogs
 	ActionList
 	ActionRollback
 	ActionUpdate
@@ -66,7 +67,7 @@ func (a Action) String() string {
 		act = "debug"
 	case ActionDelete:
 		act = "delete"
-	case ActionInspect:
+	case ActionInspect, ActionInspectCertificates, ActionInspectLogs:
 		act = "inspect"
 	case ActionList:
 		act = "list"

--- a/lib/install/management/dispatcher.go
+++ b/lib/install/management/dispatcher.go
@@ -42,40 +42,40 @@ type Action int
 
 // Action definitions
 const (
-	NoAction        Action = iota // 0
-	CreateAction                  // 1
-	ConfigureAction               // 2
-	UpgradeAction                 // 3
-	RollbackAction                // 4
-	DeleteAction                  // 5
-	InspectAction                 // 6
-	ListAction                    // 7
-	UpdateAction                  // 8
-	DebugAction                   // 9
+	ActionNone Action = iota
+	ActionConfigure
+	ActionCreate
+	ActionDebug
+	ActionDelete
+	ActionInspect
+	ActionList
+	ActionRollback
+	ActionUpdate
+	ActionUpgrade
 )
 
 // stringer for action
 func (a Action) String() string {
 	var act string
 	switch a {
-	case CreateAction:
-		act = "create"
-	case ConfigureAction:
+	case ActionConfigure:
 		act = "configure"
-	case UpgradeAction:
-		act = "upgrade"
-	case DeleteAction:
-		act = "delete"
-	case InspectAction:
-		act = "inspect"
-	case ListAction:
-		act = "list"
-	case DebugAction:
+	case ActionCreate:
+		act = "create"
+	case ActionDebug:
 		act = "debug"
-	case UpdateAction:
-		act = "update"
-	case RollbackAction:
+	case ActionDelete:
+		act = "delete"
+	case ActionInspect:
+		act = "inspect"
+	case ActionList:
+		act = "list"
+	case ActionRollback:
 		act = "rollback"
+	case ActionUpdate:
+		act = "update"
+	case ActionUpgrade:
+		act = "upgrade"
 	}
 	return act
 }


### PR DESCRIPTION
Rename action constants to follow the convention of sharing a common
prefix. Additionally, sort constants. This makes it easier to find a
constant via either reading or auto-completion.

Switch several places where the API uses a non-specific action iota
to use a specific/accurate/meaningful iota, introducing new ones as
necessary.

Towards #6032