### PR TITLE
Extract en/decode packages for vic-machine API

### DIFF
--- a/lib/apiservers/service/restapi/handlers/decode/certificates.go
+++ b/lib/apiservers/service/restapi/handlers/decode/certificates.go
@@ -1,0 +1,30 @@
+// Copyright 2018 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package decode
+
+import (
+	"github.com/vmware/vic/lib/apiservers/service/models"
+)
+
+func FromPemCertificates(m []*models.X509Data) []byte {
+	var b []byte
+
+	for _, ca := range m {
+		c := []byte(ca.Pem)
+		b = append(b, c...)
+	}
+
+	return b
+}

--- a/lib/apiservers/service/restapi/handlers/decode/decode.go
+++ b/lib/apiservers/service/restapi/handlers/decode/decode.go
@@ -1,0 +1,17 @@
+// Copyright 2018 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package decode converts model objects used by the API into objects used by
+// the management package. Functions are grouped by area.
+package decode

--- a/lib/apiservers/service/restapi/handlers/decode/delete.go
+++ b/lib/apiservers/service/restapi/handlers/decode/delete.go
@@ -1,0 +1,57 @@
+// Copyright 2018 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package decode
+
+import (
+	"github.com/vmware/vic/lib/apiservers/service/models"
+	"github.com/vmware/vic/lib/install/management"
+)
+
+// FromDeletionSpecification parses a DeletionSpecification into granular deletion settings expressed via iotas
+func FromDeletionSpecification(specification *models.DeletionSpecification) (deleteContainers *management.DeleteContainers, deleteVolumeStores *management.DeleteVolumeStores) {
+	if specification != nil {
+		if specification.Containers != nil {
+			var dc management.DeleteContainers
+
+			switch *specification.Containers {
+			case models.DeletionSpecificationContainersAll:
+				dc = management.AllContainers
+			case models.DeletionSpecificationContainersOff:
+				dc = management.PoweredOffContainers
+			default:
+				panic("Deletion API handler received unexpected input")
+			}
+
+			deleteContainers = &dc
+		}
+
+		if specification.VolumeStores != nil {
+			var dv management.DeleteVolumeStores
+
+			switch *specification.VolumeStores {
+			case models.DeletionSpecificationVolumeStoresAll:
+				dv = management.AllVolumeStores
+			case models.DeletionSpecificationVolumeStoresNone:
+				dv = management.NoVolumeStores
+			default:
+				panic("Deletion API handler received unexpected input")
+			}
+
+			deleteVolumeStores = &dv
+		}
+	}
+
+	return
+}

--- a/lib/apiservers/service/restapi/handlers/decode/networking.go
+++ b/lib/apiservers/service/restapi/handlers/decode/networking.go
@@ -1,0 +1,84 @@
+// Copyright 2018 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package decode
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/vmware/vic/cmd/vic-machine/common"
+	"github.com/vmware/vic/lib/apiservers/service/models"
+)
+
+func FromCIDR(m *models.CIDR) string {
+	if m == nil {
+		return ""
+	}
+
+	return string(*m)
+}
+
+func FromCIDRs(m *[]models.CIDR) *[]string {
+	s := make([]string, 0, len(*m))
+	for _, d := range *m {
+		s = append(s, FromCIDR(&d))
+	}
+
+	return &s
+}
+
+func FromIPAddress(m *models.IPAddress) string {
+	if m == nil {
+		return ""
+	}
+
+	return string(*m)
+}
+
+func FromIPAddresses(m []models.IPAddress) []string {
+	s := make([]string, 0, len(m))
+	for _, ip := range m {
+		s = append(s, FromIPAddress(&ip))
+	}
+
+	return s
+}
+
+func FromGateway(m *models.Gateway) string {
+	if m == nil {
+		return ""
+	}
+
+	if m.RoutingDestinations == nil {
+		return fmt.Sprintf("%s",
+			m.Address,
+		)
+	}
+
+	return fmt.Sprintf("%s:%s",
+		strings.Join(*FromCIDRs(&m.RoutingDestinations), ","),
+		m.Address,
+	)
+}
+
+func FromImageFetchProxy(p *models.VCHRegistryImageFetchProxy) common.Proxies {
+	http := string(p.HTTP)
+	https := string(p.HTTPS)
+
+	return common.Proxies{
+		HTTPProxy:  &http,
+		HTTPSProxy: &https,
+	}
+}

--- a/lib/apiservers/service/restapi/handlers/decode/references.go
+++ b/lib/apiservers/service/restapi/handlers/decode/references.go
@@ -1,0 +1,50 @@
+// Copyright 2018 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package decode
+
+import (
+	"context"
+
+	"github.com/vmware/govmomi/list"
+	"github.com/vmware/govmomi/vim25/types"
+
+	"github.com/vmware/vic/lib/apiservers/service/models"
+	"github.com/vmware/vic/pkg/trace"
+)
+
+// This interface is declared so that we can enable mocking finder in tests
+// as the govmomi types do not use interfaces themselves.
+type finder interface {
+	Element(context.Context, types.ManagedObjectReference) (*list.Element, error)
+}
+
+func FromManagedObject(op trace.Operation, finder finder, t string, m *models.ManagedObject) (string, error) {
+	if m == nil {
+		return "", nil
+	}
+
+	if m.ID != "" {
+		managedObjectReference := types.ManagedObjectReference{Type: t, Value: m.ID}
+		element, err := finder.Element(op, managedObjectReference)
+
+		if err != nil {
+			return "", err
+		}
+
+		return element.Path, nil
+	}
+
+	return m.Name, nil
+}

--- a/lib/apiservers/service/restapi/handlers/decode/resources.go
+++ b/lib/apiservers/service/restapi/handlers/decode/resources.go
@@ -1,0 +1,125 @@
+// Copyright 2018 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package decode
+
+import (
+	"fmt"
+	"math"
+
+	"github.com/docker/go-units"
+
+	"github.com/vmware/govmomi/vim25/types"
+
+	"github.com/vmware/vic/lib/apiservers/service/models"
+)
+
+func FromValueBytesMetric(m *models.ValueBytesMetric) string {
+	v := float64(m.Value.Value)
+
+	var bytes float64
+	switch m.Value.Units {
+	case models.ValueBytesMetricUnitsB:
+		bytes = v
+	case models.ValueBytesMetricUnitsKB:
+		bytes = v * float64(units.KB)
+	case models.ValueBytesMetricUnitsMB:
+		bytes = v * float64(units.MB)
+	case models.ValueBytesMetricUnitsGB:
+		bytes = v * float64(units.GB)
+	case models.ValueBytesMetricUnitsTB:
+		bytes = v * float64(units.TB)
+	case models.ValueBytesMetricUnitsPB:
+		bytes = v * float64(units.PB)
+	}
+
+	return fmt.Sprintf("%d B", int64(bytes))
+}
+
+func MBFromValueBytes(m *models.ValueBytes) *int {
+	if m == nil {
+		return nil
+	}
+
+	v := float64(m.Value.Value)
+
+	var mbs float64
+	switch m.Value.Units {
+	case models.ValueBytesUnitsB:
+		mbs = v / float64(units.MiB)
+	case models.ValueBytesUnitsKiB:
+		mbs = v / (float64(units.MiB) / float64(units.KiB))
+	case models.ValueBytesUnitsMiB:
+		mbs = v
+	case models.ValueBytesUnitsGiB:
+		mbs = v * (float64(units.GiB) / float64(units.MiB))
+	case models.ValueBytesUnitsTiB:
+		mbs = v * (float64(units.TiB) / float64(units.MiB))
+	case models.ValueBytesUnitsPiB:
+		mbs = v * (float64(units.PiB) / float64(units.MiB))
+	}
+
+	i := int(math.Ceil(mbs))
+	return &i
+}
+
+func MHzFromValueHertz(m *models.ValueHertz) *int {
+	if m == nil {
+		return nil
+	}
+
+	v := float64(m.Value.Value)
+
+	var mhzs float64
+	switch m.Value.Units {
+	case models.ValueHertzUnitsHz:
+		mhzs = v / float64(units.MB)
+	case models.ValueHertzUnitsKHz:
+		mhzs = v / (float64(units.MB) / float64(units.KB))
+	case models.ValueHertzUnitsMHz:
+		mhzs = v
+	case models.ValueHertzUnitsGHz:
+		mhzs = v * (float64(units.GB) / float64(units.MB))
+	}
+
+	i := int(math.Ceil(mhzs))
+	return &i
+}
+
+func FromShares(m *models.Shares) *types.SharesInfo {
+	if m == nil {
+		return nil
+	}
+
+	var level types.SharesLevel
+	switch types.SharesLevel(m.Level) {
+	case types.SharesLevelLow:
+		level = types.SharesLevelLow
+	case types.SharesLevelNormal:
+		level = types.SharesLevelNormal
+	case types.SharesLevelHigh:
+		level = types.SharesLevelHigh
+	default:
+		level = types.SharesLevelCustom
+	}
+
+	return &types.SharesInfo{
+		Level:  level,
+		Shares: int32(m.Number),
+	}
+}
+
+func FromValueBits(m *models.ValueBits) int {
+	return int(m.Value.Value)
+}

--- a/lib/apiservers/service/restapi/handlers/encode/certificates.go
+++ b/lib/apiservers/service/restapi/handlers/encode/certificates.go
@@ -1,0 +1,54 @@
+// Copyright 2018 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package encode
+
+import (
+	"bytes"
+	"encoding/pem"
+
+	"github.com/vmware/vic/lib/apiservers/service/models"
+)
+
+func AsPemCertificates(certificates []byte) []*models.X509Data {
+	var buf bytes.Buffer
+
+	m := make([]*models.X509Data, 0)
+	for c := &certificates; len(*c) > 0; {
+		b, rest := pem.Decode(*c)
+
+		err := pem.Encode(&buf, b)
+		if err != nil {
+			continue // TODO (#6716): Handle? (We probably don't want to let this fail the request, but may want to convey that something unexpected happened.)
+		}
+
+		m = append(m, &models.X509Data{
+			Pem: models.PEM(buf.String()),
+		})
+
+		c = &rest
+	}
+
+	return m
+}
+
+func AsPemCertificate(certificates []byte) *models.X509Data {
+	m := AsPemCertificates(certificates)
+
+	if len(m) > 1 {
+		// TODO (#6716): Error? (We probably don't want to let this fail the request, but may want to convey that something unexpected happened.)
+	}
+
+	return m[0]
+}

--- a/lib/apiservers/service/restapi/handlers/encode/encode.go
+++ b/lib/apiservers/service/restapi/handlers/encode/encode.go
@@ -1,0 +1,17 @@
+// Copyright 2018 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package encode converts objects used by the management package into model
+// objects used by the API. Functions are grouped by area.
+package encode

--- a/lib/apiservers/service/restapi/handlers/encode/networking.go
+++ b/lib/apiservers/service/restapi/handlers/encode/networking.go
@@ -1,0 +1,113 @@
+// Copyright 2018 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package encode
+
+import (
+	"net"
+	"strings"
+
+	"github.com/go-openapi/strfmt"
+
+	"github.com/vmware/vic/lib/apiservers/service/models"
+	"github.com/vmware/vic/lib/config/executor"
+	"github.com/vmware/vic/pkg/ip"
+)
+
+func AsIPAddress(address net.IP) models.IPAddress {
+	return models.IPAddress(address.String())
+}
+
+func AsIPAddresses(addresses *[]net.IP) *[]models.IPAddress {
+	m := make([]models.IPAddress, 0, len(*addresses))
+	for _, value := range *addresses {
+		m = append(m, AsIPAddress(value))
+	}
+
+	return &m
+}
+
+func AsCIDR(network *net.IPNet) models.CIDR {
+	if network == nil {
+		return models.CIDR("")
+	}
+
+	return models.CIDR(network.String())
+}
+
+func AsCIDRs(networks *[]net.IPNet) *[]models.CIDR {
+	m := make([]models.CIDR, 0, len(*networks))
+	for _, value := range *networks {
+		m = append(m, AsCIDR(&value))
+	}
+
+	return &m
+}
+
+func AsIPRange(network *net.IPNet) models.IPRange {
+	if network == nil {
+		return models.IPRange("")
+	}
+
+	return models.IPRange(models.CIDR(network.String()))
+}
+
+func AsIPRanges(networks *[]ip.Range) *[]models.IPRange {
+	m := make([]models.IPRange, 0, len(*networks))
+	for _, value := range *networks {
+		m = append(m, AsIPRange(value.Network()))
+	}
+
+	return &m
+}
+
+func AsNetwork(network *executor.NetworkEndpoint) *models.Network {
+	if network == nil {
+		return nil
+	}
+
+	m := &models.Network{
+		PortGroup: &models.ManagedObject{
+			ID: AsManagedObjectID(network.Network.Common.ID),
+		},
+		Nameservers: *AsIPAddresses(&network.Network.Nameservers),
+	}
+
+	if network.Network.Gateway.IP != nil {
+		m.Gateway = &models.Gateway{
+			Address:             AsIPAddress(network.Network.Gateway.IP),
+			RoutingDestinations: *AsCIDRs(&network.Network.Destinations),
+		}
+	}
+
+	return m
+}
+
+func AsImageFetchProxy(sessionConfig *executor.SessionConfig, http, https string) *models.VCHRegistryImageFetchProxy {
+	var httpProxy, httpsProxy strfmt.URI
+	for _, env := range sessionConfig.Cmd.Env {
+		if strings.HasPrefix(env, http+"=") {
+			httpProxy = strfmt.URI(strings.SplitN(env, "=", 2)[1])
+		}
+		if strings.HasPrefix(env, https+"=") {
+			httpsProxy = strfmt.URI(strings.SplitN(env, "=", 2)[1])
+		}
+	}
+
+	if httpProxy == "" && httpsProxy == "" {
+		return nil
+	}
+
+	return &models.VCHRegistryImageFetchProxy{HTTP: httpProxy, HTTPS: httpsProxy}
+}

--- a/lib/apiservers/service/restapi/handlers/encode/references.go
+++ b/lib/apiservers/service/restapi/handlers/encode/references.go
@@ -1,0 +1,29 @@
+// Copyright 2018 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package encode
+
+import (
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+func AsManagedObjectID(mobid string) string {
+	moref := new(types.ManagedObjectReference)
+	ok := moref.FromString(mobid)
+	if !ok {
+		return "" // TODO (#6717): Handle? (We probably don't want to let this fail the request, but may want to convey that something unexpected happened.)
+	}
+
+	return moref.Value
+}

--- a/lib/apiservers/service/restapi/handlers/encode/resources.go
+++ b/lib/apiservers/service/restapi/handlers/encode/resources.go
@@ -1,0 +1,79 @@
+// Copyright 2018 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package encode
+
+import (
+	"github.com/vmware/govmomi/vim25/types"
+
+	"github.com/vmware/vic/lib/apiservers/service/models"
+)
+
+func AsBytes(value *int, units string) *models.ValueBytes {
+	if value == nil || *value == 0 {
+		return nil
+	}
+
+	return &models.ValueBytes{
+		Value: models.Value{
+			Value: int64(*value),
+			Units: units,
+		},
+	}
+}
+
+func AsMiB(value *int) *models.ValueBytes {
+	return AsBytes(value, models.ValueBytesUnitsMiB)
+}
+
+func AsBytesMetric(value *int, units string) *models.ValueBytesMetric {
+	if value == nil || *value == 0 {
+		return nil
+	}
+
+	return &models.ValueBytesMetric{
+		Value: models.Value{
+			Value: int64(*value),
+			Units: units,
+		},
+	}
+}
+
+func AsKB(value *int) *models.ValueBytesMetric {
+	return AsBytesMetric(value, models.ValueBytesMetricUnitsKB)
+}
+
+func AsMHz(value *int) *models.ValueHertz {
+	if value == nil || *value == 0 {
+		return nil
+	}
+
+	return &models.ValueHertz{
+		Value: models.Value{
+			Value: int64(*value),
+			Units: models.ValueHertzUnitsMHz,
+		},
+	}
+}
+
+func AsShares(shares *types.SharesInfo) *models.Shares {
+	if shares == nil {
+		return nil
+	}
+
+	return &models.Shares{
+		Level:  string(shares.Level),
+		Number: int64(shares.Shares),
+	}
+}

--- a/lib/apiservers/service/restapi/handlers/vch_cert_get.go
+++ b/lib/apiservers/service/restapi/handlers/vch_cert_get.go
@@ -22,6 +22,7 @@ import (
 	"github.com/go-openapi/runtime/middleware"
 
 	"github.com/vmware/vic/lib/apiservers/service/models"
+	"github.com/vmware/vic/lib/apiservers/service/restapi/handlers/encode"
 	"github.com/vmware/vic/lib/apiservers/service/restapi/handlers/errors"
 	"github.com/vmware/vic/lib/apiservers/service/restapi/operations"
 	"github.com/vmware/vic/lib/config"
@@ -55,7 +56,7 @@ func (h *VCHCertGet) Handle(params operations.GetTargetTargetVchVchIDCertificate
 			errors.StatusCode(err)).WithPayload(&models.Error{Message: err.Error()})
 	}
 
-	cert := asPemCertificate(c.Cert)
+	cert := encode.AsPemCertificate(c.Cert)
 	return NewGetTargetTargetVchVchIDCertificateOK(cert.Pem)
 }
 
@@ -81,7 +82,7 @@ func (h *VCHDatacenterCertGet) Handle(params operations.GetTargetTargetDatacente
 			errors.StatusCode(err)).WithPayload(&models.Error{Message: err.Error()})
 	}
 
-	cert := asPemCertificate(c.Cert)
+	cert := encode.AsPemCertificate(c.Cert)
 	return NewGetTargetTargetDatacenterDatacenterVchVchIDCertificateOK(cert.Pem)
 }
 

--- a/lib/apiservers/service/restapi/handlers/vch_create.go
+++ b/lib/apiservers/service/restapi/handlers/vch_create.go
@@ -17,14 +17,12 @@ package handlers
 import (
 	"context"
 	"fmt"
-	"math"
 	"net"
 	"net/http"
 	"path"
 	"strings"
 
 	"github.com/Sirupsen/logrus"
-	"github.com/docker/go-units"
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/go-openapi/strfmt"
 	"gopkg.in/urfave/cli.v1"
@@ -34,6 +32,7 @@ import (
 	"github.com/vmware/vic/cmd/vic-machine/common"
 	"github.com/vmware/vic/cmd/vic-machine/create"
 	"github.com/vmware/vic/lib/apiservers/service/models"
+	"github.com/vmware/vic/lib/apiservers/service/restapi/handlers/decode"
 	"github.com/vmware/vic/lib/apiservers/service/restapi/handlers/errors"
 	"github.com/vmware/vic/lib/apiservers/service/restapi/operations"
 	"github.com/vmware/vic/lib/config/executor"
@@ -167,18 +166,18 @@ func buildCreate(op trace.Operation, d *data.Data, finder finder, vch *models.VC
 
 		if vch.Compute != nil {
 			if vch.Compute.CPU != nil {
-				c.ResourceLimits.VCHCPULimitsMHz = mhzFromValueHertz(vch.Compute.CPU.Limit)
-				c.ResourceLimits.VCHCPUReservationsMHz = mhzFromValueHertz(vch.Compute.CPU.Reservation)
-				c.ResourceLimits.VCHCPUShares = fromShares(vch.Compute.CPU.Shares)
+				c.ResourceLimits.VCHCPULimitsMHz = decode.MHzFromValueHertz(vch.Compute.CPU.Limit)
+				c.ResourceLimits.VCHCPUReservationsMHz = decode.MHzFromValueHertz(vch.Compute.CPU.Reservation)
+				c.ResourceLimits.VCHCPUShares = decode.FromShares(vch.Compute.CPU.Shares)
 			}
 
 			if vch.Compute.Memory != nil {
-				c.ResourceLimits.VCHMemoryLimitsMB = mbFromValueBytes(vch.Compute.Memory.Limit)
-				c.ResourceLimits.VCHMemoryReservationsMB = mbFromValueBytes(vch.Compute.Memory.Reservation)
-				c.ResourceLimits.VCHMemoryShares = fromShares(vch.Compute.Memory.Shares)
+				c.ResourceLimits.VCHMemoryLimitsMB = decode.MBFromValueBytes(vch.Compute.Memory.Limit)
+				c.ResourceLimits.VCHMemoryReservationsMB = decode.MBFromValueBytes(vch.Compute.Memory.Reservation)
+				c.ResourceLimits.VCHMemoryShares = decode.FromShares(vch.Compute.Memory.Shares)
 			}
 
-			resourcePath, err := fromManagedObject(op, finder, "ResourcePool", vch.Compute.Resource) // TODO (#6711): Do we need to handle clusters differently?
+			resourcePath, err := decode.FromManagedObject(op, finder, "ResourcePool", vch.Compute.Resource) // TODO (#6711): Do we need to handle clusters differently?
 			if err != nil {
 				return nil, errors.NewError(http.StatusBadRequest, fmt.Sprintf("Error finding resource pool: %s", err))
 			}
@@ -194,7 +193,7 @@ func buildCreate(op trace.Operation, d *data.Data, finder finder, vch *models.VC
 
 		if vch.Network != nil {
 			if vch.Network.Bridge != nil {
-				path, err := fromManagedObject(op, finder, "Network", vch.Network.Bridge.PortGroup)
+				path, err := decode.FromManagedObject(op, finder, "Network", vch.Network.Bridge.PortGroup)
 				if err != nil {
 					return nil, errors.NewError(http.StatusBadRequest, fmt.Sprintf("Error finding bridge network: %s", err))
 				}
@@ -202,7 +201,7 @@ func buildCreate(op trace.Operation, d *data.Data, finder finder, vch *models.VC
 					return nil, errors.NewError(http.StatusBadRequest, "Bridge network portgroup must be specified (by name or id)")
 				}
 				c.BridgeNetworkName = path
-				c.BridgeIPRange = fromCIDR(&vch.Network.Bridge.IPRange)
+				c.BridgeIPRange = decode.FromCIDR(&vch.Network.Bridge.IPRange)
 
 				if err := c.ProcessBridgeNetwork(); err != nil {
 					return nil, errors.WrapError(http.StatusBadRequest, err)
@@ -210,7 +209,7 @@ func buildCreate(op trace.Operation, d *data.Data, finder finder, vch *models.VC
 			}
 
 			if vch.Network.Client != nil {
-				path, err := fromManagedObject(op, finder, "Network", vch.Network.Client.PortGroup)
+				path, err := decode.FromManagedObject(op, finder, "Network", vch.Network.Client.PortGroup)
 				if err != nil {
 					return nil, errors.NewError(http.StatusBadRequest, fmt.Sprintf("Error finding client network portgroup: %s", err))
 				}
@@ -218,8 +217,8 @@ func buildCreate(op trace.Operation, d *data.Data, finder finder, vch *models.VC
 					return nil, errors.NewError(http.StatusBadRequest, "Client network portgroup must be specified (by name or id)")
 				}
 				c.ClientNetworkName = path
-				c.ClientNetworkGateway = fromGateway(vch.Network.Client.Gateway)
-				c.ClientNetworkIP = fromCIDR(&vch.Network.Client.Static)
+				c.ClientNetworkGateway = decode.FromGateway(vch.Network.Client.Gateway)
+				c.ClientNetworkIP = decode.FromCIDR(&vch.Network.Client.Static)
 
 				if err := c.ProcessNetwork(op, &c.Data.ClientNetwork, "client", c.ClientNetworkName, c.ClientNetworkIP, c.ClientNetworkGateway); err != nil {
 					return nil, errors.WrapError(http.StatusBadRequest, err)
@@ -227,7 +226,7 @@ func buildCreate(op trace.Operation, d *data.Data, finder finder, vch *models.VC
 			}
 
 			if vch.Network.Management != nil {
-				path, err := fromManagedObject(op, finder, "Network", vch.Network.Management.PortGroup)
+				path, err := decode.FromManagedObject(op, finder, "Network", vch.Network.Management.PortGroup)
 				if err != nil {
 					return nil, errors.NewError(http.StatusBadRequest, fmt.Sprintf("Error finding management network portgroup: %s", err))
 				}
@@ -235,8 +234,8 @@ func buildCreate(op trace.Operation, d *data.Data, finder finder, vch *models.VC
 					return nil, errors.NewError(http.StatusBadRequest, "Management network portgroup must be specified (by name or id)")
 				}
 				c.ManagementNetworkName = path
-				c.ManagementNetworkGateway = fromGateway(vch.Network.Management.Gateway)
-				c.ManagementNetworkIP = fromCIDR(&vch.Network.Management.Static)
+				c.ManagementNetworkGateway = decode.FromGateway(vch.Network.Management.Gateway)
+				c.ManagementNetworkIP = decode.FromCIDR(&vch.Network.Management.Static)
 
 				if err := c.ProcessNetwork(op, &c.Data.ManagementNetwork, "management", c.ManagementNetworkName, c.ManagementNetworkIP, c.ManagementNetworkGateway); err != nil {
 					return nil, errors.WrapError(http.StatusBadRequest, err)
@@ -244,7 +243,7 @@ func buildCreate(op trace.Operation, d *data.Data, finder finder, vch *models.VC
 			}
 
 			if vch.Network.Public != nil {
-				path, err := fromManagedObject(op, finder, "Network", vch.Network.Public.PortGroup)
+				path, err := decode.FromManagedObject(op, finder, "Network", vch.Network.Public.PortGroup)
 				if err != nil {
 					return nil, errors.NewError(http.StatusBadRequest, fmt.Sprintf("Error finding public network portgroup: %s", err))
 				}
@@ -252,15 +251,15 @@ func buildCreate(op trace.Operation, d *data.Data, finder finder, vch *models.VC
 					return nil, errors.NewError(http.StatusBadRequest, "Public network portgroup must be specified (by name or id)")
 				}
 				c.PublicNetworkName = path
-				c.PublicNetworkGateway = fromGateway(vch.Network.Public.Gateway)
-				c.PublicNetworkIP = fromCIDR(&vch.Network.Public.Static)
+				c.PublicNetworkGateway = decode.FromGateway(vch.Network.Public.Gateway)
+				c.PublicNetworkIP = decode.FromCIDR(&vch.Network.Public.Static)
 
 				if err := c.ProcessNetwork(op, &c.Data.PublicNetwork, "public", c.PublicNetworkName, c.PublicNetworkIP, c.PublicNetworkGateway); err != nil {
 					return nil, errors.WrapError(http.StatusBadRequest, err)
 				}
 
 				c.Nameservers = common.DNS{
-					DNS: fromIPAddresses(vch.Network.Public.Nameservers),
+					DNS: decode.FromIPAddresses(vch.Network.Public.Nameservers),
 				}
 				c.DNS, err = c.Nameservers.ProcessDNSServers(op)
 				if err != nil {
@@ -280,7 +279,7 @@ func buildCreate(op trace.Operation, d *data.Data, finder finder, vch *models.VC
 				for _, cnetwork := range vch.Network.Container {
 					alias := cnetwork.Alias
 
-					path, err := fromManagedObject(op, finder, "Network", cnetwork.PortGroup)
+					path, err := decode.FromManagedObject(op, finder, "Network", cnetwork.PortGroup)
 					if err != nil {
 						return nil, errors.NewError(http.StatusBadRequest, fmt.Sprintf("Error finding portgroup for container network %s: %s", alias, err))
 					}
@@ -361,7 +360,7 @@ func buildCreate(op trace.Operation, d *data.Data, finder finder, vch *models.VC
 
 			c.ScratchSize = constants.DefaultBaseImageScratchSize
 			if vch.Storage.BaseImageSize != nil {
-				c.ScratchSize = fromValueBytesMetric(vch.Storage.BaseImageSize)
+				c.ScratchSize = decode.FromValueBytesMetric(vch.Storage.BaseImageSize)
 			}
 		}
 
@@ -370,7 +369,7 @@ func buildCreate(op trace.Operation, d *data.Data, finder finder, vch *models.VC
 
 			if vch.Auth.Client != nil {
 				c.Certs.NoTLSverify = vch.Auth.Client.NoTLSVerify
-				c.Certs.ClientCAs = fromPemCertificates(vch.Auth.Client.CertificateAuthorities)
+				c.Certs.ClientCAs = decode.FromPemCertificates(vch.Auth.Client.CertificateAuthorities)
 				c.ClientCAs = c.Certs.ClientCAs
 			}
 
@@ -379,7 +378,7 @@ func buildCreate(op trace.Operation, d *data.Data, finder finder, vch *models.VC
 				if vch.Auth.Server.Generate != nil {
 					c.Certs.Cname = vch.Auth.Server.Generate.Cname
 					c.Certs.Org = vch.Auth.Server.Generate.Organization
-					c.Certs.KeySize = fromValueBits(vch.Auth.Server.Generate.Size)
+					c.Certs.KeySize = decode.FromValueBits(vch.Auth.Server.Generate.Size)
 
 					c.Certs.NoSaveToDisk = true
 					c.Certs.Networks = c.Networks
@@ -400,7 +399,7 @@ func buildCreate(op trace.Operation, d *data.Data, finder finder, vch *models.VC
 		c.MemoryMB = constants.DefaultEndpointMemoryMB
 		if vch.Endpoint != nil {
 			if vch.Endpoint.Memory != nil {
-				c.MemoryMB = *mbFromValueBytes(vch.Endpoint.Memory)
+				c.MemoryMB = *decode.MBFromValueBytes(vch.Endpoint.Memory)
 			}
 			if vch.Endpoint.CPU != nil {
 				c.NumCPUs = int(vch.Endpoint.CPU.Sockets)
@@ -423,10 +422,10 @@ func buildCreate(op trace.Operation, d *data.Data, finder finder, vch *models.VC
 			c.InsecureRegistries = vch.Registry.Insecure
 			c.WhitelistRegistries = vch.Registry.Whitelist
 
-			c.RegistryCAs = fromPemCertificates(vch.Registry.CertificateAuthorities)
+			c.RegistryCAs = decode.FromPemCertificates(vch.Registry.CertificateAuthorities)
 
 			if vch.Registry.ImageFetchProxy != nil {
-				c.Proxies = fromImageFetchProxy(vch.Registry.ImageFetchProxy)
+				c.Proxies = decode.FromImageFetchProxy(vch.Registry.ImageFetchProxy)
 
 				hproxy, sproxy, err := c.Proxies.ProcessProxies()
 				if err != nil {
@@ -482,194 +481,4 @@ func handleCreate(op trace.Operation, c *create.Create, validator *validate.Vali
 	}
 
 	return nil, nil
-}
-
-func fromManagedObject(op trace.Operation, finder finder, t string, m *models.ManagedObject) (string, error) {
-	if m == nil {
-		return "", nil
-	}
-
-	if m.ID != "" {
-		managedObjectReference := types.ManagedObjectReference{Type: t, Value: m.ID}
-		element, err := finder.Element(op, managedObjectReference)
-
-		if err != nil {
-			return "", err
-		}
-
-		return element.Path, nil
-	}
-
-	return m.Name, nil
-}
-
-func fromCIDR(m *models.CIDR) string {
-	if m == nil {
-		return ""
-	}
-
-	return string(*m)
-}
-
-func fromCIDRs(m *[]models.CIDR) *[]string {
-	s := make([]string, 0, len(*m))
-	for _, d := range *m {
-		s = append(s, fromCIDR(&d))
-	}
-
-	return &s
-}
-
-func fromIPAddress(m *models.IPAddress) string {
-	if m == nil {
-		return ""
-	}
-
-	return string(*m)
-}
-
-func fromIPAddresses(m []models.IPAddress) []string {
-	s := make([]string, 0, len(m))
-	for _, ip := range m {
-		s = append(s, fromIPAddress(&ip))
-	}
-
-	return s
-}
-
-func fromGateway(m *models.Gateway) string {
-	if m == nil {
-		return ""
-	}
-
-	if m.RoutingDestinations == nil {
-		return fmt.Sprintf("%s",
-			m.Address,
-		)
-	}
-
-	return fmt.Sprintf("%s:%s",
-		strings.Join(*fromCIDRs(&m.RoutingDestinations), ","),
-		m.Address,
-	)
-}
-
-func fromValueBytesMetric(m *models.ValueBytesMetric) string {
-	v := float64(m.Value.Value)
-
-	var bytes float64
-	switch m.Value.Units {
-	case models.ValueBytesMetricUnitsB:
-		bytes = v
-	case models.ValueBytesMetricUnitsKB:
-		bytes = v * float64(units.KB)
-	case models.ValueBytesMetricUnitsMB:
-		bytes = v * float64(units.MB)
-	case models.ValueBytesMetricUnitsGB:
-		bytes = v * float64(units.GB)
-	case models.ValueBytesMetricUnitsTB:
-		bytes = v * float64(units.TB)
-	case models.ValueBytesMetricUnitsPB:
-		bytes = v * float64(units.PB)
-	}
-
-	return fmt.Sprintf("%d B", int64(bytes))
-}
-
-func mbFromValueBytes(m *models.ValueBytes) *int {
-	if m == nil {
-		return nil
-	}
-
-	v := float64(m.Value.Value)
-
-	var mbs float64
-	switch m.Value.Units {
-	case models.ValueBytesUnitsB:
-		mbs = v / float64(units.MiB)
-	case models.ValueBytesUnitsKiB:
-		mbs = v / (float64(units.MiB) / float64(units.KiB))
-	case models.ValueBytesUnitsMiB:
-		mbs = v
-	case models.ValueBytesUnitsGiB:
-		mbs = v * (float64(units.GiB) / float64(units.MiB))
-	case models.ValueBytesUnitsTiB:
-		mbs = v * (float64(units.TiB) / float64(units.MiB))
-	case models.ValueBytesUnitsPiB:
-		mbs = v * (float64(units.PiB) / float64(units.MiB))
-	}
-
-	i := int(math.Ceil(mbs))
-	return &i
-}
-
-func mhzFromValueHertz(m *models.ValueHertz) *int {
-	if m == nil {
-		return nil
-	}
-
-	v := float64(m.Value.Value)
-
-	var mhzs float64
-	switch m.Value.Units {
-	case models.ValueHertzUnitsHz:
-		mhzs = v / float64(units.MB)
-	case models.ValueHertzUnitsKHz:
-		mhzs = v / (float64(units.MB) / float64(units.KB))
-	case models.ValueHertzUnitsMHz:
-		mhzs = v
-	case models.ValueHertzUnitsGHz:
-		mhzs = v * (float64(units.GB) / float64(units.MB))
-	}
-
-	i := int(math.Ceil(mhzs))
-	return &i
-}
-
-func fromShares(m *models.Shares) *types.SharesInfo {
-	if m == nil {
-		return nil
-	}
-
-	var level types.SharesLevel
-	switch types.SharesLevel(m.Level) {
-	case types.SharesLevelLow:
-		level = types.SharesLevelLow
-	case types.SharesLevelNormal:
-		level = types.SharesLevelNormal
-	case types.SharesLevelHigh:
-		level = types.SharesLevelHigh
-	default:
-		level = types.SharesLevelCustom
-	}
-
-	return &types.SharesInfo{
-		Level:  level,
-		Shares: int32(m.Number),
-	}
-}
-
-func fromValueBits(m *models.ValueBits) int {
-	return int(m.Value.Value)
-}
-
-func fromPemCertificates(m []*models.X509Data) []byte {
-	var b []byte
-
-	for _, ca := range m {
-		c := []byte(ca.Pem)
-		b = append(b, c...)
-	}
-
-	return b
-}
-
-func fromImageFetchProxy(p *models.VCHRegistryImageFetchProxy) common.Proxies {
-	http := string(p.HTTP)
-	https := string(p.HTTPS)
-
-	return common.Proxies{
-		HTTPProxy:  &http,
-		HTTPSProxy: &https,
-	}
 }


### PR DESCRIPTION
Better organize the functionality related to converting between the
model objects used by the API and the objects used by the management
package by extracting dedicated "encode" and "decode" packages.

This simplifies handler definitions and provides a clearer way to
reuse code for new operations.

Towards #6032 

`[specific ci=Group23-VIC-Machine-Service]`