### PR TITLE
Correct bad merge resolution in 517f3ac505

### DIFF
--- a/lib/apiservers/service/restapi/handlers/vch_log_get.go
+++ b/lib/apiservers/service/restapi/handlers/vch_log_get.go
@@ -103,7 +103,7 @@ func getDatastoreHelper(op trace.Operation, d *data.Data, validator *validate.Va
 		return nil, errors.NewError(http.StatusNotFound, fmt.Sprintf("Unable to find VCH %s: %s", d.ID, err))
 	}
 
-	if err := validate.SetDataFromVM(op, validator.Session().Finder, vch, d); err != nil {
+	if err := validator.SetDataFromVM(op, vch, d); err != nil {
 		return nil, errors.NewError(http.StatusInternalServerError, fmt.Sprintf("Failed to load VCH data: %s", err))
 	}
 


### PR DESCRIPTION
A conflict between commits 517f3ac505 and 6d1ae660eb was not properly
resolved, resulting in a compilation error. Correct the merge.