### PR TITLE
Stop abusing validator within the VCH Management API

### DIFF
--- a/lib/apiservers/service/restapi/handlers/target/target.go
+++ b/lib/apiservers/service/restapi/handlers/target/target.go
@@ -73,7 +73,6 @@ func Validate(op trace.Operation, action management.Action, params Params, princ
 		data.ID = *params.VCHID
 	}
 
-	// TODO (#6032): clean this up
 	var validator *validate.Validator
 	var allowEmptyDC bool
 	if params.Datacenter != nil {
@@ -94,18 +93,9 @@ func Validate(op trace.Operation, action management.Action, params Params, princ
 			return data, nil, errors.NewError(http.StatusBadRequest, "validation error: datacenter parameter is not a datacenter moref")
 		}
 
-		// Set datacenter path and corresponding finder config
-		s.DatacenterPath = dc.Name()
-		s.Datacenter = dc
-		s.Finder.SetDatacenter(dc)
-
-		// Do what validator.Session().Populate would have done if datacenterPath is set
-		if s.Datacenter != nil {
-			folders, err := s.Datacenter.Folders(op)
-			if err != nil {
-				return data, nil, errors.NewError(http.StatusBadRequest, "validation error: error finding datacenter folders: %s", err)
-			}
-			s.VMFolder = folders.VmFolder
+		err = s.SetDatacenter(op, dc)
+		if err != nil {
+			return data, nil, errors.NewError(http.StatusBadRequest, "validation error: error finding datacenter folders: %s", err)
 		}
 
 		v, err := validate.CreateFromSession(op, s)

--- a/pkg/vsphere/session/session.go
+++ b/pkg/vsphere/session/session.go
@@ -369,10 +369,46 @@ func (s *Session) Populate(ctx context.Context) (*Session, error) {
 		op.Debugf("Cached pool: %s", s.PoolPath)
 	}
 
+	err = s.setDatacenterFolders(op)
+	if err != nil {
+		errs = append(errs, fmt.Sprintf("Failure finding folders (%s): %s", s.DatacenterPath, err.Error()))
+	}
+
+	if len(errs) > 0 {
+		op.Debugf("Error count populating vSphere cache: (%d)", len(errs))
+		return nil, errors.New(strings.Join(errs, "\n"))
+	}
+	op.Debug("vSphere resource cache populated...")
+	return s, nil
+}
+
+func (s *Session) SetDatacenter(op trace.Operation, datacenter *object.Datacenter) error {
+	s.Datacenter = datacenter
+	s.Finder.SetDatacenter(datacenter)
+
+	if datacenter == nil {
+		s.DatacenterPath = ""
+		return nil
+	}
+
+	s.DatacenterPath = datacenter.InventoryPath
+
+	// Do what Populate would have done if datacenterPath were set
+	err := s.setDatacenterFolders(op)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (s *Session) setDatacenterFolders(op trace.Operation) error {
+	var err error
+
 	if s.Datacenter != nil {
-		folders, err := s.Datacenter.Folders(op)
-		if err != nil {
-			errs = append(errs, fmt.Sprintf("Failure finding folders (%s): %s", s.DatacenterPath, err.Error()))
+		folders, e := s.Datacenter.Folders(op)
+		if e != nil {
+			err = e
 		} else {
 			op.Debugf("Cached folders: %s", s.DatacenterPath)
 		}
@@ -387,12 +423,7 @@ func (s *Session) Populate(ctx context.Context) (*Session, error) {
 		s.VCHFolder = folders.VmFolder
 	}
 
-	if len(errs) > 0 {
-		op.Debugf("Error count populating vSphere cache: (%d)", len(errs))
-		return nil, errors.New(strings.Join(errs, "\n"))
-	}
-	op.Debug("vSphere resource cache populated...")
-	return s, nil
+	return err
 }
 
 func (s *Session) logEnvironmentInfo(op trace.Operation) {


### PR DESCRIPTION
Split the process for constructing a new `Validator` into several steps. These constructors are located in `validate` instead of `session` as they construct the objects specifically for use by `Validator`.

Then, use this decomposed process to restructure the `Session` and `Validator` construction process to allow lookup of a `datacenter` by ID without abusing `Validator` to get a `Session` and `Finder` to perform the lookup.

Deduplicate the logic for setting a `Session`'s datacenter and associated folders by adding new methods to `Session`.

Fixes #7942

`[specific ci=Group23-VIC-Machine-Service]`