### PR TITLE
Calculate CI passrate based on sprint dates

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -358,7 +358,7 @@ pipeline:
       status: success
 
   pass-rate:
-    image: 'wdc-harbor-ci.eng.vmware.com/default-project/vic-integration-test:1.48'
+    image: 'wdc-harbor-ci.eng.vmware.com/default-project/vic-pass-rate:1.0'
     pull: true
     environment:
       BIN: bin
@@ -366,8 +366,8 @@ pipeline:
     secrets:
       - github_automation_api_key
       - slack_url
-    commands:
-      - tests/pass-rate.sh
     when:
+      repo: vmware/vic
+      event: [push, tag]
+      branch: [master, 'releases/*']
       status: [success, failure]
-

--- a/infra/integration-image/Dockerfile.passrate
+++ b/infra/integration-image/Dockerfile.passrate
@@ -1,0 +1,24 @@
+# Building:
+# docker build --no-cache -t vic-pass-rate -f Dockerfile.passrate ../..
+# docker tag vic-pass-rate gcr.io/eminent-nation-87317/vic-pass-rate:1.x
+# gcloud auth login
+# gcloud docker -- push gcr.io/eminent-nation-87317/vic-pass-rate:1.x
+# download and install harbor certs, then docker login, then:
+# docker tag vic-pass-rate wdc-harbor-ci.eng.vmware.com/default-project/vic-pass-rate:1.x
+# docker push wdc-harbor-ci.eng.vmware.com/default-project/vic-pass-rate:1.x
+
+FROM vmware/photon:2.0
+
+RUN set -eux; \
+     tdnf distro-sync --refresh -y; \
+# Removing toybox installs GNU date
+     tdnf remove toybox -y; \
+     tdnf install jq -y; \
+     tdnf install bc -y; \
+     tdnf info installed; \
+     tdnf clean all
+
+COPY tests/pass-rate.sh /usr/bin/pass-rate.sh
+
+ENTRYPOINT ["pass-rate.sh"]
+

--- a/tests/pass-rate.sh
+++ b/tests/pass-rate.sh
@@ -19,21 +19,27 @@
 sprint_start=$(gdate -d "last wednesday-$(( ($(gdate +%W 2>/dev/null)+0)%2 )) weeks" "+%Y-%m-%dT%H:%M:%S" 2>/dev/null) || sprint_start=$(date -d "last wednesday-$(( ($(date +%W)+0)%2 )) weeks" "+%Y-%m-%dT%H:%M:%S")
 
 commits=$(curl -s https://api.github.com/repos/vmware/vic/commits?access_token=$GITHUB_AUTOMATION_API_KEY\&since=$sprint_start | jq -r ' map(.sha) | join(",")')
-curl -s https://api.github.com/repos/vmware/vic/statuses/{$commits}?access_token=$GITHUB_AUTOMATION_API_KEY | jq '.[] | select((.context == "continuous-integration/vic/push") and (.state != "pending")) | "\(.target_url): \(.state)"' | tee status.out
+curl -s https://api.github.com/repos/vmware/vic/status/{$commits}?access_token=$GITHUB_AUTOMATION_API_KEY | jq '.statuses[] | select(.context == "continuous-integration/vic/push") | "\(.target_url): \(.state)"' | tee status.out
 
 failures=$(cat status.out | grep -c failure)
 successes=$(cat status.out | grep -c success)
+pending=$(cat status.out | grep -c pending)
 
-let total=$successes+$failures
-if [ $total -eq 0 ]; then
+let complete=$successes+$failures
+if [ $complete -eq 0 ]; then
     # This should be "undefined", but starting at 100% seems reasonable given how this is used.
     passrate="100.00"
 else
-    passrate=$(bc -l <<< "scale=2;100 * ($successes / $total)")
+    passrate=$(bc -l <<< "scale=2;100 * ($successes / $complete)")
 fi
 
-echo "Number of failed merges to master in the $total merges since $sprint_start: $failures"
-echo "Number of successful merges to master in the $total merges since $sprint_start: $successes"
+echo "Number of failed runs on merges to master in the $complete completed builds since $sprint_start: $failures"
+echo "Number of successful runs on merges to master in the $complete completed builds since $sprint_start: $successes"
+echo "Number of runs since $sprint_start which are still pending: $pending"
 
-echo "Current vmware/vic CI passrate: $passrate"
-curl --max-time 10 --retry 3 -s -d "payload={'channel': '#vic-bots', 'text': 'Current vmware/vic CI passrate: $passrate%'}" "$SLACK_URL"
+echo "Current vmware/vic CI passrate: $passrate (of completed)"
+if [ $complete -eq 0 ]; then
+    curl --max-time 10 --retry 3 -s --data-urlencode "payload={'channel': '#vic-bots', 'text': 'Current <https://github.com/vmware/vic|vmware/vic> CI passrate: $passrate% (of $complete completed this sprint)'}" "$SLACK_URL"
+else
+    curl --max-time 10 --retry 3 -s --data-urlencode "payload={'channel': '#vic-bots', 'attachments':[{'text': 'Current <https://github.com/vmware/vic|vmware/vic> CI passrate: $passrate% (of $complete completed this sprint)', 'image_url': 'http://chart.googleapis.com/chart?cht=p&chs=250x150&chco=dc3912|109618|3366cc&chl=failure|success|pending&chd=t:$failures,$successes,$pending', 'footer':'pass-rate.sh'}]}" "$SLACK_URL"
+fi

--- a/tests/pass-rate.sh
+++ b/tests/pass-rate.sh
@@ -39,7 +39,7 @@ echo "Number of runs since $sprint_start which are still pending: $pending"
 
 echo "Current vmware/vic CI passrate: $passrate (of completed)"
 if [ $complete -eq 0 ]; then
-    curl --max-time 10 --retry 3 -s --data-urlencode "payload={'channel': '#vic-bots', 'text': 'Current <https://github.com/vmware/vic|vmware/vic> CI passrate: $passrate% (of $complete completed this sprint)'}" "$SLACK_URL"
+    curl --max-time 10 --retry 3 -s --data-urlencode "payload={'channel': '#notifications', 'text': 'Current <https://github.com/vmware/vic|vmware/vic> CI passrate: $passrate% (of $complete completed this sprint)'}" "$SLACK_URL"
 else
-    curl --max-time 10 --retry 3 -s --data-urlencode "payload={'channel': '#vic-bots', 'attachments':[{'text': 'Current <https://github.com/vmware/vic|vmware/vic> CI passrate: $passrate% (of $complete completed this sprint)', 'image_url': 'http://chart.googleapis.com/chart?cht=p&chs=250x150&chco=dc3912|109618|3366cc&chl=failure|success|pending&chd=t:$failures,$successes,$pending', 'footer':'pass-rate.sh'}]}" "$SLACK_URL"
+    curl --max-time 10 --retry 3 -s --data-urlencode "payload={'channel': '#notifications', 'attachments':[{'text': 'Current <https://github.com/vmware/vic|vmware/vic> CI passrate: $passrate% (of $complete completed this sprint)', 'image_url': 'http://chart.googleapis.com/chart?cht=p&chs=250x150&chco=dc3912|109618|3366cc&chl=failure|success|pending&chd=t:$failures,$successes,$pending', 'footer':'pass-rate.sh'}]}" "$SLACK_URL"
 fi


### PR DESCRIPTION
Currently, our CI passrate is calculated as a percentage of the last
30-ish merges to master. This sliding window can lead to confusing
results as the passrate calculation is influenced by both new results
and the phase-out of old results.

The impacts of this variability can be made more significant by our
long turn-around time for full CI runs or the merge of commits on
which CI will not be run (e.g., due to a "Rebase & Merge").

By establishing a fixed window, we begin each sprint with a "clean
slate" and limit the sources of change so that we can be confident
that a decreasing passrate reflects recent failures and an increasing
passrate reflects recent successes.

`[skip unit]`
`[skip ci]`