### PR TITLE
Add timeout variable for overflow servers

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -107,6 +107,7 @@ pipeline:
       - test_password
       - test_username
       - haas_url_array
+      - overflow_test_timeout
       - overflow_url_array
       - ssh_test_username
       - ssh_test_password

--- a/tests/resources/VCH-Util.robot
+++ b/tests/resources/VCH-Util.robot
@@ -37,9 +37,10 @@ Set Test Environment Variables
     Set Environment Variable  GOVC_PASSWORD  %{TEST_PASSWORD}
 
     ${IN_HAAS}=  Run Keyword And Return Status  Should Contain  %{HAAS_URL_ARRAY}  %{TEST_URL}
+    ${IN_OVERFLOW}=  Run Keyword And Return Status  Should Contain  %{OVERFLOW_URL_ARRAY}  %{TEST_URL}
     Run Keyword If  ${IN_HAAS}  Log To Console  Test Server is in HaaS
-    Run Keyword Unless  ${IN_HAAS}  Log To Console  Test Server is in Nimbus
-    Run Keyword Unless  ${IN_HAAS}  Set Environment Variable  TEST_TIMEOUT  %{OVERFLOW_TEST_TIMEOUT}
+    Run Keyword If  ${IN_OVERFLOW}  Log To Console  Test Server is in Nimbus
+    Run Keyword If  ${IN_OVERFLOW}  Set Environment Variable  TEST_TIMEOUT  %{OVERFLOW_TEST_TIMEOUT}
 
     ${rc}  ${thumbprint}=  Run And Return Rc And Output  govc about.cert -k -json | jq -r .ThumbprintSHA1
     Should Be Equal As Integers  ${rc}  0

--- a/tests/resources/VCH-Util.robot
+++ b/tests/resources/VCH-Util.robot
@@ -26,6 +26,8 @@ Set Test Environment Variables
     Run Keyword If  '${status}' == 'FAIL'  Set Environment Variable  TEST_DATACENTER  ${SPACE}
     ${status}  ${message}=  Run Keyword And Ignore Error  Environment Variable Should Be Set  DRONE_MACHINE
     Run Keyword If  '${status}' == 'FAIL'  Set Environment Variable  DRONE_MACHINE  'local'
+    ${status}  ${message}=  Run Keyword And Ignore Error  Environment Variable Should Be Set  OVERFLOW_TEST_TIMEOUT
+    Run Keyword If  '${status}' == 'FAIL'  Set Environment Variable  OVERFLOW_TEST_TIMEOUT  3m
 
     @{URLs}=  Split String  %{TEST_URL_ARRAY}
     ${len}=  Get Length  ${URLs}

--- a/tests/resources/VCH-Util.robot
+++ b/tests/resources/VCH-Util.robot
@@ -39,6 +39,7 @@ Set Test Environment Variables
     ${IN_HAAS}=  Run Keyword And Return Status  Should Contain  %{HAAS_URL_ARRAY}  %{TEST_URL}
     Run Keyword If  ${IN_HAAS}  Log To Console  Test Server is in HaaS
     Run Keyword Unless  ${IN_HAAS}  Log To Console  Test Server is in Nimbus
+    Run Keyword Unless  ${IN_HAAS}  Set Environment Variable  TEST_TIMEOUT  %{OVERFLOW_TEST_TIMEOUT}
 
     ${rc}  ${thumbprint}=  Run And Return Rc And Output  govc about.cert -k -json | jq -r .ThumbprintSHA1
     Should Be Equal As Integers  ${rc}  0


### PR DESCRIPTION
Add new secret variable `OVERFLOW_TEST_TIMEOUT` to set a separate value if run on Nimbus VCs.