### PR TITLE
WIP Fix incorrect exit codes from Exec

### DIFF
--- a/lib/apiservers/engine/backends/container.go
+++ b/lib/apiservers/engine/backends/container.go
@@ -490,7 +490,8 @@ func (c *ContainerBackend) ContainerExecStart(ctx context.Context, eid string, s
 		op.Errorf("Failed to start Exec task for container(%s) due to error (%s)", id, err)
 		return err
 	}
-	return nil
+
+	return c.containerProxy.WaitTask(op, id, name, eid)
 }
 
 // ExecExists looks up the exec instance and returns a bool if it exists or not.

--- a/lib/apiservers/engine/backends/container.go
+++ b/lib/apiservers/engine/backends/container.go
@@ -296,21 +296,8 @@ func (c *ContainerBackend) ContainerExecInspect(eid string) (*backend.ExecInspec
 	if err != nil {
 		return nil, err
 	}
-	log.Debugf("exit code was reported as %d", ec.ExitCode)
-	for !ec.Running {
-		handle, err = c.Handle(id, name)
-		if err != nil {
-			op.Error(err)
-			return nil, engerr.InternalServerError(err.Error())
-		}
-		time.Sleep(5 * time.Second)
-		ec, err = c.containerProxy.InspectTask(op, handle, eid, id)
-		if err != nil {
-			return nil, err
-		}
-		log.Debugf("(retry) exit code was reported as %d", ec.ExitCode)
-	}
 
+	log.Debugf("exit code was reported as %d", ec.ExitCode)
 	exit := int(ec.ExitCode)
 	return &backend.ExecInspect{
 		ID:       ec.ID,

--- a/lib/apiservers/engine/proxy/container_proxy.go
+++ b/lib/apiservers/engine/proxy/container_proxy.go
@@ -533,6 +533,35 @@ func (c *ContainerProxy) BindTask(op trace.Operation, handle string, eid string)
 }
 
 func (c *ContainerProxy) WaitTask(op trace.Operation, cid string, cname string, eid string) error {
+	if c.client == nil {
+		return errors.NillPortlayerClientError("ContainerProxy")
+	}
+
+	handle, err := c.Handle(op, cid, cname)
+	if err != nil {
+		return err
+	}
+
+	// wait the Task to start
+	config := &models.TaskWaitConfig{
+		Handle: handle,
+		TaskID: eid,
+	}
+
+	params := tasks.NewWaitParamsWithContext(op).WithConfig(config)
+	_, err = c.client.Tasks.Wait(params)
+	if err != nil {
+		switch err := err.(type) {
+		case *tasks.WaitNotFound:
+			return errors.InternalServerError(fmt.Sprintf("the Container(%s) has been shutdown during execution of the exec operation", cid))
+		case *tasks.WaitPreconditionRequired:
+			return errors.InternalServerError(fmt.Sprintf("container(%s) must be powered on in order to perform the desired exec operation", cid))
+		case *tasks.WaitInternalServerError:
+			return errors.InternalServerError(err.Payload.Message)
+		default:
+			return errors.InternalServerError(err.Error())
+		}
+	}
 
 	return nil
 }
@@ -553,8 +582,8 @@ func (c *ContainerProxy) WaitStartTask(op trace.Operation, cid string, cname str
 		TaskID: eid,
 	}
 
-	params := tasks.NewWaitParamsWithContext(op).WithConfig(config)
-	_, err = c.client.Tasks.Wait(params)
+	params := tasks.NewWaitStartParamsWithContext(op).WithConfig(config)
+	_, err = c.client.Tasks.WaitStart(params)
 	if err != nil {
 		switch err := err.(type) {
 		case *tasks.WaitNotFound:

--- a/lib/apiservers/engine/proxy/container_proxy.go
+++ b/lib/apiservers/engine/proxy/container_proxy.go
@@ -90,6 +90,7 @@ type VicContainerProxy interface {
 	InspectTask(op trace.Operation, handle string, eid string, cid string) (*models.TaskInspectResponse, error)
 	BindTask(op trace.Operation, handle string, eid string) (string, error)
 	WaitTask(op trace.Operation, cid string, cname string, eid string) error
+	WaitStartTask(op trace.Operation, cid string, cname string, eid string) error
 
 	Handle(ctx context.Context, id, name string) (string, error)
 
@@ -532,6 +533,11 @@ func (c *ContainerProxy) BindTask(op trace.Operation, handle string, eid string)
 }
 
 func (c *ContainerProxy) WaitTask(op trace.Operation, cid string, cname string, eid string) error {
+
+	return nil
+}
+
+func (c *ContainerProxy) WaitStartTask(op trace.Operation, cid string, cname string, eid string) error {
 	if c.client == nil {
 		return errors.NillPortlayerClientError("ContainerProxy")
 	}
@@ -544,7 +550,7 @@ func (c *ContainerProxy) WaitTask(op trace.Operation, cid string, cname string, 
 	// wait the Task to start
 	config := &models.TaskWaitConfig{
 		Handle: handle,
-		ID:     eid,
+		TaskID: eid,
 	}
 
 	params := tasks.NewWaitParamsWithContext(op).WithConfig(config)
@@ -563,7 +569,6 @@ func (c *ContainerProxy) WaitTask(op trace.Operation, cid string, cname string, 
 	}
 
 	return nil
-
 }
 
 // Stop will stop (shutdown) a VIC container.

--- a/lib/apiservers/portlayer/restapi/handlers/task_handlers.go
+++ b/lib/apiservers/portlayer/restapi/handlers/task_handlers.go
@@ -265,8 +265,12 @@ func (handler *TaskHandlersImpl) InspectHandler(params tasks.InspectParams) midd
 
 // WaitHandler calls wait
 func (handler *TaskHandlersImpl) WaitHandler(params tasks.WaitParams) middleware.Responder {
+	return nil
+}
+
+func (handler *TaskHandlersImpl) WaitStartHandler(params tasks.WaitStartParams) middleware.Responder {
 	defer trace.End(trace.Begin(""))
-	op := trace.NewOperation(context.Background(), "task.Wait(%s, %s)", params.Config.Handle, params.Config.ID)
+	op := trace.NewOperation(context.Background(), "task.Wait(%s, %s)", params.Config.Handle, params.Config.TaskID)
 
 	handle := exec.HandleFromInterface(params.Config.Handle)
 	if handle == nil {
@@ -275,7 +279,7 @@ func (handler *TaskHandlersImpl) WaitHandler(params tasks.WaitParams) middleware
 	}
 
 	// wait task to set started field to something
-	err := task.Wait(&op, handle, params.Config.ID)
+	err := task.Wait(&op, handle, params.Config.TaskID)
 	if err != nil {
 		switch err := err.(type) {
 		case *task.TaskPowerStateError:

--- a/lib/apiservers/portlayer/restapi/handlers/task_handlers.go
+++ b/lib/apiservers/portlayer/restapi/handlers/task_handlers.go
@@ -279,7 +279,7 @@ func (handler *TaskHandlersImpl) WaitStartHandler(params tasks.WaitStartParams) 
 	}
 
 	// wait task to set started field to something
-	err := task.Wait(&op, handle, params.Config.TaskID)
+	err := task.WaitStart(&op, handle, params.Config.TaskID)
 	if err != nil {
 		switch err := err.(type) {
 		case *task.TaskPowerStateError:

--- a/lib/apiservers/portlayer/swagger.json
+++ b/lib/apiservers/portlayer/swagger.json
@@ -1737,14 +1737,64 @@
 				}
 			}
 		},
-		"/tasks": {
-			"put": {
-				"description": "Initiates an task wait operation",
-				"summary": "Initiates an task wait operation",
-				"operationId": "Wait",
-				"tags": [
-					"tasks"
+    "/tasks/start": {
+        "put": {
+				  "description": "Initiates a wait for the specified task to start",
+				  "summary": "Initiates a waot for the specified task to start",
+				  "operationId": "WaitStart",
+				  "tags": [
+					  "tasks"
+				  ],
+				"consumes": [
+					"application/json",
+					"application/octet-stream"
 				],
+				"produces": [
+					"application/json"
+				],
+				"parameters": [
+					{
+						"name": "config",
+						"in": "body",
+						"required": true,
+						"schema": {
+							"$ref": "#/definitions/TaskWaitConfig"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK"
+					},
+					"404": {
+						"description": "not found",
+						"schema": {
+							"$ref": "#/definitions/Error"
+						}
+					},
+					"428": {
+						"description": "target resource is not powered on",
+						"schema": {
+							"$ref": "#/definitions/Error"
+						}
+					},
+					"500": {
+						"description": "Wait of task failed",
+						"schema": {
+							"$ref": "#/definitions/Error"
+						}
+					}
+				}
+       }
+      },
+		"/tasks": {
+			  "put": {
+				  "description": "Initiates a task wait operation",
+				  "summary": "Initiates a task wait operation",
+				  "operationId": "Wait",
+				  "tags": [
+					  "tasks"
+				  ],
 				"consumes": [
 					"application/json",
 					"application/octet-stream"
@@ -1787,8 +1837,8 @@
 				}
 			},
 			"get": {
-				"description": "Initiates an task inspect operation",
-				"summary": "Initiates an task inspect operation",
+				"description": "Initiates a task inspect operation",
+				"summary": "Initiates a task inspect operation",
 				"operationId": "Inspect",
 				"tags": [
 					"tasks"
@@ -1838,8 +1888,8 @@
 				}
 			},
 			"post": {
-				"description": "Initiates an task join operation",
-				"summary": "Initiates an task join operation",
+				"description": "Initiates a task join operation",
+				"summary": "Initiates a task join operation",
 				"operationId": "Join",
 				"tags": [
 					"tasks"
@@ -3789,10 +3839,10 @@
 			"type": "object",
 			"required": [
 				"handle",
-				"id"
+				"taskID"
 			],
 			"properties": {
-				"id": {
+				"taskID": {
 					"type": "string",
 					"x-nullable": false
 				},

--- a/pkg/vsphere/vm/vm.go
+++ b/pkg/vsphere/vm/vm.go
@@ -237,6 +237,22 @@ func (vm *VirtualMachine) FetchExtraConfig(ctx context.Context) (map[string]stri
 	return info, nil
 }
 
+func (vm *VirtualMachine) GetKeyFromExtraConfig(op trace.Operation, key string) (string, error) {
+	op.Debugf("Collecting key(%s) from vm(%s)", key, vm.Name())
+
+	// get the key from the extraConfig
+	keys, err := vm.FetchExtraConfig(op)
+	if err != nil {
+		return "", err
+	}
+
+	if ecValue, ok := keys[key]; ok {
+		return ecValue, nil
+	}
+
+	return "", fmt.Errorf("Key(%s) not found", key)
+}
+
 // WaitForExtraConfig waits until key shows up with the expected value inside the ExtraConfig
 func (vm *VirtualMachine) WaitForExtraConfig(ctx context.Context, waitFunc func(pc []types.PropertyChange) bool) error {
 	op := trace.FromContext(ctx, "WaitForExtraConfig")


### PR DESCRIPTION
Fixes #5692 

NOTE: I still have to add the test I have written for the CI, I am not done tweaking it. 

This PR is not quite complete. It still has a few problems around context handling which is causing a CDE. 

This PR adds TaskWaitStart to the portlayer as a means for a portlayer call to wait for a Task to "begin". It also changes TaskWait to wait for the indicated task to exit/terminate before returning. This will allow users of the portlayer to properly wait on a task and get the correct exit code when performing an inspect against the task. To do this, I added an additional api target `/tasks/start` to the portlayer which can be used with a task ID. 