### PR TITLE
Uncomment teardown in upgrade tests [specific ci=Group11-Upgrade]

### DIFF
--- a/tests/test-cases/Group11-Upgrade/11-01-Upgrade.robot
+++ b/tests/test-cases/Group11-Upgrade/11-01-Upgrade.robot
@@ -16,7 +16,7 @@
 Documentation  Test 11-01 - Upgrade
 Resource  ../../resources/Util.robot
 Suite Setup  Disable Ops User And Install VIC To Test Server
-#Suite Teardown  Re-Enable Ops User And Clean Up VIC Appliance
+Suite Teardown  Re-Enable Ops User And Clean Up VIC Appliance
 Default Tags
 
 *** Variables ***


### PR DESCRIPTION
This uncomments the teardown in 11-01-Upgrade that should not have made it into master.

[specific ci=Group11-Upgrade]