### PR TITLE
Fix VSAN testbed for 6.7 testing

### DIFF
--- a/tests/nightly/jenkins-nightly-run.sh
+++ b/tests/nightly/jenkins-nightly-run.sh
@@ -85,7 +85,7 @@ elif [[ $target == "6.5" ]]; then
     cat 65/pabot_results/*/stdout.txt | grep '::' | grep -E 'PASS|FAIL' > console.log
 elif [[ $target == "6.7" ]]; then
     echo "Executing nightly tests on vSphere 6.7"
-    pabot --processes 4 --removekeywords TAG:secret --exclude nsx --exclude hetero --exclude vsan-complex --variable ESX_VERSION:$ESX_67_VERSION --variable VC_VERSION:$VC_67_VERSION -d 67/$i tests/manual-test-cases/Group5-Functional-Tests tests/manual-test-cases/Group13-vMotion tests/manual-test-cases/Group21-Registries tests/manual-test-cases/Group23-Future-Tests
+    pabot --processes 4 --removekeywords TAG:secret --exclude nsx --exclude hetero --variable ESX_VERSION:$ESX_67_VERSION --variable VC_VERSION:$VC_67_VERSION -d 67/$i tests/manual-test-cases/Group5-Functional-Tests tests/manual-test-cases/Group13-vMotion tests/manual-test-cases/Group21-Registries tests/manual-test-cases/Group23-Future-Tests
     cat 67/pabot_results/*/stdout.txt | grep '::' | grep -E 'PASS|FAIL' > console.log
 fi
 # Pretty up the email results

--- a/tests/resources/nimbus-testbeds/vic-vsan.rb
+++ b/tests/resources/nimbus-testbeds/vic-vsan.rb
@@ -141,7 +141,7 @@ $testbed = Proc.new do |type, esxStyle, vcStyle, dbType, location|
     testbed['vc']['dbHost'] = 'vc-mssql'
   end
 
-  testbed = VcQaTestbedCommon.addSharedDisks testbed, [20, 10, 20, 10], sharedStorageStyle   # 2 x 20gb shared vmfs, 2 x 10gb free luns as defined by 'freeSharedLuns', DON'T CHANGE THE ORDERING UNLESS YOU KNOW WHAT YOU'RE DOING!
+  testbed = VcQaTestbedCommon.addSharedDisks testbed, [10, 10, 20, 20], sharedStorageStyle   # 2 x 20gb shared vmfs, 2 x 10gb free luns as defined by 'freeSharedLuns', DON'T CHANGE THE ORDERING UNLESS YOU KNOW WHAT YOU'RE DOING!
 
   testbed
 end


### PR DESCRIPTION
[skip unit]
fixes #7590 

Nimbus internal libraries were fixed, but we do need to make this fix as well in order to get 6.7 vsan testing working again.