### PR TITLE
Scope the installed version of VIC in upgrade tests, so that parallel testing succeeds

### DIFF
--- a/tests/resources/VCH-Util.robot
+++ b/tests/resources/VCH-Util.robot
@@ -713,12 +713,13 @@ Install VIC with version to Test Server
     [Arguments]  ${version}  ${insecureregistry}=  ${cleanup}=${true}  ${additional-args}=
     Log To Console  \nDownloading vic ${version} from gcp...
     ${rc}  ${output}=  Run And Return Rc And Output  wget https://storage.googleapis.com/vic-engine-releases/vic_${version}.tar.gz -O vic.tar.gz
-    ${rc}  ${output}=  Run And Return Rc And Output  tar zxvf vic.tar.gz
-    Install VIC Appliance To Test Server  vic-machine=./vic/vic-machine-linux  appliance-iso=./vic/appliance.iso  bootstrap-iso=./vic/bootstrap.iso  certs=${false}  cleanup=${cleanup}  additional-args=${additional-args}  vol=default ${insecureregistry}
+    Create Directory  ${version}
+    ${rc}  ${output}=  Run And Return Rc And Output  tar zxvf vic.tar.gz -C ${version}
+    Install VIC Appliance To Test Server  vic-machine=./${version}/vic/vic-machine-linux  appliance-iso=./${version}/vic/appliance.iso  bootstrap-iso=./${version}/vic/bootstrap.iso  certs=${false}  cleanup=${cleanup}  additional-args=${additional-args}  vol=default ${insecureregistry}
 
     Set Environment Variable  VIC-ADMIN  %{VCH-IP}:2378
     Set Environment Variable  INITIAL-VERSION  ${version}
-    Run  rm -rf vic.tar.gz vic
+    Run  rm -rf vic.tar.gz ${version}
 
 Clean up VIC Appliance And Local Binary
     Cleanup VIC Appliance On Test Server


### PR DESCRIPTION
[skip unit]
[specific ci=Group11-Upgrade]

Need to scope where we are storing our upgrade installs otherwise, when run in parallel different versions will clobber each other.