### PR TITLE
Change encoding when attempting to cat syslog file

### DIFF
--- a/tests/test-cases/Group6-VIC-Machine/6-15-Syslog.robot
+++ b/tests/test-cases/Group6-VIC-Machine/6-15-Syslog.robot
@@ -64,7 +64,7 @@ Verify VCH remote syslog
 
     Wait Until Container Stops  ${id}  5
 
-    ${syslog-conn}=  Open Connection  %{SYSLOG_SERVER}
+    ${syslog-conn}=  Open Connection  %{SYSLOG_SERVER}  encoding=unicode_escape
     Login  %{SYSLOG_USER}  %{SYSLOG_PASSWD}
     ${out}=  Wait Until Keyword Succeeds  10x  3s  Execute Command  cat ${SYSLOG_FILE}
     Close Connection


### PR DESCRIPTION
[skip unit]
[specific ci=6-15-Syslog]

This will hopefully eliminate this problem:

UnicodeDecodeError: 'utf8' codec can't decode byte 0xb5 in position 1787713: invalid start byte