### PR TITLE
Provide per-suite vic-machine-server logs in CI

### DIFF
--- a/tests/resources/Group23-VIC-Machine-Service-Util.robot
+++ b/tests/resources/Group23-VIC-Machine-Service-Util.robot
@@ -28,13 +28,14 @@ ${SERVING_AT_TEXT}           Serving vic machine at
 *** Keywords ***
 Start VIC Machine Server
     ${dir_name}=  Evaluate  'group23_log_dir' + str(random.randint(1000,9999))  modules=random
+    Set Suite Variable    ${SERVER_LOG_FILE}    ${dir_name}/${VIC_MACHINE_SERVER_LOG}
 
     ${handle}=    Start Process    ./bin/vic-machine-server --scheme http --log-directory ${dir_name}/    shell=True    cwd=/go/src/github.com/vmware/vic
-    Set Suite Variable    ${server_handle}    ${handle}
+    Set Suite Variable    ${SERVER_HANDLE}    ${handle}
     Process Should Be Running    ${handle}
     Sleep  5sec
 
-    ${output}=    Run    cat ${dir_name}/${VIC_MACHINE_SERVER_LOG}
+    ${output}=    Run    cat ${SERVER_LOG_FILE}
     @{output}=    Split To Lines    ${output}
     :FOR    ${line}    IN    @{output}
     \   ${status}=    Run Keyword And Return Status    Should Contain    ${line}    ${SERVING_AT_TEXT}
@@ -42,8 +43,10 @@ Start VIC Machine Server
     \   Run Keyword If    ${status}    Set Suite Variable    ${VIC_MACHINE_SERVER_URL}    ${server_url}
 
 Stop VIC Machine Server
-    Terminate Process    ${server_handle}    kill=true
-    Process Should Be Stopped    ${server_handle}
+    Run Keyword And Ignore Error    Copy File    ${SERVER_LOG_FILE}    ${SUITE NAME}-${VIC_MACHINE_SERVER_LOG}
+
+    Terminate Process    ${SERVER_HANDLE}    kill=true
+    Process Should Be Stopped    ${SERVER_HANDLE}
 
 Get Path
     [Arguments]    ${path}


### PR DESCRIPTION
Leverage the recent change which introduced per-suite logging from `vic-machine-server` to provide per-suite log files. These log files will be included in the CI log bundle, and they will be written to the local filesystem when running CI locally.

`[specific ci=Group23-VIC-Machine-Service]`