### PR TITLE
Improve docker cp test concurrency

### DIFF
--- a/tests/test-cases/Group1-Docker-Commands/1-43-Docker-CP-Offline.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-43-Docker-CP-Offline.robot
@@ -32,7 +32,7 @@ Set up test files and install VIC appliance to test server
     Create File  ${CURDIR}/mnt/root.txt   rw layer file
     Create File  ${CURDIR}/mnt/vol1/v1.txt   vol1 file
     Create File  ${CURDIR}/mnt/vol2/v2.txt   vol2 file
-    ${rc}  ${output}=  Run And Return Rc And Output  dd if=/dev/urandom of=${CURDIR}/largefile.txt count=4096 bs=4096
+    ${rc}  ${output}=  Run And Return Rc And Output  dd if=/dev/urandom of=${CURDIR}/largefile-offline.txt count=4096 bs=4096
     Should Be Equal As Integers  ${rc}  0
     Should Not Contain  ${output}  Error
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} volume create vol1
@@ -51,7 +51,7 @@ Set up test files and install VIC appliance to test server
 Clean up test files and VIC appliance to test server
     Run Keyword and Continue on Failure  Remove File  ${CURDIR}/foo.txt
     Run Keyword and Continue on Failure  Remove File  ${CURDIR}/content
-    Run Keyword and Continue on Failure  Remove File  ${CURDIR}/largefile.txt
+    Run Keyword and Continue on Failure  Remove File  ${CURDIR}/largefile-offline.txt
     Run Keyword and Continue on Failure  Remove Directory  ${CURDIR}/bar  recursive=True
     Run Keyword and Continue on Failure  Remove Directory  ${CURDIR}/mnt  recursive=True
     Cleanup VIC Appliance On Test Server
@@ -137,7 +137,7 @@ Copy a large file that exceeds the container volume into an offline container
     ${rc}  ${cid}=  Run And Return Rc And Output  docker %{VCH-PARAMS} create -i -v smallVol:/small ${busybox}
     Should Be Equal As Integers  ${rc}  0
     Should Not Contain  ${cid}  Error
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} cp ${CURDIR}/largefile.txt ${cid}:/small
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} cp ${CURDIR}/largefile-offline.txt ${cid}:/small
     Should Not Be Equal As Integers  ${rc}  0
     Should Contain  ${output}  Error
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} rm -f ${cid}
@@ -210,7 +210,7 @@ Concurrent copy: repeat copy a large file from host to offline container several
     ${pids}=  Create List
     Log To Console  \nIssue 10 docker cp commands for large file
     :FOR  ${idx}  IN RANGE  0  10
-    \   ${pid}=  Start Process  docker %{VCH-PARAMS} cp ${CURDIR}/largefile.txt concurrent:/vol1/lg-${idx}  shell=True
+    \   ${pid}=  Start Process  docker %{VCH-PARAMS} cp ${CURDIR}/largefile-offline.txt concurrent:/vol1/lg-${idx}  shell=True
     \   Append To List  ${pids}  ${pid}
     Log To Console  \nWait for them to finish and check their RC
     :FOR  ${pid}  IN  @{pids}

--- a/tests/test-cases/Group1-Docker-Commands/1-43-Docker-CP-Offline.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-43-Docker-CP-Offline.robot
@@ -196,6 +196,7 @@ Concurrent copy: create processes to copy a small file from host to offline cont
     :FOR  ${pid}  IN  @{pids}
     \   Log To Console  \nWaiting for ${pid}
     \   ${res}=  Wait For Process  ${pid}
+    \   Log  ${res.stderr}
     \   Log  ${res.stdout}
     \   Should Be Equal As Integers  ${res.rc}  0
     ${output}=  Start Container and Exec Command  concurrent  ls /
@@ -216,6 +217,7 @@ Concurrent copy: repeat copy a large file from host to offline container several
     :FOR  ${pid}  IN  @{pids}
     \   Log To Console  \nWaiting for ${pid}
     \   ${res}=  Wait For Process  ${pid}
+    \   Log  ${res.stderr}
     \   Log  ${res.stdout}
     \   Should Be Equal As Integers  ${res.rc}  0
     ${output}=  Start Container and Exec Command  concurrent  ls /vol1
@@ -237,6 +239,7 @@ Concurrent copy: repeat copy a large file from offline container to host several
     :FOR  ${pid}  IN  @{pids}
     \   Log To Console  \nWaiting for ${pid}
     \   ${res}=  Wait For Process  ${pid}
+    \   Log  ${res.stderr}
     \   Log  ${res.stdout}
     \   Should Be Equal As Integers  ${res.rc}  0
     Log To Console  \nCheck if the copy operations succeeded

--- a/tests/test-cases/Group1-Docker-Commands/1-44-Docker-CP-Online.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-44-Docker-CP-Online.robot
@@ -23,16 +23,17 @@ Test Timeout  20 minutes
 Set up test files and install VIC appliance to test server
     Conditional Install VIC Appliance To Test Server
     Remove All Volumes
-    Create File  ${CURDIR}/foo-online.txt   hello world
-    Create File  ${CURDIR}/content-online   fake file content for testing only
-    Create Directory  ${CURDIR}/bar-online
-    Create Directory  ${CURDIR}/mnt-online
-    Create Directory  ${CURDIR}/mnt-online/vol1-online
-    Create Directory  ${CURDIR}/mnt-online/vol2-online
-    Create File  ${CURDIR}/mnt-online/root-online.txt   rw layer file
-    Create File  ${CURDIR}/mnt-online/vol1-online/v1-online.txt   vol1 file
-    Create File  ${CURDIR}/mnt-online/vol2-online/v2-online.txt   vol2 file
-    ${rc}  ${output}=  Run And Return Rc And Output  dd if=/dev/urandom of=${CURDIR}/largefile-online.txt count=1024 bs=1024
+    Create Directory  ${CURDIR}/online
+    Create File  ${CURDIR}/online/foo.txt   hello world
+    Create File  ${CURDIR}/online/content   fake file content for testing only
+    Create Directory  ${CURDIR}/online/bar
+    Create Directory  ${CURDIR}/online/mnt
+    Create Directory  ${CURDIR}/online/mnt/vol1
+    Create Directory  ${CURDIR}/online/mnt/vol2
+    Create File  ${CURDIR}/online/mnt/root.txt   rw layer file
+    Create File  ${CURDIR}/online/mnt/vol1/v1.txt   vol1 file
+    Create File  ${CURDIR}/online/mnt/vol2/v2.txt   vol2 file
+    ${rc}  ${output}=  Run And Return Rc And Output  dd if=/dev/urandom of=${CURDIR}/online/largefile.txt count=1024 bs=1024
     Should Be Equal As Integers  ${rc}  0
     Should Not Contain  ${output}  Error
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} volume create vol1
@@ -46,11 +47,7 @@ Set up test files and install VIC appliance to test server
     Should Not Contain  ${output}  Error
 
 Clean up test files and VIC appliance to test server
-    Run Keyword and Continue on Failure  Remove File  ${CURDIR}/foo-online.txt
-    Run Keyword and Continue on Failure  Remove File  ${CURDIR}/content-online
-    Run Keyword and Continue on Failure  Remove File  ${CURDIR}/largefile-online.txt
-    Run Keyword and Continue on Failure  Remove Directory  ${CURDIR}/bar-online  recursive=True
-    Run Keyword and Continue on Failure  Remove Directory  ${CURDIR}/mnt-online  recursive=True
+    Run Keyword and Continue on Failure  Remove Directory  ${CURDIR}/online  recursive=True
     Cleanup VIC Appliance On Test Server
 
 *** Test Cases ***
@@ -64,44 +61,44 @@ Copy a directory from online container to host, destination path doesn't exist
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} exec online sh -c 'mkdir newdir && echo "testing" > /newdir/test.txt'
     Should Be Equal As Integers  ${rc}  0
     Should Not Contain  ${output}  Error
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} cp online:/newdir ${CURDIR}/newdir
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} cp online:/newdir ${CURDIR}/online/newdir
     Should Be Equal As Integers  ${rc}  0
     Should Not Contain  ${output}  Error
-    OperatingSystem.Directory Should Exist  ${CURDIR}/newdir
-    OperatingSystem.File Should Exist  ${CURDIR}/newdir/test.txt
-    Remove Directory  ${CURDIR}/newdir  recursive=True
+    OperatingSystem.Directory Should Exist  ${CURDIR}/online/newdir
+    OperatingSystem.File Should Exist  ${CURDIR}/online/newdir/test.txt
+    Remove Directory  ${CURDIR}/online/newdir  recursive=True
 
 Copy the content of a directory from online container to host
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} cp online:/newdir/. ${CURDIR}/bar-online
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} cp online:/newdir/. ${CURDIR}/online/bar
     Should Be Equal As Integers  ${rc}  0
     Should Not Contain  ${output}  Error
-    OperatingSystem.File Should Exist  ${CURDIR}/bar-online/test.txt
-    Remove File  ${CURDIR}/bar-online/test.txt
+    OperatingSystem.File Should Exist  ${CURDIR}/online/bar/test.txt
+    Remove File  ${CURDIR}/online/bar/test.txt
 
 Copy a file from online container to host, overwrite destination file
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} cp online:/newdir/test.txt ${CURDIR}/foo-online.txt
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} cp online:/newdir/test.txt ${CURDIR}/online/foo.txt
     Should Be Equal As Integers  ${rc}  0
     Should Not Contain  ${output}  Error
-    ${content}=  OperatingSystem.Get File  ${CURDIR}/foo-online.txt
+    ${content}=  OperatingSystem.Get File  ${CURDIR}/online/foo.txt
     Should Contain  ${content}   testing
 
 Copy a file from host to online container, destination directory doesn't exist
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} cp ${CURDIR}/foo-online.txt online:/doesnotexist/
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} cp ${CURDIR}/online/foo.txt online:/doesnotexist/
     Should Not Be Equal As Integers  ${rc}  0
     Should Contain  ${output}  no such directory
 
 Copy a file and directory from host to online container
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} cp ${CURDIR}/foo-online.txt online:/
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} cp ${CURDIR}/online/foo.txt online:/
     Should Be Equal As Integers  ${rc}  0
     Should Not Contain  ${output}  Error
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} cp ${CURDIR}/bar-online online:/
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} cp ${CURDIR}/online/bar online:/
     Should Be Equal As Integers  ${rc}  0
     Should Not Contain  ${output}  Error
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} exec online ls /
     Should Be Equal As Integers  ${rc}  0
     Should Not Contain  ${output}  Error
-    Should Contain  ${output}  foo-online.txt
-    Should Contain  ${output}  bar-online
+    Should Contain  ${output}  foo.txt
+    Should Contain  ${output}  bar
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} rm -f online
     Should Be Equal As Integers  ${rc}  0
     Should Not Contain  ${output}  Error
@@ -110,55 +107,55 @@ Copy a directory from host to online container, destination is a volume
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -d -it --name online_vol -v vol1:/vol1 ${busybox}
     Should Be Equal As Integers  ${rc}  0
     Should Not Contain  ${output}  Error
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} cp ${CURDIR}/bar-online online_vol:/vol1/
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} cp ${CURDIR}/online/bar online_vol:/vol1/
     Should Be Equal As Integers  ${rc}  0
     Should Not Contain  ${output}  Error
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} exec online_vol ls /vol1
     Should Be Equal As Integers  ${rc}  0
     Should Not Contain  ${output}  Error
-    Should Contain  ${output}  bar-online
+    Should Contain  ${output}  bar
 
 Copy a file from host to offline container, destination is a volume shared with an online container
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} create -i --name offline -v vol1:/vol1 ${busybox}
     Should Be Equal As Integers  ${rc}  0
     Should Not Contain  ${output}  Error
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} cp ${CURDIR}/content-online offline:/vol1
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} cp ${CURDIR}/online/content offline:/vol1
     Should Be Equal As Integers  ${rc}  0
     Should Not Contain  ${output}  Error
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} exec online_vol ls /vol1
     Should Be Equal As Integers  ${rc}  0
     Should Not Contain  ${output}  Error
-    Should Contain  ${output}  content-online
+    Should Contain  ${output}  content
 
 Copy a directory from offline container to host, destination is a volume shared with an online container
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} cp offline:/vol1 ${CURDIR}
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} cp offline:/vol1 ${CURDIR}/online
     Should Be Equal As Integers  ${rc}  0
     Should Not Contain  ${output}  Error
-    OperatingSystem.Directory Should Exist  ${CURDIR}/vol1
-    OperatingSystem.Directory Should Exist  ${CURDIR}/vol1/bar-online
-    OperatingSystem.File Should Exist  ${CURDIR}/vol1/content-online
-    Remove Directory  ${CURDIR}/vol1  recursive=True
+    OperatingSystem.Directory Should Exist  ${CURDIR}/online/vol1
+    OperatingSystem.Directory Should Exist  ${CURDIR}/online/vol1/bar
+    OperatingSystem.File Should Exist  ${CURDIR}/online/vol1/content
+    Remove Directory  ${CURDIR}/online/vol1  recursive=True
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} rm -f offline
     Should Be Equal As Integers  ${rc}  0
     Should Not Contain  ${output}  Error
 
 Copy a large file to an online container, destination is a volume
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} cp ${CURDIR}/largefile-online.txt online_vol:/vol1/
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} cp ${CURDIR}/online/largefile.txt online_vol:/vol1/
     Should Be Equal As Integers  ${rc}  0
     Should Not Contain  ${output}  Error
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} exec online_vol ls -l /vol1/
     Should Be Equal As Integers  ${rc}  0
     Should Not Contain  ${output}  Error
     Should Contain  ${output}  1048576
-    Should Contain  ${output}  largefile-online.txt
+    Should Contain  ${output}  largefile.txt
 
 Copy a non-existent file out of an online container
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} cp online_vol:/dne/dne ${CURDIR}
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} cp online_vol:/dne/dne ${CURDIR}/online
     Should Not Be Equal As Integers  ${rc}  0
     Should Contain  ${output}  Error
 
 Copy a non-existent directory out of an online container
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} cp online_vol:/dne/. ${CURDIR}
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} cp online_vol:/dne/. ${CURDIR}/online
     Should Not Be Equal As Integers  ${rc}  0
     Should Contain  ${output}  Error
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} rm -f online_vol
@@ -172,7 +169,7 @@ Concurrent copy: create processes to copy a small file from host to online conta
     ${pids}=  Create List
     Log To Console  \nIssue 10 docker cp commands for small file
     :FOR  ${idx}  IN RANGE  0  10
-    \   ${pid}=  Start Process  docker %{VCH-PARAMS} cp ${CURDIR}/foo-online.txt concurrent:/foo-online-${idx}  shell=True
+    \   ${pid}=  Start Process  docker %{VCH-PARAMS} cp ${CURDIR}/online/foo.txt concurrent:/foo-${idx}  shell=True
     \   Append To List  ${pids}  ${pid}
     Log To Console  \nWait for them to finish and check their RC
     :FOR  ${pid}  IN  @{pids}
@@ -186,13 +183,13 @@ Concurrent copy: create processes to copy a small file from host to online conta
     Should Not Contain  ${output}  Error
     Log To Console  \nCheck if the copy operations succeeded
     :FOR  ${idx}  IN RANGE  0  10
-    \   Should Contain  ${output}  foo-online-${idx}
+    \   Should Contain  ${output}  foo-${idx}
 
 Concurrent copy: repeat copy a large file from host to online container several times
     ${pids}=  Create List
     Log To Console  \nIssue 10 docker cp commands for large file
     :FOR  ${idx}  IN RANGE  0  10
-    \   ${pid}=  Start Process  docker %{VCH-PARAMS} cp ${CURDIR}/largefile-online.txt concurrent:/vol1/lg-online-${idx}  shell=True
+    \   ${pid}=  Start Process  docker %{VCH-PARAMS} cp ${CURDIR}/online/largefile.txt concurrent:/vol1/lg-${idx}  shell=True
     \   Append To List  ${pids}  ${pid}
     Log To Console  \nWait for them to finish and check their RC
     :FOR  ${pid}  IN  @{pids}
@@ -206,13 +203,13 @@ Concurrent copy: repeat copy a large file from host to online container several 
     Should Not Contain  ${output}  Error
     Log To Console  \nCheck if the copy operations succeeded
     :FOR  ${idx}  IN RANGE  0  10
-    \   Should Contain  ${output}  lg-online-${idx}
+    \   Should Contain  ${output}  lg-${idx}
 
 Concurrent copy: repeat copy a large file from online container to host several times
     ${pids}=  Create List
     Log To Console  \nIssue 10 docker cp commands for large file
     :FOR  ${idx}  IN RANGE  0  10
-    \   ${pid}=  Start Process  docker %{VCH-PARAMS} cp concurrent:/vol1/lg-online-${idx} ${CURDIR}  shell=True
+    \   ${pid}=  Start Process  docker %{VCH-PARAMS} cp concurrent:/vol1/lg-${idx} ${CURDIR}/online  shell=True
     \   Append To List  ${pids}  ${pid}
     Log To Console  \nWait for them to finish and check their RC
     :FOR  ${pid}  IN  @{pids}
@@ -223,8 +220,8 @@ Concurrent copy: repeat copy a large file from online container to host several 
     \   Should Be Equal As Integers  ${res.rc}  0
     Log To Console  \nCheck if the copy operations succeeded
     :FOR  ${idx}  IN RANGE  0  10
-    \   OperatingSystem.File Should Exist  ${CURDIR}/lg-online-${idx}
-    \   Remove File  ${CURDIR}/lg-online-${idx}
+    \   OperatingSystem.File Should Exist  ${CURDIR}/online/lg-${idx}
+    \   Remove File  ${CURDIR}/online/lg-${idx}
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} rm -f concurrent
     Should Be Equal As Integers  ${rc}  0
     Should Not Contain  ${output}  Error
@@ -233,27 +230,27 @@ Sub volumes: copy from host to an online container, destination includes several
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -d -it -v A:/mnt/vol1 -v B:/mnt/vol2 --name subVol ${busybox}
     Should Be Equal As Integers  ${rc}  0
     Should Not Contain  ${output}  Error
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} cp ${CURDIR}/mnt-online subVol:/
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} cp ${CURDIR}/online/mnt subVol:/
     Should Be Equal As Integers  ${rc}  0
     Should Not Contain  ${output}  Error
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} exec subVol find /mnt-online
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} exec subVol find /mnt
     Should Be Equal As Integers  ${rc}  0
     Should Not Contain  ${output}  Error
-    Should Contain  ${output}  /mnt-online/root-online.txt
-    Should Contain  ${output}  /mnt-online/vol1-online/v1-online.txt
-    Should Contain  ${output}  /mnt-online/vol2-online/v2-online.txt
+    Should Contain  ${output}  /mnt/root.txt
+    Should Contain  ${output}  /mnt/vol1/v1.txt
+    Should Contain  ${output}  /mnt/vol2/v2.txt
 
 Sub volumes: copy from online container to host, source includes several volumes
     Remove Directory  ${CURDIR}/result1  recursive=True
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} cp subVol:/mnt-online ${CURDIR}/result1
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} cp subVol:/mnt ${CURDIR}/online/result1
     Should Be Equal As Integers  ${rc}  0
     Should Not Contain  ${output}  Error
-    OperatingSystem.Directory Should Exist  ${CURDIR}/result1/vol1-online
-    OperatingSystem.Directory Should Exist  ${CURDIR}/result1/vol2-online
-    OperatingSystem.File Should Exist  ${CURDIR}/result1/root-online.txt
-    OperatingSystem.File Should Exist  ${CURDIR}/result1/vol1-online/v1-online.txt
-    OperatingSystem.File Should Exist  ${CURDIR}/result1/vol2-online/v2-online.txt
-    Remove Directory  ${CURDIR}/result1  recursive=True
+    OperatingSystem.Directory Should Exist  ${CURDIR}/online/result1/vol1
+    OperatingSystem.Directory Should Exist  ${CURDIR}/online/result1/vol2
+    OperatingSystem.File Should Exist  ${CURDIR}/online/result1/root.txt
+    OperatingSystem.File Should Exist  ${CURDIR}/online/result1/vol1/v1.txt
+    OperatingSystem.File Should Exist  ${CURDIR}/online/result1/vol2/v2.txt
+    Remove Directory  ${CURDIR}/online/result1  recursive=True
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} rm -f subVol
     Should Be Equal As Integers  ${rc}  0
     Should Not Contain  ${output}  Error
@@ -265,16 +262,16 @@ Sub volumes: copy from host to an offline container, destination includes a shar
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} create -i -v vol1:/mnt/vol1 --name subVol_off ${busybox}
     Should Be Equal As Integers  ${rc}  0
     Should Not Contain  ${output}  Error
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} cp ${CURDIR}/mnt-online subVol_off:/
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} cp ${CURDIR}/online/mnt subVol_off:/
     Should Be Equal As Integers  ${rc}  0
     Should Not Contain  ${output}  Error
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} stop subVol_on
     Should Be Equal As Integers  ${rc}  0
     Should Not Contain  ${output}  Error
-    ${output}=  Start Container and Exec Command  subVol_off  find /mnt-online
-    Should Contain  ${output}  /mnt-online/root-online.txt
-    Should Contain  ${output}  /mnt-online/vol1-online/v1-online.txt
-    Should Contain  ${output}  /mnt-online/vol2-online/v2-online.txt
+    ${output}=  Start Container and Exec Command  subVol_off  find /mnt
+    Should Contain  ${output}  /mnt/root.txt
+    Should Contain  ${output}  /mnt/vol1/v1.txt
+    Should Contain  ${output}  /mnt/vol2/v2.txt
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} stop subVol_off
     Should Be Equal As Integers  ${rc}  0
     Should Not Contain  ${output}  Error
@@ -283,16 +280,16 @@ Sub volumes: copy from host to an offline container, destination includes a shar
     Should Not Contain  ${output}  Error
 
 Sub volumes: copy from an offline container to host, source includes a shared vol with an online container
-    Remove Directory  ${CURDIR}/result2  recursive=True
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} cp subVol_off:/mnt-online ${CURDIR}/result2
+    Remove Directory  ${CURDIR}/online/result2  recursive=True
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} cp subVol_off:/mnt ${CURDIR}/online/result2
     Should Be Equal As Integers  ${rc}  0
     Should Not Contain  ${output}  Error
-    OperatingSystem.Directory Should Exist  ${CURDIR}/result2/vol1-online
-    OperatingSystem.Directory Should Exist  ${CURDIR}/result2/vol2-online
-    OperatingSystem.File Should Exist  ${CURDIR}/result2/root-online.txt
-    OperatingSystem.File Should Exist  ${CURDIR}/result2/vol1-online/v1-online.txt
-    OperatingSystem.File Should Exist  ${CURDIR}/result2/vol2-online/v2-online.txt
-    Remove Directory  ${CURDIR}/result2  recursive=True
+    OperatingSystem.Directory Should Exist  ${CURDIR}/online/result2/vol1
+    OperatingSystem.Directory Should Exist  ${CURDIR}/online/result2/vol2
+    OperatingSystem.File Should Exist  ${CURDIR}/online/result2/root.txt
+    OperatingSystem.File Should Exist  ${CURDIR}/online/result2/vol1/v1.txt
+    OperatingSystem.File Should Exist  ${CURDIR}/online/result2/vol2/v2.txt
+    Remove Directory  ${CURDIR}/online/result2  recursive=True
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} rm -f subVol_off
     Should Be Equal As Integers  ${rc}  0
     Should Not Contain  ${output}  Error

--- a/tests/test-cases/Group1-Docker-Commands/1-44-Docker-CP-Online.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-44-Docker-CP-Online.robot
@@ -245,7 +245,7 @@ Sub volumes: copy from host to an online container, destination includes several
 
 Sub volumes: copy from online container to host, source includes several volumes
     Remove Directory  ${CURDIR}/result1  recursive=True
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} cp subVol:/mnt ${CURDIR}/result1
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} cp subVol:/mnt-online ${CURDIR}/result1
     Should Be Equal As Integers  ${rc}  0
     Should Not Contain  ${output}  Error
     OperatingSystem.Directory Should Exist  ${CURDIR}/result1/vol1-online

--- a/tests/test-cases/Group1-Docker-Commands/1-44-Docker-CP-Online.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-44-Docker-CP-Online.robot
@@ -23,16 +23,16 @@ Test Timeout  20 minutes
 Set up test files and install VIC appliance to test server
     Conditional Install VIC Appliance To Test Server
     Remove All Volumes
-    Create File  ${CURDIR}/foo.txt   hello world
-    Create File  ${CURDIR}/content   fake file content for testing only
-    Create Directory  ${CURDIR}/bar
-    Create Directory  ${CURDIR}/mnt
-    Create Directory  ${CURDIR}/mnt/vol1
-    Create Directory  ${CURDIR}/mnt/vol2
-    Create File  ${CURDIR}/mnt/root.txt   rw layer file
-    Create File  ${CURDIR}/mnt/vol1/v1.txt   vol1 file
-    Create File  ${CURDIR}/mnt/vol2/v2.txt   vol2 file
-    ${rc}  ${output}=  Run And Return Rc And Output  dd if=/dev/urandom of=${CURDIR}/largefile.txt count=1024 bs=1024
+    Create File  ${CURDIR}/foo-online.txt   hello world
+    Create File  ${CURDIR}/content-online   fake file content for testing only
+    Create Directory  ${CURDIR}/bar-online
+    Create Directory  ${CURDIR}/mnt-online
+    Create Directory  ${CURDIR}/mnt-online/vol1-online
+    Create Directory  ${CURDIR}/mnt-online/vol2-online
+    Create File  ${CURDIR}/mnt-online/root-online.txt   rw layer file
+    Create File  ${CURDIR}/mnt-online/vol1-online/v1-online.txt   vol1 file
+    Create File  ${CURDIR}/mnt-online/vol2-online/v2-online.txt   vol2 file
+    ${rc}  ${output}=  Run And Return Rc And Output  dd if=/dev/urandom of=${CURDIR}/largefile-online.txt count=1024 bs=1024
     Should Be Equal As Integers  ${rc}  0
     Should Not Contain  ${output}  Error
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} volume create vol1
@@ -46,11 +46,11 @@ Set up test files and install VIC appliance to test server
     Should Not Contain  ${output}  Error
 
 Clean up test files and VIC appliance to test server
-    Run Keyword and Continue on Failure  Remove File  ${CURDIR}/foo.txt
-    Run Keyword and Continue on Failure  Remove File  ${CURDIR}/content
-    Run Keyword and Continue on Failure  Remove File  ${CURDIR}/largefile.txt
-    Run Keyword and Continue on Failure  Remove Directory  ${CURDIR}/bar  recursive=True
-    Run Keyword and Continue on Failure  Remove Directory  ${CURDIR}/mnt  recursive=True
+    Run Keyword and Continue on Failure  Remove File  ${CURDIR}/foo-online.txt
+    Run Keyword and Continue on Failure  Remove File  ${CURDIR}/content-online
+    Run Keyword and Continue on Failure  Remove File  ${CURDIR}/largefile-online.txt
+    Run Keyword and Continue on Failure  Remove Directory  ${CURDIR}/bar-online  recursive=True
+    Run Keyword and Continue on Failure  Remove Directory  ${CURDIR}/mnt-online  recursive=True
     Cleanup VIC Appliance On Test Server
 
 *** Test Cases ***
@@ -72,36 +72,36 @@ Copy a directory from online container to host, destination path doesn't exist
     Remove Directory  ${CURDIR}/newdir  recursive=True
 
 Copy the content of a directory from online container to host
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} cp online:/newdir/. ${CURDIR}/bar
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} cp online:/newdir/. ${CURDIR}/bar-online
     Should Be Equal As Integers  ${rc}  0
     Should Not Contain  ${output}  Error
-    OperatingSystem.File Should Exist  ${CURDIR}/bar/test.txt
-    Remove File  ${CURDIR}/bar/test.txt
+    OperatingSystem.File Should Exist  ${CURDIR}/bar-online/test.txt
+    Remove File  ${CURDIR}/bar-online/test.txt
 
 Copy a file from online container to host, overwrite destination file
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} cp online:/newdir/test.txt ${CURDIR}/foo.txt
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} cp online:/newdir/test.txt ${CURDIR}/foo-online.txt
     Should Be Equal As Integers  ${rc}  0
     Should Not Contain  ${output}  Error
-    ${content}=  OperatingSystem.Get File  ${CURDIR}/foo.txt
+    ${content}=  OperatingSystem.Get File  ${CURDIR}/foo-online.txt
     Should Contain  ${content}   testing
 
 Copy a file from host to online container, destination directory doesn't exist
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} cp ${CURDIR}/foo.txt online:/doesnotexist/
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} cp ${CURDIR}/foo-online.txt online:/doesnotexist/
     Should Not Be Equal As Integers  ${rc}  0
     Should Contain  ${output}  no such directory
 
 Copy a file and directory from host to online container
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} cp ${CURDIR}/foo.txt online:/
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} cp ${CURDIR}/foo-online.txt online:/
     Should Be Equal As Integers  ${rc}  0
     Should Not Contain  ${output}  Error
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} cp ${CURDIR}/bar online:/
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} cp ${CURDIR}/bar-online online:/
     Should Be Equal As Integers  ${rc}  0
     Should Not Contain  ${output}  Error
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} exec online ls /
     Should Be Equal As Integers  ${rc}  0
     Should Not Contain  ${output}  Error
-    Should Contain  ${output}  foo.txt
-    Should Contain  ${output}  bar
+    Should Contain  ${output}  foo-online.txt
+    Should Contain  ${output}  bar-online
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} rm -f online
     Should Be Equal As Integers  ${rc}  0
     Should Not Contain  ${output}  Error
@@ -110,47 +110,47 @@ Copy a directory from host to online container, destination is a volume
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -d -it --name online_vol -v vol1:/vol1 ${busybox}
     Should Be Equal As Integers  ${rc}  0
     Should Not Contain  ${output}  Error
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} cp ${CURDIR}/bar online_vol:/vol1/
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} cp ${CURDIR}/bar-online online_vol:/vol1/
     Should Be Equal As Integers  ${rc}  0
     Should Not Contain  ${output}  Error
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} exec online_vol ls /vol1
     Should Be Equal As Integers  ${rc}  0
     Should Not Contain  ${output}  Error
-    Should Contain  ${output}  bar
+    Should Contain  ${output}  bar-online
 
 Copy a file from host to offline container, destination is a volume shared with an online container
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} create -i --name offline -v vol1:/vol1 ${busybox}
     Should Be Equal As Integers  ${rc}  0
     Should Not Contain  ${output}  Error
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} cp ${CURDIR}/content offline:/vol1
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} cp ${CURDIR}/content-online offline:/vol1
     Should Be Equal As Integers  ${rc}  0
     Should Not Contain  ${output}  Error
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} exec online_vol ls /vol1
     Should Be Equal As Integers  ${rc}  0
     Should Not Contain  ${output}  Error
-    Should Contain  ${output}  content
+    Should Contain  ${output}  content-online
 
 Copy a directory from offline container to host, destination is a volume shared with an online container
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} cp offline:/vol1 ${CURDIR}
     Should Be Equal As Integers  ${rc}  0
     Should Not Contain  ${output}  Error
     OperatingSystem.Directory Should Exist  ${CURDIR}/vol1
-    OperatingSystem.Directory Should Exist  ${CURDIR}/vol1/bar
-    OperatingSystem.File Should Exist  ${CURDIR}/vol1/content
+    OperatingSystem.Directory Should Exist  ${CURDIR}/vol1/bar-online
+    OperatingSystem.File Should Exist  ${CURDIR}/vol1/content-online
     Remove Directory  ${CURDIR}/vol1  recursive=True
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} rm -f offline
     Should Be Equal As Integers  ${rc}  0
     Should Not Contain  ${output}  Error
 
 Copy a large file to an online container, destination is a volume
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} cp ${CURDIR}/largefile.txt online_vol:/vol1/
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} cp ${CURDIR}/largefile-online.txt online_vol:/vol1/
     Should Be Equal As Integers  ${rc}  0
     Should Not Contain  ${output}  Error
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} exec online_vol ls -l /vol1/
     Should Be Equal As Integers  ${rc}  0
     Should Not Contain  ${output}  Error
     Should Contain  ${output}  1048576
-    Should Contain  ${output}  largefile.txt
+    Should Contain  ${output}  largefile-online.txt
 
 Copy a non-existent file out of an online container
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} cp online_vol:/dne/dne ${CURDIR}
@@ -172,12 +172,13 @@ Concurrent copy: create processes to copy a small file from host to online conta
     ${pids}=  Create List
     Log To Console  \nIssue 10 docker cp commands for small file
     :FOR  ${idx}  IN RANGE  0  10
-    \   ${pid}=  Start Process  docker %{VCH-PARAMS} cp ${CURDIR}/foo.txt concurrent:/foo-${idx}  shell=True
+    \   ${pid}=  Start Process  docker %{VCH-PARAMS} cp ${CURDIR}/foo-online.txt concurrent:/foo-online-${idx}  shell=True
     \   Append To List  ${pids}  ${pid}
     Log To Console  \nWait for them to finish and check their RC
     :FOR  ${pid}  IN  @{pids}
     \   Log To Console  \nWaiting for ${pid}
     \   ${res}=  Wait For Process  ${pid}
+    \   Log  ${res.stderr}
     \   Log  ${res.stdout}
     \   Should Be Equal As Integers  ${res.rc}  0
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} exec concurrent ls /
@@ -185,18 +186,19 @@ Concurrent copy: create processes to copy a small file from host to online conta
     Should Not Contain  ${output}  Error
     Log To Console  \nCheck if the copy operations succeeded
     :FOR  ${idx}  IN RANGE  0  10
-    \   Should Contain  ${output}  foo-${idx}
+    \   Should Contain  ${output}  foo-online-${idx}
 
 Concurrent copy: repeat copy a large file from host to online container several times
     ${pids}=  Create List
     Log To Console  \nIssue 10 docker cp commands for large file
     :FOR  ${idx}  IN RANGE  0  10
-    \   ${pid}=  Start Process  docker %{VCH-PARAMS} cp ${CURDIR}/largefile.txt concurrent:/vol1/lg-${idx}  shell=True
+    \   ${pid}=  Start Process  docker %{VCH-PARAMS} cp ${CURDIR}/largefile-online.txt concurrent:/vol1/lg-online-${idx}  shell=True
     \   Append To List  ${pids}  ${pid}
     Log To Console  \nWait for them to finish and check their RC
     :FOR  ${pid}  IN  @{pids}
     \   Log To Console  \nWaiting for ${pid}
     \   ${res}=  Wait For Process  ${pid}
+    \   Log  ${res.stderr}
     \   Log  ${res.stdout}
     \   Should Be Equal As Integers  ${res.rc}  0
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} exec concurrent ls /vol1
@@ -204,24 +206,25 @@ Concurrent copy: repeat copy a large file from host to online container several 
     Should Not Contain  ${output}  Error
     Log To Console  \nCheck if the copy operations succeeded
     :FOR  ${idx}  IN RANGE  0  10
-    \   Should Contain  ${output}  lg-${idx}
+    \   Should Contain  ${output}  lg-online-${idx}
 
 Concurrent copy: repeat copy a large file from online container to host several times
     ${pids}=  Create List
     Log To Console  \nIssue 10 docker cp commands for large file
     :FOR  ${idx}  IN RANGE  0  10
-    \   ${pid}=  Start Process  docker %{VCH-PARAMS} cp concurrent:/vol1/lg-${idx} ${CURDIR}  shell=True
+    \   ${pid}=  Start Process  docker %{VCH-PARAMS} cp concurrent:/vol1/lg-online-${idx} ${CURDIR}  shell=True
     \   Append To List  ${pids}  ${pid}
     Log To Console  \nWait for them to finish and check their RC
     :FOR  ${pid}  IN  @{pids}
     \   Log To Console  \nWaiting for ${pid}
     \   ${res}=  Wait For Process  ${pid}
+    \   Log  ${res.stderr}
     \   Log  ${res.stdout}
     \   Should Be Equal As Integers  ${res.rc}  0
     Log To Console  \nCheck if the copy operations succeeded
     :FOR  ${idx}  IN RANGE  0  10
-    \   OperatingSystem.File Should Exist  ${CURDIR}/lg-${idx}
-    \   Remove File  ${CURDIR}/lg-${idx}
+    \   OperatingSystem.File Should Exist  ${CURDIR}/lg-online-${idx}
+    \   Remove File  ${CURDIR}/lg-online-${idx}
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} rm -f concurrent
     Should Be Equal As Integers  ${rc}  0
     Should Not Contain  ${output}  Error
@@ -230,26 +233,26 @@ Sub volumes: copy from host to an online container, destination includes several
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -d -it -v A:/mnt/vol1 -v B:/mnt/vol2 --name subVol ${busybox}
     Should Be Equal As Integers  ${rc}  0
     Should Not Contain  ${output}  Error
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} cp ${CURDIR}/mnt subVol:/
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} cp ${CURDIR}/mnt-online subVol:/
     Should Be Equal As Integers  ${rc}  0
     Should Not Contain  ${output}  Error
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} exec subVol find /mnt
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} exec subVol find /mnt-online
     Should Be Equal As Integers  ${rc}  0
     Should Not Contain  ${output}  Error
-    Should Contain  ${output}  /mnt/root.txt
-    Should Contain  ${output}  /mnt/vol1/v1.txt
-    Should Contain  ${output}  /mnt/vol2/v2.txt
+    Should Contain  ${output}  /mnt-online/root-online.txt
+    Should Contain  ${output}  /mnt-online/vol1-online/v1-online.txt
+    Should Contain  ${output}  /mnt-online/vol2-online/v2-online.txt
 
 Sub volumes: copy from online container to host, source includes several volumes
     Remove Directory  ${CURDIR}/result1  recursive=True
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} cp subVol:/mnt ${CURDIR}/result1
     Should Be Equal As Integers  ${rc}  0
     Should Not Contain  ${output}  Error
-    OperatingSystem.Directory Should Exist  ${CURDIR}/result1/vol1
-    OperatingSystem.Directory Should Exist  ${CURDIR}/result1/vol2
-    OperatingSystem.File Should Exist  ${CURDIR}/result1/root.txt
-    OperatingSystem.File Should Exist  ${CURDIR}/result1/vol1/v1.txt
-    OperatingSystem.File Should Exist  ${CURDIR}/result1/vol2/v2.txt
+    OperatingSystem.Directory Should Exist  ${CURDIR}/result1/vol1-online
+    OperatingSystem.Directory Should Exist  ${CURDIR}/result1/vol2-online
+    OperatingSystem.File Should Exist  ${CURDIR}/result1/root-online.txt
+    OperatingSystem.File Should Exist  ${CURDIR}/result1/vol1-online/v1-online.txt
+    OperatingSystem.File Should Exist  ${CURDIR}/result1/vol2-online/v2-online.txt
     Remove Directory  ${CURDIR}/result1  recursive=True
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} rm -f subVol
     Should Be Equal As Integers  ${rc}  0
@@ -262,16 +265,16 @@ Sub volumes: copy from host to an offline container, destination includes a shar
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} create -i -v vol1:/mnt/vol1 --name subVol_off ${busybox}
     Should Be Equal As Integers  ${rc}  0
     Should Not Contain  ${output}  Error
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} cp ${CURDIR}/mnt subVol_off:/
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} cp ${CURDIR}/mnt-online subVol_off:/
     Should Be Equal As Integers  ${rc}  0
     Should Not Contain  ${output}  Error
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} stop subVol_on
     Should Be Equal As Integers  ${rc}  0
     Should Not Contain  ${output}  Error
-    ${output}=  Start Container and Exec Command  subVol_off  find /mnt
-    Should Contain  ${output}  /mnt/root.txt
-    Should Contain  ${output}  /mnt/vol1/v1.txt
-    Should Contain  ${output}  /mnt/vol2/v2.txt
+    ${output}=  Start Container and Exec Command  subVol_off  find /mnt-online
+    Should Contain  ${output}  /mnt-online/root-online.txt
+    Should Contain  ${output}  /mnt-online/vol1-online/v1-online.txt
+    Should Contain  ${output}  /mnt-online/vol2-online/v2-online.txt
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} stop subVol_off
     Should Be Equal As Integers  ${rc}  0
     Should Not Contain  ${output}  Error
@@ -281,14 +284,14 @@ Sub volumes: copy from host to an offline container, destination includes a shar
 
 Sub volumes: copy from an offline container to host, source includes a shared vol with an online container
     Remove Directory  ${CURDIR}/result2  recursive=True
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} cp subVol_off:/mnt ${CURDIR}/result2
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} cp subVol_off:/mnt-online ${CURDIR}/result2
     Should Be Equal As Integers  ${rc}  0
     Should Not Contain  ${output}  Error
-    OperatingSystem.Directory Should Exist  ${CURDIR}/result2/vol1
-    OperatingSystem.Directory Should Exist  ${CURDIR}/result2/vol2
-    OperatingSystem.File Should Exist  ${CURDIR}/result2/root.txt
-    OperatingSystem.File Should Exist  ${CURDIR}/result2/vol1/v1.txt
-    OperatingSystem.File Should Exist  ${CURDIR}/result2/vol2/v2.txt
+    OperatingSystem.Directory Should Exist  ${CURDIR}/result2/vol1-online
+    OperatingSystem.Directory Should Exist  ${CURDIR}/result2/vol2-online
+    OperatingSystem.File Should Exist  ${CURDIR}/result2/root-online.txt
+    OperatingSystem.File Should Exist  ${CURDIR}/result2/vol1-online/v1-online.txt
+    OperatingSystem.File Should Exist  ${CURDIR}/result2/vol2-online/v2-online.txt
     Remove Directory  ${CURDIR}/result2  recursive=True
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} rm -f subVol_off
     Should Be Equal As Integers  ${rc}  0


### PR DESCRIPTION
[skip unit]
[specific ci=1-44-Docker-CP-Online --suite 1-43-Docker-CP-Offline]

These two tests use a lot of the same dir and file names locally, so switch to scoping them within an online and offline folder structure to prevent parallel test failures.