### PR TITLE
Removed unnecessary kube API server address/port

### DIFF
--- a/cmd/kubelet-starter/main.go
+++ b/cmd/kubelet-starter/main.go
@@ -100,8 +100,6 @@ func main() {
 	os.Setenv("PORTLAYER_ADDR", portlayerAddr)
 
 	op.Infof("KUBELET_NAME = %s", os.Getenv("KUBELET_NAME"))
-	op.Infof("KUBERNETES_SERVICE_HOST = %s", os.Getenv("KUBERNETES_SERVICE_HOST"))
-	op.Infof("KUBERNETES_SERVICE_PORT = %s", os.Getenv("KUBERNETES_SERVICE_PORT"))
 	op.Infof("PERSONA_ADDR = %s", os.Getenv("PERSONA_ADDR"))
 	op.Infof("PORTLAYER_ADDR = %s", os.Getenv("PORTLAYER_ADDR"))
 

--- a/cmd/vic-machine/common/kubelet.go
+++ b/cmd/vic-machine/common/kubelet.go
@@ -17,25 +17,16 @@ package common
 import (
 	"gopkg.in/urfave/cli.v1"
 
-	"github.com/vmware/vic/pkg/errors"
 	"github.com/vmware/vic/pkg/flags"
-	"github.com/vmware/vic/pkg/trace"
 )
 
 // Kubelet holds credentials for the VCH operations user
 type Kubelet struct {
-	ServerAddress *string `cmd:"kubelet"`
-	ConfigFile    *string
+	ConfigFile *string
 }
 
 func (v *Kubelet) Flags(hidden bool) []cli.Flag {
 	return []cli.Flag{
-		cli.GenericFlag{
-			Name:   "k8s-server-address",
-			Value:  flags.NewOptionalString(&v.ServerAddress),
-			Usage:  "The Kubernetes Server URL, <hostname/ip>:<port>",
-			Hidden: hidden,
-		},
 		cli.GenericFlag{
 			Name:   "k8s-config",
 			Value:  flags.NewOptionalString(&v.ConfigFile),
@@ -43,17 +34,4 @@ func (v *Kubelet) Flags(hidden bool) []cli.Flag {
 			Hidden: hidden,
 		},
 	}
-}
-
-func (v *Kubelet) ProcessKubelet(op trace.Operation, isCreateOp bool) error {
-	if isCreateOp {
-		if v.ServerAddress != nil && v.ConfigFile == nil {
-			return errors.Errorf("A Kubernetes Config File must be specified when specifying a Kubernetes Server Address")
-		}
-		if v.ServerAddress == nil && v.ConfigFile != nil {
-			return errors.Errorf("A Kubernetes Server Address must be specified when specifying a Kubernetes Config File")
-		}
-	}
-
-	return nil
 }

--- a/cmd/vic-machine/create/create.go
+++ b/cmd/vic-machine/create/create.go
@@ -322,10 +322,6 @@ func (c *Create) ProcessParams(op trace.Operation) error {
 		return err
 	}
 
-	if err := c.Kubelet.ProcessKubelet(op, true); err != nil {
-		return err
-	}
-
 	var err error
 	c.ContainerNetworks, err = c.containerNetworks.ProcessContainerNetworks(op)
 	if err != nil {

--- a/isos/bootstrap/bootstrap
+++ b/isos/bootstrap/bootstrap
@@ -101,7 +101,7 @@ if timeout --signal=KILL 2m mount -t ext4 ${ROOTFS} ${MOUNTPOINT}; then
     # WARNING WARNING WARNING WARNING WARNING
     # if the tmpfs is not large enough odd hangs can occur and the ESX event log will
     # report the guest disabling the CPU
-    mount -t tmpfs -o size=80m tmpfs ${MOUNTPOINT}/.tether/
+    mount -t tmpfs -o size=120m tmpfs ${MOUNTPOINT}/.tether/
 
     # enable full system functionality in the container
     ln -s lib64 ${MOUNTPOINT}/.tether/lib

--- a/lib/install/validate/validator.go
+++ b/lib/install/validate/validator.go
@@ -946,11 +946,10 @@ func (v *Validator) syslog(op trace.Operation, conf *config.VirtualContainerHost
 func (v *Validator) kubelet(op trace.Operation, conf *config.VirtualContainerHostConfigSpec, input *data.Data) {
 	defer trace.End(trace.Begin("", op))
 
-	if input.Kubelet.ServerAddress == nil || input.Kubelet.ConfigFile == nil {
+	if input.Kubelet.ConfigFile == nil {
 		return
 	}
 
-	conf.KubernetesServerAddress = *input.Kubelet.ServerAddress
 	conf.KubeletConfigFile = *input.Kubelet.ConfigFile
 
 	err := kubelet.ReadKubeletConfigFile(op, conf)


### PR DESCRIPTION
Clean-up of the vic-machine create parameters. There is no need to pass in the Kube API server address/port-number as that information is contained in the kubeconfig file. 