### PR TITLE
Fix build errors from host affinity cherry-picks

### DIFF
--- a/cmd/vic-machine/create/create.go
+++ b/cmd/vic-machine/create/create.go
@@ -270,15 +270,6 @@ func (c *Create) Flags() []cli.Flag {
 		},
 	}
 
-	affinity := []cli.Flag{
-		cli.BoolFlag{
-			Name:        "affinity-vm-group",
-			Usage:       "Use a DRS VM Group to allow VM-Host affinity rules to be defined for the VCH",
-			Destination: &c.UseVMGroup,
-			Hidden:      true,
-		},
-	}
-
 	util := []cli.Flag{
 		// miscellaneous
 		cli.BoolFlag{


### PR DESCRIPTION
Replaying the host affinity work on the release branch led to re-declaration of a variable, causing the build to fail with:

cmd/vic-machine/create/create.go:315: no new variables on left side of :=

`[specific ci=Group25-Host-Affinity]`