### PR TITLE
Fix panic in listVCH if a VM is deleted in the middle

### DIFF
--- a/pkg/vsphere/vm/vm.go
+++ b/pkg/vsphere/vm/vm.go
@@ -216,10 +216,10 @@ func (vm *VirtualMachine) FetchExtraConfigBaseOptions(ctx context.Context) ([]ty
 		return nil, err
 	}
 
-       if mvm.Config.ExtraConfig == nil {
-               return nil, errors.New("ExtraConfig came back nil, the vm was likely deleted")
-       }
-       return mvm.Config.ExtraConfig, nil
+	if mvm.Config.ExtraConfig == nil {
+		return nil, errors.New("ExtraConfig came back nil, the vm was likely deleted")
+	}
+	return mvm.Config.ExtraConfig, nil
 }
 
 func (vm *VirtualMachine) FetchExtraConfig(ctx context.Context) (map[string]string, error) {

--- a/pkg/vsphere/vm/vm.go
+++ b/pkg/vsphere/vm/vm.go
@@ -216,7 +216,10 @@ func (vm *VirtualMachine) FetchExtraConfigBaseOptions(ctx context.Context) ([]ty
 		return nil, err
 	}
 
-	return mvm.Config.ExtraConfig, nil
+       if mvm.Config.ExtraConfig == nil {
+               return nil, errors.New("ExtraConfig came back nil, the vm was likely deleted")
+       }
+       return mvm.Config.ExtraConfig, nil
 }
 
 func (vm *VirtualMachine) FetchExtraConfig(ctx context.Context) (map[string]string, error) {


### PR DESCRIPTION
[specific ci=6-10-List]
fixes #7986 