### PR TITLE
Skip empty layers during image download [specific ci=Group1-Docker-Commands]

### DIFF
--- a/lib/apiservers/engine/backends/container.go
+++ b/lib/apiservers/engine/backends/container.go
@@ -663,7 +663,7 @@ func (c *ContainerBackend) ContainerCreate(config types.ContainerCreateConfig) (
 
 	// Reserve the container name to prevent duplicates during a parallel operation.
 	if config.Name != "" {
-		err := cache.ContainerCache().ReserveName(container, config.Name)
+		err = cache.ContainerCache().ReserveName(container, config.Name)
 		if err != nil {
 			return containertypes.ContainerCreateCreatedBody{}, derr.NewRequestConflictError(err)
 		}
@@ -1757,7 +1757,7 @@ func clientFriendlyContainerName(name string) string {
 func createInternalVicContainer(image *metadata.ImageConfig, config *types.ContainerCreateConfig) (*viccontainer.VicContainer, error) {
 	// provide basic container config via the image
 	container := viccontainer.NewVicContainer()
-	container.LayerID = image.V1Image.ID // store childmost layer ID to map to the proper vmdk
+	container.LayerID = image.VMDK // store childmost layer ID to map to the proper vmdk
 	container.ImageID = image.ImageID
 	container.Config = image.Config //Set defaults.  Overrides will get copied below.
 

--- a/lib/apiservers/engine/backends/image.go
+++ b/lib/apiservers/engine/backends/image.go
@@ -123,7 +123,7 @@ func (i *ImageBackend) ImageDelete(imageRef string, force, prune bool) ([]types.
 			keepNodes[idx] = imgURL.String()
 		}
 
-		params := storage.NewDeleteImageParamsWithContext(ctx).WithStoreName(storeName).WithID(img.ID).WithKeepNodes(keepNodes)
+		params := storage.NewDeleteImageParamsWithContext(ctx).WithStoreName(storeName).WithID(img.VMDK).WithKeepNodes(keepNodes)
 		// TODO: This will fail if any containerVMs are referencing the vmdk - vanilla docker
 		// allows the removal of an image (via force flag) even if a container is referencing it
 		// should vic?

--- a/lib/imagec/docker.go
+++ b/lib/imagec/docker.go
@@ -45,8 +45,14 @@ import (
 
 const (
 	// DigestSHA256EmptyTar is the canonical sha256 digest of empty tar file -
-	// (1024 NULL bytes)
+	// (1024 NULL bytes) - aka, the "empty" layer diffID.
 	DigestSHA256EmptyTar = string(dlayer.DigestSHA256EmptyTar)
+
+	// DigestSHA256EmptyBlobSum is the canonical sha256 digest of a gzipped empty tar file -
+	// (1024 NULL bytes, gzipped) - aka, the "empty" blobsum. This is used to identify empty
+	// layers using the schema v1 manifest without having to download, unzip and sha256 the
+	// 1024-byte empty layer tar.
+	DigestSHA256EmptyBlobSum = "sha256:a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4"
 )
 
 // FSLayer is a container struct for BlobSums defined in an image manifest

--- a/lib/imagec/storage.go
+++ b/lib/imagec/storage.go
@@ -98,7 +98,7 @@ func WriteImage(host string, image *ImageWithMeta, data io.ReadCloser) error {
 	r, err := client.Storage.WriteImage(
 		storage.NewWriteImageParamsWithContext(ctx).
 			WithImageID(image.ID).
-			WithParentID(image.Parent).
+			WithParentID(image.DiskParent).
 			WithStoreName(image.Store).
 			WithMetadatakey(key).
 			WithMetadataval(blob).
@@ -112,5 +112,4 @@ func WriteImage(host string, image *ImageWithMeta, data io.ReadCloser) error {
 	log.Printf("Created an image %#v", r.Payload)
 
 	return nil
-
 }

--- a/lib/metadata/image_config.go
+++ b/lib/metadata/image_config.go
@@ -18,7 +18,8 @@ import (
 	docker "github.com/docker/docker/image"
 )
 
-// ImageConfig contains configuration data describing images and their layers
+// ImageConfig defines the docker format for representing an image. When marshaled to JSON, the sha256 sum
+// of the resulting bytes is the image ID.
 type ImageConfig struct {
 	docker.V1Image
 
@@ -30,4 +31,11 @@ type ImageConfig struct {
 	DiffIDs   map[string]string `json:"diff_ids,omitempty"`
 	History   []docker.History  `json:"history,omitempty"`
 	Reference string            `json:"registry"`
+
+	// VMDK is the ID of the VMDK to be used as the R/W layer's parent disk when
+	// creating a container from the image. This is the type that is stored in our
+	// image cache.
+	//
+	// This field is ignored when marshalling into JSON to preserve the image ID.
+	VMDK string `json:"vmdk,omitempty"`
 }


### PR DESCRIPTION
This change to the image pull path adds functionality to skip empty layers during download. The metadata for each empty layer is stored in the image config, and VMDKs are not created for empty layers. This provides a substantial time reduction when pulling images containing one or more instances of the empty layer.

Examples:

nginx - VIC 1.4.0 - 1 minute 16 seconds
```
zach@devbox:~/vic/1.4.0$ time docker -H 10.160.129.199:2376 --tls pull nginx
Using default tag: latest
latest: Pulling from library/nginx
f2aa67a397c4: Pull complete
a3ed95caeb02: Pull complete
3c091c23e29d: Pull complete
4a99993b8636: Pull complete
Digest: sha256:e4f0474a75c510f40b37b6b7dc2516241ffa8bde5a442bde3d372c9519c84d90
Status: Downloaded newer image for library/nginx:latest

real    1m16.313s
user    0m0.087s
sys     0m0.024s
```

nginx - HEAD - 30 seconds
```
zach@devbox:~/go/src/github.com/vmware/vic (emptylayer *$%)$ time docker -H 10.160.152.54:2376 --tls pull nginx
Using default tag: latest
latest: Pulling from library/nginx
f2aa67a397c4: Pull complete
3c091c23e29d: Pull complete
4a99993b8636: Pull complete
Digest: sha256:e4f0474a75c510f40b37b6b7dc2516241ffa8bde5a442bde3d372c9519c84d90
Status: Downloaded newer image for library/nginx:latest

real    0m30.279s
user    0m0.075s
sys     0m0.014s
```

tomcat - VIC 1.4.0 - 3 minutes, 59 seconds
```
zach@devbox:~/vic/1.4.0$ time docker -H 10.160.129.199:2376 --tls pull tomcat
Using default tag: latest
latest: Pulling from library/tomcat
cc1a78bfd46b: Pull complete
a3ed95caeb02: Pull complete
6861473222a6: Pull complete
7e0b9c3b5ae0: Pull complete
ae14ee39877a: Pull complete
8085c1b536f0: Pull complete
6e1431e84c0c: Pull complete
ca0e3df5a1fd: Pull complete
d2cb611ced6c: Pull complete
268dc3e43e66: Pull complete
79a7e8d254c7: Pull complete
5c848af92738: Pull complete
789b92e37607: Pull complete
Digest: sha256:8238fb3b0f8e15219399069a4aa78e88cbbce28834de5f1e55749067b82d14dc
Status: Downloaded newer image for library/tomcat:latest

real    3m58.785s
user    0m0.114s
sys     0m0.084s
```

tomcat - HEAD - 1 minute 40 seconds
```
zach@devbox:~/go/src/github.com/vmware/vic (emptylayer $%)$ time docker -H 10.160.152.54:2376 --tls pull tomcat
Using default tag: latest
latest: Pulling from library/tomcat
cc1a78bfd46b: Pull complete
6861473222a6: Pull complete
7e0b9c3b5ae0: Pull complete
ae14ee39877a: Pull complete
8085c1b536f0: Pull complete
6e1431e84c0c: Pull complete
ca0e3df5a1fd: Pull complete
d2cb611ced6c: Pull complete
268dc3e43e66: Pull complete
79a7e8d254c7: Pull complete
5c848af92738: Pull complete
789b92e37607: Pull complete
Digest: sha256:8238fb3b0f8e15219399069a4aa78e88cbbce28834de5f1e55749067b82d14dc
Status: Downloaded newer image for library/tomcat:latest

real    1m40.479s
user    0m0.103s
sys     0m0.062s
```

Fixes #4168 

[specific ci=Group1-Docker-Commands]