### PR TITLE
Add Operation to all the API entry points. Also add an INFO log

### DIFF
--- a/lib/apiservers/engine/backends/commit.go
+++ b/lib/apiservers/engine/backends/commit.go
@@ -58,8 +58,7 @@ import (
 // The image can optionally be tagged into a repository.
 func (i *ImageBackend) Commit(name string, config *backend.ContainerCommitConfig) (imageID string, err error) {
 	op := trace.NewOperation(context.Background(), "Commit: %s", name)
-	defer trace.End(trace.Begin(name, op))
-	op.Auditf("Commit: %s", name)
+	defer trace.End(trace.Audit(name, op))
 
 	// Look up the container name in the metadata cache to get long ID
 	vc := cache.ContainerCache().GetContainer(name)

--- a/lib/apiservers/engine/backends/commit.go
+++ b/lib/apiservers/engine/backends/commit.go
@@ -57,8 +57,10 @@ import (
 // Commit creates a new filesystem image from the current state of a container.
 // The image can optionally be tagged into a repository.
 func (i *ImageBackend) Commit(name string, config *backend.ContainerCommitConfig) (imageID string, err error) {
-	defer trace.End(trace.Begin(name))
-	op := trace.NewOperation(context.Background(), "Commit")
+	op := trace.NewOperation(context.Background(), "Commit: %s", name)
+	defer trace.End(trace.Begin(name, op))
+	op.Auditf("Commit: %s", name)
+
 	// Look up the container name in the metadata cache to get long ID
 	vc := cache.ContainerCache().GetContainer(name)
 	if vc == nil {

--- a/lib/apiservers/engine/backends/container.go
+++ b/lib/apiservers/engine/backends/container.go
@@ -193,8 +193,7 @@ func (c *ContainerBackend) Handle(id, name string) (string, error) {
 // ContainerExecCreate sets up an exec in a running container.
 func (c *ContainerBackend) ContainerExecCreate(name string, config *types.ExecConfig) (string, error) {
 	op := trace.NewOperation(context.Background(), "ContainerExecCreate: %s", name)
-	defer trace.End(trace.Begin(name, op))
-	op.Auditf("ContainerExecCreate: %s", name)
+	defer trace.End(trace.Audit(name, op))
 
 	// Look up the container name in the metadata cache to get long ID
 	vc := cache.ContainerCache().GetContainer(name)
@@ -273,8 +272,7 @@ func (c *ContainerBackend) ContainerExecCreate(name string, config *types.ExecCo
 // command. An error is returned if the exec cannot be found.
 func (c *ContainerBackend) ContainerExecInspect(eid string) (*backend.ExecInspect, error) {
 	op := trace.NewOperation(context.Background(), "ContainerExecInspect: %s", eid)
-	defer trace.End(trace.Begin(eid, op))
-	op.Auditf("ContainerExecInspect: %s", eid)
+	defer trace.End(trace.Audit(eid, op))
 
 	// Look up the container name in the metadata cache to get long ID
 	vc := cache.ContainerCache().GetContainerFromExec(eid)
@@ -324,8 +322,7 @@ func (c *ContainerBackend) ContainerExecInspect(eid string) (*backend.ExecInspec
 // width.
 func (c *ContainerBackend) ContainerExecResize(eid string, height, width int) error {
 	op := trace.NewOperation(context.Background(), "ContainerExecResize: %s", eid)
-	defer trace.End(trace.Begin(eid, op))
-	op.Auditf("ContainerExecResize: %s", eid)
+	defer trace.End(trace.Audit(eid, op))
 
 	// Look up the container eid in the metadata cache to get long ID
 	vc := cache.ContainerCache().GetContainerFromExec(eid)
@@ -494,8 +491,7 @@ func (c *ContainerBackend) taskStateWaitHelper(op trace.Operation, id, eid, name
 // std streams are set up.
 func (c *ContainerBackend) ContainerExecStart(ctx context.Context, eid string, stdin io.ReadCloser, stdout, stderr io.Writer) error {
 	op := trace.FromContext(ctx, "ContainerExecStart: %s", eid)
-	defer trace.End(trace.Begin(eid, op))
-	op.Auditf("ContainerExecStart: %s", eid)
+	defer trace.End(trace.Audit(eid, op))
 
 	// 0. start task (with retry)
 	// 1. If attaching, start attach logic (background)
@@ -633,8 +629,7 @@ func (c *ContainerBackend) ContainerExecStart(ctx context.Context, eid string, s
 // It will also return the error produced by `getConfig`
 func (c *ContainerBackend) ExecExists(eid string) (bool, error) {
 	op := trace.NewOperation(context.Background(), "ExecExists: %s", eid)
-	defer trace.End(trace.Begin(eid, op))
-	op.Auditf("ExecExists: %s", eid)
+	defer trace.End(trace.Audit(eid, op))
 
 	vc := cache.ContainerCache().GetContainerFromExec(eid)
 	if vc == nil {
@@ -646,8 +641,7 @@ func (c *ContainerBackend) ExecExists(eid string) (bool, error) {
 // ContainerCreate creates a container.
 func (c *ContainerBackend) ContainerCreate(config types.ContainerCreateConfig) (containertypes.ContainerCreateCreatedBody, error) {
 	op := trace.NewOperation(context.Background(), "ContainerCreate: %s", config.Name)
-	defer trace.End(trace.Begin(config.Name, op))
-	op.Auditf("ContainerCreate: %s", config.Name)
+	defer trace.End(trace.Audit(config.Name, op))
 
 	var err error
 
@@ -776,8 +770,7 @@ func (c *ContainerBackend) containerCreate(vc *viccontainer.VicContainer, config
 // If a signal is given, then just send it to the container and return.
 func (c *ContainerBackend) ContainerKill(name string, sig uint64) error {
 	op := trace.NewOperation(context.Background(), "ContainerKill: %s, sig: %d", name, sig)
-	defer trace.End(trace.Begin(name, op))
-	op.Auditf("ContainerKill: %s", name)
+	defer trace.End(trace.Audit(name, op))
 
 	// Look up the container name in the metadata cache to get long ID
 	vc := cache.ContainerCache().GetContainer(name)
@@ -799,8 +792,7 @@ func (c *ContainerBackend) ContainerKill(name string, sig uint64) error {
 // ContainerPause pauses a container
 func (c *ContainerBackend) ContainerPause(name string) error {
 	op := trace.NewOperation(context.Background(), "ContainerPause: %s", name)
-	defer trace.End(trace.Begin(name, op))
-	op.Auditf("ContainerPause: %s", name)
+	defer trace.End(trace.Audit(name, op))
 
 	return engerr.APINotSupportedMsg(ProductName(), "ContainerPause")
 }
@@ -809,8 +801,7 @@ func (c *ContainerBackend) ContainerPause(name string) error {
 // in the container with the given name to the given height and width.
 func (c *ContainerBackend) ContainerResize(name string, height, width int) error {
 	op := trace.NewOperation(context.Background(), "ContainerResize: %s", name)
-	defer trace.End(trace.Begin(name, op))
-	op.Auditf("ContainerResize: %s", name)
+	defer trace.End(trace.Audit(name, op))
 
 	// Look up the container name in the metadata cache to get long ID
 	vc := cache.ContainerCache().GetContainer(name)
@@ -843,8 +834,7 @@ func (c *ContainerBackend) ContainerResize(name string, height, width int) error
 // there is an underlying error at any stage of the restart.
 func (c *ContainerBackend) ContainerRestart(name string, seconds *int) error {
 	op := trace.NewOperation(context.Background(), "ContainerRestart: %s", name)
-	defer trace.End(trace.Begin(name, op))
-	op.Auditf("ContainerRestart: %s", name)
+	defer trace.End(trace.Audit(name, op))
 
 	// Look up the container name in the metadata cache ot get long ID
 	vc := cache.ContainerCache().GetContainer(name)
@@ -878,8 +868,7 @@ func (c *ContainerBackend) ContainerRestart(name string, seconds *int) error {
 // vicnetwork links are removed.
 func (c *ContainerBackend) ContainerRm(name string, config *types.ContainerRmConfig) error {
 	op := trace.NewOperation(context.Background(), "ContainerRm: %s", name)
-	defer trace.End(trace.Begin(name, op))
-	op.Auditf("ContainerRm: %s", name)
+	defer trace.End(trace.Audit(name, op))
 
 	// Look up the container name in the metadata cache to get long ID
 	vc := cache.ContainerCache().GetContainer(name)
@@ -995,8 +984,7 @@ func (c *ContainerBackend) cleanupPortBindings(vc *viccontainer.VicContainer) er
 // ContainerStart starts a container.
 func (c *ContainerBackend) ContainerStart(name string, hostConfig *containertypes.HostConfig, checkpoint string, checkpointDir string) error {
 	op := trace.NewOperation(context.Background(), "ContainerStart: %s", name)
-	defer trace.End(trace.Begin(name, op))
-	op.Auditf("ContainerStart:%s ", name)
+	defer trace.End(trace.Audit(name, op))
 
 	operation := func() error {
 		return c.containerStart(op, name, hostConfig, true)
@@ -1204,8 +1192,7 @@ func (c *ContainerBackend) findPortBoundNetworkEndpoint(hostconfig *containertyp
 // problem stopping the container.
 func (c *ContainerBackend) ContainerStop(name string, seconds *int) error {
 	op := trace.NewOperation(context.Background(), "ContainerStop: %s", name)
-	defer trace.End(trace.Begin(name, op))
-	op.Auditf("ContainerStop: %s", name)
+	defer trace.End(trace.Audit(name, op))
 
 	// Look up the container name in the metadata cache to get long ID
 	vc := cache.ContainerCache().GetContainer(name)
@@ -1240,8 +1227,7 @@ func (c *ContainerBackend) ContainerStop(name string, seconds *int) error {
 // ContainerUnpause unpauses a container
 func (c *ContainerBackend) ContainerUnpause(name string) error {
 	op := trace.NewOperation(context.Background(), "ContainerUnpause: %s", name)
-	defer trace.End(trace.Begin(name, op))
-	op.Auditf("ContainerUnpause: %s", name)
+	defer trace.End(trace.Audit(name, op))
 
 	return engerr.APINotSupportedMsg(ProductName(), "ContainerUnpause")
 }
@@ -1249,8 +1235,7 @@ func (c *ContainerBackend) ContainerUnpause(name string) error {
 // ContainerUpdate updates configuration of the container
 func (c *ContainerBackend) ContainerUpdate(name string, hostConfig *containertypes.HostConfig) (containertypes.ContainerUpdateOKBody, error) {
 	op := trace.NewOperation(context.Background(), "ContainerUpdate: %s", name)
-	defer trace.End(trace.Begin(name, op))
-	op.Auditf("ContainerUpdate: %s", name)
+	defer trace.End(trace.Audit(name, op))
 
 	return containertypes.ContainerUpdateOKBody{}, engerr.APINotSupportedMsg(ProductName(), "ContainerUpdate")
 }
@@ -1262,8 +1247,7 @@ func (c *ContainerBackend) ContainerUpdate(name string, hostConfig *containertyp
 // a negative duration for the timeout.
 func (c *ContainerBackend) ContainerWait(name string, timeout time.Duration) (int, error) {
 	op := trace.NewOperation(context.Background(), "ContainerWait: %s", name)
-	defer trace.End(trace.Begin(name, op))
-	op.Auditf("ContainerWait: %s", name)
+	defer trace.End(trace.Audit(name, op))
 
 	// Look up the container name in the metadata cache to get long ID
 	vc := cache.ContainerCache().GetContainer(name)
@@ -1284,8 +1268,7 @@ func (c *ContainerBackend) ContainerWait(name string, timeout time.Duration) (in
 // ContainerChanges returns a list of container fs changes
 func (c *ContainerBackend) ContainerChanges(name string) ([]docker.Change, error) {
 	op := trace.NewOperation(context.Background(), "ContainerChanges: %s", name)
-	defer trace.End(trace.Begin(name, op))
-	op.Auditf("ContainerWait: %s", name)
+	defer trace.End(trace.Audit(name, op))
 
 	vc := cache.ContainerCache().GetContainer(name)
 	if vc == nil {
@@ -1363,8 +1346,7 @@ func (c *ContainerBackend) GetContainerChanges(op trace.Operation, vc *viccontai
 // there is an error getting the data.
 func (c *ContainerBackend) ContainerInspect(name string, size bool, version string) (interface{}, error) {
 	op := trace.NewOperation(context.Background(), "ContainerInspect: %s", name)
-	defer trace.End(trace.Begin(name, op))
-	op.Auditf("ContainerInspect: %s", name)
+	defer trace.End(trace.Audit(name, op))
 
 	// Look up the container name in the metadata cache to get long ID
 	vc := cache.ContainerCache().GetContainer(name)
@@ -1404,8 +1386,7 @@ func (c *ContainerBackend) ContainerInspect(name string, size bool, version stri
 // configured with the given struct.
 func (c *ContainerBackend) ContainerLogs(ctx context.Context, name string, config *backend.ContainerLogsConfig, started chan struct{}) error {
 	op := trace.FromContext(ctx, "ContainerLogs: %s", name)
-	defer trace.End(trace.Begin(name, op))
-	op.Auditf("ContainerLogs: %s", name)
+	defer trace.End(trace.Audit(name, op))
 
 	// Look up the container name in the metadata cache to get long ID
 	vc := cache.ContainerCache().GetContainer(name)
@@ -1447,8 +1428,7 @@ func (c *ContainerBackend) ContainerLogs(ctx context.Context, name string, confi
 // given in the config object.
 func (c *ContainerBackend) ContainerStats(ctx context.Context, name string, config *backend.ContainerStatsConfig) error {
 	op := trace.FromContext(ctx, "ContainerStats: %s", name)
-	defer trace.End(trace.Begin(name, op))
-	op.Auditf("ContainerStats: %s", name)
+	defer trace.End(trace.Audit(name, op))
 
 	// Look up the container name in the metadata cache to get long ID
 	vc := cache.ContainerCache().GetContainer(name)
@@ -1507,8 +1487,7 @@ func (c *ContainerBackend) ContainerStats(ctx context.Context, name string, conf
 // running ps, or parsing the output.
 func (c *ContainerBackend) ContainerTop(name string, psArgs string) (*types.ContainerProcessList, error) {
 	op := trace.NewOperation(context.Background(), "ContainerTop: %s", name)
-	defer trace.End(trace.Begin(name, op))
-	op.Auditf("ContainerTop: %s", name)
+	defer trace.End(trace.Audit(name, op))
 
 	return nil, engerr.APINotSupportedMsg(ProductName(), "ContainerTop")
 }
@@ -1516,8 +1495,7 @@ func (c *ContainerBackend) ContainerTop(name string, psArgs string) (*types.Cont
 // Containers returns the list of containers to show given the user's filtering.
 func (c *ContainerBackend) Containers(config *types.ContainerListOptions) ([]*types.Container, error) {
 	op := trace.NewOperation(context.Background(), "Containers")
-	defer trace.End(trace.Begin("", op))
-	op.Auditf("Containers")
+	defer trace.End(trace.Audit("", op))
 
 	// validate filters for support and validity
 	listContext, err := filter.ValidateContainerFilters(config, acceptedPsFilterTags, unSupportedPsFilters)
@@ -1641,8 +1619,7 @@ payloadLoop:
 
 func (c *ContainerBackend) ContainersPrune(pruneFilters filters.Args) (*types.ContainersPruneReport, error) {
 	op := trace.NewOperation(context.Background(), "ContainersPrune")
-	defer trace.End(trace.Begin("", op))
-	op.Auditf("ContainersPrune")
+	defer trace.End(trace.Audit("", op))
 
 	return nil, engerr.APINotSupportedMsg(ProductName(), "ContainersPrune")
 }
@@ -1652,8 +1629,7 @@ func (c *ContainerBackend) ContainersPrune(pruneFilters filters.Args) (*types.Co
 // ContainerAttach attaches to logs according to the config passed in. See ContainerAttachConfig.
 func (c *ContainerBackend) ContainerAttach(name string, ca *backend.ContainerAttachConfig) error {
 	op := trace.NewOperation(context.Background(), "ContainerAttach: %s", name)
-	defer trace.End(trace.Begin(name, op))
-	op.Auditf("ContainerAttach: %s", name)
+	defer trace.End(trace.Audit(name, op))
 
 	operation := func() error {
 		return c.containerAttach(&op, name, ca)
@@ -1742,8 +1718,7 @@ func (c *ContainerBackend) containerAttach(op *trace.Operation, name string, ca 
 // reserved.
 func (c *ContainerBackend) ContainerRename(oldName, newName string) error {
 	op := trace.NewOperation(context.Background(), "Container Rename: %s -> %s", oldName, newName)
-	defer trace.End(trace.Begin("", op))
-	op.Auditf("ContainerRename: %s -> %s", oldName, newName)
+	defer trace.End(trace.Audit("", op))
 
 	if oldName == "" || newName == "" {
 		err := fmt.Errorf("neither old nor new names may be empty")

--- a/lib/apiservers/engine/backends/container.go
+++ b/lib/apiservers/engine/backends/container.go
@@ -170,7 +170,14 @@ const (
 	defaultEnvPath = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 )
 
+// All the API entry points create an Operation and log a message at INFO
+// Level, this is done so that the Operation can be tracked as it moves
+// through the server and propagates to the portlayer
+
 func (c *ContainerBackend) Handle(id, name string) (string, error) {
+	op := trace.NewOperation(context.Background(), "Handle: %s", name)
+	defer trace.End(trace.Begin(name, op))
+
 	handle, err := c.containerProxy.Handle(context.Background(), id, name)
 	if err != nil {
 		if engerr.IsNotFoundError(err) {
@@ -185,8 +192,9 @@ func (c *ContainerBackend) Handle(id, name string) (string, error) {
 
 // ContainerExecCreate sets up an exec in a running container.
 func (c *ContainerBackend) ContainerExecCreate(name string, config *types.ExecConfig) (string, error) {
-	op := trace.NewOperation(context.TODO(), "")
-	defer trace.End(trace.Begin(fmt.Sprintf("%s: name=(%s)", op, name)))
+	op := trace.NewOperation(context.Background(), "ContainerExecCreate: %s", name)
+	defer trace.End(trace.Begin(name, op))
+	op.Auditf("ContainerExecCreate: %s", name)
 
 	// Look up the container name in the metadata cache to get long ID
 	vc := cache.ContainerCache().GetContainer(name)
@@ -264,8 +272,9 @@ func (c *ContainerBackend) ContainerExecCreate(name string, config *types.ExecCo
 // ContainerExecInspect returns low-level information about the exec
 // command. An error is returned if the exec cannot be found.
 func (c *ContainerBackend) ContainerExecInspect(eid string) (*backend.ExecInspect, error) {
-	op := trace.NewOperation(context.TODO(), "")
-	defer trace.End(trace.Begin(fmt.Sprintf("opID=(%s) eid=(%s)", op, eid)))
+	op := trace.NewOperation(context.Background(), "ContainerExecInspect: %s", eid)
+	defer trace.End(trace.Begin(eid, op))
+	op.Auditf("ContainerExecInspect: %s", eid)
 
 	// Look up the container name in the metadata cache to get long ID
 	vc := cache.ContainerCache().GetContainerFromExec(eid)
@@ -314,7 +323,9 @@ func (c *ContainerBackend) ContainerExecInspect(eid string) (*backend.ExecInspec
 // running in the exec with the given name to the given height and
 // width.
 func (c *ContainerBackend) ContainerExecResize(eid string, height, width int) error {
-	defer trace.End(trace.Begin(eid))
+	op := trace.NewOperation(context.Background(), "ContainerExecResize: %s", eid)
+	defer trace.End(trace.Begin(eid, op))
+	op.Auditf("ContainerExecResize: %s", eid)
 
 	// Look up the container eid in the metadata cache to get long ID
 	vc := cache.ContainerCache().GetContainerFromExec(eid)
@@ -482,8 +493,9 @@ func (c *ContainerBackend) taskStateWaitHelper(op trace.Operation, id, eid, name
 // ContainerExecStart starts a previously set up exec instance. The
 // std streams are set up.
 func (c *ContainerBackend) ContainerExecStart(ctx context.Context, eid string, stdin io.ReadCloser, stdout, stderr io.Writer) error {
-	op := trace.FromContext(ctx, "exec start")
-	defer trace.End(trace.Begin("", op))
+	op := trace.FromContext(ctx, "ContainerExecStart: %s", eid)
+	defer trace.End(trace.Begin(eid, op))
+	op.Auditf("ContainerExecStart: %s", eid)
 
 	// 0. start task (with retry)
 	// 1. If attaching, start attach logic (background)
@@ -620,7 +632,9 @@ func (c *ContainerBackend) ContainerExecStart(ctx context.Context, eid string, s
 // ExecExists looks up the exec instance and returns a bool if it exists or not.
 // It will also return the error produced by `getConfig`
 func (c *ContainerBackend) ExecExists(eid string) (bool, error) {
-	defer trace.End(trace.Begin(eid))
+	op := trace.NewOperation(context.Background(), "ExecExists: %s", eid)
+	defer trace.End(trace.Begin(eid, op))
+	op.Auditf("ExecExists: %s", eid)
 
 	vc := cache.ContainerCache().GetContainerFromExec(eid)
 	if vc == nil {
@@ -631,7 +645,9 @@ func (c *ContainerBackend) ExecExists(eid string) (bool, error) {
 
 // ContainerCreate creates a container.
 func (c *ContainerBackend) ContainerCreate(config types.ContainerCreateConfig) (containertypes.ContainerCreateCreatedBody, error) {
-	defer trace.End(trace.Begin(""))
+	op := trace.NewOperation(context.Background(), "ContainerCreate: %s", config.Name)
+	defer trace.End(trace.Begin(config.Name, op))
+	op.Auditf("ContainerCreate: %s", config.Name)
 
 	var err error
 
@@ -759,7 +775,9 @@ func (c *ContainerBackend) containerCreate(vc *viccontainer.VicContainer, config
 // for the container to exit.
 // If a signal is given, then just send it to the container and return.
 func (c *ContainerBackend) ContainerKill(name string, sig uint64) error {
-	defer trace.End(trace.Begin(fmt.Sprintf("%s, %d", name, sig)))
+	op := trace.NewOperation(context.Background(), "ContainerKill: %s, sig: %d", name, sig)
+	defer trace.End(trace.Begin(name, op))
+	op.Auditf("ContainerKill: %s", name)
 
 	// Look up the container name in the metadata cache to get long ID
 	vc := cache.ContainerCache().GetContainer(name)
@@ -780,13 +798,19 @@ func (c *ContainerBackend) ContainerKill(name string, sig uint64) error {
 
 // ContainerPause pauses a container
 func (c *ContainerBackend) ContainerPause(name string) error {
+	op := trace.NewOperation(context.Background(), "ContainerPause: %s", name)
+	defer trace.End(trace.Begin(name, op))
+	op.Auditf("ContainerPause: %s", name)
+
 	return engerr.APINotSupportedMsg(ProductName(), "ContainerPause")
 }
 
 // ContainerResize changes the size of the TTY of the process running
 // in the container with the given name to the given height and width.
 func (c *ContainerBackend) ContainerResize(name string, height, width int) error {
-	defer trace.End(trace.Begin(name))
+	op := trace.NewOperation(context.Background(), "ContainerResize: %s", name)
+	defer trace.End(trace.Begin(name, op))
+	op.Auditf("ContainerResize: %s", name)
 
 	// Look up the container name in the metadata cache to get long ID
 	vc := cache.ContainerCache().GetContainer(name)
@@ -818,8 +842,9 @@ func (c *ContainerBackend) ContainerResize(name string, height, width int) error
 // stop. Returns an error if the container cannot be found, or if
 // there is an underlying error at any stage of the restart.
 func (c *ContainerBackend) ContainerRestart(name string, seconds *int) error {
-	op := trace.NewOperation(context.Background(), "ContainerRestart - %s", name)
+	op := trace.NewOperation(context.Background(), "ContainerRestart: %s", name)
 	defer trace.End(trace.Begin(name, op))
+	op.Auditf("ContainerRestart: %s", name)
 
 	// Look up the container name in the metadata cache ot get long ID
 	vc := cache.ContainerCache().GetContainer(name)
@@ -852,7 +877,9 @@ func (c *ContainerBackend) ContainerRestart(name string, seconds *int) error {
 // fails. If the remove succeeds, the container name is released, and
 // vicnetwork links are removed.
 func (c *ContainerBackend) ContainerRm(name string, config *types.ContainerRmConfig) error {
-	defer trace.End(trace.Begin(name))
+	op := trace.NewOperation(context.Background(), "ContainerRm: %s", name)
+	defer trace.End(trace.Begin(name, op))
+	op.Auditf("ContainerRm: %s", name)
 
 	// Look up the container name in the metadata cache to get long ID
 	vc := cache.ContainerCache().GetContainer(name)
@@ -967,8 +994,9 @@ func (c *ContainerBackend) cleanupPortBindings(vc *viccontainer.VicContainer) er
 
 // ContainerStart starts a container.
 func (c *ContainerBackend) ContainerStart(name string, hostConfig *containertypes.HostConfig, checkpoint string, checkpointDir string) error {
-	op := trace.NewOperation(context.Background(), "ContainerStart - %s", name)
+	op := trace.NewOperation(context.Background(), "ContainerStart: %s", name)
 	defer trace.End(trace.Begin(name, op))
+	op.Auditf("ContainerStart:%s ", name)
 
 	operation := func() error {
 		return c.containerStart(op, name, hostConfig, true)
@@ -1175,7 +1203,9 @@ func (c *ContainerBackend) findPortBoundNetworkEndpoint(hostconfig *containertyp
 // container is not found, is already stopped, or if there is a
 // problem stopping the container.
 func (c *ContainerBackend) ContainerStop(name string, seconds *int) error {
-	defer trace.End(trace.Begin(name))
+	op := trace.NewOperation(context.Background(), "ContainerStop: %s", name)
+	defer trace.End(trace.Begin(name, op))
+	op.Auditf("ContainerStop: %s", name)
 
 	// Look up the container name in the metadata cache to get long ID
 	vc := cache.ContainerCache().GetContainer(name)
@@ -1209,11 +1239,19 @@ func (c *ContainerBackend) ContainerStop(name string, seconds *int) error {
 
 // ContainerUnpause unpauses a container
 func (c *ContainerBackend) ContainerUnpause(name string) error {
+	op := trace.NewOperation(context.Background(), "ContainerUnpause: %s", name)
+	defer trace.End(trace.Begin(name, op))
+	op.Auditf("ContainerUnpause: %s", name)
+
 	return engerr.APINotSupportedMsg(ProductName(), "ContainerUnpause")
 }
 
 // ContainerUpdate updates configuration of the container
 func (c *ContainerBackend) ContainerUpdate(name string, hostConfig *containertypes.HostConfig) (containertypes.ContainerUpdateOKBody, error) {
+	op := trace.NewOperation(context.Background(), "ContainerUpdate: %s", name)
+	defer trace.End(trace.Begin(name, op))
+	op.Auditf("ContainerUpdate: %s", name)
+
 	return containertypes.ContainerUpdateOKBody{}, engerr.APINotSupportedMsg(ProductName(), "ContainerUpdate")
 }
 
@@ -1223,7 +1261,9 @@ func (c *ContainerBackend) ContainerUpdate(name string, hostConfig *containertyp
 // timeout, an error is returned. If you want to wait forever, supply
 // a negative duration for the timeout.
 func (c *ContainerBackend) ContainerWait(name string, timeout time.Duration) (int, error) {
-	defer trace.End(trace.Begin(fmt.Sprintf("name(%s):timeout(%s)", name, timeout)))
+	op := trace.NewOperation(context.Background(), "ContainerWait: %s", name)
+	defer trace.End(trace.Begin(name, op))
+	op.Auditf("ContainerWait: %s", name)
 
 	// Look up the container name in the metadata cache to get long ID
 	vc := cache.ContainerCache().GetContainer(name)
@@ -1243,8 +1283,9 @@ func (c *ContainerBackend) ContainerWait(name string, timeout time.Duration) (in
 
 // ContainerChanges returns a list of container fs changes
 func (c *ContainerBackend) ContainerChanges(name string) ([]docker.Change, error) {
-	defer trace.End(trace.Begin(name))
 	op := trace.NewOperation(context.Background(), "ContainerChanges: %s", name)
+	defer trace.End(trace.Begin(name, op))
+	op.Auditf("ContainerWait: %s", name)
 
 	vc := cache.ContainerCache().GetContainer(name)
 	if vc == nil {
@@ -1296,6 +1337,8 @@ func (c *ContainerBackend) ContainerChanges(name string) ([]docker.Change, error
 // GetContainerChanges returns container changes from portlayer.
 // Set data to true will return file data, otherwise, only return file headers with change type.
 func (c *ContainerBackend) GetContainerChanges(op trace.Operation, vc *viccontainer.VicContainer, data bool) (io.ReadCloser, error) {
+	defer trace.End(trace.Begin("", op))
+
 	host, err := sys.UUID()
 	if err != nil {
 		return nil, engerr.InternalServerError("Failed to determine host UUID")
@@ -1319,8 +1362,9 @@ func (c *ContainerBackend) GetContainerChanges(op trace.Operation, vc *viccontai
 // container. Returns an error if the container cannot be found, or if
 // there is an error getting the data.
 func (c *ContainerBackend) ContainerInspect(name string, size bool, version string) (interface{}, error) {
-	// Ignore version.  We're supporting post-1.20 version.
-	defer trace.End(trace.Begin(name))
+	op := trace.NewOperation(context.Background(), "ContainerInspect: %s", name)
+	defer trace.End(trace.Begin(name, op))
+	op.Auditf("ContainerInspect: %s", name)
 
 	// Look up the container name in the metadata cache to get long ID
 	vc := cache.ContainerCache().GetContainer(name)
@@ -1359,7 +1403,9 @@ func (c *ContainerBackend) ContainerInspect(name string, size bool, version stri
 // ContainerLogs hooks up a container's stdout and stderr streams
 // configured with the given struct.
 func (c *ContainerBackend) ContainerLogs(ctx context.Context, name string, config *backend.ContainerLogsConfig, started chan struct{}) error {
-	defer trace.End(trace.Begin(""))
+	op := trace.FromContext(ctx, "ContainerLogs: %s", name)
+	defer trace.End(trace.Begin(name, op))
+	op.Auditf("ContainerLogs: %s", name)
 
 	// Look up the container name in the metadata cache to get long ID
 	vc := cache.ContainerCache().GetContainer(name)
@@ -1400,7 +1446,9 @@ func (c *ContainerBackend) ContainerLogs(ctx context.Context, name string, confi
 // ContainerStats writes information about the container to the stream
 // given in the config object.
 func (c *ContainerBackend) ContainerStats(ctx context.Context, name string, config *backend.ContainerStatsConfig) error {
-	defer trace.End(trace.Begin(name))
+	op := trace.FromContext(ctx, "ContainerStats: %s", name)
+	defer trace.End(trace.Begin(name, op))
+	op.Auditf("ContainerStats: %s", name)
 
 	// Look up the container name in the metadata cache to get long ID
 	vc := cache.ContainerCache().GetContainer(name)
@@ -1458,12 +1506,18 @@ func (c *ContainerBackend) ContainerStats(ctx context.Context, name string, conf
 // is not found, or is not running, or if there are any problems
 // running ps, or parsing the output.
 func (c *ContainerBackend) ContainerTop(name string, psArgs string) (*types.ContainerProcessList, error) {
+	op := trace.NewOperation(context.Background(), "ContainerTop: %s", name)
+	defer trace.End(trace.Begin(name, op))
+	op.Auditf("ContainerTop: %s", name)
+
 	return nil, engerr.APINotSupportedMsg(ProductName(), "ContainerTop")
 }
 
 // Containers returns the list of containers to show given the user's filtering.
 func (c *ContainerBackend) Containers(config *types.ContainerListOptions) ([]*types.Container, error) {
-	defer trace.End(trace.Begin(fmt.Sprintf("ListOptions %#v", config)))
+	op := trace.NewOperation(context.Background(), "Containers")
+	defer trace.End(trace.Begin("", op))
+	op.Auditf("Containers")
 
 	// validate filters for support and validity
 	listContext, err := filter.ValidateContainerFilters(config, acceptedPsFilterTags, unSupportedPsFilters)
@@ -1586,6 +1640,10 @@ payloadLoop:
 }
 
 func (c *ContainerBackend) ContainersPrune(pruneFilters filters.Args) (*types.ContainersPruneReport, error) {
+	op := trace.NewOperation(context.Background(), "ContainersPrune")
+	defer trace.End(trace.Begin("", op))
+	op.Auditf("ContainersPrune")
+
 	return nil, engerr.APINotSupportedMsg(ProductName(), "ContainersPrune")
 }
 
@@ -1593,8 +1651,9 @@ func (c *ContainerBackend) ContainersPrune(pruneFilters filters.Args) (*types.Co
 
 // ContainerAttach attaches to logs according to the config passed in. See ContainerAttachConfig.
 func (c *ContainerBackend) ContainerAttach(name string, ca *backend.ContainerAttachConfig) error {
-	op := trace.FromContext(context.Background(), "container Attach")
+	op := trace.NewOperation(context.Background(), "ContainerAttach: %s", name)
 	defer trace.End(trace.Begin(name, op))
+	op.Auditf("ContainerAttach: %s", name)
 
 	operation := func() error {
 		return c.containerAttach(&op, name, ca)
@@ -1682,7 +1741,9 @@ func (c *ContainerBackend) containerAttach(op *trace.Operation, name string, ca 
 // to find the container. An error is returned if newName is already
 // reserved.
 func (c *ContainerBackend) ContainerRename(oldName, newName string) error {
-	defer trace.End(trace.Begin(newName))
+	op := trace.NewOperation(context.Background(), "Container Rename: %s -> %s", oldName, newName)
+	defer trace.End(trace.Begin("", op))
+	op.Auditf("ContainerRename: %s -> %s", oldName, newName)
 
 	if oldName == "" || newName == "" {
 		err := fmt.Errorf("neither old nor new names may be empty")

--- a/lib/apiservers/engine/backends/image.go
+++ b/lib/apiservers/engine/backends/image.go
@@ -78,8 +78,7 @@ func (i *ImageBackend) Exists(containerName string) bool {
 // TODO fix the errors so the client doesnt print the generic POST or DELETE message
 func (i *ImageBackend) ImageDelete(imageRef string, force, prune bool) ([]types.ImageDelete, error) {
 	op := trace.NewOperation(context.Background(), "ImageDelete: %s", imageRef)
-	defer trace.End(trace.Begin(imageRef, op))
-	op.Auditf("ImageDelete: %s", imageRef)
+	defer trace.End(trace.Audit(imageRef, op))
 
 	var (
 		deletedRes  []types.ImageDelete
@@ -217,16 +216,14 @@ func (i *ImageBackend) ImageDelete(imageRef string, force, prune bool) ([]types.
 
 func (i *ImageBackend) ImageHistory(imageName string) ([]*types.ImageHistory, error) {
 	op := trace.NewOperation(context.Background(), "ImageHistory: %s", imageName)
-	defer trace.End(trace.Begin(imageName, op))
-	op.Auditf("ImageHistory: %s", imageName)
+	defer trace.End(trace.Audit(imageName, op))
 
 	return nil, errors.APINotSupportedMsg(ProductName(), "ImageHistory")
 }
 
 func (i *ImageBackend) Images(imageFilters filters.Args, all bool, withExtraAttrs bool) ([]*types.ImageSummary, error) {
 	op := trace.NewOperation(context.Background(), "Images: %#v", imageFilters)
-	defer trace.End(trace.Begin("", op))
-	op.Auditf("ImageHistory: %#v", imageFilters)
+	defer trace.End(trace.Audit("", op))
 
 	// validate filters for accuracy and support
 	filterContext, err := vicfilter.ValidateImageFilters(imageFilters, acceptedImageFilterTags, unSupportedImageFilters)
@@ -278,8 +275,7 @@ imageLoop:
 // ImageInspect structure.
 func (i *ImageBackend) LookupImage(name string) (*types.ImageInspect, error) {
 	op := trace.NewOperation(context.Background(), "LookupImage: %s", name)
-	defer trace.End(trace.Begin(name, op))
-	op.Auditf("LookupImage: %s", name)
+	defer trace.End(trace.Audit(name, op))
 
 	imageConfig, err := cache.ImageCache().Get(name)
 	if err != nil {
@@ -291,8 +287,7 @@ func (i *ImageBackend) LookupImage(name string) (*types.ImageInspect, error) {
 
 func (i *ImageBackend) TagImage(imageName, repository, tag string) error {
 	op := trace.NewOperation(context.Background(), "TagImage: %s", imageName)
-	defer trace.End(trace.Begin(imageName, op))
-	op.Auditf("TagImage: %s", imageName)
+	defer trace.End(trace.Audit(imageName, op))
 
 	img, err := cache.ImageCache().Get(imageName)
 	if err != nil {
@@ -323,40 +318,35 @@ func (i *ImageBackend) TagImage(imageName, repository, tag string) error {
 
 func (i *ImageBackend) ImagesPrune(pruneFilters filters.Args) (*types.ImagesPruneReport, error) {
 	op := trace.NewOperation(context.Background(), "ImagesPrune")
-	defer trace.End(trace.Begin("", op))
-	op.Auditf("ImagesPrune")
+	defer trace.End(trace.Audit("", op))
 
 	return nil, errors.APINotSupportedMsg(ProductName(), "ImagesPrune")
 }
 
 func (i *ImageBackend) LoadImage(inTar io.ReadCloser, outStream io.Writer, quiet bool) error {
 	op := trace.NewOperation(context.Background(), "LoadImage")
-	defer trace.End(trace.Begin("", op))
-	op.Auditf("LoadImage")
+	defer trace.End(trace.Audit("", op))
 
 	return errors.APINotSupportedMsg(ProductName(), "LoadImage")
 }
 
 func (i *ImageBackend) ImportImage(src string, repository, tag string, msg string, inConfig io.ReadCloser, outStream io.Writer, changes []string) error {
 	op := trace.NewOperation(context.Background(), "ImportImage")
-	defer trace.End(trace.Begin("", op))
-	op.Auditf("ImportImage")
+	defer trace.End(trace.Audit("", op))
 
 	return errors.APINotSupportedMsg(ProductName(), "ImportImage")
 }
 
 func (i *ImageBackend) ExportImage(names []string, outStream io.Writer) error {
 	op := trace.NewOperation(context.Background(), "ExportImage")
-	defer trace.End(trace.Begin("", op))
-	op.Auditf("ExportImage")
+	defer trace.End(trace.Audit("", op))
 
 	return errors.APINotSupportedMsg(ProductName(), "ExportImage")
 }
 
 func (i *ImageBackend) PullImage(ctx context.Context, image, tag string, metaHeaders map[string][]string, authConfig *types.AuthConfig, outStream io.Writer) error {
 	op := trace.NewOperation(context.Background(), "PullImage: %s", image)
-	defer trace.End(trace.Begin(image, op))
-	op.Auditf("PullImage: %s", image)
+	defer trace.End(trace.Audit(image, op))
 
 	log.Debugf("PullImage: image = %s, tag = %s, metaheaders = %+v\n", image, tag, metaHeaders)
 
@@ -448,16 +438,14 @@ func (i *ImageBackend) PullImage(ctx context.Context, image, tag string, metaHea
 
 func (i *ImageBackend) PushImage(ctx context.Context, image, tag string, metaHeaders map[string][]string, authConfig *types.AuthConfig, outStream io.Writer) error {
 	op := trace.NewOperation(context.Background(), "PushImage: %s", image)
-	defer trace.End(trace.Begin(image, op))
-	op.Auditf("PushImage: %s", image)
+	defer trace.End(trace.Audit(image, op))
 
 	return errors.APINotSupportedMsg(ProductName(), "PushImage")
 }
 
 func (i *ImageBackend) SearchRegistryForImages(ctx context.Context, filtersArgs string, term string, limit int, authConfig *types.AuthConfig, metaHeaders map[string][]string) (*registry.SearchResults, error) {
 	op := trace.NewOperation(context.Background(), "SearchRegistryForImages")
-	defer trace.End(trace.Begin("", op))
-	op.Auditf("SearchRegistryForImages")
+	defer trace.End(trace.Audit("", op))
 
 	return nil, errors.APINotSupportedMsg(ProductName(), "SearchRegistryForImages")
 }

--- a/lib/apiservers/engine/backends/network.go
+++ b/lib/apiservers/engine/backends/network.go
@@ -15,6 +15,7 @@
 package backends
 
 import (
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -40,6 +41,7 @@ import (
 	"github.com/vmware/vic/lib/apiservers/portlayer/client/scopes"
 	"github.com/vmware/vic/lib/apiservers/portlayer/models"
 	"github.com/vmware/vic/pkg/retry"
+	"github.com/vmware/vic/pkg/trace"
 )
 
 type NetworkBackend struct {
@@ -54,6 +56,10 @@ func (n *NetworkBackend) NetworkControllerEnabled() bool {
 }
 
 func (n *NetworkBackend) FindNetwork(idName string) (libnetwork.Network, error) {
+	op := trace.NewOperation(context.Background(), "FindNetwork: %s", idName)
+	defer trace.End(trace.Begin(idName, op))
+	op.Auditf("FindNetwork: %s", idName)
+
 	ok, err := PortLayerClient().Scopes.List(scopes.NewListParamsWithContext(ctx).WithIDName(idName))
 	if err != nil {
 		switch err := err.(type) {
@@ -72,6 +78,10 @@ func (n *NetworkBackend) FindNetwork(idName string) (libnetwork.Network, error) 
 }
 
 func (n *NetworkBackend) GetNetworkByName(idName string) (libnetwork.Network, error) {
+	op := trace.NewOperation(context.Background(), "GetNetworkByName: %s", idName)
+	defer trace.End(trace.Begin(idName, op))
+	op.Auditf("GetNetworkByName: %s", idName)
+
 	ok, err := PortLayerClient().Scopes.List(scopes.NewListParamsWithContext(ctx).WithIDName(idName))
 	if err != nil {
 		switch err := err.(type) {
@@ -90,6 +100,9 @@ func (n *NetworkBackend) GetNetworkByName(idName string) (libnetwork.Network, er
 }
 
 func (n *NetworkBackend) GetNetworksByID(partialID string) []libnetwork.Network {
+	op := trace.NewOperation(context.Background(), "GetNetworksByID: %s", partialID)
+	defer trace.End(trace.Begin(partialID, op))
+	op.Auditf("GetNetworksByID: %s", partialID)
 	ok, err := PortLayerClient().Scopes.List(scopes.NewListParamsWithContext(ctx).WithIDName(partialID))
 	if err != nil {
 		return nil
@@ -104,6 +117,9 @@ func (n *NetworkBackend) GetNetworksByID(partialID string) []libnetwork.Network 
 }
 
 func (n *NetworkBackend) GetNetworks() []libnetwork.Network {
+	op := trace.NewOperation(context.Background(), "GetNetworks")
+	defer trace.End(trace.Begin("", op))
+	op.Auditf("GetNetworks")
 	ok, err := PortLayerClient().Scopes.ListAll(scopes.NewListAllParamsWithContext(ctx))
 	if err != nil {
 		return nil
@@ -119,6 +135,10 @@ func (n *NetworkBackend) GetNetworks() []libnetwork.Network {
 }
 
 func (n *NetworkBackend) CreateNetwork(nc types.NetworkCreateRequest) (*types.NetworkCreateResponse, error) {
+	op := trace.NewOperation(context.Background(), "CreateNetwork: %s", nc.Name)
+	defer trace.End(trace.Begin(nc.Name, op))
+	op.Auditf("CreateNetwork: %s", nc.Name)
+
 	if nc.IPAM != nil && len(nc.IPAM.Config) > 1 {
 		return nil, fmt.Errorf("at most one ipam config supported")
 	}
@@ -293,6 +313,10 @@ func connectContainerToNetwork(containerName, networkName string, endpointConfig
 // ConnectContainerToNetwork connects a container to a container vicnetwork. It wraps the portlayer operations
 // in a retry for when there's a conflict error received, such as one during a similar concurrent operation.
 func (n *NetworkBackend) ConnectContainerToNetwork(containerName, networkName string, endpointConfig *apinet.EndpointSettings) error {
+	op := trace.NewOperation(context.Background(), "ConnectContainerToNetwork: %s to %s", containerName, networkName)
+	defer trace.End(trace.Begin(containerName, op))
+	op.Auditf("ConnectContainerToNetwork: %s to %s", containerName, networkName)
+
 	vc := cache.ContainerCache().GetContainer(containerName)
 	if vc != nil {
 		containerName = vc.ContainerID
@@ -321,7 +345,11 @@ func (n *NetworkBackend) ConnectContainerToNetwork(containerName, networkName st
 	return nil
 }
 
-func (n *NetworkBackend) DisconnectContainerFromNetwork(containerName string, networkName string, force bool) error {
+func (n *NetworkBackend) DisconnectContainerFromNetwork(containerName, networkName string, force bool) error {
+	op := trace.NewOperation(context.Background(), "DisconnectContainerFromNetwork: %s to %s", containerName, networkName)
+	defer trace.End(trace.Begin(containerName, op))
+	op.Auditf("DisconnectContainerFromNetwork: %s to %s", containerName, networkName)
+
 	vc := cache.ContainerCache().GetContainer(containerName)
 	if vc != nil {
 		containerName = vc.ContainerID
@@ -330,6 +358,10 @@ func (n *NetworkBackend) DisconnectContainerFromNetwork(containerName string, ne
 }
 
 func (n *NetworkBackend) DeleteNetwork(name string) error {
+	op := trace.NewOperation(context.Background(), "DeleteNetwork: %s", name)
+	defer trace.End(trace.Begin(name, op))
+	op.Auditf("DeleteNetwork: %s", name)
+
 	client := PortLayerClient()
 
 	if _, err := client.Scopes.DeleteScope(scopes.NewDeleteScopeParamsWithContext(ctx).WithIDName(name)); err != nil {

--- a/lib/apiservers/engine/backends/network.go
+++ b/lib/apiservers/engine/backends/network.go
@@ -57,8 +57,7 @@ func (n *NetworkBackend) NetworkControllerEnabled() bool {
 
 func (n *NetworkBackend) FindNetwork(idName string) (libnetwork.Network, error) {
 	op := trace.NewOperation(context.Background(), "FindNetwork: %s", idName)
-	defer trace.End(trace.Begin(idName, op))
-	op.Auditf("FindNetwork: %s", idName)
+	defer trace.End(trace.Audit(idName, op))
 
 	ok, err := PortLayerClient().Scopes.List(scopes.NewListParamsWithContext(ctx).WithIDName(idName))
 	if err != nil {
@@ -79,8 +78,7 @@ func (n *NetworkBackend) FindNetwork(idName string) (libnetwork.Network, error) 
 
 func (n *NetworkBackend) GetNetworkByName(idName string) (libnetwork.Network, error) {
 	op := trace.NewOperation(context.Background(), "GetNetworkByName: %s", idName)
-	defer trace.End(trace.Begin(idName, op))
-	op.Auditf("GetNetworkByName: %s", idName)
+	defer trace.End(trace.Audit(idName, op))
 
 	ok, err := PortLayerClient().Scopes.List(scopes.NewListParamsWithContext(ctx).WithIDName(idName))
 	if err != nil {
@@ -101,8 +99,8 @@ func (n *NetworkBackend) GetNetworkByName(idName string) (libnetwork.Network, er
 
 func (n *NetworkBackend) GetNetworksByID(partialID string) []libnetwork.Network {
 	op := trace.NewOperation(context.Background(), "GetNetworksByID: %s", partialID)
-	defer trace.End(trace.Begin(partialID, op))
-	op.Auditf("GetNetworksByID: %s", partialID)
+	defer trace.End(trace.Audit(partialID, op))
+
 	ok, err := PortLayerClient().Scopes.List(scopes.NewListParamsWithContext(ctx).WithIDName(partialID))
 	if err != nil {
 		return nil
@@ -118,8 +116,8 @@ func (n *NetworkBackend) GetNetworksByID(partialID string) []libnetwork.Network 
 
 func (n *NetworkBackend) GetNetworks() []libnetwork.Network {
 	op := trace.NewOperation(context.Background(), "GetNetworks")
-	defer trace.End(trace.Begin("", op))
-	op.Auditf("GetNetworks")
+	defer trace.End(trace.Audit("", op))
+
 	ok, err := PortLayerClient().Scopes.ListAll(scopes.NewListAllParamsWithContext(ctx))
 	if err != nil {
 		return nil
@@ -136,8 +134,7 @@ func (n *NetworkBackend) GetNetworks() []libnetwork.Network {
 
 func (n *NetworkBackend) CreateNetwork(nc types.NetworkCreateRequest) (*types.NetworkCreateResponse, error) {
 	op := trace.NewOperation(context.Background(), "CreateNetwork: %s", nc.Name)
-	defer trace.End(trace.Begin(nc.Name, op))
-	op.Auditf("CreateNetwork: %s", nc.Name)
+	defer trace.End(trace.Audit(nc.Name, op))
 
 	if nc.IPAM != nil && len(nc.IPAM.Config) > 1 {
 		return nil, fmt.Errorf("at most one ipam config supported")
@@ -314,8 +311,7 @@ func connectContainerToNetwork(containerName, networkName string, endpointConfig
 // in a retry for when there's a conflict error received, such as one during a similar concurrent operation.
 func (n *NetworkBackend) ConnectContainerToNetwork(containerName, networkName string, endpointConfig *apinet.EndpointSettings) error {
 	op := trace.NewOperation(context.Background(), "ConnectContainerToNetwork: %s to %s", containerName, networkName)
-	defer trace.End(trace.Begin(containerName, op))
-	op.Auditf("ConnectContainerToNetwork: %s to %s", containerName, networkName)
+	defer trace.End(trace.Audit(containerName, op))
 
 	vc := cache.ContainerCache().GetContainer(containerName)
 	if vc != nil {
@@ -347,8 +343,7 @@ func (n *NetworkBackend) ConnectContainerToNetwork(containerName, networkName st
 
 func (n *NetworkBackend) DisconnectContainerFromNetwork(containerName, networkName string, force bool) error {
 	op := trace.NewOperation(context.Background(), "DisconnectContainerFromNetwork: %s to %s", containerName, networkName)
-	defer trace.End(trace.Begin(containerName, op))
-	op.Auditf("DisconnectContainerFromNetwork: %s to %s", containerName, networkName)
+	defer trace.End(trace.Audit(containerName, op))
 
 	vc := cache.ContainerCache().GetContainer(containerName)
 	if vc != nil {
@@ -359,8 +354,7 @@ func (n *NetworkBackend) DisconnectContainerFromNetwork(containerName, networkNa
 
 func (n *NetworkBackend) DeleteNetwork(name string) error {
 	op := trace.NewOperation(context.Background(), "DeleteNetwork: %s", name)
-	defer trace.End(trace.Begin(name, op))
-	op.Auditf("DeleteNetwork: %s", name)
+	defer trace.End(trace.Audit(name, op))
 
 	client := PortLayerClient()
 

--- a/lib/apiservers/engine/backends/system.go
+++ b/lib/apiservers/engine/backends/system.go
@@ -92,8 +92,7 @@ func NewSystemBackend() *SystemBackend {
 
 func (s *SystemBackend) SystemInfo() (*types.Info, error) {
 	op := trace.NewOperation(context.Background(), "SystemInfo")
-	defer trace.End(trace.Begin("", op))
-	op.Auditf("SystemInfo")
+	defer trace.End(trace.Audit("", op))
 
 	client := PortLayerClient()
 
@@ -264,8 +263,7 @@ const buildTimeLayout = "2006/01/02@15:04:05"
 
 func (s *SystemBackend) SystemVersion() types.Version {
 	op := trace.NewOperation(context.Background(), "SystemVersion")
-	defer trace.End(trace.Begin("", op))
-	op.Auditf("SystemVersion")
+	defer trace.End(trace.Audit("", op))
 
 	Arch := runtime.GOARCH
 
@@ -320,8 +318,7 @@ func (s *SystemBackend) SystemCPUMhzLimit() (int64, error) {
 
 func (s *SystemBackend) SystemDiskUsage() (*types.DiskUsage, error) {
 	op := trace.NewOperation(context.Background(), "SystemDiskUsage")
-	defer trace.End(trace.Begin("", op))
-	op.Auditf("SystemDiskUsage")
+	defer trace.End(trace.Audit("", op))
 
 	return nil, errors.APINotSupportedMsg(ProductName(), "SystemDiskUsage")
 }
@@ -341,8 +338,7 @@ func (s *SystemBackend) UnsubscribeFromEvents(listener chan interface{}) {
 // AuthenticateToRegistry handles docker logins
 func (s *SystemBackend) AuthenticateToRegistry(ctx context.Context, authConfig *types.AuthConfig) (string, string, error) {
 	op := trace.NewOperation(context.Background(), "AuthenticateToRegistry")
-	defer trace.End(trace.Begin("", op))
-	op.Auditf("AuthenticateToRegistry: %s", authConfig.ServerAddress)
+	defer trace.End(trace.Audit("", op))
 
 	// Only look at V2 registries
 	registryAddress := authConfig.ServerAddress

--- a/lib/apiservers/engine/backends/system.go
+++ b/lib/apiservers/engine/backends/system.go
@@ -91,7 +91,10 @@ func NewSystemBackend() *SystemBackend {
 }
 
 func (s *SystemBackend) SystemInfo() (*types.Info, error) {
-	defer trace.End(trace.Begin("SystemInfo"))
+	op := trace.NewOperation(context.Background(), "SystemInfo")
+	defer trace.End(trace.Begin("", op))
+	op.Auditf("SystemInfo")
+
 	client := PortLayerClient()
 
 	// Retrieve container status from port layer
@@ -260,6 +263,10 @@ func (s *SystemBackend) SystemInfo() (*types.Info, error) {
 const buildTimeLayout = "2006/01/02@15:04:05"
 
 func (s *SystemBackend) SystemVersion() types.Version {
+	op := trace.NewOperation(context.Background(), "SystemVersion")
+	defer trace.End(trace.Begin("", op))
+	op.Auditf("SystemVersion")
+
 	Arch := runtime.GOARCH
 
 	BuildTime := version.BuildDate
@@ -312,6 +319,10 @@ func (s *SystemBackend) SystemCPUMhzLimit() (int64, error) {
 }
 
 func (s *SystemBackend) SystemDiskUsage() (*types.DiskUsage, error) {
+	op := trace.NewOperation(context.Background(), "SystemDiskUsage")
+	defer trace.End(trace.Begin("", op))
+	op.Auditf("SystemDiskUsage")
+
 	return nil, errors.APINotSupportedMsg(ProductName(), "SystemDiskUsage")
 }
 
@@ -329,7 +340,9 @@ func (s *SystemBackend) UnsubscribeFromEvents(listener chan interface{}) {
 
 // AuthenticateToRegistry handles docker logins
 func (s *SystemBackend) AuthenticateToRegistry(ctx context.Context, authConfig *types.AuthConfig) (string, string, error) {
-	defer trace.End(trace.Begin(""))
+	op := trace.NewOperation(context.Background(), "AuthenticateToRegistry")
+	defer trace.End(trace.Begin("", op))
+	op.Auditf("AuthenticateToRegistry: %s", authConfig.ServerAddress)
 
 	// Only look at V2 registries
 	registryAddress := authConfig.ServerAddress

--- a/lib/apiservers/engine/backends/volume.go
+++ b/lib/apiservers/engine/backends/volume.go
@@ -67,8 +67,7 @@ func NewVolumeBackend() *VolumeBackend {
 // Volumes docker personality implementation for VIC
 func (v *VolumeBackend) Volumes(filter string) ([]*types.Volume, []string, error) {
 	op := trace.NewOperation(context.Background(), "Volumes")
-	defer trace.End(trace.Begin("", op))
-	op.Auditf("Volumes")
+	defer trace.End(trace.Audit("", op))
 
 	var volumes []*types.Volume
 
@@ -129,8 +128,7 @@ func (v *VolumeBackend) Volumes(filter string) ([]*types.Volume, []string, error
 // VolumeInspect : docker personality implementation for VIC
 func (v *VolumeBackend) VolumeInspect(name string) (*types.Volume, error) {
 	op := trace.NewOperation(context.Background(), "VolumeInspect: %s", name)
-	defer trace.End(trace.Begin(name, op))
-	op.Auditf("VolumeInspect: %s", name)
+	defer trace.End(trace.Audit(name, op))
 
 	volInfo, err := v.storageProxy.VolumeInfo(context.Background(), name)
 	if err != nil {
@@ -149,8 +147,7 @@ func (v *VolumeBackend) VolumeInspect(name string) (*types.Volume, error) {
 // VolumeCreate : docker personality implementation for VIC
 func (v *VolumeBackend) VolumeCreate(name, driverName string, volumeData, labels map[string]string) (*types.Volume, error) {
 	op := trace.NewOperation(context.Background(), "VolumeCreate: %s", name)
-	defer trace.End(trace.Begin(name, op))
-	op.Auditf("VolumeCreate: %s", name)
+	defer trace.End(trace.Audit(name, op))
 
 	result, err := v.storageProxy.Create(context.Background(), name, driverName, volumeData, labels)
 	if err != nil {
@@ -163,8 +160,7 @@ func (v *VolumeBackend) VolumeCreate(name, driverName string, volumeData, labels
 // VolumeRm : docker personality for VIC
 func (v *VolumeBackend) VolumeRm(name string, force bool) error {
 	op := trace.NewOperation(context.Background(), "VolumeRm: %s", name)
-	defer trace.End(trace.Begin(name, op))
-	op.Auditf("VolumeRm: %s", name)
+	defer trace.End(trace.Audit(name, op))
 
 	err := v.storageProxy.Remove(context.Background(), name)
 	if err != nil {
@@ -176,8 +172,7 @@ func (v *VolumeBackend) VolumeRm(name string, force bool) error {
 
 func (v *VolumeBackend) VolumesPrune(pruneFilters filters.Args) (*types.VolumesPruneReport, error) {
 	op := trace.NewOperation(context.Background(), "VolumesPrune")
-	defer trace.End(trace.Begin("", op))
-	op.Auditf("VolumesPrune")
+	defer trace.End(trace.Audit("", op))
 
 	return nil, errors.APINotSupportedMsg(ProductName(), "VolumesPrune")
 }

--- a/lib/apiservers/engine/backends/volume.go
+++ b/lib/apiservers/engine/backends/volume.go
@@ -66,7 +66,9 @@ func NewVolumeBackend() *VolumeBackend {
 
 // Volumes docker personality implementation for VIC
 func (v *VolumeBackend) Volumes(filter string) ([]*types.Volume, []string, error) {
-	defer trace.End(trace.Begin(filter))
+	op := trace.NewOperation(context.Background(), "Volumes")
+	defer trace.End(trace.Begin("", op))
+	op.Auditf("Volumes")
 
 	var volumes []*types.Volume
 
@@ -126,7 +128,9 @@ func (v *VolumeBackend) Volumes(filter string) ([]*types.Volume, []string, error
 
 // VolumeInspect : docker personality implementation for VIC
 func (v *VolumeBackend) VolumeInspect(name string) (*types.Volume, error) {
-	defer trace.End(trace.Begin(name))
+	op := trace.NewOperation(context.Background(), "VolumeInspect: %s", name)
+	defer trace.End(trace.Begin(name, op))
+	op.Auditf("VolumeInspect: %s", name)
 
 	volInfo, err := v.storageProxy.VolumeInfo(context.Background(), name)
 	if err != nil {
@@ -144,7 +148,9 @@ func (v *VolumeBackend) VolumeInspect(name string) (*types.Volume, error) {
 
 // VolumeCreate : docker personality implementation for VIC
 func (v *VolumeBackend) VolumeCreate(name, driverName string, volumeData, labels map[string]string) (*types.Volume, error) {
-	defer trace.End(trace.Begin(name))
+	op := trace.NewOperation(context.Background(), "VolumeCreate: %s", name)
+	defer trace.End(trace.Begin(name, op))
+	op.Auditf("VolumeCreate: %s", name)
 
 	result, err := v.storageProxy.Create(context.Background(), name, driverName, volumeData, labels)
 	if err != nil {
@@ -156,7 +162,9 @@ func (v *VolumeBackend) VolumeCreate(name, driverName string, volumeData, labels
 
 // VolumeRm : docker personality for VIC
 func (v *VolumeBackend) VolumeRm(name string, force bool) error {
-	defer trace.End(trace.Begin(name))
+	op := trace.NewOperation(context.Background(), "VolumeRm: %s", name)
+	defer trace.End(trace.Begin(name, op))
+	op.Auditf("VolumeRm: %s", name)
 
 	err := v.storageProxy.Remove(context.Background(), name)
 	if err != nil {
@@ -167,6 +175,10 @@ func (v *VolumeBackend) VolumeRm(name string, force bool) error {
 }
 
 func (v *VolumeBackend) VolumesPrune(pruneFilters filters.Args) (*types.VolumesPruneReport, error) {
+	op := trace.NewOperation(context.Background(), "VolumesPrune")
+	defer trace.End(trace.Begin("", op))
+	op.Auditf("VolumesPrune")
+
 	return nil, errors.APINotSupportedMsg(ProductName(), "VolumesPrune")
 }
 

--- a/pkg/trace/operation.go
+++ b/pkg/trace/operation.go
@@ -130,7 +130,7 @@ func (o *Operation) ID() string {
 }
 
 func (o *Operation) Auditf(format string, args ...interface{}) {
-	o.Info(fmt.Sprintf(format, args...))
+	o.Infof(format, args...)
 }
 
 func (o *Operation) Infof(format string, args ...interface{}) {

--- a/pkg/trace/operation.go
+++ b/pkg/trace/operation.go
@@ -129,6 +129,10 @@ func (o *Operation) ID() string {
 	return o.id
 }
 
+func (o *Operation) Auditf(format string, args ...interface{}) {
+	o.Info(fmt.Sprintf(format, args...))
+}
+
 func (o *Operation) Infof(format string, args ...interface{}) {
 	o.Info(fmt.Sprintf(format, args...))
 }

--- a/pkg/trace/trace.go
+++ b/pkg/trace/trace.go
@@ -108,7 +108,7 @@ func newTrace(msg string, skip int, opID string) *Message {
 // Begin starts the trace.  Msg is the msg to log.
 // context provided to allow tracing of operationID
 // context added as optional to avoid breaking current usage
-func Begin(msg string, ctx ...context.Context) *Message {
+func begin(msg string, ctx ...context.Context) *Message {
 	if tracingEnabled && Logger.Level >= logrus.DebugLevel {
 		var opID string
 		// populate operationID if provided
@@ -117,7 +117,7 @@ func Begin(msg string, ctx ...context.Context) *Message {
 				opID = id
 			}
 		}
-		if t := newTrace(msg, 2, opID); t != nil {
+		if t := newTrace(msg, 3, opID); t != nil {
 			if msg == "" {
 				Logger.Debugf("[BEGIN] %s [%s:%d]", t.operationID, t.funcName, t.lineNo)
 			} else {
@@ -130,9 +130,13 @@ func Begin(msg string, ctx ...context.Context) *Message {
 	return nil
 }
 
+func Begin(msg string, ctx ...context.Context) *Message {
+	return begin(msg, ctx...)
+}
+
 // Audit is a wrapper around Begin which logs an Audit message after
 func Audit(msg string, op Operation) *Message {
-	m := Begin(msg, op)
+	m := begin(msg, op)
 	if len(op.t) > 0 { // We expect an operation to always have at least one frame, but check for safety
 		op.Auditf(op.t[0].msg)
 	}

--- a/pkg/trace/trace.go
+++ b/pkg/trace/trace.go
@@ -130,6 +130,15 @@ func Begin(msg string, ctx ...context.Context) *Message {
 	return nil
 }
 
+// Audit is a wrapper around Begin which logs an Audit message after
+func Audit(msg string, op Operation) *Message {
+	m := Begin(msg, op)
+	if len(op.t) > 0 { // We expect an operation to always have at least one frame, but check for safety
+		op.Auditf(op.t[0].msg)
+	}
+	return m
+}
+
 // End ends the trace.
 func End(t *Message) {
 	if t == nil {


### PR DESCRIPTION
This is a first step in implementing the ability to track a request through the different servers. Create new operation of each of the API entry points in the docker engine backend.

Towards: #7993