### PR TITLE
Add per-field suppression to extraconfig encoder

### DIFF
--- a/lib/install/management/appliance.go
+++ b/lib/install/management/appliance.go
@@ -1083,7 +1083,7 @@ func (d *Dispatcher) ensureApplianceInitializes(conf *config.VirtualContainerHos
 	}
 
 	d.op.Info("Waiting for IP information")
-	d.waitForKey(extraconfig.CalculateKeys(conf, "ExecutorConfig.Networks.client.Assigned.IP", "")[0])
+	d.waitForKey(extraconfig.CalculateKey(conf, "ExecutorConfig.Networks.client.Assigned.IP", ""))
 	ctxerr := d.op.Err()
 
 	if ctxerr == nil {

--- a/lib/install/management/finder_test.go
+++ b/lib/install/management/finder_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/vmware/govmomi/simulator"
 	"github.com/vmware/govmomi/vim25/mo"
 	"github.com/vmware/govmomi/vim25/types"
+	"github.com/vmware/vic/lib/config"
 	"github.com/vmware/vic/lib/install/data"
 	"github.com/vmware/vic/lib/install/validate"
 	"github.com/vmware/vic/pkg/trace"
@@ -120,8 +121,10 @@ func testSearchVCHs(ctx context.Context, t *testing.T, v *validate.Validator, ex
 			ref := vm.Reference()
 			svm := simulator.Map.Get(ref).(*simulator.VirtualMachine)
 
+			template := config.VirtualContainerHostConfigSpec{}
+			keys := extraconfig.CalculateKeys(template, "ExecutorConfig.ExecutorConfigCommon.ID", "")
 			svm.Config.ExtraConfig = []types.BaseOptionValue{&types.OptionValue{
-				Key:   extraconfig.DefaultGuestInfoPrefix + "/init/common/id",
+				Key:   keys[0],
 				Value: ref.String(),
 			}}
 		}

--- a/lib/install/management/finder_test.go
+++ b/lib/install/management/finder_test.go
@@ -122,9 +122,9 @@ func testSearchVCHs(ctx context.Context, t *testing.T, v *validate.Validator, ex
 			svm := simulator.Map.Get(ref).(*simulator.VirtualMachine)
 
 			template := config.VirtualContainerHostConfigSpec{}
-			keys := extraconfig.CalculateKeys(template, "ExecutorConfig.ExecutorConfigCommon.ID", "")
+			key := extraconfig.CalculateKey(template, "ExecutorConfig.ExecutorConfigCommon.ID", "")
 			svm.Config.ExtraConfig = []types.BaseOptionValue{&types.OptionValue{
-				Key:   keys[0],
+				Key:   key,
 				Value: ref.String(),
 			}}
 		}

--- a/lib/tether/tether.go
+++ b/lib/tether/tether.go
@@ -463,7 +463,7 @@ func (t *tether) processSessions() error {
 
 					// FIXME: we cannot have this embedded knowledge of the extraconfig encoding pattern, but not
 					// currently sure how to expose it neatly via a utility function
-					extraconfig.EncodeWithPrefix(t.sink, session, extraconfig.CalculateKeys(t.config, fmt.Sprintf("%s.%s", session.extraconfigKey, id), "")[0])
+					extraconfig.EncodeWithPrefix(t.sink, session, extraconfig.CalculateKey(t.config, fmt.Sprintf("%s.%s", session.extraconfigKey, id), ""))
 					log.Warnf("Re-launching process for session %s (count: %d)", id, session.Diagnostics.ResurrectionCount)
 					session.Cmd = *restartableCmd(&session.Cmd)
 				}
@@ -700,7 +700,7 @@ func (t *tether) handleSessionExit(session *SessionConfig) {
 	// this returns an arbitrary closure for invocation after the session status update
 	f := t.ops.HandleSessionExit(t.config, session)
 
-	extraconfig.EncodeWithPrefix(t.sink, session, extraconfig.CalculateKeys(t.config, fmt.Sprintf("%s.%s", session.extraconfigKey, session.ID), "")[0])
+	extraconfig.EncodeWithPrefix(t.sink, session, extraconfig.CalculateKey(t.config, fmt.Sprintf("%s.%s", session.extraconfigKey, session.ID), ""))
 
 	if f != nil {
 		log.Debugf("Calling t.ops.HandleSessionExit")
@@ -758,7 +758,7 @@ func (t *tether) launch(session *SessionConfig) error {
 		}
 
 		// encode the result whether success or error
-		prefix := extraconfig.CalculateKeys(t.config, fmt.Sprintf("%s.%s", session.extraconfigKey, session.ID), "")[0]
+		prefix := extraconfig.CalculateKey(t.config, fmt.Sprintf("%s.%s", session.extraconfigKey, session.ID), "")
 		log.Debugf("Encoding result of launch for session %s under key: %s", session.ID, prefix)
 		extraconfig.EncodeWithPrefix(t.sink, session, prefix)
 	}()

--- a/pkg/vsphere/extraconfig/decode.go
+++ b/pkg/vsphere/extraconfig/decode.go
@@ -60,7 +60,7 @@ func init() {
 // decode is the generic switcher that decides which decoder to use for a field
 func decode(src DataSource, dest reflect.Value, prefix string, depth recursion) (reflect.Value, error) {
 	// if depth has reached zero, we skip decoding entirely
-	if depth.depth == 0 {
+	if depth.depth == 0 || depth.skipDecode {
 		return dest, nil
 	}
 	depth.depth--
@@ -445,7 +445,7 @@ func Decode(src DataSource, dest interface{}) interface{} {
 	}
 
 	// #nosec: Errors unhandled.
-	value, _ := decode(src, reflect.ValueOf(dest), DefaultPrefix, Unbounded)
+	value, _ := decode(src, reflect.ValueOf(dest), "", Unbounded)
 
 	return value.Interface()
 }

--- a/pkg/vsphere/extraconfig/decode_linux.go
+++ b/pkg/vsphere/extraconfig/decode_linux.go
@@ -42,7 +42,7 @@ func GuestInfoSourceWithPrefix(prefix string) (DataSource, error) {
 
 	source := func(key string) (string, error) {
 		if key != GuestInfoSecretKey {
-			key = addPrefixToKey(DefaultGuestInfoPrefix, prefix, key)
+			key = addPrefixToKey(defaultGuestInfoPrefix(), prefix, key)
 		}
 
 		value, err := guestinfo.String(key, "")

--- a/pkg/vsphere/extraconfig/encode.go
+++ b/pkg/vsphere/extraconfig/encode.go
@@ -62,7 +62,7 @@ func init() {
 // decode is the generic switcher that decides which decoder to use for a field
 func encode(sink DataSink, src reflect.Value, prefix string, depth recursion) {
 	// if depth has reached zero, we skip encoding entirely
-	if depth.depth == 0 {
+	if depth.depth == 0 || depth.skipEncode {
 		return
 	}
 	depth.depth--
@@ -258,7 +258,7 @@ type DataSink func(string, string) error
 
 // Encode serializes the given type to the supplied data sink
 func Encode(sink DataSink, src interface{}) {
-	encode(sink, reflect.ValueOf(src), DefaultPrefix, Unbounded)
+	encode(sink, reflect.ValueOf(src), "", Unbounded)
 }
 
 // EncodeWithPrefix serializes the given type to the supplied data sink, using

--- a/pkg/vsphere/extraconfig/encode_linux.go
+++ b/pkg/vsphere/extraconfig/encode_linux.go
@@ -47,7 +47,7 @@ func GuestInfoSinkWithPrefix(prefix string) (DataSink, error) {
 			return nil
 		}
 
-		key = addPrefixToKey(DefaultGuestInfoPrefix, prefix, key)
+		key = addPrefixToKey(defaultGuestInfoPrefix(), prefix, key)
 
 		if value == "" {
 			value = "<nil>"

--- a/pkg/vsphere/extraconfig/keys.go
+++ b/pkg/vsphere/extraconfig/keys.go
@@ -559,3 +559,14 @@ func calculateKeys(v reflect.Value, field string, prefix string) []string {
 func CalculateKeys(obj interface{}, field string, prefix string) []string {
 	return calculateKeys(reflect.ValueOf(obj), field, prefix)
 }
+
+// CalculateKey is a specific case of CalculateKeys that will panic if more than one key
+// matches the field pattern passed in.
+func CalculateKey(obj interface{}, field string, prefix string) string {
+	keys := calculateKeys(reflect.ValueOf(obj), field, prefix)
+	if len(keys) != 1 {
+		panic("CalculateKey should only ever return one key")
+	}
+
+	return keys[0]
+}

--- a/pkg/vsphere/extraconfig/keys.go
+++ b/pkg/vsphere/extraconfig/keys.go
@@ -27,22 +27,63 @@ import (
 )
 
 const (
-	// DefaultTagName value
+	// GuestInfoPrefix is dictated by vSphere
+	GuestInfoPrefix = "guestinfo."
+
+	// ScopeTag is the tag name used for declaring scopes for a field
+	ScopeTag = "scope"
+	// KeyTag is the tag name by which to override default key naming based on field name
+	KeyTag = "key"
+	// RecurseTag is the tag name with which different recursion properties are declared
+	RecurseTag = "recurse"
+
+	// HiddenScope means the key is hidden from the guest and will not have a GuestInfoPrefix
+	HiddenScope = "hidden"
+	// ReadOnlyScope means the key is read-only from the guest
+	ReadOnlyScope = "read-only"
+	// ReadWriteScope means the key may be read and modified by the guest
+	ReadWriteScope = "read-write"
+	// VolatileScope means that the value is expected to change and should be refreshed on use
+	VolatileScope = "volatile"
+
+	// SecretSuffix means the value should be encrypted in the vmx.
+	SecretSuffix = "secret"
+	// NonPersistentSuffix means the key should only be written if the key will be deleted on guest power off.
+	NonPersistentSuffix = "non-persistent"
+
+	// RecurseDepthProperty controls how deep to recuse into a structure field from this level. A value of zero
+	// prevents both encode and decode of that field. This is provided to control recursion into unannotated structures.
+	// This is unbounded if not specified.
+	RecurseDepthProperty = "depth"
+	// RecurseFollowProperty instructs encode and decode to follow pointers.
+	RecurseFollowProperty = "follow"
+	// RecurseNoFollowProperty instructs encode and decode not to follow pointers.
+	RecurseNoFollowProperty = "nofollow"
+	// RecurseSkipEncodeProperty causes the marked field and subfields to be skipped when encoding.
+	RecurseSkipEncodeProperty = "skip-encode"
+	// RecurseSkipDecodeProperty causes the marked field and subfields to be skipped when decoding.
+	RecurseSkipDecodeProperty = "skip-decode"
+)
+
+// TODO: this entire section of variables should be turned into a config struct
+// that can be passed to Encode and Decode, or that Encode and Decode are method on
+var (
+	// DefaultTagName is the annotation tag name we use for basic semantic version. Not currently used.
 	DefaultTagName = "vic"
-	// DefaultPrefix value
-	DefaultPrefix = ""
-	// DefaultGuestInfoPrefix value
-	DefaultGuestInfoPrefix = "guestinfo.vice."
+
+	// DefaultPrefix is prepended to generated key paths for basic namespacing
+	DefaultPrefix = "vice."
+
 	//Separator for slice values and map keys
 	Separator = "|"
 
 	// suffix separator character
 	suffixSeparator = "@"
-	// secret suffix
-	secretSuffix = "secret"
-	// non-persistent suffix
-	nonpersistentSuffix = "non-persistent"
 )
+
+func defaultGuestInfoPrefix() string {
+	return GuestInfoPrefix + DefaultPrefix
+}
 
 const (
 	// Invalid value
@@ -51,6 +92,8 @@ const (
 	Hidden
 	// ReadOnly value
 	ReadOnly
+	// WriteOnly value
+	WriteOnly
 	// ReadWrite value
 	ReadWrite
 	// NonPersistent value
@@ -66,6 +109,10 @@ type recursion struct {
 	depth int
 	// follow controls whether we follow pointers
 	follow bool
+	// set to skip decode of a field but still allow encode
+	skipDecode bool
+	// set to skip encode of a field but still allow decode
+	skipEncode bool
 }
 
 // Unbounded is the value used for unbounded recursion
@@ -103,17 +150,17 @@ func calculateScope(scopes []string) uint {
 
 	for _, v := range scopes {
 		switch v {
-		case "hidden":
+		case HiddenScope:
 			scope |= Hidden
-		case "read-only":
+		case ReadOnlyScope:
 			scope |= ReadOnly
-		case "read-write":
+		case ReadWriteScope:
 			scope |= ReadWrite
-		case nonpersistentSuffix:
-			scope |= NonPersistent
-		case "volatile":
+		case VolatileScope:
 			scope |= Volatile
-		case secretSuffix:
+		case NonPersistentSuffix:
+			scope |= NonPersistent
+		case SecretSuffix:
 			scope |= Secret | ReadOnly
 		default:
 			return Invalid
@@ -130,7 +177,7 @@ func isSecret(key string) bool {
 	}
 
 	for i := range suffix[1:] {
-		if suffix[i+1] == secretSuffix {
+		if suffix[i+1] == SecretSuffix {
 			return true
 		}
 	}
@@ -146,7 +193,7 @@ func isNonPersistent(key string) bool {
 	}
 
 	for i := range suffix[1:] {
-		if suffix[i+1] == nonpersistentSuffix {
+		if suffix[i+1] == NonPersistentSuffix {
 			return true
 		}
 	}
@@ -157,22 +204,22 @@ func isNonPersistent(key string) bool {
 func calculateScopeFromKey(key string) []string {
 	scopes := []string{}
 
-	if !strings.HasPrefix(key, DefaultGuestInfoPrefix) {
-		scopes = append(scopes, "hidden")
+	if !strings.HasPrefix(key, GuestInfoPrefix) {
+		scopes = append(scopes, HiddenScope)
 	}
 
 	if strings.Contains(key, "/") {
-		scopes = append(scopes, "read-only")
+		scopes = append(scopes, ReadOnlyScope)
 	} else {
-		scopes = append(scopes, "read-write")
+		scopes = append(scopes, ReadWriteScope)
 	}
 
 	if isSecret(key) {
-		scopes = append(scopes, secretSuffix)
+		scopes = append(scopes, SecretSuffix)
 	}
 
 	if isNonPersistent(key) {
-		scopes = append(scopes, nonpersistentSuffix)
+		scopes = append(scopes, NonPersistentSuffix)
 	}
 
 	return scopes
@@ -202,21 +249,21 @@ func calculateKeyFromField(field reflect.StructField, prefix string, depth recur
 	// do we have DefaultTagName?
 	if tags.Get(DefaultTagName) != "" {
 		// get the scopes
-		scopes = strings.Split(tags.Get("scope"), ",")
+		scopes = strings.Split(tags.Get(ScopeTag), ",")
 		logger.Debugf("Scopes: %#v", scopes)
 
 		// get the keys and split properties from it
-		key = tags.Get("key")
+		key = tags.Get(KeyTag)
 		logger.Debugf("Key specified: %s", key)
 
 		// get the keys and split properties from it
-		recurse := tags.Get("recurse")
+		recurse := tags.Get(RecurseTag)
 		if recurse != "" {
 			props := strings.Split(recurse, ",")
 			// process properties
 			for _, prop := range props {
 				// determine recursion depth
-				if strings.HasPrefix(prop, "depth") {
+				if strings.HasPrefix(prop, RecurseDepthProperty) {
 					parts := strings.Split(prop, "=")
 					if len(parts) != 2 {
 						logger.Warnf("Skipping field with incorrect recurse property: %s", prop)
@@ -229,10 +276,14 @@ func calculateKeyFromField(field reflect.StructField, prefix string, depth recur
 						return "", skip
 					}
 					fdepth.depth = int(val)
-				} else if prop == "nofollow" {
+				} else if prop == RecurseNoFollowProperty {
 					fdepth.follow = false
-				} else if prop == "follow" {
+				} else if prop == RecurseFollowProperty {
 					fdepth.follow = true
+				} else if prop == RecurseSkipDecodeProperty {
+					fdepth.skipDecode = true
+				} else if prop == RecurseSkipEncodeProperty {
+					fdepth.skipEncode = true
 				} else {
 					logger.Warnf("Ignoring unknown recurse property %s (%s)", key, prop)
 					continue
@@ -278,7 +329,7 @@ func calculateKey(scope uint, prefix string, key string) string {
 
 	hide := scope&Hidden != 0
 	write := scope&ReadWrite != 0
-	visible := strings.HasPrefix(prefix, DefaultGuestInfoPrefix)
+	visible := strings.HasPrefix(prefix, GuestInfoPrefix)
 
 	if !hide && write {
 		oldSep = "/"
@@ -298,7 +349,7 @@ func calculateKey(scope uint, prefix string, key string) string {
 	}
 
 	if scope&Secret != 0 {
-		out += suffixSeparator + secretSuffix
+		out += suffixSeparator + SecretSuffix
 	}
 
 	if scope&NonPersistent != 0 {
@@ -306,7 +357,7 @@ func calculateKey(scope uint, prefix string, key string) string {
 			logger.Debugf("Unable to combine non-persistent and hidden scopes")
 			return ""
 		}
-		out += suffixSeparator + nonpersistentSuffix
+		out += suffixSeparator + NonPersistentSuffix
 	}
 
 	// we don't care about existing separators when hiden
@@ -316,7 +367,7 @@ func calculateKey(scope uint, prefix string, key string) string {
 		}
 
 		// strip the prefix and the leading r/w signifier
-		return out[len(DefaultGuestInfoPrefix)+1:]
+		return out[len(defaultGuestInfoPrefix())+1:]
 	}
 
 	// ensure that separators are correct
@@ -324,11 +375,11 @@ func calculateKey(scope uint, prefix string, key string) string {
 
 	// Assemble the base that controls key publishing in guest
 	if !visible {
-		return DefaultGuestInfoPrefix + newSep + out
+		return defaultGuestInfoPrefix() + newSep + out
 	}
 
 	// prefix will have been mangled by strings.Replace
-	return DefaultGuestInfoPrefix + out[len(DefaultGuestInfoPrefix):]
+	return defaultGuestInfoPrefix() + out[len(defaultGuestInfoPrefix()):]
 }
 
 // utility function to allow adding of arbitrary prefix into key

--- a/pkg/vsphere/extraconfig/keys_test.go
+++ b/pkg/vsphere/extraconfig/keys_test.go
@@ -23,23 +23,23 @@ import (
 )
 
 func visibleRO(key string) string {
-	return calculateKey(calculateScope([]string{"read-only"}), "", key)
+	return calculateKey(calculateScope([]string{ReadOnlyScope}), "", key)
 }
 
 func visibleRONonpersistent(key string) string {
-	return calculateKey(calculateScope([]string{"read-only", "non-persistent"}), "", key)
+	return calculateKey(calculateScope([]string{ReadOnlyScope, NonPersistentSuffix}), "", key)
 }
 
 func visibleRW(key string) string {
-	return calculateKey(calculateScope([]string{"read-write"}), "", key)
+	return calculateKey(calculateScope([]string{ReadWriteScope}), "", key)
 }
 
 func hidden(key string) string {
-	return calculateKey(calculateScope([]string{"hidden"}), "", key)
+	return calculateKey(calculateScope([]string{HiddenScope}), "", key)
 }
 
 func TestHidden(t *testing.T) {
-	scopes := []string{"hidden"}
+	scopes := []string{HiddenScope}
 
 	key := calculateKey(calculateScope(scopes), "a/b", "c")
 
@@ -47,7 +47,7 @@ func TestHidden(t *testing.T) {
 }
 
 func TestHide(t *testing.T) {
-	scopes := []string{"hidden"}
+	scopes := []string{HiddenScope}
 
 	key := calculateKey(calculateScope(scopes), defaultGuestInfoPrefix()+"/a/b", "c")
 
@@ -55,7 +55,7 @@ func TestHide(t *testing.T) {
 }
 
 func TestReveal(t *testing.T) {
-	scopes := []string{"read-only"}
+	scopes := []string{ReadOnlyScope}
 
 	key := calculateKey(calculateScope(scopes), "a/b", "c")
 
@@ -63,7 +63,7 @@ func TestReveal(t *testing.T) {
 }
 
 func TestVisibleReadOnly(t *testing.T) {
-	scopes := []string{"read-only"}
+	scopes := []string{ReadOnlyScope}
 
 	key := calculateKey(calculateScope(scopes), defaultGuestInfoPrefix()+"/a/b", "c")
 
@@ -71,7 +71,7 @@ func TestVisibleReadOnly(t *testing.T) {
 }
 
 func TestVisibleReadWrite(t *testing.T) {
-	scopes := []string{"read-write"}
+	scopes := []string{ReadWriteScope}
 
 	key := calculateKey(calculateScope(scopes), defaultGuestInfoPrefix()+".a.b", "c")
 
@@ -79,7 +79,7 @@ func TestVisibleReadWrite(t *testing.T) {
 }
 
 func TestTopLevelReadOnly(t *testing.T) {
-	scopes := []string{"read-only"}
+	scopes := []string{ReadOnlyScope}
 
 	key := calculateKey(calculateScope(scopes), "", "a")
 
@@ -87,7 +87,7 @@ func TestTopLevelReadOnly(t *testing.T) {
 }
 
 func TestReadOnlyToReadWrite(t *testing.T) {
-	scopes := []string{"read-write"}
+	scopes := []string{ReadWriteScope}
 
 	key := calculateKey(calculateScope(scopes), defaultGuestInfoPrefix()+"/a/b", "c")
 
@@ -95,7 +95,7 @@ func TestReadOnlyToReadWrite(t *testing.T) {
 }
 
 func TestReadWriteToReadOnly(t *testing.T) {
-	scopes := []string{"read-only"}
+	scopes := []string{ReadOnlyScope}
 
 	key := calculateKey(calculateScope(scopes), defaultGuestInfoPrefix()+".a.b", "c")
 
@@ -103,7 +103,7 @@ func TestReadWriteToReadOnly(t *testing.T) {
 }
 
 func TestCompoundKey(t *testing.T) {
-	scopes := []string{"read-write"}
+	scopes := []string{ReadWriteScope}
 
 	key := calculateKey(calculateScope(scopes), defaultGuestInfoPrefix()+".a", "b/c")
 
@@ -124,7 +124,7 @@ func TestNoScopes(t *testing.T) {
 }
 
 func TestSecret(t *testing.T) {
-	scopes := []string{"secret", "read-write"}
+	scopes := []string{SecretSuffix, ReadWriteScope}
 
 	key := calculateKey(calculateScope(scopes), defaultGuestInfoPrefix()+".a.b", "c")
 
@@ -132,7 +132,7 @@ func TestSecret(t *testing.T) {
 }
 
 func TestNonpersistent(t *testing.T) {
-	scopes := []string{"non-persistent", "read-write"}
+	scopes := []string{NonPersistentSuffix, ReadWriteScope}
 
 	key := calculateKey(calculateScope(scopes), defaultGuestInfoPrefix()+".a.b", "c")
 
@@ -140,7 +140,7 @@ func TestNonpersistent(t *testing.T) {
 }
 
 func TestMultipleSuffixes(t *testing.T) {
-	scopes := []string{"non-persistent", "secret", "read-write"}
+	scopes := []string{NonPersistentSuffix, SecretSuffix, ReadWriteScope}
 
 	key := calculateKey(calculateScope(scopes), defaultGuestInfoPrefix()+".a.b", "c")
 

--- a/pkg/vsphere/extraconfig/keys_test.go
+++ b/pkg/vsphere/extraconfig/keys_test.go
@@ -49,7 +49,7 @@ func TestHidden(t *testing.T) {
 func TestHide(t *testing.T) {
 	scopes := []string{"hidden"}
 
-	key := calculateKey(calculateScope(scopes), DefaultGuestInfoPrefix+"/a/b", "c")
+	key := calculateKey(calculateScope(scopes), defaultGuestInfoPrefix()+"/a/b", "c")
 
 	assert.Equal(t, "a/b/c", key, "Key should be hidden")
 }
@@ -59,23 +59,23 @@ func TestReveal(t *testing.T) {
 
 	key := calculateKey(calculateScope(scopes), "a/b", "c")
 
-	assert.Equal(t, DefaultGuestInfoPrefix+"/a/b/c", key, "Key should be exposed")
+	assert.Equal(t, defaultGuestInfoPrefix()+"/a/b/c", key, "Key should be exposed")
 }
 
 func TestVisibleReadOnly(t *testing.T) {
 	scopes := []string{"read-only"}
 
-	key := calculateKey(calculateScope(scopes), DefaultGuestInfoPrefix+"/a/b", "c")
+	key := calculateKey(calculateScope(scopes), defaultGuestInfoPrefix()+"/a/b", "c")
 
-	assert.Equal(t, DefaultGuestInfoPrefix+"/a/b/c", key, "Key should be remain visible and read-only")
+	assert.Equal(t, defaultGuestInfoPrefix()+"/a/b/c", key, "Key should be remain visible and read-only")
 }
 
 func TestVisibleReadWrite(t *testing.T) {
 	scopes := []string{"read-write"}
 
-	key := calculateKey(calculateScope(scopes), DefaultGuestInfoPrefix+".a.b", "c")
+	key := calculateKey(calculateScope(scopes), defaultGuestInfoPrefix()+".a.b", "c")
 
-	assert.Equal(t, DefaultGuestInfoPrefix+".a.b.c", key, "Key should be remain visible and read-write")
+	assert.Equal(t, defaultGuestInfoPrefix()+".a.b.c", key, "Key should be remain visible and read-write")
 }
 
 func TestTopLevelReadOnly(t *testing.T) {
@@ -83,40 +83,40 @@ func TestTopLevelReadOnly(t *testing.T) {
 
 	key := calculateKey(calculateScope(scopes), "", "a")
 
-	assert.Equal(t, DefaultGuestInfoPrefix+"/a", key, "Key should be visible and read-only")
+	assert.Equal(t, defaultGuestInfoPrefix()+"/a", key, "Key should be visible and read-only")
 }
 
 func TestReadOnlyToReadWrite(t *testing.T) {
 	scopes := []string{"read-write"}
 
-	key := calculateKey(calculateScope(scopes), DefaultGuestInfoPrefix+"/a/b", "c")
+	key := calculateKey(calculateScope(scopes), defaultGuestInfoPrefix()+"/a/b", "c")
 
-	assert.Equal(t, DefaultGuestInfoPrefix+".a.b.c", key, "Key should be visible and change to read-write")
+	assert.Equal(t, defaultGuestInfoPrefix()+".a.b.c", key, "Key should be visible and change to read-write")
 }
 
 func TestReadWriteToReadOnly(t *testing.T) {
 	scopes := []string{"read-only"}
 
-	key := calculateKey(calculateScope(scopes), DefaultGuestInfoPrefix+".a.b", "c")
+	key := calculateKey(calculateScope(scopes), defaultGuestInfoPrefix()+".a.b", "c")
 
-	assert.Equal(t, DefaultGuestInfoPrefix+"/a/b/c", key, "Key should be visible and change to read-only")
+	assert.Equal(t, defaultGuestInfoPrefix()+"/a/b/c", key, "Key should be visible and change to read-only")
 }
 
 func TestCompoundKey(t *testing.T) {
 	scopes := []string{"read-write"}
 
-	key := calculateKey(calculateScope(scopes), DefaultGuestInfoPrefix+".a", "b/c")
+	key := calculateKey(calculateScope(scopes), defaultGuestInfoPrefix()+".a", "b/c")
 
-	assert.Equal(t, DefaultGuestInfoPrefix+".a.b.c", key, "Key should be visible and read-write")
+	assert.Equal(t, defaultGuestInfoPrefix()+".a.b.c", key, "Key should be visible and read-write")
 }
 
 func TestNoScopes(t *testing.T) {
 	scopes := []string{}
 
-	key := calculateKey(calculateScope(scopes), DefaultGuestInfoPrefix+".a/b", "c")
+	key := calculateKey(calculateScope(scopes), defaultGuestInfoPrefix()+".a/b", "c")
 	assert.Equal(t, "a/b/c", key, "Key should be completely proscriptive")
 
-	key = calculateKey(calculateScope(scopes), DefaultGuestInfoPrefix+".a.b", "c")
+	key = calculateKey(calculateScope(scopes), defaultGuestInfoPrefix()+".a.b", "c")
 	assert.Equal(t, "a.b/c", key, "Key should be hidden")
 
 	key = calculateKey(calculateScope(scopes), "a.b", "c")
@@ -126,25 +126,25 @@ func TestNoScopes(t *testing.T) {
 func TestSecret(t *testing.T) {
 	scopes := []string{"secret", "read-write"}
 
-	key := calculateKey(calculateScope(scopes), DefaultGuestInfoPrefix+".a.b", "c")
+	key := calculateKey(calculateScope(scopes), defaultGuestInfoPrefix()+".a.b", "c")
 
-	assert.Equal(t, DefaultGuestInfoPrefix+".a.b.c"+suffixSeparator+secretSuffix, key, "Key should have secret suffix")
+	assert.Equal(t, defaultGuestInfoPrefix()+".a.b.c"+suffixSeparator+SecretSuffix, key, "Key should have secret suffix")
 }
 
 func TestNonpersistent(t *testing.T) {
 	scopes := []string{"non-persistent", "read-write"}
 
-	key := calculateKey(calculateScope(scopes), DefaultGuestInfoPrefix+".a.b", "c")
+	key := calculateKey(calculateScope(scopes), defaultGuestInfoPrefix()+".a.b", "c")
 
-	assert.Equal(t, DefaultGuestInfoPrefix+".a.b.c"+suffixSeparator+nonpersistentSuffix, key, "Key should have non-persistent suffix")
+	assert.Equal(t, defaultGuestInfoPrefix()+".a.b.c"+suffixSeparator+NonPersistentSuffix, key, "Key should have non-persistent suffix")
 }
 
 func TestMultipleSuffixes(t *testing.T) {
 	scopes := []string{"non-persistent", "secret", "read-write"}
 
-	key := calculateKey(calculateScope(scopes), DefaultGuestInfoPrefix+".a.b", "c")
+	key := calculateKey(calculateScope(scopes), defaultGuestInfoPrefix()+".a.b", "c")
 
-	assert.True(t, strings.Contains(key, suffixSeparator+secretSuffix) && strings.Contains(key, suffixSeparator+nonpersistentSuffix), "Key should contain both secret and non-persistent suffix")
+	assert.True(t, strings.Contains(key, suffixSeparator+SecretSuffix) && strings.Contains(key, suffixSeparator+NonPersistentSuffix), "Key should contain both secret and non-persistent suffix")
 }
 
 func TestCalculateKeys(t *testing.T) {

--- a/pkg/vsphere/extraconfig/secret.go
+++ b/pkg/vsphere/extraconfig/secret.go
@@ -27,7 +27,7 @@ import (
 
 // The value of this key is hidden from API requests, but visible within the guest
 // #nosec: Potential hardcoded credentials
-const GuestInfoSecretKey = "guestinfo.ovfEnv"
+const GuestInfoSecretKey = GuestInfoPrefix + "ovfEnv"
 
 // SecretKey provides helpers to encrypt/decrypt extraconfig values
 type SecretKey struct {

--- a/pkg/vsphere/extraconfig/secret_test.go
+++ b/pkg/vsphere/extraconfig/secret_test.go
@@ -45,7 +45,7 @@ func TestSecretFields(t *testing.T) {
 	encoded := map[string]string{}
 	Encode(out.Sink(MapSink(encoded)), config)
 
-	password := encoded["guestinfo.vice./password"+suffixSeparator+SecretSuffix]
+	password := encoded[defaultGuestInfoPrefix()+"/password"+suffixSeparator+SecretSuffix]
 	assert.NotEmpty(t, password, "encrypted password")
 	assert.NotEqual(t, password, config.Password, "encrypted password")
 

--- a/pkg/vsphere/extraconfig/secret_test.go
+++ b/pkg/vsphere/extraconfig/secret_test.go
@@ -45,7 +45,7 @@ func TestSecretFields(t *testing.T) {
 	encoded := map[string]string{}
 	Encode(out.Sink(MapSink(encoded)), config)
 
-	password := encoded["guestinfo.vice./password"+suffixSeparator+secretSuffix]
+	password := encoded["guestinfo.vice./password"+suffixSeparator+SecretSuffix]
 	assert.NotEmpty(t, password, "encrypted password")
 	assert.NotEqual(t, password, config.Password, "encrypted password")
 


### PR DESCRIPTION
Turns the annotation string labels for controlling serialization behaviour
into constants with comments. Still requires package level descripton
and examples.

Adds a recursion property to skip encode or decode of a field. If skipping
both the depth=0 should be used.

Splits DefaultGuestInfoPrefix into pieces. The vSphere mandatory guestinfo
prefix should not be user configurations, whereas the key "namespacing"
prefix should have been. For VIC this was the "vice" namespace prefix which
was _not_ applied to the hidden (non-guestinfo) keys. As such this commit
drops the DefaultPrefix from the encode/decode paths for now due to
upgrade constraints.

There is now an explicit separation between those elements that should not
be modified (constants) and those that should be usage configuration (vars).
Future work should extend this with a defined config structure that Encode
and Decode can operate from.

If it turns out that we need `initialize once` rather than `skip-decode` for any
field, we can look at making the field a pointer and having explicit logic based
around whether the target is a nil pointer or not. This gives us easy inline
tracking of whether initialization has occurred, although with unfortunate
dependence on the user not having explicitly initialized some pointer paths in
the target structure ahead of time.

```
[full ci]
```

Towards #7410 
