### PR TITLE
Change Swagger Specs to send OPID and Portlayer to use it

### DIFF
--- a/lib/apiservers/engine/backends/image.go
+++ b/lib/apiservers/engine/backends/image.go
@@ -128,7 +128,7 @@ func (i *ImageBackend) ImageDelete(imageRef string, force, prune bool) ([]types.
 			keepNodes[idx] = imgURL.String()
 		}
 
-		params := storage.NewDeleteImageParamsWithContext(ctx).WithStoreName(storeName).WithID(img.ID).WithKeepNodes(keepNodes)
+		params := storage.NewDeleteImageParamsWithContext(op).WithStoreName(storeName).WithID(img.ID).WithKeepNodes(keepNodes)
 		// TODO: This will fail if any containerVMs are referencing the vmdk - vanilla docker
 		// allows the removal of an image (via force flag) even if a container is referencing it
 		// should vic?

--- a/lib/apiservers/engine/backends/system.go
+++ b/lib/apiservers/engine/backends/system.go
@@ -168,7 +168,7 @@ func (s *SystemBackend) SystemInfo() (*types.Info, error) {
 	info.SystemStatus = make([][2]string, 0)
 
 	// Add in volume label from the VCH via guestinfo
-	volumeStoreString, err := FetchVolumeStores(client)
+	volumeStoreString, err := FetchVolumeStores(op, client)
 	if err != nil {
 		log.Infof("Unable to get the volume store list from the portlayer : %s", err.Error())
 	} else {
@@ -443,9 +443,9 @@ func getImageCount() int {
 	return len(images)
 }
 
-func FetchVolumeStores(client *client.PortLayer) (string, error) {
+func FetchVolumeStores(op trace.Operation, client *client.PortLayer) (string, error) {
 
-	res, err := client.Storage.VolumeStoresList(storage.NewVolumeStoresListParamsWithContext(ctx))
+	res, err := client.Storage.VolumeStoresList(storage.NewVolumeStoresListParamsWithContext(op))
 	if err != nil {
 		return "", err
 	}

--- a/lib/apiservers/portlayer/restapi/handlers/task_handlers.go
+++ b/lib/apiservers/portlayer/restapi/handlers/task_handlers.go
@@ -45,8 +45,8 @@ func (handler *TaskHandlersImpl) Configure(api *operations.PortLayerAPI, _ *Hand
 
 // JoinHandler calls the Join
 func (handler *TaskHandlersImpl) JoinHandler(params tasks.JoinParams) middleware.Responder {
-	defer trace.End(trace.Begin(""))
-	op := trace.NewOperation(context.Background(), "task.Join(%s, %s)", params.Config.Handle, params.Config.ID)
+	op := trace.NewOperationFromID(context.Background(), params.OpID, "task.JoinHandler(%s, %s)", params.Config.Handle, params.Config.ID)
+	defer trace.End(trace.Begin("JoinHandler", op))
 
 	handle := exec.HandleFromInterface(params.Config.Handle)
 	if handle == nil {
@@ -113,8 +113,8 @@ func (handler *TaskHandlersImpl) JoinHandler(params tasks.JoinParams) middleware
 
 // BindHandler calls the Bind
 func (handler *TaskHandlersImpl) BindHandler(params tasks.BindParams) middleware.Responder {
-	defer trace.End(trace.Begin(""))
-	op := trace.NewOperation(context.Background(), "task.Bind(%s, %s)", params.Config.Handle, params.Config.ID)
+	op := trace.NewOperationFromID(context.Background(), params.OpID, "task.BindHandler(%s, %s)", params.Config.Handle, params.Config.ID)
+	defer trace.End(trace.Begin("BindHandler", op))
 
 	handle := exec.HandleFromInterface(params.Config.Handle)
 	if handle == nil {
@@ -148,8 +148,8 @@ func (handler *TaskHandlersImpl) BindHandler(params tasks.BindParams) middleware
 
 // UnbindHandler calls the Unbind
 func (handler *TaskHandlersImpl) UnbindHandler(params tasks.UnbindParams) middleware.Responder {
-	defer trace.End(trace.Begin(""))
-	op := trace.NewOperation(context.Background(), "task.Unbind(%s, %s)", params.Config.Handle, params.Config.ID)
+	op := trace.NewOperationFromID(context.Background(), params.OpID, "task.UnbindHandler(%s, %s)", params.Config.Handle, params.Config.ID)
+	defer trace.End(trace.Begin("UnbindHandler", op))
 
 	handle := exec.HandleFromInterface(params.Config.Handle)
 	if handle == nil {
@@ -182,8 +182,8 @@ func (handler *TaskHandlersImpl) UnbindHandler(params tasks.UnbindParams) middle
 
 // RemoveHandler calls remove
 func (handler *TaskHandlersImpl) RemoveHandler(params tasks.RemoveParams) middleware.Responder {
-	defer trace.End(trace.Begin(""))
-	op := trace.NewOperation(context.Background(), "task.Remove(%s, %s)", params.Config.Handle, params.Config.ID)
+	op := trace.NewOperationFromID(context.Background(), params.OpID, "task.RemoveHandler(%s, %s)", params.Config.Handle, params.Config.ID)
+	defer trace.End(trace.Begin("RemoveHandler", op))
 
 	handle := exec.HandleFromInterface(params.Config.Handle)
 	if handle == nil {
@@ -208,8 +208,8 @@ func (handler *TaskHandlersImpl) RemoveHandler(params tasks.RemoveParams) middle
 
 // InspectHandler calls inspect
 func (handler *TaskHandlersImpl) InspectHandler(params tasks.InspectParams) middleware.Responder {
-	defer trace.End(trace.Begin(""))
-	op := trace.NewOperation(context.Background(), "task.Inspect(%s, %s)", params.Config.Handle, params.Config.ID)
+	op := trace.NewOperationFromID(context.Background(), params.OpID, "task.InspectHandler(%s, %s)", params.Config.Handle, params.Config.ID)
+	defer trace.End(trace.Begin("InspectHandler", op))
 
 	handle := exec.HandleFromInterface(params.Config.Handle)
 	if handle == nil {
@@ -270,8 +270,8 @@ func (handler *TaskHandlersImpl) InspectHandler(params tasks.InspectParams) midd
 
 // WaitHandler calls wait
 func (handler *TaskHandlersImpl) WaitHandler(params tasks.WaitParams) middleware.Responder {
-	defer trace.End(trace.Begin(""))
-	op := trace.NewOperation(context.Background(), "task.Wait(%s, %s)", params.Config.Handle, params.Config.ID)
+	op := trace.NewOperationFromID(context.Background(), params.OpID, "task.WaitHandler(%s, %s)", params.Config.Handle, params.Config.ID)
+	defer trace.End(trace.Begin("WaitHandler", op))
 
 	handle := exec.HandleFromInterface(params.Config.Handle)
 	if handle == nil {

--- a/lib/apiservers/portlayer/swagger.json
+++ b/lib/apiservers/portlayer/swagger.json
@@ -15,8 +15,22 @@
 	"schemes": [
 		"http"
 	],
+	"parameters": {
+		"operationID": {
+			"name": "Op-ID",
+			"type": "string",
+			"pattern": "[0-9]+\\.[0-9]+",
+			"in": "header",
+			"required": false
+		}
+	},
 	"paths": {
 		"/_ping": {
+			"parameters": [
+				{
+					"$ref": "#/parameters/operationID"
+				}
+			],
 			"get": {
 				"description": "Pings the server to see if it's running",
 				"summary": "ping the portlayer server",
@@ -38,6 +52,11 @@
 			}
 		},
 		"/vch/info": {
+			"parameters": [
+				{
+					"$ref": "#/parameters/operationID"
+				}
+			],
 			"get": {
 				"description": "Gets vital information about the vch",
 				"tags": [
@@ -61,6 +80,11 @@
 			}
 		},
 		"/kv/{key}": {
+			"parameters": [
+				{
+					"$ref": "#/parameters/operationID"
+				}
+			],
 			"get": {
 				"description": "Gets value from k/v store",
 				"tags": [
@@ -176,6 +200,11 @@
 			}
 		},
 		"/archive": {
+			"parameters": [
+				{
+					"$ref": "#/parameters/operationID"
+				}
+			],
 			"get": {
 				"description": "Exports a tar archive from the target device.",
 				"summary": "Export tar archive from supplied target",
@@ -391,6 +420,11 @@
 			}
 		},
 		"/storage": {
+			"parameters": [
+				{
+					"$ref": "#/parameters/operationID"
+				}
+			],
 			"post": {
 				"description": "Creates a location to store images",
 				"summary": "creates an image store",
@@ -430,6 +464,11 @@
 			}
 		},
 		"/storage/{store_name}": {
+			"parameters": [
+				{
+					"$ref": "#/parameters/operationID"
+				}
+			],
 			"get": {
 				"description": "Retrieves a list of images given a list of image IDs, or all images in the image store if no param is passed.",
 				"summary": "Retrieve a list of images in an image store",
@@ -551,6 +590,11 @@
 			}
 		},
 		"/storage/{store_name}/info/{id}": {
+			"parameters": [
+				{
+					"$ref": "#/parameters/operationID"
+				}
+			],
 			"get": {
 				"description": "Inspect an image by id in an image store",
 				"summary": "Inspect an image",
@@ -656,6 +700,11 @@
 			}
 		},
 		"/storage/{store_name}/tar/{id}": {
+			"parameters": [
+				{
+					"$ref": "#/parameters/operationID"
+				}
+			],
 			"get": {
 				"description": "Get an image by id in an image store as a tar file",
 				"summary": "Get an image as a tar file",
@@ -698,6 +747,11 @@
 			}
 		},
 		"/storage/volumestores": {
+			"parameters": [
+				{
+					"$ref": "#/parameters/operationID"
+				}
+			],
 			"get": {
 				"description": "Get a list of available volume store locations",
 				"operationId": "VolumeStoresList",
@@ -734,6 +788,11 @@
 			}
 		},
 		"/storage/volumes": {
+			"parameters": [
+				{
+					"$ref": "#/parameters/operationID"
+				}
+			],
 			"get": {
 				"description": "Get a list of available volumes",
 				"operationId": "ListVolumes",
@@ -838,6 +897,11 @@
 			}
 		},
 		"/storage/volumes/{name}": {
+			"parameters": [
+				{
+					"$ref": "#/parameters/operationID"
+				}
+			],
 			"get": {
 				"description": "Get info about a volume",
 				"operationId": "GetVolume",
@@ -973,6 +1037,11 @@
 			}
 		},
 		"/scopes": {
+			"parameters": [
+				{
+					"$ref": "#/parameters/operationID"
+				}
+			],
 			"post": {
 				"summary": "Create a new scope",
 				"tags": [
@@ -1034,6 +1103,11 @@
 			}
 		},
 		"/scopes/{idName}": {
+			"parameters": [
+				{
+					"$ref": "#/parameters/operationID"
+				}
+			],
 			"get": {
 				"tags": [
 					"scopes"
@@ -1104,6 +1178,11 @@
 			}
 		},
 		"/scopes/{scope}/containers": {
+			"parameters": [
+				{
+					"$ref": "#/parameters/operationID"
+				}
+			],
 			"post": {
 				"description": "Add a container to scopes modifying the container VM's config as necessary",
 				"tags": [
@@ -1149,6 +1228,11 @@
 			}
 		},
 		"/scopes/{scope}/containers/{handle}": {
+			"parameters": [
+				{
+					"$ref": "#/parameters/operationID"
+				}
+			],
 			"delete": {
 				"description": "Remove a container from a scope",
 				"tags": [
@@ -1192,6 +1276,11 @@
 			}
 		},
 		"/scopes/containers/{handleOrId}": {
+			"parameters": [
+				{
+					"$ref": "#/parameters/operationID"
+				}
+			],
 			"get": {
 				"tags": [
 					"scopes"
@@ -1239,6 +1328,11 @@
 			}
 		},
 		"/scopes/containers/{handle}/binding": {
+			"parameters": [
+				{
+					"$ref": "#/parameters/operationID"
+				}
+			],
 			"post": {
 				"tags": [
 					"scopes"
@@ -1324,6 +1418,11 @@
 			}
 		},
 		"/events": {
+			"parameters": [
+				{
+					"$ref": "#/parameters/operationID"
+				}
+			],
 			"get": {
 				"description": "Gets portlayer events",
 				"summary": "Gets portlayer events",
@@ -1352,6 +1451,11 @@
 			}
 		},
 		"/containers": {
+			"parameters": [
+				{
+					"$ref": "#/parameters/operationID"
+				}
+			],
 			"post": {
 				"description": "Initiates a container create operation",
 				"summary": "Initiates a container create operation",
@@ -1399,6 +1503,11 @@
 			}
 		},
 		"/containers/info/{id}": {
+			"parameters": [
+				{
+					"$ref": "#/parameters/operationID"
+				}
+			],
 			"get": {
 				"description": "Gets information about a container by id",
 				"operationId": "GetContainerInfo",
@@ -1442,6 +1551,11 @@
 			}
 		},
 		"/containers/list": {
+			"parameters": [
+				{
+					"$ref": "#/parameters/operationID"
+				}
+			],
 			"get": {
 				"description": "Gets a list of all containers",
 				"operationId": "GetContainerList",
@@ -1482,6 +1596,11 @@
 			}
 		},
 		"/containers/{id}": {
+			"parameters": [
+				{
+					"$ref": "#/parameters/operationID"
+				}
+			],
 			"get": {
 				"description": "Get a container handle",
 				"operationId": "Get",
@@ -1585,6 +1704,11 @@
 			}
 		},
 		"/containers/{handle}": {
+			"parameters": [
+				{
+					"$ref": "#/parameters/operationID"
+				}
+			],
 			"put": {
 				"description": "Commit and close a container handle",
 				"operationId": "Commit",
@@ -1638,6 +1762,11 @@
 			}
 		},
 		"/containers/{handle}/state": {
+			"parameters": [
+				{
+					"$ref": "#/parameters/operationID"
+				}
+			],
 			"put": {
 				"description": "Changes the state of a container",
 				"operationId": "StateChange",
@@ -1737,7 +1866,12 @@
 				}
 			}
 		},
-    "/tasks/wait": {
+		"/tasks/wait": {
+			"parameters": [
+				{
+					"$ref": "#/parameters/operationID"
+				}
+			],
 			"get": {
 				"description": "Initiates a task wait operation",
 				"summary": "Initiates a task wait operation",
@@ -1786,8 +1920,13 @@
 					}
 				}
 			}
-    },
+		},
 		"/tasks": {
+			"parameters": [
+				{
+					"$ref": "#/parameters/operationID"
+				}
+			],
 			"get": {
 				"description": "Initiates a task inspect operation",
 				"summary": "Initiates a task inspect operation",
@@ -1931,6 +2070,11 @@
 			}
 		},
 		"/tasks/binding": {
+			"parameters": [
+				{
+					"$ref": "#/parameters/operationID"
+				}
+			],
 			"post": {
 				"description": "Activate a task that exists within the context of the provided handle",
 				"summary": "Activate an existing task",
@@ -2023,6 +2167,11 @@
 			}
 		},
 		"/containers/{handle}/name": {
+			"parameters": [
+				{
+					"$ref": "#/parameters/operationID"
+				}
+			],
 			"patch": {
 				"description": "Rename a container to the new name",
 				"operationId": "ContainerRename",
@@ -2080,6 +2229,11 @@
 			}
 		},
 		"/containers/{id}/signal": {
+			"parameters": [
+				{
+					"$ref": "#/parameters/operationID"
+				}
+			],
 			"post": {
 				"description": "Sends a signal to a container by id",
 				"summary": "Signal a running container",
@@ -2125,6 +2279,11 @@
 			}
 		},
 		"/containers/{id}/stats": {
+			"parameters": [
+				{
+					"$ref": "#/parameters/operationID"
+				}
+			],
 			"get": {
 				"description": "Gets the container stats by id",
 				"summary": "Gets the container stats",
@@ -2169,6 +2328,11 @@
 			}
 		},
 		"/containers/{id}/logs": {
+			"parameters": [
+				{
+					"$ref": "#/parameters/operationID"
+				}
+			],
 			"get": {
 				"description": "Gets the container logs by id",
 				"summary": "Gets the container logs",
@@ -2242,6 +2406,11 @@
 			}
 		},
 		"/logging": {
+			"parameters": [
+				{
+					"$ref": "#/parameters/operationID"
+				}
+			],
 			"post": {
 				"description": "Adds logging capabilities to given handle",
 				"summary": "Add logging capability",
@@ -2289,6 +2458,11 @@
 			}
 		},
 		"/logging/binding": {
+			"parameters": [
+				{
+					"$ref": "#/parameters/operationID"
+				}
+			],
 			"post": {
 				"description": "Enable/bind/activate the VirtualDevice",
 				"summary": "Enable/bind/activate the VirtualDevice",
@@ -2381,6 +2555,11 @@
 			}
 		},
 		"/interaction": {
+			"parameters": [
+				{
+					"$ref": "#/parameters/operationID"
+				}
+			],
 			"post": {
 				"description": "Adds interaction capabilities to given handle",
 				"summary": "Add interaction capability",
@@ -2428,6 +2607,11 @@
 			}
 		},
 		"/interaction/binding": {
+			"parameters": [
+				{
+					"$ref": "#/parameters/operationID"
+				}
+			],
 			"post": {
 				"description": "Enable/bind/activate the VirtualDevice",
 				"summary": "Enable/bind/activate the VirtualDevice",
@@ -2520,6 +2704,11 @@
 			}
 		},
 		"/containers/{id}/wait": {
+			"parameters": [
+				{
+					"$ref": "#/parameters/operationID"
+				}
+			],
 			"get": {
 				"description": "Wait for the container to stop",
 				"operationId": "ContainerWait",
@@ -2571,6 +2760,11 @@
 			}
 		},
 		"/interaction/{id}/resize": {
+			"parameters": [
+				{
+					"$ref": "#/parameters/operationID"
+				}
+			],
 			"post": {
 				"description": "Resize the container's tty session",
 				"summary": "Resize tty session",
@@ -2627,6 +2821,11 @@
 			}
 		},
 		"/interaction/{id}/stdin": {
+			"parameters": [
+				{
+					"$ref": "#/parameters/operationID"
+				}
+			],
 			"post": {
 				"description": "Set a stdin for the container",
 				"summary": "Set stdin",
@@ -2715,6 +2914,11 @@
 			}
 		},
 		"/interaction/{id}/stdout": {
+			"parameters": [
+				{
+					"$ref": "#/parameters/operationID"
+				}
+			],
 			"get": {
 				"description": "Get a stdout for the container",
 				"summary": "Get stdout",
@@ -2759,6 +2963,11 @@
 			}
 		},
 		"/interaction/{id}/stderr": {
+			"parameters": [
+				{
+					"$ref": "#/parameters/operationID"
+				}
+			],
 			"get": {
 				"description": "Get a stderr for the container",
 				"summary": "Get stderr",

--- a/pkg/trace/operation.go
+++ b/pkg/trace/operation.go
@@ -217,11 +217,20 @@ func (o *Operation) Fatal(args ...interface{}) {
 	}
 }
 
-func (o *Operation) newChild(ctx context.Context, msg string) Operation {
-	child := newOperation(ctx, o.id, 4, msg)
+func (o Operation) newChildCommon(ctx context.Context, opID string, msg string) Operation {
+	child := newOperation(ctx, opID, 5, msg)
 	child.t = append(child.t, o.t...)
 	child.Logger = o.Logger
 	return child
+}
+
+func (o Operation) newChild(ctx context.Context, msg string) Operation {
+	return o.newChildCommon(ctx, o.id, msg)
+}
+
+func (o Operation) newChildWithChainedID(ctx context.Context, msg string) Operation {
+	childOpID := fmt.Sprintf("%s.%d", o.id, atomic.AddUint64(&opCount, 1))
+	return o.newChildCommon(ctx, childOpID, msg)
 }
 
 func opID(opNum uint64) string {
@@ -234,6 +243,24 @@ func NewOperation(ctx context.Context, format string, args ...interface{}) Opera
 
 	frame := o.t[0]
 	o.Debugf("[NewOperation] %s [%s:%d]", o.header(), frame.funcName, frame.lineNo)
+	return o
+}
+
+// NewOperationFromID returns a an Operation with the incoming ID if valid
+// It creates a parent operation with the incoming ID and a child with
+// the parent operation ID as a prefix and a monotonically incremented
+// integer as the suffix
+func NewOperationFromID(ctx context.Context, ID *string, format string, args ...interface{}) Operation {
+	var o Operation
+	if ID == nil || *ID == "" {
+		o = newOperation(ctx, opID(atomic.AddUint64(&opCount, 1)), 3, fmt.Sprintf(format, args...))
+	} else {
+		msg := fmt.Sprintf(format, args...)
+		o = newOperation(ctx, *ID, 3, msg).newChildWithChainedID(ctx, msg)
+	}
+
+	frame := o.t[0]
+	o.Debugf("[NewOperationFromID] %s [%s:%d]", o.header(), frame.funcName, frame.lineNo)
 	return o
 }
 


### PR DESCRIPTION
This PR includes three set of changes:
- Add Operation ID in the Swagger specs to send it across to the Portlayer
- Add code to Portlayer to read the Operation ID from the incoming message and build an operation with the incoming ID
- Remove global context from the Docker Engine, provide proper trace.Operation as first parameters to methods.

Towards: #7993