### PR TITLE
Parameterize nightly script and remove user dir dependency

### DIFF
--- a/tests/manual-test-cases/Group5-Functional-Tests/5-11-Multiple-Cluster.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-11-Multiple-Cluster.robot
@@ -24,7 +24,7 @@ Multiple Cluster Setup
     [Timeout]    110 minutes
     Run Keyword And Ignore Error  Nimbus Cleanup Single VM  '*5-11-multiple-cluster*'  ${false}
     Log To Console  \nStarting testbed deploy...
-    ${out}=  Deploy Nimbus Testbed  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}  --noSupportBundles --plugin testng --vcvaBuild ${VC_VERSION} --esxBuild ${ESX_VERSION} --testbedName vic-multiple-cluster --testbedSpecRubyFile /dbc/pa-dbc1111/mhagen/nimbus-testbeds/testbeds/vic-multiple-cluster.rb --runName 5-11-multiple-cluster
+    ${out}=  Deploy Nimbus Testbed  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}  spec=vic-multiple-cluster.rb  args=--noSupportBundles --plugin testng --vcvaBuild ${VC_VERSION} --esxBuild ${ESX_VERSION} --testbedName vic-multiple-cluster --runName 5-11-multiple-cluster
     Log  ${out}
 
     Open Connection  %{NIMBUS_GW}
@@ -56,7 +56,6 @@ Multiple Cluster Setup
 *** Test Cases ***
 Test
     Log To Console  \nStarting test...
-    Custom Testbed Keepalive  /dbc/pa-dbc1111/mhagen
 
     Install VIC Appliance To Test Server  certs=${false}  vol=default
     Run Regression Tests

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-15-NFS-Datastore.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-15-NFS-Datastore.robot
@@ -23,7 +23,7 @@ NFS Datastore Setup
     [Timeout]    110 minutes
     Run Keyword And Ignore Error  Nimbus Cleanup Single VM  '*5-15-nfs-datastore*'  ${false}
     Log To Console  \nStarting testbed deploy...    
-    ${out}=  Deploy Nimbus Testbed  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}  --noSupportBundles --plugin testng --vcvaBuild ${VC_VERSION} --esxBuild ${ESX_VERSION} --testbedName vic-simple-cluster --testbedSpecRubyFile /dbc/pa-dbc1111/mhagen/nimbus-testbeds/testbeds/vic-simple-cluster.rb --runName 5-15-nfs-datastore
+    ${out}=  Deploy Nimbus Testbed  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}  spec=vic-simple-cluster.rb  args=--noSupportBundles --plugin testng --vcvaBuild ${VC_VERSION} --esxBuild ${ESX_VERSION} --testbedName vic-simple-cluster --runName 5-15-nfs-datastore
     Log  ${out}
 
     Open Connection  %{NIMBUS_GW}

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-22-NFS-Volume.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-22-NFS-Volume.robot
@@ -38,7 +38,7 @@ Setup ESX And NFS Suite
     Run Keyword And Ignore Error  Nimbus Cleanup  ${list}  ${false}
     Log To Console  \nStarting test...
 
-    ${nfs}  ${nfs_ro}  ${esx1}  ${nfs_ip}  ${nfs_ro_ip}  ${esx1_ip}=  Deploy Simple NFS Testbed  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}  additional-args=--testbedSpecRubyFile /dbc/w3-dbc302/rashok/vic-nfs.rb --esxBuild ${ESX_VERSION} --esxPxeDir ${ESX_VERSION} --plugin testng
+    ${nfs}  ${nfs_ro}  ${esx1}  ${nfs_ip}  ${nfs_ro_ip}  ${esx1_ip}=  Deploy Simple NFS Testbed  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}  spec=vic-nfs.rb  args=--esxBuild ${ESX_VERSION} --esxPxeDir ${ESX_VERSION} --plugin testng
 
     Set Suite Variable  @{list}  ${esx1}  ${nfs}  ${nfs_ro}
     Set Suite Variable  ${ESX1}  ${esx1}

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-26-Static-IP-Address.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-26-Static-IP-Address.robot
@@ -27,7 +27,6 @@ Setup VC With Static IP
 *** Test Cases ***
 Test
     Log To Console  \nStarting test...
-    Custom Testbed Keepalive  /dbc/pa-dbc1111/mhagen
 
     Install VIC Appliance To Test Server  additional-args=--public-network-ip &{static}[ip]/&{static}[netmask] --public-network-gateway &{static}[gateway] --dns-server 10.170.16.48
     Run Regression Tests

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-27-Selenium-Grid.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-27-Selenium-Grid.robot
@@ -24,7 +24,7 @@ Selenium Grid Test Setup
     Log To Console  Starting testbed deployment...
     Run Keyword And Ignore Error  Nimbus Cleanup  ${list}  ${false}
     ${name}=  Evaluate  'vic-5-27-' + str(random.randint(1000,9999))  modules=random
-    ${out}=  Deploy Nimbus Testbed  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}  --noSupportBundles --plugin testng --vcvaBuild ${VC_VERSION} --esxBuild ${ESX_VERSION} --testbedName vic-iscsi-cluster --testbedSpecRubyFile /dbc/pa-dbc1111/mhagen/nimbus-testbeds/testbeds/vic-iscsi-cluster.rb --runName ${name}
+    ${out}=  Deploy Nimbus Testbed  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}  spec=vic-iscsi-cluster.rb  args=--noSupportBundles --plugin testng --vcvaBuild ${VC_VERSION} --esxBuild ${ESX_VERSION} --testbedName vic-iscsi-cluster --runName ${name}
     Log  ${out}
 
     Open Connection  %{NIMBUS_GW}
@@ -71,7 +71,6 @@ Wait Until Selenium Node Is Ready
 *** Test Cases ***    
 Test
     Log To Console  Starting Selenium Grid test...
-    Custom Testbed Keepalive  /dbc/pa-dbc1111/mhagen
 
     Install VIC Appliance To Test Server
 

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-6-1-VSAN-Simple.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-6-1-VSAN-Simple.robot
@@ -68,8 +68,6 @@ Check VSAN DOMs In Datastore
 Simple VSAN
     Wait Until Keyword Succeeds  10x  30s  Check VSAN DOMs In Datastore  %{TEST_DATASTORE}
 
-    Custom Testbed Keepalive  /dbc/pa-dbc1111/mhagen
-
     Install VIC Appliance To Test Server
     Run Regression Tests
     Cleanup VIC Appliance On Test Server

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-6-2-VSAN-Complex.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-6-2-VSAN-Complex.robot
@@ -71,8 +71,6 @@ Check VSAN DOMs In Datastore
 Complex VSAN
     Wait Until Keyword Succeeds  10x  30s  Check VSAN DOMs In Datastore  %{TEST_DATASTORE}
 
-    Custom Testbed Keepalive  /dbc/pa-dbc1111/mhagen
-
     Install VIC Appliance To Test Server
     Run Regression Tests
     Cleanup VIC Appliance On Test Server

--- a/tests/nightly/jenkins-nightly-run.sh
+++ b/tests/nightly/jenkins-nightly-run.sh
@@ -16,84 +16,102 @@
 ESX_60_VERSION="ob-5251623"
 VC_60_VERSION="ob-5112509"
 
+ESX_65_VERSION="ob-7867845"
+VC_65_VERSION="ob-7867539"
+
 ESX_67_VERSION="ob-8169922"
 VC_67_VERSION="ob-8217866"
+
+DEFAULT_LOG_UPLOAD_DEST="vic-ci-logs"
+DEFAULT_VCH_BUILD="*"
+DEFAULT_TESTCASES="tests/manual-test-cases/Group5-Functional-Tests tests/manual-test-cases/Group13-vMotion tests/manual-test-cases/Group21-Registries tests/manual-test-cases/Group23-Future-Tests"
+
 
 export RUN_AS_OPS_USER=0
 
 if [[ $1 != "6.0" && $1 != "6.5" && $1 != "6.7" ]]; then
-    echo "Please specify a target cluster. One of: 6.0, 6.5, 6.7"
+    echo "Please specify a target version. One of: 6.0, 6.5, 6.7"
     exit 1
 fi
+
+# process the CLI arguments
 target="$1"
-echo "Target cluster: "$target
+echo "Target version: ${target}"
+shift
+# Take the remaining CLI arguments as a test case list
+testcases="${*:-$DEFAULT_TESTCASES}"
 
-input=$(gsutil ls -l gs://vic-engine-builds/vic_* | grep -v TOTAL | sort -k2 -r | head -n1 | xargs | cut -d ' ' -f 3 | cut -d '/' -f 4)
-buildNumber=${input:4}
+# TODO: the version downloaded by this logic is not coupled with the tests that will be run against it. This should be altered to pull a version that matches the commit SHA of the tests
+# we will be running or similar mechanism.
+VCH_BUILD=${VCH_BUILD:-${DEFAULT_VCH_BUILD}}
+input=$(gsutil ls -l gs://vic-engine-builds/vic_${VCH_BUILD} | grep -v TOTAL | sort -k2 -r | head -n1 | xargs | cut -d ' ' -f 3 | cut -d '/' -f 4)
+VCH_BUILD=${input:4}
 
-n=0
-   until [ $n -ge 5 ]
-   do
-      echo "Retry.. $n"
-      echo "Downloading gcp file $input"
-      wget https://storage.googleapis.com/vic-engine-builds/$input
-      if [ -f "$input" ]
-      then
-      echo "File found.."
-      break
-      else
-      echo "File NOT found"
-      fi
-      n=$[$n+1]
-      sleep 15
-   done
+# Enforce short SHA
+GIT_COMMIT=${GIT_COMMIT:0:7}
 
-n=0
-   until [ $n -ge 5 ]
-   do
-      mkdir bin
-      echo "Extracting .tar.gz"
-      tar xvzf $input -C bin/ --strip 1
-      if [ -f "bin/vic-machine-linux" ]
-      then
-      echo "tar extraction complete.."
-      canContinue="Yes"
-      break
-      else
-      echo "tar extraction failed"
-      canContinue="No"
-      rm -rf bin
-      fi
-      n=$[$n+1]
-      sleep 15
-   done
+case "$target" in
+    "6.0")
+        excludes="--exclude nsx"
+        ESX_BUILD=${ESX_BUILD:-$ESX_60_VERSION}
+        VC_BUILD=${VC_BUILD:-$VC_60_VERSION}
+        ;;
+    "6.5")
+        ESX_BUILD=${ESX_BUILD:-$ESX_65_VERSION}
+        VC_BUILD=${VC_BUILD:-$VC_65_VERSION}
+        ;;
+    "6.7")
+        excludes="--exclude nsx --exclude hetero"
+        ESX_BUILD=${ESX_BUILD:-$ESX_67_VERSION}
+        VC_BUILD=${VC_BUILD:-$VC_67_VERSION}
+        ;;
+esac
 
-if [[ $canContinue = "No" ]]; then
+LOG_UPLOAD_DEST="${LOG_UPLOAD_DEST:-${DEFAULT_LOG_UPLOAD_DEST}}"
+
+n=0 && rm -f "${input}"
+until [ $n -ge 5 -o -f "${input}" ]; do
+    echo "Retry.. $n"
+    echo "Downloading gcp file ${input}"
+    wget -nv https://storage.googleapis.com/vic-engine-builds/${input}
+
+    ((n++))
+    sleep 15
+done
+
+echo "Extracting .tar.gz"
+mkdir bin && tar xvzf ${input} -C bin/ --strip 1
+
+if [ ! -f  "bin/vic-machine-linux" ]; then
     echo "Tarball extraction failed..quitting the run"
-    break
+    rm -rf bin
+    exit
 else
+    VCH_COMMIT=$(bin/vic-machine-linux version | awk -F '-' '{print $NF}')
     echo "Tarball extraction passed, Running nightlies test.."
 fi
 
-if [[ $target == "6.0" ]]; then
-    echo "Executing nightly tests on vSphere 6.0"
-    pabot --processes 4 --removekeywords TAG:secret --exclude nsx --variable ESX_VERSION:$ESX_60_VERSION --variable VC_VERSION:$VC_60_VERSION -d 60/$i tests/manual-test-cases/Group5-Functional-Tests tests/manual-test-cases/Group13-vMotion tests/manual-test-cases/Group21-Registries tests/manual-test-cases/Group23-Future-Tests
-    cat 60/pabot_results/*/stdout.txt | grep '::' | grep -E 'PASS|FAIL' > console.log
-elif [[ $target == "6.5" ]]; then
-    echo "Executing nightly tests on vSphere 6.5"
-    pabot --processes 4 --removekeywords TAG:secret -d 65/$i tests/manual-test-cases/Group5-Functional-Tests tests/manual-test-cases/Group13-vMotion tests/manual-test-cases/Group21-Registries tests/manual-test-cases/Group23-Future-Tests
-    cat 65/pabot_results/*/stdout.txt | grep '::' | grep -E 'PASS|FAIL' > console.log
-elif [[ $target == "6.7" ]]; then
-    echo "Executing nightly tests on vSphere 6.7"
-    pabot --processes 4 --removekeywords TAG:secret --exclude nsx --exclude hetero --variable ESX_VERSION:$ESX_67_VERSION --variable VC_VERSION:$VC_67_VERSION -d 67/$i tests/manual-test-cases/Group5-Functional-Tests tests/manual-test-cases/Group13-vMotion tests/manual-test-cases/Group21-Registries tests/manual-test-cases/Group23-Future-Tests
-    cat 67/pabot_results/*/stdout.txt | grep '::' | grep -E 'PASS|FAIL' > console.log
+
+pabot --processes 4 --removekeywords TAG:secret ${excludes} --variable ESX_VERSION:${ESX_BUILD} --variable VC_VERSION:${VC_BUILD} -d ${target} "${testcases}"
+cat ${target}/pabot_results/*/stdout.txt | grep '::' | grep -E 'PASS|FAIL' > console.log
+
+# See if any VMs leaked
+# TODO: should be a warning until clean, then changed to a failure if any leak
+echo "There should not be any VMs listed here"
+echo "======================================="
+timeout 60s sshpass -p ${NIMBUS_PASSWORD} ssh -o StrictHostKeyChecking\=no ${NIMBUS_USER}@${NIMBUS_GW} nimbus-ctl list
+echo "======================================="
+echo "If VMs are listed we should investigate why they are leaking"
+
+# archive the logs
+logarchive="logs_vch-${VCH_BUILD}-${VCH_COMMIT}_test-${BUILD_ID}-${GIT_COMMIT}_${BUILD_TIMESTAMP}.zip"
+/usr/bin/zip -9 -r "${logarchive}" "${target}" *.zip *.log *.debug *.tgz
+if [ $? -eq 0 ]; then
+    tests/nightly/upload-logs.sh ${logarchive} ${LOG_UPLOAD_DEST}
 fi
+
 # Pretty up the email results
 sed -i -e 's/^/<br>/g' console.log
 sed -i -e 's|PASS|<font color="green">PASS</font>|g' console.log
 sed -i -e 's|FAIL|<font color="red">FAIL</font>|g' console.log
 
-# See if any VMs leaked
-timeout 60s sshpass -p $NIMBUS_PASSWORD ssh -o StrictHostKeyChecking\=no $NIMBUS_USER@$NIMBUS_GW nimbus-ctl list
-
-tests/nightly/upload-logs.sh $target_$BUILD_TIMESTAMP


### PR DESCRIPTION
Update the nightly logic to remove all dependence on specific user directories and content.
Update the Jenkins entry point scripts to allow for parameterization and customization of the run.

Of note is the almost complete duplication between the jenkins and upload scripts for drs_disabled and the nightlies. Reaching out to @anchal-agrawal this is because the nightlies were not yet migrated to use a container for running the test executor.

I'm not sure where we will actually go for this given a desire to have the executors be VCH containers themselves. We could have a single image for the job class, an image for the specific jobs, or a general executor image and very task specific images for the job steps. Planning required.
