### PR TITLE
Include resource pool in VCH list API response

### DIFF
--- a/lib/apiservers/service/restapi/handlers/encode/references.go
+++ b/lib/apiservers/service/restapi/handlers/encode/references.go
@@ -16,6 +16,8 @@ package encode
 
 import (
 	"github.com/vmware/govmomi/vim25/types"
+
+	"github.com/vmware/vic/lib/apiservers/service/models"
 )
 
 func AsManagedObjectID(mobid string) string {
@@ -26,4 +28,17 @@ func AsManagedObjectID(mobid string) string {
 	}
 
 	return moref.Value
+}
+
+// common provides an interface for the relevant parts of object.Common
+type common interface {
+	Reference() types.ManagedObjectReference
+	Name() string
+}
+
+func AsManagedObject(object common) models.ManagedObject {
+	return models.ManagedObject{
+		Name: object.Name(),
+		ID:   object.Reference().Value,
+	}
 }

--- a/lib/apiservers/service/restapi/handlers/vch_list_get.go
+++ b/lib/apiservers/service/restapi/handlers/vch_list_get.go
@@ -149,6 +149,8 @@ func (h *vchListGet) vchsToModels(op trace.Operation, c *client.HandlerClient, v
 func (h *vchListGet) parent(op trace.Operation, vch *vm.VirtualMachine) *models.ManagedObject {
 	id := vch.Reference().Value
 
+	// Once we know we will never encounter vApp-based VCHs, we can probably
+	// replace much of the following with a call to `vch.ResourcePool(op)`.
 	var mvm mo.VirtualMachine
 	if err := vch.Properties(op, vch.Reference(), []string{"parentVApp", "resourcePool"}, &mvm); err != nil {
 		op.Debugf("Failed to get parent of VCH %s: %s", id, err)

--- a/lib/apiservers/service/swagger.json
+++ b/lib/apiservers/service/swagger.json
@@ -864,6 +864,9 @@
         "name": {
           "type": "string"
         },
+        "parent": {
+          "$ref": "#/definitions/Managed_Object"
+        },
         "version": {
           "type": "string"
         },

--- a/tests/test-cases/Group23-VIC-Machine-Service/23-02-VCH-List.robot
+++ b/tests/test-cases/Group23-VIC-Machine-Service/23-02-VCH-List.robot
@@ -46,6 +46,7 @@ Verify VCH List
     Property Should Not Be Empty    .vchs[] | select(.name=="%{VCH-NAME}").docker_host
     Property Should Not Be Empty    .vchs[] | select(.name=="%{VCH-NAME}").upgrade_status
     Property Should Not Be Empty    .vchs[] | select(.name=="%{VCH-NAME}").version
+    Property Should Not Be Empty    .vchs[] | select(.name=="%{VCH-NAME}").parent
 
 Get VCH List Using Session
     Get Path Under Target Using Session    vch


### PR DESCRIPTION
To allow the UI to easily omit resource pools belonging to VCHs from
selection when displaying the tree of compute resource, include the
resource pool corresponding to each VCH.

`[specific ci=Group23-VIC-Machine-Service]`