### PR TITLE
Generalize downstream-trigger to allow re-use

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -306,9 +306,10 @@ pipeline:
       status: success
 
   trigger-downstream:
-    image: 'gcr.io/eminent-nation-87317/vic-downstream-trigger:1.0'
+    image: 'gcr.io/eminent-nation-87317/vic-downstream-trigger:1.1'
     environment:
       SHELL: /bin/bash
+      DOWNSTREAM_REPO: vmware/vic-product
     secrets:
       - drone_server
       - drone_token

--- a/infra/integration-image/Dockerfile.downstream
+++ b/infra/integration-image/Dockerfile.downstream
@@ -4,8 +4,8 @@
 # gcloud auth login
 # gcloud docker -- push gcr.io/eminent-nation-87317/vic-downstream-trigger:1.x
 # open vpn to CI cluster then run:
-# docker tag vic-downstream 192.168.31.15/library/vic-downstream-trigger:1.x
-# docker push 192.168.31.15/library/vic-downstream-trigger:1.x
+# docker tag vic-downstream wdc-harbor-ci.eng.vmware.com/default-project/vic-downstream-trigger:1.x
+# docker push wdc-harbor-ci.eng.vmware.com/default-project/vic-downstream-trigger:1.x
 FROM ubuntu
 
 RUN apt-get update && apt-get install -y --no-install-recommends curl ca-certificates
@@ -14,8 +14,8 @@ RUN curl http://downloads.drone.io/release/linux/amd64/drone.tar.gz | tar zx && 
     install -t /usr/bin drone
 
 RUN echo '#!/bin/bash' >> /usr/bin/trigger
-RUN echo 'num=$(drone build list --format "{{.Number}} {{.Status}}" vmware/vic-product | grep -v running | head -n1 | cut -d" " -f1)' >> /usr/bin/trigger
-RUN echo 'for i in {1..5}; do drone build start --fork vmware/vic-product $num && break || sleep 15; done' >> /usr/bin/trigger
+RUN echo 'num=$(drone build list --format "{{.Number}} {{.Status}}" "$DOWNSTREAM_REPO" | grep -v running | head -n1 | cut -d" " -f1)' >> /usr/bin/trigger
+RUN echo 'for i in {1..5}; do drone build start --fork "$DOWNSTREAM_REPO" $num && break || sleep 15; done' >> /usr/bin/trigger
 RUN chmod +x /usr/bin/trigger
 
 ENTRYPOINT ["trigger"]


### PR DESCRIPTION
Generalize the downstream-trigger logic to allow it to be re-used by the vic-ui repository to trigger builds in the vic repository.

Update the vic repo to use the generalized trigger.

See also: vmware/vic-ui#521