### PR TITLE
Add OpID cross support for scopes/networking and storage

### DIFF
--- a/lib/apiservers/engine/backends/network.go
+++ b/lib/apiservers/engine/backends/network.go
@@ -58,8 +58,9 @@ func (n *NetworkBackend) NetworkControllerEnabled() bool {
 func (n *NetworkBackend) FindNetwork(idName string) (libnetwork.Network, error) {
 	op := trace.NewOperation(context.Background(), "FindNetwork: %s", idName)
 	defer trace.End(trace.Audit(idName, op))
+	opID := op.ID()
 
-	ok, err := PortLayerClient().Scopes.List(scopes.NewListParamsWithContext(op).WithIDName(idName))
+	ok, err := PortLayerClient().Scopes.List(scopes.NewListParamsWithContext(op).WithOpID(&opID).WithIDName(idName))
 	if err != nil {
 		switch err := err.(type) {
 		case *scopes.ListNotFound:
@@ -79,8 +80,9 @@ func (n *NetworkBackend) FindNetwork(idName string) (libnetwork.Network, error) 
 func (n *NetworkBackend) GetNetworkByName(idName string) (libnetwork.Network, error) {
 	op := trace.NewOperation(context.Background(), "GetNetworkByName: %s", idName)
 	defer trace.End(trace.Audit(idName, op))
+	opID := op.ID()
 
-	ok, err := PortLayerClient().Scopes.List(scopes.NewListParamsWithContext(op).WithIDName(idName))
+	ok, err := PortLayerClient().Scopes.List(scopes.NewListParamsWithContext(op).WithOpID(&opID).WithIDName(idName))
 	if err != nil {
 		switch err := err.(type) {
 		case *scopes.ListNotFound:
@@ -100,8 +102,9 @@ func (n *NetworkBackend) GetNetworkByName(idName string) (libnetwork.Network, er
 func (n *NetworkBackend) GetNetworksByID(partialID string) []libnetwork.Network {
 	op := trace.NewOperation(context.Background(), "GetNetworksByID: %s", partialID)
 	defer trace.End(trace.Audit(partialID, op))
+	opID := op.ID()
 
-	ok, err := PortLayerClient().Scopes.List(scopes.NewListParamsWithContext(op).WithIDName(partialID))
+	ok, err := PortLayerClient().Scopes.List(scopes.NewListParamsWithContext(op).WithOpID(&opID).WithIDName(partialID))
 	if err != nil {
 		return nil
 	}
@@ -117,8 +120,9 @@ func (n *NetworkBackend) GetNetworksByID(partialID string) []libnetwork.Network 
 func (n *NetworkBackend) GetNetworks() []libnetwork.Network {
 	op := trace.NewOperation(context.Background(), "GetNetworks")
 	defer trace.End(trace.Audit("", op))
+	opID := op.ID()
 
-	ok, err := PortLayerClient().Scopes.ListAll(scopes.NewListAllParamsWithContext(op))
+	ok, err := PortLayerClient().Scopes.ListAll(scopes.NewListAllParamsWithContext(op).WithOpID(&opID))
 	if err != nil {
 		return nil
 	}
@@ -135,6 +139,7 @@ func (n *NetworkBackend) GetNetworks() []libnetwork.Network {
 func (n *NetworkBackend) CreateNetwork(nc types.NetworkCreateRequest) (*types.NetworkCreateResponse, error) {
 	op := trace.NewOperation(context.Background(), "CreateNetwork: %s", nc.Name)
 	defer trace.End(trace.Audit(nc.Name, op))
+	opID := op.ID()
 
 	if nc.IPAM != nil && len(nc.IPAM.Config) > 1 {
 		return nil, fmt.Errorf("at most one ipam config supported")
@@ -179,7 +184,7 @@ func (n *NetworkBackend) CreateNetwork(nc types.NetworkCreateRequest) (*types.Ne
 		return nil, derr.NewErrorWithStatusCode(fmt.Errorf("unable to marshal labels: %s", err), http.StatusInternalServerError)
 	}
 
-	created, err := PortLayerClient().Scopes.CreateScope(scopes.NewCreateScopeParamsWithContext(op).WithConfig(cfg))
+	created, err := PortLayerClient().Scopes.CreateScope(scopes.NewCreateScopeParamsWithContext(op).WithOpID(&opID).WithConfig(cfg))
 	if err != nil {
 		switch err := err.(type) {
 		case *scopes.CreateScopeConflict:
@@ -210,8 +215,9 @@ func isCommitConflictError(err error) bool {
 
 // connectContainerToNetwork performs portlayer operations to connect a container to a container vicnetwork.
 func connectContainerToNetwork(op trace.Operation, containerName, networkName string, endpointConfig *apinet.EndpointSettings) error {
+	opID := op.ID()
 	client := PortLayerClient()
-	getRes, err := client.Containers.Get(containers.NewGetParamsWithContext(op).WithID(containerName))
+	getRes, err := client.Containers.Get(containers.NewGetParamsWithContext(op).WithOpID(&opID).WithID(containerName))
 	if err != nil {
 		switch err := err.(type) {
 		case *containers.GetNotFound:
@@ -238,6 +244,7 @@ func connectContainerToNetwork(op trace.Operation, containerName, networkName st
 	}
 
 	addConRes, err := client.Scopes.AddContainer(scopes.NewAddContainerParamsWithContext(op).
+		WithOpID(&opID).
 		WithScope(nc.NetworkName).
 		WithConfig(&models.ScopesAddContainerConfig{
 			Handle:        h,
@@ -259,7 +266,7 @@ func connectContainerToNetwork(op trace.Operation, containerName, networkName st
 	h = addConRes.Payload
 
 	// Get the power state of the container.
-	getStateRes, err := client.Containers.GetState(containers.NewGetStateParamsWithContext(op).WithHandle(h))
+	getStateRes, err := client.Containers.GetState(containers.NewGetStateParamsWithContext(op).WithOpID(&opID).WithHandle(h))
 	if err != nil {
 		switch err := err.(type) {
 		case *containers.GetStateNotFound:
@@ -276,7 +283,7 @@ func connectContainerToNetwork(op trace.Operation, containerName, networkName st
 	h = getStateRes.Payload.Handle
 	// Only bind if the container is running.
 	if getStateRes.Payload.State == "RUNNING" {
-		bindRes, err := client.Scopes.BindContainer(scopes.NewBindContainerParamsWithContext(op).WithHandle(h))
+		bindRes, err := client.Scopes.BindContainer(scopes.NewBindContainerParamsWithContext(op).WithOpID(&opID).WithHandle(h))
 		if err != nil {
 			switch err := err.(type) {
 			case *scopes.BindContainerNotFound:
@@ -294,7 +301,9 @@ func connectContainerToNetwork(op trace.Operation, containerName, networkName st
 			if err == nil {
 				return
 			}
-			if _, err2 := client.Scopes.UnbindContainer(scopes.NewUnbindContainerParamsWithContext(op).WithHandle(h)); err2 != nil {
+			if _, err2 := client.Scopes.UnbindContainer(scopes.NewUnbindContainerParamsWithContext(op).
+				WithOpID(&opID).
+				WithHandle(h)); err2 != nil {
 				log.Warnf("failed bind container rollback: %s", err2)
 			}
 		}()
@@ -303,7 +312,7 @@ func connectContainerToNetwork(op trace.Operation, containerName, networkName st
 	}
 
 	// Commit the handle.
-	_, err = client.Containers.Commit(containers.NewCommitParamsWithContext(op).WithHandle(h))
+	_, err = client.Containers.Commit(containers.NewCommitParamsWithContext(op).WithOpID(&opID).WithHandle(h))
 	return err
 }
 
@@ -355,10 +364,13 @@ func (n *NetworkBackend) DisconnectContainerFromNetwork(containerName, networkNa
 func (n *NetworkBackend) DeleteNetwork(name string) error {
 	op := trace.NewOperation(context.Background(), "DeleteNetwork: %s", name)
 	defer trace.End(trace.Audit(name, op))
+	opID := op.ID()
 
 	client := PortLayerClient()
 
-	if _, err := client.Scopes.DeleteScope(scopes.NewDeleteScopeParamsWithContext(op).WithIDName(name)); err != nil {
+	if _, err := client.Scopes.DeleteScope(scopes.NewDeleteScopeParamsWithContext(op).
+		WithOpID(&opID).
+		WithIDName(name)); err != nil {
 		switch err := err.(type) {
 		case *scopes.DeleteScopeNotFound:
 			return derr.NewRequestNotFoundError(fmt.Errorf("network %s not found", name))

--- a/lib/apiservers/engine/backends/volume.go
+++ b/lib/apiservers/engine/backends/volume.go
@@ -72,7 +72,7 @@ func (v *VolumeBackend) Volumes(filter string) ([]*types.Volume, []string, error
 	var volumes []*types.Volume
 
 	// Get volume list from the portlayer
-	volumeResponses, err := v.storageProxy.VolumeList(context.Background(), filter)
+	volumeResponses, err := v.storageProxy.VolumeList(op, filter)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -130,7 +130,7 @@ func (v *VolumeBackend) VolumeInspect(name string) (*types.Volume, error) {
 	op := trace.NewOperation(context.Background(), "VolumeInspect: %s", name)
 	defer trace.End(trace.Audit(name, op))
 
-	volInfo, err := v.storageProxy.VolumeInfo(context.Background(), name)
+	volInfo, err := v.storageProxy.VolumeInfo(op, name)
 	if err != nil {
 		return nil, err
 	}
@@ -149,7 +149,7 @@ func (v *VolumeBackend) VolumeCreate(name, driverName string, volumeData, labels
 	op := trace.NewOperation(context.Background(), "VolumeCreate: %s", name)
 	defer trace.End(trace.Audit(name, op))
 
-	result, err := v.storageProxy.Create(context.Background(), name, driverName, volumeData, labels)
+	result, err := v.storageProxy.Create(op, name, driverName, volumeData, labels)
 	if err != nil {
 		return nil, err
 	}
@@ -162,7 +162,7 @@ func (v *VolumeBackend) VolumeRm(name string, force bool) error {
 	op := trace.NewOperation(context.Background(), "VolumeRm: %s", name)
 	defer trace.End(trace.Audit(name, op))
 
-	err := v.storageProxy.Remove(context.Background(), name)
+	err := v.storageProxy.Remove(op, name)
 	if err != nil {
 		return err
 	}

--- a/lib/apiservers/portlayer/restapi/handlers/scopes_handlers.go
+++ b/lib/apiservers/portlayer/restapi/handlers/scopes_handlers.go
@@ -109,7 +109,8 @@ func errorPayload(err error) *models.Error {
 }
 
 func (handler *ScopesHandlersImpl) ScopesCreate(params scopes.CreateScopeParams) middleware.Responder {
-	defer trace.End(trace.Begin(""))
+	op := trace.NewOperationFromID(context.Background(), params.OpID, "ScopesCreate(%s)", params.Config.ID)
+	defer trace.End(trace.Begin("ScopesCreate", op))
 
 	cfg := params.Config
 	if cfg.ScopeType == "external" {
@@ -148,7 +149,8 @@ func (handler *ScopesHandlersImpl) ScopesCreate(params scopes.CreateScopeParams)
 }
 
 func (handler *ScopesHandlersImpl) ScopesDelete(params scopes.DeleteScopeParams) middleware.Responder {
-	defer trace.End(trace.Begin(params.IDName))
+	op := trace.NewOperationFromID(context.Background(), params.OpID, "ScopesDelete(%s)", params.IDName)
+	defer trace.End(trace.Begin("ScopesDelete", op))
 
 	if err := handler.netCtx.DeleteScope(context.Background(), params.IDName); err != nil {
 		switch err := err.(type) {
@@ -164,7 +166,8 @@ func (handler *ScopesHandlersImpl) ScopesDelete(params scopes.DeleteScopeParams)
 }
 
 func (handler *ScopesHandlersImpl) ScopesListAll(params scopes.ListAllParams) middleware.Responder {
-	defer trace.End(trace.Begin(""))
+	op := trace.NewOperationFromID(context.Background(), params.OpID, "ScopesListAll")
+	defer trace.End(trace.Begin("ScopesListAll", op))
 
 	cfgs, err := handler.listScopes("")
 	if err != nil {
@@ -175,7 +178,8 @@ func (handler *ScopesHandlersImpl) ScopesListAll(params scopes.ListAllParams) mi
 }
 
 func (handler *ScopesHandlersImpl) ScopesList(params scopes.ListParams) middleware.Responder {
-	defer trace.End(trace.Begin("ScopesList"))
+	op := trace.NewOperationFromID(context.Background(), params.OpID, "ScopesList(%s)", params.IDName)
+	defer trace.End(trace.Begin("ScopesList", op))
 
 	cfgs, err := handler.listScopes(params.IDName)
 	if _, ok := err.(network.ResourceNotFoundError); ok {
@@ -186,7 +190,8 @@ func (handler *ScopesHandlersImpl) ScopesList(params scopes.ListParams) middlewa
 }
 
 func (handler *ScopesHandlersImpl) ScopesGetContainerEndpoints(params scopes.GetContainerEndpointsParams) middleware.Responder {
-	defer trace.End(trace.Begin(params.HandleOrID))
+	op := trace.NewOperationFromID(context.Background(), params.OpID, "ScopesGetContainerEndpoints(%s)", params.HandleOrID)
+	defer trace.End(trace.Begin("ScopesGetContainerEndpoints", op))
 
 	cid := params.HandleOrID
 	// lookup by handle
@@ -209,7 +214,8 @@ func (handler *ScopesHandlersImpl) ScopesGetContainerEndpoints(params scopes.Get
 }
 
 func (handler *ScopesHandlersImpl) ScopesAddContainer(params scopes.AddContainerParams) middleware.Responder {
-	defer trace.End(trace.Begin(fmt.Sprintf("handle(%s)", params.Config.Handle)))
+	op := trace.NewOperationFromID(context.Background(), params.OpID, "ScopesAddContainer(%s)", params.Config.Handle)
+	defer trace.End(trace.Begin("ScopesAddContainer", op))
 
 	h := exec.GetHandle(params.Config.Handle)
 	if h == nil {
@@ -251,7 +257,8 @@ func (handler *ScopesHandlersImpl) ScopesAddContainer(params scopes.AddContainer
 }
 
 func (handler *ScopesHandlersImpl) ScopesRemoveContainer(params scopes.RemoveContainerParams) middleware.Responder {
-	defer trace.End(trace.Begin(fmt.Sprintf("handle(%s)", params.Handle)))
+	op := trace.NewOperationFromID(context.Background(), params.OpID, "ScopesRemoveContainer(%s)", params.Handle)
+	defer trace.End(trace.Begin("ScopesRemoveContainer", op))
 
 	h := exec.GetHandle(params.Handle)
 	if h == nil {
@@ -270,8 +277,8 @@ func (handler *ScopesHandlersImpl) ScopesRemoveContainer(params scopes.RemoveCon
 }
 
 func (handler *ScopesHandlersImpl) ScopesBindContainer(params scopes.BindContainerParams) middleware.Responder {
-	op := trace.NewOperation(context.Background(), params.Handle)
-	defer trace.End(trace.Begin(fmt.Sprintf("handle(%s)", params.Handle), op))
+	op := trace.NewOperationFromID(context.Background(), params.OpID, "ScopesBindContainer(%s)", params.Handle)
+	defer trace.End(trace.Begin("ScopesBindContainer", op))
 
 	h := exec.GetHandle(params.Handle)
 	if h == nil {
@@ -302,8 +309,8 @@ func (handler *ScopesHandlersImpl) ScopesBindContainer(params scopes.BindContain
 }
 
 func (handler *ScopesHandlersImpl) ScopesUnbindContainer(params scopes.UnbindContainerParams) middleware.Responder {
-	op := trace.NewOperation(context.Background(), params.Handle)
-	defer trace.End(trace.Begin(fmt.Sprintf("handle(%s)", params.Handle), op))
+	op := trace.NewOperationFromID(context.Background(), params.OpID, "ScopesUnbindContainer(%s)", params.Handle)
+	defer trace.End(trace.Begin("ScopesUnbindContainer", op))
 
 	h := exec.GetHandle(params.Handle)
 	if h == nil {


### PR DESCRIPTION
This PR contains changes in the docker-engine and the port-layer to generate and pass through the correct Operation ID for the storage and network(scopes) subsystems.

Towards: #7993