### PR TITLE
Update drone CLI used by downstream trigger

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -306,7 +306,7 @@ pipeline:
       status: success
 
   trigger-downstream:
-    image: 'gcr.io/eminent-nation-87317/vic-downstream-trigger:1.1'
+    image: 'gcr.io/eminent-nation-87317/vic-downstream-trigger:1.2'
     environment:
       SHELL: /bin/bash
       DOWNSTREAM_REPO: vmware/vic-product

--- a/infra/integration-image/Dockerfile.downstream
+++ b/infra/integration-image/Dockerfile.downstream
@@ -6,16 +6,21 @@
 # open vpn to CI cluster then run:
 # docker tag vic-downstream wdc-harbor-ci.eng.vmware.com/default-project/vic-downstream-trigger:1.x
 # docker push wdc-harbor-ci.eng.vmware.com/default-project/vic-downstream-trigger:1.x
-FROM ubuntu
+FROM vmware/photon:2.0
 
-RUN apt-get update && apt-get install -y --no-install-recommends curl ca-certificates
+RUN set -eux; \
+     tdnf distro-sync --refresh -y; \
+     tdnf install gzip -y; \
+     tdnf install tar -y; \
+     tdnf info installed; \
+     tdnf clean all
 
-RUN curl http://downloads.drone.io/release/linux/amd64/drone.tar.gz | tar zx && \
-    install -t /usr/bin drone
+RUN curl -L https://github.com/drone/drone-cli/releases/download/v0.8.5/drone_linux_amd64.tar.gz | tar zx && \
+    install drone /usr/bin
 
 RUN echo '#!/bin/bash' >> /usr/bin/trigger
-RUN echo 'num=$(drone build list --format "{{.Number}} {{.Status}}" "$DOWNSTREAM_REPO" | grep -v running | head -n1 | cut -d" " -f1)' >> /usr/bin/trigger
-RUN echo 'for i in {1..5}; do drone build start --fork "$DOWNSTREAM_REPO" $num && break || sleep 15; done' >> /usr/bin/trigger
+RUN echo 'num=$(drone build ls --format "{{.Number}} {{.Status}}" "$DOWNSTREAM_REPO" | grep -v running | head -n1 | cut -d" " -f1)' >> /usr/bin/trigger
+RUN echo 'for i in {1..5}; do drone build start "$DOWNSTREAM_REPO" $num && break || sleep 15; done' >> /usr/bin/trigger
 RUN chmod +x /usr/bin/trigger
 
 ENTRYPOINT ["trigger"]


### PR DESCRIPTION
To better ensure compatibility with our infrastructure, update the
drone CLI version used by the downstream trigger from v0.5 to v0.8.5.

Additionally, switch to Photon as a base image to reduce image size
and be more consistent with the product.

