### PR TITLE
Update downstream trigger to be more selective

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -306,16 +306,32 @@ pipeline:
       status: success
 
   trigger-downstream:
-    image: 'gcr.io/eminent-nation-87317/vic-downstream-trigger:1.2'
+    image: 'gcr.io/eminent-nation-87317/vic-downstream-trigger:1.3'
     environment:
       SHELL: /bin/bash
       DOWNSTREAM_REPO: vmware/vic-product
+      DOWNSTREAM_BRANCH: ${DRONE_BRANCH}
     secrets:
       - drone_server
       - drone_token
     when:
       repo: vmware/vic
-      event: [push, tag]
+      event: [push]
+      branch: [master]
+      status: success
+
+  trigger-downstream-tag:
+    image: 'gcr.io/eminent-nation-87317/vic-downstream-trigger:1.3'
+    environment:
+      SHELL: /bin/bash
+      DOWNSTREAM_REPO: vmware/vic-product
+      DOWNSTREAM_BRANCH: ${DRONE_BRANCH}
+    secrets:
+      - drone_server
+      - drone_token
+    when:
+      repo: vmware/vic
+      event: [tag]
       branch: [master, 'releases/*']
       status: success
 

--- a/infra/integration-image/Dockerfile.downstream
+++ b/infra/integration-image/Dockerfile.downstream
@@ -19,7 +19,7 @@ RUN curl -L https://github.com/drone/drone-cli/releases/download/v0.8.5/drone_li
     install drone /usr/bin
 
 RUN echo '#!/bin/bash' >> /usr/bin/trigger
-RUN echo 'num=$(drone build ls --format "{{.Number}} {{.Status}}" "$DOWNSTREAM_REPO" | grep -v running | head -n1 | cut -d" " -f1)' >> /usr/bin/trigger
+RUN echo 'num=$(drone build ls --format "{{.Number}} {{.Status}}" --event push --branch "$DOWNSTREAM_BRANCH" "$DOWNSTREAM_REPO" | grep -v running | head -n1 | cut -d" " -f1)' >> /usr/bin/trigger
 RUN echo 'for i in {1..5}; do drone build start "$DOWNSTREAM_REPO" $num && break || sleep 15; done' >> /usr/bin/trigger
 RUN chmod +x /usr/bin/trigger
 


### PR DESCRIPTION
The purpose of triggering a downstream job is to build and test the downstream component with an updated build of the upstream component.

Rebuilding a pending PR does not accomplish this goal, so we filter the history to include only push events.

Rebuilding a branch which does not consume the updated upstream branch does not accomplish this goal, and we do not want to assume matching branch names between repositories, so we require the  upstream build to supply the name of the branch to be rebuilt in the downstream repo.

Towards: #6554 

---

The master branch of vic-product consumes the latest build from the master branch of vic. Therefore it makes sense to trigger a build of master for each push to master.

The release branches of vic-product only consume tag builds of vic. Therefore it makes sense to only trigger new builds of vic-product's release branches when performing a tag build of vic.
