### PR TITLE
Clarified container state in persona to reduce errors in the future

### DIFF
--- a/lib/apiservers/engine/backends/container.go
+++ b/lib/apiservers/engine/backends/container.go
@@ -897,7 +897,7 @@ func (c *ContainerBackend) ContainerRm(name string, config *types.ContainerRmCon
 		case proxy.ContainerError:
 			// force stop if container state is error to make sure container is deletable later
 			c.containerProxy.Stop(op, vc, name, &secs, true)
-		case "Starting":
+		case proxy.ContainerStarting:
 			// if we are starting let the user know they must use the force
 			return derr.NewRequestConflictError(fmt.Errorf("The container is starting.  To remove use -f"))
 		case proxy.ContainerRunning:

--- a/lib/apiservers/engine/backends/convert/state.go
+++ b/lib/apiservers/engine/backends/convert/state.go
@@ -26,7 +26,10 @@ import (
 )
 
 // State will create and return a docker ContainerState object
-// from the passed vic ContainerInfo object
+// from the passed vic ContainerInfo object.  This state is mostly
+// used for docker ps and may not be the same value as the state
+// from docker inspect.  The value for ps may require capitalization
+// or additional text.
 func State(info *models.ContainerInfo) *types.ContainerState {
 	// ensure we have the data we need
 	if info == nil || info.ProcessConfig == nil || info.ContainerConfig == nil {

--- a/lib/apiservers/engine/backends/filter/container.go
+++ b/lib/apiservers/engine/backends/filter/container.go
@@ -17,6 +17,7 @@ package filter
 import (
 	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/docker/docker/api/types"
 
@@ -213,14 +214,8 @@ func DockerState(containerState string) string {
 	switch containerState {
 	case "Stopped":
 		state = "exited"
-	case "Running":
-		state = "running"
-	case "Created":
-		state = "created"
 	default:
-		// not sure what to do, so just return
-		// what was given
-		state = containerState
+		state = strings.ToLower(containerState)
 	}
 	return state
 }

--- a/lib/apiservers/engine/proxy/container_proxy.go
+++ b/lib/apiservers/engine/proxy/container_proxy.go
@@ -116,11 +116,14 @@ const (
 	forceLogType = "json-file" //Use in inspect to allow docker logs to work
 	ShortIDLen   = 12
 
-	ContainerRunning = "running"
-	ContainerError   = "error"
-	ContainerStopped = "stopped"
-	ContainerExited  = "exited"
-	ContainerCreated = "created"
+	// Values from the final container inspect state.  This may not be the same as the values coming from the portlayer.
+	// Any calls to VicContainerProxy.State() should check state against these consts.
+	ContainerStarting = "starting"
+	ContainerRunning  = "running"
+	ContainerError    = "error"
+	ContainerStopped  = "stopped"
+	ContainerExited   = "exited"
+	ContainerCreated  = "created"
 )
 
 // NewContainerProxy will create a new proxy


### PR DESCRIPTION
There is a subtle bit of tech debt in the code, a very old bit of
debt.  It can lead to some problems in the future.  This changes
some code and added some comments to try and reduce this possibility.
The problem is around the state of containers.  On return from the
portlayer, it maybe capitalized.  Also, in some cases Docker expects
capitalized state (ps) and other times (inspect), it doesn't.  This
code wasn't clear on this.