### PR TITLE
Correct suite retry units, delete pxe artifacts

### DIFF
--- a/tests/concurrent/concurrent.go
+++ b/tests/concurrent/concurrent.go
@@ -33,7 +33,6 @@ import (
 	"github.com/vmware/govmomi/vim25/types"
 	"github.com/vmware/vic/lib/guest"
 	"github.com/vmware/vic/lib/spec"
-	"github.com/vmware/vic/pkg/trace"
 	"github.com/vmware/vic/pkg/version"
 	"github.com/vmware/vic/pkg/vsphere/datastore"
 	"github.com/vmware/vic/pkg/vsphere/session"
@@ -299,8 +298,10 @@ func main() {
 
 	if config.Start {
 		startFunc := func(i int) error {
-			op := trace.FromContext(ctx, "power on")
-			return vms[i].PowerOn(op)
+			_, err := tasks.WaitForResult(ctx, func(ctx context.Context) (tasks.Task, error) {
+				return vms[i].PowerOn(ctx)
+			})
+			return err
 		}
 		wrap(startFunc, start)
 

--- a/tests/concurrent/concurrent.go
+++ b/tests/concurrent/concurrent.go
@@ -33,6 +33,7 @@ import (
 	"github.com/vmware/govmomi/vim25/types"
 	"github.com/vmware/vic/lib/guest"
 	"github.com/vmware/vic/lib/spec"
+	"github.com/vmware/vic/pkg/trace"
 	"github.com/vmware/vic/pkg/version"
 	"github.com/vmware/vic/pkg/vsphere/datastore"
 	"github.com/vmware/vic/pkg/vsphere/session"
@@ -298,10 +299,8 @@ func main() {
 
 	if config.Start {
 		startFunc := func(i int) error {
-			_, err := tasks.WaitForResult(ctx, func(ctx context.Context) (tasks.Task, error) {
-				return vms[i].PowerOn(ctx)
-			})
-			return err
+			op := trace.FromContext(ctx, "power on")
+			return vms[i].PowerOn(op)
 		}
 		wrap(startFunc, start)
 

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-1-Distributed-Switch.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-1-Distributed-Switch.robot
@@ -62,7 +62,7 @@ Distributed Switch Setup
     :FOR  ${IDX}  IN RANGE  ${esx_number}
     \   ${out}=  Run  govc host.add -hostname=@{esx_ips}[${IDX}] -username=root -dc=${datacenter} -password=${NIMBUS_ESX_PASSWORD} -noverify=true
     \   Should Contain  ${out}  OK
-    \   Wait Until Keyword Succeeds  5x  15 seconds  Add Host To Distributed Switch  @{esx_ips}[${IDX}]
+    \   Add Host To Distributed Switch  @{esx_ips}[${IDX}]
 
     Log To Console  Deploy VIC to the VC cluster
     Set Environment Variable  TEST_URL_ARRAY  ${vc_ip}

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-2-Cluster.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-2-Cluster.robot
@@ -69,9 +69,9 @@ Cluster Setup
 
     Create Three Distributed Port Groups  ha-datacenter
 
-    Wait Until Keyword Succeeds  5x  1 minute  Add Host To Distributed Switch  /ha-datacenter/host/cls/@{esx_ips}[0]
-    Wait Until Keyword Succeeds  5x  1 minute  Add Host To Distributed Switch  /ha-datacenter/host/cls/@{esx_ips}[1]
-    Wait Until Keyword Succeeds  5x  1 minute  Add Host To Distributed Switch  /ha-datacenter/host/cls/@{esx_ips}[2]
+    Add Host To Distributed Switch  /ha-datacenter/host/cls/@{esx_ips}[0]
+    Add Host To Distributed Switch  /ha-datacenter/host/cls/@{esx_ips}[1]
+    Add Host To Distributed Switch  /ha-datacenter/host/cls/@{esx_ips}[2]
 
     Log To Console  Enable DRS on the cluster
     ${out}=  Run  govc cluster.change -drs-enabled /ha-datacenter/host/cls

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-4-High-Availability.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-4-High-Availability.robot
@@ -136,7 +136,7 @@ High Availability Setup
     \   Should Contain  ${out}  OK
 
     Log To Console  Add all the hosts to the distributed switch
-    Wait Until Keyword Succeeds  5x  5min  Add Host To Distributed Switch  /${datacenter}/host/cls
+    Add Host To Distributed Switch  /${datacenter}/host/cls
 
     Log To Console  Enable HA and DRS on the cluster
     ${out}=  Run  govc cluster.change -drs-enabled -ha-enabled /${datacenter}/host/cls

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-8-DRS.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-8-DRS.robot
@@ -63,7 +63,7 @@ DRS Setup
     Should Contain  ${out}  OK
 
     Log To Console  Add all the hosts to the distributed switch
-    Wait Until Keyword Succeeds  5x  5min  Add Host To Distributed Switch  /ha-datacenter/host/cls
+    Add Host To Distributed Switch  /ha-datacenter/host/cls
 
     Log To Console  Deploy VIC to the VC cluster
     Set Environment Variable  TEST_URL_ARRAY  ${vc-ip}

--- a/tests/nightly/jenkins-nightly-run.sh
+++ b/tests/nightly/jenkins-nightly-run.sh
@@ -26,9 +26,16 @@ DEFAULT_LOG_UPLOAD_DEST="vic-ci-logs"
 DEFAULT_VCH_BUILD="*"
 DEFAULT_TESTCASES=("tests/manual-test-cases/Group5-Functional-Tests" "tests/manual-test-cases/Group13-vMotion" "tests/manual-test-cases/Group21-Registries" "tests/manual-test-cases/Group23-Future-Tests")
 
+DEFAULT_PARALLEL_JOBS=4
+DEFAULT_RUN_AS_OPS_USER=0
+
 VIC_BINARY_PREFIX="vic_"
 
-export RUN_AS_OPS_USER=0
+# This is exported to propagate into the pybot processes launched by pabot
+export RUN_AS_OPS_USER=${RUN_AS_OPS_USER:-${DEFAULT_RUN_AS_OPS_USER}}
+
+PARALLEL_JOBS=${PARLLEL_JOBS:-${DEFAULT_PARALLEL_JOBS}}
+
 
 if [[ $1 != "6.0" && $1 != "6.5" && $1 != "6.7" ]]; then
     echo "Please specify a target version. One of: 6.0, 6.5, 6.7"
@@ -95,8 +102,7 @@ else
     echo "Tarball extraction passed, Running nightlies test.."
 fi
 
-
-pabot --processes 4 --removekeywords TAG:secret ${excludes} --variable ESX_VERSION:${ESX_BUILD} --variable VC_VERSION:${VC_BUILD} -d ${target} "${testcases[@]}"
+pabot --processes ${PARALLEL_JOBS} --removekeywords TAG:secret ${excludes} --variable ESX_VERSION:${ESX_BUILD} --variable VC_VERSION:${VC_BUILD} -d ${target} "${testcases[@]}"
 cat ${target}/pabot_results/*/stdout.txt | grep '::' | grep -E 'PASS|FAIL' > console.log
 
 # See if any VMs leaked

--- a/tests/resources/Nimbus-Util.robot
+++ b/tests/resources/Nimbus-Util.robot
@@ -581,9 +581,9 @@ Get Name of First Local Storage For Host
 #   NIMBUS_RETRY_ATTEMPTS
 #   NIMBUS_RETRY_DELAY
 Nimbus Suite Setup
-    [Arguments]  ${keyword}  ${attempts}=1  ${delay}=1m  @{varargs}
+    [Arguments]  ${keyword}  @{varargs}
 
-    ${useAttempts}=  Get Environment Variable  NIMBUS_RETRY_ATTEMPTS  ${attempts}
-    ${useDelay}=     Get Environment Variable  NIMBUS_RETRY_DELAY     ${delay}
+    ${useAttempts}=  Get Environment Variable  NIMBUS_RETRY_ATTEMPTS  1
+    ${useDelay}=     Get Environment Variable  NIMBUS_RETRY_DELAY     1m
 
     Wait Until Keyword Succeeds  ${useAttempts}x  ${useDelay}  ${keyword}  @{varargs}

--- a/tests/resources/Nimbus-Util.robot
+++ b/tests/resources/Nimbus-Util.robot
@@ -59,8 +59,8 @@ Deploy Nimbus ESXi Server
     \   ${status}=  Run Keyword And Return Status  Should Contain  ${out}  To manage this VM use
     \   Exit For Loop If  ${status}
     \   Log To Console  ${out}
-    \   Log To Console  Nimbus deployment ${IDX} failed, trying again in 5 minutes
-    \   Sleep  5 minutes
+    \   Log To Console  Nimbus deployment ${IDX} failed, trying again in 1 minutes
+    \   Sleep  1 minutes
 
     # Now grab the IP address and return the name and ip for later use
     @{out}=  Split To Lines  ${out}
@@ -117,6 +117,7 @@ Deploy Multiple Nimbus ESXi Servers in Parallel
     \    ${result}=  Wait For Process  ${pid}
     \    Log  ${result.stdout}
     \    Log  ${result.stderr}
+    \    Should Be Equal As Integers  ${result.rc}  0
 
     &{ips}=  Create Dictionary
     :FOR  ${name}  IN  @{names}
@@ -146,8 +147,8 @@ Deploy Nimbus vCenter Server
     \   # Make sure the deploy actually worked
     \   ${status}=  Run Keyword And Return Status  Should Contain  ${out}  Overall Status: Succeeded
     \   Exit For Loop If  ${status}
-    \   Log To Console  Nimbus deployment ${IDX} failed, trying again in 5 minutes
-    \   Sleep  5 minutes
+    \   Log To Console  Nimbus deployment ${IDX} failed, trying again in 1 minute
+    \   Sleep  1 minutes
 
     # Now grab the IP address and return the name and ip for later use
     @{out}=  Split To Lines  ${out}

--- a/tests/resources/Nimbus-Util.robot
+++ b/tests/resources/Nimbus-Util.robot
@@ -222,7 +222,7 @@ Cleanup Nimbus Folders
     [Arguments]  ${deletePXE}=${false}
     Open Connection  %{NIMBUS_GW}
     Wait Until Keyword Succeeds  2 min  30 sec  Login  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}
-    Run Keyword If  ${deletePXE}  Execute Command  ${NIMBUS_LOCATION} rm -rf public_html/pxe/*
+    Run Keyword If  ${deletePXE}  Execute Command  ${NIMBUS_LOCATION} rm -rf public_html/pxe/* public_html/pxeinstall/*
     Execute Command  ${NIMBUS_LOCATION} rm -rf %{BUILD_TAG}
     Close connection
 
@@ -580,9 +580,9 @@ Get Name of First Local Storage For Host
 #   NIMBUS_RETRY_ATTEMPTS
 #   NIMBUS_RETRY_DELAY
 Nimbus Suite Setup
-    [Arguments]  ${keyword}  ${attempts}=1x  ${delay}=1m  @{varargs}
+    [Arguments]  ${keyword}  ${attempts}=1  ${delay}=1m  @{varargs}
 
-    ${useAttempts}=  Get Environment Variable  NIMBUS_RETRY_ATTEMPTS  ${attempts}x
+    ${useAttempts}=  Get Environment Variable  NIMBUS_RETRY_ATTEMPTS  ${attempts}
     ${useDelay}=     Get Environment Variable  NIMBUS_RETRY_DELAY     ${delay}
 
-    Wait Until Keyword Succeeds  ${useAttempts}  ${useDelay}  ${keyword}  @{varargs}
+    Wait Until Keyword Succeeds  ${useAttempts}x  ${useDelay}  ${keyword}  @{varargs}

--- a/tests/resources/nimbus-testbeds/vic-vsan.rb
+++ b/tests/resources/nimbus-testbeds/vic-vsan.rb
@@ -22,7 +22,7 @@ $testbed = Proc.new do |type, esxStyle, vcStyle, dbType, location|
       {
         "name" => "esx.#{idx}",
         "vc" => "vc.0",
-        "style" => "pxeInstall",
+        "style" => esxStyle,
         "desiredPassword" => "e2eFunctionalTest",
         'numMem' => 13 * 1024,
         'numCPUs' => 4,


### PR DESCRIPTION
Retry attempts for suite provisioning were incorrectly being interpreted as
seconds instead of attempts.

The new vSAN testbed spec was using a different pxe folder name than expected
in the folder cleanup logic (`pxeinstall` instead of `pxe`) leading to disk quota issues.

`Add Host To Distributed Switch` should retry within the keyword or not at all
for consistent error handling and behaviour.

Adds parameterization for number of parallel jobs and use of `ops-user`.

Towards #8067
