### PR TITLE
Cherry-pick a variety of changes into 1.4.1 (Build)

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -143,6 +143,7 @@ pipeline:
       - 'rm $BIN/vic_ui_*.tar.gz'
     when:
       event: push
+      status: [success, failure]
 
   vic-ui-release:
     image: 'wdc-harbor-ci.eng.vmware.com/default-project/vic-integration-test:1.48'
@@ -197,6 +198,7 @@ pipeline:
       repo: vmware/vic
       branch: [master, 'releases/*']
       event: [push, tag]
+      status: [success, failure]
 
   publish-gcs-builds-on-pass:
     image: 'victest/drone-gcs:1'
@@ -353,4 +355,6 @@ pipeline:
       - slack_url
     commands:
       - tests/pass-rate.sh
+    when:
+      status: [success, failure]
 

--- a/.drone.yml
+++ b/.drone.yml
@@ -53,7 +53,7 @@ pipeline:
     commands:
       - echo ${DRONE_COMMIT_AUTHOR}
       - echo $SKIP_CHECK_MEMBERSHIP
-      - if "$SKIP_CHECK_MEMBERSHIP" == true; then echo 'check-org-membership step skipped'; else /bin/bash -c '[[ ! $(curl --silent "https://api.github.com/orgs/vmware/members/${DRONE_COMMIT_AUTHOR}?access_token=$GITHUB_AUTOMATION_API_KEY") ]]'; fi
+      - if [ "$SKIP_CHECK_MEMBERSHIP" = "true" ]; then echo 'check-org-membership step skipped'; else /bin/bash -c '[[ ! $(curl --silent "https://api.github.com/orgs/vmware/members/${DRONE_COMMIT_AUTHOR}?access_token=$GITHUB_AUTOMATION_API_KEY") ]]'; fi
     when:
       status: success
 

--- a/.drone.yml
+++ b/.drone.yml
@@ -193,7 +193,7 @@ pipeline:
       - 'mkdir bundle'
       - 'mkdir bundle-release'
       - 'cp $BIN/vic_${DRONE_BUILD_NUMBER}.tar.gz bundle'
-      - 'cp $BIN/vic_${DRONE_BUILD_NUMBER}.tar.gz bundle-release/vic_`git describe --tags --abbrev=0)`.tar.gz'
+      - 'cp $BIN/vic_${DRONE_BUILD_NUMBER}.tar.gz bundle-release/vic_$(git describe --tags --abbrev=0).tar.gz'
     when:
       repo: vmware/vic
       branch: [master, 'releases/*']

--- a/.drone.yml
+++ b/.drone.yml
@@ -192,7 +192,7 @@ pipeline:
       - 'mkdir bundle'
       - 'mkdir bundle-release'
       - 'cp $BIN/vic_${DRONE_BUILD_NUMBER}.tar.gz bundle'
-      - 'cp $BIN/vic_${DRONE_BUILD_NUMBER}.tar.gz bundle-release/vic_`git describe --tags $(git rev-list --tags --max-count=1)`.tar.gz'
+      - 'cp $BIN/vic_${DRONE_BUILD_NUMBER}.tar.gz bundle-release/vic_`git describe --tags --abbrev=0)`.tar.gz'
     when:
       repo: vmware/vic
       branch: [master, 'releases/*']

--- a/Makefile
+++ b/Makefile
@@ -22,8 +22,8 @@ ifeq (vagrant, $(filter vagrant,$(USER) $(SUDO_USER)))
 	BIN_ARCH := -$(OS)
 endif
 REV :=$(shell git rev-parse --short=8 HEAD)
-TAG :=$(shell git for-each-ref --format="%(refname:short)" --sort=-authordate --count=1 refs/tags) # e.g. `v0.9.0`
-TAG_NUM :=$(shell git for-each-ref --format="%(refname:short)" --sort=-authordate --count=1 refs/tags | cut -c 2-) # e.g. `0.9.0`
+TAG :=$(shell git describe --tags --abbrev=0) # e.g. `v0.9.0`
+TAG_NUM :=$(shell git describe --tags --abbrev=0 | cut -c 2-) # e.g. `0.9.0`
 
 BASE_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 BASE_PKG := github.com/vmware/vic/

--- a/infra/scripts/focused-test.sh
+++ b/infra/scripts/focused-test.sh
@@ -20,7 +20,7 @@
 #
 
 if [ -z "$1" ]; then
-    export REMOTE=$(git remote -v | grep "github.com/vmware/vic.git (fetch)" | awk '{print$1;exit}')/master
+    export REMOTE=$(git remote -v | grep "github.com.vmware/vic.git (fetch)" | awk '{print$1;exit}')/master
     echo "Using ${REMOTE} as default remote"
 else
     echo "Using ${REMOTE} as specified remote"

--- a/tests/integration-test.sh
+++ b/tests/integration-test.sh
@@ -47,7 +47,7 @@ fi
 if [[ $DRONE_BRANCH == "master" || $DRONE_BRANCH == "releases/"* ]] && [[ $DRONE_REPO == "vmware/vic" ]] && [[ $DRONE_BUILD_EVENT == "push" ]]; then
     echo "Running full CI for $DRONE_BUILD_EVENT on $DRONE_BRANCH"
     pabot --verbose --processes $jobs --removekeywords TAG:secret --exclude skip tests/test-cases
-elif [[ $DRONE_BRANCH == *"refs/tags"* ]] && [[ $DRONE_REPO == "vmware/vic" ]] && [[ $DRONE_BUILD_EVENT == "tag" ]]; then
+elif [[ $DRONE_REPO == "vmware/vic" ]] && [[ $DRONE_BUILD_EVENT == "tag" ]]; then
     echo "Running only Group11-Upgrade and 7-01-Regression for $DRONE_BUILD_EVENT on $DRONE_BRANCH"
     pabot --verbose --processes $jobs --removekeywords TAG:secret --suite Group11-Upgrade --suite 7-01-Regression tests/test-cases
 elif (echo $prBody | grep -q "\[full ci\]"); then


### PR DESCRIPTION
(Note: This _must_ be submitted with the "rebase & merge" option, _not_ "squash & merge".)

Cherry-pick a variety of work from `master` to `releases/1.4.1` to include in 1.4.1-rc1. This should be a series of independent PRs, but I'm posting this all at once to allow a quicker turn-around cycle.

Cherry picks:
 * cbb9c1228 from #7755
 * a05eda296 from #7794
 * bfa7aaf13 from #7770
 * 7fd77b0f0 from #7791
 * 300eac88e from #7916 
 * 5a1521f29 from #8081

`[full ci]`