### PR TITLE
Cherry-pick a variety of changes into 1.4.1 (Unit Testing)

### DIFF
--- a/lib/install/management/create_test.go
+++ b/lib/install/management/create_test.go
@@ -223,7 +223,7 @@ func testCleanup(op trace.Operation, sess *session.Session, conf *config.Virtual
 		return
 	}
 
-	d.deleteVCHFolder(d.session.VCHFolder)
+	d.deleteFolder(d.session.VCHFolder)
 
 	// in this case we should expect the folder to be gone.
 	folder, err := d.session.Finder.Folder(d.op, path.Join(d.session.VMFolder.InventoryPath, conf.Name))

--- a/tests/unit-test-check.sh
+++ b/tests/unit-test-check.sh
@@ -13,10 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-prNumber=$(drone build info --format "{{ .Ref }}" vmware/vic $DRONE_BUILD_NUMBER | cut -f 3 -d'/')
-prBody=$(curl https://api.github.com/repos/vmware/vic/pulls/$prNumber?access_token=$GITHUB_AUTOMATION_API_KEY | jq -r ".body")
+set -e -o pipefail +h && [ -n "$DEBUG" ] && set -x
 
-if ! (echo $prBody | grep -q "\[skip unit\]"); then
+prNumber=$(drone build info --format "{{ .Ref }}" vmware/vic "${DRONE_BUILD_NUMBER}" | cut -f 3 -d'/')
+prBody=$(curl "https://api.github.com/repos/vmware/vic/pulls/${prNumber}?access_token=${GITHUB_AUTOMATION_API_KEY}" | jq -r ".body")
+
+if ! (echo "${prBody}" | grep -q "\[skip unit\]"); then
   make test
-  codecov --token $CODECOV_TOKEN --file .cover/cover.out
+  codecov --token "${CODECOV_TOKEN}" --file .cover/cover.out
 fi


### PR DESCRIPTION
Cherry-pick a unit test change from `master` to `releases/1.4.1` to include in 1.4.1-rc1.

Cherry picks:
* ebaedf852 from #7755
* b6f1712ba from #8083 
* 24f2f6e8c from #8088