### PR TITLE
Ignore errors in teardown of VCH List robot tests

### DIFF
--- a/tests/test-cases/Group23-VIC-Machine-Service/23-02-VCH-List.robot
+++ b/tests/test-cases/Group23-VIC-Machine-Service/23-02-VCH-List.robot
@@ -27,7 +27,7 @@ Setup
     Install VIC Appliance To Test Server
 
 Teardown
-    Run Keyword And Continue On Failure  Cleanup VIC Appliance On Test Server
+    Run Keyword And Ignore Error  Cleanup VIC Appliance On Test Server
     Stop VIC Machine Server
 
 Get VCH List


### PR DESCRIPTION
The "Run Keyword And Continue On Failure" keyword allows the rest of
the teardown to complete, but still marks the suite as failed when an
error occurs cleaning up the VCH.

If we fail to delete the VCH for whatever reason, we don't want to
mark all nine tests as failed.

Towards an issue seen in #8079.

`[specific ci=23-02-VCH-List]`