### PR TITLE
Fail the drone build when unit tests fail

### DIFF
--- a/lib/apiservers/service/restapi/handlers/client/client_test.go
+++ b/lib/apiservers/service/restapi/handlers/client/client_test.go
@@ -200,6 +200,10 @@ func checkMocks(t *testing.T, me *MockExecutor, mf *MockFinder, mv *MockValidato
 	mv.AssertExpectations(t)
 }
 
+type statusCode interface {
+	Code() int
+}
+
 func assert404(t *testing.T, err error) {
 	assert.NotNil(t, err)
 	assert.Contains(t, err.Error(), errFake.Error())

--- a/lib/apiservers/service/restapi/handlers/vch_create_test.go
+++ b/lib/apiservers/service/restapi/handlers/vch_create_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/vmware/vic/cmd/vic-machine/common"
 	"github.com/vmware/vic/cmd/vic-machine/create"
 	"github.com/vmware/vic/lib/apiservers/service/models"
+	"github.com/vmware/vic/lib/apiservers/service/restapi/handlers/decode"
 	"github.com/vmware/vic/lib/install/data"
 	"github.com/vmware/vic/pkg/trace"
 )
@@ -50,7 +51,7 @@ func TestFromManagedObject(t *testing.T) {
 	var m *models.ManagedObject
 
 	expected := ""
-	actual, err := fromManagedObject(op, nil, "t", m)
+	actual, err := decode.FromManagedObject(op, nil, "t", m)
 	assert.NoError(t, err, "Expected nil error, got %#v", err)
 	assert.Equal(t, expected, actual)
 
@@ -61,21 +62,21 @@ func TestFromManagedObject(t *testing.T) {
 	mf := mockFinder{}
 
 	expected = m.Name
-	actual, err = fromManagedObject(op, mf, "t", m)
+	actual, err = decode.FromManagedObject(op, mf, "t", m)
 	assert.NoError(t, err, "Expected nil error, got %#v", err)
 	assert.Equal(t, expected, actual)
 
 	m.ID = "testID"
 
 	expected = m.ID
-	actual, err = fromManagedObject(op, mf, "t", m)
+	actual, err = decode.FromManagedObject(op, mf, "t", m)
 	assert.NoError(t, err, "Expected nil error, got %#v", err)
 	assert.Equal(t, expected, actual)
 
 	m.Name = ""
 
 	expected = m.ID
-	actual, err = fromManagedObject(op, mf, "t", m)
+	actual, err = decode.FromManagedObject(op, mf, "t", m)
 	assert.NoError(t, err, "Expected nil error, got %#v", err)
 	assert.Equal(t, expected, actual)
 }
@@ -84,13 +85,13 @@ func TestFromCIDR(t *testing.T) {
 	var m models.CIDR
 
 	expected := ""
-	actual := fromCIDR(&m)
+	actual := decode.FromCIDR(&m)
 	assert.Equal(t, expected, actual)
 
 	m = "10.10.1.0/32"
 
 	expected = string(m)
-	actual = fromCIDR(&m)
+	actual = decode.FromCIDR(&m)
 	assert.Equal(t, expected, actual)
 }
 
@@ -98,7 +99,7 @@ func TestFromGateway(t *testing.T) {
 	var m *models.Gateway
 
 	expected := ""
-	actual := fromGateway(m)
+	actual := decode.FromGateway(m)
 	assert.Equal(t, expected, actual)
 
 	m = &models.Gateway{
@@ -110,7 +111,7 @@ func TestFromGateway(t *testing.T) {
 	}
 
 	expected = "192.168.1.1/24,172.17.0.1/24:192.168.31.37"
-	actual = fromGateway(m)
+	actual = decode.FromGateway(m)
 	assert.Equal(t, expected, actual)
 }
 
@@ -199,7 +200,7 @@ func TestCreateVCH(t *testing.T) {
 
 	mf := mockFinder{}
 
-	cb, err := buildCreate(op, data, mf, vch)
+	cb, err := new(vchCreate).buildCreate(op, data, mf, vch)
 	assert.NoError(t, err, "Error while processing params: %s", err)
 
 	a := reflect.ValueOf(ca).Elem()

--- a/lib/portlayer/storage/vsphere/image_test.go
+++ b/lib/portlayer/storage/vsphere/image_test.go
@@ -38,6 +38,7 @@ import (
 	portlayer "github.com/vmware/vic/lib/portlayer/storage"
 	"github.com/vmware/vic/pkg/trace"
 	"github.com/vmware/vic/pkg/vsphere/datastore"
+	"github.com/vmware/vic/pkg/vsphere/datastore/test"
 	"github.com/vmware/vic/pkg/vsphere/disk"
 	"github.com/vmware/vic/pkg/vsphere/session"
 )
@@ -47,7 +48,7 @@ func setup(t *testing.T) (*portlayer.NameLookupCache, *session.Session, string, 
 	trace.Logger.Level = logrus.DebugLevel
 	DetachAll = false
 
-	client := datastore.Session(context.TODO(), t)
+	client := test.Session(context.TODO(), t)
 	if client == nil {
 		return nil, nil, "", fmt.Errorf("skip")
 	}

--- a/lib/portlayer/storage/vsphere/volume_test.go
+++ b/lib/portlayer/storage/vsphere/volume_test.go
@@ -26,11 +26,12 @@ import (
 	portlayer "github.com/vmware/vic/lib/portlayer/storage"
 	"github.com/vmware/vic/pkg/trace"
 	"github.com/vmware/vic/pkg/vsphere/datastore"
+	"github.com/vmware/vic/pkg/vsphere/datastore/test"
 	"github.com/vmware/vic/pkg/vsphere/tasks"
 )
 
 func TestVolumeCreateListAndRestart(t *testing.T) {
-	client := datastore.Session(context.TODO(), t)
+	client := test.Session(context.TODO(), t)
 	if client == nil {
 		return
 	}

--- a/pkg/vsphere/datastore/datastore_test.go
+++ b/pkg/vsphere/datastore/datastore_test.go
@@ -20,48 +20,18 @@ import (
 	"os"
 	"path"
 	"testing"
-	"time"
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/vmware/vic/pkg/vsphere/session"
+	"github.com/vmware/vic/pkg/vsphere/datastore/test"
 	"github.com/vmware/vic/pkg/vsphere/tasks"
-	"github.com/vmware/vic/pkg/vsphere/test/env"
 )
-
-func testSession(ctx context.Context, t *testing.T) *session.Session {
-	config := &session.Config{
-		Service: env.URL(t),
-
-		/// XXX Why does this insist on having this field populated?
-		DatastorePath: env.DS(t),
-
-		Insecure:  true,
-		Keepalive: time.Duration(5) * time.Minute,
-	}
-
-	s := session.NewSession(config)
-	_, err := s.Connect(ctx)
-	if err != nil {
-		s.Client.Logout(ctx)
-		t.Log(err.Error())
-		t.SkipNow()
-	}
-
-	_, err = s.Populate(ctx)
-	if err != nil {
-		t.Log(err.Error())
-		t.SkipNow()
-	}
-
-	return s
-}
 
 func dsSetup(t *testing.T) (context.Context, *Helper, func()) {
 	log.SetLevel(log.DebugLevel)
 	ctx := context.Background()
-	sess := testSession(ctx, t)
+	sess := test.Session(ctx, t)
 
 	ds, err := NewHelper(ctx, sess, sess.Datastore, TestName("dstests"))
 	if !assert.NoError(t, err) {

--- a/pkg/vsphere/datastore/test/util.go
+++ b/pkg/vsphere/datastore/test/util.go
@@ -1,0 +1,52 @@
+// Copyright 2018 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/vmware/vic/pkg/vsphere/session"
+	"github.com/vmware/vic/pkg/vsphere/test/env"
+)
+
+func Session(ctx context.Context, t *testing.T) *session.Session {
+	config := &session.Config{
+		Service: env.URL(t),
+
+		/// XXX Why does this insist on having this field populated?
+		DatastorePath: env.DS(t),
+
+		Insecure:  true,
+		Keepalive: time.Duration(5) * time.Minute,
+	}
+
+	s := session.NewSession(config)
+	_, err := s.Connect(ctx)
+	if err != nil {
+		s.Client.Logout(ctx)
+		t.Log(err.Error())
+		t.SkipNow()
+	}
+
+	_, err = s.Populate(ctx)
+	if err != nil {
+		t.Log(err.Error())
+		t.SkipNow()
+	}
+
+	return s
+}

--- a/tests/unit-test-check.sh
+++ b/tests/unit-test-check.sh
@@ -13,10 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-prNumber=$(drone build info --format "{{ .Ref }}" vmware/vic $DRONE_BUILD_NUMBER | cut -f 3 -d'/')
-prBody=$(curl https://api.github.com/repos/vmware/vic/pulls/$prNumber?access_token=$GITHUB_AUTOMATION_API_KEY | jq -r ".body")
+set -e -o pipefail +h && [ -n "$DEBUG" ] && set -x
 
-if ! (echo $prBody | grep -q "\[skip unit\]"); then
+prNumber=$(drone build info --format "{{ .Ref }}" vmware/vic "${DRONE_BUILD_NUMBER}" | cut -f 3 -d'/')
+prBody=$(curl "https://api.github.com/repos/vmware/vic/pulls/${prNumber}?access_token=${GITHUB_AUTOMATION_API_KEY}" | jq -r ".body")
+
+if ! (echo "${prBody}" | grep -q "\[skip unit\]"); then
   make test
-  codecov --token $CODECOV_TOKEN --file .cover/cover.out
+  codecov --token "${CODECOV_TOKEN}" --file .cover/cover.out
 fi


### PR DESCRIPTION
So that the drone build fails when make test returns a non-zero exit
code, `set -e`.

Additionally, enable pipefail and disable command lookup hashing.

Lastly, use double quotes to avoid risk of globbing or word splitting.