### PR TITLE
Remove unused variables in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,8 +22,6 @@ ifeq (vagrant, $(filter vagrant,$(USER) $(SUDO_USER)))
 	BIN_ARCH := -$(OS)
 endif
 REV :=$(shell git rev-parse --short=8 HEAD)
-TAG :=$(shell git describe --tags --abbrev=0) # e.g. `v0.9.0`
-TAG_NUM :=$(shell git describe --tags --abbrev=0 | cut -c 2-) # e.g. `0.9.0`
 
 BASE_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 BASE_PKG := github.com/vmware/vic/


### PR DESCRIPTION
Uses of the TAG and TAG_NUM variables has been [removed](59ccc5f8794ce3d057ff66c9433d1af381c84457). Clean up definition of the variables as well.