### PR TITLE
Update dependencies for make test target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -268,7 +268,7 @@ install-govmomi:
 # manually install govmomi so the huge types package doesn't break cover
 	$(GO) install ./vendor/github.com/vmware/govmomi
 
-test: install-govmomi portlayerapi $(TEST_JOBS)
+test: install-govmomi $(portlayerapi-client) $(portlayerapi-server) $(serviceapi-server) $(admiralapi-client) $(TEST_JOBS)
 
 push:
 	$(BASE_DIR)/infra/scripts/replace-running-components.sh


### PR DESCRIPTION
The make target for test does not include a dependency for the
vic-machine-service swagger generation step, causing failures of the
target unless a build has been run that does that generation.

This adds the missing dependency and also refines the portlayer
dependency to only the swagger generation, dropping the Go
compilation step.