### PR TITLE
Remove superfluous echo in integration-test script

### DIFF
--- a/tests/integration-test.sh
+++ b/tests/integration-test.sh
@@ -90,7 +90,7 @@ echo "default_project_id = $GS_PROJECT_ID" >> $botofile
 
 
 if [ -f "$outfile" ]; then
-  echo `ls -al $outfile`
+  ls -al $outfile
   n=0
   until [ $n -ge 5 ]
   do


### PR DESCRIPTION
Because $outfile is a file, the echo has no impact on the output.