### PR TITLE
Fix current encoding errors in syslog test

### DIFF
--- a/tests/test-cases/Group6-VIC-Machine/6-15-Syslog.robot
+++ b/tests/test-cases/Group6-VIC-Machine/6-15-Syslog.robot
@@ -64,9 +64,9 @@ Verify VCH remote syslog
 
     Wait Until Container Stops  ${id}  5
 
-    ${syslog-conn}=  Open Connection  %{SYSLOG_SERVER}  encoding=unicode_escape
+    ${syslog-conn}=  Open Connection  %{SYSLOG_SERVER}
     Login  %{SYSLOG_USER}  %{SYSLOG_PASSWD}
-    ${out}=  Wait Until Keyword Succeeds  10x  3s  Execute Command  cat ${SYSLOG_FILE}
+    ${out}=  Execute Command  cat ${SYSLOG_FILE}
     Close Connection
     Log  ${out}
 


### PR DESCRIPTION
Use default encoding settings when reading syslog data over SSH to avoid errors when attempting to read some latin1-encoded characters (e.g., mu or u with umlaut) as utf-8.

This reverts 58effdf (#7977).

Additionally, remove retry of the cat operation; it seems like one of the least likely steps of this process to fail, and code history does not reveal any reason it was added.

This reverts 18841ed (#6841).

`[specific ci=6-15-Syslog]`

---

Additional work exists here. For example, using `cat` over `ssh` may not be the best way to read the contents of the file. 