### PR TITLE
Always cache go deps when doing generation

### DIFF
--- a/infra/scripts/go-deps.sh
+++ b/infra/scripts/go-deps.sh
@@ -37,19 +37,14 @@ if [ -d "$pkg" ]; then
         echo "Generating deps for $pkg" >&2
     fi
 
-    if [ -n "$VIC_CACHE_DEPS" ]; then
-        mkdir -p $cache_dir
-        if [ ! -f $cache_dir/$cachedname ]; then
+    mkdir -p $cache_dir
+    # generate the cache if not present or if not using the cached result
+    if [ -z "$VIC_CACHE_DEPS" -o ! -f $cache_dir/$cachedname ]; then
             go list -f '{{join .Deps "\n"}}' github.com/vmware/vic/"$pkg" 2>/dev/null | \
                 xargs go list -f '{{if not .Standard}}{{.ImportPath}}{{end}}' 2>/dev/null | \
                 sed -e 's:github.com/vmware/vic/\(.*\)$:\1/*:' > "$cache_dir/$cachedname"
-        fi
-        cat "$cache_dir/$cachedname"
-    else
-        go list -f '{{join .Deps "\n"}}' github.com/vmware/vic/"$pkg" 2>/dev/null | \
-            xargs go list -f '{{if not .Standard}}{{.ImportPath}}{{end}}' 2>/dev/null | \
-            sed -e 's:github.com/vmware/vic/\(.*\)$:\1/*:'
     fi
+    cat "$cache_dir/$cachedname"
 else
     if [[ "$flags" == *d* ]]
     then


### PR DESCRIPTION
This change always caches the Go dependencies when they
are generated, and the VIC_CACHE_DEPS variable is then
used solely to control whether the cache is used or whether
dependencies are regenerated.

This is done so that the cache is available for accelerating
make targets even without having had the environment
variable set previously. This change is targeted at local
development productivity.