### PR TITLE
Support id-based selection of compute via API

### DIFF
--- a/lib/apiservers/service/restapi/handlers/decode/references_test.go
+++ b/lib/apiservers/service/restapi/handlers/decode/references_test.go
@@ -1,0 +1,153 @@
+// Copyright 2018 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package decode
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
+	"github.com/vmware/govmomi/find"
+	"github.com/vmware/govmomi/list"
+	"github.com/vmware/govmomi/vim25/types"
+
+	"github.com/vmware/vic/lib/apiservers/service/models"
+	"github.com/vmware/vic/pkg/trace"
+)
+
+type mockFinder struct {
+	mock.Mock
+
+	path string
+}
+
+func (mf *mockFinder) Element(ctx context.Context, t types.ManagedObjectReference) (*list.Element, error) {
+	args := mf.Called(ctx, t)
+
+	if p := args.Get(0); p != nil {
+		return &list.Element{
+			Path: p.(string),
+		}, args.Error(1)
+	}
+
+	return nil, args.Error(1)
+}
+
+func TestFromManagedObject(t *testing.T) {
+	op := trace.NewOperation(context.Background(), "TestFromManagedObject")
+	var m *models.ManagedObject
+
+	expected := ""
+	actual, err := FromManagedObject(op, nil, m, "t")
+	assert.NoError(t, err, "Expected nil error, got %#v", err)
+	assert.Equal(t, expected, actual)
+
+	name := "testManagedObject"
+	path := "/folder/" + name
+
+	m = &models.ManagedObject{
+		Name: name,
+	}
+
+	mf := &mockFinder{}
+	mf.On("Element", op, mock.AnythingOfType("types.ManagedObjectReference")).Return(path, nil)
+
+	expected = name
+	actual, err = FromManagedObject(op, mf, m, "t")
+	assert.NoError(t, err, "Expected nil error, got %#v", err)
+	assert.Equal(t, expected, actual)
+
+	m.ID = "testID"
+
+	expected = path
+	actual, err = FromManagedObject(op, mf, m, "t")
+	assert.NoError(t, err, "Expected nil error, got %#v", err)
+	assert.Equal(t, expected, actual)
+
+	m.Name = ""
+
+	expected = path
+	actual, err = FromManagedObject(op, mf, m, "t")
+	assert.NoError(t, err, "Expected nil error, got %#v", err)
+	assert.Equal(t, expected, actual)
+}
+
+func TestFromManagedObject_Negative(t *testing.T) {
+	op := trace.NewOperation(context.Background(), "TestFromManagedObject")
+
+	m := &models.ManagedObject{
+		ID: "testID",
+	}
+
+	mf := &mockFinder{}
+	mf.On("Element", op, mock.AnythingOfType("types.ManagedObjectReference")).Return(nil, nil)
+
+	expected := ""
+	actual, err := FromManagedObject(op, mf, m, "t")
+	assert.Error(t, err, "Expected error when no resource found")
+	assert.Equal(t, expected, actual)
+
+	expected = ""
+	actual, err = FromManagedObject(op, mf, m, "t", "u", "v")
+	assert.Error(t, err, "Expected error when no resource found")
+	assert.Equal(t, expected, actual)
+}
+
+func TestFromManagedObject_Fallback(t *testing.T) {
+	op := trace.NewOperation(context.Background(), "TestFromManagedObject")
+
+	m := &models.ManagedObject{
+		ID: "testID",
+	}
+
+	mf := &mockFinder{}
+	mf.On("Element", op, mock.MatchedBy(func(t types.ManagedObjectReference) bool { return t.Type == "t" })).Return(nil, &find.NotFoundError{})
+	mf.On("Element", op, mock.MatchedBy(func(t types.ManagedObjectReference) bool { return t.Type == "u" })).Return(nil, nil)
+	mf.On("Element", op, mock.MatchedBy(func(t types.ManagedObjectReference) bool { return t.Type == "v" })).Return("Result", nil)
+	mf.On("Element", op, mock.MatchedBy(func(t types.ManagedObjectReference) bool { return t.Type == "e" })).Return(nil, fmt.Errorf("Expected"))
+
+	expected := ""
+	actual, err := FromManagedObject(op, mf, m, "t")
+	assert.Error(t, err, "Expected error when NotFoundError encountered")
+	assert.Equal(t, expected, actual)
+
+	expected = ""
+	actual, err = FromManagedObject(op, mf, m, "t", "u")
+	assert.Error(t, err, "Expected error when no resource found")
+	assert.Equal(t, expected, actual)
+
+	expected = "Result"
+	actual, err = FromManagedObject(op, mf, m, "t", "u", "v")
+	assert.NoError(t, err, "Did not expect error when third type returns valid result, but got %#v", err)
+	assert.Equal(t, expected, actual)
+
+	expected = "Result"
+	actual, err = FromManagedObject(op, mf, m, "t", "v")
+	assert.NoError(t, err, "Did not expect error when second type returns valid result, but got %#v", err)
+	assert.Equal(t, expected, actual)
+
+	expected = "Result"
+	actual, err = FromManagedObject(op, mf, m, "u", "v")
+	assert.NoError(t, err, "Did not expect error when second type returns valid result, but got %#v", err)
+	assert.Equal(t, expected, actual)
+
+	expected = "Result"
+	actual, err = FromManagedObject(op, mf, m, "u", "e", "v")
+	assert.NoError(t, err, "Did not expect error when third type returns valid result, but got %#v", err)
+	assert.Equal(t, expected, actual)
+}

--- a/lib/apiservers/service/restapi/handlers/vch_create.go
+++ b/lib/apiservers/service/restapi/handlers/vch_create.go
@@ -152,7 +152,7 @@ func (h *vchCreate) buildCreate(op trace.Operation, d *data.Data, finder client.
 				c.ResourceLimits.VCHMemoryShares = decode.FromShares(vch.Compute.Memory.Shares)
 			}
 
-			resourcePath, err := decode.FromManagedObject(op, finder, "ResourcePool", vch.Compute.Resource) // TODO (#6711): Do we need to handle clusters differently?
+			resourcePath, err := decode.FromManagedObject(op, finder, vch.Compute.Resource, "ResourcePool", "ComputeResource", "ClusterComputeResource", "HostSystem")
 			if err != nil {
 				return nil, errors.NewError(http.StatusBadRequest, "error finding resource pool: %s", err)
 			}
@@ -168,7 +168,7 @@ func (h *vchCreate) buildCreate(op trace.Operation, d *data.Data, finder client.
 
 		if vch.Network != nil {
 			if vch.Network.Bridge != nil {
-				path, err := decode.FromManagedObject(op, finder, "Network", vch.Network.Bridge.PortGroup)
+				path, err := decode.FromManagedObject(op, finder, vch.Network.Bridge.PortGroup, "Network")
 				if err != nil {
 					return nil, errors.NewError(http.StatusBadRequest, "error finding bridge network: %s", err)
 				}
@@ -184,7 +184,7 @@ func (h *vchCreate) buildCreate(op trace.Operation, d *data.Data, finder client.
 			}
 
 			if vch.Network.Client != nil {
-				path, err := decode.FromManagedObject(op, finder, "Network", vch.Network.Client.PortGroup)
+				path, err := decode.FromManagedObject(op, finder, vch.Network.Client.PortGroup, "Network")
 				if err != nil {
 					return nil, errors.NewError(http.StatusBadRequest, "error finding client network portgroup: %s", err)
 				}
@@ -201,7 +201,7 @@ func (h *vchCreate) buildCreate(op trace.Operation, d *data.Data, finder client.
 			}
 
 			if vch.Network.Management != nil {
-				path, err := decode.FromManagedObject(op, finder, "Network", vch.Network.Management.PortGroup)
+				path, err := decode.FromManagedObject(op, finder, vch.Network.Management.PortGroup, "Network")
 				if err != nil {
 					return nil, errors.NewError(http.StatusBadRequest, "error finding management network portgroup: %s", err)
 				}
@@ -218,7 +218,7 @@ func (h *vchCreate) buildCreate(op trace.Operation, d *data.Data, finder client.
 			}
 
 			if vch.Network.Public != nil {
-				path, err := decode.FromManagedObject(op, finder, "Network", vch.Network.Public.PortGroup)
+				path, err := decode.FromManagedObject(op, finder, vch.Network.Public.PortGroup, "Network")
 				if err != nil {
 					return nil, errors.NewError(http.StatusBadRequest, "error finding public network portgroup: %s", err)
 				}
@@ -254,7 +254,7 @@ func (h *vchCreate) buildCreate(op trace.Operation, d *data.Data, finder client.
 				for _, cnetwork := range vch.Network.Container {
 					alias := cnetwork.Alias
 
-					path, err := decode.FromManagedObject(op, finder, "Network", cnetwork.PortGroup)
+					path, err := decode.FromManagedObject(op, finder, cnetwork.PortGroup, "Network")
 					if err != nil {
 						return nil, errors.NewError(http.StatusBadRequest, "error finding portgroup for container network %s: %s", alias, err)
 					}

--- a/lib/apiservers/service/restapi/handlers/vch_create_test.go
+++ b/lib/apiservers/service/restapi/handlers/vch_create_test.go
@@ -46,41 +46,6 @@ func (mf mockFinder) Element(ctx context.Context, t types.ManagedObjectReference
 	}, nil
 }
 
-func TestFromManagedObject(t *testing.T) {
-	op := trace.NewOperation(context.Background(), "TestFromManagedObject")
-	var m *models.ManagedObject
-
-	expected := ""
-	actual, err := decode.FromManagedObject(op, nil, "t", m)
-	assert.NoError(t, err, "Expected nil error, got %#v", err)
-	assert.Equal(t, expected, actual)
-
-	m = &models.ManagedObject{
-		Name: "testManagedObject",
-	}
-
-	mf := mockFinder{}
-
-	expected = m.Name
-	actual, err = decode.FromManagedObject(op, mf, "t", m)
-	assert.NoError(t, err, "Expected nil error, got %#v", err)
-	assert.Equal(t, expected, actual)
-
-	m.ID = "testID"
-
-	expected = m.ID
-	actual, err = decode.FromManagedObject(op, mf, "t", m)
-	assert.NoError(t, err, "Expected nil error, got %#v", err)
-	assert.Equal(t, expected, actual)
-
-	m.Name = ""
-
-	expected = m.ID
-	actual, err = decode.FromManagedObject(op, mf, "t", m)
-	assert.NoError(t, err, "Expected nil error, got %#v", err)
-	assert.Equal(t, expected, actual)
-}
-
 func TestFromCIDR(t *testing.T) {
 	var m models.CIDR
 


### PR DESCRIPTION
Allow for id-based specification of compute resources other than
resource pools via the VCH management API.

Refactor the lookup-by-id logic to iterate through possible type
options as generic type-less lookup is not supported.

Enhance related unit tests to allow for negative testing and build
on that functionality to test the type fallback behavior.

Fixes #6711

`[specific ci=Group23-VIC-Machine-Service]`

---

I would like to add an integration testing for this functionality, but doing so requires a more complex resource topology than we currently support. Given that, relying on end-to-end testing via the UI seems like a reasonable compromise.