### PR TITLE
Fixed pull against docker store

### DIFF
--- a/cmd/imagec/main.go
+++ b/cmd/imagec/main.go
@@ -30,6 +30,7 @@ import (
 	log "github.com/Sirupsen/logrus"
 	"github.com/docker/docker/pkg/streamformatter"
 	"github.com/docker/docker/reference"
+	"github.com/docker/docker/registry"
 	"github.com/go-openapi/runtime"
 	rc "github.com/go-openapi/runtime/client"
 	"github.com/pkg/profile"
@@ -100,9 +101,9 @@ func init() {
 
 	flag.StringVar(&imageCOptions.operation, "operation", "pull", "Pull image/push image/listlayers/save image")
 
-	flag.StringVar(&imageCOptions.options.Registry, "registry", imagec.DefaultDockerURL, "Registry to pull/push images (default: registry-1.docker.io)")
+	flag.StringVar(&imageCOptions.options.Registry, "registry", registry.DefaultV2Registry.Host, "Registry to pull/push images (default: registry-1.docker.io)")
 
-	flag.StringVar(&imageCOptions.options.ImageStore, "image-store", imagec.DefaultDockerURL, "portlayer image store name or url used to query image data")
+	flag.StringVar(&imageCOptions.options.ImageStore, "image-store", registry.DefaultV2Registry.Host, "portlayer image store name or url used to query image data")
 
 	flag.Parse()
 

--- a/lib/apiservers/engine/backends/system.go
+++ b/lib/apiservers/engine/backends/system.go
@@ -43,7 +43,6 @@ import (
 	"github.com/vmware/vic/lib/apiservers/engine/proxy"
 	"github.com/vmware/vic/lib/apiservers/portlayer/client"
 	"github.com/vmware/vic/lib/apiservers/portlayer/client/storage"
-	"github.com/vmware/vic/lib/imagec"
 	urlfetcher "github.com/vmware/vic/pkg/fetcher"
 	"github.com/vmware/vic/pkg/registry"
 	"github.com/vmware/vic/pkg/trace"
@@ -54,6 +53,7 @@ import (
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/daemon/events"
 	"github.com/docker/docker/pkg/platform"
+	dockerregistry "github.com/docker/docker/registry"
 	"github.com/docker/go-units"
 )
 
@@ -115,7 +115,7 @@ func (s *SystemBackend) SystemInfo() (*types.Info, error) {
 	// Build up the struct that the Remote API and CLI wants
 	info := &types.Info{
 		Driver:             PortLayerName(),
-		IndexServerAddress: imagec.DefaultDockerURL,
+		IndexServerAddress: dockerregistry.DefaultV2Registry.Host,
 		ServerVersion:      ProductVersion(),
 		ID:                 ProductName(),
 		Containers:         running + paused + stopped,

--- a/lib/imagec/docker.go
+++ b/lib/imagec/docker.go
@@ -35,6 +35,7 @@ import (
 	"github.com/docker/docker/pkg/archive"
 	"github.com/docker/docker/pkg/progress"
 	"github.com/docker/docker/reference"
+	"github.com/docker/docker/registry"
 	"github.com/docker/libtrust"
 
 	urlfetcher "github.com/vmware/vic/pkg/fetcher"
@@ -137,8 +138,8 @@ func LearnAuthURL(op trace.Operation, options Options) (*url.URL, error) {
 
 	// Private registry returned the manifest directly as auth option is optional.
 	// https://github.com/docker/distribution/blob/master/docs/configuration.md#auth
-	if err == nil && options.Registry != DefaultDockerURL && fetcher.IsStatusOK() {
-		op.Debugf("%s does not support OAuth", url)
+	if err == nil && options.Registry != registry.DefaultV2Registry.Host && fetcher.IsStatusOK() {
+		log.Debugf("%s does not support OAuth", url)
 		return nil, nil
 	}
 

--- a/lib/imagec/docker.go
+++ b/lib/imagec/docker.go
@@ -27,7 +27,6 @@ import (
 	"os"
 	"path"
 
-	log "github.com/Sirupsen/logrus"
 	ddigest "github.com/docker/distribution/digest"
 	"github.com/docker/distribution/manifest/schema1"
 	"github.com/docker/distribution/manifest/schema2"
@@ -139,7 +138,7 @@ func LearnAuthURL(op trace.Operation, options Options) (*url.URL, error) {
 	// Private registry returned the manifest directly as auth option is optional.
 	// https://github.com/docker/distribution/blob/master/docs/configuration.md#auth
 	if err == nil && options.Registry != registry.DefaultV2Registry.Host && fetcher.IsStatusOK() {
-		log.Debugf("%s does not support OAuth", url)
+		op.Debugf("%s does not support OAuth", url)
 		return nil, nil
 	}
 
@@ -355,7 +354,7 @@ func FetchImageManifest(op trace.Operation, options Options, schemaVersion int, 
 
 	manifestFileName, err := fetcher.Fetch(op, url, &reqHeaders, true, progressOutput)
 	if err != nil {
-		log.Debugf("Failed to fetch manifest: %s", err.Error())
+		op.Debugf("Failed to fetch manifest: %s", err.Error())
 
 		switch err.(type) {
 		case urlfetcher.AccessDenied:

--- a/lib/imagec/docker.go
+++ b/lib/imagec/docker.go
@@ -27,6 +27,7 @@ import (
 	"os"
 	"path"
 
+	log "github.com/Sirupsen/logrus"
 	ddigest "github.com/docker/distribution/digest"
 	"github.com/docker/distribution/manifest/schema1"
 	"github.com/docker/distribution/manifest/schema2"
@@ -353,6 +354,13 @@ func FetchImageManifest(op trace.Operation, options Options, schemaVersion int, 
 
 	manifestFileName, err := fetcher.Fetch(op, url, &reqHeaders, true, progressOutput)
 	if err != nil {
+		log.Debugf("Failed to fetch manifest: %s", err.Error())
+
+		switch err.(type) {
+		case urlfetcher.AccessDenied:
+			return nil, "", fmt.Errorf("pull access denied for %s, repository does not exist or may require 'docker login'", options.Reference.Name())
+
+		}
 		return nil, "", err
 	}
 

--- a/lib/imagec/imagec.go
+++ b/lib/imagec/imagec.go
@@ -37,6 +37,7 @@ import (
 	"github.com/docker/docker/pkg/streamformatter"
 	"github.com/docker/docker/pkg/stringid"
 	"github.com/docker/docker/reference"
+	"github.com/docker/docker/registry"
 
 	"github.com/vmware/vic/lib/apiservers/engine/backends/cache"
 	"github.com/vmware/vic/lib/apiservers/portlayer/models"
@@ -137,9 +138,6 @@ var (
 )
 
 const (
-	// DefaultDockerURL holds the URL of Docker registry
-	DefaultDockerURL = "registry-1.docker.io"
-
 	// DefaultDestination specifies the default directory to use
 	DefaultDestination = "images"
 
@@ -175,7 +173,7 @@ func (ic *ImageC) ParseReference(ctx context.Context) {
 
 	ic.Registry = ic.Reference.Hostname()
 	if ic.Registry == reference.DefaultHostname {
-		ic.Registry = DefaultDockerURL
+		ic.Registry = registry.DefaultV2Registry.Host
 	}
 
 	ic.Image = ic.Reference.RemoteName()

--- a/lib/imagec/imagec.go
+++ b/lib/imagec/imagec.go
@@ -138,7 +138,7 @@ var (
 
 const (
 	// DefaultDockerURL holds the URL of Docker registry
-	DefaultDockerURL = "registry.hub.docker.com"
+	DefaultDockerURL = "registry-1.docker.io"
 
 	// DefaultDestination specifies the default directory to use
 	DefaultDestination = "images"

--- a/lib/imagec/imagec_test.go
+++ b/lib/imagec/imagec_test.go
@@ -602,8 +602,8 @@ func TestFetchScenarios(t *testing.T) {
 	// valid token but image is missing we shouldn't retry
 	_, _, err = FetchImageManifest(op, ic.Options, 1, ic.progressOutput)
 	if err != nil {
-		// we should get a ImageNotFoundError
-		if _, imageErr := err.(urlfetcher.ImageNotFoundError); !imageErr {
+		// we should get a AccessDenied
+		if !strings.Contains(err.Error(), "pull access denied") {
 			t.Errorf(err.Error())
 		}
 	}

--- a/lib/imagec/imagec_test.go
+++ b/lib/imagec/imagec_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/docker/distribution/digest"
 	"github.com/docker/docker/pkg/streamformatter"
 	"github.com/docker/docker/reference"
+	"github.com/docker/docker/registry"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/vmware/vic/lib/apiservers/portlayer/models"
@@ -112,14 +113,14 @@ func TestParseReference(t *testing.T) {
 	ic.ParseReference(op)
 	assert.Equal(t, ic.Tag, reference.DefaultTag)
 	assert.Equal(t, ic.Image, BusyboxImage)
-	assert.Equal(t, ic.Registry, DefaultDockerURL)
+	assert.Equal(t, ic.Registry, registry.DefaultV2Registry.Host)
 
 	ref, err = reference.ParseNamed("vmware/photon")
 	ic.Options.Reference = ref
 	ic.ParseReference(op)
 	assert.Equal(t, ic.Tag, reference.DefaultTag)
 	assert.Equal(t, ic.Image, "vmware/photon")
-	assert.Equal(t, ic.Registry, DefaultDockerURL)
+	assert.Equal(t, ic.Registry, registry.DefaultV2Registry.Host)
 
 	ref, err = reference.ParseNamed("busybox")
 	if err != nil {
@@ -129,7 +130,7 @@ func TestParseReference(t *testing.T) {
 	ic.ParseReference(op)
 	assert.Equal(t, ic.Tag, reference.DefaultTag)
 	assert.Equal(t, ic.Image, BusyboxImage)
-	assert.Equal(t, ic.Registry, DefaultDockerURL)
+	assert.Equal(t, ic.Registry, registry.DefaultV2Registry.Host)
 
 	ref, err = reference.ParseNamed("library/busybox")
 	if err != nil {
@@ -139,7 +140,7 @@ func TestParseReference(t *testing.T) {
 	ic.ParseReference(op)
 	assert.Equal(t, ic.Tag, reference.DefaultTag)
 	assert.Equal(t, ic.Image, BusyboxImage)
-	assert.Equal(t, ic.Registry, DefaultDockerURL)
+	assert.Equal(t, ic.Registry, registry.DefaultV2Registry.Host)
 
 	ref, err = reference.ParseNamed("library/busybox:latest")
 	if err != nil {
@@ -149,7 +150,7 @@ func TestParseReference(t *testing.T) {
 	ic.ParseReference(op)
 	assert.Equal(t, ic.Tag, reference.DefaultTag)
 	assert.Equal(t, ic.Image, BusyboxImage)
-	assert.Equal(t, ic.Registry, DefaultDockerURL)
+	assert.Equal(t, ic.Registry, registry.DefaultV2Registry.Host)
 
 	ic = NewImageC(options, streamformatter.NewJSONStreamFormatter())
 	ref, err = reference.ParseNamed("busybox")
@@ -168,7 +169,7 @@ func TestParseReference(t *testing.T) {
 	ic.ParseReference(op)
 	assert.Equal(t, ic.Tag, "")
 	assert.Equal(t, ic.Image, BusyboxImage)
-	assert.Equal(t, ic.Registry, DefaultDockerURL)
+	assert.Equal(t, ic.Registry, registry.DefaultV2Registry.Host)
 }
 
 func TestLearnRegistryURL(t *testing.T) {
@@ -602,8 +603,8 @@ func TestFetchScenarios(t *testing.T) {
 	// valid token but image is missing we shouldn't retry
 	_, _, err = FetchImageManifest(op, ic.Options, 1, ic.progressOutput)
 	if err != nil {
-		// we should get a AccessDenied
-		if !strings.Contains(err.Error(), "pull access denied") {
+		// we should get a V2 message
+		if !strings.Contains(err.Error(), "repository does not exist or may require 'docker login'") {
 			t.Errorf(err.Error())
 		}
 	}

--- a/pkg/fetcher/errors.go
+++ b/pkg/fetcher/errors.go
@@ -56,3 +56,17 @@ type AuthTokenError struct {
 func (e AuthTokenError) Error() string {
 	return fmt.Sprintf("Failed to fetch auth token from %s", e.TokenServer.Host)
 }
+
+// AccessDenied is returned when the resource requested
+type AccessDenied struct {
+	Err error
+	res string
+}
+
+func (e AccessDenied) Error() string {
+	if e.res == "" {
+		return fmt.Sprintf("Access denied to requested resource")
+	}
+
+	return fmt.Sprintf("Access denied to %s", e.res)
+}

--- a/pkg/fetcher/fetcher.go
+++ b/pkg/fetcher/fetcher.go
@@ -173,7 +173,7 @@ func (u *URLFetcher) Fetch(ctx context.Context, url *url.URL, reqHdrs *http.Head
 		}
 
 		switch err := err.(type) {
-		case DoNotRetry, TagNotFoundError, ImageNotFoundError:
+		case DoNotRetry, TagNotFoundError, ImageNotFoundError, AccessDenied:
 			log.Debugf("Error: %s", err.Error())
 			return "", err
 		}
@@ -285,10 +285,10 @@ func (u *URLFetcher) fetch(ctx context.Context, url *url.URL, reqHdrs *http.Head
 		if u.IsStatusUnauthorized() {
 			hdr := res.Header.Get("www-authenticate")
 
-			// check if image is non-existent (#757)
+			// Fix insufficient_scope return value.
+			// https://github.com/vmware/vic/blob/master/vendor/github.com/docker/distribution/registry/client/errors.go#L112
 			if strings.Contains(hdr, "error=\"insufficient_scope\"") {
-				err = fmt.Errorf("image not found")
-				return nil, nil, ImageNotFoundError{Err: err}
+				return nil, nil, AccessDenied{Err: err, res: url.String()}
 			} else if strings.Contains(hdr, "error=\"invalid_token\"") {
 				return nil, nil, fmt.Errorf("not authorized")
 			} else {

--- a/tests/test-cases/Group1-Docker-Commands/1-02-Docker-Pull.md
+++ b/tests/test-cases/Group1-Docker-Commands/1-02-Docker-Pull.md
@@ -37,6 +37,9 @@ This test requires that an vSphere server is running and available.
     * gcr.io/google_samples/gb-redisslave:v1
     * gcr.io/google_samples/cassandra:v11
     * gcr.io/google_samples/cassandra:v12
+20. Verify image manifest digest against vanilla docker
+21. Attempt docker pull mitm
+22. Issue docker pull for store/ibmcorp/mqadvanced-server-dev:9.0.5.0
 
 # Expected Outcome:
 VIC appliance should respond with a properly formatted pull response to each command issued to it. No errors should be seen, except in the case of step 7, 8 and 9. In step 13, the image ID and size for ubuntu should match before and after removing and re-pulling the image.

--- a/tests/test-cases/Group1-Docker-Commands/1-02-Docker-Pull.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-02-Docker-Pull.robot
@@ -75,13 +75,13 @@ Deploy Proxified VCH
     # We're just going to eschew helpers and install this VCH manually to avoid mutating hidden environmental state which is difficult to debug
     ${rc}  ${output}=  Run And Return Rc And Output  bin/vic-machine-linux create --name=VCH-XPLT --target=%{TEST_URL}%{TEST_DATACENTER} --user=%{TEST_USERNAME} --password=%{TEST_PASSWORD} --force=true --compute-resource=%{TEST_RESOURCE} --timeout %{TEST_TIMEOUT} --bridge-network=%{BRIDGE_NETWORK} --container-network=%{PUBLIC_NETWORK}:public --public-network=%{PUBLIC_NETWORK} ${vicmachinetls} --image-store=%{TEST_DATASTORE} --insecure-registry=http://${registry} --http-proxy http://${mitm}
     Log  ${output}
+    Should Be Equal As Integers  ${rc}  0
 
     ${br2}=  Get Environment Variable  BRIDGE_NETWORK
     Set Environment Variable  BRIDGE_NETWORK_2  ${br2}
     # suite teardown fails if we don't set this back, and we're informed not to edit the Suite Teardown at the top of the file, so
     Set Environment Variable  BRIDGE_NETWORK  ${br1}
 
-    Should Be Equal As Integers  ${rc}  0
     ${rc}  ${vch2-params}=  Run And Return Rc And Output  echo '${output}' | grep -A1 "Connect to docker" | tail -n1 | cut -d' ' -f4- | sed 's/ info" $//g'
 
     # this comment fixes syntax highlighting "

--- a/tests/test-cases/Group1-Docker-Commands/1-02-Docker-Pull.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-02-Docker-Pull.robot
@@ -250,3 +250,10 @@ Attempt docker pull mitm
     Enable SSH on MITMed VCH
     Check For Injected Binary  ${vch2-IP}
     [Teardown]  Destroy Proxified VCH
+
+Pull from docker store
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} login --username=victest --password=%{REGISTRY_PASSWORD}
+    Should Contain  ${output}  Login Succeeded
+    Should Be Equal As Integers  ${rc}  0
+
+    Wait Until Keyword Succeeds  5x  15 seconds  Pull image  store/ibmcorp/mqadvanced-server-dev:9.0.5.0

--- a/tests/test-cases/Group1-Docker-Commands/1-02-Docker-Pull.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-02-Docker-Pull.robot
@@ -136,7 +136,8 @@ Pull non-existent image
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} pull fakebadimage
     Log  ${output}
     Should Be Equal As Integers  ${rc}  1
-    Should contain  ${output}  pull access denied
+    # Check for registry V2 pull message
+    Should contain  ${output}  repository does not exist or may require 'docker login'
 
 Pull image from non-existent repo
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} pull fakebadrepo.com:9999/ubuntu

--- a/tests/test-cases/Group1-Docker-Commands/1-02-Docker-Pull.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-02-Docker-Pull.robot
@@ -136,7 +136,7 @@ Pull non-existent image
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} pull fakebadimage
     Log  ${output}
     Should Be Equal As Integers  ${rc}  1
-    Should contain  ${output}  image library/fakebadimage not found
+    Should contain  ${output}  pull access denied
 
 Pull image from non-existent repo
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} pull fakebadrepo.com:9999/ubuntu

--- a/tests/test-cases/Group1-Docker-Commands/1-04-Docker-Create.md
+++ b/tests/test-cases/Group1-Docker-Commands/1-04-Docker-Create.md
@@ -56,7 +56,7 @@ This test requires that a vSphere server is running and available
 * Step 12 should return with the error message - Error response from daemon: vSphere Integrated Containers does not support mounting directories as a data volume.
 * Steps 13 and 14 should succeed
 * Step 15's and 16's output should contain the named volume created in Step 13
-* Step 18 should return with the error message - Error: image library/fakeimage not found
+* Step 18 should return with the error message - pull access denied for fakeimage, repository does not exist or may require 'docker login'
 * Step 19 should return with the error message - Error parsing reference: "fakeImage" is not a valid repository/tag
 * Step 22 should result in success and the busy2 container should exist
 * Step 24 should show that busy2 was able to successfully ping busy1 just using the linked name

--- a/tests/test-cases/Group1-Docker-Commands/1-04-Docker-Create.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-04-Docker-Create.robot
@@ -113,7 +113,7 @@ Create simple top example
 Create fakeimage image
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} create fakeimage
     Should Be Equal As Integers  ${rc}  1
-    Should Contain  ${output}  pull access denied
+    Should Contain  ${output}  repository does not exist or may require 'docker login'
 
 Create fakeImage repository
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} create fakeImage

--- a/tests/test-cases/Group1-Docker-Commands/1-04-Docker-Create.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-04-Docker-Create.robot
@@ -113,7 +113,7 @@ Create simple top example
 Create fakeimage image
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} create fakeimage
     Should Be Equal As Integers  ${rc}  1
-    Should Contain  ${output}  Error: image library/fakeimage not found
+    Should Contain  ${output}  pull access denied
 
 Create fakeImage repository
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} create fakeImage

--- a/tests/test-cases/Group1-Docker-Commands/1-27-Docker-Login.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-27-Docker-Login.robot
@@ -21,6 +21,8 @@ Test Timeout  20 minutes
 
 *** Test Cases ***
 Docker login and pull from docker.io
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} logout
+    Should Be Equal As Integers  ${rc}  0
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} pull victest/busybox
     Should Be Equal As Integers  ${rc}  1
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} pull victest/public-hello-world

--- a/tests/test-cases/Group23-VIC-Machine-Service/23-03-VCH-Create.robot
+++ b/tests/test-cases/Group23-VIC-Machine-Service/23-03-VCH-Create.robot
@@ -437,7 +437,7 @@ Fail to create VCH where whitelist contains invalid character - registry setting
 
 
 Create VCH where whitelist registry contains valid registry wildcard domain and validate
-    ${wildcard_registry}=    Set Variable    "*.docker.com"
+    ${wildcard_registry}=    Set Variable    "*.docker.io"
 
     Create VCH    '{"name":"%{VCH-NAME}","compute":{"resource":{"name":"%{TEST_RESOURCE}"}},"storage":{"image_stores":["ds://%{TEST_DATASTORE}"]},"network":{"bridge":{"ip_range":"172.16.0.0/12","port_group":{"name":"%{BRIDGE_NETWORK}"}},"public":{"port_group":{"name":"${PUBLIC_NETWORK}"}}},"registry":{"whitelist":[${wildcard_registry}]},"auth":{"server":{"generate":{"cname":"vch.example.com","organization":["VMware, Inc."],"size":{"value":2048,"units":"bits"}}},"client":{"no_tls_verify": true}}}'
 

--- a/tests/test-cases/Group6-VIC-Machine/6-05-Create-Validation.robot
+++ b/tests/test-cases/Group6-VIC-Machine/6-05-Create-Validation.robot
@@ -113,7 +113,7 @@ Whitelist registries - blocked registry wildcard domain
     Log To Console  \nInstalling VCH to test server...
     # *.docker.io
     ${output-esx}=  Run Keyword If  '%{HOST_TYPE}' == 'ESXi'  Run  bin/vic-machine-linux create --name=%{VCH-NAME} --target=%{TEST_URL}/ --thumbprint=%{TEST_THUMBPRINT} --user=%{TEST_USERNAME} --password=%{TEST_PASSWORD} ${vicmachinetls} --whitelist-registry *.docker.io
-    ${output-vc}=  Run Keyword If  '%{HOST_TYPE}' == 'VC'  Run  bin/vic-machine-linux create --name=%{VCH-NAME} --target=%{TEST_URL}/ --thumbprint=%{TEST_THUMBPRINT} --user=%{TEST_USERNAME} --password=%{TEST_PASSWORD} --image-store=%{TEST_DATASTORE} --bridge-network=%{BRIDGE_NETWORK} --public-network=%{PUBLIC_NETWORK} ${vicmachinetls} --whitelist-registry *.docker.io
+    ${output-vc}=  Run Keyword If  '%{HOST_TYPE}' == 'VC'  Run  bin/vic-machine-linux create --name=%{VCH-NAME} --target=%{TEST_URL}/ --thumbprint=%{TEST_THUMBPRINT} --user=%{TEST_USERNAME} --password=%{TEST_PASSWORD} --image-store=%{TEST_DATASTORE} --bridge-network=%{BRIDGE_NETWORK} --public-network=%{PUBLIC_NETWORK} ${vicmachinetls} --whitelist-registry *.docker.com
     ${output}=  Set Variable If  '%{HOST_TYPE}' == 'ESXi'  ${output-esx}  ${output-vc}
     Should Contain  ${output}  Installer completed successfully
     Get Docker Params  ${output}  ${true}
@@ -138,7 +138,7 @@ Whitelist registries - blocked registry ip address of valid registry fqdn
 Whitelist registries - allowed registry fqdn
     Set Test Environment Variables
     ${output-esx}=  Run Keyword If  '%{HOST_TYPE}' == 'ESXi'  Run  bin/vic-machine-linux create --name=%{VCH-NAME} --target=%{TEST_URL}/ --thumbprint=%{TEST_THUMBPRINT} --user=%{TEST_USERNAME} --password=%{TEST_PASSWORD} ${vicmachinetls} --whitelist-registry registry.hub.docker.com
-    ${output-vc}=  Run Keyword If  '%{HOST_TYPE}' == 'VC'  Run  bin/vic-machine-linux create --name=%{VCH-NAME} --target=%{TEST_URL}/ --thumbprint=%{TEST_THUMBPRINT} --user=%{TEST_USERNAME} --password=%{TEST_PASSWORD} --image-store=%{TEST_DATASTORE} --bridge-network=%{BRIDGE_NETWORK} --public-network=%{PUBLIC_NETWORK} ${vicmachinetls} --whitelist-registry registry.hub.docker.com
+    ${output-vc}=  Run Keyword If  '%{HOST_TYPE}' == 'VC'  Run  bin/vic-machine-linux create --name=%{VCH-NAME} --target=%{TEST_URL}/ --thumbprint=%{TEST_THUMBPRINT} --user=%{TEST_USERNAME} --password=%{TEST_PASSWORD} --image-store=%{TEST_DATASTORE} --bridge-network=%{BRIDGE_NETWORK} --public-network=%{PUBLIC_NETWORK} ${vicmachinetls} --whitelist-registry registry-1.docker.io
     ${output}=  Set Variable If  '%{HOST_TYPE}' == 'ESXi'  ${output-esx}  ${output-vc}
     Should Contain  ${output}  Installer completed successfully
     Get Docker Params  ${output}  ${true}
@@ -150,7 +150,7 @@ Whitelist registries - allowed registry fqdn
 Whitelist registries - allowed registry wildcard domain
     Set Test Environment Variables
     ${output-esx}=  Run Keyword If  '%{HOST_TYPE}' == 'ESXi'  Run  bin/vic-machine-linux create --name=%{VCH-NAME} --target=%{TEST_URL}/ --thumbprint=%{TEST_THUMBPRINT} --user=%{TEST_USERNAME} --password=%{TEST_PASSWORD} ${vicmachinetls} --whitelist-registry *hub.docker.com
-    ${output-vc}=  Run Keyword If  '%{HOST_TYPE}' == 'VC'  Run  bin/vic-machine-linux create --name=%{VCH-NAME} --target=%{TEST_URL}/ --thumbprint=%{TEST_THUMBPRINT} --user=%{TEST_USERNAME} --password=%{TEST_PASSWORD} --image-store=%{TEST_DATASTORE} --bridge-network=%{BRIDGE_NETWORK} --public-network=%{PUBLIC_NETWORK} ${vicmachinetls} --whitelist-registry *hub.docker.com
+    ${output-vc}=  Run Keyword If  '%{HOST_TYPE}' == 'VC'  Run  bin/vic-machine-linux create --name=%{VCH-NAME} --target=%{TEST_URL}/ --thumbprint=%{TEST_THUMBPRINT} --user=%{TEST_USERNAME} --password=%{TEST_PASSWORD} --image-store=%{TEST_DATASTORE} --bridge-network=%{BRIDGE_NETWORK} --public-network=%{PUBLIC_NETWORK} ${vicmachinetls} --whitelist-registry *.docker.io
     ${output}=  Set Variable If  '%{HOST_TYPE}' == 'ESXi'  ${output-esx}  ${output-vc}
     Should Contain  ${output}  Installer completed successfully
     Get Docker Params  ${output}  ${true}


### PR DESCRIPTION
We changed the default docker registry URL back when we were
adding content trust.  That URL is causing this failure.  The
URL has been changed back to the same value that is hardcoded
in the docker distribution code.

Also fixed an error interpretation in the fetcher code to match
Docker's interpretation.  We were returning image not found
when the actual error was access denied.  This led the debugging
of this issue down the wrong path and will eventually lead us
down the wrong path with future bugs.

```
[full ci]
[parallel jobs=1]
```

Fixes #8138