### PR TITLE
Clean up `23-01-Metadata` test as discussed during demo

### DIFF
--- a/tests/resources/Group23-VIC-Machine-Service-Util.robot
+++ b/tests/resources/Group23-VIC-Machine-Service-Util.robot
@@ -23,6 +23,7 @@ ${RC}            The return code of the last curl invocation
 ${OUTPUT}        The output of the last curl invocation
 ${STATUS}        The HTTP status of the last curl invocation
 
+${VIC_MACHINE_SERVER_BIN}    ./bin/vic-machine-server
 ${VIC_MACHINE_SERVER_LOG}    vic-machine-server.log
 ${SERVING_AT_TEXT}           Serving vic machine at
 
@@ -32,7 +33,7 @@ Start VIC Machine Server
     ${dir_name}=  Evaluate  'group23_log_dir' + str(random.randint(1000,9999))  modules=random
     Set Suite Variable    ${SERVER_LOG_FILE}    ${dir_name}/${VIC_MACHINE_SERVER_LOG}
 
-    ${handle}=    Start Process    ./bin/vic-machine-server --scheme http --log-directory ${dir_name}/    shell=True    cwd=/go/src/github.com/vmware/vic
+    ${handle}=    Start Process    ${VIC_MACHINE_SERVER_BIN} --scheme http --log-directory ${dir_name}/    shell=True    cwd=/go/src/github.com/vmware/vic
     Set Suite Variable    ${SERVER_HANDLE}    ${handle}
     Process Should Be Running    ${handle}
     Sleep  5sec

--- a/tests/resources/Group23-VIC-Machine-Service-Util.robot
+++ b/tests/resources/Group23-VIC-Machine-Service-Util.robot
@@ -14,7 +14,9 @@
 
 *** Settings ***
 Documentation    This resource contains keywords which are helpful for using curl to test the vic-machine API.
-Library  Process
+Library          Process
+Resource         HTTP-Util.robot
+
 
 *** Variables ***
 ${RC}            The return code of the last curl invocation
@@ -99,30 +101,6 @@ Delete Path Under Target
 Verify Return Code
     Should Be Equal As Integers    ${RC}    0
 
-Verify Status
-    [Arguments]    ${expected}
-    Should Be Equal As Integers    ${expected}    ${STATUS}
-
-Verify Status Ok
-    Verify Status    200
-
-Verify Status Created
-    Verify Status    201
-
-Verify Status Accepted
-    Verify Status    202
-
-Verify Status Bad Request
-    Verify Status    400
-
-Verify Status Not Found
-    Verify Status    404
-
-Verify Status Unprocessable Entity
-    Verify Status    422
-
-Verify Status Internal Server Error
-    Verify Status    500
 
 Output Should Contain
     [Arguments]    ${expected}

--- a/tests/resources/HTTP-Util.robot
+++ b/tests/resources/HTTP-Util.robot
@@ -1,0 +1,48 @@
+# Copyright 2018 VMware, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#	http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License
+
+*** Settings ***
+Documentation    This resource contains keywords which are helpful dealing with HTTP services
+
+
+*** Variables ***
+${STATUS}        The HTTP status of the last curl invocation
+
+
+*** Keywords ***
+Verify Status
+    [Arguments]    ${expected}
+    Should Be Equal As Integers    ${expected}    ${STATUS}
+
+Verify Status Ok
+    Verify Status    200
+
+Verify Status Created
+    Verify Status    201
+
+Verify Status Accepted
+    Verify Status    202
+
+Verify Status Bad Request
+    Verify Status    400
+
+Verify Status Not Found
+    Verify Status    404
+
+Verify Status Unprocessable Entity
+    Verify Status    422
+
+Verify Status Internal Server Error
+    Verify Status    500
+

--- a/tests/test-cases/Group23-VIC-Machine-Service/23-01-Metadata.robot
+++ b/tests/test-cases/Group23-VIC-Machine-Service/23-01-Metadata.robot
@@ -23,12 +23,7 @@ Default Tags
 
 *** Keywords ***
 Get Version
-    ${out}=  Run  netstat -l | grep 1337
-    Log  ${out}
-    ${out}=  Run  ps aux | grep vic-machine-server
-    Log  ${out}
     Get Path    version
-    Verify Return Code
 
 Get Hello
     Get Path    hello
@@ -44,8 +39,9 @@ Verify Hello
 
 *** Test Cases ***
 Get Version
-    Wait Until Keyword Succeeds  5x  1s  Get Version
+    Get Version
 
+    Verify Return Code
     Verify Status Ok
     Verify Version
 


### PR DESCRIPTION
### Extract HTTP-related keywords into resource

Refactor the Group23-VIC-Machine-Service test resource to extract
keywords related to the handling of HTTP status codes into a dedicated
resource for that purpose.

---

### Simplify VCH management API metadata test cases

Previously, it was necessary to retry Get Version due to the potential
for a race between server initialization and test execution. Now that
the Start VIC Machine Server keyword waits for the server to start
(280704f), this race is no longer possible. Simplify the test code
accordingly.

Additionally, eliminate duplicaton of the service name between setup
and diagnostic keywords by defining a variable.

---

`[specific ci=Group23-VIC-Machine-Service]`