### PR TITLE
Cherry-pick: Changes to allow us to run nightly tests for 1.4.3

### DIFF
--- a/tests/drs-disabled/jenkins-drs-disabled-run.sh
+++ b/tests/drs-disabled/jenkins-drs-disabled-run.sh
@@ -35,10 +35,10 @@ n=0
 n=0
    until [ $n -ge 5 ]
    do
-      mkdir bin
+      mkdir vic/bin
       echo "Extracting .tar.gz"
-      tar xvzf $input -C bin/ --strip 1
-      if [ -f "bin/vic-machine-linux" ]
+      tar xvzf $input -C vic/bin --strip 1
+      if [ -f "vic/bin/vic-machine-linux" ]
       then
       echo "tar extraction complete.."
       canContinue="Yes"
@@ -46,7 +46,7 @@ n=0
       else
       echo "tar extraction failed"
       canContinue="No"
-      rm -rf bin
+      rm -rf vic/bin
       fi
       n=$[$n+1]
       sleep 15
@@ -77,5 +77,5 @@ sed -i -e 's|FAIL|<font color="red">FAIL</font>|g' console.log
 
 # Run the log upload script in a container
 cmd="tests/drs-disabled/upload-logs.sh"
-docker run --rm -v $PWD/vic:/go --env-file $envfile $image $cmd
+docker run --rm -e BUILD_TIMESTAMP -v $PWD/vic:/go --env-file $envfile $image $cmd
 

--- a/tests/drs-disabled/jenkins-drs-disabled-run.sh
+++ b/tests/drs-disabled/jenkins-drs-disabled-run.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+# Copyright 2018 VMware, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+input=$(gsutil ls -l gs://vic-engine-builds/vic_* | grep -v TOTAL | sort -k2 -r | head -n1 | xargs | cut -d ' ' -f 3 | cut -d '/' -f 4)
+
+n=0
+   until [ $n -ge 5 ]
+   do
+      echo "Retry.. $n"
+      echo "Downloading gcp file $input"
+      wget https://storage.googleapis.com/vic-engine-builds/$input
+      if [ -f "$input" ]
+      then
+      echo "File found.."
+      break
+      else
+      echo "File NOT found"
+      fi
+      n=$[$n+1]
+      sleep 15
+   done
+
+n=0
+   until [ $n -ge 5 ]
+   do
+      mkdir bin
+      echo "Extracting .tar.gz"
+      tar xvzf $input -C bin/ --strip 1
+      if [ -f "bin/vic-machine-linux" ]
+      then
+      echo "tar extraction complete.."
+      canContinue="Yes"
+      break
+      else
+      echo "tar extraction failed"
+      canContinue="No"
+      rm -rf bin
+      fi
+      n=$[$n+1]
+      sleep 15
+   done
+
+if [[ $canContinue = "No" ]]; then
+    echo "Tarball extraction failed..quitting the run"
+    break
+else
+    echo "Tarball extraction passed, Running nightlies test.."
+fi
+
+# Run the Robot tests in a container
+envfile="vic-internal/drs-disabled-secrets.list"
+image="gcr.io/eminent-nation-87317/vic-integration-test:1.48"
+cmd="pabot --processes 1 --removekeywords TAG:secret -d drs-disabled tests/manual-test-cases/Group19-DRS-Disabled"
+docker run --rm -v $PWD/vic:/go --env-file $envfile $image $cmd
+
+# Remove the VIC binary tar file
+rm $input
+
+cat vic/drs-disabled/pabot_results/*/stdout.txt | grep -E '::|\.\.\.' | grep -E 'PASS|FAIL' > console.log
+
+# Format the email output for Jenkins
+sed -i -e 's/^/<br>/g' console.log
+sed -i -e 's|PASS|<font color="green">PASS</font>|g' console.log
+sed -i -e 's|FAIL|<font color="red">FAIL</font>|g' console.log
+
+# Run the log upload script in a container
+cmd="tests/drs-disabled/upload-logs.sh"
+docker run --rm -v $PWD/vic:/go --env-file $envfile $image $cmd
+

--- a/tests/drs-disabled/upload-logs.sh
+++ b/tests/drs-disabled/upload-logs.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+# Copyright 2016-2018 VMware, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+echo "Upload drs-disabled test logs"
+
+set -x
+gsutil version -l
+set +x
+
+outfile="vic_drs_disabled_logs_"$BUILD_TIMESTAMP".zip"
+echo $outfile
+
+/usr/bin/zip -9 -r $outfile drs-disabled *.zip *.log *.debug *.tgz
+
+# GC credentials
+keyfile=~/vic-drs-disabled-logs.key
+botofile=~/.boto
+if [ ! -f $keyfile ]; then
+    echo -en $GS_PRIVATE_KEY > $keyfile
+    chmod 400 $keyfile
+fi
+if [ ! -f $botofile ]; then
+    echo "[Credentials]" >> $botofile
+    echo "gs_service_key_file = $keyfile" >> $botofile
+    echo "gs_service_client_id = $GS_CLIENT_EMAIL" >> $botofile
+    echo "[GSUtil]" >> $botofile
+    echo "content_language = en" >> $botofile
+    echo "default_project_id = $GS_PROJECT_ID" >> $botofile
+fi
+
+if [ -f "$outfile" ]; then
+  gsutil cp $outfile gs://vic-drs-disabled-logs
+  echo "----------------------------------------------"
+  echo "Download test logs here:"
+  echo "https://console.cloud.google.com/m/cloudstorage/b/vic-drs-disabled-logs/o/$outfile?authuser=1"
+  echo "----------------------------------------------"
+else
+  echo "No log output file to upload"
+fi
+
+if [ -f "$keyfile" ]; then
+  rm -f $keyfile
+fi

--- a/tests/manual-test-cases/Group13-vMotion/13-1-vMotion-VCH-Appliance.robot
+++ b/tests/manual-test-cases/Group13-vMotion/13-1-vMotion-VCH-Appliance.robot
@@ -15,7 +15,7 @@
 *** Settings ***
 Documentation  Test 13-1 - vMotion VCH Appliance
 Resource  ../../resources/Util.robot
-Suite Setup  Wait Until Keyword Succeeds  10x  10m  Create a VSAN Cluster  vic-vmotion-13-1
+Suite Setup  Nimbus Suite Setup  Create a VSAN Cluster  vic-vmotion-13-1
 Suite Teardown  Run Keyword And Ignore Error  Nimbus Cleanup  ${list}
 Test Teardown  Run Keyword If Test Failed  Gather All vSphere Logs
 

--- a/tests/manual-test-cases/Group13-vMotion/13-2-vMotion-Container.robot
+++ b/tests/manual-test-cases/Group13-vMotion/13-2-vMotion-Container.robot
@@ -15,7 +15,7 @@
 *** Settings ***
 Documentation  Test 13-2 - vMotion Container
 Resource  ../../resources/Util.robot
-Suite Setup  Wait Until Keyword Succeeds  10x  10m  Create a VSAN Cluster  vic-vmotion-13-2
+Suite Setup  Nimbus Suite Setup  Create a VSAN Cluster  vic-vmotion-13-2
 Suite Teardown  Run Keyword And Ignore Error  Nimbus Cleanup  ${list}
 Test Teardown  Run Keyword If Test Failed  Gather All vSphere Logs
 

--- a/tests/manual-test-cases/Group19-DRS-Disabled/19-3-DRS-Disabled-Placement.robot
+++ b/tests/manual-test-cases/Group19-DRS-Disabled/19-3-DRS-Disabled-Placement.robot
@@ -49,13 +49,14 @@ Teardown VCH And Cleanup Nimbus
     Run Keyword And Ignore Error  Nimbus Cleanup  ${list}
 
 *** Test Cases ***
-
 # TODO(jzt): we need to test against a single ESX host
 
 Simple Placement
-    Set Environment Variable  GOVC_URL  ${vc1-ip}
-    Set Environment Variable  TEST_URL_ARRAY  ${vc1-ip}
-    Set Environment Variable  TEST_RESOURCE  cls3
+    # TODO(anchal): these are currently set to the static testbed in the secrets file.
+    # Set Environment Variable  GOVC_URL  ${vc1-ip}
+    # Set Environment Variable  TEST_URL_ARRAY  ${vc1-ip}
+    # Set Environment Variable  TEST_RESOURCE  cls3
+
     Set Environment Variable  TEST_TIMEOUT  30m
 
     Log To Console  Deploy VIC to the VC cluster

--- a/tests/manual-test-cases/Group19-DRS-Disabled/19-4-DRS-Disabled-License-Features.md
+++ b/tests/manual-test-cases/Group19-DRS-Disabled/19-4-DRS-Disabled-License-Features.md
@@ -2,31 +2,26 @@ Test 19-4 - DRS Disabled License Features
 =======
 
 # Purpose:
-To verify that the license and feature checks required for a ROBO Advanced environment are displayed and updated on VCH Admin.
+To verify that vic-machine create checks for the DRS setting and command flags specific to resource pools in a vSphere environment without DRS, such as a ROBO deployment. If a VCH is being installed in a DRS-disabled environment, vic-machine create should warn that DRS is disabled and mention that any resource pool options supplied in the command will be ignored as they are not applicable in this environment.
 
 # References:
 1. [vSphere Remote Office and Branch Office](http://www.vmware.com/products/vsphere/remote-office-branch-office.html)
 2. [Provide License and Feature Check](https://github.com/vmware/vic/issues/7277)
-3. [vic-admin to report on license and feature compliance](https://github.com/vmware/vic/issues/7276)
+3. [vic-machine to provide license and feature check](https://github.com/vmware/vic/issues/7275)
 
 # Environment:
-This test requires access to VMware Nimbus cluster for dynamic ESXi and vCenter creation. This test should be executed in the following topologies and should have vSAN enabled.
-* 1 vCenter host with 3 clusters, where 1 cluster has 1 ESXi host and the other 2 clusters have 3 ESXi hosts each
-* 2 vCenter hosts connected with ELM, where each vCenter host has a cluster/host/datacenter topology that emulates a customer environment (exact topology TBD)
+This test requires access to VMware Nimbus cluster for dynamic ESXi and vCenter creation. This test should be executed in a vCenter environment with a cluster that has DRS turned off.
 
 See https://confluence.eng.vmware.com/display/CNA/VIC+ROBO for more details.
 
 # Test Steps:
-1. Deploy a ROBO Advanced vCenter testbed for both environments above
-2. Install a VCH on vCenter
-3. Visit the VCH Admin page and verify that the License and Feature Status sections show that required license and features are present
-4. Assign a more restrictive license such as ROBO Standard or Standard that does not have the required features (VDS, VSPC) to vCenter
-5. Assign the above license to each of the hosts within the vCenter cluster
-6. Refresh the VCH Admin page and verify that the License and Feature Status sections show that required license and features are not present
-7. Delete the VCH
+1. Deploy a vCenter testbed with DRS disabled
+2. Using vic-machine create, install a VCH with compute resource set to the cluster where DRS is off. Also supply options that are specific to resource pools: cpu, cpu-shares, cpu-reservation, memory, memory-shares and memory-reservation.
+3. Delete the VCH
 
 # Expected Outcome:
 * All test steps should complete without error
+* Step 2's output should contain a message stating that DRS is disabed and that the provided resource pool options will be ignored.
 
 # Possible Problems:
 None

--- a/tests/manual-test-cases/Group19-DRS-Disabled/19-4-DRS-Disabled-License-Features.robot
+++ b/tests/manual-test-cases/Group19-DRS-Disabled/19-4-DRS-Disabled-License-Features.robot
@@ -1,0 +1,31 @@
+# Copyright 2018 VMware, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#	http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License
+
+*** Settings ***
+Documentation  Test 19-4 - DRS-Disabled-License-Features
+Resource  ../../resources/Util.robot
+Suite Teardown  Cleanup VIC Appliance On Test Server
+
+*** Test Cases ***
+vic-machine create checks DRS setting and RP options
+    Set Environment Variable  TEST_TIMEOUT  30m
+
+    ${output}=  Install VIC Appliance To Test Server  additional-args=--memory 8000 --memory-reservation 512 --memory-shares 6000 --cpu 10000 --cpu-reservation 512 --cpu-shares high
+    Should Contain  ${output}  DRS is recommended, but is disabled
+    Should Contain  ${output}  Memory Limit
+    Should Contain  ${output}  Memory Reservation
+    Should Contain  ${output}  Memory Shares
+    Should Contain  ${output}  CPU Limit
+    Should Contain  ${output}  CPU Reservation
+    Should Contain  ${output}  CPU Shares

--- a/tests/manual-test-cases/Group21-Registries/21-1-Whitelist.robot
+++ b/tests/manual-test-cases/Group21-Registries/21-1-Whitelist.robot
@@ -42,6 +42,7 @@ Setup Harbor
     Simple ESXi Setup
 
     # Install a Harbor server with HTTPS a Harbor server with HTTP
+    Run Keyword and Ignore Error  Remove File  ${HARBOR_VERSION}.ova
     Install Harbor To Test Server  protocol=https  name=harbor-https
     Set Environment Variable  HTTPS_HARBOR_IP  %{HARBOR-IP}
 

--- a/tests/manual-test-cases/Group21-Registries/21-1-Whitelist.robot
+++ b/tests/manual-test-cases/Group21-Registries/21-1-Whitelist.robot
@@ -16,7 +16,7 @@
 Documentation  Test 21-01 - Whitelist
 Resource  ../../resources/Util.robot
 Resource  ../../resources/Harbor-Util.robot
-Suite Setup  Wait Until Keyword Succeeds  10x  10m  Setup Harbor
+Suite Setup  Nimbus Suite Setup  Setup Harbor
 Suite Teardown  Nimbus Cleanup  ${list}  ${false}
 Test Teardown  Run Keyword If Test Failed  Cleanup VIC Appliance On Test Server
 

--- a/tests/manual-test-cases/Group21-Registries/21-2-Artifactory.robot
+++ b/tests/manual-test-cases/Group21-Registries/21-2-Artifactory.robot
@@ -15,7 +15,7 @@
 *** Settings ***
 Documentation  Test 21-2 - Artifactory
 Resource  ../../resources/Util.robot
-Suite Setup  Wait Until Keyword Succeeds  10x  10m  Artifactory Setup
+Suite Setup  Nimbus Suite Setup  Artifactory Setup
 Suite Teardown  Run Keyword And Ignore Error  Nimbus Cleanup  ${list}
 
 *** Keywords ***

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-1-Distributed-Switch.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-1-Distributed-Switch.robot
@@ -15,7 +15,7 @@
 *** Settings ***
 Documentation  Test 5-1 - Distributed Switch
 Resource  ../../resources/Util.robot
-Suite Setup  Wait Until Keyword Succeeds  10x  10m  Distributed Switch Setup
+Suite Setup  Nimbus Suite Setup  Distributed Switch Setup
 Suite Teardown  Run Keyword And Ignore Error  Nimbus Cleanup  ${list}
 
 *** Variables ***

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-1-Distributed-Switch.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-1-Distributed-Switch.robot
@@ -62,7 +62,7 @@ Distributed Switch Setup
     :FOR  ${IDX}  IN RANGE  ${esx_number}
     \   ${out}=  Run  govc host.add -hostname=@{esx_ips}[${IDX}] -username=root -dc=${datacenter} -password=${NIMBUS_ESX_PASSWORD} -noverify=true
     \   Should Contain  ${out}  OK
-    \   Wait Until Keyword Succeeds  5x  15 seconds  Add Host To Distributed Switch  @{esx_ips}[${IDX}]
+    \   Add Host To Distributed Switch  @{esx_ips}[${IDX}]
 
     Log To Console  Deploy VIC to the VC cluster
     Set Environment Variable  TEST_URL_ARRAY  ${vc_ip}

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-10-Multiple-Datacenter.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-10-Multiple-Datacenter.robot
@@ -15,7 +15,7 @@
 *** Settings ***
 Documentation  Test 5-10 - Multiple Datacenters
 Resource  ../../resources/Util.robot
-Suite Setup  Wait Until Keyword Succeeds  10x  10m  Multiple Datacenter Setup
+Suite Setup  Nimbus Suite Setup  Multiple Datacenter Setup
 Suite Teardown  Run Keyword And Ignore Error  Nimbus Cleanup  ${list}
 
 *** Keywords ***

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-11-Multiple-Cluster.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-11-Multiple-Cluster.robot
@@ -24,7 +24,7 @@ Multiple Cluster Setup
     [Timeout]    110 minutes
     Run Keyword And Ignore Error  Nimbus Cleanup Single VM  '*5-11-multiple-cluster*'  ${false}
     Log To Console  \nStarting testbed deploy...
-    ${out}=  Deploy Nimbus Testbed  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}  --noSupportBundles --plugin testng --vcvaBuild ${VC_VERSION} --esxBuild ${ESX_VERSION} --testbedName vic-multiple-cluster --testbedSpecRubyFile /dbc/pa-dbc1111/mhagen/nimbus-testbeds/testbeds/vic-multiple-cluster.rb --runName 5-11-multiple-cluster
+    ${out}=  Deploy Nimbus Testbed  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}  spec=vic-multiple-cluster.rb  args=--noSupportBundles --plugin testng --vcvaBuild ${VC_VERSION} --esxBuild ${ESX_VERSION} --testbedName vic-multiple-cluster --runName 5-11-multiple-cluster
     Log  ${out}
 
     Open Connection  %{NIMBUS_GW}
@@ -56,7 +56,6 @@ Multiple Cluster Setup
 *** Test Cases ***
 Test
     Log To Console  \nStarting test...
-    Custom Testbed Keepalive  /dbc/pa-dbc1111/mhagen
 
     Install VIC Appliance To Test Server  certs=${false}  vol=default
     Run Regression Tests

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-11-Multiple-Cluster.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-11-Multiple-Cluster.robot
@@ -15,7 +15,7 @@
 *** Settings ***
 Documentation  Test 5-11 - Multiple Clusters
 Resource  ../../resources/Util.robot
-Suite Setup  Wait Until Keyword Succeeds  10x  10m  Multiple Cluster Setup
+Suite Setup  Nimbus Suite Setup  Multiple Cluster Setup
 Suite Teardown  Run Keyword And Ignore Error  Nimbus Cleanup Single VM  '*5-11-multiple-cluster*'  ${false}
 Test Teardown  Cleanup VIC Appliance On Test Server
 

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-11-Multiple-Cluster.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-11-Multiple-Cluster.robot
@@ -16,7 +16,7 @@
 Documentation  Test 5-11 - Multiple Clusters
 Resource  ../../resources/Util.robot
 Suite Setup  Wait Until Keyword Succeeds  10x  10m  Multiple Cluster Setup
-Suite Teardown  Run Keyword And Ignore Error  Nimbus Cleanup  ${list}
+Suite Teardown  Run Keyword And Ignore Error  Nimbus Cleanup Single VM  '*5-11-multiple-cluster*'
 
 *** Keywords ***
 # Insert elements from dict2 into dict1, overwriting conflicts in dict1 & returning new dict
@@ -30,51 +30,37 @@ Combine Dictionaries
 
 Multiple Cluster Setup
     [Timeout]    110 minutes
-    Run Keyword And Ignore Error  Nimbus Cleanup  ${list}  ${false}
-    &{esxes}=  Create Dictionary
-    ${num_of_esxes}=  Evaluate  2
-    :FOR  ${i}  IN RANGE  3
-    # Deploy some ESXi instances
-    \    &{new_esxes}=  Deploy Multiple Nimbus ESXi Servers in Parallel  ${num_of_esxes}  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}
-    \    ${esxes}=  Combine Dictionaries  ${esxes}  ${new_esxes}
+    Run Keyword And Ignore Error  Nimbus Cleanup Single VM  '*5-11-multiple-cluster*'  ${false}
+    Log To Console  \nStarting testbed deploy...
+    ${out}=  Deploy Nimbus Testbed  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}  --noSupportBundles --plugin testng --vcvaBuild ${VC_VERSION} --esxBuild ${ESX_VERSION} --testbedName vic-multiple-cluster --testbedSpecRubyFile /dbc/pa-dbc1111/mhagen/nimbus-testbeds/testbeds/vic-multiple-cluster.rb --runName 5-11-multiple-cluster
+    Log  ${out}
 
-    # Investigate to see how many were actually deployed
-    \    ${len}=  Get Length  ${esxes}
-    \    ${num_of_esxes}=  Evaluate  ${num_of_esxes} - ${len}
+    Open Connection  %{NIMBUS_GW}
+    Wait Until Keyword Succeeds  10 min  30 sec  Login  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}
+    ${vc-ip}=  Get IP  5-11-multiple-cluster.vc.0
+    Close Connection
+    
+    Log To Console  Set environment variables up for GOVC
+    Set Environment Variable  GOVC_URL  ${vc-ip}
+    Set Environment Variable  GOVC_USERNAME  Administrator@vsphere.local
+    Set Environment Variable  GOVC_PASSWORD  Admin\!23
 
-    # Exit if we've got enough & continue loop if we don't
-    \    Exit For Loop If  ${len} >= 2
-    \    Log To Console  Only got ${len} ESXi instance(s); Trying again
-
-    @{esx-names}=  Get Dictionary Keys  ${esxes}
-    @{esx-ips}=  Get Dictionary Values  ${esxes}
-    ${esx1}=  Get From List  ${esx-names}  0
-    ${esx2}=  Get From List  ${esx-names}  1
-    ${esx1-ip}=  Get From List  ${esx-ips}  0
-    ${esx2-ip}=  Get From List  ${esx-ips}  1
-
-    ${esx3}  ${esx4}  ${esx5}  ${vc}  ${esx3-ip}  ${esx4-ip}  ${esx5-ip}  ${vc-ip}=  Create a Simple VC Cluster  datacenter1  cls1
-    Set Suite Variable  @{list}  ${esx1}  ${esx2}  ${esx3}  ${esx4}  ${esx5}  %{NIMBUS_USER}-${vc}
-
-    Log To Console  Create cluster2 on the VC
-    ${out}=  Run  govc cluster.create cls2
-    Should Be Empty  ${out}
-    ${out}=  Run  govc cluster.add -hostname=${esx1-ip} -username=root -dc=datacenter1 -cluster=cls2 -password=e2eFunctionalTest -noverify=true
-    Should Contain  ${out}  OK
-
-    Log To Console  Create cluster3 on the VC
-    ${out}=  Run  govc cluster.create cls3
-    Should Be Empty  ${out}
-    ${out}=  Run  govc cluster.add -hostname=${esx2-ip} -username=root -dc=datacenter1 -cluster=cls3 -password=e2eFunctionalTest -noverify=true
-    Should Contain  ${out}  OK
+    Log To Console  Deploy VIC to the VC cluster
+    Set Environment Variable  TEST_URL_ARRAY  ${vc-ip}
+    Set Environment Variable  TEST_USERNAME  Administrator@vsphere.local
+    Set Environment Variable  TEST_PASSWORD  Admin\!23
+    Set Environment Variable  BRIDGE_NETWORK  bridge
+    Set Environment Variable  PUBLIC_NETWORK  vm-network
+    Remove Environment Variable  TEST_DATACENTER
+    Set Environment Variable  TEST_DATASTORE  local-0
+    Set Environment Variable  TEST_RESOURCE  cls
+    Set Environment Variable  TEST_TIMEOUT  15m
 
 *** Test Cases ***
 Test
     Log To Console  \nStarting test...
-    
+    Custom Testbed Keepalive  /dbc/pa-dbc1111/mhagen
 
     Install VIC Appliance To Test Server  certs=${false}  vol=default
-
     Run Regression Tests
-
     Cleanup VIC Appliance On Test Server

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-11-Multiple-Cluster.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-11-Multiple-Cluster.robot
@@ -16,18 +16,10 @@
 Documentation  Test 5-11 - Multiple Clusters
 Resource  ../../resources/Util.robot
 Suite Setup  Wait Until Keyword Succeeds  10x  10m  Multiple Cluster Setup
-Suite Teardown  Run Keyword And Ignore Error  Nimbus Cleanup Single VM  '*5-11-multiple-cluster*'
+Suite Teardown  Run Keyword And Ignore Error  Nimbus Cleanup Single VM  '*5-11-multiple-cluster*'  ${false}
+Test Teardown  Cleanup VIC Appliance On Test Server
 
 *** Keywords ***
-# Insert elements from dict2 into dict1, overwriting conflicts in dict1 & returning new dict
-Combine Dictionaries
-    [Arguments]  ${dict1}  ${dict2}
-    ${dict2keys}=  Get Dictionary Keys  ${dict2}
-    :FOR  ${key}  IN  @{dict2keys}
-    \    ${elem}=  Get From Dictionary  ${dict2}  ${key}
-    \    Set To Dictionary  ${dict1}  ${key}  ${elem}
-    [Return]  ${dict1}
-
 Multiple Cluster Setup
     [Timeout]    110 minutes
     Run Keyword And Ignore Error  Nimbus Cleanup Single VM  '*5-11-multiple-cluster*'  ${false}
@@ -52,9 +44,14 @@ Multiple Cluster Setup
     Set Environment Variable  BRIDGE_NETWORK  bridge
     Set Environment Variable  PUBLIC_NETWORK  vm-network
     Remove Environment Variable  TEST_DATACENTER
-    Set Environment Variable  TEST_DATASTORE  local-0
-    Set Environment Variable  TEST_RESOURCE  cls
     Set Environment Variable  TEST_TIMEOUT  15m
+    Set Environment Variable  TEST_RESOURCE  cls
+
+    # Get one of the hosts in the cluster we want and make sure we use the correct local datastore
+    ${hosts}=  Run  govc ls -t HostSystem host/cls
+    @{hosts}=  Split To Lines  ${hosts}
+    ${datastore}=  Get Name of First Local Storage For Host  @{hosts}[0]
+    Set Environment Variable  TEST_DATASTORE  "${datastore}"
 
 *** Test Cases ***
 Test
@@ -63,4 +60,3 @@ Test
 
     Install VIC Appliance To Test Server  certs=${false}  vol=default
     Run Regression Tests
-    Cleanup VIC Appliance On Test Server

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-12-Multiple-VLAN.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-12-Multiple-VLAN.robot
@@ -15,7 +15,7 @@
 *** Settings ***
 Documentation  Test 5-12 - Multiple VLAN
 Resource  ../../resources/Util.robot
-Suite Setup  Wait Until Keyword Succeeds  10x  10m  Multiple VLAN Setup
+Suite Setup  Nimbus Suite Setup  Multiple VLAN Setup
 Suite Teardown  Run Keyword And Ignore Error  Nimbus Cleanup  ${list}
 Test Teardown  Cleanup VIC Appliance On Test Server
 

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-13-Invalid-ESXi-Install.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-13-Invalid-ESXi-Install.robot
@@ -15,7 +15,7 @@
 *** Settings ***
 Documentation  Test 5-13 - Invalid ESXi Install
 Resource  ../../resources/Util.robot
-Suite Setup  Wait Until Keyword Succeeds  10x  10m  Invalid ESXi Install Setup
+Suite Setup  Nimbus Suite Setup  Invalid ESXi Install Setup
 Suite Teardown  Run Keyword And Ignore Error  Nimbus Cleanup  ${list}
 
 *** Keywords ***

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-14-Remove-Container-OOB.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-14-Remove-Container-OOB.robot
@@ -15,7 +15,7 @@
 *** Settings ***
 Documentation  Test 5-14 - Remove Container OOB
 Resource  ../../resources/Util.robot
-Suite Setup  Wait Until Keyword Succeeds  10x  10m  Remove Container OOB Setup
+Suite Setup  Nimbus Suite Setup  Remove Container OOB Setup
 Suite Teardown  Run Keyword And Ignore Error  Nimbus Cleanup  ${list}
 
 *** Keywords ***

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-15-NFS-Datastore.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-15-NFS-Datastore.robot
@@ -15,7 +15,7 @@
 *** Settings ***
 Documentation  Test 5-15 - NFS Datastore
 Resource  ../../resources/Util.robot
-Suite Setup  Wait Until Keyword Succeeds  10x  10m  NFS Datastore Setup
+Suite Setup  Nimbus Suite Setup  NFS Datastore Setup
 Suite Teardown  Run Keyword And Ignore Error  Nimbus Cleanup Single VM  '*5-15-nfs-datastore*'
 
 *** Keywords ***

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-15-NFS-Datastore.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-15-NFS-Datastore.robot
@@ -23,7 +23,7 @@ NFS Datastore Setup
     [Timeout]    110 minutes
     Run Keyword And Ignore Error  Nimbus Cleanup Single VM  '*5-15-nfs-datastore*'  ${false}
     Log To Console  \nStarting testbed deploy...    
-    ${out}=  Deploy Nimbus Testbed  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}  --noSupportBundles --plugin testng --vcvaBuild ${VC_VERSION} --esxBuild ${ESX_VERSION} --testbedName vic-simple-cluster --testbedSpecRubyFile /dbc/pa-dbc1111/mhagen/nimbus-testbeds/testbeds/vic-simple-cluster.rb --runName 5-15-nfs-datastore
+    ${out}=  Deploy Nimbus Testbed  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}  spec=vic-simple-cluster.rb  args=--noSupportBundles --plugin testng --vcvaBuild ${VC_VERSION} --esxBuild ${ESX_VERSION} --testbedName vic-simple-cluster --runName 5-15-nfs-datastore
     Log  ${out}
 
     Open Connection  %{NIMBUS_GW}

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-17-FC-Datastore.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-17-FC-Datastore.robot
@@ -15,7 +15,7 @@
 *** Settings ***
 Documentation  Test 5-17 - FC Datastore
 Resource  ../../resources/Util.robot
-Suite Setup  Wait Until Keyword Succeeds  10x  10m  FC Datastore Setup
+Suite Setup  Nimbus Suite Setup  FC Datastore Setup
 Suite Teardown  Run Keyword And Ignore Error  Nimbus Cleanup  ${list}
 
 *** Keywords ***

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-18-Datastore-Cluster-SDRS.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-18-Datastore-Cluster-SDRS.robot
@@ -15,7 +15,7 @@
 *** Settings ***
 Documentation  Test 5-18 - Datastore Cluster SDRS
 Resource  ../../resources/Util.robot
-#Suite Setup  Wait Until Keyword Succeeds  10x  10m  SDRS Datastore Setup
+#Suite Setup  Nimbus Suite Setup  SDRS Datastore Setup
 #Test Teardown  Run Keyword And Ignore Error  Nimbus Cleanup  ${list}
 
 *** Keywords ***

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-2-Cluster.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-2-Cluster.robot
@@ -15,7 +15,7 @@
 *** Settings ***
 Documentation  Test 5-2 - Cluster
 Resource  ../../resources/Util.robot
-Suite Setup  Wait Until Keyword Succeeds  10x  10m  Cluster Setup
+Suite Setup  Nimbus Suite Setup  Cluster Setup
 Suite Teardown  Run Keyword And Ignore Error  Nimbus Cleanup  ${list}
 
 *** Keywords ***

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-2-Cluster.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-2-Cluster.robot
@@ -69,9 +69,9 @@ Cluster Setup
 
     Create Three Distributed Port Groups  ha-datacenter
 
-    Wait Until Keyword Succeeds  5x  1 minute  Add Host To Distributed Switch  /ha-datacenter/host/cls/@{esx_ips}[0]
-    Wait Until Keyword Succeeds  5x  1 minute  Add Host To Distributed Switch  /ha-datacenter/host/cls/@{esx_ips}[1]
-    Wait Until Keyword Succeeds  5x  1 minute  Add Host To Distributed Switch  /ha-datacenter/host/cls/@{esx_ips}[2]
+    Add Host To Distributed Switch  /ha-datacenter/host/cls/@{esx_ips}[0]
+    Add Host To Distributed Switch  /ha-datacenter/host/cls/@{esx_ips}[1]
+    Add Host To Distributed Switch  /ha-datacenter/host/cls/@{esx_ips}[2]
 
     Log To Console  Enable DRS on the cluster
     ${out}=  Run  govc cluster.change -drs-enabled /ha-datacenter/host/cls

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-21-Datastore-Path.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-21-Datastore-Path.robot
@@ -15,7 +15,7 @@
 *** Settings ***
 Documentation    Test 5-21 - Datastore-Path
 Resource  ../../resources/Util.robot
-Suite Setup  Wait Until Keyword Succeeds  10x  10m  Setup Suite ESX
+Suite Setup  Nimbus Suite Setup  Setup Suite ESX
 Suite Teardown  Run Keyword And Ignore Error  Nimbus Cleanup  ${list}
 
 *** Variables ***

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-21-Datastore-Path.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-21-Datastore-Path.robot
@@ -1,4 +1,4 @@
-# Copyright 2016-2017 VMware, Inc. All Rights Reserved.
+# Copyright 2016-2018 VMware, Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -57,7 +57,7 @@ Datastore - DS Scheme Specified in Volume Store
 
     Log To Console  \nRunning custom vic-machine create - with DS Scheme in Volume Store
     # Need to run custom vic-machine create to specify volume store with DS scheme
-    ${output}=  Run  bin/vic-machine-linux create --debug 1 --name=%{VCH-NAME} --target=%{TEST_URL_ARRAY} --user=%{TEST_USERNAME} --bridge-network=%{BRIDGE_NETWORK} --public-network=%{PUBLIC_NETWORK} --image-store=%{TEST_DATASTORE} --volume-store=${dsScheme}%{TEST_DATASTORE}/images:default --password=%{TEST_PASSWORD} --appliance-iso=bin/appliance.iso --bootstrap-iso=bin/bootstrap.iso --insecure-registry harbor.ci.drone.local --force --kv
+    ${output}=  Run  bin/vic-machine-linux create --debug 1 --name=%{VCH-NAME} --target=%{TEST_URL_ARRAY} --user=%{TEST_USERNAME} --bridge-network=%{BRIDGE_NETWORK} --public-network=%{PUBLIC_NETWORK} --image-store=%{TEST_DATASTORE} --volume-store=${dsScheme}%{TEST_DATASTORE}/images:default --password=%{TEST_PASSWORD} --appliance-iso=bin/appliance.iso --bootstrap-iso=bin/bootstrap.iso --insecure-registry harbor.ci.drone.local --force --kv --timeout=%{TEST_TIMEOUT}
     Should Contain  ${output}  Installer completed successfully
 
 
@@ -89,5 +89,5 @@ Datastore - Space in Path with Scheme
 
     Log To Console  \nRunning custom vic-machine create - with DS Scheme in Volume Store with space in path
     # Need to run custom vic-machine create to specify volume store with DS scheme
-    ${output}=  Run  bin/vic-machine-linux create --debug 1 --name=%{VCH-NAME} --target=%{TEST_URL_ARRAY} --user=%{TEST_USERNAME} --bridge-network=%{BRIDGE_NETWORK} --public-network=%{PUBLIC_NETWORK} --image-store=%{TEST_DATASTORE} --volume-store=${dsScheme}%{TEST_DATASTORE}/images:default --password=%{TEST_PASSWORD} --appliance-iso=bin/appliance.iso --bootstrap-iso=bin/bootstrap.iso --insecure-registry harbor.ci.drone.local --force --kv
+    ${output}=  Run  bin/vic-machine-linux create --debug 1 --name=%{VCH-NAME} --target=%{TEST_URL_ARRAY} --user=%{TEST_USERNAME} --bridge-network=%{BRIDGE_NETWORK} --public-network=%{PUBLIC_NETWORK} --image-store=%{TEST_DATASTORE} --volume-store=${dsScheme}%{TEST_DATASTORE}/images:default --password=%{TEST_PASSWORD} --appliance-iso=bin/appliance.iso --bootstrap-iso=bin/bootstrap.iso --insecure-registry harbor.ci.drone.local --force --kv --timeout=%{TEST_TIMEOUT}
     Should Contain  ${output}  Installer completed successfully

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-22-NFS-Volume.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-22-NFS-Volume.robot
@@ -38,23 +38,14 @@ Setup ESX And NFS Suite
     Run Keyword And Ignore Error  Nimbus Cleanup  ${list}  ${false}
     Log To Console  \nStarting test...
 
-    ${esx1}  ${esx1_ip}=  Deploy Nimbus ESXi Server  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}
-    Open Connection  %{NIMBUS_GW}
-    Wait Until Keyword Succeeds  2 min  30 sec  Login  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}
-    ${POD}=  Fetch POD  ${esx1}
-    Log To Console  ${POD}
-    Close Connection
+    ${nfs}  ${nfs_ro}  ${esx1}  ${nfs_ip}  ${nfs_ro_ip}  ${esx1_ip}=  Deploy Simple NFS Testbed  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}  additional-args=--testbedSpecRubyFile /dbc/w3-dbc302/rashok/vic-nfs.rb --esxBuild ${ESX_VERSION} --esxPxeDir ${ESX_VERSION} --plugin testng
 
-    ${nfs}  ${nfs_ip}=  Deploy Nimbus NFS Datastore  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}  additional-args=--nimbus ${POD}
-
-    ${nfs_readonly}  ${nfs_readonly_ip}=  Deploy Nimbus NFS Datastore  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}  additional-args=--disk 5000000 --disk 5000000 --mountOpt ro --nfsOpt ro --mountPoint=storage1 --mountPoint=storage2 --nimbus ${POD}
-
-    Set Suite Variable  @{list}  ${esx1}  ${nfs}  ${nfs_readonly}
+    Set Suite Variable  @{list}  ${esx1}  ${nfs}  ${nfs_ro}
     Set Suite Variable  ${ESX1}  ${esx1}
     Set Suite Variable  ${ESX1_IP}  ${esx1_ip}
     Set Suite Variable  ${NFS_IP}  ${nfs_ip}
     Set Suite Variable  ${NFS}  ${nfs}
-    Set Suite Variable  ${NFS_READONLY_IP}  ${nfs_readonly_ip}
+    Set Suite Variable  ${NFS_READONLY_IP}  ${nfs_ro_ip}
 
     # Add the NFS servers to SSH known host list
     ${out}=  Run Keyword And Ignore Error  Run  sshpass -p %{DEPLOYED_PASSWORD} ssh -o StrictHostKeyChecking\=no root@${NFS_IP} exit
@@ -84,7 +75,7 @@ Setup ENV Variables for VIC Appliance Install
     Set Environment Variable  TEST_URL  ${ESX1_IP}
     Set Environment Variable  TEST_USERNAME  root
     Set Environment Variable  TEST_PASSWORD  ${NIMBUS_ESX_PASSWORD}
-    Set Environment Variable  TEST_DATASTORE  datastore1
+    Set Environment Variable  TEST_DATASTORE  local-0
     Set Environment Variable  TEST_TIMEOUT  30m
     Set Environment Variable  HOST_TYPE  ESXi
     Remove Environment Variable  TEST_DATACENTER
@@ -328,7 +319,6 @@ Docker Inspect Mount Data after Reboot
     Reboot VM and Verify Basic VCH Info
 
     Verify Volume Inspect Info  After VM Reboot  ${mntDataTestContainer}  ${checkList}
-
 
 Kill NFS Server
     Sleep  5 minutes

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-22-NFS-Volume.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-22-NFS-Volume.robot
@@ -15,7 +15,7 @@
 *** Settings ***
 Documentation  Test 5-22 - NFS Volume
 Resource  ../../resources/Util.robot
-Suite Setup  Wait Until Keyword Succeeds  10x  10m  Setup ESX And NFS Suite
+Suite Setup  Nimbus Suite Setup  Setup ESX And NFS Suite
 Suite Teardown  Run Keyword And Ignore Error  NFS Volume Cleanup
 Test Teardown  Gather NFS Logs
 

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-22-NFS-Volume.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-22-NFS-Volume.robot
@@ -38,7 +38,7 @@ Setup ESX And NFS Suite
     Run Keyword And Ignore Error  Nimbus Cleanup  ${list}  ${false}
     Log To Console  \nStarting test...
 
-    ${nfs}  ${nfs_ro}  ${esx1}  ${nfs_ip}  ${nfs_ro_ip}  ${esx1_ip}=  Deploy Simple NFS Testbed  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}  additional-args=--testbedSpecRubyFile /dbc/w3-dbc302/rashok/vic-nfs.rb --esxBuild ${ESX_VERSION} --esxPxeDir ${ESX_VERSION} --plugin testng
+    ${nfs}  ${nfs_ro}  ${esx1}  ${nfs_ip}  ${nfs_ro_ip}  ${esx1_ip}=  Deploy Simple NFS Testbed  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}  spec=vic-nfs.rb  args=--esxBuild ${ESX_VERSION} --esxPxeDir ${ESX_VERSION} --plugin testng
 
     Set Suite Variable  @{list}  ${esx1}  ${nfs}  ${nfs_ro}
     Set Suite Variable  ${ESX1}  ${esx1}

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-24-Non-vSphere-Local-Cluster.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-24-Non-vSphere-Local-Cluster.robot
@@ -15,7 +15,7 @@
 *** Settings ***
 Documentation  Test 5-24 - Non vSphere Local Cluster
 Resource  ../../resources/Util.robot
-Suite Setup  Wait Until Keyword Succeeds  10x  10m  Non vSphere Local Cluster Install Setup
+Suite Setup  Nimbus Suite Setup  Non vSphere Local Cluster Install Setup
 Suite Teardown  Run Keyword And Ignore Error  Nimbus Cleanup  ${list}
 Test Teardown  Cleanup VIC Appliance On Test Server
 

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-25-OPS-User-Grant.md
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-25-OPS-User-Grant.md
@@ -17,7 +17,7 @@ This test requires access to VMware Nimbus cluster for dynamic ESXi and vCenter 
 7. Create a container
 8. Use govc to attempt to out-of-band destroy the container from Step 7
 9. Clean up the VCH
-10. Install version v1.3.0 of the VIC appliance into the cluster with the --ops-grant-perms option
+10. Install version v1.3.1 of the VIC appliance into the cluster with the --ops-grant-perms option
 11. Perform a VCH upgrade to the current version
 12. With the ops-user, use govc to attempt to create a resource pool
 13. Run a variety of docker operations on the VCH

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-25-OPS-User-Grant.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-25-OPS-User-Grant.robot
@@ -15,7 +15,7 @@
 *** Settings ***
 Documentation  Test 5-25 - OPS-User-Grant
 Resource  ../../resources/Util.robot
-Suite Setup  Wait Until Keyword Succeeds  10x  10m  Ops User Create
+Suite Setup  Nimbus Suite Setup  Ops User Create
 Suite Teardown  Run Keyword And Ignore Error  Nimbus Cleanup  ${list}
 
 *** Keywords ***

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-25-OPS-User-Grant.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-25-OPS-User-Grant.robot
@@ -51,6 +51,7 @@ Ops User Create
     Log  Output, govc role.usage: ${out}
 
 Run privilege-dependent docker operations
+    [Timeout]  15 minutes
     # Run containers with volumes and container networks to test scenarios requiring containerVMs
     # to have the highest privileges.
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} pull ${busybox}

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-25-OPS-User-Grant.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-25-OPS-User-Grant.robot
@@ -15,10 +15,9 @@
 *** Settings ***
 Documentation  Test 5-25 - OPS-User-Grant
 Resource  ../../resources/Util.robot
-Suite Setup  Ops User Create
-#Suite Setup  Wait Until Keyword Succeeds  10x  10m  Ops User Create
-#Suite Teardown  Run Keyword And Ignore Error  Nimbus Cleanup  ${list}
-#Test Teardown  Run Keyword If Test Failed  Gather vSphere Logs
+Suite Setup  Wait Until Keyword Succeeds  10x  10m  Ops User Create
+Suite Teardown  Run Keyword And Ignore Error  Nimbus Cleanup  ${list}
+Test Teardown  Run Keyword If Test Failed  Gather vSphere Logs
 
 *** Keywords ***
 Ops User Create

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-25-OPS-User-Grant.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-25-OPS-User-Grant.robot
@@ -142,20 +142,24 @@ vic-machine create grants ops-user perms
     Cleanup VIC Appliance On Test Server
 
 granted ops-user perms work after upgrade
-    Install VIC with version to Test Server  v1.3.0  additional-args=--ops-user ${ops_user_name} --ops-password ${ops_user_password} --ops-grant-perms
+    ${status}=  Get State Of Github Issue  7796
+    Run Keyword If  '${status}' == 'closed'  Fail  Test 5-25-OPS-User-Grant.robot needs to be updated now that Issue #7796 has been resolved
+    Log  Issue \#7796 is blocking implementation  WARN
 
-    Check Original Version
-    Upgrade
-    Check Upgraded Version
-
+    #Install VIC with version to Test Server  v1.3.0  additional-args=--ops-user ${ops_user_name} --ops-password ${ops_user_password} --ops-grant-perms
+    #
+    #Check Original Version
+    #Upgrade
+    #Check Upgraded Version
+    #
     # Run a govc test to check that access is denied on some resources
-    Attempt To Create Resource Pool
-
-    Run Regression Tests
-
-    Run privilege-dependent docker operations
-
-    Cleanup VIC Appliance On Test Server
+    #Attempt To Create Resource Pool
+    #
+    #Run Regression Tests
+    #
+    #Run privilege-dependent docker operations
+    #
+    #Cleanup VIC Appliance On Test Server
 
 Test with VM-Host Affinity
     Log To Console  \nStarting test...

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-25-OPS-User-Grant.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-25-OPS-User-Grant.robot
@@ -17,7 +17,6 @@ Documentation  Test 5-25 - OPS-User-Grant
 Resource  ../../resources/Util.robot
 Suite Setup  Wait Until Keyword Succeeds  10x  10m  Ops User Create
 Suite Teardown  Run Keyword And Ignore Error  Nimbus Cleanup  ${list}
-Test Teardown  Run Keyword If Test Failed  Gather vSphere Logs
 
 *** Keywords ***
 Ops User Create
@@ -139,27 +138,23 @@ vic-machine create grants ops-user perms
 
     Run privilege-dependent docker operations
 
-    Cleanup VIC Appliance On Test Server
+    [Teardown]  Cleanup VIC Appliance On Test Server
 
 granted ops-user perms work after upgrade
-    ${status}=  Get State Of Github Issue  7796
-    Run Keyword If  '${status}' == 'closed'  Fail  Test 5-25-OPS-User-Grant.robot needs to be updated now that Issue #7796 has been resolved
-    Log  Issue \#7796 is blocking implementation  WARN
+    Install VIC with version to Test Server  v1.3.1  additional-args=--ops-user ${ops_user_name} --ops-password ${ops_user_password} --ops-grant-perms
 
-    #Install VIC with version to Test Server  v1.3.0  additional-args=--ops-user ${ops_user_name} --ops-password ${ops_user_password} --ops-grant-perms
-    #
-    #Check Original Version
-    #Upgrade
-    #Check Upgraded Version
-    #
+    Check Original Version
+    Upgrade
+    Check Upgraded Version
+
     # Run a govc test to check that access is denied on some resources
-    #Attempt To Create Resource Pool
-    #
-    #Run Regression Tests
-    #
-    #Run privilege-dependent docker operations
-    #
-    #Cleanup VIC Appliance On Test Server
+    Attempt To Create Resource Pool
+
+    Run Regression Tests
+
+    Run privilege-dependent docker operations
+
+    [Teardown]  Cleanup VIC Appliance On Test Server
 
 Test with VM-Host Affinity
     Log To Console  \nStarting test...
@@ -172,7 +167,7 @@ Test with VM-Host Affinity
 
     Run privilege-dependent docker operations
 
-    Cleanup VIC Appliance On Test Server
+    [Teardown]  Cleanup VIC Appliance On Test Server
 
 vic-machine configure grants ops-user perms
     Install VIC Appliance To Test Server
@@ -184,4 +179,4 @@ vic-machine configure grants ops-user perms
 
     Run privilege-dependent docker operations
 
-    Cleanup VIC Appliance On Test Server
+    [Teardown]  Cleanup VIC Appliance On Test Server

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-26-Static-IP-Address.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-26-Static-IP-Address.robot
@@ -15,48 +15,15 @@
 *** Settings ***
 Documentation  Test 5-26 - Static IP Address
 Resource  ../../resources/Util.robot
-Suite Setup  Wait Until Keyword Succeeds  10x  10m  Static IP Address Create
+Suite Setup  Setup VC With Static IP
 Suite Teardown  Run Keyword And Ignore Error  Nimbus Cleanup  ${list}
 
+
 *** Keywords ***
-Static IP Address Create
-    [Timeout]    110 minutes
-    Log To Console  Starting Static IP Address test...
-    Set Suite Variable  ${NIMBUS_LOCATION}  NIMBUS_LOCATION=wdc
-    Run Keyword And Ignore Error  Nimbus Cleanup  ${list}  ${false}
+Setup VC With Static IP
     ${name}=  Evaluate  'vic-5-26-' + str(random.randint(1000,9999))  modules=random
-    ${out}=  Deploy Nimbus Testbed  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}  --noSupportBundles --plugin testng --vcvaBuild ${VC_VERSION} --esxBuild ${ESX_VERSION} --testbedName vic-simple-cluster --testbedSpecRubyFile /dbc/pa-dbc1111/mhagen/nimbus-testbeds/testbeds/vic-simple-cluster.rb --runName ${name}
-
-    Open Connection  %{NIMBUS_GW}
-    Wait Until Keyword Succeeds  10 min  30 sec  Login  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}
-    ${vc-ip}=  Get IP  ${name}.vc.0
-    ${pod}=  Fetch POD  ${name}.vc.0
-    Set Suite Variable  ${NIMBUS_POD}  ${pod}
-    Close Connection
-
-    Set Suite Variable  @{list}  %{NIMBUS_USER}-${name}.esx.0  %{NIMBUS_USER}-${name}.esx.1  %{NIMBUS_USER}-${name}.esx.2  %{NIMBUS_USER}-${name}.nfs.0  %{NIMBUS_USER}-${name}.vc.0
-    Log To Console  Finished Creating Cluster ${name}
-
-    ${out}=  Get Static IP Address
-    Set Suite Variable  ${static}  ${out}
-    Append To List  ${list}  %{STATIC_WORKER_NAME}
+    Wait Until Keyword Succeeds  10x  10m  Create Simple VC Cluster With Static IP  ${name}
     
-    Log To Console  Set environment variables up for GOVC
-    Set Environment Variable  GOVC_URL  ${vc-ip}
-    Set Environment Variable  GOVC_USERNAME  Administrator@vsphere.local
-    Set Environment Variable  GOVC_PASSWORD  Admin\!23
-
-    Log To Console  Deploy VIC to the VC cluster
-    Set Environment Variable  TEST_URL_ARRAY  ${vc-ip}
-    Set Environment Variable  TEST_USERNAME  Administrator@vsphere.local
-    Set Environment Variable  TEST_PASSWORD  Admin\!23
-    Set Environment Variable  BRIDGE_NETWORK  bridge
-    Set Environment Variable  PUBLIC_NETWORK  vm-network
-    Remove Environment Variable  TEST_DATACENTER
-    Set Environment Variable  TEST_DATASTORE  nfs0-1
-    Set Environment Variable  TEST_RESOURCE  cls
-    Set Environment Variable  TEST_TIMEOUT  15m
-
 *** Test Cases ***
 Test
     Log To Console  \nStarting test...

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-26-Static-IP-Address.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-26-Static-IP-Address.robot
@@ -22,7 +22,7 @@ Suite Teardown  Run Keyword And Ignore Error  Nimbus Cleanup  ${list}
 *** Keywords ***
 Setup VC With Static IP
     ${name}=  Evaluate  'vic-5-26-' + str(random.randint(1000,9999))  modules=random
-    Wait Until Keyword Succeeds  10x  10m  Create Simple VC Cluster With Static IP  ${name}
+    Nimbus Suite Setup  Create Simple VC Cluster With Static IP  ${name}
     
 *** Test Cases ***
 Test

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-26-Static-IP-Address.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-26-Static-IP-Address.robot
@@ -27,7 +27,6 @@ Setup VC With Static IP
 *** Test Cases ***
 Test
     Log To Console  \nStarting test...
-    Custom Testbed Keepalive  /dbc/pa-dbc1111/mhagen
 
     Install VIC Appliance To Test Server  additional-args=--public-network-ip &{static}[ip]/&{static}[netmask] --public-network-gateway &{static}[gateway] --dns-server 10.170.16.48
     Run Regression Tests

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-27-Selenium-Grid.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-27-Selenium-Grid.robot
@@ -15,7 +15,7 @@
 *** Settings ***
 Documentation  Test 5-27 - Selenium Grid
 Resource  ../../resources/Util.robot
-Suite Setup  Wait Until Keyword Succeeds  10x  10m  Selenium Grid Test Setup
+Suite Setup  Nimbus Suite Setup  Selenium Grid Test Setup
 Suite Teardown  Run Keyword And Ignore Error  Nimbus Cleanup  ${list}
 
 *** Keywords ***

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-27-Selenium-Grid.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-27-Selenium-Grid.robot
@@ -24,7 +24,7 @@ Selenium Grid Test Setup
     Log To Console  Starting testbed deployment...
     Run Keyword And Ignore Error  Nimbus Cleanup  ${list}  ${false}
     ${name}=  Evaluate  'vic-5-27-' + str(random.randint(1000,9999))  modules=random
-    ${out}=  Deploy Nimbus Testbed  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}  --noSupportBundles --plugin testng --vcvaBuild ${VC_VERSION} --esxBuild ${ESX_VERSION} --testbedName vic-iscsi-cluster --testbedSpecRubyFile /dbc/pa-dbc1111/mhagen/nimbus-testbeds/testbeds/vic-iscsi-cluster.rb --runName ${name}
+    ${out}=  Deploy Nimbus Testbed  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}  spec=vic-iscsi-cluster.rb  args=--noSupportBundles --plugin testng --vcvaBuild ${VC_VERSION} --esxBuild ${ESX_VERSION} --testbedName vic-iscsi-cluster --runName ${name}
     Log  ${out}
 
     Open Connection  %{NIMBUS_GW}
@@ -71,7 +71,6 @@ Wait Until Selenium Node Is Ready
 *** Test Cases ***    
 Test
     Log To Console  Starting Selenium Grid test...
-    Custom Testbed Keepalive  /dbc/pa-dbc1111/mhagen
 
     Install VIC Appliance To Test Server
 

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-28-VICAdmin-Isolated.md
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-28-VICAdmin-Isolated.md
@@ -1,0 +1,50 @@
+Test 5-28 - VIC Admin Isolated
+=======
+
+# Purpose:
+Verify that VIC Admin can display logs on an isolated network with no wan connection.
+
+# Environment:
+This test requires that a vSphere environment be running and available, which dSwitch test-ds available.
+
+# Test Steps:
+
+1. Create a DVS Port Group that does not have internet connectivity by setting a random vlan id
+2. Deploy VIC appliance to the vSphere server using the no-wan port group
+3. Verify login functions properly
+4. Verify vic admin internet connectivity status is showing a warning icon
+5. Pull the VCH-Init log and verify that it contains valid data
+6. Pull the Docker Personality log and verify that it contains valid data
+7. Create a container via the appliance
+8. Pull the container log bundle from the appliance and verify that it contains the new container's logs
+
+# Test Cases:
+
+## Display HTML
+1. Log in
+2. Page displays vic-machine name in title
+
+## WAN Status Should Fail
+1. Log in
+2. Page displays warning symbols for wan connection status
+
+## Fail To Pull Docker Image
+1. Log in
+2. Pull docker busybox
+3. Fail to pull busybox
+
+## Get Portlayer Log
+1. Log in
+2. Portlayer Log access is allowed and logs are downloaded
+
+## Get VCH-Init Log
+1. Log in
+2. VCH-Init Log access is allowed and logs are downloaded
+
+## Get Docker Personality Log
+1. Log in
+2. Docker Personality Log access is allowed and logs are downloaded
+
+## Get VICAdmin Log
+1. Log in
+2. VICAdmin Log access is allowed and logs are downloaded

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-28-VICAdmin-Isolated.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-28-VICAdmin-Isolated.robot
@@ -25,7 +25,7 @@ Deploy Testbed With Static IP
 
 Setup VC With No WAN
     ${name}=  Evaluate  'vic-5-28-' + str(random.randint(1000,9999))  modules=random
-    Wait Until Keyword Succeeds  10x  10m  Create Simple VC Cluster With Static IP  ${name}
+    Nimbus Suite Setup  Create Simple VC Cluster With Static IP  ${name}
     Set Test Environment Variables
     
     Log To Console  Create a vch with a public network on a no-wan portgroup.

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-28-VICAdmin-Isolated.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-28-VICAdmin-Isolated.robot
@@ -1,0 +1,99 @@
+# Copyright 2016-2018 VMware, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#	http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License
+*** Settings ***
+Documentation  Test 5-28 - VICAdmin Isolated
+Resource  ../../resources/Util.robot
+Suite Setup  Deploy Testbed With Static IP
+Suite Teardown  Teardown VCH With No WAN
+Default Tags
+
+*** Keywords ***
+Deploy Testbed With Static IP
+    Setup VC With No WAN
+    Deploy VCH With No WAN
+
+Setup VC With No WAN
+    ${name}=  Evaluate  'vic-5-28-' + str(random.randint(1000,9999))  modules=random
+    Wait Until Keyword Succeeds  10x  10m  Create Simple VC Cluster With Static IP  ${name}
+    Set Test Environment Variables
+    
+    Log To Console  Create a vch with a public network on a no-wan portgroup.
+
+    ${vlan}=  Evaluate  str(random.randint(1, 195))  modules=random
+
+    ${dvs}=  Run  govc find -type DistributedVirtualSwitch | head -n1
+    ${rc}  ${output}=  Run And Return Rc And Output  govc dvs.portgroup.add -vlan=${vlan} -dvs ${dvs} dpg-no-wan
+    Should Be Equal As Integers  ${rc}  0
+    
+Deploy VCH With No WAN
+    ${out}=  Deploy VCH With No WAN Secret
+    Log  ${out}
+    Get Docker Params  ${out}  ${false}
+
+Deploy VCH With No WAN Secret
+    [Tags]  secret
+    ${output}=  Run  bin/vic-machine-linux create --debug 1 --name=%{VCH-NAME} --target=%{TEST_URL}%{TEST_DATACENTER} --thumbprint=%{TEST_THUMBPRINT} --user=%{TEST_USERNAME} --image-store=%{TEST_DATASTORE} --password=%{TEST_PASSWORD} --force=true --compute-resource=%{TEST_RESOURCE} --no-tlsverify --bridge-network=%{BRIDGE_NETWORK} --management-network=%{PUBLIC_NETWORK} --client-network=%{PUBLIC_NETWORK} --client-network-ip &{static}[ip]/&{static}[netmask] --client-network-gateway 10.0.0.0/8:&{static}[gateway] --public-network dpg-no-wan --public-network-ip 192.168.100.2/24 --public-network-gateway 192.168.100.1 --dns-server 10.170.16.48 --insecure-registry wdc-harbor-ci.eng.vmware.com
+    [Return]  ${output}
+
+Teardown VCH With No WAN
+    Run Keyword And Ignore Error  Nimbus Cleanup  ${list}
+
+Login And Save Cookies
+    [Tags]  secret
+    ${rc}  ${output}=  Run And Return Rc And Output  curl -sk %{VIC-ADMIN}/authentication -XPOST -F username=%{TEST_USERNAME} -F password=%{TEST_PASSWORD} -D /tmp/cookies-%{VCH-NAME}
+    Should Be Equal As Integers  ${rc}  0
+
+*** Test Cases ***
+Display HTML
+    Login And Save Cookies
+    ${rc}  ${output}=  Run And Return Rc And Output  curl -sk %{VIC-ADMIN} -b /tmp/cookies-%{VCH-NAME}
+    Log  ${output}
+    Should contain  ${output}  <title>VIC: %{VCH-NAME}</title>
+
+WAN Status Should Fail
+    Login And Save Cookies
+    ${rc}  ${output}=  Run And Return Rc And Output  curl -sk %{VIC-ADMIN} -b /tmp/cookies-%{VCH-NAME}
+    Log  ${output}
+    Should contain  ${output}  <div class="sixty">Registry and Internet Connectivity<span class="error-message">
+
+Fail To Pull Docker Image
+    Login And Save Cookies
+    ${rc}  ${output}=  Run And Return Rc and Output  docker %{VCH-PARAMS} pull ${busybox}
+    Log  ${output}
+    Should Be Equal As Integers  ${rc}  1
+    Should contain  ${output}  no route to host
+
+Get Portlayer Log
+    Login And Save Cookies
+    ${rc}  ${output}=  Run And Return Rc And Output  curl -sk %{VIC-ADMIN}/logs/port-layer.log -b /tmp/cookies-%{VCH-NAME}
+    Log  ${output}
+    Should contain  ${output}  Launching portlayer server
+
+Get VCH-Init Log
+    Login And Save Cookies
+    ${rc}  ${output}=  Run And Return Rc And Output  curl -sk %{VIC-ADMIN}/logs/init.log -b /tmp/cookies-%{VCH-NAME}
+    Log  ${output}
+    Should contain  ${output}  reaping child processes
+
+Get Docker Personality Log
+    Login And Save Cookies
+    ${rc}  ${output}=  Run And Return Rc And Output  curl -sk %{VIC-ADMIN}/logs/docker-personality.log -b /tmp/cookies-%{VCH-NAME}
+    Log  ${output}
+    Should contain  ${output}  docker personality
+
+Get VICAdmin Log
+    Login And Save Cookies
+    ${rc}  ${output}=  Run And Return Rc And Output  curl -sk %{VIC-ADMIN}/logs/vicadmin.log -b /tmp/cookies-%{VCH-NAME}
+    Log  ${output}
+    Should contain  ${output}  Launching vicadmin pprof server

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-3-Enhanced-Linked-Mode.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-3-Enhanced-Linked-Mode.robot
@@ -15,7 +15,7 @@
 *** Settings ***
 Documentation  Test 5-3 - Enhanced Linked Mode
 Resource  ../../resources/Util.robot
-Suite Setup  Wait Until Keyword Succeeds  10x  10m  Enhanced Link Mode Setup
+Suite Setup  Nimbus Suite Setup  Enhanced Link Mode Setup
 Suite Teardown  Run Keyword And Ignore Error  Nimbus Cleanup  ${list}
 
 *** Keywords ***

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-4-High-Availability.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-4-High-Availability.robot
@@ -15,7 +15,7 @@
 *** Settings ***
 Documentation  Test 5-4 - High Availability
 Resource  ../../resources/Util.robot
-Suite Setup  Wait Until Keyword Succeeds  10x  10m  High Availability Setup
+Suite Setup  Nimbus Suite Setup  High Availability Setup
 Suite Teardown  Nimbus Cleanup  ${list}
 Test Teardown  Run Keyword If Test Failed  Gather vSphere Logs
 

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-4-High-Availability.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-4-High-Availability.robot
@@ -136,7 +136,7 @@ High Availability Setup
     \   Should Contain  ${out}  OK
 
     Log To Console  Add all the hosts to the distributed switch
-    Wait Until Keyword Succeeds  5x  5min  Add Host To Distributed Switch  /${datacenter}/host/cls
+    Add Host To Distributed Switch  /${datacenter}/host/cls
 
     Log To Console  Enable HA and DRS on the cluster
     ${out}=  Run  govc cluster.change -drs-enabled -ha-enabled /${datacenter}/host/cls

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-5-Heterogeneous-ESXi.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-5-Heterogeneous-ESXi.robot
@@ -15,7 +15,7 @@
 *** Settings ***
 Documentation  Test 5-5 - Heterogeneous ESXi
 Resource  ../../resources/Util.robot
-Suite Setup  Wait Until Keyword Succeeds  10x  10m  Heterogenous ESXi Setup
+Suite Setup  Nimbus Suite Setup  Heterogenous ESXi Setup
 Suite Teardown  Run Keyword And Ignore Error  Nimbus Cleanup  ${list}
 Force Tags  hetero
 
@@ -27,15 +27,15 @@ Heterogenous ESXi Setup
     ${pid-vc}=  Deploy Nimbus vCenter Server Async  ${vc}
     Set Suite Variable  @{list}  %{NIMBUS_USER}-${vc}
 
-    Run Keyword And Ignore Error  Cleanup Nimbus PXE folder  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}
+    Run Keyword And Ignore Error  Cleanup Nimbus Folders  ${deletePXE}=%{true}
     ${esx1}  ${esx1-ip}=  Deploy Nimbus ESXi Server  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}  3029944
     Append To List  ${list}  ${esx1}
 
-    Run Keyword And Ignore Error  Cleanup Nimbus PXE folder  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}
+    Run Keyword And Ignore Error  Cleanup Nimbus Folders  ${deletePXE}=%{true}
     ${esx2}  ${esx2-ip}=  Deploy Nimbus ESXi Server  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}  5572656
     Append To List  ${list}  ${esx2}
 
-    Run Keyword And Ignore Error  Cleanup Nimbus PXE folder  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}
+    Run Keyword And Ignore Error  Cleanup Nimbus Folders  ${deletePXE}=%{true}
     ${esx3}  ${esx3-ip}=  Deploy Nimbus ESXi Server  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}
     Append To List  ${list}  ${esx3}
 

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-6-1-VSAN-Simple.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-6-1-VSAN-Simple.robot
@@ -15,7 +15,7 @@
 *** Settings ***
 Documentation  Test 5-6-1 - VSAN-Simple
 Resource  ../../resources/Util.robot
-Suite Setup  Wait Until Keyword Succeeds  10x  10m  Simple VSAN Setup
+Suite Setup  Nimbus Suite Setup  Simple VSAN Setup
 Suite Teardown  Run Keyword And Ignore Error  Nimbus Cleanup  ${list}
 
 *** Keywords ***
@@ -24,27 +24,24 @@ Simple VSAN Setup
     Run Keyword And Ignore Error  Nimbus Cleanup  ${list}  ${false}
     ${name}=  Evaluate  'vic-vsan-' + str(random.randint(1000,9999))  modules=random
     Set Suite Variable  ${user}  %{NIMBUS_USER}
-    ${out}=  Deploy Nimbus Testbed  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}  --plugin testng --vcfvtBuildPath /dbc/pa-dbc1111/mhagen/ --noSupportBundles --vcvaBuild ${VC_VERSION} --esxPxeDir ${ESX_VERSION} --esxBuild ${ESX_VERSION} --testbedName vic-vsan-simple-pxeBoot-vcva --runName ${name}
+    ${out}=  Deploy Nimbus Testbed  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}  spec=vic-vsan.rb  args=--plugin testng --noSupportBundles --vcvaBuild ${VC_VERSION} --esxPxeDir ${ESX_VERSION} --esxBuild ${ESX_VERSION} --testbedName vic-vsan-simple-pxeBoot-vcva --runName ${name}
+
+    Log  ${out}
     Should Contain  ${out}  "deployment_result"=>"PASS"
+
     ${out}=  Split To Lines  ${out}
     :FOR  ${line}  IN  @{out}
-    \   ${status}=  Run Keyword And Return Status  Should Contain  ${line}  .vcva-${VC_VERSION}' is up. IP:
+    \   ${status}=  Run Keyword And Return Status  Should Contain  ${line}  .vc.0' is up. IP:
     \   ${ip}=  Run Keyword If  ${status}  Fetch From Right  ${line}  ${SPACE}
     \   Run Keyword If  ${status}  Set Suite Variable  ${vc-ip}  ${ip}
     \   Exit For Loop If  ${status}
 
-    Set Suite Variable  @{list}  ${user}-${name}.vcva-${VC_VERSION}  ${user}-${name}.esx.0  ${user}-${name}.esx.1  ${user}-${name}.esx.2  ${user}-${name}.esx.3  ${user}-${name}.nfs.0  ${user}-${name}.iscsi.0
+    Set Suite Variable  @{list}  ${user}-${name}.vcva-${VC_VERSION}  ${user}-${name}.esx.0  ${user}-${name}.esx.1  ${user}-${name}.esx.2  ${user}-${name}.esx.3  ${user}-${name}.nfs.0
     
     Log To Console  Set environment variables up for GOVC
     Set Environment Variable  GOVC_URL  ${vc-ip}
     Set Environment Variable  GOVC_USERNAME  Administrator@vsphere.local
     Set Environment Variable  GOVC_PASSWORD  Admin\!23
-
-    Add Host To Distributed Switch  /vcqaDC/host/cls
-
-    Log To Console  Enable DRS and VSAN on the cluster
-    ${out}=  Run  govc cluster.change -drs-enabled /vcqaDC/host/cls
-    Should Be Empty  ${out}
 
     Log To Console  Deploy VIC to the VC cluster
     Set Environment Variable  TEST_URL_ARRAY  ${vc-ip}

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-6-1-VSAN-Simple.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-6-1-VSAN-Simple.robot
@@ -68,8 +68,6 @@ Check VSAN DOMs In Datastore
 Simple VSAN
     Wait Until Keyword Succeeds  10x  30s  Check VSAN DOMs In Datastore  %{TEST_DATASTORE}
 
-    Custom Testbed Keepalive  /dbc/pa-dbc1111/mhagen
-
     Install VIC Appliance To Test Server
     Run Regression Tests
     Cleanup VIC Appliance On Test Server

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-6-1-VSAN-Simple.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-6-1-VSAN-Simple.robot
@@ -1,4 +1,4 @@
-# Copyright 2016-2017 VMware, Inc. All Rights Reserved.
+# Copyright 2016-2018 VMware, Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -34,7 +34,7 @@ Simple VSAN Setup
     \   Exit For Loop If  ${status}
 
     Set Suite Variable  @{list}  ${user}-${name}.vcva-${VC_VERSION}  ${user}-${name}.esx.0  ${user}-${name}.esx.1  ${user}-${name}.esx.2  ${user}-${name}.esx.3  ${user}-${name}.nfs.0  ${user}-${name}.iscsi.0
-
+    
     Log To Console  Set environment variables up for GOVC
     Set Environment Variable  GOVC_URL  ${vc-ip}
     Set Environment Variable  GOVC_USERNAME  Administrator@vsphere.local
@@ -57,10 +57,16 @@ Simple VSAN Setup
     Set Environment Variable  TEST_RESOURCE  cls
     Set Environment Variable  TEST_TIMEOUT  15m
 
+
+Check VSAN DOMs In Datastore
+    [Arguments]  ${test_datastore}
+    ${out}=  Run  govc datastore.vsan.dom.ls -ds ${test_datastore} -l -o
+    Should Be Empty  ${out}
+
+
 *** Test Cases ***
 Simple VSAN
-    ${out}=  Run  govc datastore.vsan.dom.ls -ds %{TEST_DATASTORE} -l -o
-    Should Be Empty  ${out}
+    Wait Until Keyword Succeeds  10x  30s  Check VSAN DOMs In Datastore  %{TEST_DATASTORE}
 
     Custom Testbed Keepalive  /dbc/pa-dbc1111/mhagen
 
@@ -68,5 +74,4 @@ Simple VSAN
     Run Regression Tests
     Cleanup VIC Appliance On Test Server
 
-    ${out}=  Run  govc datastore.vsan.dom.ls -ds %{TEST_DATASTORE} -l -o
-    Should Be Empty  ${out}
+    Wait Until Keyword Succeeds  10x  30s  Check VSAN DOMs In Datastore  %{TEST_DATASTORE}

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-6-2-VSAN-Complex.disabled
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-6-2-VSAN-Complex.disabled
@@ -1,4 +1,4 @@
-# Copyright 2016-2017 VMware, Inc. All Rights Reserved.
+# Copyright 2016-2018 VMware, Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
 *** Settings ***
 Documentation  Test 5-6-2 - VSAN-Complex
 Resource  ../../resources/Util.robot
-Suite Setup  Wait Until Keyword Succeeds  10x  10m  VSAN Complex Setup
+Suite Setup  Nimbus Suite Setup  VSAN Complex Setup
 Suite Teardown  Run Keyword And Ignore Error  Nimbus Cleanup  ${list}
 Force Tags  vsan-complex
 
@@ -25,9 +25,11 @@ VSAN Complex Setup
     Run Keyword And Ignore Error  Nimbus Cleanup  ${list}  ${false}
     ${name}=  Evaluate  'vic-vsan-complex-' + str(random.randint(1000,9999))  modules=random
     Set Suite Variable  ${user}  %{NIMBUS_USER}
-    ${out}=  Deploy Nimbus Testbed  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}  --plugin testng --vcfvtBuildPath /dbc/pa-dbc1111/mhagen/ --noSupportBundles --vcvaBuild ${VC_VERSION} --esxPxeDir ${ESX_VERSION} --esxBuild ${ESX_VERSION} --testbedName vic-vsan-complex-pxeBoot-vcva --runName ${name}
+    ${out}=  Deploy Nimbus Testbed  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}  spec=vic-vsan.rb  args=--plugin testng --noSupportBundles --vcvaBuild ${VC_VERSION} --esxPxeDir ${ESX_VERSION} --esxBuild ${ESX_VERSION} --testbedName vic-vsan-complex-pxeBoot-vcva --runName ${name}
+
     Log  ${out}
     Should Contain  ${out}  "deployment_result"=>"PASS"
+
     ${out}=  Split To Lines  ${out}
     :FOR  ${line}  IN  @{out}
     \   ${status}=  Run Keyword And Return Status  Should Contain  ${line}  .vcva-${VC_VERSION}' is up. IP:

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-6-2-VSAN-Complex.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-6-2-VSAN-Complex.robot
@@ -71,8 +71,6 @@ Check VSAN DOMs In Datastore
 Complex VSAN
     Wait Until Keyword Succeeds  10x  30s  Check VSAN DOMs In Datastore  %{TEST_DATASTORE}
 
-    Custom Testbed Keepalive  /dbc/pa-dbc1111/mhagen
-
     Install VIC Appliance To Test Server
     Run Regression Tests
     Cleanup VIC Appliance On Test Server

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-6-2-VSAN-Complex.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-6-2-VSAN-Complex.robot
@@ -60,11 +60,16 @@ VSAN Complex Setup
     Set Environment Variable  TEST_RESOURCE  cluster-vsan-1
     Set Environment Variable  TEST_TIMEOUT  30m
 
-*** Test Cases ***
-Complex VSAN
-    ${out}=  Run  govc datastore.vsan.dom.ls -ds %{TEST_DATASTORE} -l -o
+
+Check VSAN DOMs In Datastore
+    [Arguments]  ${test_datastore}
+    ${out}=  Run  govc datastore.vsan.dom.ls -ds ${test_datastore} -l -o
     Log  ${out}
     Should Be Empty  ${out}
+
+*** Test Cases ***
+Complex VSAN
+    Wait Until Keyword Succeeds  10x  30s  Check VSAN DOMs In Datastore  %{TEST_DATASTORE}
 
     Custom Testbed Keepalive  /dbc/pa-dbc1111/mhagen
 
@@ -72,6 +77,4 @@ Complex VSAN
     Run Regression Tests
     Cleanup VIC Appliance On Test Server
 
-    ${out}=  Run  govc datastore.vsan.dom.ls -ds %{TEST_DATASTORE} -l -o
-    Log  ${out}
-    Should Be Empty  ${out}
+    Wait Until Keyword Succeeds  10x  30s  Check VSAN DOMs In Datastore  %{TEST_DATASTORE}

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-8-DRS.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-8-DRS.robot
@@ -63,7 +63,7 @@ DRS Setup
     Should Contain  ${out}  OK
 
     Log To Console  Add all the hosts to the distributed switch
-    Wait Until Keyword Succeeds  5x  5min  Add Host To Distributed Switch  /ha-datacenter/host/cls
+    Add Host To Distributed Switch  /ha-datacenter/host/cls
 
     Log To Console  Deploy VIC to the VC cluster
     Set Environment Variable  TEST_URL_ARRAY  ${vc-ip}

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-8-DRS.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-8-DRS.robot
@@ -15,7 +15,7 @@
 *** Settings ***
 Documentation  Test 5-8 - DRS
 Resource  ../../resources/Util.robot
-Suite Setup  Wait Until Keyword Succeeds  10x  10m  DRS Setup
+Suite Setup  Nimbus Suite Setup  DRS Setup
 Suite Teardown  Nimbus Cleanup  ${list}
 
 *** Keywords ***

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-8-DRS.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-8-DRS.robot
@@ -79,14 +79,13 @@ DRS Setup
 *** Test Cases ***
 Test
     Log To Console  \nStarting test...
-    ${status}  ${message}=  Run Keyword And Ignore Error  Install VIC Appliance To Test Server  certs=${false}  vol=default
-    Should Contain  ${message}  DRS must be enabled to use VIC
-    Should Be Equal As Strings  ${status}  FAIL
+    Install VIC Appliance To Test Server  certs=${false}  vol=default
+    Run Regression Tests
+    Cleanup VIC Appliance On Test Server
 
     Log To Console  Enable DRS on the cluster
     ${out}=  Run  govc cluster.change -drs-enabled /ha-datacenter/host/cls
     Should Be Empty  ${out}
 
     Install VIC Appliance To Test Server  certs=${false}  vol=default
-
     Run Regression Tests

--- a/tests/manual-test-cases/Group5-Functional-Tests/TestCases.md
+++ b/tests/manual-test-cases/Group5-Functional-Tests/TestCases.md
@@ -52,4 +52,4 @@ Group 5 - Functional Tests
 -
 [Test 5-27 - Selenium Grid](5-27-Selenium-Grid.md)
 -
-
+[Test 5-28 - VICAdmin Isolated](5-28-VICAdmin-Isolated.md)

--- a/tests/nightly/jenkins-nightly-run.sh
+++ b/tests/nightly/jenkins-nightly-run.sh
@@ -24,7 +24,7 @@ VC_67_VERSION="ob-8217866"
 
 DEFAULT_LOG_UPLOAD_DEST="vic-ci-logs"
 DEFAULT_VCH_BUILD="*"
-DEFAULT_TESTCASES="tests/manual-test-cases/Group5-Functional-Tests tests/manual-test-cases/Group13-vMotion tests/manual-test-cases/Group21-Registries tests/manual-test-cases/Group23-Future-Tests"
+DEFAULT_TESTCASES=("tests/manual-test-cases/Group5-Functional-Tests" "tests/manual-test-cases/Group13-vMotion" "tests/manual-test-cases/Group21-Registries" "tests/manual-test-cases/Group23-Future-Tests")
 
 
 if [[ $1 != "6.0" && $1 != "6.5" && $1 != "6.7" ]]; then
@@ -36,8 +36,8 @@ fi
 target="$1"
 echo "Target version: ${target}"
 shift
-# Take the remaining CLI arguments as a test case list
-testcases="${*:-$DEFAULT_TESTCASES}"
+# Take the remaining CLI arguments as a test case list - this is treated as an array to preserve quoting when passing to pabot
+testcases=("${@:-${DEFAULT_TESTCASES[@]}}")
 
 # TODO: the version downloaded by this logic is not coupled with the tests that will be run against it. This should be altered to pull a version that matches the commit SHA of the tests
 # we will be running or similar mechanism.
@@ -90,7 +90,7 @@ else
 fi
 
 
-pabot --processes 4 --removekeywords TAG:secret ${excludes} --variable ESX_VERSION:${ESX_BUILD} --variable VC_VERSION:${VC_BUILD} -d ${target} "${testcases}"
+pabot --processes 4 --removekeywords TAG:secret ${excludes} --variable ESX_VERSION:${ESX_BUILD} --variable VC_VERSION:${VC_BUILD} -d ${target} "${testcases[@]}"
 cat ${target}/pabot_results/*/stdout.txt | grep '::' | grep -E 'PASS|FAIL' > console.log
 
 # See if any VMs leaked

--- a/tests/nightly/jenkins-nightly-run.sh
+++ b/tests/nightly/jenkins-nightly-run.sh
@@ -83,7 +83,7 @@ elif [[ $target == "6.5" ]]; then
     cat 65/pabot_results/*/stdout.txt | grep '::' | grep -E 'PASS|FAIL' > console.log
 elif [[ $target == "6.7" ]]; then
     echo "Executing nightly tests on vSphere 6.7"
-    pabot --processes 4 --removekeywords TAG:secret --exclude nsx --exclude hetero --exclude vsan-complex --variable ESX_VERSION:$ESX_67_VERSION --variable VC_VERSION:$VC_67_VERSION -d 67/$i tests/manual-test-cases/Group5-Functional-Tests tests/manual-test-cases/Group13-vMotion tests/manual-test-cases/Group21-Registries tests/manual-test-cases/Group23-Future-Tests
+    pabot --processes 4 --removekeywords TAG:secret --exclude nsx --exclude hetero --variable ESX_VERSION:$ESX_67_VERSION --variable VC_VERSION:$VC_67_VERSION -d 67/$i tests/manual-test-cases/Group5-Functional-Tests tests/manual-test-cases/Group13-vMotion tests/manual-test-cases/Group21-Registries tests/manual-test-cases/Group23-Future-Tests
     cat 67/pabot_results/*/stdout.txt | grep '::' | grep -E 'PASS|FAIL' > console.log
 fi
 # Pretty up the email results

--- a/tests/nightly/jenkins-nightly-run.sh
+++ b/tests/nightly/jenkins-nightly-run.sh
@@ -26,6 +26,7 @@ DEFAULT_LOG_UPLOAD_DEST="vic-ci-logs"
 DEFAULT_VCH_BUILD="*"
 DEFAULT_TESTCASES=("tests/manual-test-cases/Group5-Functional-Tests" "tests/manual-test-cases/Group13-vMotion" "tests/manual-test-cases/Group21-Registries" "tests/manual-test-cases/Group23-Future-Tests")
 
+VIC_BINARY_PREFIX="vic_"
 
 if [[ $1 != "6.0" && $1 != "6.5" && $1 != "6.7" ]]; then
     echo "Please specify a target version. One of: 6.0, 6.5, 6.7"
@@ -42,8 +43,11 @@ testcases=("${@:-${DEFAULT_TESTCASES[@]}}")
 # TODO: the version downloaded by this logic is not coupled with the tests that will be run against it. This should be altered to pull a version that matches the commit SHA of the tests
 # we will be running or similar mechanism.
 VCH_BUILD=${VCH_BUILD:-${DEFAULT_VCH_BUILD}}
-input=$(gsutil ls -l gs://vic-engine-builds/vic_${VCH_BUILD} | grep -v TOTAL | sort -k2 -r | head -n1 | xargs | cut -d ' ' -f 3 | cut -d '/' -f 4)
-VCH_BUILD=${input:4}
+input=$(gsutil ls -l gs://vic-engine-builds/${VIC_BINARY_PREFIX}${VCH_BUILD} | grep -v TOTAL | sort -k2 -r | head -n1 | xargs | cut -d ' ' -f 3 | cut -d '/' -f 4)
+
+# strip prefix and suffix from archive filename
+VCH_BUILD=${input#${VIC_BINARY_PREFIX}}
+VCH_BUILD=${VCH_BUILD%%.*}
 
 # Enforce short SHA
 GIT_COMMIT=${GIT_COMMIT:0:7}

--- a/tests/nightly/jenkins-nightly-run.sh
+++ b/tests/nightly/jenkins-nightly-run.sh
@@ -16,8 +16,8 @@
 ESX_60_VERSION="ob-5251623"
 VC_60_VERSION="ob-5112509"
 
-ESX_67_VERSION="ob-8126342"
-VC_67_VERSION="ob-8130682"
+ESX_67_VERSION="ob-8169922"
+VC_67_VERSION="ob-8217866"
 
 if [[ $1 != "6.0" && $1 != "6.5" && $1 != "6.7" ]]; then
     echo "Please specify a target cluster. One of: 6.0, 6.5, 6.7"

--- a/tests/nightly/jenkins-nightly-run.sh
+++ b/tests/nightly/jenkins-nightly-run.sh
@@ -26,7 +26,12 @@ DEFAULT_LOG_UPLOAD_DEST="vic-ci-logs"
 DEFAULT_VCH_BUILD="*"
 DEFAULT_TESTCASES=("tests/manual-test-cases/Group5-Functional-Tests" "tests/manual-test-cases/Group13-vMotion" "tests/manual-test-cases/Group21-Registries" "tests/manual-test-cases/Group23-Future-Tests")
 
+DEFAULT_PARALLEL_JOBS=4
+
 VIC_BINARY_PREFIX="vic_"
+
+PARALLEL_JOBS=${PARLLEL_JOBS:-${DEFAULT_PARALLEL_JOBS}}
+
 
 if [[ $1 != "6.0" && $1 != "6.5" && $1 != "6.7" ]]; then
     echo "Please specify a target version. One of: 6.0, 6.5, 6.7"
@@ -93,8 +98,7 @@ else
     echo "Tarball extraction passed, Running nightlies test.."
 fi
 
-
-pabot --processes 4 --removekeywords TAG:secret ${excludes} --variable ESX_VERSION:${ESX_BUILD} --variable VC_VERSION:${VC_BUILD} -d ${target} "${testcases[@]}"
+pabot --processes ${PARALLEL_JOBS} --removekeywords TAG:secret ${excludes} --variable ESX_VERSION:${ESX_BUILD} --variable VC_VERSION:${VC_BUILD} -d ${target} "${testcases[@]}"
 cat ${target}/pabot_results/*/stdout.txt | grep '::' | grep -E 'PASS|FAIL' > console.log
 
 # See if any VMs leaked

--- a/tests/nightly/jenkins-nightly-run.sh
+++ b/tests/nightly/jenkins-nightly-run.sh
@@ -13,12 +13,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-ESX_60_VERSION="ob-5251623"
-VC_60_VERSION="ob-5112509"
 
-ESX_65_VERSION="ob-7867845"
-VC_65_VERSION="ob-7867539"
+# Permalink to ESX build numbers/versions: https://kb.vmware.com/kb/2143832
+# Permalink to vCenter build numbers/versions: https://kb.vmware.com/kb/2143838
 
+# 6.0u3e
+ESX_60_VERSION="ob-7967664"
+VC_60_VERSION="ob-7924803"
+
+# 6.5u2b
+ESX_65_VERSION="ob-8935087"
+VC_65_VERSION="ob-8815520" 
+
+# 6.7
 ESX_67_VERSION="ob-8169922"
 VC_67_VERSION="ob-8217866"
 

--- a/tests/nightly/jenkins-nightly-run.sh
+++ b/tests/nightly/jenkins-nightly-run.sh
@@ -17,9 +17,9 @@
 # Permalink to ESX build numbers/versions: https://kb.vmware.com/kb/2143832
 # Permalink to vCenter build numbers/versions: https://kb.vmware.com/kb/2143838
 
-# 6.0u3e
-ESX_60_VERSION="ob-7967664"
-VC_60_VERSION="ob-7924803"
+# 6.0u3
+ESX_60_VERSION="ob-5050593"
+VC_60_VERSION="ob-5112509" # the cloudvm build corresponding to the vpx build that is noted in the kb link above
 
 # 6.5u2b
 ESX_65_VERSION="ob-8935087"

--- a/tests/nightly/upload-logs.sh
+++ b/tests/nightly/upload-logs.sh
@@ -29,8 +29,15 @@ if [ ${dest:0:1} == "/" ]; then
   exit 1
 fi
 
+# extract first path element as bucket name
+bucket=${dest%%/*}
+# drop bucket portion from path
+path=${dest#*/}
+# drop trailing / if any
+path=${path%/}
+
 # GC credentials
-keyfile=~/${dest%%/*}.key
+keyfile=~/${bucket}.key
 botofile=~/.boto
 if [ ! -f $keyfile ]; then
     echo -en $GS_PRIVATE_KEY > $keyfile
@@ -49,7 +56,7 @@ echo "----------------------------------------------"
 echo "Uploading logs to ${dest}"
 echo "----------------------------------------------"
 if gsutil cp "${source}" "gs://${dest}"; then
-  url="https://console.cloud.google.com/m/cloudstorage/b/${dest}/o/${source}?authuser=1"
+  url="https://console.cloud.google.com/m/cloudstorage/b/${bucket}/o/${path}/${source}?authuser=1"
   echo "$url" > log-download.url
   echo "Download test logs here:"
   echo "$url"

--- a/tests/resources/Docker-Util.robot
+++ b/tests/resources/Docker-Util.robot
@@ -123,6 +123,7 @@ Verify Container Rename
     Should Contain  ${output}  ${vmName}
 
 Run Regression Tests
+    [Timeout]  15 minutes
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} pull ${busybox}
     Log  ${output}
     Should Be Equal As Integers  ${rc}  0

--- a/tests/resources/Harbor-Util.robot
+++ b/tests/resources/Harbor-Util.robot
@@ -36,9 +36,7 @@ Install Harbor To Test Server
     [Arguments]  ${name}=harbor  ${protocol}=http  ${verify}=off  ${host}=%{TEST_URL_ARRAY}  ${datastore}=%{TEST_DATASTORE}  ${network}=VM Network
     Log To Console  \nFetching harbor ova...
     ${status}  ${message}=  Run Keyword And Ignore Error  OperatingSystem.File Should Exist  ${HARBOR_VERSION}.ova
-    ${rc}  ${output}=  Run Keyword If  '${status}' == 'FAIL'  Run And Return Rc And Output  wget https://github.com/vmware/harbor/releases/download/${HARBOR_SHORT_VERSION}/${HARBOR_VERSION}.ova
-    Log  ${output}
-    Should Be Equal As Integers  ${rc}  0
+    Run Keyword If  '${status}' == 'FAIL'  Download Harbor ova
     ${status}  ${message}=  Run Keyword And Ignore Error  Environment Variable Should Be Set  DRONE_BUILD_NUMBER
     Run Keyword If  '${status}' == 'FAIL'  Set Environment Variable  DRONE_BUILD_NUMBER  0
     @{URLs}=  Split String  %{TEST_URL_ARRAY}
@@ -88,6 +86,12 @@ Install Harbor Self Signed Cert
     Move File  getcert  /etc/docker/certs.d/%{HARBOR_IP}/ca.crt
     ${out}=  Run  systemctl daemon-reload
     ${out}=  Run  systemctl restart docker
+
+Download Harbor ova
+    ${rc}  ${output}=   Run And Return Rc And Output  wget https://github.com/vmware/harbor/releases/download/${HARBOR_SHORT_VERSION}/${HARBOR_VERSION}.ova
+    Log  ${output}
+    Should Be Equal As Integers  ${rc}  0
+    Log To Console    Harbor OVA download successful
 
 Log Into Harbor
     [Arguments]  ${user}=%{TEST_USERNAME}  ${pw}=%{TEST_PASSWORD}

--- a/tests/resources/Harbor-Util.robot
+++ b/tests/resources/Harbor-Util.robot
@@ -36,7 +36,9 @@ Install Harbor To Test Server
     [Arguments]  ${name}=harbor  ${protocol}=http  ${verify}=off  ${host}=%{TEST_URL_ARRAY}  ${datastore}=%{TEST_DATASTORE}  ${network}=VM Network
     Log To Console  \nFetching harbor ova...
     ${status}  ${message}=  Run Keyword And Ignore Error  OperatingSystem.File Should Exist  ${HARBOR_VERSION}.ova
-    ${out}=  Run Keyword If  '${status}' == 'FAIL'  Run  wget https://github.com/vmware/harbor/releases/download/${HARBOR_SHORT_VERSION}/${HARBOR_VERSION}.ova
+    ${rc}  ${output}=  Run Keyword If  '${status}' == 'FAIL'  Run And Return Rc And Output  wget https://github.com/vmware/harbor/releases/download/${HARBOR_SHORT_VERSION}/${HARBOR_VERSION}.ova
+    Log  ${output}
+    Should Be Equal As Integers  ${rc}  0
     ${status}  ${message}=  Run Keyword And Ignore Error  Environment Variable Should Be Set  DRONE_BUILD_NUMBER
     Run Keyword If  '${status}' == 'FAIL'  Set Environment Variable  DRONE_BUILD_NUMBER  0
     @{URLs}=  Split String  %{TEST_URL_ARRAY}

--- a/tests/resources/Network-Util.robot
+++ b/tests/resources/Network-Util.robot
@@ -1,0 +1,25 @@
+# Copyright 2018 VMware, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#	http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License
+
+*** Settings ***
+Documentation  This resource contains any keywords related to networking
+
+*** Keywords ***
+Ping Host Successfully
+    [Arguments]  ${host}
+    ${rc}  ${output}=  Run And Return Rc And Output  ping -c 1 ${host}
+    Log  ${output}
+    Should Be Equal As Integers  ${rc}  0
+    Should Contain  ${output}  1 packets transmitted, 1 packets received, 0% packet loss
+    [Return]  ${output}

--- a/tests/resources/Nimbus-Util.robot
+++ b/tests/resources/Nimbus-Util.robot
@@ -487,23 +487,22 @@ Create Simple VC Cluster With Static IP
     [Timeout]    110 minutes
     Set Suite Variable  ${NIMBUS_LOCATION}  NIMBUS_LOCATION=wdc
     Run Keyword And Ignore Error  Nimbus Cleanup  ${list}  ${false}
-    Log To Console  Create a new simple vc cluser with static ip support...
-    ${out}=  Deploy Nimbus Testbed  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}  --noSupportBundles --plugin testng --vcvaBuild ${VC_VERSION} --esxBuild ${ESX_VERSION} --testbedName vic-simple-cluster --testbedSpecRubyFile /dbc/pa-dbc1111/mhagen/nimbus-testbeds/testbeds/vic-simple-cluster.rb --runName ${name}
+    Log To Console  Create a new simple vc cluster with static ip support...
+    ${out}=  Deploy Nimbus Testbed  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}  --noSupportBundles --plugin testng --vcvaBuild ${VC_VERSION} --esxBuild ${ESX_VERSION} --testbedName vic-simple-cluster-with-static --testbedSpecRubyFile /dbc/pa-dbc1111/mhagen/nimbus-testbeds/testbeds/vic-simple-cluster-with-static.rb --runName ${name}
     Log  ${out}
 
     Open Connection  %{NIMBUS_GW}
     Wait Until Keyword Succeeds  10 min  30 sec  Login  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}
     ${vc-ip}=  Get IP  ${name}.vc.0
-    ${pod}=  Fetch POD  ${name}.vc.0
-    Set Suite Variable  ${NIMBUS_POD}  ${pod}
+    ${worker-ip}=  Get IP  ${name}.worker.0
     Close Connection
 
-    Set Suite Variable  @{list}  %{NIMBUS_USER}-${name}.esx.0  %{NIMBUS_USER}-${name}.esx.1  %{NIMBUS_USER}-${name}.esx.2  %{NIMBUS_USER}-${name}.nfs.0  %{NIMBUS_USER}-${name}.vc.0
-    Log To Console  Finished Creating Cluster ${name}
+    Set Suite Variable  @{list}  %{NIMBUS_USER}-${name}.esx.0  %{NIMBUS_USER}-${name}.esx.1  %{NIMBUS_USER}-${name}.esx.2  %{NIMBUS_USER}-${name}.nfs.0  %{NIMBUS_USER}-${name}.vc.0  %{NIMBUS_USER}-${name}.worker.0
+    Log To Console  Finished creating cluster ${name}
 
+    Set Environment Variable  STATIC_WORKER_IP  ${worker-ip}
     ${out}=  Get Static IP Address
     Set Suite Variable  ${static}  ${out}
-    Append To List  ${list}  %{STATIC_WORKER_NAME}
 
     Log To Console  Set environment variables up for GOVC
     Set Environment Variable  GOVC_URL  ${vc-ip}

--- a/tests/resources/Nimbus-Util.robot
+++ b/tests/resources/Nimbus-Util.robot
@@ -189,16 +189,16 @@ Deploy Nimbus vCenter Server Async
 # Deploys a nimbus testbed based on the specified testbed spec and options
 # user [required] - nimbus user
 # password [required] - password for nimbus user
+# args [optional] - args to pass into testbeddeploy
 # spec [optional] - name of spec file in tests/resources/nimbus-testbeds
-# args [optiona;] - args to pass into testbeddeploy
 Deploy Nimbus Testbed
-    [Arguments]  ${user}  ${password}  ${spec}=  ${args}=
+    [Arguments]  ${user}  ${password}  ${args}=  ${spec}=${EMPTY}
 
     Open Connection  %{NIMBUS_GW}
     Wait Until Keyword Succeeds  2 min  30 sec  Login  ${user}  ${password}
 
-    Run Keyword Unless  ${spec} == ${EMPTY}  Set Test Variable  ${specarg}  --testbedSpecRubyFile ./%{BUILD_TAG}/testbeds/${spec}
-    Run Keyword Unless  ${spec} == ${EMPTY}  Put File  tests/resources/nimbus-testbeds/${spec}  destination=./%{BUILD_TAG}/testbeds/
+    ${specarg}=  Set Variable If  '${spec}' == '${EMPTY}'  ${EMPTY}  --testbedSpecRubyFile ./%{BUILD_TAG}/testbeds/${spec}    
+    Run Keyword Unless  '${spec}' == '${EMPTY}'  Put File  tests/resources/nimbus-testbeds/${spec}  destination=./%{BUILD_TAG}/testbeds/
 
     :FOR  ${IDX}  IN RANGE  1  5
     \   ${out}=  Execute Command  ${NIMBUS_LOCATION} nimbus-testbeddeploy --lease 0.25 ${specarg} ${args}

--- a/tests/resources/Nimbus-Util.robot
+++ b/tests/resources/Nimbus-Util.robot
@@ -451,6 +451,45 @@ Power Off Host
     ${out}=  Execute Command  poweroff -d 0 -f
     Close connection
 
+Create Simple VC Cluster With Static IP
+    [Arguments]  ${name}=vic-simple-vc-static-ip
+    [Timeout]    110 minutes
+    Set Suite Variable  ${NIMBUS_LOCATION}  NIMBUS_LOCATION=wdc
+    Run Keyword And Ignore Error  Nimbus Cleanup  ${list}  ${false}
+    Log To Console  Create a new simple vc cluser with static ip support...
+    ${out}=  Deploy Nimbus Testbed  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}  --noSupportBundles --plugin testng --vcvaBuild ${VC_VERSION} --esxBuild ${ESX_VERSION} --testbedName vic-simple-cluster --testbedSpecRubyFile /dbc/pa-dbc1111/mhagen/nimbus-testbeds/testbeds/vic-simple-cluster.rb --runName ${name}
+    Log  ${out}
+
+    Open Connection  %{NIMBUS_GW}
+    Wait Until Keyword Succeeds  10 min  30 sec  Login  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}
+    ${vc-ip}=  Get IP  ${name}.vc.0
+    ${pod}=  Fetch POD  ${name}.vc.0
+    Set Suite Variable  ${NIMBUS_POD}  ${pod}
+    Close Connection
+
+    Set Suite Variable  @{list}  %{NIMBUS_USER}-${name}.esx.0  %{NIMBUS_USER}-${name}.esx.1  %{NIMBUS_USER}-${name}.esx.2  %{NIMBUS_USER}-${name}.nfs.0  %{NIMBUS_USER}-${name}.vc.0
+    Log To Console  Finished Creating Cluster ${name}
+
+    ${out}=  Get Static IP Address
+    Set Suite Variable  ${static}  ${out}
+    Append To List  ${list}  %{STATIC_WORKER_NAME}
+
+    Log To Console  Set environment variables up for GOVC
+    Set Environment Variable  GOVC_URL  ${vc-ip}
+    Set Environment Variable  GOVC_USERNAME  Administrator@vsphere.local
+    Set Environment Variable  GOVC_PASSWORD  Admin\!23
+
+    Log To Console  Deploy VIC to the VC cluster
+    Set Environment Variable  TEST_URL_ARRAY  ${vc-ip}
+    Set Environment Variable  TEST_USERNAME  Administrator@vsphere.local
+    Set Environment Variable  TEST_PASSWORD  Admin\!23
+    Set Environment Variable  BRIDGE_NETWORK  bridge
+    Set Environment Variable  PUBLIC_NETWORK  vm-network
+    Remove Environment Variable  TEST_DATACENTER
+    Set Environment Variable  TEST_DATASTORE  nfs0-1
+    Set Environment Variable  TEST_RESOURCE  cls
+    Set Environment Variable  TEST_TIMEOUT  15m
+
 Create Static IP Worker
     Open Connection  %{NIMBUS_GW}
     Wait Until Keyword Succeeds  10 min  30 sec  Login  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}

--- a/tests/resources/Nimbus-Util.robot
+++ b/tests/resources/Nimbus-Util.robot
@@ -562,3 +562,9 @@ Is Nimbus Location WDC
     ${status}=  Run Keyword And Return Status  Should Not Be Empty  ${out}
     Close Connection
     [Return]  ${status}
+
+Get Name of First Local Storage For Host
+    [Arguments]  ${host}
+    ${datastores}=  Run  govc host.info -host ${host} -json | jq -r '.HostSystems[].Config.FileSystemVolume.MountInfo[].Volume | select (.Type\=\="VMFS") | select (.Local\=\=true) | .Name'
+    @{datastores}=  Split To Lines  ${datastores}
+    [Return]  @{datastores}[0]

--- a/tests/resources/Nimbus-Util.robot
+++ b/tests/resources/Nimbus-Util.robot
@@ -230,6 +230,12 @@ Nimbus Cleanup
     ${list}=  Catenate  @{vm_list}
     Run Keyword And Ignore Error  Kill Nimbus Server  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}  ${list}
 
+Nimbus Cleanup Single VM
+    [Arguments]  ${vm}  ${collect_log}=True  ${dontDelete}=${false}
+    Run Keyword If  ${collect_log}  Run Keyword And Continue On Failure  Gather Logs From Test Server
+    Return From Keyword If  ${dontDelete}
+    Run Keyword And Ignore Error  Kill Nimbus Server  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}  ${vm}
+
 Gather Host IPs
     ${out}=  Run  govc ls host/cls
     ${out}=  Split To Lines  ${out}

--- a/tests/resources/Nimbus-Util.robot
+++ b/tests/resources/Nimbus-Util.robot
@@ -433,6 +433,29 @@ Deploy Simple NFS Testbed
 
     [Return]  ${user}-${name}.nfs.0  ${user}-${name}.nfs.1  ${user}-${name}.esx.0  ${nfs-ip}  ${nfs-ro-ip}  ${esx-ip}
 
+Deploy Nimbus NFS Datastore
+    [Arguments]  ${user}  ${password}  ${additional-args}=
+    ${name}=  Evaluate  'NFS-' + str(random.randint(1000,9999)) + str(time.clock())  modules=random,time
+    Log To Console  \nDeploying Nimbus NFS server: ${name}
+    Open Connection  %{NIMBUS_GW}
+    Wait Until Keyword Succeeds  2 min  30 sec  Login  ${user}  ${password}
+
+    ${out}=  Execute Command  ${NIMBUS_LOCATION} nimbus-nfsdeploy ${name} ${additional-args}
+    Log  ${out}
+    # Make sure the deploy actually worked
+    Should Contain  ${out}  To manage this VM use
+    # Now grab the IP address and return the name and ip for later use
+    @{out}=  Split To Lines  ${out}
+    :FOR  ${item}  IN  @{out}
+    \   ${status}  ${message}=  Run Keyword And Ignore Error  Should Contain  ${item}  IP is
+    \   Run Keyword If  '${status}' == 'PASS'  Set Suite Variable  ${line}  ${item}
+    @{gotIP}=  Split String  ${line}  ${SPACE}
+    ${ip}=  Remove String  @{gotIP}[5]  ,
+
+    Log To Console  Successfully deployed new NFS server - ${user}-${name}
+    Close connection
+    [Return]  ${user}-${name}  ${ip}
+
 Change ESXi Server Password
     [Arguments]  ${password}
     ${out}=  Run  govc host.account.update -id root -password ${password}

--- a/tests/resources/Util.robot
+++ b/tests/resources/Util.robot
@@ -32,6 +32,7 @@ Resource  Admiral-Util.robot
 Resource  OVA-Util.robot
 Resource  Cert-Util.robot
 Resource  Slack-Util.robot
+Resource  Network-Util.robot
 Resource  nimbus-testbeds/ELM-DRS-Disabled.robot
 
 Variables  dynamic-vars.py

--- a/tests/resources/nimbus-testbeds/vic-multiple-cluster.rb
+++ b/tests/resources/nimbus-testbeds/vic-multiple-cluster.rb
@@ -1,0 +1,152 @@
+oneGB = 1 * 1000 * 1000 # in KB
+ 
+$testbed = Proc.new do
+  {
+    "name" => "multiple-cluster",
+    "version" => 3,
+    "esx" => [ 
+        {
+            "name" => "esx.0",
+            "vc" => "vc.0",
+            "style" => "fullInstall",
+            "desiredPassword" => "e2eFunctionalTest",
+            "memory" => 8192, # 2x default
+            "disks" => [ 30 * oneGB, 30 * oneGB, 30 * oneGB],
+            "nics" => 2,
+            "clusterName" => "cls",
+        },
+        {
+            "name" => "esx.1",
+            "vc" => "vc.0",
+            "style" => "fullInstall",
+            "desiredPassword" => "e2eFunctionalTest",
+            "memory" => 8192, # 2x default
+            "disks" => [ 30 * oneGB, 30 * oneGB, 30 * oneGB],
+            "nics" => 2,
+            "clusterName" => "cls",
+        },
+        {
+            "name" => "esx.2",
+            "vc" => "vc.0",
+            "style" => "fullInstall",
+            "desiredPassword" => "e2eFunctionalTest",
+            "memory" => 8192, # 2x default
+            "disks" => [ 30 * oneGB, 30 * oneGB, 30 * oneGB],
+            "nics" => 2,
+            "clusterName" => "cls2",
+        },
+        {
+            "name" => "esx.3",
+            "vc" => "vc.0",
+            "style" => "fullInstall",
+            "desiredPassword" => "e2eFunctionalTest",
+            "memory" => 8192, # 2x default
+            "disks" => [ 30 * oneGB, 30 * oneGB, 30 * oneGB],
+            "nics" => 2,
+            "clusterName" => "cls3",
+        },
+        {
+            "name" => "esx.4",
+            "vc" => "vc.0",
+            "style" => "fullInstall",
+            "desiredPassword" => "e2eFunctionalTest",
+            "memory" => 8192, # 2x default
+            "disks" => [ 30 * oneGB, 30 * oneGB, 30 * oneGB],
+            "nics" => 2
+        }
+    ],
+ 
+    "vcs" => [
+      {
+        "name" => "vc.0",
+        "type" => "vcva",
+        "dcName" => "dc1",
+        "clusters" => [
+                       {"name" => "cls", "vsan" => false, "enableDrs" => true, "enableHA" => true},
+                       {"name" => "cls2", "vsan" => false, "enableDrs" => true, "enableHA" => true},
+                       {"name" => "cls3", "vsan" => false, "enableDrs" => true, "enableHA" => true}
+                      ],
+        "addHosts" => "multiple-clusters",
+      }
+    ],
+
+    "postBoot" => Proc.new do |runId, testbedSpec, vmList, catApi, logDir|
+      esxList = vmList['esx']
+        esxList.each do |host|
+          host.ssh do |ssh|
+            ssh.exec!("esxcli network firewall set -e false")
+          end
+      end
+      vc = vmList['vc'][0]
+      vim = VIM.connect vc.rbvmomiConnectSpec
+      datacenters = vim.serviceInstance.content.rootFolder.childEntity.grep(RbVmomi::VIM::Datacenter)
+      raise "Couldn't find a Datacenter precreated"  if datacenters.length == 0
+      datacenter = datacenters.first
+      Log.info "Found a datacenter successfully in the system, name: #{datacenter.name}"
+      clusters = datacenter.hostFolder.children
+      raise "Couldn't find a cluster precreated"  if clusters.length == 0
+      cluster = datacenter.hostFolder.allChildren.find{|x| x.name == 'cls'}
+      Log.info "Found a cluster successfully in the system, name: #{cluster.name}"
+
+      dvs = datacenter.networkFolder.CreateDVS_Task(
+        :spec => {
+          :configSpec => {
+            :name => "test-ds"
+          },
+	    }
+      ).wait_for_completion
+      Log.info "Vds DSwitch created"
+
+      dvpg1 = dvs.AddDVPortgroup_Task(
+        :spec => [
+          {
+            :name => "management",
+            :type => :earlyBinding,
+            :numPorts => 12,
+          }
+        ]
+      ).wait_for_completion
+      Log.info "management DPG created"
+
+      dvpg2 = dvs.AddDVPortgroup_Task(
+        :spec => [
+          {
+            :name => "vm-network",
+            :type => :earlyBinding,
+            :numPorts => 12,
+          }
+        ]
+      ).wait_for_completion
+      Log.info "vm-network DPG created"
+
+      dvpg3 = dvs.AddDVPortgroup_Task(
+        :spec => [
+          {
+            :name => "bridge",
+            :type => :earlyBinding,
+            :numPorts => 12,
+          }
+        ]
+      ).wait_for_completion
+      Log.info "bridge DPG created"
+
+      Log.info "Add hosts to the DVS"
+      onecluster_pnic_spec = [ VIM::DistributedVirtualSwitchHostMemberPnicSpec({:pnicDevice => 'vmnic1'}) ]
+      dvs_config = VIM::DVSConfigSpec({
+        :configVersion => dvs.config.configVersion,
+        :host => cluster.host.map do |host|
+        {
+          :operation => :add,
+          :host => host,
+          :backing => VIM::DistributedVirtualSwitchHostMemberPnicBacking({
+            :pnicSpec => onecluster_pnic_spec
+          })
+        }
+        end
+      })
+      dvs.ReconfigureDvs_Task(:spec => dvs_config).wait_for_completion
+      Log.info "Hosts added to DVS successfully"
+    end
+  }
+end
+

--- a/tests/resources/nimbus-testbeds/vic-nfs.rb
+++ b/tests/resources/nimbus-testbeds/vic-nfs.rb
@@ -1,0 +1,43 @@
+require '/mts/git/nimbus/lib/testframeworks/testng/testng.rb'
+oneGB = 1 * 1000 * 1000
+$testbed = Proc.new do |sharedStorageStyle, esxStyle|
+  esxStyle ||= 'fullInstall'
+  esxStyle = esxStyle.to_s
+  sharedStorageStyle = sharedStorageStyle.to_s
+
+  testbed = {
+    'version' => 3,
+    'name' => "nfs-1esx-#{sharedStorageStyle}-#{esxStyle}",
+    'esx' => [
+      {
+        'name' => "esx.0",
+        'style' => esxStyle,
+        'numMem' => 16 * 1024,
+        'numCPUs' => 6,
+        "disks" => [ 30 * oneGB, 30 * oneGB, 30 * oneGB],
+        'disableNfsMounts' => true,
+        'nics' => 2,
+        'staf' => false,
+        'desiredPassword' => 'e2eFunctionalTest',
+    }],
+    'nfs' => [{
+    'name' => 'dev-nfs',
+    'type' => 'NFS',
+    'nfsOpt' => 'rw',
+    'numMem' => 16 * 1024,
+    },
+    'nfs' => {
+    'name' => 'dev-nfs',
+    'type' => 'NFS',
+    'nfsOpt' => 'ro',
+    'numMem' => 16 * 1024,
+    }],
+  }
+end
+
+[:pxeBoot, :fullInstall].each do |esxStyle|
+    [:iscsi, :fc].each do |sharedStorageStyle|
+      testbedSpec = $testbed.call(sharedStorageStyle, esxStyle)
+      Nimbus::TestbedRegistry.registerTestbed testbedSpec
+    end
+  end

--- a/tests/resources/nimbus-testbeds/vic-simple-cluster-with-static.rb
+++ b/tests/resources/nimbus-testbeds/vic-simple-cluster-with-static.rb
@@ -1,0 +1,126 @@
+oneGB = 1 * 1000 * 1000 # in KB
+ 
+$testbed = Proc.new do
+  {
+    "name" => "vic-simple-cluster-with-static",
+    "version" => 3,
+    "esx" => (0..2).map do | idx |
+      {
+        "name" => "esx.#{idx}",
+        "vc" => "vc.0",
+        "style" => "fullInstall",
+        "desiredPassword" => "e2eFunctionalTest",
+        "memory" => 8192, # 2x default
+        "disks" => [ 30 * oneGB, 30 * oneGB, 30 * oneGB],
+        "nics" => 2,
+        "mountNfs" => ["nfs.0"],
+        "clusterName" => "cls",
+      }
+    end,
+
+    "nfs" => [
+      {
+        "name" => "nfs.0",
+        "type" => "NFS41"
+      }
+    ],
+ 
+    "vcs" => [
+      {
+        "name" => "vc.0",
+        "type" => "vcva",
+        "dcName" => "dc1",
+        "clusters" => [{"name" => "cls", "vsan" => false, "enableDrs" => true, "enableHA" => true}],
+        "addHosts" => "allInSameCluster",
+      }
+    ],
+
+    "worker" => [
+      {
+         "name" => "worker.0",
+         "enableStaticIpService" => true,
+      },
+     ],
+
+    "postBoot" => Proc.new do |runId, testbedSpec, vmList, catApi, logDir|
+      workerVM = vmList['worker'][0]
+      Log.info "static ip service endpoint is #{workerVM.info['nsips']}"
+      esxList = vmList['esx']
+        esxList.each do |host|
+          host.ssh do |ssh|
+            ssh.exec!("esxcli network firewall set -e false")
+          end
+      end
+      vc = vmList['vc'][0]
+      vim = VIM.connect vc.rbvmomiConnectSpec
+      datacenters = vim.serviceInstance.content.rootFolder.childEntity.grep(RbVmomi::VIM::Datacenter)
+      raise "Couldn't find a Datacenter precreated"  if datacenters.length == 0
+      datacenter = datacenters.first
+      Log.info "Found a datacenter successfully in the system, name: #{datacenter.name}"
+      clusters = datacenter.hostFolder.children
+      raise "Couldn't find a cluster precreated"  if clusters.length == 0
+      cluster = clusters.first
+      Log.info "Found a cluster successfully in the system, name: #{cluster.name}"
+
+      dvs = datacenter.networkFolder.CreateDVS_Task(
+        :spec => {
+          :configSpec => {
+            :name => "test-ds"
+          },
+	    }
+      ).wait_for_completion
+      Log.info "Vds DSwitch created"
+
+      dvpg1 = dvs.AddDVPortgroup_Task(
+        :spec => [
+          {
+            :name => "management",
+            :type => :earlyBinding,
+            :numPorts => 12,
+          }
+        ]
+      ).wait_for_completion
+      Log.info "management DPG created"
+
+      dvpg2 = dvs.AddDVPortgroup_Task(
+        :spec => [
+          {
+            :name => "vm-network",
+            :type => :earlyBinding,
+            :numPorts => 12,
+          }
+        ]
+      ).wait_for_completion
+      Log.info "vm-network DPG created"
+
+      dvpg3 = dvs.AddDVPortgroup_Task(
+        :spec => [
+          {
+            :name => "bridge",
+            :type => :earlyBinding,
+            :numPorts => 12,
+          }
+        ]
+      ).wait_for_completion
+      Log.info "bridge DPG created"
+
+      Log.info "Add hosts to the DVS"
+      onecluster_pnic_spec = [ VIM::DistributedVirtualSwitchHostMemberPnicSpec({:pnicDevice => 'vmnic1'}) ]
+      dvs_config = VIM::DVSConfigSpec({
+        :configVersion => dvs.config.configVersion,
+        :host => cluster.host.map do |host|
+        {
+          :operation => :add,
+          :host => host,
+          :backing => VIM::DistributedVirtualSwitchHostMemberPnicBacking({
+            :pnicSpec => onecluster_pnic_spec
+          })
+        }
+        end
+      })
+      dvs.ReconfigureDvs_Task(:spec => dvs_config).wait_for_completion
+      Log.info "Hosts added to DVS successfully"
+    end
+  }
+end
+

--- a/tests/resources/nimbus-testbeds/vic-vsan.rb
+++ b/tests/resources/nimbus-testbeds/vic-vsan.rb
@@ -141,7 +141,7 @@ $testbed = Proc.new do |type, esxStyle, vcStyle, dbType, location|
     testbed['vc']['dbHost'] = 'vc-mssql'
   end
 
-  testbed = VcQaTestbedCommon.addSharedDisks testbed, [20, 10, 20, 10], sharedStorageStyle   # 2 x 20gb shared vmfs, 2 x 10gb free luns as defined by 'freeSharedLuns', DON'T CHANGE THE ORDERING UNLESS YOU KNOW WHAT YOU'RE DOING!
+  testbed = VcQaTestbedCommon.addSharedDisks testbed, [10, 10, 20, 20], sharedStorageStyle   # 2 x 20gb shared vmfs, 2 x 10gb free luns as defined by 'freeSharedLuns', DON'T CHANGE THE ORDERING UNLESS YOU KNOW WHAT YOU'RE DOING!
 
   testbed
 end

--- a/tests/resources/nimbus-testbeds/vic-vsan.rb
+++ b/tests/resources/nimbus-testbeds/vic-vsan.rb
@@ -22,7 +22,7 @@ $testbed = Proc.new do |type, esxStyle, vcStyle, dbType, location|
       {
         "name" => "esx.#{idx}",
         "vc" => "vc.0",
-        "style" => "pxeInstall",
+        "style" => esxStyle,
         "desiredPassword" => "e2eFunctionalTest",
         'numMem' => 13 * 1024,
         'numCPUs' => 4,

--- a/tests/test-cases/Group23-VIC-Machine-Service/23-02-VCH-List.robot
+++ b/tests/test-cases/Group23-VIC-Machine-Service/23-02-VCH-List.robot
@@ -121,14 +121,3 @@ Get VCH List Within Invalid Datacenter and Compute Resource
 
     Verify Return Code
     Verify Status Not Found
-
-
-Get Empty VCH List When No VCH deployed
-    Cleanup VIC Appliance On Test Server
-
-    Get VCH List
-
-    Verify Return Code
-    Verify Status Ok
-
-    Verify VCH List Empty

--- a/tests/test-cases/Group24-Multi-VCH/24-01-Multi-VCH-PS.robot
+++ b/tests/test-cases/Group24-Multi-VCH/24-01-Multi-VCH-PS.robot
@@ -23,6 +23,7 @@ Clean Up VCHs
     Set Environment Variable  VCH-NAME  ${old-vm}
     Set Environment Variable  BRIDGE_NETWORK  ${old-vch-bridge}
     Set Environment Variable  VCH-PARAMS  ${old-vch-params}
+    Set Environment Variable  VIC-ADMIN  ${old-vic-admin}
     Run Keyword And Continue On Failure  Cleanup VIC Appliance On Test Server
 
 *** Test Cases ***
@@ -34,6 +35,7 @@ Create Multi VCH - Docker Ps Only Contains The Correct Containers
     Set Suite Variable  ${old-vm}  %{VCH-NAME}
     Set Suite Variable  ${old-vch-params}  %{VCH-PARAMS}
     Set Suite Variable  ${old-vch-bridge}  %{BRIDGE_NETWORK}
+    Set Suite Variable  ${old-vic-admin}  %{VIC-ADMIN}
 
     # make sure we create two different bridge networks
     Remove Environment Variable  BRIDGE_NETWORK

--- a/tests/test-cases/Group24-Multi-VCH/24-02-Multi-VCH-Delete.robot
+++ b/tests/test-cases/Group24-Multi-VCH/24-02-Multi-VCH-Delete.robot
@@ -23,6 +23,7 @@ Cleanup VCHs
     Run Keyword If  '${old-vch}' != '${EMPTY}'  Set Environment Variable  VCH-NAME  ${old-vch}
     Run Keyword If  '${old-vch-bridge}' != '${EMPTY}'  Set Environment Variable  BRIDGE_NETWORK  ${old-vch-bridge}
     Run Keyword If  '${old-vch-params}' != '${EMPTY}'  Set Environment Variable  VCH-PARAMS  ${old-vch-params}
+    Run Keyword If  '${old-vic-admin}' != '${EMPTY}'  Set Environment Variable  VIC-ADMIN  ${old-vic-admin}
     Run Keyword And Continue On Failure  Cleanup VIC Appliance On Test Server
 
 *** Test Cases ***
@@ -40,6 +41,7 @@ VCH delete only removes its own containers
     Set Suite Variable  ${old-vch}  %{VCH-NAME}
     Set Suite Variable  ${old-vch-params}  %{VCH-PARAMS}
     Set Suite Variable  ${old-vch-bridge}  %{BRIDGE_NETWORK}
+    Set Suite Variable  ${old-vic-admin}  %{VIC-ADMIN}
 
     # Unset BRIDGE_NETWORK so the new VCH uses a unique bridge network
     Remove Environment Variable  BRIDGE_NETWORK
@@ -64,4 +66,5 @@ VCH delete only removes its own containers
     Set Environment Variable  VCH-NAME  ${old-vch}
     Set Environment Variable  BRIDGE_NETWORK  ${old-vch-bridge}
     Set Environment Variable  VCH-PARAMS  ${old-vch-params}
+    Set Environment Variable  VIC-ADMIN  ${old-vic-admin}
     Cleanup VIC Appliance On Test Server

--- a/tests/test-cases/Group6-VIC-Machine/6-13-TLS.robot
+++ b/tests/test-cases/Group6-VIC-Machine/6-13-TLS.robot
@@ -123,6 +123,7 @@ Create VCH - Server certificate with multiple blocks
     Should Contain  ${output}  Failed to load x509 leaf
     Should Contain  ${output}  Loaded server certificate
     Should Contain  ${output}  Installer completed successfully
+    Get Docker Params  ${output}  ${true}
 
     Cleanup VIC Appliance On Test Server
 
@@ -137,6 +138,7 @@ Create VCH - Invalid keys
     Run Keyword And Ignore Error  Cleanup Datastore On Test Server
 
     ${output}=  Run  bin/vic-machine-linux create --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --image-store=%{TEST_DATASTORE} --bridge-network=%{BRIDGE_NETWORK} --public-network=%{PUBLIC_NETWORK} ${vicmachinetls}
+    Get Docker Params  ${output}  ${true}
 
     # Invalid server key
     ${output}=  Run  bin/vic-machine-linux create --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --image-store=%{TEST_DATASTORE} --bridge-network=%{BRIDGE_NETWORK} --public-network=%{PUBLIC_NETWORK} ${vicmachinetls} --tls-ca="./%{VCH-NAME}/ca.pem" --tls-server-cert="./%{VCH-NAME}/server-cert.pem" --tls-server-key="./%{VCH-NAME}/ca.pem"
@@ -177,6 +179,7 @@ Create VCH - Reuse keys
     Should Contain  ${output}  Loaded server certificate
     Should Contain  ${output}  Loaded CA with default name from certificate path
     Should Contain  ${output}  Loaded client certificate with default name from certificate path
+    Get Docker Params  ${output}  ${true}
 
     Cleanup VIC Appliance On Test Server
 


### PR DESCRIPTION
Cherry-pick a variety of changes related to nightly testing to allow us to run nightly tests on the 1.4.3 release branch:
* Update DRS test to our new non-drs support (453200e from #7765)
* Add retry on vSAN DOM objects in DS check (f1c9787 from #7792)
* Add vSAN DOM check retry for vSAN Complex test (760046b from #7799)
* Add nightly for vicadmin tests on isolated vch (d5135e4 from #7793)
* Fix setup/teardown in opsuser tests (c6ea3e2 from #7836)
* nightly: Disable 5-25-OPS-User-Grant upgrade test (7b6cde7 from #7863)
* Nimbus testbed for nfs volume nightly test (ff6baa9 from #7853)
* Use 1.3.1 in ops user upgrade test (47851e3 from #7874)
* Fix several tests that did not appropriately use the vic-admin env var (b5bad94 from #7879)
* Update the nightlies builds (70e4c2b from #7883)
* Configure ROBO nightlies with Group19-DRS-Disabled (fe040e0 from #7876)
* Add timeouts in case of hung operations (72391e5 from #7884)
* Fix tar extraction path in DRS-disabled nightlies (0cf0634 from #7889)
* Add test for no-DRS VCH create with RP options (e3991c1 from #7881)
* New testbed for multiple cluster test (0ce740b from #7888)
* Switch to testbed for NFS Datastore test (29f07bb from #7900)
* VCH install timeout set to 30m for 5-21-Datastore-Path (0e43ea6 from #7902)
* Add NFS datastore keyword back (b7784b8 from #7906)
* Select correct datastore for the test (86c0c52 from #7909)
* Create a new testbed that includes a static IP address worker (de44136 from #7918)
* Add ping to NFS Volume nightly tests (71664a5 from #7821)
* Fix VSAN testbed for 6.7 testing (4573c60 from #7971)
* Improving 21-1-Whitelist Test -Harbor Setup (ef61c13 from #7997)
* fix harbor-util (2c5ded5 from #8011)
* Parameterize nightly job script (3b269fa from #8047)
* Preserve quoting in test runner script (88d047f from #8060)
* Integration test script refinement and fixes (0f68789 from #8063)
* Additional fixes to integration tests (d533414 from #8069)
* Updates to suite&dvs retry logic, increased predictability (1387ab1 from #8074)
* Update vsphere build numbers for scenario tests (3af7fa6 from #8136)
* Scenario tests run on 6.0u3 instead of 6.0u3e (e0dd53e from #8139)