### PR TITLE
Allow nightly tests to get artifacts from a url [skip ci]

### DIFF
--- a/tests/nightly/jenkins-nightly-run.sh
+++ b/tests/nightly/jenkins-nightly-run.sh
@@ -30,6 +30,7 @@ ESX_67_VERSION="ob-8169922"
 VC_67_VERSION="ob-8217866"
 
 DEFAULT_LOG_UPLOAD_DEST="vic-ci-logs"
+DEFAULT_ARTIFACT_BUCKET="vic-engine-builds"
 DEFAULT_VCH_BRANCH=""
 DEFAULT_VCH_BUILD="*"
 DEFAULT_TESTCASES=("tests/manual-test-cases/Group5-Functional-Tests" "tests/manual-test-cases/Group13-vMotion" "tests/manual-test-cases/Group21-Registries" "tests/manual-test-cases/Group23-Future-Tests")
@@ -61,7 +62,11 @@ testcases=("${@:-${DEFAULT_TESTCASES[@]}}")
 # we will be running or similar mechanism.
 VCH_BUILD=${VCH_BUILD:-${DEFAULT_VCH_BUILD}}
 VCH_BRANCH=${VCH_BRANCH:-${DEFAULT_VCH_BRANCH}}
-input=$(gsutil ls -l gs://vic-engine-builds/${VCH_BRANCH}${VCH_BRANCH:+/}${VIC_BINARY_PREFIX}${VCH_BUILD} | grep -v TOTAL | sort -k2 -r | head -n1 | xargs | cut -d ' ' -f 3 | cut -d '/' -f 4)
+ARTIFACT_BUCKET=${ARTIFACT_BUCKET:-${DEFAULT_ARTIFACT_BUCKET}}
+input=$(gsutil ls -l gs://${ARTIFACT_BUCKET}/${VCH_BRANCH}${VCH_BRANCH:+/}${VIC_BINARY_PREFIX}${VCH_BUILD} | grep -v TOTAL | sort -k2 -r | head -n1 | xargs | cut -d ' ' -f 3 | xargs basename)
+constructed_url="https://storage.googleapis.com/${ARTIFACT_BUCKET}/${VCH_BRANCH}${VCH_BRANCH:+/}${input}"
+ARTIFACT_URL="${ARTIFACT_URL:-${constructed_url}}"
+input=$(basename ${ARTIFACT_URL})
 
 # strip prefix and suffix from archive filename
 VCH_BUILD=${input#${VIC_BINARY_PREFIX}}
@@ -92,8 +97,8 @@ LOG_UPLOAD_DEST="${LOG_UPLOAD_DEST:-${DEFAULT_LOG_UPLOAD_DEST}}"
 n=0 && rm -f "${input}"
 until [ $n -ge 5 -o -f "${input}" ]; do
     echo "Retry.. $n"
-    echo "Downloading gcp file ${input}"
-    wget -nv https://storage.googleapis.com/vic-engine-builds/${input}
+    echo "Downloading gcp file ${input} from ${ARTIFACT_URL}"
+    wget -nv ${ARTIFACT_URL}
 
     ((n++))
     sleep 15


### PR DESCRIPTION
Enable downloading artifacts from a given url so we can run nightly
tests against a specific build. Also enable constructing the url
according to bucket, branch folder and build number.

<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[  ] There is an associated issue that is labelled
[  ] Code is up-to-date with the `master` branch
[  ] You've successfully run `make test` locally
[  ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/vmware/vic/blob/master/.github/CONTRIBUTING.md
-->

Fixes #

<!--
To trigger a custom build with this PR, include one of these in the PR's body:
- To skip running tests (e.g. for a work-in-progress PR), add `[ci skip]` or `[skip ci]`
to the commit message or the PR title.
- To run the full test suite, use `[full ci]`.
- To run _one_ integration test or group, use `[specific ci=$test]`. Examples:
  - To run the `1-01-Docker-Info` suite: `[specific ci=1-01-Docker-Info]`
  - To run all suites under the `Group1-Docker-Commands` group: `[specific ci=Group1-Docker-Commands]`
- To skip running the unit tests, use `[skip unit]`.
- To fail fast (make normal failures fatal) during the integration testing, use `[fast fail]`.
-->
