### PR TITLE
Change kill and stop implementation to enhance compatibility

### DIFF
--- a/lib/tether/shared/constants.go
+++ b/lib/tether/shared/constants.go
@@ -22,4 +22,7 @@ const (
 	FilterSpecQueryName  = "filter-spec"
 	SkipRecurseQueryName = "skip-recurse"
 	SkipDataQueryName    = "skip-data"
+	GuestActionReload    = "reload"
+	GuestActionKill      = "kill"
+	GuestActionGroupKill = "group-kill"
 )

--- a/lib/tether/tether.go
+++ b/lib/tether/tether.go
@@ -677,10 +677,6 @@ func (t *tether) cleanupSession(session *SessionConfig) {
 func (t *tether) handleSessionExit(session *SessionConfig) {
 	defer trace.End(trace.Begin("handling exit of session " + session.ID))
 
-	log.Debugf("Waiting on session.wait")
-	session.wait.Wait()
-	log.Debugf("Wait on session.wait completed")
-
 	log.Debugf("Calling wait on cmd")
 	if err := session.Cmd.Wait(); err != nil {
 		// we expect this to get an error because the child reaper will have gathered it

--- a/lib/tether/tether_linux.go
+++ b/lib/tether/tether_linux.go
@@ -138,7 +138,15 @@ func (t *tether) childReaper() error {
 						log.Debugf("Removed child pid: %d", pid)
 						session.Lock()
 						session.ExitStatus = exitCode
+						session.Unlock()
 
+						// Don't hold the lock while waiting for the file descriptors
+						// to close as these can be held open by child processes
+						log.Debugf("Waiting on session.wait")
+						session.wait.Wait()
+						log.Debugf("Wait on session.wait completed")
+
+						session.Lock()
 						t.handleSessionExit(session)
 						session.Unlock()
 						continue


### PR DESCRIPTION
This PR implements a set of changes that makes VIC behave like the Docker server when dealing with "kill" and "stop" commands. When a "kill" command is sent to a container, only the top process receives the signal. When a "stop" command is sent to a container the Stop Signal is sent to the top process, after 10 seconds a SIGKILL signal is sent to all the member of the process group. 

This PR contains the following set of changes:

1. Send signals only to top process (instead of to the process group) when sending  **kill** (fixes issue #8152)
2. For **stop** send the  Stop Signal (default SIGTERM) to the top process, followed by a SIGKILL to the members of the process group (if all processes have not exited within 10 seconds)
3. Fix issue where the Tether would block while trying to send the SIGKILL and leave the VM in an incorrect state, causing the following PowerOff command to fail on ESXi (issue https://github.com/vmware/vic-tasks/issues/73)

---

`[specific ci=1-14-Docker-Kill]`