### PR TITLE
Prevent vicadmin from being loaded in an iframe

### DIFF
--- a/tests/test-cases/Group9-VIC-Admin/9-01-VICAdmin-ShowHTML.robot
+++ b/tests/test-cases/Group9-VIC-Admin/9-01-VICAdmin-ShowHTML.robot
@@ -78,6 +78,11 @@ Display HTML
     ${rc}  ${output}=  Run And Return Rc And Output  curl -sk %{VIC-ADMIN} -b ${cookies}
     Should contain  ${output}  <title>VIC: %{VCH-NAME}</title>
 
+Content-Security-Policy
+    ${cookies}=  Login To VCH Admin And Save Cookies
+    ${rc}  ${output}=  Run And Return Rc And Output  curl -sk -vvv %{VIC-ADMIN} -b ${cookies}
+    Should contain  ${output}  Content-Security-Policy: frame-ancestors 'none';
+
 Get Portlayer Log
     ${cookies}=  Login To VCH Admin And Save Cookies
     ${rc}  ${output}=  Run And Return Rc And Output  curl -sk %{VIC-ADMIN}/logs/port-layer.log -b ${cookies}


### PR DESCRIPTION
In order to protect the vicadmin page from being embedded in a page
controlled by an attacker, set the Content-Security-Policy header to
disallow rendering of the page within an iframe.

Fixes #8174 

---

`[Group9-VIC-Admin]`