### PR TITLE
Fix typo in syntax for collapsable section

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -278,11 +278,11 @@ Consider formatting longer logs so that they are not shown by default.
 
 Example:
 ```
-<detail><summary>View Logs</summary>
+<details><summary>View Logs</summary>
 <pre><code>
 ... (log content)
 </code></pre>
-</detail>
+</details>
 ```
 
 [code]:https://help.github.com/articles/creating-and-highlighting-code-blocks/


### PR DESCRIPTION
The element is named `details`, not `detail` [1].

1 - https://developer.mozilla.org/en-US/docs/Web/HTML/Element/details

---

`[skip ci]`