### PR TITLE
Enhance locking/serialization for concurrent exec

### DIFF
--- a/lib/apiservers/engine/errors/errors.go
+++ b/lib/apiservers/engine/errors/errors.go
@@ -178,3 +178,25 @@ type DetachError struct{}
 func (DetachError) Error() string {
 	return "detached from container"
 }
+
+// LockTimeoutError is returned when a tryLock operation times out
+type LockTimeoutError struct {
+	Desc string
+}
+
+func (e LockTimeoutError) Error() string {
+	return fmt.Sprintf("LockTimeoutError error: %s", e.Desc)
+}
+
+func NewLockTimeoutError(desc string) error {
+	return LockTimeoutError{Desc: desc}
+}
+
+func IsLockTimeoutOrConflictError(err error) bool {
+	// Is Error is due to Timeout or a Conflict return true
+	if _, ok := err.(LockTimeoutError); ok {
+		return true
+	}
+
+	return IsConflictError(err)
+}

--- a/lib/portlayer/task/common.go
+++ b/lib/portlayer/task/common.go
@@ -32,13 +32,6 @@ func toggleActive(op *trace.Operation, h interface{}, id string, active bool) (i
 		return nil, fmt.Errorf("Type assertion failed for %#+v", handle)
 	}
 
-	op.Debugf("target task ID: %s", id)
-	op.Debugf("session tasks during inspect: %s", handle.ExecConfig.Sessions)
-	// print all of them, otherwise we will have to assemble the id list regardless of
-	// the log level at the moment. If there is a way to check the log level we should
-	// do that. since the other approach will slow down all calls to toggleActive.
-	op.Debugf("exec tasks during inspect: %s", handle.ExecConfig.Execs)
-
 	var task *executor.SessionConfig
 	if taskS, okS := handle.ExecConfig.Sessions[id]; okS {
 		task = taskS

--- a/lib/portlayer/task/inspect.go
+++ b/lib/portlayer/task/inspect.go
@@ -34,10 +34,6 @@ func Inspect(op *trace.Operation, h interface{}, id string) (*executor.SessionCo
 	stasks := handle.ExecConfig.Sessions
 	etasks := handle.ExecConfig.Execs
 
-	op.Debugf("target task ID: %s", id)
-	op.Debugf("session tasks during inspect: %s", stasks)
-	op.Debugf("exec tasks during inspect: %s", etasks)
-
 	if _, ok := stasks[id]; ok {
 		return stasks[id], nil
 	}

--- a/tests/test-cases/Group1-Docker-Commands/1-38-Docker-Exec.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-38-Docker-Exec.robot
@@ -226,11 +226,11 @@ Concurrent Simple Exec
     ${rc}  ${id}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -itd --name ${ExecSimpleContainer} ${busybox} /bin/top
     Should Be Equal As Integers  ${rc}  0
 
-    :FOR  ${idx}  IN RANGE  1  20
+    :FOR  ${idx}  IN RANGE  1  50
     \   Start Process  docker %{VCH-PARAMS} exec ${id} /bin/ls  alias=exec-simple-%{VCH-NAME}-${idx}  shell=true
 
-    :FOR  ${idx}  IN RANGE  1  20
-    \   ${result}=  Wait For Process  exec-simple-%{VCH-NAME}-${idx}  timeout=40s
+    :FOR  ${idx}  IN RANGE  1  50
+    \   ${result}=  Wait For Process  exec-simple-%{VCH-NAME}-${idx}  timeout=300s
     \   Should Be Equal As Integers  ${result.rc}  0
     \   Verify LS Output For Busybox  ${result.stdout}
     # stop the container now that we have a successful series of concurrent execs
@@ -248,11 +248,11 @@ Concurrent Simple Exec Detached
     ${rc}  ${id}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -itd --name ${ExecSimpleContainer} ${busybox} /bin/top
     Should Be Equal As Integers  ${rc}  0
 
-    :FOR  ${idx}  IN RANGE  1  20
+    :FOR  ${idx}  IN RANGE  1  50
     \   Start Process  docker %{VCH-PARAMS} exec -d ${id} touch /tmp/${idx}  alias=exec-simple-detached-%{VCH-NAME}-${idx}  shell=true
 
-    :FOR  ${idx}  IN RANGE  1  20
-    \   ${result}=  Wait For Process  exec-simple-detached-%{VCH-NAME}-${idx}  timeout=40s
+    :FOR  ${idx}  IN RANGE  1  50
+    \   ${result}=  Wait For Process  exec-simple-detached-%{VCH-NAME}-${idx}  timeout=300s
     \   Should Be Equal As Integers  ${result.rc}  0
 
     ### TODO: check inspect status and wait for execs to stop


### PR DESCRIPTION
This PR contains two sets of changes:

**Locking and serialization**
The current implementation consists of two separate mechanisms to provide serialization. The external mechanism is based on multi-versioned concurrency control, (sometime called snapshot isolation), two or more concurrent updates are allowed to occur, but only one wins. The failed ones are retried automatically up to a certain max elapsed time. The internal mechanism uses  a traditional lock, which fully serializes operations on both ExecCreate and ExecStart. Requests block on this lock for up to 3 minutes then they are allowed to continue in parallel, basically falling back to the external retry mechanism. Notice that the internal mechanism rely on the same lock for both ExecCreate and ExecStart.

Unfortunately the chosen timeout value guarantees that after timing out on the lock (3 minutes) no retries are executed by the external mechanism (since the max elapsed time is 1 minute). This may result in the following error:

```Conflict error from portlayer: [PUT /containers/{handle}][409] commitConflict  &{Code:0 Message:Cannot complete operation due to concurrent modification by another operation.}```

To ameliorate this issue the following changes have been made:
- Increase external max elapsed time (from 1 minute to 15),
- Instead of blocking for a long time on the internal lock, requests block for a maximum of 1 second
   then rely on the external retry mechanism,
- The average interval between two retries on the external mechanism has been customized to favor 
   ExecStart over ExecCreate. Requests that have made it through the Create phase are now privileged 
   over new incoming requests. This provides a more even response output to the end user.

**Removal of extensive Logging**
There were a couple of places in the Port Layer where extensive logging was performed. These have been removed since OpID are now correctly propagated from the Engine to the Portlayer.

---

`[specific ci=1-38-Docker-Exec]`