### PR TITLE
Cherry-pick: Prevent vicadmin from being loaded in an iframe (#8177)

### DIFF
--- a/cmd/vicadmin/server.go
+++ b/cmd/vicadmin/server.go
@@ -380,6 +380,21 @@ func (s *server) loginPage(res http.ResponseWriter, req *http.Request) {
 	}
 }
 
+// cspMiddleware sets the Content-Security-Policy header to prevent clickjacking
+// https://www.owasp.org/index.php/Content_Security_Policy_Cheat_Sheet#Preventing_Clickjacking
+func (s *server) cspMiddleware() func(next http.Handler) http.Handler {
+	header := "Content-Security-Policy"
+	value := "frame-ancestors 'none';"
+
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Add(header, value)
+
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
 func (s *server) serve() error {
 	defer trace.End(trace.Begin(""))
 
@@ -420,7 +435,7 @@ func (s *server) serve() error {
 	s.Authenticated("/logout", s.logoutHandler)
 	s.Authenticated("/", s.index)
 	server := &http.Server{
-		Handler: s.mux,
+		Handler: s.cspMiddleware()(s.mux),
 	}
 
 	return server.Serve(s.l)

--- a/tests/test-cases/Group9-VIC-Admin/9-01-VICAdmin-ShowHTML.robot
+++ b/tests/test-cases/Group9-VIC-Admin/9-01-VICAdmin-ShowHTML.robot
@@ -72,6 +72,11 @@ Display HTML
     ${rc}  ${output}=  Run And Return Rc And Output  curl -sk %{VIC-ADMIN} -b ${cookies}
     Should contain  ${output}  <title>VIC: %{VCH-NAME}</title>
 
+Content-Security-Policy
+    ${cookies}=  Login To VCH Admin And Save Cookies
+    ${rc}  ${output}=  Run And Return Rc And Output  curl -sk -vvv %{VIC-ADMIN} -b ${cookies}
+    Should contain  ${output}  Content-Security-Policy: frame-ancestors 'none';
+
 Get Portlayer Log
     ${cookies}=  Login To VCH Admin And Save Cookies
     ${rc}  ${output}=  Run And Return Rc And Output  curl -sk %{VIC-ADMIN}/logs/port-layer.log -b ${cookies}


### PR DESCRIPTION
In order to protect the vicadmin page from being embedded in a page
controlled by an attacker, set the Content-Security-Policy header to
disallow rendering of the page within an iframe.

(cherry picked from commit 3f683603662c5ffd2271b94b30c826509af27767)

---

`[specific ci=Group9-VIC-Admin]`