### PR TITLE
Cherry-pick: Add a retry logic in Create Uniquer Bridge Network to avoid conflict (#8156)

### DIFF
--- a/tests/resources/VCH-Util.robot
+++ b/tests/resources/VCH-Util.robot
@@ -81,26 +81,29 @@ Set Test Environment Variables
 
     # create a new, unique bridge if there isn't one already
     ${status}=  Run Keyword And Return Status  Environment Variable Should Not Be Set  BRIDGE_NETWORK
-    Run Keyword If  ${status}  Wait Until Keyword Succeeds  5x  1s  Create Unique Bridge Network
+    Run Keyword If  ${status}  Create Unique Bridge Network
 
 Create Unique Bridge Network
-    #Retry 3 times if ${rc} not return 0; there might be vlan conflict while parallel tests are running.
-    :FOR  ${index}  IN RANGE  3
+    #Retry 5 times,there might be vlan conflict while parallel tests are running
+    Wait Until Keyword Succeeds  5x  1s  Create Unique Bridge Network Internal
+Create Unique Bridge Network Internal
     # Ensure unique bridges are non-overlapping in a shared build environment (our CI)
-    \  @{URLs}=  Split String  %{TEST_URL_ARRAY}
-    \  ${idx}=  Get Index From List  ${URLs}  %{TEST_URL}
-    \  ${lowerVLAN}=  Evaluate  (${idx}+2) * 100
-    \  ${upperVLAN}=  Evaluate  ${lowerVLAN}+100
+    @{URLs}=  Split String  %{TEST_URL_ARRAY}
+    ${idx}=  Get Index From List  ${URLs}  %{TEST_URL}
+    ${lowerVLAN}=  Evaluate  (${idx}+2) * 100
+    ${upperVLAN}=  Evaluate  ${lowerVLAN}+100
 
     # Set a unique bridge network for each VCH that has a random VLAN ID
-    \  ${vlan}=  Evaluate  str(random.randint(${lowerVLAN}, ${upperVLAN}))  modules=random
-    \  ${vswitch}=  Run Keyword If  '%{HOST_TYPE}' == 'ESXi'  Run  govc host.vswitch.info -json | jq -r ".Vswitch[0].Name"
-    \  ${rc}  ${output}=  Run Keyword If  '%{HOST_TYPE}' == 'ESXi'  Run And Return Rc And Output  govc host.portgroup.add -vlan=${vlan} -vswitch ${vswitch} VCH-%{DRONE_BUILD_NUMBER}-${vlan}
+    ${vlan}=  Evaluate  str(random.randint(${lowerVLAN}, ${upperVLAN}))  modules=random
+    ${vswitch}=  Run Keyword If  '%{HOST_TYPE}' == 'ESXi'  Run  govc host.vswitch.info -json | jq -r ".Vswitch[0].Name"
+    ${rc}  ${output}=  Run Keyword If  '%{HOST_TYPE}' == 'ESXi'  Run And Return Rc And Output  govc host.portgroup.add -vlan=${vlan} -vswitch ${vswitch} VCH-%{DRONE_BUILD_NUMBER}-${vlan}
 
-    \  ${dvs}=  Run Keyword If  '%{HOST_TYPE}' == 'VC'  Run  govc find -type DistributedVirtualSwitch | head -n1
-    \  ${rc}  ${output}=  Run Keyword If  '%{HOST_TYPE}' == 'VC'  Run And Return Rc And Output  govc dvs.portgroup.add -vlan=${vlan} -dvs ${dvs} VCH-%{DRONE_BUILD_NUMBER}-${vlan}
-    \  Run Keyword If  ${rc} == 0  Run Keyword And Return  Set Environment Variable  BRIDGE_NETWORK  VCH-%{DRONE_BUILD_NUMBER}-${vlan}
-    \  ...  ELSE  Log  ${output}  level=WARN
+    ${dvs}=  Run Keyword If  '%{HOST_TYPE}' == 'VC'  Run  govc find -type DistributedVirtualSwitch | head -n1
+    ${rc}  ${output}=  Run Keyword If  '%{HOST_TYPE}' == 'VC'  Run And Return Rc And Output  govc dvs.portgroup.add -vlan=${vlan} -dvs ${dvs} VCH-%{DRONE_BUILD_NUMBER}-${vlan}
+
+    Run Keyword If  ${rc} == 0  Run Keyword And Return  Set Environment Variable  BRIDGE_NETWORK  VCH-%{DRONE_BUILD_NUMBER}-${vlan}
+        ...  ELSE  Log  ${output}  level=WARN
+    Should Be Equal As Integers  ${rc}  0
 
 Set Test VCH Name
     ${name}=  Evaluate  'VCH-%{DRONE_BUILD_NUMBER}-' + str(random.randint(1000,9999))  modules=random


### PR DESCRIPTION
Fixes #8061
Testing done:
1.run local-integration-test.sh with limit the lowerVLAN/upperVLAN to 217/220,
by creating portgroup VCH-0-218,VCH-0-220 in vCenter before the tests.
check debug.log to make sure the retry logic performs correctly.
2.run full regression in CI system to make sure no regression from the change.

(cherry picked from commit 3df36b3bd3da77a0e75268907702bb1f73f63bc9)

---

`[full ci]`