### PR TITLE
Cherry-pick: Clean up volume store after VCH delete test (#8103)

### DIFF
--- a/tests/test-cases/Group23-VIC-Machine-Service/23-08-VCH-Delete.robot
+++ b/tests/test-cases/Group23-VIC-Machine-Service/23-08-VCH-Delete.robot
@@ -410,7 +410,7 @@ Delete VCH with powered off container deletes files
     Verify VCH Not Exists             vch/${id}
 
     # No VCH to delete
-    [Teardown]                        NONE
+    [Teardown]                        Run  govc datastore.rm %{VCH-NAME}-VOL
 
 Delete VCH without deleting powered on container
     ${id}=    Get VCH ID %{VCH-NAME}


### PR DESCRIPTION
This adds explicit deletion of the volume store associated with the test
VCH after the test case completes. This is necessary given the test is
explicitly NOT deleting the volume store along with the VCH.

(cherry picked from commit 28e42052348913b0ea63a412bc33af872b94a726)

---

`[specific ci=Group23-VIC-Machine-Service]`