### PR TITLE
Move the publicIfaceName setting out of the go initializer

### DIFF
--- a/lib/apiservers/engine/backends/backends.go
+++ b/lib/apiservers/engine/backends/backends.go
@@ -97,6 +97,9 @@ type dynConfig struct {
 
 func Init(portLayerAddr, product string, port uint, config *config.VirtualContainerHostConfigSpec) error {
 	op := trace.NewOperation(context.Background(), "backends.Init")
+
+	network.Init()
+
 	servicePort = port
 	_, _, err := net.SplitHostPort(portLayerAddr)
 	if err != nil {

--- a/lib/apiservers/engine/network/utils.go
+++ b/lib/apiservers/engine/network/utils.go
@@ -52,24 +52,29 @@ var (
 
 	cbpLock         sync.Mutex
 	ContainerByPort map[string]string // port:containerID
+	once            sync.Once
 )
 
 func init() {
 	portMapper = portmap.NewPortMapper()
 	btbRules = make(map[string][]string)
 	ContainerByPort = make(map[string]string)
+}
 
-	l, err := netlink.LinkByName(publicIfaceName)
-	if l == nil {
-		l, err = netlink.LinkByAlias(publicIfaceName)
-		if err != nil {
-			log.Errorf("interface %s not found", publicIfaceName)
-			return
+func Init() {
+	once.Do(func() {
+		l, err := netlink.LinkByName(publicIfaceName)
+		if l == nil {
+			l, err = netlink.LinkByAlias(publicIfaceName)
+			if err != nil {
+				log.Errorf("interface %s not found", publicIfaceName)
+				return
+			}
 		}
-	}
 
-	// don't use interface alias for iptables rules
-	publicIfaceName = l.Attrs().Name
+		// don't use interface alias for iptables rules
+		publicIfaceName = l.Attrs().Name
+	})
 }
 
 // requestHostPort finds a free port on the host


### PR DESCRIPTION
The code is needed for VIC to get ip tables working, but it does not need to
be in the go initializer.  For projects that vendor VIC, having this in the
go initializer may generate an error message in the logs that has no meaning
to those projects.  Moved the code to a public Init() function and call it
from backends.go.