### PR TITLE
Log vic-machine version for all operations

### DIFF
--- a/cmd/vic-machine/configure/configure.go
+++ b/cmd/vic-machine/configure/configure.go
@@ -332,6 +332,7 @@ func (c *Configure) Run(clic *cli.Context) (err error) {
 	}
 
 	op.Infof("### Configuring VCH ####")
+	op.Debugf("Version %s", version.GetBuild().ShortVersion())
 
 	validator, err := validate.NewValidator(op, c.Data)
 	if err != nil {

--- a/cmd/vic-machine/configure/configure.go
+++ b/cmd/vic-machine/configure/configure.go
@@ -332,7 +332,7 @@ func (c *Configure) Run(clic *cli.Context) (err error) {
 	}
 
 	op.Infof("### Configuring VCH ####")
-	op.Debugf("Version %s", version.GetBuild().ShortVersion())
+	op.Debugf("vic-machine version %s", version.GetBuild().ShortVersion())
 
 	validator, err := validate.NewValidator(op, c.Data)
 	if err != nil {

--- a/cmd/vic-machine/create/create.go
+++ b/cmd/vic-machine/create/create.go
@@ -655,7 +655,7 @@ func (c *Create) Run(clic *cli.Context) (err error) {
 	// These operations will be executed without timeout
 	op := common.NewOperation(clic, c.Debug.Debug)
 	op.Infof("### Installing VCH ####")
-	op.Debugf("Version %s", version.GetBuild().ShortVersion())
+	op.Debugf("vic-machine version %s", version.GetBuild().ShortVersion())
 
 	defer func() {
 		// urfave/cli will print out exit in error handling, so no more information in main method can be printed out.

--- a/cmd/vic-machine/create/create.go
+++ b/cmd/vic-machine/create/create.go
@@ -655,8 +655,7 @@ func (c *Create) Run(clic *cli.Context) (err error) {
 	// These operations will be executed without timeout
 	op := common.NewOperation(clic, c.Debug.Debug)
 	op.Infof("### Installing VCH ####")
-	ver := version.GetBuild().ShortVersion()
-	op.Debugf("Version %s", ver)
+	op.Debugf("Version %s", version.GetBuild().ShortVersion())
 
 	defer func() {
 		// urfave/cli will print out exit in error handling, so no more information in main method can be printed out.

--- a/cmd/vic-machine/debug/debug.go
+++ b/cmd/vic-machine/debug/debug.go
@@ -131,6 +131,7 @@ func (d *Debug) Run(clic *cli.Context) (err error) {
 	}
 
 	op.Info("### Configuring VCH for debug ####")
+	op.Debugf("Version %s", version.GetBuild().ShortVersion())
 
 	validator, err := validate.NewValidator(op, d.Data)
 

--- a/cmd/vic-machine/debug/debug.go
+++ b/cmd/vic-machine/debug/debug.go
@@ -131,7 +131,7 @@ func (d *Debug) Run(clic *cli.Context) (err error) {
 	}
 
 	op.Info("### Configuring VCH for debug ####")
-	op.Debugf("Version %s", version.GetBuild().ShortVersion())
+	op.Debugf("vic-machine version %s", version.GetBuild().ShortVersion())
 
 	validator, err := validate.NewValidator(op, d.Data)
 

--- a/cmd/vic-machine/delete/delete.go
+++ b/cmd/vic-machine/delete/delete.go
@@ -108,7 +108,7 @@ func (d *Uninstall) Run(clic *cli.Context) (err error) {
 	}
 
 	op.Infof("### Removing VCH ####")
-	op.Debugf("Version %s", version.GetBuild().ShortVersion())
+	op.Debugf("vic-machine version %s", version.GetBuild().ShortVersion())
 
 	validator, err := validate.NewValidator(op, d.Data)
 	if err != nil {

--- a/cmd/vic-machine/delete/delete.go
+++ b/cmd/vic-machine/delete/delete.go
@@ -108,6 +108,7 @@ func (d *Uninstall) Run(clic *cli.Context) (err error) {
 	}
 
 	op.Infof("### Removing VCH ####")
+	op.Debugf("Version %s", version.GetBuild().ShortVersion())
 
 	validator, err := validate.NewValidator(op, d.Data)
 	if err != nil {

--- a/cmd/vic-machine/inspect/inspect.go
+++ b/cmd/vic-machine/inspect/inspect.go
@@ -144,6 +144,7 @@ func (i *Inspect) run(clic *cli.Context, op trace.Operation, cmd command) (err e
 	}
 
 	op.Infof("### Inspecting VCH ####")
+	op.Debugf("Version %s", version.GetBuild().ShortVersion())
 
 	validator, err := validate.NewValidator(op, i.Data)
 

--- a/cmd/vic-machine/inspect/inspect.go
+++ b/cmd/vic-machine/inspect/inspect.go
@@ -144,7 +144,7 @@ func (i *Inspect) run(clic *cli.Context, op trace.Operation, cmd command) (err e
 	}
 
 	op.Infof("### Inspecting VCH ####")
-	op.Debugf("Version %s", version.GetBuild().ShortVersion())
+	op.Debugf("vic-machine version %s", version.GetBuild().ShortVersion())
 
 	validator, err := validate.NewValidator(op, i.Data)
 

--- a/cmd/vic-machine/list/list.go
+++ b/cmd/vic-machine/list/list.go
@@ -155,7 +155,7 @@ func (l *List) Run(clic *cli.Context) (err error) {
 	}
 
 	op.Infof("### Listing VCHs ####")
-	op.Debugf("Version %s", version.GetBuild().ShortVersion())
+	op.Debugf("vic-machine version %s", version.GetBuild().ShortVersion())
 
 	var validator *validate.Validator
 	if validator, err = validate.NewValidator(op, l.Data); err != nil {

--- a/cmd/vic-machine/list/list.go
+++ b/cmd/vic-machine/list/list.go
@@ -155,6 +155,7 @@ func (l *List) Run(clic *cli.Context) (err error) {
 	}
 
 	op.Infof("### Listing VCHs ####")
+	op.Debugf("Version %s", version.GetBuild().ShortVersion())
 
 	var validator *validate.Validator
 	if validator, err = validate.NewValidator(op, l.Data); err != nil {

--- a/cmd/vic-machine/update/firewall.go
+++ b/cmd/vic-machine/update/firewall.go
@@ -122,7 +122,7 @@ func (i *UpdateFw) Run(clic *cli.Context) (err error) {
 	}
 
 	op.Infof("### Updating Firewall ####")
-	op.Debugf("Version %s", version.GetBuild().ShortVersion())
+	op.Debugf("vic-machine version %s", version.GetBuild().ShortVersion())
 
 	var validator *validate.Validator
 	if validator, err = validate.NewValidator(op, i.Data); err != nil {

--- a/cmd/vic-machine/update/firewall.go
+++ b/cmd/vic-machine/update/firewall.go
@@ -26,6 +26,7 @@ import (
 	"github.com/vmware/vic/lib/install/validate"
 	"github.com/vmware/vic/pkg/errors"
 	"github.com/vmware/vic/pkg/trace"
+	"github.com/vmware/vic/pkg/version"
 )
 
 // UpdateFw has all input parameters for vic-machine update firewall command
@@ -121,6 +122,7 @@ func (i *UpdateFw) Run(clic *cli.Context) (err error) {
 	}
 
 	op.Infof("### Updating Firewall ####")
+	op.Debugf("Version %s", version.GetBuild().ShortVersion())
 
 	var validator *validate.Validator
 	if validator, err = validate.NewValidator(op, i.Data); err != nil {

--- a/cmd/vic-machine/upgrade/upgrade.go
+++ b/cmd/vic-machine/upgrade/upgrade.go
@@ -129,7 +129,7 @@ func (u *Upgrade) Run(clic *cli.Context) (err error) {
 		op.Infof("### Rolling back VCH ####")
 		action = management.ActionRollback
 	}
-	op.Debugf("Version %s", version.GetBuild().ShortVersion())
+	op.Debugf("vic-machine version %s", version.GetBuild().ShortVersion())
 
 	validator, err := validate.NewValidator(op, u.Data)
 	if err != nil {

--- a/cmd/vic-machine/upgrade/upgrade.go
+++ b/cmd/vic-machine/upgrade/upgrade.go
@@ -26,6 +26,7 @@ import (
 	"github.com/vmware/vic/lib/install/validate"
 	"github.com/vmware/vic/pkg/errors"
 	"github.com/vmware/vic/pkg/trace"
+	"github.com/vmware/vic/pkg/version"
 	"github.com/vmware/vic/pkg/vsphere/vm"
 )
 
@@ -128,6 +129,7 @@ func (u *Upgrade) Run(clic *cli.Context) (err error) {
 		op.Infof("### Rolling back VCH ####")
 		action = management.ActionRollback
 	}
+	op.Debugf("Version %s", version.GetBuild().ShortVersion())
 
 	validator, err := validate.NewValidator(op, u.Data)
 	if err != nil {


### PR DESCRIPTION
To aid in debugging, print the `vic-machine` version at the beginning of each operation.