### PR TITLE
Fix for orphaned containers when VMotion is active

### DIFF
--- a/lib/portlayer/exec/container.go
+++ b/lib/portlayer/exec/container.go
@@ -781,7 +781,7 @@ func (c *Container) onEvent(op trace.Operation, newState State, e events.Event) 
 		case StateRemoved:
 			if c.vm != nil && c.vm.IsFixing() {
 				// is fixing vm, which will be registered back soon, so do not remove from containers cache
-				op.Debugf("Container(%s) %s is being fixed - %s event ignored", c, newState)
+				op.Debugf("Container(%s) %s is being fixed - %s event ignored", c, newState, e.String())
 
 				// Received remove event triggered by unregister VM operation - leave
 				// fixing state now. In a loaded environment, the remove event may be
@@ -792,6 +792,20 @@ func (c *Container) onEvent(op trace.Operation, newState State, e events.Event) 
 				// a container event to be propogated to subscribers
 				return
 			}
+			if c.state != StateRemoving {
+				// Check using findByInventoryPath
+				op.Infof("Container(%s) in state: %s, has received unexpected Removed event", c, c.state)
+
+				// Sometimes we get this event when a VM has been migrated, in that case
+				// we should not remove it from the cache as the container still exists, issue #7322
+				found, err := c.vmExists(op)
+				if found && err == nil {
+					op.Infof("Container(%s) still exists, ignoring event: %s", c, e.String())
+					// Ignore this Removed event, do not remove container from the cache
+					return
+				}
+			}
+
 			op.Debugf("Container(%s) %s via event activity", c, newState)
 			// if we are here the containerVM has been removed from vSphere, so lets remove it
 			// from the portLayer cache
@@ -806,6 +820,41 @@ func (c *Container) onEvent(op trace.Operation, newState State, e events.Event) 
 		publishContainerEvent(op, c.ExecConfig.ID, e.Created(), publishEventType)
 		return
 	}
+}
+
+func (c *Container) vmExists(op trace.Operation) (bool, error) {
+	// Check if there is an underlying vm and
+	// if there is and appropriate Session
+	if c.vm == nil || c.vm.Session == nil {
+		return false, nil
+	}
+
+	// Check Vim25 Client
+	client := c.vm.Session.Vim25()
+	if client == nil {
+		return false, nil
+	}
+
+	vm := c.vm
+	// Check power state
+	state, err := vm.PowerState(op)
+	if err == nil {
+		op.Debugf("container(%s) vmExists, PowerState: %s", c, state)
+		return true, nil
+	}
+
+	inventoryPath := vm.InventoryPath
+	op.Debugf("container(%s) vmExists, InventoryPath: %s", c, inventoryPath)
+
+	searchIndex := object.NewSearchIndex(client)
+	ref, err := searchIndex.FindByInventoryPath(op, inventoryPath)
+	moRef := ref.Reference()
+	if err == nil {
+		op.Debugf("container(%s) vmExists, Ref: %s", c, moRef.String())
+		return true, nil
+	}
+
+	return false, err
 }
 
 // get the containerVMs from infrastructure for this resource pool or the VCH Folder


### PR DESCRIPTION
This PR contains a change that fixes the most common case of orphaned containers. A container is orphaned when it is removed from VIC (the docker ps command does not show it), but its container VM still exists on vCenter. The problem is triggered when Stopped event is sent to the Portlayer during a migration. In the current implementation the event is processed and the container is removed from the VIC caches, while the container VM is left on  vCenter.

The problematic Stopped event is not sent on all migrations. In our testing we observe a few cases over hundreds of migrations. It may be caused by a timing window in the event squashing logic in vCenter.

The change consists of adding two checks before processing the event. The first check is to run a PowerState() call to verify if the underlying VM is still in existence. The second check does a search for the specific VM. If either of them succeeds the Stop event is ignored.

Fixes #6342