### PR TITLE
Add --no-proxy option

### DIFF
--- a/cmd/vic-machine/common/proxy.go
+++ b/cmd/vic-machine/common/proxy.go
@@ -15,17 +15,20 @@
 package common
 
 import (
+	"bytes"
 	"fmt"
 	"net/url"
-
-	"github.com/vmware/vic/pkg/flags"
+	"strings"
 
 	"gopkg.in/urfave/cli.v1"
+
+	"github.com/vmware/vic/pkg/flags"
 )
 
 type Proxies struct {
 	HTTPSProxy *string
 	HTTPProxy  *string
+	NoProxy    *string
 	IsSet      bool
 }
 
@@ -44,13 +47,20 @@ func (p *Proxies) ProxyFlags() []cli.Flag {
 			Usage:  "An HTTP proxy for use when fetching images, in the form http(s)://fqdn_or_ip:port",
 			Hidden: true,
 		},
+		cli.GenericFlag{
+			Name:   "no-proxy",
+			Value:  flags.NewOptionalString(&p.NoProxy),
+			Usage:  "URLs that should be excluded from proxying. This should be * or a comma-separated list of hostnames, domain names, or a mixture of both, e.g. localhost,.example.com",
+			Hidden: true,
+		},
 	}
 }
 
-func (p *Proxies) ProcessProxies() (hproxy, sproxy *url.URL, err error) {
+func (p *Proxies) ProcessProxies() (hproxy, sproxy *url.URL, nproxy *string, err error) {
 	if p.HTTPProxy != nil || p.HTTPSProxy != nil {
 		p.IsSet = true
 	}
+
 	if p.HTTPProxy != nil && *p.HTTPProxy != "" {
 		hproxy, err = p.validate(*p.HTTPProxy)
 		if err != nil {
@@ -60,6 +70,13 @@ func (p *Proxies) ProcessProxies() (hproxy, sproxy *url.URL, err error) {
 
 	if p.HTTPSProxy != nil && *p.HTTPSProxy != "" {
 		sproxy, err = p.validate(*p.HTTPSProxy)
+		if err != nil {
+			return
+		}
+	}
+
+	if p.NoProxy != nil && *p.NoProxy != "" {
+		nproxy, err = p.validateURIs(strings.Split(*p.NoProxy, ","))
 	}
 	return
 }
@@ -72,5 +89,23 @@ func (p *Proxies) validate(ref string) (proxy *url.URL, err error) {
 	if proxy.Host == "" || (proxy.Scheme != "http" && proxy.Scheme != "https") {
 		err = cli.NewExitError(fmt.Sprintf("Could not parse HTTP(S) proxy - expected format http(s)://fqnd_or_ip:port: %s", ref), 1)
 	}
+	return
+}
+
+func (p *Proxies) validateURIs(refs []string) (trimedNproxy *string, err error) {
+	var buffer bytes.Buffer
+	buffer.WriteString(strings.TrimSpace(refs[0]))
+	for _, ref := range refs[1:] {
+		trimedRef := strings.TrimSpace(ref)
+		_, err = url.Parse(trimedRef)
+		if err != nil {
+			err = cli.NewExitError(fmt.Sprintf("Could not parse no-proxy - expected format is * or a comma-separated list of hostnames, domain names, or a mixture of both, e.g. localhost,.example.com: %s", ref), 1)
+			return
+		}
+		buffer.WriteString(",")
+		buffer.WriteString(trimedRef)
+	}
+	trimedStr := buffer.String()
+	trimedNproxy = &trimedStr
 	return
 }

--- a/cmd/vic-machine/common/proxy_test.go
+++ b/cmd/vic-machine/common/proxy_test.go
@@ -22,6 +22,7 @@ import (
 
 func TestProcessProxies(t *testing.T) {
 	gurls := [...]string{
+		"",
 		"https://fully.qualified.example.com",
 		"https://fully.qualified.example.com:443",
 		"http://fully.qualified.example.com",
@@ -39,13 +40,22 @@ func TestProcessProxies(t *testing.T) {
 		"httpd://example.com",
 	}
 
+	gnproxies := [...]string{
+		"*",
+		"localhost, .example.com",
+		"localhost,.example.com",
+		"192.168.2.5",
+	}
+
 	for _, ghttp := range gurls {
 		for _, ghttps := range gurls {
-			gproxy := Proxies{HTTPProxy: &ghttp, HTTPSProxy: &ghttps}
+			for _, uri := range gnproxies {
+				gproxy := Proxies{HTTPProxy: &ghttp, HTTPSProxy: &ghttps, NoProxy: &uri}
 
-			_, _, err := gproxy.ProcessProxies()
-			assert.NoError(t, err, "Expected %s and %s to be accepted", ghttp, ghttps)
-			assert.True(t, gproxy.IsSet, "Expected proxy to be marked as set")
+				_, _, nproxy, err := gproxy.ProcessProxies()
+				assert.NoError(t, err, "Expected %s, %s, %s and %s to be accepted", ghttp, ghttps, uri, nproxy)
+				assert.True(t, gproxy.IsSet, "Expected proxy to be marked as set")
+			}
 		}
 	}
 
@@ -53,7 +63,7 @@ func TestProcessProxies(t *testing.T) {
 		for _, bhttps := range burls {
 			bproxy := Proxies{HTTPProxy: &ghttp, HTTPSProxy: &bhttps}
 
-			_, _, err := bproxy.ProcessProxies()
+			_, _, _, err := bproxy.ProcessProxies()
 			assert.Error(t, err, "Expected %s to be rejected", bhttps)
 		}
 	}
@@ -62,7 +72,7 @@ func TestProcessProxies(t *testing.T) {
 		for _, ghttps := range gurls {
 			bproxy := Proxies{HTTPProxy: &bhttp, HTTPSProxy: &ghttps}
 
-			_, _, err := bproxy.ProcessProxies()
+			_, _, _, err := bproxy.ProcessProxies()
 			assert.Error(t, err, "Expected %s to be rejected", bhttp)
 		}
 	}
@@ -71,7 +81,7 @@ func TestProcessProxies(t *testing.T) {
 		for _, bhttps := range burls {
 			bproxy := Proxies{HTTPProxy: &bhttp, HTTPSProxy: &bhttps}
 
-			_, _, err := bproxy.ProcessProxies()
+			_, _, _, err := bproxy.ProcessProxies()
 			assert.Error(t, err, "Expected %s and %s to be rejected", bhttp, bhttps)
 		}
 	}

--- a/cmd/vic-machine/converter/converter_test.go
+++ b/cmd/vic-machine/converter/converter_test.go
@@ -406,10 +406,10 @@ func TestGuestInfo(t *testing.T) {
 		"guestinfo.vice./init/networks|public/network/Common/id":                       "DistributedVirtualPortgroup:dvportgroup-56",
 		"guestinfo.vice./storage/image_stores|0/ForceQuery":                            "false",
 		"guestinfo.vice./init/imageid":                                                 "",
-		"guestinfo.vice./init/sessions|docker-personality/cmd/Env":                     "3",
+		"guestinfo.vice./init/sessions|docker-personality/cmd/Env":                     "4",
 		"guestinfo.vice./init/sessions|docker-personality/common/id":                   "docker-personality",
 		"guestinfo.vice./storage/VolumeLocations|vol1/Fragment":                        "",
-		"guestinfo.vice./init/sessions|vicadmin/cmd/Env":                               "3",
+		"guestinfo.vice./init/sessions|vicadmin/cmd/Env":                               "4",
 		"guestinfo.vice./init/sessions|vicadmin/common/ExecutionEnvironment":           "",
 		"guestinfo.vice./init/sessions|vicadmin/User":                                  "vicadmin",
 		"guestinfo.vice..init.networks|public.network.assigned.dns":                    "1",
@@ -559,8 +559,8 @@ func TestGuestInfo(t *testing.T) {
 		"guestinfo.vice./registry/whitelist_registries~":                     "harbor.com:2345|insecure:2345",
 		"guestinfo.vice./registry/insecure_registries~":                      "insecure:2345",
 		"guestinfo.vice./registry/insecure_registries":                       "0",
-		"guestinfo.vice./init/sessions|vicadmin/cmd/Env~":                    "PATH=/sbin:/bin|GOTRACEBACK=all|HTTP_PROXY=http://proxy.vmware.com:2318|HTTPS_PROXY=https://proxy.vmware.com:2318",
-		"guestinfo.vice./init/sessions|docker-personality/cmd/Env~":          "PATH=/sbin|GOTRACEBACK=all|HTTP_PROXY=http://proxy.vmware.com:2318|HTTPS_PROXY=https://proxy.vmware.com:2318",
+		"guestinfo.vice./init/sessions|vicadmin/cmd/Env~":                    "PATH=/sbin:/bin|GOTRACEBACK=all|HTTP_PROXY=http://proxy.vmware.com:2318|HTTPS_PROXY=https://proxy.vmware.com:2318|NO_PROXY=localhost",
+		"guestinfo.vice./init/sessions|docker-personality/cmd/Env~":          "PATH=/sbin|GOTRACEBACK=all|HTTP_PROXY=http://proxy.vmware.com:2318|HTTPS_PROXY=https://proxy.vmware.com:2318|NO_PROXY=localhost",
 	}
 
 	commands := map[string][]string{
@@ -584,6 +584,7 @@ func TestGuestInfo(t *testing.T) {
 		"whitelist-registry": {"harbor.com:2345", "insecure:2345"},
 		"http-proxy":         {"http://proxy.vmware.com:2318"},
 		"https-proxy":        {"https://proxy.vmware.com:2318"},
+		"no-proxy":           {"localhost"},
 	}
 	conf := &config.VirtualContainerHostConfigSpec{}
 	extraconfig.DecodeWithPrefix(extraconfig.MapSource(kv), conf, "")

--- a/cmd/vic-machine/create/create.go
+++ b/cmd/vic-machine/create/create.go
@@ -372,12 +372,13 @@ func (c *Create) ProcessParams(op trace.Operation) error {
 	c.WhitelistRegistries = c.Registries.WhitelistRegistries
 	c.RegistryCAs = c.Registries.RegistryCAs
 
-	hproxy, sproxy, err := c.Proxies.ProcessProxies()
+	hproxy, sproxy, nproxy, err := c.Proxies.ProcessProxies()
 	if err != nil {
 		return err
 	}
 	c.HTTPProxy = hproxy
 	c.HTTPSProxy = sproxy
+	c.NoProxy = nproxy
 
 	if err = c.ProcessSyslog(); err != nil {
 		return err
@@ -701,6 +702,7 @@ func (c *Create) Run(clic *cli.Context) (err error) {
 
 	vConfig.HTTPProxy = c.HTTPProxy
 	vConfig.HTTPSProxy = c.HTTPSProxy
+	vConfig.NoProxy = c.NoProxy
 
 	vConfig.Timeout = c.Data.Timeout
 

--- a/cmd/vic-machine/create/create_test.go
+++ b/cmd/vic-machine/create/create_test.go
@@ -72,7 +72,7 @@ func TestParseGatewaySpec(t *testing.T) {
 func TestFlags(t *testing.T) {
 	c := NewCreate()
 	flags := c.Flags()
-	numberOfFlags := 61
+	numberOfFlags := 62
 	assert.Equal(t, numberOfFlags, len(flags), "Missing flags during Create.")
 }
 

--- a/lib/apiservers/service/restapi/handlers/decode/networking.go
+++ b/lib/apiservers/service/restapi/handlers/decode/networking.go
@@ -15,6 +15,7 @@
 package decode
 
 import (
+	"bytes"
 	"fmt"
 	"strings"
 
@@ -76,9 +77,21 @@ func FromGateway(m *models.Gateway) string {
 func FromImageFetchProxy(p *models.VCHRegistryImageFetchProxy) common.Proxies {
 	http := string(p.HTTP)
 	https := string(p.HTTPS)
+	var nproxy *string
+	if p.NoProxy != nil {
+		var buffer bytes.Buffer
+		buffer.WriteString(string(p.NoProxy[0]))
+		for _, v := range p.NoProxy[1:] {
+			buffer.WriteString(",")
+			buffer.WriteString(string(v))
+		}
+		nproxyStr := buffer.String()
+		nproxy = &nproxyStr
+	}
 
 	return common.Proxies{
 		HTTPProxy:  &http,
 		HTTPSProxy: &https,
+		NoProxy:    nproxy,
 	}
 }

--- a/lib/apiservers/service/restapi/handlers/vch_create.go
+++ b/lib/apiservers/service/restapi/handlers/vch_create.go
@@ -407,12 +407,13 @@ func (h *vchCreate) buildCreate(op trace.Operation, d *data.Data, finder client.
 			if vch.Registry.ImageFetchProxy != nil {
 				c.Proxies = decode.FromImageFetchProxy(vch.Registry.ImageFetchProxy)
 
-				hproxy, sproxy, err := c.Proxies.ProcessProxies()
+				hproxy, sproxy, nproxy, err := c.Proxies.ProcessProxies()
 				if err != nil {
 					return nil, errors.NewError(http.StatusBadRequest, "error processing proxies: %s", err)
 				}
 				c.HTTPProxy = hproxy
 				c.HTTPSProxy = sproxy
+				c.NoProxy = nproxy
 			}
 		}
 
@@ -455,6 +456,7 @@ func (h *vchCreate) handleCreate(op trace.Operation, c *create.Create, hc *clien
 
 	vConfig.HTTPProxy = c.HTTPProxy
 	vConfig.HTTPSProxy = c.HTTPSProxy
+	vConfig.NoProxy = c.NoProxy
 
 	err = hc.Executor().CreateVCH(vchConfig, vConfig, receiver)
 	if err != nil {

--- a/lib/apiservers/service/restapi/handlers/vch_create_test.go
+++ b/lib/apiservers/service/restapi/handlers/vch_create_test.go
@@ -23,6 +23,7 @@ import (
 	"sort"
 	"testing"
 
+	"github.com/go-openapi/strfmt"
 	"github.com/stretchr/testify/assert"
 	cli "gopkg.in/urfave/cli.v1"
 
@@ -111,8 +112,9 @@ func TestCreateVCH(t *testing.T) {
 		},
 		Registry: &models.VCHRegistry{
 			ImageFetchProxy: &models.VCHRegistryImageFetchProxy{
-				HTTP:  "http://example.com",
-				HTTPS: "https://example.com",
+				HTTP:    "http://example.com",
+				HTTPS:   "https://example.com",
+				NoProxy: []strfmt.URI{"localhost", ".example.com"},
 			},
 			Insecure: []string{
 				"https://insecure.example.com",
@@ -190,9 +192,11 @@ func newCreate() *create.Create {
 	ca.Certs.KeySize = 2048
 	httpProxy := "http://example.com"
 	httpsProxy := "https://example.com"
+	noProxy := "localhost,.example.com"
 	ca.Proxies = common.Proxies{
 		HTTPProxy:  &httpProxy,
 		HTTPSProxy: &httpsProxy,
+		NoProxy:    &noProxy,
 	}
 	ca.Registries = common.Registries{
 		InsecureRegistriesArg:  cli.StringSlice{"https://insecure.example.com"},

--- a/lib/apiservers/service/restapi/handlers/vch_get.go
+++ b/lib/apiservers/service/restapi/handlers/vch_get.go
@@ -220,7 +220,7 @@ func (h *vchGet) vchToModel(op trace.Operation, d *data.Data, vch *vm.VirtualMac
 		Insecure:               vchConfig.Registry.InsecureRegistries,
 		Whitelist:              vchConfig.Registry.RegistryWhitelist,
 		CertificateAuthorities: encode.AsPemCertificates(vchConfig.Certificate.RegistryCertificateAuthorities),
-		ImageFetchProxy:        encode.AsImageFetchProxy(vchConfig.ExecutorConfig.Sessions[config.VicAdminService], config.VICAdminHTTPProxy, config.VICAdminHTTPSProxy),
+		ImageFetchProxy:        encode.AsImageFetchProxy(vchConfig.ExecutorConfig.Sessions[config.VicAdminService], config.VICAdminHTTPProxy, config.VICAdminHTTPSProxy, config.VICAdminNoProxy),
 	}
 
 	// runtime

--- a/lib/apiservers/service/swagger.json
+++ b/lib/apiservers/service/swagger.json
@@ -828,6 +828,13 @@
                 "https": {
                   "type": "string",
                   "format": "uri"
+                },
+                "no_proxy": {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "format": "uri"
+                  }
                 }
               }
             }

--- a/lib/config/virtual_container_host.go
+++ b/lib/config/virtual_container_host.go
@@ -56,8 +56,10 @@ const (
 
 	GeneralHTTPProxy   = "HTTP_PROXY"
 	GeneralHTTPSProxy  = "HTTPS_PROXY"
+	GeneralNoProxy     = "NO_PROXY"
 	VICAdminHTTPProxy  = "VICADMIN_HTTP_PROXY"
 	VICAdminHTTPSProxy = "VICADMIN_HTTPS_PROXY"
+	VICAdminNoProxy    = "NO_PROXY"
 
 	AddPerms = "ADD"
 )

--- a/lib/install/data/data.go
+++ b/lib/install/data/data.go
@@ -67,6 +67,7 @@ type Data struct {
 
 	HTTPSProxy *url.URL `cmd:"https-proxy"`
 	HTTPProxy  *url.URL `cmd:"http-proxy"`
+	NoProxy    *string  `cmd:"no-proxy"`
 	ProxyIsSet bool
 
 	NumCPUs  int `cmd:"endpoint-cpu"`
@@ -138,6 +139,7 @@ type InstallerData struct {
 
 	HTTPSProxy *url.URL
 	HTTPProxy  *url.URL
+	NoProxy    *string
 
 	// Used only for configure, so that the current state can be validated relative to the requested changes
 	CreateVMGroup bool
@@ -296,6 +298,10 @@ func (d *Data) CopyNonEmpty(src *Data) error {
 	if src.ProxyIsSet {
 		d.HTTPProxy = src.HTTPProxy
 		d.HTTPSProxy = src.HTTPSProxy
+	}
+
+	if src.NoProxy != nil {
+		d.NoProxy = src.NoProxy
 	}
 
 	if src.Debug.Debug != nil {

--- a/lib/install/management/appliance.go
+++ b/lib/install/management/appliance.go
@@ -624,6 +624,9 @@ func (d *Dispatcher) createAppliance(conf *config.VirtualContainerHostConfigSpec
 	if settings.HTTPSProxy != nil {
 		vicadmin.Env = append(vicadmin.Env, fmt.Sprintf("%s=%s", config.VICAdminHTTPSProxy, settings.HTTPSProxy.String()))
 	}
+	if settings.NoProxy != nil {
+		vicadmin.Env = append(vicadmin.Env, fmt.Sprintf("%s=%s", config.VICAdminNoProxy, *settings.NoProxy))
+	}
 
 	conf.AddComponent(config.VicAdminService, &executor.SessionConfig{
 		User:    "vicadmin",
@@ -654,6 +657,9 @@ func (d *Dispatcher) createAppliance(conf *config.VirtualContainerHostConfigSpec
 	}
 	if settings.HTTPSProxy != nil {
 		personality.Env = append(personality.Env, fmt.Sprintf("%s=%s", config.GeneralHTTPSProxy, settings.HTTPSProxy.String()))
+	}
+	if settings.NoProxy != nil {
+		personality.Env = append(personality.Env, fmt.Sprintf("%s=%s", config.GeneralNoProxy, *settings.NoProxy))
 	}
 
 	conf.AddComponent(config.PersonaService, &executor.SessionConfig{

--- a/lib/install/validate/config_to_data.go
+++ b/lib/install/validate/config_to_data.go
@@ -36,6 +36,7 @@ import (
 const (
 	httpProxy  = "HTTP_PROXY"
 	httpsProxy = "HTTPS_PROXY"
+	noProxy    = "NO_PROXY"
 )
 
 // Finder is defined for easy to test
@@ -296,22 +297,27 @@ func setHTTPProxies(d *data.Data, conf *config.VirtualContainerHostConfigSpec) e
 		return nil
 	}
 	for _, env := range persona.Cmd.Env {
-		if !strings.HasPrefix(env, httpProxy) && !strings.HasPrefix(env, httpsProxy) {
-			continue
-		}
-
 		strs := strings.Split(env, "=")
 		if len(strs) != 2 {
 			return fmt.Errorf("wrong env format: %s", env)
 		}
-		url, err := url.Parse(strs[1])
-		if err != nil {
-			return err
-		}
-		if strs[0] == httpProxy {
+		switch {
+		case strings.HasPrefix(env, httpProxy):
+			url, err := url.Parse(strs[1])
+			if err != nil {
+				return err
+			}
 			d.HTTPProxy = url
-		} else {
+
+		case strings.HasPrefix(env, httpsProxy):
+			url, err := url.Parse(strs[1])
+			if err != nil {
+				return err
+			}
 			d.HTTPSProxy = url
+
+		case strings.HasPrefix(env, noProxy):
+			d.NoProxy = &strs[1]
 		}
 	}
 	return nil

--- a/tests/test-cases/Group6-VIC-Machine/6-16-Config.robot
+++ b/tests/test-cases/Group6-VIC-Machine/6-16-Config.robot
@@ -171,11 +171,11 @@ Configure VCH https-proxy
     Should Be Equal As Integers  ${rc}  0
     Should Contain  ${output}  https://proxy.vmware.com:3128
     ${rc}  ${output}=  Run And Return Rc And Output  govc vm.info -e %{VCH-NAME} | grep HTTP_PROXY
-    Should Be Equal As Integers  ${rc}  1
-    Should Not Contain  ${output}  proxy.vmware.com:3128
+    Should Be Equal As Integers  ${rc}  0
+    Should Contain  ${output}  https://proxy.vmware.com:3128
     ${output}=  Run  bin/vic-machine-linux inspect config --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT}
     Should Contain  ${output}  --https-proxy=https://proxy.vmware.com:3128
-    Should Not Contain  ${output}  --http-proxy
+    Should Contain  ${output}  --http-proxy=https://proxy.vmware.com:3128
 
     ${output}=  Run  bin/vic-machine-linux configure --name=%{VCH-NAME} --target=%{TEST_URL}%{TEST_DATACENTER} --thumbprint=%{TEST_THUMBPRINT} --user=%{TEST_USERNAME} --password=%{TEST_PASSWORD} --timeout %{TEST_TIMEOUT} --https-proxy http://proxy.vmware.com:3128
     Should Contain  ${output}  Completed successfully
@@ -183,11 +183,25 @@ Configure VCH https-proxy
     Should Be Equal As Integers  ${rc}  0
     Should Contain  ${output}  http://proxy.vmware.com:3128
     ${rc}  ${output}=  Run And Return Rc And Output  govc vm.info -e %{VCH-NAME} | grep HTTP_PROXY
-    Should Be Equal As Integers  ${rc}  1
-    Should Not Contain  ${output}  proxy.vmware.com:3128
+    Should Be Equal As Integers  ${rc}  0
+    Should Contain  ${output}  https://proxy.vmware.com:3128
     ${output}=  Run  bin/vic-machine-linux inspect config --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT}
     Should Contain  ${output}  --https-proxy=http://proxy.vmware.com:3128
-    Should Not Contain  ${output}  --http-proxy
+    Should Contain  ${output}  --http-proxy=https://proxy.vmware.com:3128
+
+    ${output}=  Run  bin/vic-machine-linux configure --name=%{VCH-NAME} --target=%{TEST_URL}%{TEST_DATACENTER} --thumbprint=%{TEST_THUMBPRINT} --user=%{TEST_USERNAME} --password=%{TEST_PASSWORD} --timeout %{TEST_TIMEOUT} --https-proxy http://proxy.vmware.com:3128 --no-proxy='localhost, .vmware.com'
+    Should Contain  ${output}  Completed successfully
+    ${rc}  ${output}=  Run And Return Rc And Output  govc vm.info -e %{VCH-NAME} | grep NO_PROXY
+    Should Be Equal As Integers  ${rc}  0
+    Should Contain  ${output}  .vmware.com
+    ${output}=  Run  bin/vic-machine-linux inspect config --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT}
+    Should Contain  ${output}  --no-proxy=localhost,.vmware.com
+
+    ${output}=  Run  bin/vic-machine-linux configure --name=%{VCH-NAME} --target=%{TEST_URL}%{TEST_DATACENTER} --thumbprint=%{TEST_THUMBPRINT} --user=%{TEST_USERNAME} --password=%{TEST_PASSWORD} --timeout %{TEST_TIMEOUT} --http-proxy http://exmaple.com:3128 --https-proxy http://exmaple.com:3128 --no-proxy='*'
+    Should Contain  ${output}  Completed successfully
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} pull ${alpine}
+    Should Be Equal As Integers  ${rc}  0
+
 
 Configure VCH ops user credentials and thumbprint
     ${output}=  Run  bin/vic-machine-linux configure --name=%{VCH-NAME} --target=%{TEST_URL} --thumbprint=%{TEST_THUMBPRINT} --user=%{TEST_USERNAME} --password=%{TEST_PASSWORD} --timeout %{TEST_TIMEOUT} --ops-user=%{TEST_USERNAME} --ops-password=%{TEST_PASSWORD}
@@ -202,7 +216,12 @@ Configure VCH https-proxy through vch id
     Should Contain  ${output}  Completed successfully
     ${rc}  ${output}=  Run And Return Rc And Output  govc vm.info -e %{VCH-NAME} | grep HTTPS_PROXY
     Should Be Equal As Integers  ${rc}  1
-    Should Not Contain  ${output}  proxy.vmware.com:3128
+    Should Not Contain  ${output}  example.com:3128
+
+    ${output}=  Run  bin/vic-machine-linux configure --id=${vch-id} --target=%{TEST_URL}%{TEST_DATACENTER} --thumbprint=%{TEST_THUMBPRINT} --user=%{TEST_USERNAME} --password=%{TEST_PASSWORD} --timeout %{TEST_TIMEOUT} --no-proxy ""
+    Should Contain  ${output}  Completed successfully
+    ${rc}  ${output}=  Run And Return Rc And Output  govc vm.info -e %{VCH-NAME} | grep NO_PROXY
+    Should Be Equal As Integers  ${rc}  1
 
 Configure VCH DNS server
     ${output}=  Run  bin/vic-machine-linux inspect config --name=%{VCH-NAME} --target=%{TEST_URL} --thumbprint=%{TEST_THUMBPRINT} --user=%{TEST_USERNAME} --password=%{TEST_PASSWORD} --timeout %{TEST_TIMEOUT}


### PR DESCRIPTION
The previous vic-machine proxy configuration behaviour has an issue in that http and https settings will overwrite each other if we only configure one each time. This issue has been fixed as well.

Fixes #8144 