### PR TITLE
No ssh known hosts for VCHs with DHCP

### DIFF
--- a/tests/test-cases/Group1-Docker-Commands/1-02-Docker-Pull.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-02-Docker-Pull.robot
@@ -60,7 +60,7 @@ Enable SSH On MITMed VCH
 
 Check For Injected Binary
     [Arguments]  ${vch2-IP}
-    ${rc}  ${output}=  Run And Return Rc And Output  sshpass -ppassword ssh ${vch2-IP} -lroot -C -oStrictHostKeyChecking=no "ls /tmp | grep pingme"
+    ${rc}  ${output}=  Run And Return Rc And Output  sshpass -ppassword ssh ${vch2-IP} -lroot -C -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null "ls /tmp | grep pingme"
     Log  ${output}
     Should Not Contain  ${output}  pingme
 

--- a/tests/test-cases/Group1-Docker-Commands/1-43-Docker-CP-Offline.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-43-Docker-CP-Offline.robot
@@ -66,7 +66,7 @@ Try to exploit VCH with offline copy of malicious tarball
 
     Enable VCH SSH
 
-    ${rc}  ${output}=  Run And Return Rc And Output  sshpass -ppassword ssh %{VCH-IP} -lroot -C -oStrictHostKeyChecking=no "ls /tmp | grep pingme"
+    ${rc}  ${output}=  Run And Return Rc And Output  sshpass -ppassword ssh %{VCH-IP} -lroot -C -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null "ls /tmp | grep pingme"
 
     Log  ${output}
     Should Not Be Equal As Integers  ${rc}  0

--- a/tests/test-cases/Group6-VIC-Machine/6-11-Debug.robot
+++ b/tests/test-cases/Group6-VIC-Machine/6-11-Debug.robot
@@ -49,7 +49,7 @@ Check Password Change When Expired
     Should Be Equal As Integers  ${rc}  0
 
     # push the date forward, past the support duration
-    ${rc}  ${output}=  Run And Return Rc And Output  ssh -o StrictHostKeyChecking=no -i %{VCH-NAME}.key root@%{VCH-IP} 'date -s " +6 year"'
+    ${rc}  ${output}=  Run And Return Rc And Output  ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i %{VCH-NAME}.key root@%{VCH-IP} 'date -s " +6 year"'
     Should Be Equal As Integers  ${rc}  0
 
     # command should fail with expired password
@@ -61,7 +61,7 @@ Check Password Change When Expired
     Should Be Equal As Integers  ${rc}  0
 
     # check we can now log in cleanly - log in via password
-    ${rc}=  Run And Return Rc  sshpass -p dictionary ssh -o StrictHostKeyChecking=no root@%{VCH-IP} /bin/true
+    ${rc}=  Run And Return Rc  sshpass -p dictionary ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null root@%{VCH-IP} /bin/true
     Should Be Equal As Integers  ${rc}  0
 
     # delete the keys

--- a/tests/test-cases/Group6-VIC-Machine/6-16-Config.robot
+++ b/tests/test-cases/Group6-VIC-Machine/6-16-Config.robot
@@ -211,12 +211,12 @@ Configure VCH DNS server
     Should Contain  ${output}  Completed successfully
 
     Enable VCH SSH
-    ${rc}  ${output}=  Run And Return Rc and Output  sshpass -p %{TEST_PASSWORD} ssh -o StrictHostKeyChecking=no root@%{VCH-IP} cat /etc/resolv.conf
+    ${rc}  ${output}=  Run And Return Rc and Output  sshpass -p %{TEST_PASSWORD} ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null root@%{VCH-IP} cat /etc/resolv.conf
     Should Be Equal As Integers  ${rc}  0
     Should Contain  ${output}  nameserver 10.118.81.1
     Should Contain  ${output}  nameserver 10.118.81.2
 
-    ${rc}  ${output}=  Run And Return Rc and Output  sshpass -p %{TEST_PASSWORD} ssh -o StrictHostKeyChecking=no root@%{VCH-IP} cat /etc/resolv.conf | grep nameserver | wc -l
+    ${rc}  ${output}=  Run And Return Rc and Output  sshpass -p %{TEST_PASSWORD} ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null root@%{VCH-IP} cat /etc/resolv.conf | grep nameserver | wc -l
     Should Be Equal As Integers  ${rc}  0
     Should Contain  ${output}  2
 
@@ -233,7 +233,7 @@ Configure VCH DNS server
     Should Be Equal As Integers  ${rc}  0
 
     Enable VCH SSH
-    ${rc}  ${output}=  Run And Return Rc and Output  sshpass -p %{TEST_PASSWORD} ssh -o StrictHostKeyChecking=no root@%{VCH-IP} cat /etc/resolv.conf
+    ${rc}  ${output}=  Run And Return Rc and Output  sshpass -p %{TEST_PASSWORD} ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null root@%{VCH-IP} cat /etc/resolv.conf
     Should Be Equal As Integers  ${rc}  0
     Should Not Contain  ${output}  nameserver 10.118.81.1
     Should Not Contain  ${output}  nameserver 10.118.81.2


### PR DESCRIPTION
We are seeing occasional reuse of DHCP addresses within a test run which
can cause ssh to warn about changing host keys.
The host keys are regenerated per call to vic-machine debug to enable SSH
so these are not expected to remain constant.
Other uses of sshpass that reference stable hosts have been left alone.

This is addressing the issue observed in https://ci-vic.vmware.com/vmware/vic/19750
```
[skip unit]
[full ci]
[parallel jobs=4]
```