### PR TITLE
User-agent related cherry-picks for 1.4.3

### DIFF
--- a/cmd/vic-ui/ui/ui.go
+++ b/cmd/vic-ui/ui/ui.go
@@ -27,6 +27,7 @@ import (
 	"github.com/vmware/vic/lib/install/plugin"
 	"github.com/vmware/vic/pkg/errors"
 	"github.com/vmware/vic/pkg/trace"
+	"github.com/vmware/vic/pkg/version"
 	"github.com/vmware/vic/pkg/vsphere/session"
 )
 
@@ -300,6 +301,7 @@ func (p *Plugin) Install(cli *cli.Context) error {
 			User:       p.Target.URL.User,
 			Thumbprint: p.Thumbprint,
 			Insecure:   true,
+			UserAgent:  version.UserAgent("vic-ui-installer"),
 		}
 
 		// Configure the OVA vm to be managed by this plugin

--- a/lib/apiservers/engine/backends/backends.go
+++ b/lib/apiservers/engine/backends/backends.go
@@ -529,7 +529,7 @@ func newSession(ctx context.Context, config *config.VirtualContainerHostConfigSp
 		User:       url.UserPassword(config.Username, config.Token),
 		Thumbprint: config.TargetThumbprint,
 		Keepalive:  defaultSessionKeepAlive,
-		UserAgent:  version.UserAgent("vic-engine"),
+		UserAgent:  version.UserAgent("vic-dynamic-config"),
 	}
 
 	sess := session.NewSession(sessCfg)

--- a/lib/apiservers/engine/backends/backends.go
+++ b/lib/apiservers/engine/backends/backends.go
@@ -48,6 +48,7 @@ import (
 	"github.com/vmware/vic/lib/imagec"
 	"github.com/vmware/vic/pkg/errors"
 	"github.com/vmware/vic/pkg/registry"
+	"github.com/vmware/vic/pkg/version"
 	"github.com/vmware/vic/pkg/vsphere/session"
 	"github.com/vmware/vic/pkg/vsphere/sys"
 )
@@ -528,6 +529,7 @@ func newSession(ctx context.Context, config *config.VirtualContainerHostConfigSp
 		User:       url.UserPassword(config.Username, config.Token),
 		Thumbprint: config.TargetThumbprint,
 		Keepalive:  defaultSessionKeepAlive,
+		UserAgent:  version.UserAgent("vic-engine"),
 	}
 
 	sess := session.NewSession(sessCfg)

--- a/lib/install/plugin/register.go
+++ b/lib/install/plugin/register.go
@@ -15,6 +15,7 @@
 package plugin
 
 import (
+	"context"
 	"crypto/tls"
 	"errors"
 	"fmt"
@@ -27,9 +28,8 @@ import (
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/vim25/types"
 	"github.com/vmware/vic/pkg/trace"
+	"github.com/vmware/vic/pkg/version"
 	"github.com/vmware/vic/pkg/vsphere/session"
-
-	"context"
 )
 
 type Info struct {
@@ -117,6 +117,7 @@ func (p *Pluginator) connect() error {
 
 	sessionconfig := &session.Config{
 		Thumbprint: p.tThumbprint,
+		UserAgent:  version.UserAgent("vic-ui-installer"),
 	}
 	sessionconfig.Service = p.tURL.String()
 

--- a/pkg/vsphere/session/session.go
+++ b/pkg/vsphere/session/session.go
@@ -226,6 +226,9 @@ func (s *Session) Connect(ctx context.Context) (*Session, error) {
 	}
 
 	soapClient.UserAgent = s.UserAgent
+	if s.UserAgent == "" {
+		op.Debug("DEVNOTICE: Session created with default user agent.")
+	}
 
 	soapClient.SetThumbprint(soapURL.Host, s.Thumbprint)
 


### PR DESCRIPTION
### session: Note operations which omit UserAgent (#7887)

Log a message (at debug, since this indicates a programming error, not
something a user could address) any time we create a Session without
specifying a UserAgent.

Specify a UserAgent in several places where we were not doing so.

(cherry picked from commit ff1db6e)

### Update admiral user-agent to allow differentiation 

This ensures that each vmomi client has a unique user-agent string so it
is possible to link vmomi sessions back to the originating component
within a VCH. The only user-agent that needed updating was the one used to
pull project specific configuration from admiral/harbor.

This follows on from PR #7887

(cherry picked from commit 686535b)

---

Like any PR which cherry-picks multiple commits, this should be merged using the "Rebase & Merge" option (not "Squash & Merge").