### PR TITLE
Re-enable docker run --rm concurrent integration test

### DIFF
--- a/tests/test-cases/Group1-Docker-Commands/1-06-Docker-Run.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-06-Docker-Run.robot
@@ -219,30 +219,30 @@ Docker run --hostname to set hostname and domainname
     Should Contain  ${output}  vic.test
 
 Docker run --rm concurrent
-    ${status}=  Get State Of Github Issue  6342
-    Run Keyword If  '${status}' == 'closed'  Fail  Test 1-06-Docker-Run.robot needs to be updated now that Issue #6342 has been resolved
+    ${IN_HAAS}=  Run Keyword And Return Status  Should Contain  %{HAAS_URL_ARRAY}  %{TEST_URL}
+    Run Keyword Unless  ${IN_HAAS}  Pass Execution  This test is too resource intensive for Nimbus currently
+
+    # Make sure all old containers are cleaned up first, to maximize likelihood of not hitting insufficient resources issue
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} ps -aq | xargs docker %{VCH-PARAMS} rm -f
     
-    #${IN_HAAS}=  Run Keyword And Return Status  Should Contain  %{HAAS_URL_ARRAY}  %{TEST_URL}
-    #Run Keyword Unless  ${IN_HAAS}  Pass Execution  This test is too resource intensive for Nimbus currently
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} pull ${ubuntu}
+    Should Be Equal As Integers  ${rc}  0
 
-    ## Make sure all old containers are cleaned up first, to maximize likelihood of not hitting insufficient resources issue
-    #${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} ps -aq | xargs docker %{VCH-PARAMS} rm -f
-    
-    #${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} pull ${ubuntu}
-    #Should Be Equal As Integers  ${rc}  0
+    ${pids}=  Create List
+    :FOR  ${idx}  IN RANGE  0  16
+    \   ${pid}=  Start Process  docker %{VCH-PARAMS} run -d --rm --name rm-concurrent-${idx} --cpuset-cpus 1 --memory 1GB ubuntu /bin/sh -c 'for i in `seq 0 75`; do echo $i; sleep 2; done'  shell=True
+    \   Append To List  ${pids}  ${pid}
 
-    #${pids}=  Create List
-    #:FOR  ${idx}  IN RANGE  0  16
-    #\   ${pid}=  Start Process  docker %{VCH-PARAMS} run -d --rm --name rm-concurrent-${idx} --cpuset-cpus 1 --memory 1GB ubuntu /bin/sh -c 'for i in `seq 0 75`; do echo $i; sleep 2; done'  shell=True
-    #\   Append To List  ${pids}  ${pid}
+    :FOR  ${pid}  IN  @{pids}
+    \   Log To Console  \nWaiting for ${pid}
+    \   ${res}=  Wait For Process  ${pid}
+    \   Log  ${res.stdout}
+    \   Should Be Equal As Integers  ${res.rc}  0
 
-    #:FOR  ${pid}  IN  @{pids}
-    #\   Log To Console  \nWaiting for ${pid}
-    #\   ${res}=  Wait For Process  ${pid}
-    #\   Log  ${res.stdout}
-    #\   Should Be Equal As Integers  ${res.rc}  0
+    # Wait for the first container to exit, use a 4 minutes timeout
+    Wait Until Keyword Succeeds  4 min  10 sec  Verify container is removed  rm-concurrent-0
 
-    #Sleep  3 minutes
+    :FOR  ${idx}  IN RANGE  1  16
+    \   Wait Until Keyword Succeeds  10x  3s  Verify container is removed  rm-concurrent-${idx}
 
-    #:FOR  ${idx}  IN RANGE  0  16
-    #\   Wait Until Keyword Succeeds  10x  3s  Verify container is removed  rm-concurrent-${idx}
+    Sleep  1 minutes


### PR DESCRIPTION
This test was disabled due to issue: #6342. The issue has been closed and the test should be re-enabled.
------
`[full ci]`

Fixes: #6342