### PR TITLE
Fix possible null/invalid pointer reference when checking if vm exists

### DIFF
--- a/lib/portlayer/exec/container.go
+++ b/lib/portlayer/exec/container.go
@@ -849,8 +849,8 @@ func (c *Container) vmExists(op trace.Operation) (bool, error) {
 
 	searchIndex := object.NewSearchIndex(client)
 	ref, err := searchIndex.FindByInventoryPath(op, inventoryPath)
-	moRef := ref.Reference()
-	if err == nil {
+	if err == nil && ref != nil {
+		moRef := ref.Reference()
 		op.Debugf("container(%s) vmExists, Ref: %s", c, moRef.String())
 		return true, nil
 	}

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-14-Remove-Container-OOB.md
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-14-Remove-Container-OOB.md
@@ -10,7 +10,7 @@ To verify that VIC works properly when a container is removed OOB in VC
 # Environment:
 This test requires access to VMware Nimbus cluster for dynamic ESXi and vCenter creation
 
-# Test Steps:
+# Docker run a container and verify cannot destroy the VM Out of Band - test steps:
 1. Deploy a new vCenter with a simple cluster
 2. Install the VIC appliance into one of the clusters
 3. Run docker run -itd busybox /bin/top
@@ -21,3 +21,20 @@ Step 4 should result in and error and a message stating that OOB deletion is dis
 
 # Possible Problems:
 None
+
+# Docker run a container destroy VM Out Of Band verify container is cleaned up - test steps:
+1. Deploy a new vCenter with a simple cluster
+2. Install the VIC appliance into one of the clusters
+3. Deploy a busybox anchor container to prevent losing images/scrachdisk when the main containerVM is removed
+4. Run docker run -itd busybox /bin/top as the main containerVM
+5. Enable removal of the container vm OOB
+6. Remove the container vm OOB
+7. Verify the associated container has been removed
+8. Remove anchor container
+
+# Expected Outcome:
+Step 7 should result in not finding the container in the list
+
+# Possible Problems:
+None
+


### PR DESCRIPTION
The code that checks for vm existence may generate and invalid/null pointer reference when the call to:
```
searchIndex.FindByInventoryPath(op, inventoryPath)
```
returns an error or a null reference. This PR fixes the potential invalid reference.

Fixes: #8214 
------

```
[specific ci=5-21-Datastore-Path]
```