### PR TITLE
Cherry-pick: Stabilize ESX server deployment (#8190)

### DIFF
--- a/tests/manual-test-cases/Group5-Functional-Tests/5-5-Heterogeneous-ESXi.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-5-Heterogeneous-ESXi.robot
@@ -27,15 +27,15 @@ Heterogenous ESXi Setup
     ${pid-vc}=  Deploy Nimbus vCenter Server Async  ${vc}
     Set Suite Variable  @{list}  %{NIMBUS_USER}-${vc}
 
-    Run Keyword And Ignore Error  Cleanup Nimbus Folders  ${deletePXE}=%{true}
+    Run Keyword And Ignore Error  Cleanup Nimbus Folders  True
     ${esx1}  ${esx1-ip}=  Deploy Nimbus ESXi Server  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}  3029944
     Append To List  ${list}  ${esx1}
 
-    Run Keyword And Ignore Error  Cleanup Nimbus Folders  ${deletePXE}=%{true}
+    Run Keyword And Ignore Error  Cleanup Nimbus Folders  True
     ${esx2}  ${esx2-ip}=  Deploy Nimbus ESXi Server  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}  5572656
     Append To List  ${list}  ${esx2}
 
-    Run Keyword And Ignore Error  Cleanup Nimbus Folders  ${deletePXE}=%{true}
+    Run Keyword And Ignore Error  Cleanup Nimbus Folders  True
     ${esx3}  ${esx3-ip}=  Deploy Nimbus ESXi Server  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}
     Append To List  ${list}  ${esx3}
 

--- a/tests/resources/Nimbus-Util.robot
+++ b/tests/resources/Nimbus-Util.robot
@@ -61,6 +61,7 @@ Deploy Nimbus ESXi Server
     \   Log To Console  ${out}
     \   Log To Console  Nimbus deployment ${IDX} failed, trying again in 1 minutes
     \   Sleep  1 minutes
+    Should Be True  ${status}
 
     # Now grab the IP address and return the name and ip for later use
     @{out}=  Split To Lines  ${out}


### PR DESCRIPTION
PXE installation of ESXi will increase disk space of Nimbus user home
directory, when it exceeds quota deployment will fail. Clean up it
before deploy ESXi.

After 5 time retry deployment, test should fail if deployment status
is not True. Or else last successful deployed ESXi IP address will be
returned because variable line caches previous value.
