### PR TITLE
WIP: Increase DHCP_DISCOVER timeout to 1m

### DIFF
--- a/lib/dhcp/client/client.go
+++ b/lib/dhcp/client/client.go
@@ -62,7 +62,7 @@ type client struct {
 }
 
 // The default timeout for the client
-const defaultTimeout = 10 * time.Second
+const defaultTimeout = 1 * time.Minute
 
 // NewClient creates a new DHCP client. Note the returned object is not thread-safe.
 func NewClient(ifIndex int, hwaddr net.HardwareAddr) (Client, error) {


### PR DESCRIPTION
CI has been seeing timeouts waiting for a DHCP discover response. Various
locations on the internet have similar questions, and some people have
noted that their DHCP server can be taking a long time to offer IPs even
if addresses are available and the server is not heavily loaded.

This is a speculative change to see if simply increasing the DHCP timeout
is sufficient to address the lease failures.

```
[full ci]
[parallel jobs=6]
```