### PR TITLE
Portlayer finalize tolerates incomplete init stage

### DIFF
--- a/lib/portlayer/exec/exec.go
+++ b/lib/portlayer/exec/exec.go
@@ -180,10 +180,12 @@ func Init(ctx context.Context, sess *session.Session, source extraconfig.DataSou
 }
 
 func Finalize(ctx context.Context) error {
-	collectors := Config.EventManager.Collectors()
-	for name, collector := range collectors {
-		log.Infof("Shutting down event collector %s", name)
-		collector.Stop()
+	if Config.EventManager != nil {
+		collectors := Config.EventManager.Collectors()
+		for name, collector := range collectors {
+			log.Infof("Shutting down event collector %s", name)
+			collector.Stop()
+		}
 	}
 
 	return nil

--- a/lib/portlayer/storage/storage.go
+++ b/lib/portlayer/storage/storage.go
@@ -94,7 +94,9 @@ func Init(ctx context.Context, session *session.Session, pool *object.ResourcePo
 // TODO: figure out why the Init calls are wrapped in once.Do - implies it can be called
 // multiple times, but once Finalize is called things will not be functional.
 func Finalize(ctx context.Context) error {
-	Config.ContainerView.Destroy(ctx)
+	if Config.ContainerView != nil {
+		Config.ContainerView.Destroy(ctx)
+	}
 
 	return nil
 }


### PR DESCRIPTION
Portlayer component finalization methods were not all checking whether the
component working state was fully initialized. If there is an error during
portlayer initialization then this led to nil pointer segfault.
The portlayer is relaunched and recovers (the same path as before the
finalizers were introduced) but the presence of the segv in the logs is
detected by the tests and flagged as an error.

Seen in https://ci-vic.vmware.com/vmware/vic/19871
