### PR TITLE
Fix verifying default docker registry

### DIFF
--- a/tests/manual-test-cases/Group21-Registries/21-1-Whitelist.robot
+++ b/tests/manual-test-cases/Group21-Registries/21-1-Whitelist.robot
@@ -72,7 +72,7 @@ Basic Whitelisting
     Should Be Equal As Integers  ${rc}  0
     Should Contain  ${output}  Registry Whitelist Mode: enabled
     Should Contain  ${output}  Whitelisted Registries:
-    Should Contain  ${output}  Registry: registry.hub.docker.com
+    Should Contain  ${output}  Registry: registry-1.docker.io
 
     # Try to login and pull from the HTTPS whitelisted registry (should succeed)
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} login -u admin -p %{TEST_PASSWORD} %{HTTPS_HARBOR_IP}


### PR DESCRIPTION
The default docker registry has been changed from
registry.hub.docker.com to registry-1.docker.io
in PR#8140. Scenario test should also rectify the
URL.

Fixes #8140
