### PR TITLE
Trigger downstream after push to release branch

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -345,22 +345,7 @@ pipeline:
       - drone_token
     when:
       repo: vmware/vic
-      event: [push]
-      branch: [master]
-      status: success
-
-  trigger-downstream-tag:
-    image: 'gcr.io/eminent-nation-87317/vic-downstream-trigger:1.3'
-    environment:
-      SHELL: /bin/bash
-      DOWNSTREAM_REPO: vmware/vic-product
-      DOWNSTREAM_BRANCH: ${DRONE_BRANCH}
-    secrets:
-      - drone_server
-      - drone_token
-    when:
-      repo: vmware/vic
-      event: [tag]
+      event: [push, tag]
       branch: [master, 'releases/*']
       status: success
 


### PR DESCRIPTION
Now that the release branch of vic-product consumes the latest builds
from the release branch of vic, trigger downstream builds on pushes to
the release branch of vic.

This allows for continuous integration of changes on release branches.

Note that we assume that the branch in vic-product is the same as the
branch in vic.

---

Builds on #8058, https://github.com/vmware/vic-product/pull/1961.