### PR TITLE
Cherry-pick: Downstream trigger improvements

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -284,15 +284,32 @@ pipeline:
       status: success
 
   trigger-downstream:
-    image: 'gcr.io/eminent-nation-87317/vic-downstream-trigger:1.0'
+    image: 'gcr.io/eminent-nation-87317/vic-downstream-trigger:1.3'
     environment:
       SHELL: /bin/bash
+      DOWNSTREAM_REPO: vmware/vic-product
+      DOWNSTREAM_BRANCH: ${DRONE_BRANCH}
     secrets:
       - drone_server
       - drone_token
     when:
       repo: vmware/vic
-      event: [push, tag]
+      event: [push]
+      branch: [master]
+      status: success
+
+  trigger-downstream-tag:
+    image: 'gcr.io/eminent-nation-87317/vic-downstream-trigger:1.3'
+    environment:
+      SHELL: /bin/bash
+      DOWNSTREAM_REPO: vmware/vic-product
+      DOWNSTREAM_BRANCH: ${DRONE_BRANCH}
+    secrets:
+      - drone_server
+      - drone_token
+    when:
+      repo: vmware/vic
+      event: [tag]
       branch: [master, 'releases/*']
       status: success
 

--- a/.drone.yml
+++ b/.drone.yml
@@ -294,22 +294,7 @@ pipeline:
       - drone_token
     when:
       repo: vmware/vic
-      event: [push]
-      branch: [master]
-      status: success
-
-  trigger-downstream-tag:
-    image: 'gcr.io/eminent-nation-87317/vic-downstream-trigger:1.3'
-    environment:
-      SHELL: /bin/bash
-      DOWNSTREAM_REPO: vmware/vic-product
-      DOWNSTREAM_BRANCH: ${DRONE_BRANCH}
-    secrets:
-      - drone_server
-      - drone_token
-    when:
-      repo: vmware/vic
-      event: [tag]
+      event: [push, tag]
       branch: [master, 'releases/*']
       status: success
 


### PR DESCRIPTION
### Update drone config to specify downstream branch (#8058)

The master branch of vic-product consumes the latest build from the
master branch of vic. Therefore it makes sense to trigger a build of
master for each push to master.

The release branches of vic-product only consume tag builds of vic.
Therefore it makes sense to only trigger new builds of vic-product's
release branches when performing a tag build of vic.

(cherry picked from commit 07f619a)


### Trigger downstream after push to release branch (#8240)

Now that the release branch of vic-product consumes the latest builds
from the release branch of vic, trigger downstream builds on pushes to
the release branch of vic.

(cherry picked from commit 8878bef)