### PR TITLE
Allow to specify VSS type when ambiguous network exists

### DIFF
--- a/cmd/vic-machine/create/create.go
+++ b/cmd/vic-machine/create/create.go
@@ -123,7 +123,7 @@ func (c *Create) Flags() []cli.Flag {
 		cli.StringFlag{
 			Name:        "bridge-network, b",
 			Value:       "",
-			Usage:       "The bridge network port group name (private port group for containers). Defaults to the Virtual Container Host name",
+			Usage:       "The bridge network port group inventory path or name (private port group for containers). Defaults to the Virtual Container Host name",
 			Destination: &c.BridgeNetworkName,
 		},
 		cli.StringFlag{
@@ -138,7 +138,7 @@ func (c *Create) Flags() []cli.Flag {
 		cli.StringFlag{
 			Name:        "client-network, cln",
 			Value:       "",
-			Usage:       "The client network port group name (restricts DOCKER_API access to this network). Defaults to DCHP - see advanced help (-x)",
+			Usage:       "The client network port group inventory path or name (restricts DOCKER_API access to this network). Defaults to DHCP - see advanced help (-x)",
 			Destination: &c.ClientNetworkName,
 		},
 		cli.StringFlag{
@@ -160,7 +160,7 @@ func (c *Create) Flags() []cli.Flag {
 		cli.StringFlag{
 			Name:        "public-network, pn",
 			Value:       "VM Network",
-			Usage:       "The public network port group name (port forwarding and default route). Defaults to 'VM Network' and DHCP -- see advanced help (-x)",
+			Usage:       "The public network port group inventory path or name (port forwarding and default route). Defaults to 'VM Network' and DHCP -- see advanced help (-x)",
 			Destination: &c.PublicNetworkName,
 		},
 		cli.StringFlag{
@@ -182,7 +182,7 @@ func (c *Create) Flags() []cli.Flag {
 		cli.StringFlag{
 			Name:        "management-network, mn",
 			Value:       "",
-			Usage:       "The management network port group name (provides route to target hosting vSphere). Defaults to DCHP - see advanced help (-x)",
+			Usage:       "The management network port group inventory path or name (provides route to target hosting vSphere). Defaults to DCHP - see advanced help (-x)",
 			Destination: &c.ManagementNetworkName,
 		},
 		cli.StringFlag{

--- a/lib/install/validate/network.go
+++ b/lib/install/validate/network.go
@@ -443,7 +443,7 @@ func (v *Validator) checkBridgeIPRange(bridgeIPRange *net.IPNet) error {
 	return nil
 }
 
-// getNetwork gets a moref based on the network name
+// getNetwork gets a moref based on the network name or network inventory path
 func (v *Validator) getNetwork(op trace.Operation, name string) (object.NetworkReference, error) {
 	defer trace.End(trace.Begin(name, op))
 
@@ -626,10 +626,23 @@ func (v *Validator) suggestNetwork(op trace.Operation, flag string, incStdNets b
 		return
 	}
 
+	// Find out the duplicate network name
+	count := make(map[string]int)
+	for _, n := range nets {
+		shortName := path.Base(n)
+		count[shortName] = count[shortName] + 1
+	}
+
 	op.Infof("Suggested values for %s:", flag)
 	for _, n := range nets {
 		if v.isNetworkNameValid(n, flag) {
-			op.Infof("  %q", path.Base(n))
+			// Show whole inventory path if network name is duplicated
+			shortName := path.Base(n)
+			if count[shortName] > 1 {
+				op.Infof("  %q", n)
+			} else {
+				op.Infof("  %q", shortName)
+			}
 		}
 	}
 }

--- a/lib/install/validate/validator_test.go
+++ b/lib/install/validate/validator_test.go
@@ -103,6 +103,7 @@ func TestValidator(t *testing.T) {
 		conf := testCompute(ctx, validator, input, t)
 		testTargets(ctx, validator, input, conf, t)
 		testStorage(ctx, validator, input, conf, t)
+		testNetwork(ctx, validator, input, conf, t)
 	}
 }
 
@@ -330,6 +331,16 @@ func testCompute(ctx context.Context, v *Validator, input *data.Data, t *testing
 		v.issues = nil
 	}
 	return conf
+}
+
+func testNetwork(ctx context.Context, v *Validator, input *data.Data, conf *config.VirtualContainerHostConfigSpec, t *testing.T) {
+	op := trace.FromContext(ctx, "testNetwork")
+
+	inValidNetworkPath := "/DC0/missing-network/management"
+	input.PublicNetwork.Name = inValidNetworkPath
+	v.network(op, input, conf)
+	v.ListIssues(op)
+	assert.True(t, len(v.issues) > 0, "Error checking network for")
 }
 
 func testTargets(ctx context.Context, v *Validator, input *data.Data, conf *config.VirtualContainerHostConfigSpec, t *testing.T) {


### PR DESCRIPTION
For VC case, the standard network name may be same as distributed
port group name, so we should allow to limit which one will be used.

By default, the distributed port group will be preferred when dup
came out. If the customer wants to use the VSS, the CLI should like:
Network/<network name>.

Fixes #6628 
