### PR TITLE
Fixing CI 6-15-Syslog.robot failure due to "ps -C" not working properly

### DIFF
--- a/tests/test-cases/Group6-VIC-Machine/6-15-Syslog.robot
+++ b/tests/test-cases/Group6-VIC-Machine/6-15-Syslog.robot
@@ -25,8 +25,11 @@ ${SYSLOG_FILE}  /var/log/syslog
 *** Keywords ***
 Get Remote PID
     [Arguments]  ${proc}
-    ${pid}=  Execute Command  ps -C ${proc} -o pid=
+    #photon 4.4.152 version truncates the proc name to 15 characters in /proc/xxx/status.
+    ${proc_realname}=  Get SubString  ${proc}  0  15
+    ${pid}=  Execute Command  ps -C ${proc_realname} -o pid=
     ${pid}=  Strip String  ${pid}
+    Should Not Be Empty  ${pid}
     [Return]  ${pid}
 
 *** Test Cases ***


### PR DESCRIPTION
It seems new photon 4.4.152 version truncates the process name to 16
characters. which causes the "ps -C" doesn't work as expected.

This changes fix the issue and add a assert check.

Fixes #8250

[specific ci=6-15-Syslog]
