### PR TITLE
Fix Volume inspect always yields null Options

### DIFF
--- a/lib/apiservers/engine/backends/volume.go
+++ b/lib/apiservers/engine/backends/volume.go
@@ -117,7 +117,7 @@ func (v *VolumeBackend) Volumes(filter string) ([]*types.Volume, []string, error
 		// Include the volume in the output if it meets the filtering criteria
 		filterAction := vicfilter.IncludeVolume(volumeFilters, volFilterContext)
 		if filterAction == vicfilter.IncludeAction {
-			volume := NewVolumeModel(vol, volumeMetadata.Labels)
+			volume := NewVolumeModel(vol, volumeMetadata.Labels, volumeMetadata.DriverOpts)
 			volumes = append(volumes, volume)
 		}
 	}
@@ -139,8 +139,7 @@ func (v *VolumeBackend) VolumeInspect(name string) (*types.Volume, error) {
 	if err != nil {
 		return nil, errors.VolumeInternalServerError(fmt.Errorf("error unmarshalling docker metadata: %s", err))
 	}
-	volume := NewVolumeModel(volInfo, volumeMetadata.Labels)
-
+	volume := NewVolumeModel(volInfo, volumeMetadata.Labels, volumeMetadata.DriverOpts)
 	return volume, nil
 }
 
@@ -181,12 +180,14 @@ func (v *VolumeBackend) VolumesPrune(pruneFilters filters.Args) (*types.VolumesP
 // Utility Functions
 //------------------------------------
 
-func NewVolumeModel(volume *models.VolumeResponse, labels map[string]string) *types.Volume {
+func NewVolumeModel(volume *models.VolumeResponse, labels map[string]string, opts map[string]string) *types.Volume {
+
 	return &types.Volume{
 		Driver:     volume.Driver,
 		Name:       volume.Name,
 		Labels:     labels,
 		Mountpoint: volume.Label,
+		Options:    opts,
 	}
 }
 

--- a/tests/test-cases/Group1-Docker-Commands/1-20-Docker-Volume-Inspect.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-20-Docker-Volume-Inspect.robot
@@ -33,3 +33,12 @@ Docker volume inspect invalid object
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} volume inspect fakeVolume
     Should Be Equal As Integers  ${rc}  1
     Should Contain  ${output}  Error: No such volume: fakeVolume
+
+Docker volume inpect options
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} volume create --opt Capacity=200MB --name test1
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} volume inspect test1
+    Should Be Equal As Integers  ${rc}  0
+    ${output}=  Evaluate  json.loads(r'''${output}''')  json
+    ${capacity}=  Get From Dictionary  ${output[0]['Options']}  Capacity
+    Should Be Equal As Strings  ${capacity}  200MB


### PR DESCRIPTION
When doing `docker volume inspect`, the `Options` field of the result is
always null. 
The `VolumeInspect()` function fetches volume info and constructs 
 the `Volume` struct. But when constructing the struct, it doesn't assign
corresponding values into the `Options` fields of `Volume` struct.
The fix fills this field by modifying the `NewVolumeModel()` function.

The `VolumeCreate()` function also returns a `Volume` struct which
leaves `Options` field empty. But I find no usage of its detail info. Thus, 
the fix makes no changes to this function.

Fix #7325
Fix ##8357
[specific ci=1-20-Docker-Volume-Inspect]