### PR TITLE
Move a selenium problematic test to need-to-fix

### DIFF
--- a/tests/manual-test-cases/Disabled-tests.robot
+++ b/tests/manual-test-cases/Disabled-tests.robot
@@ -24,3 +24,7 @@ Test 5-27-Selenium-Grid
     ${status}=  Get State Of Github Issue  8236
     Run Keyword If  '${status}' == 'closed'  Fail  5-27-Selenium-Grid.robot needs to be moved out of "need-to-fix" folder now that Issue #8236 has been resolved
     Log  Test skipped; see issue \#8236  WARN
+
+    ${status}=  Get State Of Github Issue  7682
+    Run Keyword If  '${status}' == 'closed'  Fail  5-27-Selenium-Grid.robot needs to be moved out of "need-to-fix" folder now that Issue #7682 has been resolved
+    Log  Test skipped; see issue \#7682  WARN


### PR DESCRIPTION
The issue #7682 should be fixed later. 
Before being fixed, the corresponding test should be skipped: `5-27-Selenium-Grid`: selenium node chrome2 fail to start properly
Add three lines that skipping test case according to issue status  in the below of `Test 5-27-Selenium-Grid` in file `tests/manul-test-cases/Disabled-tests.robot` 