### PR TITLE
[WIP]Fixing 6-15-Syslog failure.

### DIFF
--- a/tests/test-cases/Group6-VIC-Machine/6-15-Syslog.robot
+++ b/tests/test-cases/Group6-VIC-Machine/6-15-Syslog.robot
@@ -67,6 +67,8 @@ Verify VCH remote syslog
 
     Wait Until Container Stops  ${id}  5
 
+    Sleep  60
+
     ${syslog-conn}=  Open Connection  %{SYSLOG_SERVER}
     Login  %{SYSLOG_USER}  %{SYSLOG_PASSWD}
     ${out}=  Execute Command  cat ${SYSLOG_FILE}


### PR DESCRIPTION
By reading the /var/log/syslog file in the syslog server, we found the
port-layer-server logs are delayed to be writtent to syslog server, this
might be caused by network slowness. Adding some delay see if if the
issue still occurs.

Fixes #8259

[specific ci=6-15-Syslog]

