### PR TITLE
Fix missing branch for tag event

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -240,7 +240,7 @@ pipeline:
     cache_control: 'public,max-age=3600'
     when:
       repo: vmware/vic
-      branch: ['releases/*']
+      branch: ['releases/*', 'refs/tags/*']
       event: tag
       status: success
 
@@ -272,7 +272,7 @@ pipeline:
     when:
       repo: vmware/vic
       event: tag
-      branch: 'releases/*'
+      branch: ['releases/*', 'refs/tags/*']
       status: success
 
   vic-machine-server-publish:
@@ -285,7 +285,7 @@ pipeline:
     when:
       repo: vmware/vic
       event: [push, tag]
-      branch: [master, 'releases/*']
+      branch: [master, 'releases/*', 'refs/tags/*']
       status: success
 
   trigger-downstream:
@@ -300,7 +300,7 @@ pipeline:
     when:
       repo: vmware/vic
       event: [push, tag]
-      branch: [master, 'releases/*']
+      branch: [master, 'releases/*', 'refs/tags/*']
       status: success
 
   notify-slack-on-fail:
@@ -313,7 +313,7 @@ pipeline:
     when:
       repo: vmware/vic
       event: [push, tag]
-      branch: [master, 'releases/*']
+      branch: [master, 'releases/*', 'refs/tags/*']
       status: failure
 
   notify-slack-on-pass:
@@ -338,7 +338,7 @@ pipeline:
     template: "The latest version of VIC engine has been released, find the build here: https://console.cloud.google.com/storage/browser/vic-engine-releases\n"
     when:
       repo: vmware/vic
-      branch: ['releases/*']
+      branch: ['releases/*', 'refs/tags/*']
       event: tag
       status: success
 


### PR DESCRIPTION
Adding tag from git command is different from tagging from
github web, the branch is refs/tags/* instead of releases/*
. Add refs/tags/* to branch so tag from git command can
also publish builds.

Fixes #
