### PR TITLE
Cherry-pick: Purge inflight entries during layer cache hydration (#8032)

### DIFF
--- a/lib/imagec/layer_cache.go
+++ b/lib/imagec/layer_cache.go
@@ -89,6 +89,19 @@ func InitializeLayerCache(client *client.PortLayer) error {
 		layerCache.layers = l.Layers
 	}
 
+	// Sanitize cache - evict inconsistent elements
+	evict := make([]string, 0, len(l.Layers))
+	// build the list for eviction - we should not iterate and modify in the same loop
+	for k, v := range l.Layers {
+		if v.Downloading {
+			evict = append(evict, k)
+		}
+	}
+
+	for _, k := range evict {
+		layerCache.Remove(k)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
The layer cache is persisting the download state for inflight layers which
causes problems when attempting to re-pull an image after an interruption.
This is triggered by:
a. a layer download in progress
b. a different layer completing download and committing while (a)
continues
c. interruption (by VM restart in this case) of (a)
d. re-pull image using layer from (a)

It's possible  that the download state doesn't need to be persisted but
unable to confirm/refute this without further investigation. This commit
is effective in addressing the specifically observed behaviour.

Adds stochastic test for interrupted pull.

(cherry picked from commit 9ad53ee7f7e4beb3897e0e1d4a190f07a21b4280)

Towards #8029
