### PR TITLE
Cherry-pick: Fixing 1-26-Docker-Hello-World failure (#8268)

### DIFF
--- a/tests/manual-test-cases/Group17-ManualTTY/17-1-TTY-Tests.robot
+++ b/tests/manual-test-cases/Group17-ManualTTY/17-1-TTY-Tests.robot
@@ -71,13 +71,13 @@ Hello world with -i
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -i hello-world
     Log  ${output}
     Should Be Equal As Integers  ${rc}  0
-    Should Contain  ${output}  https://docs.docker.com/engine/userguide/
+    Should Contain  ${output}  https://docs.docker.com/get-started/
 
 Hello world with -it
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -it hello-world
     Log  ${output}
     Should Be Equal As Integers  ${rc}  0
-    Should Contain  ${output}  https://docs.docker.com/engine/userguide/
+    Should Contain  ${output}  https://docs.docker.com/get-started/
 
 Start with attach and interactive
     ${fifo}=  Make Fifo

--- a/tests/test-cases/Group1-Docker-Commands/1-26-Docker-Hello-World.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-26-Docker-Hello-World.robot
@@ -24,10 +24,10 @@ Hello world
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run hello-world
     Log  ${output}
     Should Be Equal As Integers  ${rc}  0
-    Should Contain  ${output}  https://docs.docker.com/engine/userguide/
+    Should Contain  ${output}  https://docs.docker.com/get-started/
 
 Hello world with -t
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -t hello-world
     Log  ${output}
     Should Be Equal As Integers  ${rc}  0
-    Should Contain  ${output}  https://docs.docker.com/engine/userguide/
+    Should Contain  ${output}  https://docs.docker.com/get-started/


### PR DESCRIPTION
Due to latest hello-world changes, the test 1-26-Docker-Hello-World failed.
This patch fixes it, also fixes the 17-1-TTY-Tests related cases.

(cherry picked from commit 284aeb730f10eb26b5d5a390c419dd3cfee29017)

[specific ci=1-26-Docker-Hello-World]