### PR TITLE
Cherry-pick: Fix PXE folder cleanup failure (#8237)

### DIFF
--- a/tests/resources/Nimbus-Util.robot
+++ b/tests/resources/Nimbus-Util.robot
@@ -198,7 +198,7 @@ Deploy Nimbus vCenter Server Async
 Deploy Nimbus Testbed
     [Arguments]  ${user}  ${password}  ${args}=  ${spec}=${EMPTY}
 
-    Run Keyword And Ignore Error  Cleanup Nimbus Folders  deletePxe=${true}
+    Run Keyword And Ignore Error  Cleanup Nimbus Folders  deletePXE=${true}
 
     Open Connection  %{NIMBUS_GW}
     Wait Until Keyword Succeeds  2 min  30 sec  Login  ${user}  ${password}


### PR DESCRIPTION
deletePXE is the correct varialbe name for keyword
"Cleanup Nimbus Folders"

(cherry picked from commit 20781bf832780c1c7b1b5de38f6ebbed247850cd)