### PR TITLE
Cherry-Pick: Fix missing branch for tag event (#8261)

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -235,7 +235,7 @@ pipeline:
     cache_control: 'public,max-age=3600'
     when:
       repo: vmware/vic
-      branch: ['releases/*']
+      branch: ['releases/*', 'refs/tags/*']
       event: tag
       status: success
 
@@ -267,7 +267,7 @@ pipeline:
     when:
       repo: vmware/vic
       event: tag
-      branch: 'releases/*'
+      branch: ['releases/*', 'refs/tags/*']
       status: success
 
   vic-machine-server-publish:
@@ -280,7 +280,7 @@ pipeline:
     when:
       repo: vmware/vic
       event: [push, tag]
-      branch: [master, 'releases/*']
+      branch: [master, 'releases/*', 'refs/tags/*']
       status: success
 
   trigger-downstream:
@@ -295,7 +295,7 @@ pipeline:
     when:
       repo: vmware/vic
       event: [push, tag]
-      branch: [master, 'releases/*']
+      branch: [master, 'releases/*', 'refs/tags/*']
       status: success
 
   notify-slack-on-fail:
@@ -308,7 +308,7 @@ pipeline:
     when:
       repo: vmware/vic
       event: [push, tag]
-      branch: [master, 'releases/*']
+      branch: [master, 'releases/*', 'refs/tags/*']
       status: failure
 
   notify-slack-on-pass:
@@ -333,7 +333,7 @@ pipeline:
     template: "The latest version of VIC engine has been released, find the build here: https://console.cloud.google.com/storage/browser/vic-engine-releases\n"
     when:
       repo: vmware/vic
-      branch: ['releases/*']
+      branch: ['releases/*', 'refs/tags/*']
       event: tag
       status: success
 


### PR DESCRIPTION
Adding tag from git command is different from tagging from
github web, the branch is refs/tags/* instead of releases/*
. Add refs/tags/* to branch so tag from git command can
also publish builds.

(cherry picked from commit c9c079e0f6f3c43bae3bc46f61acf5befd4ea56d)

Fixes #
