### PR TITLE
Partial handling for missing vSphere VM PoweredOn event

### DIFF
--- a/lib/portlayer/exec/container.go
+++ b/lib/portlayer/exec/container.go
@@ -430,7 +430,20 @@ func (c *Container) start(op trace.Operation) error {
 	//   Starting - if the power on event was received before the process reported success or failure
 	//   Running - if the power on event was received after the process reported success
 	if err = c.transitionState(op, StateStarting, StateRunning); err != nil {
+		// We have observed powerOn events not being delivered (unknown if they're generated or not)
+		// If waitForSession has returned successfully then we are guaranteed that the VM has powered on as
+		// the key we're waiting on is set from the guest.
+		// We cannot make any assumptions for a cVM that's being restarted as it's initial state is Stopped and
+		// we could legitimately have started, run, and stopped before this code runs. However for first execution
+		// which is the most common case we can assert that it should not be in Created state at this time.
 		op.Debugf(err.Error())
+
+		if c.State() == StateCreated {
+			op.Debugf("Attempting conditional transition to Running assuming missing PoweredOn event")
+			if err = c.transitionState(op, StateCreated, StateRunning); err != nil {
+				op.Debugf(err.Error())
+			}
+		}
 	}
 
 	return nil
@@ -733,8 +746,9 @@ func (c *Container) onEvent(op trace.Operation, newState State, e events.Event) 
 
 	if !stateEvent {
 		if (newState == StateStarting && !started) || newState == StateStopping {
-			// inherently transient state. Starting with started == true is just accounting that will
-			// happen below and doesn't need a refresh.
+			// inherently transient state.
+			// We filter out `Starting && started == true` as that's just accounting and an update will
+			// happen below without a refresh.
 			refresh = true
 		}
 


### PR DESCRIPTION
We are seeing frequent intermittent failures in the concurrent rm testing
and an investigation of one such failure shows that we never received the
powered on event from vSphere. We depend on that event to transition the
portlayer recorded state of the cVM to Starting so that we can generate
correct container level events for the personality.

This change makes use of the fact that a cVM should _never_ be in Created
state if we have had a Session key updated given that is an in-guest
operation. This DOES NOT handle the same missing event if the container is
being restarted as there's no effective way for us to differentiate
between the Stopped state being because we missed the event vs the cVM
having started, completed its task and exited.
We could try looking at StartTime/StopTime but it's inlining a lot of
logic that's totally specific to working around a vSphere issue. If it
becomes a significant factor then we should consider it, but there's no
easy way to disable that extra complexity when running against vSphere
versions that do not have the same problem.
It's worth noting that restart will never happen for a cVM configured for
auto-removal so that case is logically different in terms of call flows
anyway.

Fixes #8275 

```
[skip unit]
[specific ci=1-06-Docker-Run]
```