### PR TITLE
Gather vSphere logs for custom VCH deployment

### DIFF
--- a/tests/resources/VCH-Util.robot
+++ b/tests/resources/VCH-Util.robot
@@ -444,16 +444,19 @@ Portlayer Log Should Match Regexp
     ${rc}=  Run And Return Rc  curl -sk %{VIC-ADMIN}/logs/port-layer.log -b ${cookies} | grep -ie \'${pattern1}\' | grep -iqe \'${pattern2}\'
     Should Be Equal As Integers  ${rc}  0
 
+# Grab the vSphere logs for a VCH. This takes two optional parameters:
+# name-suffix: a suffix to append to the log bundle to allow for capture before/after reboot of VCH for example
+# name: override the default use of %{VCH-NAME} and specify a specific VCH name
 Gather Logs From Test Server
-    [Arguments]  ${name-suffix}=${EMPTY}
-    Run Keyword And Continue On Failure  Run  zip %{VCH-NAME}-certs -r %{VCH-NAME}
+    [Arguments]  ${name-suffix}=${EMPTY}  ${name}=%{VCH-NAME}
+    Run Keyword And Continue On Failure  Run  zip ${name}-certs -r ${name}
     Curl Container Logs  ${name-suffix}
-    ${host}=  Wait Until Keyword Succeeds  12x  10s  Get VM Host Name  %{VCH-NAME}
+    ${host}=  Wait Until Keyword Succeeds  12x  10s  Get VM Host Name  ${name}
     Log  ${host}
-    ${out}=  Run  govc datastore.download -host ${host} %{VCH-NAME}/vmware.log %{VCH-NAME}-vmware${name-suffix}.log
+    ${out}=  Run  govc datastore.download -host ${host} ${name}/vmware.log ${name}-vmware${name-suffix}.log
     Log  ${out}
     Should Contain  ${out}  OK
-    ${out}=  Run  govc datastore.download -host ${host} %{VCH-NAME}/tether.debug %{VCH-NAME}-tether${name-suffix}.debug
+    ${out}=  Run  govc datastore.download -host ${host} ${name}/tether.debug ${name}-tether${name-suffix}.debug
     Log  ${out}
     Should Contain  ${out}  OK
     Run Keyword If  '%{HOST_TYPE}' == 'ESXi'  Run  govc logs -log=vmkernel -n=10000 > vmkernel${name-suffix}.log

--- a/tests/test-cases/Group1-Docker-Commands/1-02-Docker-Pull.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-02-Docker-Pull.robot
@@ -73,8 +73,9 @@ Deploy Proxified VCH
     # Run VIC Machine Command assumes %{VCH-NAME}
     # Install VIC Appliance on Test Server assumes a bunch of environment variables
     # We're just going to eschew helpers and install this VCH manually to avoid mutating hidden environmental state which is difficult to debug
-    ${rc}  ${output}=  Run And Return Rc And Output  bin/vic-machine-linux create --name=VCH-XPLT --target=%{TEST_URL}%{TEST_DATACENTER} --user=%{TEST_USERNAME} --password=%{TEST_PASSWORD} --force=true --compute-resource=%{TEST_RESOURCE} --timeout %{TEST_TIMEOUT} --bridge-network=%{BRIDGE_NETWORK} --container-network=%{PUBLIC_NETWORK}:public --public-network=%{PUBLIC_NETWORK} ${vicmachinetls} --image-store=%{TEST_DATASTORE} --insecure-registry=http://${registry} --http-proxy http://${mitm}
+    ${rc}  ${output}=  Run And Return Rc And Output  bin/vic-machine-linux create --name=VCH-XPLT --target=%{TEST_URL}%{TEST_DATACENTER} --user=%{TEST_USERNAME} --password=%{TEST_PASSWORD} --force=true --compute-resource=%{TEST_RESOURCE} --timeout %{TEST_TIMEOUT} --bridge-network=%{BRIDGE_NETWORK} --container-network=%{PUBLIC_NETWORK}:public --public-network=%{PUBLIC_NETWORK} ${vicmachinetls} --image-store=%{TEST_DATASTORE} --insecure-registry=http://${registry} --http-proxy http://${mitm} --debug=2
     Log  ${output}
+    Gather Logs From Test Server  name=VCH-XPLT
     Should Be Equal As Integers  ${rc}  0
 
     ${br2}=  Get Environment Variable  BRIDGE_NETWORK


### PR DESCRIPTION
There is a custom VCH deployed that is configured to use a
man-in-the-middle proxy to test our handling of image tampering. This VCH
is currently experiencing frequent intermittent failures to deploy,
however we are not capturing the tether.debug or vmware.log for the VCH so
cannot diagnose the cause.
This parameterizes the current log collection keyword to allow
specification of a target VCH instead of using the default from the
environment and makes use of that keyword for the MITM VCH.

```
[skip unit]
[specific ci=1-02-Docker-Pull]
```