### PR TITLE
Missing gateway information when using docker inspect to show network

### DIFF
--- a/lib/apiservers/portlayer/restapi/handlers/containers_handlers.go
+++ b/lib/apiservers/portlayer/restapi/handlers/containers_handlers.go
@@ -651,8 +651,8 @@ func convertContainerToContainerInfo(c *exec.Container) *models.ContainerInfo {
 			Direct:      endpoint.Network.Type == constants.ExternalScopeType,
 		}
 
-		if !ip.IsUnspecifiedIP(endpoint.Network.Gateway.IP) {
-			ep.Gateway = endpoint.Network.Gateway.String()
+		if !ip.IsUnspecifiedIP(endpoint.Network.Assigned.Gateway.IP) {
+			ep.Gateway = endpoint.Network.Assigned.Gateway.IP.String()
 		}
 
 		if !ip.IsUnspecifiedIP(endpoint.Assigned.IP) {

--- a/tests/test-cases/Group1-Docker-Commands/1-23-Docker-Inspect.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-23-Docker-Inspect.robot
@@ -98,6 +98,13 @@ Docker inspect container with multiple networks
     Should Contain  ${out}  net-one
     Should Be Equal As Integers  ${rc}  0
 
+Docker inspect container with correct gateway
+    ${rc}  ${container}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run --name=test-gateway -d ${busybox} sleep 600
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${out}=  Run And Return Rc And Output  docker %{VCH-PARAMS} inspect -f '{{range .NetworkSettings.Networks}}{{.Gateway}}{{end}}' test-gateway
+    Should Contain  ${out}  172.16.0.1
+    Should Not Contain  ${out}  /
+
 Docker inspect invalid object
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} inspect fake
     Should Be Equal As Integers  ${rc}  1


### PR DESCRIPTION
We cannot use the endpoint.Network information to show gateway, because
the container network may use dhcp mode. So we should use the Assigned
property to show address, gateway information.

<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[  ] There is an associated issue that is labelled
[  ] Code is up-to-date with the `master` branch
[  ] You've successfully run `make test` locally
[  ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/vmware/vic/blob/master/.github/CONTRIBUTING.md
-->

[specific ci=1-23-Docker-Inspect]

Fixes #6010 
