### PR TITLE
Set the specified DNS to container VM

### DIFF
--- a/lib/apiservers/engine/proxy/container_proxy.go
+++ b/lib/apiservers/engine/proxy/container_proxy.go
@@ -1152,6 +1152,13 @@ func toModelsNetworkConfig(cc types.ContainerCreateConfig) *models.NetworkConfig
 		nc.Ports = append(nc.Ports, fromPortbinding(p, cc.HostConfig.PortBindings[p])...)
 	}
 
+	if len(cc.HostConfig.DNS) > 0 {
+		for _, dns := range cc.HostConfig.DNS {
+			if dns != "" {
+				nc.Nameservers = append(nc.Nameservers, dns)
+			}
+		}
+	}
 	return nc
 }
 
@@ -1280,15 +1287,14 @@ func hostConfigFromContainerInfo(vc *viccontainer.VicContainer, info *models.Con
 	hostConfig.Resources = resourceConfig
 	hostConfig.DNS = make([]string, 0)
 
-	if len(info.Endpoints) > 0 {
-		for _, ep := range info.Endpoints {
-			for _, dns := range ep.Nameservers {
-				if dns != "" {
-					hostConfig.DNS = append(hostConfig.DNS, dns)
-				}
+	if len(vc.HostConfig.DNS) > 0 {
+		for _, dns := range vc.HostConfig.DNS {
+			if dns != "" {
+				hostConfig.DNS = append(hostConfig.DNS, dns)
 			}
 		}
-
+	}
+	if len(info.Endpoints) > 0 {
 		hostConfig.NetworkMode = container.NetworkMode(info.Endpoints[0].Scope)
 	}
 

--- a/lib/apiservers/portlayer/restapi/handlers/scopes_handlers.go
+++ b/lib/apiservers/portlayer/restapi/handlers/scopes_handlers.go
@@ -237,10 +237,11 @@ func (handler *ScopesHandlersImpl) ScopesAddContainer(params scopes.AddContainer
 		}
 
 		options := &network.AddContainerOptions{
-			Scope:   params.Config.NetworkConfig.NetworkName,
-			IP:      ip,
-			Aliases: params.Config.NetworkConfig.Aliases,
-			Ports:   params.Config.NetworkConfig.Ports,
+			Scope:       params.Config.NetworkConfig.NetworkName,
+			IP:          ip,
+			Aliases:     params.Config.NetworkConfig.Aliases,
+			Ports:       params.Config.NetworkConfig.Ports,
+			Nameservers: params.Config.NetworkConfig.Nameservers,
 		}
 		return handler.netCtx.AddContainer(h, options)
 	}()

--- a/lib/apiservers/portlayer/swagger.json
+++ b/lib/apiservers/portlayer/swagger.json
@@ -3350,6 +3350,12 @@
 					"items": {
 						"type": "string"
 					}
+				},
+				"nameservers": {
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
 				}
 			}
 		},

--- a/lib/portlayer/network/context.go
+++ b/lib/portlayer/network/context.go
@@ -61,10 +61,11 @@ type Context struct {
 }
 
 type AddContainerOptions struct {
-	Scope   string
-	IP      net.IP
-	Aliases []string
-	Ports   []string
+	Scope       string
+	IP          net.IP
+	Aliases     []string
+	Ports       []string
+	Nameservers []string
 }
 
 func NewContext(config *Configuration, kv kvstore.KeyValueStore) (*Context, error) {
@@ -1196,6 +1197,15 @@ func (c *Context) AddContainer(h *exec.Handle, options *AddContainerOptions) err
 	ne.Network.Pools = make([]ip.Range, len(pools))
 	for i, p := range pools {
 		ne.Network.Pools[i] = *p
+	}
+
+	ne.Network.Nameservers = make([]net.IP, 0)
+	if len(options.Nameservers) > 0 {
+		for _, dns := range options.Nameservers {
+			if dns != "" {
+				ne.Network.Nameservers = append(ne.Network.Nameservers, net.ParseIP(dns))
+			}
+		}
 	}
 
 	ne.Static = false

--- a/tests/test-cases/Group1-Docker-Commands/1-23-Docker-Inspect.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-23-Docker-Inspect.robot
@@ -162,3 +162,22 @@ Docker inspect container status
     # keyword at top of file
     ${stopped}=  Get container inspect status  ${container}
     Should Contain  ${stopped}  exited
+
+Docker inspect container with specified DNS
+    ${rc}  ${container}=  Run And Return Rc And Output  docker %{VCH-PARAMS} create --dns=8.8.8.8 --name=test-with-specified-dns busybox sleep 600
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} inspect ${container}
+    Should Be Equal As Integers  ${rc}  0
+    Should Contain  ${output}  8.8.8.8
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} start ${container}
+    Should Be Equal As Integers  ${rc}  0
+
+Docker inspect container with multiple specified DNS
+    ${rc}  ${container}=  Run And Return Rc And Output  docker %{VCH-PARAMS} create --dns=8.8.8.8 --dns=8.8.8.9 --name=test-with-multiple-specified-dns busybox sleep 600
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} inspect ${container}
+    Should Be Equal As Integers  ${rc}  0
+    Should Contain  ${output}  8.8.8.8
+    Should Contain  ${output}  8.8.8.9
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} start ${container}
+    Should Be Equal As Integers  ${rc}  0


### PR DESCRIPTION
docker inspect does not show dns information when using parameter
--dns to customize the DNS. And the container VM is not configured
the DNS with specified one.

<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[  ] There is an associated issue that is labelled
[  ] Code is up-to-date with the `master` branch
[  ] You've successfully run `make test` locally
[  ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/vmware/vic/blob/master/.github/CONTRIBUTING.md
-->

[specific ci=1-23-Docker-Inspect]

Fixes #3727 
