### PR TITLE
Specified hostname is not shown when using docker inspect

### DIFF
--- a/lib/apiservers/engine/backends/container.go
+++ b/lib/apiservers/engine/backends/container.go
@@ -2055,6 +2055,8 @@ func copyConfigOverrides(vc *viccontainer.VicContainer, config types.ContainerCr
 	vc.Config.StdinOnce = config.Config.StdinOnce
 	vc.Config.StopSignal = config.Config.StopSignal
 	vc.Config.Volumes = config.Config.Volumes
+	vc.Config.Hostname = config.Config.Hostname
+	vc.Config.Domainname = config.Config.Domainname
 	vc.HostConfig = config.HostConfig
 }
 

--- a/lib/apiservers/engine/proxy/container_proxy.go
+++ b/lib/apiservers/engine/proxy/container_proxy.go
@@ -1355,7 +1355,7 @@ func containerConfigFromContainerInfo(vc *viccontainer.VicContainer, info *model
 	// Copy the working copy of our container's config
 	container := *vc.Config
 
-	if info.ContainerConfig.ContainerID != "" {
+	if container.Hostname == "" && info.ContainerConfig.ContainerID != "" {
 		container.Hostname = stringid.TruncateID(info.ContainerConfig.ContainerID) // Hostname
 	}
 	if info.ContainerConfig.AttachStdin != nil {

--- a/tests/test-cases/Group1-Docker-Commands/1-23-Docker-Inspect.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-23-Docker-Inspect.robot
@@ -162,3 +162,9 @@ Docker inspect container status
     # keyword at top of file
     ${stopped}=  Get container inspect status  ${container}
     Should Contain  ${stopped}  exited
+
+Docker inspect container with specified hostname
+    ${rc}  ${container}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -h testhostname --name=test-hostname -d ${busybox} sleep 600
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${out}=  Run And Return Rc And Output  docker %{VCH-PARAMS} inspect -f '{{.Config.Hostname}}' test-hostname
+    Should Be Equal  ${out}  testhostname


### PR DESCRIPTION
When using docker inspect to show container information, the
config.Hostname is still using container id instead of hostname

<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[  ] There is an associated issue that is labelled
[  ] Code is up-to-date with the `master` branch
[  ] You've successfully run `make test` locally
[  ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/vmware/vic/blob/master/.github/CONTRIBUTING.md
-->

Fixes #8318 

[specific ci=1-23-Docker-Inspect]
