### PR TITLE
Check connectivity to VMware instead of Google

### DIFF
--- a/lib/vicadmin/validate.go
+++ b/lib/vicadmin/validate.go
@@ -181,7 +181,7 @@ func NewValidator(ctx context.Context, vch *config.VirtualContainerHostConfigSpe
 
 	// Network Connection Check
 	hosts := []string{
-		"http://google.com",
+		"http://vmware.com",
 		"https://docker.io",
 	}
 


### PR DESCRIPTION
The vicadmin page checks connectivity from the Endpoint VM to external addresses to help detect potential configuration issues. Switch from using google.com to vmware.com because google.com is not accessible
from China.
