### PR TITLE
Add storage-quota into VCH

### DIFF
--- a/cmd/vic-machine/common/limits.go
+++ b/cmd/vic-machine/common/limits.go
@@ -30,6 +30,8 @@ type ResourceLimits struct {
 	VCHMemoryReservationsMB *int              `cmd:"memory-reservation"`
 	VCHMemoryShares         *types.SharesInfo `cmd:"memory-shares"`
 
+	StorageQuotaGB *int `cmd:"storage-quota"`
+
 	IsSet bool
 }
 
@@ -73,6 +75,16 @@ func (r *ResourceLimits) VCHCPULimitFlags() []cli.Flag {
 			Value:  flags.NewSharesFlag(&r.VCHCPUShares),
 			Usage:  "VCH resource pool vCPUs shares, in level or share number, e.g. high, normal, low, or 4000",
 			Hidden: true,
+		},
+	}
+}
+
+func (r *ResourceLimits) VCHStorageQuotaFlag() []cli.Flag {
+	return []cli.Flag{
+		cli.GenericFlag{
+			Name:  "storage-quota, sq",
+			Value: flags.NewOptionalInt(&r.StorageQuotaGB),
+			Usage: "Storage quota for images and containers in GB (unlimited=0)",
 		},
 	}
 }

--- a/cmd/vic-machine/configure/configure.go
+++ b/cmd/vic-machine/configure/configure.go
@@ -354,7 +354,7 @@ func (c *Configure) Run(clic *cli.Context) (err error) {
 	}
 	defer validator.Session().Logout(parentOp) // parentOp is used here to ensure the logout occurs, even in the event of timeout
 
-	updatedStorageQuota := c.Data.StorageQuotaGB != nil && *c.Data.StorageQuotaGB != 0
+	updatedStorageQuota := c.Data.StorageQuotaGB != nil && *c.Data.StorageQuotaGB > 0
 
 	_, err = validator.ValidateTarget(op, c.Data, false)
 	if err != nil {
@@ -479,7 +479,12 @@ func (c *Configure) Run(clic *cli.Context) (err error) {
 	c.Data.ResourceLimits = mergedResources
 
 	if c.StorageQuotaGB != nil {
-		vchConfig.StorageQuota = int64(*c.StorageQuotaGB) * units.GiB
+		// Treat minus values as unlimited
+		if *c.StorageQuotaGB <= 0 {
+			vchConfig.StorageQuota = 0
+		} else {
+			vchConfig.StorageQuota = int64(*c.StorageQuotaGB) * units.GiB
+		}
 	}
 
 	// TODO: copy changed configuration here. https://github.com/vmware/vic/issues/2911

--- a/cmd/vic-machine/configure/configure.go
+++ b/cmd/vic-machine/configure/configure.go
@@ -467,7 +467,7 @@ func (c *Configure) Run(clic *cli.Context) (err error) {
 	}
 
 	if updatedStorageQuota {
-		err = validator.ValidateStorageQuota(op, *c.StorageQuotaGB, vchConfig, vch)
+		_, err = validator.ValidateStorageQuota(op, *c.StorageQuotaGB, vchConfig, vch)
 		if err != nil {
 			op.Error("Configuring cannot continue: storage quota validation failed")
 			return err

--- a/cmd/vic-machine/configure/configure.go
+++ b/cmd/vic-machine/configure/configure.go
@@ -467,7 +467,7 @@ func (c *Configure) Run(clic *cli.Context) (err error) {
 	}
 
 	if updatedStorageQuota {
-		err = validator.ValidateStorageQuota(op, *c.StorageQuotaGB, vchConfig, true)
+		err = validator.ValidateStorageQuota(op, *c.StorageQuotaGB, vchConfig, vch)
 		if err != nil {
 			op.Error("Configuring cannot continue: storage quota validation failed")
 			return err

--- a/cmd/vic-machine/configure/configure.go
+++ b/cmd/vic-machine/configure/configure.go
@@ -24,6 +24,8 @@ import (
 
 	"gopkg.in/urfave/cli.v1"
 
+	"github.com/docker/go-units"
+
 	"github.com/vmware/vic/cmd/vic-machine/common"
 	"github.com/vmware/vic/lib/config"
 	"github.com/vmware/vic/lib/config/executor"
@@ -104,10 +106,11 @@ func (c *Configure) Flags() []cli.Flag {
 	certificates := c.certificates.CertFlags()
 	registries := c.registries.Flags()
 	help := c.help.HelpFlags()
+	squota := c.VCHStorageQuotaFlag()
 
 	// flag arrays are declared, now combined
 	var flags []cli.Flag
-	for _, f := range [][]cli.Flag{target, ops, id, compute, affinity, container, volume, dns, cNetwork, memory, cpu, certificates, registries, proxies, util, debug, help} {
+	for _, f := range [][]cli.Flag{target, ops, id, compute, affinity, container, volume, dns, cNetwork, memory, cpu, squota, certificates, registries, proxies, util, debug, help} {
 		flags = append(flags, f...)
 	}
 
@@ -351,6 +354,8 @@ func (c *Configure) Run(clic *cli.Context) (err error) {
 	}
 	defer validator.Session().Logout(parentOp) // parentOp is used here to ensure the logout occurs, even in the event of timeout
 
+	updatedStorageQuota := c.Data.StorageQuotaGB != nil && *c.Data.StorageQuotaGB != 0
+
 	_, err = validator.ValidateTarget(op, c.Data, false)
 	if err != nil {
 		op.Errorf("Configuring cannot continue - target validation failed: %s", err)
@@ -460,9 +465,22 @@ func (c *Configure) Run(clic *cli.Context) (err error) {
 		op.Error("Configuring cannot continue: configuration validation failed")
 		return err
 	}
+
+	if updatedStorageQuota {
+		err = validator.ValidateStorageQuota(op, *c.StorageQuotaGB, vchConfig, true)
+		if err != nil {
+			op.Error("Configuring cannot continue: storage quota validation failed")
+			return err
+		}
+	}
+
 	// The user supplied resource information has been validated, so
 	// switch back to the merged results
 	c.Data.ResourceLimits = mergedResources
+
+	if c.StorageQuotaGB != nil {
+		vchConfig.StorageQuota = int64(*c.StorageQuotaGB) * units.GiB
+	}
 
 	// TODO: copy changed configuration here. https://github.com/vmware/vic/issues/2911
 	c.copyChangedConf(vchConfig, newConfig, clic)

--- a/cmd/vic-machine/converter/converter_test.go
+++ b/cmd/vic-machine/converter/converter_test.go
@@ -299,7 +299,7 @@ func testConvertContainerNetworks(t *testing.T) {
 	assert.Equal(t, "172.16.0.2/12", options["management-network-ip"][0], "not expected management-network-ip option")
 }
 
-func TestConvertSharesInfo(t *testing.T) {
+func TestConvertLimitsInfo(t *testing.T) {
 	data := data.NewData()
 	cLimit, cReserve := 29300, 1024
 	data.NumCPUs = 2
@@ -317,10 +317,12 @@ func TestConvertSharesInfo(t *testing.T) {
 		Shares: 163840,
 		Level:  types.SharesLevelNormal,
 	}
+	quota := 100
+	data.StorageQuotaGB = &quota
 
 	options, err := DataToOption(data)
 	assert.Empty(t, err)
-	assert.Equal(t, 7, len(options), "should not have other option generated")
+	assert.Equal(t, 8, len(options), "should not have other option generated")
 	assert.Equal(t, "2", options["endpoint-cpu"][0], "not expected endpoint-cpu option")
 	assert.Equal(t, "4096", options["endpoint-memory"][0], "not expected endpoint-memory option")
 	assert.Equal(t, "13144", options["memory"][0], "not expected memory option")
@@ -328,6 +330,7 @@ func TestConvertSharesInfo(t *testing.T) {
 	assert.Equal(t, "29300", options["cpu"][0], "not expected cpu option")
 	assert.Equal(t, "1024", options["cpu-reservation"][0], "not expected cpu-reservation option")
 	assert.Equal(t, "6000", options["cpu-shares"][0], "not expected cpu-shares option")
+	assert.Equal(t, "100", options["storage-quota"][0], "not expected storage-quota option")
 }
 
 func TestGuestInfo(t *testing.T) {

--- a/cmd/vic-machine/create/create.go
+++ b/cmd/vic-machine/create/create.go
@@ -695,7 +695,7 @@ func (c *Create) Run(clic *cli.Context) (err error) {
 		return err
 	}
 
-	if c.StorageQuotaGB != nil {
+	if c.StorageQuotaGB != nil && *c.StorageQuotaGB > 0 {
 		err = validator.ValidateStorageQuota(op, *c.StorageQuotaGB, nil, false)
 		if err != nil {
 			op.Error("Configuring cannot continue: storage quota validation failed")

--- a/cmd/vic-machine/create/create.go
+++ b/cmd/vic-machine/create/create.go
@@ -27,8 +27,6 @@ import (
 
 	"gopkg.in/urfave/cli.v1"
 
-	"github.com/docker/go-units"
-
 	"github.com/vmware/vic/cmd/vic-machine/common"
 	"github.com/vmware/vic/lib/constants"
 	"github.com/vmware/vic/lib/install/data"
@@ -696,12 +694,12 @@ func (c *Create) Run(clic *cli.Context) (err error) {
 	}
 
 	if c.StorageQuotaGB != nil && *c.StorageQuotaGB > 0 {
-		err = validator.ValidateStorageQuota(op, *c.StorageQuotaGB, nil, nil)
+		quotaBytes, err := validator.ValidateStorageQuota(op, *c.StorageQuotaGB, nil, nil)
 		if err != nil {
 			op.Error("Configuring cannot continue: storage quota validation failed")
 			return err
 		}
-		vchConfig.StorageQuota = int64(*c.StorageQuotaGB) * units.GiB
+		vchConfig.StorageQuota = quotaBytes
 	}
 
 	// persist cli args used to create the VCH

--- a/cmd/vic-machine/create/create.go
+++ b/cmd/vic-machine/create/create.go
@@ -696,7 +696,7 @@ func (c *Create) Run(clic *cli.Context) (err error) {
 	}
 
 	if c.StorageQuotaGB != nil && *c.StorageQuotaGB > 0 {
-		err = validator.ValidateStorageQuota(op, *c.StorageQuotaGB, nil, false)
+		err = validator.ValidateStorageQuota(op, *c.StorageQuotaGB, nil, nil)
 		if err != nil {
 			op.Error("Configuring cannot continue: storage quota validation failed")
 			return err

--- a/cmd/vic-machine/create/create_test.go
+++ b/cmd/vic-machine/create/create_test.go
@@ -72,7 +72,7 @@ func TestParseGatewaySpec(t *testing.T) {
 func TestFlags(t *testing.T) {
 	c := NewCreate()
 	flags := c.Flags()
-	numberOfFlags := 62
+	numberOfFlags := 63
 	assert.Equal(t, numberOfFlags, len(flags), "Missing flags during Create.")
 }
 

--- a/lib/apiservers/engine/backends/backends.go
+++ b/lib/apiservers/engine/backends/backends.go
@@ -140,7 +140,7 @@ func Init(portLayerAddr, product string, port uint, staticConfig *config.Virtual
 	// the vic-machine installer timeout will intervene if this blocks for too long
 	pingPortLayer()
 
-	if err := hydrateCaches(op, vchConfig.Cfg.ScratchSize); err != nil {
+	if err := hydrateCaches(op); err != nil {
 		return err
 	}
 
@@ -169,7 +169,7 @@ func Finalize(ctx context.Context) error {
 	return nil
 }
 
-func hydrateCaches(op trace.Operation, vs int64) error {
+func hydrateCaches(op trace.Operation) error {
 	const waiters = 3
 
 	wg := sync.WaitGroup{}
@@ -196,7 +196,7 @@ func hydrateCaches(op trace.Operation, vs int64) error {
 
 		// container cache relies on image cache so we share a goroutine to update
 		// them serially
-		if err := syncContainerCache(op, vs); err != nil {
+		if err := syncContainerCache(op); err != nil {
 			errChan <- fmt.Errorf("Failed to update container cache: %s", err)
 			return
 		}
@@ -299,7 +299,7 @@ func createImageStore(op trace.Operation) error {
 }
 
 // syncContainerCache runs once at startup to populate the container cache
-func syncContainerCache(op trace.Operation, vs int64) error {
+func syncContainerCache(op trace.Operation) error {
 	log.Debugf("Updating container cache")
 
 	backend := NewContainerBackend()

--- a/lib/apiservers/engine/backends/cache/container_cache.go
+++ b/lib/apiservers/engine/backends/cache/container_cache.go
@@ -22,7 +22,6 @@ import (
 
 	derr "github.com/docker/docker/api/errors"
 	"github.com/docker/docker/pkg/truncindex"
-
 	"github.com/docker/go-units"
 
 	"github.com/vmware/vic/lib/apiservers/engine/backends/container"

--- a/lib/apiservers/engine/backends/cache/container_cache.go
+++ b/lib/apiservers/engine/backends/cache/container_cache.go
@@ -23,6 +23,8 @@ import (
 	derr "github.com/docker/docker/api/errors"
 	"github.com/docker/docker/pkg/truncindex"
 
+	"github.com/docker/go-units"
+
 	"github.com/vmware/vic/lib/apiservers/engine/backends/container"
 )
 
@@ -34,9 +36,12 @@ type CCache struct {
 	containersByID     map[string]*container.VicContainer
 	containersByName   map[string]*container.VicContainer
 	containersByExecID map[string]*container.VicContainer
+
+	vmStorageUsage int64
 }
 
 var containerCache *CCache
+var vmScratchSize int64
 
 func init() {
 	containerCache = &CCache{
@@ -50,6 +55,10 @@ func init() {
 // ContainerCache returns a reference to the container cache
 func ContainerCache() *CCache {
 	return containerCache
+}
+
+func SetVMScratchSize(size int64) {
+	vmScratchSize = size
 }
 
 func (cc *CCache) getContainerByName(nameOnly string) *container.VicContainer {
@@ -101,6 +110,7 @@ func (cc *CCache) AddContainer(container *container.VicContainer) {
 	}
 	cc.containersByID[container.ContainerID] = container
 	cc.containersByName[container.Name] = container
+	cc.vmStorageUsage += container.HostConfig.Memory*units.MiB + vmScratchSize*units.KB
 }
 
 func (cc *CCache) DeleteContainer(nameOrID string) {
@@ -123,6 +133,8 @@ func (cc *CCache) DeleteContainer(nameOrID string) {
 	for _, id := range container.List() {
 		container.Delete(id)
 	}
+
+	cc.vmStorageUsage -= container.HostConfig.Memory*units.MiB + vmScratchSize*units.KB
 }
 
 func (cc *CCache) AddExecToContainer(container *container.VicContainer, eid string) {
@@ -196,4 +208,8 @@ func (cc *CCache) ReleaseName(name string) {
 	}
 
 	delete(cc.containersByName, name)
+}
+
+func (cc *CCache) VMStorageSize() int64 {
+	return cc.vmStorageUsage
 }

--- a/lib/apiservers/engine/backends/commit.go
+++ b/lib/apiservers/engine/backends/commit.go
@@ -60,12 +60,9 @@ func (i *ImageBackend) Commit(name string, config *backend.ContainerCommitConfig
 	op := trace.NewOperation(context.Background(), "Commit: %s", name)
 	defer trace.End(trace.Audit(name, op))
 
-	valid, err := validateStorageQuota()
+	err = validateStorageQuota()
 	if err != nil {
-		return "", errors.InternalServerError(err.Error())
-	}
-	if !valid {
-		return "", fmt.Errorf("Storage quota exceeds")
+		return "", err
 	}
 
 	// Look up the container name in the metadata cache to get long ID

--- a/lib/apiservers/engine/backends/commit.go
+++ b/lib/apiservers/engine/backends/commit.go
@@ -60,6 +60,14 @@ func (i *ImageBackend) Commit(name string, config *backend.ContainerCommitConfig
 	op := trace.NewOperation(context.Background(), "Commit: %s", name)
 	defer trace.End(trace.Audit(name, op))
 
+	valid, err := validateStorageQuota()
+	if err != nil {
+		return "", errors.InternalServerError(err.Error())
+	}
+	if !valid {
+		return "", fmt.Errorf("Storage quota exceeds")
+	}
+
 	// Look up the container name in the metadata cache to get long ID
 	vc := cache.ContainerCache().GetContainer(name)
 	if vc == nil {

--- a/lib/apiservers/engine/backends/container.go
+++ b/lib/apiservers/engine/backends/container.go
@@ -129,8 +129,6 @@ var (
 
 	// allow mocking
 	randomName = namesgenerator.GetRandomName
-
-	kvlock sync.Mutex
 )
 
 func init() {

--- a/lib/apiservers/engine/backends/filter/container_test.go
+++ b/lib/apiservers/engine/backends/filter/container_test.go
@@ -21,6 +21,9 @@ import (
 	"github.com/docker/docker/api/types/filters"
 	"github.com/stretchr/testify/assert"
 
+	containertypes "github.com/docker/docker/api/types/container"
+	"github.com/docker/go-units"
+
 	"github.com/vmware/vic/lib/apiservers/engine/backends/cache"
 	viccontainer "github.com/vmware/vic/lib/apiservers/engine/backends/container"
 	"github.com/vmware/vic/lib/apiservers/portlayer/models"
@@ -82,6 +85,14 @@ func TestValidateContainerFilters(t *testing.T) {
 		ContainerID: "12345",
 		Name:        "fuzzy",
 	}
+	cache.SetVMScratchSize(8 * units.GiB)
+	resources := containertypes.Resources{
+		Memory: 2048,
+	}
+	hostConfig := containertypes.HostConfig{
+		Resources: resources,
+	}
+	containerBefore.HostConfig = &hostConfig
 	cache.ContainerCache().AddContainer(containerBefore)
 
 	// successful before validation

--- a/lib/apiservers/engine/backends/image.go
+++ b/lib/apiservers/engine/backends/image.go
@@ -33,7 +33,6 @@ import (
 	"github.com/docker/docker/api/types/registry"
 	"github.com/docker/docker/pkg/streamformatter"
 	"github.com/docker/docker/reference"
-
 	"github.com/docker/go-units"
 
 	"github.com/vmware/vic/lib/apiservers/engine/backends/cache"

--- a/lib/apiservers/engine/backends/system.go
+++ b/lib/apiservers/engine/backends/system.go
@@ -217,6 +217,10 @@ func (s *SystemBackend) SystemInfo() (*types.Info, error) {
 			customInfo := [2]string{systemStatusMemory, units.BytesSize(float64(info.MemTotal))}
 			info.SystemStatus = append(info.SystemStatus, customInfo)
 		}
+		if cfg.StorageQuota > 0 {
+			storageQuota := [2]string{systemStatusStorageQuota, units.BytesSize(float64(cfg.StorageQuota))}
+			info.SystemStatus = append(info.SystemStatus, storageQuota)
+		}
 		if vchInfo.CPUUsage >= 0 {
 			customInfo := [2]string{systemStatusCPUUsageMhz, fmt.Sprintf("%d MHz", int(vchInfo.CPUUsage))}
 			info.SystemStatus = append(info.SystemStatus, customInfo)
@@ -224,10 +228,6 @@ func (s *SystemBackend) SystemInfo() (*types.Info, error) {
 		if vchInfo.MemUsage >= 0 {
 			customInfo := [2]string{systemStatusMemUsage, units.BytesSize(float64(vchInfo.MemUsage))}
 			info.SystemStatus = append(info.SystemStatus, customInfo)
-		}
-		if cfg.StorageQuota > 0 {
-			storageQuota := [2]string{systemStatusStorageQuota, units.BytesSize(float64(cfg.StorageQuota))}
-			info.SystemStatus = append(info.SystemStatus, storageQuota)
 		}
 		imageStorageUsage, err := cache.ImageCache().GetImageStorageUsage()
 		if err != nil {

--- a/lib/apiservers/engine/backends/system.go
+++ b/lib/apiservers/engine/backends/system.go
@@ -62,19 +62,23 @@ type SystemBackend struct {
 }
 
 const (
-	systemStatusMhz          = " VCH CPU limit"
-	systemStatusMemory       = " VCH memory limit"
-	systemStatusCPUUsageMhz  = " VCH CPU usage"
-	systemStatusMemUsage     = " VCH memory usage"
-	systemOS                 = " VMware OS"
-	systemOSVersion          = " VMware OS version"
-	systemProductName        = " VMware Product"
-	volumeStoresID           = "VolumeStores"
-	loginTimeout             = 20 * time.Second
-	infoTimeout              = 5 * time.Second
-	vchWhitelistMode         = " Registry Whitelist Mode"
-	whitelistRegistriesLabel = " Whitelisted Registries"
-	insecureRegistriesLabel  = " Insecure Registries"
+	systemStatusMhz                   = " VCH CPU limit"
+	systemStatusMemory                = " VCH memory limit"
+	systemStatusStorageQuota          = " VCH storage limit"
+	systemStatusCPUUsageMhz           = " VCH CPU usage"
+	systemStatusMemUsage              = " VCH memory usage"
+	systemStatusStorageUsage          = " VCH storage usage"
+	systemStatusImageStorageUsage     = " VCH images storage usage"
+	systemStatusContainerStorageUsage = " VCH containers storage usage"
+	systemOS                          = " VMware OS"
+	systemOSVersion                   = " VMware OS version"
+	systemProductName                 = " VMware Product"
+	volumeStoresID                    = "VolumeStores"
+	loginTimeout                      = 20 * time.Second
+	infoTimeout                       = 5 * time.Second
+	vchWhitelistMode                  = " Registry Whitelist Mode"
+	whitelistRegistriesLabel          = " Whitelisted Registries"
+	insecureRegistriesLabel           = " Insecure Registries"
 )
 
 // var for use by other engine components
@@ -221,6 +225,26 @@ func (s *SystemBackend) SystemInfo() (*types.Info, error) {
 			customInfo := [2]string{systemStatusMemUsage, units.BytesSize(float64(vchInfo.MemUsage))}
 			info.SystemStatus = append(info.SystemStatus, customInfo)
 		}
+		if cfg.StorageQuota > 0 {
+			storageQuota := [2]string{systemStatusStorageQuota, units.BytesSize(float64(cfg.StorageQuota))}
+			info.SystemStatus = append(info.SystemStatus, storageQuota)
+		}
+		imageStorageUsage, err := cache.ImageCache().GetImageStorageUsage()
+		if err != nil {
+			op.Infof("Unable to get the image storage usage : %s", err.Error())
+		}
+		vmStorageUsage := cache.ContainerCache().VMStorageSize()
+		storageUsage := [2]string{systemStatusStorageUsage, units.BytesSize(float64(imageStorageUsage + vmStorageUsage))}
+		info.SystemStatus = append(info.SystemStatus, storageUsage)
+		if imageStorageUsage > 0 {
+			imageStorageInfo := [2]string{systemStatusImageStorageUsage, units.BytesSize(float64(imageStorageUsage))}
+			info.SystemStatus = append(info.SystemStatus, imageStorageInfo)
+		}
+		if vmStorageUsage > 0 {
+			vmStorageInfo := [2]string{systemStatusContainerStorageUsage, units.BytesSize(float64(vmStorageUsage))}
+			info.SystemStatus = append(info.SystemStatus, vmStorageInfo)
+		}
+
 		if vchInfo.HostProductName != "" {
 			customInfo := [2]string{systemProductName, vchInfo.HostProductName}
 			info.SystemStatus = append(info.SystemStatus, customInfo)

--- a/lib/apiservers/engine/proxy/container_proxy.go
+++ b/lib/apiservers/engine/proxy/container_proxy.go
@@ -1249,12 +1249,13 @@ func hostConfigFromContainerInfo(vc *viccontainer.VicContainer, info *models.Con
 	//
 	// The values we fill out below is an abridged list of the original struct.
 	resourceConfig := container.Resources{
-	// Applicable to all platforms
-	//			CPUShares int64 `json:"CpuShares"` // CPU shares (relative weight vs. other containers)
-	//			Memory    int64 // Memory limit (in bytes)
+		Memory: info.ContainerConfig.MemorySizeMB,
+		// Applicable to all platforms
+		//			CPUShares int64 `json:"CpuShares"` // CPU shares (relative weight vs. other containers)
+		//			Memory    int64 // Memory limit (in bytes)
 
-	//			// Applicable to UNIX platforms
-	//			DiskQuota            int64           // Disk limit (in bytes)
+		//			// Applicable to UNIX platforms
+		//			DiskQuota            int64           // Disk limit (in bytes)
 	}
 
 	hostConfig.VolumeDriver = portlayerName

--- a/lib/apiservers/portlayer/restapi/handlers/containers_handlers.go
+++ b/lib/apiservers/portlayer/restapi/handlers/containers_handlers.go
@@ -583,6 +583,7 @@ func convertContainerToContainerInfo(c *exec.Container) *models.ContainerInfo {
 	info.ContainerConfig.Names = []string{container.ExecConfig.Name}
 	info.ContainerConfig.RestartCount = int64(container.ExecConfig.Diagnostics.ResurrectionCount)
 	info.ContainerConfig.StorageSize = container.VMUnsharedDisk
+	info.ContainerConfig.MemorySizeMB = int64(container.MemorySizeMB)
 
 	if container.ExecConfig.Annotations != nil && len(container.ExecConfig.Annotations) > 0 {
 		info.ContainerConfig.Annotations = make(map[string]string)

--- a/lib/apiservers/portlayer/swagger.json
+++ b/lib/apiservers/portlayer/swagger.json
@@ -760,6 +760,44 @@
 				}
 			}
 		},
+		"/storage/{store_name}/usage": {
+			"parameters": [
+				{
+					"$ref": "#/parameters/operationID"
+				}
+			],
+			"get": {
+				"description": "Get images storage usage in an image store",
+				"summary": "Get images storage usage",
+				"tags": [
+					"storage"
+				],
+				"operationId": "GetImageStorageUsage",
+				"parameters": [
+					{
+						"name": "store_name",
+						"type": "string",
+						"in": "path",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"type": "integer",
+							"format": "int64"
+						}
+					},
+					"default": {
+						"description": "error",
+						"schema": {
+							"$ref": "#/definitions/Error"
+						}
+					}
+				}
+			}
+		},
 		"/storage/{store_name}/tar/{id}": {
 			"parameters": [
 				{
@@ -3689,6 +3727,9 @@
 					"$ref": "#/definitions/ReservationConfig"
 				},
 				"storageSize": {
+					"type": "integer"
+				},
+				"memorySizeMB": {
 					"type": "integer"
 				}
 			}

--- a/lib/config/virtual_container_host.go
+++ b/lib/config/virtual_container_host.go
@@ -60,6 +60,7 @@ const (
 	VICAdminHTTPProxy  = "VICADMIN_HTTP_PROXY"
 	VICAdminHTTPSProxy = "VICADMIN_HTTPS_PROXY"
 	VICAdminNoProxy    = "NO_PROXY"
+	PortLayerDCPath    = "DC_PATH"
 
 	AddPerms = "ADD"
 )
@@ -158,6 +159,8 @@ type Network struct {
 type Storage struct {
 	// Datastore URLs for image stores - the top layer is [0], the bottom layer is [len-1]
 	ImageStores []url.URL `vic:"0.1" scope:"read-only" key:"image_stores"`
+	// Storage quota for images and container vms
+	StorageQuota int64 `vic:"0.1" scope:"read-only" key:"storage_quota"`
 	// Permitted datastore URL roots for volumes
 	// Keyed by the volume store name (which is used by the docker user to
 	// refer to the datstore + path), valued by the datastores and the path.

--- a/lib/config/virtual_container_host.go
+++ b/lib/config/virtual_container_host.go
@@ -60,7 +60,6 @@ const (
 	VICAdminHTTPProxy  = "VICADMIN_HTTP_PROXY"
 	VICAdminHTTPSProxy = "VICADMIN_HTTPS_PROXY"
 	VICAdminNoProxy    = "NO_PROXY"
-	PortLayerDCPath    = "DC_PATH"
 
 	AddPerms = "ADD"
 )

--- a/lib/install/data/data.go
+++ b/lib/install/data/data.go
@@ -354,6 +354,10 @@ func (d *Data) CopyNonEmpty(src *Data) error {
 		d.VCHMemoryShares = src.VCHMemoryShares
 		resourceIsSet = true
 	}
+	if src.StorageQuotaGB != nil {
+		d.StorageQuotaGB = src.StorageQuotaGB
+		resourceIsSet = true
+	}
 	d.ResourceLimits.IsSet = resourceIsSet
 
 	d.Timeout = src.Timeout

--- a/lib/install/validate/config_to_data.go
+++ b/lib/install/validate/config_to_data.go
@@ -37,6 +37,8 @@ const (
 	httpProxy  = "HTTP_PROXY"
 	httpsProxy = "HTTPS_PROXY"
 	noProxy    = "NO_PROXY"
+
+	APIKV = "apiKV"
 )
 
 // Finder is defined for easy to test
@@ -216,6 +218,7 @@ func NewDataFromConfig(ctx context.Context, finder Finder, conf *config.VirtualC
 	if err = setImageStore(d, conf); err != nil {
 		return
 	}
+
 	setVolumeLocations(op, d, conf)
 	d.InsecureRegistries = conf.InsecureRegistries
 	d.WhitelistRegistries = conf.RegistryWhitelist
@@ -230,6 +233,10 @@ func NewDataFromConfig(ctx context.Context, finder Finder, conf *config.VirtualC
 
 	d.ContainerNameConvention = conf.ContainerNameConvention
 	d.UseVMGroup = conf.UseVMGroup
+	if conf.StorageQuota != 0 {
+		quotaGB := (int)(conf.StorageQuota / units.GiB)
+		d.StorageQuotaGB = &quotaGB
+	}
 	return
 }
 

--- a/lib/install/validate/config_to_data.go
+++ b/lib/install/validate/config_to_data.go
@@ -37,8 +37,6 @@ const (
 	httpProxy  = "HTTP_PROXY"
 	httpsProxy = "HTTPS_PROXY"
 	noProxy    = "NO_PROXY"
-
-	APIKV = "apiKV"
 )
 
 // Finder is defined for easy to test

--- a/lib/install/validate/storage.go
+++ b/lib/install/validate/storage.go
@@ -222,3 +222,13 @@ func (v *Validator) suggestDatastore(op trace.Operation, path string, label stri
 		}
 	}
 }
+
+func (v *Validator) getDatastoreFreeSpace(op trace.Operation) int64 {
+	ds := datastore.NewHelperFromSession(op, v.session)
+	summary, err := ds.Summary(op)
+	if err != nil {
+		op.Error(err)
+		return 0
+	}
+	return summary.FreeSpace
+}

--- a/lib/install/validate/validator.go
+++ b/lib/install/validate/validator.go
@@ -21,12 +21,11 @@ import (
 	"fmt"
 	"net/url"
 	"path"
+	"strconv"
 	"strings"
 	"time"
 
 	"github.com/docker/go-units"
-
-	"strconv"
 
 	"github.com/vmware/govmomi"
 	"github.com/vmware/govmomi/find"

--- a/lib/portlayer/exec/container.go
+++ b/lib/portlayer/exec/container.go
@@ -147,6 +147,8 @@ type ContainerInfo struct {
 
 	state State
 
+	MemorySizeMB int32
+
 	// Size of the leaf (unused)
 	VMUnsharedDisk int64
 }
@@ -946,6 +948,8 @@ func convertInfraContainers(ctx context.Context, sess *session.Session, vms []mo
 		if v.Summary.Storage != nil {
 			c.VMUnsharedDisk = v.Summary.Storage.Unshared
 		}
+
+		c.MemorySizeMB = v.Summary.Config.MemorySizeMB
 
 		cons = append(cons, c)
 	}

--- a/lib/portlayer/storage/image/image.go
+++ b/lib/portlayer/storage/image/image.go
@@ -76,6 +76,9 @@ type ImageStorer interface {
 	// container, this will return an error.
 	DeleteImage(op trace.Operation, image *Image) (*Image, error)
 
+	// GetImageStorageUsage gets the image storage usage from the image store.
+	GetImageStorageUsage(op trace.Operation) (int64, error)
+
 	storage.Resolver
 	storage.Importer
 	storage.Exporter

--- a/lib/portlayer/storage/image/mock/store.go
+++ b/lib/portlayer/storage/image/mock/store.go
@@ -186,3 +186,7 @@ func (c *MockDataStore) DeleteImage(op trace.Operation, image *image.Image) (*im
 	delete(c.db[*image.Store], image.ID)
 	return image, nil
 }
+
+func (c *MockDataStore) GetImageStorageUsage(op trace.Operation) (int64, error) {
+	return 0, nil
+}

--- a/lib/portlayer/storage/image/vsphere/store.go
+++ b/lib/portlayer/storage/image/vsphere/store.go
@@ -590,6 +590,10 @@ func (v *ImageStore) ListImages(op trace.Operation, store *url.URL, IDs []string
 	return images, nil
 }
 
+func (v *ImageStore) GetImageStorageUsage(op trace.Operation) (int64, error) {
+	return v.Helper.GetFilesSize(op, "", "*.vmdk", true)
+}
+
 // DeleteImage deletes an image from the image store.  If the image is in
 // use either by way of inheritance or because it's attached to a
 // container, this will return an error.

--- a/lib/portlayer/storage/image/vsphere/store.go
+++ b/lib/portlayer/storage/image/vsphere/store.go
@@ -591,7 +591,7 @@ func (v *ImageStore) ListImages(op trace.Operation, store *url.URL, IDs []string
 }
 
 func (v *ImageStore) GetImageStorageUsage(op trace.Operation) (int64, error) {
-	return v.Helper.GetFilesSize(op, "", "*.vmdk", true)
+	return v.Helper.GetFilesSize(op, "", true, "*.vmdk")
 }
 
 // DeleteImage deletes an image from the image store.  If the image is in

--- a/pkg/kvstore/kvstore.go
+++ b/pkg/kvstore/kvstore.go
@@ -82,7 +82,7 @@ func NewKeyValueStore(ctx context.Context, store Backend, name string) (KeyValue
 		return nil, err
 	}
 
-	log.Infof("NewKeyValueStore(%s) restored %d keys", name, len(p.kv))
+	log.Debugf("NewKeyValueStore(%s) restored %d keys", name, len(p.kv))
 
 	return p, nil
 }

--- a/pkg/vsphere/datastore/datastore.go
+++ b/pkg/vsphere/datastore/datastore.go
@@ -212,8 +212,12 @@ func (d *Helper) Ls(ctx context.Context, p string, match ...string) (*types.Host
 	return &res, nil
 }
 
-// LsDirs returns a list of dirents at the given path (relative to root)
 func (d *Helper) LsDirs(ctx context.Context, p string, match ...string) (*types.ArrayOfHostDatastoreBrowserSearchResults, error) {
+	return d.LsDirsWithPatterns(ctx, p, match)
+}
+
+// LsDirs returns a list of dirents at the given path (relative to root)
+func (d *Helper) LsDirsWithPatterns(ctx context.Context, p string, match []string) (*types.ArrayOfHostDatastoreBrowserSearchResults, error) {
 	if len(match) == 0 {
 		match = []string{"*"}
 	}
@@ -246,8 +250,8 @@ func (d *Helper) LsDirs(ctx context.Context, p string, match ...string) (*types.
 	return &res, nil
 }
 
-func (d *Helper) GetFilesSize(ctx context.Context, p string, match string, noscratch bool) (int64, error) {
-	res, err := d.LsDirs(ctx, p, match)
+func (d *Helper) GetFilesSize(ctx context.Context, p string, noscratch bool, match ...string) (int64, error) {
+	res, err := d.LsDirsWithPatterns(ctx, p, match)
 	if err != nil {
 		return 0, err
 	}

--- a/tests/resources/Group26-Storage-Quota-Util.robot
+++ b/tests/resources/Group26-Storage-Quota-Util.robot
@@ -1,0 +1,41 @@
+# Copyright 2018 VMware, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#	http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License
+
+*** Settings ***
+Documentation    This resource contains keywords which are helpful for testing storage quota.
+
+*** Keywords ***
+Get storage quota limit and usage
+    [Arguments]  ${info}
+
+    ${limitline}=  Get Lines Containing String  ${info}  VCH storage limit:
+    ${usageline}=  Get Lines Containing String  ${info}  VCH storage usage:
+    @{limitline}=  Split String  ${limitline}
+    Length Should Be  ${limitline}  5
+    @{usageline}=  Split String  ${usageline}
+    Length Should Be  ${usageline}  5
+    ${limitval}=  Convert To Number  @{limitline}[3]
+    ${usageval}=  Convert To Number  @{usageline}[3]
+
+    [Return]  ${limitval}  ${usageval}
+
+Get storage usage
+    [Arguments]  ${info}
+
+    ${usageline}=  Get Lines Containing String  ${info}  VCH storage usage:
+    @{usageline}=  Split String  ${usageline}
+    Length Should Be  ${usageline}  5
+    ${usageval}=  Convert To Number  @{usageline}[3]
+
+    [Return]  ${usageval}

--- a/tests/resources/VCH-Util.robot
+++ b/tests/resources/VCH-Util.robot
@@ -296,7 +296,7 @@ Use Target VIC Appliance
     [Return]  ${True}
 
 Conditional Install VIC Appliance To Test Server
-    [Arguments]  ${certs}=${true}  ${init}=${False}
+    [Arguments]  ${certs}=${true}  ${init}=${False}  ${additional-args}=${EMPTY}
     ${target-vch}=  Get Environment Variable  TARGET_VCH  ${EMPTY}
     ${multi-vch}=  Get Environment Variable  MULTI_VCH  ${EMPTY}
 
@@ -304,7 +304,7 @@ Conditional Install VIC Appliance To Test Server
     Run Keyword If  '${target-vch}' != '${EMPTY}'  Use Target VIC Appliance  target-vch=${target-vch}
     Return From Keyword If  '${target-vch}' != '${EMPTY}'  ${True}
 
-    Install VIC Appliance To Test Server  certs=${certs}
+    Install VIC Appliance To Test Server  certs=${certs}  additional-args=${additional-args}
 
     # If MULT_VCH set to 1, then we are in multi VCH mode, otherwise, we are in single VCH mode
     ${single-vch-mode}=  Run Keyword If  '${multi-vch}' == '1'  Set Variable  ${False}

--- a/tests/test-cases/Group26-Storage-Quota/26-01-Basic.md
+++ b/tests/test-cases/Group26-Storage-Quota/26-01-Basic.md
@@ -1,0 +1,121 @@
+Suite 26-01 - Basic
+===================
+
+# Purpose:
+To verify storage quota functionality
+
+# Environment:
+This suite requires a vCenter Server environment where VCHs can be deployed and container VMs created.
+
+
+### 1. Create a VCH with storage quota and docker info shows the storage quota and storage usage
+
+#### Test Steps:
+1. Create a VCH with a storage quota of 15GB
+2. Verify that docker info shows the storage quota and storage usage is 0
+
+#### Expected Outcome:
+* The VCH with storage quota is created.
+
+
+### 2. Create a container and docker info shows the storage usage has changed
+
+#### Test Steps:
+1. Create a busybox container
+2. Verify that docker info shows the storage usage is larger than 9GB(the default container vm will create a 2GB swap vmdk and an about maximum 8GB delta vmdk)
+
+#### Expected Outcome:
+* The container is created and storage usage has changed.
+
+
+### 3. Pull a debian image and docker info shows the storage usage has changed
+
+#### Test Steps:
+1. Pull a debian image.
+2. Verify that docker info show the storage usage has increased(the new image layers contribute to the storage usage)
+
+#### Expected Outcome:
+* The image is downloaded and storage usage has increased.
+
+
+### 4. Create second container and get storage quota exceeding failure
+
+#### Test Steps:
+1. Verify that the container creation fails with storage quota exceeding error message.
+2. Verify that docker info show the storage usage is the same
+
+#### Expected Outcome:
+* Contiainer creation fails because storage quota exceeds.
+
+
+### 5. Configure VCH with a larger storage quota of 35GB
+
+#### Test Steps:
+1. Configure VCH with a larger storage quota of 35GB.
+2. Verify that docker info show the storage quota is set to 35GB and storage usage does not change.
+
+#### Expected Outcome:
+* VCH configure succeeds and storage quota is updated.
+
+
+### 6. Create second container successfully
+
+#### Test Steps:
+1. Create second busybox container.
+2. Verify that docker info show the storage usage is larger than 18GB
+
+#### Expected Outcome:
+* The second container creation succeeds.
+
+
+### 7. Remove a container successfully with storage usage changes
+
+#### Test Steps:
+1. Delete a busybox container.
+2. Verify that docker info show the storage usage decreases
+
+#### Expected Outcome:
+* The container deletion decreases storage usage.
+
+
+### 8. Create a busybox container with memory of 4GB successfully
+
+#### Test Steps:
+1. Create a busybox container with memory of 4GB
+2. Verify that docker info show the storage usage is larger than 20GB(swap vmdk is equal to memory size)
+
+#### Expected Outcome:
+* The container creation succeeds with correct storage usage.
+
+
+### 9. Create a debian container and commit to an image successfully
+
+#### Test Steps:
+1. Create a debian container
+2. Verify that the storage usage is larger than 29GB
+3. Commit it to an image
+4. Verify that the storage usage increases
+
+#### Expected Outcome:
+* The container commits to an image and storage usage increases.
+
+
+### 10. Delete an image successfully with storage usage decreased
+
+#### Test Steps:
+1. Delete the debian container committed image
+2. Verify that the storage uasge decreases
+
+#### Expected Outcome:
+* The image deletion makes storage usage decrease.
+
+
+### 11. Create a busybox continainer afer unsetting storage quota
+
+#### Test Steps:
+1. Verify that the container creation fails with storage quota exceeding error message
+2. Configure VCH storage quota to 0(unlimited)
+3. Verify that the container creation succeeds
+
+#### Expected Outcome:
+* The container creation succeeds after unsetting storage quota

--- a/tests/test-cases/Group26-Storage-Quota/26-01-Basic.robot
+++ b/tests/test-cases/Group26-Storage-Quota/26-01-Basic.robot
@@ -1,0 +1,163 @@
+# Copyright 2018 VMware, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#	http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License
+
+*** Settings ***
+Documentation     Suite 26-01 - Basic
+Resource          ../../resources/Util.robot
+Resource          ../../resources/Group26-Storage-Quota-Util.robot
+Suite Setup  Install VIC Appliance To Test Server  additional-args='--storage-quota=15'
+Suite Teardown  Cleanup VIC Appliance On Test Server
+Test Timeout  30 minutes
+
+*** Test Cases ***
+Create a VCH with storage quota and docker info shows the storage quota and storage usage
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} info
+    Should Be Equal As Integers  ${rc}  0
+
+    ${limitval}  ${usageval}=  Get storage quota limit and usage  ${output}
+    Should Be Equal As Integers  ${limitval}  15
+    Should Be Equal As Integers  ${usageval}  0
+
+Create a container and docker info shows the storage usage has changed
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -id ${busybox}
+    Should Be Equal As Integers  ${rc}  0
+
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} info
+    Should Be Equal As Integers  ${rc}  0
+
+    ${limitval}  ${usageval}=  Get storage quota limit and usage  ${output}
+
+    Should Be Equal As Integers  ${limitval}  15
+    Should Be True  ${usageval} > 9
+    Set Suite Variable  ${pre_usage_val}  ${usageval}
+
+Pull a debian image and docker info shows the storage usage has changed
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} pull ${debian}
+    Should Be Equal As Integers  ${rc}  0
+
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} info
+    Should Be Equal As Integers  ${rc}  0
+
+    ${limitval}  ${usageval}=  Get storage quota limit and usage  ${output}
+    Should Be Equal As Integers  ${limitval}  15
+    Should Be True  ${usageval} > ${pre_usage_val}
+    Set Suite Variable  ${pre_usage_val}  ${usageval}
+
+Create second container and get storage quota exceeding failure
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -id ${busybox}
+    Should Be Equal As Integers  ${rc}  125
+    Should Contain  ${output}  Storage quota exceeds
+
+Configure VCH with a larger storage quota of 35GB
+    ${output}=  Run  bin/vic-machine-linux configure --name=%{VCH-NAME} --target=%{TEST_URL}%{TEST_DATACENTER} --thumbprint=%{TEST_THUMBPRINT} --user=%{TEST_USERNAME} --password=%{TEST_PASSWORD} --timeout %{TEST_TIMEOUT} --storage-quota 35
+    Should Contain  ${output}  Completed successfully
+
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} info
+    Should Be Equal As Integers  ${rc}  0
+
+    ${limitval}  ${usageval}=  Get storage quota limit and usage  ${output}
+    Should Be Equal As Integers  ${limitval}  35
+
+Create second container successfully
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -id --name secondc ${busybox}
+    Should Be Equal As Integers  ${rc}  0
+
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} info
+    Should Be Equal As Integers  ${rc}  0
+
+    ${limitval}  ${usageval}=  Get storage quota limit and usage  ${output}
+
+    Should Be Equal As Integers  ${limitval}  35
+    Should Be True  ${usageval} > 18
+
+Remove a container successfully with storage usage changes
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} rm -f secondc
+    Should Be Equal As Integers  ${rc}  0
+
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} info
+    Should Be Equal As Integers  ${rc}  0
+
+    ${limitval}  ${usageval}=  Get storage quota limit and usage  ${output}
+
+    Should Be Equal As Integers  ${limitval}  35
+    Should Be Equal As Integers  ${usageval}  ${pre_usage_val}
+
+Create a busybox container with memory of 4GB successfully
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -m=4g -id ${busybox}
+    Should Be Equal As Integers  ${rc}  0
+
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} info
+    Should Be Equal As Integers  ${rc}  0
+
+    ${limitval}  ${usageval}=  Get storage quota limit and usage  ${output}
+
+    Should Be Equal As Integers  ${limitval}  35
+    Should Be True  ${usageval} > 20
+
+Create a debian container and commit to an image successfully
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -d --name commit1 ${debian} tail -f /dev/null
+    Should Be Equal As Integers  ${rc}  0
+
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} info
+    Should Be Equal As Integers  ${rc}  0
+
+    ${limitval}  ${usageval}=  Get storage quota limit and usage  ${output}
+
+    Should Be Equal As Integers  ${limitval}  35
+    Should Be True  ${usageval} > 29
+    Set Suite Variable  ${pre_usage_val}  ${usageval}
+
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} exec commit1 apt-get update
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} exec commit1 apt-get install nano
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} stop -t1 commit1
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} commit commit1 debian-nano
+    Should Be Equal As Integers  ${rc}  0
+
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} info
+    Should Be Equal As Integers  ${rc}  0
+
+    ${limitval}  ${usageval}=  Get storage quota limit and usage  ${output}
+
+    Should Be Equal As Integers  ${limitval}  35
+    Should Be True  ${usageval} > ${pre_usage_val}
+
+Delete an image successfully with storage usage decreased
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} rmi debian-nano
+    Should Be Equal As Integers  ${rc}  0
+
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} info
+    Should Be Equal As Integers  ${rc}  0
+
+    ${limitval}  ${usageval}=  Get storage quota limit and usage  ${output}
+
+    Should Be Equal As Integers  ${limitval}  35
+    Should Be Equal As Integers  ${usageval}  ${pre_usage_val}
+
+Create a busybox continainer afer unsetting storage quota
+    ${output}=  Run  bin/vic-machine-linux configure --name=%{VCH-NAME} --target=%{TEST_URL}%{TEST_DATACENTER} --thumbprint=%{TEST_THUMBPRINT} --user=%{TEST_USERNAME} --password=%{TEST_PASSWORD} --timeout %{TEST_TIMEOUT} --storage-quota 0
+    Should Contain  ${output}  Completed successfully
+
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -id ${busybox}
+    Should Be Equal As Integers  ${rc}  0
+
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} info
+    Should Be Equal As Integers  ${rc}  0
+    Should Not Contain  ${output}  storage limit
+
+    ${usageval}=  Get storage usage  ${output}
+
+    Should Be True  ${usageval} > 38

--- a/tests/test-cases/Group26-Storage-Quota/26-02-Reconfigure.md
+++ b/tests/test-cases/Group26-Storage-Quota/26-02-Reconfigure.md
@@ -1,0 +1,47 @@
+Suite 26-02 - Reconfigure
+===================
+
+# Purpose:
+To verify adding storage quota settings during configure functionality
+
+# Environment:
+This suite requires a vCenter Server environment where VCHs can be deployed and container VMs created.
+
+
+### 1. Create a VCH without storage quota and docker info shows the storage usage
+
+#### Test Steps:
+1. Create a VCH without storage quota
+2. Verify that docker info output has no storage quota information, but has storage usage information
+3. Create a busybox container
+4. Verify that docker info shows the storage usage is larger than 9GB
+
+#### Expected Outcome:
+* The VCH and container creation succeeds without setting storage quota and keep storage usage track(this is required when VCH is reconfigured with storage quota).
+
+### 2. Create a container and docker info shows the storage usage has changed
+
+#### Test Steps:
+1. Create a busybox container
+2. Verify that docker info shows the storage usage is larger than 9GB(the default container vm will create a 2GB swap vmdk and an about maximum 8GB delta vmdk)
+
+#### Expected Outcome:
+* The container is created and storage usage has changed.
+
+### 3. Configure VCH with a larger storage quota of 15GB
+
+#### Test Steps:
+1. Configure VCH with a larger storage quota of 15GB.
+2. Verify that docker info show the storage quota is set to 35GB and storage usage does not change.
+
+#### Expected Outcome:
+* VCH configure succeeds and storage quota is updated.
+
+### 4. Create second container and get storage quota exceeding failure
+
+#### Test Steps:
+1. Verify that the container creation fails with storage quota exceeding error message.
+2. Verify that docker info show the storage usage is the same
+
+#### Expected Outcome:
+* Contiainer creation fails because storage quota exceeds.

--- a/tests/test-cases/Group26-Storage-Quota/26-02-Reconfigure.robot
+++ b/tests/test-cases/Group26-Storage-Quota/26-02-Reconfigure.robot
@@ -1,0 +1,58 @@
+# Copyright 2018 VMware, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#	http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License
+
+*** Settings ***
+Documentation     Suite 26-01 - Basic
+Resource          ../../resources/Util.robot
+Resource          ../../resources/Group26-Storage-Quota-Util.robot
+Suite Setup  Install VIC Appliance To Test Server
+Suite Teardown  Cleanup VIC Appliance On Test Server
+Test Timeout  10 minutes
+
+*** Test Cases ***
+Create a VCH without storage quota and docker info shows the storage usage
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} info
+    Should Be Equal As Integers  ${rc}  0
+    Should Not Contain  ${output}  storage limit
+
+    ${usageval}=  Get storage usage  ${output}
+    Should Be Equal As Integers  ${usageval}  0
+
+Create a container and docker info shows the storage usage has changed
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -id ${busybox}
+    Should Be Equal As Integers  ${rc}  0
+
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} info
+    Should Be Equal As Integers  ${rc}  0
+
+    ${usageval}=  Get storage usage  ${output}
+
+    Should Be True  ${usageval} > 9
+    Set Suite Variable  ${pre_usage_val}  ${usageval}
+
+Configure VCH with a larger storage quota of 15GB
+    ${output}=  Run  bin/vic-machine-linux configure --name=%{VCH-NAME} --target=%{TEST_URL}%{TEST_DATACENTER} --thumbprint=%{TEST_THUMBPRINT} --user=%{TEST_USERNAME} --password=%{TEST_PASSWORD} --timeout %{TEST_TIMEOUT} --storage-quota 15
+    Should Contain  ${output}  Completed successfully
+
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} info
+    Should Be Equal As Integers  ${rc}  0
+
+    ${limitval}  ${usageval}=  Get storage quota limit and usage  ${output}
+    Should Be Equal As Integers  ${limitval}  15
+    Should Be Equal As Integers  ${usageval}  ${pre_usage_val}
+
+Create second container and get storage quota exceeding failure
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -id ${busybox}
+    Should Be Equal As Integers  ${rc}  125
+    Should Contain  ${output}  Storage quota exceeds

--- a/tests/test-cases/Group26-Storage-Quota/TestCases.md
+++ b/tests/test-cases/Group26-Storage-Quota/TestCases.md
@@ -1,0 +1,6 @@
+Group 26 - Storage Quota
+========================
+
+[Suite 26-01 - Basic Testing](26-01-Basic.md)
+-
+[Suite 26-02 - Reconfigure](26-02-Reconfigure.md)

--- a/tests/test-cases/Group6-VIC-Machine/6-04-Create-Basic.robot
+++ b/tests/test-cases/Group6-VIC-Machine/6-04-Create-Basic.robot
@@ -123,6 +123,17 @@ Create VCH - URL without user and password
     # Delete the portgroup added by env vars keyword
     Run Keyword If  %{DRONE_BUILD_NUMBER} != 0  Cleanup VCH Bridge Network
 
+Create VCH - invalid storage quota
+    Set Test Environment Variables
+    Run Keyword And Ignore Error  Cleanup Dangling VMs On Test Server
+    Run Keyword And Ignore Error  Cleanup Datastore On Test Server
+
+    ${output}=  Run  bin/vic-machine-linux create --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --image-store=%{TEST_DATASTORE} --bridge-network=%{BRIDGE_NETWORK} --public-network=%{PUBLIC_NETWORK} ${vicmachinetls} --storage-quota=1200
+    Should Contain  ${output}  Storage quota exceeds datastore free space
+
+    # Delete the portgroup added by env vars keyword
+    Run Keyword If  %{DRONE_BUILD_NUMBER} != 0  Cleanup VCH Bridge Network
+
 Create VCH - target URL
     Set Test Environment Variables
     Run Keyword And Ignore Error  Cleanup Dangling VMs On Test Server

--- a/tests/test-cases/Group6-VIC-Machine/6-16-Config.md
+++ b/tests/test-cases/Group6-VIC-Machine/6-16-Config.md
@@ -43,7 +43,7 @@ This test requires that a vSphere server is running and available
 30. Run vic-machine inspect config
 31. Configure VCH resources
 32. Verify VCH configuration through vic-machine inspect
-33. Configure VCH resources with too small values
+33. Configure VCH resources with too small or too large values
 34. Verify VCH configuration is rollback to old value
 35. Configure the VCH by adding a new volume store
 36. Run vic-machine inspect config

--- a/tests/test-cases/Group6-VIC-Machine/6-16-Config.robot
+++ b/tests/test-cases/Group6-VIC-Machine/6-16-Config.robot
@@ -247,10 +247,6 @@ Configure VCH DNS server
     Should Contain  ${output}  Completed successfully
     Should Not Contain  ${output}  --dns-server
 
-    # Remove old SSH key since it changes after reboot.
-    ${rc}=  Run And Return Rc  ssh-keygen -f "/root/.ssh/known_hosts" -R %{VCH-IP}
-    Should Be Equal As Integers  ${rc}  0
-
     Enable VCH SSH
     ${rc}  ${output}=  Run And Return Rc and Output  sshpass -p %{TEST_PASSWORD} ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null root@%{VCH-IP} cat /etc/resolv.conf
     Should Be Equal As Integers  ${rc}  0
@@ -277,6 +273,14 @@ Configure VCH resources
     Should Contain  ${output}  --memory=4096
     Should Contain  ${output}  --memory-reservation=10
     Should Contain  ${output}  --memory-shares=163840
+
+    ${output}=  Run  bin/vic-machine-linux configure --name=%{VCH-NAME} --target=%{TEST_URL}%{TEST_DATACENTER} --thumbprint=%{TEST_THUMBPRINT} --user=%{TEST_USERNAME} --password=%{TEST_PASSWORD} --timeout %{TEST_TIMEOUT} --storage-quota 5
+    Should Contain  ${output}  Completed successfully
+    ${output}=  Run  bin/vic-machine-linux inspect config --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT}
+    Should Contain  ${output}  --storage-quota=5
+
+    ${output}=  Run  bin/vic-machine-linux configure --name=%{VCH-NAME} --target=%{TEST_URL}%{TEST_DATACENTER} --thumbprint=%{TEST_THUMBPRINT} --user=%{TEST_USERNAME} --password=%{TEST_PASSWORD} --timeout %{TEST_TIMEOUT} --storage-quota 1000
+    Should Contain  ${output}  Storage quota exceeds datastore free space
 
 Configure VCH volume stores
     ${output}=  Run  bin/vic-machine-linux configure --name=%{VCH-NAME} --target=%{TEST_URL} --thumbprint=%{TEST_THUMBPRINT} --user=%{TEST_USERNAME} --password=%{TEST_PASSWORD} --timeout %{TEST_TIMEOUT} --volume-store=%{TEST_DATASTORE}/%{VCH-NAME}-VOL:default --volume-store=%{TEST_DATASTORE}/%{VCH-NAME}-conf:configure

--- a/tests/test-cases/TestGroups.md
+++ b/tests/test-cases/TestGroups.md
@@ -28,3 +28,5 @@ VIC Integration Test Suite
 -
 [Group 25 - Host Affinity](Group25-Host-Affinity/TestCases.md)
 -
+[Group 26 - Storage Quota](Group26-Storage-Quota/TestCases.md)
+-


### PR DESCRIPTION
Enable --storage-quota flag during VCH creation and configuration.
'docker info' shows storage quota, storage usage, image storage usage,
and container vm storage usage.

The backend uses cache to keep containerVM and image storage usage. The
 current version of containerVM storage usage only considers a containerVM's
 swap disk and root disk.
   
There are a few cases that will change storage usage:
    - container create
    - container rm
    - write image
    - delete image
    
 kv store keeps the value of container vm storage usage for configure command
 to validate the resized storage quota.
    
 Add container memory information for storage usage calculation
 after restarting VCH for configuration.
    
 Add test cases of Group26-Storage-Quota for storage quota settings and usage
 track scenarios.
Fixes #[43](https://github.com/vmware/vic-planning/issues/43)
[specific ci=Group26-Storage-Quota]