### PR TITLE
Show prefix "sha256:" while running docker images --no-trunc.

### DIFF
--- a/lib/apiservers/engine/backends/image.go
+++ b/lib/apiservers/engine/backends/image.go
@@ -508,9 +508,7 @@ func imageConfigToDockerImageInspect(imageConfig *metadata.ImageConfig, productN
 
 	inspectData.GraphDriver.Name = productName + " " + PortlayerName
 
-	// ImageID is currently stored within VIC without the "sha256:" prefix
-	// so we add it here to match Docker output.
-	inspectData.ID = digest.Canonical.String() + ":" + imageConfig.ImageID
+	inspectData.ID = imageConfig.ImageID
 
 	return inspectData
 }

--- a/lib/imagec/imagec.go
+++ b/lib/imagec/imagec.go
@@ -441,10 +441,9 @@ func (ic *ImageC) CreateImageConfig(ctx context.Context, images []*ImageWithMeta
 		return metadata.ImageConfig{}, fmt.Errorf("Failed to marshall image metadata: %s", err)
 	}
 
-	// calculate image ID
-	sum := fmt.Sprintf("%x", sha256.Sum256(imageConfigBytes))
-	log.Infof("Image ID: sha256:%s", sum)
-
+	// calculate image ID, add sha256 as prefix, to be compatible with image inspect and image --no-trunc result format.
+	sum := fmt.Sprintf("sha256:%x", sha256.Sum256(imageConfigBytes))
+	log.Infof("Image ID: %s", sum)
 	// prepare metadata
 	result.V1Image.Parent = image.Parent
 	result.Size = size

--- a/tests/test-cases/Group1-Docker-Commands/1-03-Docker-Images.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-03-Docker-Images.robot
@@ -62,6 +62,7 @@ No-trunc images
     @{lines}=  Split To Lines  ${output}
     @{line}=  Split String  @{lines}[2]
     Length Should Be  @{line}[2]  71
+    Should Contain  @{line}[2]  sha256:
 
 Filter images before
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} images -f before=busybox

--- a/tests/test-cases/Group1-Docker-Commands/1-03-Docker-Images.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-03-Docker-Images.robot
@@ -61,7 +61,7 @@ No-trunc images
     Should Be True  ${count} >= 3
     @{lines}=  Split To Lines  ${output}
     @{line}=  Split String  @{lines}[2]
-    Length Should Be  @{line}[2]  64
+    Length Should Be  @{line}[2]  71
 
 Filter images before
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} images -f before=busybox


### PR DESCRIPTION
Fixes #1054 
[specific ci=1-03-Docker-Images]
