### PR TITLE
Improve build workflow and add test robustness.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -145,6 +145,10 @@ iso-base: $(iso-base)
 iso-base-custom: $(iso-base-custom)
 
 vic-machine: $(vic-machine-linux) $(vic-machine-windows) $(vic-machine-darwin)
+vic-machine-linux: $(vic-machine-linux)
+vic-machine-windows: $(vic-machine-windows)
+vic-machine-darwin: $(vic-machine-darwin)
+
 # NOT BUILT WITH make all TARGET
 # vic-dns variants to create standalone DNS service.
 vic-dns: $(vic-dns-linux) $(vic-dns-windows) $(vic-dns-darwin)

--- a/infra/build-image/Dockerfile.tdnf
+++ b/infra/build-image/Dockerfile.tdnf
@@ -1,7 +1,7 @@
 # This is an image used for building bootstrap.iso and application.iso with photon 2.0 operate system.
 #
 # To use this image:
-# docker run -v $(pwd):/go/src/github.com/vmware/vic gcr.io/eminent-nation-87317/vic-build-image:tdnf make isos
+# docker run -v $(pwd):/go/src/github.com/vmware/vic gcr.io/eminent-nation-87317/vic-build-image:tdnf make most
 #
 # To build this image:
 # docker build -t vic-build-image-tdnf -f infra/build-image/Dockerfile.tdnf infra/build-image/
@@ -16,6 +16,8 @@ ENV GOPATH /go
 ENV PATH $PATH:${GOPATH}/bin:/${GOROOT}/bin
 ENV SRCDIR ${GOPATH}/src/github.com/vmware/vic
 ENV TERM linux
+ENV VIC_CACHE_DEPS=1
+
 WORKDIR ${SRCDIR}
 
 # gawk added purely for tolower function used in Makefile
@@ -45,7 +47,7 @@ RUN cd /usr/local && tar -zxf /tmp/go.tgz
 
 RUN mkdir -p ${SRCDIR}
 
-COPY infra/build-image/setup-repo.sh /usr/local/bin
+COPY setup-repo.sh /usr/local/bin
 RUN chmod a+x /usr/local/bin/setup-repo.sh
 
-# ENTRYPOINT [ "/usr/local/bin/setup-repo.sh" ]
+ENTRYPOINT [ "/usr/local/bin/setup-repo.sh" ]

--- a/infra/build-image/Dockerfile.yum
+++ b/infra/build-image/Dockerfile.yum
@@ -1,7 +1,7 @@
 # This is an image used for building bootstrap.iso and application.iso with centos 6.9 operate system.
 #
 # To use this image:
-# docker run -v $(pwd):/go/src/github.com/vmware/vic gcr.io/eminent-nation-87317/vic-build-image:yum make isos
+# docker run -v $(pwd):/go/src/github.com/vmware/vic gcr.io/eminent-nation-87317/vic-build-image:yum make most
 #
 # To build this image:
 # docker build -t vic-build-image-yum -f infra/build-image/Dockerfile.yum infra/build-image/
@@ -16,6 +16,8 @@ ENV GOPATH /go
 ENV PATH $PATH:${GOPATH}/bin:/${GOROOT}/bin
 ENV SRCDIR ${GOPATH}/src/github.com/vmware/vic
 ENV TERM linux
+ENV VIC_CACHE_DEPS=1
+
 WORKDIR ${SRCDIR}
 
 # rpm used for initialize_bundle - yum seems to require rpm -initdb to work
@@ -44,7 +46,7 @@ RUN cd /usr/local && tar -zxf /tmp/go.tgz
 
 RUN mkdir -p ${SRCDIR}
 
-COPY infra/build-image/setup-repo.sh /usr/local/bin
+COPY setup-repo.sh /usr/local/bin
 RUN chmod a+x /usr/local/bin/setup-repo.sh
 
-# ENTRYPOINT [ "/usr/local/bin/setup-repo.sh" ]
+ENTRYPOINT [ "/usr/local/bin/setup-repo.sh" ]

--- a/infra/build-image/setup-repo.sh
+++ b/infra/build-image/setup-repo.sh
@@ -30,7 +30,7 @@ echo "Usage: $0 -p pull-request OR -b github_user/branch" 1>&2
 exit 1
 }
 
-while getopts "p:b:" flag
+while getopts "p:b:h" flag
 do
     case $flag in
 
@@ -38,41 +38,50 @@ do
             # Optional. Pull request number
             pull_req="$OPTARG"
             github_user=vmware
+
+            refspec=refs/pull/${pull_req}/head:refs/remotes/origin/pr/${pull_req}
+            localbranch=pr/${pull_req}
             ;;
 
         b)
             # Optional. Branch specifier
-            # bit of an abuse of dirname/basename but hey, / separators
-            github_user=$(dirname $OPTARG)
-            branch=$(basename $OPTARG)
-            ;;
+            github_user=${OPTARG%%/*}
+            branch=${OPTARG#*/}
 
-        *)
+            refspec=refs/heads/${branch}:refs/remotes/origin/${branch}
+            localbranch=origin/${branch}
+            ;;
+        h)
             usage
+            ;;
+        *)
+            break
             ;;
     esac
 done
 
 shift $((OPTIND-1))
 
-# check there were no extra args and the required ones are set
-if [ ! -z "$*" -o -z "${github_user}" -o -n "${pull_req}" -a -n "${branch}" ]; then
-    usage
+mkdir -p ${SRCDIR:?Expected script to be run with SRCDIR set} && cd ${SRCDIR}
+url=https://github.com/${github_user}/vic
+
+if ! git remote show -n origin >/dev/null 2>&1 ; then
+    git init . && git remote add origin ${url}
 fi
 
-mkdir -p ${SRCDIR:?Expected script to be run with SRCDIR set} && cd ${SRCDIR} && git init .
-git remote add origin https://github.com/${github_user}/vic
-
-if [ ! -z ${pull_req} ]; then
-    git fetch origin --depth=5 -v refs/pull/${pull_req}/head:refs/remotes/origin/pr/${pull_req}
-    git checkout pr/${pull_req}
-elif [ ! -b ${branch} ]; then
-    git fetch origin --depth=5 -v refs/heads/${branch}:refs/remotes/origin/${branch}
-    git checkout origin/${branch}
+if [ ! -z ${refspec} ]; then
+    # we don't limit the depth as that was resulting in failure to find the most recent tag for a given commit
+    git fetch origin -v ${refspec}
+    if [ "$(git rev-parse --abbrev-ref HEAD)" != "$branch" ]; then
+        git checkout -b ${branch} ${localbranch}
+    fi
+    # try to fast-forward but just checkout if that fails
+    git pull --ff-only || git checkout ${localbranch}
 fi
 
-# Fix tags not available
-git fetch --tags
-
-# drop to interactive shell
-exec bash
+if [ $# -ne 0 ]; then
+    exec bash -c "$*"
+else
+    # drop to interactive shell after running any 
+    exec bash
+fi

--- a/tests/test-cases/Group22-Docker-Apps/22-04-mysql.robot
+++ b/tests/test-cases/Group22-Docker-Apps/22-04-mysql.robot
@@ -33,4 +33,5 @@ Simple background mysql
     Log  ${output}
     Should Be Equal As Integers  ${rc}  0
     ${ip}=  Get IP Address of Container  mysql1
+    Should Not Be Empty  ${ip}
     Wait Until Keyword Succeeds  5x  6s  Check mysql container  ${ip}

--- a/tests/test-cases/Group22-Docker-Apps/22-05-mongo.robot
+++ b/tests/test-cases/Group22-Docker-Apps/22-05-mongo.robot
@@ -33,4 +33,5 @@ Simple background mongo
     Log  ${output}
     Should Be Equal As Integers  ${rc}  0
     ${ip}=  Get IP Address of Container  mongo1
+    Should Not Be Empty  ${ip}
     Wait Until Keyword Succeeds  5x  6s  Check mongo container  ${ip}

--- a/tests/test-cases/Group22-Docker-Apps/22-06-postgres.robot
+++ b/tests/test-cases/Group22-Docker-Apps/22-06-postgres.robot
@@ -34,4 +34,6 @@ Simple background postgres
     Log  ${output}
     Should Be Equal As Integers  ${rc}  0
     ${ip}=  Get IP Address of Container  postgres1
+    Should Not Be Empty  ${ip}
+
     Wait Until Keyword Succeeds  5x  6s  Check postgres container  ${ip}

--- a/tests/test-cases/Group22-Docker-Apps/22-08-node.robot
+++ b/tests/test-cases/Group22-Docker-Apps/22-08-node.robot
@@ -43,10 +43,11 @@ Simple background node application
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} cp app copier:/mydata
     Should Be Equal As Integers  ${rc}  0
     
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run --name node1 -v vol1:/usr/src -d node sh -c "cd /usr/src/app && npm install && npm start"
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run --name node1 -v vol1:/usr/src -d node sh -c "cd /usr/src/app && echo 'Installing...' && npm install && echo 'Starting...' && npm start"
     Log  ${output}
     Should Be Equal As Integers  ${rc}  0
     ${ip}=  Get IP Address of Container  node1
+    Should Not Be Empty  ${ip}
     
     Wait Until Keyword Succeeds  10x  12s  Check node container  ${ip}
     
@@ -68,6 +69,7 @@ Simple background node application on alpine
     Log  ${output}
     Should Be Equal As Integers  ${rc}  0
     ${ip}=  Get IP Address of Container  node2
+    Should Not Be Empty  ${ip}
     
     Wait Until Keyword Succeeds  10x  12s  Check node container  ${ip}
     

--- a/tests/test-cases/Group22-Docker-Apps/22-09-httpd.robot
+++ b/tests/test-cases/Group22-Docker-Apps/22-09-httpd.robot
@@ -36,6 +36,7 @@ Httpd with a mapped volume folder
     Should Be Equal As Integers  ${rc}  0
 
     ${ip}=  Get IP Address of Container  httpd1
+    Should Not Be Empty  ${ip}
 
     ${output}=  Wait Until Keyword Succeeds  10x  10s  Curl httpd endpoint  %{VCH-IP}:8080/test.html
     Should Contain  ${output}  HelloWorld

--- a/tests/test-cases/Group22-Docker-Apps/22-13-consul.robot
+++ b/tests/test-cases/Group22-Docker-Apps/22-13-consul.robot
@@ -38,6 +38,7 @@ Multi-agent consul topology
     #Log  ${output}
     #Should Be Equal As Integers  ${rc}  0
     #${ip}=  Get IP Address of Container  dev-consul
+    #Should Not Be Empty  ${ip}
 
     #${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -d -e CONSUL_BIND_INTERFACE=eth0 consul agent -dev -join=${ip}
     #Log  ${output}


### PR DESCRIPTION
Addresses some usability issues with the build workflows and adds some test robustness. This work was done to reduce previously convoluted DCH based instructions into the following - this should be easily translated to regular docker as well, simply by dropping the capacity option from the `volume create`:
```
docker volume create --name=vic-build --opt Capacity=4G
docker run -it -v vic-build:/go/src/github.com/vmware/vic --name=main-builder hickeng/vic-build-image-tdnf -b vmware/feature/custom-iso-kernel rm bin/tether-linux bin/unpack \&\& make most vic-machine

docker create -it -e REPO=my-repo-v vic-build:/go/src/github.com/vmware/vic --name=custom-builder hickeng/vic-build-image-yum -b vmware/feature/custom-iso-kernel rm bin/tether-linux bin/unpack \&\& make bootstrap-custom
docker cp isos/base/repos/my-repo custom-builder:/go/src/github.com/vmware/vic/isos/base/repos/
docker start -ai custom-builder

docker cp custom-builder:/go/src/github.com/vmware/vic/bin/bootstrap-my-repo.iso .
docker cp custom-builder:/go/src/github.com/vmware/vic/bin/bootstrap.iso .
docker cp custom-builder:/go/src/github.com/vmware/vic/bin/appliance.iso .
docker cp custom-builder:/go/src/github.com/vmware/vic/bin/vic-machine-linux .
docker cp custom-builder:/go/src/github.com/vmware/vic/bin/vic-machine-darwin .
docker cp custom-builder:/go/src/github.com/vmware/vic/bin/vic-machine-windows.exe .
```