### PR TITLE
Ensure /dev/fd symlink in sysvinit bootstrap

### DIFF
--- a/isos/bootstrap/sysv-init
+++ b/isos/bootstrap/sysv-init
@@ -33,6 +33,8 @@ mknod -m 666 /dev/tty c 5 0
 mknod -m 444 /dev/random c 1 8
 mknod -m 444 /dev/urandom c 1 9
 chown root:tty /dev/{console,ptmx,tty}
+# ensure the /dev/fd symlink is created - not all udevd seem to do so
+ln -s /proc/self/fd /dev/fd
 
 mkdir -p /dev/{pts,shm}
 mount -t devpts -o gid=4,mode=620 none /dev/pts


### PR DESCRIPTION
The udevd in centos-6.9 (other distros unconfirmed) does not create the
symlink /dev/fd->/proc/self/fd. This results in various images (postgres
specifically) reporting errors such as:
initdb: could not open file "/dev/fd/63" for reading: No such file or
directory

Fixes #8343
