### PR TITLE
Fix cgroup error info by testing existence

### DIFF
--- a/isos/bootstrap/bootstrap
+++ b/isos/bootstrap/bootstrap
@@ -106,7 +106,9 @@ if timeout -s KILL 2m mount -t ext4 /dev/disk/by-label/containerfs ${MOUNTPOINT}
     echo 262144 > /proc/sys/vm/max_map_count
 
     # mount the cgroup hierarchy to allow DinV
-    mount -t cgroup -o all cgroup /sys/fs/cgroup
+    if [ -d /sys/fs/cgroup ];then
+        mount -t cgroup -o all cgroup /sys/fs/cgroup
+    fi
 
     until [[ $(ls -1 /dev/disk/by-label | wc -l) -eq $(ls -1 /sys/block/ | grep -v 'loop*' | grep -v 'ram*' | wc -l) ]]; do sleep 0.1;done
 


### PR DESCRIPTION

In some distro with older kernel version, like centos6, cgroup is not
mounted on /sys/fs/cgroup but on /cgroup, in which case, we would not
use cgroup. Now we test this directory's existence before mounting it
to prevent error message.

<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[  ] There is an associated issue that is labelled
[  ] Code is up-to-date with the `master` branch
[  ] You've successfully run `make test` locally
[  ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/vmware/vic/blob/master/.github/CONTRIBUTING.md
-->

Fixes #

<!--
To trigger a custom build with this PR, include one of these in the PR's body:
- To skip running tests (e.g. for a work-in-progress PR), add `[ci skip]` or `[skip ci]`
to the commit message or the PR title.
- To run the full test suite, use `[full ci]`.
- To run _one_ integration test or group, use `[specific ci=$test]`. Examples:
  - To run the `1-01-Docker-Info` suite: `[specific ci=1-01-Docker-Info]`
  - To run all suites under the `Group1-Docker-Commands` group: `[specific ci=Group1-Docker-Commands]`
- To skip running the unit tests, use `[skip unit]`.
- To fail fast (make normal failures fatal) during the integration testing, use `[fast fail]`.
-->
