### PR TITLE
Update build context for building vic-build-image

### DIFF
--- a/infra/build-image/build-images.sh
+++ b/infra/build-image/build-images.sh
@@ -22,7 +22,7 @@ REGISTRY="gcr.io/eminent-nation-87317"
 IMAGE="vic-build-image"
 
 for PKGMGR in yum tdnf; do
-    docker build -t "$IMAGE-$PKGMGR:$REV" -f ./infra/build-image/Dockerfile.$PKGMGR .
+    docker build -t "$IMAGE-$PKGMGR:$REV" -f ./infra/build-image/Dockerfile.$PKGMGR ./infra/build-image
     docker tag "$IMAGE-$PKGMGR:$REV" "$REGISTRY/$IMAGE:$PKGMGR"
     docker tag "$IMAGE-$PKGMGR:$REV" "$REGISTRY/$IMAGE:$PKGMGR-$REV"
     # gcloud docker -- push "$REGISTRY/$IMAGE:$PKGMGR"


### PR DESCRIPTION
Update build context to be infra/build-image so copy instruction
works.

Fixes #

