### PR TITLE
/dev/pts/ owned by tty and ptmx with correct mode

### DIFF
--- a/isos/bootstrap/systemd-init
+++ b/isos/bootstrap/systemd-init
@@ -35,7 +35,8 @@ mknod -m 444 /dev/urandom c 1 9
 chown root:tty /dev/{console,ptmx,tty}
 
 mkdir -p /dev/{pts,shm}
-mount -t devpts -o gid=4,mode=620 none /dev/pts
+# attempt with ptmxmode first
+mount -t devpts -o gid=5,mode=620,ptmxmode=666 none /dev/pts || mount -t devpts -o gid=5,mode=620 none /dev/pts
 mount -t tmpfs none /dev/shm
 
 # don't use `--daemon` option so that we can easily get the pid to kill it later

--- a/isos/bootstrap/sysv-init
+++ b/isos/bootstrap/sysv-init
@@ -37,7 +37,8 @@ chown root:tty /dev/{console,ptmx,tty}
 ln -s /proc/self/fd /dev/fd
 
 mkdir -p /dev/{pts,shm}
-mount -t devpts -o gid=4,mode=620 none /dev/pts
+# attempt with ptmxmode first
+mount -t devpts -o gid=5,mode=620,ptmxmode=666 none /dev/pts || mount -t devpts -o gid=5,mode=620 none /dev/pts
 mount -t tmpfs none /dev/shm
 
 # don't use `--daemon` option so that we can easily get the pid to kill it later


### PR DESCRIPTION
The /dev/pts entries should be owned by group "tty" (gid=5) as has been
the convention for many years.
/dev/pts/ptmx should be mode 666 to allow creation of additional pty
device pairs.