### PR TITLE
Propagate the truncated message to DNS client.

### DIFF
--- a/lib/dns/dns.go
+++ b/lib/dns/dns.go
@@ -307,8 +307,15 @@ func (s *Server) HandleForwarding(w mdns.ResponseWriter, r *mdns.Msg) (bool, err
 
 		if err != nil || m == nil {
 			// Seen an error, this can only mean, "server not reached", or similar
-			log.Errorf("Failure to forward request to %s: %q", nameserver, err)
-			continue
+			// Propagating truncated DNS record to client. Client should retry using TCP.
+			if err == mdns.ErrTruncated {
+				log.Debugf("Propagate error: '%q' from %s to client", err, nameserver)
+
+			} else {
+				log.Errorf("Failure to forward request to %s: %q", nameserver, err)
+				continue
+			}
+
 		}
 
 		if m.Authoritative {

--- a/tests/test-cases/Group22-Docker-Apps/22-08-node.robot
+++ b/tests/test-cases/Group22-Docker-Apps/22-08-node.robot
@@ -71,11 +71,6 @@ Simple background node application on alpine
     ${ip}=  Get IP Address of Container  node2
     Should Not Be Empty  ${ip}
     
-    ${status}=  Get State Of Github Issue  8168
-    Run Keyword If  '${status}' == 'closed'  Fail  Test 22-08-node.robot needs to be updated now that Issue #8168 has been resolved
-
-    # once Issue #8168 is fixed, revert 60s to 12s
-    Wait Until Keyword Succeeds  10x  60s  Check node container  ${ip}
-
+    Wait Until Keyword Succeeds  10x  12s  Check node container  ${ip}
+    
     [Teardown]  Remove Directory  app  recursive=${true}
-


### PR DESCRIPTION
Propagate the truncated message to DNS client.

The truncated messaged from 22-08-node test is caused by npm application
is requesting an IPV6 addres, it is doing something like, for example:
'nslookup -type AAAA registry.npmjs.org 10.172.40.1', dns server 10.172.40.1
will send a response message > 512 bytes.

RFC https://tools.ietf.org/html/rfc1123#section-6.1.3.2 recommends:
"If the Answer section of the response is truncated and if the requester
supports TCP, it SHOULD try the query again using TCP."

The fix propagates the truncated message to DNS client instead of dropping
it in forwarder logic.

Reverting the workaround fix for 22-08-node.robot.

Testing done:
1. 22-08 passed.
2. Testing using image tutum/dnsutils by running 'nslookup -type AAAA
   registry.npmjs.org', can observed that the nslookup client will retry
   using TCP if UDP returns a truncated DNS packet.
   Please note not all the nslookup version does the same, like busybox
   will not re-try using TCP, but it will get a truncated DNS packet.

[full ci]
Fixes #8168 