### PR TITLE
Update error check message in test case

### DIFF
--- a/tests/test-cases/Group6-VIC-Machine/6-07-Create-Network.robot
+++ b/tests/test-cases/Group6-VIC-Machine/6-07-Create-Network.robot
@@ -263,7 +263,7 @@ Bridge network - vCenter none
 
     ${output}=  Run  bin/vic-machine-linux create --name=%{VCH-NAME} --target="%{TEST_USERNAME}:%{TEST_PASSWORD}@%{TEST_URL}" --thumbprint=%{TEST_THUMBPRINT} --image-store=%{TEST_DATASTORE} ${vicmachinetls}
     Should Contain  ${output}  error
-    Should Contain  ${output}  An existing distributed port group must be specified for bridge network on vCenter
+    Should Contain  ${output}  An existing distributed port group or opaque network must be specified for bridge network on vCenter
 
     # Delete the portgroup added by env vars keyword
     Run Keyword If  %{DRONE_BUILD_NUMBER} != 0  Cleanup VCH Bridge Network


### PR DESCRIPTION
The network error message is updated to support opaque network, so
we need to update the error message check in test cases.

[specific ci=6-07-Create-Network]