### PR TITLE
Add input param to avoid gathering log from non-exsit VCH

### DIFF
--- a/tests/manual-test-cases/Group5-Functional-Tests/5-13-Invalid-ESXi-Install.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-13-Invalid-ESXi-Install.robot
@@ -16,7 +16,7 @@
 Documentation  Test 5-13 - Invalid ESXi Install
 Resource  ../../resources/Util.robot
 Suite Setup  Nimbus Suite Setup  Invalid ESXi Install Setup
-Suite Teardown  Run Keyword And Ignore Error  Nimbus Cleanup  ${list}
+Suite Teardown  Run Keyword And Ignore Error  Nimbus Cleanup  ${list}  ${false}
 
 *** Keywords ***
 Invalid ESXi Install Setup


### PR DESCRIPTION
Modify script <5-13-Invalid-ESXi-Install.robot>, add a input parameter and set is as false to avoid gathering log from a non-exist VCH.

Signed-off-by: danfengliu <danfengl@vmware.com>