### PR TITLE
Fix vch missing gpgkey

### DIFF
--- a/isos/base/utils.sh
+++ b/isos/base/utils.sh
@@ -86,8 +86,13 @@ setup_pm() {
     #place corresponding gpgkey files if gpgkey provided as a file rather than a url
     for keypath in $(awk -F'gpgkey=file:' '/gpgkey=file:/{print $2}' $REPODIR/*.repo)
     do
+        keyd=$(dirname $keypath)
         keyf=$(basename $keypath)
-        [ -f $REPODIR/$keyf ] && rpm --root=$(rootfs_dir $PKGDIR) --import $REPODIR/$keyf
+        [ -f $REPODIR/$keyf ] && {
+            rpm --root=$(rootfs_dir $PKGDIR) --import $REPODIR/$keyf
+            mkdir -p $(rootfs_dir $PKGDIR)/$keyd
+            cp $REPODIR/$keyf $(rootfs_dir $PKGDIR)/$keyd   #to enable gpgcheck in VCH
+        }
     done
 
     # Copy tdnf config to iso for later use with a relative rootfs

--- a/tests/test-cases/Group23-VIC-Machine-Service/23-13-VCH-Tdnf.md
+++ b/tests/test-cases/Group23-VIC-Machine-Service/23-13-VCH-Tdnf.md
@@ -1,0 +1,23 @@
+Test 23-13 - VCH Tdnf 
+======
+
+# Purpose:
+To test whether tdnf in VCH work well 
+
+# References:
+[1 - tdnf](https://github.com/vmware/tdnf/wiki)
+
+# Environment:
+* requires a working VCSA setup with VCH installed
+* Target VCSA has Bash enabled for the root account
+
+# Test Steps:
+1. Enable VCH SSh
+2. SSH into VCH and check gpgcheck=1 in photon.repo
+3. SSH into VCH and run tdnf install which -y
+
+# Expected Outcome:
+* Each step should return success
+
+# Possible Problems:
+None

--- a/tests/test-cases/Group23-VIC-Machine-Service/23-13-VCH-Tdnf.robot
+++ b/tests/test-cases/Group23-VIC-Machine-Service/23-13-VCH-Tdnf.robot
@@ -1,0 +1,31 @@
+# Copyright 2017 VMware, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License
+
+*** Settings ***
+Documentation  Test 23-13 - VCH-tdnf
+Resource  ../../resources/Util.robot
+Suite Setup  Install VIC Appliance To Test Server
+Suite Teardown  Cleanup VIC Appliance On Test Server
+
+*** Test Cases ***
+Gpgcheck Being Enabled
+    Enable VCH SSH
+    ${rc}  ${output}=  Run And Return Rc and Output  sshpass -p %{TEST_PASSWORD} ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null root@%{VCH-IP} grep gpgcheck=1 /etc/yum.repos.d/photon.repo
+    Log  ${output}
+    Should Be Equal As Integers  ${rc}  0
+
+Tdnf Install Which
+    ${rc}  ${output}=  Run And Return Rc and Output  sshpass -p %{TEST_PASSWORD} ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null root@%{VCH-IP} tdnf install -y which
+    Log  ${output}
+    Should Be Equal As Integers  ${rc}  0

--- a/tests/test-cases/Group23-VIC-Machine-Service/TestCases.md
+++ b/tests/test-cases/Group23-VIC-Machine-Service/TestCases.md
@@ -23,4 +23,6 @@ Group 23 - VIC Machine Service
 [Test 23-10 - VCH Debug](23-10-VCH-Debug.md)
 -
 [Test 23-11 - VCH Firewall](23-11-VCH-Firewall.md)
+
+[Test 23-13 - VCH Tdnf](23-13-VCH-Tdnf.md)
 -


### PR DESCRIPTION
In VCH,  running `tdnf install -y` prompts missing gpgkey. 

Now we fix it by copying the gpgkey into the corresponding directory when  building iso.

Add test cases of tdnf in VCH into Group23

[specific ci=Group23-VIC-Machine-Service]