### PR TITLE
Replace ifconfig with ip to bring up interface

### DIFF
--- a/isos/base/repos/photon-1.0-passthrough/repo-spec.json
+++ b/isos/base/repos/photon-1.0-passthrough/repo-spec.json
@@ -5,7 +5,7 @@
     "init": "/lib/systemd/systemd",
     "packages": {
         "base": "filesystem coreutils kmod haveged iptables",
-        "bootstrap": "util-linux-ng grep which linux-tools",
+        "bootstrap": "util-linux-ng grep which linux-tools iproute2",
         "appliance": "procps-ng util-linux-ng e2fsprogs shadow systemd iputils iproute2 tdnf gzip lsof logrotate photon-release mingetty rpm dbus net-tools openssh ca-certificates sudo vim lsof"
     }
 }

--- a/isos/base/repos/photon-1.0/repo-spec.json
+++ b/isos/base/repos/photon-1.0/repo-spec.json
@@ -5,7 +5,7 @@
     "init": "/bin/init",
     "packages": {
         "base": "filesystem coreutils kmod haveged iptables",
-        "bootstrap": "",
+        "bootstrap": "grep iproute2",
         "appliance": "procps-ng e2fsprogs shadow systemd iputils iproute2 tdnf gzip lsof logrotate photon-release mingetty rpm dbus net-tools openssh ca-certificates sudo vim lsof"
     }
 }

--- a/isos/base/repos/photon-2.0/repo-spec.json
+++ b/isos/base/repos/photon-2.0/repo-spec.json
@@ -9,6 +9,6 @@
     },
     "packages": {
         "base": "filesystem toybox kmod haveged iptables",
-        "bootstrap": "",
+        "bootstrap": "iproute2",
         "appliance": "procps-ng e2fsprogs shadow systemd iputils iproute2 tdnf gzip lsof logrotate photon-release mingetty rpm dbus net-tools openssh ca-certificates sudo vim lsof bash"
     }}

--- a/isos/bootstrap/systemd-init
+++ b/isos/bootstrap/systemd-init
@@ -46,8 +46,8 @@ UDEV_PID=$!
 udevadm trigger
 
 echo 'Bring up loopback interface'
-until ifconfig lo;do sleep 0.1;done
-ifconfig lo up
+until ip link show lo;do sleep 0.1;done
+ip link set lo up
 
 # launch the main entry point
 echo "######## Launching bootstrap entrypoint ########"


### PR DESCRIPTION
There is no ifconfig present in photon 1.0 and the container VM
fails to start. Replace ifconfig with ip to bring up interface.
This is to keep backwards compatibility for VIC <= 1.5.

