### PR TITLE
Move vic-machine-server OS to Photon 2.0

### DIFF
--- a/cmd/vic-machine-server/Dockerfile
+++ b/cmd/vic-machine-server/Dockerfile
@@ -5,7 +5,7 @@
 # gcloud auth login
 # gcloud docker -- push gcr.io/eminent-nation-87317/vic-machine-server:1.x
 
-FROM vmware/photon:1.0
+FROM photon:2.0
 
 RUN set -eux; \
      tdnf distro-sync --refresh -y; \


### PR DESCRIPTION
Change the operate system of vic-machine-server image to Photon 2.0.

Fixes #8292 
```
[specific ci=Group23-VIC-Machine-Service]
```