### PR TITLE
Add package docker for vic-product

### DIFF
--- a/infra/integration-image/local-repo/Dockerfile.photon-2.0
+++ b/infra/integration-image/local-repo/Dockerfile.photon-2.0
@@ -16,7 +16,7 @@ RUN mkdir -p /usr/share/nginx/html/photon/x86_64 && \
     mkdir -p /usr/share/nginx/html/photon-updates/noarch
 
 ENV EXCLUDE_LIST "index.html*,openjdk*,postgresql*,\
-ruby*,subversion*,gnome*,NetworkManager*,cloud*,docker*,grub*,ktap*,\
+ruby*,subversion*,gnome*,NetworkManager*,cloud*,grub*,ktap*,\
 kubernetes*,linux-docs*,linux-sound*,linux-tools*,docbook*,httpd*,go-*,jna*,\
 linux-debuginfo*,linux-dev*,linux-docs*,linux-drivers*,linux-oprofile*,linux-sound*,\
 linux-tools*,linux-esx-debuginfo*,linux-esx-devel*,linux-esx-docs*,nginx*,sysdig*"


### PR DESCRIPTION
In vic ova appliance, docker is required package. Remove it from
excluded list.

<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[  ] There is an associated issue that is labelled
[  ] Code is up-to-date with the `master` branch
[  ] You've successfully run `make test` locally
[  ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/vmware/vic/blob/master/.github/CONTRIBUTING.md
-->

Fixes #
