### PR TITLE
Fix  609-607 test cases' conflict failure

### DIFF
--- a/tests/test-cases/Group6-VIC-Machine/6-09-Inspect.robot
+++ b/tests/test-cases/Group6-VIC-Machine/6-09-Inspect.robot
@@ -20,10 +20,10 @@ Test Timeout  20 minutes
 
 *** Keywords ***
 Cleanup Container Network Test Networks
-    ${out}=  Run Keyword If  '%{HOST_TYPE}' == 'ESXi'  Run  govc host.portgroup.remove published-net
-    ${out}=  Run Keyword If  '%{HOST_TYPE}' == 'ESXi'  Run  govc host.portgroup.remove peers-net
-    ${out}=  Run Keyword If  '%{HOST_TYPE}' == 'VC'  Remove VC Distributed Portgroup  published-net
-    ${out}=  Run Keyword If  '%{HOST_TYPE}' == 'VC'  Remove VC Distributed Portgroup  peers-net
+    ${out}=  Run Keyword If  '%{HOST_TYPE}' == 'ESXi'  Run  govc host.portgroup.remove published-net-609
+    ${out}=  Run Keyword If  '%{HOST_TYPE}' == 'ESXi'  Run  govc host.portgroup.remove peers-net-609
+    ${out}=  Run Keyword If  '%{HOST_TYPE}' == 'VC'  Remove VC Distributed Portgroup  published-net-609
+    ${out}=  Run Keyword If  '%{HOST_TYPE}' == 'VC'  Remove VC Distributed Portgroup  peers-net-609
 
 Cleanup Container Network Test
     Cleanup VIC Appliance On Test Server
@@ -137,22 +137,22 @@ Inspect VCH Configuration with Container Networks
     Cleanup Container Network Test Networks
 
     ${vswitch}=  Run Keyword If  '%{HOST_TYPE}' == 'ESXi'  Run  govc host.vswitch.info -json | jq -r ".Vswitch[0].Name"
-    ${out}=  Run Keyword If  '%{HOST_TYPE}' == 'ESXi'  Run  govc host.portgroup.add -vswitch ${vswitch} published-net
-    ${out}=  Run Keyword If  '%{HOST_TYPE}' == 'ESXi'  Run  govc host.portgroup.add -vswitch ${vswitch} peers-net
+    ${out}=  Run Keyword If  '%{HOST_TYPE}' == 'ESXi'  Run  govc host.portgroup.add -vswitch ${vswitch} published-net-609
+    ${out}=  Run Keyword If  '%{HOST_TYPE}' == 'ESXi'  Run  govc host.portgroup.add -vswitch ${vswitch} peers-net-609
     ${dvs}=  Run Keyword If  '%{HOST_TYPE}' == 'VC'  Run  govc find -type DistributedVirtualSwitch | head -n1
-    ${out}=  Run Keyword If  '%{HOST_TYPE}' == 'VC'  Add VC Distributed Portgroup  ${dvs}  published-net
-    ${out}=  Run Keyword If  '%{HOST_TYPE}' == 'VC'  Add VC Distributed Portgroup  ${dvs}  peers-net
+    ${out}=  Run Keyword If  '%{HOST_TYPE}' == 'VC'  Add VC Distributed Portgroup  ${dvs}  published-net-609
+    ${out}=  Run Keyword If  '%{HOST_TYPE}' == 'VC'  Add VC Distributed Portgroup  ${dvs}  peers-net-609
 
-    Install VIC Appliance To Test Server  additional-args=-container-network published-net -container-network peers-net -cnf peers-net:peers --container-network-ip-range peers-net:10.10.10.0/24 -cng peers-net:10.10.10.1/24
+    Install VIC Appliance To Test Server  additional-args=-container-network published-net-609 -container-network peers-net-609 -cnf peers-net-609:peers --container-network-ip-range peers-net-609:10.10.10.0/24 -cng peers-net-609:10.10.10.1/24
 
     ${rc}  ${output}=  Run And Return Rc And Output  bin/vic-machine-linux inspect config --target=%{TEST_URL} --thumbprint=%{TEST_THUMBPRINT} --user %{TEST_USERNAME} --password=%{TEST_PASSWORD} --name=%{VCH-NAME} --compute-resource=%{TEST_RESOURCE} --format raw
 
-    Should Contain  ${output}  --container-network=published-net:published-net
-    Should Not Contain  ${output}  --container-network-firewall=published-net:published
-    Should Contain  ${output}  --container-network=peers-net:peers-net
-    Should Contain  ${output}  --container-network-gateway=peers-net:10.10.10.1/24
-    Should Contain  ${output}  --container-network-ip-range=peers-net:10.10.10.0/24
-    Should Contain  ${output}  --container-network-firewall=peers-net:peers
+    Should Contain  ${output}  --container-network=published-net-609:published-net-609
+    Should Not Contain  ${output}  --container-network-firewall=published-net-609:published
+    Should Contain  ${output}  --container-network=peers-net-609:peers-net-609
+    Should Contain  ${output}  --container-network-gateway=peers-net-609:10.10.10.1/24
+    Should Contain  ${output}  --container-network-ip-range=peers-net-609:10.10.10.0/24
+    Should Contain  ${output}  --container-network-firewall=peers-net-609:peers
     Should Be Equal As Integers  0  ${rc}
 
 Verify inspect output for a full tls VCH


### PR DESCRIPTION
Fix  609-607 test cases' conflict failure

-   Test 6-07-Create-Network and 6-09-Inspect-Network using the same  portgroup name: published-net and peers-net, which could cause failure when running this two cases parallelly.
-   Rename published-net to published-net-609, peers-net to peers-net-609  in 6-09 test case

[specific ci=Group6-VIC-Machine]
