### PR TITLE
Avoid allocate conflict IP address when cVM is powered off from vSphere

### DIFF
--- a/lib/portlayer/network/network.go
+++ b/lib/portlayer/network/network.go
@@ -152,7 +152,19 @@ func handleEvent(netctx *Context, ie events.Event) {
 		if err := handle.Commit(op, nil, nil); err != nil {
 			op.Warnf("Failed to commit handle after network unbind for container %s: %s", ie.Reference(), err)
 		}
+	case events.ContainerStarted:
+		op := trace.NewOperation(context.Background(), fmt.Sprintf("handleEvent(%s)", ie.EventID()))
+		op.Infof("Handling Event: %s", ie.EventID())
+		// grab the operation from the event
+		handle := exec.GetContainer(op, uid.Parse(ie.Reference()))
+		if _, err := netctx.BindContainer(op, handle); err != nil {
+			op.Warnf("Failed to bind container %s: %s", ie.Reference(), err)
+			return
+		}
 
+		if err := handle.Commit(op, nil, nil); err != nil {
+			op.Warnf("Failed to commit handle after network bind for container %s: %s", ie.Reference(), err)
+		}
 	}
 	return
 }


### PR DESCRIPTION

When container VM is powered off from vSphere client, the VIC will
receive the PoweredOff event and invoke the unbindContainer method
to release IP address. But VIC does not do any update if the cVM
is powered on from vSphere client, so cVM will use the previous
netlink configuration, VIC will allocate the released IP address to
the next container VM, this will result in IP conflict.

Fixes #8405 
