### PR TITLE
Fix broken make issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ drone exec
 
 To build inside a Docker container:
 ```shell
-docker run -v $(pwd):/go/src/github.com/vmware/vic gcr.io/eminent-nation-87317/vic-build-image:tdnf make all
+docker run -v $GOPATH/bin:/go/bin -v $(pwd):/go/src/github.com/vmware/vic gcr.io/eminent-nation-87317/vic-build-image:tdnf make all
 ```
 
 To build directly, you also need the Go 1.8 toolchain installed:

--- a/infra/build-image/docker-iso-build.sh
+++ b/infra/build-image/docker-iso-build.sh
@@ -34,7 +34,7 @@ function main {
   -v $GOPATH/src/github.com/vmware/vic/bin:/go/src/github.com/vmware/vic/bin \
   -e DEBUG=${DEBUG} \
   -e BUILD_NUMBER=${BUILD_NUMBER} \
-  gcr.io/eminent-nation-87317/vic-build-image:${PKGMGR:-tdnf} /bin/bash -c "$*"
+  gcr.io/eminent-nation-87317/vic-build-image:${PKGMGR:-tdnf} "$*"
 }
 
 REPO="photon-2.0"

--- a/infra/build-image/setup-repo.sh
+++ b/infra/build-image/setup-repo.sh
@@ -88,7 +88,7 @@ if ! git remote show -n origin >/dev/null 2>&1 ; then
     git init . && git remote add origin ${url}
 fi
 
-if [ ! -z ${refspec} ]; then
+if [ -n "${refspec}" ]; then
     # we don't limit the depth as that was resulting in failure to find the most recent tag for a given commit
     git fetch origin -v ${refspec}
     if [ "$(git rev-parse --abbrev-ref HEAD)" != "$branch" ]; then
@@ -96,7 +96,7 @@ if [ ! -z ${refspec} ]; then
     fi
 fi
 
-if [ -n ${localbranch} ]; then
+if [ -n "${localbranch}" ]; then
     # try to fast-forward but just checkout if that fails
     git pull --ff-only || git checkout ${localbranch}
 fi

--- a/isos/base.sh
+++ b/isos/base.sh
@@ -21,7 +21,7 @@ DIR=$(dirname $(readlink -f "$0"))
 . $DIR/base/utils.sh
 
 function usage() {
-echo "Usage: $0 -p package-name(tgz) [-c package-cache]" 1>&2
+echo "Usage: $0 -p package-name(tgz) [-c package-cache] [-r repo]" 1>&2
 exit 1
 }
 

--- a/isos/base/utils.sh
+++ b/isos/base/utils.sh
@@ -18,9 +18,7 @@
 [ -n "$DEBUG" ] && set -x
 BASE_DIR=$(dirname $(readlink -f "$BASH_SOURCE"))
 
-if [ -z ${BUILD_NUMBER+x} ]; then
-  BUILD_NUMBER=0
-fi
+BUILD_NUMBER=${BUILD_NUMBER:-0}
 
 VERSION=`git describe --abbrev=0 --tags`-${BUILD_NUMBER}-`git rev-parse --short HEAD`
 


### PR DESCRIPTION
Make iso fails if it is not issued in build container. Fix build
scripts to be able to run make directly.

Fixes #8417 

