### PR TITLE
Add image layer storage usage

### DIFF
--- a/lib/portlayer/storage/image/image.go
+++ b/lib/portlayer/storage/image/image.go
@@ -79,6 +79,9 @@ type ImageStorer interface {
 	// GetImageStorageUsage gets the image storage usage from the image store.
 	GetImageStorageUsage(op trace.Operation, storeName string) (int64, error)
 
+	// GetImageLayerStorageUsage gets the image layer storage usage from the image store.
+	GetImageLayerStorageUsage(op trace.Operation, storeName, ID string) (int64, error)
+
 	storage.Resolver
 	storage.Importer
 	storage.Exporter

--- a/lib/portlayer/storage/image/mock/store.go
+++ b/lib/portlayer/storage/image/mock/store.go
@@ -190,3 +190,7 @@ func (c *MockDataStore) DeleteImage(op trace.Operation, image *image.Image) (*im
 func (c *MockDataStore) GetImageStorageUsage(op trace.Operation, storeName string) (int64, error) {
 	return 0, nil
 }
+
+func (c *MockDataStore) GetImageLayerStorageUsage(op trace.Operation, storeName, ID string) (int64, error) {
+	return 0, nil
+}

--- a/lib/portlayer/storage/image/vsphere/store.go
+++ b/lib/portlayer/storage/image/vsphere/store.go
@@ -122,7 +122,7 @@ func (v *ImageStore) imageStorePath(storeName string) string {
 
 // Returns the path to the image relative to the given
 // store.  The dir structure for an image in the datastore is
-// `/VIC/imageStoreName (currently the vch uuid)/imageName/imageName.vmkd`
+// `/VIC/imageStoreName (currently the vch uuid)/imageName/imageName.vmdk`
 func (v *ImageStore) imageDirPath(storeName, imageName string) string {
 	return path.Join(v.imageStorePath(storeName), imageName)
 }
@@ -592,6 +592,10 @@ func (v *ImageStore) ListImages(op trace.Operation, store *url.URL, IDs []string
 
 func (v *ImageStore) GetImageStorageUsage(op trace.Operation, storeName string) (int64, error) {
 	return v.Helper.GetFilesSize(op, v.imageStorePath(storeName), true, "*.vmdk")
+}
+
+func (v *ImageStore) GetImageLayerStorageUsage(op trace.Operation, storeName, ID string) (int64, error) {
+	return v.Helper.GetFilesSize(op, v.imageDirPath(storeName, ID), true, "*.vmdk")
 }
 
 // DeleteImage deletes an image from the image store.  If the image is in


### PR DESCRIPTION
The current implementation of image storage usage always use
vCenter datastore file browser to get all layers of images
and sum the related vmdk file sizes. In some vsphere environments,
the browser response is very slow with 30+ seconds with
only 10 layers.

This fix changes to accumulate storage usage when a layer is added
or deleted from datastore, and keep the latest usage value into cache.

Fixes #8415 
[specific ci=Group26-Storage-Quota]