### PR TITLE
Add storage reservation for parallel requests

### DIFF
--- a/lib/apiservers/engine/backends/cache/container_cache.go
+++ b/lib/apiservers/engine/backends/cache/container_cache.go
@@ -36,7 +36,8 @@ type CCache struct {
 	containersByName   map[string]*container.VicContainer
 	containersByExecID map[string]*container.VicContainer
 
-	vmStorageUsage int64
+	vmStorageUsage     int64
+	storageReservation int64
 }
 
 var containerCache *CCache
@@ -209,6 +210,24 @@ func (cc *CCache) ReleaseName(name string) {
 	delete(cc.containersByName, name)
 }
 
-func (cc *CCache) VMStorageSize() int64 {
+func (cc *CCache) VMStorageUsage() int64 {
 	return cc.vmStorageUsage
+}
+
+func (cc *CCache) StorageReservation() int64 {
+	return cc.storageReservation
+}
+
+func (cc *CCache) AddStorageReservation(r int64) int64 {
+	cc.m.Lock()
+	defer cc.m.Unlock()
+	cc.storageReservation += r
+	return cc.storageReservation
+}
+
+func (cc *CCache) RemoveStorageReservation(r int64) int64 {
+	cc.m.Lock()
+	defer cc.m.Unlock()
+	cc.storageReservation -= r
+	return cc.storageReservation
 }

--- a/lib/apiservers/engine/backends/image.go
+++ b/lib/apiservers/engine/backends/image.go
@@ -463,7 +463,7 @@ func validateStorageQuota() error {
 	if vchConfig.Cfg.StorageQuota == 0 {
 		return nil
 	}
-	vmStorageUsage := cache.ContainerCache().VMStorageSize()
+	vmStorageUsage := cache.ContainerCache().VMStorageUsage()
 	imageStorageUsage, err := cache.ImageCache().GetImageStorageUsage()
 	if err != nil {
 		log.Errorf("failed to get image storage usage: %v", err)

--- a/lib/apiservers/engine/backends/system.go
+++ b/lib/apiservers/engine/backends/system.go
@@ -233,7 +233,7 @@ func (s *SystemBackend) SystemInfo() (*types.Info, error) {
 		if err != nil {
 			op.Infof("Unable to get the image storage usage : %s", err.Error())
 		}
-		vmStorageUsage := cache.ContainerCache().VMStorageSize()
+		vmStorageUsage := cache.ContainerCache().VMStorageUsage()
 		storageUsage := [2]string{systemStatusStorageUsage, units.BytesSize(float64(imageStorageUsage + vmStorageUsage))}
 		info.SystemStatus = append(info.SystemStatus, storageUsage)
 		if imageStorageUsage > 0 {


### PR DESCRIPTION
During parallel container creation requests, storage usage is not enough
to check storage quota, and need to use storage reservation to control
quota. When a request comes in, storage reservation is added. When a
Container creation finishes, storage reservation is removed. Storage quota
check will compare quota with sum of storage usage and reservation. In
this way, parallel requests can be processed as well.

[specific ci=Group26-Storage-Quota]