### PR TITLE
Rectify building custom iso doc

### DIFF
--- a/isos/base/repos/README.md
+++ b/isos/base/repos/README.md
@@ -165,14 +165,14 @@ unset DOCKER_HOST DOCKER_TLS_VERIFY DOCKER_CERT_PATH
 rm -f bin/tether-linux bin/unpack  
 
 # builds vic-machine binaries and both appliance.iso and bootstrap.iso with photon-2.0
-docker run -v $(pwd):/go/src/github.com/vmware/vic  gcr.io/eminent-nation-87317/vic-build-image:tdnf  rm -f bin/tether-linux bin/unpack \&\& make isos vic-machine
+docker run -v $GOPATH/bin:/go/bin -v $(pwd):/go/src/github.com/vmware/vic  gcr.io/eminent-nation-87317/vic-build-image:tdnf  rm -f bin/tether-linux bin/unpack \&\& make isos vic-machine
 
 # builds appliance.iso with photon-2.0 and bootstrap.iso by photon-1.0
-docker run -v $(pwd):/go/src/github.com/vmware/vic  -e REPO=photon-1.0  gcr.io/eminent-nation-87317/vic-build-image:tdnf  rm -f bin/tether-linux bin/unpack \&\& make appliance bootstrap-custom
+docker run -v $GOPATH/bin:/go/bin -v $(pwd):/go/src/github.com/vmware/vic  -e REPO=photon-1.0  gcr.io/eminent-nation-87317/vic-build-image:tdnf  rm -f bin/tether-linux bin/unpack \&\& make appliance bootstrap-custom
 
 
 # builds a bootstrap iso with a centos-6.9 kernel and package layout
-docker run -v $(pwd):/go/src/github.com/vmware/vic  -e REPO=centos-6.9  gcr.io/eminent-nation-87317/vic-build-image:yum  rm -f bin/tether-linux bin/unpack \&\& make bootstrap-custom
+docker run -v $GOPATH/bin:/go/bin -v $(pwd):/go/src/github.com/vmware/vic  -e REPO=centos-6.9  gcr.io/eminent-nation-87317/vic-build-image:yum  rm -f bin/tether-linux bin/unpack \&\& make bootstrap-custom
 ```
 
 The output from these files will be in `bin/` titled `bootstrap[-repo].iso`. The default bootstrap build from the `bootstrap` make target will produce the `bootstrap.iso` file with no suffix.


### PR DESCRIPTION
Add mounting volume for swagger cache to building custom iso
instruction.

<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[  ] There is an associated issue that is labelled
[  ] Code is up-to-date with the `master` branch
[  ] You've successfully run `make test` locally
[  ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/vmware/vic/blob/master/.github/CONTRIBUTING.md
-->

Fixes #

<!--
To trigger a custom build with this PR, include one of these in the PR's body:
- To skip running tests (e.g. for a work-in-progress PR), add `[ci skip]` or `[skip ci]`
to the commit message or the PR title.
- To run the full test suite, use `[full ci]`.
- To run _one_ integration test or group, use `[specific ci=$test]`. Examples:
  - To run the `1-01-Docker-Info` suite: `[specific ci=1-01-Docker-Info]`
  - To run all suites under the `Group1-Docker-Commands` group: `[specific ci=Group1-Docker-Commands]`
- To skip running the unit tests, use `[skip unit]`.
- To fail fast (make normal failures fatal) during the integration testing, use `[fast fail]`.
-->
