### PR TITLE
Include COMPOSE_TLS_VERSION variable in VCH environment file

### DIFF
--- a/lib/install/management/inspect.go
+++ b/lib/install/management/inspect.go
@@ -245,6 +245,7 @@ func (d *Dispatcher) GetDockerAPICommand(conf *config.VirtualContainerHostConfig
 		}
 	}
 	dEnv = append(dEnv, fmt.Sprintf("DOCKER_HOST=%s:%s", d.HostIP, d.DockerPort))
+	dEnv = append(dEnv, "COMPOSE_TLS_VERSION=TLSv1_2")
 
 	cmd = fmt.Sprintf("docker -H %s:%s%s info", d.HostIP, d.DockerPort, tls)
 	env = strings.Join(dEnv, " ")


### PR DESCRIPTION
Putting COMPOSE_TLS_VERSION=TLSv1_2 into CLI output and vch environment
file. We have to manually export "COMPOSE_TLS_VERSION=TLSv1_2"
 variable as docker-compose does not support earlier tls versions.

This fixes vic-product 2127