### PR TITLE
Setting dynamic DNS update information if container hostname is set

### DIFF
--- a/cmd/tether/ops.go
+++ b/cmd/tether/ops.go
@@ -24,8 +24,8 @@ func (t *operations) Cleanup() error {
 	return t.BaseOperations.Cleanup()
 }
 
-func (t *operations) Apply(endpoint *tether.NetworkEndpoint) error {
-	return t.BaseOperations.Apply(endpoint)
+func (t *operations) Apply(endpoint *tether.NetworkEndpoint, hostname string) error {
+	return t.BaseOperations.Apply(endpoint, hostname)
 }
 
 // HandleSessionExit controls the behaviour on session exit - for the tether if the session exiting

--- a/cmd/tether/tether_test.go
+++ b/cmd/tether/tether_test.go
@@ -152,8 +152,8 @@ func (t *Mocker) SetupFirewall(ctx context.Context, config *tether.ExecutorConfi
 }
 
 // Apply takes the network endpoint configuration and applies it to the system
-func (t *Mocker) Apply(endpoint *tether.NetworkEndpoint) error {
-	return tether.ApplyEndpoint(t, &t.Base, endpoint)
+func (t *Mocker) Apply(endpoint *tether.NetworkEndpoint, hostname string) error {
+	return tether.ApplyEndpoint(t, &t.Base, endpoint, hostname)
 }
 
 // MountLabel performs a mount with the source treated as a disk label

--- a/cmd/vic-init/ops.go
+++ b/cmd/vic-init/ops.go
@@ -83,8 +83,8 @@ func (t *operations) SetHostname(name string, aliases ...string) error {
 	return t.BaseOperations.SetHostname(aliases[0])
 }
 
-func (t *operations) Apply(endpoint *tether.NetworkEndpoint) error {
-	return t.BaseOperations.Apply(endpoint)
+func (t *operations) Apply(endpoint *tether.NetworkEndpoint, hostname string) error {
+	return t.BaseOperations.Apply(endpoint, hostname)
 }
 
 // Log will redirect logging to both a file on disk and to stdout for the process

--- a/cmd/vic-init/tether_test.go
+++ b/cmd/vic-init/tether_test.go
@@ -133,7 +133,7 @@ func (t *Mocker) SetupFirewall(cxt context.Context, conf *tether.ExecutorConfig)
 }
 
 // Apply takes the network endpoint configuration and applies it to the system
-func (t *Mocker) Apply(endpoint *tether.NetworkEndpoint) error {
+func (t *Mocker) Apply(endpoint *tether.NetworkEndpoint, hostname string) error {
 	defer trace.End(trace.Begin("mocking endpoint configuration for " + endpoint.Network.Name))
 	t.IPs[endpoint.Network.Name] = endpoint.Assigned.IP
 

--- a/lib/tether/interfaces.go
+++ b/lib/tether/interfaces.go
@@ -38,7 +38,7 @@ type Operations interface {
 
 	SetHostname(hostname string, aliases ...string) error
 	SetupFirewall(ctx context.Context, config *ExecutorConfig) error
-	Apply(endpoint *NetworkEndpoint) error
+	Apply(endpoint *NetworkEndpoint, hostname string) error
 	MountLabel(ctx context.Context, label, target string) error
 	MountTarget(ctx context.Context, source url.URL, target string, mountOptions string) error
 	CopyExistingContent(source string) error

--- a/lib/tether/tether.go
+++ b/lib/tether/tether.go
@@ -289,7 +289,7 @@ func (t *tether) setNetworks() error {
 		if !network.Internal {
 			continue
 		}
-		if err := t.ops.Apply(network); err != nil {
+		if err := t.ops.Apply(network, ""); err != nil {
 			return fmt.Errorf("failed to apply network endpoint config: %s", err)
 		}
 	}
@@ -297,7 +297,16 @@ func (t *tether) setNetworks() error {
 		if network.Internal {
 			continue
 		}
-		if err := t.ops.Apply(network); err != nil {
+		full := t.config.Hostname
+		if t.config.Hostname != "" && t.config.Domainname != "" {
+			full = fmt.Sprintf("%s.%s", t.config.Hostname, t.config.Domainname)
+		}
+		var hostname string
+		if full != "" {
+			hostname = full
+		}
+		// Adding hostname for dns dynamic update, for more information refer to issue 8397
+		if err := t.ops.Apply(network, hostname); err != nil {
 			return fmt.Errorf("failed to apply network endpoint config: %s", err)
 		}
 	}

--- a/lib/tether/tether_test.go
+++ b/lib/tether/tether_test.go
@@ -155,8 +155,8 @@ func (t *Mocker) SetHostname(hostname string, aliases ...string) error {
 }
 
 // Apply takes the network endpoint configuration and applies it to the system
-func (t *Mocker) Apply(endpoint *NetworkEndpoint) error {
-	return ApplyEndpoint(t, &t.Base, endpoint)
+func (t *Mocker) Apply(endpoint *NetworkEndpoint, hostname string) error {
+	return ApplyEndpoint(t, &t.Base, endpoint, hostname)
 }
 
 // MountLabel performs a mount with the source treated as a disk label


### PR DESCRIPTION
This change will set the dynamic DNS update for DHCP server when
container hostname is specified.

For more information you can refer to link:
https://docs.infoblox.com/display/N83EA2/Understanding+DDNS+Updates+from+DHCP

Fixes #8397 
