### PR TITLE
Avoid errors: ip conflict and ip address already in use

### DIFF
--- a/lib/apiservers/engine/backends/container.go
+++ b/lib/apiservers/engine/backends/container.go
@@ -1096,13 +1096,14 @@ func (c *ContainerBackend) containerStart(op trace.Operation, name string, hostC
 		handle = bindRes.Payload.Handle
 		endpoints = bindRes.Payload.Endpoints
 
+		// due to issue 8405, 7128 and 8052, we will not clear out assigned IP address besides container is removed
 		// unbind in case we fail later
-		defer func() {
-			if err != nil {
-				op.Debugf("Unbinding %s due to error - %s", id, err.Error())
-				client.Scopes.UnbindContainer(scopes.NewUnbindContainerParamsWithContext(op).WithOpID(&opID).WithHandle(handle))
-			}
-		}()
+		//defer func() {
+		//	if err != nil {
+		//op.Debugf("Unbinding %s due to error - %s", id, err.Error())
+		//		client.Scopes.UnbindContainer(scopes.NewUnbindContainerParamsWithContext(op).WithOpID(&opID).WithHandle(handle))
+		//	}
+		//}()
 
 		// unmap ports that vc needs if they're not being used by previously mapped container
 		err = c.cleanupPortBindings(op, vc)
@@ -1263,7 +1264,7 @@ func (c *ContainerBackend) containerStop(op trace.Operation, name string, second
 	}
 
 	operation := func() error {
-		return c.containerProxy.Stop(op, vc, name, seconds, true)
+		return c.containerProxy.Stop(op, vc, name, seconds, false)
 	}
 
 	config := retry.NewBackoffConfig()

--- a/lib/portlayer/network/network.go
+++ b/lib/portlayer/network/network.go
@@ -144,10 +144,12 @@ func handleEvent(netctx *Context, ie events.Event) {
 			return
 		}
 
-		if _, err := netctx.UnbindContainer(op, handle); err != nil {
-			op.Warnf("Failed to unbind container %s: %s", ie.Reference(), err)
-			return
-		}
+		// due to issue 8405, 7128 and 8052, we will not clear out assigned IP address when container is unbounded
+		// when restarted, the container is still using the assigned IP address at the first time
+		//if _, err := netctx.UnbindContainer(op, handle); err != nil {
+		//	op.Warnf("Failed to unbind container %s: %s", ie.Reference(), err)
+		//	return
+		//}
 
 		if err := handle.Commit(op, nil, nil); err != nil {
 			op.Warnf("Failed to commit handle after network unbind for container %s: %s", ie.Reference(), err)

--- a/lib/portlayer/network/scope.go
+++ b/lib/portlayer/network/scope.go
@@ -161,6 +161,7 @@ func (s *Scope) reserveEndpointIP(e *Endpoint) error {
 				e.ip = eip
 				return nil
 			}
+			err = fmt.Errorf("No available IP address in current network %s", s.name)
 		}
 	}
 
@@ -240,6 +241,25 @@ func (s *Scope) RemoveContainer(con *Container) error {
 
 	op.Debugf("Container %s removed from the scope %s(%s)", con.id, s.name, s.id)
 
+	return nil
+}
+
+func (s *Scope) UpdateContainer(con *Container, name string) error {
+	s.Lock()
+	defer s.Unlock()
+
+	if con == nil {
+		return fmt.Errorf("container is nil")
+	}
+
+	op := trace.NewOperation(context.Background(), "Updating container name in the scope")
+	c, ok := s.containers[con.id]
+	if !ok || c != con {
+		op.Debugf("Container %s not found in the scope %s(%s)", con.id, s.name, s.id)
+		return fmt.Errorf("container is not found")
+	}
+	c.name = name
+	s.containers[con.id] = c
 	return nil
 }
 

--- a/tests/test-cases/Group0-Bugs/7137.robot
+++ b/tests/test-cases/Group0-Bugs/7137.robot
@@ -47,9 +47,9 @@ Check for die events when forcing update via state refresh
     Should Contain  ${events}  die
     Should Not Contain  ${events}  stop
 
-    # network endpoints should have been unbound regardless of which state update was hit (inline triggered by inspect or event based from vsphere)
+    # due to issue 8405 7128 and 8052, the network will not be unbound from containers besides the container is deleted.
     ${rc}  ${bridge}=  Run And Return Rc And Output  docker %{VCH-PARAMS} network inspect bridge
     Should Be Equal As Integers  ${rc}  0
-    Should Not Contain  ${bridge}  ${id}
+    Should Contain  ${bridge}  ${id}
 
 

--- a/tests/test-cases/Group1-Docker-Commands/1-05-Docker-Start.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-05-Docker-Start.robot
@@ -114,11 +114,10 @@ Start a container with removed network
     Should Be Equal As Integers  ${rc}  0
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} stop ${container}
     Should Be Equal As Integers  ${rc}  0
+    # due to issue 8405 7128 and 8052, the network will not be unbound from containers besides the container is deleted.
     ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} network rm test-network
-    Should Be Equal As Integers  ${rc}  0
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} start ${container}
     Should Be Equal As Integers  ${rc}  1
-    Should Contain  ${output}  network test-network not found
+    Should Contain  ${output}  test-network has active endpoints
 
 Simple start with attach
     Run And Return Rc And Output  docker %{VCH-PARAMS} pull ${busybox}

--- a/tests/test-cases/Group1-Docker-Commands/1-07-Docker-Stop.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-07-Docker-Stop.robot
@@ -167,3 +167,13 @@ Stop a container with Docker 1.13 CLI
     Should Be Equal As Integers  ${rc}  0
     ${rc}  ${output}=  Run And Return Rc And Output  docker1.13 %{VCH-PARAMS} stop ${container}
     Should Be Equal As Integers  ${rc}  0
+
+Inspect the bridge network including the stopped container
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -d --name test ${busybox} top
+    Should Be Equal As Integers  ${rc}  0
+    ${ip}=  Get Container IP  %{VCH-PARAMS}  test  bridge
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} stop test
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} network inspect -f '{{.Containers}}' bridge
+    Should Be Equal As Integers  ${rc}  0
+    Should Contain  ${output}  ${ip}

--- a/tests/test-cases/Group1-Docker-Commands/1-36-Docker-Rename.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-36-Docker-Rename.robot
@@ -124,15 +124,15 @@ Name resolution for a running container after renaming it
     ${status}=  Get State Of Github Issue  4375
     Run Keyword If  '${status}' == 'closed'  Fail  Test 1-35-Docker-Rename needs to be updated now that #4375 is closed
 
-    # ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -dit --name cont9-name1 busybox
-    # Should Be Equal As Integers  ${rc}  0
-    # Should Not Contain  ${output}  Error
-    # ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} rename cont9-name1 cont9-name2
-    # Should Be Equal As Integers  ${rc}  0
-    # Should Not Contain  ${output}  Error
-    # ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run --link cont9-name2:cont9alias busybox ping -c2 cont9alias
-    # Should Be Equal As Integers  ${rc}  0
-    # Should Contain  ${output}  2 packets transmitted, 2 packets received
-    # ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run busybox ping -c2 cont9-name2
-    # Should Be Equal As Integers  ${rc}  0
-    # Should Contain  ${output}  2 packets transmitted, 2 packets received
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -dit --name cont9-name1 busybox
+    Should Be Equal As Integers  ${rc}  0
+    Should Not Contain  ${output}  Error
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} rename cont9-name1 cont9-name2
+    Should Be Equal As Integers  ${rc}  0
+    Should Not Contain  ${output}  Error
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run --link cont9-name2:cont9alias busybox ping -c2 cont9alias
+    Should Be Equal As Integers  ${rc}  0
+    Should Contain  ${output}  2 packets transmitted, 2 packets received
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run busybox ping -c2 cont9-name2
+    Should Be Equal As Integers  ${rc}  0
+    Should Contain  ${output}  2 packets transmitted, 2 packets received


### PR DESCRIPTION
If the container VM is operated from vSphere client, in some cases
VIC will allocate duplicate IP address for cVMs. For example: when
the first cVM is poweroff from VC, the assigned IP address will be
released, but the guestinfo is still saving the assigned IP address
for VC HA or migration functionality; the second cVM will be assigned
the first cVM ip address, when the first cVM is powered on from VC,
these two cVMs are using same IP address.

Another related error scenario is the docker network inspect will not
show container endpoint if cVM is powered on from vSphere.

[full ci]
Fixes #8405 #7128 #8052 
