### PR TITLE
Ignore FileNotFound error during VCH deletion

### DIFF
--- a/lib/install/management/store_files.go
+++ b/lib/install/management/store_files.go
@@ -173,7 +173,7 @@ func (d *Dispatcher) deleteFilesIteratively(m *object.DatastoreFileManager, ds *
 		}
 
 		for _, path := range res {
-			if err = d.deleteVMFSFiles(m, ds, path); err != nil {
+			if err = d.deleteVMFSFiles(m, ds, path); err != nil && !types.IsFileNotFound(err) {
 				return err
 			}
 		}


### PR DESCRIPTION
During VCH deletion, there is some delay between vc file browser
returned data and the actual datastore files structure when a
couple of datastore files deletion are invoked to cope with timeout.
Therefore, the second deletion may meet FileNotFound error which should
be ignored.