### PR TITLE
Add VCH uuid directory during image files browsing

### DIFF
--- a/lib/install/management/delete.go
+++ b/lib/install/management/delete.go
@@ -86,7 +86,7 @@ func (d *Dispatcher) DeleteVCH(conf *config.VirtualContainerHostConfigSpec, cont
 		}
 	}
 
-	if err = d.deleteImages(conf); err != nil {
+	if err = d.deleteImages(conf, vmm); err != nil {
 		errs = append(errs, err.Error())
 	}
 

--- a/lib/install/management/store_files.go
+++ b/lib/install/management/store_files.go
@@ -29,6 +29,7 @@ import (
 	"github.com/vmware/vic/pkg/errors"
 	"github.com/vmware/vic/pkg/trace"
 	"github.com/vmware/vic/pkg/vsphere/datastore"
+	"github.com/vmware/vic/pkg/vsphere/vm"
 )
 
 const (
@@ -36,10 +37,14 @@ const (
 	dsScheme   = "ds"
 )
 
-func (d *Dispatcher) deleteImages(conf *config.VirtualContainerHostConfigSpec) error {
+func (d *Dispatcher) deleteImages(conf *config.VirtualContainerHostConfigSpec, vch *vm.VirtualMachine) error {
 	defer trace.End(trace.Begin("", d.op))
 	var errs []string
 
+	uuid, err := vch.UUID(d.op)
+	if err != nil {
+		return err
+	}
 	d.op.Info("Removing image stores")
 
 	for _, imageDir := range conf.ImageStores {
@@ -58,7 +63,7 @@ func (d *Dispatcher) deleteImages(conf *config.VirtualContainerHostConfigSpec) e
 		}
 
 		// delete images subfolder
-		imagePath := path.Join(imageDir.Path, constants.StorageParentDir)
+		imagePath := path.Join(imageDir.Path, constants.StorageParentDir, uuid)
 		if _, err = d.deleteDatastoreFiles(imageDSes[0], imagePath, true); err != nil {
 			errs = append(errs, err.Error())
 		}
@@ -83,7 +88,7 @@ func (d *Dispatcher) deleteImages(conf *config.VirtualContainerHostConfigSpec) e
 			continue
 		}
 
-		if len(children) == 0 {
+		if len(children) == 0 || len(children) == 1 { // when image store path is given, we need to delete VIC dir too when it is empty.
 			d.op.Debugf("Removing empty image store parent directory [%s] %s", imageDir.Host, imageDir.Path)
 			if _, err = d.deleteDatastoreFiles(imageDSes[0], imageDir.Path, true); err != nil {
 				errs = append(errs, err.Error())
@@ -103,7 +108,7 @@ func (d *Dispatcher) deleteImages(conf *config.VirtualContainerHostConfigSpec) e
 func (d *Dispatcher) deleteParent(ds *object.Datastore, root string) (bool, error) {
 	defer trace.End(trace.Begin("", d.op))
 
-	// alway forcing delete images
+	// always forcing delete images
 	return d.deleteDatastoreFiles(ds, root, true)
 }
 

--- a/lib/install/management/store_files.go
+++ b/lib/install/management/store_files.go
@@ -88,7 +88,7 @@ func (d *Dispatcher) deleteImages(conf *config.VirtualContainerHostConfigSpec, v
 			continue
 		}
 
-		if len(children) == 0 || len(children) == 1 { // when image store path is given, we need to delete VIC dir too when it is empty.
+		if len(children) == 1 { // when image store path is given, we need to delete VIC dir too when it is empty.
 			d.op.Debugf("Removing empty image store parent directory [%s] %s", imageDir.Host, imageDir.Path)
 			if _, err = d.deleteDatastoreFiles(imageDSes[0], imageDir.Path, true); err != nil {
 				errs = append(errs, err.Error())

--- a/lib/install/validate/validator.go
+++ b/lib/install/validate/validator.go
@@ -352,7 +352,7 @@ func (v *Validator) ValidateStorageQuota(ctx context.Context, quotaGB int, conf 
 		if err != nil {
 			return 0, err
 		}
-		imageStorageUsage, err = v.getImageStorageUsage(op, conf)
+		imageStorageUsage, err = v.getImageStorageUsage(op, conf, vch)
 		if err != nil {
 			return 0, err
 		}
@@ -409,11 +409,16 @@ func (v *Validator) getVMStorageUsage(op trace.Operation, vch *vm.VirtualMachine
 	return total, nil
 }
 
-func (v *Validator) getImageStorageUsage(op trace.Operation, conf *config.VirtualContainerHostConfigSpec) (int64, error) {
+func (v *Validator) getImageStorageUsage(op trace.Operation, conf *config.VirtualContainerHostConfigSpec, vch *vm.VirtualMachine) (int64, error) {
+	uuid, err := vch.UUID(op)
+	if err != nil {
+		return 0, err
+	}
+
 	imageURL := conf.ImageStores[0]
 	// get a ds helper for this ds url
 	dsHelper, err := datastore.NewHelper(trace.NewOperation(op, "datastore helper creation"), v.session,
-		v.session.Datastore, fmt.Sprintf("%s/%s", imageURL.Path, constants.StorageParentDir))
+		v.session.Datastore, fmt.Sprintf("%s/%s/%s", imageURL.Path, constants.StorageParentDir, uuid))
 	if err != nil {
 		return 0, err
 	}


### PR DESCRIPTION
When multiple VCHs share the same image datastore path, we need to
use VCH uuid directory to distinguish images related to a specific
VCH.

[specific ci=Group6-VIC-Machine.6-04-Create-Basic]
Fix #8455 