### PR TITLE
Stop port-layer-server when volume-store fails

### DIFF
--- a/lib/apiservers/portlayer/restapi/handlers/storage_handlers.go
+++ b/lib/apiservers/portlayer/restapi/handlers/storage_handlers.go
@@ -145,9 +145,10 @@ func (h *StorageHandlersImpl) configureVolumeStores(op trace.Operation, handlerC
 			op.Error(err)
 		}
 
-		// if an error has been logged skip volume store cache addition
+		// if an error has been logged, stop starting port-layer which would cause port-layer-server to restart continually
 		if err != nil {
-			continue
+			op.Errorf("%s:%s volume store error %s", dsurl.String(), name, err)
+			os.Exit(1)
 		}
 
 		op.Infof("Adding volume store %s (%s)", name, dsurl.String())


### PR DESCRIPTION
Issue:
   - nfs volume store disconnected
   - restart vch, the vch would ignore failed nfs volume store
   - use nfs volume, the vch would regard nfs volume as a new one
Solution: stop port-layer-server when encountering volume store error
   - first create, stop
   - restart vch, stop
   - vic-machine configure: in this case, we follow the original designation
not checking nfs volume. When being used, it would cause an error.

Port-layer-server is designed to always restart, the portlayer log would show.

Fixes #7621 
