### PR TITLE
Remove unnecessary logrotate configurations

### DIFF
--- a/cmd/vic-init/main_linux.go
+++ b/cmd/vic-init/main_linux.go
@@ -125,10 +125,10 @@ func main() {
 	logrotate, err := logmgr.NewLogManager(time.Second * 300)
 	const maxLogSizeBytes = 20 * 1024 * 1024
 	if err == nil {
-		logrotate.AddLogRotate("/var/log/vic/port-layer.log", logmgr.Daily, maxLogSizeBytes, 2, true)
-		logrotate.AddLogRotate("/var/log/vic/init.log", logmgr.Daily, maxLogSizeBytes, 2, true)
-		logrotate.AddLogRotate("/var/log/vic/docker-personality.log", logmgr.Daily, maxLogSizeBytes, 2, true)
-		logrotate.AddLogRotate("/var/log/vic/vicadmin.log", logmgr.Daily, maxLogSizeBytes, 2, true)
+		logrotate.AddLogRotate("/var/log/vic/port-layer.log", maxLogSizeBytes, 2, true)
+		logrotate.AddLogRotate("/var/log/vic/init.log", maxLogSizeBytes, 2, true)
+		logrotate.AddLogRotate("/var/log/vic/docker-personality.log", maxLogSizeBytes, 2, true)
+		logrotate.AddLogRotate("/var/log/vic/vicadmin.log", maxLogSizeBytes, 2, true)
 		tthr.Register("logrotate", logrotate)
 	} else {
 		log.Error(err)

--- a/pkg/logmgr/logmgr.go
+++ b/pkg/logmgr/logmgr.go
@@ -30,9 +30,6 @@ import (
 	"github.com/vmware/vic/pkg/trace"
 )
 
-// RotateInterval defines a type for a log rotate frequency.
-type RotateInterval uint32
-
 // LogRotateBinary points to a logrotate path in the system. For testing purposes it should be overwritten to be empty.
 var LogRotateBinary = "/usr/sbin/logrotate"
 

--- a/pkg/logmgr/logmgr.go
+++ b/pkg/logmgr/logmgr.go
@@ -36,19 +36,7 @@ type RotateInterval uint32
 // LogRotateBinary points to a logrotate path in the system. For testing purposes it should be overwritten to be empty.
 var LogRotateBinary = "/usr/sbin/logrotate"
 
-const (
-	// Daily to trim logs daily.
-	Daily RotateInterval = iota
-	// Hourly to trim logs hourly.
-	Hourly
-	// Weekly to trim logs weekly.
-	Weekly
-	// Monthly to trim logs monthly.
-	Monthly
-)
-
 type logRotateConfig struct {
-	rotateInterval  RotateInterval
 	logFilePath     string
 	logFileName     string
 	maxLogSizeBytes int64
@@ -63,26 +51,9 @@ func (lrc *logRotateConfig) ConfigFileContent() string {
 		b = append(b, "compress")
 	}
 
-	switch lrc.rotateInterval {
-	case Hourly:
-		b = append(b, string("hourly"))
-	case Daily:
-		b = append(b, string("daily"))
-	case Weekly:
-		b = append(b, string("weekly"))
-	case Monthly:
-		fallthrough
-	default:
-		b = append(b, string("monthly"))
-	}
-
 	b = append(b, fmt.Sprintf("rotate %d", lrc.maxLogFiles))
 	if lrc.maxLogSizeBytes > 0 {
 		b = append(b, fmt.Sprintf("size %d", lrc.maxLogSizeBytes))
-	}
-
-	if lrc.maxLogSizeBytes > 2 {
-		b = append(b, fmt.Sprintf("minsize %d", lrc.maxLogSizeBytes-1))
 	}
 
 	// VIC doesn't support HUP yet, thus we are using logrotate copytruncate option that
@@ -140,9 +111,8 @@ func NewLogManager(runInterval time.Duration) (*LogManager, error) {
 }
 
 // AddLogRotate adds a log to rotate.
-func (lm *LogManager) AddLogRotate(logFilePath string, ri RotateInterval, maxSize, maxLogFiles int64, compress bool) {
+func (lm *LogManager) AddLogRotate(logFilePath string, maxSize, maxLogFiles int64, compress bool) {
 	lm.logFiles = append(lm.logFiles, &logRotateConfig{
-		rotateInterval:  ri,
 		logFilePath:     logFilePath,
 		logFileName:     filepath.Base(logFilePath),
 		maxLogSizeBytes: maxSize,

--- a/pkg/logmgr/logmgr_test.go
+++ b/pkg/logmgr/logmgr_test.go
@@ -37,27 +37,23 @@ func TestContentIsGeneratedAndSaved(t *testing.T) {
 	}
 	expectedConfig := `/var/log/test.log {
     compress
-    hourly
     rotate 3
     size 10000
-    minsize 9999
     copytruncate
     dateext
     dateformat -%Y%m%d-%s
 }
 
 /var/log/test1.log {
-    daily
     rotate 2
     size 20000
-    minsize 19999
     copytruncate
     dateext
     dateformat -%Y%m%d-%s
 }
 `
-	m.AddLogRotate("/var/log/test.log", Hourly, 10000, 3, true)
-	m.AddLogRotate("/var/log/test1.log", Daily, 20000, 2, false)
+	m.AddLogRotate("/var/log/test.log", 10000, 3, true)
+	m.AddLogRotate("/var/log/test1.log", 20000, 2, false)
 	actualConfig := m.buildConfig()
 	assert.Equal(t, expectedConfig, actualConfig)
 
@@ -86,8 +82,8 @@ func TestStartAndStop(t *testing.T) {
 	if !assert.Nil(t, e) {
 		return
 	}
-	m.AddLogRotate("/var/log/test.log", Hourly, 10000, 3, true)
-	m.AddLogRotate("/var/log/test1.log", Daily, 20000, 2, false)
+	m.AddLogRotate("/var/log/test.log", 10000, 3, true)
+	m.AddLogRotate("/var/log/test1.log", 20000, 2, false)
 
 	go func() {
 		assert.Nil(t, m.Start(nil))


### PR DESCRIPTION
rotated log files and file size are enough, given
we invoke logrotate in the codes every 5 minutes.

Fixes #8399 