### PR TITLE
Fix IPAM calculation error

### DIFF
--- a/lib/apiservers/service/restapi/handlers/vch_create.go
+++ b/lib/apiservers/service/restapi/handlers/vch_create.go
@@ -183,7 +183,11 @@ func (h *vchCreate) buildCreate(op trace.Operation, d *data.Data, finder client.
 				}
 				c.BridgeNetworkName = path
 				c.BridgeIPRange = decode.FromCIDR(&vch.Network.Bridge.IPRange)
-				c.BridgeNetworkWidth = strconv.Itoa(int(vch.Network.Bridge.NetworkWidth))
+				if vch.Network.Bridge.NetworkWidth == 0 {
+					c.BridgeNetworkWidth = strconv.Itoa(constants.DefaultBridgeNetworkWidth)
+				} else {
+					c.BridgeNetworkWidth = strconv.Itoa(int(vch.Network.Bridge.NetworkWidth))
+				}
 
 				if err := c.ProcessBridgeNetwork(); err != nil {
 					return nil, errors.WrapError(http.StatusBadRequest, err)

--- a/lib/apiservers/service/swagger.json
+++ b/lib/apiservers/service/swagger.json
@@ -690,7 +690,7 @@
               "type": "object",
               "properties": {
                 "ip_range": { "$ref": "#/definitions/CIDR" },
-                "network_width": { "type": "integer", "minimum": 8, "maximum": 30, "default": 16},
+                "network_width": { "type": "integer", "minimum": 1, "maximum": 30, "default": 16},
                 "port_group": { "$ref": "#/definitions/Managed_Object" }
               }
             },

--- a/lib/constants/constants.go
+++ b/lib/constants/constants.go
@@ -38,6 +38,8 @@ const (
 	ExternalScopeType = "external"
 	// DefaultBridgeRange is the default pool for bridge networks
 	DefaultBridgeRange = "172.16.0.0/12"
+	// DefaultBridgeNetworkWidth is the default allocation prefix for bridge networks
+	DefaultBridgeNetworkWidth = 16
 	// PortsOpenNetwork indicates no port blocking
 	PortsOpenNetwork = "0-65535"
 	// Constants for assemble the VM display name on vSphere

--- a/lib/portlayer/network/ipam.go
+++ b/lib/portlayer/network/ipam.go
@@ -311,7 +311,9 @@ func (s *AddressSpace) ReserveIP4Range(firstIP net.IP, lastIP net.IP) (*AddressS
 			firstIP.String(), lastIP.String(), s.Pool.FirstIP, s.Pool.LastIP)
 	}
 
-	log.Errorf(err.Error())
+	// For some cases, it is not an error if the IP range cannot be reserved in an existing pool
+	// For example, --container-network-ip-range cnr:192.168.10.10-192.168.10.100 --container-network-gateway cnr:192.168.10.1/24
+	log.Infof(err.Error())
 
 	return nil, err
 }

--- a/lib/portlayer/network/scope.go
+++ b/lib/portlayer/network/scope.go
@@ -136,7 +136,6 @@ func (s *Scope) pools() []*ip.Range {
 			pools[i] = r
 			continue
 		}
-
 		pools[i] = sp.Pool
 	}
 

--- a/pkg/ip/ip.go
+++ b/pkg/ip/ip.go
@@ -89,6 +89,9 @@ func (i *Range) Network() *net.IPNet {
 		if l != last[j] {
 			return nil
 		}
+		if f != (f & mask[j]) {
+			return nil
+		}
 	}
 
 	return &net.IPNet{IP: first, Mask: mask}

--- a/pkg/ip/ip_test.go
+++ b/pkg/ip/ip_test.go
@@ -137,7 +137,7 @@ func TestRangeNetwork(t *testing.T) {
 		r *Range
 		n *net.IPNet
 	}{
-		{ParseRange("10.10.10.10/24"), &net.IPNet{IP: net.ParseIP("10.10.10.10"), Mask: net.CIDRMask(24, 32)}},
+		{ParseRange("10.10.10.10/24"), nil},
 		{ParseRange("10.10.10.10-10.10.14.11"), nil},
 		{ParseRange("10.10.10.10-10.10.10.11"), &net.IPNet{IP: net.ParseIP("10.10.10.10"), Mask: net.CIDRMask(31, 32)}},
 	}
@@ -165,13 +165,13 @@ func TestRangeNetworkStringer(t *testing.T) {
 		input  string
 		result string
 	}{
-		{"10.10.10.10/24", symmetric},
+		{"10.10.10.10/24", "10.10.10.10-10.10.10.255"},
 		{"10.10.10.10-10.10.14.11", symmetric},
 		{"10.10.10.10-10.10.10.11", "10.10.10.10/31"},
 		{"10.10.10.128-10.10.10.129", "10.10.10.128/31"},
 		// test the boundaries of full subnets where the range is not the full subnet
-		{"10.10.10.125-10.10.10.127", "10.10.10.125/30"},
-		{"10.10.10.5-10.10.10.127", "10.10.10.5/25"},
+		{"10.10.10.125-10.10.10.127", symmetric},
+		{"10.10.10.5-10.10.10.127", symmetric},
 		{"10.10.10.0-10.10.10.127", "10.10.10.0/25"},
 		{"10.10.10.128-10.10.10.254", symmetric},
 		{"10.10.10.252-10.10.10.255", "10.10.10.252/30"},


### PR DESCRIPTION
When we specified the ip range for container network, and the network inspect
always show the wrong cidr using docker cmd to get information.

Fixes #6516
