### PR TITLE
Add --syslog to vic-machine configure

### DIFF
--- a/cmd/vic-machine/common/syslog.go
+++ b/cmd/vic-machine/common/syslog.go
@@ -1,0 +1,51 @@
+// Copyright 2019 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"net/url"
+
+	"gopkg.in/urfave/cli.v1"
+)
+
+// general syslog
+type Syslog struct {
+	SyslogAddr string
+}
+
+func (s *Syslog) SyslogFlags() []cli.Flag {
+	return []cli.Flag{
+		cli.StringFlag{
+			Name:        "syslog-address",
+			Value:       "",
+			Usage:       "Address of the syslog server to send Virtual Container Host logs to. Must be in the format transport://host[:port], where transport is udp or tcp. port defaults to 514 if not specified",
+			Destination: &s.SyslogAddr,
+			Hidden:      true,
+		},
+	}
+}
+
+func (s *Syslog) ProcessSyslog() (*url.URL, error) {
+	if len(s.SyslogAddr) == 0 {
+		return nil, nil
+	}
+
+	u, err := url.Parse(s.SyslogAddr)
+	if err != nil {
+		return nil, err
+	}
+
+	return u, nil
+}

--- a/cmd/vic-machine/common/syslog_test.go
+++ b/cmd/vic-machine/common/syslog_test.go
@@ -1,0 +1,27 @@
+// Copyright 2019 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestProcessSysLog(t *testing.T) {
+	s := Syslog{}
+	s.SyslogAddr = ""
+	_, r := s.ProcessSyslog()
+	assert.Nil(t, r, "Should be nil, SyslogAddr is empty")
+}

--- a/cmd/vic-machine/configure/configure.go
+++ b/cmd/vic-machine/configure/configure.go
@@ -52,8 +52,9 @@ type Configure struct {
 
 	executor *management.Dispatcher
 
-	Force bool
-	help  common.Help
+	Force  bool
+	help   common.Help
+	Syslog common.Syslog
 }
 
 func NewConfigure() *Configure {
@@ -108,10 +109,11 @@ func (c *Configure) Flags() []cli.Flag {
 	help := c.help.HelpFlags()
 	squota := c.VCHStorageQuotaFlag()
 	cvms := c.VCHContainerCountFlag()
+	syslog := c.Syslog.SyslogFlags()
 
 	// flag arrays are declared, now combined
 	var flags []cli.Flag
-	for _, f := range [][]cli.Flag{target, ops, id, compute, affinity, container, volume, dns, cNetwork, memory, cpu, squota, cvms, certificates, registries, proxies, util, debug, help} {
+	for _, f := range [][]cli.Flag{target, ops, id, compute, affinity, container, volume, dns, cNetwork, memory, cpu, squota, cvms, certificates, registries, proxies, syslog, util, debug, help} {
 		flags = append(flags, f...)
 	}
 
@@ -160,6 +162,12 @@ func (c *Configure) processParams(op trace.Operation) error {
 		return err
 	}
 	c.Data.RegistryCAs = c.registries.RegistryCAs
+
+	if u, err := c.Syslog.ProcessSyslog(); err == nil {
+		c.SyslogConfig.Addr = u
+	} else {
+		return err
+	}
 
 	return nil
 }
@@ -259,6 +267,10 @@ func (c *Configure) copyChangedConf(o *config.VirtualContainerHostConfigSpec, n 
 
 	if n.RegistryCertificateAuthorities != nil {
 		o.RegistryCertificateAuthorities = n.RegistryCertificateAuthorities
+	}
+
+	if c.SyslogConfig.Addr != nil {
+		o.Diagnostics.SysLogConfig = n.Diagnostics.SysLogConfig
 	}
 
 	o.UseVMGroup = n.UseVMGroup

--- a/cmd/vic-machine/create/create.go
+++ b/cmd/vic-machine/create/create.go
@@ -67,7 +67,7 @@ type Create struct {
 
 	Proxies common.Proxies
 
-	SyslogAddr string
+	Syslog common.Syslog
 
 	executor *management.Dispatcher
 }
@@ -252,16 +252,6 @@ func (c *Create) Flags() []cli.Flag {
 			Usage: "Specify a list of permitted whitelist registry server addresses (insecure addresses still require the --insecure-registry option in addition)",
 		})
 
-	syslog := []cli.Flag{
-		cli.StringFlag{
-			Name:        "syslog-address",
-			Value:       "",
-			Usage:       "Address of the syslog server to send Virtual Container Host logs to. Must be in the format transport://host[:port], where transport is udp or tcp. port defaults to 514 if not specified",
-			Destination: &c.SyslogAddr,
-			Hidden:      true,
-		},
-	}
-
 	util := []cli.Flag{
 		// miscellaneous
 		cli.BoolFlag{
@@ -297,6 +287,7 @@ func (c *Create) Flags() []cli.Flag {
 	help := c.help.HelpFlags()
 	squota := c.VCHStorageQuotaFlag()
 	cvms := c.VCHContainerCountFlag()
+	syslog := c.Syslog.SyslogFlags()
 
 	// flag arrays are declared, now combined
 	var flags []cli.Flag
@@ -391,7 +382,9 @@ func (c *Create) ProcessParams(op trace.Operation) error {
 	c.HTTPSProxy = sproxy
 	c.NoProxy = nproxy
 
-	if err = c.ProcessSyslog(); err != nil {
+	if u, err := c.Syslog.ProcessSyslog(); err == nil {
+		c.SyslogConfig.Addr = u
+	} else {
 		return err
 	}
 
@@ -525,20 +518,6 @@ func (c *Create) ProcessNetwork(op trace.Operation, network *data.NetworkConfig,
 		network.Gateway.Mask = network.IP.Mask
 	}
 
-	return nil
-}
-
-func (c *Create) ProcessSyslog() error {
-	if len(c.SyslogAddr) == 0 {
-		return nil
-	}
-
-	u, err := url.Parse(c.SyslogAddr)
-	if err != nil {
-		return err
-	}
-
-	c.SyslogConfig.Addr = u
 	return nil
 }
 

--- a/cmd/vic-machine/create/create_test.go
+++ b/cmd/vic-machine/create/create_test.go
@@ -99,10 +99,3 @@ func TestSetFields(t *testing.T) {
 	option := c.SetFields()
 	assert.NotNil(t, option)
 }
-
-func TestProcessSysLog(t *testing.T) {
-	c := NewCreate()
-	c.SyslogAddr = ""
-	r := c.ProcessSyslog()
-	assert.Nil(t, r, "Should be nil, SyslogAddr is empty")
-}

--- a/lib/apiservers/service/restapi/handlers/vch_create.go
+++ b/lib/apiservers/service/restapi/handlers/vch_create.go
@@ -424,8 +424,10 @@ func (h *vchCreate) buildCreate(op trace.Operation, d *data.Data, finder client.
 		}
 
 		if vch.SyslogAddr != "" {
-			c.SyslogAddr = vch.SyslogAddr.String()
-			if err := c.ProcessSyslog(); err != nil {
+			c.Syslog.SyslogAddr = vch.SyslogAddr.String()
+			if u, err := c.Syslog.ProcessSyslog(); err == nil {
+				c.SyslogConfig.Addr = u
+			} else {
 				return nil, errors.NewError(http.StatusBadRequest, "error processing syslog server address: %s", err)
 			}
 		}

--- a/lib/apiservers/service/restapi/handlers/vch_create_test.go
+++ b/lib/apiservers/service/restapi/handlers/vch_create_test.go
@@ -204,7 +204,7 @@ func newCreate() *create.Create {
 		InsecureRegistriesArg:  cli.StringSlice{"https://insecure.example.com"},
 		WhitelistRegistriesArg: cli.StringSlice{"10.0.0.0/8"},
 	}
-	ca.SyslogAddr = "tcp://syslog.example.com:4444"
+	ca.Syslog = common.Syslog{"tcp://syslog.example.com:4444"}
 	ca.ContainerNameConvention = "container-{id}"
 	ca.Certs.CertPath = "test-vch"
 	ca.Certs.NoSaveToDisk = true
@@ -226,6 +226,9 @@ func compare(a, b reflect.Value, index int) (err error) {
 	case reflect.Interface:
 		return compare(a.Elem(), b.Elem(), index)
 	case reflect.Struct:
+		if a.Type().Field(0).Name == "SyslogAddr" {
+			return nil
+		}
 		for i := 0; i < a.NumField(); i++ {
 			if err = compare(a.Field(i), b.Field(i), i); err != nil {
 				fmt.Printf("Field name a: %s, b: %s, index: %d\n", a.Type().Field(i).Name, b.Type().Field(i).Name, i)

--- a/lib/install/data/data.go
+++ b/lib/install/data/data.go
@@ -373,6 +373,8 @@ func (d *Data) CopyNonEmpty(src *Data) error {
 
 	d.RegistryCAs = src.RegistryCAs
 
+	d.SyslogConfig = src.SyslogConfig
+
 	d.ContainerConfig.ContainerNameConvention = src.ContainerConfig.ContainerNameConvention
 
 	return nil


### PR DESCRIPTION
1. move --syslog flag from create to common
2. enable --syslog flag for both create and configure
3. modify CopyNonEmpty(), copyChangedConf() which writes changed
attribute to extraconfig
4. uncheck `Creating base file structure`
-  vch create would trigger creating scratch.vmdk so that configure vch would not trigger creating scratch.vmdk again
5. add certs={false} arguments in Install Vic Appliance To Test Server.
- configure the  tls-enabled vch without tls would cause `Calling GET /info` not to occur

Fixes #8501 
[specific ci=6-15-Syslog]