### PR TITLE
VCH upgrade and configure different snapshot names

### DIFF
--- a/cmd/vic-machine/configure/configure.go
+++ b/cmd/vic-machine/configure/configure.go
@@ -559,7 +559,7 @@ func (c *Configure) Run(clic *cli.Context) (err error) {
 	}()
 
 	if !c.Data.Rollback {
-		err = executor.Configure(vchConfig, vConfig)
+		err = executor.Configure(vchConfig, vConfig, false)
 	} else {
 		executor.Action = management.ActionRollback
 		err = executor.Rollback(vchConfig, vConfig)

--- a/cmd/vic-machine/upgrade/upgrade.go
+++ b/cmd/vic-machine/upgrade/upgrade.go
@@ -224,7 +224,7 @@ func (u *Upgrade) Run(clic *cli.Context) (err error) {
 	}
 
 	if !u.Data.Rollback {
-		err = executor.Configure(vchConfig, vConfig)
+		err = executor.Configure(vchConfig, vConfig, true)
 	} else {
 		err = executor.Rollback(vchConfig, vConfig)
 	}

--- a/lib/install/management/delete_test.go
+++ b/lib/install/management/delete_test.go
@@ -113,7 +113,7 @@ func testUpgrade(op trace.Operation, computePath string, name string, v *validat
 
 		t.Errorf("Failed to get vch configuration: %s", err)
 	}
-	if err := d.Configure(conf, settings); err != nil {
+	if err := d.Configure(conf, settings, true); err != nil {
 		t.Errorf("Failed to upgrade: %s", err)
 	}
 }

--- a/tests/test-cases/Group11-Upgrade/11-06-Upgrade-StorageQuota.robot
+++ b/tests/test-cases/Group11-Upgrade/11-06-Upgrade-StorageQuota.robot
@@ -231,6 +231,12 @@ Configure VCH With Storage Quota
     Log  ${output}
     Should Contain  ${output}  Completed successfully
 
+Configure Rollback
+    [Arguments]  ${vchName}
+    ${output}=  Run  bin/vic-machine-linux configure --name=${vchName} --target=%{TEST_URL}%{TEST_DATACENTER} --thumbprint=%{TEST_THUMBPRINT} --user=%{TEST_USERNAME} --password=%{TEST_PASSWORD} --timeout %{TEST_TIMEOUT} --rollback
+    Log  ${output}
+    Should Contain  ${output}  Completed successfully
+
 Get Docker Info Exec Time
     [Arguments]  ${info}
     ${execTimeline}=  Get Lines Containing String  ${info}  elapsed
@@ -333,14 +339,11 @@ Test Storage Quota
     Check After Upgrade  ${output}  2  2  0  0  2  22  24
     Should Not Contain  ${output}  VCH storage limit:
 
-    ${status}=  Get State Of Github Issue  8437
-    Run Keyword If  '${status}' == 'closed'  Fail  Test 11-06-Upgrade-StorageQuota.robot needs to be updated now that Issue #8437 has been resolved
-
- #   Reload VCH Related Environment Variables  ${vchName1}  ${vchIP1}  ${vchParams1}  ${vchAdmin1}
- #   Rollback
- #   Check Original Version
- #   Upgrade with ID
- #   ${output}=  Run Docker Info Cmd  ${vchParams1}
- #   ${output}=  Run Docker Info Cmd  ${vchParams1}
- #   Check After Upgrade  ${output}  4  2  0  2  2  36  40
-
+    Reload VCH Related Environment Variables  ${vchName1}  ${vchIP1}  ${vchParams1}  ${vchAdmin1}
+    Configure Rollback  ${vchName1}
+    Rollback
+    Check Original Version
+    Upgrade with ID
+    ${output}=  Run Docker Info Cmd  ${vchParams1}
+    ${output}=  Run Docker Info Cmd  ${vchParams1}
+    Check After Upgrade  ${output}  4  2  0  2  2  36  40


### PR DESCRIPTION
Give different names for upgrade and configure snapshots, so we can
rollback to old version even we do some configurations after upgrade.
The old upgrade snapshot needs to be kept when we configure after
upgrade.

Fixes #8437 
[specific ci=Group11-Upgrade.11-06-Upgrade-StorageQuota]