### PR TITLE
fix window \r\n in cert file

### DIFF
--- a/lib/apiservers/service/swagger.json
+++ b/lib/apiservers/service/swagger.json
@@ -633,7 +633,7 @@
     },
     "PEM": {
       "type": "string",
-      "pattern": "^.*-----BEGIN [A-Z ]+-----\\s+[A-Za-z0-9+\/\\s]+={0,2}\\s-----END [A-Z ]+-----\\s*$"
+      "pattern": "^.*-----BEGIN [A-Z ]+-----\\s+[A-Za-z0-9+\/\\s]+={0,2}\\s+-----END [A-Z ]+-----\\s*$"
     },
     "X509_Data": {
       "type": "object",


### PR DESCRIPTION
if user use windows to generate server certificate. The line ending will be\r\n instead of \n in linux. We need to support \r\n in the swagger regex validation. 