### PR TITLE
Verify container label to show normally when called VCH containers API

### DIFF
--- a/tests/test-cases/Group1-Docker-Commands/1-06-Docker-Run.md
+++ b/tests/test-cases/Group1-Docker-Commands/1-06-Docker-Run.md
@@ -45,6 +45,7 @@ This test requires that a vSphere server is running and available
 32. Issue docker run run -it -d --name test_nolabel -p 9090:80 nginx:alpine
 33. Issue docker inspect test_nolabel -f "{{.Config.Labels}}"
 34. Issue docker image inspect nginx:alpine -f "{{.ContainerConfig.Labels}}"
+35. Issue curl -k -s https://VCH-IP:2376/containers/json --cert cert_path --key cert_key_path --cacert ca_cert_path
 
 # Expected Outcome:
 * Step 2 and 3 should result in success and print the dmesg of the container
@@ -76,7 +77,8 @@ docker: Error parsing reference: "fakeImage" is not a valid repository/tag.
 * Step 29 should result in all containers being removed as expected on exit
 * Step 31 only show setting label information
 * Step 33 not show any label information
-* Step 34 show origin docker image label information
+* Step 34 show original docker image label information
+* Step 35 should show correct container label information
 
 # Possible Problems:
 None

--- a/tests/test-cases/Group1-Docker-Commands/1-06-Docker-Run.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-06-Docker-Run.robot
@@ -274,6 +274,14 @@ Docker run with label
     Should Be Equal As Integers  ${rc}  0
     Should Contain  ${output}  maintainer
     Should Not Contain Any  ${output}  test1  test2
+
+    ${rc}  ${output}=  Run And Return Rc And Output  curl -k -s https://%{VCH-IP}:2376/containers/json --cert %{DOCKER_CERT_PATH}/cert.pem --key %{DOCKER_CERT_PATH}/key.pem --cacert %{DOCKER_CERT_PATH}/ca.pem | jq '.[].Labels' 
+    Log  ${output}
+    Should Be Equal As Integers  ${rc}  0
+    Should Contain  ${output}  test1
+    Should Contain  ${output}  test2
+    Should Contain  ${output}  null
+
     Stop All Containers
    
    


### PR DESCRIPTION
testing labels.
[specific ci=1-06-Docker-Run]