### PR TITLE
Avoid panic for invalid container network name

### DIFF
--- a/lib/install/validate/network.go
+++ b/lib/install/validate/network.go
@@ -393,6 +393,7 @@ func (v *Validator) network(op trace.Operation, input *data.Data, conf *config.V
 				v.suggestNetwork(op, "--container-network", true)
 				suggestedMapped = true
 			}
+			continue
 		}
 		mappedNet := &executor.ContainerNetwork{
 			Common: executor.Common{


### PR DESCRIPTION
Avoids a nil pointer dereference in vic-machine when an invalid or
ambiguous container network name is passed.

- [ ] There is an associated issue that is labelled
   - #8576 exists but is not labelled, unsure what labels are required
- [x] Code is up-to-date with the `master` branch
- [ ] You've successfully run `make test` locally
   - `make test` fails for me with "Unable to load configuration from guestinfo: not in a virtual world" in code that I haven't changed (github.com/vmware/vic/cmd/docker), even on `master`. I am unable to run `make test`.
- [x] There are new or updated unit tests validating the change

Fixes #8576