### PR TITLE
Fix exception when running docker-compose up again

### DIFF
--- a/lib/apiservers/engine/backends/network.go
+++ b/lib/apiservers/engine/backends/network.go
@@ -176,6 +176,9 @@ func (n *NetworkBackend) CreateNetwork(nc types.NetworkCreateRequest) (*types.Ne
 	}
 
 	// Marshal and encode the labels for transport and storage in the portlayer
+	if nc.Labels == nil {
+		nc.Labels = make(map[string]string, 0)
+	}
 	if labelsBytes, err := json.Marshal(nc.Labels); err == nil {
 		encodedLabels := base64.StdEncoding.EncodeToString(labelsBytes)
 		cfg.Annotations[convert.AnnotationKeyLabels] = encodedLabels


### PR DESCRIPTION
With traditional docker, the network created by docker-compose
contains labels property with empty object {}. But in VIC, labels
will be set to NULL. This error is only found when docker-compose
version is 2.0.

Fixes #6405
[specific ci=3-01-Docker-Compose]