### PR TITLE
Rename the nic name to management when management network is specified

### DIFF
--- a/lib/install/validate/network.go
+++ b/lib/install/validate/network.go
@@ -259,7 +259,7 @@ func (v *Validator) network(op trace.Operation, input *data.Data, conf *config.V
 	conf.AddNetwork(e)
 
 	// Management net - defaults to connect to the same portgroup as client
-	e, err = v.getEndpoint(op, conf, input.ManagementNetwork, "", config.ManagementNetworkName, false, input.DNS)
+	e, err = v.getEndpoint(op, conf, input.ManagementNetwork, config.ManagementNetworkName, config.ManagementNetworkName, false, input.DNS)
 	if err != nil {
 		v.NoteIssue(fmt.Errorf("Error checking network for --management-network: %s", err))
 		v.suggestNetwork(op, "--management-network", true)


### PR DESCRIPTION
In VCH, all nics are named to client, public and bridge except
management. It still shows ethX.

[specific ci=1-01-Docker-Commands]