### PR TITLE
Fix SetEntityPermission error

### DIFF
--- a/pkg/vsphere/rbac/rbac.go
+++ b/pkg/vsphere/rbac/rbac.go
@@ -293,9 +293,10 @@ func (am *AuthzManager) AddPermission(ctx context.Context, ref types.ManagedObje
 		Propagate: resource.Propagate,
 		Group:     isGroup,
 	}
-	permissions = append(permissions, permission)
 
-	if err = am.authzManager.SetEntityPermissions(ctx, ref, permissions); err != nil {
+	newPermission := []types.Permission{permission}
+
+	if err = am.authzManager.SetEntityPermissions(ctx, ref, newPermission); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
We only need to pass the new added permission to this api, but not
the existing permissions. VC 7.0 does not allow passing existing
permissions anymore.

[specific ci=Group26-Quota.26-01-Basic]