### PR TITLE
logrus: fix case-insensitive import collision.

### DIFF
--- a/pkg/vsphere/tags/tags.go
+++ b/pkg/vsphere/tags/tags.go
@@ -23,7 +23,7 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/pkg/errors"
 )
 


### PR DESCRIPTION
fix github.com/vmware/vic/pkg/vsphere/tags/tags.go:26:2: case-insensitive import collision: "github.com/Sirupsen/logrus" and "github.com/sirupsen/logrus"

<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[  ] There is an associated issue that is labelled
[ x] Code is up-to-date with the `master` branch
[  ] You've successfully run `make test` locally
[  ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/vmware/vic/blob/master/.github/CONTRIBUTING.md
-->

Fixes #

<!--
To trigger a custom build with this PR, include one of these in the PR's body:
- To skip running tests (e.g. for a work-in-progress PR), add `[ci skip]` or `[skip ci]`
to the commit message or the PR title.
- To run the full test suite, use `[full ci]`.
- To run _one_ integration test or group, use `[specific ci=$test]`. Examples:
  - To run the `1-01-Docker-Info` suite: `[specific ci=1-01-Docker-Info]`
  - To run all suites under the `Group1-Docker-Commands` group: `[specific ci=Group1-Docker-Commands]`
- To skip running the unit tests, use `[skip unit]`.
- To fail fast (make normal failures fatal) during the integration testing, use `[fast fail]`.
-->
