### PR TITLE
Include datastore path in download error message

### DIFF
--- a/lib/install/management/configure.go
+++ b/lib/install/management/configure.go
@@ -548,7 +548,8 @@ func (d *Dispatcher) GuestInfoSecret(vchName, vmPath string, ds *object.Datastor
 	path := fmt.Sprintf("%s.vmx", vchName)
 	rc, err := helper.Download(d.op, path)
 	if err != nil {
-		return nil, err
+		dp := object.DatastorePath{Datastore: ds.Name(), Path: path}
+		return nil, fmt.Errorf("failed to download %q: %s", dp, err)
 	}
 
 	secret, err := extractSecretFromFile(rc)


### PR DESCRIPTION
Adds path context to the current message of:
 Failed to decode VM configuration "VirtualMachine:vm-488722": 404 Not Found
