### PR TITLE
Set a test tag for skipping test case used the tag

### DIFF
--- a/tests/manual-test-cases/Group5-Functional-Tests/5-25-OPS-User-Grant.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-25-OPS-User-Grant.robot
@@ -171,6 +171,7 @@ vic-machine create grants ops-user perms
     [Teardown]  Cleanup VIC Appliance On Test Server
 
 granted ops-user perms work after upgrade
+    [Tags]  vsphere70-not-support
     Install VIC with version to Test Server  v1.4.0  additional-args=--ops-user ${ops_user_name} --ops-password ${ops_user_password} --ops-grant-perms
 
     Check Original Version

--- a/tests/manual-test-cases/Group5-Functional-Tests/5-3-Enhanced-Linked-Mode.robot
+++ b/tests/manual-test-cases/Group5-Functional-Tests/5-3-Enhanced-Linked-Mode.robot
@@ -17,6 +17,7 @@ Documentation  Test 5-3 - Enhanced Linked Mode
 Resource  ../../resources/Util.robot
 Suite Setup  Nimbus Suite Setup  Enhanced Link Mode Setup
 Suite Teardown  Run Keyword And Ignore Error  Nimbus Pod Cleanup  ${nimbus_pod}  ${testbedname}
+Force Tags  vsphere70-not-support
 
 *** Variables ***
 ${NIMBUS_LOCATION}  sc


### PR DESCRIPTION
Some test cases are not supported in the vsphere7.0,
so set a tag named vsphere70-not-support order to skip
some test cases.
[skip ci]
