### PR TITLE
Add a POSTGRES_PASSWORD environment variable

### DIFF
--- a/demos/compose/voting-app/docker-compose.yml
+++ b/demos/compose/voting-app/docker-compose.yml
@@ -30,6 +30,7 @@ services:
     image: postgres:9.4
     environment:
       - PGDATA=/var/lib/postgresql/data/data
+      - POSTGRES_PASSWORD=password
 
   result:
     image: victest/vote-result

--- a/tests/test-cases/Group1-Docker-Commands/1-06-Docker-Run.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-06-Docker-Run.robot
@@ -205,7 +205,7 @@ Docker run mariadb container
     Verify container is running and remove it  test-mariadb-${suffix}
 
 Docker run postgres container
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -d --name test-postgres postgres
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -d --name test-postgres -e POSTGRES_PASSWORD=password postgres
     Should Be Equal As Integers  ${rc}  0
     Should Not Contain  ${output}  Error
     Verify container is running and remove it  test-postgres


### PR DESCRIPTION
when running postgresql using docker, POSTGRES_PASSWORD
environment variable have to be set, otherwise postgresql
container run failed.
[specific ci=1-06-Docker-Run]