### PR TITLE
Support edit of config for running cVMs and endpointVM

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -212,7 +212,7 @@ whitespace:
 	@infra/scripts/whitespace-check.sh
 
 # exit 1 if golint complains about anything other than comments
-golintf = $(GOLINT) $(1) | sh -c "! grep -v 'lib/apiservers/portlayer/restapi/operations'" | sh -c "! grep -v 'lib/config/dynamic/admiral/client'" | sh -c "! grep -v 'should have comment'" | sh -c "! grep -v 'comment on exported'" | sh -c "! grep -v 'by other packages, and that stutters'" | sh -c "! grep -v 'error strings should not be capitalized'"
+golintf = $(GOLINT) $(1) | sh -c "! grep -v 'lib/apiservers/service/restapi/operations'" | sh -c "! grep -v 'lib/apiservers/portlayer/restapi/operations'" | sh -c "! grep -v 'lib/config/dynamic/admiral/client'" | sh -c "! grep -v 'should have comment'" | sh -c "! grep -v 'comment on exported'" | sh -c "! grep -v 'by other packages, and that stutters'" | sh -c "! grep -v 'error strings should not be capitalized'"
 
 golint: $(GOLINT)
 	@echo checking go lint...

--- a/lib/config/executor/container_vm.go
+++ b/lib/config/executor/container_vm.go
@@ -78,7 +78,7 @@ type ExecutorConfigCommon struct {
 	ID string `vic:"0.1" scope:"read-only" key:"id"`
 
 	// Convenience field to record a human readable name
-	Name string `vic:"0.1" scope:"hidden" key:"name"`
+	Name string `vic:"0.1" scope:"read-only" key:"name"`
 
 	// Freeform notes related to the entity
 	Notes string `vic:"0.1" scope:"hidden" key:"notes"`

--- a/lib/migration/feature/feature.go
+++ b/lib/migration/feature/feature.go
@@ -32,6 +32,15 @@ const (
 	// VM folder support for the VCH.
 	VCHFolderSupportVersion
 
+	// Requires minimum ESX patch versions to support live update of guest visible
+	// fields while VM is running.
+	// Migrates Name back to guest visible - undoes this specific portion of the
+	// AddCommonSpecForContainerVersion migration.
+	// There are two plugin versions because we cannot combine changes to appliance
+	// and container configs
+	ContainerGuestVisibleName
+	ApplianceGuestVisibleName
+
 	// Add new feature flag here
 
 	// MaxPluginVersion must be the last

--- a/lib/migration/plugins/init.go
+++ b/lib/migration/plugins/init.go
@@ -23,4 +23,5 @@ import (
 	_ "github.com/vmware/vic/lib/migration/plugins/plugin7"
 	_ "github.com/vmware/vic/lib/migration/plugins/plugin8"
 	_ "github.com/vmware/vic/lib/migration/plugins/plugin9"
+	_ "github.com/vmware/vic/lib/migration/plugins/plugina"
 )

--- a/lib/migration/plugins/plugina/guest_visible_name_appliance.go
+++ b/lib/migration/plugins/plugina/guest_visible_name_appliance.go
@@ -1,0 +1,88 @@
+// Copyright 2017 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package plugina
+
+import (
+	"context"
+	"fmt"
+
+	log "github.com/Sirupsen/logrus"
+
+	"github.com/vmware/vic/lib/migration/errors"
+	"github.com/vmware/vic/lib/migration/feature"
+	"github.com/vmware/vic/lib/migration/manager"
+	"github.com/vmware/vic/pkg/trace"
+	"github.com/vmware/vic/pkg/vsphere/extraconfig"
+	"github.com/vmware/vic/pkg/vsphere/session"
+)
+
+const (
+	atarget = manager.ApplianceConfigure
+)
+
+func init() {
+	defer trace.End(trace.Begin(fmt.Sprintf("Registering plugins %s:%d", atarget, feature.ApplianceGuestVisibleName)))
+
+	if err := manager.Migrator.Register(feature.ApplianceGuestVisibleName, atarget, &ApplianceGuestVisibleName{}); err != nil {
+		log.Errorf("Failed to register plugin %s:%d, %s", atarget, feature.ApplianceGuestVisibleName, err)
+		panic(err)
+	}
+}
+
+// VCHGuestVisibleName is plugin for vic 1.5.6 version upgrade
+type ApplianceGuestVisibleName struct {
+}
+
+// Migrate is almost identical to the Migrate for containers, but with the UpdatedExecutorConfig nested into
+// the VCH config. This could likely be avoid using extraconfig.DecodeWithPrefix but I chose to follow the
+// pattern from prior plugins.
+func (p *ApplianceGuestVisibleName) Migrate(ctx context.Context, s *session.Session, data interface{}) error {
+	defer trace.End(trace.Begin(fmt.Sprintf("ApplianceGuestVisibleName version: %d", feature.ApplianceGuestVisibleName)))
+	if data == nil {
+		return nil
+	}
+	mapData, ok := data.(map[string]string)
+	if !ok {
+		// Log the error here and return nil so that other plugins can proceed
+		log.Errorf("Migration data format is not map: %+v", data)
+		return nil
+	}
+	oldStruct := &VirtualContainerHostConfigSpec{}
+	result := extraconfig.Decode(extraconfig.MapSource(mapData), oldStruct)
+	log.Debugf("The oldStruct is %+v", oldStruct)
+	if result == nil {
+		return &errors.DecodeError{Err: fmt.Errorf("decode oldStruct %+v failed", oldStruct)}
+	}
+
+	newStruct := &UpdatedVCHConfigSpec{
+		UpdatedExecutorConfig: UpdatedExecutorConfig{
+			UpdatedCommon: UpdatedCommon{
+				Name:                 oldStruct.Name,
+				ID:                   oldStruct.ID,
+				ExecutionEnvironment: oldStruct.ExecutionEnvironment,
+				Notes:                oldStruct.Notes,
+			},
+		},
+	}
+
+	cfg := make(map[string]string)
+	extraconfig.Encode(extraconfig.MapSink(cfg), newStruct)
+
+	for k, v := range cfg {
+		log.Debugf("New data: %s:%s", k, v)
+		mapData[k] = v
+	}
+	return nil
+}

--- a/lib/migration/plugins/plugina/guest_visible_name_container.go
+++ b/lib/migration/plugins/plugina/guest_visible_name_container.go
@@ -1,0 +1,83 @@
+// Copyright 2017 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package plugina
+
+import (
+	"context"
+	"fmt"
+
+	log "github.com/Sirupsen/logrus"
+
+	"github.com/vmware/vic/lib/migration/errors"
+	"github.com/vmware/vic/lib/migration/feature"
+	"github.com/vmware/vic/lib/migration/manager"
+	"github.com/vmware/vic/pkg/trace"
+	"github.com/vmware/vic/pkg/vsphere/extraconfig"
+	"github.com/vmware/vic/pkg/vsphere/session"
+)
+
+const (
+	ctarget = manager.ContainerConfigure
+)
+
+func init() {
+	defer trace.End(trace.Begin(fmt.Sprintf("Registering plugins %s:%d", ctarget, feature.ContainerGuestVisibleName)))
+
+	if err := manager.Migrator.Register(feature.ContainerGuestVisibleName, ctarget, &ContainerGuestVisibleName{}); err != nil {
+		log.Errorf("Failed to register plugin %s:%d, %s", ctarget, feature.ContainerGuestVisibleName, err)
+		panic(err)
+	}
+}
+
+// ContainerGuestVisibleName is plugin for vic 1.5.6 version upgrade
+type ContainerGuestVisibleName struct {
+}
+
+// Migrate deals with the container config and is distinct from the Migrate which is for VCH config.
+func (p *ContainerGuestVisibleName) Migrate(ctx context.Context, s *session.Session, data interface{}) error {
+	defer trace.End(trace.Begin(fmt.Sprintf("ContainerGuestVisibleName version %d", feature.ContainerGuestVisibleName)))
+	if data == nil {
+		return nil
+	}
+	mapData, ok := data.(map[string]string)
+	if !ok {
+		// Log the error here and return nil so that other plugins can proceed
+		log.Errorf("Migration data format is not map: %+v", data)
+		return nil
+	}
+	oldStruct := &ExecutorConfig{}
+	result := extraconfig.Decode(extraconfig.MapSource(mapData), oldStruct)
+	log.Debugf("The oldStruct is %+v", oldStruct)
+	if result == nil {
+		return &errors.DecodeError{Err: fmt.Errorf("decode oldStruct %+v failed", oldStruct)}
+	}
+
+	newStruct := &UpdatedExecutorConfig{
+		UpdatedCommon: UpdatedCommon{
+			Name:                 oldStruct.Name,
+			ID:                   oldStruct.ID,
+			Notes:                oldStruct.Notes,
+			ExecutionEnvironment: oldStruct.ExecutionEnvironment,
+		}}
+
+	cfg := make(map[string]string)
+	extraconfig.Encode(extraconfig.MapSink(cfg), newStruct)
+
+	for k, v := range cfg {
+		log.Debugf("New data: %s:%s", k, v)
+		mapData[k] = v
+	}
+	return nil
+}

--- a/lib/migration/plugins/plugina/types.go
+++ b/lib/migration/plugins/plugina/types.go
@@ -1,0 +1,59 @@
+// Copyright 2017 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package plugina
+
+type ExecutorConfig struct {
+	Common `vic:"0.1" scope:"read-only" key:"common"`
+}
+
+type Common struct {
+	// A reference to the components hosting execution environment, if any
+	ExecutionEnvironment string
+
+	// Unambiguous ID with meaning in the context of its hosting execution environment
+	ID string `vic:"0.1" scope:"read-only" key:"id"`
+
+	// Convenience field to record a human readable name
+	Name string `vic:"0.1" scope:"hidden" key:"name"`
+
+	// Freeform notes related to the entity
+	Notes string `vic:"0.1" scope:"hidden" key:"notes"`
+}
+
+type UpdatedCommon struct {
+	// A reference to the components hosting execution environment, if any
+	ExecutionEnvironment string
+
+	// Unambiguous ID with meaning in the context of its hosting execution environment
+	ID string `vic:"0.1" scope:"read-only" key:"id"`
+
+	// Convenience field to record a human readable name
+	Name string `vic:"0.1" scope:"read-only" key:"name"`
+
+	// Freeform notes related to the entity
+	Notes string `vic:"0.1" scope:"hidden" key:"notes"`
+}
+
+type VirtualContainerHostConfigSpec struct {
+	ExecutorConfig `vic:"0.1" scope:"read-only" key:"init"`
+}
+
+type UpdatedVCHConfigSpec struct {
+	UpdatedExecutorConfig `vic:"0.1" scope:"read-only" key:"init"`
+}
+
+type UpdatedExecutorConfig struct {
+	UpdatedCommon `vic:"0.1" scope:"read-only" key:"common"`
+}

--- a/lib/portlayer/exec/handle.go
+++ b/lib/portlayer/exec/handle.go
@@ -226,7 +226,9 @@ func (h *Handle) Commit(op trace.Operation, sess *session.Session, waitTime *int
 		// any values set with VM powered off are inherently persistent
 		filter = ^extraconfig.NonPersistent
 	} else {
-		filter = extraconfig.NonPersistent | extraconfig.Hidden
+		// API side changes should no longer convert persistent keys to non-persistent while VM is running
+		// allow write of everything
+		filter = ^0
 	}
 
 	extraconfig.Encode(extraconfig.ScopeFilterSink(uint(filter), extraconfig.MapSink(cfg)), h.ExecConfig)


### PR DESCRIPTION
This updates config handling to make use of the fact that the bug1985862 has been addressed and in the field for a while now. That bug prevented us from using the vim API to update guestinfo keys while the VM was running as they would convert to non-persistent.

*NOTE* this PR should not be shipped without determining which ESX builds include that fix and a check of some kind during vic-machine install/upgrade to confirm that the target, or all _current_ ESXs in the target cluster are of sufficiently high version.

This enables any of the blocked work such as `docker network add <bridgenet> <cid>` for running containers that was previously blocked.

There is a quirk in my validation of `rename` after upgrade; the rename applies in ESX but does not update the VIC metadata for the VM.
If I recall correctly we had a statement about levels of support for old containers, particularly those that had never been run. I think that's what I'm seeing but haven't tracked down the support statement. 

```
ghicken@kube-worker:~/vic$ docker ps -a
CONTAINER ID        IMAGE               COMMAND             CREATED              STATUS              PORTS               NAMES
bbd2a3a574e8        busybox             "/bin/ash"          6 seconds ago        Created                                 never-start
e0396488a573        busybox             "/bin/ash"          34 seconds ago       Up 20 seconds                           will-exit-after-rename
c358443dfe3a        busybox             "/bin/ash"          About a minute ago   Up 47 seconds                           will-rename
ab8fff253b49        busybox             "/bin/ash"          About a minute ago   Up About a minute                       wont-rename
ghicken@kube-worker:~/vic$ docker rename will-rename renamed
ghicken@kube-worker:~/vic$ docker rename will-exit-after-rename rename-and-exit
ghicken@kube-worker:~/vic$ docker rename never-start rename-not-started
ghicken@kube-worker:~/vic$ docker ps -a
CONTAINER ID        IMAGE               COMMAND             CREATED              STATUS              PORTS               NAMES
bbd2a3a574e8        busybox             "/bin/ash"          About a minute ago   Created                                 rename-not-started
e0396488a573        busybox             "/bin/ash"          About a minute ago   Up About a minute                       rename-and-exit
c358443dfe3a        busybox             "/bin/ash"          2 minutes ago        Up About a minute                       renamed
ab8fff253b49        busybox             "/bin/ash"          2 minutes ago        Up 2 minutes                            wont-rename
ghicken@kube-worker:~/vic$ vic-ls
INFO[0000] ### Listing VCHs ####
INFO[0000] Validating target

ID        PATH                                                                  NAME           VERSION                      UPGRADE STATUS
8         /ha-datacenter/host/sc2-10-185-251-91.eng.vmware.com/Resources        vic-esx        v1.5.5-21324-50a44954        VCH has newer version
ghicken@kube-worker:~/vic$ vic-upgrade --force
INFO[0000] ### Upgrading VCH ####
INFO[0000] Validating target
WARN[0000] Disabling ha-host hostd.log collection (ServerFaultCode: Cannot complete the operation due to an incorrect request to the server.)
INFO[0000]
INFO[0000] VCH ID: VirtualMachine:8
INFO[0000] Creating directory [datastore1] vic-esx
INFO[0000] datastore root [datastore1] vic-esx already exists
INFO[0000] Datastore path is [datastore1] vic-esx
INFO[0000] Uploading ISO images
INFO[0000] Uploading appliance.iso as V1.5.5-0-5F70FBD30-appliance.iso
INFO[0009] Uploading bootstrap.iso as V1.5.5-0-5F70FBD30-bootstrap.iso
INFO[0015] Switching appliance iso to [datastore1] vic-esx/V1.5.5-0-5F70FBD30-appliance.iso
INFO[0015] Setting VM configuration
INFO[0016] Waiting for IP information
INFO[0022] Waiting for major appliance components to launch
INFO[0031] Obtained IP address for client interface: "10.185.246.19"
INFO[0031] Checking VCH connectivity with vSphere target
INFO[0031] vSphere API Test: https://10.185.251.91 vSphere API target responds as expected
WARN[0034] Server certificate hostname doesn't match: x509: cannot validate certificate for 10.185.246.19 because it doesn't contain any IP SANs
INFO[0034] Completed successfully
ghicken@kube-worker:~/vic$ vic-ssh
SSH to sc2-10-185-246-19.eng.vmware.com
Warning: Permanently added 'sc2-10-185-246-19.eng.vmware.com,10.185.246.19' (ECDSA) to the list of known hosts.
Warning: your password will expire in 0 days
root@vic-esx [ ~ ]# exit
ghicken@kube-worker:~/vic$ docker ps -a
CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS                       PORTS               NAMES
bbd2a3a574e8        busybox             "/bin/ash"          7 minutes ago       Created                                          rename-not-started
e0396488a573        busybox             "/bin/ash"          7 minutes ago       Exited (143) 5 minutes ago                       rename-and-exit
c358443dfe3a        busybox             "/bin/ash"          8 minutes ago       Up 8 minutes                                     renamed
ab8fff253b49        busybox             "/bin/ash"          9 minutes ago       Up 8 minutes                                     wont-rename
ghicken@kube-worker:~/vic$ docker rename rename-and-exit renamed-again
ghicken@kube-worker:~/vic$ docker ps -a
CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS                       PORTS               NAMES
bbd2a3a574e8        busybox             "/bin/ash"          8 minutes ago       Created                                          rename-not-started
e0396488a573        busybox             "/bin/ash"          8 minutes ago       Exited (143) 6 minutes ago                       renamed-again
c358443dfe3a        busybox             "/bin/ash"          8 minutes ago       Up 8 minutes                                     renamed
ab8fff253b49        busybox             "/bin/ash"          9 minutes ago       Up 9 minutes                                     wont-rename
ghicken@kube-worker:~/vic$ docker rename rename-not-started not-started-renamed-post-upgrade
ghicken@kube-worker:~/vic$ docker ps -a
CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS                       PORTS               NAMES
bbd2a3a574e8        busybox             "/bin/ash"          8 minutes ago       Created                                          rename-not-started
e0396488a573        busybox             "/bin/ash"          9 minutes ago       Exited (143) 6 minutes ago                       renamed-again
c358443dfe3a        busybox             "/bin/ash"          9 minutes ago       Up 9 minutes                                     renamed
ab8fff253b49        busybox             "/bin/ash"          10 minutes ago      Up 10 minutes                                    wont-rename
ghicken@kube-worker:~/vic$ govc ls /ha-datacenter/vm
/ha-datacenter/vm/renamed-c358443dfe3a
/ha-datacenter/vm/renamed-again-e0396488a573
/ha-datacenter/vm/not-started-renamed-post-upgrade-bbd2a3a574e8
/ha-datacenter/vm/vic-esx
/ha-datacenter/vm/wont-rename-ab8fff253b49
ghicken@kube-worker:~/vic$
```

Related #5553

`[full ci]`