### PR TITLE
Update photon repo url

### DIFF
--- a/isos/base/repos/photon-2.0/photon-2.0.repo.local
+++ b/isos/base/repos/photon-2.0/photon-2.0.repo.local
@@ -1,13 +1,13 @@
 [photon-2.0]
 name=VMware WDC Photon Linux 2.0(x86_64)
-baseurl=http://wdc-yum-builder-ci.eng.vmware.com/photon
+baseurl=https://packages.vmware.com/photon/2.0/photon_release_2.0_x86_64/
 gpgkey=file:///etc/pki/rpm-gpg/VMWARE-RPM-GPG-KEY
 gpgcheck=1
 enabled=1
 
 [photon-updates-2.0]
 name=VMware WDC Photon Linux 2.0(x86_64) Updates
-baseurl=http://wdc-yum-builder-ci.eng.vmware.com/photon-updates
+baseurl=https://packages.vmware.com/photon/2.0/photon_updates_2.0_x86_64/
 gpgkey=file:///etc/pki/rpm-gpg/VMWARE-RPM-GPG-KEY
 gpgcheck=1
 enabled=1

--- a/isos/base/repos/photon-2.0/photon.repo
+++ b/isos/base/repos/photon-2.0/photon.repo
@@ -1,13 +1,13 @@
 [photon-2.0]
 name=VMware Photon Linux 2.0(x86_64)
-baseurl=https://dl.bintray.com/vmware/photon_release_2.0_x86_64/
+baseurl=https://packages.vmware.com/photon/2.0/photon_release_2.0_x86_64/
 gpgkey=file:///etc/pki/rpm-gpg/VMWARE-RPM-GPG-KEY
 gpgcheck=1
 enabled=1
 
 [photon-updates-2.0]
 name=VMware Photon Linux 2.0(x86_64) Updates
-baseurl=https://dl.bintray.com/vmware/photon_updates_2.0_x86_64/
+baseurl=https://packages.vmware.com/photon/2.0/photon_updates_2.0_x86_64/
 gpgkey=file:///etc/pki/rpm-gpg/VMWARE-RPM-GPG-KEY
 gpgcheck=1
 enabled=1


### PR DESCRIPTION
[full ci]

after the remote photon repo was migrated, we do not see some latest rpm package
on the browser, so we do not download these rpm package to local photon repo,
so we have to replace local repo to remote repo.
