### PR TITLE
Add error return for handle

### DIFF
--- a/lib/apiservers/portlayer/restapi/handlers/containers_handlers.go
+++ b/lib/apiservers/portlayer/restapi/handlers/containers_handlers.go
@@ -198,7 +198,10 @@ func (handler *ContainersHandlersImpl) GetHandler(params containers.GetParams) m
 	op := trace.NewOperationFromID(context.Background(), params.OpID, "containers.GetHandler(%s)", params.ID)
 	defer trace.End(trace.Begin("GetHandler", op))
 
-	h := exec.GetContainer(context.Background(), uid.Parse(params.ID))
+	h, err := exec.GetContainer(context.Background(), uid.Parse(params.ID))
+	if err != nil {
+		return containers.NewGetDefault(503).WithPayload(&models.Error{Message: err.Error()})
+	}
 	if h == nil {
 		return containers.NewGetNotFound().WithPayload(&models.Error{Message: fmt.Sprintf("container %s not found", params.ID)})
 	}

--- a/lib/portlayer/exec/container.go
+++ b/lib/portlayer/exec/container.go
@@ -217,14 +217,14 @@ func newContainer(base *containerBase) *Container {
 	return c
 }
 
-func GetContainer(ctx context.Context, id uid.UID) *Handle {
+func GetContainer(ctx context.Context, id uid.UID) (*Handle, error) {
 	// get from the cache
 	container := Containers.Container(id.String())
 	if container != nil {
 		return container.NewHandle(ctx)
 	}
 
-	return nil
+	return nil, nil
 }
 
 func (c *ContainerInfo) String() string {
@@ -318,20 +318,20 @@ func (c *Container) WaitForState(s State) <-chan struct{} {
 	return eventChan
 }
 
-func (c *Container) NewHandle(ctx context.Context) *Handle {
+func (c *Container) NewHandle(ctx context.Context) (*Handle, error) {
 	// Call property collector to fill the data
 	if c.vm != nil {
 		op := trace.FromContext(ctx, "")
 		// FIXME: this should be calling the cache to decide if a refresh is needed
 		if err := c.Refresh(op); err != nil {
 			op.Errorf("refreshing container %s failed: %s", c, err)
-			return nil // nil indicates error
+			return nil, err
 		}
 	}
 
 	// return a handle that represents zero changes over the current configuration
 	// for this container
-	return newHandle(c)
+	return newHandle(c), nil
 }
 
 // Refresh updates config and runtime info, holding a lock only while swapping

--- a/lib/portlayer/logging/logging.go
+++ b/lib/portlayer/logging/logging.go
@@ -73,9 +73,9 @@ func eventCallback(ie events.Event) {
 		operation := func() error {
 			var err error
 
-			handle := container.NewHandle(op)
-			if handle == nil {
-				err = fmt.Errorf("Handle for %s cannot be created", ie.Reference())
+			handle, err := container.NewHandle(op)
+			if err != nil {
+				err = fmt.Errorf("Handle for %s cannot be created: %s", ie.Reference(), err)
 				log.Error(err)
 				return err
 			}

--- a/lib/portlayer/network/container.go
+++ b/lib/portlayer/network/container.go
@@ -101,7 +101,10 @@ func (c *Container) Refresh(ctx context.Context) error {
 
 	// this will "refresh" the container executor config that contains
 	// the current ip addresses
-	h := exec.GetContainer(ctx, c.ID())
+	h, err := exec.GetContainer(ctx, c.ID())
+	if err != nil {
+		return fmt.Errorf("could not find container %s: %s", c.ID(), err)
+	}
 	if h == nil {
 		return fmt.Errorf("could not find container %s", c.ID())
 	}

--- a/lib/portlayer/portlayer.go
+++ b/lib/portlayer/portlayer.go
@@ -148,9 +148,9 @@ func TakeCareOfSerialPorts(op trace.Operation, sess *session.Session) {
 
 		operation := func() error {
 			// Obtain a container handle
-			handle := containers[i].NewHandle(op)
-			if handle == nil {
-				err := fmt.Errorf("unable to obtain a handle for container %s", containerID)
+			handle, err := containers[i].NewHandle(op)
+			if err != nil {
+				err := fmt.Errorf("unable to obtain a handle for container %s: %s", containerID, err)
 				op.Errorf("%s", err)
 
 				return err


### PR DESCRIPTION
When vcenter is unaccessible, we cannot always return nil which
indicates the container VM does not exist anymore so get removed
from cache.

Manual tests for container vm start/stop/exec/delete passed after
power off vcenter and enable vcenter again.

<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[  ] There is an associated issue that is labelled
[  ] Code is up-to-date with the `master` branch
[  ] You've successfully run `make test` locally
[  ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/vmware/vic/blob/master/.github/CONTRIBUTING.md
-->

Fixes #

<!--
To trigger a custom build with this PR, include one of these in the PR's body:
- To skip running tests (e.g. for a work-in-progress PR), add `[ci skip]` or `[skip ci]`
to the commit message or the PR title.
- To run the full test suite, use `[full ci]`.
- To run _one_ integration test or group, use `[specific ci=$test]`. Examples:
  - To run the `1-01-Docker-Info` suite: `[specific ci=1-01-Docker-Info]`
  - To run all suites under the `Group1-Docker-Commands` group: `[specific ci=Group1-Docker-Commands]`
- To skip running the unit tests, use `[skip unit]`.
- To fail fast (make normal failures fatal) during the integration testing, use `[fast fail]`.
-->
