### PR TITLE
Replace base image to gcr.io/eminent-nation-87317/photon:2.0

### DIFF
--- a/cmd/vic-machine-server/Dockerfile
+++ b/cmd/vic-machine-server/Dockerfile
@@ -5,7 +5,7 @@
 # gcloud auth login
 # gcloud docker -- push gcr.io/eminent-nation-87317/vic-machine-server:1.x
 
-FROM photon:2.0
+FROM gcr.io/eminent-nation-87317/photon:2.0
 
 RUN set -eux; \
      tdnf distro-sync --refresh -y; \


### PR DESCRIPTION


Since the docker hub limits rate, we need to pull the base image from gcr for vic-machine-server.