### PR TITLE
Fix goimport check for stretchr/testify

### DIFF
--- a/cmd/vic-machine/common/syslog_test.go
+++ b/cmd/vic-machine/common/syslog_test.go
@@ -15,8 +15,9 @@
 package common
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestProcessSysLog(t *testing.T) {


### PR DESCRIPTION
In a fresh build env, using the docker contianer to build, goimports throws an error:
```
ghicken@ghicken-z01:~/vic$ docker run -v $GOPATH/bin:/go/bin -v $(pwd):/go/src/github.com/vmware/vic gcr.io/eminent-nation-87317/vic-build-image:tdnf make all
Unable to find image 'gcr.io/eminent-nation-87317/vic-build-image:tdnf' locally
tdnf: Pulling from eminent-nation-87317/vic-build-image
b2fe08cc4eaa: Pull complete
5c5ccf14dbac: Pull complete
b5d2fe3102d3: Pull complete
933796be132a: Pull complete
c139887958ed: Pull complete
2f6f4ffd6111: Pull complete
fb35a0b066cb: Pull complete
Digest: sha256:d93a6b52b10a6325664ec75c20412c42f1b458ec95d3ce93a44666785a6d2a78
Status: Downloaded newer image for gcr.io/eminent-nation-87317/vic-build-image:tdnf
Generating dependency set for cmd/imagec/
Generating dependency set for cmd/vic-machine/
Generating dependency set for cmd/vicadmin/
Generating dependency set for cmd/port-layer-server/
Generating dependency set for cmd/vic-dns/
Generating dependency set for cmd/tether/
Generating dependency set for cmd/vic-machine-server/
Generating dependency set for cmd/rpctool/
Generating dependency set for cmd/docker/
Generating dependency set for cmd/vic-init/
Generating dependency set for cmd/archive/
Generating dependency set for cmd/gandalf/
checking go version...
building /go/bin/goimports...
checking go imports...
diff -u ./cmd/vic-machine/common/syslog_test.go.orig ./cmd/vic-machine/common/syslog_test.go
--- ./cmd/vic-machine/common/syslog_test.go.orig        2021-09-03 19:02:49.645602753 +0000
+++ ./cmd/vic-machine/common/syslog_test.go     2021-09-03 19:02:49.645602753 +0000
@@ -15,8 +15,9 @@
 package common

 import (
-       "github.com/stretchr/testify/assert"
        "testing"
+
+       "github.com/stretchr/testify/assert"
 )

 func TestProcessSysLog(t *testing.T) {
make: *** [Makefile:230: goimports] Error 1
```