### PR TITLE
Fixing bundle format for zipDefaultLogs from TGZ to Zip

### DIFF
--- a/cmd/vicadmin/server.go
+++ b/cmd/vicadmin/server.go
@@ -518,7 +518,7 @@ func (s *server) tarDefaultLogs(res http.ResponseWriter, req *http.Request) {
 func (s *server) zipDefaultLogs(res http.ResponseWriter, req *http.Request) {
 	defer trace.End(trace.Begin(""))
 
-	s.bundleContainerLogs(res, req, formatTGZ, false)
+	s.bundleContainerLogs(res, req, formatZip, false)
 }
 
 func (s *server) bundleLogs(res http.ResponseWriter, req *http.Request, readers map[string]entryReader, f format) {


### PR DESCRIPTION
As explained in VIC Issue : https://github.com/vmware/vic/issues/8674
The produced archive logs.zip cannot be opened, without changing its file extension to .tar
After reviewing the code, the format used is not ZIP